### PR TITLE
mentions 'Locations' in Advanced Search Form helper text

### DIFF
--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2310,7 +2310,7 @@
   advanced_search_none_found: No matches found
   advanced_search_observer_help: Who observed the mushroom
   advanced_search_result_type: Result Type
-  advanced_search_result_type_help: Do you want [:observations], [:images] or [:names]/[:descriptions]?
+  advanced_search_result_type_help: Do you want [:observations], [:images], [:locations] or [:names]/[:descriptions]?
 
   advanced_search_filters: Search Filters
   advanced_search_filters_explain: Apply to this search only, overrides your normal preferred content filters


### PR DESCRIPTION
(#129803613) It now says "Result Type: Do you want observations, images or names/descriptions?" But Locations is also a valid result type.

It's been included like so:
"Result Type: Do you want observations, images, locations or names/descriptions?"