### PR TITLE
Makes the matrix box presenter handle longer user login names, hopefully...

### DIFF
--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -47,7 +47,7 @@ class MatrixBoxPresenter
     self.what = view.link_with_query(name, controller: image.show_controller,
                 action: image.show_action, id: image.id)
     self.thumbnail = view.thumbnail(image, link: {controller: image.show_controller,
-                     action: image.show_action, id: image.id})
+                     action: image.show_action, id: image.id}, responsive: true)
   end
 
   # Grabs all the information needed for view from Observation instance.

--- a/app/views/image/_image_thumbnail.html.erb
+++ b/app/views/image/_image_thumbnail.html.erb
@@ -5,7 +5,7 @@
   image, image_id = image.is_a?(Image) ? [image, image.id] : [nil, image]
 
   link     ||= {controller: :image, action: :show_image, id: image_id}
-  size     ||= default_thumbnail_size
+  size     ||= :small
   votes    ||= image ? true : false
   original ||= false
   responsive = responsive.nil? ? true : responsive  ##Should the image be forced to fit in its container. Default is true
@@ -18,7 +18,7 @@
   <div style="<%= "display: inline-block;" unless responsive%>">
     <div>
       <div style="position: absolute; right: 0;">
-    <a href="" class="glyphicon glyphicon-fullscreen theater-btn hidden-xs" data-toggle="theater" data-image="<%=Image.url(:huge, image_id) %>"></a>
+    <a href="" class="glyphicon glyphicon-fullscreen theater-btn hidden-xs" data-toggle="theater" data-image="<%=Image.url(:large, image_id) %>"></a>
       </div>
     <%= link_with_query(image_tag(url, class: responsive ? 'img-responsive center-block' : ''), link) %>
     </div>

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -5,18 +5,20 @@
 %>
 
 <% if presenter %>
-    <div class="list-group">
+    <div class="list-group" style="min-height: 200px;">
       <div class="list-group-item" style="min-height: 57px; height: 57px;">
         <div class="row">
           <div class="col-xs-12">
             <%= presenter.title %>
-            <br>
-            <small>
+            <small class="rss-fancy-time"><%= presenter.fancy_time %></small>
+          </div>
+          <div class="col-xs-12">
+            <small style="text-overflow: ellipsis; white-space: nowrap;">
               <% unless presenter.when.blank? %>
                   <%= presenter.when %>: <%= presenter.who %>
               <% end %>
             </small>
-            <small class="rss-fancy-time"><%= presenter.fancy_time %></small>
+
           </div>
         </div>
 


### PR DESCRIPTION
Makes the matrix box presenter handle longer user login names, hopefully eliminates flash.  Sets default thumbnail size to small unless overridden. uses large file instead of huge file for theater mode. 