### PR TITLE
Fix Pivotal #129185765 (blank tracking template messed up).

### DIFF
--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1501,7 +1501,7 @@ class NameController < ApplicationController
         if @notification
           @note_template = @notification.note_template
         else
-          mailing_address = @user.mailing_address.strip
+          mailing_address = @user.mailing_address.strip if @user.mailing_address
           mailing_address = ":mailing_address" if mailing_address.blank?
           @note_template = :email_tracking_note_template.l(
             species_name: @name.real_text_name,

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1489,47 +1489,55 @@ class NameController < ApplicationController
   def email_tracking # :norobots:
     pass_query_params
     name_id = params[:id].to_s
-    if @name = find_or_goto_index(Name, name_id)
-      flavor = Notification.flavors[:name]
-      @notification = Notification.find_by_flavor_and_obj_id_and_user_id(flavor, name_id, @user.id)
+    return unless @name = find_or_goto_index(Name, name_id)
 
-      # Initialize form.
-      if request.method != "POST"
-        unless @name.at_or_below_genus?
-          flash_warning(:email_tracking_enabled_only_for.t(name: @name.display_name, rank: @name.rank))
-        end
-        if @notification
-          @note_template = @notification.note_template
-        else
-          @note_template = :email_tracking_note_template.l(
-            species_name: @name.real_text_name,
-            mailing_address: @user.mailing_address_for_tracking_template,
-            users_name: @user.legal_name
-          )
-        end
-
-      # Submit form.
-      else
-        case params[:commit]
-        when :ENABLE.l, :UPDATE.l
-          note_template = params[:notification][:note_template]
-          note_template = nil if note_template.blank?
-          if @notification.nil?
-            @notification = Notification.new(flavor: :name, user: @user,
-                                             obj_id: name_id, note_template: note_template)
-            flash_notice(:email_tracking_now_tracking.t(name: @name.display_name))
-          else
-            @notification.note_template = note_template
-            flash_notice(:email_tracking_updated_messages.t)
-          end
-          @notification.save
-        when :DISABLE.l
-          @notification.destroy
-          flash_notice(:email_tracking_no_longer_tracking.t(name: @name.display_name))
-        end
-        redirect_with_query(action: "show_name", id: name_id)
-      end
+    flavor = Notification.flavors[:name]
+    @notification = Notification.
+                      find_by_flavor_and_obj_id_and_user_id(flavor, name_id,
+                                                            @user.id)
+    if request.method != "POST"
+      initialize_tracking_form
+    else
+      submit_tracking_form(name_id)
     end
+  end
+
+  def initialize_tracking_form
+    unless @name.at_or_below_genus?
+      flash_warning(:email_tracking_enabled_only_for.t(name: @name.display_name,
+                                                       rank: @name.rank))
+    end
+    if @notification
+      @note_template = @notification.note_template
+    else
+      @note_template = :email_tracking_note_template.l(
+        species_name: @name.real_text_name,
+        mailing_address: @user.mailing_address_for_tracking_template,
+        users_name: @user.legal_name
+      )
+    end
+  end
+
+  def submit_tracking_form(name_id)
+    case params[:commit]
+    when :ENABLE.l, :UPDATE.l
+      note_template = params[:notification][:note_template]
+      note_template = nil if note_template.blank?
+      if @notification.nil?
+        @notification = Notification.new(flavor: :name, user: @user,
+                                         obj_id: name_id,
+                                         note_template: note_template)
+        flash_notice(:email_tracking_now_tracking.t(name: @name.display_name))
+      else
+        @notification.note_template = note_template
+        flash_notice(:email_tracking_updated_messages.t)
+      end
+      @notification.save
+    when :DISABLE.l
+      @notification.destroy
+      flash_notice(:email_tracking_no_longer_tracking.t(name: @name.display_name))
+    end
+    redirect_with_query(action: "show_name", id: name_id)
   end
 
   ################################################################################

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1501,11 +1501,9 @@ class NameController < ApplicationController
         if @notification
           @note_template = @notification.note_template
         else
-          mailing_address = @user.mailing_address.strip if @user.mailing_address
-          mailing_address = ":mailing_address" if mailing_address.blank?
           @note_template = :email_tracking_note_template.l(
             species_name: @name.real_text_name,
-            mailing_address: mailing_address,
+            mailing_address: @user.mailing_address_for_tracking_template,
             users_name: @user.legal_name
           )
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -654,7 +654,7 @@ class User < AbstractModel
 
   ##############################################################################
   #
-  #  :section: Interests
+  #  :section: Interests and Tracking
   #
   ##############################################################################
 
@@ -694,6 +694,11 @@ class User < AbstractModel
   #
   def ignoring?(object)
     interest_in(object) == :ignoring
+  end
+
+  def mailing_address_for_tracking_template
+    result = mailing_address.strip if mailing_address
+    result = "**insert mailing address for specimens**" if result.blank?
   end
 
   ##############################################################################

--- a/app/views/name/email_tracking.html.erb
+++ b/app/views/name/email_tracking.html.erb
@@ -1,16 +1,15 @@
 <%
-  @title = :email_tracking_title.t(:name => @name.display_name)
+  @title = :email_tracking_title.t(name: @name.display_name)
 
   tabs = [
-    link_to(:cancel_and_show.t(:type => :name),
-            :action => 'show_name', :id => @name.id)
+    link_to(:cancel_and_show.t(type: :name), action: :show_name, id: @name.id)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 
 <%= :email_tracking_help.tp %>
 
-<%= form_tag(:action => 'email_tracking', :id => @name.id) do %>
+<%= form_tag(action: :email_tracking, id: @name.id) do %>
   <br/><center>
     <%= if @notification
       submit_tag(:UPDATE.t, class: "btn") + ' ' + submit_tag(:DISABLE.t, class: "btn")
@@ -21,5 +20,6 @@
 
   <label for="notification_note_template"><%= :email_tracking_note.t %></label>:<br/>
   <span class="HelpNote"><%= :email_tracking_note_help.t %></span><br/>
-  <%= text_area('notification', 'note_template', cols: 80, value: @note_template, autofocus: true) %><br/>
+  <%= text_area(:notification, :note_template, cols: 80, rows: 16,
+                value: @note_template, autofocus: true) %><br/>
 <% end %>

--- a/test/integration/capybara_lurker_test.rb
+++ b/test/integration/capybara_lurker_test.rb
@@ -88,6 +88,7 @@ class CapybarLurkerTest < IntegrationTestCase
     name = obs.name
 
     # First login
+    reset_session!
     visit(root_path)
     first(:link, "Login").click
     assert_equal("#{:app_title.l }: Please login", page.title, "Wrong page")

--- a/test/integration/name_controller_supplemental_test.rb
+++ b/test/integration/name_controller_supplemental_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+# Tests which supplement controller/name_controller_test.rb
+class NameControllerSupplementalTest < IntegrationTestCase
+  # Email tracking template should not contain ":mailing_address"
+  # because, when email is sent, that will be interpreted as
+  # recipient's mailing_address
+  def test_email_tracking_template_no_email_address_symbol
+    visit("/account/login")
+    fill_in("User name or Email address:", with: "rolf")
+    fill_in("Password:", with: "testpassword")
+    click_button("Login")
+
+    visit("/name/email_tracking/#{names(:boletus_edulis).id}")
+    template = find("#notification_note_template")
+    template.assert_no_text(":mailing_address")
+  end
+end


### PR DESCRIPTION
Deliver bug fix of [Pivotal #129185765](https://www.pivotaltracker.com/story/show/129185765).

The bug is described in more detail at [MO Developers › Fwd: [MO] Research Request](https://groups.google.com/forum/#!topic/mo-developers/tKE1zLQ_L40) and
[MO Developers ›Re: [MO] Mailing Address for Collections](https://groups.google.com/forum/#!topic/mo-developers/lkYesX_Jf8w).

Manual test script:
- Log in
- if your Profile (/account/profile) includes a Mailing Address for Collections, temporarily delete it.
- Go to any Name which you are not already tracking.
- Click on Email Tracking

Result:
- You should see the entire default Template.  (in master you see only 2 lines.)
- The template should include `**insert mailing address for specimens**`.  (in master, it instead includes `:mailing_address`.)

(When done, restore your Mailing Address for Collections.)
