### PR TITLE
Remove `get_with_dump`

### DIFF
--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -101,19 +101,6 @@ module ControllerExtensions
     user
   end
 
-  # Send a GET request, and save the result in a file for w3c validation.
-  #
-  #   # Send request, but ignore response.
-  #   get(:action, params)
-  #
-  #   # Send request, and save response in ../html/action_0.html.
-  #   get_with_dump(:action, params)
-  #
-  def get_with_dump(page, params = {})
-    get(page, params: params)
-    # html_dump(page, @response.body, params)
-  end
-
   # Send a POST request, and save the result in a file for w3c validation.
   #
   #   # Send request, but ignore response.

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -4,23 +4,22 @@ require "test_helper"
 
 class CommentsControllerTest < FunctionalTestCase
   def test_list_comments
-    get_with_dump(:index)
+    get(:index)
     assert_template("index")
   end
 
   def test_show_comment
-    get_with_dump(:show,
-                  id: comments(:minimal_unknown_obs_comment_1).id)
+    get(:show, id: comments(:minimal_unknown_obs_comment_1).id)
     assert_template("show")
   end
 
   def test_show_comments_for_user
-    get_with_dump(:show_comments_for_user, id: rolf.id)
+    get(:show_comments_for_user, id: rolf.id)
     assert_template("index")
   end
 
   def test_show_comments_by_user
-    get_with_dump(:show_comments_by_user, id: rolf.id)
+    get(:show_comments_by_user, id: rolf.id)
     assert_redirected_to(action: :show,
                          id: comments(:minimal_unknown_obs_comment_1).id,
                          params: @controller.query_params(QueryRecord.last))

--- a/test/controllers/email_controller_test.rb
+++ b/test/controllers/email_controller_test.rb
@@ -148,7 +148,7 @@ class EmailControllerTest < FunctionalTestCase
     get(:email_merge_request, params: params.merge(new_id: -456))
     assert_response(:redirect)
 
-    get_with_dump(:email_merge_request, params)
+    get(:email_merge_request, params)
     assert_response(:success)
     assert_names_equal(name1, assigns(:old_obj))
     assert_names_equal(name2, assigns(:new_obj))

--- a/test/controllers/glossary_controller_test.rb
+++ b/test/controllers/glossary_controller_test.rb
@@ -37,18 +37,17 @@ class GlossaryControllerShowAndIndexTest < GlossaryControllerTest
   # ***** show *****
   def test_show_glossary_term
     glossary_term = glossary_terms(:plane_glossary_term)
-    get_with_dump(:show, id: glossary_term.id)
+    get(:show, id: glossary_term.id)
     assert_template("show")
   end
 
   def test_show_past_glossary_term
-    get_with_dump(:show_past_glossary_term, id: conic.id,
-                                            version: conic.version - 1)
+    get(:show_past_glossary_term, id: conic.id, version: conic.version - 1)
     assert_template(:show_past_glossary_term, partial: "_glossary_term")
   end
 
   def test_show_past_glossary_term_no_version
-    get_with_dump(:show_past_glossary_term, id: conic.id)
+    get(:show_past_glossary_term, id: conic.id)
     assert_response(:redirect)
   end
 
@@ -61,7 +60,7 @@ class GlossaryControllerShowAndIndexTest < GlossaryControllerTest
 
   # ***** index *****
   def test_index
-    get_with_dump(:index)
+    get(:index)
     assert_template(:index)
   end
 end
@@ -100,7 +99,7 @@ class GlossaryControllerCreateTest < GlossaryControllerTest
 
   def test_create_glossary_term_logged_in
     login
-    get_with_dump(:new)
+    get(:new)
     assert_template(:new)
   end
 
@@ -151,13 +150,13 @@ class GlossaryControllerEditTest < GlossaryControllerTest
 
   ##### tests #####
   def test_edit_glossary_term_no_login
-    get_with_dump(:edit, id: conic.id)
+    get(:edit, id: conic.id)
     assert_response(:redirect)
   end
 
   def test_edit_glossary_term_logged_in
     login
-    get_with_dump(:edit, id: conic.id)
+    get(:edit, id: conic.id)
     assert_template(:edit)
   end
 
@@ -186,7 +185,7 @@ class GlossaryControllerEditTest < GlossaryControllerTest
 
     assert_equal(old_count + 1, glossary_term.versions.length)
 
-    get_with_dump(:show_past_glossary_term, id: glossary_term.id,
+    get(:show_past_glossary_term, id: glossary_term.id,
                                             version: glossary_term.version - 1)
     assert_template(:show_past_glossary_term, partial: "_glossary_term")
   end

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -17,16 +17,16 @@ class HerbariaControllerTest < FunctionalTestCase
   end
 
   def test_index
-    get_with_dump(:index)
+    get(:index)
     assert_template(:index)
   end
 
   def test_list_herbaria
-    get_with_dump(:index)
+    get(:index)
   end
 
   def test_herbarium_search
-    get_with_dump(:herbarium_search, pattern: "Personal Herbarium")
+    get(:herbarium_search, pattern: "Personal Herbarium")
   end
 
   def test_list_herbaria_merge_source
@@ -157,7 +157,7 @@ class HerbariaControllerTest < FunctionalTestCase
 
   def test_show_herbarium
     nybg = herbaria(:nybg_herbarium)
-    get_with_dump(:show, id: nybg.id)
+    get(:show, id: nybg.id)
     assert_template(:show)
   end
 
@@ -187,7 +187,7 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:new)
+    get(:new)
     assert_template(:new)
   end
 
@@ -314,7 +314,7 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("mary")
-    get_with_dump(:edit, id: nybg.id)
+    get(:edit, id: nybg.id)
     assert_template("edit_herbarium")
   end
 
@@ -330,7 +330,7 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:edit, id: nybg.id)
+    get(:edit, id: nybg.id)
     assert_template("edit_herbarium")
 
     make_admin("mary")
@@ -533,7 +533,7 @@ class HerbariaControllerTest < FunctionalTestCase
     get(:request_to_be_curator)
     assert_response(:redirect)
 
-    get_with_dump(:request_to_be_curator, id: nybg.id)
+    get(:request_to_be_curator, id: nybg.id)
     assert_response(:success)
   end
 

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -16,25 +16,24 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
   end
 
   def test_herbarium_index
-    get_with_dump(:herbarium_index, id: herbaria(:nybg_herbarium).id)
+    get(:herbarium_index, id: herbaria(:nybg_herbarium).id)
     assert_template(:index)
   end
 
   def test_herbarium_with_no_herbarium_records_index
-    get_with_dump(:herbarium_index, id: herbaria(:dick_herbarium).id)
+    get(:herbarium_index, id: herbaria(:dick_herbarium).id)
     assert_template(:index)
     assert_flash_text(/No matching herbarium records found/)
   end
 
   def test_observation_index
-    get_with_dump(:observation_index,
+    get(:observation_index,
                   id: observations(:coprinus_comatus_obs).id)
     assert_template(:index)
   end
 
   def test_observation_with_no_herbarium_records_index
-    get_with_dump(:observation_index,
-                  id: observations(:strobilurus_diminutivus_obs).id)
+    get(:observation_index, id: observations(:strobilurus_diminutivus_obs).id)
     assert_template(:index)
     assert_flash_text(/No matching herbarium records found/)
   end
@@ -50,8 +49,8 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
   end
 
   def test_herbarium_record_search_with_one_herbarium_record_index
-    get_with_dump(:herbarium_record_search,
-                  pattern: herbarium_records(:interesting_unknown).id)
+    get(:herbarium_record_search,
+        pattern: herbarium_records(:interesting_unknown).id)
     assert_response(:redirect)
     assert_no_flash
   end
@@ -67,14 +66,14 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
   def test_show_herbarium_record_without_notes
     herbarium_record = herbarium_records(:coprinus_comatus_nybg_spec)
     assert(herbarium_record)
-    get_with_dump(:show, id: herbarium_record.id)
+    get(:show, id: herbarium_record.id)
     assert_template(:show, partial: "shared/log_item")
   end
 
   def test_show_herbarium_record_with_notes
     herbarium_record = herbarium_records(:interesting_unknown)
     assert(herbarium_record)
-    get_with_dump(:show, id: herbarium_record.id)
+    get(:show, id: herbarium_record.id)
     assert_template(:show, partial: "shared/log_item")
   end
 
@@ -97,7 +96,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:new,
+    get(:new,
                   id: observations(:coprinus_comatus_obs).id)
     assert_template("create_herbarium_record", partial: "shared/log_item")
     assert(assigns(:herbarium_record))
@@ -201,20 +200,20 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
 
   def test_edit_herbarium_record
     nybg = herbarium_records(:coprinus_comatus_nybg_spec)
-    get_with_dump(:edit, id: nybg.id)
+    get(:edit, id: nybg.id)
     assert_response(:redirect)
 
     login("mary") # Non-curator
-    get_with_dump(:edit, id: nybg.id)
+    get(:edit, id: nybg.id)
     assert_flash_text(/permission denied/i)
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:edit, id: nybg.id)
+    get(:edit, id: nybg.id)
     assert_template(:edit)
 
     make_admin("mary") # Non-curator, but an admin
-    get_with_dump(:edit, id: nybg.id)
+    get(:edit, id: nybg.id)
     assert_template(:edit)
   end
 

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -4,22 +4,22 @@ require "test_helper"
 
 class ImagesControllerTest < FunctionalTestCase
   def test_list_images
-    get_with_dump(:index)
+    get(:index)
     assert_template("index", partial: "_image")
   end
 
   def test_images_by_user
-    get_with_dump(:images_by_user, id: rolf.id)
+    get(:images_by_user, id: rolf.id)
     assert_template("index", partial: "_image")
   end
 
   def test_images_for_project
-    get_with_dump(:images_for_project, id: projects(:bolete_project).id)
+    get(:images_for_project, id: projects(:bolete_project).id)
     assert_template("index", partial: "_image")
   end
 
   def test_next_image
-    get_with_dump(:next_image, id: images(:turned_over_image).id)
+    get(:next_image, id: images(:turned_over_image).id)
     # Default sort order is inverse chronological (created_at DESC, id DESC).
     # So here, "next" image is one created immediately previously.
     assert_redirected_to(%r{show_image/#{images(:in_situ_image).id}[\b|\?]})
@@ -121,7 +121,7 @@ class ImagesControllerTest < FunctionalTestCase
   end
 
   def test_prev_image
-    get_with_dump(:prev_image, id: images(:in_situ_image).id) # oldest image
+    get(:prev_image, id: images(:in_situ_image).id) # oldest image
     # so "prev" is the 2nd oldest
     assert_redirected_to(%r{show_image/#{images(:turned_over_image).id}[\b|\?]})
   end
@@ -185,7 +185,7 @@ class ImagesControllerTest < FunctionalTestCase
 
   def test_show_original
     img_id = images(:in_situ_image).id
-    get_with_dump(:show_original, id: img_id)
+    get(:show_original, id: img_id)
     assert_redirected_to(action: :show,
                          size: "full_size",
                          id: img_id)
@@ -194,7 +194,7 @@ class ImagesControllerTest < FunctionalTestCase
   def test_show_image
     image = images(:in_situ_image)
     num_views = image.num_views
-    get_with_dump(:show, id: image.id)
+    get(:show, id: image.id)
     assert_template("show", partial: "_form_ccbyncsa25")
     image.reload
     assert_equal(num_views + 1, image.num_views)
@@ -239,12 +239,12 @@ class ImagesControllerTest < FunctionalTestCase
   end
 
   def test_image_search
-    get_with_dump(:image_search, pattern: "Notes")
+    get(:image_search, pattern: "Notes")
     assert_template("list_images", partial: "_image")
     assert_equal(:query_title_pattern_search.t(types: "Images",
                                                pattern: "Notes"),
                  @controller.instance_variable_get("@title"))
-    get_with_dump(:image_search, pattern: "Notes", page: 2)
+    get(:image_search, pattern: "Notes", page: 2)
     assert_template("list_images")
     assert_equal(:query_title_pattern_search.t(types: "Images",
                                                pattern: "Notes"),
@@ -252,13 +252,13 @@ class ImagesControllerTest < FunctionalTestCase
   end
 
   def test_image_search_next
-    get_with_dump(:image_search, pattern: "Notes")
+    get(:image_search, pattern: "Notes")
     assert_template("list_images", partial: "_image")
   end
 
   def test_image_search_by_number
     img_id = images(:commercial_inquiry_image).id
-    get_with_dump(:image_search, pattern: img_id)
+    get(:image_search, pattern: img_id)
     assert_redirected_to(action: :show, id: img_id)
   end
 
@@ -278,7 +278,7 @@ class ImagesControllerTest < FunctionalTestCase
     assert_form_action(action: :new,
                        id: observations(:coprinus_comatus_obs).id)
     # Check that image cannot be added to an observation the user doesn't own.
-    get_with_dump(:new, id: observations(:minimal_unknown_obs).id)
+    get(:new, id: observations(:minimal_unknown_obs).id)
     assert_redirected_to(controller: :observations,
                          action: :show)
   end
@@ -508,7 +508,8 @@ class ImagesControllerTest < FunctionalTestCase
                          id: obs.id)
 
     login("rolf", "testpassword")
-    send(:get_with_dump, :reuse_image, params)
+    # send(:get_with_dump, :reuse_image, params)
+    send(:get, :reuse_image, params)
     assert_response(:success)
     assert_form_action(action: :reuse_image, mode: "observation",
                        obs_id: obs.id)
@@ -541,7 +542,7 @@ class ImagesControllerTest < FunctionalTestCase
     assert_not(obs.reload.images.member?(image))
 
     login(owner)
-    get_with_dump(:reuse_image, params)
+    get(:reuse_image, params)
     # assert_template(controller: :observations, action: :show)
     assert_redirected_to(controller: :observations, action: :show,
                          id: obs.id)
@@ -558,7 +559,7 @@ class ImagesControllerTest < FunctionalTestCase
       img_id: image.id.to_s
     }
     login("mary")
-    get_with_dump(:reuse_image_for_glossary_term, params)
+    get(:reuse_image_for_glossary_term, params)
     assert_redirected_to(controller: :glossary, action: :show,
                          id: glossary_term.id)
     assert(glossary_term.reload.images.member?(image))

--- a/test/controllers/interests_controller_test.rb
+++ b/test/controllers/interests_controller_test.rb
@@ -11,7 +11,7 @@ class InterestsControllerTest < FunctionalTestCase
                     user: rolf, state: true)
     Interest.create(target: names(:agaricus_campestris), user: rolf,
                     state: true)
-    get_with_dump(:list_interests)
+    get(:list_interests)
     assert_template("list_interests")
   end
 

--- a/test/controllers/locations/descriptions_controller_test.rb
+++ b/test/controllers/locations/descriptions_controller_test.rb
@@ -11,30 +11,27 @@ class Locations::DescriptionsControllerTest < IntegrationControllerTest
       location_id: burbank.id,
       source_type: "public"
     )
-    get_with_dump location_descriptions_path
+    get location_descriptions_path
     assert_template("index")
   end
 
   def test_index_by_author
     descs = Location::Description.all
     desc = location_descriptions(:albion_desc)
-    get_with_dump location_descriptions_index_by_author_path(
-      id: rolf.id)
+    get location_descriptions_index_by_author_path(id: rolf.id)
     assert_redirected_to location_description_path(location_id:
       desc.location_id, id: desc.id)
   end
 
   def test_index_by_editor
-    get_with_dump location_descriptions_index_by_editor_path(
-      id: rolf.id)
+    get location_descriptions_index_by_editor_path(id: rolf.id)
     assert_template(:index)
   end
 
   def test_show
     # happy path
     desc = location_descriptions(:albion_desc)
-    get_with_dump location_description_path(location_id: desc.location_id,
-      id: desc.id)
+    get location_description_path(location_id: desc.location_id, id: desc.id)
     assert_template "show"
     assert_template partial: "locations/descriptions/_location_description"
     # assert_response :success
@@ -44,23 +41,20 @@ class Locations::DescriptionsControllerTest < IntegrationControllerTest
 
     # description is private and belongs to a project
     desc = location_descriptions(:bolete_project_private_location_desc)
-    get_with_dump location_description_path(location_id: desc.location_id,
-      id: desc.id)
+    get location_description_path(location_id: desc.location_id, id: desc.id)
     assert_flash_error
     assert_redirected_to(project_path(id: desc.project.id))
 
     # description is private, for a project, project doesn't exist
     # but project doesn't exist
     desc = location_descriptions(:non_ex_project_private_location_desc)
-    get_with_dump location_description_path(location_id: desc.location_id,
-      id: desc.id)
+    get location_description_path(location_id: desc.location_id, id: desc.id)
     assert_flash_error
     assert_redirected_to(location_path(id: desc.location_id))
 
     # description is private, not for a project
     desc = location_descriptions(:user_private_location_desc)
-    get_with_dump location_description_path(location_id: desc.location_id,
-      id: desc.id)
+    get location_description_path(location_id: desc.location_id, id: desc.id)
     assert_flash_error
     assert_redirected_to(location_path(id: desc.location_id))
   end
@@ -73,8 +67,8 @@ class Locations::DescriptionsControllerTest < IntegrationControllerTest
     desc.reload
     new_versions = desc.versions.length
     assert(new_versions > old_versions)
-    get_with_dump location_descriptions_show_past_path(
-      location_id: desc.location_id, id: desc.id),
+    get location_descriptions_show_past_path(location_id: desc.location_id,
+                                             id: desc.id),
     assert_template(:show_past, partial: "_location_description")
   end
 
@@ -113,7 +107,7 @@ class Locations::DescriptionsControllerTest < IntegrationControllerTest
     loc = locations(:albion)
     user = login(users(:spammer).name)
     assert_false(user.is_successful_contributor?)
-    get_with_dump new_location_description_path(id: loc.id)
+    get new_location_description_path(id: loc.id)
     assert_response(:redirect)
   end
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -71,14 +71,14 @@ class LocationsControllerTest < FunctionalTestCase
   ##############################################################################
 
   def test_location_help
-    get_with_dump(:help)
+    get(:help)
   end
 
   def test_show_location
     location = locations(:albion)
     updated_at = location.updated_at
     log_updated_at = location.rss_log.updated_at
-    get_with_dump(:show, id: location.id)
+    get(:show, id: location.id)
     assert_template(partial: "_location")
     assert_template(partial: "_location_description")
     assert_template(partial: "_show_comments")
@@ -91,24 +91,24 @@ class LocationsControllerTest < FunctionalTestCase
     login("mary")
     make_admin("mary")
     location = locations(:albion)
-    get_with_dump(:show, id: location.id)
+    get(:show, id: location.id)
   end
 
   def test_show_past_location
     location = locations(:albion)
-    get_with_dump(:show_past_location, id: location.id,
+    get(:show_past_location, id: location.id,
                                        version: location.version - 1)
     assert_template("show_past_location", partial: "_location")
   end
 
   def test_show_past_location_no_version
     location = locations(:albion)
-    get_with_dump(:show_past_location, id: location.id)
+    get(:show_past_location, id: location.id)
     assert_response(:redirect)
   end
 
   def test_list_locations
-    get_with_dump(:index)
+    get(:index)
     assert_template(:index)
   end
 
@@ -137,17 +137,17 @@ class LocationsControllerTest < FunctionalTestCase
   end
 
   def test_list_countries
-    get_with_dump(:list_countries)
+    get(:list_countries)
     assert_template("list_countries")
   end
 
   def test_list_by_country
-    get_with_dump(:list_by_country, country: "USA")
+    get(:list_by_country, country: "USA")
     assert_template(:index)
   end
 
   def test_list_by_country_with_quote
-    get_with_dump(:list_by_country, country: "Cote d'Ivoire")
+    get(:list_by_country, country: "Cote d'Ivoire")
     assert_template(:index)
   end
 
@@ -192,12 +192,12 @@ class LocationsControllerTest < FunctionalTestCase
   end
 
   def test_locations_by_user
-    get_with_dump(:locations_by_user, id: rolf.id)
+    get(:locations_by_user, id: rolf.id)
     assert_template(:index)
   end
 
   def test_locations_by_editor
-    get_with_dump(:locations_by_editor, id: rolf.id)
+    get(:locations_by_editor, id: rolf.id)
     assert_template(:index)
   end
 
@@ -612,15 +612,15 @@ class LocationsControllerTest < FunctionalTestCase
 
   def test_map_locations
     # test_map_locations - map everything
-    get_with_dump(:map_locations)
+    get(:map_locations)
     assert_template(:map_locations)
 
     # test_map_locations_empty - map nothing
-    get_with_dump(:map_locations, pattern: "Never Never Land")
+    get(:map_locations, pattern: "Never Never Land")
     assert_template(:map_locations)
 
     # test_map_locations_some - map something
-    get_with_dump(:map_locations, pattern: "California")
+    get(:map_locations, pattern: "California")
     assert_template(:map_locations)
   end
 

--- a/test/controllers/names/descriptions_controller_test.rb
+++ b/test/controllers/names/descriptions_controller_test.rb
@@ -201,17 +201,17 @@ class Names::DescriptionsControllerTest < IntegrationControllerTest
   end
 
   def test_index_description_index
-    get_with_dump(:index_name_description)
+    get(:index_name_description)
     assert_template(:index)
   end
 
   def test_observation_index
-    get_with_dump(:observation_index)
+    get(:observation_index)
     assert_template(:index)
   end
 
   def test_observation_index_by_letter
-    get_with_dump(:observation_index, letter: "A")
+    get(:observation_index, letter: "A")
     assert_template(:index)
   end
 

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -54,33 +54,33 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def test_index_name
-    get_with_dump(:index_name)
+    get(:index_name)
     assert_template(:index)
   end
 
   def test_name_index
-    get_with_dump(:index)
+    get(:index)
     assert_template(:index)
   end
 
   def test_observation_index
-    get_with_dump(:observation_index)
+    get(:observation_index)
     assert_template(:index)
   end
 
   def test_observation_index_by_letter
-    get_with_dump(:observation_index, letter: "A")
+    get(:observation_index, letter: "A")
     assert_template(:index)
   end
 
   def test_authored_names
-    get_with_dump(:authored_names)
+    get(:authored_names)
     assert_template(:index)
   end
 
   def test_show_name
     assert_equal(0, QueryRecord.count)
-    get_with_dump(:show, id: names(:coprinus_comatus).id)
+    get(:show, id: names(:coprinus_comatus).id)
     assert_template(:show, partial: "_name")
     # Creates three for children and all four observations sections,
     # but one never used.
@@ -126,46 +126,46 @@ class NamesControllerTest < FunctionalTestCase
 
   def test_show_name_locked
     name = Name.where(locked: true).first
-    get_with_dump(:show, id: name.id)
+    get(:show, id: name.id)
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     login("rolf")
-    get_with_dump(:show, id: name.id)
+    get(:show, id: name.id)
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     make_admin("mary")
-    get_with_dump(:show, id: name.id)
+    get(:show, id: name.id)
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 1)
     assert_select("a[href*=change_synonyms]", count: 1)
 
     Name.update(name.id, deprecated: true)
     logout
-    get_with_dump(:show, id: name.id)
+    get(:show, id: name.id)
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     login("rolf")
-    get_with_dump(:show, id: name.id)
+    get(:show, id: name.id)
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     make_admin("mary")
-    get_with_dump(:show, id: name.id)
+    get(:show, id: name.id)
     assert_select("a[href*=approve_name]", count: 1)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 1)
   end
 
   def test_show_past_name
-    get_with_dump(:show_past_name, id: names(:coprinus_comatus).id)
+    get(:show_past_name, id: names(:coprinus_comatus).id)
     assert_template(:show_past_name, partial: "_name")
   end
 
   def test_show_past_name_with_misspelling
-    get_with_dump(:show_past_name, id: names(:petigera).id)
+    get(:show_past_name, id: names(:petigera).id)
     assert_template(:show_past_name, partial: "_name")
   end
 
@@ -212,23 +212,23 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def test_names_by_user
-    get_with_dump(:names_by_user, id: rolf.id)
+    get(:names_by_user, id: rolf.id)
     assert_template(:index)
   end
 
   def test_names_by_editor
-    get_with_dump(:names_by_editor, id: rolf.id)
+    get(:names_by_editor, id: rolf.id)
     assert_template(:index)
   end
 
   def test_needed_descriptions
-    get_with_dump(:needed_descriptions)
+    get(:needed_descriptions)
     assert_template(:index)
   end
 
   def test_name_search
     id = names(:agaricus).id
-    get_with_dump(:name_search, pattern: id)
+    get(:name_search, pattern: id)
     assert_redirected_to(
       action: :show,
       id: id
@@ -236,12 +236,12 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def test_name_search_help
-    get_with_dump(:name_search, pattern: "help:me")
+    get(:name_search, pattern: "help:me")
     assert_match(/unexpected term/i, @response.body)
   end
 
   def test_name_search_with_spelling_correction
-    get_with_dump(:name_search, pattern: "agaricis campestrus")
+    get(:name_search, pattern: "agaricis campestrus")
     assert_template(:index)
     assert_select("div.alert-warning", 1)
     assert_select("a[href*='show_name/#{names(:agaricus_campestrus).id}']",
@@ -336,7 +336,7 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def test_eol_preview
-    get_with_dump("eol_preview")
+    get("eol_preview")
   end
 
   def ids_from_links(links)
@@ -527,19 +527,19 @@ class NamesControllerTest < FunctionalTestCase
 
   # name with Observations that have Locations
   def test_map
-    get_with_dump(:map, id: names(:agaricus_campestris).id)
+    get(:map, id: names(:agaricus_campestris).id)
     assert_template(:map)
   end
 
   # name with Observations that don't have Locations
   def test_map_no_loc
-    get_with_dump(:map, id: names(:coprinus_comatus).id)
+    get(:map, id: names(:coprinus_comatus).id)
     assert_template(:map)
   end
 
   # name with no Observations
   def test_map_no_obs
-    get_with_dump(:map, id: names(:conocybe_filaris).id)
+    get(:map, id: names(:conocybe_filaris).id)
     assert_template(:map)
   end
 
@@ -3585,7 +3585,7 @@ class NamesControllerTest < FunctionalTestCase
     login("rolf")
 
     # No interest in this name yet.
-    get_with_dump(:show, id: peltigera.id)
+    get(:show, id: peltigera.id)
     assert_response(:success)
     assert_image_link_in_html(/watch\d*.png/,
                               controller: :interests,
@@ -3602,7 +3602,7 @@ class NamesControllerTest < FunctionalTestCase
 
     # Turn interest on and make sure there is an icon linked to delete it.
     Interest.create(target: peltigera, user: rolf, state: true)
-    get_with_dump(:show, id: peltigera.id)
+    get(:show, id: peltigera.id)
     assert_response(:success)
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: :interests,
@@ -3620,7 +3620,7 @@ class NamesControllerTest < FunctionalTestCase
     # Destroy that interest, create new one with interest off.
     Interest.where(user_id: rolf.id).last.destroy
     Interest.create(target: peltigera, user: rolf, state: false)
-    get_with_dump(:show, id: peltigera.id)
+    get(:show, id: peltigera.id)
     assert_response(:success)
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: :interests,
@@ -3740,7 +3740,7 @@ class NamesControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     # Make sure it doesn't crash if id is bogus.
-    get_with_dump(:inherit_classification, id: name.id)
+    get(:inherit_classification, id: name.id)
     assert_no_flash
     assert_response(:success)
     assert_template("inherit_classification")
@@ -3852,7 +3852,7 @@ class NamesControllerTest < FunctionalTestCase
     assert_textarea_value(:classification, "")
 
     name = names(:agaricus_campestris)
-    get_with_dump(:edit_classification, id: name.id)
+    get(:edit_classification, id: name.id)
     assert_response(:success)
     assert_template(:edit_classification)
     assert_textarea_value(:classification, name.classification)

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -107,12 +107,12 @@ class ObservationsControllerTest < FunctionalTestCase
     img = images(:rolf_profile_image)
     assert_nil(img.notes)
     assert(obs.images.member?(img))
-    get_with_dump(:show, id: obs.id)
+    get(:show, id: obs.id)
   end
 
   def test_show_observation_noteful_image
     obs = observations(:detailed_unknown_obs)
-    get_with_dump(:show, id: obs.id)
+    get(:show, id: obs.id)
   end
 
   def test_show_observation_change_thumbnail_size
@@ -147,7 +147,7 @@ class ObservationsControllerTest < FunctionalTestCase
   end
 
   def test_page_loads
-    get_with_dump(:index)
+    get(:index)
     assert_template(
       :index,
       partial: :_rss_log
@@ -163,23 +163,23 @@ class ObservationsControllerTest < FunctionalTestCase
       action: :signup
     )
 
-    get_with_dump(:ask_webmaster_question)
+    get(:ask_webmaster_question)
     assert_template(:ask_webmaster_question)
     assert_form_action(action: :ask_webmaster_question)
 
-    get_with_dump(:how_to_help)
+    get(:how_to_help)
     assert_template(:how_to_help)
 
-    get_with_dump(:how_to_use)
+    get(:how_to_use)
     assert_template(:how_to_use)
 
-    get_with_dump(:intro)
+    get(:intro)
     assert_template(:intro)
 
     get(:search_bar_help)
     assert_response(:success)
 
-    get_with_dump(:index)
+    get(:index)
     assert_template(
       :index,
       partial: :_rss_log
@@ -201,16 +201,16 @@ class ObservationsControllerTest < FunctionalTestCase
     )
 
     # TODO: NIMMO move to rss_logs_controller_test
-    get_with_dump(:list_rss_logs)
+    get(:list_rss_logs)
     assert_template(
       :index,
       partial: :_rss_log
     )
 
-    get_with_dump(:news)
+    get(:news)
     assert_template(:news)
 
-    get_with_dump(:observations_by_name)
+    get(:observations_by_name)
     assert_template(
       :index,
       partial: :_rss_log
@@ -224,24 +224,24 @@ class ObservationsControllerTest < FunctionalTestCase
     )
 
     # TODO: NIMMO move to rss_logs_controller_test
-    get_with_dump(:rss)
+    get(:rss)
     assert_template(:rss)
 
-    get_with_dump(:show, id: rss_logs(:observation_rss_log).id)
+    get(:show, id: rss_logs(:observation_rss_log).id)
     assert_template(:show)
 
     # TODO: NIMMO move to users_controller_test
-    get_with_dump(:users_by_contribution)
+    get(:users_by_contribution)
     assert_template(:users_by_contribution)
 
-    get_with_dump(:show, id: rolf.id)
+    get(:show, id: rolf.id)
     assert_template(:show)
 
     # TODO: NIMMO move to info_controller_test
-    get_with_dump(:show_site_stats)
+    get(:show_site_stats)
     assert_template(:show_site_stats)
 
-    get_with_dump(:observations_by_user, id: rolf.id)
+    get(:observations_by_user, id: rolf.id)
     assert_template(
       :index,
       partial: :_rss_log
@@ -250,10 +250,10 @@ class ObservationsControllerTest < FunctionalTestCase
     # get_with_dump(:login)
     # assert_redirected_to(controller: :account, action: :login)
 
-    get_with_dump(:textile)
+    get(:textile)
     assert_template(:textile_sandbox)
 
-    get_with_dump(:textile_sandbox)
+    get(:textile_sandbox)
     assert_template(:textile_sandbox)
   end
 
@@ -266,7 +266,7 @@ class ObservationsControllerTest < FunctionalTestCase
   end
 
   def test_page_load_user_by_contribution
-    get_with_dump(:users_by_contribution)
+    get(:users_by_contribution)
     assert_template(:users_by_contribution)
   end
 
@@ -554,13 +554,13 @@ class ObservationsControllerTest < FunctionalTestCase
   end
 
   def test_observation_search_help
-    get_with_dump(:observation_search, pattern: "help:me")
+    get(:observation_search, pattern: "help:me")
     assert_match(/unexpected term/i, @response.body)
   end
 
   def test_observation_search
     pattern = "Boletus edulis"
-    get_with_dump(:observation_search, pattern: pattern)
+    get(:observation_search, pattern: pattern)
     assert_template(:index)
     assert_equal(
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
@@ -568,7 +568,7 @@ class ObservationsControllerTest < FunctionalTestCase
     )
     assert_not_empty(css_select('[id="right_tabs"]').text, "Tabset is empty")
 
-    get_with_dump(:observation_search, pattern: pattern, page: 2)
+    get(:observation_search, pattern: pattern, page: 2)
     assert_template(:index)
     assert_equal(
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
@@ -579,7 +579,7 @@ class ObservationsControllerTest < FunctionalTestCase
     # When there are no hits, no title is displayed, there's no rh tabset, and
     # html <title> contents are the action name
     pattern = "no hits"
-    get_with_dump(:observation_search, pattern: pattern)
+    get(:observation_search, pattern: pattern)
     assert_template(:index)
     assert_empty(@controller.instance_variable_get("@title"))
     assert_empty(css_select('[id="right_tabs"]').text, "Tabset should be empty")
@@ -589,7 +589,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
     # If pattern is id of a real Observation, go directly to that Observation.
     obs = Observation.first
-    get_with_dump(:observation_search, pattern: obs.id)
+    get(:observation_search, pattern: obs.id)
     assert_redirected_to(action: :show, id: Observation.first.id)
   end
 
@@ -669,21 +669,21 @@ class ObservationsControllerTest < FunctionalTestCase
   # Created in response to a bug seen in the wild
   def test_where_search_next_page
     params = { place_name: "Burbank", page: 2 }
-    get_with_dump(:observations_at_where, params)
+    get(:observations_at_where, params)
     assert_template(:index)
   end
 
   # Created in response to a bug seen in the wild
   def test_where_search_pattern
     params = { place_name: "Burbank" }
-    get_with_dump(:observations_at_where, params)
+    get(:observations_at_where, params)
     assert_template(:index, partial: :_rss_log)
   end
 
   def test_observations_of_name
     params = { species_list_id: species_lists(:unknown_species_list).id,
                name: observations(:minimal_unknown_obs).name }
-    get_with_dump(:observations_of_name, params)
+    get(:observations_of_name, params)
     # Needs an assertion. Was
     # assert_select("title", /Observations of Synonyms of/)
     # but that broken by PR 497.
@@ -692,7 +692,7 @@ class ObservationsControllerTest < FunctionalTestCase
   # Prove that lichen content_filter works on observations
   def test_observations_with_lichen_filter
     login(users(:lichenologist).name)
-    get_with_dump(:index)
+    get(:index)
     results = @controller.instance_variable_get("@objects")
 
     assert(results.count.positive?)
@@ -700,7 +700,7 @@ class ObservationsControllerTest < FunctionalTestCase
            "All results should be lichen-ish")
 
     login(users(:antilichenologist).name)
-    get_with_dump(:index)
+    get(:index)
     results = @controller.instance_variable_get("@objects")
 
     assert(results.count.positive?)
@@ -719,7 +719,7 @@ class ObservationsControllerTest < FunctionalTestCase
     num_views = obs.num_views
     last_view = obs.last_view
     # obs.update_view_stats
-    get_with_dump(:show, id: obs.id)
+    get(:show, id: obs.id)
     obs.reload
     assert_equal(num_views + 1, obs.num_views)
     assert_not_equal(last_view, obs.last_view)
@@ -742,27 +742,27 @@ class ObservationsControllerTest < FunctionalTestCase
 
     # Test it on obs with no namings first.
     obs_id = observations(:unknown_with_no_naming).id
-    get_with_dump(:show, id: obs_id)
+    get(:show, id: obs_id)
     assert_show_observation
     assert_form_action(controller: :votes, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings (Rolf's and Mary's), but no one logged in.
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get(:show, id: obs_id)
     assert_show_observation
     assert_form_action(controller: :votes, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings, with owner logged in.
     login("rolf")
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get(:show, id: obs_id)
     assert_show_observation
     assert_form_action(controller: :votes, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings, with non-owner logged in.
     login("mary")
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get(:show, id: obs_id)
     assert_show_observation
     assert_form_action(controller: :votes, action: :cast_votes, id: obs_id)
 
@@ -782,11 +782,11 @@ class ObservationsControllerTest < FunctionalTestCase
     obs = observations(:coprinus_comatus_obs)
     user = login(users(:public_voter).name)
 
-    get_with_dump(:show, id: obs.id, go_private: 1)
+    get(:show, id: obs.id, go_private: 1)
     user.reload
     assert_equal(:yes, user.votes_anonymous)
 
-    get_with_dump(:show, id: obs.id, go_public: 1)
+    get(:show, id: obs.id, go_public: 1)
     user.reload
     assert_equal(:no, user.votes_anonymous)
   end
@@ -794,13 +794,13 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_show_owner_id
     login(user_with_view_owner_id_true)
     obs = observations(:owner_only_favorite_ne_consensus)
-    get_with_dump(:show, id: obs.id)
+    get(:show, id: obs.id)
     assert_select("div[class *= 'owner-id']",
                   { text: /#{obs.owner_preference.text_name}/,
                     count: 1 },
                   "Observation should show Observer ID")
 
-    get_with_dump(:show,
+    get(:show,
                   id: observations(:owner_multiple_favorites).id)
     assert_select("div[class *= 'owner-id']",
                   { text: /#{:show_observation_no_clear_preference.t}/,
@@ -810,7 +810,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_show_owner_id_view_owner_id_false
     login(user_with_view_owner_id_false)
-    get_with_dump(:show,
+    get(:show,
                   id: observations(:owner_only_favorite_ne_consensus).id)
     assert_select("div[class *= 'owner-id']", { count: 0 },
                   "Do not show Observer ID when user has not opted for it")
@@ -818,7 +818,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_show_owner_id_noone_logged_in
     logout
-    get_with_dump(:show,
+    get(:show,
                   id: observations(:owner_only_favorite_ne_consensus).id)
     assert_select("div[class *= 'owner-id']", { count: 0 },
                   "Do not show Observer ID when nobody logged in")
@@ -834,7 +834,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_observation_external_links_exist
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get(:show, id: obs_id)
 
     assert_select("a[href *= 'images.google.com']")
     assert_select("a[href *= 'mycoportal.org']")

--- a/test/controllers/pivotal_controller_test.rb
+++ b/test/controllers/pivotal_controller_test.rb
@@ -6,7 +6,7 @@ class PivotalControllerTest < FunctionalTestCase
   def test_index_disabled
     enabled = MO.pivotal_enabled
     MO.pivotal_enabled = false
-    get_with_dump(:index)
+    get(:index)
     assert_response("index")
     MO.pivotal_enabled = enabled
   end
@@ -46,7 +46,7 @@ class PivotalControllerTest < FunctionalTestCase
                   headers: {})
     enabled = MO.pivotal_enabled
     MO.pivotal_enabled = true
-    get_with_dump(:index)
+    get(:index)
     assert_response("index")
     MO.pivotal_enabled = enabled
   end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -71,7 +71,7 @@ class ProjectsControllerTest < FunctionalTestCase
 
   def test_show_project
     p_id = projects(:eol_project).id
-    get_with_dump(:show, id: p_id)
+    get(:show, id: p_id)
     assert_template("show_project")
     assert_select("a[href*='admin_request/#{p_id}']")
     assert_select("a[href*='projects/#{p_id}/edit']", count: 0)
@@ -82,7 +82,7 @@ class ProjectsControllerTest < FunctionalTestCase
   def test_show_project_logged_in
     p_id = projects(:eol_project).id
     requires_login(:new)
-    get_with_dump(:show, id: p_id)
+    get(:show, id: p_id)
     assert_template("show_project")
     assert_select("a[href*='admin_request/']")
     assert_select("a[href*='projects/#{p_id}/edit']")
@@ -91,7 +91,7 @@ class ProjectsControllerTest < FunctionalTestCase
   end
 
   def test_list_projects
-    get_with_dump(:index)
+    get(:index)
     assert_template("list_projects")
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -25,38 +25,38 @@ class SearchControllerTest < FunctionalTestCase
 
   def test_pattern_search
     params = { search: { pattern: "12", type: :observation } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :observations, action: :observation_search,
                          pattern: "12")
 
     params = { search: { pattern: "34", type: :image } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :images, action: :image_search,
                          pattern: "34")
 
     params = { search: { pattern: "56", type: :name } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :names, action: :name_search,
                          pattern: "56")
 
     params = { search: { pattern: "78", type: :location } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :locations, action: :location_search,
                          pattern: "78")
 
     params = { search: { pattern: "90", type: :comment } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :comments, action: :comment_search,
                          pattern: "90")
 
     params = { search: { pattern: "12", type: :species_list } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :species_lists,
                          action: :species_list_search,
                          pattern: "12")
 
     params = { search: { pattern: "34", type: :user } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :users, action: :user_search,
                          pattern: "34")
 
@@ -65,19 +65,19 @@ class SearchControllerTest < FunctionalTestCase
     params = { search: { pattern: pattern, type: :google } }
     target =
       "https://google.com/search?q=site%3Amushroomobserver.org+#{pattern}"
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(target)
 
     params = { search: { pattern: "", type: :google } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :rss_logs, action: :list_rss_logs)
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :rss_logs, action: :list_rss_logs)
 
     params = { search: { pattern: "", type: :observation } }
-    get_with_dump(:pattern_search, params)
+    get(:pattern_search, params)
     assert_redirected_to(controller: :observations, action: :list_observations)
   end
 

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 # Controller tests for nucleotide sequences
 class SequencesControllerTest < FunctionalTestCase
   def test_list_sequences
-    get_with_dump(:index)
+    get(:index)
     assert(:success)
   end
 
@@ -47,7 +47,7 @@ class SequencesControllerTest < FunctionalTestCase
   def test_show_sequence
     # Prove sequence displayed if called with id of sequence in db
     sequence = sequences(:local_sequence)
-    get_with_dump(:show, id: sequence.id)
+    get(:show, id: sequence.id)
     assert_response(:success)
 
     # Prove index displayed if called with id of sequence not in db
@@ -70,7 +70,7 @@ class SequencesControllerTest < FunctionalTestCase
 
     # Prove Observation owner can add Sequence
     login(owner.login)
-    get_with_dump(:new, id: obs.id)
+    get(:new, id: obs.id)
     assert_response(:success)
 
     # Prove admin can add Sequence

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -176,17 +176,17 @@ class SpeciesListsControllerTest < FunctionalTestCase
   end
 
   def test_species_lists_by_title
-    get_with_dump(:species_lists_by_title)
+    get(:species_lists_by_title)
     assert_template(:list_species_lists)
   end
 
   def test_species_lists_by_user
-    get_with_dump(:species_lists_by_user, id: rolf.id)
+    get(:species_lists_by_user, id: rolf.id)
     assert_template(:list_species_lists)
   end
 
   def test_species_lists_for_project
-    get_with_dump(:species_lists_for_project,
+    get(:species_lists_for_project,
                   id: projects(:bolete_project).id)
     assert_template(:list_species_lists)
   end
@@ -237,7 +237,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     assert(spl.reload.observations.member?(obs))
 
     login owner
-    get_with_dump(:remove_observation_from_species_list, params)
+    get(:remove_observation_from_species_list, params)
     assert_redirected_to(species_lists_manage_species_lists_path(id: obs.id))
     assert_not(spl.reload.observations.member?(obs))
   end
@@ -324,7 +324,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
   def test_unsuccessful_create_location_description
     user = login("spamspamspam")
     assert_false(user.is_successful_contributor?)
-    get_with_dump(:new)
+    get(:new)
     assert_response(:redirect)
   end
 
@@ -1308,7 +1308,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     assert_template(:bulk_editor)
 
     login("mary")
-    get_with_dump(:bulk_editor, params)
+    get(:bulk_editor, params)
     assert_template(:bulk_editor)
 
     # No changes.
@@ -1573,7 +1573,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
 
     # Owner of list always can.
     login("mary")
-    get_with_dump(:manage_projects, id: list.id)
+    get(:manage_projects, id: list.id)
     assert_response(:success)
   end
 

--- a/test/controllers/support_controller_test.rb
+++ b/test/controllers/support_controller_test.rb
@@ -14,13 +14,13 @@ class SupportControllerTest < FunctionalTestCase
       :wrapup_2012
     ].each do |template|
       assert_template_with_dump(template)
-      get_with_dump(template)
+      get(template)
       assert_template(template)
     end
   end
 
   def assert_template_with_dump(template)
-    get_with_dump(template)
+    get(template)
     assert_template(template)
   end
 

--- a/test/controllers/translation_controller_test.rb
+++ b/test/controllers/translation_controller_test.rb
@@ -180,7 +180,7 @@ class TranslationControllerTest < FunctionalTestCase
 
   def test_edit_translation_form_get_tag_two
     login("rolf")
-    get_with_dump(:edit_translations, locale: "en", tag: "two")
+    get(:edit_translations, locale: "en", tag: "two")
     assert_no_flash
     assert_response(:success)
     assert_select("input[type=submit][value=#{:SAVE.l}]", 1)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -8,7 +8,7 @@ class UsersControllerTest < FunctionalTestCase
   # ------------------------------------------------------------
 
   def test_show_user_no_id
-    get_with_dump(:show)
+    get(:show)
     assert_redirected_to(action: :index_user)
   end
 
@@ -27,7 +27,7 @@ class UsersControllerTest < FunctionalTestCase
       assert_flash_text(/denied|only.*admin/i)
 
       make_admin("rolf")
-      get_with_dump(page, params)
+      get(page, params)
       assert_template(response) # 1
     end
   end

--- a/test/controllers/votes_controller_test.rb
+++ b/test/controllers/votes_controller_test.rb
@@ -142,7 +142,7 @@ class VotesControllerTest < FunctionalTestCase
 
   def test_show_votes
     # First just make sure the page displays.
-    get_with_dump(:show, id: namings(:coprinus_comatus_naming).id)
+    get(:show, id: namings(:coprinus_comatus_naming).id)
     assert_template(:show, partial: "_votes_table")
 
     # Now try to make somewhat sure the content is right.


### PR DESCRIPTION
- Change non-comment `get_with_dump` to `get`
- Fix all resulting argument alignment issues
- Delete definition of `get_with_dump`