### PR TITLE
[136653151] - Feature Tracker page is missing stories

### DIFF
--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -8,7 +8,7 @@ class Pivotal
 
   class << self
     def get_stories(_verbose = false)
-      json = get_request("stories?limit=500&filter=state:unscheduled,started,unstarted&#{story_fields}")
+      json = get_request("stories?limit=500&#{story_filters}&#{story_fields}")
       stories = []
       JSON.parse(json).each do |obj|
         id   = obj["id"]
@@ -68,6 +68,10 @@ class Pivotal
 
     def story_fields
       "fields=story_type,estimate,current_state,name,description,updated_at,labels(name),comments(created_at,text)"
+    end
+
+    def story_filters
+      "filter=state:unscheduled,started,unstarted"
     end
 
     def comment_fields

--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -6,7 +6,6 @@ class Pivotal
   require "net/https"
   require "json"
   require "time"
-  require "benchmark"
 
   class << self
     def get_stories(_verbose = false)

--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -1,26 +1,31 @@
 # encoding: utf-8
+# /pivotal
 class Pivotal
   require "fileutils"
   require "net/http"
   require "net/https"
   require "json"
   require "time"
+  require "benchmark"
 
   class << self
     def get_stories(_verbose = false)
-      states = ['unscheduled', 'started', 'unstarted']
       stories = []
 
-      states.each do |state|
-        json = get_request("stories?limit=500&filter=state:#{state}&#{story_fields}")
-        JSON.parse(json).each do |obj|
-          id   = obj["id"]
-          name = obj["name"]
-          date = obj["updated_at"]
-          if Rails.env == "test" || name != "test"
-            story = Pivotal::Story.new(obj)
-            stories << story
-          end
+      request_stories("", stories)
+      request_stories("&offset=501", stories) if stories.count == 500
+
+      stories
+    end
+
+    def request_stories(api_params, stories)
+      json = get_request("stories?limit=500&filter=state:unscheduled,"\
+                         "started,unstarted&#{story_fields}" + api_params)
+
+      JSON.parse(json).each do |obj|
+        if Rails.env == "test" || obj["name"] != "test"
+          story = Pivotal::Story.new(obj)
+          stories << story
         end
       end
 
@@ -72,7 +77,8 @@ class Pivotal
     end
 
     def story_fields
-      "fields=story_type,estimate,current_state,name,description,updated_at,labels(name),comments(created_at,text)"
+      "fields=story_type,estimate,current_state,name,description,updated_at,"\
+      "labels(name),comments(created_at,text)"
     end
 
     def comment_fields

--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -8,7 +8,7 @@ class Pivotal
 
   class << self
     def get_stories(_verbose = false)
-      json = get_request("stories?limit=10000&#{story_fields}")
+      json = get_request("stories?limit=500&filter=state:unscheduled,started,unstarted&#{story_fields}")
       stories = []
       JSON.parse(json).each do |obj|
         id   = obj["id"]

--- a/app/classes/pivotal/http.rb
+++ b/app/classes/pivotal/http.rb
@@ -8,17 +8,22 @@ class Pivotal
 
   class << self
     def get_stories(_verbose = false)
-      json = get_request("stories?limit=500&#{story_filters}&#{story_fields}")
+      states = ['unscheduled', 'started', 'unstarted']
       stories = []
-      JSON.parse(json).each do |obj|
-        id   = obj["id"]
-        name = obj["name"]
-        date = obj["updated_at"]
-        if Rails.env == "test" || name != "test"
-          story = Pivotal::Story.new(obj)
-          stories << story
+
+      states.each do |state|
+        json = get_request("stories?limit=500&filter=state:#{state}&#{story_fields}")
+        JSON.parse(json).each do |obj|
+          id   = obj["id"]
+          name = obj["name"]
+          date = obj["updated_at"]
+          if Rails.env == "test" || name != "test"
+            story = Pivotal::Story.new(obj)
+            stories << story
+          end
         end
       end
+
       stories
     end
 
@@ -68,10 +73,6 @@ class Pivotal
 
     def story_fields
       "fields=story_type,estimate,current_state,name,description,updated_at,labels(name),comments(created_at,text)"
-    end
-
-    def story_filters
-      "filter=state:unscheduled,started,unstarted"
     end
 
     def comment_fields

--- a/app/classes/pivotal/story.rb
+++ b/app/classes/pivotal/story.rb
@@ -12,14 +12,6 @@ class Pivotal
     attr_accessor :comments
     attr_accessor :votes
 
-    ACTIVE_STATES = {
-      "unscheduled" => true,
-      "unstarted"   => true,
-      "started"     => true,
-      "finished"    => false,
-      "accepted"    => false
-    }
-
     LABEL_VALUE = {
       "critical"        => 4,
       "bottleneck"      => 3,
@@ -93,10 +85,6 @@ class Pivotal
           true
         end
       end.join("\n").sub(/\A\s+/, "").sub(/\s+\Z/, "\n")
-    end
-
-    def active?
-      ACTIVE_STATES[state] || false
     end
 
     def activity

--- a/app/controllers/pivotal_controller.rb
+++ b/app/controllers/pivotal_controller.rb
@@ -28,10 +28,10 @@ class PivotalController < ApplicationController
   require_dependency "pivotal"
 
   def index
-    if MO.pivotal_enabled
-      @stories = Pivotal.get_stories.sort_by(&:story_order)
-    else
-      @stories = []
-    end
+    @stories = if MO.pivotal_enabled
+                 Pivotal.get_stories.sort_by(&:story_order)
+               else
+                 []
+               end
   end
 end

--- a/app/controllers/pivotal_controller.rb
+++ b/app/controllers/pivotal_controller.rb
@@ -29,7 +29,7 @@ class PivotalController < ApplicationController
 
   def index
     if MO.pivotal_enabled
-      @stories = Pivotal.get_stories.sort_by(&:story_order).select(&:active?)
+      @stories = Pivotal.get_stories.sort_by(&:story_order)
     else
       @stories = []
     end

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -88,7 +88,7 @@ MushroomObserver::Application.configure do
   config.pivotal_url      = "www.pivotaltracker.com"
   config.pivotal_path     = "/services/v5"
   config.pivotal_project  = "224629"
-  config.pivotal_token    = ""
+  config.pivotal_token    = "xxx"
   config.pivotal_max_vote = 1
   config.pivotal_min_vote = -1
   config.pivotal_test_id  = 77_165_602

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -88,7 +88,7 @@ MushroomObserver::Application.configure do
   config.pivotal_url      = "www.pivotaltracker.com"
   config.pivotal_path     = "/services/v5"
   config.pivotal_project  = "224629"
-  config.pivotal_token    = "xxx"
+  config.pivotal_token    = ""
   config.pivotal_max_vote = 1
   config.pivotal_min_vote = -1
   config.pivotal_test_id  = 77_165_602


### PR DESCRIPTION
This applies fixes to the initial codeclimate issues.

-----

The Pivotal Tracker API will only return 500 stories. Currently, we grab them regardless of their state, so we are grabbing 'Approved' stories which will be filtered out locally.

I've adjusted the API call to specifically grab the last 500 stories with an 'Unscheduled', 'Started' or
'Unstarted' state.