### PR TITLE
Modernized app/views/account/*

### DIFF
--- a/app/assets/javascripts/api_key.js
+++ b/app/assets/javascripts/api_key.js
@@ -3,13 +3,15 @@ function ApiKeyModule() {
 
     // bindings
     jQuery('[data-role="edit_api_key"]').click(function(event){
+      var keyId = $(this).data().id;
       event.preventDefault();
-      shouldShowEditFields($(this).data().id, true);
+      shouldShowEditFields(keyId, true);
     });
 
     jQuery('[data-role="activate_api_key"]').click(function(event){
+      var keyId = $(this).data().id;
       event.preventDefault();
-      activateKey($(this).data().id);
+      activateKey(keyId);
     });
 
     jQuery('[data-role="key_notes_input"]').keypress(function (e) {
@@ -35,14 +37,15 @@ function ApiKeyModule() {
 
     // functions
     function shouldShowEditFields(keyId, showEdit, newNoteText) {
-      var $editFormContainer = jQuery('.edit_key_notes_container[data-target-key=' + keyId +']'),
-          $currentNotesContainer = jQuery('.view_key_notes_container[data-target-key=' + keyId +']')
+      var $editFormContainer     = jQuery('.edit_key_notes_container[data-target-key=' + keyId + ']'),
+          $currentNotesContainer = jQuery('.view_key_notes_container[data-target-key=' + keyId + ']');
 
       if (showEdit) {
         jQuery("#remove_button, #create_button").attr('disabled', true);
         allowFormSubmit(false);
         $currentNotesContainer.hide();
         $editFormContainer.show();
+        $editFormContainer.children('input').first().focus();
       }
 
       else {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -2,6 +2,10 @@
  * This should be included on every page.
  */
 jQuery(document).ready(function () {
+    // this works better than straing autofocus attribute in firefox
+    // normal autofocus causes it to scroll window hiding title etc.
+    jQuery('[data-autofocus=true]').first().focus();
+
     jQuery('[data-toggle="tooltip"]').tooltip({container: 'body'}); //enable tooltips
 
     jQuery('[data-toggle="offcanvas"]').click(function () {

--- a/app/assets/stylesheets/defaults.scss
+++ b/app/assets/stylesheets/defaults.scss
@@ -28,6 +28,7 @@ $BUTTON_PRIMARY_HOVER_BORDER_COLOR: #286192;
 $BUTTON_BORDER_WIDTH:               1px;
 $BUTTON_BORDER_STYLE:               solid;
 $BUTTON_BORDER_RADIUS:              5px;
+ // not doing disabled right
 
 $INPUT_FG_COLOR:                    #000000;
 $INPUT_BG_COLOR:                    #FFFFFF;

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -44,7 +44,7 @@ $btn-default-border: $BUTTON_BORDER_COLOR;
 $btn-primary-color: $BUTTON_PRIMARY_FG_COLOR;
 $btn-primary-bg: $BUTTON_PRIMARY_BG_COLOR2;
 $btn-primary-border: $BUTTON_PRIMARY_BORDER_COLOR;
-$btn-link-disabled-color: mix($BUTTON_FG_COLOR, $BUTTON_BG_COLOR2);
+$btn-link-disabled-color: mix($BUTTON_FG_COLOR, $BUTTON_BG_COLOR2, 75%);
 
 $input-bg: $INPUT_BG_COLOR;
 $input-bg-disabled: mix($INPUT_FG_COLOR, $INPUT_BG_COLOR);
@@ -66,7 +66,7 @@ $dropdown-link-hover-color: $MENU_HOT_FG_COLOR;
 $dropdown-link-hover-bg: $MENU_HOT_BG_COLOR;
 $dropdown-link-active-color: $MENU_WARM_FG_COLOR;
 $dropdown-link-active-bg: $MENU_WARM_BG_COLOR;
-$dropdown-link-disabled-color: mix($MENU_FG_COLOR, $MENU_BG_COLOR);
+$dropdown-link-disabled-color: mix($MENU_FG_COLOR, $MENU_BG_COLOR, 75%);
 $dropdown-header-color: $MENU_FG_COLOR;
 $dropdown-caret-color: $BODY_FG_COLOR;
 
@@ -85,7 +85,7 @@ $navbar-default-link-hover-color: $TOP_BAR_LINK_HOVER_FG_COLOR;
 $navbar-default-link-hover-bg: $TOP_BAR_LINK_HOVER_BG_COLOR;
 $navbar-default-link-active-color: $TOP_BAR_LINK_FG_COLOR;
 $navbar-default-link-active-bg: $TOP_BAR_LINK_BG_COLOR;
-$navbar-default-link-disabled-color: mix($TOP_BAR_LINK_FG_COLOR, $TOP_BAR_LINK_BG_COLOR);
+$navbar-default-link-disabled-color: mix($TOP_BAR_LINK_FG_COLOR, $TOP_BAR_LINK_BG_COLOR, 75%);
 $navbar-default-link-disabled-bg: $TOP_BAR_LINK_BG_COLOR;
 
 $pagination-color: $PAGER_FG_COLOR;
@@ -97,7 +97,7 @@ $pagination-hover-border: $PAGER_HOVER_BORDER_COLOR;
 $pagination-active-color: $PAGER_ACTIVE_FG_COLOR;
 $pagination-active-bg: $PAGER_ACTIVE_BG_COLOR;
 $pagination-active-border: $PAGER_ACTIVE_BORDER_COLOR;
-$pagination-disabled-color: mix($PAGER_FG_COLOR, $PAGER_BG_COLOR);
+$pagination-disabled-color: mix($PAGER_FG_COLOR, $PAGER_BG_COLOR, 75%);
 $pagination-disabled-bg: $PAGER_BG_COLOR;
 $pagination-disabled-border: $PAGER_BORDER_COLOR;
 
@@ -503,9 +503,7 @@ a:hover {
 .pagination > .disabled > a,
 .pagination > .disabled > a:hover,
 .pagination > .disabled > a:focus {
-    // color: $body_light;
     cursor: default;
-    // background-color: transparent;
 }
 
 //
@@ -866,6 +864,10 @@ a.p4, a.p4:visited { color: #3b2821; background: #FF0 }
     white-space: nowrap;
 }
 
+.max-text-width {
+    max-width: 600px;
+}
+
 //
 // style tweaks
 // --------------------------------------------------
@@ -881,6 +883,12 @@ table.table-compact tr td {
 
 .input-group .icon-addon .form-control {
     border-radius: 0;
+}
+
+input[type=checkbox] {
+    // fixes alignment issue in firefox; bootstrap applies this only to IE9:
+    // margin-top: 1px \9;
+    margin-top: 1px;
 }
 
 //

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -664,7 +664,7 @@ class AccountController < ApplicationController
               @user2.errors.add(:alert_type)
               redirect = false
             else
-              @user2.alert_created      = now = Time.now
+              @user2.alert_created_at   = now = Time.now
               @user2.alert_next_showing = now
               @user2.alert_user_id      = @user.id
               @user2.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -461,6 +461,10 @@ class User < AbstractModel
     "#<User #{id}: #{unique_text_name.inspect}>"
   end
 
+  def lang
+    Language.lang_from_locale(locale)
+  end
+
   ##############################################################################
   #
   #  :section: Names

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -736,16 +736,11 @@ class User < AbstractModel
     [:bounced_email, :other]
   end
 
-  def lang
-    Language.lang_from_locale(locale)
-  end
-
-  protected
   # Get alert structure, initializing it with an empty hash if necessary.
   def get_alert # :nodoc:
     self.alert ||= {}
   end
-  public
+  protected :get_alert
 
   # When the alert was created.
   def alert_created_at

--- a/app/views/account/add_user_to_group.html.erb
+++ b/app/views/account/add_user_to_group.html.erb
@@ -1,13 +1,21 @@
 <% @title = :add_user_to_group_title.t %>
 
-<%= form_tag(:action => "add_user_to_group") do %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :add_user_to_group) do %>
 
-  <label for="user_name"><%= :add_user_to_group_user.t %>:</label><br/>
-  <input type="text" name="user_name" id="user_name" size="30"/><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:user_name, :add_user_to_group_user.t) %>:
+        <%= text_field_tag(:user_name, "", class: "form-control") %>
+      </div>
 
-  <label for="group_name"><%= :add_user_to_group_group.t %>:</label><br/>
-  <input type="text" name="group_name" id="group_name" size="30"/><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:group_name, :add_user_to_group_group.t) %>:
+        <%= text_field_tag(:group_name, "", class: "form-control") %>
+      </div>
 
-  <input type="submit" name="save" value="<%= :ADD.t %>" class="btn" />
+      <%= submit_tag(:ADD.t, class: "btn push-down center-block") %>
 
-<% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/api_keys.html.erb
+++ b/app/views/account/api_keys.html.erb
@@ -1,81 +1,80 @@
 <%
   @title = :account_api_keys_title.t
   new_tab_set do
-    add_tab(:prefs_link.t,
-            :controller => 'account', :action => 'prefs')
-    add_tab(:profile_link.t,
-            :controller => 'account', :action => 'profile')
+    add_tab(:prefs_link.t,   controller: :account, action: :prefs)
+    add_tab(:profile_link.t, controller: :account, action: :profile)
   end
 
-  javascript_include('api_key')
-  inject_javascript_at_end "ApiKeyModule()"
+  javascript_include("api_key")
+  inject_javascript_at_end("ApiKeyModule()")
 %>
 
-<%= :account_api_keys_help.tp %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= :account_api_keys_help.tp %>
+  </div>
+</div>
 
-<% if @user.api_keys.any? %>
-  <%= form_tag({}, { class: "pad-bottom-2x"}) %>
-    <table class="table table-striped slight-pad">
-      <tr>
-        <th></th>
-        <th><%= :CREATED.t %></th>
-        <th><%= :account_api_keys_last_used_column_label.t %></th>
-        <th><%= :account_api_keys_num_uses_column_label.t %></th>
-        <th><%= :API_KEY.t %></th>
-        <th><%= :NOTES.t %></th>
-      </tr>
-      <%
-      @user.api_keys.sort_by {|k| k.num_uses > 0 ?
-                   [-k.num_uses, Time.now - k.last_used, k.id] :
-                   [0, 0, k.id] }.each do |key|
-        %>
-        <tr>
-          <td><%= check_box_tag("key_#{key.id}") %></td>
-          <td><%= key.created_at.web_date %></td>
-          <td id="key_time_<%= key.id %>">
-            <%=
-            if key.verified
-              key.last_used ? key.last_used.web_date : '--'
-            else
-              "[#{link_to("[:ACTIVATE.t}]",
-                      {action: :activate_api_key, id: key.id},
-                      data: {role: "activate_api_key", id: key.id})}]".html_safe
-            end
-            %>
-          </td>
-          <td><%= key.num_uses > 0 ? key.num_uses : '--' %></td>
-          <td><%= h(key.key) %></td>
-          <td id="key_notes_<%= key.id %>">
-            <div class="edit_key_notes_container hidden" data-target-key="<%= key.id %>">
-                <%=text_field_tag("key_notes_#{key.id}", key.notes, data:{role: "key_notes_input", id: key.id}) %>
-                <br/>
-                <%=button_tag(:SAVE.l, type: "button", class: "btn", data: {role: "key_notes_save", id: key.id}) %>
-                <%=button_tag(:CANCEL.l, type: "button", class: "btn", data: {role: "key_notes_cancel", id: key.id}) %>
-            </div>
-            <div class="view_key_notes_container" data-target-key="<%= key.id%>">
-             <span class="current_notes">
-                  <%= key.notes.t %>
-             </span>
-            <%= "[#{link_to(:EDIT.t, {action: :edit_api_key, id: key.id},
-                data: {role: "edit_api_key", id: key.id})}]".html_safe %>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-    <%= submit_tag(:account_api_keys_remove_button.l, id: "remove_button", class: "btn") %>
-  </form>
-<% end %>
+<div class="row push-down">
+  <div class="col-xs-12">
+    <% if @user.api_keys.any? %>
+      <%= form_tag({}, { class: "pad-bottom-2x"}) %>
+        <table class="table table-striped slight-pad">
+          <tr>
+            <th></th>
+            <th><%= :CREATED.t %></th>
+            <th><%= :account_api_keys_last_used_column_label.t %></th>
+            <th><%= :account_api_keys_num_uses_column_label.t %></th>
+            <th><%= :API_KEY.t %></th>
+            <th><%= :NOTES.t %></th>
+          </tr>
+          <% @user.api_keys.sort_by do |key|
+            last_use = Time.now - key.last_used rescue 0
+            [-key.num_uses, last_use, key.id]
+          end.each do |key| %>
+            <tr>
+              <td><%= check_box_tag("key_#{key.id}") %></td>
+              <td><%= key.created_at.web_date %></td>
+              <td id="key_time_<%= key.id %>">
+                <%= if key.verified
+                  key.last_used ? key.last_used.web_date : '--'
+                else
+                  "[#{link_to("[:ACTIVATE.t}]",
+                    {action: :activate_api_key, id: key.id},
+                    data: {role: "activate_api_key", id: key.id})}]".html_safe
+                end %>
+              </td>
+              <td><%= key.num_uses > 0 ? key.num_uses : '--' %></td>
+              <td><%= h(key.key) %></td>
+              <td id="key_notes_<%= key.id %>">
+                <div class="edit_key_notes_container" data-target-key="<%= key.id %>" style="display:none">
+                  <%=text_field_tag("key_notes_#{key.id}", key.notes, data:{role: "key_notes_input", id: key.id}) %><br/>
+                  <%=button_tag(:SAVE.l, type: "button", class: "btn", data: {role: "key_notes_save", id: key.id}) %>
+                  <%=button_tag(:CANCEL.l, type: "button", class: "btn", data: {role: "key_notes_cancel", id: key.id}) %>
+                </div>
+                <div class="view_key_notes_container" data-target-key="<%= key.id %>">
+                  <span class="current_notes"><%= key.notes.t %></span>
+                  <%= "[#{link_to(:EDIT.t, {action: :edit_api_key, id: key.id},
+                        data: {role: "edit_api_key", id: key.id})}]".html_safe %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+        <%= submit_tag(:account_api_keys_remove_button.l, id: "remove_button", class: "btn center-block") %>
+      </form>
+    <% end %>
+  </div>
+</div>
 
-<%= form_for(:key) do |form| %>
-  <div>
-    <label for="notes"><%= :account_api_keys_notes_label.t %></label>
+<div class="row push-down">
+  <div class="col-xs-12 max-text-width">
+    <%= form_for(:key) do |form| %>
+      <div class="form-group push-down">
+        <%= label_tag(:notes, :account_api_keys_notes_label.t) %>
+        <%= form.text_field(:notes, class: "form-control") %>
+      </div>
+      <%= submit_tag(:account_api_keys_create_button.l, id: "create_button", class: "btn center-block push-down") %>
+    <% end %>
   </div>
-  <div>
-    <%= form.text_field(:notes, :size => 80) %>
-  </div>
-  <div>
-    <%= submit_tag(:account_api_keys_create_button.l, id: "create_button", class: "btn") %>
-  </div>
-<% end %>
-<br/>
+</div>

--- a/app/views/account/choose_password.html.erb
+++ b/app/views/account/choose_password.html.erb
@@ -3,12 +3,22 @@
   focus_on_password = @user.password.blank?
 %>
 
-<%= form_tag(:action=> "verify", :id => @user.id, :auth_code => @user.auth_code) do %>
-  <label for="user_password"><%= :signup_choose_password.t %>:</label><br/>
-  <%= password_field(:user, :password, size: 30, value: @user.password, autofocus: focus_on_password) %><br/><br/>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :verify, id: @user.id, auth_code: @user.auth_code) do %>
 
-  <label for="user_password_confirmation"><%= :signup_confirm_password.t %>:</label><br/>
-  <%= password_field(:user, :password_confirmation, size: 30, autofocus: !focus_on_password) %><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:user_password, :signup_choose_password.t) %>:
+        <%= password_field(:user, :password, value: @user.password, data: {autofocus: focus_on_password}, class: "form-control") %>
+      </div>
 
-  <input type="submit" value="<%= :SUBMIT.l %>" class="btn" />
-<% end %>
+      <div class="form-group push-down">
+        <%= label_tag(:user_password_confirmation, :signup_confirm_password.t) %>:
+        <%= password_field(:user, :password_confirmation, data: {autofocus: !focus_on_password}, class: "form-control") %>
+      </div>
+
+      <%= submit_tag(:SUBMIT.l, class: "btn center-block push-down") %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/create_alert.html.erb
+++ b/app/views/account/create_alert.html.erb
@@ -1,27 +1,37 @@
-<% @title = :user_alert_create_title.t(:user => @user2.legal_name) %>
+<% @title = :user_alert_create_title.t(user: @user2.legal_name) %>
 
-<%= form_tag(:action => "create_alert", :id => @user2.id) do %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :create_alert, id: @user2.id) do %>
 
-  <% if @user2.alert_created_at %>
-    <label for="user2_created_at"><%= :user_alert_created_at.t %>:</label>
-    <%= @user2.alert_created_at.web_time %><br/>
-    <label for="user2_next_showing"><%= :user_alert_next_showing.t %>:</label>
-    <%= @user2.alert_next_showing.web_time %><br/>
-    <label for="user2_user"><%= :user_alert_user.t %>:</label>
-    <%= @user2.alert_user.login %><br/><br/>
-  <% end %>
+      <% if @user2.alert_created_at %>
+        <div class="form-group push-down">
+          <%= label_tag(:user2_created_at, :user_alert_created_at.t) %>:
+          <%= @user2.alert_created_at.web_time %><br/>
+          <%= label_tag(:user2_next_showing, :user_alert_next_showing.t) %>:
+          <%= @user2.alert_next_showing.web_time %><br/>
+          <%= label_tag(:user2_user, :user_alert_user.t) %>:
+          <%= @user2.alert_user.login %><br/>
+        </div>
+      <% end %>
 
-  <label for="user2_alert_type"><%= :user_alert_type.t %>:</label>
-  <%= select('user2', 'alert_type', [['','']] + User.all_alert_types.map \
-    {|x| ["user_alert_type_#{x}".to_sym.l, x.to_s]})%><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:user2_alert_type, :user_alert_type.t) %>:
+        <%= select(:user2, :alert_type, [['','']] + User.all_alert_types.map \
+          {|x| ["user_alert_type_#{x}".to_sym.l, x.to_s]}, class: "form-control") %>
+      </div>
 
-  <label for="user2_alert_notes"><%= :user_alert_notes.t %>:</label><br/>
-  <%= text_area('user2', 'alert_notes', :cols => 80, :rows => 8) %><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:user2_alert_notes, :user_alert_notes.t) %>:
+        <%= text_area(:user2, :alert_notes, rows: 8, class: "form-control") %>
+      </div>
 
-  <center>
-    <input type="submit" name="commit" value="<%= :user_alert_save.l %>" class="btn" />
-    <span style="padding-right:50px">&nbsp;</span>
-    <input type="submit" name="commit" value="<%= :user_alert_delete.l %>" class="btn" />
-  </center>
-<% end %>
+      <center class="push-down">
+        <%= submit_tag(:user_alert_save.l, class: "btn") %>
+        <span style="padding-right:50px">&nbsp;</span>
+        <%= submit_tag(:user_alert_delete.l, class: "btn") %>
+      </center>
 
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/edit_api_key.html.erb
+++ b/app/views/account/edit_api_key.html.erb
@@ -2,38 +2,46 @@
   @title = :account_api_keys_title.t
 
   new_tab_set do
-    add_tab(:prefs_link.t,
-            :controller => 'account', :action => 'prefs')
-    add_tab(:profile_link.t,
-            :controller => 'account', :action => 'profile')
+    add_tab(:prefs_link.t,   controller: :account, action: :prefs)
+    add_tab(:profile_link.t, controller: :account, action: :profile)
   end
 %>
 
-<%= :account_api_keys_help.tp %>
-<br/>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= :account_api_keys_help.tp %>
 
-<%= form_for(:key, :url => {id: @key.id}) do |form| %>
-  <table><tr><td>
-    <table>
-      <tr><td><%= :CREATED.t %>: </td>
-        <td><%= @key.created_at.web_date %></td></tr>
-      <tr><td><%= :account_api_keys_last_used_column_label.t %>: </td>
-        <td><%= @key.last_used ? @key.last_used.web_date : '--' %></td></tr>
-      <tr><td><%= :account_api_keys_num_uses_column_label.t %>: </td>
-        <td><%= @key.num_uses > 0 ? @key.num_uses : '--' %></td></tr>
-      <tr><td><%= :API_KEY.t %>: </td>
-        <td><%= h(@key.key) %></td></tr>
-    </table>
-    <br/>
+    <%= form_for(:key, url: {id: @key.id}) do |form| %>
+      <table>
+        <tr>
+          <td><%= :CREATED.t %>:&nbsp;</td>
+          <td><%= @key.created_at.web_date %></td>
+        </tr>
+        <tr>
+          <td><%= :account_api_keys_last_used_column_label.t %>:&nbsp;</td>
+          <td><%= @key.last_used ? @key.last_used.web_date : '--' %></td>
+        </tr>
+        <tr>
+          <td><%= :account_api_keys_num_uses_column_label.t %>:&nbsp;</td>
+          <td><%= @key.num_uses > 0 ? @key.num_uses : '--' %></td>
+        </tr>
+        <tr>
+          <td><%= :API_KEY.t %>:&nbsp;</td>
+          <td><%= h(@key.key) %></td>
+        </tr>
+      </table>
 
-    <label for="notes"><%= :NOTES.t %>:</label><br/>
-      <%= form.text_field(:notes, :size => 80) %><br/>
-    <br/>
+      <div class="form-group push-down">
+        <%= label_tag(:notes, :NOTES.t) %>:
+        <%= form.text_field(:notes, class: "form-control") %>
+      </div>
 
-    <center>
-      <%= submit_tag(:UPDATE.l, class: "btn") %>
-      <span style="margin-left:5em"></span>
-      <%= submit_tag(:CANCEL.l, class: "btn") %>
-    </center>
-  </td></tr></table>
-<% end %>
+      <center class="push-down">
+        <%= submit_tag(:UPDATE.l, class: "btn") %>
+        <span style="margin-left:5em"></span>
+        <%= submit_tag(:CANCEL.l, class: "btn") %>
+      </center>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/email_new_password.html.erb
+++ b/app/views/account/email_new_password.html.erb
@@ -1,8 +1,16 @@
 <% @title = :email_new_password_title.t %>
 
-<%= form_tag(:action => "email_new_password") do %>
-  <label for="new_user_login"><%= :login_user.t %>:</label><br/>
-  <%= text_field(:new_user, :login, size: 30, autofocus: true) %><br/><br/>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :email_new_password) do %>
 
-  <input type="submit" value="<%= :SEND.l %>" class="btn" />
-<% end %>
+      <div class="form-group">
+        <%= label_tag(:new_user_login, :login_user.t) %>:
+        <%= text_field(:new_user, :login, data: {autofocus: true}) %>
+      </div>
+
+      <%= submit_tag(:SEND.l, class: "btn center-block push-down") %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -1,42 +1,32 @@
 <% @title = :login_please_login.t %>
 
-<%= form_tag(action: "login") do %>
-  <div class="row">
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :login) do %>
 
-    <div class="col-xs-12 form-inline">
       <div class="form-group push-down">
-        <label for="user_login"><%= :login_user.t %>:</label><br/>
-        <%= text_field(:user, :login, value: @login, autofocus: @login.blank?, class: "form-control", size: 40) %>
+        <%= label_tag(:user_login, :login_user.t) %>:
+        <%= text_field(:user, :login, value: @login, data: {autofocus: @login.blank?}, class: "form-control") %>
       </div>
-    </div>
 
-    <div class="col-xs-12 form-inline">
       <div class="form-group push-down">
-        <label for="user_password"><%= :login_password.t %>:</label><br/>
-        <%= password_field(:user, :password, value: "", autofocus: !@login.blank?, class: "form-control", size: 40) %>
+        <%= label_tag(:user_password, :login_password.t) %>:
+        <%= password_field(:user, :password, value: "", data: {autofocus: !@login.blank?}, class: "form-control") %>
       </div>
-    </div>
 
-    <div class="col-xs-12 form-inline">
-      <div class="form-group push-down">
-        <%= check_box(:user, :remember_me, checked: @remember) %>
-        <label for="user_remember_me"><%= :login_remember_me.t %></label>
+      <div class="form-group push-down form-inline">
+        <%= check_box(:user, :remember_me, checked: @remember, class: "form-control") %>
+        <%= label_tag(:user_remember_me, :login_remember_me.t) %>
       </div>
-    </div>
 
-    <div class="col-xs-12 form-inline">
-      <div class="form-group push-down">
-        <input type="submit" name="login" value="<%= :login_login.l %>" class="btn" />
-      </div>
-    </div>
+      <%= submit_tag(:login_login.l, class: "btn center-block push-down") %>
 
-    <div class="col-xs-12 form-inline">
       <div class="form-group push-down">
         <%= :login_forgot_password.tp %>
         <%= :login_no_account.tp %>
         <%= :login_having_problems.tp %>
       </div>
-    </div>
 
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/account/logout_user.html.erb
+++ b/app/views/account/logout_user.html.erb
@@ -1,5 +1,7 @@
 <% @title = :logout_title.t %>
 
-<div class="memo">
-  <%= :logout_note.tp %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= :logout_note.tp %>
+  </div>
 </div>

--- a/app/views/account/no_email.html.erb
+++ b/app/views/account/no_email.html.erb
@@ -1,7 +1,9 @@
-<% @title = :email_welcome.t(:user => @user.legal_name) %>
+<% @title = :email_welcome.t(user: @user.legal_name) %>
 
-<div class="memo">
-  <%= @note.tp %>
-  <%= :no_email_how_to_reenable.tp %>
-  <%= :no_email_some_maybe_queued.tp %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= @note.tp %>
+    <%= :no_email_how_to_reenable.tp %>
+    <%= :no_email_some_maybe_queued.tp %>
+  </div>
 </div>

--- a/app/views/account/prefs.html.erb
+++ b/app/views/account/prefs.html.erb
@@ -2,205 +2,218 @@
   @title = :prefs_title.t
 
   new_tab_set do
-    add_tab(:bulk_license_link.t,
-            :controller => 'image', :action => 'license_updater')
-    add_tab(:prefs_change_image_vote_anonymity.t,
-            :controller => 'image', :action => 'bulk_vote_anonymity_updater')
-    add_tab(:profile_link.t,
-            :controller => 'account', :action => 'profile')
-    add_tab(:show_user_your_notifications.t,
-            :controller => 'interest', :action => 'list_interests')
-    add_tab(:account_api_keys_link.t,
-            :controller => 'account', :action => 'api_keys')
-    add_tab(:turn_javascript_nil_title.t,
-            :controller => 'observer', :action => 'turn_javascript_nil') if session[:js_override] != nil
-    add_tab(:turn_javascript_on_title.t,
-            :controller => 'observer', :action => 'turn_javascript_on') if !@js
-    add_tab(:turn_javascript_off_title.t,
-            :controller => 'observer', :action => 'turn_javascript_off') if @js
+    add_tab(:bulk_license_link.t, controller: :image, action: :license_updater)
+    add_tab(:prefs_change_image_vote_anonymity.t, controller: :image, action: :bulk_vote_anonymity_updater)
+    add_tab(:profile_link.t, controller: :account, action: :profile)
+    add_tab(:show_user_your_notifications.t, controller: :interest, action: :list_interests)
+    add_tab(:account_api_keys_link.t, controller: :account, action: :api_keys)
   end
 %>
 
-<%= form_for(:user, :url => {action: :prefs}) do |form| %>
-  <table width="1" style="min-width:800px"><tr><td>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_for(:user, url: {action: :prefs}) do |form| %>
 
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <!-- ---------------------------------------------------------------- -->
 
-  <br/><center><input type="submit" value="<%= :SAVE_EDITS.l %>" class="btn" /></center>
+      <div class="form-group push-down">
+        <%= label_tag(:user_login, :prefs_login.t) %>:
+        <%= form.text_field(:login, class: "form-control") %>
+      </div>
 
-  <p><label for="user_login"><%= :prefs_login.t %></label>:<br/>
-    <%= form.text_field("login", :size => 60) %></p>
+      <div class="form-group push-down">
+        <%= label_tag(:user_email, :prefs_email.t) %>:
+        <%= form.text_field(:email, class: "form-control") %>
+      </div>
 
-  <p><label for="user_email"><%= :prefs_email.t %></label>:<br/>
-    <%= form.text_field("email", :size => 60) %></p>
+      <div class="form-group push-down">
+        <%= label_tag(:user_password, :prefs_password_new.t) %>:
+        <%= form.password_field(:password, value: "", class: "form-control") %>
+      </div>
 
-  <p><label for="user_password"><%= :prefs_password_new.t %></label>:<br/>
-    <%= form.password_field("password", :value => '', :size => 30) %></p>
+      <div class="form-group push-down">
+        <%= label_tag(:user_password_confirmation, :prefs_password_confirm.t) %>:
+        <%= form.password_field("password_confirmation", value: "", class: "form-control") %></p>
+      </div>
 
-  <p><label for="user_password_confirmation"><%= :prefs_password_confirm.t %></label>:<br/>
-    <%= form.password_field("password_confirmation", :value => '', :size => 30) %></p>
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <!-- ---------------------------------------------------------------- -->
 
+      <div class="form-group push-down bold">
+        <%= :prefs_privacy.t %>
+      </div>
 
+      <div class="form-group push-down">
+        <%= label_tag(:user_votes_anonymous, :prefs_votes_anonymous.t) %>:<br/>
+        <%= values = [
+          [:prefs_votes_anonymous_no.l, :no],
+          [:prefs_votes_anonymous_yes.l, :yes],
+        ]
+        # Allow old users to granfather in old anonymous votes, but choose to go public from here forward.
+        if @user.created_at && @user.created_at < Time.parse(MO.vote_cutoff)
+          values << [:prefs_votes_anonymous_old.l(cutoff: MO.vote_cutoff), :old]
+        end
+        form.select(:votes_anonymous, values, class: "form-control") %>
+        <span class="HelpNote">(<%= link_to(:prefs_change_image_vote_anonymity.t,
+          controller: :image, action: :bulk_vote_anonymity_updater) %>)</span>
+      <div>
 
-  <br/><center><input type="submit" value="<%= :SAVE_EDITS.l %>" class="btn" /></center>
-  <p><b><%= :prefs_privacy.t %></b></p>
+      <div class="form-group push-down">
+        <%= label_tag(:user_keep_filenames, :prefs_keep_image_filenames.t) %>:<br/>
+        <%= form.select(:keep_filenames, [
+          [:prefs_keep_image_filenames_toss.l, :toss],
+          [:prefs_keep_image_filenames_keep_but_hide.l, :keep_but_hide],
+          [:prefs_keep_image_filenames_keep_and_show.l, :keep_and_show]
+        ], class: "form-control") %>
+        <span class="HelpNote">(<%= link_to(:prefs_bulk_filename_purge.t,
+          { controller: :image, action: :bulk_filename_purge },
+          { data: {confirm: :prefs_bulk_filename_purge_confirm.l} }) %>)</span>
+      <div>
 
-  <p><label for="user_votes_anonymous"><%= :prefs_votes_anonymous.t %></label>:
-    <span class="HelpNote">(<%= link_to(:prefs_change_image_vote_anonymity.t,
-      :controller => 'image', :action => 'bulk_vote_anonymity_updater') %>)</span><br/>
-    <%= values = [
-      [:prefs_votes_anonymous_no.l, :no],
-      [:prefs_votes_anonymous_yes.l, :yes],
-    ]
-    # Allow old users to granfather in old anonymous votes, but choose to go public from here forward.
-    if @user.created_at && @user.created_at < Time.parse(MO.vote_cutoff)
-      values << [:prefs_votes_anonymous_old.l(:cutoff => MO.vote_cutoff), :old]
-    end
-    form.select(:votes_anonymous, values) %></p>
+      <div class="form-group push-down">
+        <%= label_tag(:user_license_id, :License.t) %>:
+        <span class="HelpNote">(<%= :prefs_license_note.t %>)</span><br/>
+        <%= form.select(:license_id, @licenses, class: "form-control") %>
+        <span class="HelpNote">(<%= link_to(:bulk_license_link.t,
+          controller: :image, action: :license_updater) %>)</span>
+      <div>
 
-  <p><label for="user_keep_filenames"><%= :prefs_keep_image_filenames.t %></label>:
-    <span class="HelpNote">(<%= link_to(:prefs_bulk_filename_purge.t,
-      {controller: 'image', action: 'bulk_filename_purge'},
-      { data: { confirm: :prefs_bulk_filename_purge_confirm.l } }) %>)</span><br/>
-    <%= form.select(:keep_filenames, [
-    [:prefs_keep_image_filenames_toss.l, :toss],
-    [:prefs_keep_image_filenames_keep_but_hide.l, :keep_but_hide],
-    [:prefs_keep_image_filenames_keep_and_show.l, :keep_and_show]]) %></p>
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <!-- ---------------------------------------------------------------- -->
 
-  <p><label for="user_license_id"><%= :License.t %>:</label>
-    <span class="HelpNote">(<%= :prefs_license_note.t %>)</span>
-    <span class="HelpNote">(<%= link_to(:bulk_license_link.t,
-      :controller => 'image', :action => 'license_updater') %>)</span><br/>
-    <%= form.select(:license_id, @licenses) %></p>
+      <div class="form-group push-down bold">
+        <%= :prefs_appearance.t %>
+      </div>
 
+      <div class="form-group push-down form-inline">
+        <%= label_tag(:user_hide_authors, :prefs_hide_authors.t) %>:
+        <%= form.select(:hide_authors, [
+          [:prefs_hide_authors_none.l, :none],
+          [:prefs_hide_authors_above_species.l, :above_species]
+        ], class: "form-control") %><br/>
 
+        <%= label_tag(:user_location_format, :prefs_location_format.t) %>:
+        <%= form.select(:location_format, [
+          [:prefs_location_format_postal.l, :postal],
+          [:prefs_location_format_scientific.l, :scientific]
+        ], class: "form-control") %><br/>
 
-  <br/><center><input type="submit" value="<%= :SAVE_EDITS.l %>" class="btn" /></center>
-  <p><b><%= :prefs_appearance.t %></b></p>
+        <%= label_tag(:user_theme, :prefs_theme.t) %>:
+        <%= form.select(:theme, [
+          [:theme_random.l, "NULL"]
+        ] + MO.themes.map {|t| [t.to_sym.l, t]}, class: "form-control") %><br/>
 
-  <p><label for="user_hide_authors"><%= :prefs_hide_authors.t %></label>:<br/>
-    <%= form.select(:hide_authors, [
-    [:prefs_hide_authors_none.l, :none],
-    [:prefs_hide_authors_above_species.l, :above_species]]) %></p>
-
-  <p><label for="user_location_format"><%= :prefs_location_format.t %></label>:<br/>
-    <%= form.select(:location_format, [
-    [:prefs_location_format_postal.l, :postal],
-    [:prefs_location_format_scientific.l, :scientific]]) %></p>
-
-  <table cellpadding="0" cellspacing="0">
-    <tr>
-      <td><label for="user_theme"><%= :prefs_theme.t %>:</label><br/>
-        <%= form.select(:theme, [[:theme_random.l, "NULL"]] + MO.themes.map {|t| [t.to_sym.l, t]}) %></td>
-      <td width="20"></td>
-      <td><label for="user_locale"><%= :prefs_locale.t %>:</label><br/>
+        <%= label_tag(:user_locale, :prefs_locale.t) %>:
         <%= locales = Language.all.map do |lang|
           name = lang.name
-          name += ' (beta)' if lang.beta
+          name += " (beta)" if lang.beta
           [name, lang.locale]
         end
-        form.select(:locale, locales) %></td>
-    </tr>
-  </table><br/>
+        form.select(:locale, locales, class: "form-control") %><br/>
 
-  <table cellpadding="0" cellspacing="0">
-    <tr>
-      <td><label for="user_thumbnail_size"><%= :prefs_thumbnail_size.t %>:</label><br/>
+        <%= label_tag(:user_thumbnail_size, :prefs_thumbnail_size.t) %>:
         <%= form.select(:thumbnail_size, [
           [:prefs_thumbnail_small.l, :thumbnail],
           [:prefs_thumbnail_large.l, :small],
-        ]) %></td>
-      <td width="20"></td>
-      <td><label for="user_image_size"><%= :prefs_image_size.t %>:</label>
-        <span class="HelpNote">(<%= :prefs_image_size_help.t %>)</span><br/>
-        <%= form.select(:image_size, [
-          [:prefs_image_small.l,     :small],
-          [:prefs_image_medium.l,    :medium],
-          [:prefs_image_large.l,     :large],
-          [:prefs_image_huge.l,      :huge],
-          [:prefs_image_full_size.l, :full_size],
-        ]) %></td>
-    </tr>
-  </table><br/>
+        ], class: "form-control") %><br/>
 
-  <p><%= form.check_box('thumbnail_maps') %>
-    <%= :prefs_thumbnail_maps.t %></p>
+        <%= form.check_box(:thumbnail_maps, class: "form-control") %>
+          <%= label_tag(:thumbnail_maps, :prefs_thumbnail_maps.t) %><br/>
 
-  <p><%= :prefs_layout_title.t %>:<br/>
-  <%= form.select(:rows, [1, 2, 3, 4, 5, 10, 20, 50]) %>
-    <label for="user_rows"><%= :prefs_rows_by.t %></label>
-    <%= form.select(:columns, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) %>
-    <label for="user_columns"><%= :prefs_columns.t %></label><br/>
-  <%= form.check_box("alternate_rows") %>
-    <label for="user_alternate_rows"><%= :prefs_alt_row_colors.t %></label><br/>
-  <%= form.check_box("alternate_columns") %>
-    <label for="user_alternate_columns"><%= :prefs_alt_col_colors.t %></label><br/>
-  <%= form.check_box("vertical_layout") %>
-    <label for="user_vertical_layout"><%= :prefs_text_below_images.t %></label><br/></p>
+        <%= label_tag(:user_layout, :prefs_layout_title.t) %>:<br/>
+        <%= form.select(:rows, [1, 2, 3, 4, 5, 10, 20, 50], class: "form-control") %>
+          <%= label_tag(:user_rows, :prefs_rows_by.t) %>
+        <%= form.select(:columns, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], class: "form-control") %>
+          <%= label_tag(:user_columns, :prefs_columns.t) %><br/>
+        <%= form.check_box(:alternate_rows, class: "form-control") %>
+          <%= label_tag(:user_alternate_rows, :prefs_alt_row_colors.t) %><br/>
+        <%= form.check_box(:vertical_layout, class: "form-control") %>
+          <%= label_tag(:user_vertical_layout, :prefs_text_below_images.t) %><br/>
+      </div>
 
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <!-- ---------------------------------------------------------------- -->
 
+      <div class="form-group push-down bold">
+        <%= :prefs_email_prefs.t %>
+      </div>
 
+      <div class="form-group form-inline">
+        <%= form.check_box(:email_html, class: "form-control") %>
+          <%= label_tag(:user_email_html, :prefs_email_html.t) %>
+      </div>
 
-  <br/><center><input type="submit" value="<%= :SAVE_EDITS.l %>" class="btn" /></center>
-  <p><b><%= :prefs_email_prefs.t %></b></p>
+      <div class="form-group push-down form-inline">
+        <%= :prefs_email_comments.t %>:
+          <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
+        <%= form.check_box(:email_comments_owner, class: "form-control") %>
+          <%= label_tag(:user_email_comments_owner, :prefs_email_comments_owner.t) %><br/>
+        <%= form.check_box(:email_comments_response, class: "form-control") %>
+          <%= label_tag(:user_email_comments_response, :prefs_email_comments_response.t) %><br/>
+        <%= form.check_box(:email_comments_all, class: "form-control") %>
+          <%= label_tag(:user_email_comments_all, :prefs_email_comments_all.t) %><br/>
+      </div>
 
-  <p><%= form.check_box("email_html") %>
-    <label for="user_email_html"><%= :prefs_email_html.t %></label></p>
+      <div class="form-group push-down form-inline">
+        <%= :prefs_email_observations.t %>:
+          <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
+        <%= form.check_box(:email_observations_consensus, class: "form-control") %>
+          <%= label_tag(:user_email_observations_consensus, :prefs_email_observations_consensus.t) %><br/>
+        <%= form.check_box(:email_observations_naming, class: "form-control") %>
+          <%= label_tag(:user_email_observations_naming, :prefs_email_observations_naming.t) %><br/>
+        <%= form.check_box(:email_observations_all, class: "form-control") %>
+          <%= label_tag(:user_email_observations_all, :prefs_email_observations_all.t) %><br/>
+      </div>
 
-  <p><%= :prefs_email_comments.t %>:
-    <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
-  <%= form.check_box("email_comments_owner") %>
-    <label for="user_email_comments_owner"><%= :prefs_email_comments_owner.t %></label><br/>
-  <%= form.check_box("email_comments_response") %>
-    <label for="user_email_comments_response"><%= :prefs_email_comments_response.t %></label><br/>
-  <%= form.check_box("email_comments_all") %>
-    <label for="user_email_comments_all"><%= :prefs_email_comments_all.t %></label><br/></p>
+      <div class="form-group push-down form-inline">
+        <%= :prefs_email_names.t %>:
+          <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
+        <%= form.check_box(:email_names_admin, class: "form-control") %>
+          <%= label_tag(:user_email_names_admin, :prefs_email_names_admin.t) %><br/>
+        <%= form.check_box(:email_names_author, class: "form-control") %>
+          <%= label_tag(:user_email_names_author, :prefs_email_names_author.t) %><br/>
+        <%= form.check_box(:email_names_editor, class: "form-control") %>
+          <%= label_tag(:user_email_names_editor, :prefs_email_names_editor.t) %><br/>
+        <%= form.check_box(:email_names_reviewer, class: "form-control") %>
+          <%= label_tag(:user_email_names_reviewer, :prefs_email_names_reviewer.t) %><br/>
+        <%= form.check_box(:email_names_all, class: "form-control") %>
+          <%= label_tag(:user_email_names_all, :prefs_email_names_all.t) %><br/>
+      </div>
 
-  <p><%= :prefs_email_observations.t %>:
-    <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
-  <%= form.check_box("email_observations_consensus") %>
-    <label for="user_email_observations_consensus"><%= :prefs_email_observations_consensus.t %></label><br/>
-  <%= form.check_box("email_observations_naming") %>
-    <label for="user_email_observations_naming"><%= :prefs_email_observations_naming.t %></label><br/>
-  <%= form.check_box("email_observations_all") %>
-    <label for="user_email_observations_all"><%= :prefs_email_observations_all.t %></label><br/></p>
+      <div class="form-group push-down form-inline">
+        <%= :prefs_email_locations.t %>:
+          <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
+        <%= form.check_box(:email_locations_admin, class: "form-control") %>
+          <%= label_tag(:user_email_locations_admin, :prefs_email_locations_admin.t) %><br/>
+        <%= form.check_box(:email_locations_author, class: "form-control") %>
+          <%= label_tag(:user_email_locations_author, :prefs_email_locations_author.t) %><br/>
+        <%= form.check_box(:email_locations_editor, class: "form-control") %>
+          <%= label_tag(:user_email_locations_editor, :prefs_email_locations_editor.t) %><br/>
+        <%= form.check_box(:email_locations_all, class: "form-control") %>
+          <%= label_tag(:user_email_locations_all, :prefs_email_locations_all.t) %><br/>
+      </div>
 
-  <p><%= :prefs_email_names.t %>:
-    <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
-  <%= form.check_box("email_names_admin") %>
-    <label for="user_email_names_admin"><%= :prefs_email_names_admin.t %></label><br/>
-  <%= form.check_box("email_names_author") %>
-    <label for="user_email_names_author"><%= :prefs_email_names_author.t %></label><br/>
-  <%= form.check_box("email_names_editor") %>
-    <label for="user_email_names_editor"><%= :prefs_email_names_editor.t %></label><br/>
-  <%= form.check_box("email_names_reviewer") %>
-    <label for="user_email_names_reviewer"><%= :prefs_email_names_reviewer.t %></label><br/>
-  <%= form.check_box("email_names_all") %>
-    <label for="user_email_names_all"><%= :prefs_email_names_all.t %></label><br/></p>
+      <div class="form-group push-down form-inline">
+        <%= :prefs_email_general.t %>:
+          <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
+        <%= form.check_box(:email_general_feature, class: "form-control") %>
+          <%= label_tag(:user_email_general_feature, :prefs_email_general_features.t) %><br/>
+        <%= form.check_box(:email_general_commercial, class: "form-control") %>
+          <%= label_tag(:user_email_general_commercial, :prefs_email_general_commercial.t) %><br/>
+        <%= form.check_box(:email_general_question, class: "form-control") %>
+          <%= label_tag(:user_email_general_question, :prefs_email_general_questions.t) %><br/>
+      </div>
 
-  <p><%= :prefs_email_locations.t %>:
-    <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
-  <%= form.check_box("email_locations_admin") %>
-    <label for="user_email_locations_admin"><%= :prefs_email_locations_admin.t %></label><br/>
-  <%= form.check_box("email_locations_author") %>
-    <label for="user_email_locations_author"><%= :prefs_email_locations_author.t %></label><br/>
-  <%= form.check_box("email_locations_editor") %>
-    <label for="user_email_locations_editor"><%= :prefs_email_locations_editor.t %></label><br/>
-  <%= form.check_box("email_locations_all") %>
-    <label for="user_email_locations_all"><%= :prefs_email_locations_all.t %></label><br/></p>
+      <div class="form-group push-down form-inline">
+        <div class="help-block">
+          <%= :prefs_email_note.tp %>
+        </div>
+      </div>
 
-  <p><%= :prefs_email_general.t %>:
-    <span class="HelpNote">(<%= :prefs_email_please_notify.t %>)</span><br/>
-  <%= form.check_box("email_general_feature") %>
-    <label for="user_email_general_feature"><%= :prefs_email_general_features.t %></label><br/>
-  <%= form.check_box("email_general_commercial") %>
-    <label for="user_email_general_commercial"><%= :prefs_email_general_commercial.t %></label><br/>
-  <%= form.check_box("email_general_question") %>
-    <label for="user_email_general_question"><%= :prefs_email_general_questions.t %></label><br/></p>
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <!-- ---------------------------------------------------------------- -->
 
-  <div class="HelpNoteIndent">
-    <%= :prefs_email_note.tp %>
+    <% end %>
   </div>
-
-  <br/><center><input type="submit" value="<%= :SAVE_EDITS.l %>" class="btn" /></center>
-  </td></tr></table>
-<% end %>
+</div>

--- a/app/views/account/profile.html.erb
+++ b/app/views/account/profile.html.erb
@@ -1,58 +1,72 @@
 <%
-   @title = :profile_title.t
-   @tabsets = {right: render(partial: "shared/tab_set",
-                            locals: {
-                                    links: [link_to(:bulk_license_link.t, controller: :image, action: :license_updater),
-                                            link_to(:show_user_your_notifications.t, controller: :interest, action: :list_interests),
-                                            link_to(:prefs_link.t, controller: :account, action: :prefs),
-                                            link_to(:account_api_keys_link.t, controller: :account, action: :api_keys)]
-                            })}
+  @title = :profile_title.t
+  @tabsets = {
+    right: render(partial: "shared/tab_set", locals: {
+      links: [
+        link_to(:bulk_license_link.t, controller: :image, action: :license_updater),
+        link_to(:show_user_your_notifications.t, controller: :interest, action: :list_interests),
+        link_to(:prefs_link.t, controller: :account, action: :prefs),
+        link_to(:account_api_keys_link.t, controller: :account, action: :api_keys)
+      ]
+    })
+  }
 %>
 
-<%= form_for(:user, :url => {action: :profile}, :html => {multipart: true, style: "max-width: 600px"}) do |form| %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_for(:user, url: {action: :profile}, html: {multipart: true}) do |form| %>
 
-    <%= submit_tag(:profile_button.l, class: "center-block btn") %>
-    <div class="form-group">
-      <label for="user_name"><%= :profile_name.t %>:</label>
-      <%= form.text_field("name", class: "form-control") %>
-    </div>
-    <div class="form-group">
-      <label for="user_place_name"><%= :profile_location.t %></label> (33%)<br/>
-      <%= text_field('user', 'place_name', value: @place_name, class: "form-control") %>
-      <% turn_into_location_auto_completer("user_place_name") %>
-    </div>
-    <div class="form-group">
-      <label for="user_notes"><%= :profile_notes.t %></label> (33%)
-      <%= form.text_area("notes", rows: 6, class: "form-control") %>
-    </div>
-    <div class="form-group">
-      <label for="user_upload_image"><%= @user.image_id ?
-                                                 :profile_image_change.t : :profile_image_create.t %></label> (33%)
-      <%= link_to(:profile_image_reuse.t, controller: :image, action: :reuse_image, mode: :profile) %>
-      <%= link_to(:profile_image_remove.t, {action: :remove_image},
-                  {data: {confirm: :are_you_sure.l}}) if @user.image %>
-      <%= image_file_field(:user, :upload_image) %>
-    </div>
-    <div class="form-group">
-      <label for="copyright_holder"><%= :profile_copyright_holder.t %></label>
+      <%= submit_tag(:profile_button.l, class: "btn center-block push-down") %>
 
-      <div class="row">
-        <div class="col-sm-8">
-          <%= text_field_tag("copyright_holder", @copyright_holder, class: "form-control") %>
-        </div>
-        <div class="col-sm-4">
-          <%= select_year(@copyright_year, {field_name: "copyright_year",
-                                            start_year: 1980, end_year: Time.now.year}, {class: "form-control"}) %>
-        </div>
+      <div class="form-group push-down">
+        <%= label_tag(:user_name, :profile_name.t) %>:
+        <%= form.text_field(:name, class: "form-control") %>
       </div>
-    </div>
-    <div class="form-group">
-      <%= select("upload", "license_id", @licenses, {selected: @upload_license_id}, {class: "form-control"}) %>
-      <p class="help-block">(<%= :profile_copyright_warning.t %>)</p>
-    </div>
-    <div class="form-group">
-      <label for="user_mailing_address"><%= :profile_mailing_address.t %></label>
-      <%= form.text_area("mailing_address", rows: 5, class: "form-control") %>
-    </div>
-    <%= submit_tag(:profile_button.l, class: "center-block btn") %>
-<% end %>
+
+      <div class="form-group push-down">
+        <%= label_tag(:user_place_name, :profile_location.t) %>: (33%)
+        <%= text_field(:user, :place_name, value: @place_name, class: "form-control") %>
+        <% turn_into_location_auto_completer("user_place_name") %>
+      </div>
+
+      <div class="form-group push-down">
+        <%= label_tag(:user_notes, :profile_notes.t) %>: (33%)
+        <%= form.text_area(:notes, rows: 10, class: "form-control") %>
+      </div>
+
+      <div class="form-group push-down">
+        <%= label_tag(:user_upload_image, @user.image_id ? :profile_image_change.t : :profile_image_create.t) %>: (33%)
+        <%= link_to(:profile_image_reuse.t, controller: :image, action: :reuse_image, mode: :profile) %>
+        <%= link_to(:profile_image_remove.t, {action: :remove_image},
+                    {data: {confirm: :are_you_sure.l}}) if @user.image %>
+        <%= image_file_field(:user, :upload_image) %>
+      </div>
+
+      <div class="form-group push-down">
+        <%= label_tag(:copyright_holder, :profile_copyright_holder.t) %>:
+        <div class="row">
+          <div class="col-xs-8">
+            <%= text_field_tag(:copyright_holder, @copyright_holder, class: "form-control") %>
+          </div>
+          <div class="col-xs-4">
+            <%= select_year(@copyright_year,
+                  {field_name: :copyright_year, start_year: 1980, end_year: Time.now.year},
+                  {class: "form-control"}) %>
+          </div>
+        </div>
+        <div class="push-down">
+          <%= select(:upload, :license_id, @licenses, {selected: @upload_license_id}, {class: "form-control"}) %>
+        </div>
+        <div class="help-block">(<%= :profile_copyright_warning.t %>)</div>
+      </div>
+
+      <div class="form-group push-down">
+        <%= label_tag(:user_mailing_address, :profile_mailing_address.t) %>:
+        <%= form.text_area(:mailing_address, rows: 5, class: "form-control") %>
+      </div>
+
+      <%= submit_tag(:profile_button.l, class: "btn center-block push-down") %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/reverify.html.erb
+++ b/app/views/account/reverify.html.erb
@@ -1,6 +1,8 @@
-<% @title = :email_welcome.t(:user => @unverified_user.legal_name) %>
+<% @title = :email_welcome.t(user: @unverified_user.legal_name) %>
 
-<div class="memo">
-  <%= :reverify_note.tp(:user => @unverified_user.login) %>
-  <%= link_to(:reverify_link.t, :action => "send_verify", :id => @unverified_user.id) %>  
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= :reverify_note.tp(user: @unverified_user.login) %>
+    <%= link_to(:reverify_link.t, action: :send_verify, id: @unverified_user.id) %>
+  </div>
 </div>

--- a/app/views/account/show_alert.html.erb
+++ b/app/views/account/show_alert.html.erb
@@ -1,24 +1,30 @@
-<% @title = :user_alert_show_title.t(:user => @user.legal_name) %>
+<% @title = :user_alert_show_title.t(user: @user.legal_name) %>
 
-<%= form_tag(:action => "show_alert") do %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :show_alert) do %>
+      <input type="hidden" id="back" name="back" value="<%= escape_once(@back)%>" />
 
-  <div class="memo">
-    <%= @user.alert_message.tp(
-      :email      => @user.email,
-      :login      => @user.login,
-      :last_login => @user.last_login,
-      :time       => @user.alert_created_at.web_time,
-      :notes      => @user.alert_notes
-    ) %>
+      <div class="form-group push-down">
+        <%= @user.alert_message.tp(
+          email:      @user.email,
+          login:      @user.login,
+          last_login: @user.last_login,
+          time:       @user.alert_created_at.web_time,
+          notes:      @user.alert_notes
+        ) %>
+      </div>
+
+      <div class="form-group push-down form-inline">
+        <%= submit_tag(:user_alert_okay.l, class: "btn") %>
+        <%= :user_alert_okay_help.t %>
+      </div>
+
+      <div class="form-group push-down form-inline">
+        <%= submit_tag(:user_alert_later.l, class: "btn") %>
+        <%= :user_alert_later_help.t %>
+      </div>
+
+    <% end %>
   </div>
-
-  <input type="hidden" id="back" name="back" value="<%= escape_once(@back)%>" />
-
-  <br/><br/>
-  <input type="submit" name="commit" value="<%= :user_alert_okay.l %>" class="btn" />
-  <%= :user_alert_okay_help.t %>
-
-  <br/><br/>
-  <input type="submit" name="commit" value="<%= :user_alert_later.l %>" class="btn" />
-  <%= :user_alert_later_help.t %>
-<% end %>
+</div>

--- a/app/views/account/signup.html.erb
+++ b/app/views/account/signup.html.erb
@@ -1,26 +1,42 @@
 <% @title = :signup_title.t %>
 
-<%= form_tag(:action=> "signup") do %>
-  
-  <label for="new_user_login"><%= :signup_login.t %>:</label><br/>
-  <%= text_field(:new_user, :login, size: 30, autofocus: true) %><br/><br/>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= form_tag(action: :signup) do %>
+      
+      <div class="form-group push-down">
+        <%= label_tag(:new_user_login, :signup_login.t) %>:
+        <%= text_field(:new_user, :login, data: {autofocus: true}, class: "form-control") %>
+      </div>
 
-  <label for="new_user_password"><%= :signup_choose_password.t %>:</label><br/>
-  <%= password_field "new_user", "password", :size => 30, :value => @new_user.password %><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:new_user_password, :signup_choose_password.t) %>:
+        <%= password_field(:new_user, :password, value: @new_user.password, class: "form-control") %>
+      </div>
 
-  <label for="new_user_password_confirmation"><%= :signup_confirm_password.t %>:</label><br/>
-  <%= password_field "new_user", "password_confirmation", :size => 30 %><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:new_user_password_confirmation, :signup_confirm_password.t) %>:
+        <%= password_field(:new_user, :password_confirmation, class: "form-control") %>
+      </div>
 
-  <label for="new_user_email"><%= :signup_email_address.t %>:</label><br/>
-  <%= text_field "new_user", "email", :size => 60 %><br/>
-  <div class="HelpNote"><%= :signup_email_help.tp %></div><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:new_user_email, :signup_email_address.t) %>:
+        <%= text_field(:new_user, :email, class: "form-control") %>
+        <div class="HelpNote"><%= :signup_email_help.tp %></div>
+      </div>
 
-  <label for="new_user_name"><%= :signup_name.t %>:</label><br/>
-  <%= text_field "new_user", "name", :size => 60 %><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:new_user_name, :signup_name.t) %>:
+        <%= text_field(:new_user, :name, class: "form-control") %>
+      </div>
 
-  <label for="new_user_name"><%= :signup_preferred_theme.t %>:</label><br/>
-  <%= select(:new_user, :theme, [[:theme_random.l, "NULL"]] + MO.themes) %><br/><br/>
+      <div class="form-group push-down">
+        <%= label_tag(:new_user_name, :signup_preferred_theme.t) %>:
+        <%= select(:new_user, :theme, [[:theme_random.l, "NULL"]] + MO.themes, class: "form-control") %>
+      </div>
 
-  <input type="submit" value="<%= :signup_button.l %>" class="btn" />
+      <%= submit_tag(:signup_button.l, class: "btn center-block push-down") %>
 
-<% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/account/test_autologin.html.erb
+++ b/app/views/account/test_autologin.html.erb
@@ -1,1 +1,5 @@
-<p>This page is used to test the autologin feature.</p>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <p>This page is used to test the autologin feature.</p>
+  </div>
+</div>

--- a/app/views/account/verify.html.erb
+++ b/app/views/account/verify.html.erb
@@ -1,5 +1,7 @@
-<% @title = :email_welcome.t(:user => @user.legal_name) %>
+<% @title = :email_welcome.t(user: @user.legal_name) %>
 
-<div class="memo">
-  <%= :verify_note.tp(:domain => MO.http_domain) %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <%= :verify_note.tp(domain: MO.http_domain) %>
+  </div>
 </div>

--- a/app/views/account/welcome.html.erb
+++ b/app/views/account/welcome.html.erb
@@ -1,10 +1,12 @@
-<% @title = @user ? :email_welcome.t(:user => @user.legal_name) : :welcome_no_user_title.t %>
+<% @title = @user ? :email_welcome.t(user: @user.legal_name) : :welcome_no_user_title.t %>
 
-<div class="memo">
-  <% if @user %>
-    <%= :welcome_note.tp %>
-    <%= link_to(:welcome_logout_link.t, :action => "logout_user") %>
-  <% else %>
-    <%= :welcome_no_user_note.tp %>
-  <% end %>
+<div class="row">
+  <div class="col-xs-12 max-text-width">
+    <% if @user %>
+      <%= :welcome_note.tp %>
+      <%= link_to(:welcome_logout_link.t, action: :logout_user) %>
+    <% else %>
+      <%= :welcome_no_user_note.tp %>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
Also fixed bug in api key manager: jquery.show() doesn't seem to be able to show something hidden with class="hidden".  Changed it to "display:none" and now jquery.show() can manage it.  Weird.  I could've sworn this worked before.

Also added data-autofocus as an alternative to plain vanilla autofocus.  I don't know about other browsers, but autofocus causes firefox to scroll stupidly down the page, hiding the title and stuff.  If instead wewait until the page is loaded and then focus on the first element with data-autofocus=true, then it just focuses without scrolling.