### PR TITLE
[Fixes #164679875] Remove extra `AllCops` line in RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,10 +12,8 @@ AllCops:
   # Ignore cops for Ruby versions which are newer than that used by MO
   TargetRubyVersion: 2.4.1
 
-###################### Exclusions ##############################################
-
-# Completely ignore the following
-AllCops:
+  ###################### Exclusions ############################################
+  # Completely ignore the following
   Exclude:
     - .codeclimate.yml
     - app/assets/javascripts/bootstrap.js


### PR DESCRIPTION
When RuboCop was run locally, this line:
- caused a warning/error message, and
- may have caused RuboCop to ignore the TargetRubyVersion, which may have reported inappropriate offenses.