### PR TITLE
Turn on CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,6 +94,10 @@ class ApplicationController < ActionController::Base
   require "csv"
   include LoginSystem
 
+# Prevent CSRF attacks by raising an exception.
+# For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+
   around_filter :catch_errors # if Rails.env == "test"
   before_filter :block_ip_addresses
   before_filter :kick_out_robots
@@ -143,16 +147,6 @@ class ApplicationController < ActionController::Base
     else
       block_given? ? yield(result) : result
     end
-  end
-
-  # The default CSRF handler silently resets the session.  The problem is
-  # autologin will circumvent this, so we would need to disable autologin
-  # temporarily.  Or we can just make forgeries fail, but leave valid requests
-  # alone.  This seems much more graceful... and it lets the user know why they
-  # are experiencing otherwise bewildering and incorrect behavior.
-  def handle_unverified_request
-    render(text: "Cross-site Request Forgery detected!", layout: false)
-    return false
   end
 
   # Physically eject robots unless they're looking at accepted pages.


### PR DESCRIPTION
Also deleted patch of Rails method `handle_unverified_request`
I don't know why forgery protection was not turned on in ror4.  Maybe I misunderstood the documentation and thought it was on by default.  
Questions:
1.  Will raising an exception and deleting our patch of handle_unverified_request work with the API? It would be helpful if @raysuelzer and @pellaea could review the notes at http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html to see if the changes will work with the API.
2.  Do we use persistent cookies to store user information?  See http://guides.rubyonrails.org/security.html#csrf-countermeasures