### PR TITLE
add a little more padding to the navigation column

### DIFF
--- a/app/assets/stylesheets/general.scss
+++ b/app/assets/stylesheets/general.scss
@@ -124,7 +124,7 @@
 }
 
 .list-group.list-group-compact .list-group-item {
-    padding: 3px;
+    padding: 5px;
 }
 
 .input-group .icon-addon .form-control {


### PR DESCRIPTION
Increased the padding for 3px to 5px on the navigation buttons. Makes it much easier to click on mobile and less crowded.