### PR TITLE
Update Release Notes to include info about PRs 2016/01/14 - /08/16.

### DIFF
--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1477,11 +1477,12 @@
   name_map_no_maps: No observations of [name] have mappable location information.
 
   # observer/news
-  news_title: "Latest Release: August 16, 2015"
+  news_title: "Latest Release: September 9, 2016"
   news_header: This page provides notes on the latest releases and changes to [:app_title].
-  news_content: "[:news_content_commit_22deee6] \n\n[:news_content_commit_33639d5] \n\n[:news_content_commit_96e27e9] \n\n[:news_content_pr_236] \n\n[:news_content_pr_235] \n\n[:news_content_pr_233] \n\n[:news_content_pr_232] \n\n[:news_content_pr_231] \n\n[:news_content_pr_230] \n\n[:news_content_pr_226] \n\n[:news_content_pr_224] \n\n[:news_content_pr_223] \n\n[:news_content_pr_221] \n\n[:news_content_pr_220] \n\n[:news_content_pr_219] \n\n[:news_content_pr_217] \n\n[:news_content_pr_216] \n\n[:news_content_pr_215] \n\n[:news_content_pr_213] \n\n[:news_content_pr_212] \n\n[:news_content_pr_208]"
+  news_content: "[:news_content_pr_238] \n\n[:news_content_commit_22deee6] \n\n[:news_content_commit_33639d5] \n\n[:news_content_commit_96e27e9] \n\n[:news_content_pr_236] \n\n[:news_content_pr_235] \n\n[:news_content_pr_233] \n\n[:news_content_pr_232] \n\n[:news_content_pr_231] \n\n[:news_content_pr_230] \n\n[:news_content_pr_226] \n\n[:news_content_pr_224] \n\n[:news_content_pr_223] \n\n[:news_content_pr_221] \n\n[:news_content_pr_220] \n\n[:news_content_pr_219] \n\n[:news_content_pr_217] \n\n[:news_content_pr_216] \n\n[:news_content_pr_215] \n\n[:news_content_pr_213] \n\n[:news_content_pr_212] \n\n[:news_content_pr_208]"
 
   # observer/news individual updates
+  news_content_pr_238: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/238\">PR #238</a> (September 9, 2016) Fixes bug in email tracking which caused uploader's mailing address to be used in place of the person who wants the notifications."
   news_content_commit_22deee6: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/22deee6\">Commit #22deee6</a> (Aug 16, 2016) Fix errors cause by corrupted RSS log. Make failures more graceful if log gets corrupted in the future."
   news_content_commit_33639d5: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/33639d5\">Commit #33639d5</a> (Aug 10, 2016) Letter to MO Community stating policy on abuse, community openness.  Block user account."
   news_content_commit_96e27e9: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/96e27e9\">Commit #96e27e9</a> (Aug 7, 2016) Add basic documentation of API to GitHub."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1477,9 +1477,32 @@
   name_map_no_maps: No observations of [name] have mappable location information.
 
   # observer/news
-  news_title: "Latest Release: August 3, 2015"
-  news_header: This page provides notes on the latest release of the [:app_title] website.
-  news_content: "December 13, 2015. <u>Rails 4.2.5</u>\n\nAt long last the Mushroom Observer website is up to date with the latest stable version of Ruby on Rails (4.2.5). This has not been true since at least March of 2009.  The upgrade process started last August when we were still using the 2.1.1 version of Ruby on Rails.\n\nThis has been a huge team effort by all the volunteer developers on the project. Thanks to every one of you for helping to make this happen.\n\nFor those who are interested in the technical low-down of this specific release, we got to 4.1 last month and the biggest change between 4.1 and 4.2 was a new HTML parsing library that required many minor code changes throughout out code base. There have also been some changes to how email is handled and a variety of other small changes to the code base.  You should see no new changes in the site due to this latest upgrade, but of course <a href=\"/observer/ask_webmaster_question\">send us a note</a> if you see anything wrong."
+  news_title: "Latest Release: August 16, 2015"
+  news_header: This page provides notes on the latest releases and changes to [:app_title].
+  news_content: "[:news_content_commit_22deee6] \n\n[:news_content_commit_33639d5] \n\n[:news_content_commit_96e27e9] \n\n[:news_content_pr_236] \n\n[:news_content_pr_235] \n\n[:news_content_pr_233] \n\n[:news_content_pr_232] \n\n[:news_content_pr_231] \n\n[:news_content_pr_230] \n\n[:news_content_pr_226] \n\n[:news_content_pr_224] \n\n[:news_content_pr_223] \n\n[:news_content_pr_221] \n\n[:news_content_pr_220] \n\n[:news_content_pr_219] \n\n[:news_content_pr_217] \n\n[:news_content_pr_216] \n\n[:news_content_pr_215] \n\n[:news_content_pr_213] \n\n[:news_content_pr_212] \n\n[:news_content_pr_208]"
+
+  # observer/news individual updates
+  news_content_commit_22deee6: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/22deee6\">Commit #22deee6</a> (Aug 16, 2016) Fix errors cause by corrupted RSS log. Make failures more graceful if log gets corrupted in the future."
+  news_content_commit_33639d5: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/33639d5\">Commit #33639d5</a> (Aug 10, 2016) Letter to MO Community stating policy on abuse, community openness.  Block user account."
+  news_content_commit_96e27e9: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/96e27e9\">Commit #96e27e9</a> (Aug 7, 2016) Add basic documentation of API to GitHub."
+  news_content_pr_236: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/236\">PR #236</a> (July 28, 2016) Prevent use of the Name \"Imageless\"."
+  news_content_pr_235: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/235\">PR #235</a> (July 28, 2016) Improve link to MycoBank for taxa at the Group rank."
+  news_content_pr_233: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/233\">PR #233</a> (July 28, 2016) Restore padding of tables created with Textile. Reduce size of Textile quoted paragraphs."
+  news_content_pr_232: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/232\">PR #232</a> (July 28, 2016) Wrap long words (to prevent them from extending into other windows)."
+  news_content_pr_231: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/230\">PR #231</a> (July 28, 2016) Improve test coverage of extensions."
+  news_content_pr_230: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/230\">PR #230</a> (July 28, 2016) Refactor fixtures and tests to use Advanced Fixtures."
+  news_content_pr_226: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/226\">PR #226</a> (May 30, 2016) Fix intermittent testing bug (in export_round_trip)."
+  news_content_pr_224: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/224\">PR #224</a> (May 7, 2016) Prevent changes to the \"Unknown\" Location."
+  news_content_pr_223: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/221\">PR #223</a> (April 24, 2016) Expand Show RSS Log page so it is easier to read."
+  news_content_pr_221: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/221\">PR #221</a> (April 24, 2016) Fix bug where weakened confidence level vote sometimes caused mistaken calculation of Observer's favorite."
+  news_content_pr_220: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/220\">PR #220</a> (February 1, 2016) Allow creation of Observations with observation date more than 20 years old."
+  news_content_pr_219: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/219\">PR #219</a> (January 16, 2016) Create Vote Controller."
+  news_content_pr_217: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/217\">PR #217</a> (January 15, 2016) Make \"Textile markup system\" a link everywhere on edit_name form."
+  news_content_pr_216: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/216\">PR #216</a> (January 15, 2016) Remove IP address blocking from Rails code."
+  news_content_pr_215: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/215\">PR #215</a> (January 15, 2016) Always show Observer Preference line in Observations if user checks \"View Observer’s Preferred ID?\"."
+  news_content_pr_213: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/213\">PR #213</a> (January 14, 2016) Add Capybara gem and counterparts of 2 older integration tests."
+  news_content_pr_212: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/212\">PR #212</a> (January 14, 2016) Enable web console in development mode on the VM."
+  news_content_pr_208: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/208\">PR #208</a> (December 13, 2015) <u>Rails 4.2.5</u> \n\nAt long last the Mushroom Observer website is up to date with the latest stable version of Ruby on Rails (4.2.5). This has not been true since at least March of 2009.  The upgrade process started last August when we were still using the 2.1.1 version of Ruby on Rails.\n\nThis has been a huge team effort by all the volunteer developers on the project. Thanks to every one of you for helping to make this happen.\n\nFor those who are interested in the technical low-down of this specific release, we got to 4.1 last month and the biggest change between 4.1 and 4.2 was a new HTML parsing library that required many minor code changes throughout out code base. There have also been some changes to how email is handled and a variety of other small changes to the code base.  You should see no new changes in the site due to this latest upgrade, but of course <a href=\"/observer/ask_webmaster_question\">send us a note</a> if you see anything wrong."
 
   # shared/_observation_list
   observation_made_confidence: Community confidence


### PR DESCRIPTION
Manual test script:
- Go to /observer/news

Result: You should see one-liners about most of the 2016 PRs.
