### PR TITLE
Some small refactors to address some rubocop offenses

### DIFF
--- a/app/classes/query/species_list_base.rb
+++ b/app/classes/query/species_list_base.rb
@@ -55,6 +55,11 @@ module Query
         'LENGTH(COALESCE(species_lists.notes,"")) > 0',
         'LENGTH(COALESCE(species_lists.notes,"")) = 0'
       )
+      add_joins
+      super
+    end
+
+    def add_joins
       add_join(:comments) if params[:has_comments]
       if params[:comments_has].present?
         initialize_model_do_search(
@@ -63,7 +68,6 @@ module Query
         )
         add_join(:comments)
       end
-      super
     end
 
     def default_order

--- a/app/controllers/description_controller_helpers.rb
+++ b/app/controllers/description_controller_helpers.rb
@@ -42,18 +42,19 @@ module DescriptionControllerHelpers
   # readable and writable.
   def make_description_default # :norobots:
     pass_query_params
-    if desc = find_description(params[:id].to_s)
-      if !desc.fully_public
-        flash_error(:runtime_description_make_default_only_public.t)
-      else
-        desc.parent.description_id = desc.id
-        desc.parent.log(:log_changed_default_description, user: @user.login,
-                                                          name: desc.unique_partial_format_name,
-                                                          touch: true)
-        desc.parent.save
-      end
-      redirect_with_query(action: desc.show_action, id: desc.id)
+    desc = find_description(params[:id].to_s)
+    return unless desc
+    redirect_with_query(action: desc.show_action, id: desc.id)
+    unless desc.fully_public
+      flash_error(:runtime_description_make_default_only_public.t)
+      return
     end
+    desc.parent.description_id = desc.id
+    desc.parent.log(:log_changed_default_description,
+                    user: @user.login,
+                    name: desc.unique_partial_format_name,
+                    touch: true)
+    desc.parent.save
   end
 
   # Merge a description with another.  User must be both an admin for the

--- a/app/controllers/translation_controller.rb
+++ b/app/controllers/translation_controller.rb
@@ -65,6 +65,11 @@ class TranslationController < ApplicationController
   def get_language_and_authorize_user
     locale = params[:locale] || I18n.locale
     lang = Language.find_by_locale(locale)
+    validate_language_and_user(locale, lang)
+    lang
+  end
+
+  def validate_language_and_user(locale, lang)
     if !lang
       fail(:edit_translations_bad_locale.t(locale: locale))
     elsif !@user
@@ -74,7 +79,6 @@ class TranslationController < ApplicationController
     elsif lang.official && !reviewer?
       fail(:edit_translations_reviewer_required.t)
     end
-    lang
   end
 
   def get_record_maps(lang, tags)

--- a/app/helpers/description_helper.rb
+++ b/app/helpers/description_helper.rb
@@ -1,15 +1,22 @@
 module DescriptionHelper
+  def is_writer?(desc)
+    desc.is_writer?(@user) || in_admin_mode?
+  end
+
+  def is_admin?(desc)
+    desc.is_admin?(@user) || in_admin_mode?
+  end
+
   # Create tabs for show_description page.
   def show_description_tab_set(desc)
     type = desc.type_tag.to_s.sub(/_description/, "").to_sym
-    writer = desc.is_writer?(@user) || in_admin_mode?
-    admin  = desc.is_admin?(@user) || in_admin_mode?
+    admin = is_admin?(desc)
     tabs = []
     if true
       tabs << link_with_query(:show_object.t(type: type),
                               action: "show_#{type}", id: desc.parent_id)
     end
-    if writer
+    if is_writer?(desc)
       tabs << link_with_query(:show_description_edit.t,
                               action: "edit_#{type}_description", id: desc.id)
     end
@@ -63,12 +70,13 @@ module DescriptionHelper
     type = desc.type_tag
     title = description_title(desc)
     links = []
-    if @user && desc.is_writer?(@user) || in_admin_mode?
+    if is_writer?(desc)
       links << link_with_query(:EDIT.t, action: "edit_#{type}", id: desc.id)
     end
-    if @user && desc.is_admin?(@user) || in_admin_mode?
-      links << link_with_query(:DESTROY.t, { action: "destroy_#{type}",
-                                             id: desc.id }, data: { confirm: :are_you_sure.l })
+    if is_admin?(desc)
+      links << link_with_query(:DESTROY.t,
+                               { action: "destroy_#{type}", id: desc.id },
+                               data: { confirm: :are_you_sure.l })
     end
     content_tag(:p, content_tag(:big, title) + links.safe_join(" | "))
   end
@@ -101,8 +109,8 @@ module DescriptionHelper
     list.map! do |desc|
       any = true
       item = description_link(desc)
-      writer = desc.is_writer?(@user) || in_admin_mode?
-      admin  = desc.is_admin?(@user) || in_admin_mode?
+      writer = is_writer?(desc)
+      admin  = is_admin?(desc)
       if writer || admin
         links = []
         if writer

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -3890,7 +3890,7 @@ class NameControllerTest < FunctionalTestCase
     assert_not_equal(desc, desc.parent.description)
     assert_equal(current_default, desc.parent.description)
   end
-  
+
   # Owner can publish.
   def test_publish_draft
     publish_draft_helper(name_descriptions(:draft_coprinus_comatus), nil,

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -147,6 +147,14 @@ class NameControllerTest < FunctionalTestCase
     end
   end
 
+  def make_description_default_helper(desc)
+    user = desc.user
+    params = {
+      id: desc.id
+    }
+    requires_login(:make_description_default, params, user.login)
+  end
+
   # Destroy a draft of a project.
   def destroy_draft_helper(draft, user, success = true)
     assert(draft)
@@ -3866,6 +3874,23 @@ class NameControllerTest < FunctionalTestCase
     )
   end
 
+  def test_make_description_default
+    desc = name_descriptions(:peltigera_alt_desc)
+    assert_not_equal(desc, desc.parent.description)
+    make_description_default_helper(desc)
+    desc.parent.reload
+    assert_equal(desc, desc.parent.description)
+  end
+
+  def test_non_public_description_cannot_be_default
+    desc = name_descriptions(:peltigera_user_desc)
+    current_default = desc.parent.description
+    make_description_default_helper(desc)
+    desc.parent.reload
+    assert_not_equal(desc, desc.parent.description)
+    assert_equal(current_default, desc.parent.description)
+  end
+  
   # Owner can publish.
   def test_publish_draft
     publish_draft_helper(name_descriptions(:draft_coprinus_comatus), nil,

--- a/test/controllers/translation_controller_test.rb
+++ b/test/controllers/translation_controller_test.rb
@@ -132,6 +132,20 @@ class TranslationControllerTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  def test_authorization_zero_user
+    login("zero_user")
+    get(:edit_translations, locale: "en")
+    assert_flash_error
+    assert_response(:redirect)
+  end
+
+  def test_authorization_user_bad_locale
+    login("mary")
+    get(:edit_translations, locale: "bad")
+    assert_flash_error
+    assert_response(:redirect)
+  end
+
   def test_authorization_user_el
     login("mary")
     get(:edit_translations, locale: "el")


### PR DESCRIPTION
Several small refactors to reduce the number of Metrics/AbcSize offenses.
- rubocop should report 6 fewer Metrics/AbcSize offense.
- All code changes should have coverage.
- All tests should pass.
