### PR TITLE
Added admin util to block / unblock IP at rails level.

### DIFF
--- a/app/classes/robots.rb
+++ b/app/classes/robots.rb
@@ -13,6 +13,26 @@ class Robots
       @@blocked_ips.include?(ip)
     end
 
+    def blocked_ips
+      populate_blocked_ips unless blocked_ips_current?
+      @@blocked_ips
+    end
+
+    def add_blocked_ip(ip)
+      file = MO.blocked_ips_file
+      ip.gsub!(/[^\d\.]/, "")
+      `echo #{ip} >> #{file}`
+      `sort -u #{file} > #{file}.xxx`
+      `mv -f #{file}.xxx #{file}`
+    end
+
+    def remove_blocked_ip(ip)
+      file = MO.blocked_ips_file
+      ip.gsub!(/[^\d\.]/, "")
+      `cat #{file} | grep -v #{ip} > #{file}.xxx`
+      `mv -f #{file}.xxx #{file}`
+    end
+
     def populate_allowed_robot_actions
       file = MO.robots_dot_text_file
       @@allowed_robot_actions = parse_robots_dot_text(file)

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -33,6 +33,7 @@
 #  add_user_to_group::  <tt>(R V .)</tt>
 #  create_alert::       <tt>(R V .)</tt>
 #  destroy_user::       <tt>(R . .)</tt>
+#  blocked_ips::        <tt>(R V .)</tt>
 #
 #  ==== Testing
 #  test_autologin::     <tt>(L V .)</tt>
@@ -673,9 +674,49 @@ class AccountController < ApplicationController
     redirect_back_or_default("/")
   end
 
+  def blocked_ips # :root:
+    if in_admin_mode?
+      process_blocked_ip_commands
+      @report = blocked_ips_report
+      @blocked_ips = Robots.blocked_ips
+    else
+      redirect_back_or_default("/")
+    end
+  end
+
   # ========= private Admin utilities section methods ==========
 
   private
+
+  def process_blocked_ip_commands
+    if params[:add].present? && validate_ip!(params[:add])
+      Robots.add_blocked_ip(params[:add])
+    elsif params[:remove].present? && validate_ip!(params[:remove])
+      Robots.remove_blocked_ip(params[:remove])
+    end
+  end
+
+  def validate_ip!(ip)
+    match = ip.to_s.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
+    return true if match &&
+                   valid_ip_num(match[1]) &&
+                   valid_ip_num(match[2]) &&
+                   valid_ip_num(match[3]) &&
+                   valid_ip_num(match[4])
+
+    flash_error("Invalid IP address: \"#{ip}\"")
+  end
+
+  def valid_ip_num(num)
+    num.to_i >= 0 && num.to_i < 256
+  end
+
+  def blocked_ips_report
+    logs   = "#{MO.root}/log/production.log*"
+    script = "#{MO.root}/script/identify_robots.prl"
+    output = "#{MO.root}/config/blocked_ips.txt.tmp"
+    `(cat #{logs} | #{script} > #{output}) 2>&1`.split("\n")
+  end
 
   def add_user_to_group_admin_mode
     return unless request.method == "POST"
@@ -751,7 +792,7 @@ class AccountController < ApplicationController
   private
 
   def initialize_new_user
-    now = Time.now
+    now = Time.zone.now
     @new_user.attributes = {
       created_at: now,
       updated_at: now,

--- a/app/views/account/blocked_ips.html.erb
+++ b/app/views/account/blocked_ips.html.erb
@@ -1,0 +1,29 @@
+<%
+  @title = :app_blocked_ips.t
+%>
+
+<div class="row">
+  <div class="col-xs-6 max-width-text">
+    <% @blocked_ips.each do |ip| %>
+      <% link = {controller: :account, action: :blocked_ips, remove: ip} %>
+      <%= ip.t %> [<%= link_to(:REMOVE.t, link) %>]<br/>
+    <% end %>
+  </div>
+
+  <div class="col-xs-6 max-width-text">
+    <%= form_tag({}, { class: "pad-bottom-2x"}) %>
+      <div class="form-group form-inline">
+        <%= label_tag(:add, "IP:") %>
+        <%= text_field_tag(:add, "", size: 20, data: {autofocus: true}, class: "form-control") %>
+        <%= submit_tag(:ADD.l, class: "btn", style: "margin-left: 1em") %>
+      </div>
+    </form>
+
+    <div style="font-style: mono">
+      <% @report.each do |line| %>
+        <% if line.sub!(/\s+/, "") %>&nbsp;&nbsp;<% end %>
+        <%= line.t %><br/>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_nav_left.html.erb
+++ b/app/views/shared/_nav_left.html.erb
@@ -10,6 +10,7 @@
     <div class="list-group-item disabled bold">
       <%= :app_admin.t %>:
     </div>
+    <%= link_to(:app_blocked_ips.t, {controller: :account, action: :blocked_ips}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:app_users.t, {controller: :observer, action: :users_by_name}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:change_banner_title.t, {controller: :observer, action: :change_banner}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:app_email_all_users.t, {controller: :observer, action: :email_features}, {class: "list-group-item list-group-item-danger indent"}) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1185,6 +1185,7 @@
   app_join_mailing_list: Join Mailing List
   app_logout: Logout
   app_admin: Admin
+  app_blocked_ips: Blocked IPs
   app_users: "[:list_objects(type=:user)]"
   app_email_all_users: Email All Users
   app_add_to_group: Add to Group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ ACTIONS = {
     activate_api_key: {},
     add_user_to_group: {},
     api_keys: {},
+    blocked_ips: {},
     create_alert: {},
     create_api_key: {},
     destroy_user: {},


### PR DESCRIPTION
Not terribly elegant, but just an admin utility, and probably temporary.

Note that this does not block IPs at the firewall.  Instead it uses the pre-existing config/blocked_ips.txt mechanism to send a message to the user along the lines of:

"we've noticed a lot of traffic from this IP, there is almost certainly a better and more respectful way of doing whatever you're doing that won't strain our server's resources, please contact the webmaster to discuss what you're doing"

This PR is just intended to make it easier for me to copy IPs from the script/identify_robots cronjob emails into the production server's copy of blocked_ips.txt.

I'll leave the PR up for a day or two in case anyone has the time or interest in reviewing it.  But I'm assuming no one is interested, and I'd rather have this utility sooner than later, because there is someone really hammering MO right now and switching IPs regularly, so I'm having to log into MO and add IPs multiple times a day, a real pain with my bandwidth the way it is.