### PR TITLE
Add notice re check spam folder for email from MO

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -105,7 +105,7 @@ class AccountController < ApplicationController
           flash_object_errors(@new_user)
         else
           group = UserGroup.create_user(@new_user)
-          flash_notice :runtime_signup_success.t
+          flash_notice (:runtime_signup_success.tp + :email_spam_notice.t)
           VerifyEmail.build(@new_user).deliver_now
           redirect_back_or_default(action: :welcome)
         end
@@ -207,7 +207,7 @@ class AccountController < ApplicationController
   def send_verify # :nologin:
     if user = find_or_goto_index(User, params[:id].to_s)
       VerifyEmail.build(user).deliver_now
-      flash_notice :runtime_reverify_sent.t
+      flash_notice (:runtime_reverify_sent.tp + :email_spam_notice.t)
       redirect_back_or_default(action: :welcome)
     end
   end
@@ -281,7 +281,8 @@ class AccountController < ApplicationController
         password = String.random(10)
         @new_user.change_password(password)
         if @new_user.save
-          flash_notice :runtime_email_new_password_success.t
+          flash_notice (:runtime_email_new_password_success.tp +
+                        :email_spam_notice.t)
           PasswordEmail.build(@new_user, password).deliver_now
           render(action: "login")
         else

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -105,7 +105,7 @@ class AccountController < ApplicationController
           flash_object_errors(@new_user)
         else
           group = UserGroup.create_user(@new_user)
-          flash_notice (:runtime_signup_success.tp + :email_spam_notice.t)
+          flash_notice (:runtime_signup_success.tp + :email_spam_notice.tp)
           VerifyEmail.build(@new_user).deliver_now
           redirect_back_or_default(action: :welcome)
         end
@@ -207,7 +207,7 @@ class AccountController < ApplicationController
   def send_verify # :nologin:
     if user = find_or_goto_index(User, params[:id].to_s)
       VerifyEmail.build(user).deliver_now
-      flash_notice (:runtime_reverify_sent.tp + :email_spam_notice.t)
+      flash_notice (:runtime_reverify_sent.tp + :email_spam_notice.tp)
       redirect_back_or_default(action: :welcome)
     end
   end
@@ -282,7 +282,7 @@ class AccountController < ApplicationController
         @new_user.change_password(password)
         if @new_user.save
           flash_notice (:runtime_email_new_password_success.tp +
-                        :email_spam_notice.t)
+                        :email_spam_notice.tp)
           PasswordEmail.build(@new_user, password).deliver_now
           render(action: "login")
         else

--- a/app/views/account/email_new_password.html.erb
+++ b/app/views/account/email_new_password.html.erb
@@ -3,6 +3,9 @@
 %>
 
 <div class="max-width-text">
+  <div class="HelpNote">
+    <%= :email_new_password_help.tp + :email_spam_notice.tp %>
+  </div>
   <%= form_tag(action: :email_new_password) do %>
     <div class="form-group">
       <%= label_tag(:new_user_login, :login_user.t + ":") %>

--- a/app/views/account/reverify.html.erb
+++ b/app/views/account/reverify.html.erb
@@ -1,8 +1,7 @@
 <%
   @title = :email_welcome.t(user: @unverified_user.legal_name)
 %>
-
 <div class="max-width-text">
-  <%= :reverify_note.tp(user: @unverified_user.login) %>
+  <%= :reverify_note.tp(user: @unverified_user.login) + :email_spam_notice.tp %>
   <%= link_to(:reverify_link.t, action: :send_verify, id: @unverified_user.id) %>
 </div>

--- a/app/views/account/signup.html.erb
+++ b/app/views/account/signup.html.erb
@@ -22,7 +22,9 @@
     <div class="form-group push-down">
       <%= label_tag(:new_user_email, :signup_email_address.t + ":") %>
       <%= text_field(:new_user, :email, class: "form-control") %>
-      <div class="HelpNote"><%= :signup_email_help.tp %></div>
+      <div class="HelpNote">
+        <%= :signup_email_help.tp + :email_spam_notice.tp %>
+      </div>
     </div>
 
     <div class="form-group push-down">

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1431,6 +1431,8 @@
   login_forgot_password: I forgot my password.  "Email me a new one.":/account/email_new_password
   login_no_account: I don't have an account.  "Create a new account.":/account/signup
   login_having_problems: If you are having problems logging into your account, send "email to the webmaster":/observer/ask_webmaster_question.
+  email_new_password_help: When you complete this page and click "Send", we will send you an email with verification information.
+  email_spam_notice: If you do not see the email in your inbox, check your spam folder. If it's in your spam folder, please (1) notify your email provider that it's  not spam and (2) whitelist "mushroomobserver.org". This may prevent future MO emails from ending up in your -- or other users' -- spam folders.
 
   # account/logout
   logout_title: Logout
@@ -1580,7 +1582,7 @@
   # account/reverify
   reverify_welcome: Reverify Account
   reverify_link: Reverify
-  reverify_note: "Your account, [user], has not been verified yet.\n\nCheck your email for your verification URL or click the link below to have the mail resent."
+  reverify_note: "Your account, [user], has not been verified yet.\n\nCheck your email for your verification URL or click the link below to have the verification email resent."
 
   # observer/rss
   rss_description: List of changes to [:app_title] as they happen.
@@ -1816,7 +1818,7 @@
   signup_preferred_theme: Preferred Theme (optional)
   signup_random: Random
   signup_button: Signup
-  signup_email_help: A working email address is required to verify your account.  This helps us keep the spammers out.  Once you have verified your account, you can change it or remove it entirely by going to the Preferences page. We are very careful to never show your email address on a webpage that others can access.  We will never sell your email address.  We will only share your email address if you ask us to (e.g., when you send an email to another member, they will see your email).  By default your email address will be used to send you information about changes to the site as well as notifications relevant to your contributions to the site.  You can opt out of these uses by changing your Preferences.
+  signup_email_help: A working email address is required to verify your account.  This helps us keep the spammers out. \n\nOnce you verify your account, you can change your email on your account Preferences page. We are very careful to never show your email address on a webpage that others can access.  We will never sell your email address.  We will only share your email address if you ask us to (e.g., when you send an email to another member, they will see your email).  By default your email address will be used to send you information about changes to the site as well as notifications relevant to your contributions to the site.  You can opt out of these uses by changing your Preferences. \n\nWhen you complete this page and click "Signup", we will send you an email with account verification information.
 
   # species_list/create_species_list
   species_list_create_title: "[:create_object(type=:species_list)]"
@@ -3289,10 +3291,10 @@
   runtime_object_not_found: "Sorry, the [type] you tried to display (id #[id]) no longer exists.  Someone has either deleted it or merged it into another."
   runtime_profile_must_define: You must define this location before we can make it your primary location. Any other changes to your profile have been saved.
   runtime_reverify_already_verified: Your account is already verified!  Please log in.
-  runtime_reverify_sent: Another verification email was sent to your email account.
+  runtime_reverify_sent: Another verification email was sent.
   runtime_show_description_denied: You have not been given permission to see this description.
   runtime_show_draft_denied: "Permission denied: only project members can view drafts in progress."
-  runtime_signup_success: Signup successful.  Verification sent to your email account.
+  runtime_signup_success: Signup successful.  Verification email sent.
   runtime_species_list_need_to_use_bulk: Synonyms can only be created from the [:name_bulk_title] page.
 
   ################################################################################


### PR DESCRIPTION
Add notice re check spam folder for email from MO

- Should avoid some questions to MO webmaster
- Rewrite 7 separate spam notices as one notice, tweak some text to work with rewritten notice. See #209
- Refinishes [Pivotal #105363482](https://www.pivotaltracker.com/story/show/105363482)