### PR TITLE
Remove parens around literals which call `match?`

### DIFF
--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -41,8 +41,8 @@ module PatternSearch
       raise MissingValueError.new(var: var) if vals.empty?
       raise TooManyValuesError.new(var: var) if vals.length > 1
       val = vals.first
-      return true  if (/^(1|yes|true)$/i).match?(val)
-      return false if (/^(0|no|false)$/i).match?(val) && !only_yes
+      return true  if /^(1|yes|true)$/i.match?(val)
+      return false if /^(0|no|false)$/i.match?(val) && !only_yes
       raise BadYesError.new(var: var, val: val) if only_yes
       raise BadBooleanError.new(var: var, val: val)
     end
@@ -55,9 +55,9 @@ module PatternSearch
       raise MissingValueError.new(var: var) if vals.empty?
       raise TooManyValuesError.new(var: var) if vals.length > 1
       val = vals.first
-      return "only"   if (/^(1|yes|true)$/i).match?(val)
-      return "no"     if (/^(0|no|false)$/i).match?(val)
-      return "either" if (/^(both|either)$/i).match?(val)
+      return "only"   if /^(1|yes|true)$/i.match?(val)
+      return "no"     if /^(0|no|false)$/i.match?(val)
+      return "either" if /^(both|either)$/i.match?(val)
       raise BadYesNoBothError.new(var: var, val: val)
     end
 
@@ -70,8 +70,8 @@ module PatternSearch
       raise MissingValueError.new(var: var) if vals.empty?
       raise TooManyValuesError.new(var: var) if vals.length > 1
       val = vals.first
-      return "TRUE"  if (/^(1|yes|true)$/i).match?(val)
-      return "FALSE" if (/^(0|no|false)$/i).match?(val) && !only_yes
+      return "TRUE"  if /^(1|yes|true)$/i.match?(val)
+      return "FALSE" if /^(0|no|false)$/i.match?(val) && !only_yes
       raise BadYesError.new(var: var, val: val) if only_yes
       raise BadBooleanError.new(var: var, val: val)
     end
@@ -85,8 +85,8 @@ module PatternSearch
       raise MissingValueError.new(var: var) if vals.empty?
       raise TooManyValuesError.new(var: var) if vals.length > 1
       val = vals.first
-      return "NOT NULL" if (/^(1|yes|true)$/i).match?(val)
-      return "NULL"     if (/^(0|no|false)$/i).match?(val) && !only_yes
+      return "NOT NULL" if /^(1|yes|true)$/i.match?(val)
+      return "NULL"     if /^(0|no|false)$/i.match?(val) && !only_yes
       raise BadYesError.new(var: var, val: val) if only_yes
       raise BadBooleanError.new(var: var, val: val)
     end
@@ -183,7 +183,7 @@ module PatternSearch
       raise TooManyValuesError.new(var: var) if vals.length > 1
       val = vals.first
       raise BadFloatError.new(var: var, val:val, min: min, max: max) \
-        unless (/^-?(\d+(\.\d+)?|\.\d+)$/).match?(val.to_s)
+        unless /^-?(\d+(\.\d+)?|\.\d+)$/.match?(val.to_s)
       raise BadFloatError.new(var: var, val:val, min: min, max: max) \
         unless val.to_f >= min && val.to_f <= max
       return val.to_f

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -192,9 +192,9 @@ module Query::Modules::Validation
   def validate_date(arg, val)
     if val.acts_like?(:date)
       "%04d-%02d-%02d" % [val.year, val.mon, val.day]
-    elsif (/^\d\d\d\d(-\d\d?){0,2}$/i).match?(val.to_s)
+    elsif /^\d\d\d\d(-\d\d?){0,2}$/i.match?(val.to_s)
       val
-    elsif (/^\d\d?(-\d\d?)?$/i).match?(val.to_s)
+    elsif /^\d\d?(-\d\d?)?$/i.match?(val.to_s)
       val
     elsif val.blank? || val.to_s == "0"
       nil
@@ -209,7 +209,7 @@ module Query::Modules::Validation
       val = val.utc
       "%04d-%02d-%02d-%02d-%02d-%02d" %
         [val.year, val.mon, val.day, val.hour, val.min, val.sec]
-    elsif (/^\d\d\d\d(-\d\d?){0,5}$/i).match?(val.to_s)
+    elsif /^\d\d\d\d(-\d\d?){0,5}$/i.match?(val.to_s)
       val
     elsif val.blank? || val.to_s == "0"
       nil

--- a/app/classes/site_data.rb
+++ b/app/classes/site_data.rb
@@ -296,7 +296,7 @@ class SiteData
     if cond = FIELD_CONDITIONS[field]
       query << "WHERE #{cond}"
     end
-    if (/^(\w+)s_versions/).match?(field.to_s)
+    if /^(\w+)s_versions/.match?(field.to_s)
       # Does this actually make sense??
       # parent = $1
       # query[0] = "SELECT COUNT(DISTINCT #{parent}_id, user_id)"

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -221,7 +221,7 @@ class NameController < ApplicationController
     args = {
       action: "list_names",
       letters: "names.sort_name",
-      num_per_page: ((/^[a-z]/i).match?(params[:letter].to_s) ? 500 : 50)
+      num_per_page: (/^[a-z]/i.match?(params[:letter].to_s) ? 500 : 50)
     }.merge(args)
 
     # Tired of not having an easy link to list_names.

--- a/app/helpers/description_helper.rb
+++ b/app/helpers/description_helper.rb
@@ -223,7 +223,7 @@ module DescriptionHelper
              else
                :private.l
     end
-    result += " (#{permit})" unless (/(^| )#{permit}( |$)/i).match?(result)
+    result += " (#{permit})" unless /(^| )#{permit}( |$)/i.match?(result)
 
     t(result)
   end

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -271,8 +271,8 @@ module LanguageExporter
     val = clean_string(val)
     if /\\n|\n/.match?(val)
       val = format_multiline_string(escape_string(val))
-    elsif (/:(\s|$)| #/).match?(val) ||
-          (/^(no|yes)$/i).match?(val) ||
+    elsif /:(\s|$)| #/.match?(val) ||
+          /^(no|yes)$/i.match?(val) ||
           (/^\W/.match?(val) && val[0].is_ascii_character?)
       val = escape_string(val)
     elsif val == ""
@@ -373,7 +373,7 @@ module LanguageExporter
               "invalid tag quotes: #{quoted_tag.inspect}")
       @pass = false
     end
-    if (/^(yes|no)$/i).match?(quoted_tag)
+    if /^(yes|no)$/i.match?(quoted_tag)
       verbose("#{locale} #{@line_number}: " \
               "'yes' and 'no' must be quoted in YAML files")
       @pass = false
@@ -420,7 +420,7 @@ module LanguageExporter
   def validate_string(str)
     str = str.strip.squeeze(" ")
     pass = true
-    if (/^(yes|no)$/i).match?(str)
+    if /^(yes|no)$/i.match?(str)
       pass = false
     elsif /^'/.match?(str)
       pass = false unless /^'([^'\\]|\\.)*'$/.match?(str)
@@ -458,9 +458,9 @@ module LanguageExporter
   def validate_square_brackets_args(args)
     pass = true
     args.split(",").each do |pair|
-      unless (/^ :?\w+ = (
+      unless /^ :?\w+ = (
             '.*' | ".*" | -?\d+(\.\d+)? | :\w+ | [a-z][a-z_]*\d*
-          )$/x).match?(pair)
+          )$/x.match?(pair)
         pass = false
         break
       end

--- a/app/models/name/parse.rb
+++ b/app/models/name/parse.rb
@@ -444,17 +444,17 @@ class Name < AbstractModel
     # every other word, starting next-from-last, is an abbreviation
     i = words.length - 2
     while i > 0
-      words[i] = if (/^f/i).match?(words[i])
+      words[i] = if /^f/i.match?(words[i])
                    "f."
-                 elsif (/^v/i).match?(words[i])
+                 elsif /^v/i.match?(words[i])
                    "var."
-                 elsif (/^sect/i).match?(words[i])
+                 elsif /^sect/i.match?(words[i])
                    "sect."
-                 elsif (/^stirps/i).match?(words[i])
+                 elsif /^stirps/i.match?(words[i])
                    "stirps"
-                 elsif (/^subg/i).match?(words[i])
+                 elsif /^subg/i.match?(words[i])
                    "subgenus"
-                 elsif (/^subsect/i).match?(words[i])
+                 elsif /^subsect/i.match?(words[i])
                   "subsect."
                  else
                    "subsp."

--- a/test/models/pattern_search_test.rb
+++ b/test/models/pattern_search_test.rb
@@ -114,6 +114,82 @@ class PatternSearchTest < UnitTestCase
     assert_equal("either", x.parse_yes_no_both)
   end
 
+  def test_parse_to_true_false_string
+    x = PatternSearch::Term.new(:xxx)
+    x.vals = []
+    assert_raises(
+      PatternSearch::MissingValueError
+    ) { x.parse_to_true_false_string }
+    x.vals = [1, 2]
+    assert_raises(
+      PatternSearch::TooManyValuesError
+    ) { x.parse_to_true_false_string }
+    x.vals = ["1"]
+    assert_equal("TRUE", x.parse_to_true_false_string)
+    x.vals = ["yes"]
+    assert_equal("TRUE", x.parse_to_true_false_string)
+    x.vals = ["true"]
+    assert_equal("TRUE", x.parse_to_true_false_string)
+    x.vals = ["TRUE"]
+    assert_equal("TRUE", x.parse_to_true_false_string)
+
+    x.vals = ["0"]
+    assert_equal("FALSE", x.parse_to_true_false_string)
+    x.vals = ["no"]
+    assert_equal("FALSE", x.parse_to_true_false_string)
+    x.vals = ["false"]
+    assert_equal("FALSE", x.parse_to_true_false_string)
+    x.vals = ["FALSE"]
+    assert_equal("FALSE", x.parse_to_true_false_string)
+
+    x.vals = ["xxx"]
+    assert_raises(
+      PatternSearch::BadBooleanError
+    ) { x.parse_to_true_false_string }
+    x.vals = ["no"]
+    assert_raises(
+      PatternSearch::BadYesError
+    ) { x.parse_to_true_false_string(:only_yes) }
+  end
+
+  def test_parse_to_null_not_null_string
+    x = PatternSearch::Term.new(:xxx)
+    x.vals = []
+    assert_raises(
+      PatternSearch::MissingValueError
+    ) { x.parse_to_null_not_null_string }
+    x.vals = [1, 2]
+    assert_raises(
+      PatternSearch::TooManyValuesError
+    ) { x.parse_to_null_not_null_string }
+    x.vals = ["1"]
+    assert_equal("NOT NULL", x.parse_to_null_not_null_string)
+    x.vals = ["yes"]
+    assert_equal("NOT NULL", x.parse_to_null_not_null_string)
+    x.vals = ["true"]
+    assert_equal("NOT NULL", x.parse_to_null_not_null_string)
+    x.vals = ["TRUE"]
+    assert_equal("NOT NULL", x.parse_to_null_not_null_string)
+
+    x.vals = ["0"]
+    assert_equal("NULL", x.parse_to_null_not_null_string)
+    x.vals = ["no"]
+    assert_equal("NULL", x.parse_to_null_not_null_string)
+    x.vals = ["false"]
+    assert_equal("NULL", x.parse_to_null_not_null_string)
+    x.vals = ["FALSE"]
+    assert_equal("NULL", x.parse_to_null_not_null_string)
+
+    x.vals = ["xxx"]
+    assert_raises(
+      PatternSearch::BadBooleanError
+    ) { x.parse_to_null_not_null_string }
+    x.vals = ["no"]
+    assert_raises(
+      PatternSearch::BadYesError
+    ) { x.parse_to_null_not_null_string(:only_yes) }
+  end
+
   def test_parse_float
     x = PatternSearch::Term.new(:xxx)
     x.vals = []


### PR DESCRIPTION
These are unnecessary and they make RuboCop sad.