### PR TITLE
Fix RegexpError [Fixes #155486281]

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -133,7 +133,7 @@ module ObjectLinkHelper
   #
   def description_link(desc)
     result = description_title(desc)
-    return result if "(#{:private.t})$".match?(result)
+    return result if result.match?("(#{:private.t})$")
     link_with_query(result, desc.show_link_args)
   end
 


### PR DESCRIPTION
Stop RegexpError from being thrown when rendering description titles.
Fixes a bug which I introduced when I merged the Ruby 2.4 branch into master.

There's still a bug in how the description title renders, but
- it no longer throws an error; and
- the remaining bug wasn't introduced in the Ruby 2.4 branch. 
It's at least as old as Commit 0aa5066a59dcdf986e1c7eadf4049fe74c1e41e7 which was the merger of #389. I haven't had time to track it down further or do more debugging.
