### PR TITLE
Test BackwardsCompatibility and fix one bug

### DIFF
--- a/app/controllers/observer_controller/backwards_compatibility.rb
+++ b/app/controllers/observer_controller/backwards_compatibility.rb
@@ -8,7 +8,7 @@ class ObserverController
       args = url.sub(/^[^?]*/, "")
     elsif url.match(/\/\d+$/)
       base = url.sub(/\/\d+$/, "")
-      args = url.sub(/.*(\/\d+)$/, "\1")
+      args = url.sub(/.*(\/\d+)$/, '\1')
     else
       base = url
       args = ""

--- a/test/integration/observer_controller_supplemental_test.rb
+++ b/test/integration/observer_controller_supplemental_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+# Tests which supplement controller/observer_controller_test.rb
+class ObserverControllerSupplementalTest < IntegrationTestCase
+  # ----------------------------
+  #  BackwardsCompatibility
+  # ----------------------------
+  def test_backward_compatibility
+    obj = "name"
+    old_method = "bogus_name_method"
+    new_method = "show_name"
+    id = names(:coprinus_comatus).id
+
+    # Prove that action_has_moved creates method named old_method
+    ObserverController::action_has_moved(obj, old_method, new_method)
+    assert(ObserverController.method_defined?(old_method))
+
+    # Log in to avoid issues with before_action :login_required.
+    # (This should go away if BackwardCompatibility gets changed
+    # to not require login for every old method.)
+    user = users(:rolf)
+    visit("/account/login")
+    fill_in("User name or Email address:", with: user.login)
+    fill_in("Password:", with: "testpassword")
+    click_button("Login")
+
+    # Prove that request to observer/old_method?id=x
+    # redirects to obj/new_method?id=x
+    visit("/observer/#{old_method}?id=#{id}")
+    assert_equal("http://www.example.com/#{obj}/#{new_method}?id=#{id}",
+                 page.current_url)
+
+    # Prove that request to observer/old_method/nnn
+    # redirects to obj/new_method/nnn
+    visit("/observer/#{old_method}/#{id.to_s}")
+    assert_equal("http://www.example.com/#{obj}/#{new_method}/#{id}",
+                 page.current_url)
+
+    # Clean up the bogus method.
+    ObserverController.send(:remove_method, old_method)
+    refute(ObserverController.method_defined?(old_method))
+  end
+end


### PR DESCRIPTION
- Also add test of BackwardsCompatibility methods, and
- Fixes bug exposed by test.

The bug is that `/observer/old_method/nnn` redirects to `/obj/new_method/\u001` instead of `/obj/new_method/nnn`
The problem is the second argument to `sub` was `”\1”`. This was intended to be the  regexp capture group, but actually was the *string* `\l`.  To get the capture group, we need single quotes or an extra backslash.  See https://ruby-doc.org/core-2.2.0/String.html#method-i-sub.

There's still at least one issue with `BackwardsCompatibility#action_has_moved`
(assuming that we should not change the login requirements on any route):
None of the methods created by `action_has_moved` are excepted from the `before_action :login_required` callback, but many should be excepted.

Four ways to address this (and there are probably more):
- Add a skip_before_action to `backwards_compatibility` with a manual list of methods to except.
- Manually add those methods to the exceptions in observer_controller.rb (and maybe move all the `action_has_moved` calls to that file).
- More metaprogramming, e.g., add a parameter to `action_has_moved` which is a list of filters to be excepted, with `action_has_moved`to reflect on that list and create appropriate exceptions.

Another possibility (suggested by @nwilson-eol) is ditching BackwardsCompatibility and adding routes.  (And another is to keep BackwardsCompatibility but have it metaprogramatically add routes instead of methods. Ugh!)
