### PR TITLE
Rubocop tests controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,12 @@ AllCops:
     - public/design_test/jquery-1.5.2.min.js
     - "tmp/**/*"
 
+###################### Global Disables #########################################
+
+# Disable using Rails < 5.0; it's relevant only to >= 5.0
+Rails/HttpPositionalArguments:
+  Enabled: False
+
 ###################### Metrics #################################################
 
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,17 +70,28 @@ Metrics/PerceivedComplexity:
 
 ###################### Layout and Style ########################################
 
+# Rubocop supports multiple options and MO uses a non-default
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
 # Allow non-ascii characters in comments; we need to use accented chars
 Style/AsciiComments:
   Enabled: false
 
-# Cops where Rubocop supports multiple options and MO uses a non-default.
+# Repeat the RuboCop defaults because CodeClimate silently overrides them
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: "()"
+    '%i':    "[]"
+    '%I':    "[]"
+    '%r':    "{}"
+    '%w':    "[]"
+    '%W':    "[]"
 
-Layout/DotPosition:
-  EnforcedStyle: trailing
-
+# Rubocop supports multiple options and MO uses a non-default
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+# Rubocop supports multiple options and MO uses a non-default
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes

--- a/app/classes/observation_report/darwin.rb
+++ b/app/classes/observation_report/darwin.rb
@@ -2,7 +2,7 @@ module ObservationReport
   # Darwin format.
   class Darwin < ObservationReport::CSV
     def labels
-      %w(
+      %w[
         DateLastModified
         InstitutionCode
         CollectionCode
@@ -27,7 +27,7 @@ module ObservationReport
         MinimumElevation
         MaximumElevation
         Notes
-      )
+      ]
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/classes/observation_report/mycoflora.rb
+++ b/app/classes/observation_report/mycoflora.rb
@@ -2,7 +2,7 @@ module ObservationReport
   # Format for export to Mycoflora.
   class Mycoflora < ObservationReport::CSV
     def labels
-      %w(
+      %w[
         scientificName
         scientificNameAuthorship
         recordedBy
@@ -21,7 +21,7 @@ module ObservationReport
         year
         moUrl
         imageUrls
-      )
+      ]
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/classes/observation_report/raw.rb
+++ b/app/classes/observation_report/raw.rb
@@ -3,7 +3,7 @@ module ObservationReport
   class Raw < ObservationReport::CSV
     # rubocop:disable Metrics/MethodLength
     def labels
-      %w(
+      %w[
         observation_id
         user_id
         user_login
@@ -33,7 +33,7 @@ module ObservationReport
         is_collection_location
         thumbnail_image_id
         notes
-      )
+      ]
     end
 
     # rubocop:disable Metrics/AbcSize Metrics/MethodLength

--- a/app/classes/observation_report/symbiota.rb
+++ b/app/classes/observation_report/symbiota.rb
@@ -2,7 +2,7 @@ module ObservationReport
   # Symbiota-style csv report.
   class Symbiota < ObservationReport::CSV
     def labels
-      %w(
+      %w[
         scientificName
         scientificNameAuthorship
         taxonRank
@@ -25,7 +25,7 @@ module ObservationReport
         maximumElevationInMeters
         updated_at
         fieldNotes
-      )
+      ]
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -288,12 +288,12 @@ class Textile < String
       id = Regexp.last_match(3)
       matches = [
         ["comment"],
-        %w(image img),
-        %w(location loc),
+        %w[image img],
+        %w[location loc],
         ["name"],
-        %w(observation obs ob),
-        %w(project proj),
-        %w(species_list spl),
+        %w[observation obs ob],
+        %w[project proj],
+        %w[species_list spl],
         ["user"]
       ].select { |x| x[0] == type.downcase || x[1] == type.downcase }
       if matches.length == 1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -505,7 +505,7 @@ class ApplicationController < ActionController::Base
   # flavor :name, which corresponds to QueuedEmail's with flavor :naming.)
   def unshown_notifications?(user, flavor = :naming)
     QueuedEmail.where(flavor: flavor, to_user_id: user.id).each do |q|
-      ints = q.get_integers(%w(shown notification), true)
+      ints = q.get_integers(%w[shown notification], true)
       next if ints["shown"]
       notification = Notification.safe_find(ints["notification"].to_i)
       next unless notification && notification.note_template

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -187,7 +187,7 @@ class LocationController < ApplicationController
     end
     @query = restrict_query_to_box(@query)
     @timer_start = Time.now
-    columns = %w(name north south east west).map { |x| "locations.#{x}" }
+    columns = %w[name north south east west].map { |x| "locations.#{x}" }
     args = { select: "DISTINCT(locations.id), #{columns.join(", ")}" }
     @locations = @query.select_rows(args).map do |id, name, n, s, e, w|
       MinimalMapLocation.new(id, name, n, s, e, w)

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1527,7 +1527,7 @@ class NameController < ApplicationController
     end
 
     report = CSV.generate(col_sep: "\t") do |csv|
-      csv << %w(name rank number_observations family)
+      csv << %w[name rank number_observations family]
       data.each do |name, rank, number|
         genus = name.split(" ").first
         family = families[genus] || ""

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -169,7 +169,7 @@ class ObserverController
 
     # Get matching observations.
     locations = {}
-    columns = %w(id lat long location_id).map { |x| "observations.#{x}" }
+    columns = %w[id lat long location_id].map { |x| "observations.#{x}" }
     args = {
       select: columns.join(", "),
       where: "observations.lat IS NOT NULL OR " \

--- a/app/controllers/species_list_controller.rb
+++ b/app/controllers/species_list_controller.rb
@@ -236,7 +236,7 @@ class SpeciesListController < ApplicationController
       raise "Unsupported CSV report charset: #{charset}"
     end
     str = CSV.generate do |csv|
-      csv << %w(scientific_name authority citation accepted)
+      csv << %w[scientific_name authority citation accepted]
       names.each do |name|
         csv << [name.real_text_name, name.author, name.citation,
                 name.deprecated ? "" : "1"].map { |v| v.blank? ? nil : v }

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -37,7 +37,7 @@ module PaginationHelper
       args = args.dup
       args[:params] = (args[:params] || {}).dup
       args[:params][pages.number_arg] = nil
-      str = %w(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z).map do |letter|
+      str = %w[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z].map do |letter|
         if !pages.used_letters || pages.used_letters.include?(letter)
           pagination_link(letter, letter, pages.letter_arg, args)
         else

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -291,7 +291,7 @@ class Image < AbstractModel
   # Return an Array of all the extensions of all the image types we explicitly
   # support.
   def self.all_extensions
-    %w(jpg gif png tiff bmp raw)
+    %w[jpg gif png tiff bmp raw]
   end
 
   # Return an Array of all the extensions of all the image content types we

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -90,7 +90,7 @@ class Location < AbstractModel
 
   acts_as_versioned(
     table_name: "locations_versions",
-    if_changed: %w(
+    if_changed: %w[
       name
       north
       south
@@ -99,7 +99,7 @@ class Location < AbstractModel
       high
       low
       notes
-    )
+    ]
   )
   non_versioned_columns.push(
     "created_at",

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -300,7 +300,7 @@ class Name < AbstractModel
 
   acts_as_versioned(
     table_name: "names_versions",
-    if_changed: %w(
+    if_changed: %w[
       rank
       text_name
       search_name
@@ -311,7 +311,7 @@ class Name < AbstractModel
       deprecated
       correct_spelling
       notes
-    )
+    ]
   )
   non_versioned_columns.push(
     "created_at",

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -165,7 +165,7 @@ class RssLog < AbstractModel
   # List of all object types that can have RssLog's.  (This is the order they
   # appear on the activity log page.)
   def self.all_types
-    %w(observation name location species_list project glossary_term article)
+    %w[observation name location species_list project glossary_term article]
   end
 
   # Returns the associated object, or nil if it's an orphan.

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,10 +12,10 @@ module MushroomObserver
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(
+    config.autoload_paths += %W[
       #{config.root}/app/classes
       #{config.root}/app/extensions
-    )
+    ]
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -56,7 +56,7 @@ MushroomObserver::Application.configure do
   config.default_theme = "BlackOnWhite"
 
   # Available themes.
-  config.themes = %w(Agaricus Amanita Cantharellaceae Hygrocybe BlackOnWhite)
+  config.themes = %w[Agaricus Amanita Cantharellaceae Hygrocybe BlackOnWhite]
 
   # Queued email only gets delivered if you have run the rake task email:send.
   # script/send_email is a cron script for running email:send.  (Delay is in
@@ -177,7 +177,7 @@ MushroomObserver::Application.configure do
   # Set of javascript and stylesheet files not included by default and
   # therefore need to be precompiled explicitly.
   if config.assets && config.assets.precompile
-    config.assets.precompile += %w(
+    config.assets.precompile += %w[
       advanced_search.js
       api_key.js
       date_select.js
@@ -198,7 +198,7 @@ MushroomObserver::Application.configure do
       BlackOnWhite.css
       Cantharellaceae.css
       Hygrocybe.css
-    )
+    ]
   end
 
   # Max number of results Query will put in "IN (...)" clauses.

--- a/lib/tasks/jason.rake
+++ b/lib/tasks/jason.rake
@@ -34,7 +34,7 @@ namespace :jason do
   desc "Dump out all notes for obs, names, spls, comments to test RedCloth."
   task(dump_notes: :environment) do
     notes = []
-    for table in %w(
+    for table in %w[
       comments
       draft_names
       images
@@ -48,7 +48,7 @@ namespace :jason do
       projects
       species_lists
       users
-      votes)
+      votes]
       File.open("db/schema.rb", "r") do |fh|
         table2 = nil
         fh.each_line do |line|

--- a/script/mushroom_mapper.rb
+++ b/script/mushroom_mapper.rb
@@ -109,7 +109,7 @@ for id, genus, classification in Name.connection.select_rows %(
   num_obs = observations[genus].to_i
   list = classifications[genus] ||= []
   list << [id, kingdom, klass, order, family, genus, num_obs]
-  if %w(Amoebozoa Fungi Protozoa).include?(kingdom)
+  if %w[Amoebozoa Fungi Protozoa].include?(kingdom)
     family2 = family || "Unknown Family in #{order || klass || kingdom}"
     hash = genus_to_family[genus] ||= {}
     hash[family2] = hash[family2].to_i + num_obs
@@ -182,7 +182,7 @@ end
 
 # Write raw data file.
 File.open(RAW_FILE, "w") do |fh|
-  fh.puts(%w(id kingdom class order family genus num_obs).join("\t"))
+  fh.puts(%w[id kingdom class order family genus num_obs].join("\t"))
   for genus in classifications.keys.sort do
     fh.puts(classifications[genus].join("\t"))
   end

--- a/script/old/update_images
+++ b/script/old/update_images
@@ -45,10 +45,10 @@ OFFICIAL_SERVERS = [
 DEFAULT_IMAGE_SERVER = "dreamhost"
 
 # List of all image sizes available.
-ALL_SIZES = %w(thumb 320 640 960 1280 orig)
+ALL_SIZES = %w[thumb 320 640 960 1280 orig]
 
 # List of sizes we don't want to keep on slicehost due to space constraints.
-DELETE_SIZES = %w(640 960 1280 orig)
+DELETE_SIZES = %w[640 960 1280 orig]
 
 # ----------------------------
 #  Command line parsing.

--- a/script/old/upload_observation.rb
+++ b/script/old/upload_observation.rb
@@ -246,7 +246,7 @@ class Observation
   def parse_name(str)
     name = str.sub(/\?$/, "")
     if name.match(/^(\S+) (\S+) (\S+)/) &&
-       !%w(ssp. var. f.).include?(Regexp.last_match(3))
+       !%w[ssp. var. f.].include?(Regexp.last_match(3))
       fail "Missing 'ssp.' or 'var.' in #{name.inspect}"
     end
     name

--- a/script/slowest_pages
+++ b/script/slowest_pages
@@ -42,7 +42,7 @@ for path, rec in data
 end
 
 n = 0
-puts "%-40s %6s %6s %6s %6s" % %w(path mean sigma num robot)
+puts "%-40s %6s %6s %6s %6s" % %w[path mean sigma num robot]
 for path in data.keys.sort { |a, b| data[b][0] <=> data[a][0] }
   avg, sig, num, robots = data[path]
   puts "%-40s %6.3f %6.3f %6d %5d%%" % [path, avg, sig, num, 100.0 * robots / num]

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class AccountControllerTest < FunctionalTestCase
@@ -7,7 +6,7 @@ class AccountControllerTest < FunctionalTestCase
     super
   end
 
-  ################################################################################
+  ##############################################################################
 
   def test_auth_rolf
     @request.session["return-to"] = "http://localhost/bogus/location"
@@ -138,7 +137,7 @@ class AccountControllerTest < FunctionalTestCase
     assert_nil(@request.session["user_id"])
     assert_template("login")
 
-    user.update_attribute(:verified, Time.now)
+    user.update(verified: Time.zone.now)
     post(:login, user: { login: "api", password: "" })
     assert_nil(@request.session["user_id"])
     assert_template("login")
@@ -155,7 +154,8 @@ class AccountControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     # Make sure cookie is not set if clear remember_me box in login.
-    post(:login, user: { login: "rolf", password: "testpassword", remember_me: "" })
+    post(:login,
+         user: { login: "rolf", password: "testpassword", remember_me: "" })
     assert(session[:user_id])
     assert(!cookies["mo_user"])
 
@@ -164,7 +164,8 @@ class AccountControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     # Now clear session and try again with remember_me box set.
-    post(:login, user: { login: "rolf", password: "testpassword", remember_me: "1" })
+    post(:login,
+         user: { login: "rolf", password: "testpassword", remember_me: "1" })
     assert(session[:user_id])
     assert(cookies["mo_user"])
 
@@ -182,7 +183,7 @@ class AccountControllerTest < FunctionalTestCase
       password_confirmation: "mouse",
       email: "mm@disney.com"
     )
-    assert(!user.auth_code.blank?)
+    assert(user.auth_code.present?)
     assert(user.auth_code.length > 10)
 
     get(:verify, id: user.id, auth_code: "bogus_code")
@@ -389,8 +390,9 @@ class AccountControllerTest < FunctionalTestCase
     setup_image_dirs
 
     # Open file we want to upload.
-    file = Rack::Test::UploadedFile.new("#{::Rails.root}/test/images/sticky.jpg",
-                                        "image/jpeg")
+    file = Rack::Test::UploadedFile.new(
+      "#{::Rails.root}/test/images/sticky.jpg", "image/jpeg"
+    )
 
     # It should create a new image: this is the current number of images.
     num_images = Image.count
@@ -421,23 +423,23 @@ class AccountControllerTest < FunctionalTestCase
   end
 
   def test_no_email_hooks
-    [
-      :comments_owner,
-      :comments_response,
-      :comments_all,
-      :observations_consensus,
-      :observations_naming,
-      :observations_all,
-      :names_author,
-      :names_editor,
-      :names_reviewer,
-      :names_all,
-      :locations_author,
-      :locations_editor,
-      :locations_all,
-      :general_feature,
-      :general_commercial,
-      :general_question
+    %i[
+      comments_owner
+      comments_response
+      comments_all
+      observations_consensus
+      observations_naming
+      observations_all
+      names_author
+      names_editor
+      names_reviewer
+      names_all
+      locations_author
+      locations_editor
+      locations_all
+      general_feature
+      general_commercial
+      general_question
     ].each do |type|
       assert_request(
         action: "no_email_#{type}",
@@ -569,7 +571,8 @@ class AccountControllerTest < FunctionalTestCase
     assert_response(:success) # means failure
 
     # Change notes correctly.
-    post(:edit_api_key, commit: :UPDATE.l, id: key.id, key: { notes: "new name" })
+    post(:edit_api_key,
+         commit: :UPDATE.l, id: key.id, key: { notes: "new name" })
     assert_flash_success
     assert_redirected_to(action: :api_keys)
     assert_equal("new name", key.reload.notes)

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 require "rexml/document"
 
@@ -69,8 +68,8 @@ class ApiControllerTest < FunctionalTestCase
   end
 
   def do_basic_get_request_for_model(model)
-    [:none, :low, :high].each do |detail|
-      [:xml, :json].each do |format|
+    %i[none low high].each do |detail|
+      %i[xml json].each do |format|
         get(model.table_name.to_sym, detail: detail, format: format)
         assert_no_api_errors("Get #{model.name} #{detail} #{format}")
         assert_objs_equal(model.first, @api.results.first)
@@ -88,8 +87,7 @@ class ApiControllerTest < FunctionalTestCase
   def test_post_minimal_observation
     post(:observations,
          api_key: api_keys(:rolfs_api_key).key,
-         location: "Unknown"
-        )
+         location: "Unknown")
     assert_no_api_errors
     obs = Observation.last
     assert_users_equal(rolf, obs.user)
@@ -124,11 +122,11 @@ class ApiControllerTest < FunctionalTestCase
          has_specimen: "yes",
          is_collection_location: "yes",
          notes: "These are notes.\nThey look like this.\n",
-         images: "#{images(:in_situ_image).id}, #{images(:turned_over_image).id}",
+         images: "#{images(:in_situ_image).id}, " \
+                 "#{images(:turned_over_image).id}",
          thumbnail: images(:turned_over_image).id.to_s,
          projects: "EOL Project",
-         species_lists: "Another Species List"
-        )
+         species_lists: "Another Species List")
     assert_no_api_errors
     obs = Observation.last
     assert_users_equal(rolf, obs.user)
@@ -145,7 +143,8 @@ class ApiControllerTest < FunctionalTestCase
     assert_equal(true, obs.specimen)
     assert_equal(true, obs.is_collection_location)
     assert_equal("These are notes.\nThey look like this.", obs.notes)
-    assert_obj_list_equal([images(:in_situ_image), images(:turned_over_image)], obs.images)
+    assert_obj_list_equal([images(:in_situ_image), images(:turned_over_image)],
+                          obs.images)
     assert_objs_equal(images(:turned_over_image), obs.thumb_image)
     assert_obj_list_equal([projects(:eol_project)], obs.projects)
     assert_obj_list_equal([species_lists(:another_species_list)],
@@ -157,8 +156,7 @@ class ApiControllerTest < FunctionalTestCase
     count = Image.count
     file = "#{::Rails.root}/test/images/sticky.jpg"
     post_and_send_file(:images, file, "image/jpeg",
-                       api_key: api_keys(:rolfs_api_key).key
-                      )
+                       api_key: api_keys(:rolfs_api_key).key)
     assert_no_api_errors
     assert_equal(count + 1, Image.count)
     img = Image.last
@@ -187,8 +185,7 @@ class ApiControllerTest < FunctionalTestCase
                        license: licenses(:ccnc30).id.to_s,
                        original_name: "Coprinus_comatus.jpg",
                        projects: (proj = rolf.projects_member.first).id,
-                       observations: (obs = rolf.observations.first).id
-                      )
+                       observations: (obs = rolf.observations.first).id)
     assert_no_api_errors
     img = Image.last
     assert_users_equal(rolf, img.user)
@@ -211,8 +208,7 @@ class ApiControllerTest < FunctionalTestCase
          login: "miles",
          email: "miles@davis.com",
          create_key: "New API Key",
-         detail: :high
-        )
+         detail: :high)
     assert_no_api_errors
     user = User.last
     assert_equal("miles", user.login)
@@ -246,8 +242,7 @@ class ApiControllerTest < FunctionalTestCase
     rolfs_key = api_keys(:rolfs_api_key)
     post(:api_keys,
          api_key: rolfs_key.key,
-         app: "Mushroom Mapper"
-        )
+         app: "Mushroom Mapper")
     assert_no_api_errors
     api_key = ApiKey.last
     assert_equal("Mushroom Mapper", api_key.notes)
@@ -258,8 +253,7 @@ class ApiControllerTest < FunctionalTestCase
     post(:api_keys,
          api_key: rolfs_key.key,
          app: "Mushroom Mapper",
-         for_user: mary.id
-        )
+         for_user: mary.id)
     assert_no_api_errors
     api_key = ApiKey.last
     assert_equal("Mushroom Mapper", api_key.notes)

--- a/test/controllers/application_helper_test.rb
+++ b/test/controllers/application_helper_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
@@ -66,7 +65,7 @@ class ApplicationHelperTest < ActionView::TestCase
   def test_content_tag_if_with_content_block_with_options
     assert_equal('<div class="strong highlight">Hello world!</div>',
                  content_tag_if(true, :div, "Hello world!",
-                                class: %w(strong highlight)))
+                                class: %w[strong highlight]))
   end
 
   def test_content_tag_if_with_attribute_with_no_value

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class CommentControllerTest < FunctionalTestCase
@@ -36,8 +35,11 @@ class CommentControllerTest < FunctionalTestCase
     obs = comment.target
     params = { id: comment.id.to_s }
     assert_equal("rolf", comment.user.login)
-    requires_user(:edit_comment, { controller: :observer,
-                                   action: :show_observation, id: obs.id }, params)
+    requires_user(
+      :edit_comment,
+      { controller: :observer, action: :show_observation, id: obs.id },
+      params
+    )
     assert_form_action(action: "edit_comment", id: comment.id.to_s)
   end
 
@@ -47,8 +49,11 @@ class CommentControllerTest < FunctionalTestCase
     assert(obs.comments.member?(comment))
     assert_equal("rolf", comment.user.login)
     params = { id: comment.id.to_s }
-    requires_user(:destroy_comment, { controller: :observer,
-                                      action: :show_observation, id: obs.id }, params)
+    requires_user(
+      :destroy_comment,
+      { controller: :observer, action: :show_observation, id: obs.id },
+      params
+    )
     assert_equal(9, rolf.reload.contribution)
     obs.reload
     assert(!obs.comments.member?(comment))
@@ -76,9 +81,12 @@ class CommentControllerTest < FunctionalTestCase
     obs = comment.target
     params = { id: comment.id,
                comment: { summary: "New Summary", comment: "New text." } }
-    assert("rolf" == comment.user.login)
-    post_requires_user(:edit_comment, { controller: :observer,
-                                        action: :show_observation, id: obs.id }, params)
+    assert_equal("rolf", comment.user.login)
+    post_requires_user(
+      :edit_comment,
+      { controller: :observer, action: :show_observation, id: obs.id },
+      params
+    )
     assert_equal(10, rolf.reload.contribution)
     comment = Comment.find(comment.id)
     assert_equal("New Summary", comment.summary)

--- a/test/controllers/conference_controller_test.rb
+++ b/test/controllers/conference_controller_test.rb
@@ -22,7 +22,8 @@ class ConferenceControllerTest < FunctionalTestCase
   end
 
   def create_event_params
-    { event: { name: "Cape Cod Foray",
+    {
+      event: { name: "Cape Cod Foray",
                location: "Cape Cod, MA, USA",
                description: "Find 555 fungal friends!",
                registration_note: "Bring $5 and a sack lunch",
@@ -83,12 +84,14 @@ class ConferenceControllerTest < FunctionalTestCase
   end
 
   def create_registration_params
-    { id: conference_events(:msa_annual_meeting).id,
+    {
+      id: conference_events(:msa_annual_meeting).id,
       registration: {
         name: "Rolf Singer",
         email: "rolf@mo.com",
         how_many: 4,
-        notes: "I like to eat meat!" }
+        notes: "I like to eat meat!"
+      }
     }
   end
 

--- a/test/controllers/glossary_controller_test.rb
+++ b/test/controllers/glossary_controller_test.rb
@@ -72,7 +72,8 @@ class GlossaryControllerCreateTest < GlossaryControllerTest
 
   # ***** create *****
   def convex_params
-    { glossary_term:
+    {
+      glossary_term:
       { name: "Convex", description: "Boring" },
       copyright_holder: "Me",
       date: { copyright_year: 2013 },
@@ -128,11 +129,12 @@ class GlossaryControllerEditTest < GlossaryControllerTest
   end
 
   def changes_to_conic
-    { id: conic.id,
+    {
+      id: conic.id,
       glossary_term: { name: "Convex", description: "Boring old convex" },
       copyright_holder: "Insil Choi", date: { copyright_year: 2013 },
       upload: { license_id: licenses(:ccnc25).id }
-     }
+    }
   end
 
   def post_conic_edit_changes

--- a/test/controllers/herbarium_controller_test.rb
+++ b/test/controllers/herbarium_controller_test.rb
@@ -10,7 +10,8 @@ class HerbariumControllerTest < FunctionalTestCase
   end
 
   def show_herbarium_params
-    { id: herbaria(:nybg_herbarium).id,
+    {
+      id: herbaria(:nybg_herbarium).id,
       curator: { name: users(:mary).login }
     }
   end
@@ -40,14 +41,16 @@ class HerbariumControllerTest < FunctionalTestCase
   end
 
   def create_herbarium_params
-    { herbarium: {
-      name: "Rolf's Personal Herbarium",
-      description: "Rolf wants Melanolucas!!!",
-      email: rolf.email,
-      mailing_address: "",
-      place_name: "",
-      code: "RPH"
-    }
+    {
+      herbarium:
+      {
+        name: "Rolf's Personal Herbarium",
+        description: "Rolf wants Melanolucas!!!",
+        email: rolf.email,
+        mailing_address: "",
+        place_name: "",
+        code: "RPH"
+      }
     }
   end
 

--- a/test/controllers/interest_controller_test.rb
+++ b/test/controllers/interest_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 # users interests

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class LocationControllerTest < FunctionalTestCase
@@ -22,8 +21,7 @@ class LocationControllerTest < FunctionalTestCase
         high: loc.high,
         low: loc.low,
         notes: loc.notes
-      }
-    }
+      } }
   end
 
   # A location that isn't in fixtures.
@@ -51,7 +49,7 @@ class LocationControllerTest < FunctionalTestCase
     desc_count = LocationDescription.count
     past_desc_count = LocationDescription::Version.count
     post_requires_login(page, params)
-    assert_action_partials(page.to_s, %w(_form_location _textilize_help))
+    assert_action_partials(page.to_s, %w[_form_location _textilize_help])
     assert_equal(loc_count, Location.count)
     assert_equal(past_loc_count, Location::Version.count)
     assert_equal(desc_count, LocationDescription.count)
@@ -68,7 +66,7 @@ class LocationControllerTest < FunctionalTestCase
     location_error(:edit_location, params)
   end
 
-  ################################################################################
+  ##############################################################################
 
   def test_location_help
     get_with_dump(:help)
@@ -80,9 +78,8 @@ class LocationControllerTest < FunctionalTestCase
     log_updated_at = location.rss_log.updated_at
     get_with_dump(:show_location, id: location.id)
     assert_action_partials("show_location",
-                           %w(_location _show_comments
-                              _location_description)
-                          )
+                           %w[_location _show_comments
+                              _location_description])
     location.reload
     assert_equal(updated_at, location.updated_at)
     assert_equal(log_updated_at, location.rss_log.updated_at)
@@ -149,32 +146,35 @@ class LocationControllerTest < FunctionalTestCase
                                east: -116.88,
                                south: 34.1571,
                                notes: "Santa Fe",
-                               user: @mary
-                              )
+                               user: @mary)
     get(:list_by_country, country: "USA")
-    assert_obj_list_equal(usa_loc_array << loc_usa, @controller.instance_variable_get("@objects"))
+    assert_obj_list_equal(usa_loc_array << loc_usa,
+                          @controller.instance_variable_get("@objects"))
 
     get(:list_by_country, country: "Mexico")
     assert_obj_list_equal([], @controller.instance_variable_get("@objects"))
 
-    loc_mex1 = Location.create!(name: "Somewhere, Chihuahua, Mexico",
-                                north: 28.7729082,
-                                west: -106.1671059,
-                                east: -105.9612896,
-                                south: 28.5586774,
-                                notes: "somewhere Mexico",
-                                user: @mary
-                               )
-    loc_mex2 = Location.create!(name: "Oaxaca, Oaxaca, Mexico",
-                                north: 17.1332939,
-                                west: -96.7806765,
-                                east: -96.6907866,
-                                south: 17.0293023,
-                                notes: "somewhere else in Mexico or this test will not work",
-                                user: @mary
-                               )
+    loc_mex1 = Location.create!(
+      name: "Somewhere, Chihuahua, Mexico",
+      north: 28.7729082,
+      west: -106.1671059,
+      east: -105.9612896,
+      south: 28.5586774,
+      notes: "somewhere Mexico",
+      user: @mary
+    )
+    loc_mex2 = Location.create!(
+      name: "Oaxaca, Oaxaca, Mexico",
+      north: 17.1332939,
+      west: -96.7806765,
+      east: -96.6907866,
+      south: 17.0293023,
+      notes: "somewhere else in Mexico or this test will not work",
+      user: @mary
+    )
     get(:list_by_country, country: "Mexico")
-    assert_obj_list_equal([loc_mex1, loc_mex2], @controller.instance_variable_get("@objects"))
+    assert_obj_list_equal([loc_mex1, loc_mex2],
+                          @controller.instance_variable_get("@objects"))
   end
 
   def test_locations_by_user
@@ -201,7 +201,7 @@ class LocationControllerTest < FunctionalTestCase
     assert_redirected_to(
       %r{/location/show_location_description/#{ descs.first.id }}
     )
-    end
+  end
 
   def test_location_descriptions_by_editor
     get_with_dump(:location_descriptions_by_editor, id: rolf.id)
@@ -212,7 +212,7 @@ class LocationControllerTest < FunctionalTestCase
     desc = location_descriptions(:albion_desc)
     get_with_dump(:show_location_description, id: desc.id)
     assert_action_partials("show_location_description",
-                           %w(_show_description _location_description))
+                           %w[_show_description _location_description])
   end
 
   def test_show_past_location_description
@@ -298,7 +298,7 @@ class LocationControllerTest < FunctionalTestCase
                          id: loc.descriptions.last.id)
     refute_empty(loc.descriptions)
     assert_equal(params[:description][:notes], loc.descriptions.last.notes)
-end
+  end
 
   def test_create_location
     requires_login(:create_location)
@@ -311,8 +311,7 @@ end
     post(:create_location,
          where: "",
          approved_where: "",
-         location: { display_name: "" }
-        )
+         location: { display_name: "" })
   end
 
   # Test a simple location creation.
@@ -330,7 +329,11 @@ end
     assert_equal(10 + @new_pts, rolf.reload.contribution)
     # Make sure it's the right Location
     assert_equal(display_name, loc.display_name)
+
+    # rubocop:disable Rails/DynamicFindBy
+    # find_by_name_or_reverse_name is an MO method, not a Rails finder
     loc = Location.find_by_name_or_reverse_name(display_name)
+    # rubocop:enable Rails/DynamicFindBy
     assert_nil(loc.description)
     assert_not_nil(loc.rss_log)
   end
@@ -417,8 +420,7 @@ end
     loc = locations(:unknown_location)
     old_loc_display_name = loc.display_name
     params = { id: loc.id,
-               location: { display_name: "Rome, Italy" }
-             }
+               location: { display_name: "Rome, Italy" } }
     post_requires_login(:edit_location, params)
 
     assert_equal(old_loc_display_name, loc.reload.display_name,
@@ -436,8 +438,8 @@ end
     log_updated_at = loc.rss_log.updated_at
     old_params = update_params_from_loc(loc)
     params = barton_flats_params
-    params[:location][:display_name] = Location.user_name(rolf,
-                                                          params[:location][:display_name])
+    params[:location][:display_name] =
+      Location.user_name(rolf, params[:location][:display_name])
     params[:id] = loc.id
     post_requires_login(:edit_location, params)
     assert_redirected_to(controller: :location, action: :show_location,
@@ -460,7 +462,7 @@ end
     # Only compare the keys that are in both.
     bfp = barton_flats_params
     key_count = 0
-    for k in bfp.keys
+    bfp.keys.each do |k|
       if new_params[k]
         key_count += 1
         assert_equal(new_params[k], bfp[k])
@@ -598,14 +600,14 @@ end
     User.current = rolf
     albion = locations(:albion)
     obs = Observation.create!(
-      when: Time.now,
-      where: (where = "undefined location"),
+      when: Time.zone.now,
+      where: "undefined location",
       notes: "new observation"
     )
     assert_nil(obs.location)
-    where = obs.where
+
     params = {
-      where:    where,
+      where:    obs.where,
       location: albion.id
     }
     requires_login(:add_to_location, params)
@@ -618,7 +620,7 @@ end
     login("roy")
     albion = locations(:albion)
     obs = Observation.create!(
-      when:  Time.now,
+      when:  Time.zone.now,
       where: (where = "Albion, Mendocino Co., California, USA"),
       notes: "new observation"
     )
@@ -649,8 +651,8 @@ end
   end
 
   def assert_show_location
-    assert_action_partials("show_location", %w(_location _show_comments
-                                               _location_description))
+    assert_action_partials("show_location", %w[_location _show_comments
+                                               _location_description])
   end
 
   def test_interest_in_show_location
@@ -661,12 +663,10 @@ end
     assert_show_location
     assert_image_link_in_html(/watch\d*.png/,
                               controller: "interest", action: "set_interest",
-                              type: "Location", id: albion.id, state: 1
-                             )
+                              type: "Location", id: albion.id, state: 1)
     assert_image_link_in_html(/ignore\d*.png/,
                               controller: "interest", action: "set_interest",
-                              type: "Location", id: albion.id, state: -1
-                             )
+                              type: "Location", id: albion.id, state: -1)
 
     # Turn interest on and make sure there is an icon linked to delete it.
     Interest.new(target: albion, user: rolf, state: true).save
@@ -674,12 +674,10 @@ end
     assert_show_location
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: "interest", action: "set_interest",
-                              type: "Location", id: albion.id, state: 0
-                             )
+                              type: "Location", id: albion.id, state: 0)
     assert_image_link_in_html(/ignore\d*.png/,
                               controller: "interest", action: "set_interest",
-                              type: "Location", id: albion.id, state: -1
-                             )
+                              type: "Location", id: albion.id, state: -1)
 
     # Destroy that interest, create new one with interest off.
     Interest.where(user_id: rolf.id).last.destroy
@@ -688,12 +686,10 @@ end
     assert_show_location
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: "interest", action: "set_interest",
-                              type: "Location", id: albion.id, state: 0
-                             )
+                              type: "Location", id: albion.id, state: 0)
     assert_image_link_in_html(/watch\d*.png/,
                               controller: "interest", action: "set_interest",
-                              type: "Location", id: albion.id, state: 1
-                             )
+                              type: "Location", id: albion.id, state: 1)
   end
 
   def test_update_location_scientific_name

--- a/test/controllers/naming_controller_test.rb
+++ b/test/controllers/naming_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class NamingControllerTest < FunctionalTestCase
@@ -177,7 +176,6 @@ class NamingControllerTest < FunctionalTestCase
   def test_edit_thats_being_used_just_change_reasons
     obs  = observations(:coprinus_comatus_obs)
     nam1 = namings(:coprinus_comatus_naming)
-    nam2 = namings(:coprinus_comatus_other_naming)
 
     o_count = Observation.count
     g_count = Naming.count
@@ -195,8 +193,7 @@ class NamingControllerTest < FunctionalTestCase
            "2" => { check: "1", notes: "" },
            "3" => { check: "0", notes: "Add some micro notes." },
            "4" => { check: "0", notes: "" }
-         }
-        )
+         })
     assert_equal(10, rolf.reload.contribution)
 
     # Make sure the right number of objects were created.
@@ -229,7 +226,6 @@ class NamingControllerTest < FunctionalTestCase
   def test_edit_thats_being_used_change_name
     obs  = observations(:coprinus_comatus_obs)
     nam1 = namings(:coprinus_comatus_naming)
-    nam2 = namings(:coprinus_comatus_other_naming)
 
     o_count = Observation.count
     g_count = Naming.count
@@ -248,8 +244,7 @@ class NamingControllerTest < FunctionalTestCase
            "2" => { check: "0", notes: "" },
            "3" => { check: "0", notes: "" },
            "4" => { check: "0", notes: "" }
-         }
-        )
+         })
     assert_response(:redirect) # redirect indicates success
     assert_equal(12, rolf.reload.contribution)
 
@@ -309,8 +304,9 @@ class NamingControllerTest < FunctionalTestCase
     assert(namings(:coprinus_comatus_other_naming).user_voted?(mary))
     assert(!namings(:coprinus_comatus_other_naming).user_voted?(dick))
 
-    # Rolf, the owner of observations(:coprinus_comatus_obs), already has a naming, which
-    # he's 80% sure of.  Create a new one (the genus Agaricus) that he's 100%
+    # Rolf, the owner of observations(:coprinus_comatus_obs),
+    # already has a naming, which he's 80% sure of.
+    # Create a new one (the genus Agaricus) that he's 100%
     # sure of.  (Mary also has a naming with two votes.)
     params = {
       id: observations(:coprinus_comatus_obs).id,
@@ -345,7 +341,8 @@ class NamingControllerTest < FunctionalTestCase
 
     # Make sure observation was updated and referenced correctly.
     assert_equal(3, observations(:coprinus_comatus_obs).namings.length)
-    assert_equal(names(:agaricus).id, observations(:coprinus_comatus_obs).name_id)
+    assert_equal(names(:agaricus).id,
+                 observations(:coprinus_comatus_obs).name_id)
 
     # Make sure naming was created correctly and referenced.
     assert_equal(observations(:coprinus_comatus_obs), naming.observation)
@@ -383,7 +380,6 @@ class NamingControllerTest < FunctionalTestCase
 
   # Now see what happens when rolf's new naming is less confident than old.
   def test_propose_uncertain_naming
-    g_count = Naming.count
     params = {
       id: observations(:coprinus_comatus_obs).id,
       name: { name: "Agaricus" },
@@ -398,11 +394,9 @@ class NamingControllerTest < FunctionalTestCase
     observations(:coprinus_comatus_obs).reload
     namings(:coprinus_comatus_naming).reload
 
-    # Get new objects.
-    naming = Naming.last
-
     # Make sure observation was updated right.
-    assert_equal(names(:coprinus_comatus).id, observations(:coprinus_comatus_obs).name_id)
+    assert_equal(names(:coprinus_comatus).id,
+                 observations(:coprinus_comatus_obs).name_id)
 
     # Sure, check the votes, too, while we're at it.
     assert_equal(3, namings(:coprinus_comatus_naming).vote_sum) # 2+1 = 3
@@ -447,7 +441,8 @@ class NamingControllerTest < FunctionalTestCase
     assert_equal(1, naming.votes.length)
 
     # Make sure observation was updated right.
-    assert_equal(names(:conocybe_filaris).id, observations(:coprinus_comatus_obs).name_id)
+    assert_equal(names(:conocybe_filaris).id,
+                 observations(:coprinus_comatus_obs).name_id)
   end
 
   # Test a bug in name resolution: was failing to recognize that
@@ -499,7 +494,7 @@ class NamingControllerTest < FunctionalTestCase
     login("dick")
     post(:create, params)
     assert_response(:success) # really means failed
-    assert(name = Name.find_by_text_name('Foo "bar"'))
+    assert(name = Name.find_by(text_name: 'Foo "bar"'))
     assert_equal('Foo "bar" Author', name.search_name)
   end
 
@@ -589,10 +584,11 @@ class NamingControllerTest < FunctionalTestCase
   end
 
   def assert_edit
-    assert_action("edit", %w(
-      _show_observation
-      _form_name_feedback
-      _form
-      _show_images))
+    assert_action("edit", %w[
+                    _show_observation
+                    _form_name_feedback
+                    _form
+                    _show_images
+                  ])
   end
 end

--- a/test/controllers/pivotal_controller_test.rb
+++ b/test/controllers/pivotal_controller_test.rb
@@ -1,8 +1,15 @@
-# encoding: utf-8
 require "test_helper"
 
 class PivotalControllerTest < FunctionalTestCase
   def test_index
+    # Don't create entries on Pivotal unless enabled.
+    # Unit tests for Pivotal actually post (and then delete) test comments
+    # on the live pivotal account.  This is great if we really wanted to test
+    # the pivotal code.  But the vast majority of the time no one was touching
+    # the pivotal code, and this level of testing was not required.
+    # And it generated email notifications via pivotal each time,
+    # and just generally didn't seem respectful to pivotal.
+    # -- per JPH
     return unless MO.pivotal_enabled
 
     get_with_dump(:index)

--- a/test/controllers/specimen_controller_test.rb
+++ b/test/controllers/specimen_controller_test.rb
@@ -50,7 +50,8 @@ class SpecimenControllerTest < FunctionalTestCase
   end
 
   def test_observation_with_no_specimens_index
-    get_with_dump(:observation_index, id: observations(:strobilurus_diminutivus_obs).id)
+    get_with_dump(:observation_index,
+                  id: observations(:strobilurus_diminutivus_obs).id)
     assert_response(:redirect)
     assert_flash(/no specimens/)
   end
@@ -71,7 +72,8 @@ class SpecimenControllerTest < FunctionalTestCase
       id: observations(:strobilurus_diminutivus_obs).id,
       specimen: {
         herbarium_name: rolf.preferred_herbarium_name,
-        herbarium_label: "Strobilurus diminutivus det. Rolf Singer - NYBG 1234567",
+        herbarium_label:
+          "Strobilurus diminutivus det. Rolf Singer - NYBG 1234567",
         "when(1i)"      => "2012",
         "when(2i)"      => "11",
         "when(3i)"      => "26",
@@ -128,13 +130,13 @@ class SpecimenControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
-  # I keep thinking only curators should be able to add specimens.  However, for now anyone can.
+  # I keep thinking only curators should be able to add specimens.
+  # However, for now anyone can.
   def test_add_specimen_post_not_curator
     user = login("mary")
     nybg = herbaria(:nybg_herbarium)
     assert(!nybg.curators.member?(user))
     specimen_count = Specimen.count
-    herbarium_count = Herbarium.count
     params = add_specimen_params
     params[:specimen][:herbarium_name] = nybg.name
     post(:add_specimen, params)
@@ -200,11 +202,13 @@ class SpecimenControllerTest < FunctionalTestCase
     specimen_count = Specimen.count
     specimen = Specimen.find(params[:id])
     observations = specimen.observations
-    obs_spec_count = observations.map { |o| o.specimens.count }.reduce { |a, b| a + b }
+    obs_spec_count = observations.map { |o| o.specimens.count }.
+                     reduce { |a, b| a + b }
     post(:delete_specimen, params)
     assert_equal(specimen_count - 1, Specimen.count)
     observations.map(&:reload)
-    assert_true(obs_spec_count > observations.map { |o| o.specimens.count }.reduce { |a, b| a + b })
+    assert_true(obs_spec_count > observations.map { |o| o.specimens.count }.
+                                 reduce { |a, b| a + b })
     assert_response(:redirect)
   end
 
@@ -212,9 +216,6 @@ class SpecimenControllerTest < FunctionalTestCase
     login("mary")
     params = delete_specimen_params
     specimen_count = Specimen.count
-    specimen = Specimen.find(params[:id])
-    observations = specimen.observations
-    obs_spec_count = observations.map { |o| o.specimens.count }.reduce { |a, b| a + b }
     post(:delete_specimen, params)
     assert_equal(specimen_count, Specimen.count)
     assert_response(:redirect)
@@ -224,9 +225,6 @@ class SpecimenControllerTest < FunctionalTestCase
     make_admin("mary")
     params = delete_specimen_params
     specimen_count = Specimen.count
-    specimen = Specimen.find(params[:id])
-    observations = specimen.observations
-    obs_spec_count = observations.map { |o| o.specimens.count }.reduce { |a, b| a + b }
     post(:delete_specimen, params)
     assert_equal(specimen_count - 1, Specimen.count)
     assert_response(:redirect)

--- a/test/controllers/support_controller_test.rb
+++ b/test/controllers/support_controller_test.rb
@@ -1,10 +1,10 @@
-# encoding: utf-8
 require "test_helper"
 
 class SupportControllerTest < FunctionalTestCase
   def test_gets
-    [:donors, :confirm, :thanks, :governance,
-     :letter, :wrapup_2011, :wrapup_2012].each do |template|
+    %i[
+      donors confirm thanks governance letter wrapup_2011 wrapup_2012
+    ].each do |template|
       assert_template_with_dump(template)
       get_with_dump(template)
       assert_template(template)

--- a/test/controllers/translation_controller_test.rb
+++ b/test/controllers/translation_controller_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class TranslationControllerTest < FunctionalTestCase
@@ -42,34 +41,30 @@ class TranslationControllerTest < FunctionalTestCase
   end
 
   def hashify(*args)
-    hash = {}
-    for arg in args
-      hash[arg] = true
-    end
-    hash
+    args.each_with_object({}) { |arg, h| h[arg] = true }
   end
 
   def assert_major_header(str, item)
-    assert(item.is_a? TranslationController::TranslationFormMajorHeader)
+    assert(item.is_a?(TranslationController::TranslationFormMajorHeader))
     assert_equal(str, item.string)
   end
 
   def assert_minor_header(str, item)
-    assert(item.is_a? TranslationController::TranslationFormMinorHeader)
+    assert(item.is_a?(TranslationController::TranslationFormMinorHeader))
     assert_equal(str, item.string)
   end
 
   def assert_comment(str, item)
-    assert(item.is_a? TranslationController::TranslationFormComment)
+    assert(item.is_a?(TranslationController::TranslationFormComment))
     assert_equal(str, item.string)
   end
 
   def assert_tag_field(tag, item)
-    assert(item.is_a? TranslationController::TranslationFormTagField)
+    assert(item.is_a?(TranslationController::TranslationFormTagField))
     assert_equal(tag, item.tag)
   end
 
-  ################################################################################
+  ##############################################################################
 
   def test_edit_translations_with_page
     Language.track_usage
@@ -188,8 +183,7 @@ class TranslationControllerTest < FunctionalTestCase
          locale: locale,
          tag: "one",
          tag_one: value,
-         commit: :SAVE.l
-        )
+         commit: :SAVE.l)
   end
 
   def test_edit_translation_form_post_save_z
@@ -213,8 +207,7 @@ class TranslationControllerTest < FunctionalTestCase
          locale: "en-US",
          tag: "one",
          tag_one: "ichi",
-         commit: :CANCEL.l
-        )
+         commit: :CANCEL.l)
     assert_no_flash
     assert_equal(old_one, :one.l)
     assert_select("input[type=submit][value=#{:SAVE.l}]", 0)
@@ -227,8 +220,7 @@ class TranslationControllerTest < FunctionalTestCase
          locale: "el-GR",
          tag: "one",
          tag_one: "ichi",
-         commit: :RELOAD.l
-        )
+         commit: :RELOAD.l)
     assert_no_flash
     assert_equal(old_one, :one.l)
     assert_select("input[type=submit][value=#{:SAVE.l}]", 1)
@@ -325,7 +317,8 @@ class TranslationControllerTest < FunctionalTestCase
     assert_no_flash
     assert_equal(2, assigns(:show_tags).length)
 
-    # Simulate page expiration: result is it will display all tags, not just the two used above.
+    # Simulate page expiration:
+    # result is it will display all tags, not just the two used above.
     get(:edit_translations, locale: "en-US", page: "xxx")
     assert_flash_error
     assert(assigns(:show_tags).length > 2)

--- a/test/controllers/vote_controller_test.rb
+++ b/test/controllers/vote_controller_test.rb
@@ -49,7 +49,6 @@ class VoteControllerTest < FunctionalTestCase
   def test_cast_vote_rolf_change
     obs  = observations(:coprinus_comatus_obs)
     nam1 = namings(:coprinus_comatus_naming)
-    nam2 = namings(:coprinus_comatus_other_naming)
 
     login("rolf")
     post(:cast_vote, value: "2", id: nam1.id)
@@ -67,7 +66,6 @@ class VoteControllerTest < FunctionalTestCase
   # Votes: rolf=2/-3->3, mary=1/3, dick=x/x
   def test_cast_vote_rolf_second_greater
     obs  = observations(:coprinus_comatus_obs)
-    nam1 = namings(:coprinus_comatus_naming)
     nam2 = namings(:coprinus_comatus_other_naming)
 
     login("rolf")
@@ -93,8 +91,7 @@ class VoteControllerTest < FunctionalTestCase
     login("rolf")
     post(:cast_vote,
          value: "-1",
-         id: nam2.id
-    )
+         id: nam2.id)
     assert_equal(10, rolf.reload.contribution)
 
     # Make sure observation was updated right.
@@ -106,13 +103,15 @@ class VoteControllerTest < FunctionalTestCase
     assert_equal(2, nam2.votes.length)
   end
 
-  # Now, have Mary delete her vote against Rolf's naming.  This NO LONGER has the effect
-  # of excluding Rolf's naming from the consensus calculation due to too few votes.
-  # (Have Dick vote first... I forget what this was supposed to test for, but it's clearly
-  # superfluous now).
+  # Now, have Mary delete her vote against Rolf's naming.
+  # This NO LONGER has the effect of excluding Rolf's naming
+  # from the consensus calculation due to too few votes.
+  # (Have Dick vote first... I forget what this was supposed to test for,
+  # but it's clearly superfluous now).
   # Votes: rolf=2/-3, mary=1->x/3, dick=x/x->3
   # Summing after Dick votes,   3 gets 2+1/3=1, 9 gets -3+3+3/4=.75, 3 keeps it.
-  # Summing after Mary deletes, 3 gets 2/2=1,   9 gets -3+3+3/4=.75, 3 still keeps it in this voting algorithm, arg.
+  # Summing after Mary deletes, 3 gets 2/2=1,   9 gets -3+3+3/4=.75,
+  # 3 still keeps it in this voting algorithm, arg.
   def test_cast_vote_mary
     obs  = observations(:coprinus_comatus_obs)
     nam1 = namings(:coprinus_comatus_naming)
@@ -148,7 +147,7 @@ class VoteControllerTest < FunctionalTestCase
     table = namings(:coprinus_comatus_naming).calc_vote_table
     str1 = Vote.confidence(votes(:coprinus_comatus_owner_vote).value)
     str2 = Vote.confidence(votes(:coprinus_comatus_other_vote).value)
-    for str in table.keys
+    table.keys.each do |str|
       if str == str1 && str1 == str2
         assert_equal(2, table[str][:num])
       elsif str == str1
@@ -160,5 +159,4 @@ class VoteControllerTest < FunctionalTestCase
       end
     end
   end
-
 end

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -14,7 +14,7 @@ class AbstractModelTest < UnitTestCase
           assert(new_val > 1.hour.ago, msg + "#{key} more than one hour old")
           assert(new_val > old_val, msg + "#{key} wasn't updated") if old_val
         end
-      elsif %w(rss_log_id reasons).member?(key) && (new_val != old_val)
+      elsif %w[rss_log_id reasons].member?(key) && (new_val != old_val)
         assert(new_val)
       elsif key == "updated_at"
         assert(new_val >= old_val, msg + "#{key} is older than it was")

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -723,7 +723,7 @@ class ApiTest < UnitTestCase
     assert_parse(:parse_string, API::StringTooLong, "abcde", limit: 4)
     assert_parse(:parse_strings, nil, nil)
     assert_parse(:parse_strings, ["foo"], "foo")
-    assert_parse(:parse_strings, %w(foo bar), "foo,bar", limit: 4)
+    assert_parse(:parse_strings, %w[foo bar], "foo,bar", limit: 4)
     assert_parse(:parse_strings, API::StringTooLong, "foo,abcde", limit: 4)
   end
 

--- a/test/models/array_extensions_test.rb
+++ b/test/models/array_extensions_test.rb
@@ -6,7 +6,7 @@ class ArrayExtensionsTest < UnitTestCase
   def test_to_boolean_hash
     assert_equal({}, [].to_boolean_hash)
     assert_equal({ "a" => true, "b" => true, "c" => true },
-                 %w(a b c).to_boolean_hash)
+                 %w[a b c].to_boolean_hash)
   end
 
   # rubocop:disable Rails/OutputSafety

--- a/test/models/auto_complete_test.rb
+++ b/test/models/auto_complete_test.rb
@@ -42,7 +42,7 @@ class AutoCompleteTest < UnitTestCase
   end
 
   def test_truncate
-    list = %w(b0 b1 b2 b3 b4 b5 b6 b7 b8 b9)
+    list = %w[b0 b1 b2 b3 b4 b5 b6 b7 b8 b9]
     auto = AutoCompleteMock.new("blah")
     auto.matches = list
     assert_equal(list, auto.matches)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,7 @@ require "rails/test_help"
 # Enable mocking and stubbing in Ruby (must be required after rails/test_help).
 require "mocha/mini_test"
 
-%w(
+%w[
   general_extensions
   flash_extensions
   controller_extensions
@@ -57,7 +57,7 @@ require "mocha/mini_test"
   unit_test_case
   functional_test_case
   integration_test_case
-).each do |file|
+].each do |file|
   require File.expand_path(File.dirname(__FILE__) + "/#{file}")
 end
 

--- a/test/unit/image_s3_test.rb
+++ b/test/unit/image_s3_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class ImageS3Test < UnitTestCase
@@ -14,7 +13,8 @@ class ImageS3Test < UnitTestCase
     s3.list.each do |_obj|
       break
     end
-    file = "#{Rails.root}/test/fixtures/robots.txt"
+    file = Rails.root.join("test", "fixtures", "robots.txt")
+
     s3.upload("key", file, content_type: "text/plain")
     File.open(file, "rb") do |fh|
       s3.upload("key", fh, content_type: "text/plain")


### PR DESCRIPTION
This is 99% fixing of RuboCop offenses.
There are two goals:
1. Reduce CodeClimate offenses during CI.  See # 334.
2. In conjunction with 1, expedite the (soon-to-start) upgrade to Rails 5.0.  That upgrade is likely to cause a bunch of deprecation warnings in test files. When fixing those, I don't want to also have to contend with pre-existing RuboCop offenses.  So I'm getting rid of them in advance.
