### PR TITLE
Relax rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,32 @@
+# RuboCop configuration
+# Uses Rubcop's default configuration, except as specified below
+# For more info, see http://rubocop.readthedocs.io/en/latest/configuration/
+
+###################### Metrics #################################################
+
+# Relaxed metrics based on CodeClimages default .rubocop.yml
+
+Metrics/ClassLength:
+# Max: 100
+  Max: 250
+
+Metrics/MethodLength:
+# Max: 10
+  Max: 30
+
+Metrics/ModuleLength:
+# Max: 100
+  Max: 250
+
+###################### Style ###################################################
+
+# Cops where Rubocop supports multiple styles and MO uses a non-default.
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
 Style/DotPosition:
   EnforcedStyle: trailing
+
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,8 +1,23 @@
-# RuboCop configuration for use on /test files
+# RuboCop non-default configuration for tests
 
 # dafault rules
 inherit_from: ../.rubocop.yml
 
-# with following modifications
+#################### Metrics ###############################
+
+# Disable Cops which make less sense in tests, and which we regularly ignore.
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
- Relaxes various RuboCop metrics application-wide: uses CodeClimate's suggested max's instead of RuboCop's
- Ignores various RuboCop metrics in test files: disables various Cops which we regularly ignore in test files and which make less sense there.

This should get rid of > 1,000 purported RuboCop offenses which are should not be offenses and which are a distraction to developers.
