### PR TITLE
dump `<action>_with_dump`

### DIFF
--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -456,7 +456,7 @@ module ControllerExtensions
 
     # Finally, login correct user and let it do its thing.
     login(user, password)
-    send("#{method}_with_dump", action, params)
+    send("#{method}", action, params)
     assert_response(args[:result])
   end
 

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -10,10 +10,8 @@
 #  login::                      Login a user.
 #  logout::                     Logout current user.
 #  make_admin::                 Make current user an admin & turn on admin mode.
-#  get_with_dump::              Send GET, no login required.
 #  requires_login::             Send GET, login required.
 #  requires_user::              Send GET, certain user must be logged in.
-#  post_with_dump::             Send POST, no login required.
 #  post_requires_login::        Send POST, login required.
 #  post_requires_user::         Send POST, certain user must be logged in.
 #  html_dump::                  Dump response body to file for W3C validation.
@@ -99,19 +97,6 @@ module ControllerExtensions
       user.save
     end
     user
-  end
-
-  # Send a POST request, and save the result in a file for w3c validation.
-  #
-  #   # Send request, but ignore response.
-  #   post(:action, params)
-  #
-  #   # Send request, and save response in ../html/action_0.html.
-  #   post_with_dump(:action, params)
-  #
-  def post_with_dump(page, params = {})
-    post(page, params: params)
-    # html_dump(page, @response.body, params)
   end
 
   # Send GET request to a page that should require login.

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -524,7 +524,7 @@ class AccountControllerTest < FunctionalTestCase
         mailing_address: ""
       }
     }
-    post_with_dump(:profile, params)
+    post(:profile, params)
     assert_flash_text(:runtime_profile_success.t)
 
     # Make sure changes were made.
@@ -562,7 +562,7 @@ class AccountControllerTest < FunctionalTestCase
     }
     File.stub(:rename, false) do
       login("rolf", "testpassword")
-      post_with_dump(:profile, params)
+      post(:profile, params)
     end
     assert_redirected_to(controller: :users, action: :show, id: rolf.id)
     assert_flash_success

--- a/test/controllers/email_controller_test.rb
+++ b/test/controllers/email_controller_test.rb
@@ -79,7 +79,7 @@ class EmailControllerTest < FunctionalTestCase
     assert_flash_text(/denied|only.*admin/i)
 
     make_admin("rolf")
-    post_with_dump(page, params)
+    post(page, params)
     assert_redirected_to(controller: :users, action: :users_by_name)
   end
 

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -601,7 +601,7 @@ class ImagesControllerTest < FunctionalTestCase
     }
     File.stub(:rename, false) do
       login("rolf", "testpassword")
-      post_with_dump(:add_image, params)
+      post(:add_image, params)
     end
     assert_equal(20, rolf.reload.contribution)
     assert(obs.reload.images.size == (img_count + 1))

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -476,7 +476,7 @@ class LocationsControllerTest < FunctionalTestCase
     past_descs_to_go = 0
 
     make_admin("rolf")
-    post_with_dump(:edit, params)
+    post(:edit, params)
 
     # assert_template(action: :show)
     assert_redirected_to(action: :show, id: to_stay.id)

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -776,7 +776,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     assert_equal(sp_count, spl.reload.observations.size)
 
     login owner
-    post_with_dump(:edit, params)
+    post(:edit, params)
     assert_redirected_to(species_list_path(id: spl.id))
     assert_equal(10 + v_obs * 2, spl.user.reload.contribution)
     assert_equal(sp_count + 2, spl.reload.observations.size)
@@ -827,7 +827,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     assert(spl.reload.observations.size == sp_count)
 
     login owner
-    post_with_dump(:edit, params)
+    post(:edit, params)
     # assert_redirected_to(controller: :locations, action: :new)
     assert_redirected_to(new_location_path)
     assert_equal(10 + v_obs, spl.user.reload.contribution)
@@ -1057,7 +1057,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
       }
     }
     login("rolf", "testpassword")
-    post_with_dump(:upload_species_list, params)
+    post(:upload_species_list, params)
     assert_edit_species_list
     assert_equal(10, rolf.reload.contribution)
     # Doesn't actually change list, just feeds it to edit
@@ -1078,7 +1078,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
       }
     }
     login("rolf", "testpassword")
-    post_with_dump(:upload_species_list, params)
+    post(:upload_species_list, params)
     assert_edit_species_list
     assert_equal(10, rolf.reload.contribution)
     new_data = @controller.instance_variable_get("@list_members")


### PR DESCRIPTION
- Deletes `post_with_dump`
- Fixes a bug created by #579 (Remove `get_with_dump`)
