### PR TITLE
Always show owner_id line if user opts to show observer preference

### DIFF
--- a/app/helpers/show_observation_helper.rb
+++ b/app/helpers/show_observation_helper.rb
@@ -28,7 +28,7 @@ module ShowObservationHelper
     return unless obs.show_owner_id?
     capture do
       concat(:show_observation_owner_id.t + ": ")
-      concat(obs.owners_only_favorite_name.format_name.t)
+      concat(obs.owner_favorite_or_explanation.t)
     end
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -364,12 +364,12 @@ class Observation < AbstractModel
     result
   end
 
-  def owner_favorite_votes
-    votes.where(user_id: user_id, favorite: true)
-  end
-
-  def owner_favorite_vote
-    owner_favorite_votes.first
+  def owner_favorite_or_explanation
+    if showable_owner_id?
+      owners_only_favorite_name.format_name
+    else
+      :show_observation_no_clear_preference
+    end
   end
 
   def owners_only_favorite_name
@@ -377,18 +377,22 @@ class Observation < AbstractModel
     favs[0].naming.name if favs.count == 1
   end
 
+  def owner_favorite_vote
+    owner_favorite_votes.first
+  end
+
+  def owner_favorite_votes
+    votes.where(user_id: user_id, favorite: true)
+  end
+
   # show Observer ID? (observer's identification of Observation)
   # (in code, Observer ID is "owner_id")
   def show_owner_id?
-    User.view_owner_id_on? && showable_owner_id?
+    User.view_owner_id_on?
   end
 
   def showable_owner_id?
-    owner_id_differs? && owner_sure_enough? && owner_id_known?
-  end
-
-  def owner_id_differs?
-    name != try(:owners_only_favorite_name)
+    owner_sure_enough? && owner_id_known?
   end
 
   def owner_sure_enough?

--- a/app/views/account/_prefs_appearance.html.erb
+++ b/app/views/account/_prefs_appearance.html.erb
@@ -32,7 +32,7 @@
   <div>
     <%= form.check_box(:view_owner_id, class: "form-control") %>
     <%= add_context_help(label_tag(:user_view_owner_id, :prefs_view_owner_id.t),
-                        :view_owner_id_help.t) %>
+                        :prefs_view_owner_id_help.t) %>
   </div>
   <%= label_tag(:layout_count, :prefs_layout_count.t + ":") %>
   <%= form.number_field(:layout_count, class: "form-control", min: 1) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1514,7 +1514,9 @@
   prefs_alt_col_colors: Alternate column colors.
   prefs_alt_row_colors: Alternate row colors.
   prefs_text_below_images: Put text below images.
-  prefs_view_owner_id: View Observer identification of Observations?
+  prefs_view_owner_id: View Observer's Preferred ID?
+  prefs_view_owner_id_help: View Observer's preferred ID for Observation (in addition to consensus ID)
+
 
   prefs_privacy: Privacy Settings
   prefs_votes_anonymous: Votes on proposed names and images
@@ -1723,8 +1725,8 @@
   show_observation_title: "[:OBSERVATION]: [name]"
   show_observation_header: "[:OBSERVATION]"
   show_observation_site_id: Site ID
-  show_observation_owner_id: Observer ID
-  view_owner_id_help: When checked, causes Observations to display Observer ID (the observer's choice of name for the taxon), if it is different from consensus and if observer is sufficiently confident of his/her identification.
+  show_observation_owner_id: Observer Preference
+  show_observation_no_clear_preference: no clear preference
   show_observation_edit_observation: "[:edit_object(type=:observation)]"
   show_observation_propose_new_name: "[:show_namings_propose_new_name]"
   show_observation_debug_consensus: Debug Consensus

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -553,36 +553,44 @@ class ObserverControllerTest < FunctionalTestCase
                   "Observation should show Observer ID")
   end
 
-  def test_show_owner_id_with_favorite_equal_to_site_id
+  def test_show_owner_id_equals_site_id
     login(user_with_view_owner_id_true)
-    get_with_dump(:show_observation,
-                  id: observations(:owner_only_favorite_eq_consensus).id)
-    assert_select("div[class *= 'owner-id']", { count: 0 },
-                  "Do not show Observer ID when same as consensus")
+    obs = observations(:owner_only_favorite_eq_consensus)
+    get_with_dump(:show_observation, id: obs.id)
+    assert_select("div[class *= 'owner-id']",
+                  { text: /#{obs.owners_only_favorite_name.text_name}/,
+                    count: 1 },
+                  "Observation should show Observer preference")
   end
 
   def test_show_owner_id_with_multiple_favorites
     login(user_with_view_owner_id_true)
     get_with_dump(:show_observation,
                   id: observations(:owner_multiple_favorites).id)
-    assert_select("div[class *= 'owner-id']", { count: 0 },
-                  "Do not show Observer ID when observer has >1 'favorite'")
+    assert_select("div[class *= 'owner-id']",
+                  { text: /#{:show_observation_no_unique_owner_id.t}/,
+                    count: 1 },
+                  "Observation should show lack of Observer preference")
   end
 
-  def test_show_owner_id_with_uncertain_favorite
+  def test_show_owner_id_with_uncertain_high_vote
     login(user_with_view_owner_id_true)
     get_with_dump(:show_observation,
                   id: observations(:owner_uncertain_favorite).id)
-    assert_select("div[class *= 'owner-id']", { count: 0 },
-                  "Do not show Observer ID when observer not sure enough of id")
+    assert_select("div[class *= 'owner-id']",
+                  { text: /#{:show_observation_no_unique_owner_id.t}/,
+                    count: 1 },
+                  "Observation should show lack of Observer preference")
   end
 
   def test_show_owner_id_with_fungi
     login(user_with_view_owner_id_true)
-    get_with_dump(:show_observation,
-                  id: observations(:owner_only_favorite_eq_fungi).id)
-    assert_select("div[class *= 'owner-id']", { count: 0 },
-                  "Do not show Observer ID when observer favorite is 'Fungi'")
+    obs = observations(:owner_only_favorite_eq_fungi)
+    get_with_dump(:show_observation, id: obs.id)
+    assert_select("div[class *= 'owner-id']",
+                  { text: /#{:show_observation_no_unique_owner_id.t}/,
+                    count: 1 },
+                  "Observation should show lack of Observer preference")
   end
 
   def test_show_owner_id_view_owner_id_false

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -568,7 +568,7 @@ class ObserverControllerTest < FunctionalTestCase
     get_with_dump(:show_observation,
                   id: observations(:owner_multiple_favorites).id)
     assert_select("div[class *= 'owner-id']",
-                  { text: /#{:show_observation_no_unique_owner_id.t}/,
+                  { text: /#{:show_observation_no_clear_preference.t}/,
                     count: 1 },
                   "Observation should show lack of Observer preference")
   end
@@ -578,7 +578,7 @@ class ObserverControllerTest < FunctionalTestCase
     get_with_dump(:show_observation,
                   id: observations(:owner_uncertain_favorite).id)
     assert_select("div[class *= 'owner-id']",
-                  { text: /#{:show_observation_no_unique_owner_id.t}/,
+                  { text: /#{:show_observation_no_clear_preference.t}/,
                     count: 1 },
                   "Observation should show lack of Observer preference")
   end
@@ -588,7 +588,7 @@ class ObserverControllerTest < FunctionalTestCase
     obs = observations(:owner_only_favorite_eq_fungi)
     get_with_dump(:show_observation, id: obs.id)
     assert_select("div[class *= 'owner-id']",
-                  { text: /#{:show_observation_no_unique_owner_id.t}/,
+                  { text: /#{:show_observation_no_clear_preference.t}/,
                     count: 1 },
                   "Observation should show lack of Observer preference")
   end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -87,13 +87,13 @@ class ObservationTest < UnitTestCase
   end
 
   def test_owner_id
-    obs = observations(:owner_only_favorite_eq_consensus)
-    assert_equal(obs.name, obs.owners_only_favorite_name)
-    refute(obs.showable_owner_id?)
-
     obs = observations(:owner_only_favorite_ne_consensus)
     refute_nil(obs.owners_only_favorite_name)
     refute_equal(obs.name, obs.owners_only_favorite_name)
+    assert(obs.showable_owner_id?)
+
+    obs = observations(:owner_only_favorite_eq_consensus)
+    assert_equal(obs.name, obs.owners_only_favorite_name)
     assert(obs.showable_owner_id?)
 
     obs = observations(:owner_multiple_favorites)


### PR DESCRIPTION
- Avoids ambiguity/confusion about missing line
  - If no clear owner preference, line says "no clear preference"
  - If consensus = observer preference, shows that name
- Other changes to more clearly state intent of option and code
 - "Observer ID" => "Observer Preference"
 - Re-order and re-name some methods and variables
- I want to merge these changes before working more on this branch

Manual test script (essentially duplicated in ObserverControllerTest)
- While logged in, goto Preferences, check "View Observer’s Preferred ID?", Save Edits
- Click Create Observation, Fill in form with:  
  - Where: any existing location
  - What: **leave blank**
  - Confidence: Could Be
  - Create
- Observation should have Observer Preference line, which says "no clear preference"
![screen shot 2016-01-10 at 16 32 01](https://cloud.githubusercontent.com/assets/45460/12225156/5a68bfac-b7b9-11e5-9a1a-bf7b155f8f55.png)
- Propose a name:  _Coprinus comatus_, Confidence: Could Be
  - Result:
![screen shot 2016-01-10 at 16 46 47](https://cloud.githubusercontent.com/assets/45460/12225185/d1060dcc-b7b9-11e5-81cd-5086763f4937.png)
- Propose another name:  _Agaricus_, Confidence: Could Be
  - Result:  no clear preference (because of tie vote)
- Destroy Proposed Name _Agaricus_;  Edit Proposed Name  _Coprinus comatus_ Confidence: Doubtful
   - Result:  no clear preference (because confidence is negative)
- Change Preferences to **un**check "View Observer’s Preferred ID?", Save Edits, 
- In browser go back to Observation and refresh
 - Result: no Observer Preference line

