### PR TITLE
Fix bug: EditObservation dropped Notes fields

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -375,9 +375,17 @@ class Observation < AbstractModel
 
   # value of notes part
   #   notes: { Other: abc }
-  #   obervation.notes_part_value("Other") #=> "abc"
+  #   observation.notes_part_value("Other") #=> "abc"
+  #   observation.notes_part_value(:Other)  #=> "abc"
   def notes_part_value(part)
-    notes.blank? ? "" : notes[part.to_sym]
+    notes.blank? ? "" : notes[notes_normalized_key(part)]
+  end
+
+  # Change spaces to underscores in keys
+  #   notes_normalized_key("Nearby trees") #=> :Nearby_trees
+  #   notes_normalized_key(:Other)         #=> :Other
+  def notes_normalized_key(part)
+    part.to_s.tr(" ", "_").to_sym
   end
 
   # Array of note parts (Strings) to display in create & edit form,

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -854,4 +854,12 @@ class ObservationTest < UnitTestCase
              "orphaned_caption_2", "Other"]
     assert_equal(parts, obs.form_notes_parts(obs.user))
   end
+
+  # Prove that part value is returned for the given key,
+  # including any required normalization of the key
+  def test_notes_parts_values
+    obs = observations(:template_and_orphaned_notes_scrambled_obs)
+    assert_equal("red", obs.notes_part_value("Cap"))
+    assert_equal("pine", obs.notes_part_value("Nearby trees"))
+  end
 end


### PR DESCRIPTION
It was dropping contents of Notes Template fields where the template entry was multiple words, e.g. "Nearest tree".

Problem:
* the view filled those fields using Observation#notes_part_value(part), where part was "Nearest tree",
* notes_part_value got the value of the key `:Nearest tree`, but
* the actual key is `:Nearest_tree`, i.e, with an underscore instead of a space.

Fix is to translate spaces to underscores when looking for the value of the key.  Also added a simple test to prevent reversion.