### PR TITLE
Fix expect in failing test re json-api

### DIFF
--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -51,7 +51,7 @@ class ApiControllerTest < FunctionalTestCase
     Digest::MD5.hexdigest(string)
   end
 
-  ################################################################################
+  ##############################################################################
 
   def test_basic_get_requests
     assert_no_api_errors
@@ -80,7 +80,7 @@ class ApiControllerTest < FunctionalTestCase
   def test_num_of_pages
     get(:observations, detail: :high, format: :json)
     json = JSON.parse(response.body)
-    assert_equal(4, json["number_of_pages"],
+    assert_equal(5, json["number_of_pages"],
                  "Number of pages was not correctly calculated.")
   end
 


### PR DESCRIPTION
 FAIL["test_num_of_pages", ApiControllerTest, 191.35738450102508]
 test_num_of_pages#ApiControllerTest (191.36s)
        Number of pages was not correctly calculated..
        Expected: 4
          Actual: 5
        test/controllers/api_controller_test.rb:83:in `test_num_of_pages'

In pre-merger branch, there were 35 Observations.  At 10 Obs/page, there are 4 pages.
But after merger: 43 Observations (because of more fixtures), 10/page, 5 pages.