### PR TITLE
removes reverse_ from influencing page title

### DIFF
--- a/app/classes/query/modules/titles.rb
+++ b/app/classes/query/modules/titles.rb
@@ -19,7 +19,7 @@ module Query
       def add_sort_order_to_title
         return unless params[:by]
         self.title_tag = :query_title_all_by
-        title_args[:order] = :"sort_by_#{params[:by]}"
+        title_args[:order] = :"sort_by_#{params[:by].sub(/^reverse_/, "")}"
       end
     end
   end


### PR DESCRIPTION
(#144750485) - Page title messed up for any index sorted in reverse

Title arguments [:order] was using the value for params[:by] which, for example, could be sort_by_* or sort_by_reverse_* and then pulling the translation.

None of those values existed for sort_by_reverse_* so I've removed it from title argument, since they're displaying the same copy.