### PR TITLE
Sequence codes

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -41,13 +41,14 @@ class Sequence < AbstractModel
   ##############################################################################
 
   # matchers for bases
-
   BLANK_LINE_IN_MIDDLE = /(\s*)\S.*\n # non-blank line
                           ^\s*\n      # followed by blank line
                           (\s*)\S/x   # and later non-whitespace character
-  DESCRIPTION   = /\A>.*$/
-  VALID_CODES   = /ACGTNU\-*\d\s/i
-  INVALID_CODES = /[^#{VALID_CODES}]/i
+  DESCRIPTION        = /\A>.*$/
+  # nucleotide codes from http://www.bioinformatics.org/sms2/iupac.html
+  # FASTA allows interspersed numbers, spaces. See https://goo.gl/NYbptK
+  VALID_CODES        = /ACGTURYSWKMBDHVN.\-\d\s/i
+  INVALID_CODES      = /[^#{VALID_CODES}]/i
 
   ##############################################################################
   #

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -121,7 +121,11 @@ class Sequence < AbstractModel
   end
 
   def accession_added?
-    accession.present? && accession_was_blank?
+    accession_changed? && accession_was_blank? && accession.present?
+  end
+
+  def accession_changed?
+    changes[:accession].present?
   end
 
   def accession_was_blank?

--- a/app/views/sequence/show_sequence.html.erb
+++ b/app/views/sequence/show_sequence.html.erb
@@ -22,8 +22,9 @@
           <td><%= @sequence.locus %></td>
         </tr>
         <tr>
-          <td class="bold"><%= :BASES.t %>:</td>
-          <td class="monospace" ><%= @sequence.bases %></td>
+          <td class="bold align-top"><%= :BASES.t %>:</td>
+          <td class="col-md-9 monospace max-width-text">
+            <%= @sequence.bases %></td>
         </tr>
         <tr>
           <td class="bold"><%= :DEPOSIT.t %>:</td>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,6 +23,12 @@ ActiveRecord::Schema.define(version: 20170827000729) do
     t.datetime "verified"
   end
 
+  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
+    t.string   "value",      limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
+
   create_table "articles", force: :cascade do |t|
     t.string   "title",      limit: 255
     t.text     "body",       limit: 65535

--- a/test/controllers/sequence_controller_test.rb
+++ b/test/controllers/sequence_controller_test.rb
@@ -199,6 +199,22 @@ class SequenceControllerTest < FunctionalTestCase
     assert(obs.rss_log.notes.include?("log_sequence_accessioned"),
            "Failed to include Sequence accessioned in RssLog for Observation")
 
+    # Prove Observation owner user can edit locus
+    locus  = "ITS"
+    params = {
+      id: sequence.id,
+      sequence:  { locus:     locus,
+                   bases:     bases,
+                   archive:   archive,
+                   accession: accession }
+    }
+
+    post(:edit_sequence, params)
+    sequence.reload
+    obs.rss_log.reload
+
+    assert_equal(locus, sequence.locus)
+
     # Prove returned to form if parameters invalid
     params = {
       id: sequence.id,

--- a/test/models/sequence_test.rb
+++ b/test/models/sequence_test.rb
@@ -218,8 +218,13 @@ class SequenceTest < UnitTestCase
     sequence = Sequence.new(params)
     assert(sequence.invalid?)
 
+    # Prove we allow all IUPAC or FASTA nucleotide codes
+    params[:bases] = "ACGTURYSWKMBDHVN.-0123456789 \n\r\t"
+    sequence = Sequence.new(params)
+    assert(sequence.valid?, "Bases should allow all valid nucleotide codes")
+
     # Prove bases with invalid nucleic acid codes are invalid
-    params[:bases] = "acgt plus some BS"
+    params[:bases] = "acgt plus sOmE craP"
     sequence = Sequence.new(params)
     assert(sequence.invalid?, "Bases with invalid code should be invalid")
   end


### PR DESCRIPTION
- Fixes "NoMethodError: undefined method `first' for nil:NilClass" which sometimes occurred when editing a Sequence
- Allows all IUPAC valid base codes - including ambiguous bases - in MO Sequences. (Fixes https://www.pivotaltracker.com/story/show/152022995)
- Prevents long Sequence from scrolling right indefinitely. (Fixes https://www.pivotaltracker.com/story/show/152023063)