### PR TITLE
Fix typo in help for Species List section of create_observation

### DIFF
--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1296,7 +1296,7 @@
   form_observations_where_help: "Where the observation was made.  In the US this should be at least accurate to the county.  Examples:\nAlbion, Mendocino Co., California, USA\nHotel Parque dos Coqueiros, Aracaju, Sergipe, Brazil"
   form_observations_dubious_help: Click '[button]' to use this location name or edit the text below to correct any typo.
   form_observations_project_help: Check any projects you wish to attach this observation to.  All images you upload will also automatically be attached to these projects, too.
-  form_observations_list_help: Check and species lists you would like to add this observation to.
+  form_observations_list_help: Check any species lists you would like to add this observation to.
   form_observations_delete_specimens_help: This observation has one or more specimen records. If a specimen has been destroyed, please delete the specimen record by returning to the observation, clicking the specimen link and deleting from there.
   form_observations_use_date: Use this date
   form_observations_date_warning: "Note: The camera date on some of your photos doesn't match the observation date you have entered."


### PR DESCRIPTION
- fixes [Pivotal #105588802](https://www.pivotaltracker.com/story/show/105588802)
- (requires rake lang:update)

Manual test script:
- Make sure there's at least one Species List
- Click Create Observation
- scroll down to Species List area
- make sure help text says "Check **any** species lists ..."