### PR TITLE
[Fixes #13471951]Add Observation count to Location pages

### DIFF
--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -1,6 +1,20 @@
+# frozen_string_literal: true
+
+# helper methods for Location-related views:
+# ListCountries, ListLocations, ShowLocation
 module LocationHelper
   def country_link(country, count = nil)
     str = country + (count ? ": #{count}" : "")
-    result = link_to(str, action: :list_by_country, country: country)
+    link_to(str, action: :list_by_country, country: country)
+  end
+
+  # title of a link to Observations at a location, with observation count
+  # Observations at this Location(nn)
+  def show_obs_link_title_with_count(location)
+    "#{:show_location_observations.t} (#{observation_count(location)})"
+  end
+
+  def observation_count(location)
+    Observation.where(location: location).count
   end
 end

--- a/app/views/location/list_locations.html.erb
+++ b/app/views/location/list_locations.html.erb
@@ -13,6 +13,12 @@
   flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
 %>
 
+<div>
+  <br>
+  <%= :list_place_names_popularity.t %>
+  <%= :list_place_names_parenthetical.t %>
+</div>
+
 <div class="row push-down">
   <div class="col-md-7">
     <% if @known_pages.any? && @known_data.any? %>
@@ -22,9 +28,11 @@
       </div>
       <%= paginate_block(@known_pages) do %>
         <div class="list-group">
-          <% for location in @known_data %>
+          <% @known_data.each do |location| %>
             <div class="list-group-item">
-              <%= link_with_query(location.display_name.t, location.show_link_args) %>
+              <%= link_with_query(location.display_name.t,
+                                  location.show_link_args) %>
+              (<%= observation_count(location) %>)
             </div>
           <% end %>
         </div>
@@ -40,7 +48,7 @@
       </div>
       <%= paginate_block(@undef_pages) do %>
         <div class="list-group">
-          <% for location, count in @undef_data
+          <% @undef_data.each do |location, count|
             if @undef_location_format == :scientific
               location = Location.reverse_name(location)
             end %>

--- a/app/views/location/show_location.html.erb
+++ b/app/views/location/show_location.html.erb
@@ -2,8 +2,9 @@
   @title = :show_location_title.t(name: @location.display_name)
 
   tabs = [
-    link_with_query(:show_location_observations.t, controller: :observer,
-                    action: :observations_at_location, id: @location.id),
+    link_with_query(show_obs_link_title_with_count(@location),
+                    controller: :observer, action: :observations_at_location,
+                    id: @location.id),
     link_to(:all_objects.t(type: :location), action: :list_locations),
     link_with_query(:show_location_create.t, action: :create_location),
     link_with_query(:show_location_edit.t, action: :edit_location,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1571,13 +1571,15 @@
   list_observations_add_to_list: Add/Remove From Species List
   list_observations_download_as_csv: Download Observations
 
-  # location/list_place_names
+  # location/list_place_names (list_locations)
   list_place_names_known: Known Locations
   list_place_names_known_order: "(by name)"
-  list_place_names_undef: Undefined Locations
-  list_place_names_undef_order: "(by frequency)"
   list_place_names_map: Map Locations
   list_place_names_merge: Merge
+  list_place_names_parenthetical: Number in parentheses shows Observation count.
+  list_place_names_popularity: "\"[:sort_by_num_views]\" means how many times the page was visited."
+  list_place_names_undef: Undefined Locations
+  list_place_names_undef_order: "(by frequency)"
 
   # location/list_countries
   list_countries: Country List


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/13471951

- Add a count of Observations at a location to ShowLocation and ListLocation
- Explain difference between "Popularity" and parenthetical Observation count

Manual Test Script:
- http://localhost:3000/location/list_locations. Result: Observation count is included for each Know Location. (Master included a count only for Undefined Locations).
- show any location, e.g., http://localhost:3000/location/show_location/15431. Result: Observation count appears after "Observations at this Location" (upper RH corner).