### PR TITLE
Remove simplecov filter of query/old files

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,6 +2,3 @@ require "simplecov"
 require "coveralls"
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-   add_filter "/app/classes/query/old"
-end


### PR DESCRIPTION
This filter is obsolete; the files it excludes no longer exist.

I added this filter to prevent simplecov from including these files in its coverage report.
@mo-nathan removed all these files 3 months ago.  See b91e14d6707f48cff9b5f5db3e3c9a48a76e9e92.