### PR TITLE
Generate simple enum class scope- and instance "!" and "?" methods

### DIFF
--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -62,7 +62,6 @@ class LocationDescription < Description
             user: 5
           },
           source: :source_type,
-          with: [],
           accessor: :whiny
          )
 

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -282,7 +282,6 @@ class Name < AbstractModel
             Group: 16 # used for both "group" and "clade"
           },
           source: :rank,
-          with: [],
           accessor: :whiny)
 
   belongs_to :correct_spelling, class_name: "Name",

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -75,7 +75,6 @@ class NameDescription < Description
             inaccurate: 4
           },
           source: :review_status,
-          with: [],
           accessor: :whiny
          )
   as_enum(:source_type,
@@ -86,7 +85,6 @@ class NameDescription < Description
             user: 5
           },
           source: :source_type,
-          with: [],
           accessor: :whiny
          )
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -42,7 +42,6 @@ class Notification < AbstractModel
             all_comments: 4
           },
           source: :flavor,
-          with: [],
           accessor: :whiny
          )
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,7 +230,6 @@ class User < AbstractModel
             small: 2
           },
           source: :thumbnail_size,
-          with: [],
           accessor: :whiny)
   as_enum(:image_size,
           {
@@ -242,7 +241,6 @@ class User < AbstractModel
             full_size: 6
           },
           source: :image_size,
-          with: [],
           accessor: :whiny)
   as_enum(:votes_anonymous,
           {
@@ -251,7 +249,6 @@ class User < AbstractModel
             old: 3
           },
           source: :votes_anonymous,
-          with: [],
           accessor: :whiny)
   as_enum(:location_format,
           {
@@ -259,7 +256,6 @@ class User < AbstractModel
             scientific: 2
           },
           source: :location_format,
-          with: [],
           accessor: :whiny)
   as_enum(:hide_authors,
           {
@@ -267,7 +263,6 @@ class User < AbstractModel
             above_species: 2
           },
           source: :hide_authors,
-          with: [],
           accessor: :whiny)
   as_enum(:keep_filenames,
           {
@@ -276,7 +271,6 @@ class User < AbstractModel
             keep_and_show: 3
           },
           source: :keep_filenames,
-          with: [],
           accessor: :whiny)
 
   has_many :api_keys, dependent: :destroy


### PR DESCRIPTION
Lets us to do:
`Name.Species` instead of 
`Name.where(rank: Name.ranks[:Species])`
and
`Observation.joins(:name).merge(Name.Species)` instead of 
`Observation.joins(:name).where("names.rank = #{Name.ranks[:Species]}")`

We also get
```ruby
name.Species! # => "Species"
name.rank     # => :Species
name.Species? # => true
```
See generally https://github.com/lwe/simple_enum/blob/master/README.md

This is also the behavior of Rails' built-in enums, so the change also helps prepare for an eventual switchover.  See http://api.rubyonrails.org/classes/ActiveRecord/Enum.html