### PR TITLE
Bump RuboCop "channel" used by Travis to 0.64

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -118,7 +118,8 @@ plugins:
     # Specify RuboCop version so that we're not stuck with Code Climate's
     # default, which can be different than what's in Gemfile.lock.
     # WARNING: update this setting whenever we update RuboCop
-    channel: rubocop-0-63
+    # See https://docs.codeclimate.com/docs/rubocop
+    channel: rubocop-0-64
 
 # scss style checker
   scss-lint:

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem "coveralls", require: false
 
 # Use rubocop for code style quality control
 # TODO: update .codeclimate.yml's RuboCop channel whenever we update RuboCop.
+#  See https://docs.codeclimate.com/docs/rubocop
 gem "rubocop", require: false
 
 # use mry to support safe updating of .rubocop.yml

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -650,7 +650,7 @@ class Location < AbstractModel
 
     # Log the action.
     old_loc.rss_log&.orphan(old_loc.name, :log_location_merged,
-                           this: old_loc.name, that: name)
+                            this: old_loc.name, that: name)
 
     # Destroy past versions.
     editors = []

--- a/app/models/name/merge.rb
+++ b/app/models/name/merge.rb
@@ -81,7 +81,7 @@ class Name < AbstractModel
 
     # Log the action.
     old_name.rss_log&.orphan(old_name.display_name, :log_name_merged,
-                              this: old_name.display_name, that: display_name)
+                             this: old_name.display_name, that: display_name)
 
     # Destroy past versions.
     editors = []


### PR DESCRIPTION
We have installed RuboCop 0.65, but Code Climate was configured to use 0.63.
That can create inconsistencies between local and CI reports.

This gets the two versions a little closer together. (Unfortunately a Code Climate 0-65 channel is not yet available.)