### PR TITLE
Include preferred Name in Observation title

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -570,9 +570,3 @@ Style/LineEndConcatenation:
   Exclude:
     - 'test/general_extensions.rb'
     - 'test/integration/curator_test.rb'
-
-# Offense count: 653
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 212

--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -243,50 +243,38 @@ module PatternSearch
       raise TooManyValuesError.new(var: var) if vals.length > 1
 
       val = vals.first
-      if val =~ /^(\d\d\d\d)$/
-        [format("%04d-%02d-%02d", Regexp.last_match(1).to_i, 1, 1),
-         format("%04d-%02d-%02d", Regexp.last_match(1).to_i, 12, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 1),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i,
-                Regexp.last_match(3).to_i),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i,
-                Regexp.last_match(3).to_i)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d\d\d)$/
-        [format("%04d-%02d-%02d", Regexp.last_match(1).to_i, 1, 1),
-         format("%04d-%02d-%02d", Regexp.last_match(2).to_i, 12, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)-(\d\d\d\d)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, 1),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(3).to_i, Regexp.last_match(4).to_i, 31)]
-      elsif val =~ /^(\d\d\d\d)-(\d\d?)-(\d\d?)-(\d\d\d\d)-(\d\d?)-(\d\d?)$/
-        [format("%04d-%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i,
-                Regexp.last_match(3).to_i),
-         format("%04d-%02d-%02d",
-                Regexp.last_match(4).to_i, Regexp.last_match(5).to_i,
-                Regexp.last_match(6).to_i)]
-      elsif val =~ /^(\d\d?)$/
-        [format("%02d-%02d", Regexp.last_match(1).to_i, 1),
-         format("%02d-%02d", Regexp.last_match(1).to_i, 31)]
-      elsif val =~ /^(\d\d?)-(\d\d?)$/
-        [format("%02d-%02d", Regexp.last_match(1).to_i, 1),
-         format("%02d-%02d", Regexp.last_match(2).to_i, 31)]
-      elsif val =~ /^(\d\d?)-(\d\d?)-(\d\d?)-(\d\d?)$/
-        [format("%02d-%02d",
-                Regexp.last_match(1).to_i, Regexp.last_match(2).to_i),
-         format("%02d-%02d",
-                Regexp.last_match(3).to_i, Regexp.last_match(4).to_i)]
+      if /^(?<yr>\d{4})$/ =~ val
+        yyyymmdd([yr, 1, 1], [yr, 12, 31])
+      elsif /^(?<yr>\d{4})-(?<mo>\d\d?)$/ =~ val
+        yyyymmdd([yr, mo, 1], [yr, mo, 31])
+      elsif /^(?<yr>\d{4})-(?<mo>\d\d?)-(?<day>\d\d?)$/ =~ val
+        yyyymmdd([yr, mo, day], [yr, mo, day])
+      elsif /^(?<yr1>\d{4})-(?<yr2>\d{4})$/ =~ val
+        yyyymmdd([yr1, 1, 1], [yr2, 12, 31])
+      elsif /^(?<yr1>\d{4})-(?<mo1>\d\d?)-(?<yr2>\d{4})-(?<mo2>\d\d?)$/ =~ val
+        yyyymmdd([yr1, mo1, 1], [yr2, mo2, 31])
+      elsif /^(?<yr1>\d{4})-(?<mo1>\d\d?)-(?<dy1>\d\d?)-
+             (?<yr2>\d{4})-(?<mo2>\d\d?)-(?<dy2>\d\d?)$/x =~ val
+        yyyymmdd([yr1, mo1, dy1], [yr2, mo2, dy2])
+      elsif /^(?<mo>\d\d?)$/ =~ val
+        mmdd([mo, 1], [mo, 31])
+      elsif /^(?<mo1>\d\d?)-(?<mo2>\d\d?)$/ =~ val
+        mmdd([mo1, 1], [mo2, 31])
+      elsif /^(?<mo1>\d\d?)-(?<dy1>\d\d?)-(?<mo2>\d\d?)-(?<dy2>\d\d?)$/ =~ val
+        mmdd([mo1, dy1], [mo2, dy2])
       else
         raise BadDateRangeError.new(var: var, val: val)
       end
+    end
+
+    def yyyymmdd(from, to)
+      [format("%04d-%02d-%02d", from.first, from.second.to_i, from.third.to_i),
+       format("%04d-%02d-%02d", to.first, to.second.to_i, to.third.to_i)]
+    end
+
+    def mmdd(from, to)
+      [format("%02d-%02d", from.first.to_i, from.second.to_i),
+       format("%02d-%02d", to.first.to_i, to.second.to_i)]
     end
 
     def parse_rank_range

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -782,15 +782,15 @@ class AccountController < ApplicationController
     end
   end
 
-  SPAM_BLOCKERS = %w(
+  SPAM_BLOCKERS = %w[
     hotmail.com
-  )
+  ].freeze
 
   def notify_root_of_blocked_verification_email(user)
     domain = user.email.to_s.sub(/^.*@/, "")
     return unless SPAM_BLOCKERS.any? { |d| domain == d }
 
-    url = "#{MO.http_domain}/account/verify/#{user.id}?" +
+    url = "#{MO.http_domain}/account/verify/#{user.id}?" \
           "auth_code=#{user.auth_code}"
     subject = :email_subject_verify.l
     content = :email_verify_intro.tp(user: @user.login, link: url)

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -793,7 +793,7 @@ class AccountController < ApplicationController
     url = "#{MO.http_domain}/account/verify/#{user.id}?" \
           "auth_code=#{user.auth_code}"
     subject = :email_subject_verify.l
-    content = :email_verify_intro.tp(user: @user.login, link: url)
+    content = :email_verify_intro.tp(user: user.login, link: url)
     content = "email: #{user.email}\n\n" + content.html_to_ascii
     WebmasterEmail.build(user.email, content, subject).deliver_now
   end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -794,6 +794,7 @@ class AccountController < ApplicationController
           "auth_code=#{user.auth_code}"
     subject = :email_subject_verify.l
     content = :email_verify_intro.tp(user: @user.login, link: url)
+    content = "email: #{user.email}\n\n" + content.html_to_ascii
     WebmasterEmail.build(user.email, content, subject).deliver_now
   end
 end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -44,7 +44,7 @@ module ObjectLinkHelper
       str ||= :NAME.t + " #" + name.to_s
       link_to(str, Name.show_link_args(name))
     else
-      str ||= name.short_authors_display_name.t
+      str ||= name.display_name_brief_authors.t
       link_to(str, name.show_link_args)
     end
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -44,7 +44,7 @@ module ObjectLinkHelper
       str ||= :NAME.t + " #" + name.to_s
       link_to(str, Name.show_link_args(name))
     else
-      str ||= name.display_name.t
+      str ||= name.short_authors_display_name.t
       link_to(str, name.show_link_args)
     end
   end

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -1,37 +1,59 @@
 # frozen_string_literal: true
 
 # helpers for show Observation view
-module ObservationHelper
+module ObserverHelper
+  ##### Portion of page title that includes consensus (site id) ################
+
   def show_obs_title(obs)
-    @owner_id ? show_obs_title_site_id(obs) : show_obs_title_num_after_name(obs)
+    @owner_id ? obs_title_with_name_and_site_id(obs) : obs_title_with_name(obs)
   end
 
-  # Observation: Agaricus (5)
-  def show_obs_title_num_after_name(obs)
+  # Observation nnn: Hydnum washingtonianum (Site ID)
+  #   or, if name is deprecated, include preferred name in parentheses
+  # Observation nnn: Hydnum neorepandum (Hydnum washingtonianum) (Site ID)
+  def obs_title_with_name_and_site_id(obs)
     capture do
-      concat(:show_observation_header.t)
-      concat(" #{obs.id || "?"}: ")
-      concat(obs.name.format_name.t)
-    end
-  end
-
-  # Observation 5: Agaricus (Site ID)
-  def show_obs_title_site_id(obs)
-    capture do
-      concat(:show_observation_header.t)
-      concat(" #{obs.id || "?"}: ")
-      concat(obs.name.format_name.t)
+      concat(obs_title_with_name(obs))
+      # "(Site ID)" differentiates this Name from Observer Preference
       concat(" (#{:show_observation_site_id.t})")
     end
   end
 
-  # Observer Preference: Agaricus L.
+  # Same as above, sans (Site ID)
+  # Used when user prefers not to display Observer Preference
+  def obs_title_with_name(obs)
+    capture do
+      concat(:show_observation_header.t)
+      concat(" #{obs.id || "?"}: ")
+      concat(obs_title_consensus_id(obs.name))
+    end
+  end
+
+  ##### Portion of page title that includes Observer Preference ################
+
+  # Observer Preference: Hydnum repandum
   def owner_id_line(obs)
     return unless User.view_owner_id_on?
 
     capture do
       concat(:show_observation_owner_id.t + ": ")
       concat(owner_favorite_or_explanation(obs).t)
+    end
+  end
+
+  private ######################################################################
+
+  # name portion of Observation title
+  def obs_title_consensus_id(name)
+    capture do
+      concat(name.short_display_name.t)
+      # Disable cop because a guard clause (or break) inside a `capture` block
+      # doesn't return correct value for the method
+      if name.deprecated #rubocop:disable GuardClause
+        # concat leading space separately because `.t` would strip it
+        concat(" ")
+        concat("(#{name.best_preferred_synonym.short_display_name})".t)
+      end
     end
   end
 

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -46,12 +46,12 @@ module ObserverHelper
   # name portion of Observation title
   def obs_title_consensus_id(name)
     capture do
-      concat(name.short_display_name.t)
+      concat(name.short_authors_display_name.t)
       if name.deprecated &&
          (current_name = name.best_preferred_synonym).present?
         # concat leading space separately because `.t` would strip it
         concat(" ")
-        concat("(#{current_name.short_display_name})".t)
+        concat("(#{current_name.short_authors_display_name})".t)
       end
     end
   end

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # helpers for show Observation view
-module ShowObservationHelper
+module ObservationHelper
   def show_obs_title(obs)
     @owner_id ? show_obs_title_site_id(obs) : show_obs_title_num_after_name(obs)
   end

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -40,7 +40,7 @@ module ObserverHelper
     if name.deprecated &&
        (current_name = name.best_preferred_synonym).present?
       capture do
-        concat(link_to_short_authors_display_name(name))
+        concat(link_to_display_name_brief_authors(name))
         # Differentiate deprecated consensus from preferred name
         concat(" (#{:show_observation_site_id.t})")
         concat(" ") # concat space separately, else `.t` strips it
@@ -50,7 +50,7 @@ module ObserverHelper
       end
     else
       capture do
-        concat(link_to_short_authors_display_name(name))
+        concat(link_to_display_name_brief_authors(name))
         # Differentiate this Name from Observer Preference
         concat(" (#{:show_observation_site_id.t})") if @owner_id
       end
@@ -59,14 +59,14 @@ module ObserverHelper
 
   def owner_favorite_or_explanation(obs)
     if (name = obs.owner_preference)
-      link_to_short_authors_display_name(name)
+      link_to_display_name_brief_authors(name)
     else
       :show_observation_no_clear_preference
     end
   end
 
-  def link_to_short_authors_display_name(name)
-    link_to(name.short_authors_display_name.t,
+  def link_to_display_name_brief_authors(name)
+    link_to(name.display_name_brief_authors.t,
             controller: :name,
             action: :show_name, id: name.id)
   end

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -58,7 +58,11 @@ module ObserverHelper
   end
 
   def owner_favorite_or_explanation(obs)
-    obs.owner_preference&.format_name || :show_observation_no_clear_preference
+    if (name = obs.owner_preference)
+      link_to_short_authors_display_name(name)
+    else
+      :show_observation_no_clear_preference
+    end
   end
 
   def link_to_short_authors_display_name(name)

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -47,12 +47,11 @@ module ObserverHelper
   def obs_title_consensus_id(name)
     capture do
       concat(name.short_display_name.t)
-      # Disable cop because a guard clause (or break) inside a `capture` block
-      # doesn't return correct value for the method
-      if name.deprecated #rubocop:disable GuardClause
+      if name.deprecated &&
+         (current_name = name.best_preferred_synonym).present?
         # concat leading space separately because `.t` would strip it
         concat(" ")
-        concat("(#{name.best_preferred_synonym.short_display_name})".t)
+        concat("(#{current_name.short_display_name})".t)
       end
     end
   end

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -19,7 +19,7 @@ module ObserverHelper
     end
   end
 
-  # Same as above, sans (Site ID)
+  # Same as above, without (Site ID)
   # Used when user prefers not to display Observer Preference
   def obs_title_with_name(obs)
     capture do
@@ -48,16 +48,30 @@ module ObserverHelper
     if name.deprecated &&
        (current_name = name.best_preferred_synonym).present?
       capture do
-        concat(name.short_authors_display_name.t)
-        concat(" ") # concat leading space separately since `.t` would strip it
-        concat("(#{current_name.display_name_without_authors})".t)
+        concat(link_to_short_authors_display_name(name))
+        concat(" ") # concat leading space separately, else `.t` would strip it
+        concat("(")
+        concat(link_to_display_name_without_authors(current_name))
+        concat(")")
       end
     else
-      name.short_authors_display_name.t
+      link_to_short_authors_display_name(name)
     end
   end
 
   def owner_favorite_or_explanation(obs)
     obs.owner_preference&.format_name || :show_observation_no_clear_preference
+  end
+
+  def link_to_short_authors_display_name(name)
+    link_to(name.short_authors_display_name.t,
+            controller: :name,
+            action: :show_name, id: name.id)
+  end
+
+  def link_to_display_name_without_authors(name)
+    link_to(name.display_name_without_authors.t,
+            controller: :name,
+            action: :show_name, id: name.id)
   end
 end

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -3,25 +3,17 @@
 # helpers for show Observation view
 module ObserverHelper
   ##### Portion of page title that includes consensus (site id) ################
-
+  #
+  # Depends on whether consensus is deprecated and user preferences include
+  # showing Observer's Preference
+  #
+  # Consensus not deprecated, observer preference not shown:
+  #   Observation nnn: Aaa bbb Author(s)
+  # Consensus deprecated, observer preference not shown:
+  #   Observation nnn: Ccc ddd Author(s) (Site ID) (Aaa bbb)
+  # Observer preference shown, consensus not deprecated:
+  #   Observation nnn: Aaa bbb Author(s) (Site ID)
   def show_obs_title(obs)
-    @owner_id ? obs_title_with_name_and_site_id(obs) : obs_title_with_name(obs)
-  end
-
-  # Observation nnn: Hydnum washingtonianum (Site ID)
-  #   or, if name is deprecated, include preferred name in parentheses
-  # Observation nnn: Hydnum neorepandum (Hydnum washingtonianum) (Site ID)
-  def obs_title_with_name_and_site_id(obs)
-    capture do
-      concat(obs_title_with_name(obs))
-      # "(Site ID)" differentiates this Name from Observer Preference
-      concat(" (#{:show_observation_site_id.t})")
-    end
-  end
-
-  # Same as above, without (Site ID)
-  # Used when user prefers not to display Observer Preference
-  def obs_title_with_name(obs)
     capture do
       concat(:show_observation_header.t)
       concat(" #{obs.id || "?"}: ")
@@ -49,13 +41,19 @@ module ObserverHelper
        (current_name = name.best_preferred_synonym).present?
       capture do
         concat(link_to_short_authors_display_name(name))
-        concat(" ") # concat leading space separately, else `.t` would strip it
+        # Differentiate deprecated consensus from preferred name
+        concat(" (#{:show_observation_site_id.t})")
+        concat(" ") # concat space separately, else `.t` strips it
         concat("(")
         concat(link_to_display_name_without_authors(current_name))
         concat(")")
       end
     else
-      link_to_short_authors_display_name(name)
+      capture do
+        concat(link_to_short_authors_display_name(name))
+        # Differentiate this Name from Observer Preference
+        concat(" (#{:show_observation_site_id.t})") if @owner_id
+      end
     end
   end
 

--- a/app/helpers/observer_helper.rb
+++ b/app/helpers/observer_helper.rb
@@ -45,14 +45,15 @@ module ObserverHelper
 
   # name portion of Observation title
   def obs_title_consensus_id(name)
-    capture do
-      concat(name.short_authors_display_name.t)
-      if name.deprecated &&
-         (current_name = name.best_preferred_synonym).present?
-        # concat leading space separately because `.t` would strip it
-        concat(" ")
-        concat("(#{current_name.short_authors_display_name})".t)
+    if name.deprecated &&
+       (current_name = name.best_preferred_synonym).present?
+      capture do
+        concat(name.short_authors_display_name.t)
+        concat(" ") # concat leading space separately since `.t` would strip it
+        concat("(#{current_name.display_name_without_authors})".t)
       end
+    else
+      name.short_authors_display_name.t
     end
   end
 

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -61,7 +61,7 @@ module ShowNameHelper
       query = Query.lookup(:Observation, :of_name, name: nm, by: :confidence)
       next if query.select_count.zero?
 
-      lines << link_to_obss_of(query, nm.display_name.t)
+      lines << link_to_obss_of(query, nm.display_name_brief_authors.t)
     end
   end
 

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -94,7 +94,7 @@ module ShowNameHelper
     return unless count > 1
 
     link_to(
-      :show_consensus_species.t(name: genus.display_name.t),
+      :show_consensus_species.t(name: genus.short_authors_display_name.t),
       add_query_param({ controller: :name, action: :index_name }, query)
     ) + " (#{count})"
   end

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -94,7 +94,7 @@ module ShowNameHelper
     return unless count > 1
 
     link_to(
-      :show_consensus_species.t(name: genus.short_authors_display_name.t),
+      :show_consensus_species.t(name: genus.display_name_brief_authors.t),
       add_query_param({ controller: :name, action: :index_name }, query)
     ) + " (#{count})"
   end

--- a/app/models/add_herbarium_record_email.rb
+++ b/app/models/add_herbarium_record_email.rb
@@ -9,6 +9,6 @@ class AddHerbariumRecordEmail < AccountMailer
     @herbarium_record = herbarium_record
     debug_log(:add_herbarium_record_not_curator, sender, receiver,
               herbarium_record: herbarium_record)
-    mo_mail(@title, to: receiver, reply_to: sender)
+    mo_mail(@title, to: receiver)
   end
 end

--- a/app/models/comment_email.rb
+++ b/app/models/comment_email.rb
@@ -8,7 +8,6 @@ class CommentEmail < AccountMailer
     @comment = comment
     debug_log(:comment, sender, receiver,
               object: "#{target.type_tag}-#{target.id}")
-    reply_to = receiver == target.user ? sender : nil
-    mo_mail(@title, to: receiver, reply_to: reply_to)
+    mo_mail(@title, to: receiver)
   end
 end

--- a/app/models/denied_email.rb
+++ b/app/models/denied_email.rb
@@ -1,4 +1,4 @@
-# Email sent to Nathan when sign-up is denied.
+# Email sent to admins when sign-up is denied.
 class DeniedEmail < AccountMailer
   def build(user_params)
     I18n.locale = MO.default_locale

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -190,7 +190,7 @@
 #  format_name::             "Xxx sp. Author"
 #  unique_text_name::        "Xxx (123)"
 #  unique_format_name::      "Xxx sp. Author (123)"
-#  short_authors_display_name:: Marked up name with authors shortened:
+#  display_name_brief_authors:: Marked up name with authors shortened:
 #                            **__"Xxx yyy__ author**
 #                            **__"Xxx yyy__ author1 & author2**
 #                            **__"Xxx yyy__ author1 et al.**

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -190,7 +190,10 @@
 #  format_name::             "Xxx sp. Author"
 #  unique_text_name::        "Xxx (123)"
 #  unique_format_name::      "Xxx sp. Author (123)"
-#  short_display_name::      **__"Xanthoparmelia" coloradoënsis__**
+#  short_authors_display_name:: Marked up name with authors shortened:
+#                            **__"Xxx yyy__ author**
+#                            **__"Xxx yyy__ author1 & author2**
+#                            **__"Xxx yyy__ author1 et al.**
 #  change_text_name::        Change name, updating formats.
 #  change_author::           Change author, updating formats.
 #

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -118,7 +118,7 @@
 #  real_text_name::   (V) "Xanthoparmelia" coloradoënsis
 #  search_name::      (V) "Xanthoparmelia" coloradoensis Fries
 #  real_search_name:: (V) "Xanthoparmelia" coloradoënsis Fries
-#  sort_name::        (V) Xanthoparmelia" coloradoensis Fries
+#  sort_name::        (V) "Xanthoparmelia" coloradoensis Fries
 #  display_name::     (V) **__"Xanthoparmelia" coloradoënsis__** Fries
 #  observation_name:: (V) **__"Xanthoparmelia" coloradoënsis__** Fries
 #                         (adds "sp." on the fly for genera)
@@ -190,6 +190,7 @@
 #  format_name::             "Xxx sp. Author"
 #  unique_text_name::        "Xxx (123)"
 #  unique_format_name::      "Xxx sp. Author (123)"
+#  short_display_name::      **__"Xanthoparmelia" coloradoënsis__**
 #  change_text_name::        Change name, updating formats.
 #  change_author::           Change author, updating formats.
 #
@@ -211,6 +212,7 @@
 #  synonym_ids:              List of IDs of all synonyms, including this Name
 #  sort_synonyms::           List of approved then deprecated synonyms.
 #  approved_synonyms::       List of approved synonyms.
+#  best_approved_synonym::   Single "best" approved synonym
 #  clear_synonym::           Remove this Name from its Synonym.
 #  merge_synonyms::          Merge Synonym's of this and another Name.
 #  transfer_synonym::        Transfer a Name from another Synonym

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -45,6 +45,19 @@ class Name < AbstractModel
     end
   end
 
+  # display_name less author
+  # This depends on display_name having markup around name proper
+  # Otherwise, it might delete author if that were part of the name proper
+  def display_name_without_authors
+    if rank == :Group
+      # Remove author and preceding space at end
+      display_name.sub(/ #{Regexp.quote(author)}$/, "")
+    else
+      # Remove author and preceding space after markup
+      display_name.sub(/(\*+|_+) #{Regexp.quote(author)}/, "\\1")
+    end
+  end
+
   # Tack id on to end of +text_name+.
   def unique_text_name
     real_text_name + " (#{id || "?"})"

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -30,18 +30,18 @@ class Name < AbstractModel
     display_name
   end
 
-  # display_name less author
-  # This depends on display_name having markup around name proper
-  # Otherwise, it might delete author if that were part of the name proper
-  def short_display_name
-    if author.blank?
-      display_name
-    elsif rank == :Group
-      # Remove author and preceding space at end
-      display_name.sub(/ #{Regexp.quote(author)}$/, "")
+  # Marked up Name, authors shortened per ICN Recommendation 46C.2,
+  #  e.g.: **__"Xxx yyy__ author1 et al.**
+  def short_authors_display_name
+    if rank == :Group
+      # Xxx yyy group author
+      display_name.sub(/ #{Regexp.quote(author)}$/," #{brief_author}")
     else
-      # Remove author and preceding space after markup
-      display_name.sub(/(\*+|_+) #{Regexp.quote(author)}/, "\\1")
+      # Xxx yyy author, Xxx sect. yyy author, Xxx author sect. yyy
+      # Relies on display_name having markup around name proper
+      # Otherwise, it might delete author if that were part of the name proper
+      display_name.sub(/(\*+|_+) #{Regexp.quote(author)}/,
+                       "\\1 #{brief_author}")
     end
   end
 
@@ -126,5 +126,16 @@ class Name < AbstractModel
     num_obs     = observations.count
     num_namings = namings.count
     "#{:NAME.l} ##{id}: #{real_search_name} [o=#{num_obs}, n=#{num_namings}]"
+  end
+
+  ##############################################################################
+
+  private
+
+  # author(s) string shortened per ICN Recommendation 46C.2
+  # Relies on name.author having a comma only if there are > 2 authors
+  def brief_author
+    author.sub(/(\(*.),.*\)/, "\\1 et al.)"). # shorten > 2 authors in parens
+           sub(/\,.*/, " et al.") # then shorten any remaining > 2 authors
   end
 end

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -32,7 +32,7 @@ class Name < AbstractModel
 
   # Marked up Name, authors shortened per ICN Recommendation 46C.2,
   #  e.g.: **__"Xxx yyy__ author1 et al.**
-  def short_authors_display_name
+  def display_name_brief_authors
     if rank == :Group
       # Xxx yyy group author
       display_name.sub(/ #{Regexp.quote(author)}$/," #{brief_author}")

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# portion of Name dealing for formatting of Names for display
 class Name < AbstractModel
-##### Display of names #########################################################
+  ##### Display of names #######################################################
   def display_name
     str = self[:display_name]
     if User.current &&
@@ -76,7 +79,7 @@ class Name < AbstractModel
   # Make sure display names are in boldface for accepted names, and not in
   # boldface for deprecated names.
   def self.make_sure_names_are_bolded_correctly
-    msgs = Name.connection.select_values(%(
+    Name.connection.select_values(%(
       SELECT id FROM names
       WHERE IF(deprecated, display_name LIKE "%*%", display_name NOT LIKE "%*%")
     )).map do |id|
@@ -124,5 +127,4 @@ class Name < AbstractModel
     num_namings = namings.count
     "#{:NAME.l} ##{id}: #{real_search_name} [o=#{num_obs}, n=#{num_namings}]"
   end
-
 end

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -35,7 +35,7 @@ class Name < AbstractModel
   def display_name_brief_authors
     if rank == :Group
       # Xxx yyy group author
-      display_name.sub(/ #{Regexp.quote(author)}$/," #{brief_author}")
+      display_name.sub(/ #{Regexp.quote(author)}$/, " #{brief_author}")
     else
       # Xxx yyy author, Xxx sect. yyy author, Xxx author sect. yyy
       # Relies on display_name having markup around name proper
@@ -149,6 +149,6 @@ class Name < AbstractModel
   # Relies on name.author having a comma only if there are > 2 authors
   def brief_author
     author.sub(/(\(*.),.*\)/, "\\1 et al.)"). # shorten > 2 authors in parens
-           sub(/\,.*/, " et al.") # then shorten any remaining > 2 authors
+      sub(/\,.*/, " et al.") # then shorten any remaining > 2 authors
   end
 end

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -215,4 +215,29 @@ class Name < AbstractModel
       last_use || created_at
     end
   end
+
+  # "Best" preferred synonym of a deprecated name.
+  def best_preferred_synonym
+    candidates = preferred_synonyms_with_most_observations
+    candidates.blank? ? nil : most_recently_updated(candidates)
+  end
+
+  ##############################################################################
+
+  private
+
+  # array of synonyms with the most observations, sorted by observation_count
+  def preferred_synonyms_with_most_observations
+    betters = preferreds_by_observation_count_descending
+    max_observations = betters.first&.observation_count
+    betters.select { |name| name.observation_count == max_observations }
+  end
+
+  def preferreds_by_observation_count_descending
+    other_approved_synonyms.sort_by { |name| -name.observation_count }
+  end
+
+  def most_recently_updated(names)
+    names.sort_by { |name| name.updated_at }.last
+  end
 end

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -218,8 +218,7 @@ class Name < AbstractModel
 
   # "Best" preferred synonym of a deprecated name.
   def best_preferred_synonym
-    candidates = preferred_synonyms_with_most_observations
-    candidates.blank? ? nil : most_recently_updated(candidates)
+    most_recently_updated(preferred_synonyms_with_most_observations)
   end
 
   ##############################################################################
@@ -238,6 +237,6 @@ class Name < AbstractModel
   end
 
   def most_recently_updated(names)
-    names.sort_by { |name| name.updated_at }.last
+    names.max_by(&:updated_at)
   end
 end

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -132,8 +132,8 @@ class Naming < AbstractModel
     name ? name.observation_name : ""
   end
 
-  def short_authors_display_name
-    name ? name.short_authors_display_name : ""
+  def display_name_brief_authors
+    name ? name.display_name_brief_authors : ""
   end
 
   # Return name in Textile format (with id tacked on to make unique).

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -132,6 +132,10 @@ class Naming < AbstractModel
     name ? name.observation_name : ""
   end
 
+  def short_authors_display_name
+    name ? name.short_authors_display_name : ""
+  end
+
   # Return name in Textile format (with id tacked on to make unique).
   def unique_format_name
     format_name + " (#{id || "?"})"

--- a/app/views/comment_email/build.html.erb
+++ b/app/views/comment_email/build.html.erb
@@ -43,9 +43,7 @@
 
   # Only give the owner of the object being commented on access to the email
   # address of the user who commented on it.
-  handy_links = is_owner ?
-    :email_can_respond.l(name: @comment.user.legal_name, email: @comment.user.email) :
-    "*#{:email_no_respond.l}* #{:email_respond_via_comment.l}"
+  handy_links = "*#{:email_no_respond.l}* #{:email_respond_via_comment.l}"
   handy_links.sub!(/\n*\Z/, "\n" + :email_handy_links.l)
 
   links = []

--- a/app/views/naming/_show.html.erb
+++ b/app/views/naming/_show.html.erb
@@ -24,7 +24,7 @@
           <tr>
             <% Textile.register_name(naming.name) %>
             <td>
-              <%= link_with_query(naming.short_authors_display_name.t,
+              <%= link_with_query(naming.display_name_brief_authors.t,
                                   controller: :name, action: :show_name,
                                   id: naming.name) %>
               <% if check_permission(naming) %>

--- a/app/views/naming/_show.html.erb
+++ b/app/views/naming/_show.html.erb
@@ -24,7 +24,7 @@
           <tr>
             <% Textile.register_name(naming.name) %>
             <td>
-              <%= link_with_query(naming.format_name.t,
+              <%= link_with_query(naming.short_authors_display_name.t,
                                   controller: :name, action: :show_name,
                                   id: naming.name) %>
               <% if check_permission(naming) %>

--- a/app/views/observer/_show_name_info.html.erb
+++ b/app/views/observer/_show_name_info.html.erb
@@ -6,7 +6,7 @@
       About Polyozellus
       on MyCoPortal
       on MycoBank %>
-<%= content_tag(:p, link_to(:show_name.t(name: name.short_authors_display_name),
+<%= content_tag(:p, link_to(:show_name.t(name: name.display_name_brief_authors),
                             controller: :name,
                             action: :show_name, id: name.id)) %>
 <%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),

--- a/app/views/observer/_show_name_info.html.erb
+++ b/app/views/observer/_show_name_info.html.erb
@@ -6,7 +6,7 @@
       About Polyozellus
       on MyCoPortal
       on MycoBank %>
-<%= content_tag(:p, link_to(:show_name.t(name: name.display_name),
+<%= content_tag(:p, link_to(:show_name.t(name: name.short_authors_display_name),
                             controller: :name,
                             action: :show_name, id: name.id)) %>
 <%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),

--- a/app/views/observer/ask_user_question.html.erb
+++ b/app/views/observer/ask_user_question.html.erb
@@ -2,6 +2,7 @@
 
 <div class="max-width-text">
   <%= form_tag(add_query_param(action: :ask_user_question, id: @target.id)) do %>
+    <%= :ask_user_question_label.tp(user: @target.legal_name) %>
 
     <div class="form-group">
       <%= label_tag(:email_subject, :ask_user_question_subject.t + ":") %>

--- a/app/views/observer/author_request.html.erb
+++ b/app/views/observer/author_request.html.erb
@@ -3,6 +3,7 @@
 <div class="max-width-text">
   <%= form_tag(add_query_param(action: :author_request, id: @object.id,
                                type: @object.type_tag)) do %>
+    <%= :author_request_note.tp %>
 
     <div class="form-group push-down">
       <%= label_tag(:email_subject, :request_subject.t + ":") %>

--- a/app/views/observer/commercial_inquiry.html.erb
+++ b/app/views/observer/commercial_inquiry.html.erb
@@ -2,11 +2,13 @@
 
 <div class="max-width-text-plus_image">
   <%= form_tag(add_query_param(action: :commercial_inquiry, id: @image.id)) do %>
-    <div class="pull-right">
+    <div>
       <%= thumbnail(@image, size: :medium, border: 0, votes: true) %>
     </div>
-    <%= :commercial_inquiry_header.tp(user: @image.user.legal_name) %>
-    <%= text_area(:commercial_inquiry, :content, rows: 10, class: "form-control") %>
-    <%= submit_tag(:SEND.l, class: "btn center-block push-down") %>
+    <div>
+      <%= :commercial_inquiry_header.tp(user: @image.user.legal_name) %>
+      <%= text_area(:commercial_inquiry, :content, rows: 10, class: "form-control") %>
+      <%= submit_tag(:SEND.l, class: "btn center-block push-down") %>
+    </div>
   <% end %>
 </div>

--- a/app/views/observer/show_user.html.erb
+++ b/app/views/observer/show_user.html.erb
@@ -50,8 +50,8 @@
     tabs += [
       link_to(:change_user_bonuses.t, controller: :observer,
               action: :change_user_bonuses, id: @show_user.id),
-      link_to(:DESTROY.t, controller: :account, action: :destroy_user,
-              id: @show_user.id)
+      link_to(:DESTROY.t, {controller: :account, action: :destroy_user,
+              id: @show_user.id}, data: {confirm: :are_you_sure.l})
     ]
   end
   @tabsets = {

--- a/app/views/project/admin_request.html.erb
+++ b/app/views/project/admin_request.html.erb
@@ -4,6 +4,8 @@
 
 <div class="max-width-text">
   <%= form_tag(add_query_param(action: :admin_request, id: @project.id)) do %>
+    <%= :admin_request_note.tp %>
+
     <div class="form-group push-down">
       <%= label_tag(:email_subject, :request_subject.t + ":") %>
       <%= text_field(:email, :subject, class: "form-control", data: {autofocus: true}) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1210,6 +1210,7 @@
 
   # observer/ask_user_question
   ask_user_question_title: Email Message for [user]
+  ask_user_question_label: Enter your question below.  When you hit "[:SEND]" it will be emailed to [user].  The email will include your email address as the 'Reply To' address.
   ask_user_question_message: "[:Message]"
   ask_user_question_subject: "[:Subject]"
 
@@ -2898,8 +2899,10 @@
   admin_request_change_member_status: Change [:user]'s status
   admin_request_success: Successfully sent admin request for [title]
   admin_request_title: Admin Request for [title]
+  admin_request_note: Enter your request below.  When you hit "[:SEND]" it will be emailed to to project admins.  The email will include your email address so that they can respond to your request.
   author_request_add_author: Make sender an author
   author_request_title: Authorship Request for [title]
+  author_request_note: "[:admin_request_note]"
   request_message: Message
   request_show_user: Show details on sender
   request_subject: Subject

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1690,8 +1690,8 @@
   prefs_location_format_postal: Postal (New York, USA)
   prefs_location_format_scientific: Scientific (USA, New York)
   prefs_hide_authors: "[:AUTHORITYS]"
-  prefs_hide_authors_none: show all authorities (default)
-  prefs_hide_authors_above_species: hide authorities for genera and higher ranks
+  prefs_hide_authors_none: show author for all ranks (default)
+  prefs_hide_authors_above_species: hide author for gunus and higher ranks
   prefs_thumbnail_size: Thumbnail size
   prefs_thumbnail_small: "[:image_show_small]"
   prefs_thumbnail_large: "[:image_show_large]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1242,7 +1242,7 @@
 
   # observer/commercial_inquiry
   commercial_inquiry_title: Commercial Inquiry About [name]
-  commercial_inquiry_header: Enter your commercial inquiry about this image.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this image.
+  commercial_inquiry_header: Enter your commercial inquiry about this image.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this image as well as your email address.
 
   # location/create_location_description
   create_location_description_title: "[:create_name_description_title]"

--- a/lib/tasks/jason.rake
+++ b/lib/tasks/jason.rake
@@ -676,15 +676,16 @@ namespace :jason do
       loc ||= val
     elsif !loc
       val2 = val.downcase.gsub(/\W+/, " ")
-      # results = Location.find(:all, :conditions => "search_name like '%#{val2}%'", :order => "name asc") # Rails 3
       results = Location.where("search_name LIKE ?", "%#{val2}%").
                 order(name).to_a
       if results.empty?
-        lines.push('>>>>>>>> couldn\'t find any matching locations (add "*" to end to create)')
+        lines.push(">>>>>>>> couldn't find any matching locations" \
+                   "(add '*' to end to create)")
       elsif results.length == 1
         loc = results.first
       elsif results.length > 1
-        lines.push('>>>>>>>> multiple locations match: (add "*" to end to create)')
+        lines.push(">>>>>>>> multiple locations match: "\
+                   "(add '*' to end to create)")
         for x in results
           lines.push(">>>>>>>>   %s" % x.name)
         end

--- a/test/account_mailer/add_herbarium_record_not_curator.html
+++ b/test/account_mailer/add_herbarium_record_not_curator.html
@@ -1,5 +1,5 @@
 From: news@mushroomobserver.org
-Reply-To: mary@collectivesource.com
+Reply-To: no-reply@mushroomobserver.org
 To: rolf@collectivesource.com
 Subject: [MO] Herbarium Record Added to The New York Botanical Garden
 <html>

--- a/test/account_mailer/add_herbarium_record_not_curator.text
+++ b/test/account_mailer/add_herbarium_record_not_curator.text
@@ -1,5 +1,5 @@
 From: news@mushroomobserver.org
-Reply-To: mary@collectivesource.com
+Reply-To: no-reply@mushroomobserver.org
 To: rolf@collectivesource.com
 Subject: [MO] Herbarium Record Added to The New York Botanical Garden
 

--- a/test/account_mailer/comment.html
+++ b/test/account_mailer/comment.html
@@ -1,5 +1,5 @@
 From: news@mushroomobserver.org
-Reply-To: rolf@collectivesource.com
+Reply-To: no-reply@mushroomobserver.org
 To: mary@collectivesource.com
 Subject: [MO] Comment About Fungi (<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %>)
 <html>
@@ -16,7 +16,7 @@ Subject: [MO] Comment About Fungi (<%= ActiveRecord::FixtureSet.identify(:minima
 <div style='margin-left:20px; margin-right:20px; padding-left:20px; padding-right:20px; padding-top:10px; padding-bottom:10px; border:1px dotted; background:#E0E0E0; color:#000000;'>
 <div class="textile"><p>Wow!  That&#8217;s really cool</p></div>
 </div>
-<div class="textile"><p>It is entirely up to you whether you want to reply to Rolf Singer (rolf&#64;collectivesource.com) by replying directly to this email.<br />
+<div class="textile"><p><strong>Please do not reply to this email!</strong> Use the link below to respond via your own public comment.<br />
 Here are some handy links:</p></div>
 <ul type=none>
 <li>Show this observation: <a href="http://mushroomobserver.org/observer/show_observation/<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %>">http://mushroomobserver.org/observer/show_observation/<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %></a></li>

--- a/test/account_mailer/comment.text
+++ b/test/account_mailer/comment.text
@@ -1,5 +1,5 @@
 From: news@mushroomobserver.org
-Reply-To: rolf@collectivesource.com
+Reply-To: no-reply@mushroomobserver.org
 To: mary@collectivesource.com
 Subject: [MO] Comment About Fungi (<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %>)
 
@@ -16,7 +16,7 @@ Wow!  That's really cool
 
 --------------------------------------------------
 
-It is entirely up to you whether you want to reply to Rolf Singer (rolf@collectivesource.com) by replying directly to this email.
+Please do not reply to this email! Use the link below to respond via your own public comment.
 Here are some handy links:
 
 Show this observation: http://mushroomobserver.org/observer/show_observation/<%= ActiveRecord::FixtureSet.identify(:minimal_unknown_obs) %>

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -286,6 +286,15 @@ class AccountControllerTest < FunctionalTestCase
     assert_flash_success
   end
 
+  def test_send_verify_hotmail
+    user = User.create!(
+      login: "micky",
+      email: "mm@hotmail.com"
+    )
+    post(:send_verify, id: user.id)
+    assert_flash_success
+  end
+
   def test_edit_prefs
     # First make sure it can serve the form to start with.
     requires_login(:prefs)

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -246,7 +246,8 @@ macrolepiota_rachodes: # 19
   sort_name: Macrolepiota rachodes  (Vittad.) Singer
   synonym: macrolepiota_rachodes_synonym
   created_at: 2007-04-30 21:34:00
-  updated_at: 2007-04-30 21:34:00
+  # later than rhacodes; used in test for best synonym
+  updated_at: 2007-04-30 21:34:01
 
 macrolepiota_rhacodes: # 20
   <<: *DEFAULTS
@@ -295,7 +296,8 @@ chlorophyllum_rhacodes: # 23
   sort_name: Chlorophyllum rhacodes  (Vittad.) Vellinga
   synonym: chlorophyllum_rachodes_synonym
   created_at: 2007-04-30 21:34:00
-  updated_at: 2007-04-30 21:34:00
+  # later than rachodes; used in test for best synonym
+  updated_at: 2007-04-30 21:34:01
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
 lactarius: # 24

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -12,16 +12,24 @@ class ObserverHelperTest < ActionView::TestCase
     Observation.new(
       name: current_name, user: user, when: Time.current, where: location
     )
-    assert_equal(current_name.short_authors_display_name.t,
-                 obs_title_consensus_id(current_name))
+    assert_match(
+      link_to(current_name.short_authors_display_name.t,
+              controller: :name,
+              action: :show_name, id: current_name.id),
+      obs_title_consensus_id(current_name),
+      "Observation of a current Name should link to that Name"
+    )
 
     # deprecated name
     deprecated_name = names(:lactarius_alpigenes)
     Observation.new(
       name: deprecated_name, user: user, when: Time.current, where: location
     )
-    assert_equal("#{deprecated_name.short_authors_display_name.t} " \
-                 "(#{current_name.display_name_without_authors.t})",
-                 obs_title_consensus_id(deprecated_name))
+    assert_match(
+      "#{link_to_short_authors_display_name(deprecated_name)} " \
+      "(#{link_to_display_name_without_authors(current_name)})",
+      obs_title_consensus_id(deprecated_name),
+      "Observation of deprecated Name should link to it and approved Name"
+    )
   end
 end

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -13,7 +13,7 @@ class ObserverHelperTest < ActionView::TestCase
       name: current_name, user: user, when: Time.current, where: location
     )
     assert_match(
-      link_to(current_name.short_authors_display_name.t,
+      link_to(current_name.display_name_brief_authors.t,
               controller: :name,
               action: :show_name, id: current_name.id),
       obs_title_consensus_id(current_name),
@@ -26,7 +26,7 @@ class ObserverHelperTest < ActionView::TestCase
       name: deprecated_name, user: user, when: Time.current, where: location
     )
     assert_match(
-      "#{link_to_short_authors_display_name(deprecated_name)} (Site ID) " \
+      "#{link_to_display_name_brief_authors(deprecated_name)} (Site ID) " \
       "(#{link_to_display_name_without_authors(current_name)})",
       obs_title_consensus_id(deprecated_name),
       "Observation of deprecated Name should link to it and approved Name"

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "test_helper"
+
+# test the helpers for ObserverController
+class ObserverHelperTest < ActionView::TestCase
+  def test_show_observation_name
+    user = users(:rolf)
+    location = locations(:albion)
+
+    # approved name
+    current_name = names(:lactarius_alpinus)
+    obs = Observation.create!(
+      name: current_name, user: user, when: Time.now, where: location
+    )
+    assert_equal(current_name.short_display_name.t,
+                 obs_title_consensus_id(current_name))
+
+    # deprecated name
+    deprecated_name = names(:lactarius_alpigenes)
+    obs = Observation.create!(
+      name: deprecated_name, user: user, when: Time.now, where: location
+    )
+    assert_equal("#{deprecated_name.short_display_name.t} " \
+                 "(#{current_name.short_display_name.t})",
+                 obs_title_consensus_id(deprecated_name))
+  end
+end

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -9,7 +9,7 @@ class ObserverHelperTest < ActionView::TestCase
 
     # approved name
     current_name = names(:lactarius_alpinus)
-    Observation.create!(
+    Observation.new(
       name: current_name, user: user, when: Time.current, where: location
     )
     assert_equal(current_name.short_authors_display_name.t,
@@ -17,11 +17,11 @@ class ObserverHelperTest < ActionView::TestCase
 
     # deprecated name
     deprecated_name = names(:lactarius_alpigenes)
-    Observation.create!(
+    Observation.new(
       name: deprecated_name, user: user, when: Time.current, where: location
     )
-    assert_equal("#{deprecated_name.display_name_without_authors.t} " \
-                 "(#{current_name.short_authors_display_name.t})",
+    assert_equal("#{deprecated_name.short_authors_display_name.t} " \
+                 "(#{current_name.display_name_without_authors.t})",
                  obs_title_consensus_id(deprecated_name))
   end
 end

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -9,16 +9,16 @@ class ObserverHelperTest < ActionView::TestCase
 
     # approved name
     current_name = names(:lactarius_alpinus)
-    obs = Observation.create!(
-      name: current_name, user: user, when: Time.now, where: location
+    Observation.create!(
+      name: current_name, user: user, when: Time.current, where: location
     )
     assert_equal(current_name.short_display_name.t,
                  obs_title_consensus_id(current_name))
 
     # deprecated name
     deprecated_name = names(:lactarius_alpigenes)
-    obs = Observation.create!(
-      name: deprecated_name, user: user, when: Time.now, where: location
+    Observation.create!(
+      name: deprecated_name, user: user, when: Time.current, where: location
     )
     assert_equal("#{deprecated_name.short_display_name.t} " \
                  "(#{current_name.short_display_name.t})",

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -26,7 +26,7 @@ class ObserverHelperTest < ActionView::TestCase
       name: deprecated_name, user: user, when: Time.current, where: location
     )
     assert_match(
-      "#{link_to_short_authors_display_name(deprecated_name)} " \
+      "#{link_to_short_authors_display_name(deprecated_name)} (Site ID) " \
       "(#{link_to_display_name_without_authors(current_name)})",
       obs_title_consensus_id(deprecated_name),
       "Observation of deprecated Name should link to it and approved Name"

--- a/test/helpers/observer_helper_test.rb
+++ b/test/helpers/observer_helper_test.rb
@@ -12,7 +12,7 @@ class ObserverHelperTest < ActionView::TestCase
     Observation.create!(
       name: current_name, user: user, when: Time.current, where: location
     )
-    assert_equal(current_name.short_display_name.t,
+    assert_equal(current_name.short_authors_display_name.t,
                  obs_title_consensus_id(current_name))
 
     # deprecated name
@@ -20,8 +20,8 @@ class ObserverHelperTest < ActionView::TestCase
     Observation.create!(
       name: deprecated_name, user: user, when: Time.current, where: location
     )
-    assert_equal("#{deprecated_name.short_display_name.t} " \
-                 "(#{current_name.short_display_name.t})",
+    assert_equal("#{deprecated_name.display_name_without_authors.t} " \
+                 "(#{current_name.short_authors_display_name.t})",
                  obs_title_consensus_id(deprecated_name))
   end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2195,27 +2195,27 @@ class NameTest < UnitTestCase
     assert_equal("Ach.", name.author)
   end
 
-  # Prove that short_authors_display_name is shortened correctly
-  def test_short_authors_display_name
+  # Prove that display_name_brief_authors is shortened correctly
+  def test_display_name_brief_authors
     # Name 0 authors
     assert_equal(names(:russula_brevipes_no_author).display_name,
-                 names(:russula_brevipes_no_author).short_authors_display_name)
+                 names(:russula_brevipes_no_author).display_name_brief_authors)
 
     # Name 1 author
     assert_equal(
       names(:russula_brevipes_author_notes).display_name,
-      names(:russula_brevipes_author_notes).short_authors_display_name
+      names(:russula_brevipes_author_notes).display_name_brief_authors
     )
 
     # Name 2 authors
     assert_equal(
       names(:hygrocybe_russocoriacea_good_author).display_name,
-      names(:hygrocybe_russocoriacea_good_author).short_authors_display_name
+      names(:hygrocybe_russocoriacea_good_author).display_name_brief_authors
     )
 
     # Name > 2 authors
     assert_equal("**__Coprinellus micaceus__** (Bull.) Vilgalys et al.",
-                 names(:coprinellus_micaceus).short_authors_display_name)
+                 names(:coprinellus_micaceus).display_name_brief_authors)
 
     # Name > 2 authors in parentheses
     authors = "(Author1, Author2 & Author3) Author4, Author5 & Author6"
@@ -2228,7 +2228,7 @@ class NameTest < UnitTestCase
       user: users(:rolf)
     )
     assert_equal("**__Xxx__** (Author1 et al.) Author4 et al.",
-                 name.short_authors_display_name)
+                 name.display_name_brief_authors)
 
     # Autonym <= 2 authors
     autonym = Name.new(
@@ -2240,7 +2240,7 @@ class NameTest < UnitTestCase
       user: users(:rolf)
     )
     assert_equal(autonym.display_name,
-                 autonym.short_authors_display_name)
+                 autonym.display_name_brief_authors)
 
     # Autonym > 2 authors
     authors = "Redhead, Vizzini, Drehmel & Contu"
@@ -2253,11 +2253,11 @@ class NameTest < UnitTestCase
       user: users(:rolf)
     )
     assert_equal("**__Saproamanita__** Redhead et al. sect. Saproamanita",
-                 autonym.short_authors_display_name)
+                 autonym.display_name_brief_authors)
 
     # group <= 2 authors
     assert_equal(names(:authored_group).display_name,
-                 names(:authored_group).short_authors_display_name)
+                 names(:authored_group).display_name_brief_authors)
 
     # group > 2 authors
     authors = "Author1, Author2 & Author3"
@@ -2270,7 +2270,7 @@ class NameTest < UnitTestCase
       user: users(:rolf)
     )
     assert_equal("**__Xxx yyy__** clade Author1 et al.",
-                 group_name.short_authors_display_name)
+                 group_name.display_name_brief_authors)
   end
 
   def test_display_name_without_authors

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2195,10 +2195,83 @@ class NameTest < UnitTestCase
     assert_equal("Ach.", name.author)
   end
 
-  def test_short_display_name
-    # Name without author
-    assert_equal("**__Russula brevipes__**",
-                 names(:russula_brevipes_no_author).short_display_name)
+  # Prove that short_authors_display_name is shortened correctly
+  def test_short_authors_display_name
+    # Name 0 authors
+    assert_equal(names(:russula_brevipes_no_author).display_name,
+                 names(:russula_brevipes_no_author).short_authors_display_name)
+
+    # Name 1 author
+    assert_equal(
+      names(:russula_brevipes_author_notes).display_name,
+      names(:russula_brevipes_author_notes).short_authors_display_name
+    )
+
+    # Name 2 authors
+    assert_equal(
+      names(:hygrocybe_russocoriacea_good_author).display_name,
+      names(:hygrocybe_russocoriacea_good_author).short_authors_display_name
+    )
+
+    # Name > 2 authors
+    assert_equal("**__Coprinellus micaceus__** (Bull.) Vilgalys et al.",
+                 names(:coprinellus_micaceus).short_authors_display_name)
+
+    # Name > 2 authors in parentheses
+    authors = "(Author1, Author2 & Author3) Author4, Author5 & Author6"
+    name = Name.new(
+      text_name: "Xxx #{authors}",
+      display_name: "**__Xxx__** #{authors}",
+      author: "#{authors}",
+      rank: :Genus,
+      deprecated: false, correct_spelling: nil,
+      user: users(:rolf)
+    )
+    assert_equal("**__Xxx__** (Author1 et al.) Author4 et al.",
+                 name.short_authors_display_name)
+
+    # Autonym <= 2 authors
+    autonym = Name.new(
+      text_name: "Russula sect. Russula",
+      display_name: "**__Russula__** Pers. sect. **__Russula__**",
+      author: "Pers.",
+      rank: :Section,
+      deprecated: false, correct_spelling: nil,
+      user: users(:rolf)
+    )
+    assert_equal(autonym.display_name,
+                 autonym.short_authors_display_name)
+
+    # Autonym > 2 authors
+    authors = "Redhead, Vizzini, Drehmel & Contu"
+    autonym = Name.new(
+      text_name: "Saproamanita sect. Saproamanita",
+      display_name: "**__Saproamanita__** #{authors} sect. Saproamanita",
+      author: authors,
+      rank: :Section,
+      deprecated: false, correct_spelling: nil,
+      user: users(:rolf)
+    )
+    assert_equal("**__Saproamanita__** Redhead et al. sect. Saproamanita",
+                 autonym.short_authors_display_name)
+
+    # group <= 2 authors
+    assert_equal(names(:authored_group).display_name,
+                 names(:authored_group).short_authors_display_name)
+
+    # group > 2 authors
+    authors = "Author1, Author2 & Author3"
+    group_name = Name.new(
+      text_name: "Xxx yyy clade #{authors}",
+      display_name: "**__Xxx yyy__** clade #{authors}",
+      author: authors,
+      rank: :Group,
+      deprecated: false, correct_spelling: nil,
+      user: users(:rolf)
+    )
+    assert_equal("**__Xxx yyy__** clade Author1 et al.",
+                 group_name.short_authors_display_name)
+  end
 
     # Name with author
     assert_equal("**__Russula brevipes__**",

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2273,9 +2273,18 @@ class NameTest < UnitTestCase
                  group_name.short_authors_display_name)
   end
 
+  def test_display_name_without_authors
+    # Name with 0 authors
+    assert_equal(
+      names(:russula_brevipes_no_author).display_name,
+      names(:russula_brevipes_no_author).display_name_without_authors
+    )
+
     # Name with author
-    assert_equal("**__Russula brevipes__**",
-                 names(:russula_brevipes_author_notes).short_display_name)
+    assert_equal(
+      "**__Russula brevipes__**",
+      names(:russula_brevipes_author_notes).display_name_without_authors
+    )
 
     # Autonym with author
     autonym = Name.create!(
@@ -2287,15 +2296,15 @@ class NameTest < UnitTestCase
       user: users(:rolf)
     )
     assert_equal("**__Russula__** sect. **__Russula__**",
-                 autonym.short_display_name)
+                 autonym.display_name_without_authors)
 
     # group without author
     assert_equal(names(:unauthored_group).display_name,
-                 names(:unauthored_group).short_display_name)
+                 names(:unauthored_group).display_name_without_authors)
 
     # group with author
     assert_equal("**__Groupauthored__** group",
-                 names(:authored_group).short_display_name)
+                 names(:authored_group).display_name_without_authors)
   end
 
   def test_format_autonym

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2206,7 +2206,7 @@ class NameTest < UnitTestCase
 
     # Autonym with author
     autonym = Name.create!(
-      text_name:   "Russula sect. Russula",
+      text_name: "Russula sect. Russula",
       display_name: "**__Russula__** Pers. sect. **__Russula__**",
       author: "Pers.",
       rank: :Section,
@@ -2535,7 +2535,7 @@ class NameTest < UnitTestCase
 
   def test_best_preferred_synonym
     # no preferred synonyms
-    assert_nil(names(:pluteus_petasatus_deprecated).best_preferred_synonym)
+    assert_empty(names(:pluteus_petasatus_deprecated).best_preferred_synonym)
 
     # only 1 preferred synonym
     assert_equal(names(:lactarius_alpinus),
@@ -2546,7 +2546,8 @@ class NameTest < UnitTestCase
     # no observations
     # Create a deprecated synonym and test it
     deprecated_name = Name.create!(
-      text_name:   "Lepiota rhacodes", author: "(Vittad.) Quél.",
+      text_name: "Lepiota rhacodes",
+      author: "(Vittad.) Quél.",
       display_name: "__Lepiota rhacodes__ (Vittad.) Quél.",
       synonym: synonyms(:macrolepiota_rachodes_synonym),
       deprecated: true,
@@ -2562,7 +2563,8 @@ class NameTest < UnitTestCase
     # C. rachodes is approved, has 0 Observations
     # Create a deprecated synonym and test it
     deprecated_name = Name.create!(
-      text_name:   "Agaricus rhacodes", author: "Vittad.",
+      text_name: "Agaricus rhacodes",
+      author: "Vittad.",
       display_name: "__Agaricus rhacodes__ Vittad.",
       synonym: synonyms(:chlorophyllum_rachodes_synonym),
       deprecated: true,
@@ -2578,7 +2580,7 @@ class NameTest < UnitTestCase
     revised_best_synonym = names(:chlorophyllum_rhacodes)
     Observation.create(
       name: revised_best_synonym,
-      user: users(:rolf), when: Time.now, location: locations(:albion)
+      user: users(:rolf), when: Time.current, location: locations(:albion)
     )
     # other_approved_synonyms.name.observations is cached by Rails, so
     # it didn't change when we created the Observation above.
@@ -2594,7 +2596,7 @@ class NameTest < UnitTestCase
     revised_best_synonym = names(:chlorophyllum_rachodes)
     Observation.create(
       name: revised_best_synonym,
-      user: users(:rolf), when: Time.now, location: locations(:albion)
+      user: users(:rolf), when: Time.current, location: locations(:albion)
     )
     # other_approved_synonyms.name.observations is cached by Rails, so
     # it didn't change when we created the Observation above.

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2222,7 +2222,7 @@ class NameTest < UnitTestCase
     name = Name.new(
       text_name: "Xxx #{authors}",
       display_name: "**__Xxx__** #{authors}",
-      author: "#{authors}",
+      author: authors.to_s,
       rank: :Genus,
       deprecated: false, correct_spelling: nil,
       user: users(:rolf)


### PR DESCRIPTION
Include the Preferred Name in the Observation title.
Omit author(s) in the Observation title top line.

The Preferred Name is included as a step toward demotivating needless nomenclatural voting and arguments.
Authors are omitted to save space and improve the data-to-ink ratio. 

I had considered making the Preferred Name a link to it's Name page. I decided against that because such a link -- author included -- already appears twice: in the About  and in Proposed Names. 