### PR TITLE
Test previously uncovered lines in ApplicationController

### DIFF
--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -106,6 +106,23 @@ class LocationControllerTest < FunctionalTestCase
     assert_template("list_locations")
   end
 
+  def test_location_bounding_box
+    delta = 0.001
+    get(:list_locations, north: 0, south: 0, east: 0, west: 0)
+    query = Query.find(QueryRecord.last.id)
+    assert_equal(0 + delta, query.params[:north])
+    assert_equal(0 - delta, query.params[:south])
+    assert_equal(0 + delta, query.params[:east])
+    assert_equal(0 - delta, query.params[:west])
+
+    get(:list_locations, north: 90, south: -90, east: 180, west: -180)
+    query = Query.find(QueryRecord.last.id)
+    assert_equal(90, query.params[:north])
+    assert_equal(-90, query.params[:south])
+    assert_equal(180, query.params[:east])
+    assert_equal(-180, query.params[:west])
+  end
+
   def test_list_countries
     get_with_dump(:list_countries)
     assert_template("list_countries")


### PR DESCRIPTION
* Prevents regression of bug which was fixed in fb7305c676fe0b656f6a307cc68d836942a843f7.
  (Or, to put another spin on it, closes the stable door after the horse has bolted.)

Here is the Slack dialogue which led to this PR:
[08:47]  
jasonphollinger Joe, there is something you can do.  Apparently tweaked_bounding_box_params is not covered by a test.  I've fixed the bug, but if you wouldn't mind adding a test for it, that would be great.  Thanks!  (When you split it out we didn't notice that it relied on the local variable 'query'.  I refactored it slightly so that it doesn't need to know about the query.  Just running tests now, will push it out to production in a second.  It's on master.) (edited)

[08:48]  
jdcohenesq I’ll have a look.

[16:05]  
jdcohenesq @jasonphollinger re test for tweaked_bounding_box_params
Sorry about the local variable, and thanks for running down the issue and fixing it.
I had noticed that the predecessor code wasn’t tested, but couldn’t figure out how to test it.  After scratching my head most of the day, the best I could come up with is in the following snippet.

[16:06]  
jdcohenesq added and commented on this Ruby snippet
``` ruby
  def test_location_bounding_box
    delta = 0.001
    get(:list_locations, north: 0, south: 0, east: 0, west: 0)
    query = Query.find(QueryRecord.last.id)
    assert_equal(0 + delta, query.params[:north])
    assert_equal(0 - delta, query.params[:south])
    assert_equal(0 + delta, query.params[:east])
    assert_equal(0 - delta, query.params[:west])
​
    get(:list_locations, north: 90, south: -90, east: 180, west: -180)
    query = Query.find(QueryRecord.last.id)
    assert_equal(90, query.params[:north])
    assert_equal(-90, query.params[:south])
    assert_equal(180, query.params[:east])
    assert_equal(-180, query.params[:west])
  end
```
1 Comment 
This goes in LocationControllerTest.

[16:07]  
jdcohenesq Questions:
1. Is there a better way to test it?
2. Is there a better way — inside a controller test — to get the params of the last query? (edited)
[16:30]  
jdcohenesq PS: If the test is OK, I’ll push it up and create a PR.

[16:30]  
jasonphollinger Darn, I was hoping you knew how that code was used! :slightly_smiling_face:

I like your direct test, but I feel like there should be a way to test it at a higher-level, too.

I think it has something to do with maps.  If there are too many observations, it starts simplifying the map by lumping nearby points into "bounding boxes".

But it might be tricky getting it to do that in test mode, since there's no way to get close to the limit -- we just don't have nearly enough observations in our test fixtures.  I think we'll need to temporarily lower the limit, maybe have the test create a bunch of nearby locations to ensure we hit that limit, then let it go to make sure it combines all those new locations and lets us request a "blow up map" for those lumped locations.

Blah.  Sounds like _a lot_ of work.  Which is presumably why I never wrote the test in the first place. :disappointed:

[16:39]  
jdcohenesq I think it would require at most 4 points: 2 widely spaced (e.g., Nome and Capetown) to force display of small-scale map, plus 2 closely spaced (e.g., 2 adjacent corners in Reno) to force the boxing.
But I don’t know how to test that.

[16:40]  
jasonphollinger The more I think about it, the more I think we should stick with your test.  The whole mapping thing will probably get ripped out eventually anyway.  There are packages out there which deal with simplifying overcomplex maps, and probably do a better job.  Check out how CNALH (Symbiota) does it, for example.  Not perfect; it still causes my laptop to hang for several seconds; but it's better than what we have. http://lichenportal.org/portal/map/googlemap.php?maptype=taxa&taxon=54388&clid=0

[16:45]  
jdcohenesq OK. I’ll push it up and create a PR.  If you have second thoughts, then simply comment on the PR.
17:18]  
jdcohenesq You’re right; it need a lot of points — 4 are not enough.
(When I was banging my head against this today, I did figure out that this was used only by maps. But when I couldn’t think how to test that, I stopped looking into it.)

[17:19]  
jasonphollinger Okay, it's a sign.  At least now this test would have caught the little typo.  Good start.