### PR TITLE
Remove list_notifications

### DIFF
--- a/app/controllers/observer_controller/notification_controller.rb
+++ b/app/controllers/observer_controller/notification_controller.rb
@@ -26,12 +26,4 @@ class ObserverController
   def name_tracking_emails(user_id)
     QueuedEmail.where(flavor: "QueuedEmail::NameTracking", to_user_id: user_id)
   end
-
-  # Lists notifications that the given user has created.
-  # Inputs: none
-  # Outputs:
-  #   @notifications
-  def list_notifications # :norobots:
-    @notifications = Notification.where(user_id: @user.id).order(:flavor)
-  end
 end


### PR DESCRIPTION
- This method was unused.
- It also had the only line in this file which was not covered by the test suite. Therefore its removal finishes https://www.pivotaltracker.com/story/show/137757299 (Improve NotificationController coverage).