### PR TITLE
Make param[:link] a hash

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1417,11 +1417,10 @@ end
   # votes::     Show vote buttons?
   def thumbnail(image, args={}) ##TODO: Add size option
     image = Image.find(image) unless image.is_a?(Image)
-    link = args[:link].is_a?(Symbol) ? args[:link].to_s : args[:link]
 
     render(partial: "image/image_thumbnail",
            locals: { image:    image,
-                     link:     link,
+                     link:     args[:link],
                      votes:    args[:votes],
                      size:     args[:size],
                      original: args[:original]
@@ -1438,17 +1437,17 @@ end
     end
     result = image.license.copyright_text(image.year, link)
     if div
-      result = content_tag(:div, result, :id => "copyright")
+      result = content_tag(:div, result, id: "copyright")
     end
     result
   end
 
   def export_link(image_id, exported)
     if exported
-      link_to('', {} ,:onclick => "image_export(#{image_id},0)") ##TODO: really fix this.
+      link_to('', {}, onclick: "image_export(#{image_id},0)") ##TODO: really fix this.
       #link_to_function('Not for Export', "image_export(#{image_id},0)")
     else
-      link_to('', {} ,:onclick => "image_export(#{image_id},1)") ##TODO: really fix this.
+      link_to('', {}, onclick: "image_export(#{image_id},1)") ##TODO: really fix this.
       #link_to_function('For Export', "image_export(#{image_id},1)")
     end
   end
@@ -1456,7 +1455,7 @@ end
   def image_exporter(image_id, exported)
     javascript_include('jquery')
     javascript_include('image_export')
-    content_tag(:div, export_link(image_id, exported), :id => "image_export_#{image_id}")
+    content_tag(:div, export_link(image_id, exported), id: "image_export_#{image_id}")
   end
 
 
@@ -1464,7 +1463,7 @@ end
   def image_vote_link(image, vote)
     current_vote = image.users_vote(@user)
     vote_text = vote == 0 ? "(x)" : image_vote_as_short_string(vote)
-    link = link_to(vote_text, {}, :title =>  image_vote_as_help_string(vote), data:{:role => "image_vote", :id => image.id, :val => vote })  ##return a link if the user has NOT voted this way
+    link = link_to(vote_text, {}, title:  image_vote_as_help_string(vote), data:{role: "image_vote", id: image.id, val: vote })  ##return a link if the user has NOT voted this way
     if (current_vote == vote)
       link = content_tag('span', image_vote_as_short_string(vote))  ##return a span if the user has voted this way
     end
@@ -1478,14 +1477,14 @@ end
       if obj.ok_for_export
         content_tag(:b, :review_ok_for_export.t)
       else
-        link_with_query(:review_ok_for_export.t, :controller => 'observer',
-          :action => 'set_export_status', :type => obj.type_tag,
-          :id => obj.id, :value => '1')
+        link_with_query(:review_ok_for_export.t, controller: 'observer',
+          action: 'set_export_status', type: obj.type_tag,
+          id: obj.id, value: '1')
       end + safe_br +
       if obj.ok_for_export
-        link_with_query(:review_no_export.t, :controller => 'observer',
-          :action => 'set_export_status', :type => obj.type_tag,
-          :id => obj.id, :value => '0')
+        link_with_query(:review_no_export.t, controller: 'observer',
+          action: 'set_export_status', type: obj.type_tag,
+          id: obj.id, value: '0')
       else
         content_tag(:b, :review_no_export.t)
       end
@@ -1496,7 +1495,7 @@ end
     count = obs.specimens.count
     if count > 0
       link_to(pluralize(count, :specimen.t),
-              :controller => 'specimen', :action => 'observation_index', :id => obs.id)
+              controller: 'specimen', action: 'observation_index', id: obs.id)
     else
       if obs.specimen
         :show_observation_specimen_available.t
@@ -1509,8 +1508,8 @@ end
   def create_specimen_link(obs)
     if check_permission(obs) or (@user && (@user.curated_herbaria.length > 0))
       " | ".html_safe + link_with_query(:show_observation_create_specimen.t,
-        :controller => 'specimen', :action => 'add_specimen',
-        :id => obs.id)
+        controller: 'specimen', action: 'add_specimen',
+        id: obs.id)
     else
       safe_empty
     end
@@ -1529,7 +1528,7 @@ end
     letters = pagination_letters(pages, args)
     numbers = pagination_numbers(pages, args)
     body = capture(&block).to_s
-    content_tag(:div, :class => 'results') do
+    content_tag(:div, class: 'results') do
       letters + numbers + body + numbers + letters
     end
   end
@@ -1540,7 +1539,7 @@ end
   #   def action
   #     query = create_query(:Name)
   #     @pages = paginate_letters(:letter, :page, 50)
-  #     @names = query.paginate(@pages, :letter_field => 'names.sort_name')
+  #     @names = query.paginate(@pages, letter_field: 'names.sort_name')
   #   end
   #
   #   # In view:
@@ -1618,7 +1617,7 @@ end
       result << '|'                                      if this < num
       result << pagination_link(nstr, this+1, arg, args) if this < num
 
-      result = content_tag(:div, result.safe_join(' '), :class => "pagination")
+      result = content_tag(:div, result.safe_join(' '), class: "pagination")
     end
     result
   end
@@ -1638,7 +1637,7 @@ end
   # Take URL that got us to this page and add one or more parameters to it.
   # Returns new URL.
   #
-  # link_to("Next Page", reload_with_args(:page => 2))
+  # link_to("Next Page", reload_with_args(page: 2))
   def reload_with_args(new_args)
     uri = request.url.sub(/^\w+:\/+[^\/]+/, '')
     add_args_to_url(uri, new_args)
@@ -1646,11 +1645,11 @@ end
 
   # Take an arbitrary URL and change the parameters. Returns new URL. Should
   # even handle the fancy "/object/id" case. (Note: use +nil+ to mean delete
-  # -- i.e. <tt>add_args_to_url(url, :old_arg => nil)</tt> deletes the
+  # -- i.e. <tt>add_args_to_url(url, old_arg: nil)</tt> deletes the
   # parameter named +old_arg+ from +url+.)
   #
-  # url = url_for(:action => "blah", ...)
-  # new_url = add_args_to_url(url, :arg1 => :val1, :arg2 => :val2, ...)
+  # url = url_for(action: "blah", ...)
+  # new_url = add_args_to_url(url, arg1: :val1, arg2: :val2, ...)
   def add_args_to_url(url, new_args)
     new_args = new_args.clone
     args = {}
@@ -1702,16 +1701,16 @@ end
     type = object.type_tag
     new_tab_set do
       args = add_query_param({
-        :controller => object.show_controller,
-        :id         => object.id,
+        controller: object.show_controller,
+        id:         object.id,
       })
-      add_tab("« #{:BACK.t}",  args.merge(:action => "prev_#{type}" ))
-      add_tab(:INDEX.t, args.merge(:action => "index_#{type}"))
+      add_tab("« #{:BACK.t}",  args.merge(action: "prev_#{type}" ))
+      add_tab(:INDEX.t, args.merge(action: "index_#{type}"))
       if mappable
-        add_tab_with_query(:MAP.t, :controller => 'location',
-          :action => 'map_locations')
+        add_tab_with_query(:MAP.t, controller: 'location',
+          action: 'map_locations')
       end
-      add_tab("#{:FORWARD.t} »",  args.merge(:action => "next_#{type}"  ))
+      add_tab("#{:FORWARD.t} »", args.merge(action: "next_#{type}"))
     end
   end
 
@@ -1721,8 +1720,8 @@ end
   #     add_tab('Bare String')
   #     add_tab('Hard-Coded Link', '/name/show_name/123')
   #     add_tab('External Link', 'http://images.google.com/')
-  #     add_tab('Normal Link', :action => :blah, :id => 123, ...)
-  #     add_tab('Dangerous Link', { :action => :destroy, :id => 123 },
+  #     add_tab('Normal Link', action: :blah, id: 123, ...)
+  #     add_tab('Dangerous Link', { action: :destroy, id: 123 },
   #                               { data: { confirm: :are_you_sure.l } })
   #   end
   #
@@ -1805,7 +1804,7 @@ end
   # +render_tab_sets+.)
   def render_tab_set(header, *links)
     header += ' ' if header
-    content_tag(:div, :class => 'tab_set') do
+    content_tag(:div, class: 'tab_set') do
       all_tabs = links.map do |tab|
         render_tab(*tab)
       end
@@ -1818,7 +1817,7 @@ end
     if !link_args
       result = label
     elsif link_args.is_a?(String) && (link_args[0..6] == 'http://')
-      result = content_tag(:a, label, :href => link_args, :target => :_new)
+      result = content_tag(:a, label, href: link_args, target: :_new)
     else
       if link_args.is_a?(Hash) && link_args.has_key?(:help)
         help = link_args[:help]
@@ -1855,8 +1854,8 @@ end
   #
   #     # Define set of linked text tabs for top-left.
   #     new_tab_set do
-  #       add_tab("Tab Label One", :link => args, ...)
-  #       add_tab("Tab Label Two", :link => args, ...)
+  #       add_tab("Tab Label One", link: args, ...)
+  #       add_tab("Tab Label Two", link: args, ...)
   #       ...
   #     end
   #
@@ -1874,33 +1873,33 @@ end
       # Create link to change interest state.
       def interest_link(label, object, state) #:nodoc:
         link_with_query(label,
-          :controller => 'interest',
-          :action => 'set_interest',
-          :id => object.id,
-          :type => object.class.name,
-          :state => state
+          controller: 'interest',
+          action: 'set_interest',
+          id: object.id,
+          type: object.class.name,
+          state: state
         )
       end
 
       # Create large icon image.
       def interest_icon_big(type, alt) #:nodoc:
         image_tag("#{type}2.png",
-          :alt => alt,
-          :width => '50px',
-          :height => '50px',
-          :class => 'interest_big',
-          :title => alt
+          alt: alt,
+          width: '50px',
+          height: '50px',
+          class: 'interest_big',
+          title: alt
         )
       end
 
       # Create small icon image.
       def interest_icon_small(type, alt) #:nodoc:
         image_tag("#{type}3.png",
-          :alt => alt,
-          :width => '23px',
-          :height => '23px',
-          :class => 'interest_small',
-          :title => alt
+          alt: alt,
+          width: '23px',
+          height: '23px',
+          class: 'interest_small',
+          title: alt
         )
       end
 
@@ -1910,9 +1909,9 @@ end
 
       case @user.interest_in(object)
       when :watching
-        alt1 = :interest_watching.l(:object => type.l)
-        alt2 = :interest_default_help.l(:object => type.l)
-        alt3 = :interest_ignore_help.l(:object => type.l)
+        alt1 = :interest_watching.l(object: type.l)
+        alt2 = :interest_default_help.l(object: type.l)
+        alt3 = :interest_ignore_help.l(object: type.l)
         img1 = interest_icon_big('watch', alt1)
         img2 = interest_icon_small('halfopen', alt2)
         img3 = interest_icon_small('ignore', alt3)
@@ -1920,9 +1919,9 @@ end
         img3 = interest_link(img3, object, -1)
 
       when :ignoring
-        alt1 = :interest_ignoring.l(:object => type.l)
-        alt2 = :interest_watch_help.l(:object => type.l)
-        alt3 = :interest_default_help.l(:object => type.l)
+        alt1 = :interest_ignoring.l(object: type.l)
+        alt2 = :interest_watch_help.l(object: type.l)
+        alt3 = :interest_default_help.l(object: type.l)
         img1 = interest_icon_big('ignore', alt1)
         img2 = interest_icon_small('watch', alt2)
         img3 = interest_icon_small('halfopen', alt3)
@@ -1930,8 +1929,8 @@ end
         img3 = interest_link(img3, object, 0)
 
       else
-        alt1 = :interest_watch_help.l(:object => type.l)
-        alt2 = :interest_ignore_help.l(:object => type.l)
+        alt1 = :interest_watch_help.l(object: type.l)
+        alt2 = :interest_ignore_help.l(object: type.l)
         img1 = interest_icon_small('watch', alt1)
         img2 = interest_icon_small('ignore', alt2)
         img1 = interest_link(img1, object, 1)
@@ -1973,8 +1972,8 @@ end
   # Create a file input fields with client-side size validation.
   def image_file_field(obj, attr, opts={})
     validated_file_field(obj, attr, opts.merge(
-      :max_upload_msg => :validate_image_file_too_big.l(:max => (MO.image_upload_max_size.to_f/1024/1024).round),
-      :max_upload_size => MO.image_upload_max_size
+      max_upload_msg: :validate_image_file_too_big.l(max: (MO.image_upload_max_size.to_f/1024/1024).round),
+      max_upload_size: MO.image_upload_max_size
     ))
   end
 
@@ -1989,7 +1988,7 @@ end
 def name_section_link(title, data, query)
   if data and data != 0
     link_to(title,
-     add_query_param({:controller => 'observer',
-       :action => 'index_observation'}, query)) + safe_br
+     add_query_param({controller: 'observer',
+       action: 'index_observation'}, query)) + safe_br
   end
 end

--- a/app/views/observer/_rss_log_old.html.erb
+++ b/app/views/observer/_rss_log_old.html.erb
@@ -3,21 +3,21 @@
    target_name = target ? target.unique_format_name.t : rss_log.unique_format_name.t
    tag, args, time = rss_log.parse_log.first rescue []
    if not target_type
-     title = :rss_destroyed.t(:type => :object)
+     title = :rss_destroyed.t(type: :object)
      detail = nil
    elsif not target or
            tag.to_s.match(/^log_#{target_type.to_s}_(merged|destroyed)/)
-     title = :rss_destroyed.t(:type => target_type)
+     title = :rss_destroyed.t(type: target_type)
      detail = tag.t(args) rescue nil
    elsif not time or time < target.created_at + 1.minute
-     title = :rss_created_at.t(:type => target_type)
+     title = :rss_created_at.t(type: target_type)
      if target_type == :observation || target_type == :species_list
        #detail = nil
      else
-       detail = :rss_by.t(:user => target.user.legal_name) rescue nil
+       detail = :rss_by.t(user: target.user.legal_name) rescue nil
      end
    else
-     title = :rss_changed.t(:type => target_type)
+     title = :rss_changed.t(type: target_type)
      detail = nil
      if (target_type == :observation ||
              target_type == :species_list) and
@@ -45,18 +45,18 @@
   <tr style="padding-bottom:0px">
     <td align="center" valign="middle" width="160" style="padding-bottom:0px">
       <%= if target and target_type == :species_list  ##TODO: turn this into a switch statement
-        link_with_query(image_tag('splist.png', :border => 0),
-          :controller => :species_list, :action => :show_species_list,
-          :id => target.id) + safe_br
+        link_with_query(image_tag('splist.png', border: 0),
+          controller: :species_list, action: :show_species_list,
+          id: target.id) + safe_br
       elsif target and target_type == :observation and target.thumb_image
-        thumbnail(target.thumb_image, :border => 0, :votes => true,
-                  :link => :show_observation, :obs => target.id) + safe_br
+        thumbnail(target.thumb_image, border: 0, votes: true,
+                  link: { action: :show_observation }, obs: target.id) + safe_br
       elsif target and target_type == :glossary_term and target.thumb_image
-        thumbnail(target.thumb_image, :border => 0, :votes => true,
-                  :link => :show_glossary_term, :glossary_term => target.id) + safe_br
+        thumbnail(target.thumb_image, border: 0, votes: true,
+                  link: { action: :show_glossary_term}, glossary_term: target.id) + safe_br
       else
         done_title = true
-        content_tag(:span, title, :class => 'ListRssHeader') ##TODO: This only happens when there is no image, deal with this case first
+        content_tag(:span, title, class: 'ListRssHeader') ##TODO: This only happens when there is no image, deal with this case first
       end %>
     </td>
 
@@ -80,11 +80,11 @@
       %>
         <span class="ListWhat">
           <%= if target  ##If a target is not nil then make a link to with the targets name to the controller.
-            link_with_query(target_name, :controller => target.show_controller,
-              :action => target.show_action, :id => target.id)
+            link_with_query(target_name, controller: target.show_controller,
+              action: target.show_action, id: target.id)
           else
-            link_with_query(target_name, :controller => :observer,
-              :action => :show_rss_log, :id => rss_log.id)
+            link_with_query(target_name, controller: :observer,
+              action: :show_rss_log, id: rss_log.id)
           end %>
         </span><br/>
       <% end %>

--- a/app/views/observer/show_site_stats.html.erb
+++ b/app/views/observer/show_site_stats.html.erb
@@ -2,8 +2,8 @@
   @title = :show_site_stats_title.t
 
   new_tab_set do
-    add_tab(:app_contributors.t, :action => :users_by_contribution)
-    add_tab(:site_stats_observed_taxa.t, :action => :checklist)
+    add_tab(:app_contributors.t, action: :users_by_contribution)
+    add_tab(:site_stats_observed_taxa.t, action: :checklist)
   end
 %>
 
@@ -18,9 +18,9 @@
       if obs_length > 0 %>
         <td>
           <% for obs in @observations[0,3] %>
-            <%= thumbnail(obs.thumb_image, :class => 'site_stats_image',
-                          :link => :show_observation, :obs => obs.id,
-                          :votes => true) %><br/>
+            <%= thumbnail(obs.thumb_image, class: 'site_stats_image',
+                          link: { action: :show_observation }, obs: obs.id,
+                          votes: true) %><br/>
           <% end %>
         </td>
       <% end %>
@@ -64,9 +64,9 @@
       <% if obs_length > 3 %>
         <td>
           <% for obs in @observations[3,3] %>
-            <%= thumbnail(obs.thumb_image, :class => 'site_stats_image',
-                          :link => :show_observation, :obs => obs.id,
-                          :votes => true) %><br/>
+            <%= thumbnail(obs.thumb_image, class: 'site_stats_image',
+                          link: { action: :show_observation }, obs: obs.id,
+                          votes: true) %><br/>
           <% end %>
         </td>
       <% end %>

--- a/app/views/observer/users_by_contribution.html.erb
+++ b/app/views/observer/users_by_contribution.html.erb
@@ -2,7 +2,7 @@
   @title = :users_by_contribution_title.t
 
   new_tab_set do
-    add_tab(:app_site_stats.t, :action => 'show_site_stats')
+    add_tab(:app_site_stats.t, action: 'show_site_stats')
   end
 %>
 
@@ -15,8 +15,10 @@
             <tr>
               <td>
                 <%= if user.image_id
-                  thumbnail(user.image_id, :border => 0, :link => :show_user,
-                        :user => user.id, :votes => false, :size => :thumbnail)
+                  thumbnail(
+                    user.image_id, border: 0, link: { action: :show_user },
+                    user: user.id, votes: false, size: :thumbnail
+                  )
                 end %>
               </td>
               <td>
@@ -24,13 +26,13 @@
                   <%= user_link(user.id, user.legal_name) %>
                 </span>
                 <%= if @user and (user.id == @user.id)
-                  link_to("(#{user.percent_complete}%)", :controller => "account", :action => "profile")
+                  link_to("(#{user.percent_complete}%)", controller: "account", action: "profile")
                 else
                   "(#{user.percent_complete}%)"
                 end %>
               </td>
               <td>
-                <%= link_to(:observations.t, :action => "observations_by_user", :id => user.id) %>
+                <%= link_to(:observations.t, action: "observations_by_user", id: user.id) %>
               </td>
               <td>
                 <%= user_link(user.id, user.contribution) %>

--- a/app/views/species_list/show_species_list.html.erb
+++ b/app/views/species_list/show_species_list.html.erb
@@ -1,37 +1,37 @@
 <%
-  @title = :species_list_show_title.t(:name => @species_list.unique_format_name)
+  @title = :species_list_show_title.t(name: @species_list.unique_format_name)
 
   new_tab_set do
     if @user
       add_tab_with_query(:species_list_show_clone_list.t,
-        { :action => 'create_species_list', :clone => @species_list.id },
-        { :help => :species_list_show_clone_list_help.l })
+        { action: 'create_species_list', clone: @species_list.id },
+        { help: :species_list_show_clone_list_help.l })
       add_tab_with_query(:species_list_show_set_source.t,
-        { :action => 'show_species_list', :id => @species_list.id,
-          :set_source => 1 },
-        { :help => :species_list_show_set_source_help.l })
+        { action: 'show_species_list', id: @species_list.id,
+          set_source: 1 },
+        { help: :species_list_show_set_source_help.l })
       add_tab(:species_list_show_bulk_edit.t,
-        { :action => 'bulk_editor', :id => @species_list.id },
-        { :help => :species_list_show_bulk_edit_help.l })
+        { action: 'bulk_editor', id: @species_list.id },
+        { help: :species_list_show_bulk_edit_help.l })
     end
     if check_permission(@species_list)
       add_tab_with_query(:species_list_show_manage_projects.t,
-        :action => 'manage_projects', :id => @species_list.id)
+        action: 'manage_projects', id: @species_list.id)
       add_tab_with_query(:species_list_show_edit.t,
-        :action => 'edit_species_list', :id => @species_list.id)
+        action: 'edit_species_list', id: @species_list.id)
       add_tab_with_query(:DESTROY.t,
-        { :action => 'destroy_species_list', :id => @species_list.id },
+        { action: 'destroy_species_list', id: @species_list.id },
         { data: { confirm: :are_you_sure.l } })
     end
   end
 
   new_tab_set do
-    add_tab(:species_list_show_save_as_txt.t, :action => 'make_report',
-            :id => @species_list.id, :type => 'txt')
-    add_tab(:species_list_show_save_as_rtf.t, :action => 'make_report',
-            :id => @species_list.id, :type => 'rtf')
-    add_tab(:species_list_show_save_as_csv.t, :action => 'make_report',
-            :id => @species_list.id, :type => 'csv')
+    add_tab(:species_list_show_save_as_txt.t, action: 'make_report',
+            id: @species_list.id, type: 'txt')
+    add_tab(:species_list_show_save_as_rtf.t, action: 'make_report',
+            id: @species_list.id, type: 'rtf')
+    add_tab(:species_list_show_save_as_csv.t, action: 'make_report',
+            id: @species_list.id, type: 'csv')
   end
 
   draw_prev_next_tabs(@species_list)
@@ -54,19 +54,19 @@
 <% if @pages && @pages.length > 0
   set_query_params(@query) %>
   <%= :species_list_show_members.t %>:
-    <%= link_with_query(:show_objects.t(:type => :observation),
-          :controller => :observer, :action => :index_observation) %> |
-    <%= link_with_query(:show_objects.t(:type => :image),
-          :controller => :image, :action => :index_image) %> |
-    <%= link_with_query(:show_objects.t(:type => :name),
-          :controller => :name, :action => :index_name) %> |
+    <%= link_with_query(:show_objects.t(type: :observation),
+          controller: :observer, action: :index_observation) %> |
+    <%= link_with_query(:show_objects.t(type: :image),
+          controller: :image, action: :index_image) %> |
+    <%= link_with_query(:show_objects.t(type: :name),
+          controller: :name, action: :index_name) %> |
     <%= link_to(:app_checklist.t,
-                :controller => :observer, :action => :checklist,
-                :species_list_id => @species_list.id) %>
+                controller: :observer, action: :checklist,
+                species_list_id: @species_list.id) %>
     <% if DEVELOPMENT || is_reviewer? %>
      | <%= link_to(:species_list_show_print_labels.t,
-             :controller => :species_list, :action => :print_labels,
-             :id => @species_list.id) %>
+             controller: :species_list, action: :print_labels,
+             id: @species_list.id) %>
     <% end %>
     <br/>
   <%= paginate_block(@pages) do %>
@@ -78,18 +78,19 @@
           <tr valign="top" class="ListLine<%= odd_or_even %>">
             <td width="110" align="center" valign="middle">
               <%= if observation.thumb_image_id
-                thumbnail(observation.thumb_image, :border => 0,
-                  :link => :show_observation, :obs => observation.id,
-                  :votes => true)
+                thumbnail(observation.thumb_image, border: 0,
+                  link: { action: :show_observation }, obs: observation.id,
+                  votes: true)
               end %>
             </td>
             <td width="100%" valign="middle">
               <span class="ListName">
                 <%= link_with_query(observation.unique_format_name.t,
-                      :controller => 'observer',
-                      :action => 'show_observation', :id => observation.id) %>
+                      controller: 'observer', action: 'show_observation',
+                      id: observation.id) %>
               </span><br/>
-              <span class="ListWhere"><%= location_link(observation.place_name, observation.location) %></span>:
+              <span class="ListWhere"><%= location_link(observation.place_name,
+                                            observation.location) %></span>:
               <span class="ListWho"><%= user_link(observation.user) %></span>:
               <span class="ListWhen"><%= observation.when.web_date %></span>
             </td>
@@ -103,7 +104,7 @@
 <% end %>
 <br/>
 
-<%= render(:partial => 'comment/show_comments', :locals =>
-           { :object => @species_list, :controls => true, :limit => nil }) %>
+<%= render(partial: 'comment/show_comments', locals:
+           { object: @species_list, controls: true, limit: nil }) %>
 
 <%= show_object_footer(@species_list) %>


### PR DESCRIPTION
Change template "link" arguments to Hashes
(~~link: action~~ `link: { action: action } `)
Fixes several errors. See comments to Pull Request #41
Revert now-unneeded part of fix of Pull Request #41
Trivial refactoring of touched files
(use new-style hash format: ~~`:key => value`~~ `key: value`)
Test results now:
1160 tests, 16457 assertions, 8 failures, 0 errors, 1 skips
