### PR TITLE
Mycoflora

### DIFF
--- a/app/classes/observation_report/mycoflora.rb
+++ b/app/classes/observation_report/mycoflora.rb
@@ -28,6 +28,10 @@ module ObservationReport
         eventID
         imageUrls
         labelProject
+        collectorsName
+        substrate
+        habitat
+        host
         occurrenceRemarks
       ]
     end
@@ -62,8 +66,27 @@ module ObservationReport
         row.obs_url,
         image_urls(row),
         "NA Mycoflora Project",
-        row.obs_notes.to_s.t.html_to_ascii
+        *explode_notes(row)
       ]
+    end
+
+    def explode_notes(row)
+      notes = row.obs_notes_as_hash
+      [
+        extract_notes_field(notes, :"Collector's_Name"),
+        extract_notes_field(notes, :Substrate),
+        extract_notes_field(notes, :Habitat),
+        extract_notes_field(notes, :Host),
+        export_other_notes(notes)
+      ]
+    end
+
+    def extract_notes_field(notes, field)
+      notes.delete(field).to_s.strip.t.html_to_ascii
+    end
+
+    def export_other_notes(notes)
+      Observation.export_formatted(notes).strip.t.html_to_ascii
     end
 
     # 6371000 = radius of earth in meters

--- a/app/classes/observation_report/row.rb
+++ b/app/classes/observation_report/row.rb
@@ -78,7 +78,11 @@ module ObservationReport
     end
 
     def obs_notes
-      @vals[9].blank? ? nil : notes_exported_formatted
+      @vals[9].blank? ? nil : notes_export_formatted
+    end
+
+    def obs_notes_as_hash
+      @vals[9].blank? ? nil : notes_to_hash
     end
 
     def obs_updated_at
@@ -355,7 +359,7 @@ module ObservationReport
 
     # --------------------
 
-    def notes_exported_formatted
+    def notes_export_formatted
       Observation.export_formatted(notes_to_hash).strip
     end
 

--- a/test/models/observation_report_test.rb
+++ b/test/models/observation_report_test.rb
@@ -122,6 +122,10 @@ class ObservationReportTest < UnitTestCase
       "http://mushroomobserver.org//remote_images/orig/#{img1.id}.jpg " \
         "http://mushroomobserver.org//remote_images/orig/#{img2.id}.jpg",
       "NA Mycoflora Project",
+      "",
+      "",
+      "",
+      "",
       "Found in a strange place... & with śtrangè characters™"
     ]
     do_report_test(ObservationReport::Mycoflora, obs, expect, &:id)
@@ -129,6 +133,16 @@ class ObservationReportTest < UnitTestCase
 
   def test_mycoflora_with_exact_lat_long
     obs = observations(:unknown_with_lat_long)
+    obs.notes = {
+      :"Collector's_Name" => "John Doe",
+      Substrate: "wood chips",
+      Habitat: "lawn",
+      Host: "_Agaricus_",
+      Foo: "Bar",
+      Other: "Things"
+    }
+    obs.save!
+
     expect = [
       "Fungi",
       nil,
@@ -153,7 +167,11 @@ class ObservationReportTest < UnitTestCase
       "http://mushroomobserver.org/#{obs.id}",
       "",
       "NA Mycoflora Project",
-      "unknown_with_lat_long"
+      "John Doe",
+      "wood chips",
+      "lawn",
+      "Agaricus",
+      "Foo: Bar\nOther: Things"
     ]
     do_report_test(ObservationReport::Mycoflora, obs, expect, &:id)
   end


### PR DESCRIPTION
More tweaks to mycoflora report.  Split four fields out of notes into their own dedicated columns in report.