### PR TITLE
adds filter to PivotalTracker API to specify stories with unscheduled…

### DIFF
--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -8,7 +8,7 @@ class Pivotal
 
   class << self
     def get_stories(_verbose = false)
-      json = get_request("stories?limit=500&filter=state:unscheduled,started,unstarted&#{story_fields}")
+      json = get_request("stories?limit=500&#{story_filters}&#{story_fields}")
       stories = []
       JSON.parse(json).each do |obj|
         id   = obj["id"]
@@ -72,6 +72,10 @@ class Pivotal
 
     def comment_fields
       "fields=created_at,text"
+    end
+
+    def story_filters
+      "filter=state:unscheduled,started,unstarted"
     end
 
     private

--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -8,7 +8,7 @@ class Pivotal
 
   class << self
     def get_stories(_verbose = false)
-      json = get_request("stories?limit=10000&#{story_fields}")
+      json = get_request("stories?limit=500&filter=state:unscheduled,started,unstarted&#{story_fields}")
       stories = []
       JSON.parse(json).each do |obj|
         id   = obj["id"]

--- a/app/classes/pivotal/story.rb
+++ b/app/classes/pivotal/story.rb
@@ -12,14 +12,6 @@ class Pivotal
     attr_accessor :comments
     attr_accessor :votes
 
-    ACTIVE_STATES = {
-      "unscheduled" => true,
-      "unstarted"   => true,
-      "started"     => true,
-      "finished"    => false,
-      "accepted"    => false
-    }
-
     LABEL_VALUE = {
       "critical"        => 4,
       "bottleneck"      => 3,
@@ -93,10 +85,6 @@ class Pivotal
           true
         end
       end.join("\n").sub(/\A\s+/, "").sub(/\s+\Z/, "\n")
-    end
-
-    def active?
-      ACTIVE_STATES[state] || false
     end
 
     def activity

--- a/app/controllers/pivotal_controller.rb
+++ b/app/controllers/pivotal_controller.rb
@@ -28,10 +28,10 @@ class PivotalController < ApplicationController
   require_dependency "pivotal"
 
   def index
-    if MO.pivotal_enabled
-      @stories = Pivotal.get_stories.sort_by(&:story_order)
-    else
-      @stories = []
-    end
+    @stories = if MO.pivotal_enabled
+                 Pivotal.get_stories.sort_by(&:story_order)
+               else
+                 @stories = []
+               end
   end
 end

--- a/app/controllers/pivotal_controller.rb
+++ b/app/controllers/pivotal_controller.rb
@@ -29,7 +29,7 @@ class PivotalController < ApplicationController
 
   def index
     if MO.pivotal_enabled
-      @stories = Pivotal.get_stories.sort_by(&:story_order).select(&:active?)
+      @stories = Pivotal.get_stories.sort_by(&:story_order)
     else
       @stories = []
     end

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -84,11 +84,11 @@ MushroomObserver::Application.configure do
   config.name_lister_cache_file = "#{config.root}/public/name_list_data.js"
 
   # Access data for Pivotal Tracker's API.
-  config.pivotal_enabled  = true
+  config.pivotal_enabled  = false
   config.pivotal_url      = "www.pivotaltracker.com"
   config.pivotal_path     = "/services/v5"
   config.pivotal_project  = "224629"
-  config.pivotal_token    = "295d867c4d6d991436af59362c2f8d45"
+  config.pivotal_token    = "xxx"
   config.pivotal_max_vote = 1
   config.pivotal_min_vote = -1
   config.pivotal_test_id  = 77_165_602

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -84,11 +84,11 @@ MushroomObserver::Application.configure do
   config.name_lister_cache_file = "#{config.root}/public/name_list_data.js"
 
   # Access data for Pivotal Tracker's API.
-  config.pivotal_enabled  = false
+  config.pivotal_enabled  = true
   config.pivotal_url      = "www.pivotaltracker.com"
   config.pivotal_path     = "/services/v5"
   config.pivotal_project  = "224629"
-  config.pivotal_token    = "xxx"
+  config.pivotal_token    = "295d867c4d6d991436af59362c2f8d45"
   config.pivotal_max_vote = 1
   config.pivotal_min_vote = -1
   config.pivotal_test_id  = 77_165_602


### PR DESCRIPTION
The Pivotal Tracker API will only return 500 stories. Currently, we grab them regardless of their state, so we are grabbing 'Approved' stories which will be filtered out locally.

I've adjusted the API call to specifically grab the last 500 stories with an 'Unscheduled', 'Started' or 
'Unstarted' state.