### PR TITLE
Observation name not recognized

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-inherit_from: .rubocop_todo.yml
+# inherit_from: .rubocop_todo.yml
 
 # RuboCop configuration
 # Uses Rubcop's default configuration, except as specified below

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-# inherit_from: .rubocop_todo.yml
+inherit_from: .rubocop_todo.yml
 
 # RuboCop configuration
 # Uses Rubcop's default configuration, except as specified below

--- a/app/views/shared/_form_name_feedback.html.erb
+++ b/app/views/shared/_form_name_feedback.html.erb
@@ -1,35 +1,48 @@
-<% # Section for handling deprecated, new and multiple names on naming creation and edit pages
-if !what.blank?
+<%# Handling deprecated, new & multiple Names on naming create and edit pages %>
+<%
+if what.present?
   if valid_names
     flash_warning(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-warning max-width-text" id="name_messages">
-      <span class="Data"><%= if suggest_corrections
-        :form_naming_not_recognized.t(name: what)
-      elsif parent_deprecated
-        :form_naming_parent_deprecated.t(parent: parent_deprecated.display_name,
-                                         rank: :"rank_#{parent_deprecated.rank.to_s.downcase}")
+    <span class="Data"><%=
+    if suggest_corrections
+      :form_naming_not_recognized.t(name: what)
+    elsif parent_deprecated
+      :form_naming_parent_deprecated.t(
+        parent: parent_deprecated.display_name,
+        rank: :"rank_#{parent_deprecated.rank.to_s.downcase}"
+      )
+    else
+      :form_naming_deprecated.t(name: what)
+    end %>
+    </span><br/><%
+    if valid_names.length > 0 %>
+      if suggest_corrections
+        <span class="HelpNote">
+          <%= :form_naming_correct_help.t(button: button_name, name: what) %>
+        </span><br/>
       else
-        :form_naming_deprecated.t(name: what)
-      end %></span><br/>
-      <% if valid_names.length > 0 %>
-        <span class="HelpNote"><%= if suggest_corrections
-          :form_naming_correct_help.t(button: button_name, name: what)
-        else
-          :form_naming_deprecated_help.t(button: button_name, name: what)
-        end %></span><br/>
-        <% if !suggest_corrections and !parent_deprecated %>
-          <span class="Data"><%= :form_naming_valid_synonyms.t %>:<br/>
-        <% end %>
-          <% for n in valid_names %>
-            <%= indent + radio_button(:chosen_name, :name_id, n.id) %>
-            <%= n.display_name.t %><br/>
-          <% end %>
-        </span>
-      <% else %>
-        <span class="HelpNote"><%= :form_naming_not_recognized_help.t(button: button_name) %></span><br/>
-      <% end %>
+        <span class="HelpNote">
+          <%= :form_naming_deprecated_help.t(button: button_name, name: what) %>
+         </span><br/>
+      end %>
+      <span class="Data"><%
+      if !suggest_corrections && !parent_deprecated %>
+        <%= :form_naming_valid_synonyms.t %>:<br/><%
+      end %><%
+      valid_names.each do |n|  %>
+          <%= indent + radio_button(:chosen_name, :name_id, n.id) %>
+          <%= n.display_name.t %><br/><%
+      end %>
+      </span><%
+    else %>
+      <span class="HelpNote">
+      <%= :form_naming_not_recognized_help.t(button: button_name) %>
+      </span><br/><%
+    end %>
     </div>
-  <% elsif names && names.length == 0
+    <%
+  elsif names && names.length == 0
     flash_error(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-danger max-width-text" id="name_messages">
       <span class="Data">
@@ -38,20 +51,20 @@ if !what.blank?
       <span class="HelpNote">
         <%= :form_naming_not_recognized_help.t(button: button_name) %>
       </span><br/>
-    </div>
-  <% elsif names && names.length > 1
+    </div><%
+  elsif names && names.length > 1
     flash_error(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-danger max-width-text" id="name_messages">
       <span class="Data">
-        <%= :form_naming_multiple_names.t(name: what) %>:<br/>
-        <% for n in names %>
+        <%= :form_naming_multiple_names.t(name: what) %>:<br/><%
+        names.each do |n| %>
           <%= indent + radio_button(:chosen_name, :name_id, n.id) %>
-          <%= n.display_name.t %> (<%= n.observations.size %>)<br/>
-        <% end %>
+          <%= n.display_name.t %> (<%= n.observations.size %>)<br/><%
+        end %>
       </span>
       <span class="HelpNote">
         <%= :form_naming_multiple_names_help.t %>
       </span><br/>
-    </div>
-  <% end
+    </div><%
+  end
 end %>

--- a/app/views/shared/_form_name_feedback.html.erb
+++ b/app/views/shared/_form_name_feedback.html.erb
@@ -2,9 +2,9 @@
 # Handling deprecated, new & multiple Names
 # Used by Name and Naming create and edit pages
 # Does three things:
-#   Flashes either Warning or Error
-#   Describes the issue, either Deprecated or Not Recognized
-#   Adds Help on how to proceed; text depends on the issue and the button
+#   Flashes - Warning or Error
+#   Describes the issue - Deprecated, Parent Deprecated, or Not Recognized
+#   Adds Help how to proceed - depends on issue and the button
 #
 # locals:
 # what - text typed by user
@@ -16,6 +16,7 @@
 
 if what.present?
   if valid_names
+    ##### Warnings #####
     flash_warning(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-warning max-width-text" id="name_messages">
     <span class="Data"><%=
@@ -55,6 +56,8 @@ if what.present?
       </span><br/><%
     end %>
     </div><%
+
+  ##### Errors #####
   elsif names.blank?
     flash_error(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-danger max-width-text" id="name_messages">

--- a/app/views/shared/_form_name_feedback.html.erb
+++ b/app/views/shared/_form_name_feedback.html.erb
@@ -1,36 +1,50 @@
-<%# Handling deprecated, new & multiple Names on naming create and edit pages %>
 <%
+# Handling deprecated, new & multiple Names
+# Used by Name and Naming create and edit pages
+# Does three things:
+#   Flashes either Warning or Error
+#   Describes the issue, either Deprecated or Not Recognized
+#   Adds Help on how to proceed; text depends on the issue and the button
+#
+# locals:
+# what - text typed by user
+# names - Name(s) corresponding to what
+# valid_names - Name(s) that are valid synonyms
+# suggest_corections - t/f whether to suggest correction(s)
+# parent_deprecated - t/f
+# button_name - text: button to complete the action, e.g. Submit, Create
+
 if what.present?
   if valid_names
     flash_warning(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-warning max-width-text" id="name_messages">
     <span class="Data"><%=
-    if suggest_corrections
+    if suggest_corrections || names.blank?
       :form_naming_not_recognized.t(name: what)
     elsif parent_deprecated
       :form_naming_parent_deprecated.t(
         parent: parent_deprecated.display_name,
         rank: :"rank_#{parent_deprecated.rank.to_s.downcase}"
       )
-    else
+    elsif names.present?
       :form_naming_deprecated.t(name: what)
     end %>
     </span><br/><%
-    if valid_names.length > 0 %>
-      if suggest_corrections
+    if valid_names.length > 0
+      if suggest_corrections %>
         <span class="HelpNote">
           <%= :form_naming_correct_help.t(button: button_name, name: what) %>
-        </span><br/>
-      else
+        </span><br/><%
+      else %>
         <span class="HelpNote">
           <%= :form_naming_deprecated_help.t(button: button_name, name: what) %>
-         </span><br/>
+         </span><br/><%
       end %>
       <span class="Data"><%
       if !suggest_corrections && !parent_deprecated %>
         <%= :form_naming_valid_synonyms.t %>:<br/><%
       end %><%
-      valid_names.each do |n|  %>
+      valid_names.each do |n| %>
           <%= indent + radio_button(:chosen_name, :name_id, n.id) %>
           <%= n.display_name.t %><br/><%
       end %>
@@ -40,9 +54,8 @@ if what.present?
       <%= :form_naming_not_recognized_help.t(button: button_name) %>
       </span><br/><%
     end %>
-    </div>
-    <%
-  elsif names && names.length == 0
+    </div><%
+  elsif names.blank?
     flash_error(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-danger max-width-text" id="name_messages">
       <span class="Data">
@@ -52,7 +65,7 @@ if what.present?
         <%= :form_naming_not_recognized_help.t(button: button_name) %>
       </span><br/>
     </div><%
-  elsif names && names.length > 1
+  elsif names&.length > 1
     flash_error(:form_observations_there_is_a_problem_with_name.t) %>
     <div class="alert alert-danger max-width-text" id="name_messages">
       <span class="Data">

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1412,7 +1412,7 @@
   form_naming_name_help: "<strong>Scientific names are currently required</strong>, but do not include any author information.  If multiple names apply, you will be given the option to select between them.  If the name is not recognized in the database, then you will be given the option to add the name or fix the spelling if it's just a typo."
   form_naming_deprecated_help: Select a valid name or click '[button]' to use '[name]'.
   form_naming_correct_help: Did you mean one of the following names? [:form_naming_deprecated_help]
-  form_naming_not_recognized_help: "To proceed: \nLeave the '[:What]' field blank and click '[button]' \nOR \nIf you are certain the name is a valid, scientific name, then correct any misspelling and click '[button]' to create a new MO Name."
+  form_naming_not_recognized_help: "To proceed: Edit the name to be a valid, correctly spelled, scientific name\n (or -- if you are creating an Observation -- erase the name). \nThen click '[button]'."
   form_naming_multiple_names: Multiple names match '[name]'.  Select the one you intended.
   form_naming_multiple_names_help: The number after each name is how many observations are currently using that name.
   form_naming_confidence_help: How confident are you of this identification?  Please justify how you arrived at your decision in the boxes below, as well.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1406,13 +1406,13 @@
   form_naming_confidence: Confidence
   form_naming_valid_synonyms: Valid synonyms are
   form_naming_deprecated: The name '[name]' is deprecated.
-  form_naming_not_recognized: The name '[name]' was not recognized.
+  form_naming_not_recognized: MO does not recognize the name '[name]'.
   form_naming_parent_deprecated: The [rank] [parent] is deprecated.
   form_naming_name_help_create: The name you would apply to this observation.  If you don't know what it is, just leave it blank.  If you find a better name in the future, you can always propose a name later.
-  form_naming_name_help: Scientific names are currently required, but do not include any author information.  If multiple names apply, you will be given the option to select between them.  If the name is not recognized in the database, then you will be given the option to add the name or fix the spelling if it's just a typo.
+  form_naming_name_help: "<strong>Scientific names are currently required</strong>, but do not include any author information.  If multiple names apply, you will be given the option to select between them.  If the name is not recognized in the database, then you will be given the option to add the name or fix the spelling if it's just a typo."
   form_naming_deprecated_help: Select a valid name or click '[button]' to use '[name]'.
   form_naming_correct_help: Did you mean one of the following names? [:form_naming_deprecated_help]
-  form_naming_not_recognized_help: Click '[button]' to create this name or edit the name below to correct any typo.
+  form_naming_not_recognized_help: "To proceed: \nLeave the '[:What]' field blank and click '[button]' \nOR \nIf you are certain the name is a valid, scientific name, then correct any misspelling and click '[button]' to create a new MO Name."
   form_naming_multiple_names: Multiple names match '[name]'.  Select the one you intended.
   form_naming_multiple_names_help: The number after each name is how many observations are currently using that name.
   form_naming_confidence_help: How confident are you of this identification?  Please justify how you arrived at your decision in the boxes below, as well.

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -83,6 +83,17 @@ class ObserverControllerTest < FunctionalTestCase
     )
   end
 
+  def test_create_observation_with_unrecognized_name
+    text_name = "Elfin saddle"
+    params = { name: { name: text_name },
+               user: rolf,
+               where: locations.first.name }
+    post_requires_login(:create_observation, params)
+
+    assert_select("div[id='name_messages']",
+                  /MO does not recognize the name.*#{text_name}/)
+  end
+
   ##############################################################################
 
   # ----------------------------

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -124,15 +124,15 @@ class ObserverControllerTest < FunctionalTestCase
 
   def test_show_observation_hidden_gps
     obs = observations(:unknown_with_lat_long)
-    get(:show_observation, id: obs.id)
+    get(:show_observation, id: obs.id) # rubocop:disable HttpPositionalArguments
     assert_match(/34.1622|118.3521/, @response.body)
 
-    obs.update_attribute(:gps_hidden, true)
-    get(:show_observation, id: obs.id)
+    obs.update(gps_hidden: true)
+    get(:show_observation, id: obs.id) # rubocop:disable HttpPositionalArguments
     assert_no_match(/34.1622|118.3521/, @response.body)
 
     login("mary")
-    get(:show_observation, id: obs.id)
+    get(:show_observation, id: obs.id) # rubocop:disable HttpPositionalArguments
     assert_match(/34.1622|118.3521/, @response.body)
     assert_match(:show_observation_gps_hidden.t, @response.body)
   end
@@ -653,7 +653,7 @@ class ObserverControllerTest < FunctionalTestCase
     assert_true(assigns(:observations).map(&:long).map(&:to_s).join("").
                                        include?("118.3521"))
 
-    obs.update_attribute(:gps_hidden, true)
+    obs.update(gps_hidden: true)
     get(:map_observation, params: { id: obs.id })
     assert_false(assigns(:observations).map(&:lat).map(&:to_s).join("").
                                         include?("34.1622"))
@@ -672,7 +672,7 @@ class ObserverControllerTest < FunctionalTestCase
     assert_true(assigns(:observations).map(&:long).map(&:to_s).join("").
                                        include?("118.3521"))
 
-    obs.update_attribute(:gps_hidden, true)
+    obs.update(gps_hidden: true)
     get(:map_observations, params: { q: query.id.alphabetize })
     assert_false(assigns(:observations).map(&:lat).map(&:to_s).join("").
                                         include?("34.1622"))
@@ -1670,7 +1670,7 @@ class ObserverControllerTest < FunctionalTestCase
                        users(:rolf).preferred_herbarium_name)
     assert_input_value(:herbarium_record_herbarium_id, "")
     assert_true(@response.body.include?("Albion, Mendocino Co., California"))
-    users(:rolf).update_attribute(:location_format, :scientific)
+    users(:rolf).update(location_format: :scientific)
     get(:create_observation)
     assert_true(@response.body.include?("California, Mendocino Co., Albion"))
   end
@@ -2481,7 +2481,7 @@ class ObserverControllerTest < FunctionalTestCase
     FileUtils.mkdir_p(path) unless File.directory?(path)
     FileUtils.cp(fixture, orig_file)
 
-    post(
+    post( # rubocop:disable HttpPositionalArguments
       :create_observation,
       observation: {
         when: Time.zone.now,
@@ -2745,7 +2745,7 @@ class ObserverControllerTest < FunctionalTestCase
     FileUtils.mkdir_p(path) unless File.directory?(path)
     FileUtils.cp(fixture, orig_file)
 
-    post(
+    post( # rubocop:disable HttpPositionalArguments
       :edit_observation,
       id: obs.id,
       observation: {

--- a/test/integration/amateur_test.rb
+++ b/test/integration/amateur_test.rb
@@ -384,7 +384,9 @@ class AmateurTest < IntegrationTestCase
       end
       assert_template("naming/create")
       assert_select("div.alert-warning") do |elems|
-        assert(elems.any? { |e| e.to_s.match(/#{text_name}.*not recognized/i) },
+        assert(elems.any? do |e|
+                /MO does not recognize the name.*#{text_name}/ =~ e.to_s
+               end,
                "Expected error about name not existing yet.")
       end
 

--- a/test/integration/amateur_test.rb
+++ b/test/integration/amateur_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 # Test typical sessions of amateur user who just posts the occasional comment,
@@ -68,7 +70,7 @@ class AmateurTest < IntegrationTestCase
   # ----------------------------
 
   def test_autologin
-    rolf_cookies = get_cookies(rolf, :true)
+    rolf_cookies = get_cookies(rolf, true)
     mary_cookies = get_cookies(mary, true)
     dick_cookies = get_cookies(dick, false)
     try_autologin(rolf_cookies, rolf)
@@ -77,7 +79,6 @@ class AmateurTest < IntegrationTestCase
   end
 
   def get_cookies(user, autologin)
-    result = nil
     sess = open_session
     sess.login(user, "testpassword", autologin)
     result = sess.cookies.dup
@@ -197,7 +198,6 @@ class AmateurTest < IntegrationTestCase
 
   def test_proposing_names
     namer_session = open_session.extend(NamerDsl)
-    app = namer_session.app
     namer = katrina
 
     obs = observations(:detailed_unknown_obs)
@@ -223,7 +223,6 @@ class AmateurTest < IntegrationTestCase
 
   def test_sessions
     rolf_session = open_session.extend(NamerDsl)
-    app = rolf_session.app
     rolf_session.login!(rolf)
     mary_session = open_session.extend(VoterDsl)
     mary_session.login!(mary)
@@ -385,7 +384,7 @@ class AmateurTest < IntegrationTestCase
       assert_template("naming/create")
       assert_select("div.alert-warning") do |elems|
         assert(elems.any? do |e|
-                /MO does not recognize the name.*#{text_name}/ =~ e.to_s
+                 /MO does not recognize the name.*#{text_name}/ =~ e.to_s
                end,
                "Expected error about name not existing yet.")
       end
@@ -480,7 +479,7 @@ class AmateurTest < IntegrationTestCase
       obs.reload
       assert_names_equal(original_name, obs.name)
       assert_nil(Naming.safe_find(naming.id))
-      refute_match(text_name, response.body)
+      assert_no_match(text_name, response.body)
     end
   end
 end


### PR DESCRIPTION
Fixes [Pivotal #156561981](https://www.pivotaltracker.com/story/show/156561981) ("Screwy error message when creating obs with name not in db.")

**Manual Test Script**
- click [Create Observation](https://mushroomobserver.org/observer/create_observation)
- in Where, type an existing location, e.g., "USA"
- in What type a name that's not in the MO db, e.g., "Anabanana plantana"
- select any Confidence 
- Submit

Result: MO warns that it "does not recognize" the name you type. (In master, MO incorrectly says that the name "is deprecated"). 

**Notes**
- I had huge trouble reading/parsing FormNameFeedback (the source of the bug). So I reformatted it to emphasize nesting of Ruby conditionals (rather than of html elements).  (The actual fix is in lines 23, "if suggest_corrections **|| names.blank?** and 30 "~~else~~ **elsif names.present?**".)
(i also got rid of some interlacing of Ruby conditionals and html elements, fixed some RuboCop-type issues.)
- Per [Alan's suggestion when he reported the bug](https://groups.google.com/d/msg/mo-developers/IiLK2Rywokc/DwXVR2OCBgAJ), I also tweaked some help messages to emphasize correct spelling of scientific names.
