### PR TITLE
Refactor Name::primer

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -511,11 +511,6 @@ Metrics/PerceivedComplexity:
 Naming/AccessorMethodName:
   Enabled: false
 
-# Offense count: 1
-Naming/BinaryOperatorParameterName:
-  Exclude:
-    - 'app/models/name.rb'
-
 # Offense count: 14
 # Configuration parameters: Blacklist.
 # Blacklist: END, (?-mix:EO[A-Z]{1})
@@ -676,7 +671,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/image.rb'
     - 'app/models/license.rb'
     - 'app/models/location.rb'
-    - 'app/models/name.rb'
     - 'app/models/observation.rb'
     - 'app/models/synonym.rb'
     - 'app/models/user.rb'
@@ -692,7 +686,6 @@ Rails/InverseOf:
     - 'app/models/image.rb'
     - 'app/models/location.rb'
     - 'app/models/location_description.rb'
-    - 'app/models/name.rb'
     - 'app/models/name_description.rb'
     - 'app/models/observation.rb'
     - 'app/models/project.rb'
@@ -961,7 +954,6 @@ Style/IdenticalConditionalBranches:
     - 'app/controllers/location_controller.rb'
     - 'app/controllers/name_controller.rb'
     - 'app/controllers/species_list_controller.rb'
-    - 'app/models/name.rb'
     - 'script/s3ls.rb'
 
 # Offense count: 7

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1,4 +1,3 @@
-#
 #  = Name Model
 #
 #  This model describes a single scientific name.  The related class Synonym,
@@ -228,7 +227,6 @@
 #  deprecated::              Is this name deprecated?
 #  status::                  Returns "Deprecated" or "Valid".
 #  change_deprecated::       Changes deprecation status.
-#  reviewed_observations::   (not used by anyone)
 #
 #  ==== Attachments
 #  versions::                Old versions.
@@ -372,11 +370,6 @@ class Name < AbstractModel
 
   def best_brief_description
     (description.gen_desc.presence || description.diag_desc) if description
-  end
-
-  # Get an Array of Observation's for this Name that have > 80% confidence.
-  def reviewed_observations
-    Observation.where("name_id = #{id} AND vote_cache >= 2.4").to_a
   end
 
   # Get list of most used names to prime auto-completer.  Returns a simple Array

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 #  = Name Model
 #
 #  This model describes a single scientific name.  The related class Synonym,
@@ -291,17 +293,21 @@ class Name < AbstractModel
           source: :rank,
           accessor: :whiny)
 
-  belongs_to :correct_spelling, class_name: "Name",
-                                foreign_key: "correct_spelling_id"
-  belongs_to :description, class_name: "NameDescription" # (main one)
+  belongs_to :correct_spelling, # rubocop:disable Rails/InverseOf
+             class_name: "Name",
+             foreign_key: "correct_spelling_id"
+  belongs_to :description, class_name: "NameDescription",
+                           inverse_of: :name # (main one)
   belongs_to :rss_log
   belongs_to :synonym
+
   belongs_to :user
 
   has_many :descriptions, -> { order "num_views DESC" },
-           class_name: "NameDescription"
-  has_many :comments,  as: :target, dependent: :destroy
-  has_many :interests, as: :target, dependent: :destroy
+           class_name: "NameDescription",
+           inverse_of:  :name
+  has_many :comments,  as: :target, dependent: :destroy, inverse_of: :target
+  has_many :interests, as: :target, dependent: :destroy, inverse_of: :target
   has_many :namings
   has_many :observations
 
@@ -365,8 +371,8 @@ class Name < AbstractModel
     end
   end
 
-  def <=>(x)
-    sort_name <=> x.sort_name
+  def <=>(other)
+    sort_name <=> other.sort_name
   end
 
   def best_brief_description

--- a/app/models/name/primer.rb
+++ b/app/models/name/primer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 # Prime the name auto-completer
 class Name < AbstractModel
   # Get list of most used names to prime auto-completer.
@@ -24,7 +26,7 @@ class Name < AbstractModel
 
     def name_primer_cache_current?
       File.exist?(MO.name_primer_cache_file) &&
-        File.mtime(MO.name_primer_cache_file) >= Time.now - 1.day
+        File.mtime(MO.name_primer_cache_file) >= Time.now.getlocal - 1.day
     end
 
     def refreshed_name_cache

--- a/app/models/name/primer.rb
+++ b/app/models/name/primer.rb
@@ -1,0 +1,53 @@
+# Prime the name auto-completer
+class Name < AbstractModel
+  # Get list of most used names to prime auto-completer.
+  # Return a simple Array of up to 1000 name String's (no authors).
+  #
+  # *NOTE*: Since this is an expensive query (well, okay it only takes a tenth
+  # of a second but that could change...), it gets cached periodically (daily?)
+  # in a plain old file (MO.name_primer_cache_file).
+  #
+  def self.primer
+    current_name_cache || refreshed_name_cache
+  end
+
+  # private class methods
+  class << self
+    private
+
+    def current_name_cache
+      return unless name_primer_cache_current?
+      File.open(MO.name_primer_cache_file, "r:UTF-8") do |file|
+        return file.readlines.map(&:chomp)
+      end
+    end
+
+    def name_primer_cache_current?
+      File.exist?(MO.name_primer_cache_file) &&
+        File.mtime(MO.name_primer_cache_file) >= Time.now - 1.day
+    end
+
+    def refreshed_name_cache
+      result = most_used_names
+      FileUtils.mkdir_p(File.dirname(MO.name_primer_cache_file))
+      File.open(MO.name_primer_cache_file, "w:utf-8") do |file|
+        file.write(result.join("\n") + "\n")
+      end
+      result
+    end
+
+    # List of names sorted by how many times they've been used,
+    # then re-sorted by name.
+    def most_used_names(limit = 1000)
+      connection.select_values(%(
+        SELECT names.text_name, COUNT(*) AS n
+        FROM namings
+        LEFT OUTER JOIN names ON names.id = namings.name_id
+        WHERE correct_spelling_id IS NULL
+        GROUP BY names.text_name
+        ORDER BY n DESC
+        LIMIT #{limit}
+      )).uniq.sort
+    end
+  end
+end

--- a/app/models/name/primer.rb
+++ b/app/models/name/primer.rb
@@ -38,7 +38,7 @@ class Name < AbstractModel
 
     # List of names sorted by how many times they've been used,
     # then re-sorted by name.
-    def most_used_names(limit = 1000)
+    def most_used_names
       connection.select_values(%(
         SELECT names.text_name, COUNT(*) AS n
         FROM namings
@@ -46,7 +46,7 @@ class Name < AbstractModel
         WHERE correct_spelling_id IS NULL
         GROUP BY names.text_name
         ORDER BY n DESC
-        LIMIT #{limit}
+        LIMIT 1000
       )).uniq.sort
     end
   end


### PR DESCRIPTION
- Refactor Name::primer, including moving it to separate file
- Fix most Rubocop offenses in Name

They are incidental changes which I don't want to lose from now-closed #398.
