### PR TITLE
Tweaked how member values are initialized in edit_species_list.

### DIFF
--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -772,11 +772,11 @@ module ControllerExtensions
       assert_select("input##{id}", 1)
       assert_select("input##{id}[checked=checked]", 0)
       assert_select("input##{id}[disabled=disabled]", 1)
-    when :checked
+    when :checked, true
       assert_select("input##{id}", 1)
       assert_select("input##{id}[checked=checked]", 1)
       assert_select("input##{id}[disabled=disabled]", 0)
-    when :unchecked
+    when :unchecked, false
       assert_select("input##{id}", 1)
       assert_select("input##{id}[checked=checked]", 0)
       assert_select("input##{id}[disabled=disabled]", 0)

--- a/test/controllers/species_list_controller_test.rb
+++ b/test/controllers/species_list_controller_test.rb
@@ -1638,4 +1638,51 @@ class SpeciesListControllerTest < FunctionalTestCase
     )
     assert_flash_warning # already done
   end
+
+  def test_edit_species_list_member_parameters_initialization
+    login("mary")
+    spl = species_lists(:unknown_species_list)
+    obs1, obs2 = spl.observations
+
+    # If existing observations are all the same, use their values
+    # as defaults for future observations.
+    obs1.notes = obs2.notes = "test notes"
+    obs1.lat   = obs2.lat   = "12.3456"
+    obs1.long  = obs2.long  = "-76.5432"
+    obs1.alt   = obs2.alt   = "789"
+    obs1.is_collection_location = false
+    obs2.is_collection_location = false
+    obs1.specimen = true
+    obs2.specimen = true
+    obs1.save!
+    obs2.save!
+
+    get(:edit_species_list, id: spl.id)
+    assert_edit_species_list
+    assert_textarea_value(:member_notes, "test notes")
+    assert_input_value(:member_lat,   "12.3456")
+    assert_input_value(:member_long,  "-76.5432")
+    assert_input_value(:member_alt,   "789")
+    assert_checkbox_state(:member_is_collection_location, false)
+    assert_checkbox_state(:member_specimen, true)
+
+    # When existing observations have differing values, it should use
+    # standard defaults from create_observation, instead.
+    obs1.notes = "different notes"
+    obs1.lat   = "-12.3456"
+    obs1.long  = "76.5432"
+    obs1.alt   = "123"
+    obs1.is_collection_location = true
+    obs1.specimen = false
+    obs1.save!
+
+    get(:edit_species_list, id: spl.id)
+    assert_edit_species_list
+    assert_textarea_value(:member_notes, "")
+    assert_input_value(:member_lat, "")
+    assert_input_value(:member_long, "")
+    assert_input_value(:member_alt, "")
+    assert_checkbox_state(:member_is_collection_location, true)
+    assert_checkbox_state(:member_specimen, false)
+  end
 end


### PR DESCRIPTION
Now only provides as defaults values which are the same for all existing obs.  So, if all obs in list have same lat/long, that will be the default for new obs.  But if each obs has different notes, it will leave that blank instead of using as default the notes from the last obs, like it was before.