### PR TITLE
Delete stray Rails 5 table from schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,12 +23,6 @@ ActiveRecord::Schema.define(version: 20170827000729) do
     t.datetime "verified"
   end
 
-  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
-    t.string   "value",      limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-  end
-
   create_table "articles", force: :cascade do |t|
     t.string   "title",      limit: 255
     t.text     "body",       limit: 65535


### PR DESCRIPTION
ar_internal_metadata is an internal table added by Rails 5. See https://github.com/rails/rails/pull/22967
I must have inadvertently added it to the prior merged PR when switching branches on my local repo.

I don't think it's doing any harm. But it's cleaner to delete it.