### PR TITLE
Add coverage to observer_controller/user_controller

### DIFF
--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2579,4 +2579,19 @@ class ObserverControllerTest < FunctionalTestCase
     actual = @controller.external_sites_user_can_add_links_to(obs)
     assert_equal(expect.map(&:name), actual.map(&:name))
   end
+
+  # -------------------------------------
+  #  observer_controller/user_controller
+  # -------------------------------------
+
+  # Prove that user_index is restricted to admins
+  def test_index_user
+    login("rolf")
+    get(:index_user)
+    assert_redirected_to(:root)
+
+    make_admin
+    get(:index_user)
+    assert_response(:success)
+  end
 end

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2580,9 +2580,11 @@ class ObserverControllerTest < FunctionalTestCase
     assert_equal(expect.map(&:name), actual.map(&:name))
   end
 
-  # -------------------------------------
+  # ------------------------------------------------------------
+  #  User
   #  observer_controller/user_controller
-  # -------------------------------------
+  #  Also see test/integration/observer_user_controller_test.rb
+  # ------------------------------------------------------------
 
   # Prove that user_index is restricted to admins
   def test_index_user

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2596,4 +2596,35 @@ class ObserverControllerTest < FunctionalTestCase
     get(:index_user)
     assert_response(:success)
   end
+
+  def test_change_user_bonuses
+    user = users(:mary)
+    old_contribution = mary.contribution
+    bonus = "7 lucky \n 13 unlucky"
+
+    # Prove that non-admin cannot change bonuses and attempt to do so
+    # redirects to target user's page
+    login("rolf")
+    get(:change_user_bonuses, id: user.id)
+    assert_redirected_to(action: :show_user, id: user.id)
+
+    # Prove that admin posting bonuses in wrong format causes a flash error,
+    # leaving bonuses and contributions unchanged.
+    make_admin
+    post(:change_user_bonuses, id: user.id, val: "wong format 7")
+    assert_flash_error
+    user.reload
+    assert_empty(user.bonuses)
+    assert_equal(old_contribution, user.contribution)
+
+    # Prove that admin can change bonuses
+    post(:change_user_bonuses, id: user.id, val: bonus)
+    user.reload
+    assert_equal([[7, "lucky"], [13, "unlucky"]], user.bonuses)
+    assert_equal(old_contribution + 20, user.contribution)
+
+    # Prove that admin can get bonuses
+    get(:change_user_bonuses, id: user.id)
+    assert_response(:success)
+  end
 end

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2221,7 +2221,7 @@ class ObserverControllerTest < FunctionalTestCase
   def init_for_list_checkbox_tests
     @spl1 = species_lists(:first_species_list)
     @spl2 = species_lists(:unknown_species_list)
-    @obs1 = observations(:coprinus_comatus_obs)
+    @obs1 = observations(:unlisted_rolf_obs)
     @obs2 = observations(:detailed_unknown_obs)
     assert_users_equal(rolf, @spl1.user)
     assert_users_equal(mary, @spl2.user)

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -9,6 +9,7 @@
 # in order to override DEFAULTS, e.g.:
 #   where: somewhere
 #   location:
+
 DEFAULTS: &DEFAULTS
   name: boletus_edulis
   notes: $LABEL # sometimes useful for debugging
@@ -56,6 +57,7 @@ coprinus_comatus_obs:
   vote_cache: 1
   thumb_image: connected_coprinus_comatus_image
   images: connected_coprinus_comatus_image
+  species_lists: one_genus_three_species_list
   specimens: coprinus_comatus_nybg_spec, coprinus_comatus_rolf_spec
 
 agaricus_campestris_obs:
@@ -68,6 +70,7 @@ agaricus_campestris_obs:
   notes: From the lawn next door
   thumb_image: agaricus_campestris_image
   images: agaricus_campestris_image
+  species_lists: one_genus_three_species_list
   specimens: agaricus_campestris_spec
 
 agaricus_campestrus_obs:
@@ -153,6 +156,7 @@ peltigera_obs:
   vote_cache: 3
   thumb_image: peltigera_image
   images: peltigera_image
+  species_lists: one_genus_three_species_list
 
 peltigera_rolf_obs:
   <<: *DEFAULTS
@@ -190,6 +194,7 @@ boletus_edulis_obs:
   is_collection_location: 0
   notes: 'A tasty bolete!'
   vote_cache: 3
+  species_lists: one_genus_three_species_list
 
 owner_only_favorite_eq_fungi:
   <<: *DEFAULTS
@@ -246,7 +251,8 @@ imageless_unvouchered_obs:
   when: 2016-08-25
   user: ignore_imageless_user
 
-imged_unvouchered_obs:      # need >=2 imaged B edulis Obs's for filter tests
+# need >=2 imaged B edulis Obs's for filter tests
+imged_unvouchered_obs:
   <<: *DEFAULTS
   when: 2016-08-27
   images: query_first_image
@@ -268,3 +274,10 @@ updated_2013_obs:
   <<: *DEFAULTS
   when: 2013-09-08
   updated_at: 2013-09-08 17:21:00
+
+unlisted_rolf_obs:
+  <<: *DEFAULTS
+  location: point_reyes
+  user: rolf
+  when: 2017-01-20
+

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -2,10 +2,17 @@
 # references for associations. Some associations for this fixture may be defined
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-#
+
+DEFAULTS: &DEFAULTS
+  user: dick
+  user_group: dick_only
+  admin_group: dick_only
+  title: $LABEL
+
 # admins: rolf (1), mary (2)
 # members: rolf (1), mary (2), katrina (5)
 eol_project:
+  <<: *DEFAULTS
   user: rolf
   user_group: eol_users
   admin_group: eol_admins
@@ -20,7 +27,7 @@ eol_project:
 # images: 1 and 2 (detailed_unknown_obs's images - owned by mary)
 # species_lists: 3 (unknown_species_list - owned by mary)
 bolete_project:
-  user: dick
+  <<: *DEFAULTS
   user_group: bolete_users
   admin_group: bolete_admins
   title: Bolete Project
@@ -32,37 +39,31 @@ bolete_project:
   species_lists: unknown_species_list
 
 empty_project:
+  <<: *DEFAULTS
   user: mary
   user_group: mary_only
   admin_group: mary_only
-  title: $LABEL
   summary: No Images Observations or Lists
 
 two_list_project: # 2 lists, 0 observations, 0 images
+  <<: *DEFAULTS
   user: mary
   user_group: mary_only
   admin_group: mary_only
-  title: $LABEL
   species_lists: query_first_list, query_second_list
 
 obs_collected_and_displayed_project:
-  user: dick
-  user_group: dick_only
-  admin_group: dick_only
-  title: $LABEL
+  <<: *DEFAULTS
   observations: collected_at_obs, displayed_at_obs
 
 two_img_obs_project:
-  user: dick
-  user_group: dick_only
-  admin_group: dick_only
-  title: $LABEL
+  <<: *DEFAULTS
   observations: two_img_obs
 
 rss_log_project:
-  user: dick
-  user_group: dick_only
-  admin_group: dick_only
-  title: $LABEL
+  <<: *DEFAULTS
   rss_log: project_rss_log
 
+one_genus_two_species_project:
+  <<: *DEFAULTS
+  observations: peltigera_obs, agaricus_campestris_obs, boletus_edulis_obs

--- a/test/fixtures/species_lists.yml
+++ b/test/fixtures/species_lists.yml
@@ -69,3 +69,8 @@ where_list:
   when: 2006-03-09
   where: wherenolocation  # 1-word where, unique for SpeciesList
   location: nil
+
+one_genus_three_species_list:
+  <<: *DEFAULTS
+  when: 2017-01-20
+

--- a/test/fixtures/species_lists.yml
+++ b/test/fixtures/species_lists.yml
@@ -3,76 +3,69 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+DEFAULTS: &DEFAULTS
+  user:     mary
+  where:    nil
+  location: burbank
+  title:    $LABEL
+
 # has no obs
-first_species_list: # id: 1
+first_species_list:
+  <<: *DEFAULTS
   created_at: 2006-03-01 21:14:00
   updated_at: 2006-03-01 21:14:00
   when: 2006-03-01
   user: rolf
-  where: nil
-  location: burbank
   title: A Species List
   notes: ¡Got Skunked!
   rss_log: species_list_rss_log
 
 # has no obs
-another_species_list: # id: 2
+another_species_list:
+  <<: *DEFAULTS
   created_at: 2006-03-02 21:14:00
   updated_at: 2006-03-02 21:14:00
   when: 2006-03-02
   user: rolf
-  where: nil
-  location: burbank
   title: Another Species List
   notes: Got Skunked Again!
 
 # has: minimal_unknown_obs (1) and detailed_unknown_obs (2)
-unknown_species_list: # id: 3
+unknown_species_list:
+  <<: *DEFAULTS
   created_at: 2006-03-09 21:14:00
   updated_at: 2006-03-09 21:14:00
   when: 2006-03-09
-  user: mary
-  where: nil
-  location: burbank
   title: List of mysteries
   notes: Things I don't know
 
+# used by QueryTest
 query_first_list:
+  <<: *DEFAULTS
   when: 2006-03-09
-  user: mary
-  where: nil
-  location: burbank
-  title: $LABEL
-  notes: Used by QueryTest
 
+# used by QueryTest
 query_second_list:
+  <<: *DEFAULTS
   when: 2006-03-09
-  user: mary
-  where: nil
-  location: burbank
-  title: $LABEL
-  notes: Used by QueryTest
 
+# used by QueryTest
+# has 1-word notes which is unique for SpeciesList
 query_notes_list:
+  <<: *DEFAULTS
   when: 2006-03-09
-  user: mary
-  where: nil
-  location: burbank
-  title: $LABEL
-  notes: amazingraremushroom # 1-word notes, unique for SpeciesList
+  notes: amazingraremushroom
 
+# used by QueryTest
 where_no_mushrooms_list:
+  <<: *DEFAULTS
   when: 2006-03-09
-  user: mary
   where: no mushrooms
   location: no_mushrooms_location
-  title: $LABEL
-  notes: Used by QueryTest
 
+# used by QueryTest
 where_list:
+  <<: *DEFAULTS
   when: 2006-03-09
-  user: mary
   where: wherenolocation  # 1-word where, unique for SpeciesList
   location: nil
-  title: $LABEL
-  notes: Used by QueryTest

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -93,3 +93,17 @@ vouchered_only_user:
   verified:  2016-09-02 13:50:00
   content_filter: <%= { has_specimen: "yes" }.to_yaml.inspect %>
   layout_count: 24
+
+uniquely_named_user:
+  <<: *DEFAULTS
+
+# Used by integration test of user_search
+first_name_sorts_user:
+  <<: *DEFAULTS
+  name: name sorts second
+
+second_name_sorts_user:
+  <<: *DEFAULTS
+  name: name sorts first
+
+

--- a/test/integration/observer_user_controller_test.rb
+++ b/test/integration/observer_user_controller_test.rb
@@ -143,6 +143,16 @@ class ObserverUserControllerTest < IntegrationTestCase
     prove_checklist_content(expect)
   end
 
+  # Prove that Site checklist goes to correct page with correct content
+  def prove_site_checklist
+    expect = Name.where(rank: Name.ranks[:Species])
+
+    visit("/observer/checklist")
+    assert_match(%r{Checklist for #{:app_title.l}}, page.title, "Wrong page")
+
+    prove_checklist_content(expect)
+  end
+
   # Prove that checklist has as many links as species expected,
   # and no species is missing
   def prove_checklist_content(expect)

--- a/test/integration/observer_user_controller_test.rb
+++ b/test/integration/observer_user_controller_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+require "capybara_helper"
+
+# Test observer_controller/user_controller
+class ObserverUserControllerTest < IntegrationTestCase
+  def test_user_controller
+    # -------------------------------------------------------
+    #  user_search
+    #  Also see test/controllers/observer_controller_test.rb
+    # -------------------------------------------------------
+
+    # Prove that user-type pattern searches go to correct page
+
+    visit("/")
+
+    # When pattern is a user's id, go directly to that user's page
+    user = users(:rolf)
+    fill_in("search_pattern", with: user.id)
+    page.select("User", from: :search_type)
+    click_button("Search")
+    assert_match(%r{Contribution Summary for #{user.name}}, page.title,
+                 "Wrong page")
+
+    # When a non-id pattern matches only one user, show that user.
+    user = users(:uniquely_named_user)
+    fill_in("search_pattern", with: user.name)
+    page.select("User", from: :search_type)
+    click_button("Search")
+    assert_match(%r{Contribution Summary for #{user.name}}, page.title,
+                 "Wrong page")
+
+    # When pattern has no matches, go to list page, and display flash message.
+    pattern = "NonexistentUserContent"
+    fill_in("search_pattern", with: pattern)
+    page.select("User", from: :search_type)
+    click_button("Search")
+    assert_match(%r{Users Matching .+#{pattern}}, page.title,
+                 "Wrong page")
+    flash = (:runtime_no_matches.l).sub("[types]", "users")
+    page.assert_selector(".alert", text: "#{flash}")
+
+    # When pattern matches multiple users, list them.
+    pattern = "name_sorts_user"
+    expected_hits = User.where("login LIKE ?", "%#{pattern}").order(:name)
+
+    fill_in("search_pattern", with: pattern)
+    page.select("User", from: :search_type)
+    click_button("Search")
+    assert_match(%r{Users Matching .+#{pattern}}, page.title,
+                 "Wrong page")
+
+    # -------------------------------------------------------
+    #  show_selected_users
+    #  Also see test/controllers/observer_controller_test.rb
+    # -------------------------------------------------------
+
+    # Prove that sorting links include "Contribution" (when not in admin mode)
+    sorting_links = page.find("#sorts")
+    assert_match(/Contribution/, sorting_links.text)
+
+=begin Following test fails, and I don't know how to get it to pass.
+    # -------------------------------------------------------
+    #  next_user and prev_user
+    #  Also see test/controllers/observer_controller_test.rb
+    # -------------------------------------------------------
+
+    # Results should have correct # of users
+    # (Fixtures should be defined so that there are only 2 matches.)
+    results = page.find(".results")
+    results.assert_selector("a", count: 2)
+
+    # First result should be User whose name is first in alpha order.
+    assert_match(/#{expected_hits.first.name}/, results.first("a").text)
+
+    # Different sort order should change the order of the results
+    # (because of the definitions of Fixtures which match this search).
+    click_on("Login Name")
+    results = page.find(".results")
+    refute_match(/#{expected_hits.first.name}/, results.first("a").text)
+
+    results.first("a").click
+    assert_match(%r{Contribution Summary for #{expected_hits.second.name}},
+                    page.title, "Wrong page")
+
+    # Prove that next_user and prev_user redirect to correct page
+    click_on("Next")
+    assert_match(%r{Contribution Summary for #{expected_hits.first.name}},
+                    page.title, "Wrong page")
+
+    click_on("Previous")
+    assert_match(%r{Contribution Summary for #{expected_hits.second.name}},
+                    page.title, "Wrong page")
+=end
+  end
+
+end

--- a/test/integration/observer_user_controller_test.rb
+++ b/test/integration/observer_user_controller_test.rb
@@ -106,7 +106,7 @@ class ObserverUserControllerTest < IntegrationTestCase
                   uniq
 
     visit("/observer/show_user/#{user.id}")
-    click_on(:app_life_list.l)
+    click_on(:app_life_list.l, match: :first)
     assert_match(%r{Checklist for #{user.name}}, page.title, "Wrong page")
 
     prove_checklist_content(expect)
@@ -114,7 +114,7 @@ class ObserverUserControllerTest < IntegrationTestCase
 
   # Prove that Species List checklist goes to correct page with correct content
   def test_species_list_checklist
-    list = species_lists(:unknown_species_list)
+    list = species_lists(:one_genus_three_species_list)
     expect = Name.joins(observations: :observations_species_lists).
                         where("observations_species_lists.species_list_id
                                = #{list.id}

--- a/test/integration/observer_user_controller_test.rb
+++ b/test/integration/observer_user_controller_test.rb
@@ -128,6 +128,21 @@ class ObserverUserControllerTest < IntegrationTestCase
     prove_checklist_content(expect)
   end
 
+  # Prove that Project checklist goes to correct page with correct content
+  def test_project_checklist
+    project = projects(:one_genus_two_species_project)
+    expect = Name.joins(observations: :observations_projects).
+                        where("observations_projects.project_id = #{project.id}
+                               AND names.rank = #{Name.ranks[:Species]}").
+                        uniq
+
+    visit("/project/show_project/#{project.id}")
+    click_on("Checklist")
+    assert_match(%r{Checklist for #{project.title}}, page.title, "Wrong page")
+
+    prove_checklist_content(expect)
+  end
+
   # Prove that checklist has as many links as species expected,
   # and no species is missing
   def prove_checklist_content(expect)

--- a/test/models/checklist_test.rb
+++ b/test/models/checklist_test.rb
@@ -12,6 +12,7 @@ class ChecklistTest < UnitTestCase
       "Agaricus campestris",
       "Agaricus campestros",
       "Agaricus campestrus",
+      "Boletus edulis",
       "Coprinus comatus",
       "Strobilurus diminutivus"
     ]
@@ -29,8 +30,8 @@ class ChecklistTest < UnitTestCase
 
   def test_checklist_for_site
     data = Checklist::ForSite.new
-    all_species = (rolfs_species + katrinas_species + dicks_species).sort
-    all_genera = genera(all_species)
+    all_species = (rolfs_species + katrinas_species + dicks_species).uniq.sort
+    all_genera = genera(all_species).uniq
     assert_equal(all_genera, data.genera)
     assert_equal(all_species, data.species)
   end
@@ -49,8 +50,14 @@ class ChecklistTest < UnitTestCase
     assert_equal(katrinas_species, data.species)
 
     data = Checklist::ForUser.new(rolf)
-    assert_equal(3, data.num_genera)
-    assert_equal(6, data.num_species)
+    assert_equal(4, data.num_genera)
+
+    expect = Name.joins(observations: :user).
+                  where("observations.user_id = #{users(:rolf).id}
+                         AND names.rank = #{Name.ranks[:Species]}").
+                  uniq.size
+    assert_equal(expect, data.num_species)
+
     assert_equal(genera(rolfs_species), data.genera)
     assert_equal(rolfs_species, data.species)
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1559,11 +1559,15 @@ class QueryTest < UnitTestCase
     assert_query([locations(:howarth_park).id,
                   locations(:salt_point).id],
                  :Location, :advanced_search, location: "park")
-    assert_query([locations(:burbank).id],
+
+    assert_query(Location.joins(observations: :user).
+                          where(observations: { user: rolf }).uniq,
                  :Location, :advanced_search, user: "rolf")
+
     assert_query(Location.joins(:observations).
-                          where(:observations => { user: dick }).distinct,
+                          where(observations: { user: dick }).uniq,
                  :Location, :advanced_search, user: "dick")
+
     # content in obs.notes
     assert_query([locations(:burbank).id],
                  :Location, :advanced_search, content: '"strange place"')


### PR DESCRIPTION
Coverage had been at 40.21.  See [Coveralls report](https://coveralls.io/builds/9716352/source?filename=app%2Fcontrollers%2Fobserver_controller%2Fuser_controller.rb). This branch should cover pretty much all the red lines in the report.

Questions/Comments:
In general, I preferred adding integration tests rather than functional tests. (This is partly due to Rails changes which we will hit when we move to 5.0. See, e.g., http://blog.bigbinary.com/2016/04/19/changes-to-test-controllers-in-rails-5.html.)
QUESTION: Do you prefer functional tests?

When testing whether the correct page was being displayed, I matched against <title> in <head>. I thought it would be the most stable (least brittle) match. 
QUESTIONS: Do you think the response url is more stable? Can you suggest a more stable match? 