### PR TITLE
Observer argument error

### DIFF
--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -1257,8 +1257,7 @@ class ObserverController < ApplicationController
   end
 
   def update_whitelisted_observation_attributes
-    return unless whitelisted_observation_params
-    @observation.attributes = whitelisted_observation_params
+    @observation.attributes = whitelisted_observation_params || {}
   end
 
   # Callback to destroy an observation (and associated namings, votes, etc.)

--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -1199,8 +1199,7 @@ class ObserverController < ApplicationController
     else
       any_errors = false
 
-      # Update observation attributes
-      @observation.attributes = whitelisted_observation_params
+      update_whitelisted_observation_attributes
 
       # Validate place name
       @place_name = @observation.place_name
@@ -1255,6 +1254,11 @@ class ObserverController < ApplicationController
                             id: @observation.id)
       end
     end
+  end
+
+  def update_whitelisted_observation_attributes
+    return unless whitelisted_observation_params
+    @observation.attributes = whitelisted_observation_params
   end
 
   # Callback to destroy an observation (and associated namings, votes, etc.)
@@ -2294,7 +2298,7 @@ class ObserverController < ApplicationController
   end
 
   def whitelisted_observation_params
-    return nil unless params[:observation]
+    return unless params[:observation]
     params[:observation].permit(whitelisted_observation_args)
   end
 end


### PR DESCRIPTION
Don't use `nil` to set observation.attributes hash

- Delivers [Pivotal #107725660](https://www.pivotaltracker.com/story/show/107725660)
- fixes test Error, ArgumentError: When assigning attributes, you must pass a hash as an argument.
- Also deleted unnecessary `nil`
(Sorry, couldn't help myself from tidying this tiny bit in a method I had added to ror40.)