### PR TITLE
[Fixes #168234594] Block evil signups

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -685,20 +685,33 @@ class AccountController < ApplicationController
     user       = User.find_by(login: user_name)
     group      = UserGroup.find_by(name: group_name)
 
-    flash_error :add_user_to_group_no_user.t(user: user_name) unless user
-    flash_error :add_user_to_group_no_group.t(group: group_name) unless group
-
-    if user && group
-      if user.user_groups.member?(group)
-        flash_warning :add_user_to_group_already. \
-          t(user: user_name, group: group_name)
-      else
-        user.user_groups << group
-        flash_notice :add_user_to_group_success. \
-          t(user: user_name, group: group_name)
-      end
+    if can_add_user_to_group?(user, group)
+      do_add_user_to_group(user, group)
+    else
+      do_not_add_user_to_group(user, group, user_name, group_name)
     end
+
     redirect_back_or_default(controller: "observer", action: "index")
+  end
+
+  def can_add_user_to_group?(user, group)
+    user && group && !user.user_groups.member?(group)
+  end
+
+  def do_add_user_to_group(user, group)
+    user.user_groups << group
+    flash_notice :add_user_to_group_success. \
+      t(user: user.name, group: group.name)
+  end
+
+  def do_not_add_user_to_group(user, group, user_name, group_name)
+    if user && group
+      flash_warning :add_user_to_group_already. \
+        t(user: user_name, group: group_name)
+    else
+      flash_error :add_user_to_group_no_user.t(user: user_name) unless user
+      flash_error :add_user_to_group_no_group.t(group: group_name) unless group
+    end
   end
 
   def add_user_to_group_user_mode

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
+# Test user AccountControllerTest
+# signup, verification, prefs, profile, api
 class AccountControllerTest < FunctionalTestCase
   def setup
     @request.host = "localhost"
@@ -141,8 +145,7 @@ class AccountControllerTest < FunctionalTestCase
            "Signup response should be 4xx")
 
     post(:signup,
-         new_user: params.merge(email: "b.l.izk.o.ya.n201.7@gmail.com\r\n")
-    )
+         new_user: params.merge(email: "b.l.izk.o.ya.n201.7@gmail.com\r\n"))
     assert(html_client_error.include?(response.status),
            "Signup response should be 4xx")
   end
@@ -196,7 +199,7 @@ class AccountControllerTest < FunctionalTestCase
     post(:login,
          user: { login: "rolf", password: "testpassword", remember_me: "" })
     assert(session[:user_id])
-    assert(!cookies["mo_user"])
+    assert_not(cookies["mo_user"])
 
     logout
     get(:test_autologin)
@@ -227,7 +230,7 @@ class AccountControllerTest < FunctionalTestCase
 
     get(:verify, id: user.id, auth_code: "bogus_code")
     assert_template("reverify")
-    assert(!@request.session[:user_id])
+    assert_not(@request.session[:user_id])
 
     get(:verify, id: user.id, auth_code: user.auth_code)
     assert_template("verify")
@@ -243,7 +246,7 @@ class AccountControllerTest < FunctionalTestCase
     login("rolf")
     get(:verify, id: user.id, auth_code: user.auth_code)
     assert_redirected_to(action: :login)
-    assert(!@request.session[:user_id])
+    assert_not(@request.session[:user_id])
   end
 
   def test_verify_after_api_create
@@ -254,12 +257,12 @@ class AccountControllerTest < FunctionalTestCase
 
     get(:verify, id: user.id, auth_code: "bogus_code")
     assert_template("reverify")
-    assert(!@request.session[:user_id])
+    assert_not(@request.session[:user_id])
 
     get(:verify, id: user.id, auth_code: user.auth_code)
     assert_flash_warning
     assert_template("choose_password")
-    assert(!@request.session[:user_id])
+    assert_not(@request.session[:user_id])
     assert_users_equal(user, assigns(:user))
     assert_input_value("user_password", "")
     assert_input_value("user_password_confirmation", "")
@@ -298,7 +301,7 @@ class AccountControllerTest < FunctionalTestCase
     login("rolf")
     get(:verify, id: user.id, auth_code: user.auth_code)
     assert_redirected_to(action: :login)
-    assert(!@request.session[:user_id])
+    assert_not(@request.session[:user_id])
   end
 
   def test_reverify
@@ -590,7 +593,7 @@ class AccountControllerTest < FunctionalTestCase
         require_user: :index,
         result: "no_email"
       )
-      assert(!rolf.reload.send("email_#{type}"))
+      assert_not(rolf.reload.send("email_#{type}"))
     end
   end
 

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -119,6 +119,34 @@ class AccountControllerTest < FunctionalTestCase
     assert_redirected_to(referrer)
   end
 
+  def test_block_known_evil_signups
+    params = {
+      login: "newbob",
+      password: "topsykritt",
+      password_confirmation: "topsykritt",
+      email: "blah@somewhere.org",
+      email_confirmation: "blah@somewhere.org",
+      mailing_address: "",
+      theme: "NULL",
+      notes: ""
+    }
+    html_client_error = 400..499
+
+    post(:signup, new_user: params.merge(login: "xUplilla"))
+    assert(html_client_error.include?(response.status),
+           "Signup response should be 4xx")
+
+    post(:signup, new_user: params.merge(email: "foo@xxx.xyz"))
+    assert(html_client_error.include?(response.status),
+           "Signup response should be 4xx")
+
+    post(:signup,
+         new_user: params.merge(email: "b.l.izk.o.ya.n201.7@gmail.com\r\n")
+    )
+    assert(html_client_error.include?(response.status),
+           "Signup response should be 4xx")
+  end
+
   def test_invalid_login
     post(:login, user: { login: "rolf", password: "not_correct" })
     assert_nil(@request.session["user_id"])


### PR DESCRIPTION
Block attempts to register by more known bad users.
Delivers https://www.pivotaltracker.com/story/show/168234594 and https://www.pivotaltracker.com/story/show/168235248
(Also does auxiliary RuboCopping of touched files.)

Reduces number of Errors and Undelivered Mail Returned to Sender messages by catching some more bad signup attempts before sending a verification email.

Manual Test Script:
- Logout
- Create Account with email address: `b.l.izk.o.ya.n201.7@gmail.com`
- Result: "We grow weary of this. Please go away."