### PR TITLE
Gives API users ability to get list of images belonging to a list of observations.

### DIFF
--- a/app/classes/api/image_api.rb
+++ b/app/classes/api/image_api.rb
@@ -24,6 +24,7 @@ class API
         synonym_names:   parse_array(:name, :synonyms_of, as: :id),
         children_names:  parse_array(:name, :children_of, as: :id),
         locations:       parse_array(:location, :location, as: :id),
+        observations:    parse_array(:observation, :observation, as: :id),
         projects:        parse_array(:project, :project, as: :id),
         species_lists:   parse_array(:species_list, :species_list, as: :id),
         has_observation: parse(:boolean, :has_observation,

--- a/app/classes/query/image_base.rb
+++ b/app/classes/query/image_base.rb
@@ -15,6 +15,7 @@ module Query
         synonym_names?:        [:string],
         children_names?:       [:string],
         locations?:            [:string],
+        observations?:         [Observation],
         projects?:             [:string],
         species_lists?:        [:string],
         has_observation?:      { boolean: [true] },
@@ -36,6 +37,11 @@ module Query
       initialize_model_do_time(:updated_at)
       initialize_model_do_date(:date, :when)
       initialize_model_do_objects_by_id(:users)
+      initialize_model_do_objects_by_id(
+        :observations,
+        "images_observations.observation_id",
+        join: :images_observations
+      )
       initialize_model_do_objects_by_name(
         Name, :names, "observations.name_id",
         join: { images_observations: :observations }

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -1156,7 +1156,7 @@ class ApiTest < UnitTestCase
     obs2 = observations(:coprinus_comatus_obs)
     assert_not_empty(obs1.images)
     assert_not_empty(obs2.images)
-    assert_api_pass(params.merge(observation: "#{obs1.id},#{obs2.id}")
+    assert_api_pass(params.merge(observation: "#{obs1.id},#{obs2.id}"))
     assert_api_results(obs1.images + obs2.images)
 
     project = projects(:bolete_project)

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -1152,6 +1152,13 @@ class ApiTest < UnitTestCase
     assert_api_pass(params.merge(location: burbank.id))
     assert_api_results(imgs)
 
+    obs1 = observations(:detailed_unknown_obs)
+    obs2 = observations(:coprinus_comatus_obs)
+    assert_not_empty(obs1.images)
+    assert_not_empty(obs2.images)
+    assert_api_pass(params.merge(observation: "#{obs1.id},#{obs2.id}")
+    assert_api_results(obs1.images + obs2.images)
+
     project = projects(:bolete_project)
     assert_not_empty(project.images)
     assert_api_pass(params.merge(project: "Bolete Project"))

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1660,6 +1660,10 @@ class QueryTest < UnitTestCase
   def test_image_all
     expect = Image.all.reverse
     assert_query(expect, :Image, :all)
+
+    obs = observations(:two_img_obs)
+    expect = obs.images
+    assert_query(expect, :Image, :all, observations: obs)
   end
 
   def test_image_by_user


### PR DESCRIPTION
Somehow left this out of original version.  Quick fix.