### PR TITLE
License db

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Daley', :city => cities.first)
+# require "active_record/fixture_set/file.rb"
+require "active_record/fixtures.rb"
+ActiveRecord::Fixtures.create_fixtures("#{Rails.root}/test/fixtures", "licenses")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,9 @@
 #
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Daley', :city => cities.first)
-# require "active_record/fixture_set/file.rb"
+
+# seed License table.  Licenses, which are not user data, are required for
+# complete functioning of the MO development environment
 require "active_record/fixtures.rb"
-ActiveRecord::Fixtures.create_fixtures("#{Rails.root}/test/fixtures", "licenses")
+ActiveRecord::Fixtures.create_fixtures("#{Rails.root}/test/fixtures",
+  "licenses")

--- a/test/fixtures/licenses.yml
+++ b/test/fixtures/licenses.yml
@@ -19,3 +19,10 @@ ccwiki30:
   url: http://creativecommons.org/licenses/by-sa/3.0/
   deprecated: false
   form_name: ccbysa30
+
+publicdomain:
+  id: 4
+  display_name: Public Domain
+  url: http://wiki.creativecommons.org/Public_domain/
+  deprecated: false
+  form_name: publicdomain

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -1,18 +1,19 @@
 # encoding: utf-8
-require 'test_helper'
+require "test_helper"
 
 class LicenseTest < UnitTestCase
   def test_current_names_and_ids
     names_and_ids = License.current_names_and_ids()
-    assert_equal(2, names_and_ids.length)
+    assert_equal(3, names_and_ids.length)
     for (name, id) in names_and_ids
       license = License.find(id)
-      assert_equal(false, license.deprecated)
+      refute(license.deprecated,
+        "#{license.id}, #{license.display_name}, should not be deprecated.")
     end
-  end
+end
 
   def test_current_names_and_ids_ccnc25
     names_and_ids = License.current_names_and_ids(licenses(:ccnc25))
-    assert_equal(3, names_and_ids.length)
+    assert_equal(4, names_and_ids.length)
   end
 end


### PR DESCRIPTION
  * add public domain license fixture
  * correct tests which expect only 3 licenses
  * seed development db  with fixtures
  * **developers must also run `rake db:seed`**

Fixes issues discussed in https://groups.google.com/forum/#!topic/mo-developers/hTxzv61e-Zw