### PR TITLE
Fix bug where tabs throw error after specimen search

### DIFF
--- a/app/controllers/specimen_controller.rb
+++ b/app/controllers/specimen_controller.rb
@@ -1,11 +1,18 @@
 class SpecimenController < ApplicationController
   before_action :login_required, except: [
+    :index_specimen,
     :specimen_search,
     :list_specimens,
     :show_specimen,
     :herbarium_index,
     :observation_index
   ]
+
+  # Displays matrix of selected Specimen's (based on current Query).
+  def index_specimen # :nologin: :norobots:
+    query = find_or_create_query(:Specimen, by: params[:by])
+    show_selected_specimens(query, id: params[:id].to_s, always_index: true)
+  end
 
   # Display list of Specimens whose text matches a string pattern.
   def specimen_search # :nologin: :norobots:

--- a/test/controllers/specimen_controller_test.rb
+++ b/test/controllers/specimen_controller_test.rb
@@ -237,4 +237,23 @@ class SpecimenControllerTest < FunctionalTestCase
       id: specimens(:interesting_unknown).id
     }
   end
+
+  def test_specimen_search
+    # Two specimens match this pattern.
+    pattern = "Coprinus comatus"
+    get(:specimen_search, pattern: pattern)
+
+    assert_response(:success)
+    assert_template("list_specimens")
+    # In results, expect 1 row per specimen
+    assert_select(".results tr", 2)
+  end
+
+  def test_index_specimen
+    get(:index_specimen)
+    assert_response(:success)
+    assert_template("list_specimens")
+    # In results, expect 1 row per specimen
+    assert_select(".results tr", Specimen.all.size)
+  end
 end


### PR DESCRIPTION
An error was thrown by clicking a sort-order tab after a pattern search for specimens.
The tabset on the search results page calls `SpecimenController#index_specimen`, but that method didn't exist.

This PR adds the `index_specimen` method, and finishes https://www.pivotaltracker.com/story/show/104646714