### PR TITLE
Use RoR4.2 Selector matchers in LurkerTest

### DIFF
--- a/test/integration/lurker_test.rb
+++ b/test/integration/lurker_test.rb
@@ -163,20 +163,20 @@ class LurkerTest < IntegrationTestCase
     # Get a list of observations from there.  (Several so goes to index.)
     click(label: "Observations at this Location", in: :right_tabs)
     assert_template("observer/list_observations")
-    save_results = get_links("div.results a[href^=?]", /\/\d+/)
+    save_results = get_links("div.results a:match('href',?)", %r{^/\d+})
 
     # Try sorting differently.
     click(label: "User", in: :sort_tabs)
-    results = get_links("div.results a[href^=?]", /\/\d+/)
+    results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
     click(label: "Date", in: :sort_tabs)
-    results = get_links("div.results a[href^=?]", /\/\d+/)
+    results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
     click(label: "Reverse Order", in: :sort_tabs)
-    results = get_links("div.results a[href^=?]", /\/\d+/)
+    results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
     click(label: "Name", in: :sort_tabs)
-    results = get_links("div.results a[href^=?]", /\/\d+/)
+    results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
     save_results = results
     query_params = parse_query_params(save_results.first)
@@ -202,7 +202,7 @@ class LurkerTest < IntegrationTestCase
     assert_equal(save_path, @request.fullpath,
                  "Went next then prev, should be back where we started.")
     click(label: "Index", href: /index/, in: :title)
-    results = get_links("div.results a[href^=?]", /\/\d+/)
+    results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(query_params, parse_query_params(results.first))
     assert_equal(save_results, results,
                  "Went to show_obs, screwed around, then back to index. " \


### PR DESCRIPTION
- should Finish [Pivotal #108925894](https://www.pivotaltracker.com/story/show/108925894), but I cannot test immediately:
- This fix exposes another Error in the LurkerTest. See [Pivotal #108971510](https://www.pivotaltracker.com/story/show/108971510)
