### PR TITLE
Fix deprecated "What" loop [Fixed #107455054]

### DIFF
--- a/app/views/naming/_form.html.erb
+++ b/app/views/naming/_form.html.erb
@@ -1,9 +1,9 @@
 <%
-   # Changing naming form html in _form_new.erb in case we want to role back
+   # Changing naming form html in _form_new.erb in case we want to roll back
 
    # Prefer NamingParams, but use raw params if no params.
    what = @params.what rescue @what
-   valid_names = @params.valid_names rescue @valid_name
+   valid_names = @params.valid_names rescue @valid_names
    suggest_corrections = @params.suggest_corrections rescue @suggested_corrections
    parent_deprecated = @params.parent_deprecated rescue @parent_deprecated
    reason = @params.reason rescue @reason
@@ -11,14 +11,16 @@
    vote = @params.vote rescue @vote
 %>
 
-<%= render(partial: "shared/form_name_feedback", locals: {
+<%= render(partial: "shared/form_name_feedback",
+           locals: {
              button_name: button_name,
              what: what,
              valid_names: valid_names,
              suggest_corrections: suggest_corrections,
              parent_deprecated: parent_deprecated,
              names: names
-           }) %>
+           }
+          ) %>
 
 <div class="row">
   <div class="col-sm-6">
@@ -26,28 +28,33 @@
     <div class="form-group">
       <%= label_tag(:name_name, :WHAT.t + ":") %>
       <%= text_field(:name, :name, value: what, size: 40, class: "form-control",
-                                   data: { autofocus: true }) %>
+                     data: { autofocus: true }) %>
       <% turn_into_name_auto_completer(:name_name, primer: Name.primer) %>
     </div>
 
     <div class="form-group">
       <%= label_tag(:vote_value, :form_naming_confidence.t + ":") %><br>
-      <%= select(:vote, :value, options_for_select(Vote.confidence_menu, vote.value),
-                 {include_blank: (action == :create || action == :create_observation)}, class: "form-control") %>
+      <%= select(:vote, :value,
+                 options_for_select(Vote.confidence_menu, vote.value),
+                 { include_blank: (action == :create ||
+                                   action == :create_observation) } ,
+                 class: "form-control") %>
     </div>
 
     <% reason.values.sort_by(&:order).each do |r| %>
       <div class="form-group form-inline" style="margin:0">
         <label>
-          <%= check_box(:reason, :check, {
-                          index: r.num, checked: r.used?,
-                          data: {role: "collapser", target: "#reason_#{r.num}_notes"},
-                          class: ""
-                        }, "1") %>
+          <%= check_box(:reason, :check,
+                        { index: r.num, checked: r.used?,
+                          data: { role: "collapser",
+                                  target: "#reason_#{r.num}_notes" },
+                          class: "" },
+                        "1") %>
           <%= r.label.t %>
         </label>
       </div>
-      <div class="form-group <%= "collapse" if !r.used? %>" style="margin-bottom:1em">
+      <div class="form-group <%= "collapse" if !r.used? %>"
+           style="margin-bottom:1em">
         <%= text_area(:reason, :notes, index: r.num, rows: 1, value: r.notes,
                       class: "form-control") %>
       </div>


### PR DESCRIPTION
When **What** is deprecated (in create Observation), and user clicks Create,
form is reloaded without any message. Click Create again, and it keeps happening.

Problem is a typo in _form.html.erb.

- Fixed typo which caused bug
- Fixed typo in comment
- Minor reformatting for readability, e.g., align arguments, shorten long lines, etc.