### PR TITLE
Tweaked Location#force_valid_lat_longs! 

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -199,15 +199,20 @@ class Location < AbstractModel
   end
 
   # Useful if invalid lat/longs cause crash, e.g., in mapping code.
+  # New: Ensure box has nonzero size or make_editable_map fails.
   def force_valid_lat_longs!
     self.north = Location.parse_latitude(north) || 45
     self.south = Location.parse_latitude(south) || -45
     self.east = Location.parse_longitude(east) || 90
     self.west = Location.parse_longitude(west) || -90
-    return unless north < south
+    return if north > south
 
-    self.north = south
-    self.south = north
+    center_lat = (north + south) / 2
+    center_lon = (east + west) / 2
+    self.north = center_lat + 0.0001
+    self.south = center_lat - 0.0001
+    self.east = center_lon + 0.0001
+    self.west = center_lon - 0.0001
   end
 
   ##############################################################################

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -417,4 +417,42 @@ class LocationTest < UnitTestCase
     assert_equal("Trois, Deux, Un", loc.name)
     assert_equal("Un, Deux, Trois", loc.scientific_name)
   end
+
+  def test_force_valid_lat_longs
+    loc = locations(:albion)
+
+    # Make sure a good location is unchanged.
+    loc.north = 8
+    loc.south = 6
+    loc.east = 4
+    loc.west = 2
+    loc.force_valid_lat_longs!
+    assert_equal([8, 6, 4, 2], [loc.north, loc.south, loc.east, loc.west])
+
+    # Make sure north/south reversed is fixed.
+    loc.north = -8
+    loc.south = 6
+    loc.east = 4
+    loc.west = 2
+    loc.force_valid_lat_longs!
+    assert_equal([-0.9999, -1.0001, 3.0001, 2.9999],
+                 [loc.north, loc.south, loc.east, loc.west])
+
+    # Make sure point is expanded to tiny box.
+    loc.north = 6
+    loc.south = 6
+    loc.east = 4
+    loc.west = 4
+    loc.force_valid_lat_longs!
+    assert_equal([6.0001, 5.9999, 4.0001, 3.9999],
+                 [loc.north, loc.south, loc.east, loc.west])
+
+    # Make sure good box spanning dateline is unchanged.
+    loc.north = 8
+    loc.south = 6
+    loc.east = -170
+    loc.west = 170
+    loc.force_valid_lat_longs!
+    assert_equal([8, 6, -170, 170], [loc.north, loc.south, loc.east, loc.west])
+  end
 end


### PR DESCRIPTION
to have it ensure locations are never a point, because that breaks the create_ and edit_location form.