### PR TITLE
Naming focus

### DIFF
--- a/app/views/naming/_form.html.erb
+++ b/app/views/naming/_form.html.erb
@@ -9,6 +9,9 @@
    reason = @params.reason rescue @reason
    names = @params.names rescue @names
    vote = @params.vote rescue @vote
+
+  # default is true, so check for false rather than falsy
+   autofocus_name = !(autofocus_name == false)
 %>
 
 <%= render(partial: "shared/form_name_feedback",
@@ -28,7 +31,7 @@
     <div class="form-group">
       <%= label_tag(:name_name, :WHAT.t + ":") %>
       <%= text_field(:name, :name, value: what, size: 40, class: "form-control",
-                     data: { autofocus: true }) %>
+                     data: { autofocus: autofocus_name }) %>
       <% turn_into_name_auto_completer(:name_name, primer: Name.primer) %>
     </div>
 

--- a/app/views/naming/_form.html.erb
+++ b/app/views/naming/_form.html.erb
@@ -10,8 +10,7 @@
    names = @params.names rescue @names
    vote = @params.vote rescue @vote
 
-  # default is true, so check for false rather than falsy
-   autofocus_name = !(autofocus_name == false)
+   unfocused ||= false
 %>
 
 <%= render(partial: "shared/form_name_feedback",
@@ -31,7 +30,7 @@
     <div class="form-group">
       <%= label_tag(:name_name, :WHAT.t + ":") %>
       <%= text_field(:name, :name, value: what, size: 40, class: "form-control",
-                     data: { autofocus: autofocus_name }) %>
+                     data: { autofocus: !unfocused }) %>
       <% turn_into_name_auto_completer(:name_name, primer: Name.primer) %>
     </div>
 

--- a/app/views/observer/_form_observations.html.erb
+++ b/app/views/observer/_form_observations.html.erb
@@ -105,10 +105,10 @@
   <div class="col-xs-12 max-width-text-times-two">
 <%= render(partial: "naming/form",
             locals: {
-              action: action,
-              button_name: button_name,
+              action:       action,
+              button_name:  button_name,
               show_reasons: false,
-              autofocus_name: false
+              unfocused:    true
             }
           ) if include_naming %>
   </div>

--- a/app/views/observer/_form_observations.html.erb
+++ b/app/views/observer/_form_observations.html.erb
@@ -103,9 +103,14 @@
 
 <div class="row">
   <div class="col-xs-12 max-width-text-times-two">
-<%= render(partial: "naming/form", locals: {
-            action: action, button_name: button_name, show_reasons: false
-          }) if include_naming %>
+<%= render(partial: "naming/form",
+            locals: {
+              action: action,
+              button_name: button_name,
+              show_reasons: false,
+              autofocus_name: false
+            }
+          ) if include_naming %>
   </div>
 </div>
 


### PR DESCRIPTION
Fine-tune Observation & Naming autofocus [Fixes: #99865100]

Make default autofocus in **What** field.
Caller can override (turn off autofocus) by setting the local variable `unfocused = true`.
