### PR TITLE
Eliminate hanging indents in Observation Notes

### DIFF
--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -1478,6 +1478,12 @@ table.table-namings {
     color: $INPUT_FG_COLOR;
 }
 
+.obs-notes p {
+    margin: 0px;
+    padding: 0.0em 0em 0em 0em;
+    text-indent: 0em;
+}
+
 //
 // generally useful classes
 // --------------------------------------------------

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -1479,9 +1479,9 @@ table.table-namings {
 }
 
 .obs-notes p {
-    margin: 0px;
-    padding: 0.0em 0em 0em 0em;
-    text-indent: 0em;
+    margin: 0;
+    padding: 0 0 0 0;
+    text-indent: 0;
 }
 
 //
@@ -1497,8 +1497,8 @@ table.table-namings {
 }
 
 .name-section p {
-    margin: 0px;
-    padding: 0em 0em 0em 1em;
+    margin: 0;
+    padding: 0 0 0 1em;
     text-indent: -1em;
 }
 

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -1480,7 +1480,7 @@ table.table-namings {
 
 .obs-notes p {
     margin: 0;
-    padding: 0 0 0 0;
+    padding: 0;
     text-indent: 0;
 }
 

--- a/app/views/observer/_show_observation.html.erb
+++ b/app/views/observer/_show_observation.html.erb
@@ -52,7 +52,9 @@
       <%= render(partial: "observer/sequences",
                 locals: { observation: observation }) %>
     </div>
+  </div>
 
+  <div class="col-xs-12 max-width-text obs-notes">
     <%= if observation.notes?
       Textile.clear_textile_cache
       Textile.register_name(*observation.namings.map(&:name))


### PR DESCRIPTION
These were an unintended side-effect of adding hanging indents to the name area of Show Observation