### PR TITLE
Fix show previous version

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -611,7 +611,7 @@ module ApplicationHelper
     if previous_version = latest_version.previous
       html += link_with_query("#{:show_name_previous_version.t}: %d" % previous_version.version,
         :action => "show_past_#{type}", :id => obj.id,
-        :version => previous_version)
+        :version => previous_version.version)
       if (previous_version.merge_source_id rescue false)
         html += indent(1) + get_version_merge_link(obj, previous_version)
       end

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -28,3 +28,14 @@ plane_glossary_term:
   thumb_image_id: 11
   created_at: 2013-08-17 06:33:50
   updated_at: 2013-08-17 06:35:20
+  
+square_glossary_term:
+  id: 4
+  version: 3
+  user_id: 1
+  name: Square
+  description: equilateral
+  thumb_image_id: nil
+  created_at: 2013-08-17 06:33:50
+  updated_at: 2013-08-17 06:35:20
+

--- a/test/fixtures/glossary_terms_versions.yml
+++ b/test/fixtures/glossary_terms_versions.yml
@@ -23,3 +23,28 @@ conic_glossary_term_v1:
   updated_at: 2013-08-04 07:49:12
   name: Conic
   description: Cute little cone head
+  
+square_glossary_term_v1:
+  id: 4
+  glossary_term_id: 4
+  version: 1
+  updated_at: 2013-08-04 07:49:12
+  name: Square
+  description: 
+
+square_glossary_term_v2:
+  id: 5
+  glossary_term_id: 4
+  version: 2
+  updated_at: 2013-08-04 07:49:12
+  name: Square
+  description: quadrilateral
+  
+square_glossary_term_v3:
+  id: 6
+  glossary_term_id: 4
+  version: 3
+  updated_at: 2013-08-04 07:49:12
+  name: Square
+  description: equilateral
+

--- a/test/functional/glossary_controller_test.rb
+++ b/test/functional/glossary_controller_test.rb
@@ -98,4 +98,11 @@ class GlossaryControllerTest < FunctionalTestCase
     assert_template(action: 'show_past_glossary_term', partial: "_glossary_term")
   end
 
+  test "prior version link target" do
+    square = glossary_terms(:square_glossary_term)
+    prior_version_target = "/glossary/show_past_glossary_term/#{square.id}?version=#{square.version-1}"
+    get(:show_glossary_term, id: square.id)
+ 	  assert_select "a[href=?]", prior_version_target
+	end
+
 end

--- a/test/functional/glossary_controller_test.rb
+++ b/test/functional/glossary_controller_test.rb
@@ -2,27 +2,11 @@ require "test_helper"
 
 # functional tests of glossary controller and views
 class GlossaryControllerTest < FunctionalTestCase
+  # ***** show *****
   def test_show_glossary_term
     glossary_term = glossary_terms(:plane_glossary_term)
     get_with_dump(:show_glossary_term, id: glossary_term.id)
     assert_template(action: "show_glossary_term")
-  end
-
-  test "prior version link target" do
-    square = glossary_terms(:square_glossary_term)
-    prior_version_target = "/glossary/show_past_glossary_term/" \
-                          "#{square.id}?version=#{square.version - 1}"
-    get(:show_glossary_term, id: square.id)
-    assert_select "a[href=?]", prior_version_target
-  end
-
-  def test_show_past_glossary_term
-    conic = glossary_terms(:conic_glossary_term)
-    get_with_dump(:show_past_glossary_term,
-                  id: conic.id,
-                  version: conic.version - 1)
-    assert_template(action: "show_past_glossary_term",
-                    partial: "_glossary_term")
   end
 
   def test_show_past_glossary_term_no_version
@@ -31,9 +15,45 @@ class GlossaryControllerTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  def test_show_past_glossary_term_with_version
+    conic = glossary_terms(:conic_glossary_term)
+    get_with_dump(:show_past_glossary_term,
+                  id: conic.id, version: conic.version - 1)
+    assert_template(action: "show_past_glossary_term",
+                    partial: "_glossary_term")
+  end
+
+  test "show past glossary term prior version link target" do
+    square = glossary_terms(:square_glossary_term)
+    prior_version_target = "/glossary/show_past_glossary_term/" \
+                          "#{square.id}?version=#{square.version - 1}"
+    get(:show_glossary_term, id: square.id)
+    assert_select "a[href=?]", prior_version_target
+  end
+
+  # ***** index *****
   def test_index
     get_with_dump(:index)
     assert_template(action: "index")
+  end
+
+  # ***** create *****
+  def convex_params
+    { glossary_term:
+      { name: "Convex", description: "Boring" },
+      copyright_holder: "Me",
+      date: { copyright_year: 2013 }, upload: { license_id: 1 }
+    }
+  end
+
+  def posted_term
+    login_and_post_convex
+    GlossaryTerm.find(:all, order: "created_at DESC")[0]
+  end
+
+  def login_and_post_convex
+    login
+    post(:create_glossary_term, convex_params)
   end
 
   def test_create_glossary_term_not_logged_in
@@ -47,29 +67,30 @@ class GlossaryControllerTest < FunctionalTestCase
     assert_template(action: "create_glossary_term")
   end
 
-  def create_glossary_term_params
-    { glossary_term:
-      { name: "Convex", description: "Boring old convex" },
-      copyright_holder: "Insil Choi",
-      date: { copyright_year: 2013 },
-      upload: { license_id: 1 }
-      }
+  def test_create_glossary_term_name
+    assert_equal(convex_params[:glossary_term][:name], posted_term.name)
   end
 
-  def test_create_glossary_term_post
-    user = login
-    params = create_glossary_term_params
-    post(:create_glossary_term, params)
-    glossary_term = GlossaryTerm.find(:all, order: "created_at DESC")[0]
+  def test_create_glossary_term_description
+    assert_equal(convex_params[:glossary_term][:description],
+                 posted_term.description)
+  end
 
-    assert_equal(params[:glossary_term][:name], glossary_term.name)
-    assert_equal(params[:glossary_term][:description],
-                 glossary_term.description)
-    assert_not_nil(glossary_term.rss_log)
-    assert_equal(user.id, glossary_term.user_id)
+  def test_create_glossary_term_rss_log
+    assert_not_nil(posted_term.rss_log)
+  end
+
+  def test_create_glossary_term_user_id
+    user = login
+    assert_equal(user.id, posted_term.user_id)
+  end
+
+  def test_create_glossary_term_redirect
+    login_and_post_convex
     assert_response(:redirect)
   end
 
+  # ***** edit *****
   def test_edit_glossary_term
     conic = glossary_terms(:conic_glossary_term)
     get_with_dump(:edit_glossary_term, id: conic.id)
@@ -82,32 +103,36 @@ class GlossaryControllerTest < FunctionalTestCase
 
   def test_edit_glossary_term_post
     conic = glossary_terms(:conic_glossary_term)
-    count = GlossaryTerm::Version.count
+    old_count = GlossaryTerm::Version.count
     make_admin
 
-    params = create_glossary_term_params
-    params[:id] = conic.id
+    params = { id: conic.id,
+               glossary_term:
+               { name: "Convex", description: "Boring old convex" },
+               copyright_holder: "Insil Choi", date: { copyright_year: 2013 },
+               upload: { license_id: 1 }
+             }
+
     post(:edit_glossary_term, params)
+    # see if conic changed
     conic.reload
     assert_equal(params[:glossary_term][:name], conic.name)
     assert_equal(params[:glossary_term][:description], conic.description)
-    assert_equal(count + 1, GlossaryTerm::Version.count)
+    assert_equal(old_count + 1, GlossaryTerm::Version.count)
     assert_response(:redirect)
   end
 
   def test_generate_and_show_past_glossary_term
     login
     glossary_term = glossary_terms(:plane_glossary_term)
-    old_count = glossary_term.versions.length
+    old_length = glossary_term.versions.length
     glossary_term.update_attributes(description: "Are we flying yet?")
     glossary_term.reload
-    new_count = glossary_term.versions.length
-    assert_equal(1, new_count - old_count)
+    assert_equal(old_length + 1, glossary_term.versions.length)
     get_with_dump(:show_past_glossary_term,
                   id: glossary_term.id,
                   version: glossary_term.version - 1)
     assert_template(action: "show_past_glossary_term",
                     partial: "_glossary_term")
   end
-
 end

--- a/test/functional/glossary_controller_test.rb
+++ b/test/functional/glossary_controller_test.rb
@@ -1,61 +1,70 @@
-require 'test_helper'
+require "test_helper"
 
+# functional tests of glossary controller and views
 class GlossaryControllerTest < FunctionalTestCase
   def test_show_glossary_term
     glossary_term = glossary_terms(:plane_glossary_term)
-    get_with_dump(:show_glossary_term, :id => glossary_term.id)
-    assert_template(action: 'show_glossary_term')
+    get_with_dump(:show_glossary_term, id: glossary_term.id)
+    assert_template(action: "show_glossary_term")
+  end
+
+  test "prior version link target" do
+    square = glossary_terms(:square_glossary_term)
+    prior_version_target = "/glossary/show_past_glossary_term/" \
+                          "#{square.id}?version=#{square.version - 1}"
+    get(:show_glossary_term, id: square.id)
+    assert_select "a[href=?]", prior_version_target
   end
 
   def test_show_past_glossary_term
     conic = glossary_terms(:conic_glossary_term)
-    get_with_dump(:show_past_glossary_term, :id => conic.id, :version => conic.version - 1)
-    assert_template(action: 'show_past_glossary_term', partial: "_glossary_term")
+    get_with_dump(:show_past_glossary_term,
+                  id: conic.id,
+                  version: conic.version - 1)
+    assert_template(action: "show_past_glossary_term",
+                    partial: "_glossary_term")
   end
 
   def test_show_past_glossary_term_no_version
     conic = glossary_terms(:conic_glossary_term)
-    get_with_dump(:show_past_glossary_term, :id => conic.id)
+    get_with_dump(:show_past_glossary_term, id: conic.id)
     assert_response(:redirect)
   end
 
   def test_index
     get_with_dump(:index)
-    assert_template(action: 'index')
+    assert_template(action: "index")
   end
 
-  def test_create_glossary_term
+  def test_create_glossary_term_not_logged_in
     get(:create_glossary_term)
     assert_response(:redirect)
+  end
 
+  def test_create_glossary_term_logged_in
     login
     get_with_dump(:create_glossary_term)
-    assert_template(action: 'create_glossary_term')
+    assert_template(action: "create_glossary_term")
   end
-  
+
   def create_glossary_term_params
-    return {
-      :glossary_term => {
-        :name => 'Convex',
-        :description => 'Boring old convex',
-      },
-      :copyright_holder => "Insil Choi",
-      :date => {
-        :copyright_year => '2013'
-      },
-      :upload => {
-        :license_id => '1'
+    { glossary_term:
+      { name: "Convex", description: "Boring old convex" },
+      copyright_holder: "Insil Choi",
+      date: { copyright_year: 2013 },
+      upload: { license_id: 1 }
       }
-    }
   end
-  
+
   def test_create_glossary_term_post
     user = login
     params = create_glossary_term_params
     post(:create_glossary_term, params)
-    glossary_term = GlossaryTerm.find(:all, :order => "created_at DESC")[0]
+    glossary_term = GlossaryTerm.find(:all, order: "created_at DESC")[0]
+
     assert_equal(params[:glossary_term][:name], glossary_term.name)
-    assert_equal(params[:glossary_term][:description], glossary_term.description)
+    assert_equal(params[:glossary_term][:description],
+                 glossary_term.description)
     assert_not_nil(glossary_term.rss_log)
     assert_equal(user.id, glossary_term.user_id)
     assert_response(:redirect)
@@ -63,14 +72,14 @@ class GlossaryControllerTest < FunctionalTestCase
 
   def test_edit_glossary_term
     conic = glossary_terms(:conic_glossary_term)
-    get_with_dump(:edit_glossary_term, :id => conic.id)
+    get_with_dump(:edit_glossary_term, id: conic.id)
     assert_response(:redirect)
 
     login
-    get_with_dump(:edit_glossary_term, :id => conic.id)
-    assert_template(action: 'edit_glossary_term')
+    get_with_dump(:edit_glossary_term, id: conic.id)
+    assert_template(action: "edit_glossary_term")
   end
-  
+
   def test_edit_glossary_term_post
     conic = glossary_terms(:conic_glossary_term)
     count = GlossaryTerm::Version.count
@@ -82,7 +91,7 @@ class GlossaryControllerTest < FunctionalTestCase
     conic.reload
     assert_equal(params[:glossary_term][:name], conic.name)
     assert_equal(params[:glossary_term][:description], conic.description)
-    assert_equal(count+1, GlossaryTerm::Version.count)
+    assert_equal(count + 1, GlossaryTerm::Version.count)
     assert_response(:redirect)
   end
 
@@ -90,19 +99,15 @@ class GlossaryControllerTest < FunctionalTestCase
     login
     glossary_term = glossary_terms(:plane_glossary_term)
     old_count = glossary_term.versions.length
-    glossary_term.update_attributes(:description => 'Are we flying yet?')
+    glossary_term.update_attributes(description: "Are we flying yet?")
     glossary_term.reload
     new_count = glossary_term.versions.length
     assert_equal(1, new_count - old_count)
-    get_with_dump(:show_past_glossary_term, :id => glossary_term.id, :version => glossary_term.version - 1)
-    assert_template(action: 'show_past_glossary_term', partial: "_glossary_term")
+    get_with_dump(:show_past_glossary_term,
+                  id: glossary_term.id,
+                  version: glossary_term.version - 1)
+    assert_template(action: "show_past_glossary_term",
+                    partial: "_glossary_term")
   end
-
-  test "prior version link target" do
-    square = glossary_terms(:square_glossary_term)
-    prior_version_target = "/glossary/show_past_glossary_term/#{square.id}?version=#{square.version-1}"
-    get(:show_glossary_term, id: square.id)
- 	  assert_select "a[href=?]", prior_version_target
-	end
 
 end

--- a/test/functional/glossary_controller_test.rb
+++ b/test/functional/glossary_controller_test.rb
@@ -2,21 +2,37 @@ require "test_helper"
 
 # functional tests of glossary controller and views
 class GlossaryControllerTest < FunctionalTestCase
+  def conic
+    glossary_terms(:conic_glossary_term)
+  end
+
+  def plane
+    glossary_terms(:plane_glossary_term)
+  end
+
+  def square
+    glossary_terms(:square_glossary_term)
+  end
+end
+
+# tests of controller methods which do not change glossary terms
+class GlossaryControllerShowAndIndexTest < GlossaryControllerTest
+  def setup
+    @controller = GlossaryController.new
+  end
+
   # ***** show *****
   def test_show_glossary_term
-    glossary_term = glossary_terms(:plane_glossary_term)
-    get_with_dump(:show_glossary_term, id: glossary_term.id)
+    get_with_dump(:show_glossary_term, id: plane.id)
     assert_template(action: "show_glossary_term")
   end
 
   def test_show_past_glossary_term_no_version
-    conic = glossary_terms(:conic_glossary_term)
     get_with_dump(:show_past_glossary_term, id: conic.id)
     assert_response(:redirect)
   end
 
   def test_show_past_glossary_term_with_version
-    conic = glossary_terms(:conic_glossary_term)
     get_with_dump(:show_past_glossary_term,
                   id: conic.id, version: conic.version - 1)
     assert_template(action: "show_past_glossary_term",
@@ -24,7 +40,6 @@ class GlossaryControllerTest < FunctionalTestCase
   end
 
   test "show past glossary term prior version link target" do
-    square = glossary_terms(:square_glossary_term)
     prior_version_target = "/glossary/show_past_glossary_term/" \
                           "#{square.id}?version=#{square.version - 1}"
     get(:show_glossary_term, id: square.id)
@@ -35,6 +50,13 @@ class GlossaryControllerTest < FunctionalTestCase
   def test_index
     get_with_dump(:index)
     assert_template(action: "index")
+  end
+end
+
+# tests of controller methods which create glossary terms
+class GlossaryControllerCreateTest < GlossaryControllerTest
+  def setup
+    @controller = GlossaryController.new
   end
 
   # ***** create *****
@@ -56,7 +78,7 @@ class GlossaryControllerTest < FunctionalTestCase
     post(:create_glossary_term, convex_params)
   end
 
-  def test_create_glossary_term_not_logged_in
+  def test_create_glossary_term_no_login
     get(:create_glossary_term)
     assert_response(:redirect)
   end
@@ -89,49 +111,82 @@ class GlossaryControllerTest < FunctionalTestCase
     login_and_post_convex
     assert_response(:redirect)
   end
+end
+
+# tests of controller methods which edit glossary terms
+class GlossaryControllerEditTest < GlossaryControllerTest
+  def setup
+    @controller = GlossaryController.new
+  end
 
   # ***** edit *****
-  def test_edit_glossary_term
-    conic = glossary_terms(:conic_glossary_term)
+  def test_edit_glossary_term_no_login
     get_with_dump(:edit_glossary_term, id: conic.id)
     assert_response(:redirect)
+  end
 
+  def test_edit_glossary_term_logged_in
     login
     get_with_dump(:edit_glossary_term, id: conic.id)
     assert_template(action: "edit_glossary_term")
   end
 
-  def test_edit_glossary_term_post
-    conic = glossary_terms(:conic_glossary_term)
-    old_count = GlossaryTerm::Version.count
+  def changes_to_conic
+    { id: conic.id,
+      glossary_term: { name: "Convex", description: "Boring old convex" },
+      copyright_holder: "Insil Choi", date: { copyright_year: 2013 },
+      upload: { license_id: 1 }
+     }
+  end
+
+  def post_conic_edit_changes
     make_admin
+    post(:edit_glossary_term, changes_to_conic)
+  end
 
-    params = { id: conic.id,
-               glossary_term:
-               { name: "Convex", description: "Boring old convex" },
-               copyright_holder: "Insil Choi", date: { copyright_year: 2013 },
-               upload: { license_id: 1 }
-             }
-
-    post(:edit_glossary_term, params)
-    # see if conic changed
+  def post_conic_edit_changes_and_reload
+    post_conic_edit_changes
     conic.reload
-    assert_equal(params[:glossary_term][:name], conic.name)
-    assert_equal(params[:glossary_term][:description], conic.description)
-    assert_equal(old_count + 1, GlossaryTerm::Version.count)
+  end
+
+  def test_edit_glossary_term_redirect
+    post_conic_edit_changes
     assert_response(:redirect)
   end
 
-  def test_generate_and_show_past_glossary_term
+  def test_edit_glossary_term_count
+    old_count = GlossaryTerm::Version.count
+    post_conic_edit_changes
+    assert_equal(old_count + 1, GlossaryTerm::Version.count)
+  end
+
+  def test_edit_glossary_term_name
+    post_conic_edit_changes_and_reload
+    assert_equal(changes_to_conic[:glossary_term][:name], conic.name)
+  end
+
+  def test_edit_glossary_term_name_and_description
+    post_conic_edit_changes_and_reload
+    assert_equal(changes_to_conic[:glossary_term][:description],
+                 conic.description)
+  end
+
+  def update_and_reload_plane_past_version
     login
-    glossary_term = glossary_terms(:plane_glossary_term)
-    old_length = glossary_term.versions.length
-    glossary_term.update_attributes(description: "Are we flying yet?")
-    glossary_term.reload
-    assert_equal(old_length + 1, glossary_term.versions.length)
+    plane.update_attributes(description: "Are we flying yet?")
+    plane.reload
+  end
+
+  def test_generate_past_glossary_term
+    old_length = plane.versions.length
+    update_and_reload_plane_past_version
+    assert_equal(old_length + 1, plane.versions.length)
+  end
+
+  def test_generate_and_show_past_glossary_term
+    update_and_reload_plane_past_version
     get_with_dump(:show_past_glossary_term,
-                  id: glossary_term.id,
-                  version: glossary_term.version - 1)
+                  id: plane.id, version: plane.version - 1)
     assert_template(action: "show_past_glossary_term",
                     partial: "_glossary_term")
   end


### PR DESCRIPTION
Fixes [Pivotal Issue 12252025](https://www.pivotaltracker.com/story/show/12252025): 
Bug: "Show Previous Version" goes to current version instead of previous version
* Wrote test to find bug, placing test in glossary_controller_test.rb
* Fixed the bug by making trivial correction to application_helper.rb
* Refactored glossary_controller_test.rb to fix RuboCop violations