### PR TITLE
Change deprecated `render :text` to `render :plain`

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -801,7 +801,7 @@ class AccountController < ApplicationController
     if redirect
       redirect_to(redirect)
     else
-      render(text: "", layout: true)
+      render(plain: "", layout: true)
     end
   end
 

--- a/app/controllers/ajax_controller.rb
+++ b/app/controllers/ajax_controller.rb
@@ -51,7 +51,7 @@ class AjaxController < ApplicationController
   rescue => e
     msg = e.to_s + "\n"
     msg += backtrace(e) if Rails.env != "production"
-    render(text: msg, status: 500)
+    render(plain: msg, status: 500)
   end
 
   def prepare_parameters
@@ -75,6 +75,6 @@ class AjaxController < ApplicationController
 
   # Used by unit tests.
   def test
-    render(text: "test")
+    render(plain: "test")
   end
 end

--- a/app/controllers/ajax_controller/api_key.rb
+++ b/app/controllers/ajax_controller/api_key.rb
@@ -22,12 +22,12 @@ class AjaxController
 
   def activate_api_key(key)
     key.verify!
-    render(text: "")
+    render(plain: "")
   end
 
   def edit_api_key(key, value)
     raise :runtime_api_key_notes_cannot_be_blank.l if value.blank?
     key.update_attribute(:notes, value.strip_squeeze)
-    render(text: key.notes)
+    render(plain: key.notes)
   end
 end

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -11,9 +11,9 @@ class AjaxController
   def auto_complete
     string = CGI.unescape(@id).strip_squeeze
     if string.blank?
-      render(text: "\n\n")
+      render(plain: "\n\n")
     else
-      render(text: auto_complete_results(string))
+      render(plain: auto_complete_results(string))
     end
   end
 

--- a/app/controllers/ajax_controller/exif.rb
+++ b/app/controllers/ajax_controller/exif.rb
@@ -10,7 +10,7 @@ class AjaxController
     if $CHILD_STATUS.success?
       render_exif_data(result)
     else
-      render(text: result, status: 500)
+      render(plain: result, status: 500)
     end
   end
 

--- a/app/controllers/ajax_controller/external_link.rb
+++ b/app/controllers/ajax_controller/external_link.rb
@@ -63,15 +63,15 @@ class AjaxController
   def remove_link(link)
     id = link.id
     link.destroy!
-    render(text: id)
+    render(plain: id)
   end
 
   def render_errors_or_id(link)
     if link.errors.any?
       msg = link.formatted_errors.join("\n")
-      render(text: msg.strip_html, status: 500)
+      render(plain: msg.strip_html, status: 500)
     else
-      render(text: link.id)
+      render(plain: link.id)
     end
   end
 end

--- a/app/controllers/ajax_controller/old_translation.rb
+++ b/app/controllers/ajax_controller/old_translation.rb
@@ -4,6 +4,6 @@ class AjaxController
   # Return an old TranslationString by version id.
   def old_translation
     str = TranslationString::Version.find(@id)
-    render(text: str.text)
+    render(plain: str.text)
   end
 end

--- a/app/controllers/ajax_controller/upload_image.rb
+++ b/app/controllers/ajax_controller/upload_image.rb
@@ -33,7 +33,7 @@ class AjaxController
     name = args[:original_name].to_s
     errors += "\n" + :runtime_no_upload_image.t(name: name)
     logger.error("UPLOAD_FAILED: #{errors.inspect}")
-    render(text: errors.strip_html, status: 500)
+    render(plain: errors.strip_html, status: 500)
   end
 
   def create_and_upload_image(args)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -326,7 +326,7 @@ class ApplicationController < ActionController::Base
   # destroyed.
   #
   def autologin
-    # render(text: "Sorry, we've taken MO down to test something urgent."\
+    # render(plain: "Sorry, we've taken MO down to test something urgent."\
     #              "We'll be back in a few minutes. -Jason", layout: false)
     # return false
 
@@ -427,7 +427,7 @@ class ApplicationController < ActionController::Base
   end
 
   def block_user
-    render(text: "Your account has been temporarily suspended.",
+    render(plain: "Your account has been temporarily suspended.",
            layout: false)
   end
 
@@ -1727,7 +1727,7 @@ class ApplicationController < ActionController::Base
     return unless request.env["HTTP_X_MOZ"] == "prefetch"
 
     logger.debug "prefetch detected: sending 403 Forbidden"
-    render(text: "", status: 403)
+    render(plain: "", status: 403)
     false
   end
 

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -854,14 +854,14 @@ class ImageController < ApplicationController
       render_image_csv_file(data)
     end
   rescue => e
-    render(text: e.to_s, layout: false, status: 500)
+    render(plain: e.to_s, layout: false, status: 500)
   end
 
   def render_test_image_report(data)
     report = data.map do |name, id|
       "<img src='/images/320/#{id}.jpg'/><br/><i>#{name}</i><br/>"
     end.join("<br/>\n")
-    render(text: report)
+    render(plain: report)
   end
 
   def render_image_csv_file(data)

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1543,6 +1543,6 @@ class NameController < ApplicationController
              )
 
   rescue => e
-    render(text: e.to_s, layout: false, status: 500)
+    render(plain: e.to_s, layout: false, status: 500)
   end
 end

--- a/app/controllers/observer_controller/create_and_edit_observation.rb
+++ b/app/controllers/observer_controller/create_and_edit_observation.rb
@@ -373,7 +373,7 @@ class ObserverController
     rescue => err
       flash_error(:observer_recalc_caught_error.t(error: err))
     end
-    # render(text: "", layout: true)
+    # render(plain: "", layout: true)
     redirect_with_query(action: "show_observation", id: id)
   end
 

--- a/app/controllers/observer_controller/other.rb
+++ b/app/controllers/observer_controller/other.rb
@@ -14,7 +14,7 @@ class ObserverController
       # (sleight of hand to prevent localization_file_text from complaining
       # about missing test_flash_redirection_title tag)
       @title = "test_flash_redirection_title".to_sym.t
-      render(layout: "application", text: "")
+      render(html: "", layout: "application")
     end
   end
 

--- a/app/controllers/translation_controller.rb
+++ b/app/controllers/translation_controller.rb
@@ -32,7 +32,7 @@ class TranslationController < ApplicationController
     render(partial: "form")
   rescue => e
     msg = error_message(e).join("\n")
-    render(text: msg, status: 500)
+    render(plain: msg, status: 500)
   end
 
   def edit_translations_ajax_post # :norobots:


### PR DESCRIPTION
**Exception**: observation_controller/other.rb, where it's changed to `render(html`

**Question**: should others be `html` instead of `plain`?

See http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#rendering-content-from-string,
https://github.com/rails/rails/issues/12374