### PR TITLE
New improved group names

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1598,8 +1598,15 @@ class Name < AbstractModel
                           )? "?
                         )
                       )
-                      \s #{GROUP_ABBR}
-                      (\s (#{AUTHOR_START}.*))?
+                      (
+                        ( # group, optionally followed by author
+                          \s #{GROUP_ABBR} (\s (#{AUTHOR_START}.*))?
+                        )
+                        | # or
+                        ( # author followed by group
+                          ( \s (#{AUTHOR_START}.*)) \s #{GROUP_ABBR}
+                        )
+                      )
                     $/x
 
   class ParsedName

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1692,9 +1692,9 @@ class Name < AbstractModel
     if result.author.present?
       # Add "group" before author
       author = Regexp.escape(result.author)
-      result.search_name.sub!( /(.*)(#{author})/, '\1group \2')
-      result.sort_name.sub!(   /(.*)(#{author})/, '\1 group  \2')
-      result.display_name.sub!(/(.*)(#{author})/, '\1group \2')
+      result.search_name.sub!( /(#{author})$/, 'group \1')
+      result.sort_name.sub!(   /(#{author})$/, ' group  \1')
+      result.display_name.sub!(/(#{author})$/, 'group \1')
     else
       # Append "group" at end
       result.search_name += " group"

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -57,7 +57,7 @@
 #  SUBSPECIES_PAT::     (Xxx yyy ssp. zzz) (Author)
 #  VARIETY_PAT::        (Xxx yyy ... var. zzz) (Author)
 #  FORM_PAT::           (Xxx yyy ... f. zzz) (Author)
-#  GROUP_PAT::          (Xxx yyy ...) group
+#  GROUP_PAT::          (Xxx) | (Xxx yyy ...) group
 #  AUTHOR_PAT:          (any of the above) (Author)
 #
 #  * Results are grouped according to the parentheses shown above.
@@ -1551,16 +1551,49 @@ class Name < AbstractModel
   AUTHOR_START = / #{ANY_AUTHOR_ABBR} | van\s | de\s | [A-ZÀÁÂÃÄÅÆÇĐÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞČŚŠ\(] | "[^a-z\s] /x
 
   AUTHOR_PAT      = /^ ("? #{UPPER_WORD} (?: \(? (?:\s #{ANY_SUBG_ABBR} \s #{UPPER_WORD})+ \)? | \s (?!#{AUTHOR_START}|#{ANY_SUBG_ABBR}) #{LOWER_WORD} (?:\s #{ANY_SSP_ABBR} \s #{LOWER_WORD})* | \s #{SP_ABBR} )? "?) (\s (?!#{ANY_NAME_ABBR}\s) #{AUTHOR_START}.*) $/x
-  GENUS_OR_UP_PAT = /^ ("? #{UPPER_WORD} "?) (?: \s #{SP_ABBR} )? (\s #{AUTHOR_START}.*)? $/x
-  SUBGENUS_PAT    = /^ ("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD}) \)? "?)  (\s #{AUTHOR_START}.*)? $/x
-  SECTION_PAT     = /^ ("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)? (?: #{SECT_ABBR} \s #{UPPER_WORD}) \)? "?) (\s #{AUTHOR_START}.*)? $/x
-  SUBSECTION_PAT  = /^ ("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)? (?: #{SECT_ABBR} \s #{UPPER_WORD} \s)? (?: #{SUBSECT_ABBR} \s #{UPPER_WORD}) \)? "?) (\s #{AUTHOR_START}.*)? $/x
-  STIRPS_PAT      = /^ ("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)? (?: #{SECT_ABBR} \s #{UPPER_WORD} \s)? (?: #{SUBSECT_ABBR} \s #{UPPER_WORD} \s)? (?: #{STIRPS_ABBR} \s #{UPPER_WORD}) \)? "?) (\s #{AUTHOR_START}.*)? $/x
-  SPECIES_PAT     = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD_OR_SP_NOV} "?) (\s #{AUTHOR_START}.*)? $/x
+
+  # Taxa without authors (for use by GROUP PAT)
+  GENUS_OR_UP_TAXON = /("? #{UPPER_WORD} "?) (?: \s #{SP_ABBR} )?/x
+  SUBGENUS_TAXON    = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD}) \)? "?)/x
+  SECTION_TAXON     = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SECT_ABBR} \s #{UPPER_WORD}) \)? "?)/x
+  SUBSECTION_TAXON  = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SECT_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SUBSECT_ABBR} \s #{UPPER_WORD}) \)? "?)/x
+  STIRPS_TAXON      = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SECT_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SUBSECT_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{STIRPS_ABBR} \s #{UPPER_WORD}) \)? "?)/x
+  SPECIES_TAXON     = /("? #{UPPER_WORD} \s #{LOWER_WORD_OR_SP_NOV} "?)/x
+
+  GENUS_OR_UP_PAT = /^ #{GENUS_OR_UP_TAXON} (\s #{AUTHOR_START}.*)? $/x
+  SUBGENUS_PAT    = /^ #{SUBGENUS_TAXON}    (\s #{AUTHOR_START}.*)? $/x
+  SECTION_PAT     = /^ #{SECTION_TAXON}     (\s #{AUTHOR_START}.*)? $/x
+  SUBSECTION_PAT  = /^ #{SUBSECTION_TAXON}  (\s #{AUTHOR_START}.*)? $/x
+  STIRPS_PAT      = /^ #{STIRPS_TAXON}      (\s #{AUTHOR_START}.*)? $/x
+  SPECIES_PAT     = /^ #{SPECIES_TAXON}     (\s #{AUTHOR_START}.*)? $/x
   SUBSPECIES_PAT  = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD}) "?) (\s #{AUTHOR_START}.*)? $/x
   VARIETY_PAT     = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD})? (?: \s #{VAR_ABBR} \s #{LOWER_WORD}) "?) (\s #{AUTHOR_START}.*)? $/x
   FORM_PAT        = /^ ("? #{UPPER_WORD} \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD})? (?: \s #{VAR_ABBR} \s #{LOWER_WORD})? (?: \s #{F_ABBR} \s #{LOWER_WORD}) "?) (\s #{AUTHOR_START}.*)? $/x
-  GROUP_PAT       = /^ ("? #{UPPER_WORD} (?: \s #{LOWER_WORD} (?: \s #{SSP_ABBR} \s #{LOWER_WORD})? (?: \s #{VAR_ABBR} \s #{LOWER_WORD})? (?: \s #{F_ABBR} \s #{LOWER_WORD})? )? "?) \s #{GROUP_ABBR} $/x
+
+  GROUP_PAT       = /^(?<taxon>
+                        #{GENUS_OR_UP_TAXON} |
+                        #{SUBGENUS_TAXON}    |
+                        #{SECTION_TAXON}     |
+                        #{SUBSECTION_TAXON}  |
+                        #{STIRPS_TAXON}      |
+                        #{SPECIES_TAXON}     |
+                        (?: "? #{UPPER_WORD} # infra-species taxa
+                          (?: \s #{LOWER_WORD}
+                            (?: \s #{SSP_ABBR} \s #{LOWER_WORD})?
+                            (?: \s #{VAR_ABBR} \s #{LOWER_WORD})?
+                            (?: \s #{F_ABBR}   \s #{LOWER_WORD})?
+                          )? "?
+                        )
+                      )
+                      \s #{GROUP_ABBR}
+                      (\s (#{AUTHOR_START}.*))?
+                    $/x
 
   class ParsedName
     attr_accessor :text_name, :search_name, :sort_name, :display_name

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1931,11 +1931,11 @@ class Name < AbstractModel
     str.gsub(/([A-Z]\.) (?=[A-Z]\.)/, '\\1')
   end
 
-  # Add itallics and boldface to a standardized name (without author).
+  # Add italics and boldface markup to a standardized name (without author).
   def self.format_name(str, deprecated = false)
     boldness = deprecated ? "" : "**"
     words = str.split(" ")
-    if (words.length & 1) == 0
+    if words.length.even?
       genus = words.shift
       words[0] = genus + " " + words[0]
     end
@@ -1944,6 +1944,7 @@ class Name < AbstractModel
       words[i] = "#{boldness}__#{words[i]}__#{boldness}"
       i -= 2
     end
+
     words.join(" ")
   end
 

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1682,7 +1682,7 @@ class Name < AbstractModel
     return unless match = GROUP_PAT.match(str)
 
     # Parse the string without "group"
-    ungrouped_str = str.sub(/\s#{GROUP_ABBR}/, "")
+    ungrouped_str = str.sub(/\s#{GROUP_ABBR}\b/, "")
     result = parse_name(ungrouped_str)
     return nil unless result
 

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -439,7 +439,14 @@ class Name < AbstractModel
   def self.display_to_real_text(name)
     name.display_name.gsub(/ ^\*?\*?__ | __\*?\*?[^_\*]*$ /x, "").
       gsub(/__\*?\*? [^_\*]* \s (#{ANY_NAME_ABBR}) \s \*?\*?__/x, ' \1 ').
-      gsub(/__\*?\*? [^_\*]* \*?\*?__/x, " ") # (this part should be unnecessary)
+      gsub(/__\*?\*? [^_\*]* \*?\*?__/x, " "). # (this part should be unnecessary)
+      # Because "group" was removed by the 1st gsub above,
+      # tack it back on (if it was part of display_name)
+      concat(group_suffix(name))
+  end
+
+  def self.group_suffix(name)
+    / group\b/.match(name.display_name).to_s
   end
 
   def self.display_to_real_search(name)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1956,7 +1956,7 @@ class Name < AbstractModel
       strip_squeeze
   end
 
-  # Adjust +search_name+ string to collate correctly.  Pass in +search_name+.
+  # Adjust +search_name+ string to collate correctly. Pass in +search_name+.
   def self.format_sort_name(name, author)
     str = format_name(name, :deprecated).
           sub(/^_+/, "").
@@ -1980,13 +1980,12 @@ class Name < AbstractModel
           sub(/(^\w+?)o?mycota$/, '\1!1')
     1 while str.sub!(/(^| )([A-Za-z\-]+) (.*) \2( |$)/, '\1\2 \3 !\2\4') # put autonyms at the top
 
-    unless author.blank?
+    if author.present?
       str += "  " + author.
                     gsub(/"([^"]*")/, '\1'). # collate "baccata" with baccata
                     gsub(/[Đđ]/, "d"). # mysql isn't collating these right
                     gsub(/[Øø]/, "O").
-                    strip.
-                    sub(/^group$/, " group")
+                    strip
     end
     str
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1031,6 +1031,105 @@ class NameTest < UnitTestCase
     )
   end
 
+  def test_name_parse_group_names
+    do_name_parse_test( # monomial, no author
+      "Agaricus group",
+      text_name:        "Agaricus group",
+      real_text_name:   "Agaricus group",
+      search_name:      "Agaricus group",
+      real_search_name: "Agaricus group",
+      sort_name:        "Agaricus   group",
+      display_name:     "**__Agaricus__** group",
+      parent_name:      "",
+      rank:             :Group,
+      author:           ""
+    )
+    do_name_parse_test( # binomial, no author
+      "Agaricus campestris group",
+      text_name:        "Agaricus campestris group",
+      real_text_name:   "Agaricus campestris group",
+      search_name:      "Agaricus campestris group",
+      real_search_name: "Agaricus campestris group",
+      sort_name:        "Agaricus campestris   group",
+      display_name:     "**__Agaricus campestris__** group",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           ""
+    )
+    do_name_parse_test( # monomial, with author
+      "Agaricus group Author",
+      text_name:        "Agaricus group",
+      real_text_name:   "Agaricus group",
+      search_name:      "Agaricus group Author",
+      real_search_name: "Agaricus group Author",
+      sort_name:        "Agaricus   group  Author",
+      display_name:     "**__Agaricus__** group Author",
+      parent_name:      "",
+      rank:             :Group,
+      author:           "Author"
+    )
+    do_name_parse_test( # binomial, author
+      "Agaricus campestris group Author",
+      text_name:        "Agaricus campestris group",
+      real_text_name:   "Agaricus campestris group",
+      search_name:      "Agaricus campestris group Author",
+      real_search_name: "Agaricus campestris group Author",
+      sort_name:        "Agaricus campestris   group  Author",
+      display_name:     "**__Agaricus campestris__** group Author",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           "Author"
+    )
+    do_name_parse_test( # binomial, sensu author
+      "Agaricus campestris group sensu Author",
+      text_name:        "Agaricus campestris group",
+      real_text_name:   "Agaricus campestris group",
+      search_name:      "Agaricus campestris group sensu Author",
+      real_search_name: "Agaricus campestris group sensu Author",
+      sort_name:        "Agaricus campestris   group  sensu Author",
+      display_name:     "**__Agaricus campestris__** group sensu Author",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           "sensu Author"
+    )
+    do_name_parse_test( # species with Tulloss form of sp. nov.
+      "Pleurotus sp. T44 group Tulloss",
+      text_name: 'Pleurotus "sp-T44" group',
+      real_text_name: 'Pleurotus "sp-T44" group',
+      search_name: 'Pleurotus "sp-T44" group Tulloss',
+      real_search_name: 'Pleurotus "sp-T44" group Tulloss',
+      sort_name: 'Pleurotus {sp-T44"   group  Tulloss',
+      display_name: '**__Pleurotus "sp-T44"__** group Tulloss',
+      parent_name: "Pleurotus",
+      rank: :Group,
+      author: "Tulloss"
+    )
+    do_name_parse_test( # subgenus group, with author
+      "Amanita subg. Vaginatae group (L.) Ach.",
+      text_name: "Amanita subgenus Vaginatae group",
+      real_text_name: "Amanita subgenus Vaginatae group",
+      search_name: "Amanita subgenus Vaginatae group (L.) Ach.",
+      real_search_name: "Amanita subgenus Vaginatae group (L.) Ach.",
+      sort_name: "Amanita  {1subgenus  Vaginatae   group  (L.) Ach.",
+      display_name: "**__Amanita__** subgenus **__Vaginatae__** group (L.) Ach.",
+      parent_name: "Amanita",
+      rank: :Group,
+      author: "(L.) Ach."
+    )
+    do_name_parse_test( # stirps group, with sub-genus parent
+      "Amanita subgenus Vaginatae stirps Vaginatae group",
+      text_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
+      real_text_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
+      search_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
+      real_search_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
+      sort_name: "Amanita  {1subgenus  Vaginatae  {4stirps  !Vaginatae   group",
+      display_name: "**__Amanita__** subgenus **__Vaginatae__** stirps **__Vaginatae__** group",
+      parent_name: "Amanita subgenus Vaginatae",
+      rank: :Group,
+      author: ""
+    )
+  end
+
   # -----------------------------
   #  Test classification.
   # -----------------------------

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1140,6 +1140,18 @@ class NameTest < UnitTestCase
       rank:             :Group,
       author:           "Author"
     )
+    do_name_parse_test( # author duplicates a word in the taxon
+      "Agaricus group Agaricus",
+      text_name:        "Agaricus group",
+      real_text_name:   "Agaricus group",
+      search_name:      "Agaricus group Agaricus",
+      real_search_name: "Agaricus group Agaricus",
+      sort_name:        "Agaricus   group  Agaricus",
+      display_name:     "**__Agaricus__** group Agaricus",
+      parent_name:      "",
+      rank:             :Group,
+      author:           "Agaricus"
+    )
   end
 
   # -----------------------------

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -421,6 +421,9 @@ class NameTest < UnitTestCase
     assert_name_match(pat, "Amanita vaginata ssp. grisea f. grisea group", "Amanita vaginata ssp. grisea f. grisea")
     assert_name_match(pat, "Amanita vaginata var. grisea f. grisea group", "Amanita vaginata var. grisea f. grisea")
     assert_name_match(pat, "Amanita vaginata ssp. grisea var. grisea f. grisea group", "Amanita vaginata ssp. grisea var. grisea f. grisea")
+    assert_name_match(pat, "Amanita vaginata Author group", "Amanita vaginata")
+    assert_name_match(pat, "Amanita vaginata group Author", "Amanita vaginata")
+    assert_name_match(pat, "Amanita vaginata Amanita group", "Amanita vaginata")
   end
 
   def test_some_bad_names
@@ -1070,6 +1073,18 @@ class NameTest < UnitTestCase
     )
     do_name_parse_test( # binomial, author
       "Agaricus campestris group Author",
+      text_name:        "Agaricus campestris group",
+      real_text_name:   "Agaricus campestris group",
+      search_name:      "Agaricus campestris group Author",
+      real_search_name: "Agaricus campestris group Author",
+      sort_name:        "Agaricus campestris   group  Author",
+      display_name:     "**__Agaricus campestris__** group Author",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           "Author"
+    )
+    do_name_parse_test( # binomial with author, "group" at end
+      "Agaricus campestris Author group",
       text_name:        "Agaricus campestris group",
       real_text_name:   "Agaricus campestris group",
       search_name:      "Agaricus campestris group Author",

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1128,6 +1128,18 @@ class NameTest < UnitTestCase
       rank: :Group,
       author: ""
     )
+    do_name_parse_test( # binomial, "group" part of epithet
+      "Agaricus grouperi group Author",
+      text_name:        "Agaricus grouperi group",
+      real_text_name:   "Agaricus grouperi group",
+      search_name:      "Agaricus grouperi group Author",
+      real_search_name: "Agaricus grouperi group Author",
+      sort_name:        "Agaricus grouperi   group  Author",
+      display_name:     "**__Agaricus grouperi__** group Author",
+      parent_name:      "Agaricus",
+      rank:             :Group,
+      author:           "Author"
+    )
   end
 
   # -----------------------------

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1880,7 +1880,8 @@ class NameTest < UnitTestCase
     assert_equal(%w(Aehou Aeiou Aëiou aÉIOU Aeiøu Aejou), x)
   end
 
-  def test_name_sort_order
+  # Prove that Name spaceship operator (<=>) uses sort_name to sort Names
+  def test_name_spaceship_operator
     names = [
       create_test_name("Agaricomycota"),
       create_test_name("Agaricomycotina"),
@@ -1889,16 +1890,19 @@ class NameTest < UnitTestCase
       create_test_name("Agaricales"),
       create_test_name("Agaricineae"),
       create_test_name("Agaricaceae"),
-      create_test_name("Agaricus Đorn"),
+      create_test_name("Agaricus group"),
+      create_test_name("Agaricus Aaron"),
       create_test_name("Agaricus L."),
       create_test_name("Agaricus Øosting"),
-      create_test_name("Agaricus Śliwa"),
       create_test_name("Agaricus Zzyzx"),
+      create_test_name("Agaricus Śliwa"),
+      create_test_name("Agaricus Đorn"),
       create_test_name("Agaricus subgenus Dick"),
       create_test_name("Agaricus section Charlie"),
       create_test_name("Agaricus subsection Bob"),
       create_test_name("Agaricus stirps Arthur"),
       create_test_name("Agaricus aardvark"),
+      create_test_name("Agaricus aardvark group"),
       create_test_name('Agaricus "tree-beard"'),
       create_test_name("Agaricus ugliano Zoom"),
       create_test_name("Agaricus ugliano ssp. ugliano Zoom"),
@@ -1910,6 +1914,44 @@ class NameTest < UnitTestCase
       SELECT sort_name FROM names WHERE id >= #{names.first.id} AND id <= #{names.last.id}
     )
     assert_equal(names.map(&:sort_name).sort, x.sort)
+  end
+
+  # Prove that alphabetized sort_names give us names in the expected order
+    # Differs from test_name_spaceship_operator in omitting "Agaricus Śliwa",
+    # whose sort_name is after all the levels between genus and species,
+    # apparently because "Ś" sorts after "{".
+  def test_name_sort_order
+    names = [
+      create_test_name("Agaricomycota"),
+      create_test_name("Agaricomycotina"),
+      create_test_name("Agaricomycetes"),
+      create_test_name("Agaricomycetidae"),
+      create_test_name("Agaricales"),
+      create_test_name("Agaricineae"),
+      create_test_name("Agaricaceae"),
+      create_test_name("Agaricus group"),
+      create_test_name("Agaricus Aaron"),
+      create_test_name("Agaricus L."),
+      create_test_name("Agaricus Øosting"),
+      create_test_name("Agaricus Zzyzx"),
+      create_test_name("Agaricus Đorn"),
+      create_test_name("Agaricus subgenus Dick"),
+      create_test_name("Agaricus section Charlie"),
+      create_test_name("Agaricus subsection Bob"),
+      create_test_name("Agaricus stirps Arthur"),
+      create_test_name("Agaricus aardvark"),
+      create_test_name("Agaricus aardvark group"),
+      create_test_name('Agaricus "tree-beard"'),
+      create_test_name("Agaricus ugliano Zoom"),
+      create_test_name("Agaricus ugliano ssp. ugliano Zoom"),
+      create_test_name("Agaricus ugliano ssp. erik Zoom"),
+      create_test_name("Agaricus ugliano var. danny Zoom"),
+      create_test_name('Agaricus "sp-LD50"')
+    ]
+    expected_sort_names = names.map(&:sort_name)
+    sorted_sort_names = names.sort.map(&:sort_name)
+
+    assert_equal(expected_sort_names, sorted_sort_names)
   end
 
   def test_guess_rank


### PR DESCRIPTION
## Procedure for dealing with this PR
This PR replaces #290, and just improves “group”.  (it does not deal with “clade”.)  
I suggest this procedure:
1. Code review.
2. I make any desired fixes. 
3. Merge into master but do not roll out.  
4. I do another PR which  
- adds “clade” (should be very simple: add 1 or 2 tests, adjust GROUP_ABBR, tweak `parse_group`;
- expands instructions in the create_name template (tell people how to define a group or clade, where to put “sensu X”, where to put status designation (e.g., “nom. prov.”), gives some more examples.
- updates release news.
5. Once that PR passes muster, merge and roll out.
(Alternatively - if you prefer -I could add the items in #4 to this PR. Then just a single code review, merge, and rollout.)
6. Once rolled out, I will manually adjust the funny group Names in the db which you cited in https://github.com/MushroomObserver/mushroom-observer/pull/289

### Miscellaneous
In this PR, I didn't try to deal with users' putting "group" into Author.  I'd rather they put "group" where it belongs.  I will add more instructions and examples to the create_name template as part of the next PR.

The purported coverage decrease should not stand in the way of merging this PR.  (The decrease was caused by a prior PR and merger, and has nothing to do with this PR.  See https://coveralls.io/builds/10544157/source?filename=app%2Fclasses%2Fquery%2Finitializers%2Fcontent_filters.rb.)
