### PR TITLE
UserGroup keeps some important user groups cached, causing new users to ...

### DIFF
--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -74,6 +74,12 @@ class UserGroup < AbstractModel
     @@reviewers ||= get_or_construct_user('reviewers')
   end
 
+  # Need to clear these at end of each test or some changes can persist from
+  # one unit test to the next, causing very bizarre and frustrating behavior(!)
+  def self.clear_cache_for_unit_tests
+    @@all_users = @@one_users = @@reviewers = nil
+  end
+
   # Callback that fires when a new User is created.
   # 1) Adds the new User to the "all users" meta-group.
   # 2) Creates a new meta-group that contains just that User.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -92,5 +92,6 @@ class ActiveSupport::TestCase
   # images that might have been uploaded are cleared out.
   def teardown
     FileUtils.rm_rf(MO.local_image_files)
+    UserGroup.clear_cache_for_unit_tests
   end
 end


### PR DESCRIPTION
...persist from one test to the next.

Added class method to clear cache, called from teardown hook in unit tests.