### PR TITLE
Replace *_filter family of methods with *_action

### DIFF
--- a/README_CODE
+++ b/README_CODE
@@ -206,7 +206,7 @@ templates.  Example:
   class ExampleController << ActionController
 
     # This causes autologin() to be run before every action.
-    before_filter :autologin
+    before_action :autologin
 
     def my_action
       case params[:mode]

--- a/app/classes/login_system.rb
+++ b/app/classes/login_system.rb
@@ -33,7 +33,7 @@ module LoginSystem
 
   # login_required filter. add
   #
-  #   before_filter :login_required
+  #   before_action :login_required
   #
   # if the controller should be under any rights management.
   # for finer access control you can overwrite

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -44,7 +44,7 @@
 ################################################################################
 
 class AccountController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :email_new_password,
     :login,
     :logout_user,
@@ -57,7 +57,7 @@ class AccountController < ApplicationController
     :welcome
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :login,
     :signup,
     :prefs,

--- a/app/controllers/ajax_controller.rb
+++ b/app/controllers/ajax_controller.rb
@@ -31,7 +31,7 @@ require_dependency "geocoder"
 
 class AjaxController < ApplicationController
   disable_filters
-  around_filter :catch_ajax_errors
+  around_action :catch_ajax_errors
   layout false
 
   def catch_ajax_errors

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,36 +98,36 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  around_filter :catch_errors # if Rails.env == "test"
-  before_filter :block_ip_addresses
-  before_filter :kick_out_robots
-  before_filter :create_view_instance_variable
-  before_filter :verify_authenticity_token
-  before_filter :fix_bad_domains
-  before_filter :autologin
-  before_filter :set_locale
-  before_filter :set_timezone
-  before_filter :refresh_translations
-  before_filter :track_translations
-  before_filter :check_user_alert
-  # before_filter :extra_gc
-  # after_filter  :extra_gc
-  # after_filter  :log_memory_usage
+  around_action :catch_errors # if Rails.env == "test"
+  before_action :block_ip_addresses
+  before_action :kick_out_robots
+  before_action :create_view_instance_variable
+  before_action :verify_authenticity_token
+  before_action :fix_bad_domains
+  before_action :autologin
+  before_action :set_locale
+  before_action :set_timezone
+  before_action :refresh_translations
+  before_action :track_translations
+  before_action :check_user_alert
+  # before_action :extra_gc
+  # after_action  :extra_gc
+  # after_action  :log_memory_usage
 
   # Disable all filters except set_locale and block_ip_addresses.
   # (Used to streamline API and Ajax controllers.)
   def self.disable_filters
-    skip_filter :verify_authenticity_token
-    skip_filter :fix_bad_domains
-    skip_filter :autologin
-    skip_filter :set_timezone
-    skip_filter :refresh_translations
-    skip_filter :track_translations
-    skip_filter :check_user_alert
-    # skip_filter   :extra_gc
-    # skip_filter   :log_memory_usage
-    before_filter :disable_link_prefetching
-    before_filter { User.current = nil }
+    skip_action_callback :verify_authenticity_token
+    skip_action_callback :fix_bad_domains
+    skip_action_callback :autologin
+    skip_action_callback :set_timezone
+    skip_action_callback :refresh_translations
+    skip_action_callback :track_translations
+    skip_action_callback :check_user_alert
+    # skip_action_callback   :extra_gc
+    # skip_action_callback   :log_memory_usage
+    before_action :disable_link_prefetching
+    before_action { User.current = nil }
   end
 
   ## @view can be used by classes to access some view specific features like render

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -29,7 +29,7 @@
 ################################################################################
 
 class CommentController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :comment_search,
     :index_comment,
     :list_comments,
@@ -41,7 +41,7 @@ class CommentController < ApplicationController
     :show_comments_for_user
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :add_comment,
     :edit_comment,
     :show_comment

--- a/app/controllers/conference_controller.rb
+++ b/app/controllers/conference_controller.rb
@@ -1,5 +1,5 @@
 class ConferenceController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :show_event,
     :index,
     :register,

--- a/app/controllers/glossary_controller.rb
+++ b/app/controllers/glossary_controller.rb
@@ -1,6 +1,6 @@
 # create and edit Glossary terms
 class GlossaryController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :index,
     :show_past_glossary_term,
     :show_glossary_term

--- a/app/controllers/herbarium_controller.rb
+++ b/app/controllers/herbarium_controller.rb
@@ -1,6 +1,6 @@
 # virtual herbaria
 class HerbariumController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :herbarium_search,
     :list_herbariums,
     :show_herbarium,

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -41,7 +41,7 @@
 ################################################################################
 
 class ImageController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :advanced_search,
     :image_search,
     :images_by_user,
@@ -55,7 +55,7 @@ class ImageController < ApplicationController
     :test_upload_speed
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :add_image,
     :edit_image,
     :show_image

--- a/app/controllers/interest_controller.rb
+++ b/app/controllers/interest_controller.rb
@@ -14,10 +14,10 @@
 ################################################################################
 
 class InterestController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
   ]
 
   # Show list of objects user has expressed interest in.

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -5,7 +5,7 @@ require "geocoder"
 class LocationController < ApplicationController
   include DescriptionControllerHelpers
 
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :advanced_search,
     :help,
     :index_location,
@@ -32,7 +32,7 @@ class LocationController < ApplicationController
     :tweak
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :create_location,
     :create_location_description,
     :edit_location,
@@ -43,7 +43,7 @@ class LocationController < ApplicationController
     :show_past_location_description
   ]
 
-  before_filter :require_successful_user, only: [
+  before_action :require_successful_user, only: [
     :create_location_description
   ]
 

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -56,7 +56,7 @@
 class NameController < ApplicationController
   include DescriptionControllerHelpers
 
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :advanced_search,
     :authored_names,
     :eol,
@@ -84,7 +84,7 @@ class NameController < ApplicationController
     :test_index
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :approve_name,
     :bulk_name_edit,
     :change_synonyms,

--- a/app/controllers/naming_controller.rb
+++ b/app/controllers/naming_controller.rb
@@ -2,9 +2,9 @@
 
 # Controller for handling the naming of observations
 class NamingController < ApplicationController
-  before_filter :login_required
+  before_action :login_required
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :create,
     :edit]
 

--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -119,7 +119,7 @@ class ObserverController < ApplicationController
   require_dependency "observation_report"
   require_dependency "pattern_search"
 
-  before_filter :login_required, except: MO.themes + [
+  before_action :login_required, except: MO.themes + [
     :advanced_search,
     :advanced_search_form,
     :ask_webmaster_question,
@@ -179,7 +179,7 @@ class ObserverController < ApplicationController
     :wrapup_2011
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :create_observation,
     :edit_observation,
     :show_obs,
@@ -200,7 +200,7 @@ class ObserverController < ApplicationController
     list_rss_logs
   end
 
-  # Provided just as a way to verify the before_filter.
+  # Provided just as a way to verify the before_action.
   # This page should always require the user to be logged in.
   # def login # :norobots:
   #   list_rss_logs

--- a/app/controllers/project_controller.rb
+++ b/app/controllers/project_controller.rb
@@ -31,7 +31,7 @@
 ################################################################################
 
 class ProjectController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :index_project,
     :list_projects,
     :next_project,
@@ -40,7 +40,7 @@ class ProjectController < ApplicationController
     :show_project
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :admin_request,
     :edit_project,
     :show_project

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,10 +1,10 @@
 class PublicationsController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :index,
     :show
   ]
 
-  before_filter :require_successful_user, only: [
+  before_action :require_successful_user, only: [
     :create
   ]
 

--- a/app/controllers/species_list_controller.rb
+++ b/app/controllers/species_list_controller.rb
@@ -38,7 +38,7 @@
 class SpeciesListController < ApplicationController
   # require "rtf"
 
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :index_species_list,
     :list_species_lists,
     :make_report,
@@ -52,14 +52,14 @@ class SpeciesListController < ApplicationController
     :species_lists_for_project
   ]
 
-  before_filter :disable_link_prefetching, except: [
+  before_action :disable_link_prefetching, except: [
     :create_species_list,
     :edit_species_list,
     :manage_species_lists,
     :show_species_list
   ]
 
-  before_filter :require_successful_user, only: [
+  before_action :require_successful_user, only: [
     :create_species_list, :name_lister
   ]
   ##############################################################################

--- a/app/controllers/specimen_controller.rb
+++ b/app/controllers/specimen_controller.rb
@@ -1,5 +1,5 @@
 class SpecimenController < ApplicationController
-  before_filter :login_required, except: [
+  before_action :login_required, except: [
     :specimen_search,
     :list_specimens,
     :show_specimen,

--- a/app/models/language_tracking.rb
+++ b/app/models/language_tracking.rb
@@ -3,13 +3,13 @@
 #  = Tracking Usage of Translations
 #
 #  Simple global mechanism for tracking which localization strings get used on
-#  a given page.  You would enable it in a +before_filter+ in your controller,
+#  a given page.  You would enable it in a +before_action+ in your controller,
 #  then Symbol#localize will have it make note of each tag that gets used
 #  throughout the process of rendering that page.  You can save this list of
 #  tags to a temporary file, and load it again later for use in a form, for
 #  example.  It will periodically clean up old temp files.
 #
-#    before_filter { Language.track_usage }
+#    before_action { Language.track_usage }
 #
 #    <%= if Language.tracking_usage
 #      handle = Language.save_tags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,11 @@
 #  Model describing a User.
 #
 #  Login is handled by lib/login_system.rb, a third-party package that we've
-#  updated slightly.  It is enforced by adding <tt>before_filter
+#  updated slightly.  It is enforced by adding <tt>before_action
 #  :login_required</tt> filters to the controllers.
 #
 #  We now support autologin or "remember me" login via a simple cookie and the
-#  application-wide <tt>before_filter :autologin</tt> filter in
+#  application-wide <tt>before_action :autologin</tt> filter in
 #  ApplicationController.
 #
 #  == Signup / Login Process


### PR DESCRIPTION
- The *_filter methods have been removed from Rails documentation and will be deprecated
- [Rails 4.2 Release Notes](http://guides.rubyonrails.org/4_2_release_notes.html#action-pack-notable-changes) suggest immediate replacement
- Finishes [Pivotal #108871098](https://www.pivotaltracker.com/story/show/108871098)