### PR TITLE
Fix de-serialization of query params

### DIFF
--- a/app/models/abstract_query.rb
+++ b/app/models/abstract_query.rb
@@ -609,7 +609,7 @@ class AbstractQuery < ActiveRecord::Base
 
   # Deserialize params hash and cache it.
   def params
-    @params ||= params_parse_hash(@attributes["params"])
+    @params ||= params_parse_hash(@attributes["params"].value)
   end
 
   # Replace parameters Hash with a new Hash.


### PR DESCRIPTION
- in Rails 4.1, `@attributes["params"]` was a String, but,
- in Rails 4.2, it's an ActiveRecord::Attribute::FromDatabase
- so we need to turn it into a string before de-serializing it
- Fixes all the current Errors/Failures where a method was called on an empty object.
- Delivers Pivotal [#108878588](https://www.pivotaltracker.com/story/show/108878588), [#108876942](https://www.pivotaltracker.com/story/show/108876942), [#108877222](https://www.pivotaltracker.com/story/show/108877222), [#108879698](https://www.pivotaltracker.com/story/show/108879698), [#108971510](https://www.pivotaltracker.com/story/show/108971510), [#108926320](https://www.pivotaltracker.com/story/show/108926320), [#108877766](https://www.pivotaltracker.com/story/show/108877766), [#108776762](https://www.pivotaltracker.com/story/show/108776762)