### PR TITLE
Improve group names

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -442,10 +442,10 @@ class Name < AbstractModel
       gsub(/__\*?\*? [^_\*]* \*?\*?__/x, " "). # (this part should be unnecessary)
       # Because "group" was removed by the 1st gsub above,
       # tack it back on (if it was part of display_name)
-      concat(group_designation(name))
+      concat(group_suffix(name))
   end
 
-  def self.group_designation(name)
+  def self.group_suffix(name)
     / group\b/.match(name.display_name).to_s
   end
 

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -57,7 +57,7 @@
 #  SUBSPECIES_PAT::     (Xxx yyy ssp. zzz) (Author)
 #  VARIETY_PAT::        (Xxx yyy ... var. zzz) (Author)
 #  FORM_PAT::           (Xxx yyy ... f. zzz) (Author)
-#  GROUP_PAT::          (Xxx yyy ...) group
+#  GROUP_PAT::          (Xxx) | (Xxx yyy ...) group
 #  AUTHOR_PAT:          (any of the above) (Author)
 #
 #  * Results are grouped according to the parentheses shown above.
@@ -1567,7 +1567,16 @@ class Name < AbstractModel
   SUBSPECIES_PAT  = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD}) "?) (\s #{AUTHOR_START}.*)? $/x
   VARIETY_PAT     = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD})? (?: \s #{VAR_ABBR} \s #{LOWER_WORD}) "?) (\s #{AUTHOR_START}.*)? $/x
   FORM_PAT        = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD})? (?: \s #{VAR_ABBR} \s #{LOWER_WORD})? (?: \s #{F_ABBR} \s #{LOWER_WORD}) "?) (\s #{AUTHOR_START}.*)? $/x
-  GROUP_PAT       = /^ ("? #{UPPER_WORD} (?: \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD})? (?: \s #{VAR_ABBR} \s #{LOWER_WORD})? (?: \s #{F_ABBR} \s #{LOWER_WORD})? )? "?) \s #{GROUP_ABBR} $/x
+  GROUP_PAT       = /^
+                      (?<taxon> "? #{UPPER_WORD}
+                        (?: \s #{LOWER_WORD}
+                          (?: \s #{SSP_ABBR} \s #{LOWER_WORD})?
+                          (?: \s #{VAR_ABBR} \s #{LOWER_WORD})?
+                          (?: \s #{F_ABBR}   \s #{LOWER_WORD})?
+                        )? "?
+                      )
+                      \s #{GROUP_ABBR}
+                    $/x
 
   class ParsedName
     attr_accessor :text_name, :search_name, :sort_name, :display_name
@@ -1648,7 +1657,7 @@ class Name < AbstractModel
   def self.parse_group(str, deprecated = false)
     return unless match = GROUP_PAT.match(str)
 
-    name = match[1] # str - anything below species - group
+    name = match[:taxon]
     text_name = name.tr("ë", "e")
 
     ParsedName.new(

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1894,11 +1894,16 @@ class Name < AbstractModel
     str.gsub(/([A-Z]\.) (?=[A-Z]\.)/, '\\1')
   end
 
-  # Add itallics and boldface to a standardized name (without author).
+  # Add italics and boldface markup to a standardized name (without author).
   def self.format_name(str, deprecated = false)
+    # Temporarily remove "group" from end of name
+    group_suffix = / group$/.match(str)
+    str = str.sub(/ group$/, "")
+
+    # add markup
     boldness = deprecated ? "" : "**"
     words = str.split(" ")
-    if (words.length & 1) == 0
+    if words.length.even?
       genus = words.shift
       words[0] = genus + " " + words[0]
     end
@@ -1907,7 +1912,11 @@ class Name < AbstractModel
       words[i] = "#{boldness}__#{words[i]}__#{boldness}"
       i -= 2
     end
-    words.join(" ")
+
+    name = words.join(" ")
+
+    # Restore "group" at end, if it was there to start with
+    group_suffix ? name + group_suffix[0] : name
   end
 
   def self.clean_incoming_string(str)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -440,13 +440,13 @@ class Name < AbstractModel
     name.display_name.gsub(/ ^\*?\*?__ | __\*?\*?[^_\*]*$ /x, "").
       gsub(/__\*?\*? [^_\*]* \s (#{ANY_NAME_ABBR}) \s \*?\*?__/x, ' \1 ').
       gsub(/__\*?\*? [^_\*]* \*?\*?__/x, " "). # (this part should be unnecessary)
-      # Because "group" at end of display_name is removed by 1st gsub above,
+      # Because "group" was removed by the 1st gsub above,
       # tack it back on (if it was part of display_name)
       concat(group_designation(name))
   end
 
   def self.group_designation(name)
-    / group$/.match(name.display_name).to_s
+    / group\b/.match(name.display_name).to_s
   end
 
   def self.display_to_real_search(name)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1641,16 +1641,15 @@ class Name < AbstractModel
   def self.parse_group(str, deprecated = false)
     return unless match = GROUP_PAT.match(str)
 
-    name = match[1]
+    name = match[1] # str - anything below species - group
     text_name = name.tr("ë", "e")
-    parent_name = name.sub(LAST_PART, "")
 
     ParsedName.new(
       text_name: text_name + " group",
       search_name: text_name + " group",
       sort_name: format_sort_name(text_name, "group"),
       display_name: format_name(name, deprecated) + " group",
-      parent_name: parent_name,
+      parent_name: name.split.size == 1 ? "" : name.sub(LAST_PART, ""),
       rank: :Group,
       author: ""
     )

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -439,7 +439,14 @@ class Name < AbstractModel
   def self.display_to_real_text(name)
     name.display_name.gsub(/ ^\*?\*?__ | __\*?\*?[^_\*]*$ /x, "").
       gsub(/__\*?\*? [^_\*]* \s (#{ANY_NAME_ABBR}) \s \*?\*?__/x, ' \1 ').
-      gsub(/__\*?\*? [^_\*]* \*?\*?__/x, " ") # (this part should be unnecessary)
+      gsub(/__\*?\*? [^_\*]* \*?\*?__/x, " "). # (this part should be unnecessary)
+      # Because "group" at end of display_name is removed by 1st gsub above,
+      # tack it back on (if it was part of display_name)
+      concat(group_designation(name))
+  end
+
+  def self.group_designation(name)
+    / group$/.match(name.display_name).to_s
   end
 
   def self.display_to_real_search(name)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1639,22 +1639,21 @@ class Name < AbstractModel
   end
 
   def self.parse_group(str, deprecated = false)
-    results = nil
-    if match = GROUP_PAT.match(str)
-      name = match[1]
-      text_name = name.tr("ë", "e")
-      parent_name = name.sub(LAST_PART, "")
-      results = ParsedName.new(
-        text_name: text_name + " group",
-        search_name: text_name + " group",
-        sort_name: format_sort_name(text_name, "group"),
-        display_name: format_name(name, deprecated) + " group",
-        parent_name: parent_name,
-        rank: :Group,
-        author: ""
-      )
-    end
-    results
+    return unless match = GROUP_PAT.match(str)
+
+    name = match[1]
+    text_name = name.tr("ë", "e")
+    parent_name = name.sub(LAST_PART, "")
+
+    ParsedName.new(
+      text_name: text_name + " group",
+      search_name: text_name + " group",
+      sort_name: format_sort_name(text_name, "group"),
+      display_name: format_name(name, deprecated) + " group",
+      parent_name: parent_name,
+      rank: :Group,
+      author: ""
+    )
   end
 
   def self.parse_genus_or_up(str, deprecated = false, rank = :Genus)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1940,6 +1940,7 @@ class Name < AbstractModel
     # Remember whether name included "group"
     group_suffix = / group\b/.match(name)
 
+    # Markup name (after removing "group") and adjust
     str = format_name(name.sub(/ group\b/, ""), :deprecated).
           sub(/^_+/, "").
           gsub(/_+/, " "). # put genus at the top
@@ -1966,7 +1967,7 @@ class Name < AbstractModel
     # including extra spaces so that "X y group" sorts before "X y Author"
     str = str + "   group" if group_suffix
 
-    unless author.blank?
+    if author.present?
       str += "  " + author.
                     gsub(/"([^"]*")/, '\1'). # collate "baccata" with baccata
                     gsub(/[Đđ]/, "d"). # mysql isn't collating these right

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1660,20 +1660,22 @@ class Name < AbstractModel
 
     name = match[:taxon]
     author = match[:author]
-    text_name = name.tr("ë", "e")
-    search_name = text_name + " group"
-    search_name = search_name + " " + author if author
+
+    text_name = name.tr("ë", "e") + " group"
+
+    search_name = text_name + (author ? " " + author : "")
+
     display_name = format_name(name, deprecated) + " group"
     display_name = display_name + " " + author if author
 
     ParsedName.new(
-      text_name: text_name + " group",
-      search_name: search_name,
-      sort_name: format_sort_name(text_name + " group", author),
+      text_name:    text_name,
+      search_name:  search_name,
+      sort_name:    format_sort_name(text_name, author),
       display_name: display_name,
-      parent_name: name.split.size == 1 ? "" : name.sub(LAST_PART, ""),
-      rank: :Group,
-      author: (author ? author : "")
+      parent_name:  name.split.size == 1 ? "" : name.sub(LAST_PART, ""),
+      rank:         :Group,
+      author:       (author ? author : "")
     )
   end
 

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1041,6 +1041,18 @@ class NameTest < UnitTestCase
       rank:             :Group,
       author:           ""
     )
+    do_name_parse_test(  # monomial, with author
+      "Agaricus group Author",
+      text_name:        "Agaricus group",
+      real_text_name:   "Agaricus group",
+      search_name:      "Agaricus group Author",
+      real_search_name: "Agaricus group Author",
+      sort_name:        "Agaricus   group  Author",
+      display_name:     "**__Agaricus__** group Author",
+      parent_name:      "",
+      rank:             :Group,
+      author:           "Author"
+    )
   end
 
   def test_name_parse_comb

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1808,8 +1808,10 @@ class NameTest < UnitTestCase
     assert_equal(%w(Aehou Aeiou Aëiou aÉIOU Aeiøu Aejou), x)
   end
 
-  def test_name_sort_order
-    names = [
+
+   # Prove that Name spaceship operator (<=>) uses sort_name to sort Names
+   def test_name_spaceship_operator
+   names = [
       create_test_name("Agaricomycota"),
       create_test_name("Agaricomycotina"),
       create_test_name("Agaricomycetes"),
@@ -1817,16 +1819,19 @@ class NameTest < UnitTestCase
       create_test_name("Agaricales"),
       create_test_name("Agaricineae"),
       create_test_name("Agaricaceae"),
-      create_test_name("Agaricus Đorn"),
+      create_test_name("Agaricus group"),
+      create_test_name("Agaricus Aaron"),
       create_test_name("Agaricus L."),
       create_test_name("Agaricus Øosting"),
-      create_test_name("Agaricus Śliwa"),
       create_test_name("Agaricus Zzyzx"),
+      create_test_name("Agaricus Śliwa"),
+      create_test_name("Agaricus Đorn"),
       create_test_name("Agaricus subgenus Dick"),
       create_test_name("Agaricus section Charlie"),
       create_test_name("Agaricus subsection Bob"),
       create_test_name("Agaricus stirps Arthur"),
       create_test_name("Agaricus aardvark"),
+      create_test_name("Agaricus aardvark group"),
       create_test_name('Agaricus "tree-beard"'),
       create_test_name("Agaricus ugliano Zoom"),
       create_test_name("Agaricus ugliano ssp. ugliano Zoom"),
@@ -1838,6 +1843,44 @@ class NameTest < UnitTestCase
       SELECT sort_name FROM names WHERE id >= #{names.first.id} AND id <= #{names.last.id}
     )
     assert_equal(names.map(&:sort_name).sort, x.sort)
+  end
+
+    # Prove that alphabetized sort_names give us names in the expected order
+    # Differs from test_name_spaceship_operator in omitting "Agaricus Śliwa",
+    # whose sort_name is after all the levels between genus and species,
+    # apparently because "Ś" sorts after "{".
+   def test_name_sort_order
+   names = [
+      create_test_name("Agaricomycota"),
+      create_test_name("Agaricomycotina"),
+      create_test_name("Agaricomycetes"),
+      create_test_name("Agaricomycetidae"),
+      create_test_name("Agaricales"),
+      create_test_name("Agaricineae"),
+      create_test_name("Agaricaceae"),
+      create_test_name("Agaricus group"),
+      create_test_name("Agaricus Aaron"),
+      create_test_name("Agaricus L."),
+      create_test_name("Agaricus Øosting"),
+      create_test_name("Agaricus Zzyzx"),
+      create_test_name("Agaricus Đorn"),
+      create_test_name("Agaricus subgenus Dick"),
+      create_test_name("Agaricus section Charlie"),
+      create_test_name("Agaricus subsection Bob"),
+      create_test_name("Agaricus stirps Arthur"),
+      create_test_name("Agaricus aardvark"),
+      create_test_name("Agaricus aardvark group"),
+      create_test_name('Agaricus "tree-beard"'),
+      create_test_name("Agaricus ugliano Zoom"),
+      create_test_name("Agaricus ugliano ssp. ugliano Zoom"),
+      create_test_name("Agaricus ugliano ssp. erik Zoom"),
+      create_test_name("Agaricus ugliano var. danny Zoom"),
+      create_test_name('Agaricus "sp-LD50"')
+    ]
+    expected_sort_names = names.map(&:sort_name)
+    sorted_sort_names = names.sort.map(&:sort_name)
+
+    assert_equal(expected_sort_names, sorted_sort_names)
   end
 
   def test_guess_rank

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1025,7 +1025,7 @@ class NameTest < UnitTestCase
       real_search_name: "Agaricus group",
       sort_name:        "Agaricus   group",
       display_name:     "**__Agaricus__** group",
-      parent_name:      "Agaricus",
+      parent_name:      "",
       rank:             :Group,
       author:           ""
     )

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1020,7 +1020,7 @@ class NameTest < UnitTestCase
     do_name_parse_test(  # monomial, no author
       "Agaricus group",
       text_name:        "Agaricus group",
-      real_text_name:   "Agaricus",
+      real_text_name:   "Agaricus group",
       search_name:      "Agaricus group",
       real_search_name: "Agaricus group",
       sort_name:        "Agaricus   group",
@@ -1032,7 +1032,7 @@ class NameTest < UnitTestCase
     do_name_parse_test(  # binomial, no author
       "Agaricus campestris group",
       text_name:        "Agaricus campestris group",
-      real_text_name:   "Agaricus campestris",
+      real_text_name:   "Agaricus campestris group",
       search_name:      "Agaricus campestris group",
       real_search_name: "Agaricus campestris group",
       sort_name:        "Agaricus campestris   group",

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1016,6 +1016,33 @@ class NameTest < UnitTestCase
     )
   end
 
+  def test_name_parse_group_names
+    do_name_parse_test(  # monomial, no author
+      "Agaricus group",
+      text_name:        "Agaricus group",
+      real_text_name:   "Agaricus",
+      search_name:      "Agaricus group",
+      real_search_name: "Agaricus group",
+      sort_name:        "Agaricus   group",
+      display_name:     "**__Agaricus__** group",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           ""
+    )
+    do_name_parse_test(  # binomial, no author
+      "Agaricus campestris group",
+      text_name:        "Agaricus campestris group",
+      real_text_name:   "Agaricus campestris",
+      search_name:      "Agaricus campestris group",
+      real_search_name: "Agaricus campestris group",
+      sort_name:        "Agaricus campestris   group",
+      display_name:     "**__Agaricus campestris__** group",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           ""
+    )
+  end
+
   def test_name_parse_comb
     do_name_parse_test(
       "Sebacina schweinitzii comb prov",


### PR DESCRIPTION
## Procedure for dealing with this PR
This PR just improves “group”. (it does not deal with “clade”.)
I suggest this procedure:
1. Code review.
2. I make any desired fixes. 
3. Merge into master but do not roll out.  
4. I do another PR which  
- adds “clade” (should be very simple: add 1 or 2 tests, adjust GROUP_ABBR, tweak `parse_group`;
- expands instructions in the create_name template (tell people how to define a group or clade, where to put “sensu X”, where to put status designation (e.g., “nom. prov.”), gives some more examples.
- updates release news.
5. Once that PR passes muster, merge and roll out.
(Alternatively - if you prefer -I could add the items in #4 to this PR. Then just a single code review, merge, and rollout.)
6. Once rolled out, I will manually adjust the funny group Names in the db which you cited in https://github.com/MushroomObserver/mushroom-observer/pull/289

### Changes to transformation methods
I couldn’t complete https://www.pivotaltracker.com/story/show/141125771 just by tweaking `ParsedName#parse_group` and the Name parsing constants; I had to adjust the methods which transform the various types of names.  In general, I changed these transformation methods to: 
1. remove “group” from a method input;
2. transform a string;
3. restore group to the end of the string.
Perhaps there’s a more elegant way of doing this, at least for some of the transformation methods.

### Where to define transformation methods
These transformations methods are Name class methods.  This feels somewhat awkward; at their core they’re just String transformations. If they were String instance methods (defined in StringExtensions) we could send them to the string being transformed.  E.g., instead of
  Name.display_to_real_search(self)
we would do
  _string_.display_to_real_search
On the other hand, these transformations are used only in the context of names; so it would also be odd to make them general StringExtensions and it’s handy to have them in the Name file.
** What do you think?  And is there another alternative? ** (It doesn’t look like we can make them Name instance methods, as they are sometimes used before instantiation of a Name.)

### Miscellaneous
In this PR, I didn't try to deal with users' putting "group" into Author.  I'd rather they put "group" where it belongs.  I will add more instructions and examples to the create_name template as part of the next PR.

I don’t try to handle “Xxx sp. group”; I don’t think this form should be allowed.  
