### PR TITLE
[Fixes #167543713]Fix timing issue in test_blocked_ips

### DIFF
--- a/test/models/robots_test.rb
+++ b/test/models/robots_test.rb
@@ -25,6 +25,8 @@ class RobotsTest < UnitTestCase
     assert_true(Robots.blocked?("87.65.43.21"))
 
     File.rename(file2, file2_tmp)
+    # Make Robots recognize that following modification of okay_ips_file is
+    # later than in-memory modification of list of blocked ips
     sleep(1)
     system("echo 87.65.43.21 > #{file2}")
     assert_false(Robots.blocked?("87.65.43.21"))

--- a/test/models/robots_test.rb
+++ b/test/models/robots_test.rb
@@ -25,6 +25,7 @@ class RobotsTest < UnitTestCase
     assert_true(Robots.blocked?("87.65.43.21"))
 
     File.rename(file2, file2_tmp)
+    sleep(1)
     system("echo 87.65.43.21 > #{file2}")
     assert_false(Robots.blocked?("87.65.43.21"))
 


### PR DESCRIPTION
Address [Pivotal #167543713](https://www.pivotaltracker.com/story/show/167543713)

RobotsTest#test_blocked_ips was failing intermittently. The cause seems to be  :
(a) modifying a file which lists  ok ips
too soon after
(b) the modification in memory of a list of blocked ips.
I made  the test pass by adding a 1 second delay between modification of the list in memory and the file.