### PR TITLE
Rubocop integration & mailer tests [Delivers #149790226]

### DIFF
--- a/test/integration/amateur_test.rb
+++ b/test/integration/amateur_test.rb
@@ -1,9 +1,7 @@
-# encoding: utf-8
-# Test typical sessions of amateur user who just posts the occasional comment,
-# observations, or votes.
-
 require "test_helper"
 
+# Test typical sessions of amateur user who just posts the occasional comment,
+# observations, or votes.
 class AmateurTest < IntegrationTestCase
   # -------------------------------
   #  Test basic login heuristics.
@@ -12,7 +10,6 @@ class AmateurTest < IntegrationTestCase
   def test_login
     # Start at index.
     get("/")
-    save_path = path
 
     # Login.
     click(label: "Login", in: :left_panel)
@@ -206,7 +203,7 @@ class AmateurTest < IntegrationTestCase
     assert_false(obs.comments.any? { |c| c.user == namer })
     # (Make sure the name we are going to suggest doesn't exist yet.)
     text_name = "Xylaria polymorpha"
-    assert_nil(Name.find_by_text_name(text_name))
+    assert_nil(Name.find_by(text_name: text_name))
     orignal_name = obs.name
 
     namer_session.propose_then_login(namer, obs)
@@ -214,7 +211,8 @@ class AmateurTest < IntegrationTestCase
 
     voter_session = open_session.extend(VoterDsl)
     voter_session.login!(rolf)
-    assert_not_equal(namer_session.session[:session_id], voter_session.session[:session_id])
+    assert_not_equal(namer_session.session[:session_id],
+                     voter_session.session[:session_id])
     voter_session.vote_on_name(obs, naming)
     namer_session.failed_delete(obs)
     voter_session.change_mind(obs, naming)
@@ -226,7 +224,8 @@ class AmateurTest < IntegrationTestCase
     rolf_session.login!(rolf)
     mary_session = open_session.extend(VoterDsl)
     mary_session.login!(mary)
-    assert_not_equal(mary_session.session[:session_id], rolf_session.session[:session_id])
+    assert_not_equal(mary_session.session[:session_id],
+                     rolf_session.session[:session_id])
   end
 
   # ------------------------------------------------------------------------
@@ -263,23 +262,23 @@ class AmateurTest < IntegrationTestCase
   def test_thumbnail_maps
     get("/#{observations(:minimal_unknown_obs).id}")
     assert_template("observer/show_observation")
-    assert_select('div#map_div', 1)
+    assert_select("div#map_div", 1)
 
     click(label: "Hide thumbnail map.")
     assert_template("observer/show_observation")
-    assert_select('div#map_div', 0)
+    assert_select("div#map_div", 0)
 
     login("dick")
     assert_template("observer/show_observation")
-    assert_select('div#map_div', 1)
+    assert_select("div#map_div", 1)
 
     click(label: "Hide thumbnail map.")
     assert_template("observer/show_observation")
-    assert_select('div#map_div', 0)
+    assert_select("div#map_div", 0)
 
     get("/#{observations(:detailed_unknown_obs).id}")
     assert_template("observer/show_observation")
-    assert_select('div#map_div', 0)
+    assert_select("div#map_div", 0)
   end
 
   # -----------------------------------------------------------------------
@@ -294,15 +293,13 @@ class AmateurTest < IntegrationTestCase
     I18n.locale = mary.lang
     mary.save
 
-    data = TranslationString.translations("el") # Globalite.localization_data[:'el-GR']
+    data = TranslationString.translations("el")
     data[:test_tag1] = "test_tag1 value"
     data[:test_tag2] = "test_tag2 value"
     data[:test_flash_redirection_title] = "Testing Flash Redirection"
 
     session.run_test
   end
-
-  private
 
   module UserDsl
     def run_test
@@ -406,7 +403,7 @@ class AmateurTest < IntegrationTestCase
       assert_objs_equal(obs, assigns(:observation))
 
       obs.reload
-      name = Name.find_by_text_name(text_name)
+      name = Name.find_by(text_name: text_name)
       naming = Naming.last
       assert_names_equal(name, naming.name)
       assert_names_equal(name, obs.name)
@@ -422,7 +419,7 @@ class AmateurTest < IntegrationTestCase
       # Try changing it.
       author = "(Pers.) Grev."
       reason = "Test reason."
-      click(label: /edit/i, href: /naming\/edit/)
+      click(label: /edit/i, href: %r{naming/edit})
       assert_template("naming/edit")
       open_form do |form|
         form.assert_value("name", text_name)
@@ -447,7 +444,7 @@ class AmateurTest < IntegrationTestCase
       # (Make sure reason shows up, too.)
       assert_match(reason, response.body)
 
-      click(label: /edit/i, href: /naming\/edit/)
+      click(label: /edit/i, href: %r{naming/edit})
       assert_template("naming/edit")
       open_form do |form|
         form.assert_value("name", "#{text_name} #{author}")
@@ -459,19 +456,16 @@ class AmateurTest < IntegrationTestCase
         form.assert_value("reason_3_notes", "")
       end
       click(label: /cancel.*show/i)
-      # "end create_name response.body".print_thing(response.body)
       naming
     end
 
     def failed_delete(_obs)
-      # "failed_delete response.body".print_thing(response.body)
-      click(label: /destroy/i, href: /naming\/destroy/)
+      click(label: /destroy/i, href: %r{naming/destroy})
       assert_flash(/sorry/i)
     end
 
     def successful_delete(obs, naming, text_name, original_name)
-      # "successful_delete response.body".print_thing(response.body)
-      click(label: /destroy/i, href: /naming\/destroy/)
+      click(label: /destroy/i, href: %r{naming/destroy})
       assert_template("observer/show_observation")
       assert_objs_equal(obs, assigns(:observation))
       assert_flash(/success/i)

--- a/test/integration/capybara_lurker_test.rb
+++ b/test/integration/capybara_lurker_test.rb
@@ -17,11 +17,11 @@ class CapybarLurkerTest < IntegrationTestCase
     #     because (per DHH) testing content is a better practice
     # Following gives more informative error message than
     # assert(page.has_title?("#{:app_title.l }: Activity Log"), "Wrong page")
-    assert_equal("#{:app_title.l }: Activity Log", page.title, "Wrong page")
+    assert_equal("#{:app_title.l}: Activity Log", page.title, "Wrong page")
 
     # Click on first observation in feed results
     first(:xpath, rss_observation_created_xpath).click
-    assert_match(%r{#{:app_title.l }: Observation}, page.title, "Wrong page")
+    assert_match(/#{:app_title.l }: Observation/, page.title, "Wrong page")
 
     # Click on next (catches a bug seen in the wild).
     # Above comment about "next" does not match "Prev" in code
@@ -29,55 +29,56 @@ class CapybarLurkerTest < IntegrationTestCase
     go_back_after do
       click_link("« Prev")
     end # back at Observation
-    assert_match(%r{#{:app_title.l }: Observation}, page.title, "Wrong page")
+    assert_match(/#{:app_title.l }: Observation/, page.title, "Wrong page")
 
     # Click on the first image.
     go_back_after do
       first(:xpath, observation_image_xpath).click
-      assert_match(%r{#{:app_title.l }: Image}, page.title, "Wrong page")
+      assert_match(/#{:app_title.l }: Image/, page.title, "Wrong page")
     end # back at Observation
-    assert_match(%r{#{:app_title.l }: Observation}, page.title, "Wrong page")
+    assert_match(/#{:app_title.l }: Observation/, page.title, "Wrong page")
 
     # Go back to observation and click on "About...".
     click_link("About ")
-    assert_match(%r{#{:app_title.l }: Name}, page.title, "Wrong page")
+    assert_match(/#{:app_title.l }: Name/, page.title, "Wrong page")
 
     # Take a look at the occurrence map.
     click_link("Occurrence Map")
-    assert_match(%r{#{:app_title.l }: Occurrence Map}, page.title, "Wrong page")
+    assert_match(/#{:app_title.l }: Occurrence Map/, page.title, "Wrong page")
 
     # Check out a few links from left-hand panel.
     click_on("How To Use")
-    assert_match(%r{#{:app_title.l }: How to Use}, page.title, "Wrong page")
+    assert_match(/#{:app_title.l }: How to Use/, page.title, "Wrong page")
 
     click_on("Français")
-    if :how_title.has_translation?
-      subtitle = :how_title.t
-    else
-      subtitle = "How to Use"
-    end
-    assert_match(%r{#{:app_title.l }: #{subtitle}}, page.title, "Wrong page")
+    subtitle = if :how_title.has_translation?
+                 :how_title.t
+               else
+                 "How to Use"
+               end
+    assert_match(/#{:app_title.l }: #{subtitle}/, page.title, "Wrong page")
 
     click_on("Contributeurs")
-    if :users_by_contribution_title.has_translation?
-      subtitle = :users_by_contribution_title.t
-    else
-      subtitle = "List of Contributors"
-    end
-    assert_equal("#{:app_title.l }: #{subtitle}", page.title, "Wrong page")
+    subtitle = if :users_by_contribution_title.has_translation?
+                 :users_by_contribution_title.t
+               else
+                 "List of Contributors"
+               end
+    assert_equal("#{:app_title.l}: #{subtitle}", page.title, "Wrong page")
 
     click_on("English")
-    assert_equal("#{:app_title.l }: List of Contributors",
+    assert_equal("#{:app_title.l}: List of Contributors",
                  page.title, "Wrong page")
 
     click_on("Projects")
-    assert_equal("#{:app_title.l }: Projects by Title", page.title, "Wrong page")
+    assert_equal("#{:app_title.l}: Projects by Title", page.title, "Wrong page")
 
     click_on("Comments")
-    assert_equal("#{:app_title.l }: Comments by Date Created", page.title, "Wrong page")
+    assert_equal("#{:app_title.l}: Comments by Date Created",
+                 page.title, "Wrong page")
 
     click_on("Site Stats")
-    assert_equal("#{:app_title.l }: Site Statistics", page.title, "Wrong page")
+    assert_equal("#{:app_title.l}: Site Statistics", page.title, "Wrong page")
   end
 
   def test_show_observation
@@ -92,20 +93,19 @@ class CapybarLurkerTest < IntegrationTestCase
     reset_session!
     visit(root_path)
     first(:link, "Login").click
-    assert_equal("#{:app_title.l }: Please login", page.title, "Wrong page")
+    assert_equal("#{:app_title.l}: Please login", page.title, "Wrong page")
     fill_in("User name or Email address:", with: lurker.login)
     fill_in("Password:", with: "testpassword")
     click_button("Login")
-    assert_equal("#{:app_title.l }: Activity Log", page.title, "Login failed")
+    assert_equal("#{:app_title.l}: Activity Log", page.title, "Login failed")
 
     visit("/#{obs.id}")
-    assert_match(%r{#{:app_title.l }: Observation #{obs.id}}, page.title,
+    assert_match(/#{:app_title.l }: Observation #{obs.id}/, page.title,
                  "Wrong page")
 
     # Make sure we're displaying original names of images
-    img = Image.where(observation = obs.id).first
-    assert(page.has_content?(img.original_name),
-                             "Original filename of image not displayed")
+    assert(page.has_content?(obs.images.first.original_name),
+           "Original filename of image not displayed")
 
     save_path = current_path
     click_link("Show Log")
@@ -120,29 +120,30 @@ class CapybarLurkerTest < IntegrationTestCase
       # (plus a link to it is also in table of names for mobile)
       assert(
         assert_selector("#content a[href^='/observer/show_user/#{owner.id}']",
-                        minimum: 4))
+                        minimum: 4)
+      )
 
       first(:link, owner.name).click
-      assert_match(%r{Contribution Summary}, page.title, "Wrong page")
+      assert_match(/Contribution Summary/, page.title, "Wrong page")
     end # back at Observation
 
     # Check out location.
     go_back_after do
       click_link(obs.location.name)
-      assert_match(%r{^#{:app_title.l }: Location}, page.title, "Login failed")
+      assert_match(/^#{:app_title.l }: Location/, page.title, "Login failed")
     end # back at Observation
 
     # Check out species list.
     go_back_after do
       list = SpeciesList.joins(:observations).
-                         where("observation_id = ?", obs.id).first
+             where("observation_id = ?", obs.id).first
       click_link(list.title)
-      assert_match(%r{^#{:app_title.l }: Species List: #{list.title}},
+      assert_match(/^#{:app_title.l }: Species List: #{list.title}/,
                    page.title, "Wrong page")
 
       # (Make sure observation is shown somewhere.)
       assert(has_selector?("a[href^='/#{obs.id}']"),
-                           "Missing a link to Observation")
+             "Missing a link to Observation")
     end # back at Observation
 
     # Check out Name
@@ -154,13 +155,14 @@ class CapybarLurkerTest < IntegrationTestCase
       click_link("About #{name.text_name}")
       # (Make sure the page contains create_name_description.)
       assert(assert_selector(
-              "#content a[href^='/name/create_name_description/#{name.id}']"))
+               "#content a[href^='/name/create_name_description/#{name.id}']"
+      ))
     end # back at Observation
 
     # Check out images
     # Observation has at least 2 images
     image_count = all(:xpath, observation_image_xpath).count
     assert(image_count == 2,
-          "expected 2 Images in Observation, got #{image_count}")
+           "expected 2 Images in Observation, got #{image_count}")
   end
 end

--- a/test/integration/expert_test.rb
+++ b/test/integration/expert_test.rb
@@ -1,16 +1,9 @@
-# encoding: utf-8
-
-# Test a few representative sessions of a power-user.
-
 require "test_helper"
 
+# Test a few representative sessions of a power-user.
 class ExpertTest < IntegrationTestCase
   def empty_notes
-    hash = {}
-    for f in NameDescription.all_note_fields
-      hash[f] = nil
-    end
-    hash
+    NameDescription.all_note_fields.each_with_object({}) { |f, h| h[f] = nil }
   end
 
   # --------------------------------------------------------
@@ -20,15 +13,12 @@ class ExpertTest < IntegrationTestCase
   def test_bulk_name_editor
     name1 = "Caloplaca arnoldii"
     author1 = "(Wedd.) Zahlbr."
-    full_name1 = "#{name1} #{author1}"
 
     name2 = "Caloplaca arnoldii ssp. obliterate"
     author2 = "(Pers.) Gaya"
-    full_name2 = "#{name1} #{author2}"
 
     name3 = "Acarospora nodulosa var. reagens"
     author3 = "Zahlbr."
-    full_name3 = "#{name1} #{author3}"
 
     name4 = "Lactarius subalpinus"
     name5 = "Lactarius newname"
@@ -63,7 +53,7 @@ class ExpertTest < IntegrationTestCase
     assert_flash_success
     assert_template("observer/list_rss_logs")
 
-    assert_not_nil(Name.find_by_text_name("Caloplaca"))
+    assert_not_nil(Name.find_by(text_name: "Caloplaca"))
 
     names = Name.where(text_name: name1)
     assert_equal(1, names.length, names.map(&:search_name).inspect)
@@ -80,8 +70,8 @@ class ExpertTest < IntegrationTestCase
     assert_equal(author2, names.first.author)
     assert_equal(false, names.first.deprecated)
 
-    assert_not_nil(Name.find_by_text_name("Acarospora"))
-    assert_not_nil(Name.find_by_text_name("Acarospora nodulosa"))
+    assert_not_nil(Name.find_by(text_name: "Acarospora"))
+    assert_not_nil(Name.find_by(text_name: "Acarospora nodulosa"))
 
     names = Name.where(text_name: name3)
     assert_equal(1, names.length, names.map(&:search_name).inspect)
@@ -121,7 +111,6 @@ class ExpertTest < IntegrationTestCase
     amanita = Name.where(text_name: "Amanita baccata")
 
     albion = locations(:albion)
-    albion_name = albion.name
     albion_name_reverse = Location.reverse_name(albion.name)
 
     new_location = "Somewhere New, California, USA"
@@ -152,15 +141,15 @@ class ExpertTest < IntegrationTestCase
     assert_response(:success)
     assert_template("species_list/create_species_list")
 
-    assert_select('div#missing_names', /Caloplaca arnoldii ssp. obliterate/)
-    assert_select('div#deprecated_names', /Lactarius alpigenes/)
-    assert_select('div#deprecated_names', /Lactarius alpinus/)
-    assert_select('div#deprecated_names', /Petigera/)
-    assert_select('div#deprecated_names', /Peltigera/)
-    assert_select('div#ambiguous_names', /Amanita baccata.*sensu Arora/)
-    assert_select('div#ambiguous_names', /Amanita baccata.*sensu Borealis/)
-    assert_select('div#ambiguous_names', /Suillus.*Gray/)
-    assert_select('div#ambiguous_names', /Suillus.*White/)
+    assert_select("div#missing_names", /Caloplaca arnoldii ssp. obliterate/)
+    assert_select("div#deprecated_names", /Lactarius alpigenes/)
+    assert_select("div#deprecated_names", /Lactarius alpinus/)
+    assert_select("div#deprecated_names", /Petigera/)
+    assert_select("div#deprecated_names", /Peltigera/)
+    assert_select("div#ambiguous_names", /Amanita baccata.*sensu Arora/)
+    assert_select("div#ambiguous_names", /Amanita baccata.*sensu Borealis/)
+    assert_select("div#ambiguous_names", /Suillus.*Gray/)
+    assert_select("div#ambiguous_names", /Suillus.*White/)
 
     # Fix the ambiguous names: should be good now.
     open_form do |form|
@@ -221,9 +210,9 @@ class ExpertTest < IntegrationTestCase
     assert_response(:success)
     assert_template("species_list/edit_species_list")
 
-    assert_select('div#missing_names', /Agaricus nova/)
-    assert_select('div#ambiguous_names', /Amanita baccata.*sensu Arora/)
-    assert_select('div#ambiguous_names', /Amanita baccata.*sensu Borealis/)
+    assert_select("div#missing_names", /Agaricus nova/)
+    assert_select("div#ambiguous_names", /Amanita baccata.*sensu Arora/)
+    assert_select("div#ambiguous_names", /Amanita baccata.*sensu Borealis/)
 
     # Fix the ambiguous name.
     open_form do |form|
@@ -269,7 +258,7 @@ class ExpertTest < IntegrationTestCase
     end
     assert_flash_success
     assert_template("species_list/show_species_list")
-    assert_select('div#title', text: /#{spl.title}/)
+    assert_select("div#title", text: /#{spl.title}/)
     assert_select("a[href*='edit_species_list/#{spl.id}']", text: /edit/i)
 
     loc = Location.last
@@ -286,7 +275,7 @@ class ExpertTest < IntegrationTestCase
     # Try adding a comment, just for kicks.
     click(href: /add_comment/)
     assert_template("comment/add_comment")
-    assert_select('div#title', text: /#{spl.title}/)
+    assert_select("div#title", text: /#{spl.title}/)
     assert_select("a[href*='show_species_list/#{spl.id}']", text: /cancel/i)
     open_form do |form|
       form.change("comment_summary", "Slartibartfast")
@@ -295,7 +284,7 @@ class ExpertTest < IntegrationTestCase
     end
     assert_flash_success
     assert_template("species_list/show_species_list")
-    assert_select('div#title', text: /#{spl.title}/)
+    assert_select("div#title", text: /#{spl.title}/)
     assert_select("div.comment", text: /Slartibartfast/)
     assert_select("div.comment", text: /Steatopygia/)
   end

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -10,7 +10,7 @@ class FilterTest < IntegrationTestCase
     user = users(:ignore_imageless_user)
     obs = observations(:imageless_unvouchered_obs)
     imged_obss = Observation.where(name: obs.name).
-                             where.not(thumb_image_id: nil)
+                 where.not(thumb_image_id: nil)
 
     reset_session!
     visit("/account/login")
@@ -23,9 +23,12 @@ class FilterTest < IntegrationTestCase
     page.select("Observations", from: :search_type)
     click_button("Search")
 
-    assert_match(%r{#{:app_title.l }: Observations Matching ‘#{obs.name.text_name}},
-                 page.title, "Wrong page")
-    page.find_by_id("title").assert_text(:filtered.t)
+    assert_match(
+      /#{:app_title.l }: Observations Matching ‘#{obs.name.text_name}/,
+      page.title, "Wrong page"
+    )
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
     # Number of hits should == number of **imaged** Observations of obs.name
@@ -35,11 +38,13 @@ class FilterTest < IntegrationTestCase
 
     # Show Locations should be filtered
     click_link("Show Locations")
-    page.find_by_id("title").assert_text(:filtered.t)
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_text(:filtered.t)
 
     # And mapping them should also be filtered.
     click_link("Map Locations")
-    page.find_by_id("title").assert_text(:filtered.t)
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_text(:filtered.t)
 
     ### Now prove that turning filter off stops filtering ###
     # Prove that preference page UI works
@@ -50,7 +55,7 @@ class FilterTest < IntegrationTestCase
     assert(obs_imged_checkbox.checked?,
            "'#{:prefs_filters_has_images.t}' checkbox should be checked.")
     page.uncheck("user[has_images]")
-    click_button("#{:SAVE_EDITS.t}", match: :first)
+    click_button(:SAVE_EDITS.t.to_s, match: :first)
 
     obs_imged_checkbox = find_field("user[has_images]")
     refute(obs_imged_checkbox.checked?,
@@ -61,14 +66,15 @@ class FilterTest < IntegrationTestCase
     assert_nil(user.content_filter[:has_specimen],
                "Has specimen filter should be off")
     assert_blank(user.content_filter[:region],
-               "Region filter should be off")
+                 "Region filter should be off")
 
     # Repeat the search
     fill_in("search_pattern", with: obs.name.text_name)
     page.select("Observations", from: :search_type)
     click_button("Search")
 
-    page.find_by_id("title").assert_no_text(:filtered.t)
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_no_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
     # Number of hits should == **total** Observations of obs.name
@@ -98,7 +104,7 @@ class FilterTest < IntegrationTestCase
 
     #   Turn on :has_specimen
     page.check("user[has_specimen]")
-    click_button("#{:SAVE_EDITS.t}", match: :first)
+    click_button(:SAVE_EDITS.t.to_s, match: :first)
     user.reload
     assert_equal("yes", user.content_filter[:has_specimen])
 
@@ -108,7 +114,8 @@ class FilterTest < IntegrationTestCase
     page.select("Observations", from: :search_type)
 
     click_button("Search")
-    page.find_by_id("title").assert_text(:filtered.t)
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
     vouchered_obss = Observation.where(name: obs.name).where(specimen: true)
@@ -124,8 +131,6 @@ class FilterTest < IntegrationTestCase
     # Login a user who filters out imageless Observations
     user = users(:ignore_imageless_user)
     obs = observations(:imageless_unvouchered_obs)
-    imged_obss = Observation.where(name: obs.name).
-                             where.not(thumb_image_id: nil)
     visit("/account/login")
     fill_in("User name or Email address:", with: user.login)
     fill_in("Password:", with: "testpassword")
@@ -133,7 +138,6 @@ class FilterTest < IntegrationTestCase
 
     # Verfy Advanced Search form
     click_on("Advanced Search", match: :first)
-    filters = page.find("div#advanced_search_filters")
     within("div#advanced_search_filters") do
       # Verify Labels.
       assert_text(:advanced_search_filters.t)
@@ -150,7 +154,8 @@ class FilterTest < IntegrationTestCase
     find("#content").click_button("Search")
 
     # Advance Search Filters should override user's { has_images: "yes" }
-    page.find_by_id("title").assert_no_text(:filtered.t)
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_no_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
     # Number of hits should == **total** Observations of obs.name
@@ -180,7 +185,8 @@ class FilterTest < IntegrationTestCase
 
     # Advance Search Filters should override user content_filter so hits
     #   should == vouchered Observations of obs.name, both imaged and imageless
-    page.find_by_id("title").assert_no_text(:filtered.t)
+    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+      assert_no_text(:filtered.t)
     expect = Observation.where(name: obs.name).where(specimen: true)
     results = page.find("div.results", match: :first)
     results.assert_text(obs.name.text_name, count: expect.size)

--- a/test/integration/lurker_test.rb
+++ b/test/integration/lurker_test.rb
@@ -1,9 +1,6 @@
-# encoding: utf-8
-
-# Test typical sessions of user who never creates an account or contributes.
-
 require "test_helper"
 
+# Test typical sessions of user who never creates an account or contributes.
 class LurkerTest < IntegrationTestCase
   def test_poke_around
     # Start at index.
@@ -11,7 +8,7 @@ class LurkerTest < IntegrationTestCase
     assert_template("observer/list_rss_logs")
 
     # Click on first observation.
-    click(href: /^\/\d+\?/, in: :results)
+    click(href: %r{^/\d+\?}, in: :results)
     assert_template("observer/show_observation")
 
     # Click on prev/next
@@ -79,7 +76,9 @@ class LurkerTest < IntegrationTestCase
     assert_select("a[href^='/name/show_name/#{names(:fungi).id}']", minimum: 2)
     click(label: /About.*Fungi/)
     # (Make sure the page contains create_name_description.)
-    assert_select("a[href^='/name/create_name_description/#{names(:fungi).id}']")
+    assert_select(
+      "a[href^='/name/create_name_description/#{names(:fungi).id}']"
+    )
 
     # And lastly there are some images.
     get("/#{obs}")
@@ -97,19 +96,22 @@ class LurkerTest < IntegrationTestCase
     form.change("pattern", "Coprinus comatus")
     form.select("type", "Names")
     form.submit("Search")
-    assert_match(/^\/name\/show_name\/#{names(:coprinus_comatus).id}/,
+    assert_match(%r{^/name/show_name/#{names(:coprinus_comatus).id}},
                  @request.fullpath)
 
     # Search for observations of that name.  (Only one.)
     form.select("type", "Observations")
     form.submit("Search")
-    assert_match(/^\/#{observations(:coprinus_comatus_obs).id}\?/,
+    assert_match(%r{^/#{observations(:coprinus_comatus_obs).id}\?},
                  @request.fullpath)
 
     # Search for images of the same thing.  (Still only one.)
     form.select("type", "Images")
     form.submit("Search")
-    assert_match(/^\/image\/show_image\/#{images(:connected_coprinus_comatus_image).id}/, @request.fullpath)
+    assert_match(
+      %r{^/image/show_image/#{images(:connected_coprinus_comatus_image).id}},
+      @request.fullpath
+    )
 
     # There should be no locations of that name, though.
     form.select("type", "Locations")
@@ -193,7 +195,7 @@ class LurkerTest < IntegrationTestCase
     query_params = parse_query_params(save_results.first.value)
 
     # Go to first observation, and try stepping back and forth.
-    click(href: /^\/\d+\?/, in: :results)
+    click(href: %r{^/\d+\?}, in: :results)
     save_path = @request.fullpath
     assert_equal(query_params, parse_query_params(save_path))
     click(label: "« Prev", in: :title)
@@ -215,8 +217,8 @@ class LurkerTest < IntegrationTestCase
     click(label: "Index", href: /index/, in: :title)
     results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(query_params, parse_query_params(results.first.value))
-    assert_equal(save_results.map {|r| r.value},
-                 results.map {|r| r.value},
+    assert_equal(save_results.map(&:value),
+                 results.map(&:value),
                  "Went to show_obs, screwed around, then back to index. " \
                  "But the results were not the same when we returned.")
   end

--- a/test/integration/name_description_integration_test.rb
+++ b/test/integration/name_description_integration_test.rb
@@ -1,12 +1,10 @@
-# encoding: utf-8
-
 require "test_helper"
 
 class NameDescriptionIntegrationTest < IntegrationTestCase
   def test_creating_public_description
     # We want to create an empty, default public description for a name that
     # doesn't have any descriptions yet -- simplest possible case.
-    @name = Name.find_by_text_name("Strobilurus diminutivus")
+    @name = Name.find_by(text_name: "Strobilurus diminutivus")
     assert_equal([], @name.descriptions)
     @description_data = {
       source_type: :public,
@@ -52,7 +50,7 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
   def test_creating_user_description
     # We want to create an empty, default public description for a name that
     # doesn't have any descriptions yet -- simplest possible case.
-    @name = Name.find_by_text_name("Peltigera")
+    @name = Name.find_by(text_name: "Peltigera")
     assert_equal(4, @name.descriptions.length)
     @description_data = {
       source_type: :user,
@@ -131,7 +129,7 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
     sess.group_expectations = @group_expectations
   end
 
-  ################################################################################
+  ##############################################################################
 
   module NameDescriptionDsl
     attr_accessor :user
@@ -346,12 +344,14 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
     end
 
     def check_abilities
-      desc = new_name_description
       get(show_name_uri)
-      # Apparently the show_desc link is present even if not allowed to see text.
+      # Apparently the show_desc link is present
+      # even if not allowed to see text.
       # assert_link_exists(show_name_description_uri, can_see_description?)
-      assert_link_exists(edit_name_description_uri, edit_description_link_there?)
-      assert_link_exists(destroy_name_description_uri, destroy_description_link_there?)
+      assert_link_exists(edit_name_description_uri,
+                         edit_description_link_there?)
+      assert_link_exists(destroy_name_description_uri,
+                         destroy_description_link_there?)
       check_edit_description_link_behavior if edit_description_link_there?
     end
 

--- a/test/integration/observer_controller_supplemental_test.rb
+++ b/test/integration/observer_controller_supplemental_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 # Tests which supplement controller/observer_controller_test.rb
 class ObserverControllerSupplementalTest < IntegrationTestCase
-
   # Prove that when a user "Tests" the text entered in the Textile Sandbox,
   # MO displays what the entered text looks like.
   def test_post_textile
@@ -18,7 +17,7 @@ class ObserverControllerSupplementalTest < IntegrationTestCase
     visit("/name/map/#{name.id}")
     click_link("Show Observations")
     click_link("Show Map")
-    title = page.find_by_id("title")
+    title = page.find_by_id("title") # rubocop:disable Rails/DynamicFindBy
 
     title.assert_text("Observations of #{name.text_name}")
   end
@@ -48,8 +47,8 @@ class ObserverControllerSupplementalTest < IntegrationTestCase
     within("div#right_tabs") { click_link("Destroy") }
 
     # MO should show next Observation.
-    title = page.find_by_id("title")
-    assert_match(%r{#{:app_title.l}: Observation #{next_obs.id}}, page.title,
+    page.find_by_id("title") # rubocop:disable Rails/DynamicFindBy
+    assert_match(/#{:app_title.l}: Observation #{next_obs.id}/, page.title,
                  "Wrong page")
   end
 

--- a/test/integration/post_observation_test.rb
+++ b/test/integration/post_observation_test.rb
@@ -1,23 +1,21 @@
-# encoding: utf-8
-
 require "test_helper"
 
 class PostObservationTest < IntegrationTestCase
-  LOGIN_PAGE = "account/login"
-  SHOW_OBSERVATION_PAGE = "observer/show_observation"
-  CREATE_OBSERVATION_PAGE = "observer/create_observation"
-  EDIT_OBSERVATION_PAGE = "observer/edit_observation"
-  CREATE_LOCATION_PAGE = "location/create_location"
-  OBSERVATION_INDEX_PAGE = "observer/list_observations"
+  LOGIN_PAGE = "account/login".freeze
+  SHOW_OBSERVATION_PAGE = "observer/show_observation".freeze
+  CREATE_OBSERVATION_PAGE = "observer/create_observation".freeze
+  EDIT_OBSERVATION_PAGE = "observer/edit_observation".freeze
+  CREATE_LOCATION_PAGE = "location/create_location".freeze
+  OBSERVATION_INDEX_PAGE = "observer/list_observations".freeze
 
   PASADENA_EXTENTS = {
     north: 34.251905,
     south: 34.1192,
     east: -118.065479,
     west: -118.198139
-  }
+  }.freeze
 
-  def test_posting_editing_and_destroying_a_fully_detailed_observation_in_a_new_location
+  def test_post_edit_and_destroy_a_fully_detailed_observation_in_a_new_location
     setup_image_dirs
     open_create_observation_form
     submit_observation_form_with_errors
@@ -45,7 +43,9 @@ class PostObservationTest < IntegrationTestCase
     submit_form_with_changes(create_observation_form_first_changes)
     assert_template(CREATE_OBSERVATION_PAGE)
     assert_has_location_warning(/Unknown country/)
-    assert_form_has_correct_values(create_observation_form_values_after_first_changes)
+    assert_form_has_correct_values(
+      create_observation_form_values_after_first_changes
+    )
   end
 
   def submit_observation_form_without_errors
@@ -60,7 +60,9 @@ class PostObservationTest < IntegrationTestCase
     submit_form_with_changes(create_location_form_first_changes)
     assert_template(CREATE_LOCATION_PAGE)
     assert_has_location_warning(/County may not be required/)
-    assert_form_has_correct_values(create_location_form_values_after_first_changes)
+    assert_form_has_correct_values(
+      create_location_form_values_after_first_changes
+    )
   end
 
   def submit_location_form_without_errors
@@ -97,8 +99,8 @@ class PostObservationTest < IntegrationTestCase
   def assert_edit_observation_has_correct_data(expected_values)
     new_obs = Observation.last
     assert_users_equal(expected_values[:user], new_obs.user)
-    assert(new_obs.created_at > Time.now - 1.minute)
-    assert(new_obs.updated_at > Time.now - 1.minute)
+    assert(new_obs.created_at > Time.zone.now - 1.minute)
+    assert(new_obs.updated_at > Time.zone.now - 1.minute)
     assert_dates_equal(expected_values[:when], new_obs.when)
     assert_equal(expected_values[:is_collection_location],
                  new_obs.is_collection_location)
@@ -136,8 +138,8 @@ class PostObservationTest < IntegrationTestCase
   def assert_new_observation_has_correct_data(expected_values)
     new_obs = Observation.last
     assert_users_equal(expected_values[:user], new_obs.user)
-    assert(new_obs.created_at > Time.now - 1.minute)
-    assert(new_obs.updated_at > Time.now - 1.minute)
+    assert(new_obs.created_at > Time.zone.now - 1.minute)
+    assert(new_obs.updated_at > Time.zone.now - 1.minute)
     # assert_dates_equal(expected_values[:when], new_obs.when)
     assert_equal(expected_values[:is_collection_location],
                  new_obs.is_collection_location)
@@ -188,8 +190,10 @@ class PostObservationTest < IntegrationTestCase
     new_loc = Location.last
     new_img = Image.last
     assert_match(new_obs.when.web_date, response.body)
-    for token in new_loc.name.split(", ") # USA ends up as <span class="caps">USA</span>,
-      assert_match(token, response.body)  # so just search for each component
+    # USA ends up as <span class="caps">USA</span>,
+    # so just search for each component
+    new_loc.name.split(", ").each do |token|
+      assert_match(token, response.body)
     end
     if new_obs.is_collection_location
       assert_match(:show_observation_collection_location.l, response.body)
@@ -233,7 +237,8 @@ class PostObservationTest < IntegrationTestCase
   end
 
   def assert_has_location_warning(regex)
-    assert_select(".alert-warning", { text: regex }, "Expected there to be a warning about location.")
+    assert_select(".alert-warning", { text: regex },
+                  "Expected there to be a warning about location.")
   end
 
   def assert_exists_deleted_item_log
@@ -241,11 +246,14 @@ class PostObservationTest < IntegrationTestCase
     assert_select("a[href*=show_rss_log]") do |elems|
       found = true if elems.any? { |e| e.to_s.match(/Agaricus campestris/mi) }
     end
-    assert(found, 'Expected to find a "destroyed" rss log somewhere on the page.')
+    assert(found,
+           'Expected to find a "destroyed" rss log somewhere on the page.')
   end
 
   def create_observation_form_values_after_first_changes
-    create_observation_form_defaults.merge(create_observation_form_first_changes)
+    create_observation_form_defaults.merge(
+      create_observation_form_first_changes
+    )
   end
 
   def create_location_form_values_after_first_changes
@@ -253,7 +261,7 @@ class PostObservationTest < IntegrationTestCase
   end
 
   def create_observation_form_defaults
-    local_now = Time.now.in_time_zone
+    local_now = Time.zone.now.in_time_zone
     {
       "observation_when_1i" => local_now.year,
       "observation_when_2i" => local_now.month,
@@ -295,7 +303,8 @@ class PostObservationTest < IntegrationTestCase
       "observation_alt" => " 56 ft. ",
       "name_name" => " Agaricus  campestris ",
       "vote_value" => Vote.next_best_vote,
-      "image_0_image" => JpegUpload.new("#{::Rails.root}/test/images/Coprinus_comatus.jpg"),
+      "image_0_image" =>
+        JpegUpload.new("#{::Rails.root}/test/images/Coprinus_comatus.jpg"),
       "image_0_when_1i" => "2010",
       "image_0_when_2i" => "3",
       "image_0_when_3i" => "14",

--- a/test/integration/query_supplemental_test.rb
+++ b/test/integration/query_supplemental_test.rb
@@ -18,7 +18,7 @@ class QuerySupplementalTest < IntegrationTestCase
     click_link("Show Locations")
     click_link("Map Locations")
 
-    title = page.find_by_id("title")
+    title = page.find_by_id("title") # rubocop:disable Rails/DynamicFindBy
 
     title.assert_text("‘#{obs.name.text_name}’")
   end

--- a/test/integration/random_test.rb
+++ b/test/integration/random_test.rb
@@ -1,11 +1,6 @@
-# encoding: utf-8
-
 require "test_helper"
 
 class RandomTest < IntegrationTestCase
-  include SessionExtensions
-  fixtures :names
-
   test "pivotal tracker" do
     get("/")
     click(label: "Feature Tracker")
@@ -60,8 +55,9 @@ class RandomTest < IntegrationTestCase
 
     rolf_session.get("/")
     assert(/rolf/i, rolf_session.response.body)
-
-    assert_not_equal(rolf_session.session[:session_id], mary_session.session[:session_id])
-    assert_not_equal(katrina_session.session[:session_id], mary_session.session[:session_id])
+    refute_equal(rolf_session.session[:session_id],
+                 mary_session.session[:session_id])
+    refute_equal(katrina_session.session[:session_id],
+                 mary_session.session[:session_id])
   end
 end

--- a/test/integration/student_test.rb
+++ b/test/integration/student_test.rb
@@ -1,15 +1,13 @@
-# encoding: utf-8
-# Test typical sessions of university student who is writing descriptions.
-
 require "test_helper"
 
+# Test typical sessions of university student who is writing descriptions.
 class StudentTest < IntegrationTestCase
   # -----------------------------------
   #  Test creating draft for project.
   # -----------------------------------
 
   def test_creating_drafts
-    name = Name.find_by_text_name("Strobilurus diminutivus")
+    name = Name.find_by(text_name: "Strobilurus diminutivus")
     gen_desc = "Mary wrote this draft text."
 
     project = projects(:eol_project)
@@ -26,15 +24,14 @@ class StudentTest < IntegrationTestCase
     katrina_session.login!(katrina)
     dick_session.login!(dick)
 
-    assert_not_equal(mary_session.session[:session_id], dick_session.session[:session_id])
+    refute_equal(mary_session.session[:session_id],
+                 dick_session.session[:session_id])
     url = mary_session.create_draft(name, gen_desc, project)
     rolf_session.check_admin(url, gen_desc, project)
     katrina_session.check_another_student(url)
     dick_session.check_another_user(url)
     lurker_session.check_another_user(url)
   end
-
-  private
 
   module AdminDsl
     def check_admin(url, gen_desc, project)

--- a/test/mailers/queued_email_test.rb
+++ b/test/mailers/queued_email_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "test_helper"
 
 class QueuedEmailTest < UnitTestCase
@@ -17,27 +16,31 @@ class QueuedEmailTest < UnitTestCase
   end
 
   def test_comment_email
-    QueuedEmail::CommentAdd.find_or_create_email(rolf, mary, comments(:minimal_unknown_obs_comment_1))
+    QueuedEmail::CommentAdd.find_or_create_email(
+      rolf, mary, comments(:minimal_unknown_obs_comment_1)
+    )
     assert_email(0,
                  flavor: "QueuedEmail::CommentAdd",
                  from: rolf,
                  to: mary,
-                 comment: comments(:minimal_unknown_obs_comment_1).id
-                )
+                 comment: comments(:minimal_unknown_obs_comment_1).id)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_consensus_change_email
-    QueuedEmail::ConsensusChange.create_email(rolf, mary, observations(:coprinus_comatus_obs), names(:agaricus_campestris), names(:coprinus_comatus))
+    QueuedEmail::ConsensusChange.create_email(
+      rolf, mary,
+      observations(:coprinus_comatus_obs),
+      names(:agaricus_campestris), names(:coprinus_comatus)
+    )
     assert_email(0,
                  flavor: "QueuedEmail::ConsensusChange",
                  from: rolf,
                  to: mary,
                  observation: observations(:coprinus_comatus_obs).id,
                  old_name: names(:agaricus_campestris).id,
-                 new_name: names(:coprinus_comatus).id
-                )
+                 new_name: names(:coprinus_comatus).id)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
@@ -47,15 +50,15 @@ class QueuedEmailTest < UnitTestCase
     assert_email(0,
                  flavor: "QueuedEmail::Feature",
                  to: mary,
-                 note: "blah blah blah"
-                )
+                 note: "blah blah blah")
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_location_change_email
-    QueuedEmail::LocationChange.create_email(rolf, mary, locations(:albion),
-                                             location_descriptions(:albion_desc))
+    QueuedEmail::LocationChange.create_email(
+      rolf, mary, locations(:albion), location_descriptions(:albion_desc)
+    )
     assert_email(0,
                  flavor: "QueuedEmail::LocationChange",
                  from: rolf,
@@ -64,16 +67,18 @@ class QueuedEmailTest < UnitTestCase
                  description: location_descriptions(:albion_desc).id,
                  old_location_version: locations(:albion).version,
                  new_location_version: locations(:albion).version,
-                 old_description_version: location_descriptions(:albion_desc).version,
-                 new_description_version: location_descriptions(:albion_desc).version
-                )
+                 old_description_version:
+                   location_descriptions(:albion_desc).version,
+                 new_description_version:
+                   location_descriptions(:albion_desc).version)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_name_change_email
-    QueuedEmail::NameChange.create_email(rolf, mary, names(:peltigera),
-                                         name_descriptions(:peltigera_desc), true)
+    QueuedEmail::NameChange.create_email(
+      rolf, mary, names(:peltigera), name_descriptions(:peltigera_desc), true
+    )
     assert_email(0,
                  flavor: "QueuedEmail::NameChange",
                  from: rolf,
@@ -82,75 +87,88 @@ class QueuedEmailTest < UnitTestCase
                  description: name_descriptions(:peltigera_desc).id,
                  old_name_version: names(:peltigera).version,
                  new_name_version: names(:peltigera).version,
-                 old_description_version: name_descriptions(:peltigera_desc).version,
-                 new_description_version: name_descriptions(:peltigera_desc).version,
-                 review_status: name_descriptions(:peltigera_desc).review_status.to_s
-                )
+                 old_description_version:
+                   name_descriptions(:peltigera_desc).version,
+                 new_description_version:
+                   name_descriptions(:peltigera_desc).version,
+                 review_status:
+                   name_descriptions(:peltigera_desc).review_status.to_s)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_name_proposal_email
-    QueuedEmail::NameProposal.create_email(rolf, mary, observations(:coprinus_comatus_obs), namings(:coprinus_comatus_naming))
+    QueuedEmail::NameProposal.create_email(
+      rolf, mary,
+      observations(:coprinus_comatus_obs),
+      namings(:coprinus_comatus_naming)
+    )
     assert_email(0,
                  flavor: "QueuedEmail::NameProposal",
                  from: rolf,
                  to: mary,
                  naming: namings(:coprinus_comatus_naming).id,
-                 observation: observations(:coprinus_comatus_obs).id
-                )
+                 observation: observations(:coprinus_comatus_obs).id)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_naming_email
-    QueuedEmail::NameTracking.create_email(notifications(:agaricus_campestris_notification_with_note), namings(:agaricus_campestris_naming))
-    assert_email(0,
-                 flavor: "QueuedEmail::NameTracking",
-                 from: mary,
-                 to: rolf,
-                 naming: namings(:agaricus_campestris_naming).id,
-                 notification: notifications(:agaricus_campestris_notification_with_note).id
-                )
+    QueuedEmail::NameTracking.create_email(
+      notifications(:agaricus_campestris_notification_with_note),
+      namings(:agaricus_campestris_naming)
+    )
+    assert_email(
+      0,
+      flavor: "QueuedEmail::NameTracking",
+      from: mary,
+      to: rolf,
+      naming: namings(:agaricus_campestris_naming).id,
+      notification:
+       notifications(:agaricus_campestris_notification_with_note).id
+    )
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_observation_change_email
-    QueuedEmail::ObservationChange.change_observation(rolf, mary, observations(:coprinus_comatus_obs))
+    QueuedEmail::ObservationChange.change_observation(
+      rolf, mary, observations(:coprinus_comatus_obs)
+    )
     assert_email(0,
                  flavor: "QueuedEmail::ObservationChange",
                  from: rolf,
                  to: mary,
                  observation: observations(:coprinus_comatus_obs).id,
-                 note: ""
-                )
+                 note: "")
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_observation_destroy
-    QueuedEmail::ObservationChange.destroy_observation(rolf, mary, observations(:coprinus_comatus_obs))
+    QueuedEmail::ObservationChange.destroy_observation(
+      rolf, mary, observations(:coprinus_comatus_obs)
+    )
     assert_email(0,
                  flavor: "QueuedEmail::ObservationChange",
                  from: rolf,
                  to: mary,
                  observation: 0,
-                 note: observations(:coprinus_comatus_obs).unique_format_name
-                )
+                 note: observations(:coprinus_comatus_obs).unique_format_name)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
 
   def test_observation_add_image_email
-    QueuedEmail::ObservationChange.change_images(rolf, mary, observations(:coprinus_comatus_obs), :added_image)
+    QueuedEmail::ObservationChange.change_images(
+      rolf, mary, observations(:coprinus_comatus_obs), :added_image
+    )
     assert_email(0,
                  flavor: "QueuedEmail::ObservationChange",
                  from: rolf,
                  to: mary,
                  observation: observations(:coprinus_comatus_obs).id,
-                 note: "added_image"
-                )
+                 note: "added_image")
     email = QueuedEmail.first.deliver_email
     assert(email)
   end
@@ -161,8 +179,7 @@ class QueuedEmailTest < UnitTestCase
                  flavor: "QueuedEmail::Publish",
                  from: rolf,
                  to: mary,
-                 name: names(:peltigera).id
-                )
+                 name: names(:peltigera).id)
     email = QueuedEmail.first.deliver_email
     assert(email)
   end


### PR DESCRIPTION
99% fixing of RuboCop offenses.
There are two goals: 
1. Reduce CodeClimate offenses during CI. 
2. In conjunction with 1, expedite the (soon-to-start) upgrade to Rails 5.0. 
See # 334, #335, #336.
This is the final installment of RuboCopping the tests.
[Delivers #149790226]