### PR TITLE
Css adjustments

### DIFF
--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -182,6 +182,10 @@ a:hover {
     background-color: $LINK_HOVER_BG_COLOR;
 }
 
+blockquote {
+    font-size: 100%;
+}
+
 .btn, .btn:visited,
 .btn-default, .btn-default:visited {
     color: $BUTTON_FG_COLOR;

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -1271,6 +1271,16 @@ table.table-namings {
     }
 }
 
+.textile {
+    th, td {
+        padding: 0.3em;
+        vertical-align: top;
+    }
+    th {
+        vertical-align: bottom;
+    }
+}
+
 //
 // icons
 // --------------------------------------------------


### PR DESCRIPTION
Two more tweaks to css.  Delivers Pivotal [#105201914](https://www.pivotaltracker.com/story/show/105201914) and [#122350001](https://www.pivotaltracker.com/story/show/122350001).
### Manual test script
Compare the following in master vs this PR 
#### http://mushroomobserver.org/comment/show_comment/124837
Master: table cells lack padding and text is vertically centered in cell
PR: cells are padded; text starts @ top of cell, except header rows 
#### http://mushroomobserver.org/comment/show_comment/121733
Master: quoted text is larger than regular text.
PR: quoted text is same size (but still indented, with vertical bar on left).
