### PR TITLE
Mycobank groups

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -59,13 +59,12 @@ module ObjectLinkHelper
   end
 
   def mycobank_taxon(name)
-    return name.text_name.gsub(" ", "%20") unless
-      name.between_genus_and_species?
-    genus_only(name)
-  end
-
-  def genus_only(name)
-    name.text_name.match(/([^\s]+)/).to_s
+    if name.between_genus_and_species?
+      nm_text = name.text_before_rank
+    else
+      nm_text = name.text_name
+    end
+    nm_text.gsub(" ", "%20")
   end
 
   # language parameter for MycoBank link

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -51,7 +51,11 @@ module ObjectLinkHelper
 
   # Create link for name to search in MycoBank
   def mycobank_url(name)
-    mycobank_path + mycobank_taxon(name) + mycobank_language_suffix(locale).to_s
+    unescaped_str = (mycobank_path + mycobank_taxon(name) +
+                     mycobank_language_suffix(locale).to_s)
+    # CGI::escape.html(unescaped_str) should work, but throws error
+    #   ActionView::Template::Error: wrong number of arguments (0 for 1)
+    unescaped_str.gsub(" ", "%20")
   end
 
   def mycobank_path
@@ -59,12 +63,7 @@ module ObjectLinkHelper
   end
 
   def mycobank_taxon(name)
-    if name.between_genus_and_species?
-      nm_text = name.text_before_rank
-    else
-      nm_text = name.text_name
-    end
-    nm_text.gsub(" ", "%20")
+    name.between_genus_and_species? ? name.text_before_rank : name.text_name
   end
 
   # language parameter for MycoBank link

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -942,6 +942,10 @@ class Name < AbstractModel
     notes && notes.match(/\S/)
   end
 
+  def text_before_rank
+    text_name.split(" " + rank.to_s.downcase).first
+  end
+
   ##############################################################################
   #
   #  :section: Synonymy

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -512,7 +512,7 @@ class NameControllerTest < FunctionalTestCase
     assert_template(:list_names)
     name_links = css_select(".table a")
     assert_equal(10, name_links.length)
-    expected = Name.all.order("text_name, author").limit(10).offset(10).to_a
+    expected = Name.all.order("sort_name").limit(10).offset(10).to_a
     assert_equal(expected.map(&:id), ids_from_links(name_links))
     url = @controller.url_with_query(action: "show_name",
                                      id: expected.first.id, only_path: true)

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -881,7 +881,7 @@ amanita_subgenus_lepidella:
   author: '(E.-J. Gilbert) Veselý emend. Corner & Bas'
   notes: NULL
 
-amanita_boudieri_var._beillei:
+amanita_boudieri_var_beillei:
   id: 53
   # accepted_name_id: 53
   version: 1

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -895,3 +895,15 @@ amanita_boudieri_var._beillei:
   display_name: '**__Amanita boudieri__ var. __beillei__**'
   author: ''
   notes: NULL
+
+# uses auto
+boletus_edulis_group:
+  version: 1
+  rank: <%= Name.ranks[:Group] %>
+  text_name: Boletus edulis group
+  display_name: '**__Boletus edulis__** group'
+  search_name: Boletus edulis group
+  sort_name: Boletus edulis   group
+  author: ''
+  citation: ''
+  notes: NULL

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -36,6 +36,9 @@ class ObjectLinkHelperTest < ActionView::TestCase
 
     name = Name.find(53)  # Amanita boudieri var. beillei
     assert_equal("Amanita%20boudieri%20var.%20beillei", mycobank_taxon(name))
+
+    name = names(:boletus_edulis_group)
+    assert_equal("Boletus%20edulis", mycobank_taxon(name))
   end
 
   def test_link_if_object

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -20,25 +20,22 @@ class ObjectLinkHelperTest < ActionView::TestCase
   end
 
   def test_mycobank_taxon
-    name = Name.find(1)   # Fungi
-    assert_equal("Fungi", mycobank_taxon(name))
+    # Happy path (text_name)
+    name = names(:coprinus_comatus)
+    assert_equal(name.text_name, mycobank_taxon(name))
 
-    name = Name.find(18)  # Agaricus
-    assert_equal("Agaricus", mycobank_taxon(name))
+    # Also happy path; test to make sure not accidentally chopping var.
+    name = names(:amanita_boudieri_var_beillei)
+    assert_equal(name.text_name, mycobank_taxon(name))
 
-    name = Name.find(52)  # Amanita subgenus Lepidella
+    name = names(:amanita_subgenus_lepidella)
     assert_equal("Amanita", mycobank_taxon(name),
                  "MycoBank taxon name for Ranks between Genus and Species" \
-                 "should == genus")
-
-    name = Name.find(2)   # Coprinus comatus
-    assert_equal("Coprinus%20comatus", mycobank_taxon(name))
-
-    name = Name.find(53)  # Amanita boudieri var. beillei
-    assert_equal("Amanita%20boudieri%20var.%20beillei", mycobank_taxon(name))
+                 " should end before rank")
 
     name = names(:boletus_edulis_group)
-    assert_equal("Boletus%20edulis", mycobank_taxon(name))
+    assert_equal("Boletus edulis", mycobank_taxon(name),
+                 "MycoBank taxon for group should include binomial")
   end
 
   def test_link_if_object

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1174,6 +1174,17 @@ class NameTest < UnitTestCase
     assert(name.at_or_below_species?)
   end
 
+  def test_text_before_rank
+    name_above_genus = names(:fungi)
+    assert_equal("Fungi", name_above_genus.text_before_rank)
+
+    name_between_genus_and_species = names(:amanita_subgenus_lepidella)
+    assert_equal("Amanita", name_between_genus_and_species.text_before_rank)
+
+    variety_name = names(:amanita_boudieri_var_beillei)
+    assert_equal("Amanita boudieri var. beillei", variety_name.text_before_rank)
+  end
+
   # def dump_list_of_names(list)
   #   for n in list do
   #     print "id=#{n.id}, text_name='#{n.text_name}', author='#{n.author}'\n"

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -464,10 +464,10 @@ class QueryTest < UnitTestCase
 
     assert_equal("1", query.select_value.to_s) # first id
     assert_equal("11", query.select_value(limit: "10, 10").to_s) # tenth id
-    assert_equal(num.to_s, query.select_value(order: :reverse).to_s) # last id
+    assert_equal(Name.last.id, query.select_value(order: :reverse))
     assert_equal("Fungi", query.select_value(select: "text_name").to_s)
 
-    assert_equal((1..num).map(&:to_s), query.select_values.map(&:to_s))
+    assert_equal(Name.all.map(&:id), query.select_values)
     assert_equal(%w(3 18 19 20 21),
                  query.select_values(where: 'text_name LIKE "Agaricus%"').
                        map(&:to_s))
@@ -484,8 +484,8 @@ class QueryTest < UnitTestCase
       assert_equal((1..num).map { |x| { "id" => x.to_s } }, query.select_all)
       assert_equal({ "id" => "1" }, query.select_one)
     else
-      assert_equal((1..num).map { |x| [x] }, query.select_rows)
-      assert_equal((1..num).map { |x| { "id" => x } }, query.select_all)
+      assert_equal(Name.all.map { |x| [x.id] }, query.select_rows)
+      assert_equal(Name.all.map { |x| { "id" => x.id } }, query.select_all)
       assert_equal({ "id" => 1 }, query.select_one)
     end
     assert_equal([@fungi], query.find_by_sql(limit: 1))


### PR DESCRIPTION
Improves link to MycoBank for a Name with rank == group

Delivers [Pivotal ##107050456](https://www.pivotaltracker.com/story/show/107050456).

Manual test script
1. In current production branch, goto http://mushroomobserver.org/name/show_name/24858 (Name page for _Boletus edulis_ group.
2. Click on MycoBank link.
Result:  2,856 Items in 15 Page(s) (i.e., anything with "boletus" in the MycoBank Name)
3. Repeat steps 1-2 in the mycobank_groups branch.
Result:  53 Items in 1 Page (i.e., anything with "boletus edulis" in the MycoBank Name)