### PR TITLE
Make CodeClimate report results

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,7 +12,7 @@
 # For configuration of specific engines, see CodeClimate documentation
 #   for that engine.
 
- engines:
+engines:
 # check Rails apps for security vulnerabilities
   brakeman:
     enabled: true


### PR DESCRIPTION
- Eliminate stray leading space.
This space made CodeClimate (engines version) say  "No results to report" and also made OS version add files for  bootstrap.js and
lightbox.js.