### PR TITLE
Infragenus names

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1569,8 +1569,8 @@ class Name < AbstractModel
         #{UPPER_WORD}
         (?:
             # >= 1 of (rank Epithet)
-            \s \(? #{ANY_SUBG_ABBR} \s #{UPPER_WORD}
-            (?: \s #{ANY_SUBG_ABBR} \s #{UPPER_WORD} )* \)? "?
+            \s     #{ANY_SUBG_ABBR} \s #{UPPER_WORD}
+            (?: \s #{ANY_SUBG_ABBR} \s #{UPPER_WORD} )* "?
           |
             \s (?! #{AUTHOR_START} | #{ANY_SUBG_ABBR} ) #{LOWER_WORD}
             (?: \s #{ANY_SSP_ABBR} \s #{LOWER_WORD} )* "?
@@ -1583,16 +1583,16 @@ class Name < AbstractModel
 
 # Taxa without authors (for use by GROUP PAT)
   GENUS_OR_UP_TAXON = /("? #{UPPER_WORD} "?) (?: \s #{SP_ABBR} )?/x
-  SUBGENUS_TAXON    = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD}) \)? "?)/x
-  SECTION_TAXON     = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
-                       (?: #{SECT_ABBR} \s #{UPPER_WORD}) \)? "?)/x
-  SUBSECTION_TAXON  = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
+  SUBGENUS_TAXON    = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD}) "?)/x
+  SECTION_TAXON     = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SECT_ABBR} \s #{UPPER_WORD}) "?)/x
+  SUBSECTION_TAXON  = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
                        (?: #{SECT_ABBR} \s #{UPPER_WORD} \s)?
-                       (?: #{SUBSECT_ABBR} \s #{UPPER_WORD}) \)? "?)/x
-  STIRPS_TAXON      = /("? #{UPPER_WORD} \s \(? (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
+                       (?: #{SUBSECT_ABBR} \s #{UPPER_WORD}) "?)/x
+  STIRPS_TAXON      = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
                        (?: #{SECT_ABBR} \s #{UPPER_WORD} \s)?
                        (?: #{SUBSECT_ABBR} \s #{UPPER_WORD} \s)?
-                       (?: #{STIRPS_ABBR} \s #{UPPER_WORD}) \)? "?)/x
+                       (?: #{STIRPS_ABBR} \s #{UPPER_WORD}) "?)/x
   SPECIES_TAXON     = /("? #{UPPER_WORD} \s #{LOWER_WORD_OR_SP_NOV} "?)/x
 
   GENUS_OR_UP_PAT = /^ #{GENUS_OR_UP_TAXON} (\s #{AUTHOR_START}.*)? $/x
@@ -1941,8 +1941,6 @@ class Name < AbstractModel
   end
 
   def self.standardize_name(str)
-    # remove old-style "(sect. Vaginatae)"
-    str = str.sub(/ \((.*)\)$/, ' \\1')
     words = str.split(" ")
     # every other word, starting next-from-last, is an abbreviation
     i = words.length - 2

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1544,27 +1544,33 @@ class Name < AbstractModel
   NOV_ABBR     = / nova | novum | nov\.? /xi
   PROV_ABBR    = / provisional | prov\.? /xi
 
-  ANY_SUBG_ABBR   = / #{SUBG_ABBR} | #{SECT_ABBR} | #{SUBSECT_ABBR} | #{STIRPS_ABBR} /x
+  ANY_SUBG_ABBR   = / #{SUBG_ABBR} | #{SECT_ABBR} | #{SUBSECT_ABBR} |
+                      #{STIRPS_ABBR} /x
   ANY_SSP_ABBR    = / #{SSP_ABBR} | #{VAR_ABBR} | #{F_ABBR} /x
-  ANY_NAME_ABBR   = / #{ANY_SUBG_ABBR} | #{SP_ABBR} | #{ANY_SSP_ABBR} | #{GROUP_ABBR} /x
-  ANY_AUTHOR_ABBR = / (?: #{AUCT_ABBR} | #{INED_ABBR} | #{NOM_ABBR} | #{COMB_ABBR} | #{SENSU_ABBR} ) (?:\s|$) /x
+  ANY_NAME_ABBR   = / #{ANY_SUBG_ABBR} | #{SP_ABBR} | #{ANY_SSP_ABBR} |
+                      #{GROUP_ABBR} /x
+  ANY_AUTHOR_ABBR = / (?: #{AUCT_ABBR} | #{INED_ABBR} | #{NOM_ABBR} |
+                          #{COMB_ABBR} | #{SENSU_ABBR} ) (?:\s|$) /x
 
   UPPER_WORD = / [A-Z][a-zë\-]*[a-zë] | "[A-Z][a-zë\-\.]*[a-zë]" /x
   LOWER_WORD = / (?!sensu\b) [a-z][a-zë\-]*[a-zë] | "[a-z][\wë\-\.]*[\wë]" /x
   BINOMIAL   = / #{UPPER_WORD} \s #{LOWER_WORD} /x
-  LOWER_WORD_OR_SP_NOV = / (?!sp\s|sp$|species) #{LOWER_WORD} | sp\.\s\S*\d\S* /x
+  LOWER_WORD_OR_SP_NOV = / (?! sp\s|sp$|species) #{LOWER_WORD} |
+                           sp\.\s\S*\d\S* /x
 
-  # Matches the last epithet in a (standardized) name, including preceding abbreviation if there is one.
+  # Matches the last epithet in a (standardized) name,
+  # including preceding abbreviation if there is one.
   LAST_PART = / (?: \s[a-z]+\.? )? \s \S+ $/x
 
-  AUTHOR_START = / #{ANY_AUTHOR_ABBR} | van\s | de\s | [A-ZÀÁÂÃÄÅÆÇĐÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞČŚŠ\(] | "[^a-z\s] /x
+  AUTHOR_START = / #{ANY_AUTHOR_ABBR} | van\s | de\s | [
+                   A-ZÀÁÂÃÄÅÆÇĐÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞČŚŠ\(] | "[^a-z\s] /x
 
   # AUTHOR_PAT is separate from, and can't include GENUS_OR_UP_TAXON, etc.
   #   AUTHOR_PAT ensures "sp", "ssp", etc., aren't included in author.
   #   AUTHOR_PAT removes the author first thing.
   # Then the other parsers have a much easier job.
   AUTHOR_PAT =
-     /^
+    /^
       ( "?
         #{UPPER_WORD}
         (?:
@@ -1581,7 +1587,7 @@ class Name < AbstractModel
       ( \s (?! #{ANY_NAME_ABBR} \s ) #{AUTHOR_START}.* )
     $/x
 
-# Taxa without authors (for use by GROUP PAT)
+  # Taxa without authors (for use by GROUP PAT)
   GENUS_OR_UP_TAXON = /("? #{UPPER_WORD} "?) (?: \s #{SP_ABBR} )?/x
   SUBGENUS_TAXON    = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD}) "?)/x
   SECTION_TAXON     = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -165,9 +165,7 @@ class NameTest < UnitTestCase
 
   def test_standardize_name
     assert_equal("Amanita", Name.standardize_name("Amanita"))
-    assert_equal("Amanita subgenus Vaginatae", Name.standardize_name("Amanita (subg. Vaginatae)"))
     assert_equal("Amanita subgenus Vaginatae", Name.standardize_name("Amanita SUBG. Vaginatae"))
-    assert_equal("Amanita sect. Vaginatae", Name.standardize_name("Amanita (section Vaginatae)"))
     assert_equal("Amanita subsect. Vaginatae", Name.standardize_name("Amanita subsect Vaginatae"))
     assert_equal("Amanita stirps Vaginatae", Name.standardize_name("Amanita Stirps Vaginatae"))
     assert_equal("Amanita subgenus One sect. Two stirps Three", Name.standardize_name("Amanita Subg One Sect Two Stirps Three"))
@@ -304,9 +302,7 @@ class NameTest < UnitTestCase
     pat = Name::SUBGENUS_PAT
     assert_name_match_author_optional(pat, "Amanita subgenus Vaginatae")
     assert_name_match_author_optional(pat, "Amanita Subg. Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (SUBG Vaginatae)")
     assert_name_match_author_optional(pat, "Amanita subg Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (subg Vaginatae)")
     assert_name_match_author_optional(pat, '"Amanita subg. Vaginatae"')
   end
 
@@ -315,11 +311,8 @@ class NameTest < UnitTestCase
     pat = Name::SECTION_PAT
     assert_name_match_author_optional(pat, "Amanita section Vaginatae")
     assert_name_match_author_optional(pat, "Amanita Sect. Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (SECT Vaginatae)")
     assert_name_match_author_optional(pat, "Amanita sect Vaginatae")
     assert_name_match_author_optional(pat, "Amanita subg. Vaginatae sect. Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (sect Vaginatae)")
-    assert_name_match_author_optional(pat, "Amanita (subg Vaginatae sect Vaginatae)")
     assert_name_match_author_optional(pat, '"Amanita sect. Vaginatae"')
   end
 
@@ -328,11 +321,8 @@ class NameTest < UnitTestCase
     pat = Name::SUBSECTION_PAT
     assert_name_match_author_optional(pat, "Amanita subsection Vaginatae")
     assert_name_match_author_optional(pat, "Amanita SubSect. Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (SUBSECT Vaginatae)")
     assert_name_match_author_optional(pat, "Amanita subsect Vaginatae")
     assert_name_match_author_optional(pat, "Amanita subg. Vaginatae subsect. Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (subsect Vaginatae)")
-    assert_name_match_author_optional(pat, "Amanita (subg Vaginatae sect Vaginatae subsect Vaginatae)")
     assert_name_match_author_optional(pat, '"Amanita subsect. Vaginatae"')
   end
 
@@ -343,9 +333,6 @@ class NameTest < UnitTestCase
     assert_name_match_author_optional(pat, "Amanita Stirps Vaginatae")
     assert_name_match_author_optional(pat, "Amanita subg. Vaginatae sect. Vaginatae stirps Vaginatae")
     assert_name_match_author_optional(pat, "Amanita subg. Vaginatae sect. Vaginatae subsect. Vaginatae stirps Vaginatae")
-    assert_name_match_author_optional(pat, "Amanita (STIRPS Vaginatae)")
-    assert_name_match_author_optional(pat, "Amanita (stirps Vaginatae)")
-    assert_name_match_author_optional(pat, "Amanita (subgenus Vaginatae section Vaginatae stirps Vaginatae)")
     assert_name_match_author_optional(pat, '"Amanita stirps Vaginatae"')
   end
 
@@ -795,21 +782,6 @@ class NameTest < UnitTestCase
     )
   end
 
-  def test_name_parse_24
-    do_name_parse_test(
-      "Amanita (subg Vaginatae)",
-      text_name: "Amanita subgenus Vaginatae",
-      real_text_name: "Amanita subgenus Vaginatae",
-      search_name: "Amanita subgenus Vaginatae",
-      real_search_name: "Amanita subgenus Vaginatae",
-      sort_name: "Amanita  {1subgenus  Vaginatae",
-      display_name: "**__Amanita__** subgenus **__Vaginatae__**",
-      parent_name: "Amanita",
-      rank: :Subgenus,
-      author: ""
-    )
-  end
-
   def test_name_parse_25
     do_name_parse_test(
       "Amanita stirps Vaginatae Ach. & Fr.",
@@ -896,21 +868,6 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita vaginata__**",
       parent_name: "Amanita",
       rank: :Species,
-      author: ""
-    )
-  end
-
-  def test_name_parse_31
-    do_name_parse_test(
-      "Amanita (subsect Vaginatae)",
-      text_name: "Amanita subsect. Vaginatae",
-      real_text_name: "Amanita subsect. Vaginatae",
-      search_name: "Amanita subsect. Vaginatae",
-      real_search_name: "Amanita subsect. Vaginatae",
-      sort_name: "Amanita  {3subsect.  Vaginatae",
-      display_name: "**__Amanita__** subsect. **__Vaginatae__**",
-      parent_name: "Amanita",
-      rank: :Subsection,
       author: ""
     )
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -270,6 +270,7 @@ class NameTest < UnitTestCase
     assert_no_match(pat, 'Amanita subsect. "Mismatch\'')
     assert_name_match_author_required(pat, "Amanita")
     assert_name_match_author_required(pat, "Amanita sp.")
+    assert_name_match_author_required(pat, '"Amanita" sp.')
     assert_name_match_author_required(pat, "Amanita vaginata")
     assert_name_match_author_required(pat, 'Amanita "vaginata"')
     assert_name_match_author_required(pat, "Amanita Subgenus Vaginatae")


### PR DESCRIPTION
Reformats AUTHOR_PAT
DRYs some other regexp pattern matchers
Removes support for parenthesized ranks, e.g. "(sect. Foo)"
