### PR TITLE
Fix bug in ApplicationController#lookup_valid_locale.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -669,19 +669,14 @@ class ApplicationController < ActionController::Base
   # Returns our locale that best suits the HTTP_ACCEPT_LANGUAGE request header.
   # Returns a String, or <tt>nil</tt> if no valid match found.
   def lookup_valid_locale(requested_locales)
-    match = "en"
     requested_locales.each do |locale|
       logger.debug "[globalite] trying to match locale: #{locale}"
       language = locale.split("-").first
-
-      if I18n.available_locales.include?(language.to_sym)
-        match = language
-        logger.debug "[globalite] language match: #{match}"
-      end
-
-      break if match
+      next unless I18n.available_locales.include?(language.to_sym)
+      logger.debug "[globalite] language match: #{language}"
+      return language
     end
-    match
+    "en"
   end
 
   ##############################################################################

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -67,6 +67,11 @@ class AjaxControllerTest < FunctionalTestCase
     assert_equal(:pt, I18n.locale)
     session.delete("locale")
 
+    @request.env["HTTP_ACCEPT_LANGUAGE"] = "xx-xx,pt-pt"
+    good_ajax_request(:test)
+    assert_equal(:pt, I18n.locale)
+    session.delete("locale")
+
     @request.env["HTTP_ACCEPT_LANGUAGE"] = "en-xx,en;q=0.5"
     good_ajax_request(:test)
     assert_equal(:en, I18n.locale)


### PR DESCRIPTION
* If the first locales specified in HTTP_ACCEPT_LANGUAGE header was not an MO available locale, it would return “EN”, even if another specified language was an MO available locale.
* Includes test to catch bug.
* Thanks to @pellea for the tight re-write of the method.