### PR TITLE
Delete unused Observation methods

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -161,10 +161,6 @@ class Observation < AbstractModel
     true
   end
 
-  def raw_place_name
-    location ? location.name : where
-  end
-
   # Abstraction over +where+ and +location.display_name+.  Returns Location
   # name as a string, preferring +location+ over +where+ wherever both exist.
   # Also applies the location_format of the current user (defaults to :postal).

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -54,7 +54,6 @@
 #  last_view::              Last time it was viewed.
 #
 #  ==== "Fake" attributes
-#  idstr::                  Used by <tt>observer/reuse_image.rhtml</tt>.
 #  place_name::             Wrapper on top of +where+ and +location+.
 #                           Handles location_format.
 #
@@ -160,20 +159,6 @@ class Observation < AbstractModel
 
   def is_observation?
     true
-  end
-
-  # Always returns empty string.  (Used by
-  # <tt>observer/reuse_image.rhtml</tt>.)
-  def idstr
-    ""
-  end
-
-  # Adds error if couldn't find image with the given id.  (Used by
-  # <tt>observer/reuse_image.rhtml</tt>.)
-  def idstr=(id_field)
-    id = id_field.to_i
-    return if Image.safe_find(id)
-    errors.add(:thumb_image_id, :validate_observation_thumb_image_id_invalid.t)
   end
 
   def raw_place_name

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -87,7 +87,6 @@
 #  users_votes::            Get all of a given User's Vote's for this Obs..
 #  is_owners_favorite?::    Is a given naming the owner's favorite?
 #  is_users_favorite?::     Is a given naming a given user's favorite?
-#  vote_percent::           Convert Vote score to percentage.
 #  change_vote::            Change a given User's Vote for a given Naming.
 #  consensus_naming::       Guess which Naming is responsible for consensus.
 #  calc_consensus::         Calculate and cache the consensus naming/name.
@@ -389,11 +388,6 @@ class Observation < AbstractModel
 
   def owner_id_known?
     owners_only_favorite_name.try(:known?)
-  end
-
-  # Convert cached Vote score to percentage.
-  def vote_percent
-    Vote.percent(vote_cache)
   end
 
   # Change User's Vote for this naming.  Automatically recalculates the


### PR DESCRIPTION
These are 3 short methods which apparently are unused.

I found them during an ongoing effort to improve coverage of Observation, [Pivotal #140620655](https://www.pivotaltracker.com/story/show/140620655). I'd like to isolate changes to the app from changes to the tests.  So I'm putting these app changes in their own PR.