### PR TITLE
Fixing location controller list by country regexp

### DIFF
--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -69,7 +69,7 @@ class LocationController < ApplicationController
 
   # Displays a list of all locations whose country matches the id param.
   def list_by_country # :nologin:
-    query = create_query(:Location, :regexp_search, :regexp => "#{params[:country]}*")
+    query = create_query(:Location, :regexp_search, :regexp => "#{params[:country]}$")
     show_selected_locations(query, :link_all_sorts => true)
   end
 

--- a/test/functional/location_controller_test.rb
+++ b/test/functional/location_controller_test.rb
@@ -113,6 +113,45 @@ class LocationControllerTest < FunctionalTestCase
     assert_template(:list_locations)
   end
 
+  def test_list_by_country_regexp_ok
+    login('mary')
+    
+    get(:list_by_country, country: "USA")
+    usa_loc_array =  @controller.instance_variable_get("@objects")
+    loc_usa = Location.create!(name: "Santa Fe, New Mexico, USA", 
+        north: 34.1865,
+        west: -116.924,
+        east: -116.88,
+        south: 34.1571,
+        notes: "Santa Fe",
+	user: @mary
+    )
+    get(:list_by_country, country: "USA")
+    assert_obj_list_equal(usa_loc_array << loc_usa, @controller.instance_variable_get("@objects"))
+    
+    get(:list_by_country, country: "Mexico")
+    assert_obj_list_equal([], @controller.instance_variable_get("@objects"))
+    
+    loc_mex1 = Location.create!(name: "Somewhere, Chihuahua, Mexico",
+        north: 28.7729082,
+        west: -106.1671059,
+        east: -105.9612896,
+        south: 28.5586774,
+        notes: "somewhere Mexico",
+        user: @mary
+    )
+    loc_mex2 = Location.create!(name: "Oaxaca, Oaxaca, Mexico",
+        north: 17.1332939,
+        west: -96.7806765,
+        east: -96.6907866,
+        south: 17.0293023,
+	notes: "somewhere else in Mexico or this test will not work",
+        user: @mary
+    )
+    get(:list_by_country, country: "Mexico")
+    assert_obj_list_equal([loc_mex1,loc_mex2], @controller.instance_variable_get("@objects"))
+  end
+
   def test_locations_by_user
     get_with_dump(:locations_by_user, :id => 1)
     assert_template(action: 'list_locations')


### PR DESCRIPTION
As discussed here:
https://groups.google.com/forum/#!topic/mo-developers/r_vYlC6XoTk

I'm proposing a fix to get a clean list_by_country for locations in MO (Italy at the time shows spurious entier from Australia, Mexico shows New Mexico, Usa countries).

this issue was introduced by this commit:
https://github.com/MushroomObserver/mushroom-observer/commit/72c41768c27038bdad99a8588b37a6033a60f014

anyway, test_list_by_country_quote doesn't fail with the code fix.
I run script/run_tests and rake test:functionals and it looks like everything works.
If I revert the patch the regression get triggered and my test fails. 

these test fail:
Error: test_index(SemanticVernacularControllerTest)
Error: test_all_svds(SvdTest)

but they look unrelated.

Ciao!
Luca Pasquali
