### PR TITLE
[Delivers #165496704] Remove dead "risd" code

### DIFF
--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -33,7 +33,6 @@ class ObserverController < ApplicationController
     :hide_thumbnail_map,
     :how_to_help,
     :how_to_use,
-    :risd_terminology,
     :index,
     :index_observation,
     :index_rss_log,

--- a/app/controllers/observer_controller/info_controller.rb
+++ b/app/controllers/observer_controller/info_controller.rb
@@ -27,11 +27,6 @@ class ObserverController
     store_location
   end
 
-  # Terminology description for RISD illustration class
-  def risd_terminology # :nologin:
-    store_location
-  end
-
   # Simple form letting us test our implementation of Textile.
   def textile_sandbox # :nologin:
     if request.method != "POST"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -347,7 +347,6 @@ ACTIONS = {
     print_labels: {},
     recalc: {},
     review_authors: {},
-    risd_terminology: {},
     rss: {},
     set_export_status: {},
     show_location_observations: {},


### PR DESCRIPTION
This is dead code related to a Rhode Island School of Design illustration class @mo-nathan did for the Glossary. See https://www.pivotaltracker.com/story/show/165496704