### PR TITLE
add comment to location_description fix

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -462,8 +462,10 @@ class AbstractModel < ActiveRecord::Base
   #    obj.log(:log_observation_updated)
   #
   def log(*args)
-    init_rss_log unless rss_log
-    rss_log.add_with_date(*args)
+    if has_rss_log?
+      init_rss_log unless rss_log
+      rss_log.add_with_date(*args)
+    end
   end
 
   # Add message to RssLog if you're about to destroy this object, creating new

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -31,6 +31,24 @@ class CommentControllerTest < FunctionalTestCase
     assert_form_action(action: "add_comment", id: obs_id, type: "Observation")
   end
 
+
+
+  def test_save_comment_location_description
+    loc = locations(:albion)
+    comment_count = loc.description.comments.size
+    params = { id: loc.description_id,
+               type: :location_description,
+               comment: { summary: "A Summary", comment: "Some text." } }
+
+    post_requires_login(:add_comment, params)
+    assert_redirected_to(controller: :location, action: :show_location_description, id: loc.description_id)
+    loc.reload
+    assert_equal(comment_count + 1, loc.description.comments.size)
+    comment = Comment.last
+    assert_equal("A Summary", comment.summary)
+    assert_equal("Some text.", comment.comment)
+  end
+
   def test_edit_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -31,17 +31,18 @@ class CommentControllerTest < FunctionalTestCase
     assert_form_action(action: "add_comment", id: obs_id, type: "Observation")
   end
 
-
-
   def test_save_comment_location_description
     loc = locations(:albion)
     comment_count = loc.description.comments.size
-    params = { id: loc.description_id,
-               type: :location_description,
-               comment: { summary: "A Summary", comment: "Some text." } }
+    params = {id: loc.description_id,
+              type: :location_description,
+              comment: {summary: "A Summary", comment: "Some text."}
+    }
 
     post_requires_login(:add_comment, params)
-    assert_redirected_to(controller: :location, action: :show_location_description, id: loc.description_id)
+    assert_redirected_to(controller: :location,
+                         action: :show_location_description,
+                         id: loc.description_id)
     loc.reload
     assert_equal(comment_count + 1, loc.description.comments.size)
     comment = Comment.last
@@ -52,10 +53,10 @@ class CommentControllerTest < FunctionalTestCase
   def test_edit_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
-    params = { id: comment.id.to_s }
+    params = {id: comment.id.to_s}
     assert_equal("rolf", comment.user.login)
-    requires_user(:edit_comment, { controller: :observer,
-                                   action: :show_observation, id: obs.id }, params)
+    requires_user(:edit_comment, {controller: :observer,
+                                  action: :show_observation, id: obs.id}, params)
     assert_form_action(action: "edit_comment", id: comment.id.to_s)
   end
 
@@ -64,9 +65,9 @@ class CommentControllerTest < FunctionalTestCase
     obs = comment.target
     assert(obs.comments.member?(comment))
     assert_equal("rolf", comment.user.login)
-    params = { id: comment.id.to_s }
-    requires_user(:destroy_comment, { controller: :observer,
-                                      action: :show_observation, id: obs.id }, params)
+    params = {id: comment.id.to_s}
+    requires_user(:destroy_comment, {controller: :observer,
+                                     action: :show_observation, id: obs.id}, params)
     assert_equal(9, rolf.reload.contribution)
     obs.reload
     assert(!obs.comments.member?(comment))
@@ -76,9 +77,9 @@ class CommentControllerTest < FunctionalTestCase
     assert_equal(10, rolf.contribution)
     obs = observations(:minimal_unknown_obs)
     comment_count = obs.comments.size
-    params = { id: obs.id,
-               type: "Observation",
-               comment: { summary: "A Summary", comment: "Some text." } }
+    params = {id: obs.id,
+              type: "Observation",
+              comment: {summary: "A Summary", comment: "Some text."}}
     post_requires_login(:add_comment, params)
     assert_redirected_to(controller: "observer", action: "show_observation")
     assert_equal(11, rolf.reload.contribution)
@@ -92,11 +93,11 @@ class CommentControllerTest < FunctionalTestCase
   def test_update_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
-    params = { id: comment.id,
-               comment: { summary: "New Summary", comment: "New text." } }
+    params = {id: comment.id,
+              comment: {summary: "New Summary", comment: "New text."}}
     assert("rolf" == comment.user.login)
-    post_requires_user(:edit_comment, { controller: :observer,
-                                        action: :show_observation, id: obs.id }, params)
+    post_requires_user(:edit_comment, {controller: :observer,
+                                       action: :show_observation, id: obs.id}, params)
     assert_equal(10, rolf.reload.contribution)
     comment = Comment.find(comment.id)
     assert_equal("New Summary", comment.summary)

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -34,10 +34,14 @@ class CommentControllerTest < FunctionalTestCase
   def test_save_comment_location_description
     loc = locations(:albion)
     comment_count = loc.description.comments.size
-    params = { id: loc.description_id,
-               type: :location_description,
-               comment:
-                   { summary: "A Summary", comment: "Some text." }
+    params = {
+        id: loc.description_id,
+        type: :location_description,
+        comment:
+            {
+                summary: "A Summary",
+                comment: "Some text."
+            }
     }
 
     post_requires_login( :add_comment, params)
@@ -54,26 +58,36 @@ class CommentControllerTest < FunctionalTestCase
   def test_edit_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
-    params = {id: comment.id.to_s}
+    params = { id: comment.id.to_s }
     assert_equal("rolf", comment.user.login)
-    requires_user(:edit_comment, { controller: :observer,
-                                   action: :show_observation,
-                                   id: obs.id
-    }, params)
+    requires_user(:edit_comment,
+                  {
+                      controller: :observer,
+                      action: :show_observation,
+                      id: obs.id
+                  },
+                  params)
     assert_form_action(action: "edit_comment", id: comment.id.to_s)
   end
 
   def test_destroy_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
+
     assert(obs.comments.member?(comment))
     assert_equal("rolf", comment.user.login)
-    params = {id: comment.id.to_s}
-    requires_user(:destroy_comment, { controller: :observer,
-                                      action: :show_observation,
-                                      id: obs.id
-    }, params)
+
+    params = { id: comment.id.to_s }
+    requires_user(:destroy_comment,
+                  {
+                      controller: :observer,
+                      action: :show_observation,
+                      id: obs.id
+                  },
+                  params)
+
     assert_equal(9, rolf.reload.contribution)
+
     obs.reload
     assert(!obs.comments.member?(comment))
   end
@@ -82,9 +96,10 @@ class CommentControllerTest < FunctionalTestCase
     assert_equal(10, rolf.contribution)
     obs = observations(:minimal_unknown_obs)
     comment_count = obs.comments.size
-    params = { id: obs.id,
-               type: "Observation",
-               comment: { summary: "A Summary", comment: "Some text."}
+    params = {
+        id: obs.id,
+        type: "Observation",
+        comment: { summary: "A Summary", comment: "Some text." }
     }
     post_requires_login(:add_comment, params)
     assert_redirected_to(controller: "observer",
@@ -100,14 +115,23 @@ class CommentControllerTest < FunctionalTestCase
   def test_update_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
-    params = { id: comment.id,
-               comment: { summary: "New Summary", comment: "New text."}
+    params = {
+        id: comment.id,
+        comment: {
+            summary: "New Summary",
+            comment: "New text."
+        }
     }
     assert("rolf" == comment.user.login)
-    post_requires_user(:edit_comment, { controller: :observer,
-                                        action: :show_observation,
-                                        id: obs.id
-    }, params)
+
+    post_requires_user(:edit_comment,
+                       {
+                           controller: :observer,
+                           action: :show_observation,
+                           id: obs.id
+                       },
+                       params)
+
     assert_equal(10, rolf.reload.contribution)
     comment = Comment.find(comment.id)
     assert_equal("New Summary", comment.summary)

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -34,12 +34,13 @@ class CommentControllerTest < FunctionalTestCase
   def test_save_comment_location_description
     loc = locations(:albion)
     comment_count = loc.description.comments.size
-    params = {id: loc.description_id,
-              type: :location_description,
-              comment: {summary: "A Summary", comment: "Some text."}
+    params = { id: loc.description_id,
+               type: :location_description,
+               comment:
+                   { summary: "A Summary", comment: "Some text." }
     }
 
-    post_requires_login(:add_comment, params)
+    post_requires_login( :add_comment, params)
     assert_redirected_to(controller: :location,
                          action: :show_location_description,
                          id: loc.description_id)
@@ -55,8 +56,10 @@ class CommentControllerTest < FunctionalTestCase
     obs = comment.target
     params = {id: comment.id.to_s}
     assert_equal("rolf", comment.user.login)
-    requires_user(:edit_comment, {controller: :observer,
-                                  action: :show_observation, id: obs.id}, params)
+    requires_user(:edit_comment, { controller: :observer,
+                                   action: :show_observation,
+                                   id: obs.id
+    }, params)
     assert_form_action(action: "edit_comment", id: comment.id.to_s)
   end
 
@@ -66,8 +69,10 @@ class CommentControllerTest < FunctionalTestCase
     assert(obs.comments.member?(comment))
     assert_equal("rolf", comment.user.login)
     params = {id: comment.id.to_s}
-    requires_user(:destroy_comment, {controller: :observer,
-                                     action: :show_observation, id: obs.id}, params)
+    requires_user(:destroy_comment, { controller: :observer,
+                                      action: :show_observation,
+                                      id: obs.id
+    }, params)
     assert_equal(9, rolf.reload.contribution)
     obs.reload
     assert(!obs.comments.member?(comment))
@@ -77,11 +82,13 @@ class CommentControllerTest < FunctionalTestCase
     assert_equal(10, rolf.contribution)
     obs = observations(:minimal_unknown_obs)
     comment_count = obs.comments.size
-    params = {id: obs.id,
-              type: "Observation",
-              comment: {summary: "A Summary", comment: "Some text."}}
+    params = { id: obs.id,
+               type: "Observation",
+               comment: { summary: "A Summary", comment: "Some text."}
+    }
     post_requires_login(:add_comment, params)
-    assert_redirected_to(controller: "observer", action: "show_observation")
+    assert_redirected_to(controller: "observer",
+                         action: "show_observation")
     assert_equal(11, rolf.reload.contribution)
     obs.reload
     assert_equal(comment_count + 1, obs.comments.size)
@@ -93,11 +100,14 @@ class CommentControllerTest < FunctionalTestCase
   def test_update_comment
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
-    params = {id: comment.id,
-              comment: {summary: "New Summary", comment: "New text."}}
+    params = { id: comment.id,
+               comment: { summary: "New Summary", comment: "New text."}
+    }
     assert("rolf" == comment.user.login)
-    post_requires_user(:edit_comment, {controller: :observer,
-                                       action: :show_observation, id: obs.id}, params)
+    post_requires_user(:edit_comment, { controller: :observer,
+                                        action: :show_observation,
+                                        id: obs.id
+    }, params)
     assert_equal(10, rolf.reload.contribution)
     comment = Comment.find(comment.id)
     assert_equal("New Summary", comment.summary)

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -35,16 +35,16 @@ class CommentControllerTest < FunctionalTestCase
     loc = locations(:albion)
     comment_count = loc.description.comments.size
     params = {
-        id: loc.description_id,
-        type: :location_description,
-        comment:
-            {
-                summary: "A Summary",
-                comment: "Some text."
-            }
+      id: loc.description_id,
+      type: :location_description,
+      comment:
+          {
+            summary: "A Summary",
+            comment: "Some text."
+          }
     }
 
-    post_requires_login( :add_comment, params)
+    post_requires_login(:add_comment, params)
     assert_redirected_to(controller: :location,
                          action: :show_location_description,
                          id: loc.description_id)
@@ -62,9 +62,9 @@ class CommentControllerTest < FunctionalTestCase
     assert_equal("rolf", comment.user.login)
     requires_user(:edit_comment,
                   {
-                      controller: :observer,
-                      action: :show_observation,
-                      id: obs.id
+                    controller: :observer,
+                    action: :show_observation,
+                    id: obs.id
                   },
                   params)
     assert_form_action(action: "edit_comment", id: comment.id.to_s)
@@ -80,9 +80,9 @@ class CommentControllerTest < FunctionalTestCase
     params = { id: comment.id.to_s }
     requires_user(:destroy_comment,
                   {
-                      controller: :observer,
-                      action: :show_observation,
-                      id: obs.id
+                    controller: :observer,
+                    action: :show_observation,
+                    id: obs.id
                   },
                   params)
 
@@ -97,9 +97,9 @@ class CommentControllerTest < FunctionalTestCase
     obs = observations(:minimal_unknown_obs)
     comment_count = obs.comments.size
     params = {
-        id: obs.id,
-        type: "Observation",
-        comment: { summary: "A Summary", comment: "Some text." }
+      id: obs.id,
+      type: "Observation",
+      comment: { summary: "A Summary", comment: "Some text." }
     }
     post_requires_login(:add_comment, params)
     assert_redirected_to(controller: "observer",
@@ -116,19 +116,20 @@ class CommentControllerTest < FunctionalTestCase
     comment = comments(:minimal_unknown_obs_comment_1)
     obs = comment.target
     params = {
-        id: comment.id,
-        comment: {
-            summary: "New Summary",
-            comment: "New text."
+      id: comment.id,
+      comment:
+        {
+          summary: "New Summary",
+          comment: "New text."
         }
     }
     assert("rolf" == comment.user.login)
 
     post_requires_user(:edit_comment,
                        {
-                           controller: :observer,
-                           action: :show_observation,
-                           id: obs.id
+                         controller: :observer,
+                         action: :show_observation,
+                         id: obs.id
                        },
                        params)
 


### PR DESCRIPTION
Fix issue where user was unable to add/edit comments on a location description. Adds test for adding comment on location description