### PR TITLE
Use File.truncate rather than File::TRUNC

### DIFF
--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -95,11 +95,11 @@ class IpStats
     end
 
     def clear_blocked_ips
-      File.open(MO.blocked_ips_file, File::TRUNC) {}
+      File.truncate(MO.blocked_ips_file, 0)
     end
 
     def clear_okay_ips
-      File.open(MO.okay_ips_file, File::TRUNC) {}
+      File.truncate(MO.okay_ips_file, 0) {}
     end
 
     def clean_blocked_ips


### PR DESCRIPTION
File::TRUNC was causing tests to fail on the new Bionic Beaver build and based on some Google searches I tried File.truncate instead and it worked like a charm.