### PR TITLE
Fix incorrect path helper

### DIFF
--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -75,7 +75,7 @@ class SequencesControllerTest < FunctionalTestCase
 
     # Prove method requires login
     get(:new, id: obs.id)
-    assert_redirected_to(accounts_login_path)
+    assert_redirected_to(account_login_path)
 
     # Prove logged-in user can add Sequence to someone else's Observation
     login("zero")


### PR DESCRIPTION
Fixes test error (see below) 
The helper should be singular: `account_login_path`
because AccountController is singular (I'm not sure why).
```ruby
$ rails t test/controllers/sequences_controller_test.rb -n test_new
Started with run options -n test_new --seed 61320

ERROR["test_new", #<Minitest::Reporters::Suite:0x00005614160bdcd8 @name="SequencesControllerTest">, 2.4301136730064172]
 test_new#SequencesControllerTest (2.43s)
Minitest::UnexpectedError:         NameError: undefined local variable or method `accounts_login_path' for #<SequencesControllerTest:0x0000561415edf3d0>
            test/controllers/sequences_controller_test.rb:78:in `test_new'

  1/1: [===========================================================================================] 100% Time: 00:00:05, Time: 00:00:05

Finished in 5.20427s
1 tests, 1 assertions, 0 failures, 1 errors, 0 skips
```
