### PR TITLE
Relax RuboCop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -65,11 +65,11 @@ exclude_paths:
 - app/assets/javascripts/jquery.js
 - app/assets/javascripts/jstz.js
 - app/assets/javascripts/lightbox.js
+# This file makes CodeClimate error in the Duplcation engine
 - app/classes/query/modules/serialization.rb
 # Prevent analysis of migrations
 - db/
 - log/
-# This file causes a CodeClimate error, halting the analysis
 - public/design_test/jquery-1.5.2.min.js
 - tmp/
 
@@ -79,7 +79,7 @@ exclude_paths:
 #
 #####################
 #
-# These file get a letter grade (A-F) and are included in overall
+# Files which get a letter grade (A-F) and are included in overall
 # CodeClimate numerical score
 ratings:
   paths:
@@ -92,7 +92,24 @@ ratings:
 
 ############################################################################
 #
-# CodeClimate's "inferred .codeclimate.yml
+# Classic configuration
+# Kept for convenience in case we decide to drop Engine-Based configuration
+#
+############################################################################
+# languages:
+#  JavaScript: true
+#  Ruby: true
+# exclude_paths:
+# - public/design_test/jquery-1.5.2.min.js
+# - app/assets/javascripts/bootstrap.js
+# - app/assets/javascripts/jquery.js
+# - app/assets/javascripts/jstz.js
+# - app/assets/javascripts/lightbox.js
+# - app/classes/query/modules/serialization.rb
+#
+############################################################################
+#
+# CodeClimate's generated "inferred .codeclimate.yml"
 # based on the Classic configuration
 #
 ############################################################################
@@ -170,19 +187,3 @@ ratings:
 #  - public/design_test/jquery-1.5.2.min.js
 #  - app/assets/javascripts/bootstrap.js"
 #
-############################################################################
-#
-# Classic configuration
-# Kept for convenience in case we decide to drop Engine-Based configuration
-#
-############################################################################
-# languages:
-#  JavaScript: true
-#  Ruby: true
-# exclude_paths:
-# - public/design_test/jquery-1.5.2.min.js
-# - app/assets/javascripts/bootstrap.js
-# - app/assets/javascripts/jquery.js
-# - app/assets/javascripts/jstz.js
-# - app/assets/javascripts/lightbox.js
-# - app/classes/query/modules/serialization.rb

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,188 @@
-languages:
-  JavaScript: true
-  Ruby: true
+# CodeClimate Configuration
+#
+# CodeClimate can run two ways:
+# newer, "Engine-based" analysis configuration
+# older, "Classic" analysis  configuration
+#
+############################################################################
+#
+# Engine-Based Configuration
+#
+#####################
+#
+#   engines
+#
+#####################
+#
+# CodeClimate will run these "engines" when CodeClimate is triggered.
+# For configuration of specific engines, see CodeClimate documentation
+#   for that engine.
+engines:
+# check Rails apps for security vulnerabilities
+  brakeman:
+    enabled: false
+# helps find security vulnerabilities in Ruby dependencies
+  bundler-audit:
+    enabled: false
+# style-checking for CSS stylesheets
+  csslint:
+    enabled: false
+  duplication:
+    enabled: false
+    config:
+      languages:
+      - ruby
+      - javascript
+# linting, complexity analysis, & style checking for EcmaScript/JavaScript
+  eslint:
+    enabled: false
+# case-sensitive search for the following strings:
+# TODO, FIXME, HACK, XXX, BUG
+# Can be configured to search for any strings
+  fixme:
+    enabled: false
+# style and quality checks for Ruby code
+  rubocop:
+    enabled: true
+
+#####################
+#
+#   exclude_paths
+#
+#####################
+#
+# A list of file "patterns" completely excluded from analysis
+# Each pattern is either: filenames relative to the project root,
+#   or shell-style globs relative to the project root.
+# Patterns other than named paths starting at root
+#   must be enclosed in quotes, e.g.: "**.rb", "**/subdir/".
+# Patterns can be negated by prefixing them with a !.
+#   A negated pattern will include the matched files for analysis,
+#   even if they were excluded by a previous pattern.
+#
 exclude_paths:
-- public/design_test/jquery-1.5.2.min.js
 - app/assets/javascripts/bootstrap.js
 - app/assets/javascripts/jquery.js
 - app/assets/javascripts/jstz.js
 - app/assets/javascripts/lightbox.js
 - app/classes/query/modules/serialization.rb
+# Prevent analysis of migrations
+- db/
+- log/
+# This file causes a CodeClimate error, halting the analysis
+- public/design_test/jquery-1.5.2.min.js
+- tmp/
+
+#####################
+#
+#   ratings
+#
+#####################
+#
+# These file get a letter grade (A-F) and are included in overall
+# CodeClimate numerical score
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.css"
+  - "**.erb"
+  - "**.rake"
+  - "**.rb"
+  - "**.js"
+
+############################################################################
+#
+# CodeClimate's "inferred .codeclimate.yml
+# based on the Classic configuration
+#
+############################################################################
+# engines:
+#   brakeman:
+#     enabled: true
+#   bundler-audit:
+#     enabled: true
+#   duplication:
+#     enabled: true
+#     config:
+#       languages:
+#       - ruby
+#       - javascript
+#       - python
+#       - php
+#   eslint:
+#     enabled: true
+#   fixme:
+#     enabled: true
+#   rubocop:
+#     enabled: true
+# ratings:
+#   paths:
+#   - Gemfile.lock
+#   - "**.erb"
+#   - "**.haml"
+#   - "**.rb"
+#   - "**.rhtml"
+#   - "**.slim"
+#   - "**.inc"
+#   - "**.js"
+#   - "**.jsx"
+#   - "**.module"
+#   - "**.php"
+#   - "**.py"
+#  exclude_paths:
+#  - public/design_test/jquery-1.5.2.min.js
+#  - app/assets/javascripts/bootstrap.js"
+# 	"---
+# engines:
+#   brakeman:
+#     enabled: true
+#   bundler-audit:
+#     enabled: true
+#   duplication:
+#     enabled: true
+#     config:
+#       languages:
+#       - ruby
+#       - javascript
+#       - python
+#       - php
+#   eslint:
+#     enabled: true
+#   fixme:
+#     enabled: true
+#   rubocop:
+#     enabled: true
+# ratings:
+#   paths:
+#   - Gemfile.lock
+#   - "**.erb"
+#   - "**.haml"
+#   - "**.rb"
+#   - "**.rhtml"
+#   - "**.slim"
+#   - "**.inc"
+#   - "**.js"
+#   - "**.jsx"
+#   - "**.module"
+#   - "**.php"
+#   - "**.py"
+#  exclude_paths:
+#  - public/design_test/jquery-1.5.2.min.js
+#  - app/assets/javascripts/bootstrap.js"
+#
+############################################################################
+#
+# Classic configuration
+# Kept for convenience in case we decide to drop Engine-Based configuration
+#
+############################################################################
+# languages:
+#  JavaScript: true
+#  Ruby: true
+# exclude_paths:
+# - public/design_test/jquery-1.5.2.min.js
+# - app/assets/javascripts/bootstrap.js
+# - app/assets/javascripts/jquery.js
+# - app/assets/javascripts/jstz.js
+# - app/assets/javascripts/lightbox.js
+# - app/classes/query/modules/serialization.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,32 @@
+# RuboCop configuration
+# Uses Rubcop's default configuration, except as specified below
+# For more info, see http://rubocop.readthedocs.io/en/latest/configuration/
+
+###################### Metrics #################################################
+
+# Relaxed metrics based on CodeClimages default .rubocop.yml
+
+Metrics/ClassLength:
+# Max: 100
+  Max: 250
+
+Metrics/MethodLength:
+# Max: 10
+  Max: 30
+
+Metrics/ModuleLength:
+# Max: 100
+  Max: 250
+
+###################### Style ###################################################
+
+# Cops where Rubocop supports multiple styles and MO uses a non-default.
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
 Style/DotPosition:
   EnforcedStyle: trailing
+
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,8 +1,23 @@
-# RuboCop configuration for use on /test files
+# RuboCop non-default configuration for tests
 
 # dafault rules
 inherit_from: ../.rubocop.yml
 
-# with following modifications
+#################### Metrics ###############################
+
+# Disable Cops which make less sense in tests, and which we regularly ignore.
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
- Relaxes various RuboCop metrics application-wide: uses CodeClimate's suggested max's instead of RuboCop's
- Ignores various RuboCop metrics in test files: disables various Cops which we regularly ignore in test files and which make less sense there.


