### PR TITLE
Do not override maps_collapsible#max_objects for every test in Collap…

### DIFF
--- a/test/models/collapsible_map_test.rb
+++ b/test/models/collapsible_map_test.rb
@@ -13,6 +13,8 @@ class BigDecimal
   end
 end
 
+# class for the sole purpose of allowing selected tests to override
+# app/classes/map_collapsible.rb#max_objects
 class TestCollapsible < CollapsibleCollectionOfMappableObjects
   class << self
     attr_accessor :max_objects
@@ -360,7 +362,7 @@ class CollapsibleMapTest < UnitTestCase
   def test_mapping_one_observation_with_gps
     obs = observations(:amateur_observation)
     assert(obs.lat && obs.long && !obs.location)
-    coll = TestCollapsible.new(obs)
+    coll = CollapsibleCollectionOfMappableObjects.new(obs)
     assert_equal(1, coll.mapsets.length)
     mapset = coll.mapsets.first
     assert_mapset_is_point(mapset, obs.lat, obs.long)
@@ -373,7 +375,7 @@ class CollapsibleMapTest < UnitTestCase
   def test_mapping_one_observation_with_location
     obs = observations(:minimal_unknown)
     assert(!obs.lat && !obs.long && obs.location)
-    coll = TestCollapsible.new(obs)
+    coll = CollapsibleCollectionOfMappableObjects.new(obs)
     assert_equal(1, coll.mapsets.length)
     mapset = coll.mapsets.first
     assert_mapset_is_box(mapset, *obs.location.edges)
@@ -385,7 +387,7 @@ class CollapsibleMapTest < UnitTestCase
 
   def test_mapping_one_location
     loc = locations(:albion)
-    coll = TestCollapsible.new(loc)
+    coll = CollapsibleCollectionOfMappableObjects.new(loc)
     assert_equal(1, coll.mapsets.length)
     mapset = coll.mapsets.first
     assert_mapset_is_box(mapset, *loc.edges)


### PR DESCRIPTION
Do not override max_objects for all tests in CollapsibleMapTest

- Fixes order-dependent Errors thrown by rake test:models TESTOPTS="--seed=42066"
- Prevents overridden definition of maps_collapsible#max_objects from persisting to tests where max_objects it is not explicitly defined
- max_objects is overridden by the class TestCollapsible, so use that class only in tests which must override max_objects
- In other tests, use the superclass of TestCollapsible -- CollapsibleCollectionOfMappableObjects
- Fixes [Pivotal #108723288](https://www.pivotaltracker.com/story/show/108723288)
- For more details see that Story