### PR TITLE
Fix author standardization; add support for "comb".

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1532,6 +1532,8 @@ class Name < AbstractModel
   NOM_ABBR     = / nomen | nom\.? /xi
   COMB_ABBR    = / combinatio | comb\.? /xi
   SENSU_ABBR   = / sensu?\.? /xi
+  NOV_ABBR     = / nova | novum | nov\.? /xi
+  PROV_ABBR    = / provisional | prov\.? /xi
 
   ANY_SUBG_ABBR   = / #{SUBG_ABBR} | #{SECT_ABBR} | #{SUBSECT_ABBR} | #{STIRPS_ABBR} /x
   ANY_SSP_ABBR    = / #{SSP_ABBR} | #{VAR_ABBR} | #{F_ABBR} /x
@@ -1865,6 +1867,9 @@ class Name < AbstractModel
           sub(/^ ?#{NOM_ABBR}/,   "nom. ").
           sub(/^ ?#{COMB_ABBR}/,  "comb. ").
           sub(/^ ?#{SENSU_ABBR}/, "sensu ").
+          # Having fixed comb. & nom., standardize their suffixes
+          sub(/(?<=comb. |nom. ) ?#{NOV_ABBR}/,  "nov. ").
+          sub(/(?<=comb. |nom. ) ?#{PROV_ABBR}/, "prov. ").
           strip_squeeze
     squeeze_author(str)
   end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1860,11 +1860,11 @@ class Name < AbstractModel
 
   def self.standardize_author(str)
     str = str.to_s.
-          sub(/^#{AUCT_ABBR}/, "auct. ").
-          sub(/^#{INED_ABBR}/, "ined. ").
-          sub(/^#{NOM_ABBR}/, "nom. ").
-          sub(/^#{COMB_ABBR}/, "comb. ").
-          sub(/^#{SENSU_ABBR}/, "sensu ").
+          sub(/^ ?#{AUCT_ABBR}/,  "auct. ").
+          sub(/^ ?#{INED_ABBR}/,  "ined. ").
+          sub(/^ ?#{NOM_ABBR}/,   "nom. ").
+          sub(/^ ?#{COMB_ABBR}/,  "comb. ").
+          sub(/^ ?#{SENSU_ABBR}/, "sensu ").
           strip_squeeze
     squeeze_author(str)
   end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1530,12 +1530,13 @@ class Name < AbstractModel
   AUCT_ABBR    = / auct\.? /xi
   INED_ABBR    = / in\s?ed\.? /xi
   NOM_ABBR     = / nomen | nom\.? /xi
+  COMB_ABBR    = / combinatio | comb\.? /xi
   SENSU_ABBR   = / sensu?\.? /xi
 
   ANY_SUBG_ABBR   = / #{SUBG_ABBR} | #{SECT_ABBR} | #{SUBSECT_ABBR} | #{STIRPS_ABBR} /x
   ANY_SSP_ABBR    = / #{SSP_ABBR} | #{VAR_ABBR} | #{F_ABBR} /x
   ANY_NAME_ABBR   = / #{SUBG_ABBR} | #{SECT_ABBR} | #{SUBSECT_ABBR} | #{STIRPS_ABBR} | #{SP_ABBR} | #{SSP_ABBR} | #{VAR_ABBR} | #{F_ABBR} | #{GROUP_ABBR} /x
-  ANY_AUTHOR_ABBR = / (?: #{AUCT_ABBR} | #{INED_ABBR} | #{NOM_ABBR} | #{SENSU_ABBR} ) (?:\s|$) /x
+  ANY_AUTHOR_ABBR = / (?: #{AUCT_ABBR} | #{INED_ABBR} | #{NOM_ABBR} | #{COMB_ABBR} | #{SENSU_ABBR} ) (?:\s|$) /x
 
   UPPER_WORD = / [A-Z][a-zë\-]*[a-zë] | "[A-Z][a-zë\-\.]*[a-zë]" /x
   LOWER_WORD = / (?!sensu\b) [a-z][a-zë\-]*[a-zë] | "[a-z][\wë\-\.]*[\wë]" /x
@@ -1862,6 +1863,7 @@ class Name < AbstractModel
           sub(/^#{AUCT_ABBR}/, "auct. ").
           sub(/^#{INED_ABBR}/, "ined. ").
           sub(/^#{NOM_ABBR}/, "nom. ").
+          sub(/^#{COMB_ABBR}/, "comb. ").
           sub(/^#{SENSU_ABBR}/, "sensu ").
           strip_squeeze
     squeeze_author(str)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1477,11 +1477,12 @@
   name_map_no_maps: No observations of [name] have mappable location information.
 
   # observer/news
-  news_title: "Latest Release: September 9, 2016"
+  news_title: "Latest Release: September 11, 2016"
   news_header: This page provides notes on the latest releases and changes to [:app_title].
-  news_content: "[:news_content_pr_238] \n\n[:news_content_commit_22deee6] \n\n[:news_content_commit_33639d5] \n\n[:news_content_commit_96e27e9] \n\n[:news_content_pr_236] \n\n[:news_content_pr_235] \n\n[:news_content_pr_233] \n\n[:news_content_pr_232] \n\n[:news_content_pr_231] \n\n[:news_content_pr_230] \n\n[:news_content_pr_226] \n\n[:news_content_pr_224] \n\n[:news_content_pr_223] \n\n[:news_content_pr_221] \n\n[:news_content_pr_220] \n\n[:news_content_pr_219] \n\n[:news_content_pr_217] \n\n[:news_content_pr_216] \n\n[:news_content_pr_215] \n\n[:news_content_pr_213] \n\n[:news_content_pr_212] \n\n[:news_content_pr_208]"
+  news_content: "[:news_content_pr_240] \n\n[:news_content_pr_238] \n\n[:news_content_commit_22deee6] \n\n[:news_content_commit_33639d5] \n\n[:news_content_commit_96e27e9] \n\n[:news_content_pr_236] \n\n[:news_content_pr_235] \n\n[:news_content_pr_233] \n\n[:news_content_pr_232] \n\n[:news_content_pr_231] \n\n[:news_content_pr_230] \n\n[:news_content_pr_226] \n\n[:news_content_pr_224] \n\n[:news_content_pr_223] \n\n[:news_content_pr_221] \n\n[:news_content_pr_220] \n\n[:news_content_pr_219] \n\n[:news_content_pr_217] \n\n[:news_content_pr_216] \n\n[:news_content_pr_215] \n\n[:news_content_pr_213] \n\n[:news_content_pr_212] \n\n[:news_content_pr_208]"
 
   # observer/news individual updates
+  news_content_pr_240: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/240\">PR #240</a> (September 11, 2016) Allows 'comb.' e.g., comb. nov., in author field.  Standardize 'comb.' and similar status indicators in future Name edits and creates."
   news_content_pr_238: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/238\">PR #238</a> (September 9, 2016) Fixes bug in email tracking which caused uploader's mailing address to be used in place of the person who wants the notifications."
   news_content_commit_22deee6: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/22deee6\">Commit #22deee6</a> (Aug 16, 2016) Fix errors cause by corrupted RSS log. Make failures more graceful if log gets corrupted in the future."
   news_content_commit_33639d5: "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/33639d5\">Commit #33639d5</a> (Aug 10, 2016) Letter to MO Community stating policy on abuse, community openness.  Block user account."

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -73,6 +73,7 @@ class NameTest < UnitTestCase
     assert_name_match(pattern, string + " in ed.", first_match, " in ed.")
     assert_name_match(pattern, string + " nomen nudum", first_match, " nomen nudum")
     assert_name_match(pattern, string + " nom. prov.", first_match, " nom. prov.")
+    assert_name_match(pattern, string + " comb. prov.", first_match, " comb. prov.")
     assert_name_match(pattern, string + " sensu Author", first_match, " sensu Author")
     assert_name_match(pattern, string + ' sens. "Author"', first_match, ' sens. "Author"')
     assert_name_match(pattern, string + ' "(One) Two"', first_match, ' "(One) Two"')
@@ -191,6 +192,8 @@ class NameTest < UnitTestCase
     assert_equal("nom. prov", Name.standardize_author("nom prov"))
     assert_equal("nom. nudum", Name.standardize_author("Nomen nudum"))
     assert_equal("nom.", Name.standardize_author("nomen"))
+    assert_equal("comb.", Name.standardize_author("comb"))
+    assert_equal("comb. prov", Name.standardize_author("comb prov"))
     assert_equal("sensu Borealis", Name.standardize_author("SENS Borealis"))
     assert_equal('sensu "Aurora"', Name.standardize_author('sEnSu. "Aurora"'))
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -466,13 +466,13 @@ class NameTest < UnitTestCase
       "Lecidea sanguineoatra sens. Nyl",
       text_name: "Lecidea sanguineoatra",
       real_text_name: "Lecidea sanguineoatra",
-      search_name: "Lecidea sanguineoatra sens. Nyl",
-      real_search_name: "Lecidea sanguineoatra sens. Nyl",
-      sort_name: "Lecidea sanguineoatra  sens. Nyl",
-      display_name: "**__Lecidea sanguineoatra__** sens. Nyl",
+      search_name: "Lecidea sanguineoatra sensu Nyl",
+      real_search_name: "Lecidea sanguineoatra sensu Nyl",
+      sort_name: "Lecidea sanguineoatra  sensu Nyl",
+      display_name: "**__Lecidea sanguineoatra__** sensu Nyl",
       parent_name: "Lecidea",
       rank: :Species,
-      author: "sens. Nyl"
+      author: "sensu Nyl"
     )
   end
 
@@ -1013,6 +1013,21 @@ class NameTest < UnitTestCase
       parent_name: nil,
       rank: :Family,
       author: "sensu Reid"
+    )
+  end
+
+  def test_name_parse_comb
+    do_name_parse_test(
+      "Sebacina schweinitzii comb prov.",
+      text_name: "Sebacina schweinitzii",
+      real_text_name: "Sebacina schweinitzii",
+      search_name: "Sebacina schweinitzii comb. prov.",
+      real_search_name: "Sebacina schweinitzii comb. prov.",
+      sort_name: "Sebacina schweinitzii  comb. prov.",
+      display_name: "**__Sebacina schweinitzii__** comb. prov.",
+      parent_name: "Sebacina",
+      rank: :Species,
+      author: "comb. prov."
     )
   end
 

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -189,11 +189,11 @@ class NameTest < UnitTestCase
     assert_equal("auct. N. Amer.", Name.standardize_author("auct. N. Amer."))
     assert_equal("ined. Xxx", Name.standardize_author("IN ED Xxx"))
     assert_equal("ined.", Name.standardize_author("ined."))
-    assert_equal("nom. prov", Name.standardize_author("nom prov"))
+    assert_equal("nom. prov.", Name.standardize_author("nom prov"))
     assert_equal("nom. nudum", Name.standardize_author("Nomen nudum"))
     assert_equal("nom.", Name.standardize_author("nomen"))
     assert_equal("comb.", Name.standardize_author("comb"))
-    assert_equal("comb. prov", Name.standardize_author("comb prov"))
+    assert_equal("comb. prov.", Name.standardize_author("comb prov"))
     assert_equal("sensu Borealis", Name.standardize_author("SENS Borealis"))
     assert_equal('sensu "Aurora"', Name.standardize_author('sEnSu. "Aurora"'))
   end
@@ -1018,7 +1018,7 @@ class NameTest < UnitTestCase
 
   def test_name_parse_comb
     do_name_parse_test(
-      "Sebacina schweinitzii comb prov.",
+      "Sebacina schweinitzii comb prov",
       text_name: "Sebacina schweinitzii",
       real_text_name: "Sebacina schweinitzii",
       search_name: "Sebacina schweinitzii comb. prov.",

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -19,8 +19,7 @@ class NameTest < UnitTestCase
     assert parse, "Expected #{str.inspect} to parse!"
     any_errors = false
     msg = ["Name is wrong; expected -vs- actual:"]
-    i = 0
-    for var in [
+    [
       :text_name,
       :real_text_name,
       :search_name,
@@ -30,7 +29,7 @@ class NameTest < UnitTestCase
       :parent_name,
       :rank,
       :author
-    ]
+    ].each do |var|
       expect = args[var]
       if var == :real_text_name
         actual = Name.display_to_real_text(parse)
@@ -39,14 +38,14 @@ class NameTest < UnitTestCase
       else
         actual = parse.send(var)
       end
+
       if actual != expect
         any_errors = true
         var = "#{var} (*)"
       end
       msg << "%-20s %-40s %-40s" % [var.to_s, expect.inspect, actual.inspect]
-      i += 1
     end
-    assert_not any_errors, msg.join("\n")
+    refute(any_errors, msg.join("\n"))
   end
 
   def assert_name_match_author_required(pattern, string, first_match = string)


### PR DESCRIPTION
Add support for "comb", e.g., "comb. nov."  Delivers [Pivotal #127954231](#127954231).

Fix Name author standardization. Delivers [Pivotal #130136909](https://www.pivotaltracker.com/story/show/130136909).

Also standardizes "nov" and "prov" when they are suffixes to "comb" or "nom".

I put these changes in the same PR because they're related and I want to avoid local merge conflicts.

Manual test:
Create a name with Author field: "comb nov" (no periods)
  Result:  The name should be created with author including "comb. nov." (with periods).
Create a name with Author field "nomen".
  Result:  Name should be created with Author "nom."
