### PR TITLE
Wrap long words.

### DIFF
--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -182,6 +182,10 @@ a:hover {
     background-color: $LINK_HOVER_BG_COLOR;
 }
 
+body {
+  word-wrap: break-word;
+}
+
 .btn, .btn:visited,
 .btn-default, .btn-default:visited {
     color: $BUTTON_FG_COLOR;


### PR DESCRIPTION
Delivers [Pivotal #116831189](https://www.pivotaltracker.com/story/show/116831189).
Tells browsers to wrap long words (like nucleotide sequences) which otherwise would extend past the word's container.
Applies site-wide to all parts of all pages.  (Can be overridden.)

# Manual Test Script
- **Before merging**, go to http://mushroomobserver.org/90428, scroll down to earliest Comment (a long nucleotide sequence)
Result:  sequence extends out of Comment box.
- **After merging**.  Go to same place.
Result: Browser should wrap string inside Comment box.