### PR TITLE
[Fixes #161497126] Country List

### DIFF
--- a/app/classes/country_counter.rb
+++ b/app/classes/country_counter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 #  = CountryCounter
 #
@@ -6,9 +8,9 @@
 ################################################################################
 
 class CountryCounter
-  attr_accessor :known_by_count
-  attr_accessor :unknown_by_count
-  attr_accessor :missing
+  attr_accessor :known_by_count # known countries with observations
+  attr_accessor :unknown_by_count # known countries without observations
+  attr_accessor :missing # other locations with observations
 
   def initialize
     @counts = {}
@@ -32,19 +34,11 @@ class CountryCounter
   end
 
   def wheres
-    location_lookup(
-      "SELECT `where` FROM observations WHERE location_id IS NULL"
-    )
+    Observation.where(location: nil).pluck(:where)
   end
 
   def location_names
-    location_lookup(
-      "SELECT `where` FROM observations WHERE location_id IS NOT NULL"
-    )
-  end
-
-  def location_lookup(sql)
-    Location.connection.select_values(sql).to_a
+    Observation.where.not(location: nil).pluck(:where)
   end
 
   def self.load_param_hash(file)

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -13,9 +13,7 @@ class Name < AbstractModel
       if @synonyms
         @synonyms.map(&:id)
       elsif synonym_id
-        Name.connection.select_values(%(
-          SELECT id FROM names WHERE synonym_id = #{synonym_id}
-        )).map(&:to_i)
+        Name.where(synonym_id: synonym_id).pluck(:id)
       else
         [id]
       end

--- a/app/views/location/list_countries.html.erb
+++ b/app/views/location/list_countries.html.erb
@@ -9,28 +9,28 @@
 
 <div class="row">
   <div class="col-xs-4">
-    <h3>
+    <h4>
       <%= :list_countries_known.t %> (<%= @cc.known_by_count.length %>)
-    </h3>
-    <% for country, count in @cc.known_by_count %>
+    </h4>
+    <% @cc.known_by_count.each do |country, count| %>
       <%= country_link(country, count) %><br/>
     <% end %>
   </div>
 
   <div class="col-xs-4">
-    <h3>
+    <h4>
       <%= :list_countries_missing.t %> (<%= @cc.missing.length %>)
-    </h3>
-    <% for country, count in @cc.missing %>
+    </h4>
+    <% @cc.missing.each do |country, _count| %>
       <%= country %><br/>
     <% end %>
   </div>
 
   <div class="col-xs-4">
-    <h3>
+    <h4>
       <%= :list_countries_unknown.t %> (<%= @cc.unknown_by_count.length %>)
-    </h3>
-    <% for country, count in @cc.unknown_by_count %>
+    </h4>
+    <% @cc.unknown_by_count.each do |country, count| %>
       <%= country_link(country, count) %><br/>
     <% end %>
   </div>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1583,10 +1583,10 @@
 
   # location/list_countries
   list_countries: Country List
-  list_countries_known: Known Countries
-  list_countries_title: Countries with Observations
-  list_countries_unknown: Unknown Countries
-  list_countries_missing: Missing Countries
+  list_countries_known: Countries With Observations
+  list_countries_title: Countries and Other Localities
+  list_countries_unknown: Other Localities With Observations
+  list_countries_missing: Countries Without Observations
 
   # _location (RSS log display)
   location_change: Change to Location

--- a/config/location/countries.yml
+++ b/config/location/countries.yml
@@ -196,6 +196,7 @@
 - "Uganda"
 - "Ukraine"
 - "United Arab Emirates"
+- "United Kingdom" # Better than British Overseas Territories
 - "Unknown"
 - "Uruguay"
 - "Uzbekistan"

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -153,6 +153,7 @@ conocybe_filaris: # 11
   display_name: '**__Conocybe filaris__**'
   search_name: Conocybe filaris
   sort_name: Conocybe filaris
+  synonym:                        # has no synonym
   created_at: 2007-03-19 15:51:00
   updated_at: 2007-03-19 15:51:00
 

--- a/test/models/country_counter_test.rb
+++ b/test/models/country_counter_test.rb
@@ -1,17 +1,14 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
+# test methods used to count Observations by country
 class CountryCounterTest < UnitTestCase
   def test_wheres
     cc = CountryCounter.new
     wheres = cc.send(:wheres)
     assert(wheres)
     assert(wheres.member?("Briceland, California, USA"))
-  end
-
-  def test_location_lookup
-    cc = CountryCounter.new
-    lookup = cc.send(:location_lookup, "SELECT 'USA' location FROM DUAL")
-    assert_equal(["USA"], lookup)
   end
 
   def test_location_names
@@ -40,19 +37,19 @@ class CountryCounterTest < UnitTestCase
   def test_partition_with_count
     cc = CountryCounter.new
     known, unknown = cc.send(:partition_with_count)
-    assert(!known.empty?)
-    assert(!unknown.empty?)
+    assert(known.present?)
+    assert(unknown.present?)
   end
 
   def test_known_by_count
-    assert(!CountryCounter.new.known_by_count.empty?)
+    assert(CountryCounter.new.known_by_count.present?)
   end
 
   def test_unknown_by_count
-    assert(!CountryCounter.new.unknown_by_count.empty?)
+    assert(CountryCounter.new.unknown_by_count.present?)
   end
 
   def test_missing
-    assert(!CountryCounter.new.missing.empty?)
+    assert(CountryCounter.new.missing.present?)
   end
 end


### PR DESCRIPTION
Delivers (Pivotal #161497126)[https://www.pivotaltracker.com/story/show/161497126]
- Clearer headings on /location/list_countries
- Add United Kingdom (so that we can deal with Observations in British Overseas Territories, like Cayman Islands).
- Refactor CountryCounter to use ActiveRecord query instead of SQL
- Refactor CountryCounterTest per refactor of CountryCounter and to remove RuboCop offenses

Manual Test
- http://localhost:3000/location/list_countries Result: Headings differ from https://mushroomobserver.org/location/list_countries
- now click on Cayman Islands, Edit Location, change Where to "Cayman Islands, United Kingdom". Result: Successfully updated location
- Go back to http://localhost:3000/location/list_countries, and reload. Result: United Kingdom listed under Countries with Observations, Cayman Island not listed under of Other Localities with Observations.