### PR TITLE
[Delivers #163028761] Add Textile link to deprecate Name view

### DIFF
--- a/app/views/name/deprecate_name.html.erb
+++ b/app/views/name/deprecate_name.html.erb
@@ -31,6 +31,7 @@
   <p><label for="comment_comment"><%= :name_deprecate_comments.t %>:</label><br/>
   <%= text_area(:comment, :comment, cols: 80, rows: 5, value: @comment) %></p>
   <div class="HelpNote">
-    <%= :name_deprecate_comments_help.tp(name: @name.display_name) %>
+    <%= :name_deprecate_comments_help.tp(name: @name.display_name.chomp(".")) %>
+    <%= :field_textile_link.tp %>
   </div>
 <% end %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1608,8 +1608,8 @@
   name_deprecate_comment_summary: "[:Deprecated]"
   name_deprecate_comments: "[:Comments]"
   name_deprecate_submit: "[:SUBMIT]"
-  name_deprecate_preferred_help: Enter the preferred name.  Author citation is recommended but not required.
-  name_deprecate_comments_help: "Please include any notes about why this name has been deprecated.\nThis will be added to the notes for [name]."
+  name_deprecate_preferred_help: Enter the preferred name. Author citation is recommended but not required.
+  name_deprecate_comments_help: "Please say why this Name has been deprecated (e.g, a link to Index Fungorum). \nThis will be added to the Comments for [name]."
 
   # name/name_index (and other actions using same view)
   name_index_add_name: Add Name


### PR DESCRIPTION
Also improves text in that view:
- Change reference to "notes" to "Comments"
- Encourage users to provide IF link or other explanation for deprecation.