### PR TITLE
Performance improvements(?)

### DIFF
--- a/app/views/image/list_images.html.erb
+++ b/app/views/image/list_images.html.erb
@@ -3,10 +3,8 @@
   flash_error(@error) if @error and (!@objects or @objects.empty?)
 %>
 
-<%= paginate_block(@pages) do %>
-  <%= render(layout: "shared/matrix_table", locals: {objects: @objects}) do |image| %>
-    <div class="push-down push-up">
-      <%= render(partial: "shared/matrix_box", locals: {object: image}) %>
-    </div>
-  <% end %>
-<% end %>
+<div class="push-down push-up">
+      <%= paginate_block(@pages) do %>
+          <%= render(partial: "shared/matrix_box", collection: @objects, as: :object)  %>
+      <% end %>
+</div>

--- a/app/views/observer/list_observations.html.erb
+++ b/app/views/observer/list_observations.html.erb
@@ -27,13 +27,7 @@
         <%= pagination_numbers(@pages) %>
       </div>
       <div class="row results">
-        <% @objects.each do |rss_log| %>
-            <div class="col-sm-4">
-              <%= render(:partial => 'shared/matrix_box', :locals => {
-                                                                object: rss_log
-                                                        }) %>
-            </div>
-        <% end %>
+        <%= render(partial: "shared/matrix_box", collection: @objects, as: :object)  %>
       </div>
       <div class="col-xs-12">
         <%= pagination_numbers(@pages) %>

--- a/app/views/observer/list_rss_logs.html.erb
+++ b/app/views/observer/list_rss_logs.html.erb
@@ -6,7 +6,6 @@
 %>
 
 <%= paginate_block(@pages) do %>
-  <%= render(layout: "shared/matrix_table", locals: {objects: @objects}) do |rss_log| %>
-    <%= render(partial: "shared/matrix_box", locals: {object: rss_log}) %>
-  <% end %>
+  <%= render(partial: "shared/matrix_box", collection: @objects, as: :object)  %>
 <% end %>
+<div style="clear:left"></div>

--- a/app/views/observer/list_users.html.erb
+++ b/app/views/observer/list_users.html.erb
@@ -51,21 +51,18 @@
    else %>
     <div class="row">
       <div class="col-xs-12">
-        <%= pagination_letters(@pages) %>
+        <%= pagination_letters(@pages) %><br/>
         <%= pagination_numbers(@pages) %>
       </div>
-      <div class="col-xs-12 color-block">
-        <% @objects.each do |user| %>
-            <div class="col-sm-4 color-block-item">
-              <%= render(:partial => '/shared/matrix_box', locals: {object: user}) %>
-            </div>
-        <% end %>
-      </div>
+    </div>
+    <div class="row">
+      <%= render(partial: "shared/matrix_box", collection: @objects, as: :object) %>
+    </div>
+    <div class="row">
       <div class="col-xs-12">
-        <%= pagination_numbers(@pages) %>
+        <%= pagination_numbers(@pages) %><br/>
         <%= pagination_letters(@pages) %>
       </div>
     </div>
-
 <% end %>
 

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -1,38 +1,51 @@
 <%
-  ## TODO: Rename (RSS box?)
-  # Requires local variable object: RssLog, Observation, Image, etc. instance.
-  presenter = MatrixBoxPresenter.new(object, @view)
+   ## TODO: Rename (RSS box?)
+   # Requires local variable object: RssLog, Observation, Image, etc. instance.
+   presenter = MatrixBoxPresenter.new(object, @view)
+   if local_assigns.has_key? :object_counter
+     css_classes = "col-xs-12 col-sm-6 col-md-4 col-lg-3"
+   else
+     css_classes = "col-xs-12"
+   end
 %>
 
 <% if presenter %>
-  <div class="list-group" style="min-height: 200px;">
-    <div class="list-group-item rss-box-details">
-      <div class="row">
-        <div class="col-xs-12">
-          <div class="thumbnail-container" style="min-height: 30px">
-            <%= presenter.thumbnail %>
+
+    <% if local_assigns.has_key? :object_counter %>
+        <%= content_tag(:div, "", class: "hidden visible-sm-block", style: "clear:left") if object_counter % 2 == 0 %>
+        <%= content_tag(:div, "", class: "hidden visible-md-block", style: "clear:left") if object_counter % 3 == 0 %>
+        <%= content_tag(:div, "", class: "hidden visible-lg-block", style: "clear:left") if object_counter % 4 == 0 %>
+    <% end %>
+    <div class="<%= css_classes %>">
+      <div class="list-group" style="min-height: 200px;">
+        <div class="list-group-item rss-box-details">
+          <div class="row">
+            <div class="col-xs-12">
+              <div class="thumbnail-container" style="min-height: 30px">
+                <%= presenter.thumbnail %>
+              </div>
+              <div class="rss-what">
+                <h5><%= presenter.what %></h5>
+              </div>
+              <div class="rss-where">
+                <small><strong><%= presenter.where %></strong></small>
+              </div>
+              <div class="rss-what">
+                <small style="text-overflow: ellipsis; white-space: nowrap;">
+                  <% unless presenter.when.blank? %>
+                      <%= presenter.when %>: <%= presenter.who %>
+                  <% end %>
+                </small>
+              </div>
+              <div class="rss-detail">
+                <%= presenter.detail %>
+              </div>
+              <div class="rss-what">
+                <small><%= presenter.fancy_time %></small>
+              </div>
+            </div>
           </div>
-          <div class="rss-what">
-            <h5><%= presenter.what %></h5>
-          </div>
-          <div class="rss-where">
-            <small><strong><%= presenter.where %></strong></small>
-          </div>
-	  <div class="rss-what">
-            <small style="text-overflow: ellipsis; white-space: nowrap;">
-              <% unless presenter.when.blank? %>
-              <%= presenter.when %>: <%= presenter.who %>
-              <% end %>
-            </small>
-	  </div>
-          <div class="rss-detail">
-            <%= presenter.detail %>
-          </div>
-	  <div class="rss-what">
-            <small><%= presenter.fancy_time %></small>
-	  </div>
         </div>
       </div>
     </div>
-  </div>
 <% end %>

--- a/app/views/specimen/show_specimen.html.erb
+++ b/app/views/specimen/show_specimen.html.erb
@@ -23,11 +23,9 @@
   </p>
 <% end %>
 
-<% @specimen.observations.each do |observation| %>
-  <%= render(:partial => 'shared/matrix_box', :locals => {
-                                                    object: observation.rss_log
-  }) %>
-<% end %>
+<div class="row">
+<%= render(partial: "shared/matrix_box", collection: @specimen.observations, as: :object)  %>
+</div>
 
 <center>
 	<p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,7 +85,8 @@ MushroomObserver::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
+  config.assets.logger = false
 
   config.assets.digest = false
 


### PR DESCRIPTION
I turned off the assets.debug and the assets.logger in the development.rb config in order to get a better sense of how long the partial views were actually taking to render.  Feel free to change it back.
 
I converted the matrix_box views to use the collection parameter for render :partial.  This seems to drastically improve the performance, but my tests are limited to about 20 page loads with the old version and then 20 with the new version.
 
Render time for the page went from about 1000ms to 600ms.   This could probably be further improved.  
Please take a look at it.  I'm not sure it is the silver bullet solution, but might be a step in the right direction.