### PR TITLE
Added support for names of the form "Fossil-Blah".  

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -24,7 +24,7 @@
 #    text_name          Amanita muscaria var. muscaria
 #                         (pure text, no accents or authors)
 #    (real_text_name)   Amanita muscaria var. muscaria
-#                          (minus authors, but with umlauts if exist)
+#                         (minus authors, but with umlauts if exist)
 #    search_name        Amanita muscaria var. muscaria (L.) Lam.
 #                         (what one would typically search for)
 #    (real_search_name) Amanita muscaria (L.) Lam. var. muscaria
@@ -1556,7 +1556,7 @@ class Name < AbstractModel
 
   # Taxa without authors (for use by GROUP PAT)
   # rubocop:disable Metrics/LineLength
-  GENUS_OR_UP_TAXON = /("? #{UPPER_WORD} "?) (?: \s #{SP_ABBR} )?/x
+  GENUS_OR_UP_TAXON = /("? (?:Fossil-)? #{UPPER_WORD} "?) (?: \s #{SP_ABBR} )?/x
   SUBGENUS_TAXON    = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD}) "?)/x
   SECTION_TAXON     = /("? #{UPPER_WORD} \s (?: #{SUBG_ABBR} \s #{UPPER_WORD} \s)?
                        (?: #{SECT_ABBR} \s #{UPPER_WORD}) "?)/x
@@ -1685,13 +1685,14 @@ class Name < AbstractModel
     text_name.include?(" sect. ")      ? :Section    :
     text_name.include?(" subgenus ")   ? :Subgenus   :
     text_name.include?(" ")            ? :Species    :
-    text_name.match(/^\w+aceae$/)      ? :Family     :
-    text_name.match(/^\w+ineae$/)      ? :Family     : # :Suborder
-    text_name.match(/^\w+ales$/)       ? :Order      :
-    text_name.match(/^\w+mycetidae$/)  ? :Order      : # :Subclass
-    text_name.match(/^\w+mycetes$/)    ? :Class      :
-    text_name.match(/^\w+mycotina$/)   ? :Class      : # :Subphylum
-    text_name.match(/^\w+mycota$/)     ? :Phylum     :
+    text_name.match(/^\S+aceae$/)      ? :Family     :
+    text_name.match(/^\S+ineae$/)      ? :Family     : # :Suborder
+    text_name.match(/^\S+ales$/)       ? :Order      :
+    text_name.match(/^\S+mycetidae$/)  ? :Order      : # :Subclass
+    text_name.match(/^\S+mycetes$/)    ? :Class      :
+    text_name.match(/^\S+mycotina$/)   ? :Class      : # :Subphylum
+    text_name.match(/^\S+mycota$/)     ? :Phylum     :
+    text_name.match(/^Fossil-/)        ? :Phylum     :
                                          :Genus
   end
 
@@ -2010,13 +2011,13 @@ class Name < AbstractModel
           sub(" var. ",     " {6var. ").
           sub(" f. ", " {7f. ").
           strip.
-          sub(/(^\w+)aceae$/, '\1!7').
-          sub(/(^\w+)ineae$/,        '\1!6').
-          sub(/(^\w+)ales$/,         '\1!5').
-          sub(/(^\w+?)o?mycetidae$/, '\1!4').
-          sub(/(^\w+?)o?mycetes$/,   '\1!3').
-          sub(/(^\w+?)o?mycotina$/, '\1!2').
-          sub(/(^\w+?)o?mycota$/, '\1!1')
+          sub(/(^\S+)aceae$/,        '\1!7').
+          sub(/(^\S+)ineae$/,        '\1!6').
+          sub(/(^\S+)ales$/,         '\1!5').
+          sub(/(^\S+?)o?mycetidae$/, '\1!4').
+          sub(/(^\S+?)o?mycetes$/,   '\1!3').
+          sub(/(^\S+?)o?mycotina$/,  '\1!2').
+          sub(/(^\S+?)o?mycota$/,    '\1!1')
     1 while str.sub!(/(^| )([A-Za-z\-]+) (.*) \2( |$)/, '\1\2 \3 !\2\4') # put autonyms at the top
 
     if author.present?

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -365,6 +365,9 @@ class NameTest < UnitTestCase
     assert_name_match_author_optional(pat, "Amanita sp.", "Amanita")
     assert_name_match_author_optional(pat, '"Amanita"')
     assert_name_match_author_optional(pat, '"Amanita" sp.', '"Amanita"')
+    assert_name_match_author_optional(pat, 'Fossil-Okay')
+    assert_name_match_author_optional(pat, 'Fossil-Okay sp.', 'Fossil-Okay')
+    assert_no_match(pat, 'Anythingelse-Bad')
   end
 
   def test_subgenus_pat
@@ -1092,6 +1095,36 @@ class NameTest < UnitTestCase
       parent_name: nil,
       rank: :Family,
       author: "sensu Reid"
+    )
+  end
+
+  def test_name_parse_39
+    do_name_parse_test(
+      "Fossil-Ascomycetes",
+      text_name: "Fossil-Ascomycetes",
+      real_text_name: "Fossil-Ascomycetes",
+      search_name: "Fossil-Ascomycetes",
+      real_search_name: "Fossil-Ascomycetes",
+      sort_name: "Fossil-Asc!3",
+      display_name: "**__Fossil-Ascomycetes__**",
+      parent_name: nil,
+      rank: :Class,
+      author: ""
+    )
+  end
+
+  def test_name_parse_40
+    do_name_parse_test(
+      "Fossil-Fungi",
+      text_name: "Fossil-Fungi",
+      real_text_name: "Fossil-Fungi",
+      search_name: "Fossil-Fungi",
+      real_search_name: "Fossil-Fungi",
+      sort_name: "Fossil-Fungi",
+      display_name: "**__Fossil-Fungi__**",
+      parent_name: nil,
+      rank: :Phylum,
+      author: ""
     )
   end
 
@@ -2276,6 +2309,11 @@ class NameTest < UnitTestCase
     assert_equal(:Phylum, Name.guess_rank("Agaricomycota"))
     assert_equal(:Genus, Name.guess_rank("Animalia"))
     assert_equal(:Genus, Name.guess_rank("Plantae"))
+    assert_equal(:Phylum, Name.guess_rank("Fossil-Fungi"))
+    assert_equal(:Phylum, Name.guess_rank("Fossil-Ascomycota"))
+    assert_equal(:Class, Name.guess_rank("Fossil-Ascomycetes"))
+    assert_equal(:Order, Name.guess_rank("Fossil-Agaricales"))
+    assert_equal(:Phylum, Name.guess_rank("Fossil-Anythingelse"))
   end
 
   def test_parent_if_parent_deprecated
@@ -2452,7 +2490,7 @@ class NameTest < UnitTestCase
 
   def test_refresh_classification_caches
     name = names(:coprinus_comatus)
-    bad  = name.classification = "Phyllum: _Ascomycota_"
+    bad  = name.classification = "Phylum: _Ascomycota_"
     good = name.description.classification
     name.save
     assert_not_equal(good, bad)


### PR DESCRIPTION
The rank follows what the rank normally would be for "Blah", and if "Blah" is not guessable (as in Fossil-Fungi) then it assumes Phylum.  (Yes, apparently Fossil-Fungi is a Phylum, not Kingdom.  I don't make the rules, don't ask me.)