### PR TITLE
Fix bug which prevented anonymous user from using /lookup_accepted_name.

### DIFF
--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -133,6 +133,7 @@ class ObserverController < ApplicationController
     :intro,
     :list_observations,
     :list_rss_logs,
+    :lookup_accepted_name,
     :lookup_comment,
     :lookup_image,
     :lookup_location,

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2288,24 +2288,32 @@ class ObserverControllerTest < FunctionalTestCase
   end
 
   # ----------------------------
-  #  Lookup name.
+  #  Lookup's.
+  #  These are links like /lookup_name/Amanita+muscaria
+  #  They can be created by the Textile Sandbox, and should always redirect
+  #  to the appropriate model.
+  # /lookup_accepted_name is intended for use by other web sites
   # ----------------------------
 
-  def test_lookup_name
+  def test_lookup_comment
     c_id = comments(:minimal_unknown_obs_comment_1).id
     get(:lookup_comment, id: c_id)
     assert_redirected_to(controller: :comment, action: :show_comment, id: c_id)
     get(:lookup_comment, id: 10_000)
     assert_redirected_to(controller: :comment, action: :index_comment)
     assert_flash_error
+  end
 
+  def test_lookup_image
     i_id = images(:in_situ_image).id
     get(:lookup_image, id: i_id)
     assert_redirected_to(controller: :image, action: :show_image, id: i_id)
     get(:lookup_image, id: 10_000)
     assert_redirected_to(controller: :image, action: :index_image)
     assert_flash_error
+  end
 
+  def test_lookup_location
     l_id = locations(:albion).id
     get(:lookup_location, id: l_id)
     assert_redirected_to(controller: :location, action: :show_location, id: l_id)
@@ -2322,7 +2330,15 @@ class ObserverControllerTest < FunctionalTestCase
     # assert_redirected_to(controller: :location, action: :index_location)
     assert_redirected_to(%r{/location/index_location})
     assert_flash_warning
+  end
 
+  def test_lookup_accepted_name
+    get(:lookup_accepted_name, id: names(:lactarius_subalpinus).text_name)
+    assert_redirected_to(controller: :name, action: :show_name,
+                         id: names(:lactarius_alpinus))
+  end
+
+  def test_lookup_name
     n_id = names(:fungi).id
     get(:lookup_name, id: n_id)
     assert_redirected_to(controller: :name, action: :show_name, id: n_id)
@@ -2347,7 +2363,9 @@ class ObserverControllerTest < FunctionalTestCase
     get(:lookup_name, id: "Agaricus campestris Linn.")
     assert_redirected_to(controller: :name, action: :show_name,
                          id: names(:agaricus_campestris).id)
+  end
 
+  def test_lookup_project
     p_id = projects(:eol_project).id
     get(:lookup_project, id: p_id)
     assert_redirected_to(controller: :project, action: :show_project, id: p_id)
@@ -2360,7 +2378,9 @@ class ObserverControllerTest < FunctionalTestCase
     get(:lookup_project, id: "project")
     assert_redirected_to(%r{/project/index_project})
     assert_flash_warning
+  end
 
+  def test_lookup_species_list
     sl_id = species_lists(:first_species_list).id
     get(:lookup_species_list, id: sl_id)
     assert_redirected_to(controller: :species_list, action: :show_species_list,
@@ -2375,7 +2395,9 @@ class ObserverControllerTest < FunctionalTestCase
     get(:lookup_species_list, id: "Flibbertygibbets")
     assert_redirected_to(controller: :species_list, action: :index_species_list)
     assert_flash_error
+  end
 
+  def test_lookup_user
     get(:lookup_user, id: rolf.id)
     assert_redirected_to(controller: :observer, action: :show_user, id: rolf.id)
     get(:lookup_user, id: "mary")


### PR DESCRIPTION
* Add `:lookup_accepted_name` as an exception to `before_action :login_required`.
* Divide former test_lookup_name into smaller components.
* Add test of lookup_accepted_name.
