### PR TITLE
Other taxa this name

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -41,12 +41,12 @@
 #  4) observations with naming @name whose consensus is not a synonym of @name
 #
 #    query = Query.lookup(:Observation, :of_name, name: @name)
-#    query = Query.lookup(:Observation, :of_name,
-#                         name: @name, synonyms: :exclusive)
-#    query = Query.lookup(:Observation, :of_name,
-#                         name: @name, synonyms: :all, nonconsensus: :exclusive)
-#    query = Query.lookup(:Observation, :of_name,
-#                         name: @name, nonconsensus: :other_taxa)
+#    query = Query.lookup(:Observation, :of_name, name: @name,
+#                         synonyms: :exclusive)
+#    query = Query.lookup(:Observation, :of_name, name: @name,
+#                         synonyms: :all, nonconsensus: :exclusive)
+#    query = Query.lookup(:Observation, :of_name, name: @name,
+#                         synonyms: :all, nonconsensus: :mixed)
 #
 #  You may further tweak a query after it's been created:
 #

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -34,16 +34,19 @@
 #
 #    query = Query.lookup(:Observation, :by_user, user: @user)
 #
-#  Get observations in the three sections of show_name:
+#  Get observations in the sections of show_name and show_observation:
 #  1) observations whose consensus is @name
 #  2) observations whose consensus is synonym of @name
 #  3) observations with non-consensus naming that is a synonym of @name
+#  4) observations with naming @name whose consensus is not a synonym of @name
 #
 #    query = Query.lookup(:Observation, :of_name, name: @name)
 #    query = Query.lookup(:Observation, :of_name,
 #                         name: @name, synonyms: :exclusive)
 #    query = Query.lookup(:Observation, :of_name,
 #                         name: @name, synonyms: :all, nonconsensus: :exclusive)
+#    query = Query.lookup(:Observation, :of_name,
+#                         name: @name, nonconsensus: :other_taxa)
 #
 #  You may further tweak a query after it's been created:
 #

--- a/app/classes/query/initializers/of_name.rb
+++ b/app/classes/query/initializers/of_name.rb
@@ -6,7 +6,7 @@ module Query
         {
           name:          :name,
           synonyms?:     { string: [:no, :all, :exclusive] },
-          nonconsensus?: { string: [:no, :all, :exclusive, :other_taxa] }
+          nonconsensus?: { string: [:no, :all, :exclusive, :mixed] }
         }
       end
 
@@ -54,7 +54,7 @@ module Query
           add_name_conditions_all_namings(id_set)
         elsif params[:nonconsensus] == :exclusive
           add_name_conditions_just_losers(id_set)
-        elsif params[:nonconsensus] == :other_taxa
+        elsif params[:nonconsensus] == :mixed
           add_name_conditions_other_taxa(
             included_naming: names.first.id,
             excluded_names: corresponding_name_id_set(names)

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -47,8 +47,9 @@ module ShowNameHelper
   # (but this taxon is not the consensus)
   def name_proposed(name)
     query = Query.lookup(:Observation, :of_name,
-                         name: name, by: :confidence, synonyms: :no,
-                         nonconsensus: :exclusive)
+                         name: name, by: :confidence,
+                         synonyms: :all,
+                         nonconsensus: :mixed)
     link_to_obss_of(query, :obss_name_proposed.t)
   end
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2529,7 +2529,8 @@ class QueryTest < UnitTestCase
       Observation.joins(:namings).
                   where("namings.name" => this_name.id).
                   where.not(name: taxon_names),
-      :Observation, :of_name, name: this_name.id, nonconsensus: :other_taxa
+      :Observation, :of_name, name: this_name.id,
+      synonyms: :all, nonconsensus: :mixed
     )
   end
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2498,6 +2498,41 @@ class QueryTest < UnitTestCase
                                          nonconsensus: :all)
   end
 
+  def test_observation_other_taxa_this_name
+    user           = users(:rolf)
+    this_name      = names(:peltigera)
+    synonym        = names(:petigera)
+    taxon_names    = [this_name, synonym]
+    other_taxon    = names(:suillus)
+
+    # Observations of taxon
+    this_name_obs  = Observation.create(name: this_name, user: user)
+    synonym_obs    = Observation.create(name: synonym, user: user)
+
+    Observation.create(name: this_name, user: user)
+    Naming.create(observation: this_name_obs, name: synonym, user: user)
+    Observation.create(name: synonym, user: user)
+    Naming.create(observation: synonym_obs, name: this_name, user: user)
+
+    other_taxon_this_name_proposed = Observation.create(name: other_taxon,
+                                                        user: user)
+    Naming.create(
+      observation: other_taxon_this_name_proposed, name: this_name, user: user
+    )
+    other_taxon_synonym_proposed = Observation.create(name: other_taxon,
+                                                      user: user)
+    Naming.create(
+      observation: other_taxon_synonym_proposed, name: synonym, user: user
+    )
+
+    assert_query(
+      Observation.joins(:namings).
+                  where("namings.name" => this_name.id).
+                  where.not(name: taxon_names),
+      :Observation, :of_name, name: this_name.id, nonconsensus: :other_taxa
+    )
+  end
+
   def test_observation_pattern_search
     # notes
     assert_query([observations(:agaricus_campestras_obs).id,


### PR DESCRIPTION
Fix a bug in the link to Observations of: Other Taxa, this name proposed
- Add an option to the Query `nonconsensus` parameter to allow this kind of search
- Use the new search in the link

See generally [Pivotal #155310823](https://www.pivotaltracker.com/story/show/155310823)