### PR TITLE
Broaden results of user pattern search sorted by location

### DIFF
--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -69,7 +69,8 @@ module Query::Modules::Ordering
 
     when "location"
       if columns.include?("location_id")
-        add_join(:locations)
+        # Join Users with null locations, else join records with locations
+        model == User ? add_join(:locations!) : add_join(:locations)
         User.current_location_format == :scientific ?
           "locations.scientific_name ASC" : "locations.name ASC"
       end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2374,6 +2374,10 @@ class QueryTest < UnitTestCase
                 :User, :pattern_search, pattern: users(:mary).name)
     assert_query(User.all,
                 :User, :pattern_search, pattern: "")
+    # sorted by location should include Users without location
+    # (Differs from searches on other Classes or by other sort orders)
+    assert_query(User.all,
+                :User, :pattern_search, pattern: "", by: "location")
   end
 
   ##############################################################################


### PR DESCRIPTION
- Broadens the results to Include users who have no location.
- Adds test assertion to prevent regression.
- Delivers [Pivotal #137965343](https://www.pivotaltracker.com/story/show/137965343).