### PR TITLE
Change default Pattern Search for Names and Observations

### DIFF
--- a/app/controllers/observer_controller/search_controller.rb
+++ b/app/controllers/observer_controller/search_controller.rb
@@ -25,10 +25,16 @@ class ObserverController
         pattern = %Q(synonym_of:"#{pattern}")
         session[:pattern] = pattern
       end
+    when :name
+      ctrlr = :name
+      if pattern.present? && variable_absent?(pattern)
+        pattern = %Q(synonym_of:"#{pattern}")
+        session[:pattern] = pattern
+      end
     when :user
       ctrlr = :observer
     when :comment, :herbarium, :image, :location,
-      :name, :project, :species_list, :herbarium_record
+      :project, :species_list, :herbarium_record
       ctrlr = type
     when :google
       site_google_search(pattern)

--- a/app/controllers/observer_controller/search_controller.rb
+++ b/app/controllers/observer_controller/search_controller.rb
@@ -50,19 +50,17 @@ class ObserverController
       return
     end
 
-    ctrlr = pattern_search_ctrlr(type)
-
-    # sepcial cases
+    # special cases
     case type
     when :name, :observation
-      # If the pattern is a bare value, it defaults to synonym_of:"value"
-      pattern = default_synonym_pattern(pattern)
-      session[:pattern] = pattern
+      pattern = change_bare_value_to_synonym_of(pattern)
     when :google
       # external search, rather than a sql or ActiveRecord query
       site_google_search(pattern)
       return
     end
+
+    ctrlr = pattern_search_ctrlr(type)
 
     # If pattern is blank, this would devolve into a very expensive index.
     if pattern.blank?
@@ -134,13 +132,15 @@ class ObserverController
     end
   end
 
-  # Pattern can include variable(s) and value(s), e.g.: variable:value
-  # If the pattern is a bare value, it defaults to synonym_of:"value"
-  def default_synonym_pattern(pattern)
-    return if pattern.blank? || variable_present?(pattern)
+  def change_bare_value_to_synonym_of(pattern)
+    return pattern unless bare_value?(pattern)
 
     pattern = %(synonym_of:"#{pattern}")
     session[:pattern] = pattern
+  end
+
+  def bare_value?(pattern)
+    pattern.present? && !variable_present?(pattern)
   end
 
   def variable_present?(pattern)

--- a/app/controllers/observer_controller/search_controller.rb
+++ b/app/controllers/observer_controller/search_controller.rb
@@ -19,7 +19,13 @@ class ObserverController
     session[:search_type] = type
 
     case type
-    when :observation, :user
+    when :observation
+      ctrlr = :observer
+      if pattern.present? && variable_absent?(pattern)
+        pattern = %Q(synonym_of:"#{pattern}")
+        session[:pattern] = pattern
+      end
+    when :user
       ctrlr = :observer
     when :comment, :herbarium, :image, :location,
       :name, :project, :species_list, :herbarium_record
@@ -49,6 +55,14 @@ class ObserverController
       search = URI.encode_www_form(q: "site:#{MO.domain} #{pattern}")
       redirect_to("https://google.com/search?#{search}")
     end
+  end
+
+  def variable_absent?(pattern)
+    !variable_present?(pattern)
+  end
+
+  def variable_present?(pattern)
+    /\w+:/ =~ pattern
   end
 
   # Advanced search form.  When it posts it just redirects to one of several

--- a/app/views/observer/search_bar_help.html.erb
+++ b/app/views/observer/search_bar_help.html.erb
@@ -2,9 +2,12 @@
 
 <div class="max-width-text">
   <%= :pattern_search_terms_help.tp %>
-  <%= content_tag(:p, "#{:OBSERVATIONS.t} #{:SEARCHES.t}", { class: "bold" }) %>
+
+  <%= content_tag(:p, "#{:OBSERVATION.t} #{:SEARCHES.t}", { class: "bold" }) %>
+  <%= content_tag(:p, :observation_search_default.t) %>
   <%= PatternSearch::Observation.terms_help.tp %>
 
-  <%= content_tag(:p, "#{:NAMES.t} #{:SEARCHES.t}", { class: "bold" }) %>
+  <%= content_tag(:p, "#{:NAME.t} #{:SEARCHES.t}", { class: "bold" }) %>
+  <%= content_tag(:p, :name_search_default.t) %>
   <%= PatternSearch::Name.terms_help.tp %>
 </div>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3190,7 +3190,10 @@
   location_help_rule_good_habits: "*Stuff You Are Encouraged to Do* - If you are creating a new name, take some time to figure out a good name. Searching within Mushroom Observer can be helpful.  If you don't find anything there, then look things up in Google Maps (http://maps.google.com) and Wikipedia (http://wikipedia.org). Also feel free to use the notes section of either an observation or a location to be more specific."
 
   # Search bar help
-  pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.  Recognized variables include:"
+  pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.\n
+  Recognized variables include:"
+
+  observation_search_default: An Observation search without a variable defaults to synonym_of.
 
   observation_term_date: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_created: Date observation was first posted.
@@ -3219,6 +3222,8 @@
   observation_term_has_notes: Has notes?
   observation_term_has_field: Has a given notes template field filled in.
   observation_term_has_comments: Has and comments?
+
+  name_search_default: A Name search without a variable defaults to synonym_of.
 
   name_term_created: Date name was first used.
   name_term_modified: Date name was last modified.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3190,8 +3190,7 @@
   location_help_rule_good_habits: "*Stuff You Are Encouraged to Do* - If you are creating a new name, take some time to figure out a good name. Searching within Mushroom Observer can be helpful.  If you don't find anything there, then look things up in Google Maps (http://maps.google.com) and Wikipedia (http://wikipedia.org). Also feel free to use the notes section of either an observation or a location to be more specific."
 
   # Search bar help
-  pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.\n
-  Recognized variables include:"
+  pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas. \n Recognized variables include:"
 
   observation_search_default: An Observation search without a variable defaults to synonym_of.
 

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -530,7 +530,7 @@ class ObserverControllerTest < FunctionalTestCase
     params = { search: { pattern: "56", type: :name } }
     get_with_dump(:pattern_search, params)
     assert_redirected_to(controller: :name, action: :name_search,
-                         pattern: "56")
+                         pattern: 'synonym_of:"56"')
 
     params = { search: { pattern: "78", type: :location } }
     get_with_dump(:pattern_search, params)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -517,20 +517,13 @@ class ObserverControllerTest < FunctionalTestCase
   end
 
   def test_pattern_search
-    params = { search: { pattern: "12", type: :observation } }
-    get_with_dump(:pattern_search, params)
-    assert_redirected_to(controller: :observer, action: :observation_search,
-                         pattern: 'synonym_of:"12"')
+    # Test defaults (patterns without without variables)
+    # They should search for pattern
 
     params = { search: { pattern: "34", type: :image } }
     get_with_dump(:pattern_search, params)
     assert_redirected_to(controller: :image, action: :image_search,
                          pattern: "34")
-
-    params = { search: { pattern: "56", type: :name } }
-    get_with_dump(:pattern_search, params)
-    assert_redirected_to(controller: :name, action: :name_search,
-                         pattern: 'synonym_of:"56"')
 
     params = { search: { pattern: "78", type: :location } }
     get_with_dump(:pattern_search, params)
@@ -553,6 +546,18 @@ class ObserverControllerTest < FunctionalTestCase
     assert_redirected_to(controller: :observer, action: :user_search,
                          pattern: "34")
 
+    # default Observation and Name searches should search synonyms of pattern
+    params = { search: { pattern: "12", type: :observation } }
+    get_with_dump(:pattern_search, params)
+    assert_redirected_to(controller: :observer, action: :observation_search,
+                         pattern: 'synonym_of:"12"')
+
+    params = { search: { pattern: "56", type: :name } }
+    get_with_dump(:pattern_search, params)
+    assert_redirected_to(controller: :name, action: :name_search,
+                         pattern: 'synonym_of:"56"')
+
+    # default Google search should Google site for pattern
     stub_request(:any, /google.com/)
     pattern =  "hexiexiva"
     params = { search: { pattern: pattern, type: :google } }
@@ -560,6 +565,12 @@ class ObserverControllerTest < FunctionalTestCase
       "https://google.com/search?q=site%3Amushroomobserver.org+#{pattern}"
     get_with_dump(:pattern_search, params)
     assert_redirected_to(target)
+
+    # non-defaults
+    params = { search: { pattern: 'synonym_of:"56"', type: :name } }
+    get_with_dump(:pattern_search, params)
+    assert_redirected_to(controller: :name, action: :name_search,
+                         pattern: 'synonym_of:"56"')
 
     params = { search: { pattern: "", type: :google } }
     get_with_dump(:pattern_search, params)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -520,7 +520,7 @@ class ObserverControllerTest < FunctionalTestCase
     params = { search: { pattern: "12", type: :observation } }
     get_with_dump(:pattern_search, params)
     assert_redirected_to(controller: :observer, action: :observation_search,
-                         pattern: "12")
+                         pattern: 'synonym_of:"12"')
 
     params = { search: { pattern: "34", type: :image } }
     get_with_dump(:pattern_search, params)

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -38,3 +38,13 @@ fungi_comment: # 4
   comment: It really messes things up.
   target_type: Name
   target: fungi
+
+# QuerySupplementTest looks for Comments with "Agaricus campestris"
+amateur_obs_comment:
+  created_at: 2017-11-16 00:32:00
+  updated_at: 2017-11-16 00:32:00
+  user: katrina
+  summary: bad
+  comment: not Agaricus campestris
+  target_type: Observation
+  target: amateur_obs

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -24,7 +24,7 @@ class FilterTest < IntegrationTestCase
     click_button("Search")
 
     assert_match(
-      /#{:app_title.l }: Observations Matching ‘#{obs.name.text_name}/,
+      /#{:app_title.l }: Observation Index/,
       page.title, "Wrong page"
     )
     page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "capybara_helper"
 
@@ -27,7 +29,7 @@ class FilterTest < IntegrationTestCase
       /#{:app_title.l }: Observation Index/,
       page.title, "Wrong page"
     )
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
@@ -38,12 +40,12 @@ class FilterTest < IntegrationTestCase
 
     # Show Locations should be filtered
     click_link("Show Locations")
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_text(:filtered.t)
 
     # And mapping them should also be filtered.
     click_link("Map Locations")
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_text(:filtered.t)
 
     ### Now prove that turning filter off stops filtering ###
@@ -73,7 +75,7 @@ class FilterTest < IntegrationTestCase
     page.select("Observations", from: :search_type)
     click_button("Search")
 
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_no_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
@@ -114,7 +116,7 @@ class FilterTest < IntegrationTestCase
     page.select("Observations", from: :search_type)
 
     click_button("Search")
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
@@ -154,7 +156,7 @@ class FilterTest < IntegrationTestCase
     first(:button, :advanced_search_submit.l).click
 
     # Advance Search Filters should override user's { has_images: "yes" }
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_no_text(:filtered.t)
 
     results = page.find("div.results", match: :first)
@@ -185,7 +187,7 @@ class FilterTest < IntegrationTestCase
 
     # Advance Search Filters should override user content_filter so hits
     #   should == vouchered Observations of obs.name, both imaged and imageless
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
+    page.find_by_id("title").
       assert_no_text(:filtered.t)
     expect = Observation.where(name: obs.name).where(specimen: true)
     results = page.find("div.results", match: :first)

--- a/test/integration/query_supplemental_test.rb
+++ b/test/integration/query_supplemental_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 # Tests which supplement QueryTest
@@ -15,7 +17,7 @@ class QuerySupplementalTest < IntegrationTestCase
     fill_in("search_pattern", with: pattern)
     page.select("Comments", from: :search_type)
     click_button("Search")
-    title = page.find_by_id("title") # rubocop:disable Rails/DynamicFindBy
+    title = page.find_by_id("title")
 
     title.assert_text("‘#{pattern}’")
   end

--- a/test/integration/query_supplemental_test.rb
+++ b/test/integration/query_supplemental_test.rb
@@ -3,23 +3,20 @@ require "test_helper"
 # Tests which supplement QueryTest
 class QuerySupplementalTest < IntegrationTestCase
   # Test deserialization of non-ascii characters
-  # Observation and Show Location title include
+  # Some page titles include smart single quotes
   #               `             and ’
-  # as            &#8216        and &#8217;
   # serialized as %26%238216%3B and %26%238217%3B
-  # They are deserialized and displayed as pat of Map Locations title.
+  # displayed as  &#8216        and &#8217;
+  # after deserialization.
   def test_deserialize
-    obs = observations(:boletus_edulis_obs)
+    pattern = "Agaricus campestris"
 
     visit("/")
-    fill_in("search_pattern", with: obs.name.text_name)
-    page.select("Observations", from: :search_type)
+    fill_in("search_pattern", with: pattern)
+    page.select("Comments", from: :search_type)
     click_button("Search")
-    click_link("Show Locations")
-    click_link("Map Locations")
-
     title = page.find_by_id("title") # rubocop:disable Rails/DynamicFindBy
 
-    title.assert_text("‘#{obs.name.text_name}’")
+    title.assert_text("‘#{pattern}’")
   end
 end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2383,7 +2383,8 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Observation, :advanced_search, user: "rolf", by: :id)
     assert_query([observations(:coprinus_comatus_obs).id], :Observation,
                  :advanced_search, content: "second fruiting") # notes
-    assert_query([observations(:minimal_unknown_obs).id], :Observation,
+    assert_query([observations(:minimal_unknown_obs).id,
+                  observations(:amateur_obs).id], :Observation,
                  :advanced_search, content: "agaricus") # comment
   end
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "set"
 
@@ -484,12 +486,12 @@ class QueryTest < UnitTestCase
       "WHERE one = two AND foo LIKE bar " \
       "GROUP BY blah.id ORDER BY names.id ASC LIMIT 10, 10",
       clean(query.query(select: "names.*",
-                        join:   [:observations, :"users.reviewer"],
+                        join: [:observations, :"users.reviewer"],
                         tables: :images,
-                        where:  ["one = two", "foo LIKE bar"],
-                        group:  "blah.id",
-                        order:  "names.id ASC",
-                        limit:  "10, 10"))
+                        where: ["one = two", "foo LIKE bar"],
+                        group: "blah.id",
+                        order: "names.id ASC",
+                        limit: "10, 10"))
     )
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -251,8 +251,7 @@ class UserTest < UnitTestCase
     assert_equal(1, image.observations.length)
     assert_equal(observation_id, image.observations.first.id)
 
-    # Move some other user's comment over to make sure they get deleted, too.
-    assert_equal(1, katrina.comments.length)
+    assert_equal(2, katrina.comments.length)
     comment_id = katrina.comments.first.id
 
     # Fixtures have one vote for this observation,
@@ -272,12 +271,12 @@ class UserTest < UnitTestCase
 
     User.erase_user(user.id)
 
-    # Should have deleted one of each type of object.
+    # Count of each type of object should decrease by how many user had
     assert_equal(num_observations - 1, Observation.count)
     assert_equal(num_namings - 1, Naming.count)
     assert_equal(num_votes - 1, Vote.count)
     assert_equal(num_images - 1, Image.count)
-    assert_equal(num_comments - 1, Comment.count)
+    assert_equal(num_comments - 2, Comment.count)
     assert_equal(num_publications - 1, Publication.count)
     assert_raises(ActiveRecord::RecordNotFound) do
       Observation.find(observation_id)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class UserTest < UnitTestCase


### PR DESCRIPTION
Delivers [Pivotal #164957447](https://www.pivotaltracker.com/story/show/164957447)
**This is a draft PR because it cannot be merged until #494 is merged**. (Test suite will not pass until it's merged.)

Manual tests
- Pattern Search for Names, pattern "Hydnum neorepandum".
Result should include _H. neorepandum_, _H. washingtonianum_, and exclude _H._ subgenus _Hydnum_ and _H._ sect. _Hydnum_ 
- Pattern Search for Observations, pattern "Boletus edulis".
Result should include Observations only of _B. edulis_, and exclude _Caloboletus inedulis_, _Boletus austroedulis_, _Amanita muscaria_ subsp. _flavivolvata_, etc.

Note: The new default Observation pattern search does not return Observations of subtaxa of the pattern. It ideally would, but that would require a new Query parameter. IMO, this PR is an improvement over master, so it should be merged when ready, and perfected later.


