### PR TITLE
Prevent users from changing the Unknown location(s).

### DIFF
--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -603,6 +603,13 @@ class LocationController < ApplicationController
       @display_name = @location.display_name
       done = false
       if request.method == "POST"
+
+        if Location.is_unknown?(@location.name) && !is_in_admin_mode?
+          flash_error("This Location is protected (not editable). To change an Observation's location, edit Observation 'Where'.")
+          redirect_to(action: "show_location", id: @location.id)
+          return
+        end
+
         @display_name = begin
                           params[:location][:display_name].strip_squeeze
                         rescue

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -398,6 +398,18 @@ end
     assert_input_value(:location_display_name, loc.display_name)
   end
 
+  def test_edit_unknown_location
+    loc = locations(:unknown_location)
+    old_loc_display_name = loc.display_name
+    params = { id: loc.id,
+               location: { display_name: "Rome, Italy" }
+             }
+    post_requires_login(:edit_location, params)
+
+    assert_equal(old_loc_display_name, loc.reload.display_name,
+                 "Users should not be able to change Unknown location")
+  end
+
   def test_update_location
     count = Location::Version.count
     count2 = LocationDescription::Version.count


### PR DESCRIPTION
Finishes [Pivotal #38475565](https://www.pivotaltracker.com/story/show/38475565)
Also see [MO Developers › request] (https://groups.google.com/forum/#!topic/mo-developers/fvZC0q19iC8)
Changes to these location can crash MO.
Allows users to change this location only if in admin mode.
Includes controller test.

Manual test script:
Edit Location Earth.
Change it's Where field.
Click Update
Result should be:  Flash message explaining that location is protected, and user is returned to the show_location screen for Earth.