### PR TITLE
Remove geocoder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,22 +106,6 @@ gem "mimemagic"
 # using values from the Can I Use database
 gem "autoprefixer-rails"
 
-
-########## Mapping and Geocoding ###############################################
-
-# Geocoder - Provides object geocoding (by street or IP address),
-# reverse geocoding (coordinates to street address),
-# distance queries for ActiveRecord and Mongoid, result caching
-# https://github.com/alexreisner/geocoder
-gem "geocoder"
-
-# Geokit - Provides ActiveRecord distance-based finders.
-# For example, find all the points in your database within a 50-mile radius.
-# Optional IP-based location lookup utilizing hostip.info
-# http://github.com/geokit/geokit
-gem "geokit"
-
-
 ########## Presentation and Interaction ########################################
 
 # Slick Slider for Image Carousel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,8 +114,6 @@ GEM
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
-    geocoder (1.6.2)
-    geokit (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -331,8 +329,6 @@ DEPENDENCIES
   coffee-rails
   coveralls
   cure_acts_as_versioned
-  geocoder
-  geokit
   i18n
   inline_svg
   jbuilder

--- a/app/classes/geocoder.rb
+++ b/app/classes/geocoder.rb
@@ -3,11 +3,11 @@
 require "net/http"
 require "rexml/document"
 
-#  = MOGeocoder Class
+#  = Geocoder Class
 #
 #  Wraps a call to the Google Geocoding webservice
 #
-class MOGeocoder < BlankSlate
+class Geocoder < BlankSlate
   attr_reader :north
   attr_reader :south
   attr_reader :east

--- a/app/controllers/locations/create_and_edit.rb
+++ b/app/controllers/locations/create_and_edit.rb
@@ -45,7 +45,7 @@ class LocationsController
                                dubious_name?(user_name, true)
     end
     @location = Location.new
-    geocoder = MOGeocoder.new(user_name)
+    geocoder = Geocoder.new(user_name)
     if geocoder.valid
       @location.display_name = @display_name
       @location.north = geocoder.north

--- a/app/controllers/locations/create_and_edit.rb
+++ b/app/controllers/locations/create_and_edit.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "mo_geocoder"
-
 # see app/controllers/locations_controller.rb
 class LocationsController
 

--- a/test/models/geocoder_test.rb
+++ b/test/models/geocoder_test.rb
@@ -2,15 +2,15 @@
 
 require "test_helper"
 
-class MOGeocoderTest < UnitTestCase
+class GeocoderTest < UnitTestCase
   def test_unknown_place_name
-    obj = MOGeocoder.new("Somewhere Out There")
+    obj = Geocoder.new("Somewhere Out There")
     assert_not(obj.valid)
     assert_nil(obj.north)
   end
 
   def test_falmouth
-    obj = MOGeocoder.new("North Falmouth, Massachusetts, USA")
+    obj = Geocoder.new("North Falmouth, Massachusetts, USA")
     assert(obj.valid)
     assert(obj.north)
     assert(obj.south)


### PR DESCRIPTION
Removes unused geocoder and geokit gems, 
reverting changes that had been made to avoid conflict with the geocoder gem.

Delivers https://www.pivotaltracker.com/story/show/173120409.
Details in that story and links therein.