### PR TITLE
Fix bulk editor invalid date bug

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,4 +7,3 @@ exclude_paths:
 - app/assets/javascripts/jquery.js
 - app/assets/javascripts/jstz.js
 - app/assets/javascripts/lightbox.js
-- **.old.rb

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,3 +7,4 @@ exclude_paths:
 - app/assets/javascripts/jquery.js
 - app/assets/javascripts/jstz.js
 - app/assets/javascripts/lightbox.js
+- app/classes/query/modules/serialization.rb

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -230,7 +230,10 @@ class Observation < AbstractModel
 
   def when_str=(x)
     @when_str = x
-    self.when = x if Date.parse(x) rescue ArgumentError
+    begin
+      self.when = x if Date.parse(x)
+    rescue ArgumentError
+    end
     x
   end
 
@@ -1139,15 +1142,14 @@ class Observation < AbstractModel
       errors.add(:alt, :runtime_altitude_error.t)
     end
 
-    if @when_str
-      begin
-        Date.parse(@when_str)
-      rescue ArgumentError
-        if @when_str =~ /^\d{4}-\d{1,2}-\d{1,2}$/
-          errors.add(:when_str, :runtime_date_invalid.t)
-        else
-          errors.add(:when_str, :runtime_date_should_be_yyyymmdd.t)
-        end
+    return unless @when_str
+    begin
+      Date.parse(@when_str)
+    rescue ArgumentError
+      if @when_str =~ /^\d{4}-\d{1,2}-\d{1,2}$/
+        errors.add(:when_str, :runtime_date_invalid.t)
+      else
+        errors.add(:when_str, :runtime_date_should_be_yyyymmdd.t)
       end
     end
   end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1139,8 +1139,16 @@ class Observation < AbstractModel
       errors.add(:alt, :runtime_altitude_error.t)
     end
 
-    if @when_str && !Date.parse(@when_str)
-      errors.add(:when_str, :runtime_date_should_be_yyyymmdd.t)
+    if @when_str
+      begin
+        Date.parse(@when_str)
+      rescue ArgumentError
+        if @when_str =~ /^\d{4}-\d{1,2}-\d{1,2}$/
+          errors.add(:when_str, :runtime_date_invalid.t)
+        else
+          errors.add(:when_str, :runtime_date_should_be_yyyymmdd.t)
+        end
+      end
     end
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -231,7 +231,7 @@ class Observation < AbstractModel
   def when_str=(x)
     @when_str = x
     self.when = x if Date.parse(x) rescue ArgumentError
-    self.when
+    x
   end
 
   def lat=(x)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -230,8 +230,8 @@ class Observation < AbstractModel
 
   def when_str=(x)
     @when_str = x
-    self.when = x if Date.parse(x)
-    x
+    self.when = x if Date.parse(x) rescue ArgumentError
+    self.when
   end
 
   def lat=(x)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3136,6 +3136,7 @@
   runtime_created_at: Successfully created [type].
   runtime_created_id: "Successfully created [type] #[value]."
   runtime_created_name: Successfully created [type] '[value]'.
+  runtime_date_invalid: Invalid date.
   runtime_date_should_be_yyyymmdd: Date should be in year-month-day format.
   runtime_delivered_message: Successfully delivered message.
   runtime_delivered_question: Successfully delivered question.

--- a/test/controllers/species_list_controller_test.rb
+++ b/test/controllers/species_list_controller_test.rb
@@ -1413,6 +1413,23 @@ class SpeciesListControllerTest < FunctionalTestCase
     assert_equal(vote, obs.owners_votes.first.value)
   end
 
+  def test_bulk_editor_bad_when
+    spl = species_lists(:unknown_species_list)
+    obs = spl.observations.first
+    params = {
+      id: spl.id,
+      observation: {
+        obs.id.to_s => {
+          when_str: "2017-02-31",
+        }
+      }
+    }
+    login(spl.user.login)
+
+    post(:bulk_editor, params)
+    assert_flash(/#{:runtime_date_invalid.l}/)
+  end
+
   def test_project_checkboxes_in_create_species_list_form
     init_for_project_checkbox_tests
 

--- a/test/controllers/species_list_controller_test.rb
+++ b/test/controllers/species_list_controller_test.rb
@@ -1274,7 +1274,7 @@ class SpeciesListControllerTest < FunctionalTestCase
     post(:bulk_editor, params)
     assert_redirected_to(action: "show_species_list", id: spl.id)
     assert_flash_warning
-    for old_obs, old_vote in [[obs1, old_vote1], [obs2, old_vote2], [obs3, old_vote3]]
+    [[obs1, old_vote1], [obs2, old_vote2], [obs3, old_vote3]].each do |old_obs, old_vote|
       new_obs = Observation.find(old_obs.id)
       new_vote = begin
                    new_obs.namings.first.users_vote(new_obs.user).value

--- a/test/controllers/species_list_controller_test.rb
+++ b/test/controllers/species_list_controller_test.rb
@@ -1274,7 +1274,8 @@ class SpeciesListControllerTest < FunctionalTestCase
     post(:bulk_editor, params)
     assert_redirected_to(action: "show_species_list", id: spl.id)
     assert_flash_warning
-    [[obs1, old_vote1], [obs2, old_vote2], [obs3, old_vote3]].each do |old_obs, old_vote|
+    [[obs1, old_vote1], [obs2, old_vote2],
+     [obs3, old_vote3]].each do |old_obs, old_vote|
       new_obs = Observation.find(old_obs.id)
       new_vote = begin
                    new_obs.namings.first.users_vote(new_obs.user).value
@@ -1420,7 +1421,7 @@ class SpeciesListControllerTest < FunctionalTestCase
       id: spl.id,
       observation: {
         obs.id.to_s => {
-          when_str: "2017-02-31",
+          when_str: "2017-02-31"
         }
       }
     }


### PR DESCRIPTION
Fixes bug in SpeciesList Bulk Editor, delivering [Pivotal #141748815](https://www.pivotaltracker.com/story/show/141748815)

Not much code here, but the SpeciesList Bulk Editor is a bit hair, so this could use a good review.

- The Bulk Editor would throw an error when user tried to change an Observation date to a non-date (e.g., "blah") or something in YYYY-MM-DD format which is a non-existent date (e.g., 2017-02-31).
- The bug was caused by lines like
```
  if @when_str && !Date.parse(@when_str)
    errors.add(:when_str, :runtime_date_should_be_yyyymmdd.t)
```
This doesn't work because Date.parse is not a validator, see https://ruby-doc.org/stdlib-2.3.1/libdoc/date/rdoc/Date.html#method-c-_parse.
If Date.parse cannot parse its argument then you get an Error: at least a TypeError if x can’t be converted to a String (e.g. x == nil), and ArgumentError if x is an invalid string (e.g., x == "banana" or x == "2017-02-31").
- Incidentally improves coverage of Observation. Trying to improve that coverage is what made me fix the bug.  I found the bug while trying to cover:
![screen shot 2017-03-19 at 16 45 40](https://cloud.githubusercontent.com/assets/45460/24084616/a4967d66-0cc3-11e7-96a3-f23391ad91b6.png)
My solution was to Rescue the error, detect its type, and give the appropriate flash message.

I did not provide a news release update. Users will likely not notice the change because -as far as I know- I'm the only one who report the bug, .

### Manual Test
- Go to any Species List you own.
- select Bulk Editor
- fill in the Date field of the 1st Observation with  a non-existent date (e.g., 2017-02-31)
- select Update
Result: Flash message including "Invalid date", and the nonsense date remains in the date field of the 1st Observation.  (In master this would throw an error).
- fill in the date field of the 1st Observation with  a  non-date (e.g., "nonsense")
- select Update
Result: Flash message including "Date should be in year-month-day format.", and the non-date remains in the date field of the 1st Observation.  (In master this would throw an error).
