### PR TITLE
Replaces fakeweb gem with webmock.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,9 @@ gem "byebug", group: [:development, :test]
 # Use debugger
 # gem "debugger", group: [:development, :test]
 
-# Fake web responses in test mode
-gem "fakeweb", "~> 1.3", group: :test
+# Stub and set expectations on HTTP requests in test mode
+# Allow selective disabling of internet
+gem "webmock", group: :test
 
 # Use capybara to simulate user-browser interaction
 gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,15 +83,17 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     cure_acts_as_versioned (0.6.3)
       activerecord (>= 3.0.9)
     debug_inspector (0.0.2)
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
-    fakeweb (1.3.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.2)
     i18n (0.7.0)
     jmespath (1.3.1)
     jquery-rails (4.2.1)
@@ -163,6 +165,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -206,6 +209,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -224,7 +231,6 @@ DEPENDENCIES
   coffee-rails
   coveralls
   cure_acts_as_versioned
-  fakeweb (~> 1.3)
   i18n
   jquery-rails
   jquery-slick-rails (~> 1.5.0.1)
@@ -240,6 +246,7 @@ DEPENDENCIES
   uglifier
   unicorn
   web-console (~> 2.0)
+  webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require "test_helper"
-require "fakeweb"
 
 class Hash
   def remove(*keys)
@@ -475,8 +474,8 @@ class ApiTest < UnitTestCase
   def test_posting_image_via_url
     setup_image_dirs
     url = "http://mushroomobserver.org/images/thumb/459340.jpg"
-    response = File.read("#{::Rails.root}/test/images/test_image.curl")
-    FakeWeb.register_uri(:get, url, response: response)
+    stub_request(:any, url).
+      to_return(File.read("#{::Rails.root}/test/images/test_image.curl"))
     params = {
       method:     :post,
       action:     :image,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,13 @@ MiniTest::Reporters.use!
 # Allow simuluation of user-browser interaction with capybara
 require "capybara/rails"
 
+# Allow stubbing and setting expectations on HTTP, and selective
+#  disabling of internet requests.
+require "webmock/minitest"
+
+# Disable external requests while allowing localhost
+WebMock.disable_net_connect!(allow_localhost: true)
+
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"


### PR DESCRIPTION
* Allows easier stubbing and setting expectations on HTTP requests. That will let me test some corners of the app which I was having trouble testing with just fakeweb and minitest.
* Disables external networks requests during testing.
