### PR TITLE
Restore coverage content filters

### DIFF
--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -233,6 +233,16 @@ class ObserverControllerTest < FunctionalTestCase
     assert_equal("glossary_term", (rolf.reload).default_rss_type)
   end
 
+  # Prove that user content_filter works on rss_log
+  def test_rss_log_with_content_filter
+    login(users(:vouchered_only_user).name)
+    get(:index_rss_log, type: :observation)
+    results = @controller.instance_variable_get("@objects")
+
+    assert(results.exclude?(rss_logs(:imged_unvouchered_obs_rss_log)))
+    assert(results.include?(rss_logs(:observation_rss_log)))
+  end
+
   def test_next_and_prev_rss_log
     # First 2 log entries
     logs = RssLog.order(updated_at: :desc).limit(2)

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -6,7 +6,6 @@
 # Some tests expect this entry to be at the top of the Observation log.
 # Therefore insure that other observation entries have earlier updated_at's.
 observation_rss_log:
-  # id: 1
   observation: detailed_unknown_obs
   updated_at: 2006-03-02 21:14:00
   notes: "Updated Observation & Notes"
@@ -17,31 +16,26 @@ imageless_unvouchered_obs:
   notes: "Updated Observation & Notes"
 
 species_list_rss_log:
-  # id: 2
   species_list: first_species_list
   updated_at: 2006-03-02 21:14:02
   notes: "Updated Species List"
 
 name_rss_log:
-  # id: 3
   name: fungi
   updated_at: 2006-03-02 21:14:03
   notes: "Updated Name"
 
 location_rss_log:
-  # id: 4
   location: mitrula_marsh
   updated_at: 2006-03-02 21:14:09
   notes: "Updated Location"
 
 albion_rss_log:
-  # id: 5
   location: albion
   updated_at: 2007-12-27 06:41:20
   notes: "Updated Created"
 
 glossary_term_rss_log:
-  # id: 6
   glossary_term: conic_glossary_term
   updated_at: 2013-09-01 12:49:30
   notes: "Updated Glossary Term"
@@ -50,4 +44,3 @@ project_rss_log:
   project: two_list_project
   updated_at: 2016-08-08 12:00:00
   notes: "Updated Project"
-

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -10,8 +10,8 @@ observation_rss_log:
   updated_at: 2006-03-02 21:14:00
   notes: "Updated Observation & Notes"
 
-imageless_unvouchered_obs:
-  observation: imageless_unvouchered_obs
+imged_unvouchered_obs_rss_log:
+  observation: imged_unvouchered_obs
   updated_at: 2005-03-02 21:14:00
   notes: "Updated Observation & Notes"
 

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -2,10 +2,18 @@
 # references for associations. Some associations for this fixture may be defined
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# Some tests expect this entry to be at the top of the Observation log.
+# Therefore insure that other observation entries have earlier updated_at's.
 observation_rss_log:
   # id: 1
   observation: detailed_unknown_obs
   updated_at: 2006-03-02 21:14:00
+  notes: "Updated Observation & Notes"
+
+imageless_unvouchered_obs:
+  observation: imageless_unvouchered_obs
+  updated_at: 2005-03-02 21:14:00
   notes: "Updated Observation & Notes"
 
 species_list_rss_log:
@@ -42,3 +50,4 @@ project_rss_log:
   project: two_list_project
   updated_at: 2016-08-08 12:00:00
   notes: "Updated Project"
+


### PR DESCRIPTION
- Re-covers 3 lines which were un-covered by PR #273.
- Delivers https://www.pivotaltracker.com/story/show/137998397
- Should stop those annoying, incorrect Coveralls failures which are caused by these lines not being covered.  E.g., https://coveralls.io/builds/10544157 
