### PR TITLE
Link style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 rvm:
   - "2.1.5"
 
+# make Travis use its legacy infrastructure
+sudo: true
+
 # uncomment this line if your project needs to run something other than `rake`:
 # script: bundle exec rake lang:update
 

--- a/app/assets/stylesheets/defaults.scss
+++ b/app/assets/stylesheets/defaults.scss
@@ -1,7 +1,7 @@
 $BODY_FG_COLOR:                     #000000;
 $BODY_BG_COLOR:                     #F6F6F6;
 
-$LINK_WEIGHT:                       bold;
+$LINK_WEIGHT:                       normal;
 $LINK_FG_COLOR:                     #2050E0;
 $LINK_BG_COLOR:                     transparent;
 $LINK_VISITED_FG_COLOR:             #5020E0;

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -1204,7 +1204,7 @@ table.table-namings {
 }
 
 // Most browsers allow you to zoom in or out: let the user decide what
-// an optimal width for a line of text should be.  There's no way for us
+// an optimal width for a line of text should be.  There is no way for us
 // to decide for them intelligently, since browsers differ so much in how
 // they deal with print views.
 @media screen {


### PR DESCRIPTION
Makes default link weight normal (instead of bold)
Fixes: [Pivotal #101531140](https://www.pivotaltracker.com/story/show/101531140) (Link weight generally should be normal)
[#98869626](https://www.pivotaltracker.com/story/show/98869626) (No distinction is made between current and "deprecated" names)
Also:
Makes Travis use legacy infrastructure (avoids Travis build error)
removes a stylesheet single quote which confuses @JDC's text editor.