### PR TITLE
Obss of name

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -511,11 +511,6 @@ Metrics/PerceivedComplexity:
 Naming/AccessorMethodName:
   Enabled: false
 
-# Offense count: 1
-Naming/BinaryOperatorParameterName:
-  Exclude:
-    - 'app/models/name.rb'
-
 # Offense count: 14
 # Configuration parameters: Blacklist.
 # Blacklist: END, (?-mix:EO[A-Z]{1})
@@ -676,7 +671,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/image.rb'
     - 'app/models/license.rb'
     - 'app/models/location.rb'
-    - 'app/models/name.rb'
     - 'app/models/observation.rb'
     - 'app/models/synonym.rb'
     - 'app/models/user.rb'
@@ -692,7 +686,6 @@ Rails/InverseOf:
     - 'app/models/image.rb'
     - 'app/models/location.rb'
     - 'app/models/location_description.rb'
-    - 'app/models/name.rb'
     - 'app/models/name_description.rb'
     - 'app/models/observation.rb'
     - 'app/models/project.rb'
@@ -961,7 +954,6 @@ Style/IdenticalConditionalBranches:
     - 'app/controllers/location_controller.rb'
     - 'app/controllers/name_controller.rb'
     - 'app/controllers/species_list_controller.rb'
-    - 'app/models/name.rb'
     - 'script/s3ls.rb'
 
 # Offense count: 7

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -13,45 +13,6 @@ module ShowNameHelper
     label + ": " + content_tag(:span, links.safe_join(", "), class: :Data)
   end
 
-  # link to a search for Observations of name and a count of those observations
-  #   This Name (1)
-  def obss_of_name(name)
-    query = Query.lookup(:Observation, :of_name, name: name, by: :confidence)
-    link_to_obss_of(query, :obss_of_this_name.t)
-  end
-
-  # link to a search for Observations of this taxon (under any name) + count
-  def taxon_observations(name)
-    query = Query.lookup(:Observation, :of_name,
-                         name: name, by: :confidence, synonyms: :all)
-    link_to_obss_of(query, :obss_of_taxon.t)
-  end
-
-  # link to a search for observations of this taxon, under other names + count
-  def taxon_obss_other_names(name)
-    query = Query.lookup(:Observation, :of_name,
-                         name: name, by: :confidence, synonyms: :exclusive)
-    link_to_obss_of(query, :taxon_obss_other_names.t)
-  end
-
-  # link to a search for observations where this taxon was proposed + count
-  # (but is not the consensus)
-  def taxon_proposed(name)
-    query = Query.lookup(:Observation, :of_name,
-                         name: name, by: :confidence, synonyms: :all,
-                         nonconsensus: :exclusive)
-    link_to_obss_of(query, :obss_taxon_proposed.t)
-  end
-
-  # link to a search for observations where this name was proposed + count
-  # (but this taxon is not the consensus)
-  def name_proposed(name)
-    query = Query.lookup(:Observation, :of_name,
-                         name: name, by: :confidence, synonyms: :no,
-                         nonconsensus: :exclusive)
-    link_to_obss_of(query, :obss_name_proposed.t)
-  end
-
   # array of lines for other accepted synonyms, each line comprising
   # link to observations of synonym and a count of those observations
   #   Chlorophyllum rachodes (Vittadini) Vellinga (96)

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 # helpers for ShowName view and ShowNameInfo section of ShowObservation
 module ShowNameHelper
   # string of links to Names of any other non-deprecated synonyms
@@ -18,20 +20,18 @@ module ShowNameHelper
   #   Chlorophyllum rachodes (Vittadini) Vellinga (96)
   #   Chlorophyllum rhacodes (Vittadini) Vellinga (63)
   def obss_by_syn_links(name)
-    name.other_approved_synonyms.each_with_object([]) do |nm, lines|
-      query = Query.lookup(:Observation, :of_name, name: nm, by: :confidence)
+    name.other_approved_synonyms.each_with_object([]) do |synonym, lines|
+      query = synonym.obss_of_name
       next if query.select_count.zero?
 
-      lines << link_to_obss_of(query, nm.display_name.t)
+      lines << link_to_obss_of(query, synonym.display_name.t)
     end
   end
 
-  # return link to a query for observations + count of results
-  # returns nil of no results
+  # link to an Observation query, followed by count of results
+  # returns nil if no results
   # Use:
-  #   query = Query.lookup(:Observation, :of_name, name: name, by: :confidence,
-  #                        synonyms: :all)
-  #   link_to_obss_of(query, :obss_of_taxon.t)
+  #   link_to_obss_of(name.obss_of_taxon, :obss_of_taxon.t)
   #   => <a href="/observer/index_observation?q=Q">This Taxon, any name</a> (19)
   def link_to_obss_of(query, title)
     count = query.select_count

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -244,6 +244,17 @@
 #  mergeable?::              Is it safe to merge this Name into another?
 #  merge::                   Merge old name into this one and remove old one.
 #
+#  ==== Observation Queries
+#  obss_of_name              Observations of this Name
+#  obss_of_taxon             Observations of this taxon
+#  obss_of_taxon_other_names Observations of this taxon under other Names
+#  obss_of_other_taxa_this_name_proposed
+#                            Observations of other taxa
+#                            where this name was proposed
+#  obss_of_other_taxa_this_taxon_proposed(by: :confidence)
+#                            Observations of other taxa
+#                            where this taxon was proposed
+#
 #  == Callbacks
 #
 #  create_description::      After create: create (empty) official
@@ -262,6 +273,7 @@ class Name < AbstractModel
   require_dependency "name/merge"
   require_dependency "name/spelling"
   require_dependency "name/notify"
+  require_dependency "name/queries"
   require_dependency "name/parse"
   require_dependency "name/resolve"
   require_dependency "name/synonymy"

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 #  = Name Model
 #
 #  This model describes a single scientific name.  The related class Synonym,
@@ -303,17 +305,21 @@ class Name < AbstractModel
           source: :rank,
           accessor: :whiny)
 
-  belongs_to :correct_spelling, class_name: "Name",
-                                foreign_key: "correct_spelling_id"
-  belongs_to :description, class_name: "NameDescription" # (main one)
+  belongs_to :correct_spelling, # rubocop:disable Rails/InverseOf
+             class_name: "Name",
+             foreign_key: "correct_spelling_id"
+  belongs_to :description, class_name: "NameDescription",
+                           inverse_of: :name # (main one)
   belongs_to :rss_log
   belongs_to :synonym
+
   belongs_to :user
 
   has_many :descriptions, -> { order "num_views DESC" },
-           class_name: "NameDescription"
-  has_many :comments,  as: :target, dependent: :destroy
-  has_many :interests, as: :target, dependent: :destroy
+           class_name: "NameDescription",
+           inverse_of:  :name
+  has_many :comments,  as: :target, dependent: :destroy, inverse_of: :target
+  has_many :interests, as: :target, dependent: :destroy, inverse_of: :target
   has_many :namings
   has_many :observations
 
@@ -377,8 +383,8 @@ class Name < AbstractModel
     end
   end
 
-  def <=>(x)
-    sort_name <=> x.sort_name
+  def <=>(other)
+    sort_name <=> other.sort_name
   end
 
   def best_brief_description

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -391,7 +391,7 @@ class Name < AbstractModel
     Observation.where("name_id = #{id} AND vote_cache >= 2.4").to_a
   end
 
-  # Get list of common names to prime auto-completer.  Returns a simple Array
+  # Get list of most used names to prime auto-completer.  Returns a simple Array
   # of up to 1000 name String's (no authors).
   #
   # *NOTE*: Since this is an expensive query (well, okay it only takes a tenth
@@ -399,33 +399,40 @@ class Name < AbstractModel
   # in a plain old file (MO.name_primer_cache_file).
   #
   def self.primer
-    result = []
-    if !File.exist?(MO.name_primer_cache_file) ||
-       File.mtime(MO.name_primer_cache_file) < Time.now - 1.day
-
-      # Get list of names sorted by how many times they've been used, then
-      # re-sort by name.
-      result = connection.select_values(%(
-        SELECT names.text_name, COUNT(*) AS n
-        FROM namings
-        LEFT OUTER JOIN names ON names.id = namings.name_id
-        WHERE correct_spelling_id IS NULL
-        GROUP BY names.text_name
-        ORDER BY n DESC
-        LIMIT 1000
-      )).uniq.sort
-
-      FileUtils.mkdir_p(File.dirname(MO.name_primer_cache_file))
-      file = File.open(MO.name_primer_cache_file, "w:utf-8")
-      file.write(result.join("\n") + "\n")
-      file.close
+    if name_primer_cache_current?
+      File.open(MO.name_primer_cache_file, "r:UTF-8") do |file|
+        return file.readlines.map(&:chomp)
+      end
     else
-      file = File.open(MO.name_primer_cache_file, "r:UTF-8")
-      result = file.readlines.map(&:chomp)
-      file.close
+      result = most_used_names
+      FileUtils.mkdir_p(File.dirname(MO.name_primer_cache_file))
+      File.open(MO.name_primer_cache_file, "w:utf-8") do |file|
+        file.write(result.join("\n") + "\n")
+      end
+      result
     end
-    result
   end
+
+  def self.name_primer_cache_current?
+    File.exist?(MO.name_primer_cache_file) &&
+      File.mtime(MO.name_primer_cache_file) >= Time.now - 1.day
+  end
+  private_class_method :name_primer_cache_current?
+
+  # Get list of names sorted by how many times they've been used, then
+  # re-sort by name.
+  def self.most_used_names(limit = 1000)
+    connection.select_values(%(
+      SELECT names.text_name, COUNT(*) AS n
+      FROM namings
+      LEFT OUTER JOIN names ON names.id = namings.name_id
+      WHERE correct_spelling_id IS NULL
+      GROUP BY names.text_name
+      ORDER BY n DESC
+      LIMIT #{limit}
+    )).uniq.sort
+  end
+  private_class_method :most_used_names
 
   # Used by show_name.
   def self.count_observations(names)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -273,6 +273,7 @@ class Name < AbstractModel
   require_dependency "name/notify"
   require_dependency "name/queries"
   require_dependency "name/parse"
+  require_dependency "name/primer"
   require_dependency "name/resolve"
   require_dependency "name/synonymy"
   require_dependency "name/taxonomy"
@@ -383,49 +384,6 @@ class Name < AbstractModel
   def best_brief_description
     (description.gen_desc.presence || description.diag_desc) if description
   end
-
-  # Get list of most used names to prime auto-completer.  Returns a simple Array
-  # of up to 1000 name String's (no authors).
-  #
-  # *NOTE*: Since this is an expensive query (well, okay it only takes a tenth
-  # of a second but that could change...), it gets cached periodically (daily?)
-  # in a plain old file (MO.name_primer_cache_file).
-  #
-  def self.primer
-    if name_primer_cache_current?
-      File.open(MO.name_primer_cache_file, "r:UTF-8") do |file|
-        return file.readlines.map(&:chomp)
-      end
-    else
-      result = most_used_names
-      FileUtils.mkdir_p(File.dirname(MO.name_primer_cache_file))
-      File.open(MO.name_primer_cache_file, "w:utf-8") do |file|
-        file.write(result.join("\n") + "\n")
-      end
-      result
-    end
-  end
-
-  def self.name_primer_cache_current?
-    File.exist?(MO.name_primer_cache_file) &&
-      File.mtime(MO.name_primer_cache_file) >= Time.now - 1.day
-  end
-  private_class_method :name_primer_cache_current?
-
-  # Get list of names sorted by how many times they've been used, then
-  # re-sort by name.
-  def self.most_used_names(limit = 1000)
-    connection.select_values(%(
-      SELECT names.text_name, COUNT(*) AS n
-      FROM namings
-      LEFT OUTER JOIN names ON names.id = namings.name_id
-      WHERE correct_spelling_id IS NULL
-      GROUP BY names.text_name
-      ORDER BY n DESC
-      LIMIT #{limit}
-    )).uniq.sort
-  end
-  private_class_method :most_used_names
 
   # Used by show_name.
   def self.count_observations(names)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1,4 +1,3 @@
-#
 #  = Name Model
 #
 #  This model describes a single scientific name.  The related class Synonym,
@@ -228,7 +227,6 @@
 #  deprecated::              Is this name deprecated?
 #  status::                  Returns "Deprecated" or "Valid".
 #  change_deprecated::       Changes deprecation status.
-#  reviewed_observations::   (not used by anyone)
 #
 #  ==== Attachments
 #  versions::                Old versions.
@@ -384,11 +382,6 @@ class Name < AbstractModel
 
   def best_brief_description
     (description.gen_desc.presence || description.diag_desc) if description
-  end
-
-  # Get an Array of Observation's for this Name that have > 80% confidence.
-  def reviewed_observations
-    Observation.where("name_id = #{id} AND vote_cache >= 2.4").to_a
   end
 
   # Get list of most used names to prime auto-completer.  Returns a simple Array

--- a/app/models/name/primer.rb
+++ b/app/models/name/primer.rb
@@ -1,0 +1,53 @@
+# Prime the name auto-completer
+class Name < AbstractModel
+  # Get list of most used names to prime auto-completer.
+  # Return a simple Array of up to 1000 name String's (no authors).
+  #
+  # *NOTE*: Since this is an expensive query (well, okay it only takes a tenth
+  # of a second but that could change...), it gets cached periodically (daily?)
+  # in a plain old file (MO.name_primer_cache_file).
+  #
+  def self.primer
+    current_name_cache || refreshed_name_cache
+  end
+
+  # private class methods
+  class << self
+    private
+
+    def current_name_cache
+      return unless name_primer_cache_current?
+      File.open(MO.name_primer_cache_file, "r:UTF-8") do |file|
+        return file.readlines.map(&:chomp)
+      end
+    end
+
+    def name_primer_cache_current?
+      File.exist?(MO.name_primer_cache_file) &&
+        File.mtime(MO.name_primer_cache_file) >= Time.now - 1.day
+    end
+
+    def refreshed_name_cache
+      result = most_used_names
+      FileUtils.mkdir_p(File.dirname(MO.name_primer_cache_file))
+      File.open(MO.name_primer_cache_file, "w:utf-8") do |file|
+        file.write(result.join("\n") + "\n")
+      end
+      result
+    end
+
+    # List of names sorted by how many times they've been used,
+    # then re-sorted by name.
+    def most_used_names(limit = 1000)
+      connection.select_values(%(
+        SELECT names.text_name, COUNT(*) AS n
+        FROM namings
+        LEFT OUTER JOIN names ON names.id = namings.name_id
+        WHERE correct_spelling_id IS NULL
+        GROUP BY names.text_name
+        ORDER BY n DESC
+        LIMIT #{limit}
+      )).uniq.sort
+    end
+  end
+end

--- a/app/models/name/primer.rb
+++ b/app/models/name/primer.rb
@@ -38,7 +38,7 @@ class Name < AbstractModel
 
     # List of names sorted by how many times they've been used,
     # then re-sorted by name.
-    def most_used_names(limit = 1000)
+    def most_used_names
       connection.select_values(%(
         SELECT names.text_name, COUNT(*) AS n
         FROM namings
@@ -46,7 +46,7 @@ class Name < AbstractModel
         WHERE correct_spelling_id IS NULL
         GROUP BY names.text_name
         ORDER BY n DESC
-        LIMIT #{limit}
+        LIMIT 1000
       )).uniq.sort
     end
   end

--- a/app/models/name/queries.rb
+++ b/app/models/name/queries.rb
@@ -1,0 +1,34 @@
+# Wrappers around, and modifications of, various Query's
+class Name < AbstractModel
+  def obss_of_name(by: :confidence)
+    ::Query.lookup(:Observation, :of_name, name: self, by: by,
+                   synonyms: :no)
+  end
+
+  def obss_of_taxon(by: :confidence)
+    ::Query.lookup(:Observation, :of_name, name: self, by: by,
+                   synonyms: :all)
+  end
+
+  def obss_of_taxon_other_names(by: :confidence)
+    ::Query.lookup(:Observation, :of_name, name: self, by: by,
+                   synonyms: :exclusive)
+  end
+
+  def obss_of_other_taxa_this_name_proposed(by: :confidence)
+    ::Query.lookup(
+      :Observation, :of_name, name: self, by: by,
+      nonconsensus: :all,
+      where: [
+        "(observations.name_id NOT IN (#{self.synonyms.map(&:id).join(',')}) OR
+          COALESCE(observations.vote_cache,0) < 0)"
+      ]
+    )
+  end
+
+  def obss_of_other_taxa_this_taxon_proposed(by: :confidence)
+    ::Query.lookup(:Observation, :of_name, name: self, by: by,
+                   synonyms: :all,
+                   nonconsensus: :exclusive)
+  end
+end

--- a/app/models/name/queries.rb
+++ b/app/models/name/queries.rb
@@ -1,26 +1,29 @@
+# frozen_string_literal: true
+#
 # Wrappers around, and modifications of, various Query's
 class Name < AbstractModel
   def obss_of_name(by: :confidence)
     ::Query.lookup(:Observation, :of_name, name: self, by: by,
-                   synonyms: :no)
+                                           synonyms: :no)
   end
 
   def obss_of_taxon(by: :confidence)
     ::Query.lookup(:Observation, :of_name, name: self, by: by,
-                   synonyms: :all)
+                                           synonyms: :all)
   end
 
   def obss_of_taxon_other_names(by: :confidence)
     ::Query.lookup(:Observation, :of_name, name: self, by: by,
-                   synonyms: :exclusive)
+                                           synonyms: :exclusive)
   end
 
   def obss_of_other_taxa_this_name_proposed(by: :confidence)
     ::Query.lookup(
-      :Observation, :of_name, name: self, by: by,
+      :Observation, :of_name,
+      name: self, by: by,
       nonconsensus: :all,
       where: [
-        "(observations.name_id NOT IN (#{self.synonyms.map(&:id).join(',')}) OR
+        "(observations.name_id NOT IN (#{synonyms.map(&:id).join(",")}) OR
           COALESCE(observations.vote_cache,0) < 0)"
       ]
     )
@@ -28,7 +31,7 @@ class Name < AbstractModel
 
   def obss_of_other_taxa_this_taxon_proposed(by: :confidence)
     ::Query.lookup(:Observation, :of_name, name: self, by: by,
-                   synonyms: :all,
-                   nonconsensus: :exclusive)
+                                           synonyms: :all,
+                                           nonconsensus: :exclusive)
   end
 end

--- a/app/views/name/show_name.html.erb
+++ b/app/views/name/show_name.html.erb
@@ -62,20 +62,27 @@
             <div class="indent-one-em">
               <%= # Observations of this name
                 content_tag(:p,
-                  obss_of_name(@name) || "#{:obss_of_this_name.t} (0)")  %>
+                  link_to_obss_of(@name.obss_of_name, :obss_of_this_name.t) ||
+                  "#{:obss_of_this_name.t} (0)")  %>
               <%= # Observations of taxon under other names
                 content_tag(:p,
-                  taxon_obss_other_names(@name) ||
-                    "#{:taxon_obss_other_names.t} (0)") %>
+                  link_to_obss_of(@name.obss_of_taxon_other_names,
+                                  :taxon_obss_other_names.t) ||
+                  "#{:taxon_obss_other_names.t} (0)") %>
               <%= # Observations of taxon under any name
                 content_tag(:p,
-                  taxon_observations(@name) || "#{:obss_of_taxon.t} (0)") %>
+                  link_to_obss_of(@name.obss_of_taxon, :obss_of_taxon.t) ||
+                  "#{:obss_of_taxon.t} (0)") %>
               <%= # Observations of other taxa where this name was proposed
                 content_tag(:p,
-                  name_proposed(@name) || "#{:obss_name_proposed.t} (0)") %>
+                  link_to_obss_of(@name.obss_of_other_taxa_this_name_proposed,
+                                  :obss_name_proposed.t) ||
+                  "#{:obss_name_proposed.t} (0)") %>
               <%= # Observations of other taxa where this taxon was proposed
                 content_tag(:p,
-                  taxon_proposed(@name) || "#{:obss_taxon_proposed.t} (0)") %>
+                  link_to_obss_of(@name.obss_of_other_taxa_this_taxon_proposed,
+                                  :obss_taxon_proposed.t) ||
+                 "#{:obss_taxon_proposed.t} (0)") %>
               <%= name_section_link(:show_subtaxa_obss.t,
                                     @has_subtaxa, @subtaxa_query) %>
             </div>

--- a/app/views/observer/_show_name_info.html.erb
+++ b/app/views/observer/_show_name_info.html.erb
@@ -25,7 +25,10 @@
   <%= content_tag(:p, :show_observations_of.t) %>
   <div class="indent-one-em">
     <%= # Observations of this name
-    content_tag(:p, obss_of_name(name)) %>
+    content_tag(
+      :p, link_to_obss_of(name.obss_of_name, :obss_of_this_name.t)
+    )
+    %>
 
     <% # Observations of each synonym
     links = obss_by_syn_links(name)
@@ -34,15 +37,19 @@
     <% end %>
 
     <%= # Observations of taxon (under any name)
-    content_tag(:p, taxon_observations(name)) %>
+    content_tag(:p, link_to_obss_of(name.obss_of_taxon, :obss_of_taxon.t)) %>
 
     <%= # Observations of other taxa where this name was proposed
       content_tag(:p,
-        name_proposed(name) || "#{:obss_name_proposed.t} (0)") %>
+        link_to_obss_of(name.obss_of_other_taxa_this_name_proposed,
+                        :obss_name_proposed.t) ||
+        "#{:obss_name_proposed.t} (0)") %>
 
     <%= # Observations of other taxa where this taxon was proposed
       content_tag(:p,
-        taxon_proposed(name) || "#{:obss_taxon_proposed.t} (0)") %>
+        link_to_obss_of(name.obss_of_other_taxa_this_taxon_proposed,
+                        :obss_taxon_proposed.t) ||
+        "#{:obss_taxon_proposed.t} (0)") %>
   </div>
 
     <%= # List of species in the genus.

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 require "test_helper"
 
 class NameTest < UnitTestCase
@@ -18,16 +20,16 @@ class NameTest < UnitTestCase
     assert parse, "Expected #{str.inspect} to parse!"
     any_errors = false
     msg = ["Name is wrong; expected -vs- actual:"]
-    %i[
-      text_name
-      real_text_name
-      search_name
-      real_search_name
-      sort_name
-      display_name
-      parent_name
-      rank
-      author
+    [
+      :text_name,
+      :real_text_name,
+      :search_name,
+      :real_search_name,
+      :sort_name,
+      :display_name,
+      :parent_name,
+      :rank,
+      :author
     ].each do |var|
       expect = expects[var]
       actual = if var == :real_text_name
@@ -288,7 +290,7 @@ class NameTest < UnitTestCase
     assert_no_match(pat, '"Sp-ABC"')
     assert_no_match(pat, '"S01"')
     assert_no_match(pat, '"Abc\'')
-    assert_no_match(pat, '\'Abc\'')
+    assert_no_match(pat, "\'Abc\'")
     assert_no_match(pat, '\'"Abc"')
     assert_match(pat, "Abc-def")
     assert_no_match(pat, "Abcdef-")
@@ -311,7 +313,7 @@ class NameTest < UnitTestCase
     assert_no_match(pat, '"sp. S01"')
     assert_no_match(pat, '"S01"')
     assert_no_match(pat, '"abc\'')
-    assert_no_match(pat, '\'abc\'')
+    assert_no_match(pat, "\'abc\'")
     assert_no_match(pat, '\'"abc"')
     assert_match(pat, "abc-def")
     assert_no_match(pat, "abcdef-")
@@ -365,9 +367,9 @@ class NameTest < UnitTestCase
     assert_name_match_author_optional(pat, "Amanita sp.", "Amanita")
     assert_name_match_author_optional(pat, '"Amanita"')
     assert_name_match_author_optional(pat, '"Amanita" sp.', '"Amanita"')
-    assert_name_match_author_optional(pat, 'Fossil-Okay')
-    assert_name_match_author_optional(pat, 'Fossil-Okay sp.', 'Fossil-Okay')
-    assert_no_match(pat, 'Anythingelse-Bad')
+    assert_name_match_author_optional(pat, "Fossil-Okay")
+    assert_name_match_author_optional(pat, "Fossil-Okay sp.", "Fossil-Okay")
+    assert_no_match(pat, "Anythingelse-Bad")
   end
 
   def test_subgenus_pat
@@ -1568,25 +1570,24 @@ class NameTest < UnitTestCase
   # ------------------------------
 
   def test_ancestors_1
-    assert_name_list_equal([
-      names(:agaricus),
-      names(:agaricaceae),
-      names(:agaricales),
-      names(:basidiomycetes),
-      names(:basidiomycota),
-      names(:fungi)
-    ], names(:agaricus_campestris).all_parents)
-    assert_name_list_equal([
-      names(:agaricus)
-    ], names(:agaricus_campestris).parents)
-    assert_name_list_equal([ names(:agaricaceae) ], names(:agaricus).parents)
-    assert_name_list_equal([], names(:agaricus_campestris).children)
-    assert_name_list_equal([
-      names(:agaricus_campestras),
-      names(:agaricus_campestris),
-      names(:agaricus_campestros),
-      names(:agaricus_campestrus)
-    ], names(:agaricus).children, :sort)
+    assert_name_list_equal([names(:agaricus),
+                            names(:agaricaceae),
+                            names(:agaricales),
+                            names(:basidiomycetes),
+                            names(:basidiomycota),
+                            names(:fungi)],
+                           names(:agaricus_campestris).all_parents)
+    assert_name_list_equal([names(:agaricus)],
+                           names(:agaricus_campestris).parents)
+    assert_name_list_equal([names(:agaricaceae)],
+                           names(:agaricus).parents)
+    assert_name_list_equal([],
+                           names(:agaricus_campestris).children)
+    assert_name_list_equal([names(:agaricus_campestras),
+                            names(:agaricus_campestris),
+                            names(:agaricus_campestros),
+                            names(:agaricus_campestrus)],
+                           names(:agaricus).children, :sort)
   end
 
   def test_ancestors_2
@@ -1690,7 +1691,9 @@ class NameTest < UnitTestCase
   def test_ancestors_3
     # Make sure only Ascomycetes through Peltigera have
     # Ascomycota in their classification at first.
+    # rubocop:disable Style/FormatStringToken
     assert_equal(4, Name.where("classification LIKE '%Ascomycota%'").count)
+    # rubocop:enable Style/FormatStringToken
 
     kng = names(:fungi)
     phy = names(:ascomycota)
@@ -2579,10 +2582,16 @@ class NameTest < UnitTestCase
   end
 
   def test_name_queries
+    # set up: 2 Names which are synonyms; 6 Observations; 6 Namings:
+    #  Name n, Name s,
+    #  n and s synonymized.
+    #  Each of n and s needs:
+    #  an Observation where it's a naming and it's the consensus
+    #  an Observation where it's a naming and its synonym is the consensus
+    #  an Observation where it's a naming and neither is the consensus.
     user        = users(:rolf)
     name        = names(:chlorophyllum_rachodes)
     synonym     = names(:chlorophyllum_rhacodes)
-    taxon_names = [name, synonym]
     other_taxon = names(:agaricus)
 
     name_obs    = Observation.create(name: name, user: user, vote_cache: 1)
@@ -2593,16 +2602,14 @@ class NameTest < UnitTestCase
     Observation.create(name: synonym, user: user, vote_cache: 1)
     Naming.create(observation: synonym_obs, name: name, user: user)
 
-    other_taxon_name_proposed = Observation.create(name: other_taxon,
-                                                   user: user, vote_cache: 1)
-    Naming.create(
-      observation: other_taxon_name_proposed, name: name, user: user
-    )
-    other_taxon_synonym_proposed = Observation.create(name: other_taxon,
-                                                      user: user, vote_cache: 1)
-    Naming.create(
-      observation: other_taxon_synonym_proposed, name: synonym, user: user
-    )
+    other_taxon_name_proposed =
+      Observation.create(name: other_taxon, user: user, vote_cache: 1)
+    Naming.create(observation: other_taxon_name_proposed, name: name,
+                  user: user)
+    other_taxon_synonym_proposed =
+      Observation.create(name: other_taxon, user: user, vote_cache: 1)
+    Naming.create(observation: other_taxon_synonym_proposed, name: synonym,
+                  user: user)
 
     assert_equal(
       Observation.where(name: name).order(:id).to_a,

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2631,15 +2631,5 @@ class NameTest < UnitTestCase
                   order(:id).to_a,
       name.obss_of_other_taxa_this_taxon_proposed(by: :id).results
     )
-=begin
-
-    assert_equal(
-      Observation.joins(:namings).
-                  where("namings.name" => name.id).
-                  where.not(name: taxon_names),
-      :Observation, :of_name, name: name.id, synonyms: :all,
-      nonconsensus: :mixed
-    )
-=end
   end
 end


### PR DESCRIPTION
- Fix a bug in the link to Observations of: ... Other Taxa, this name proposed. See [Pivotal #155310823](https://www.pivotaltracker.com/story/show/155310823)
- Create methods on Name which wrap or modify various Query's for Observations of name.  (It took me a long time to figure out exactly how the `:synonym` and `:nonexclusive` conditions worked. The methods have names which -- at least to me -- reveal their intentions without having to dive into the Query code.
- Simplify ShowNameHelper by using the new methods directly in ShowName
- Lots of follow-on Rubocopping in the touched files.
