### PR TITLE
Added some infrastructure we'll need for content filtering.

### DIFF
--- a/app/classes/tree.rb
+++ b/app/classes/tree.rb
@@ -1,0 +1,116 @@
+# encoding: utf-8
+class Tree
+  # Searches the screwy ActiveRecord join- and include-style "trees" for a node.
+  #
+  # NOTE: Symbol, Array and Hash classes have been extended with "has_node?"
+  # methods.  It might be more readable to use those as entry points.
+  #
+  #   BAD:
+  #     Tree.has_node?(join, :names)
+  #   GOOD:
+  #     join.has_node?(:names)
+  #
+  def self.has_node?(tree, look_for)
+    case tree
+    when Symbol
+      return tree == look_for
+    when Array
+      tree.each do |val|
+        return true if has_node?(val, look_for)
+      end
+    when Hash
+      tree.each_pair do |key, val|
+        return true if key == look_for
+        return true if has_node?(val, look_for)
+      end
+    end
+    return false
+  end
+
+  # Extends the screwy ActiveRecord join- and include-style "trees" by adding
+  # a single table to hang off a given table.  Can only add a single table,
+  # but can build more complicated trees with multiple calls: 
+  #
+  #   BAD:
+  #     tree = tree.add_leaf(:a, {:b => :c})
+  #   GOOD:
+  #     tree = tree.add_leaf(:a, :b)
+  #     tree = tree.add_leaf(:b, :c)
+  #
+  #   BAD:
+  #     tree = tree.add_leaf(:a, [:b, :c]):
+  #   GOOD:
+  #     tree = tree.add_leaf(:a, :b)
+  #     tree = tree.add_leaf(:a, :c)
+  #
+  # NOTE: Symbol, Array and Hash classes have been extended with "add_leaf"
+  # methods.  It might be more readable to use those as entry points.
+  #
+  #   BAD:
+  #     self.join = Tree.add_leaf(join, :this, :that)
+  #   GOOD:
+  #     self.join = join.add_leaf(:this, :that)
+  #
+  # NOTE: For convenience there is a single-table form of this method which
+  # assumes you want to add the given table at the root level.
+  #
+  #   join.add_leaf(:table)
+  #
+  # NOTE: There is no Symbol#replace, so there is no way to do an in-place
+  # modification of an existing tree if there is any chance that that tree
+  # consists only of a single Symbol.  If you *know* your tree is an Array or
+  # Hash, then you safely ignore the return value.
+  #
+  # NOTE: If the tree already contains the leaf (hanging off of the desired
+  # parent), then this does nothing.  Thus it is safe to add the same leaf
+  # multiple times.
+  #
+  def self.add_leaf(tree, look_for, add_this=nil)
+    case tree
+    when Symbol
+      if tree == look_for
+        return tree if !add_this
+        return { look_for => add_this }
+      elsif add_this
+        return [tree, { look_for => add_this }]
+      else
+        return [tree, look_for]
+      end
+    when Array
+      tree.each_with_index do |val, i|
+        if add_this && has_node?(val, look_for)
+          tree[i] = add_leaf(val, look_for, add_this)
+          return tree
+        elsif val == look_for
+          return tree
+        end
+      end
+      if add_this
+        tree << { look_for => add_this }
+      else
+        tree << look_for
+      end
+      return tree
+    when Hash
+      raise "Can't use one-table form of Tree.add_leaf if tree is a Hash!" if !add_this
+      tree.each_pair do |key, val|
+        if key == look_for
+          case val
+          when Symbol
+            tree[key] = [val, add_this] if val != add_this
+          when Array
+            val << add_this unless val.include?(add_this)
+          when Hash
+            tree[key] = [val, add_this] unless val.has_key?(add_this)
+          end
+          return tree
+        elsif has_node?(val, look_for)
+          tree[key] = add_leaf(val, look_for, add_this)
+          return tree
+        end
+      end
+      tree[look_for] = add_this
+      return tree
+    end
+  end
+end

--- a/app/extensions/array_extensions.rb
+++ b/app/extensions/array_extensions.rb
@@ -70,4 +70,12 @@ class Array
     sep = ERB::Util.html_escape(sep)
     map { |i| ERB::Util.html_escape(i) }.join(sep).html_safe
   end
+
+  def add_leaf(*args)
+    Tree.add_leaf(self, *args)
+  end
+
+  def has_node?(*args)
+    Tree.has_node?(self, *args)
+  end
 end

--- a/app/extensions/hash_extensions.rb
+++ b/app/extensions/hash_extensions.rb
@@ -33,4 +33,12 @@ class Hash
   def remove_nils!
     delete_if {|k,v| v.nil?}
   end
+
+  def add_leaf(*args)
+    Tree.add_leaf(self, *args)
+  end
+
+  def has_node?(*args)
+    Tree.has_node?(self, *args)
+  end
 end

--- a/app/extensions/symbol_extensions.rb
+++ b/app/extensions/symbol_extensions.rb
@@ -45,6 +45,14 @@ class Symbol
     to_s.capitalize_first.to_sym
   end
 
+  def add_leaf(*args)
+    Tree.add_leaf(self, *args)
+  end
+
+  def has_node?(*args)
+    Tree.has_node?(self, *args)
+  end
+
   # Return a list of missing tags we've encountered.
   def self.missing_tags
     @@missing_tags

--- a/app/models/abstract_query.rb
+++ b/app/models/abstract_query.rb
@@ -1331,6 +1331,23 @@ class AbstractQuery < ActiveRecord::Base
     end
   end
 
+  # Add a join condition if it doesn't already exist.  There are two forms:
+  #
+  #   # Add join from root table to the given table:
+  #   add_join(:observations) 
+  #     => join << :observations
+  #
+  #   # Add join from one table to another: (will create join from root to
+  #   # first table if it doesn't already exist)
+  #   add_join(:observations, :names)
+  #     => join << {:observations => :names}
+  #   add_join(:names, :descriptions)
+  #     => join << {:observations => {:names => :descriptions}}
+  #
+  def add_join(*args)
+    join.add_leaf(*args)
+  end
+
   ##############################################################################
   #
   #  :section: Build SQL Query

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -162,7 +162,6 @@ class Naming < AbstractModel
       taxa.push(Name.find_by_text_name("Lichen")) if self.name.is_lichen?
       done_user = {}
       for taxon in taxa
-        # for n in Notification.find_all_by_flavor_and_obj_id(:name, taxon.id)
         for n in Notification.where(flavor: :name, obj_id: taxon.id)
           if n.user.created_here   and
              (n.user != user)      and

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -883,3 +883,21 @@ hygrocybe_russocoriacea_good_author:
   display_name: '**__Hygrocybe russocoriacea__** (Berk. & Jos.K. Mill.) P.D. Orton & Watling'
   author: '(Berk. & Jos.K. Mill.) P.D. Orton & Watling'
   notes: NULL
+
+lichen:
+  id: 50
+  # accepted_name_id: 50
+  created_at: 2015-02-07 11:27:00
+  updated_at: 2015-02-07 11:27:00
+  user_id: 1
+  version: 1
+  # rank: Name.ranks[:Kingdom]
+  rank: 13
+  text_name: Lichen
+  author: ''
+  display_name: '**__Lichen__**'
+  search_name: Lichen
+  sort_name: Lichen
+  citation: ''
+  notes: This is a pseudoname to apply to all unknown lichenized fungi.
+

--- a/test/fixtures/triples.yml
+++ b/test/fixtures/triples.yml
@@ -1,19 +1,31 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
-# one:
-#   column: value
-#
-# two:
-#   column: value
+peltigera_is_a_lichen_triple:
+  id: 1
+  subject: ':name/40'
+  predicate: ':lichenAuthority'
+  object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
+
+petigera_is_a_lichen_triple:
+  id: 2
+  subject: ':name/41'
+  predicate: ':lichenAuthority'
+  object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
 tremella_mesenterica_is_a_lichen_triple:
-  id: 1
+  id: 3
   subject: ':name/45'
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
 tremella_is_a_lichen_triple:
-  id: 2
+  id: 4
   subject: ':name/46'
+  predicate: ':lichenAuthority'
+  object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
+
+tremella_justpublished_is_a_lichen_triple:
+  id: 5
+  subject: ':name/47'
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1156,10 +1156,8 @@ class QueryTest < UnitTestCase
   def test_image_by_user
     expect = Image.where(user_id: rolf.id).reverse
     assert_query(expect, :Image, :by_user, user: rolf)
-#    expect = where(user_id: mary.id).reverse # Rails 3
     expect = Image.where(user_id: mary.id).reverse
     assert_query(expect, :Image, :by_user, user: mary)
-#    expect = where(user_id: dick.id).reverse # Rails 3
     expect = Image.where(user_id: dick.id).reverse
     assert_query(expect, :Image, :by_user, user: dick)
   end
@@ -1251,7 +1249,6 @@ class QueryTest < UnitTestCase
   end
 
   def test_location_all
-#    expect = Location.all # Rails 3
     expect = Location.all.to_a
     assert_query(expect, :Location, :all, by: :id)
   end
@@ -1344,7 +1341,6 @@ class QueryTest < UnitTestCase
   end
 
   def test_location_description_all
-#    all = LocationDescription.all # Rails 3
     all = LocationDescription.all.to_a
     assert_query(all, :LocationDescription, :all, by: :id)
   end
@@ -1383,13 +1379,9 @@ class QueryTest < UnitTestCase
   def test_name_advanced
     assert_query([38], :Name, :advanced_search, name: "macrocybe*titans")
     assert_query([2], :Name, :advanced_search, location: "glendale") # where
-#    expect = Name.all(conditions: 'observations.location_id = 2', # Rails 3
-#                      include: :observations, order: 'text_name, author')
     expect = Name.where("observations.location_id" => 2).
                   includes(:observations).order(:text_name, :author).to_a
     assert_query(expect, :Name, :advanced_search, location: "burbank") # location
-#    expect = Name.all(conditions: 'observations.user_id = 1', # Rails 3
-#                      include: :observations, order: 'text_name, author')
     expect = Name.where("observations.user_id" => 1).
                   includes(:observations).order(:text_name, :author).to_a
     assert_query(expect, :Name, :advanced_search, user: "rolf")
@@ -1398,7 +1390,6 @@ class QueryTest < UnitTestCase
   end
 
   def test_name_all
-#    expect = Name.all(order: "sort_name") # Rails 3
     expect = Name.all.order(:sort_name).to_a
     do_test_name_all(expect)
   rescue
@@ -1557,8 +1548,6 @@ class QueryTest < UnitTestCase
   end
 
   def test_observation_at_location
-    # expect = Observation.find_all_by_location_id(2, include: :name, # Rails 3
-    #   order: 'names.text_name, names.author, observations.id DESC')
     expect = Observation.where(location_id: 2).includes(:name).
                          order("names.text_name, names.author,
                            observations.id DESC").to_a
@@ -1657,7 +1646,6 @@ class QueryTest < UnitTestCase
   end
 
   def test_rsslog_all
-#    ids = RssLog.find(:all).map {|log| log.id} # Rails 3
     ids = RssLog.all.map {|log| log.id}
     assert_query(ids, :RssLog, :all)
   end
@@ -1667,7 +1655,6 @@ class QueryTest < UnitTestCase
   end
 
   def test_specieslist_all
-#    expect = SpeciesList.all(order: "title") # Rails 3
     expect = SpeciesList.all.order("title").to_a
     assert_query(expect, :SpeciesList, :all)
   end
@@ -1687,10 +1674,8 @@ class QueryTest < UnitTestCase
   end
 
   def test_user_all
-#    expect = User.all(order: "name") # Rails 3
     expect = User.all.order("name").to_a
     assert_query(expect, :User, :all)
-#    expect = User.all(order: "login") # Rails 3
     expect = User.all.order("login").to_a
     assert_query(expect, :User, :all, by: :login)
   end
@@ -1698,6 +1683,12 @@ class QueryTest < UnitTestCase
   def test_user_in_set
     assert_query([1,2,3], :User, :in_set, ids: [3,2,1], by: :reverse_name)
   end
+
+  ##############################################################################
+  #
+  #  :section: Other stuff
+  #
+  ##############################################################################
 
   def test_whiny_nil_in_map_locations
     query = Query.lookup(:User, :in_set, ids: [1,1000,2])
@@ -1729,5 +1720,15 @@ class QueryTest < UnitTestCase
     User.current = roy
     assert_equal(:scientific, User.current_location_format)
     assert_query([obs2, obs1], :Observation, :in_set, ids: [1, 2], by: :location)
+  end
+
+  def test_filtering_content
+    peltigera = names(:peltigera)
+    expect = Observation.where(specimen: true).order(when: :desc)
+    assert_query(expect, :Observation, :all, has_specimen: true)
+    expect = Observation.where.not(thumb_image_id: nil).order(when: :desc)
+    assert_query(expect, :Observation, :all, has_images: true)
+    # expect = Observation.where(name_id: peltigera.id).order(when: :desc)
+    # assert_query(expect, :Observation, :all, has_name_tag: ":lichenAuthority")
   end
 end

--- a/test/models/tree_test.rb
+++ b/test/models/tree_test.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+require 'test_helper'
+
+class TreeTest < UnitTestCase
+  def test_has_node?
+    tree = :foo
+    assert_true(tree.has_node?(:foo))
+    assert_false(tree.has_node?(:spam))
+
+    tree = [:foo, :bar]
+    assert_true(tree.has_node?(:foo))
+    assert_true(tree.has_node?(:bar))
+    assert_false(tree.has_node?(:spam))
+
+    tree = {:foo => :bar, :one => :two}
+    assert_true(tree.has_node?(:foo))
+    assert_true(tree.has_node?(:bar))
+    assert_true(tree.has_node?(:one))
+    assert_true(tree.has_node?(:two))
+    assert_false(tree.has_node?(:spam))
+
+    tree = [
+      {:foo => :bar},
+      :scalar,
+      {:glue => [:one, :two]},
+      {:top => {:middle => :leaf}},
+    ]
+    [:foo, :bar, :scalar, :glue, :one, :two, :top, :middle, :leaf].each do |node|
+      assert_true(tree.has_node?(node), "Tree is missing #{node.inspect}!")
+    end
+    assert_false(tree.has_node?(:spam))
+  end
+
+  def test_add_node_to_scalar
+    assert_equal(:foo, :foo.add_leaf(:foo))
+    assert_equal([:foo, :bar], :foo.add_leaf(:bar))
+    assert_equal({:foo => :bar}, :foo.add_leaf(:foo, :bar))
+    assert_equal([:spam, {:foo => :bar}], :spam.add_leaf(:foo, :bar))
+  end
+
+  def test_add_node_to_array
+    assert_equal([:foo], [].add_leaf(:foo))
+    assert_equal([:foo], [:foo].add_leaf(:foo))
+    assert_equal([:foo, :bar], [:foo].add_leaf(:bar))
+    assert_equal([{:foo => :bar}], [].add_leaf(:foo, :bar))
+    assert_equal([{:foo => :bar}], [:foo].add_leaf(:foo, :bar))
+    assert_equal([:spam, {:foo => :bar}], [:spam].add_leaf(:foo, :bar))
+  end
+
+  def test_add_node_to_hash
+    assert_raises(RuntimeError) { {}.add_leaf(:foo) }
+    assert_equal({:foo => :bar}, {}.add_leaf(:foo, :bar))
+    assert_equal({:foo => :bar}, {:foo => :bar}.add_leaf(:foo, :bar))
+    assert_equal({:foo => [:spam, :bar]}, {:foo => :spam}.add_leaf(:foo, :bar))
+    assert_equal({:one => :two, :foo => :bar}, {:one => :two}.add_leaf(:foo, :bar))
+  end
+
+  def test_add_node_to_lower_level
+    assert_equal({:one => {:two => :three}}, {:one => :two}.add_leaf(:two, :three))
+    assert_equal({:one => {:two => {:three => :four}}}, {:one => {:two => :three}}.add_leaf(:three, :four))
+    assert_equal({:one => {:two => :three}}, {:one => {:two => :three}}.add_leaf(:two, :three))
+    assert_equal({:one => [:two, {:three => :four}]}, {:one => [:two, :three]}.add_leaf(:three, :four))
+  end
+end


### PR DESCRIPTION
Basically, I plan to implement it by having controllers automagically add has_images, has_specimen, has_obs_tag, and has_name_tag parameters (based on User.current prefs) to all observation queries and coerced observation queries (e.g. when you click on "map" or "checklist" in an observation index).  So I just added basic support for these four parameters to all affected query flavors.