### PR TITLE
[Delivers #163697319] Update RuboCop to 0.63.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ gem "coveralls", require: false
 # Use rubocop for code style quality control
 gem "rubocop", require: false
 
+# use mry to support safe updating of .rubocop.yml
+gem "mry", require: false
+
 # Brakeman static analysis security scanner
 # See http://brakemanscanner.org/
 # We don't need the gem because CodeClimate CI includes a Brakeman engine.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,13 +136,15 @@ GEM
       ruby-progressbar
     mocha (1.7.0)
       metaclass (~> 0.0.1)
+    mry (0.59.0.0)
+      rubocop (>= 0.41.0)
     multi_json (1.13.1)
     mysql2 (0.5.2)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.12.1)
-    parser (2.5.3.0)
+    parallel (1.13.0)
+    parser (2.6.0.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     public_suffix (3.0.3)
@@ -186,7 +188,7 @@ GEM
     ref (2.0.0)
     regexp_parser (1.3.0)
     rtf (0.3.3)
-    rubocop (0.62.0)
+    rubocop (0.63.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -279,6 +281,7 @@ DEPENDENCIES
   minitest
   minitest-reporters
   mocha
+  mry
   mysql2
   rails (~> 5.2.2)
   rails-controller-testing


### PR DESCRIPTION
MO is using a different version of RC than Code Climate. So:
- bundle update rubocop (to get things in sync)
- Add mry gem
- Update .rubocop_yml using mry, and check for new cops. See https://github.com/pocke/mry/blob/master/README.md