### PR TITLE
Remove CreateAndEditObservation#update_observation_object

### DIFF
--- a/app/controllers/observer_controller/create_and_edit_observation.rb
+++ b/app/controllers/observer_controller/create_and_edit_observation.rb
@@ -527,16 +527,6 @@ class ObserverController
     false
   end
 
-  # Update observation, check if valid.
-  def update_observation_object(observation, args)
-    success = true
-    unless observation.update(args.permit(observation_whitelisted_args))
-      flash_object_errors(observation)
-      success = false
-    end
-    success
-  end
-
   # Attempt to upload any images.  We will attach them to the observation
   # later, assuming we can create it.  Problem is if anything goes wrong, we
   # cannot repopulate the image forms (security issue associated with giving


### PR DESCRIPTION
It’s dead code. See PR #269; Slack discussion 2017-01-16:
>[16:39]
nathan update_observation_object looks dead to me.