### PR TITLE
Geocoder no method

### DIFF
--- a/test/models/mo_geocoder_test.rb
+++ b/test/models/mo_geocoder_test.rb
@@ -2,15 +2,15 @@
 
 require "test_helper"
 
-class GeocoderTest < UnitTestCase
+class MOGeocoderTest < UnitTestCase
   def test_unknown_place_name
-    obj = Geocoder.new("Somewhere Out There")
+    obj = MOGeocoder.new("Somewhere Out There")
     assert_not(obj.valid)
     assert_nil(obj.north)
   end
 
   def test_falmouth
-    obj = Geocoder.new("North Falmouth, Massachusetts, USA")
+    obj = MOGeocoder.new("North Falmouth, Massachusetts, USA")
     assert(obj.valid)
     assert(obj.north)
     assert(obj.south)


### PR DESCRIPTION
Fix test/models Errors caused by Geocoder name change

- Changes method calls, test Class name, and test file name.

This PR fixes Errors caused by the change of Class name from `Geocoder` to `MOGeocoder` in Commit https://github.com/MushroomObserver/mushroom-observer/commit/81ddb7bb

Finishes https://www.pivotaltracker.com/story/show/173110049