### PR TITLE
Ran bundle update, but held back the mail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,3 +121,5 @@ group :test do
 end
 
 gem "web-console", group: :development
+
+gem "mail", "= 2.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,15 +41,15 @@ GEM
     ansi (1.5.0)
     arel (6.0.4)
     ast (2.4.0)
-    autoprefixer-rails (9.1.0)
+    autoprefixer-rails (9.3.1)
       execjs
-    aws-sdk (2.11.106)
-      aws-sdk-resources (= 2.11.106)
-    aws-sdk-core (2.11.106)
+    aws-sdk (2.11.173)
+      aws-sdk-resources (= 2.11.173)
+    aws-sdk-core (2.11.173)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.106)
-      aws-sdk-core (= 2.11.106)
+    aws-sdk-resources (2.11.173)
+      aws-sdk-core (= 2.11.173)
     aws-sigv4 (1.0.3)
     blankslate (3.1.3)
     bootstrap-sass (3.3.7)
@@ -58,13 +58,14 @@ GEM
     browser (2.5.3)
     builder (3.2.3)
     byebug (10.0.2)
-    capybara (3.5.1)
+    capybara (3.11.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      xpath (~> 3.1)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -72,7 +73,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -95,7 +96,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
-    jbuilder (2.7.0)
+    jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jmespath (1.4.0)
@@ -108,16 +109,16 @@ GEM
     json (2.1.0)
     kgio (2.11.2)
     libv8 (3.16.14.19)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     metaclass (0.0.4)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    minitest-reporters (1.3.1)
+    minitest-reporters (1.3.5)
       ansi
       builder
       minitest (>= 5.0)
@@ -126,14 +127,14 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.13.1)
     mysql2 (0.4.10)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    public_suffix (3.0.2)
-    rack (1.6.10)
+    public_suffix (3.0.3)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)
@@ -167,18 +168,19 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     ref (2.0.0)
+    regexp_parser (1.3.0)
     rtf (0.3.3)
-    rubocop (0.58.2)
+    rubocop (0.60.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
-    sass (3.5.7)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -203,7 +205,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    term-ansicolor (1.6.0)
+    term-ansicolor (1.7.0)
       tins (~> 1.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -211,10 +213,10 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    tins (1.16.3)
+    tins (1.20.2)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.18)
+    uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
     unicorn (5.4.1)
@@ -229,7 +231,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff
     xmlrpc (0.3.0)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
@@ -250,6 +252,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-slick-rails
+  mail (= 2.7.0)
   minitest
   minitest-reporters
   mocha
@@ -267,4 +270,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   1.16.3
+   1.17.1


### PR DESCRIPTION
Run:
`bundle update`
`rake`
All tests should pass.  Once it is merged, this change should eliminate the potential security vulnerability warning that GitHub is currently giving us on the main repository page.