### PR TITLE
Cleanup LineLength PRs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -570,9 +570,3 @@ Style/LineEndConcatenation:
   Exclude:
     - 'test/general_extensions.rb'
     - 'test/integration/curator_test.rb'
-
-# Offense count: 653
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 212

--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -243,50 +243,38 @@ module PatternSearch
       raise TooManyValuesError.new(var: var) if vals.length > 1
 
       val = vals.first
-      if val =~ /^(\d\d\d\d)$/
-        [format("%04d-%02d-%02d", Regexp.last_match(1).to_i, 1, 1),
-         format("%04d-%02d-%02d", Regexp.last_match(1).to_i, 12, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 1),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i,
-                Regexp.last_match(3).to_i),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i,
-                Regexp.last_match(3).to_i)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d\d\d)$/
-        [format("%04d-%02d-%02d", Regexp.last_match(1).to_i, 1, 1),
-         format("%04d-%02d-%02d", Regexp.last_match(2).to_i, 12, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)-(\d\d\d\d)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 1),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(3).to_i, Regexp.last_match(4).to_i, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)-(\d\d?)-(\d\d\d\d)-(\d\d?)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i,
-                Regexp.last_match(3).to_i),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(4).to_i, Regexp.last_match(5).to_i,
-                Regexp.last_match(6).to_i)]
-      elsif val =~ /^(\d\d?)$/
-        [format("%02d-%02d", Regexp.last_match(1).to_i, 1),
-         format("%02d-%02d", Regexp.last_match(1).to_i, 31)]
-      elsif val =~ /^(\d\d?)-(\d\d?)$/
-        [format("%02d-%02d", Regexp.last_match(1).to_i, 1),
-         format("%02d-%02d", Regexp.last_match(2).to_i, 31)]
-      elsif val =~ /^(\d\d?)-(\d\d?)-(\d\d?)-(\d\d?)$/
-        [format("%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i),
-         format("%02d-%02d",
-                Regexp.last_match(3).to_i, Regexp.last_match(4).to_i)]
+      if /^(?<yr>\d{4})$/ =~ val
+        yyyymmdd([yr, 1, 1], [yr, 12, 31])
+      elsif /^(?<yr>\d{4})-(?<mo>\d\d?)$/ =~ val
+        yyyymmdd([yr, mo, 1], [yr, mo, 31])
+      elsif /^(?<yr>\d{4})-(?<mo>\d\d?)-(?<day>\d\d?)$/ =~ val
+        yyyymmdd([yr, mo, day], [yr, mo, day])
+      elsif /^(?<yr1>\d{4})-(?<yr2>\d{4})$/ =~ val
+        yyyymmdd([yr1, 1, 1], [yr2, 12, 31])
+      elsif /^(?<yr1>\d{4})-(?<mo1>\d\d?)-(?<yr2>\d{4})-(?<mo2>\d\d?)$/ =~ val
+        yyyymmdd([yr1, mo1, 1], [yr2, mo2, 31])
+      elsif /^(?<yr1>\d{4})-(?<mo1>\d\d?)-(?<dy1>\d\d?)-
+             (?<yr2>\d{4})-(?<mo2>\d\d?)-(?<dy2>\d\d?)$/x =~ val
+        yyyymmdd([yr1, mo1, dy1], [yr2, mo2, dy2])
+      elsif /^(?<mo>\d\d?)$/ =~ val
+        mmdd([mo, 1], [mo, 31])
+      elsif /^(?<mo1>\d\d?)-(?<mo2>\d\d?)$/ =~ val
+        mmdd([mo1, 1], [mo2, 31])
+      elsif /^(?<mo1>\d\d?)-(?<dy1>\d\d?)-(?<mo2>\d\d?)-(?<dy2>\d\d?)$/ =~ val
+        mmdd([mo1, dy1], [mo2, dy2])
       else
         raise BadDateRangeError.new(var: var, val: val)
       end
+    end
+
+    def yyyymmdd(from, to)
+      [format("%04d-%02d-%02d", from.first, from.second.to_i, from.third.to_i),
+       format("%04d-%02d-%02d", to.first, to.second.to_i, to.third.to_i)]
+    end
+
+    def mmdd(from, to)
+      [format("%02d-%02d", from.first.to_i, from.second.to_i),
+       format("%02d-%02d", to.first.to_i, to.second.to_i)]
     end
 
     def parse_rank_range

--- a/lib/tasks/jason.rake
+++ b/lib/tasks/jason.rake
@@ -676,15 +676,16 @@ namespace :jason do
       loc ||= val
     elsif !loc
       val2 = val.downcase.gsub(/\W+/, " ")
-      # results = Location.find(:all, :conditions => "search_name like '%#{val2}%'", :order => "name asc") # Rails 3
       results = Location.where("search_name LIKE ?", "%#{val2}%").
                 order(name).to_a
       if results.empty?
-        lines.push('>>>>>>>> couldn\'t find any matching locations (add "*" to end to create)')
+        lines.push(">>>>>>>> couldn't find any matching locations" \
+                   "(add '*' to end to create)")
       elsif results.length == 1
         loc = results.first
       elsif results.length > 1
-        lines.push('>>>>>>>> multiple locations match: (add "*" to end to create)')
+        lines.push(">>>>>>>> multiple locations match: "\
+                   "(add '*' to end to create)")
         for x in results
           lines.push(">>>>>>>>   %s" % x.name)
         end


### PR DESCRIPTION
- Fix some offenses missed in "LineLength" PRs in PRs 464-476
- Unhide LineLength offenses.
(These were masked by .rubocop_todo. So remove the lines which masked it.)