### PR TITLE
Search help

### DIFF
--- a/app/classes/pattern_search/base.rb
+++ b/app/classes/pattern_search/base.rb
@@ -35,7 +35,11 @@ module PatternSearch
     end
 
     def help_message
-      "#{:pattern_search_terms_help.l}\n" + params.keys.map do |arg|
+      "#{:pattern_search_terms_help.l}\n#{self.class.terms_help}"
+    end
+
+    def self.terms_help
+      params.keys.map do |arg|
         "* *#{arg}*: #{ :"#{model.type_tag}_term_#{arg}".l }"
       end.join("\n")
     end

--- a/app/classes/pattern_search/base.rb
+++ b/app/classes/pattern_search/base.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module PatternSearch
+  # Base class for PatternSearch; handles everything but build_query
   class Base
     attr_accessor :errors
     attr_accessor :parser
@@ -18,7 +21,7 @@ module PatternSearch
     def build_query
       self.flavor = :all
       self.args   = {}
-      for term in parser.terms
+      parser.terms.each do |term|
         param = params[term.var]
         if term.var == :pattern
           self.flavor = :pattern_search
@@ -40,7 +43,7 @@ module PatternSearch
 
     def self.terms_help
       params.keys.map do |arg|
-        "* *#{arg}*: #{ :"#{model.type_tag}_term_#{arg}".l }"
+        "* *#{arg}*: #{:"#{model.type_tag}_term_#{arg}".l}"
       end.join("\n")
     end
   end

--- a/app/classes/pattern_search/name.rb
+++ b/app/classes/pattern_search/name.rb
@@ -27,12 +27,20 @@ module PatternSearch
       comments:           [:comments_has,       :parse_string]
     }.freeze
 
-    def params
+    def self.params
       PARAMS
     end
 
-    def model
+    def params
+      self.class.params
+    end
+
+    def self.model
       ::Name
+    end
+
+    def model
+      self.class.model
     end
   end
 end

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -36,12 +36,20 @@ module PatternSearch
       has_comments:    [:has_comments,     :parse_yes]
     }.freeze
 
-    def params
+    def self.params
       PARAMS
     end
 
-    def model
+    def params
+      self.class.params
+    end
+
+    def self.model
       ::Observation
+    end
+
+    def model
+      self.class.model
     end
   end
 end

--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -1,4 +1,5 @@
-#
+# frozen_string_literal: true
+
 # The original MO controller and hence a real mess!
 # The Clitocybe of controllers.
 #
@@ -23,6 +24,9 @@ class ObserverController < ApplicationController
   require_dependency "observer_controller/rss_log_controller"
   require_dependency "observer_controller/search_controller"
   require_dependency "observer_controller/user_controller"
+
+  # Disable cop: all these methods are defined in files included above.
+  # rubocop:disable Rails/LexicallyScopedActionFilter
 
   before_action :login_required, except: [
     :advanced_search,
@@ -96,4 +100,5 @@ class ObserverController < ApplicationController
     :show_observation,
     :show_user
   ]
+  # rubocop:enable Rails/LexicallyScopedActionFilter
 end

--- a/app/controllers/observer_controller.rb
+++ b/app/controllers/observer_controller.rb
@@ -68,6 +68,7 @@ class ObserverController < ApplicationController
     :prev_user,
     :print_labels,
     :rss,
+    :search_bar_help,
     :show_obs,
     :show_observation,
     :show_rss_log,

--- a/app/controllers/observer_controller/info_controller.rb
+++ b/app/controllers/observer_controller/info_controller.rb
@@ -1,17 +1,18 @@
 # TODO: move this into a new InfoController
+# Display canned informations about site
 class ObserverController
   # Intro to site.
-  def intro # :nologin:
+  def intro
     store_location
   end
 
   # Recent features.
-  def news # :nologin:
+  def news
     store_location
   end
 
   # Help page.
-  def how_to_use # :nologin:
+  def how_to_use
     store_location
     @min_pos_vote = Vote.confidence(Vote.min_pos_vote)
     @min_neg_vote = Vote.confidence(Vote.min_neg_vote)
@@ -19,26 +20,21 @@ class ObserverController
   end
 
   # A few ways in which users can help.
-  def how_to_help # :nologin:
+  def how_to_help
     store_location
   end
 
-  def wrapup_2011 # :nologin:
+  def wrapup_2011
     store_location
   end
-
-  # Disable cop as a temporary measure to make Codeclimate pass
-  # because :nologin: might have to be on same line as def
-  # rubocop:disable Style/CommentedKeyword
 
   # linked from search bar
-  def search_bar_help # :nologin:
+  def search_bar_help
     store_location
   end
-  # rubocop:enable Style/CommentedKeyword
 
   # Simple form letting us test our implementation of Textile.
-  def textile_sandbox # :nologin:
+  def textile_sandbox
     if request.method != "POST"
       @code = nil
     else
@@ -49,9 +45,9 @@ class ObserverController
   end
 
   # I keep forgetting the stupid "_sandbox" thing.
-  alias_method :textile, :textile_sandbox # :nologin:
+  alias_method :textile, :textile_sandbox
 
   # Allow translator to enter a special note linked to from the lower left.
-  def translators_note # :nologin:
+  def translators_note
   end
 end

--- a/app/controllers/observer_controller/info_controller.rb
+++ b/app/controllers/observer_controller/info_controller.rb
@@ -27,10 +27,15 @@ class ObserverController
     store_location
   end
 
+  # Disable cop as a temporary measure to make Codeclimate pass
+  # because :nologin: might have to be on same line as def
+  # rubocop:disable Style/CommentedKeyword
+
   # linked from search bar
   def search_bar_help # :nologin:
     store_location
   end
+  # rubocop:enable Style/CommentedKeyword
 
   # Simple form letting us test our implementation of Textile.
   def textile_sandbox # :nologin:

--- a/app/controllers/observer_controller/info_controller.rb
+++ b/app/controllers/observer_controller/info_controller.rb
@@ -27,6 +27,11 @@ class ObserverController
     store_location
   end
 
+  # linked from search bar
+  def search_bar_help # :nologin:
+    store_location
+  end
+
   # Simple form letting us test our implementation of Textile.
   def textile_sandbox # :nologin:
     if request.method != "POST"

--- a/app/views/observer/search_bar_help.html.erb
+++ b/app/views/observer/search_bar_help.html.erb
@@ -2,9 +2,9 @@
 
 <div class="max-width-text">
   <%= :pattern_search_terms_help.tp %>
-  <%= content_tag(:p, "#{:NAMES.t} #{:SEARCHES.t}", { class: "bold" }) %>
-  <%= PatternSearch::Name.terms_help.tp %>
-
   <%= content_tag(:p, "#{:OBSERVATIONS.t} #{:SEARCHES.t}", { class: "bold" }) %>
   <%= PatternSearch::Observation.terms_help.tp %>
+
+  <%= content_tag(:p, "#{:NAMES.t} #{:SEARCHES.t}", { class: "bold" }) %>
+  <%= PatternSearch::Name.terms_help.tp %>
 </div>

--- a/app/views/observer/search_bar_help.html.erb
+++ b/app/views/observer/search_bar_help.html.erb
@@ -1,0 +1,10 @@
+<% @title = :search_bar_help_title .t %>
+
+<div class="max-width-text">
+  <%= :pattern_search_terms_help.tp %>
+  <%= content_tag(:p, "#{:NAMES.t} #{:SEARCHES.t}", { class: "bold" }) %>
+  <%= PatternSearch::Name.terms_help.tp %>
+
+  <%= content_tag(:p, "#{:OBSERVATIONS.t} #{:SEARCHES.t}", { class: "bold" }) %>
+  <%= PatternSearch::Observation.terms_help.tp %>
+</div>

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -33,6 +33,12 @@
           <%= submit_tag(:app_search.l, class: "btn align-top",
                          style: "margin-right:0.5em") %>
         </div>
+        <%=
+            link_to(content_tag(:span, :search_bar_help.t),
+                    controller: :observer,
+                    action: :search_bar_help)
+        %>
+        |
 
         <%
           adv_search = link_to(content_tag(:span, :app_advanced_search.l,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -653,6 +653,7 @@
   save_edits: save edits
   SEARCH: Search
   search: search
+  SEARCHES: Searches
   SEND: Send
   send: send
   SHOW: Show
@@ -3238,6 +3239,12 @@
   name_term_classification: Classification contains this string.
   name_term_notes: Taxonomic notes contains this string.
   name_term_comments: One of the comments contains this string.
+
+  # link to search bar help
+  search_bar_help: Search Help
+
+  # Search bar help page
+  search_bar_help_title: Search Bar Help
 
   ##############################################################################
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -348,6 +348,7 @@ ACTIONS = {
     recalc: {},
     review_authors: {},
     rss: {},
+    search_bar_help: {},
     set_export_status: {},
     show_location_observations: {},
     show_notifications: {},

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -153,6 +153,9 @@ class ObserverControllerTest < FunctionalTestCase
     get_with_dump(:intro)
     assert_template(:intro)
 
+    get(:search_bar_help)
+    assert_response(:success)
+
     get_with_dump(:list_observations)
     assert_template(:list_observations, partial: :_rss_log)
 


### PR DESCRIPTION
Provide easy access to pattern search help via a link in the search bar. See [Pivotal #165481629](https://www.pivotaltracker.com/story/show/165481629).

Manual Test:
- All pages with a search bar should have a "Search Help" link between the Search button and Advanced Search.
- Click on the link to display the help, which describes all available pattern search terms.

Notes:
As part of fixing RuboCop offenses I deleted all :nologin: comments in InfoController; one of them caused a new offense.
