### PR TITLE
Replace deprecated assertions `assert_equal(nil, ...)`

### DIFF
--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -877,8 +877,8 @@ class ObservationTest < UnitTestCase
     assert_equal(-118.3521, obs.public_long)
 
     obs.update_attribute(:gps_hidden, true)
-    assert_equal(nil, obs.public_lat)
-    assert_equal(nil, obs.public_long)
+    assert_nil(obs.public_lat)
+    assert_nil(obs.public_long)
     User.current = mary
     assert_equal(34.1622, obs.public_lat)
     assert_equal(-118.3521, obs.public_long)


### PR DESCRIPTION
These were accidentally overlooked in PR #445 
DEPRECATED: Use assert_nil if expecting nil from test/models/observation_test.rb:880. This will fail in Minitest 6.