### PR TITLE
Moved code for changing misspelling status into Name.  When marking a…

### DIFF
--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -21,10 +21,12 @@
 require File.expand_path("../../config/boot.rb", __FILE__)
 require File.expand_path("../../config/environment.rb", __FILE__)
 
-msgs = []
-msgs += Name.refresh_classification_caches
-msgs += Name.propagate_generic_classifications
-msgs += Observation.refresh_content_filter_caches
+msgs =
+  Name.make_sure_names_are_bolded_correctly +
+  Name.refresh_classification_caches +
+  Name.propagate_generic_classifications +
+  Observation.refresh_content_filter_caches +
+  Observation.make_sure_no_observations_are_misspelled
 $stderr.puts msgs.join("\n") if msgs.any?
 
 exit 0

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1214,7 +1214,7 @@ class NameControllerTest < FunctionalTestCase
     assert_true(name.deprecated)
     assert_redirected_to(controller: :name, action: :show_name, id: name.id)
 
-    # Prove we can deprecated and call a name misspelt by checking box and
+    # Prove we can deprecate and call a name misspelt by checking box and
     # entering correct spelling.
     name.update_attributes(deprecated: false)
     params = {

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -246,6 +246,8 @@ peltigera_obs: # 16
   images: peltigera_image
   species_lists: one_genus_three_species_list
   lifeform: " lichen "
+  created_at: 2014-04-04 04:04:03
+  updated_at: 2014-04-04 04:04:03
 
 peltigera_rolf_obs: # 17
   <<: *DEFAULTS
@@ -263,6 +265,8 @@ peltigera_rolf_obs: # 17
   thumb_image: rolf_profile_image
   images: rolf_profile_image
   lifeform: " lichen "
+  created_at: 2014-04-04 04:04:04
+  updated_at: 2014-04-04 04:04:04
 
 fungi_obs: # 18
   <<: *DEFAULTS

--- a/test/integration/expert_test.rb
+++ b/test/integration/expert_test.rb
@@ -174,7 +174,7 @@ class ExpertTest < IntegrationTestCase
     obs = spl.observations
     assert_equal(5, obs.length, obs.map(&:text_name).inspect)
     assert_equal([
-      "Petigera",
+      "Peltigera (Old) New Auth.", # (spelling corrected automatically)
       "Lactarius alpigenes Kühn.",
       "Suillus E.B. White",
       "Amanita baccata sensu Arora",
@@ -230,7 +230,7 @@ class ExpertTest < IntegrationTestCase
     obs = spl.observations
     assert_equal(7, obs.length, obs.map(&:text_name).inspect)
     assert_equal([
-      "Petigera",
+      "Peltigera (Old) New Auth.",
       "Lactarius alpigenes Kühn.",
       "Suillus E.B. White",
       "Amanita baccata sensu Arora",

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -862,4 +862,19 @@ class ObservationTest < UnitTestCase
     assert_equal("red", obs.notes_part_value("Cap"))
     assert_equal("pine", obs.notes_part_value("Nearby trees"))
   end
+
+  def test_make_sure_no_observations_are_misspelled
+    good = names(:peltigera)
+    bad  = names(:petigera)
+    misspelled_obs = Observation.where(name: good)
+    misspelled_obs.each do |obs|
+      obs.update_columns(name_id: bad.id)
+      assert_operator(obs.updated_at, :<, 1.minute.ago)
+    end
+    Observation.make_sure_no_observations_are_misspelled
+    misspelled_obs.each do |obs|
+      assert_names_equal(good, obs.reload.name)
+      assert_operator(obs.updated_at, :<, 1.minute.ago)
+    end
+  end
 end


### PR DESCRIPTION
… name "misspelled", have it ensure that corresponding observations are changed as well.  Added nightly cronjob to check to make sure no observations are misspelled.  Also added nightly cronjob to make sure no deprecated names are in boldface (and vice versa).  Tested all of the above.