### PR TITLE
Fix display of deprecated :Group Names

### DIFF
--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -504,7 +504,7 @@ class NameController < ApplicationController
     in_str = Name.clean_incoming_string("#{text_name} #{author}")
     in_rank = params[:name][:rank].to_sym
     old_deprecated = @name ? @name.deprecated : false
-    parse = Name.parse_name(in_str, in_rank, old_deprecated)
+    parse = Name.parse_name(in_str, rank: in_rank, deprecated: old_deprecated)
     if !parse || parse.rank != in_rank
       rank_tag = :"rank_#{in_rank.to_s.downcase}"
       fail(:runtime_invalid_for_rank.t(rank: rank_tag, name: in_str))

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1572,7 +1572,7 @@ class Name < AbstractModel
   end
 
   # Parse a name given no additional information.  Returns a ParsedName instance.
-  def self.parse_name(str, rank = :Genus, deprecated = false)
+  def self.parse_name(str, rank: :Genus, deprecated: false)
     str = clean_incoming_string(str)
     parse_group(str, deprecated) ||
       parse_subgenus(str, deprecated) ||
@@ -1611,7 +1611,8 @@ class Name < AbstractModel
   def self.parse_group(str, deprecated = false)
     return unless match = GROUP_PAT.match(str)
 
-    result = parse_name(str_without_group(str))
+    result = parse_name(str_without_group(str),
+                        rank: :Group, deprecated: deprecated)
     return nil unless result
 
     # Adjust the parsed name
@@ -2166,7 +2167,7 @@ class Name < AbstractModel
   #
   def change_text_name(in_text_name, in_author, in_rank, save_parents = false)
     in_str = Name.clean_incoming_string("#{in_text_name} #{in_author}")
-    parse = Name.parse_name(in_str, in_rank, deprecated)
+    parse = Name.parse_name(in_str, rank: in_rank, deprecated: deprecated)
     if !parse || parse.rank != in_rank
       fail :runtime_invalid_for_rank.t(rank: :"rank_#{in_rank.to_s.downcase}", name: in_str)
     end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -14,14 +14,9 @@ class NameTest < UnitTestCase
     name
   end
 
-  # Parse a string, with detailed error message. To test a deprecated string,
-  # call this with "deprecated: true" tacked on at the end.
-  def do_name_parse_test(str, args)
-    # If final key of arg is :deprecated", remove it and
-    # separately pass it to Name.parse_name as the final argument
-    deprecated = args.delete(:deprecated) || false
-    # :Genus is the default 2nd argument of Name.parse_name
-    parse = Name.parse_name(str, :Genus, deprecated)
+  # Parse a string, with detailed error message.
+  def do_name_parse_test(str, expects, deprecated: false)
+    parse = Name.parse_name(str, deprecated: deprecated)
     assert parse, "Expected #{str.inspect} to parse!"
     any_errors = false
     msg = ["Name is wrong; expected -vs- actual:"]
@@ -36,7 +31,7 @@ class NameTest < UnitTestCase
       :rank,
       :author
     ].each do |var|
-      expect = args[var]
+      expect = expects[var]
       if var == :real_text_name
         actual = Name.display_to_real_text(parse)
       elsif var == :real_search_name
@@ -447,15 +442,17 @@ class NameTest < UnitTestCase
   def test_name_parse_1
     do_name_parse_test(
       "Lecania ryaniana van den Boom",
-      text_name: "Lecania ryaniana",
-      real_text_name: "Lecania ryaniana",
-      search_name: "Lecania ryaniana van den Boom",
-      real_search_name: "Lecania ryaniana van den Boom",
-      sort_name: "Lecania ryaniana  van den Boom",
-      display_name: "**__Lecania ryaniana__** van den Boom",
-      parent_name: "Lecania",
-      rank: :Species,
-      author: "van den Boom"
+     {
+        text_name: "Lecania ryaniana",
+        real_text_name: "Lecania ryaniana",
+        search_name: "Lecania ryaniana van den Boom",
+        real_search_name: "Lecania ryaniana van den Boom",
+        sort_name: "Lecania ryaniana  van den Boom",
+        display_name: "**__Lecania ryaniana__** van den Boom",
+        parent_name: "Lecania",
+        rank: :Species,
+        author: "van den Boom"
+      }
     )
   end
 

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1180,6 +1180,54 @@ class NameTest < UnitTestCase
     )
   end
 
+  def test_name_parse_deprecated
+    do_name_parse_test(
+      "Lecania ryaniana van den Boom",
+      {
+        text_name: "Lecania ryaniana",
+        real_text_name: "Lecania ryaniana",
+        search_name: "Lecania ryaniana van den Boom",
+        real_search_name: "Lecania ryaniana van den Boom",
+        sort_name: "Lecania ryaniana  van den Boom",
+        display_name: "__Lecania ryaniana__ van den Boom",
+        parent_name: "Lecania",
+        rank: :Species,
+        author: "van den Boom"
+      },
+      deprecated: true
+    )
+    do_name_parse_test( # binomial, no author, deprecated
+      "Agaricus campestris group",
+      {
+        text_name:        "Agaricus campestris group",
+        real_text_name:   "Agaricus campestris group",
+        search_name:      "Agaricus campestris group",
+        real_search_name: "Agaricus campestris group",
+        sort_name:        "Agaricus campestris   group",
+        display_name:     "__Agaricus campestris__ group",
+        parent_name:      "Agaricus",
+        rank:             :Group,
+        author:           "",
+      },
+      deprecated:       true
+    )
+    do_name_parse_test( # binomial, sensu author, deprecated
+      "Agaricus campestris group sensu Author",
+      {
+        text_name:        "Agaricus campestris group",
+        real_text_name:   "Agaricus campestris group",
+        search_name:      "Agaricus campestris group sensu Author",
+        real_search_name: "Agaricus campestris group sensu Author",
+        sort_name:        "Agaricus campestris   group  sensu Author",
+        display_name:     "__Agaricus campestris__ group sensu Author",
+        parent_name:      "Agaricus",
+        rank:             :Group,
+        author:           "sensu Author",
+      },
+      deprecated:       true
+   )
+  end
+
   # -----------------------------
   #  Test classification.
   # -----------------------------

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -14,8 +14,14 @@ class NameTest < UnitTestCase
     name
   end
 
+  # Parse a string, with detailed error message. To test a deprecated string,
+  # call this with "deprecated: true" tacked on at the end.
   def do_name_parse_test(str, args)
-    parse = Name.parse_name(str)
+    # If final key of arg is :deprecated", remove it and
+    # separately pass it to Name.parse_name as the final argument
+    deprecated = args.delete(:deprecated) || false
+    # :Genus is the default 2nd argument of Name.parse_name
+    parse = Name.parse_name(str, :Genus, deprecated)
     assert parse, "Expected #{str.inspect} to parse!"
     any_errors = false
     msg = ["Name is wrong; expected -vs- actual:"]

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1207,9 +1207,9 @@ class NameTest < UnitTestCase
         display_name:     "__Agaricus campestris__ group",
         parent_name:      "Agaricus",
         rank:             :Group,
-        author:           "",
+        author:           ""
       },
-      deprecated:       true
+      deprecated: true
     )
     do_name_parse_test( # binomial, sensu author, deprecated
       "Agaricus campestris group sensu Author",
@@ -1222,10 +1222,10 @@ class NameTest < UnitTestCase
         display_name:     "__Agaricus campestris__ group sensu Author",
         parent_name:      "Agaricus",
         rank:             :Group,
-        author:           "sensu Author",
+        author:           "sensu Author"
       },
-      deprecated:       true
-   )
+      deprecated: true
+    )
   end
 
   # -----------------------------

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -442,17 +442,15 @@ class NameTest < UnitTestCase
   def test_name_parse_1
     do_name_parse_test(
       "Lecania ryaniana van den Boom",
-     {
-        text_name: "Lecania ryaniana",
-        real_text_name: "Lecania ryaniana",
-        search_name: "Lecania ryaniana van den Boom",
-        real_search_name: "Lecania ryaniana van den Boom",
-        sort_name: "Lecania ryaniana  van den Boom",
-        display_name: "**__Lecania ryaniana__** van den Boom",
-        parent_name: "Lecania",
-        rank: :Species,
-        author: "van den Boom"
-      }
+      text_name: "Lecania ryaniana",
+      real_text_name: "Lecania ryaniana",
+      search_name: "Lecania ryaniana van den Boom",
+      real_search_name: "Lecania ryaniana van den Boom",
+      sort_name: "Lecania ryaniana  van den Boom",
+      display_name: "**__Lecania ryaniana__** van den Boom",
+      parent_name: "Lecania",
+      rank: :Species,
+      author: "van den Boom"
     )
   end
 


### PR DESCRIPTION
Delivers [Pivotal #147206581](https://www.pivotaltracker.com/story/show/147206581)

Deprecated :Group Names were displayed instead of roman.   The problem was that when Name#parse_group called parse_name(str_without_group(str)), it neglected to pass in `deprecated`.

In order to test this, I ended up doing the following:
- Changing Name#parse_name to use keyword parameters
- When needed, change calls to Name#parse_name throughout the app to use those keywords
- Add an additional `deprecated` parameter to NameTest#do_name_parse_test
- Add test of parsing some deprecated Names

 