### PR TITLE
hide-lichens

### DIFF
--- a/app/classes/content_filter/lichen.rb
+++ b/app/classes/content_filter/lichen.rb
@@ -17,11 +17,15 @@ class ContentFilter
       # selected for in the positive version, but only excudes the one lifeform
       # in the negative.
       table = model == Name ? "names" : "observations"
-      if val
+      if show_only_lichens?(val)
         "#{table}.lifeform LIKE '%lichen%'"
       else
         "#{table}.lifeform NOT LIKE '% lichen %'"
       end
+    end
+
+    def show_only_lichens?(val)
+      val == "yes" || val == true
     end
   end
 end

--- a/app/classes/content_filter/lichen.rb
+++ b/app/classes/content_filter/lichen.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContentFilter
   # Content filter specifically to filter out or just show lichens.
   class Lichen < BooleanFilter
@@ -25,7 +27,7 @@ class ContentFilter
     end
 
     def show_only_lichens?(val)
-      val == "yes" || val == true
+      ["yes", true].include?(val)
     end
   end
 end

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -722,6 +722,25 @@ class ObserverControllerTest < FunctionalTestCase
     # but that broken by PR 497.
   end
 
+  # Prove that lichen content_filter works on observations
+  def test_observations_with_lichen_filter
+    login(users(:lichenologist).name)
+    get_with_dump(:list_observations)
+    results = @controller.instance_variable_get("@objects")
+
+    assert(results.count.positive?)
+    assert(results.all? { |result| result.lifeform.include?("lichen") },
+           "All results should be lichen-ish")
+
+    login(users(:antilichenologist).name)
+    get_with_dump(:list_observations)
+    results = @controller.instance_variable_get("@objects")
+
+    assert(results.count.positive?)
+    assert(results.none? { |result| result.lifeform.include?(" lichen ") },
+           "No results should be lichens")
+  end
+
   def test_send_webmaster_question
     ask_webmaster_test("rolf@mushroomobserver.org",
                        response: { controller: :observer,

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -343,20 +343,26 @@ class ObserverControllerTest < FunctionalTestCase
     # When requesting non-synonym observations of n2, it should include n1,
     # since an observation of n1 was clearly intended to be an observation of
     # n2.
-    query = Query.lookup_and_save(:Observation, :all, names: n2.id,
-                                                      include_synonyms: false, by: :name)
+    query = Query.lookup_and_save(:Observation, :all,
+                                  names: n2.id,
+                                  include_synonyms: false,
+                                  by: :name)
     assert_equal(2, query.num_results)
 
     # Likewise, when requesting *synonym* observations, neither n1 nor n2
     # should be included.
-    query = Query.lookup_and_save(:Observation, :all, names: n2.id,
-                                                      include_synonyms: true,
-                                                      exclude_original_names: true, by: :name)
+    query = Query.lookup_and_save(:Observation, :all,
+                                  names: n2.id,
+                                  include_synonyms: true,
+                                  exclude_original_names: true,
+                                  by: :name)
     assert_equal(2, query.num_results)
 
     # But for our prev/next test, lets do the all-inclusive query.
-    query = Query.lookup_and_save(:Observation, :all, names: n2.id,
-                                                      include_synonyms: true, by: :name)
+    query = Query.lookup_and_save(:Observation, :all,
+                                  names: n2.id,
+                                  include_synonyms: true,
+                                  by: :name)
     assert_equal(4, query.num_results)
     qp = @controller.query_params(query)
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -130,3 +130,12 @@ thorsten:
 second_roy:
   <<: *DEFAULTS
   name: Roy Rogers
+
+lichenologist:
+  <<: *DEFAULTS
+  content_filter: <%= { lichen: "yes" }.to_yaml.inspect %>
+
+antilichenologist:
+  <<: *DEFAULTS
+  content_filter: <%= { lichen: "no" }.to_yaml.inspect %>
+


### PR DESCRIPTION
Fix user content Lichen filter [#170488100]

With user preferences set to "Hide Lichens", MO incorrectly showed **only** Lichen Observations. See https://www.pivotaltracker.com/story/show/170488100 and https://www.facebook.com/groups/mushroomobserver/permalink/801921940268757/. The problem was an incorrect conditional (in lichen.rb), which returned `true` when the filter was set to "no".
- Write test (with fixtures) to prevent reversion
- Broaden conditional to include values created by both Content Filter and Pattern Search
- Minor RuboCopping of touched files