### PR TITLE
Modernized comment views.

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -6,7 +6,11 @@ jQuery(document).ready(function () {
     // normal autofocus causes it to scroll window hiding title etc.
     jQuery('[data-autofocus=true]').first().focus();
 
-    jQuery('[data-toggle="tooltip"]').tooltip({container: 'body'}); //enable tooltips
+    jQuery('[data-role=link]').on('click', function() {
+      window.location = jQuery(this).attr('data-url');
+    });
+
+    jQuery('[data-toggle="tooltip"]').tooltip({container: 'body'});
 
     jQuery('[data-toggle="offcanvas"]').click(function () {
         jQuery(document).scrollTop(0);
@@ -17,7 +21,7 @@ jQuery(document).ready(function () {
 
     jQuery('[data-toggle="search"]').click(function () {
         jQuery(document).scrollTop(0);
-        var target = $(this).data().target;
+        var target = jQuery(this).data().target;
         jQuery(target).css('margin-top', '32px');
         jQuery(target).toggleClass('hidden-xs');
     });
@@ -51,7 +55,7 @@ jQuery(document).ready(function () {
         jQuery(document).on('keyup.hideTheater', function (e){
             if (e.keyCode == 27) {
                 hideTheater();
-                $(document).unbind('keyup.hideTheater');
+                jQuery(document).unbind('keyup.hideTheater');
             }
         })
     });
@@ -86,12 +90,12 @@ jQuery(document).ready(function () {
     jQuery('#carousel .item').each(function () {
         var next = jQuery(this).next();
         if (next)
-            next.children(':first-child').clone().addClass("extra1").appendTo($(this));
+            next.children(':first-child').clone().addClass("extra1").appendTo(jQuery(this));
 
         for (var i = 0; i < 2; i++) {
             next = next.next();
             if (next)
-                next.children(':first-child').clone().addClass("extra" + (i + 2)).appendTo($(this));
+                next.children(':first-child').clone().addClass("extra" + (i + 2)).appendTo(jQuery(this));
         }
         jQuery('[data-toggle="tooltip"]').tooltip({container: 'body'}); //enable tooltips
     });

--- a/app/assets/stylesheets/defaults.scss
+++ b/app/assets/stylesheets/defaults.scss
@@ -32,6 +32,7 @@ $BUTTON_BORDER_RADIUS:              5px;
 
 $INPUT_FG_COLOR:                    #000000;
 $INPUT_BG_COLOR:                    #FFFFFF;
+  $INPUT_BG_COLOR:                    #FFFF00;
 $INPUT_BORDER_COLOR:                #CCCCCC;
 $INPUT_BORDER_WIDTH:                1px;
 $INPUT_BORDER_STYLE:                solid;

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -864,8 +864,12 @@ a.p4, a.p4:visited { color: #3b2821; background: #FF0 }
     white-space: nowrap;
 }
 
-.max-text-width {
+.max-width-text {
     max-width: 600px;
+}
+
+.max-width-text-plus-image {
+    max-width: 850px; // 600px text column + 160pm max thumbnail
 }
 
 //
@@ -889,6 +893,10 @@ input[type=checkbox] {
     // fixes alignment issue in firefox; bootstrap applies this only to IE9:
     // margin-top: 1px \9;
     margin-top: 1px;
+}
+
+[data-role=link]:hover {
+    cursor: pointer;
 }
 
 //

--- a/app/models/image/url.rb
+++ b/app/models/image/url.rb
@@ -1,7 +1,6 @@
 class Image
   class Url
     SUBDIRECTORIES = {
-        original: 'orig',
         full_size: 'orig',
         huge: '1280',
         large: '960',
@@ -24,6 +23,7 @@ class Image
     def initialize(args)
       size = args[:size]
       size = SUBDIRECTORY_TO_SIZE[size] if !size.is_a?(Symbol)
+      size = :full_size if size == :original
       self.size        = size
       self.id          = args[:id]
       self.transferred = args[:transferred]

--- a/app/views/account/add_user_to_group.html.erb
+++ b/app/views/account/add_user_to_group.html.erb
@@ -1,7 +1,7 @@
 <% @title = :add_user_to_group_title.t %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :add_user_to_group) do %>
 
       <div class="form-group push-down">

--- a/app/views/account/api_keys.html.erb
+++ b/app/views/account/api_keys.html.erb
@@ -10,7 +10,7 @@
 %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= :account_api_keys_help.tp %>
   </div>
 </div>
@@ -68,7 +68,7 @@
 </div>
 
 <div class="row push-down">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_for(:key) do |form| %>
       <div class="form-group push-down">
         <%= label_tag(:notes, :account_api_keys_notes_label.t) %>

--- a/app/views/account/choose_password.html.erb
+++ b/app/views/account/choose_password.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :verify, id: @user.id, auth_code: @user.auth_code) do %>
 
       <div class="form-group push-down">

--- a/app/views/account/create_alert.html.erb
+++ b/app/views/account/create_alert.html.erb
@@ -1,7 +1,7 @@
 <% @title = :user_alert_create_title.t(user: @user2.legal_name) %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :create_alert, id: @user2.id) do %>
 
       <% if @user2.alert_created_at %>

--- a/app/views/account/edit_api_key.html.erb
+++ b/app/views/account/edit_api_key.html.erb
@@ -8,7 +8,7 @@
 %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= :account_api_keys_help.tp %>
 
     <%= form_for(:key, url: {id: @key.id}) do |form| %>

--- a/app/views/account/email_new_password.html.erb
+++ b/app/views/account/email_new_password.html.erb
@@ -1,7 +1,7 @@
 <% @title = :email_new_password_title.t %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :email_new_password) do %>
 
       <div class="form-group">

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -1,7 +1,7 @@
 <% @title = :login_please_login.t %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :login) do %>
 
       <div class="form-group push-down">

--- a/app/views/account/logout_user.html.erb
+++ b/app/views/account/logout_user.html.erb
@@ -1,7 +1,7 @@
 <% @title = :logout_title.t %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= :logout_note.tp %>
   </div>
 </div>

--- a/app/views/account/no_email.html.erb
+++ b/app/views/account/no_email.html.erb
@@ -1,7 +1,7 @@
 <% @title = :email_welcome.t(user: @user.legal_name) %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= @note.tp %>
     <%= :no_email_how_to_reenable.tp %>
     <%= :no_email_some_maybe_queued.tp %>

--- a/app/views/account/prefs.html.erb
+++ b/app/views/account/prefs.html.erb
@@ -11,7 +11,7 @@
 %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_for(:user, url: {action: :prefs}) do |form| %>
 
       <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>

--- a/app/views/account/profile.html.erb
+++ b/app/views/account/profile.html.erb
@@ -13,7 +13,7 @@
 %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_for(:user, url: {action: :profile}, html: {multipart: true}) do |form| %>
 
       <%= submit_tag(:profile_button.l, class: "btn center-block push-down") %>

--- a/app/views/account/reverify.html.erb
+++ b/app/views/account/reverify.html.erb
@@ -1,7 +1,7 @@
 <% @title = :email_welcome.t(user: @unverified_user.legal_name) %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= :reverify_note.tp(user: @unverified_user.login) %>
     <%= link_to(:reverify_link.t, action: :send_verify, id: @unverified_user.id) %>
   </div>

--- a/app/views/account/show_alert.html.erb
+++ b/app/views/account/show_alert.html.erb
@@ -1,7 +1,7 @@
 <% @title = :user_alert_show_title.t(user: @user.legal_name) %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :show_alert) do %>
       <input type="hidden" id="back" name="back" value="<%= escape_once(@back)%>" />
 

--- a/app/views/account/signup.html.erb
+++ b/app/views/account/signup.html.erb
@@ -1,7 +1,7 @@
 <% @title = :signup_title.t %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= form_tag(action: :signup) do %>
       
       <div class="form-group push-down">

--- a/app/views/account/test_autologin.html.erb
+++ b/app/views/account/test_autologin.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <p>This page is used to test the autologin feature.</p>
   </div>
 </div>

--- a/app/views/account/verify.html.erb
+++ b/app/views/account/verify.html.erb
@@ -1,7 +1,7 @@
 <% @title = :email_welcome.t(user: @user.legal_name) %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <%= :verify_note.tp(domain: MO.http_domain) %>
   </div>
 </div>

--- a/app/views/account/welcome.html.erb
+++ b/app/views/account/welcome.html.erb
@@ -1,7 +1,7 @@
 <% @title = @user ? :email_welcome.t(user: @user.legal_name) : :welcome_no_user_title.t %>
 
 <div class="row">
-  <div class="col-xs-12 max-text-width">
+  <div class="col-xs-12 max-width-text">
     <% if @user %>
       <%= :welcome_note.tp %>
       <%= link_to(:welcome_logout_link.t, action: :logout_user) %>

--- a/app/views/comment/_comment.html.erb
+++ b/app/views/comment/_comment.html.erb
@@ -1,43 +1,53 @@
+<%
+  target = comment.target
+  user = comment.user
+  user_url = url_for(controller: :observer, action: :show_user, id: user.id)
+%>
+
 <div class="list-group comment">
   <div class="list-group-item default">
-    <div class="row">
-      <div class="col-sm-6">
-	<% if local_assigns[:show_name] && show_name
-	     target = comment.target %>
-          <%= link_to(content_tag(:h4, target.unique_format_name.t,
-                                  class: 'ListWhat'),
-                      controller: target.show_controller,
-                      action: target.show_action,
-                      id: target.id) rescue :comment_list_deleted.t %>
-          (<span><%= target.class.name.to_sym.t rescue :runtime_object_deleted %></span>)<br/>
-	<% end %>
-        <strong><%= comment.summary.tl %></strong><br/>
-        <%= :BY.t %>: <%= user_link(comment.user) %>
+
+    <% if user.image_id %>
+      <div class="hidden-xs" style="float:right; width:25%; max-width:160px; max-height:160px; text-align:center">
+        <%= image_tag(Image.url(:thumbnail, user.image_id),
+                      style: "max-width:100%; max-height:100%",
+                      data: {role: "link", url: user_url}) %>
+      </div>
+    <% end %>
+
+    <% if local_assigns[:show_name] && show_name %>
+      <h4 style="margin-top:0">
+        <%= link_to(target.unique_format_name.t,
+                    controller: target.show_controller, action: target.show_action, id: target.id) \
+                    rescue :comment_list_deleted.t %>
+        <small>(<%= target.class.name.to_sym.t rescue :runtime_object_deleted %>)</small>
+      </h4>
+    <% end %>
+
+    <div class="bold">
+      <%= comment.summary.tl %>
+    </div>
+
+    <div class="max-width-text">
+      <%= :BY.t %>: <%= user_link(user) %>
         <% if check_permission(comment) %>
-            [<%= link_with_query(:EDIT.t, controller: 'comment',
-                                 action: 'edit_comment', id: comment.id) %> |
-            <%= link_with_query(:DESTROY.t, {controller: 'comment',
-                                             action: 'destroy_comment', id: comment.id},
+          <span class="nowrap">
+            [<%= link_with_query(:EDIT.t, controller: :comment, action: :edit_comment, id: comment.id) %> |
+            <%= link_with_query(:DESTROY.t, {controller: :comment, action: :destroy_comment, id: comment.id},
                                 {data: {confirm: :are_you_sure.l}}) %>]
-        <% end %><br/>
-      </div>
-      <div class="col-sm-6">
-        <small class="pull-right"><%= comment.created_at.web_time %></small>
-      </div>
-    </div>
-  </div>
-  <div class="list-group-item">
-    <div class="row">
-      <div class="col-sm-9">
-        <div class="pad-box"> <%= comment.comment.tpl %> </div>
-      </div>
-      <div class="col-sm-3 hidden-xs">
-        <% user = comment.user
-           if user.image_id %>
-            <%= link_to(image_tag(Image.url(:thumbnail, user.image_id), class: "img-responsive"),
-                        {controller: :observer, action: :show_user, id: user.id}) %>
+          </span>
         <% end %>
-      </div>
+        <div class="pull-right nowrap small" style="margin:0 1em">
+          <%= comment.created_at.web_time %>
+        </div>
     </div>
+
+    <div class="pad-box max-width-text push-down">
+      <%= comment.comment.tpl %>
+    </div>
+
+    <% if user.image_id %>
+      <div style="clear:right"></div>
+    <% end %>
   </div>
 </div>

--- a/app/views/comment/_form_comments.html.erb
+++ b/app/views/comment/_form_comments.html.erb
@@ -1,10 +1,14 @@
 <!--[form:comment]-->
 
-<label for="comment_summary"><%= :form_comments_summary.t %></label>:<br/>
-<%= text_field("comment", "summary", size: 80, autofocus: true) %><br/><br/>
+<div class="form-group push-down">
+  <%= label_tag(:comment_summary, :form_comments_summary.t) %>:
+  <%= text_field(:comment, :summary, size: 80, data: {autofocus: true}, class: "form-control") %>
+</div>
 
-<label for="comment_comment"><%= :form_comments_comment.t %></label>:<br/>
-<%= text_area("comment", "comment", :cols => 80, :rows => 10) %><br/>
-<%= render(:partial => 'shared/textilize_help') %>
+<div class="form-group push-down">
+  <%= label_tag(:comment_comment, :form_comments_comment.t) %>:
+  <%= text_area(:comment, :comment, rows: 10, class: "form-control") %>
+  <%= render(partial: "shared/textilize_help") %>
+</div>
 
 <!--[eoform:comment]-->

--- a/app/views/comment/_object.html.erb
+++ b/app/views/comment/_object.html.erb
@@ -1,38 +1,35 @@
 <%= case object.class.name
 
-  when 'Location'
-    render(:partial => 'location/location', :object => object)
+  when "Location"
+    render(partial: "location/location", object: object)
 
-  when 'LocationDescription'
-    render(:partial => 'location/location_description', :object => object)
+  when "LocationDescription"
+    render(partial: "location/location_description", object: object)
 
-  when 'Name'
-    str = render(:partial => 'name/name', :object => object, :locals =>
-                 {synonyms: true})
+  when "Name"
+    str = render(partial: "name/name", object: object, locals: {synonyms: true})
     if object.has_notes?
-      str += '<p>' + :show_name_notes.t + ':</p>'
+      str += "<p>" + :show_name_notes.t + ":</p>"
       str += colored_notes_box(true, object.notes.tpl)
     end
     str
 
-  when 'NameDescription'
-    render(:partial => 'name/name_description', :object => object,
-           :locals => {review: false})
+  when "NameDescription"
+    render(partial: "name/name_description", object: object, locals: {review: false})
 
-  when 'Observation'
-    render(:partial => 'observer/show_observation',
-           :locals => {observation: object})
+  when "Observation"
+    render(partial: "observer/show_observation", locals: {observation: object})
 
-  when 'Project'
-    render(:partial => 'project/project', :object => object)
+  when "Project"
+    render(partial: "project/project", object: object)
 
-  when 'SpeciesList'
-    render(:partial => 'species_list/species_list', :object => object)
+  when "SpeciesList"
+    render(partial: "species_list/species_list", object: object)
 
   else
     raise("We appear to have forgotten to tell add/edit_comment " +
           "how to display objects of type \"#{object.class.name}\".")
 end %>
 
-<%= render(:partial => 'show_comments', :locals =>
-           {object: object, controls: false, limit: 10}) %>
+<%= render(partial: "show_comments",
+           locals: {object: object, controls: false, limit: 10}) %>

--- a/app/views/comment/_show_comments.html.erb
+++ b/app/views/comment/_show_comments.html.erb
@@ -7,19 +7,20 @@
 %>
 
 <div class="row">
-  <div class="col-sm-12 col-lg-8">
-    <%= content_tag(:h4, comments.empty? ? :"show_comments_no_comments_yet".t : :COMMENTS.t, style: "display: inline-block") %>
-    <%= link_with_query(:"show_comments_add_comment".t,
+  <div class="col-xs-12 max-width-text-plus-image">
+    <%= content_tag(:h4, comments.empty? ? :"show_comments_no_comments_yet".t : :COMMENTS.t,
+                    class: "push-down", style: "display:inline-block") %>
+    <%= link_with_query(:show_comments_add_comment.t,
                         {controller: :comment, action: :add_comment, id: object.id, type: object.class.name},
-                        class: "pull-right") if controls     %>
+                        class: "pull-right") if controls %>
+
+    <% comments.each do |comment| %>
+      <%= render(partial: "comment/comment", object: comment) %>
+    <% end %>
+
+    <%= if limit && and_more > 0
+      link_to(:show_comments_and_more.t(num: and_more),
+              {controller: :comment, action: :show_comments_for_target, id: object.id, type: object.class.name})
+    end %>
   </div>
 </div>
-
-<% comments.each do |comment| %>
-  <%= render(:partial => 'comment/comment', :object => comment) %>
-<% end %>
-
-<%= if limit and (and_more > 0)
-  link_to(:show_comments_and_more.t(:num => and_more),
-          {controller: :comment, action: :show_comments_for_target, id: object.id, type: object.class.name})
-end %>

--- a/app/views/comment/add_comment.html.erb
+++ b/app/views/comment/add_comment.html.erb
@@ -1,20 +1,24 @@
 <%
-   @title = :comment_add_title.t(:name => @target.unique_format_name)
-   @tabsets = {
-           right: render(partial: "shared/tab_set", locals: {links: [link_with_query(
-                                                                            :cancel_and_show.t(:type => @comment.target_type.underscore.upcase.to_sym),
-                                                                            :controller => @target.show_controller, :action => @target.show_action,
-                                                                            :id => @target.id)]})
-   }
+  @title = :comment_add_title.t(:name => @target.unique_format_name)
+  @tabsets = {
+    right: render(partial: "shared/tab_set", locals: {
+      links: [
+        link_with_query(:cancel_and_show.t(type: @comment.target_type.underscore.upcase.to_sym),
+                        controller: @target.show_controller, action: @target.show_action, id: @target.id)
+      ]
+    })
+  }
 %>
 
-<div class="col-md-6">
-<%= form_tag(add_query_param(:action => 'add_comment', :id => @comment.target_id,
-                             :type => @comment.target_type)) do %>
-    <center><%= submit_tag(:comment_add_create.l, class: "btn") %></center>
-    <%= render(:partial => 'form_comments') %>
-    <center><%= submit_tag(:comment_add_create.l, class: "btn") %></center>
-    <hr/>
-    <%= render(:partial => 'object', :object => @target) %>
-<% end %>
+<div class="row">
+  <div class="col-xs-12 max-width-text">
+    <%= form_tag(add_query_param(action: :add_comment, id: @comment.target_id, type: @comment.target_type)) do %>
+      <%= submit_tag(:comment_add_create.l, class: "btn center-block push-down") %>
+      <%= render(partial: "form_comments") %>
+      <%= submit_tag(:comment_add_create.l, class: "btn center-block push-down") %>
+      <hr align="center" width="90%" />
+    <% end %>
+  </div>
 </div>
+
+<%= render(partial: "object", object: @target) %>

--- a/app/views/comment/edit_comment.html.erb
+++ b/app/views/comment/edit_comment.html.erb
@@ -1,15 +1,20 @@
 <%
-  @title = :comment_edit_title.t(:name => @target.unique_format_name)
-
+  @title = :comment_edit_title.t(name: @target.unique_format_name)
   new_tab_set do
-    add_tab_with_query(:cancel_and_show.t(:type => :comment),
-      :action => 'show_comment', :id => @comment.id)
+    add_tab_with_query(:cancel_and_show.t(type: :comment),
+      controller: :comment, action: :show_comment, id: @comment.id)
   end
 %>
 
-<%= form_tag(add_query_param(:action => 'edit_comment', :id => @comment.id)) do %>
-  <br/><center><%= submit_tag(:SAVE_EDITS.l, class: "btn") %></center>
-  <%= render(:partial => 'form_comments') %>
-  <br/><hr align="center" width="90%" />
-  <%= render(:partial => 'object', :object => @comment.target) %>
-<% end %>
+<div class="row">
+  <div class="col-xs-12 max-width-text">
+    <%= form_tag(add_query_param(action: :edit_comment, id: @comment.id)) do %>
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <%= render(partial: "form_comments") %>
+      <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>
+      <hr align="center" width="90%" />
+    <% end %>
+  </div>
+</div>
+    
+<%= render(partial: "object", object: @target) %>

--- a/app/views/comment/list_comments.html.erb
+++ b/app/views/comment/list_comments.html.erb
@@ -1,10 +1,14 @@
 <%
-   #new_tab_set(@links)  //no links were generated here, not sure why this is here RJS
-   flash_error(@error) if @error and (!@objects or @objects.empty?)
+  new_tab_set(@links) if @links && @links.any?
+  flash_error(@error) if @error && (!@objects || @objects.empty?)
 %>
 
-<%= paginate_block(@pages) do %>
-    <% for comment in @objects %>
-        <%= render(partial: 'comment', object: comment, locals: { show_name: true } ) %>
+<div class="row">
+  <div class="col-xs-12 max-width-text-plus-image">
+    <%= paginate_block(@pages) do %>
+      <% for comment in @objects %>
+        <%= render(partial: "comment", object: comment, locals: {show_name: true}) %>
+      <% end %>
     <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/views/comment/show_comment.html.erb
+++ b/app/views/comment/show_comment.html.erb
@@ -1,17 +1,17 @@
 <%
-  @title = :comment_show_title.t(:name => @target.unique_format_name)
+  @title = :comment_show_title.t(name: @target.unique_format_name)
   target_type = @comment.target_type_localized
 
-  # Register pertinent names so that Textile know what the "G." in "_G.
+  # Register pertinent names so that Textile knows what the "G." in "_G.
   # species_" stands for.  Include all proposed names, because there's no
   # telling which names will be referred to in the comment.  Likewise, include
   # all synonyms if commenting on taxonomy of Name.
-  if @comment.target_type == 'Observation'
+  if @comment.target_type == "Observation"
     for naming in @comment.target.namings
       Textile.register_name(naming.name)
     end
     Textile.register_name(@comment.target.name)
-  elsif @comment.target_type == 'Name'
+  elsif @comment.target_type == "Name"
     for name in @comment.target.synonyms
       Textile.register_name(name)
     end
@@ -19,23 +19,25 @@
   end
 
   new_tab_set do
-    add_tab_with_query(:comment_show_show.t(:type => target_type),
-      :controller => @target.show_controller,
-      :action => @target.show_action, :id => @target.id)
+    add_tab_with_query(:comment_show_show.t(type: target_type),
+      controller: @target.show_controller, action: @target.show_action, id: @target.id)
     if check_permission(@comment)
       add_tab_with_query(:comment_show_edit.t,
-        :action => 'edit_comment', :id => @comment.id)
+        controller: :comment, action: :edit_comment, id: @comment.id)
       add_tab_with_query(:comment_show_destroy.t,
-        {action: 'destroy_comment', id: @comment.id},
-        { data: { confirm: :are_you_sure.l } })
+        {controller: :comment, action: :destroy_comment, id: @comment.id},
+        {data: {confirm: :are_you_sure.l}})
     end
   end
 
   draw_prev_next_tabs(@comment)
 %>
 
-<p><%= :comment_show_created_at.t %>: <%= @comment.created_at.web_time %></p>
-<p><%= :comment_show_by.t %>: <%= user_link(@comment.user) %></p>
-<p><%= :comment_show_summary.t %>: <%= (@comment.summary).tl %></p>
-<%= (:comment_show_comment.l + ': ' + @comment.comment.to_s.html_safe).tpl %>
-
+<div class="row">
+  <div class="col-xs-12 max-width-text">
+    <p><%= :comment_show_created_at.t %>: <%= @comment.created_at.web_time %></p>
+    <p><%= :comment_show_by.t %>: <%= user_link(@comment.user) %></p>
+    <p><%= :comment_show_summary.t %>: <%= (@comment.summary).tl %></p>
+    <%= (:comment_show_comment.l + ": " + @comment.comment.to_s.html_safe).tpl %>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,11 +31,16 @@ MushroomObserver::Application.configure do
     },
     cdmr: {
       test: :transferred_flag,
-      read: "http://images.digitalmycology.com"
+      read: "http://images.mushroomobserver.org/cdmr"
+    },
+    cdmr_s3: {
+      test: :transferred_flag,
+      read: "http://mo-images.digitalmycology.com"
     }
   }
   config.image_precedence = {
-    default: [:local, :cdmr]
+    default:   [:local, :cdmr],
+    full_size: [:local, :cdmr_s3]
   }
   config.image_fallback_source = :cdmr
 


### PR DESCRIPTION
Fixed but in Image::Url associated with :original size.
Tweaked comment/_comment view.

Ray, check what I've done with comment/_comment.  It fits the image and date a little differently, taking up significantly less space at most screen sizes.  It also sets a max size on the image (maxes out at 160x160, the bounding box of the source image itself).  I kinda had to remove the line between subject and body, but maybe there's still a way to include it sorta under the thumbnail image(?)

I've been setting max-width on all the content, as well, to avoid over-long text lines.  That should be configurable via the max-width-text and max-width-text-plus-image classes if I've made things too narrow for your tastes.