### PR TITLE
Remove references to mo-admin Google group [Finishes #102537526]

### DIFF
--- a/config/consts.rb
+++ b/config/consts.rb
@@ -72,7 +72,7 @@ MushroomObserver::Application.configure do
   config.noreply_email_address = "no-reply@" + config.domain
   config.accounts_email_address = "webmaster@" + config.domain
   config.error_email_address = "webmaster@" + config.domain
-  config.webmaster_email_address = "mo-admin@googlegroups.com"
+  config.webmaster_email_address = "webmaster@mushroomobserver.org"
   config.exception_recipients = "webmaster@" + config.domain
   config.donation_business = "UQ23P3G6FBYKN"
 

--- a/test/account_mailer/admin_request.html
+++ b/test/account_mailer/admin_request.html
@@ -18,7 +18,7 @@ Subject: [MO] Please do something or other
 <li>Show user&#8217;s profile: <a href="http://mushroomobserver.org/observer/show_user/<%= ActiveRecord::FixtureSet.identify(:katrina) %>">http://mushroomobserver.org/observer/show_user/<%= ActiveRecord::FixtureSet.identify(:katrina) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/admin_request.text
+++ b/test/account_mailer/admin_request.text
@@ -17,4 +17,4 @@ Change user's status: http://mushroomobserver.org/project/change_user_status/<%=
 Show user's profile: http://mushroomobserver.org/observer/show_user/<%= ActiveRecord::FixtureSet.identify(:katrina) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/author_request.html
+++ b/test/account_mailer/author_request.html
@@ -29,8 +29,8 @@ user/<%= ActiveRecord::FixtureSet.identify(:katrina) %></a></li>
 server.org">http://mushroomobserver.org</a></li>
 </ul>
 <div class=3D"textile"><p>If you feel this user is abusing this service p=
-lease forward this entire email message to: mo-admin&#64;googlegroups.com=
-</p></div>
+lease forward this entire email message to: webmaster&#64;mushroomobserve=
+r.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/author_request.text
+++ b/test/account_mailer/author_request.text
@@ -22,4 +22,4 @@ Show user's profile: http://mushroomobserver.org/observer/show_user/48423=
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
 If you feel this user is abusing this service please forward this entire =
-email message to: mo-admin@googlegroups.com
+email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/comment.html
+++ b/test/account_mailer/comment.html
@@ -26,7 +26,7 @@ Here are some handy links:</p></div>
 <li>Change your preferences: <a href="http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>">http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/comment.text
+++ b/test/account_mailer/comment.text
@@ -26,4 +26,4 @@ Stop sending me email like this: http://mushroomobserver.org/account/no_email_co
 Change your preferences: http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/comment_response.html
+++ b/test/account_mailer/comment_response.html
@@ -28,7 +28,7 @@ Here are some handy links:</p></div>
 <li>Change your preferences: <a href="http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:rolf) %>">http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:rolf) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/comment_response.text
+++ b/test/account_mailer/comment_response.text
@@ -29,4 +29,4 @@ Stop sending me email like this: http://mushroomobserver.org/account/no_email_co
 Change your preferences: http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:rolf) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/commercial_inquiry.html
+++ b/test/account_mailer/commercial_inquiry.html
@@ -20,7 +20,7 @@ Here are some handy links:</p></div>
 <li>Change your preferences: <a href="http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:rolf) %>">http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:rolf) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/commercial_inquiry.text
+++ b/test/account_mailer/commercial_inquiry.text
@@ -19,4 +19,4 @@ Stop sending me email like this: http://mushroomobserver.org/account/no_email_ge
 Change your preferences: http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:rolf) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/denied.text
+++ b/test/account_mailer/denied.text
@@ -1,6 +1,6 @@
 From: webmaster@mushroomobserver.org
 Reply-To: no-reply@mushroomobserver.org
-To: mo-admin@googlegroups.com
+To: webmaster@mushroomobserver.org
 Subject: [MO] User Creation Blocked
 
 The request for account junk was denied since the theme was set to ''.

--- a/test/account_mailer/naming_for_observer.html
+++ b/test/account_mailer/naming_for_observer.html
@@ -18,7 +18,7 @@ Here are some handy links:</p></div>
 <li>Show this observation: <a href="http://mushroomobserver.org/observer/show_observation/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %>">http://mushroomobserver.org/observer/show_observation/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/naming_for_observer.text
+++ b/test/account_mailer/naming_for_observer.text
@@ -17,4 +17,4 @@ Here are some handy links:
 Show this observation: http://mushroomobserver.org/observer/show_observation/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/naming_for_tracker.html
+++ b/test/account_mailer/naming_for_tracker.html
@@ -21,7 +21,7 @@ Subject: [MO] Naming Notification - <%= ActiveRecord::FixtureSet.identify(:agari
 <li>Review your notifications: <a href="http://mushroomobserver.org/interest/list_interests">http://mushroomobserver.org/interest/list_interests</a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/naming_for_tracker.text
+++ b/test/account_mailer/naming_for_tracker.text
@@ -20,4 +20,4 @@ Disable tracking for this name: http://mushroomobserver.org/name/email_tracking/
 Review your notifications: http://mushroomobserver.org/interest/list_interests
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/observation_question.html
+++ b/test/account_mailer/observation_question.html
@@ -20,7 +20,7 @@ Here are some handy links:</p></div>
 <li>Change your preferences: <a href="http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>">http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/observation_question.text
+++ b/test/account_mailer/observation_question.text
@@ -19,4 +19,4 @@ Stop sending me email like this: http://mushroomobserver.org/account/no_email_ge
 Change your preferences: http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/user_question.html
+++ b/test/account_mailer/user_question.html
@@ -20,7 +20,7 @@ Here are some handy links:</p></div>
 <li>Change your preferences: <a href="http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>">http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="http://mushroomobserver.org">http://mushroomobserver.org</a></li>
 </ul>
-<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: mo-admin&#64;googlegroups.com</p></div>
+<div class="textile"><p>If you feel this user is abusing this service please forward this entire email message to: webmaster&#64;mushroomobserver.org</p></div>
 <br/>
 </body>
 </html>

--- a/test/account_mailer/user_question.text
+++ b/test/account_mailer/user_question.text
@@ -19,4 +19,4 @@ Stop sending me email like this: http://mushroomobserver.org/account/no_email_ge
 Change your preferences: http://mushroomobserver.org/account/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>
 Latest changes at Mushroom Observer: http://mushroomobserver.org
 
-If you feel this user is abusing this service please forward this entire email message to: mo-admin@googlegroups.com
+If you feel this user is abusing this service please forward this entire email message to: webmaster@mushroomobserver.org

--- a/test/account_mailer/verify_api_key.html
+++ b/test/account_mailer/verify_api_key.html
@@ -1,5 +1,5 @@
 From: webmaster@mushroomobserver.org
-Reply-To: mo-admin@googlegroups.com
+Reply-To: webmaster@mushroomobserver.org
 To: rolf@collectivesource.com
 Subject: [MO] Activate API Key
 <html>

--- a/test/account_mailer/verify_api_key.text
+++ b/test/account_mailer/verify_api_key.text
@@ -1,5 +1,5 @@
 From: webmaster@mushroomobserver.org
-Reply-To: mo-admin@googlegroups.com
+Reply-To: webmaster@mushroomobserver.org
 To: rolf@collectivesource.com
 Subject: [MO] Activate API Key
 

--- a/test/account_mailer/webmaster_question.text
+++ b/test/account_mailer/webmaster_question.text
@@ -1,6 +1,6 @@
-From: mo-admin@googlegroups.com
+From: webmaster@mushroomobserver.org
 Reply-To: mary@collectivesource.com
-To: mo-admin@googlegroups.com
+To: webmaster@mushroomobserver.org
 Subject: [MO] Question From mary@collectivesource.com
 
 A question


### PR DESCRIPTION
This group no longer exists, so the references didn't make sense to me.
(They were all related to the mailer tests.)

- Changed default definition of `webmaster_email_address`.
- Conformed email test fixtures to that change