### PR TITLE
Cover ObserverController/ShowObservation

### DIFF
--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -103,6 +103,12 @@ class ObserverControllerTest < FunctionalTestCase
     assert_equal(:thumbnail, user.thumbnail_size)
   end
 
+  def test_show_obs
+    obs = observations(:fungi_obs)
+    get(:show_obs, id: obs.id)
+    assert_redirected_to(action: :show_observation, id: obs.id)
+  end
+
   def test_page_loads
     get_with_dump(:index)
     assert_template(:list_rss_logs, partial: :_rss_log)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -95,6 +95,14 @@ class ObserverControllerTest < FunctionalTestCase
     get_with_dump(:show_observation, id: obs.id)
   end
 
+  def test_show_observation_change_thumbnail_size
+    user = users(:small_thumbnail_user)
+    login(user.name)
+    get(:show_observation, set_thumbnail_size: :thumbnail)
+    user.reload
+    assert_equal(:thumbnail, user.thumbnail_size)
+  end
+
   def test_page_loads
     get_with_dump(:index)
     assert_template(:list_rss_logs, partial: :_rss_log)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -114,3 +114,8 @@ obs_default_location_user:
   <<: *DEFAULTS
   verified: 2017-01-15 08:17:00
 
+small_thumbnail_user:
+  <<: *DEFAULTS
+  verified: 2017-01-28 08:17:00
+  thumbnail_size: small
+


### PR DESCRIPTION
Covers the last few previously uncovered lines of this file.

QUESTIONS: `show_obs` simply redirects to `show_observation`. 

1. Do we redirect, or are requests to this action better handled by routing (like @nwilson-eol suggested for the now-defunct backwards_compatibility stuff)? 
2. If a redirect, should the html status code be 301 (Moved Permanently), rather than 302 (Found)? See https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html. 
3. If anyone actually does anything with 301, is that generally a way to handle backwards compatibility?