### PR TITLE
[Delivers #163597896] Fix Error on adding Comment to Name

### DIFF
--- a/app/views/comment/add_comment.html.erb
+++ b/app/views/comment/add_comment.html.erb
@@ -3,17 +3,22 @@
 
   target_type = @comment.target_type.underscore.upcase.to_sym
   tabs = [
-    link_with_query(:cancel_and_show.t(type: target_type), @target.show_link_args)
+    link_with_query(:cancel_and_show.t(type: target_type),
+                    @target.show_link_args)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 
 <div class="row">
   <div class="col-xs-12 max-width-text">
-    <%= form_tag(add_query_param(action: :add_comment, id: @comment.target_id, type: @comment.target_type)) do %>
-      <%= submit_tag(:comment_add_create.l, class: "btn center-block push-down") %>
+    <%= form_tag(add_query_param(action: :add_comment,
+                                 id: @comment.target_id,
+                                 type: @comment.target_type)) do %>
+      <%= submit_tag(:comment_add_create.l,
+                     class: "btn center-block push-down") %>
       <%= render(partial: "form_comments") %>
-      <%= submit_tag(:comment_add_create.l, class: "btn center-block push-down") %>
+      <%= submit_tag(:comment_add_create.l,
+                     class: "btn center-block push-down") %>
       <hr align="center" width="90%" />
     <% end %>
   </div>

--- a/app/views/name/_name.html.erb
+++ b/app/views/name/_name.html.erb
@@ -6,41 +6,62 @@
 <p><%= :NAME.t %>: <%= h(name.real_text_name) %></p>
 <p><%= :AUTHORITY.t %>: <%= name.author.to_s.t %></p>
 <p><%= :CITATION.t %>: <%= name.citation.to_s.tl %></p>
-<% if name.is_misspelling? %>
+<%
+if name.is_misspelling? %>
   <p><%= :show_name_misspelling_correct.t %>:
-    <%= if name.correct_spelling
-      link_with_query(name.correct_spelling.display_name.t,
-        action: :show_name, id: name.correct_spelling_id)
-    else
-      # This can apparently happen for past_names.
-      name.correct_spelling_id
-    end %></p>
-<% end %>
+  <%=
+  if name.correct_spelling
+    link_with_query(name.correct_spelling.display_name.t,
+                    controller: :name,
+                    action: :show_name,
+                    id: name.correct_spelling_id)
+  else
+    # This can apparently happen for past_names.
+    name.correct_spelling_id
+  end %>
+  </p>
+<%
+end %>
 
-<% if synonyms
+<%
+if synonyms
   approved_synonyms, deprecated_synonyms = name.sort_synonyms
   misspellings = deprecated_synonyms.select(&:correct_spelling_id)
   deprecated_synonyms.reject!(&:correct_spelling_id)
   if approved_synonyms.try(&:any?)
     links = approved_synonyms.map do |n|
-      link_with_query(n.display_name.t, action: :show_name, id: n.id,)
+      link_with_query(n.display_name.t,
+                      controller: :name,
+                      action: :show_name,
+                      id: n.id,)
     end %>
-    <p><%= name.deprecated ? :show_name_preferred_synonyms.t :
-                          :show_name_synonyms.t %>:
-      <%= links.safe_join(", ") %></p>
-  <% end
+    <p><%=
+    name.deprecated ? :show_name_preferred_synonyms.t : :show_name_synonyms.t
+    %>:<%=
+    links.safe_join(", ")
+    %></p>
+  <%
+  end
   if deprecated_synonyms.try(&:any?)
     links = deprecated_synonyms.map do |n|
-      link_with_query(n.display_name.t, action: :show_name, id: n.id)
+      link_with_query(n.display_name.t,
+                      controller: :name,
+                      action: :show_name,
+                      id: n.id)
     end %>
     <p><%= :show_name_deprecated_synonyms.t %>:
       <%= links.safe_join(", ") %></p>
-  <% end
+  <%
+  end
   if misspellings.try(&:any?)
     links = misspellings.map do |n|
-      link_with_query(n.display_name.t, action: :show_name, id: n.id)
+      link_with_query(n.display_name.t,
+                      controller: :name,
+                      action: :show_name,
+                      id: n.id)
     end %>
     <p><%= :show_name_misspelled_synonyms.t %>:
       <%= links.safe_join(", ") %></p>
-  <% end
+  <%
+  end
 end %>


### PR DESCRIPTION
Adding a Comment to a Name that has synonyms was throwing an error.
The Comment form tries to create a link to all the synonyms.
It uses a partial to do this: app/views/name/_name_html.erb
Rails 4 `link_to` used to create the link route with the :name controller.
But Rails 5 does it with the :comment controller in this situation.
Solution:
- specify `controller: :name` in calls to `link_with_query` in _name_html.
- I also did some formatting changes in a couple of views so that I could read them easier. (Shortening the lines, and aligning the Rails stuff.)