### PR TITLE
Sync RuboCop version with master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,12 +155,15 @@ gem "coveralls", require: false
 gem "brakeman", require: false
 
 # Use rubocop and associated gems for code quality control
-# WARNING: update .codeclimate.yml's RuboCop channel whenever we update RuboCop.
-# See docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions
-# - Regenerate .rubocop_todo.yml
+# WARNING: Whenever updating RuboCop, also:
+#   - Update .codeclimate.yml's RuboCop channel whenever we update RuboCop.
+#       docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions
+#   - Regenerate .rubocop_todo.yml
 #     https://docs.rubocop.org/en/stable/configuration,
 #       Automatically Generated Configuration
-gem "rubocop", require: false
+# Temporarily lock RuboCop version while we are working our way through
+# auto-correctable offenses
+gem "rubocop", "= 0.83", require: false
 gem "rubocop-performance"
 gem "rubocop-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
     inline_svg (1.7.1)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
-    jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -230,8 +229,7 @@ GEM
     regexp_parser (1.7.0)
     rexml (3.2.4)
     rtf (0.3.3)
-    rubocop (0.81.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.83.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -351,7 +349,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_db
   rtf
-  rubocop
+  rubocop (= 0.83)
   rubocop-performance
   rubocop-rails
   sassc-rails


### PR DESCRIPTION
Updates bootstrap-4's RuboCop to 0.83 and freezes it (as in master)

This stops RC from throwing errors when run in bootstrap-4,
as well as getting bootstrap-4 in step with master and Travis CI.

Delivers https://www.pivotaltracker.com/story/show/173119843