### PR TITLE
Fix link in Contributors [Delivers #154929981]

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,3 +2,6 @@ require "simplecov"
 require "coveralls"
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter "/test/"
+end

--- a/app/views/observer/users_by_contribution.html.erb
+++ b/app/views/observer/users_by_contribution.html.erb
@@ -35,11 +35,12 @@
             </div>
 
             <div class="col-xs-5">
-              <div>
-                <%= thumbnail(user.image_id, link: {action: :show_user},
-                              user: user.id, votes: false, size: :thumbnail) if user.image_id
-                %>
-              </div>
+              <%= if user.image_id
+                    thumbnail(user.image_id,
+                              link: { action: :show_user, id: user.id },
+                              votes: false, size: :thumbnail)
+                  end
+              %>
             </div>
 
           </div>


### PR DESCRIPTION
Clicking on a user profile image in Contributors should go to the user's page,
but instead gets:
>Sorry, the user you tried to display (id #) does not exist. Someone may have deleted it or merged it into another.
Your query has expired, please try again.

- Fixed thumbnail link by correctly including user.id in the target
- Made relevant part of view more readble:
  - Shortened lines
  - used If .. end instead of multi-line `if` modifier
- Deleted unnecessary <div>