### PR TITLE
Cleanup hitless search display

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1379,7 +1379,11 @@ class ApplicationController < ActionController::Base
     @sorts = (num_results > 1 ? sorting_links(query, args) : nil)
 
     # Supply a default title.
-    @title ||= query.title
+    # If no results, then title is empty but not nil
+    # An empty title will cause the view to display nothing,
+    # overriding any title specified in the view,
+    # while keeping the application default (action name) as <title> metadata
+    num_results.zero? ? @title = "" : @title ||= query.title
 
     # Supply default error message to display if no results found.
     if (query.params.keys - query.required_parameters - [:by]).empty?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1373,18 +1373,6 @@ class ApplicationController < ActionController::Base
     # Pass this query on when clicking on results.
     query_params_set(query)
 
-    num_results = query.num_results
-
-    # Add magic links for sorting if enough results to sort
-    @sorts = (num_results > 1 ? sorting_links(query, args) : nil)
-
-    # Supply a default title.
-    # If no results, then title is empty but not nil
-    # An empty title will cause the view to display nothing,
-    # overriding any title specified in the view,
-    # while keeping the application default (action name) as <title> metadata
-    num_results.zero? ? @title = "" : @title ||= query.title
-
     # Supply default error message to display if no results found.
     if (query.params.keys - query.required_parameters - [:by]).empty?
       @error ||=
@@ -1460,9 +1448,19 @@ class ApplicationController < ActionController::Base
     @num_results = query.num_results
     @timer_end = Time.current
 
+    # Supply a default title.
+    # If no results, then title is empty but not nil.
+    # Result: No title is displayed
+    # (overriding any title specified in the view)
+    # and the html <title> metadata == a translated tag or the action name
+    # see ApplicationHelper#title_tag_contents
+    @num_results.zero? ? @title = "" : @title ||= query.title
+
+    # Add magic links for sorting if enough results to sort
+    @sorts = (@num_results > 1 ? sorting_links(query, args) : nil)
+
     # If only one result (before pagination), redirect to 'show' action.
-    if (query.num_results == 1) &&
-       !args[:always_index]
+    if (@num_results == 1) && !args[:always_index]
       redirect_with_query(controller: query.model.show_controller,
                           action: query.model.show_action,
                           id: query.result_ids.first)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1373,6 +1373,11 @@ class ApplicationController < ActionController::Base
     # Pass this query on when clicking on results.
     query_params_set(query)
 
+    num_results = query.num_results
+
+    # Add magic links for sorting if enough results to sort
+    @sorts = (num_results > 1 ? sorting_links(query, args) : nil)
+
     # Supply a default title.
     @title ||= query.title
 
@@ -1436,10 +1441,6 @@ class ApplicationController < ActionController::Base
         end
     end
     @error ||= :runtime_no_matches.t(type: type)
-
-    # Add magic links for sorting.
-    @sorts = sorting_links(query, args)
-    # "@sorts".print_thing(@sorts)
 
     # Get user prefs for displaying results as a matrix.
     if args[:matrix]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -282,7 +282,7 @@ module ApplicationHelper
     elsif TranslationString.where(tag: "title_for_#{action_name}").present?
       :"title_for_#{action_name}".t
     else
-      action_name.gsub("_", " ").titleize
+      action_name.tr("_", " ").titleize
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -280,7 +280,6 @@ module ApplicationHelper
     if @title.present?
       @title.strip_html.html_safe
     elsif TranslationString.where(tag: "title_for_#{action_name}").present?
-      # if translation label exists, return the translation
       :"title_for_#{action_name}".t
     else
       action_name.gsub("_", " ").titleize

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -274,4 +274,16 @@ module ApplicationHelper
       order: [:day, :month, :year]
     }
   end
+
+  # contents of the <title> in html header
+  def title_tag_contents(action_name)
+    if @title.present?
+      @title.strip_html.html_safe
+    elsif TranslationString.where(tag: "title_for_#{action_name}").present?
+      # if translation label exists, return the translation
+      :"title_for_#{action_name}".t
+    else
+      action_name.gsub("_", " ").titleize
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,15 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= auto_discovery_link_tag(:rss, {controller: :observer, action: :rss}, {title: :app_rss.l}) %>
-  <title><%= :app_title.l %>: <%=
-    if @title.present?
-      @title.strip_html.html_safe
-    elsif defined?(:"title_for_#{controller.action_name}")
-      :"title_for_#{controller.action_name}".t
-    else
-      controller.action_name
-    end
-  %></title>
+  <title><%= :app_title.l%>: <%= title_tag_contents(controller.action_name)%></title>
   <link rel="SHORTCUT ICON" href="http://mushroomobserver.org/favicon.ico"/>
   <% if @canonical_url %>
   <link href="<%= escape_once(@canonical_url) %>" rel="canonical"/>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,15 @@
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= auto_discovery_link_tag(:rss, {controller: :observer, action: :rss}, {title: :app_rss.l}) %>
-  <title><%= :app_title.l %>: <%= @title.blank? ? controller.action_name : @title.strip_html.html_safe %></title>
+  <title><%= :app_title.l %>: <%=
+    if @title.present?
+      @title.strip_html.html_safe
+    elsif defined?(:"title_for_#{controller.action_name}")
+      :"title_for_#{controller.action_name}".t
+    else
+      controller.action_name
+    end
+  %></title>
   <link rel="SHORTCUT ICON" href="http://mushroomobserver.org/favicon.ico"/>
   <% if @canonical_url %>
   <link href="<%= escape_once(@canonical_url) %>" rel="canonical"/>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= auto_discovery_link_tag(:rss, {controller: :observer, action: :rss}, {title: :app_rss.l}) %>
-  <title><%= :app_title.l %>: <%= @title.nil? ? controller.action_name : @title.strip_html.html_safe %></title>
+  <title><%= :app_title.l %>: <%= @title.blank? ? controller.action_name : @title.strip_html.html_safe %></title>
   <link rel="SHORTCUT ICON" href="http://mushroomobserver.org/favicon.ico"/>
   <% if @canonical_url %>
   <link href="<%= escape_once(@canonical_url) %>" rel="canonical"/>
@@ -107,7 +107,7 @@
               klass = case flash_notice_level
                 when 0; "alert-success"
                 when 1; "alert-warning"
-                when 2; "alert-danger" 
+                when 2; "alert-danger"
               end
               content_tag(:div, flash_get_notices,
                           class: "alert push-down #{klass}")

--- a/app/views/name/list_names.html.erb
+++ b/app/views/name/list_names.html.erb
@@ -13,7 +13,7 @@
      names = Name.suggest_alternate_spellings(@suggest_alternate_spellings)
      if names.any? %>
         <div class="alert-warning">
-          <%= :list_observations_alternate_spellings.t %><br/>
+          <%= :list_observations_suggestions.t %>:<br/>
           <ul type="none">
             <% names.sort_by(&:sort_name).each do |name| %>
                 <%= link_to(name.display_name.t, name.show_link_args) %><br/>

--- a/app/views/name/list_names.html.erb
+++ b/app/views/name/list_names.html.erb
@@ -25,7 +25,7 @@
 
 <%= @help.tp if @help %>
 
-<% # Let test_index test passing args to pagination_links.
+<% # Let test_index test pass args to pagination_links.
    args = @test_pagination_args || {} %>
 <%= paginate_block(@pages, args) do %>
     <% if @objects.any? %>

--- a/app/views/name/list_names.html.erb
+++ b/app/views/name/list_names.html.erb
@@ -13,10 +13,10 @@
      names = Name.suggest_alternate_spellings(@suggest_alternate_spellings)
      if names.any? %>
         <div class="alert-warning">
-          <%= :list_observations_suggestions.t %>:<br/>
+          <%= :list_observations_alternate_spellings.t %><br/>
           <ul type="none">
             <% names.sort_by(&:sort_name).each do |name| %>
-                <%= link_to(name.display_name.t, name.show_link_args) %><br/>
+              <%= link_to(name.display_name.t, name.show_link_args) %><br/>
             <% end %>
           </ul>
         </div>

--- a/app/views/observer/list_observations.html.erb
+++ b/app/views/observer/list_observations.html.erb
@@ -8,23 +8,37 @@
 %>
 
 <% if @suggest_alternate_spellings && @objects.empty?
-  names = Name.suggest_alternate_spellings(@suggest_alternate_spellings)
-  if names.any? %>
-    <div class="alert-warning">
-      <div><%= :list_observations_suggestions.t %>:</div>
-      <% names.sort_by(&:sort_name).each do |name| %>
-        <div>
-          <%= link_to(name.display_name.t, controller: :observer,
-                      action: :observation_search, pattern: name.text_name) %>
-        </div>
-      <% end %>
-    </div>
+    names = Name.suggest_alternate_spellings(@suggest_alternate_spellings)
+    if names.any? %>
+      <div class="alert-warning">
+        <div><%= :list_observations_suggestions.t %>:</div>
+        <% names.sort_by(&:sort_name).each do |name| %>
+          <div class="indent">
+            <%= search = PatternSearch::Observation.new(name.text_name)
+                count = search.query.num_results
+                if count.zero?
+                  # link to Name because a pattern search would be circular
+                  :list_observation_name.t + ": " +
+                  link_to(
+                    name.display_name.t, name.show_link_args
+                  ) + " (0)"
+                else
+                  :list_observation_observations.t + " " +
+                  link_to(
+                    name.display_name.t, controller: :observer,
+                    action: :observation_search, pattern: name.text_name
+                  ) + " (#{count})"
+                end %>
+          </div>
+        <% end %>
+      </div>
   <% end %>
 <% end %>
 
 <%= paginate_block(@pages) do %>
   <div class="row results push-down">
-    <%= render(partial: "shared/matrix_box", layout: "shared/matrix_table", collection: @objects, as: :object)  %>
+    <%= render(partial: "shared/matrix_box", layout: "shared/matrix_table",
+               collection: @objects, as: :object) %>
     <div style="clear: left"></div>
   </div>
 <% end %>

--- a/app/views/observer/list_observations.html.erb
+++ b/app/views/observer/list_observations.html.erb
@@ -11,7 +11,7 @@
   names = Name.suggest_alternate_spellings(@suggest_alternate_spellings)
   if names.any? %>
     <div class="alert-warning">
-      <div><%= :list_observations_alternate_spellings.t %></div>
+      <div><%= :list_observations_suggestions.t %>:</div>
       <% names.sort_by(&:sort_name).each do |name| %>
         <div>
           <%= link_to(name.display_name.t, controller: :observer,

--- a/app/views/observer/list_observations.html.erb
+++ b/app/views/observer/list_observations.html.erb
@@ -1,5 +1,5 @@
 <%
-  if @links.any?
+  if @links.any? && @objects.any?
     tabs = create_links(@links)
     @tabsets = { right: draw_tab_set(tabs) }
   end

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -1,54 +1,62 @@
 <nav class="navbar navbar-default">
-  <%= form_tag({controller: :observer, action: :pattern_search}, {class: "navbar-form navbar-left"}) do %>
-    <div>
-      <div class="inline align-top icon-addon addon-sm">
-        <%= text_field(:search, :pattern, value: session[:pattern], class: "form-control", placeholder: :app_find.t) %>
-        <label for="search_pattern" class="glyphicon glyphicon-search" title="search"> </label>
-      </div>
-      <div class="inline align-top nowrap">
-        <%=
-          options = [
-            [:COMMENTS.l, :comment],
-            [:HERBARIA.l, :herbarium],
-            [:IMAGES.l, :image],
-            [:LOCATIONS.l, :location],
-            [:NAMES.l, :name],
-            [:OBSERVATIONS.l, :observation],
-            [:PROJECTS.l, :project],
-            [:SPECIES_LISTS.l, :species_list],
-            [:HERBARIUM_RECORDS.l, :herbarium_record],
-            [:USERS.l, :user],
-            [:app_search_google.l, :google],
-          ].sort
-          select(:search, :type, options_for_select(options, session[:search_type] || :observation), {},
-                 {class: "form-control inline align-top", style: "width: auto;"})
-        %>
-        <%= submit_tag(:app_search.l, class: "btn align-top", style: "margin-right:0.5em") %>
-      </div>
+  <%=
+    form_tag({controller: :observer, action: :pattern_search},
+             {class: "navbar-form navbar-left"}) do %>
+      <div>
+        <div class="inline align-top icon-addon addon-sm">
+          <%= text_field(:search, :pattern, value: session[:pattern],
+                         class: "form-control", placeholder: :app_find.t) %>
+          <label for="search_pattern" class="glyphicon glyphicon-search" title="search"> </label>
+        </div>
+        <div class="inline align-top nowrap">
+          <%=
+            options = [
+              [:COMMENTS.l, :comment],
+              [:HERBARIA.l, :herbarium],
+              [:IMAGES.l, :image],
+              [:LOCATIONS.l, :location],
+              [:NAMES.l, :name],
+              [:OBSERVATIONS.l, :observation],
+              [:PROJECTS.l, :project],
+              [:SPECIES_LISTS.l, :species_list],
+              [:HERBARIUM_RECORDS.l, :herbarium_record],
+              [:USERS.l, :user],
+              [:app_search_google.l, :google],
+            ].sort
+            select(:search, :type,
+                   options_for_select(options,
+                                      session[:search_type] || :observation),
+                   {},
+                   {class: "form-control inline align-top",
+                    style: "width: auto;"})
+          %>
+          <%= submit_tag(:app_search.l, class: "btn align-top",
+                         style: "margin-right:0.5em") %>
+        </div>
 
-      <%
-        adv_search = link_to(:app_advanced_search.l.nowrap, controller: :observer,
-                             action: :advanced_search_form)
-        @timer_end ||= Time.now
-        secs = "%.2f" % (@timer_end.to_f - @timer_start.to_f)
-        timer = "(#{:app_index_timer.t(seconds: secs, num: @num_results.to_i)})"
-      %>
-      <% if @timer_start %>
-        <div class="inline hidden-xs" style="font-size:80%">
-          <span id="timer"><%= timer %></span><br/>
+        <%
+          adv_search = link_to(:app_advanced_search.l.nowrap, controller: :observer,
+                               action: :advanced_search_form)
+          @timer_end ||= Time.now
+          secs = "%.2f" % (@timer_end.to_f - @timer_start.to_f)
+          timer = "(#{:app_index_timer.t(seconds: secs, num: @num_results.to_i)})"
+        %>
+        <% if @timer_start %>
+          <div class="inline hidden-xs" style="font-size:80%">
+            <span id="timer"><%= timer %></span><br/>
+            <%= adv_search %>
+          </div>
+        <% else %>
+          <p class="form-control-static hidden-xs">
+            <%= adv_search %>
+          </p>
+        <% end %>
+        <div class="visible-xs">
+          <%= content_tag(:span, timer, id: "timer", class: "nowrap") if @timer_start %>
           <%= adv_search %>
         </div>
-      <% else %>
-        <p class="form-control-static hidden-xs">
-          <%= adv_search %>
-        </p>
-      <% end %>
-      <div class="visible-xs">
-        <%= content_tag(:span, timer, id: "timer", class: "nowrap") if @timer_start %>
-        <%= adv_search %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
 
   <% if @user.nil? %>
     <div class="nav navbar-nav navbar-form navbar-right hidden-xs" style="margin:0">

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1526,6 +1526,8 @@
   list_observations_location_define: Define This Location
   list_observations_location_merge: Merge With A Defined Location
   list_observations_suggestions: Other Links
+  list_observation_name: "[:NAME]"
+  list_observation_observations: Observations of
   list_observations_add_to_list: Add/Remove From Species List
   list_observations_download_as_csv: Download Observations
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3613,6 +3613,18 @@
   pattern_search_bad_date_range_error: Invalid value for [term], [value], expected date or date range of form YYYY, YYYY-YYYY, YYYY-MM, YYYY-MM-YYYY-MM, YYYY-MM-DD, YYYY-MM-DD-YYYY-MM-DD, MM, MM-MM or MM-DD-MM-DD.
   pattern_search_bad_rank_range_error: Invalid value for [term], [value], expected rank or range of ranks, e.g., "genus" or "species-form".
 
+  # <title> tags, used when there are no hits for a search
+  title_for_comment_search:          Comment Search
+  title_for_herbarium_search:        Herbarium Search
+  title_for_herbarium_record_search: Herbarium Record Search
+  title_for_image_search:            Image Search
+  title_for_location_search:         Location Search
+  title_for_name_search:             Name Search
+  title_for_observation_search:      Observation Search
+  title_for_project_search:          Project Search
+  title_for_species_list_search:     Species List Search
+  title_for_user_search:             User Search
+
   ################################################################################
 
   # LESS IMPORTANT ENUMERATED SETS OF VALUES

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1525,6 +1525,7 @@
   list_observations_location_all: All Locations
   list_observations_location_define: Define This Location
   list_observations_location_merge: Merge With A Defined Location
+  list_observations_alternate_spellings: Maybe you meant one of the following names?
   list_observations_suggestions: Other Links
   list_observation_name: "[:NAME]"
   list_observation_observations: Observations of

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1525,7 +1525,7 @@
   list_observations_location_all: All Locations
   list_observations_location_define: Define This Location
   list_observations_location_merge: Merge With A Defined Location
-  list_observations_alternate_spellings: Maybe you meant one of the following names?
+  list_observations_suggestions: Other Links
   list_observations_add_to_list: Add/Remove From Species List
   list_observations_download_as_csv: Download Observations
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3613,7 +3613,8 @@
   pattern_search_bad_date_range_error: Invalid value for [term], [value], expected date or date range of form YYYY, YYYY-YYYY, YYYY-MM, YYYY-MM-YYYY-MM, YYYY-MM-DD, YYYY-MM-DD-YYYY-MM-DD, MM, MM-MM or MM-DD-MM-DD.
   pattern_search_bad_rank_range_error: Invalid value for [term], [value], expected rank or range of ranks, e.g., "genus" or "species-form".
 
-  # <title> tags, used when there are no hits for a search
+  # content for html header title tag,
+  # used when there are no hits for a list or search
   title_for_comment_search:          Comment Search
   title_for_herbarium_search:        Herbarium Search
   title_for_herbarium_record_search: Herbarium Record Search

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -200,7 +200,8 @@ class AjaxControllerTest < FunctionalTestCase
   def test_auto_complete_user
     good_ajax_request(:auto_complete, type: :user, id: "Rover")
     assert_equal(
-      ["R", "rolf <Rolf Singer>", "roy <Roy Halling>", "second_roy <Roy Rogers>"],
+      ["R", "rolf <Rolf Singer>", "roy <Roy Halling>",
+       "second_roy <Roy Rogers>"],
       @response.body.split("\n")
     )
 

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -199,9 +199,10 @@ class AjaxControllerTest < FunctionalTestCase
 
   def test_auto_complete_user
     good_ajax_request(:auto_complete, type: :user, id: "Rover")
-    assert_equal([
-      "R", "rolf <Rolf Singer>", "roy <Roy Halling>", "second_roy <Roy Rogers>"
-    ], @response.body.split("\n"))
+    assert_equal(
+      ["R", "rolf <Rolf Singer>", "roy <Roy Halling>", "second_roy <Roy Rogers>"],
+      @response.body.split("\n")
+    )
 
     good_ajax_request(:auto_complete, type: :user, id: "Dodo")
     assert_equal(["D", "dick <Tricky Dick>"], @response.body.split("\n"))

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -199,8 +199,9 @@ class AjaxControllerTest < FunctionalTestCase
 
   def test_auto_complete_user
     good_ajax_request(:auto_complete, type: :user, id: "Rover")
-    assert_equal(["R", "rolf <Rolf Singer>", "roy <Roy Halling>"],
-                 @response.body.split("\n"))
+    assert_equal([
+      "R", "rolf <Rolf Singer>", "roy <Roy Halling>", "second_roy <Roy Rogers>"
+    ], @response.body.split("\n"))
 
     good_ajax_request(:auto_complete, type: :user, id: "Dodo")
     assert_equal(["D", "dick <Tricky Dick>"], @response.body.split("\n"))

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -541,6 +541,7 @@ class ObserverControllerTest < FunctionalTestCase
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
       @controller.instance_variable_get("@title")
     )
+    refute_empty(css_select('[id="right_tabs"]').text, "Tabset is empty")
 
     get_with_dump(:observation_search, pattern: pattern, page: 2)
     assert_template(:list_observations)
@@ -548,12 +549,14 @@ class ObserverControllerTest < FunctionalTestCase
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
       @controller.instance_variable_get("@title")
     )
+    refute_empty(css_select('[id="right_tabs"]').text, "Tabset is empty")
 
     # Prove that when there are no hits, there's no title
     pattern = "no hits"
     get_with_dump(:observation_search, pattern: pattern)
     assert_template(:list_observations)
     assert_empty(@controller.instance_variable_get("@title"))
+    assert_empty(css_select('[id="right_tabs"]').text, "Tabset should be empty")
 
     # If pattern is id of a real Observation, go directly to that Observation.
     obs = Observation.first

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -556,6 +556,9 @@ class ObserverControllerTest < FunctionalTestCase
     get_with_dump(:observation_search, pattern: pattern)
     assert_template(:list_observations)
     assert_empty(@controller.instance_variable_get("@title"))
+    assert_equal(css_select("title").text,
+                 "Mushroom Observer: Observation Search",
+                 "metadata <title> tag incorrect")
     assert_empty(css_select('[id="right_tabs"]').text, "Tabset should be empty")
 
     # If pattern is id of a real Observation, go directly to that Observation.
@@ -3436,8 +3439,8 @@ class ObserverControllerTest < FunctionalTestCase
 
     assert_empty(@controller.instance_variable_get("@title"),
                  "Displayed title should be empty")
-    assert_equal(css_select("title").text, "Mushroom Observer: user_search",
-                 "<title> metadata should be the action name")
+    assert_equal(css_select("title").text, "Mushroom Observer: User Search",
+                 "metadata <title> tag incorrect")
     assert_empty(css_select("#sorts"),
                  "There should be no sort links")
 

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -551,15 +551,16 @@ class ObserverControllerTest < FunctionalTestCase
     )
     refute_empty(css_select('[id="right_tabs"]').text, "Tabset is empty")
 
-    # Prove that when there are no hits, there's no title
+    # When there are no hits, no title is displayed, there's no rh tabset, and
+    # html <title> contents are the action name
     pattern = "no hits"
     get_with_dump(:observation_search, pattern: pattern)
     assert_template(:list_observations)
     assert_empty(@controller.instance_variable_get("@title"))
+    assert_empty(css_select('[id="right_tabs"]').text, "Tabset should be empty")
     assert_equal(css_select("title").text,
                  "Mushroom Observer: Observation Search",
                  "metadata <title> tag incorrect")
-    assert_empty(css_select('[id="right_tabs"]').text, "Tabset should be empty")
 
     # If pattern is id of a real Observation, go directly to that Observation.
     obs = Observation.first

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -534,17 +534,26 @@ class ObserverControllerTest < FunctionalTestCase
   end
 
   def test_observation_search
-    get_with_dump(:observation_search, pattern: "120")
+    pattern = "Boletus edulis"
+    get_with_dump(:observation_search, pattern: pattern)
     assert_template(:list_observations)
-    assert_equal(:query_title_pattern_search.t(types: "Observations",
-                                               pattern: "120"),
-                 @controller.instance_variable_get("@title"))
+    assert_equal(
+      :query_title_pattern_search.t(types: "Observations", pattern: pattern),
+      @controller.instance_variable_get("@title")
+    )
 
-    get_with_dump(:observation_search, pattern: "120", page: 2)
+    get_with_dump(:observation_search, pattern: pattern, page: 2)
     assert_template(:list_observations)
-    assert_equal(:query_title_pattern_search.t(types: "Observations",
-                                               pattern: "120"),
-                 @controller.instance_variable_get("@title"))
+    assert_equal(
+      :query_title_pattern_search.t(types: "Observations", pattern: pattern),
+      @controller.instance_variable_get("@title")
+    )
+
+    # Prove that when there are no hits, there's no title
+    pattern = "no hits"
+    get_with_dump(:observation_search, pattern: pattern)
+    assert_template(:list_observations)
+    assert_empty(@controller.instance_variable_get("@title"))
 
     # If pattern is id of a real Observation, go directly to that Observation.
     obs = Observation.first
@@ -3406,22 +3415,28 @@ class ObserverControllerTest < FunctionalTestCase
 
   # When pattern matches multiple users, list them.
   def test_user_search_multiple_hits
-    pattern = "name_sorts_user"
+    pattern = "Roy"
     get(:user_search, pattern: pattern)
     # matcher includes optional quotation mark (?.)
-    assert_match(/Users Matching .?#{pattern}/,
-                 css_select("title").text, "Wrong page")
+    assert_match(/Users Matching .?#{pattern}/, css_select("title").text,
+                 "Wrong page displayed")
 
     prove_sorting_links_include_contribution
   end
 
-  # When pattern has no matches, go to list page with flash message.
+  # When pattern has no matches, go to list page with flash message,
+  #  title not displayed and default metadata title
   def test_user_search_unmatched
     unmatched_pattern = "NonexistentUserContent"
     get_without_clearing_flash(:user_search, pattern: unmatched_pattern)
-    # matcher includes optional quotation mark (?.)
-    assert_match(/Users Matching .?#{unmatched_pattern}/,
-                 css_select("title").text, "Wrong page")
+    assert_template(:list_users)
+
+    assert_empty(@controller.instance_variable_get("@title"),
+                 "Displayed title should be empty")
+    assert_equal(css_select("title").text, "Mushroom Observer: user_search",
+                 "<title> metadata should be the action name")
+    assert_empty(css_select("#sorts"),
+                 "There should be no sort links")
 
     flash_text = :runtime_no_matches.l.sub("[types]", "users")
     assert_flash_text(flash_text)

--- a/test/fixtures/translation_strings.yml
+++ b/test/fixtures/translation_strings.yml
@@ -161,3 +161,12 @@ banner:
   text: This should show at the top of every page.
   updated_at: 2017-12-17 21:36:00
   user_id: 0
+
+title_for_user_search:
+  version: 1
+  language: english
+  tag: title_for_user_search
+  text: User Search
+  updated_at: 2017-12-17 21:36:00
+  user_id: 0
+

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -126,4 +126,7 @@ notes_templater: # 18
 thorsten: # 19
   <<: *DEFAULTS
   name: Thorsten Lumbsch
-  
+
+second_roy:
+  <<: *DEFAULTS
+  name: Roy Rogers

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -19,7 +19,7 @@ DEFAULTS: &DEFAULTS
 
 # Rolf is an experienced user
 # Also the default user for Images fixtures
-rolf: # 1
+rolf:
   <<: *DEFAULTS
   name: Rolf Singer
   license: ccwiki30
@@ -28,7 +28,7 @@ rolf: # 1
   user_groups: all_users, eol_users, eol_admins, reviewers, rolf_only
 
 # Mary has no images and no herbaria
-mary: # 2
+mary:
   <<: *DEFAULTS
   name: Mary Newbie
   keep_filenames: <%= User.keep_filenames[:keep_and_show] %>
@@ -36,13 +36,13 @@ mary: # 2
   mailing_address: 123 Some Pl., Pasadena, CA 91106
 
 # Junk gets denied
-junk: # 3
+junk:
   <<: *DEFAULTS
   name: Junk Box
 
 # Need third for testing votes
 # Also is the default user for Observation fixture set.
-dick: # 4
+dick:
   <<: *DEFAULTS
   name: Tricky Dick
   email_general_question: false
@@ -50,34 +50,34 @@ dick: # 4
   user_groups: all_users, bolete_users, bolete_admins, dick_only
 
 # Need fourth for testing votes
-katrina: # 5
+katrina:
   <<: *DEFAULTS
   name: Katrina
   keep_filenames: <%= User.keep_filenames[:keep_but_hide] %>
   user_groups: all_users, eol_users, katrina_only
 
 # Roy is a scientific user
-roy: # 6
+roy:
   <<: *DEFAULTS
   name: Roy Halling
   email_general_question: true
   location_format: <%= User.location_formats[:scientific] %>
 
-spammer: # 7
+spammer:
   <<: *DEFAULTS
   login: spamspamspam
 
 # Has nothing -- No: comments, descriptions, filters, images, locations, names,
 # observations, projects, publications, species lists, herbarium_records, or
 # anything except account
-zero_user: # 8
+zero_user:
   <<: *DEFAULTS
   login: zero
   contribution: 0
 
 # excludes imageless Observations from search results, rss feed
 # used by integration filter test
-ignore_imageless_user: # 9
+ignore_imageless_user:
   <<: *DEFAULTS
   verified:  2016-08-24 16:20:00
   content_filter: <%= { has_images: "yes" }.to_yaml.inspect %>
@@ -85,45 +85,45 @@ ignore_imageless_user: # 9
   layout_count: 96
 
 # hides unvouchered Observations
-vouchered_only_user: # 10
+vouchered_only_user:
   <<: *DEFAULTS
   verified:  2016-09-02 13:50:00
   content_filter: <%= { has_specimen: "yes" }.to_yaml.inspect %>
   layout_count: 24
 
-public_voter: # 11
+public_voter:
   <<: *DEFAULTS
 
 # Has multiple Observations whose sortable attributes are unique
 # Need for tests in which sort order is predictable, e.g.,
 # ObserverControllerIntegrationTest#test_destroy_observation_from_search
-sortable_obs_user: # 12
+sortable_obs_user:
   <<: *DEFAULTS
 
-uniquely_named_user: # 13
+uniquely_named_user:
   <<: *DEFAULTS
 
 # Owns the default Location for Observations
-obs_default_location_user: # 14
+obs_default_location_user:
   <<: *DEFAULTS
 
-small_thumbnail_user: # 15
+small_thumbnail_user:
   <<: *DEFAULTS
   thumbnail_size: small
 
-no_general_questions_user: # 16
+no_general_questions_user:
   <<: *DEFAULTS
   email_general_question: false
 
-article_writer: # 17
+article_writer:
   <<: *DEFAULTS
   user_groups:  all_users, $LABEL_only, article_writers
 
-notes_templater: # 18
+notes_templater:
   <<: *DEFAULTS
   notes_template: Cap, Nearby trees, odor
 
-thorsten: # 19
+thorsten:
   <<: *DEFAULTS
   name: Thorsten Lumbsch
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+# test the application-wide helpers
+class ApplicationHelperTest < ActionView::TestCase
+  def test_title_tag_contents
+    # Prove that if @title is present, <title> contents are @title
+    @title = "@title present"
+    action_name = "something_else"
+    assert_equal(@title,
+                 title_tag_contents(action_name))
+
+    # Prove that if @title is absent,
+    # and there's an en.txt label for :title_for_action_name,
+    # then <title> contents are the translation for that label
+    @title = ""
+    action_name = "user_search"
+    assert_equal("User Search",
+                 title_tag_contents(action_name))
+
+    # Prove that if @title is absent,
+    # and no en.txt label for :title_for_action_name,
+    # then <title> contents are action name humanized
+    @title = ""
+    action_name = "blah_blah"
+    assert_equal("Blah Blah",
+                 title_tag_contents(action_name))
+  end
+end


### PR DESCRIPTION
Clean up the views of search results, especially when there are no hits, or only one hit. See generally [Pivotal #154862044](#154862044) and [part of discussion, MO Developers > Synonymy etc.](#154862044)
- Prevent circular link in results of hitless Observation search;
- Improve wording of display for hitless Observation search;
- Don't show right tabset for hitless Observation search;
- On all search result pages, don't display title.
- On all search result pages, don't show sort bar unless there are at least 2 hits.