### PR TITLE
Various style work:

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -41,21 +41,25 @@ jQuery(document).ready(function () {
     });
 
     jQuery('body').delegate('[data-toggle="theater"]', 'click', function (e) {
-        console.log('click');
         e.preventDefault();
-        var img_src = jQuery(this).data().image;
-        var img_orig = jQuery(this).data().original;
-        jQuery('.img-theater').css('top', jQuery(document).scrollTop())
-        jQuery('.img-theater').show();
         jQuery('body').addClass('theater-shown');
-        jQuery('#img_append_target').html('<a href="{{orig}}"><img src="{{src}}" style="height: {{h}}; width: auto;"><//img><//a>'
-            .replace("{{src}}", img_src)
-            .replace("{{orig}}", img_orig)
-            .replace("{{h}}", jQuery(window).height() - 20 + 'px'))
-        jQuery(document).on('keyup.hideTheater', function (e){
+        var win = jQuery(window),
+            doc = jQuery(document),
+            div = jQuery('.img-theater-div'),
+            w = win.width(),
+            h = win.height(),
+            img_orig = jQuery(this).data().orig,
+            img_src = w-40 > 1280 || h-40 > 1280 ? jQuery(this).data().full :
+                      w-40 > 960  || h-40 > 960  ? jQuery(this).data().huge :
+                                                   jQuery(this).data().large;
+        div.html('<img><//img>');
+        div.find('img').attr('src', img_src)
+                       .click(function() { window.location = img_orig });
+        jQuery('.img-theater').css('top', doc.scrollTop()).show();
+        doc.on('keyup.hideTheater', function (e) {
             if (e.keyCode == 27) {
                 hideTheater();
-                jQuery(document).unbind('keyup.hideTheater');
+                doc.unbind('keyup.hideTheater');
             }
         })
     });

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -303,6 +303,10 @@ a:hover {
 // left nav bar
 // --------------------------------------------------
 
+.sidebar-offcanvas {
+    max-width: 15em;
+}
+
 #navigation {
     background-color: $LEFT_BAR_BG_COLOR;
     border-color: $LEFT_BAR_BORDER_COLOR;
@@ -540,16 +544,36 @@ a:hover {
 
 .img-theater {
     position: absolute;
-    top: 0px;
-    background: none repeat scroll 0% 0% rgba(48, 50, 48, 0.55);
+    top: 0;
+    left: 0;
+    margin: 0;
+    padding: 0;
     width: 100%;
     height: 100%;
-    z-index: 999;
+    z-index: 998;
     display: none;
-}
-
-#img_append_target {
-    padding-top: 20px;
+    background: none repeat scroll 0% 0% rgba(48, 50, 48, 0.90);
+    .img-theater-btn {
+        position: absolute;
+        top: 5px;
+        right: 20px;
+        z-index: 999;
+        @include opacity(0.50);
+    }
+    .img-theater-btn:hover {
+        @include opacity(1.00);
+    }
+    .img-theater-div {
+        width: 100%;
+        height: 100%;
+        padding: 20px;
+        text-align: center;
+        img {
+            max-width: 100%;
+            max-height: 100%;
+            vertical-align: middle;
+        }
+    }
 }
 
 //

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1714,10 +1714,18 @@ module ApplicationHelper
       output = "".html_safe
       for object in objects
         body = capture(object, &block).to_s
-        output += content_tag(:div, "", class: "hidden visible-xs-block", style: "clear:left") if idx % 2 == 0
-        output += content_tag(:div, "", class: "hidden visible-sm-block visible-md-block", style: "clear:left") if idx % 3 == 0
-        output += content_tag(:div, "", class: "hidden visible-lg-block", style: "clear:left") if idx % 4 == 0
-        output += content_tag(:div, body, class: "col-xs-6 col-sm-4 col-lg-3")
+        if false ## Maybe give users who want small thumbnails this option?
+          output += content_tag(:div, "", class: "hidden visible-xs-block", style: "clear:left") if idx % 2 == 0
+          output += content_tag(:div, "", class: "hidden visible-sm-block", style: "clear:left") if idx % 3 == 0
+          output += content_tag(:div, "", class: "hidden visible-md-block", style: "clear:left") if idx % 4 == 0
+          output += content_tag(:div, "", class: "hidden visible-lg-block", style: "clear:left") if idx % 6 == 0
+          output += content_tag(:div, body, class: "col-xs-6 col-sm-4 col-md-3 col-lg-2")
+        else
+          output += content_tag(:div, "", class: "hidden visible-sm-block", style: "clear:left") if idx % 2 == 0
+          output += content_tag(:div, "", class: "hidden visible-md-block", style: "clear:left") if idx % 3 == 0
+          output += content_tag(:div, "", class: "hidden visible-lg-block", style: "clear:left") if idx % 4 == 0
+          output += content_tag(:div, body, class: "col-xs-12 col-sm-6 col-md-4 col-lg-3")
+        end
         idx += 1
       end
       output

--- a/app/views/image/_image_thumbnail.html.erb
+++ b/app/views/image/_image_thumbnail.html.erb
@@ -5,9 +5,14 @@
   image, image_id = image.is_a?(Image) ? [image, image.id] : [nil, image]
   size_url  = Image.url(size, image_id)
   large_url = Image.url(:large, image_id)
+  huge_url  = Image.url(:huge, image_id)
+  full_url  = Image.url(:full_size, image_id)
   orig_url  = Image.url(:original, image_id)
-  html_options = {data: {toggle: :theater, image: large_url, original: orig_url}} if theater_on_click
-  html_options = {} if html_options.nil?
+  if theater_on_click
+    html_options[:data] ||= {}
+    html_options[:data] = {toggle: :theater, large: large_url, huge: huge_url,
+                           full: full_url, orig: orig_url}.merge(html_options[:data])
+  end
 %>
 
 <div style="position:relative">
@@ -19,8 +24,9 @@
                           data: {toggle: "tooltip", placement: "bottom"}) %>
       <%= link_with_query(img_tag, link, html_options) %>
       <a href="<%=orig_url%>" class="glyphicon glyphicon-fullscreen theater-btn"
-         data-toggle="theater" data-image="<%= large_url %>"
-         data-original="<%= orig_url %>"></a>
+         data-toggle="theater" data-large="<%= h large_url %>"
+         data-huge="<%= h huge_url %>" data-full="<%= h full_url %>"
+         data-orig="<%= h orig_url %>"></a>
       <div class="push-down">
         <% if User.current and votes and image %>
           <%= render(partial: "image/image_vote_links", locals: {image: image}) %>

--- a/app/views/image/_image_vote_links.html.erb
+++ b/app/views/image/_image_vote_links.html.erb
@@ -14,13 +14,13 @@
 <div id="vote_buttons">
   <div class="image_vote_links_container" id="image_vote_links_<%= image.id %>" style="margin-top:-5px">
     <center>
-      <% if user && !image.users_vote(user).blank? %>
-        <%= image_vote_link(image, 0) %>
-      <% end %>
-      <% Image.all_votes.each do |vote| %>
-        <%= "|" if vote != 1 %>
-        <small><%= image_vote_link(image, vote) %></small>
-      <% end %>
+      <small>
+        <%= if user && !image.users_vote(user).blank?
+          image_vote_link(image, 0) + "&nbsp;".html_safe
+        end %><%= Image.all_votes.map do |vote|
+          image_vote_link(image, vote)
+        end.safe_join("|") %>
+      </small>
     </center>
     <span class="hidden data_container" data-id="<%= image.id %>"
           data-percentage="<%= vote_percentage %>" data-role="image_vote_percentage"></span>

--- a/app/views/image/_theater.html.erb
+++ b/app/views/image/_theater.html.erb
@@ -1,13 +1,5 @@
-<div class="row">
-  <div class="col-sm-1">
-    <button type="button" class="visible-xs close" data-dismiss="theater" style="font-size: 50px; opacity: 1" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-  </div>
-  <div class="col-sm-10">
-    <center>
-      <div id="img_append_target"></div>
-    </center>
-  </div>
-  <div class="col-sm-1">
-    <button type="button" class="hidden-xs close" data-dismiss="theater" style="font-size: 50px; opacity: 1" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-  </div>
+<div class="img-theater-btn">
+  <button type="button" class="close" data-dismiss="theater" style="font-size: 50px; opacity: 1" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+</div>
+<div class="img-theater-div">
 </div>

--- a/app/views/image/list_images.html.erb
+++ b/app/views/image/list_images.html.erb
@@ -3,18 +3,10 @@
   flash_error(@error) if @error and (!@objects or @objects.empty?)
 %>
 
-<div class="row">
-  <div class="col-xs-12">
-    <%= pagination_numbers(@pages) %>
-  </div>
-  <div class="col-xs-12 color-block">
-    <% @objects.each do |image| %>
-      <div class="col-sm-4 color-block-item">
-        <%= render(partial: "shared/matrix_box", locals: {object: image}) %>
-      </div>
-    <% end %>
-  </div>
-  <div class="col-xs-12">
-    <%= pagination_numbers(@pages) %>
-  </div>
-</div>
+<%= paginate_block(@pages) do %>
+  <%= make_matrix(@objects) do |image| %>
+    <div class="push-down push-up">
+      <%= render(partial: "shared/matrix_box", locals: {object: image}) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/image/show_image.html.erb
+++ b/app/views/image/show_image.html.erb
@@ -53,15 +53,31 @@
         </div>
       </div>
       <div class="panel-body">
+
         <div class="hidden-lg" style="max-width:640px; max-height:640px; margin:auto">
           <%= thumbnail(@image, size: :medium, link: {}, votes: false,
                         style: "max-width:100%; max-height:100%",
                         responsive: true, theater_on_click: true) %>
         </div>
         <div class="visible-lg" style="max-width:1280px; max-height:1280px; margin:auto">
-          <%= thumbnail(@image, size: :huge, link: {}, votes: false,
+          <%= thumbnail(@image, size: :medium, link: {}, votes: false, img_class: "huge-image",
                         responsive: true, theater_on_click: true) %>
         </div>
+
+        <% # Insert huge-size image via js only when necessary to prevent
+        # some browsers from eager-loading it even when invisible.
+        inject_javascript_at_end %(
+          var huge_loaded = false;
+          function load_huge() {
+            if (!huge_loaded && jQuery(window).width() >= 1200) {
+              huge_loaded = true;
+              jQuery("img.huge-image").attr("src", "#{j Image.url(:huge, @image.id)}");
+            }
+          }
+          jQuery(window).resize(load_huge);
+          jQuery(document).ready(load_huge);
+        ) %>
+
         <div class="push-down text-center">
           <% if User.current %>
             <%= render(partial: "image/image_vote_links", locals: {image: @image}) %>
@@ -71,6 +87,7 @@
             <%= @image.original_name %>
           <% end %>
         </div>
+
       </div>
     </div>
     <!-- /IMAGE_PANEL -->
@@ -250,9 +267,11 @@
 <!-- LICENSE_AND_FOOTER -->
 <div class="row">
   <div class="col-sm-6 max-width-text">
-    <div class="small">
+    <div class="small text-center">
       <%= image_copyright(@image) %>
-      <%= render(partial: "shared/form_#{@image.license.form_name}") %>
+      <div class="slight-pad push-up">
+        <%= render(partial: "shared/form_#{@image.license.form_name}") %>
+      </div>
     </div>
   </div>
   <div class="col-sm-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -123,7 +123,7 @@
   </div>
 </div>
 
-<div class="container-fluid img-theater" data-dismiss="theater">
+<div class="img-theater" data-dismiss="theater">
  <%= render(partial: "/image/theater") %>
 </div>
 

--- a/app/views/observer/list_rss_logs.html.erb
+++ b/app/views/observer/list_rss_logs.html.erb
@@ -1,34 +1,12 @@
 <%
   @title = :rss_log_title.t.nowrap
   @full_width_tab_set = render(partial: "rss_log_tabset")
-  new_tab_set(@links)
-  flash_error(@error) if @error and (!@objects or @objects.empty?)
+  new_tab_set(@links) if @links && @links.any?
+  flash_error(@error) if @error && (!@objects || @objects.empty?)
 %>
 
-<div class="row">
-  <div class="col-xs-12">
-    <%= pagination_numbers(@pages) %>
-  </div>
-</div>
-<div class="results">
-  <% open_at = 0
-  close_at = 2
-  @objects.each_with_index do |rss_log, index|
-    if index == open_at %>
-      <div class="row">
-    <% end %>
-    <div class="col-sm-4">
-      <%= render(partial: "shared/matrix_box", locals: {object: rss_log}) %>
-    </div>
-    <% if index == close_at || index == @objects.length + 1
-      open_at = close_at + 1
-      close_at = close_at + 3 %>
-      </div>
-    <% end %>
+<%= paginate_block(@pages) do %>
+  <%= make_matrix(@objects) do |rss_log| %>
+    <%= render(partial: "shared/matrix_box", locals: {object: rss_log}) %>
   <% end %>
-</div>
-<div class="row">
-  <div class="col-xs-12">
-    <%= pagination_numbers(@pages) %>
-  </div>
-</div>
+<% end %>


### PR DESCRIPTION
Theater view: Removed side-bars tentatively in order to allow image to take up whole page.  Have js select image source appropriately based on window size. Still allows browser to upscale beyond image resolution, need to add some onload hook to img to set max-width and max-height on img to prevent this. Tried valiently for hours to get it to center image vertically, but it is impossible without js.

Matrix view: Tried out two options:

xs = 2 cols
sm = 3 cols
md = 4 cols
lg = 6 cols

But this makes for some mighty small thumbnails at times.  Went with option two instead which feels more comfortable:

xs = 1 col
sm = 2 cols
md = 3 cols
lg = 4 cols

There are resolutions where the 1-column xs view is way too large, but what can you do?  Maybe leave "small thumbnail" pref and morph it into choice between these two options?

Show image: Set default image size to 640 for all sizes, then have js watch window size to determine when to load the huge-sized image.  Should save on bandwidth for mobile devices.

Side-bar: Ray claims it's not moving with screen, but I can't reproduce this. But I did set a max width of 15em to prevent it from getting absurdly wide at largest resolutions.

Image votes: Removed spaces to tighten it up, making it take less room so it fits more comfortably when thumbnails are tiny.