### PR TITLE
Glossary rubocop cleanup

### DIFF
--- a/app/controllers/glossary_controller.rb
+++ b/app/controllers/glossary_controller.rb
@@ -22,25 +22,36 @@ class GlossaryController < ApplicationController
 
   def create_glossary_term # :norobots:
     if request.method == "POST"
-      glossary_term = GlossaryTerm.
-                      new(user: @user, name: params[:glossary_term][:name],
-                          description: params[:glossary_term][:description])
-      image_args = {
-        copyright_holder: params[:copyright_holder],
-        when: Time.local(params[:date][:copyright_year]),
-        license: License.safe_find(params[:upload][:license_id]),
-        user: @user,
-        image: params[:glossary_term][:upload_image]
-      }
-      glossary_term.add_image(process_image(image_args))
-      glossary_term.save
-      redirect_to(action: "show_glossary_term", id: glossary_term.id)
+      glossary_term_post
     else
-      @copyright_holder = @user.name
-      @copyright_year = Time.now.year
-      @upload_license_id = @user.license_id
-      @licenses = License.current_names_and_ids(@user.license)
+      glossary_term_get
     end
+  end
+
+  def glossary_term_get
+    @copyright_holder = @user.name
+    @copyright_year = Time.now.utc.year
+    @upload_license_id = @user.license_id
+    @licenses = License.current_names_and_ids(@user.license)
+  end
+
+  def glossary_term_post
+    glossary_term = \
+      GlossaryTerm.new(user: @user, name: params[:glossary_term][:name],
+                       description: params[:glossary_term][:description])
+    glossary_term.add_image(process_image(image_args))
+    glossary_term.save
+    redirect_to(action: "show_glossary_term", id: glossary_term.id)
+  end
+
+  def image_args
+    {
+      copyright_holder: params[:copyright_holder],
+      when: Time.local.utc(params[:date][:copyright_year]),
+      license: License.safe_find(params[:upload][:license_id]),
+      user: @user,
+      image: params[:glossary_term][:upload_image]
+    }
   end
 
   def process_image(args)

--- a/app/controllers/glossary_controller.rb
+++ b/app/controllers/glossary_controller.rb
@@ -47,7 +47,7 @@ class GlossaryController < ApplicationController
   def image_args
     {
       copyright_holder: params[:copyright_holder],
-      when: Time.local.utc(params[:date][:copyright_year]),
+      when: Time.local(params[:date][:copyright_year]).utc,
       license: License.safe_find(params[:upload][:license_id]),
       user: @user,
       image: params[:glossary_term][:upload_image]

--- a/app/controllers/glossary_controller.rb
+++ b/app/controllers/glossary_controller.rb
@@ -63,21 +63,25 @@ class GlossaryController < ApplicationController
         upload.respond_to?(:original_filename)
 
       image = Image.new(args)
-      if !image.save
-        flash_object_errors(image)
-      elsif !image.process_image
-        logger.error("Unable to upload image")
-        name = image.original_name
-        name = "???" if name.empty?
-        flash_error(:runtime_image_invalid_image.t(name: name))
-        flash_object_errors(image)
-      else
-        name = image.original_name
-        name = "##{image.id}" if name.empty?
-        flash_notice(:runtime_image_uploaded_image.t(name: name))
-      end
+      save_or_flash(image)
     end
     image
+  end
+
+  def save_or_flash(image)
+    if !image.save
+      flash_object_errors(image)
+    elsif !image.process_image
+      logger.error("Unable to upload image")
+      name = image.original_name
+      name = "???" if name.empty?
+      flash_error(:runtime_image_invalid_image.t(name: name))
+      flash_object_errors(image)
+    else
+      name = image.original_name
+      name = "##{image.id}" if name.empty?
+      flash_notice(:runtime_image_uploaded_image.t(name: name))
+    end
   end
 
   def edit_glossary_term # :norobots:

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -1,10 +1,15 @@
 class GlossaryTerm < AbstractModel
   require "acts_as_versioned"
 
-  belongs_to :thumb_image, class_name: "Image", foreign_key: "thumb_image_id"
+  belongs_to(:thumb_image,
+             class_name: "Image",
+             foreign_key: "thumb_image_id",
+             inverse_of: :best_glossary_terms)
   belongs_to :user
   belongs_to :rss_log
-  has_and_belongs_to_many :images, -> { order "vote_cache DESC" }
+  has_many(:images,
+           -> { order(vote_cache: :desc) },
+           through: :glossary_terms_images)
 
   ALL_TERM_FIELDS = [:name, :description].freeze
   acts_as_versioned(

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -7,9 +7,12 @@ class GlossaryTerm < AbstractModel
              inverse_of: :best_glossary_terms)
   belongs_to :user
   belongs_to :rss_log
-  has_many(:images,
-           -> { order(vote_cache: :desc) },
-           through: :glossary_terms_images)
+  # Rubocop would rather this was a has_many :through, but that
+  # requires a migration process as detailed here:
+  # chrisrolle.com/en/blog/migration-path-from-habtm-to-has_many-through
+  # rubocop:disable Rails/HasAndBelongsToMany
+  has_and_belongs_to_many :images, -> { order "vote_cache DESC" }
+  # rubocop:enable Rails/HasAndBelongsToMany
 
   ALL_TERM_FIELDS = [:name, :description].freeze
   acts_as_versioned(

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -229,7 +229,7 @@ class Image < AbstractModel
            class_name: "GlossaryTerm",
            foreign_key: "thumb_image_id",
            inverse_of: :thumb_image)
-  
+
   has_many :copyright_changes, as: :target, dependent: :destroy
 
   before_destroy :update_thumbnails

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -225,8 +225,11 @@ class Image < AbstractModel
   belongs_to :license
   belongs_to :reviewer, class_name: "User", foreign_key: "reviewer_id"
   has_many :subjects, class_name: "User", foreign_key: "image_id"
-  has_many :best_glossary_terms, class_name: "GlossaryTerm",
-                                 foreign_key: "thumb_image_id"
+  has_many(:best_glossary_terms,
+           class_name: "GlossaryTerm",
+           foreign_key: "thumb_image_id",
+           inverse_of: :thumb_image)
+  
   has_many :copyright_changes, as: :target, dependent: :destroy
 
   before_destroy :update_thumbnails


### PR DESCRIPTION
Should be no functional changes, but the files related to the glossary functionality should now pass rubocop.