### PR TITLE
[Delivers #44504007] Fix _obj CAPS_ textile links

### DIFF
--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true.
 #
 #  == Textile Parser
 #
@@ -11,8 +12,9 @@
 #  textilize::                   Parse the given string.
 #  textilize_without_paragraph:: Parse the first paragraph of the given string.
 #  ---
-#  register_name::               Register a set of names that _S. name_ abbreviations may refer to.
-#  textile_name_size::           Report on the current size of the name lookup cache.
+#  register_name::               Register a set of names that _S. name_
+#                                abbreviations may refer to.
+#  textile_name_size::           Report on current size of name lookup cache.
 #  clear_textile_cache::         Flush the name lookup cache.
 #
 #  === Instance methods
@@ -33,8 +35,9 @@ class Textile < String
 
   URL_TRUNCATION_LENGTH = 60 unless defined?(URI_TRUNCATION_LENGTH)
 
-  # Convenience wrapper on the instance method Textile#textilize_without_paragraph.
-  def self.textilize_without_paragraph(str, do_object_links = false, sanitize = true)
+  # Convenience wrapper on instance method Textile#textilize_without_paragraph.
+  def self.textilize_without_paragraph(str, do_object_links = false,
+                                       sanitize = true)
     new(str).textilize_without_paragraph(do_object_links, sanitize)
   end
 
@@ -85,61 +88,18 @@ class Textile < String
     red.sanitize_html = sanitize
     replace(red.to_html)
 
-    # Remove pre-existing links first, replacing with "<XXXnn>".
-    hrefs = []
-    gsub!(%r{(<a[^>]*>.*?</a>|<img[^>]*>)}) do |href|
-      if do_object_links
-        href = href.gsub(/
-          x\{([A-Z]+) \s+ ([^\{\}]+?) \s+\}\{\s+ ([^\{\}]+?) \s+\}x
-        /x, '\\2')
-      end
-      hrefs.push(href)
-      "<XXX#{hrefs.length - 1}>"
-    end
+    # Strip <span class="caps">...</span> tags (leaving inner text intact).
+    # When RedCloth.to_html sees an ALLCAPS word, it wraps it with these tags.
+    # They mess up our url's. And we never need them. (We don't style "caps").
+    strip_caps_class_spans!
 
-    # Now turn bare urls into links.
-    gsub!(%r{([a-z]+://([^\s<>]|<span class="caps">[A-Z]+</span>)+)}) do |url|
-      url1  = url.gsub(%r{<span class="caps">([A-Z]+)</span>}, '\\1')
-      extra = url1.sub!(%r{([^\w/]+$)}, "") ? Regexp.last_match(1) : ""
-      url2  = ""
-      if url1.length > URL_TRUNCATION_LENGTH && !url1.starts_with?(MO.http_domain)
-        if url1 =~ %r{^(\w+://[^/]+)(.*?)$}
-          url2 = Regexp.last_match(1) + "/..."
-        else
-          url2 = url1[0..URL_TRUNCATION_LENGTH] + "..."
-        end
-      else
-        url2 = url1
-      end
-      # Leave as much untouched as possible, but some characters will cause the HTML
-      # to be badly formed, so we need to at least protect those.
-      url1.gsub!(/([<>"\\]+)/) { CGI.escape(Regexp.last_match(1)) }
-      "<a href=\"#{url1}\">#{url2}</a>" + extra
-    end
-
-    # Convert _object_ tags into proper links.
-    if do_object_links
-      gsub!(/
-        x\{([A-Z]+) \s+ ([^\{\}]+?) \s+\}\{\s+ ([^\{\}]+?) \s+\}x
-      /x) do |_orig|
-        type = Regexp.last_match(1)
-        label = Regexp.last_match(2)
-        id = Regexp.last_match(3)
-        id.gsub!(/&#822[01];/, '"')
-        id = CGI.unescapeHTML(id)
-        id = CGI.escape(id)
-        url = "#{MO.http_domain}/observer/lookup_#{type.downcase}/#{id}"
-        "<a href=\"#{url}\">#{label}</a>"
-      end
-    end
-
-    # Make sure all links are fully-qualified.
-    gsub!(%r{href="/}, "href=\"#{MO.http_domain}/")
-
-    # Put pre-existing links back in (removing the _object_ tag wrappers).
-    gsub!(/<XXX(\d+)>/) do
-      hrefs[Regexp.last_match(1).to_i].to_s.gsub(/ x\{ ([^\{\}]*) \}x /x, '\\1')
-    end
+    # Replace pre-existing links with "<XXXnn>" so that they aren't modified
+    # by the following lines, saving the links so we can restore them later.
+    saved_links = pre_existing_links_replaced_by_placeholders!(do_object_links)
+    convert_bare_urls_to_links!
+    convert_object_tags_to_proper_links!
+    fully_qualify_links!
+    restore_pre_existing_links!(saved_links)
 
     self
   end
@@ -147,18 +107,16 @@ class Textile < String
   # Register one or more names (instances) so that subsequent textile strings
   # can refer to them by abbreviation.
   def self.register_name(*names)
-    for name in names
-      if name.try(:at_or_below_genus?)
-        Textile.private_register_name(name.real_text_name, name.rank)
-      end
+    names.each do |name|
+      next unless name.try(:at_or_below_genus?)
+
+      Textile.private_register_name(name.real_text_name, name.rank)
     end
   end
 
   def self.private_register_name(name, rank)
     @@name_lookup ||= {}
-    if name =~ /([A-Z])/
-      @@name_lookup[Regexp.last_match(1)] = name.split.first
-    end
+    @@name_lookup[Regexp.last_match(1)] = name.split.first if name =~ /([A-Z])/
     if rank == :Species
       @@last_species    = name
       @@last_subspecies = nil
@@ -209,8 +167,10 @@ class Textile < String
 
   private
 
-  NAME_LINK_PATTERN = / (^|\W) (?:\**_+) ([^_]+) (?:_+\**) (?= (?:s|ish|like)? (?:\W|\Z) ) /x
-  OTHER_LINK_PATTERN = / (^|\W) (?:_+) ([a-zA-Z]+) \s+ ([^_\s](?:[^_\n]+[^_\s])?) (?:_+) (?!\w) /x
+  NAME_LINK_PATTERN =
+    / (^|\W) (?:\**_+) ([^_]+) (?:_+\**) (?= (?:s|ish|like)? (?:\W|\Z) ) /x
+  OTHER_LINK_PATTERN =
+    / (^|\W) (?:_+) ([a-zA-Z]+) \s+ ([^_\s](?:[^_\n]+[^_\s])?) (?:_+) (?!\w) /x
 
   # Convert __Names__ to links in a textile string.
   def check_name_links!
@@ -226,10 +186,11 @@ class Textile < String
       name = supply_implicit_species(name)
       name = strip_out_sp_cfr_and_sensu(name)
       if (parse = Name.parse_name(name)) &&
-         # Allowing arbitrary authors on Genera and higher makes it impossible to
-         # distinguish between publication titles and taxa, e.g., "Lichen Flora
-         # of the Greater Sonoran Region".  I'm sure it can still break with species
-         # but it should be very infrequent (I don't see it in current tests). -JPH
+         # Allowing arbitrary authors on Genera and higher makes it impossible
+         # to distinguish between publication titles and taxa, e.g.,
+         # "Lichen Flora of the Greater Sonoran Region".
+         # I'm sure it can still break with species but it should be
+         # very infrequent (I don't see it in current tests). -JPH
          (parse.author.blank? || parse.rank != :Genus)
         Textile.private_register_name(parse.real_text_name, parse.rank)
         prefix + "x{NAME __#{label}__ }{ #{name} }x"
@@ -306,7 +267,8 @@ class Textile < String
       ].select { |x| x[0] == type.downcase || x[1] == type.downcase }
       if matches.length == 1
         label = (/^\d+$/.match?(id) ? "#{type} #{id}" : id)
-        result = "#{prefix}x{#{matches.first.first.upcase} __#{label}__ }{ #{id} }x"
+        result =
+          "#{prefix}x{#{matches.first.first.upcase} __#{label}__ }{ #{id} }x"
       end
       result
     end
@@ -321,5 +283,77 @@ class Textile < String
       link = "#{MO.http_domain}/image/show_image/#{id}"
       "\"!#{src}!\":#{link}"
     end
+  end
+
+  def strip_caps_class_spans!
+    gsub!(%r{((<span class="caps">[A-Z]+</span>)+)}) do |url|
+      url.gsub(%r{<span class="caps">([A-Z]+)</span>}, '\\1')
+    end
+  end
+
+  # Remove pre-existing links, replacing them with "<XXXnn>" while saving them.
+  # Return array of saved links.
+  def pre_existing_links_replaced_by_placeholders!(do_object_links)
+    saved_links = []
+    gsub!(%r{(<a[^>]*>.*?</a>|<img[^>]*>)}) do |href|
+      if do_object_links
+        href = href.gsub(/
+          x\{([A-Z]+) \s+ ([^\{\}]+?) \s+\}\{\s+ ([^\{\}]+?) \s+\}x
+        /x, '\\2')
+      end
+      saved_links.push(href)
+      "<XXX#{saved_links.length - 1}>"
+    end
+    saved_links
+  end
+
+  def restore_pre_existing_links!(saved_links)
+    gsub!(/<XXX(\d+)>/) do
+      saved_links[Regexp.last_match(1).to_i].to_s.
+        gsub(/ x\{ ([^\{\}]*) \}x /x, '\\1')
+    end
+  end
+
+  def convert_bare_urls_to_links!
+    gsub!(%r{([a-z]+:\/\/[^\s<>]+)}) do |url|
+      extra = url.sub!(%r{([^\w/]+$)}, "") ? Regexp.last_match(1) : ""
+      # Leave as much untouched as possible, but some characters will cause the
+      # HTML to be badly formed, so escape them.
+      url.gsub!(/([<>"\\]+)/) { CGI.escape(Regexp.last_match(1)) }
+      "<a href=\"#{url}\">#{link_label(url)}</a>#{extra}"
+    end
+  end
+
+  def link_label(url)
+    return url unless truncate_link_label?(url)
+
+    if url =~ %r{^(\w+://[^/]+)(.*?)$}
+      Regexp.last_match(1) + "/..."
+    else
+      url[0..URL_TRUNCATION_LENGTH] + "..."
+    end
+  end
+
+  def truncate_link_label?(url)
+    url.length > URL_TRUNCATION_LENGTH && !url.starts_with?(MO.http_domain)
+  end
+
+  def convert_object_tags_to_proper_links!
+    gsub!(/
+      x\{([A-Z]+) \s+ ([^\{\}]+?) \s+\}\{\s+ ([^\{\}]+?) \s+\}x
+    /x) do |_orig|
+      type = Regexp.last_match(1)
+      label = Regexp.last_match(2)
+      id = Regexp.last_match(3)
+      id.gsub!(/&#822[01];/, '"')
+      id = CGI.unescapeHTML(id)
+      id = CGI.escape(id)
+      url = "#{MO.http_domain}/observer/lookup_#{type.downcase}/#{id}"
+      "<a href=\"#{url}\">#{label}</a>"
+    end
+  end
+
+  def fully_qualify_links!
+    gsub!(%r{href="/}, "href=\"#{MO.http_domain}/")
   end
 end

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true.
-#
+
+require "cgi"
+require "redcloth"
+
 #  == Textile Parser
 #
 #  This class -- a subclass of String -- is a wrapper on RedCloth.  It provides
@@ -22,11 +25,6 @@
 #  textilize::                   Parse the given string.
 #  textilize_without_paragraph:: Parse the first paragraph of the given string.
 #
-################################################################################
-
-require "cgi"
-require "redcloth"
-
 class Textile < String
   @@name_lookup     = {}
   @@last_species    = nil

--- a/test/account_mailer/add_herbarium_record_not_curator.html
+++ b/test/account_mailer/add_herbarium_record_not_curator.html
@@ -8,7 +8,7 @@ Subject: [MO] Herbarium Record Added to The New York Botanical Garden
 </head>
 <body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
 <div class="textile"><h2><strong>Herbarium Record Added By Non-Curator</strong></h2>
-<p>The user, rolf, added the herbarium record, Cortinarius sp.: <span class="caps">NYBG</span> 1234, to the herbarium, The New York Botanical Garden, which you curate.</p></div>
+<p>The user, rolf, added the herbarium record, Cortinarius sp.: NYBG 1234, to the herbarium, The New York Botanical Garden, which you curate.</p></div>
 <div class="textile"><p>Here are some handy links:</p></div>
 <ul type=none>
 <li>Show this herbarium record: <a href="http://mushroomobserver.org/herbarium_record/show_herbarium_record/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %>">http://mushroomobserver.org/herbarium_record/show_herbarium_record/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %></a></li>

--- a/test/account_mailer/admin_request.html
+++ b/test/account_mailer/admin_request.html
@@ -8,7 +8,7 @@ Subject: [MO] Please do something or other
 </head>
 <body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
 <div class="textile"><h2><strong>Admin Request</strong></h2>
-<p>Katrina (katrina&#64;collectivesource.com) asked the Mushroom Observer website to forward the following request to you regarding <span class="caps">EOL</span> Project:</p></div>
+<p>Katrina (katrina&#64;collectivesource.com) asked the Mushroom Observer website to forward the following request to you regarding EOL Project:</p></div>
 <div style='margin-left:20px; margin-right:20px; padding-left:20px; padding-right:20px; padding-top:10px; padding-bottom:10px; border:1px dotted; background:#E0E0E0; color:#000000;'>
 <div class="textile"><p>and this is why&#8230;</p></div>
 </div>

--- a/test/account_mailer/comment.html
+++ b/test/account_mailer/comment.html
@@ -9,7 +9,7 @@ Subject: [MO] Comment About Fungi (<%= ActiveRecord::FixtureSet.identify(:minima
 <body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
 <div class="textile"><h2><strong>Comment on Your Observation</strong></h2>
 <p>The following comment was posted on the Mushroom Observer website regarding your observation <u><b><i>Fungi</i></b> (<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %>)</u>:</p></div>
-<div class="textile"><p><strong>Created:</strong> 2006-03-02 16:14:00 <span class="caps">EST</span> (-0500)<br />
+<div class="textile"><p><strong>Created:</strong> 2006-03-02 16:14:00 EST (-0500)<br />
 <strong>By:</strong> Rolf Singer (rolf)<br />
 <strong>Summary:</strong> A comment on minimal unknown<br />
 <strong>Comment:</strong></p></div>

--- a/test/account_mailer/comment_response.html
+++ b/test/account_mailer/comment_response.html
@@ -9,7 +9,7 @@ Subject: [MO] Comment About Fungi (<%= ActiveRecord::FixtureSet.identify(:minima
 <body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
 <div class="textile"><h2><strong>Comment Response</strong></h2>
 <p>The following comment was posted on the Mushroom Observer website in response to your comment regarding the observation <u><b><i>Fungi</i></b> (<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %>)</u>:</p></div>
-<div class="textile"><p><strong>Created:</strong> 2006-03-02 16:16:00 <span class="caps">EST</span> (-0500)<br />
+<div class="textile"><p><strong>Created:</strong> 2006-03-02 16:16:00 EST (-0500)<br />
 <strong>By:</strong> Tricky Dick (dick)<br />
 <strong>Summary:</strong> Let&#8217;s <em>try</em> a more &#8220;complicated&#8221; comment.<br />
 <strong>Comment:</strong></p></div>

--- a/test/account_mailer/consensus_change.html
+++ b/test/account_mailer/consensus_change.html
@@ -17,8 +17,7 @@ shroomobserver.org/name/show_name/<%= ActiveRecord::FixtureSet.identify(:agaricu
 <strong>New name:</strong> <a href=3D"http://mushroomobserver.org/name/sh=
 ow_name/<%= ActiveRecord::FixtureSet.identify(:coprinus_comatus) %>"><b><i>Coprinus comatus</i></b> (O.F. M=C3=BCll.) Pers.=
 </a><br />
-<strong>Time:</strong> IGNORE <span class=3D"caps">IGNORE</span=
-> IGNORE<br />
+<strong>Time:</strong> IGNORE IGNORE IGNORE<br />
 <strong>By:</strong> Tricky Dick (dick)</p></div>
 <div class=3D"textile"><p>Here are some handy links:</p></div>
 <ul type=3Dnone>

--- a/test/account_mailer/location_change.html
+++ b/test/account_mailer/location_change.html
@@ -9,10 +9,10 @@ e>
 </head>
 <body topmargin=3D0 leftmargin=3D0 rightmargin=3D0 bottommargin=3D0><br/>=
 <div class=3D"textile"><h2><strong>Location was Changed</strong></h2>
-<p>There were change(s) made to the location <u>Albion, California, <span=
-class=3D"caps">USA</span> (<%= ActiveRecord::FixtureSet.identify(:albion) %>)</u>:</p></div>
-<div class=3D"textile"><p><strong>Time:</strong> 2007-12-27 01:41:20 <spa=
-n class=3D"caps">EST</span> (-0500)<br />
+<p>There were change(s) made to the location <u>Albion, California, USA (=
+820908802)</u>:</p></div>
+<div class=3D"textile"><p><strong>Time:</strong> 2007-12-27 01:41:20 EST =
+(-0500)<br />
 <strong>By:</strong> Tricky Dick (dick)</p></div>
 <div class=3D"textile"><p><strong>North edge changed to:</strong> 39.32<b=
 r />
@@ -29,15 +29,15 @@ o play with.</p></div>
 <div class=3D"textile"><p>Here are some handy links:</p></div>
 <ul type=3Dnone>
 <li>Show this location: <a href=3D"http://mushroomobserver.org/locati=
-on/show_location/<%= ActiveRecord::FixtureSet.identify(:albion) %>">http://mushroomobserver.org/location/show_loc=
-ation/<%= ActiveRecord::FixtureSet.identify(:albion) %></a></li>
+on/show_location/820908802">http://mushroomobserver.org/location/show_loc=
+ation/820908802</a></li>
 <li>I&#8217;m not interested in this location: <a href=3D"http://mush=
-roomobserver.org/interest/set_interest?id=3D<%= ActiveRecord::FixtureSet.identify(:albion) %>&amp;type=3DLocation=
-&amp;user=3D<%= ActiveRecord::FixtureSet.identify(:mary) %>&amp;state=3D-1">http://mushroomobserver.org/interes=
-t/set_interest?id=3D<%= ActiveRecord::FixtureSet.identify(:albion) %>&amp;type=3DLocation&amp;user=3D<%= ActiveRecord::FixtureSet.identify(:mary) %>&am=
+roomobserver.org/interest/set_interest?id=3D820908802&amp;type=3DLocation=
+&amp;user=3D365790011&amp;state=3D-1">http://mushroomobserver.org/interes=
+t/set_interest?id=3D820908802&amp;type=3DLocation&amp;user=3D365790011&am=
 p;state=3D-1</a></li>
 <li>Change your preferences: <a href=3D"http://mushroomobserver.org/a=
-ccount/prefs/<%= ActiveRecord::FixtureSet.identify(:mary) %>">http://mushroomobserver.org/account/prefs/3657900=
+ccount/prefs/365790011">http://mushroomobserver.org/account/prefs/3657900=
 11</a></li>
 <li>Latest changes at Mushroom Observer: <a href=3D"http://mushroomob=
 server.org">http://mushroomobserver.org</a></li>

--- a/test/account_mailer/name_proposal.html
+++ b/test/account_mailer/name_proposal.html
@@ -10,7 +10,7 @@ Subject: [MO] Observation #<%= ActiveRecord::FixtureSet.identify(:coprinus_comat
 <div class="textile"><h2><strong>Name Proposal</strong></h2>
 <p>A name was proposed for observation #<%= ActiveRecord::FixtureSet.identify(:coprinus_comatus_obs) %>:</p></div>
 <div class="textile"><p><strong>Name:</strong> <b><i>Agaricus campestris</i></b> L.<br />
-<strong>Time:</strong> 2007-02-28 15:20:00 <span class="caps">EST</span> (-0500)<br />
+<strong>Time:</strong> 2007-02-28 15:20:00 EST (-0500)<br />
 <strong>By:</strong> Mary Newbie (mary)<br />
 <strong>Recognized by sight</strong><br />
 <strong>Used references:</strong> I asked <strong>Uncle Herb</strong></p></div>

--- a/test/account_mailer/observation_change.html
+++ b/test/account_mailer/observation_change.html
@@ -10,7 +10,7 @@ Subject: [MO] Observation Changed, Coprinus comatus (O.F. Mull.) Pers.
 <body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
 <div class="textile"><h2><strong>Observation was Changed</strong></h2>
 <p>There were change(s) made to the observation <u><b><i>Coprinus comatus</i></b> (O.F. Mull.) Pers. (<%= ActiveRecord::FixtureSet.identify(:coprinus_comatus_obs) %>)</u>:</p></div>
-<div class="textile"><p><strong>Time:</strong> 2007-02-27 15:20:00 <span class="caps">EST</span> (-0500)<br />
+<div class="textile"><p><strong>Time:</strong> 2007-02-27 15:20:00 EST (-0500)<br />
 <strong>By:</strong> Tricky Dick (dick)</p></div>
 <div class="textile"><p><strong>Date changed to:</strong> 2007-02-27<br />
 <strong>Location changed to:</strong> Glendale, California<br />

--- a/test/account_mailer/observation_destroy.html
+++ b/test/account_mailer/observation_destroy.html
@@ -9,7 +9,7 @@ Subject: [MO] Observation Destroyed, Coprinus comatus L. (123)
 <body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
 <div class="textile"><h2><strong>Observation Destroyed</strong></h2></div>
 <div class="textile"><p><strong>Observation:</strong> <b><i>Coprinus comatus</i></b> L. (123)<br />
-<strong>Time:</strong> 2007-02-27 15:20:00 <span class="caps">EST</span> (-0500)<br />
+<strong>Time:</strong> 2007-02-27 15:20:00 EST (-0500)<br />
 <strong>By:</strong> Tricky Dick (dick)</p></div>
 <div class="textile"></div>
 <div class="textile"><p>Here are some handy links:</p></div>

--- a/test/account_mailer/verify_api_key.html
+++ b/test/account_mailer/verify_api_key.html
@@ -12,17 +12,15 @@ Subject: [MO] Activate API Key
 ociated with user &#8220;dick&#8221;) has requested access to your Mushro=
 om Observer account.  If you recognize this application and wish to give =
 them permission to post observations, etc. in your name, all you have to =
-do is click on the activation link below to activate the <span class=3D"c=
-aps">API</span> key they just created.  Note that you can review your lis=
-t of <span class=3D"caps">API</span> keys at any time by visiting the <sp=
-an class=3D"caps">API</span> Key Manager from your &#8220;Preferences&#82=
-21; page.</p>
+do is click on the activation link below to activate the API key they jus=
+t created.  Note that you can review your list of API keys at any time by=
+visiting the API Key Manager from your &#8220;Preferences&#8221; page.</=
+p>
 <p>Activate Key: <a href=3D"http://mushroomobserver.org/account/activate_=
-api_key/<%= ActiveRecord::FixtureSet.identify(:rolfs_api_key) %>">http://mushroomobserver.org/account/activate_api_key/4=
+api_key/410722405">http://mushroomobserver.org/account/activate_api_key/4=
 10722405</a><br />
-<span class=3D"caps">API</span> Key Manager: <a href=3D"http://mushroomob=
-server.org/account/api_keys">http://mushroomobserver.org/account/api_keys=
-</a></p>
+API Key Manager: <a href=3D"http://mushroomobserver.org/account/api_keys"=
+>http://mushroomobserver.org/account/api_keys</a></p>
 <p>To report a suspicious access request, just respond to this email.</p>=
 </div>
 <br/>

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -274,10 +274,7 @@ class ApiControllerTest < FunctionalTestCase
               nil
             end
     assert_not_equal("", key.to_s)
-    assert_equal(
-      "&lt;p&gt;New &lt;span class=\"caps\"&gt;API&lt;/span&gt; Key&lt;/p&gt;",
-      notes.to_s
-    )
+    assert_equal(CGI.escapeHTML("<p>New API Key</p>"), notes.to_s)
   end
 
   def test_post_api_key

--- a/test/integration/post_observation_test.rb
+++ b/test/integration/post_observation_test.rb
@@ -192,11 +192,7 @@ class PostObservationTest < IntegrationTestCase
     new_loc = Location.last
     new_img = Image.last
     assert_match(new_obs.when.web_date, response.body)
-    # USA ends up as <span class="caps">USA</span>,
-    # so just search for each component
-    new_loc.name.split(", ").each do |token|
-      assert_match(token, response.body)
-    end
+    assert_match(new_loc.name, response.body)
     if new_obs.is_collection_location
       assert_match(:show_observation_collection_location.l, response.body)
     else

--- a/test/models/textile_test.rb
+++ b/test/models/textile_test.rb
@@ -123,6 +123,18 @@ class TextileTest < UnitTestCase
                  do_other_links("_user phooey_ _name gar_"))
   end
 
+  def test_location_lookup
+    # This loc has 2 all-caps words to insure we're stripping
+    # some tags added by Redcloth
+    loc = "OSU, Corvallis, Oregon, USA"
+    textile = "_location #{loc}_".tpl
+    assert_match(
+      "#{MO.http_domain}/observer/lookup_location/#{CGI.escape(loc)}", # href
+      textile
+     )
+    assert_match("<i>#{loc}</i>", textile) # anchor text
+  end
+
   def test_url_formatting
     assert_href_equal(
       "#{MO.http_domain}/observer/lookup_name/Amanita+%22sp-O01%22",

--- a/test/models/textile_test.rb
+++ b/test/models/textile_test.rb
@@ -131,7 +131,7 @@ class TextileTest < UnitTestCase
     assert_match(
       "#{MO.http_domain}/observer/lookup_location/#{CGI.escape(loc)}", # href
       textile
-     )
+    )
     assert_match("<i>#{loc}</i>", textile) # anchor text
   end
 


### PR DESCRIPTION
Textile links like `_location Utah, USA_` are broken because Redcloth wraps
`<span class="caps">...</span>` around allcaps words. 
Solution: remove all those tags after Redcloth converts something to HTML.

Rubocop changed lines .rb files (+5 squashed commits)
Squashed commits:
[08434d53] Refactor #textilize for brevity, better understanding
- Extract methods to shorten code and reduce comments
- Simplify conditional expressions
[c15eb03b] Extract stripping of caps class spans
[5224a9e9] Remove now-unneeded workaround of `<span class="caps">`
[f8ae3bae] Remove <span class="caps"> tags from test expects
[040dc296] [Delivers #44504007] Fix `_obj ALLCAPS_` textile links
- Write test to provoke bug
- Fix bug by stripping all `<span class="caps">` tags