### PR TITLE
[Delivers ##163505539] Change numerical comparisons to predicates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,8 @@ AllCops:
     - public/design_test/jquery-1.5.2.min.js
     # We need not check these scripts, and some of them cause Rubocop errors
     - "script/old/**/*"
+    # not Ruby
+    - script/perf_monitor
     - "tmp/**/*"
 
 ###################### Global Disables #########################################
@@ -125,14 +127,6 @@ Style/AsciiComments:
 # Repeat the RuboCop default because CodeClimate silently overrides it
 Style/DateTime:
   Enabled: false
-
-# Prefer n == 0, n > 0, n < 0
-# over n.zero?, n.positive? n.negative?
-# Rubocop default is "predicates".
-# But comparisons are transparent and shorter than the predicates,
-# and we've always used the comparisons.
-Style/NumericPredicate:
-  EnforcedStyle: comparison
 
 # Repeat the RuboCop defaults because CodeClimate silently overrides them
 Style/PercentLiteralDelimiters:

--- a/app/classes/gmaps.rb
+++ b/app/classes/gmaps.rb
@@ -144,7 +144,7 @@ module GM
         south = lat  if south.nil? || lat < south
         east1 = long if east1.nil? || long > east1
         west1 = long if west1.nil? || long < west1
-        long += 360 if long < 0
+        long += 360 if long.negative?
         east2 = long if east2.nil? || long > east2
         west2 = long if west2.nil? || long < west2
       end

--- a/app/classes/mo_paginator.rb
+++ b/app/classes/mo_paginator.rb
@@ -95,15 +95,15 @@ class MOPaginator
   alias_method :length, :num_total
 
   def blank?
-    num_total == 0
+    num_total.zero?
   end
 
   def empty?
-    num_total == 0
+    num_total.zero?
   end
 
   def any?
-    num_total > 0
+    num_total.positive?
   end
 
   # Create and initialize new instance.
@@ -179,7 +179,7 @@ class MOPaginator
   # First index on current page.
   def from
     n = ((number || 0) - 1) * num_per_page
-    n = 0 if n < 0
+    n = 0 if n.negative?
     n
   end
 
@@ -187,7 +187,7 @@ class MOPaginator
   def to
     n = from + num_per_page - 1
     n = num_total - 1 if n > num_total - 1
-    n = 0 if n < 0
+    n = 0 if n.negative?
     n
   end
 

--- a/app/classes/query/modules/sequence_operators.rb
+++ b/app/classes/query/modules/sequence_operators.rb
@@ -34,7 +34,7 @@ module Query::Modules::SequenceOperators
     new_self = self
     new_self = outer_first if !skip_outer && has_outer?
     id = new_self.select_value(limit: "1").to_i
-    if id > 0
+    if id.positive?
       if new_self == self
         @current_id = id
       else
@@ -53,7 +53,7 @@ module Query::Modules::SequenceOperators
     index = result_ids.index(current_id)
     if !index
       new_self = nil
-    elsif index > 0
+    elsif index.positive?
       if new_self == self
         @current_id = result_ids[index - 1]
       else
@@ -103,7 +103,7 @@ module Query::Modules::SequenceOperators
     new_self = self
     new_self = outer_last if !skip_outer && has_outer?
     id = new_self.select_value(order: :reverse, limit: "1").to_i
-    if id > 0
+    if id.positive?
       if new_self == self
         @current_id = id
       else

--- a/app/controllers/interest_controller.rb
+++ b/app/controllers/interest_controller.rb
@@ -85,7 +85,7 @@ class InterestController < ApplicationController
         elsif interest.state == false && state.negative?
           flash_notice(:set_interest_already_off.l(name: target.unique_text_name))
         else
-          interest.state = (state.positive?)
+          interest.state = state.positive?
           interest.updated_at = Time.now
           if !interest.save
             flash_notice(:set_interest_failure.l(name: target.unique_text_name))

--- a/app/controllers/interest_controller.rb
+++ b/app/controllers/interest_controller.rb
@@ -27,14 +27,14 @@ class InterestController < ApplicationController
     # notifications = Notification.find_all_by_user_id(@user.id).sort do |a,b|
     notifications = Notification.where(user_id: @user.id).sort do |a, b|
       result = a.flavor.to_s <=> b.flavor.to_s
-      result = a.summary.to_s <=> b.summary.to_s if result == 0
+      result = a.summary.to_s <=> b.summary.to_s if result.zero?
       result
     end
     # interests = Interest.find_all_by_user_id(@user.id).sort do |a,b|
     interests = Interest.where(user_id: @user.id).sort do |a, b|
       result = a.target_type <=> b.target_type
       result = (a.target ? a.target.text_name : "") <=>
-               (b.target ? b.target.text_name : "") if result == 0
+               (b.target ? b.target.text_name : "") if result.zero?
       result
     end
     @targets = notifications + interests
@@ -67,7 +67,7 @@ class InterestController < ApplicationController
           interest.target = target
           interest.user = @user
         end
-        if state == 0
+        if state.zero?
           name = target ? target.unique_text_name : "--"
           if !interest
             flash_notice(:set_interest_already_deleted.l(name: name))
@@ -80,17 +80,17 @@ class InterestController < ApplicationController
               flash_notice(:set_interest_success_was_off.l(name: name))
             end
           end
-        elsif interest.state == true && state > 0
+        elsif interest.state == true && state.positive?
           flash_notice(:set_interest_already_on.l(name: target.unique_text_name))
-        elsif interest.state == false && state < 0
+        elsif interest.state == false && state.negative?
           flash_notice(:set_interest_already_off.l(name: target.unique_text_name))
         else
-          interest.state = (state > 0)
+          interest.state = (state.positive?)
           interest.updated_at = Time.now
           if !interest.save
             flash_notice(:set_interest_failure.l(name: target.unique_text_name))
           else
-            if state > 0
+            if state.positive?
               flash_notice(:set_interest_success_on.l(name: target.unique_text_name))
             else
               flash_notice(:set_interest_success_off.l(name: target.unique_text_name))

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -172,7 +172,7 @@ class LocationController < ApplicationController
     end
 
     # Paginate the defined locations using the usual helper.
-    args[:always_index] = (@undef_pages && @undef_pages.num_total > 0)
+    args[:always_index] = (@undef_pages && @undef_pages.num_total.positive?)
     args[:action] = args[:action] || "list_locations"
     show_index_of_objects(query, args)
   end

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -182,7 +182,7 @@ class ObserverController
       MinimalMapObservation.new(id, lat, long, loc_id)
     end
 
-    if locations.length > 0
+    if locations.length.positive?
       # Eager-load corresponding locations.
       @locations = Location.connection.select_rows(%(
         SELECT id, name, north, south, east, west FROM locations

--- a/app/extensions/integer_extensions.rb
+++ b/app/extensions/integer_extensions.rb
@@ -31,7 +31,7 @@ class Integer
     num      = self
     alphabet = alphabet.to_s
     len      = alphabet.length
-    while num > 0
+    while num.positive?
       x = num % len
       num = (num - x) / len
       str = alphabet[x, 1] + str

--- a/app/helpers/description_helper.rb
+++ b/app/helpers/description_helper.rb
@@ -176,7 +176,7 @@ module DescriptionHelper
     html = content_tag(:p, html)
 
     # Show list of projects user is a member of.
-    if projects && projects.length > 0
+    if projects && projects.length.positive?
       head2 = :show_name_create_draft.t + ": "
       list = [head2] + projects.map do |project|
         item = link_with_query(project.title,

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -87,7 +87,7 @@ module FooterHelper
     num_versions = obj.respond_to?(:version) ? obj.versions.length : 0
 
     # Old version of versioned object.
-    if num_versions > 0 && obj.version < num_versions
+    if num_versions.positive? && obj.version < num_versions
       html << :footer_version_out_of.t(num: obj.version, total: num_versions)
       if obj.updated_at
         html << :footer_updated_by.t(user: user_link(obj.user),
@@ -96,7 +96,7 @@ module FooterHelper
 
     # Latest version of non-versioned object.
     else
-      if num_versions > 0
+      if num_versions.positive?
         latest_user = User.safe_find(obj.versions.latest.user_id)
         if obj.created_at
           html << :footer_created_by.t(user: user_link(obj.user),

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -196,7 +196,7 @@ module MapHelper
 
   def format_lxxxitude(val, dir1, dir2)
     deg = val.abs.round(4)
-    "#{deg}°#{val < 0 ? dir2 : dir1}".html_safe
+    "#{deg}°#{val.negative? ? dir2 : dir1}".html_safe
   end
 
   def map_control_init(gmap, marker, args, type = "ct")

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -165,7 +165,7 @@ module ObjectLinkHelper
 
   def observation_herbarium_record_link(obs)
     count = obs.herbarium_records.count
-    if count > 0
+    if count.positive?
       link_to(pluralize(count, :herbarium_record.t),
               controller: :herbarium_record, action: :observation_index,
               id: obs.id)

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -90,7 +90,7 @@ module PaginationHelper
       for n in from..to
         if n == this
           result << content_tag(:li, content_tag(:span, n), class: "active")
-        elsif n > 0 && n <= num
+        elsif n.positive? && n <= num
           result << pagination_link(n, n, arg, args)
         end
       end

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -47,9 +47,15 @@ module ThumbnailHelper
   # Create an image link vote, where vote param is vote number ie: 3
   def image_vote_link(image, vote)
     current_vote = image.users_vote(@user)
-    vote_text = vote == 0 ? "(x)" : image_vote_as_short_string(vote)
-    link = link_to(vote_text, { controller: :image, action: :show_image, id: image.id, vote: vote },
-                   title: image_vote_as_help_string(vote), data: { role: "image_vote", id: image.id, val: vote }) # #return a link if the user has NOT voted this way
+    vote_text = vote.zero? ? "(x)" : image_vote_as_short_string(vote)
+    # return a link if the user has NOT voted this way
+    link = link_to(vote_text,
+                   { controller: :image,
+                     action: :show_image,
+                     id: image.id,
+                     vote: vote },
+                   title: image_vote_as_help_string(vote),
+                   data: { role: "image_vote", id: image.id, val: vote })
     if current_vote == vote
       link = content_tag(:span, image_vote_as_short_string(vote))
     end

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -159,7 +159,11 @@ class AbstractModel < ApplicationRecord
   #   name.versions[idx].version
   #
   def find_version(idx)
-    limit = (idx < 0 ? "DESC LIMIT 1, #{-idx - 1}" : "ASC LIMIT 1, #{idx}")
+    limit = if idx.negative?
+              "DESC LIMIT 1, #{-idx - 1}"
+            else
+              "ASC LIMIT 1, #{idx}"
+            end
     num = self.class.connection.select_value %(
       SELECT version FROM #{versioned_table_name}
       WHERE #{type_tag}_id = #{id}

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -802,7 +802,7 @@ class Image < AbstractModel
       sum += value.to_f
       num += 1
     end
-    self.vote_cache = num > 0 ? sum / num : nil
+    self.vote_cache = num.positive? ? sum / num : nil
   end
 
   # Retrieve list of users who have voted as a Hash mapping user ids to

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -352,7 +352,7 @@ module LanguageExporter
       tag = Regexp.last_match(3)
       str = $'
       check_export_tag_def_line(quoted_tag, tag, str) \
-        unless (indent.length == 0) && (tag == locale) && (str.strip == "")
+        unless (indent.length.zero?) && (tag == locale) && (str.strip == "")
     elsif @in_tag
       check_export_multi_line(line)
     else

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -352,7 +352,7 @@ module LanguageExporter
       tag = Regexp.last_match(3)
       str = $'
       check_export_tag_def_line(quoted_tag, tag, str) \
-        unless (indent.length.zero?) && (tag == locale) && (str.strip == "")
+        unless indent.length.zero? && (tag == locale) && (str.strip == "")
     elsif @in_tag
       check_export_multi_line(line)
     else

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -161,7 +161,7 @@ class Location < AbstractModel
     result = nil
     match = value.to_s.match(LXXXITUDE_REGEX)
     if match && (match[4].blank? || [direction1, direction2].member?(match[4]))
-      if match[1].to_f > 0
+      if match[1].to_f.positive?
         val = match[1].to_f + match[2].to_f / 60 + match[3].to_f / 3600
       else
         val = match[1].to_f - match[2].to_f / 60 - match[3].to_f / 3600

--- a/app/models/name/parse.rb
+++ b/app/models/name/parse.rb
@@ -443,7 +443,7 @@ class Name < AbstractModel
     words = str.split(" ")
     # every other word, starting next-from-last, is an abbreviation
     i = words.length - 2
-    while i > 0
+    while i.positive?
       words[i] = if /^f/i.match?(words[i])
                    "f."
                  elsif /^v/i.match?(words[i])

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -48,7 +48,7 @@ class Name < AbstractModel
       results = guess_word("", words.first)
       (2..num).each do |i|
         if results.any?
-          if (i & 1) == 0
+          if (i & 1).zero?
             prefixes = results.map(&:text_name).uniq
             results = []
             word = (i == 2) ? words[i - 1] : "#{words[i - 2]} #{words[i - 1]}"
@@ -91,7 +91,7 @@ class Name < AbstractModel
         else
           (0..(word.length - count)).each do |j|
             sub = ""
-            sub += word[0..(j - 1)] if j > 0
+            sub += word[0..(j - 1)] if j.positive?
             sub += "%"
             sub += word[(j + count)..(-1)] if j + count < word.length
             patterns << guess_pattern(words, i, sub)

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -204,7 +204,7 @@ class NameDescription < Description
     # Save unless there are substantive changes pending.
     unless save_version?
       save_without_our_callbacks
-      fail "update_review_status failed: [#{dump_errors}]" if errors.size > 0
+      fail "update_review_status failed: [#{dump_errors}]" if errors.size.positive?
     end
   end
 

--- a/app/models/name_sorter.rb
+++ b/app/models/name_sorter.rb
@@ -244,7 +244,7 @@ class NameSorter
     unless chosen
       @all_names += names
       len = names.length
-      if len == 0
+      if len.zero?
         @new_line_strs.push(line_str)
         @new_name_strs.push(name_parse.search_name)
       elsif len == 1

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -327,7 +327,7 @@ class Naming < AbstractModel
     result = true
     for v in votes
       if (v.user_id != user_id) &&
-         (v.value > 0)
+         (v.value.positive?)
         result = false
         break
       end
@@ -342,7 +342,7 @@ class Naming < AbstractModel
     result = true
     for v in votes
       if (v.user_id != user_id) &&
-         (v.value > 0) &&
+         (v.value.positive?) &&
          (v.favorite)
         result = false
         break

--- a/app/models/queued_email.rb
+++ b/app/models/queued_email.rb
@@ -325,20 +325,12 @@ class QueuedEmail < AbstractModel
   # Look-up an object corresponding to a given integer (id).
   # key::       name of integer to get
   # model::     class of model to look for id in
-  # allow_nil:: is nil/zero id acceptible? (if not will raise RecordNotFound)
-  #
-  #   comment = email.get_object('comment', Comment, :nil_okay)
-  #
-  def get_object(key, model, allow_nil = false)
+  def get_object(key, model)
     @objects ||= {}
-    if @objects.key?(key)
-      result = @objects[key]
-    else
-      id = get_integer(key)
-      @objects[key] = (id.zero? && allow_nil) ? nil : model.safe_find(id)
-      result = @objects[key]
+    unless @objects.key?(key)
+      @objects[key] = model.safe_find(get_integer(key))
     end
-    result
+    @objects[key]
   end
 
   # Get string for the given key.

--- a/app/models/queued_email.rb
+++ b/app/models/queued_email.rb
@@ -335,7 +335,8 @@ class QueuedEmail < AbstractModel
       result = @objects[key]
     else
       id = get_integer(key)
-      result = @objects[key] = (id == 0 && allow_nil) ? nil : model.safe_find(id)
+      @objects[key] = (id.zero? && allow_nil) ? nil : model.safe_find(id)
+      result = @objects[key]
     end
     result
   end

--- a/app/models/queued_email/consensus_change.rb
+++ b/app/models/queued_email/consensus_change.rb
@@ -5,11 +5,11 @@ class QueuedEmail::ConsensusChange < QueuedEmail
   end
 
   def old_name
-    get_object(:old_name, ::Name, :allow_nil)
+    get_object(:old_name, ::Name)
   end
 
   def new_name
-    get_object(:new_name, ::Name, :allow_nil)
+    get_object(:new_name, ::Name)
   end
 
   def self.create_email(sender, recipient, observation, old_name, new_name)

--- a/app/models/queued_email/location_change.rb
+++ b/app/models/queued_email/location_change.rb
@@ -5,7 +5,7 @@ class QueuedEmail::LocationChange < QueuedEmail
   end
 
   def description
-    get_object(:description, ::LocationDescription, :nil_okay)
+    get_object(:description, ::LocationDescription)
   end
 
   def old_location_version

--- a/app/models/queued_email/name_change.rb
+++ b/app/models/queued_email/name_change.rb
@@ -6,7 +6,7 @@ class QueuedEmail::NameChange < QueuedEmail
   end
 
   def description
-    get_object(:description, ::NameDescription, :allow_nil)
+    get_object(:description, ::NameDescription)
   end
 
   def old_name_version

--- a/app/models/queued_email/observation_change.rb
+++ b/app/models/queued_email/observation_change.rb
@@ -1,7 +1,7 @@
 # Observation Change Email
 class QueuedEmail::ObservationChange < QueuedEmail
   def observation
-    get_object(:observation, ::Observation, :allow_nil)
+    get_object(:observation, ::Observation)
   end
 
   def note

--- a/lib/tasks/jason.rake
+++ b/lib/tasks/jason.rake
@@ -78,7 +78,7 @@ namespace :jason do
     results = []
     for str in notes
       if str.index("_")
-        if n % 15 == 0
+        if (n % 15).zero?
           print "%.2f%% done\n" % (100.0 * n / notes.length)
           sleep 1
         end
@@ -614,7 +614,7 @@ namespace :jason do
       # results = Location.find(:all, :conditions => "search_name like '%#{val2}%'", :order => "name asc") # Rails 3
       results = Location.where("search_name LIKE ?", "%#{val2}%").
                 order(name).to_a
-      if results.length == 0
+      if results.length.zero?
         lines.push('>>>>>>>> couldn\'t find any matching locations (add "*" to end to create)')
       elsif results.length == 1
         loc = results.first
@@ -634,7 +634,7 @@ namespace :jason do
     names = Name.find_names(val)
     valid_names = names.reject(&:deprecated)
     synonyms = names.first.approved_synonyms.sort if names.first
-    if names.length == 0
+    if names.length.zero?
       lines.push(">>>>>>>> unrecognized name, please correct or create by hand")
     elsif force
       return names.first
@@ -647,7 +647,7 @@ namespace :jason do
       end
     else
       lines.push('>>>>>>>> name is deprecated, accepted names/synonyms are: (add "*" to end to force)')
-      if valid_names.length == 0 && synonyms.length == 0
+      if valid_names.length.zero? && synonyms.length.zero?
         lines.push(">>>>>>>>   none available?!")
       end
       for name in valid_names + synonyms

--- a/lib/tasks/location.rake
+++ b/lib/tasks/location.rake
@@ -4016,7 +4016,7 @@ namespace :location do
       target_location = Location.find_by_name(target_name)
       if target_location
         obs = Observation.where(where: current_name)
-        if obs.size > 0
+        if obs.size.positive?
           for o in obs
             o.location = target_location
             o.where = nil
@@ -4028,7 +4028,7 @@ namespace :location do
         end
         if current_location && (current_location != target_location)
           obs = Observation.where(location_id: current_location.id)
-          if obs.size > 0
+          if obs.size.positive?
             for o in obs
               o.location = target_location
               o.where = nil
@@ -4039,7 +4039,7 @@ namespace :location do
             print("Moved #{obs.size} observations from location: #{current_name} to location: #{target_name}\n")
           end
           comments = current_location.comments
-          if comments.size > 0
+          if comments.size.positive?
             for comment in comments
               comment.object_id = target_location.id
               check_save(comment)
@@ -4047,7 +4047,7 @@ namespace :location do
             print("Moved #{comments.size} comments from #{current_name} to #{target_name} (#{target_location.id})\n")
           end
           descs = current_location.descriptions
-          if descs.size > 0
+          if descs.size.positive?
             for d in descs
               d.location_id = target_location.id
               check_save(d)

--- a/script/bulk_name_change
+++ b/script/bulk_name_change
@@ -203,7 +203,7 @@ def average_votes(naming)
     sum += vote.value * weight
     num += weight
   end
-  num > 0 ? sum / num : nil
+  num.positive? ? sum / num : nil
 end
 
 def users_vote(naming)

--- a/script/refresh_name_lister_cache
+++ b/script/refresh_name_lister_cache
@@ -76,7 +76,7 @@ for rec in species
   n, a, d, s = rec.values_at("n", "a", "d", "s")
   need_author = occurs[n] > 1
   n += "|" + a if a.present? && need_author
-  if s.to_i > 0 && d.to_i != 1
+  if s.to_i.positive? && d.to_i != 1
     l = valid[s] ||= []
     l.push(n) unless l.include?(n)
   end

--- a/script/refresh_sitemap
+++ b/script/refresh_sitemap
@@ -394,7 +394,7 @@ def remove_substrings_from_disallowed_paths(disallowed_paths, allowed_paths)
   disallowed_paths.reject! do |disallowed_path|
     reject = false
     for allowed_path in allowed_paths
-      if allowed_path.index(disallowed_path) == 0
+      if allowed_path.index(disallowed_path).zero?
         reject = true
         break
       end

--- a/script/s3cp.rb
+++ b/script/s3cp.rb
@@ -38,17 +38,17 @@ copy = !delete
 flags = ARGV.select { |arg| arg.match(/^-/) }.
         reject { |arg| arg.match(/^(-d|-f|-v|--delete|--force|--verbose)$/) }
 words = ARGV.reject { |arg| arg.match(/^-/) }
-abort("Bad flag(s): #{flags.inspect}") if flags.length > 0
+abort("Bad flag(s): #{flags.inspect}") if flags.length.positive?
 if copy
-  abort("Missing file!") if words.length == 0
+  abort("Missing file!") if words.length.zero?
   file = words.shift
   abort("File doesn't exist: #{file.inspect}") unless File.exist?(file)
 end
-abort("Missing server!") if words.length == 0
+abort("Missing server!") if words.length.zero?
 server = words.shift
-abort("Missing key!") if words.length == 0
+abort("Missing key!") if words.length.zero?
 key = words.shift
-abort("Unexpected parameter(s): #{words.inspect}") if words.length > 0
+abort("Unexpected parameter(s): #{words.inspect}") if words.length.positive?
 
 cache_file = "#{app_root}/public/images/#{server}.files"
 temp_file  = "#{app_root}/tmp/#{server}.files.#{Process.pid}"

--- a/script/s3ls.rb
+++ b/script/s3ls.rb
@@ -22,7 +22,7 @@ abort(<<"EOB") if ARGV.any? { |arg| ["-h", "--help"].include?(arg) }
                entries from old file where the new listing omits them.
                This makes it much more robust, since the S3 server will
                often skip entire segments of files.
-    --verbose  Print what's happening to stdout.
+    --verbose  Print what is happening to stdout.
     --help     Print this message.
 
 EOB
@@ -32,10 +32,10 @@ replace = true if ARGV.any? { |arg| ["-r", "--replace"].include?(arg) }
 flags = ARGV.select { |arg| arg.match(/^-/) }.
         reject { |arg| arg.match(/^(-v|-r|--verbose|--replace)$/) }
 words = ARGV.reject { |arg| arg.match(/^-/) }
-abort("Bad flag(s): #{flags.inspect}") if flags.length > 0
-abort("Missing server!") if words.length == 0
+abort("Bad flag(s): #{flags.inspect}") if flags.length.positive?
+abort("Missing server!") if words.length.zero?
 server = words.shift
-abort("Unexpected parameter(s): #{words.inspect}") if words.length > 0
+abort("Unexpected parameter(s): #{words.inspect}") if words.length.positive?
 
 cache_file = "#{app_root}/public/images/#{server}.files"
 temp_file1 = "#{app_root}/tmp/#{server}.files.#{Process.pid}.1"

--- a/script/s3uniq.rb
+++ b/script/s3uniq.rb
@@ -13,7 +13,7 @@ abort(<<"EOB") if ARGV.any? { |arg| ["-h", "--help"].include?(arg) }
 
 EOB
 
-abort("Unexpected parameters: #{ARGV.inspect}") if ARGV.length > 0
+abort("Unexpected parameters: #{ARGV.inspect}") if ARGV.length.positive?
 
 data = {}
 $stdin.each_line do |line|

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -316,7 +316,7 @@ class ImageControllerTest < FunctionalTestCase
     new_count = Image.where(user_id: user_id,
                             license_id: new_license.id,
                             copyright_holder: copyright_holder).length
-    assert(target_count > 0)
+    assert(target_count.positive?)
     assert(new_count.zero?)
 
     params = {
@@ -562,7 +562,7 @@ class ImageControllerTest < FunctionalTestCase
     proj = projects(:bolete_project)
     proj.observations << obs
     img_count = obs.images.size
-    assert(img_count > 0)
+    assert(img_count.positive?)
     assert(obs.thumb_image)
     file = Rack::Test::UploadedFile.new(
       "#{::Rails.root}/test/images/Coprinus_comatus.jpg", "image/jpeg"

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -466,7 +466,7 @@ class LocationControllerTest < FunctionalTestCase
         assert_equal(new_params[k], bfp[k])
       end
     end
-    assert(key_count > 0) # Make sure something was compared.
+    assert(key_count.positive?) # Make sure something was compared.
 
     # Rolf was already author, Mary doesn't become editor because
     # there was no change.

--- a/test/controllers/project_controller_test.rb
+++ b/test/controllers/project_controller_test.rb
@@ -181,7 +181,7 @@ class ProjectControllerTest < FunctionalTestCase
     assert(admin_group)
     drafts = NameDescription.where(source_name: project.title)
     project_draft_count = drafts.length
-    assert(project_draft_count > 0)
+    assert(project_draft_count.positive?)
     params = { id: project.id.to_s }
     requires_user(:destroy_project, :show_project, params, "dick")
     assert_redirected_to(action: :index_project)

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -1163,7 +1163,7 @@ class ApiTest < UnitTestCase
     assert_api_pass(params.merge(species_list: spl.title))
     assert_api_results([img1, img2])
 
-    attached   = Image.all.select { |i| i.observations.count > 0 }
+    attached   = Image.all.select { |i| i.observations.count.positive? }
     unattached = Image.all - attached
     assert_not_empty(attached)
     assert_not_empty(unattached)

--- a/test/models/eol_data_test.rb
+++ b/test/models/eol_data_test.rb
@@ -5,7 +5,7 @@ class EolDataTest < UnitTestCase
     name_id = name.id
     assert(obj.has_images?(name_id))
     assert_equal(Array, obj.images(name_id).class)
-    assert(obj.image_count(name_id) > 0,
+    assert(obj.image_count(name_id).positive?,
            "Expected #{name.text_name} image count > 0; " \
            "got #{obj.image_count(name_id)}")
     assert_equal(name.user.legal_name, obj.legal_name(name.user.id))

--- a/test/models/pattern_search_test.rb
+++ b/test/models/pattern_search_test.rb
@@ -461,21 +461,21 @@ class PatternSearchTest < UnitTestCase
 
   def test_observation_search_date
     expect = Observation.where("YEAR(`when`) = 2006")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("date:2006")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_created
     expect = Observation.where("YEAR(created_at) = 2010")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("created:2010")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_modified
     expect = Observation.where("YEAR(updated_at) = 2013")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("modified:2013")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
@@ -483,7 +483,7 @@ class PatternSearchTest < UnitTestCase
   def test_observation_search_name
     expect = Observation.where(name: names(:conocybe_filaris)) +
              Observation.where(name: names(:boletus_edulis))
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new(
       'name:"Conocybe filaris","Boletus edulis Bull."'
     )
@@ -492,7 +492,7 @@ class PatternSearchTest < UnitTestCase
 
   def test_observation_search_synonym_of
     expect = Observation.where(name: names(:peltigera))
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("synonym_of:Petigera")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
@@ -500,56 +500,56 @@ class PatternSearchTest < UnitTestCase
   def test_observation_search_child_of
     names = Name.where("text_name LIKE 'Agaricus%'")
     expect = Observation.where("name_id IN (#{names.map(&:id).join(",")})")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("child_of:Agaricus")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_location
     expect = Observation.where(location: locations(:burbank))
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new('location:"USA, California, Burbank"')
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_project
     expect = projects(:bolete_project).observations
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new('project:"Bolete Project"')
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_list
     expect = species_lists(:unknown_species_list).observations
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new('list:"List of mysteries"')
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_notes
     expect = Observation.where("notes LIKE '%somewhere else%'")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new('notes:"somewhere else"')
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_comments
     expect = Comment.where("summary LIKE '%complicated%'").map(&:target)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("comments:complicated")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_confidence
     expect = Observation.where(vote_cache: 3)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("confidence:90")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_gps
     expect = Observation.where(lat: 34.1622, long: -118.3521)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new(
       "west:-118.4 east:-118.3 north:34.2 south:34.1"
     )
@@ -558,70 +558,70 @@ class PatternSearchTest < UnitTestCase
 
   def test_observation_search_images_no
     expect = Observation.where("thumb_image_id IS NULL")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("images:no")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_images_yes
     expect = Observation.where("thumb_image_id IS NOT NULL")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("images:yes")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_specimens_no
     expect = Observation.where(specimen: false)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("specimen:no")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_specimens_yes
     expect = Observation.where(specimen: true)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("specimen:yes")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_sequence
     expect = Sequence.all.map(&:observation).uniq
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("sequence:yes")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_has_names_no
     expect = Observation.where(name: names(:fungi))
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("has_name:no")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_has_names_yes
     expect = Observation.where("name_id != #{names(:fungi).id}")
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("has_name:yes")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_has_notes_no
     expect = Observation.where("notes = ?", Observation.no_notes_persisted)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("has_notes:no")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_has_notes_yes
     expect = Observation.where("notes != ?", Observation.no_notes_persisted)
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("has_notes:yes")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_has_comments_yes
     expect = Comment.where(target_type: "Observation").map(&:target).uniq
-    assert(expect.count > 0)
+    assert(expect.count.positive?)
     x = PatternSearch::Observation.new("has_comments:yes")
     assert_obj_list_equal(expect, x.query.results, :sort)
   end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -981,7 +981,7 @@ class QueryTest < UnitTestCase
       imgs = Observation.find(obs).images.order("id ASC").map(&:id)
       # get first or last image in the list
       # depending on whether were going forward or back through results
-      img = inc > 0 ? imgs.first : imgs.last
+      img = inc.positive? ? imgs.first : imgs.last
     end
     [obs, imgs, img]
   end

--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -67,7 +67,7 @@ class ScriptTest < UnitTestCase
     script_succeeded = system(cmd)
 
     assert script_succeeded, "Script failed."
-    assert File.size(dest_file) > 0,
+    assert File.size(dest_file).positive?,
            "#{dest_file} should have content but is empty."
     assert_equal("", File.read(stdout_file),
                  "#{stdout_file} should be empty, but has content")

--- a/test/session_form_extensions.rb
+++ b/test/session_form_extensions.rb
@@ -377,7 +377,7 @@ module SessionExtensions
           matches << opt.label
         end
       end
-      context.assert(matches.length > 0,
+      context.assert(matches.length.positive?,
                      "Couldn't find any options in the pulldown " \
                      "#{field.id.inspect} that match #{label.inspect}.\n" \
                      "Have these: #{field.options.map(&:label).inspect}")


### PR DESCRIPTION
Predicates are the RuboCop default style and preferred by the MO developers. See https://mushroomobserver.slack.com/archives/C040TH9FV/p1548618290041400
- Delete configuration which used non-default style
- Change all instances of numerical comparisons to numerical predicates
- Exclude one non-Ruby file from Rubocop