### PR TITLE
Fix phony fixture IDs in bootstrap4

### DIFF
--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-rolfs_api_key: # 1
+rolfs_api_key:
   created_at: 2012-06-26 12:34:56
   verified: 2012-06-26 12:34:56
   last_used: 2014-03-23 16:57:27
@@ -12,7 +12,7 @@ rolfs_api_key: # 1
   key: bogus_api_key
   notes: For testing purpose’s only.
 
-marys_api_key: # 2
+marys_api_key:
   created_at: 2017-11-14 18:01:17
   verified: 2017-11-14 18:01:18
   last_used: 2017-11-14 18:01:19
@@ -23,19 +23,19 @@ marys_api_key: # 2
 
 # The next 3 fixtures are used to test whether sql collates accented letters.
 # Has nothing to do with APIs; This is just a convenient spot to add fixtures.
-api_key_u_1: # 3
+api_key_u_1:
   id: 1
   user_id: 1
   key: sort_test
   notes: u
 
-api_key_umlaut: # 4
+api_key_umlaut:
   id: 2
   user_id: 1
   key: sort_test
   notes: ü
 
-api_key_u_2: # 5
+api_key_u_2:
   id: 3
   user_id: 1
   key: sort_test

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -7,5 +7,5 @@ DEFAULTS: &DEFAULTS
   user:       rolf
   rss_log_id:
 
-premier_article: # 1
+premier_article:
   <<: *DEFAULTS

--- a/test/fixtures/collection_numbers.yml
+++ b/test/fixtures/collection_numbers.yml
@@ -3,35 +3,35 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-minimal_unknown_coll_num: # 1
+minimal_unknown_coll_num:
   created_at: 2005-05-12 17:20:00
   updated_at: 2005-05-12 17:21:00
   user:       mary
   name:       "Mary Newbie"
   number:     "173"
 
-detailed_unknown_coll_num_one: # 2
+detailed_unknown_coll_num_one:
   created_at: 2006-05-12 17:20:00
   updated_at: 2006-05-12 17:21:00
   user:       mary
   name:       "Mary Newbie"
   number:     "174"
 
-detailed_unknown_coll_num_two: # 3
+detailed_unknown_coll_num_two:
   created_at: 2006-05-12 18:20:00
   updated_at: 2006-05-12 18:21:00
   user:       mary
   name:       "Random Neighbor"
   number:     "s/n"
 
-coprinus_comatus_coll_num: # 4
+coprinus_comatus_coll_num:
   created_at: 2012-12-08 14:23:00
   updated_at: 2012-12-08 14:23:00
   user:       rolf
   name:       "Rolf Singer"
   number:     "1"
 
-agaricus_campestris_coll_num: # 5
+agaricus_campestris_coll_num:
   created_at: 2007-03-19 20:20:00
   updated_at: 2007-03-19 20:21:00
   user:       rolf

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-minimal_unknown_obs_comment_1: # 1
+minimal_unknown_obs_comment_1:
   created_at: 2006-03-02 21:14:00
   updated_at: 2006-03-02 21:14:00
   user: rolf
@@ -12,7 +12,7 @@ minimal_unknown_obs_comment_1: # 1
   target_type: Observation
   target: minimal_unknown_obs
 
-minimal_unknown_obs_comment_2: # 2
+minimal_unknown_obs_comment_2:
   created_at: 2006-03-02 21:16:00
   updated_at: 2006-03-02 21:16:00
   user: dick
@@ -21,7 +21,7 @@ minimal_unknown_obs_comment_2: # 2
   target_type: Observation
   target: minimal_unknown_obs
 
-detailed_unknown_obs_comment: # 3
+detailed_unknown_obs_comment:
   created_at: 2007-03-02 21:16:00
   updated_at: 2007-03-02 21:16:00
   user: mary
@@ -30,7 +30,7 @@ detailed_unknown_obs_comment: # 3
   target_type: Observation
   target: detailed_unknown_obs
 
-fungi_comment: # 4
+fungi_comment:
   created_at: 2017-11-16 00:32:00
   updated_at: 2017-11-16 00:32:00
   user: katrina

--- a/test/fixtures/donations.yml
+++ b/test/fixtures/donations.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-unreviewed: # 1
+unreviewed:
   amount: 100.00
   who: Lily White Truffle
   email: lily@mushroomobserver.org

--- a/test/fixtures/external_links.yml
+++ b/test/fixtures/external_links.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-coprinus_comatus_obs_mycoportal_link: # 1
+coprinus_comatus_obs_mycoportal_link:
   user:          mary
   created_at:    2016-12-29 15:21:00
   updated_at:    2016-12-29 15:21:00
@@ -11,7 +11,7 @@ coprinus_comatus_obs_mycoportal_link: # 1
   external_site: mycoportal
   url:           "http://mycoportal.org/portal/collections/individual/index.php?occid=1950183"
 
-coprinus_comatus_obs_inaturalist_link: # 2
+coprinus_comatus_obs_inaturalist_link:
   user:          mary
   created_at:    2017-11-11 14:14:00
   updated_at:    2017-11-11 14:14:00

--- a/test/fixtures/external_sites.yml
+++ b/test/fixtures/external_sites.yml
@@ -3,10 +3,10 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-mycoportal: # 1
+mycoportal:
   name:    MycoPortal
   project: empty_project # mary is only member and admin
 
-inaturalist: # 2
+inaturalist:
   name:    iNaturalist
   project: empty_project # mary is only member and admin

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-conic_glossary_term: # 1
+conic_glossary_term:
   version: 1
   user: rolf
   name: Conic # Want to support translations, so this should be a symbol
@@ -12,7 +12,7 @@ conic_glossary_term: # 1
   created_at: 2013-08-04 07:49:12
   updated_at: 2013-08-04 07:49:12
 
-convex_glossary_term: # 2
+convex_glossary_term:
   version: 1
   user: rolf
   name: Convex
@@ -21,7 +21,7 @@ convex_glossary_term: # 2
   created_at: 2013-08-13 17:26:20
   updated_at: 2013-08-13 17:26:20
 
-plane_glossary_term: # 3
+plane_glossary_term:
   version: 2
   user: rolf
   name: Plane
@@ -31,7 +31,7 @@ plane_glossary_term: # 3
   updated_at: 2013-08-17 06:35:20
   images: plane_image_example
 
-square_glossary_term: # 4
+square_glossary_term:
   version: 3
   user: rolf
   name: Square

--- a/test/fixtures/glossary_terms_versions.yml
+++ b/test/fixtures/glossary_terms_versions.yml
@@ -1,42 +1,42 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 # glossary term association must be referenced by id
 
-plane_glossary_term_v1: # 1
+plane_glossary_term_v1:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:plane_glossary_term) %>
   version: 1
   updated_at: 2013-08-17 06:33:50
   name: Plane
   description:
 
-plane_glossary_term_v2: # 2
+plane_glossary_term_v2:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:plane_glossary_term) %>
   version: 2
   updated_at: 2013-08-17 06:35:20
   name: Plane
   description: Three points define a plane
 
-conic_glossary_term_v1: # 3
+conic_glossary_term_v1:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:conic_glossary_term) %>
   version: 1
   updated_at: 2013-08-04 07:49:12
   name: Conic
   description: Cute little cone head
 
-square_glossary_term_v1: # 4
+square_glossary_term_v1:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
   version: 1
   updated_at: 2013-08-04 07:49:12
   name: Square
   description:
 
-square_glossary_term_v2: # 5
+square_glossary_term_v2:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
   version: 2
   updated_at: 2013-08-04 07:49:12
   name: Square
   description: quadrilateral
 
-square_glossary_term_v3: # 6
+square_glossary_term_v3:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
   version: 3
   updated_at: 2013-08-04 07:49:12

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-nybg_herbarium: # 1
+nybg_herbarium:
     created_at: 2012-10-21 12:14:00
     updated_at: 2012-10-21 12:14:00
     name: The New York Botanical Garden
@@ -14,7 +14,7 @@ nybg_herbarium: # 1
     code: NY
     curators: rolf, roy
 
-rolf_herbarium: # 2
+rolf_herbarium:
     created_at: 2012-10-21 06:40:00
     updated_at: 2012-10-21 06:41:00
     name: "Uncle Rolf's Personal Herbarium"
@@ -22,19 +22,19 @@ rolf_herbarium: # 2
     curators: rolf
 
 # Empty herbarium
-dick_herbarium: # 3
+dick_herbarium:
     created_at: 2012-12-08 14:34:00
     updated_at: 2012-10-21 14:34:00
     name: "Dick's Personal Herbarium"
     personal_user: dick
     curators: dick
 
-mycoflora_herbarium: # 4
+mycoflora_herbarium:
     created_at: 2017-11-29 18:05:00
     updated_at: 2017-11-29 18:05:00
     name: "North American Mycoflora Project"
 
-field_museum: # 5
+field_museum:
     created_at: 2017-12-16 11:15:00
     updated_at: 2017-12-16 11:15:00
     name: The Field Museum

--- a/test/fixtures/herbarium_records.yml
+++ b/test/fixtures/herbarium_records.yml
@@ -4,7 +4,7 @@
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 # Has more than one observation
-interesting_unknown: # 1
+interesting_unknown:
     created_at: 2012-10-21 10:14:00
     updated_at: 2012-10-21 10:14:00
     herbarium: nybg_herbarium
@@ -14,7 +14,7 @@ interesting_unknown: # 1
     notes: It was cleaned & dried at 115°F
 
 # Same observation with more than one herbarium record
-coprinus_comatus_nybg_spec: # 2
+coprinus_comatus_nybg_spec:
     created_at: 2012-10-21 12:22:00
     updated_at: 2012-10-21 12:22:00
     herbarium: nybg_herbarium
@@ -22,7 +22,7 @@ coprinus_comatus_nybg_spec: # 2
     initial_det: Coprinus comatus
     accession_number: 4321
 
-coprinus_comatus_rolf_spec: # 3
+coprinus_comatus_rolf_spec:
     created_at: 2012-12-08 14:23:00
     updated_at: 2012-12-08 14:23:00
     herbarium: rolf_herbarium
@@ -31,7 +31,7 @@ coprinus_comatus_rolf_spec: # 3
     accession_number: Rolf Singer 1
 
 # One observation with one herbarium record
-agaricus_campestris_spec: # 4
+agaricus_campestris_spec:
     created_at: 2012-12-08 14:31:00
     updated_at: 2012-12-08 14:31:00
     herbarium: nybg_herbarium
@@ -39,7 +39,7 @@ agaricus_campestris_spec: # 4
     initial_det: Agaricus campestris
     accession_number: 4322
 
-herbarium_record_with_notes: # 5
+herbarium_record_with_notes:
     created_at: 2012-12-08 14:31:00
     updated_at: 2012-12-08 14:31:00
     herbarium: nybg_herbarium
@@ -48,7 +48,7 @@ herbarium_record_with_notes: # 5
     accession_number: yyy
     notes: rare
 
-mycoflora_record: # 6
+mycoflora_record:
     created_at: 2017-11-29 18:08:00
     updated_at: 2017-11-29 18:08:00
     herbarium: mycoflora_herbarium
@@ -56,7 +56,7 @@ mycoflora_record: # 6
     initial_det: Fungi
     accession_number: 314159
 
-field_museum_record: # 7
+field_museum_record:
     created_at: 2017-12-16 11:20:00
     updated_at: 2017-12-16 11:20:00
     herbarium: field_museum

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -15,7 +15,7 @@ DEFAULTS: &DEFAULTS
   height:           320
   ok_for_export:    true
 
-in_situ_image: # 1
+in_situ_image:
   <<: *DEFAULTS
   created_at: 2006-05-12 17:20:00
   updated_at: 2006-05-12 17:21:00
@@ -28,7 +28,7 @@ in_situ_image: # 1
   original_name: DSCN8835.JPG
   transferred: false
 
-turned_over_image: # 2
+turned_over_image:
   <<: *DEFAULTS
   created_at: 2006-05-22 21:20:00
   updated_at: 2006-05-22 21:21:00
@@ -39,35 +39,35 @@ turned_over_image: # 2
   original_name: 1.jpg
   transferred: false
 
-commercial_inquiry_image: # 3
+commercial_inquiry_image:
   <<: *DEFAULTS
   when: 2007-02-25
   notes: Some Notes
   copyright_holder: Bob Dobbs
   original_name: Location 2007-02-25 b.jpg
 
-disconnected_coprinus_comatus_image: # 4
+disconnected_coprinus_comatus_image:
   <<: *DEFAULTS
   when: 2007-03-07
   notes: Some Notes
   copyright_holder: Bob Dobbs
   original_name: Coprinus comatus.tiff
 
-connected_coprinus_comatus_image: # 5
+connected_coprinus_comatus_image:
   <<: *DEFAULTS
   when: 2007-03-07
   notes: Some Notes
   copyright_holder: Bob Dobbs
   original_name: Coprinus comatus close-up.tiff
 
-agaricus_campestris_image: # 6
+agaricus_campestris_image:
   <<: *DEFAULTS
   when: 2007-03-19
   notes: Some Notes
   copyright_holder: Bob Dobbs
   original_name: Name with áč€εиts.gif
 
-amateur_image: # 7
+amateur_image:
   <<: *DEFAULTS
   user: katrina
   when: 2010-12-30
@@ -75,7 +75,7 @@ amateur_image: # 7
   copyright_holder: Nathan Wilson
   license: publicdomain
 
-peltigera_image: # 8
+peltigera_image:
   <<: *DEFAULTS
   when: 2012-06-07
   notes: 'Pretty lichen'
@@ -83,27 +83,27 @@ peltigera_image: # 8
   copyright_holder: Nathan Wilson
   license: publicdomain
 
-conic_image: # 9
+conic_image:
   <<: *DEFAULTS
   when: 2013-08-04
   notes: 'A scientific illustration of Conic Pileus'
   copyright_holder: Insil Choi
   vote_cache: 3
 
-convex_image: # 10
+convex_image:
   <<: *DEFAULTS
   when: 2013-08-13
   notes: 'A scientific illustration of Convex Pileus'
   copyright_holder: Insil Choi
 
-plane_image_thumb: # 11
+plane_image_thumb:
   <<: *DEFAULTS
   when: 2013-09-08
   notes: 'A scientific illustration of Plane Pileus'
   copyright_holder: Insil Choi
   vote_cache: 3
 
-plane_image_example: # 12
+plane_image_example:
   <<: *DEFAULTS
   when: 2013-09-08
   notes: 'Example image of of Plane Pileus'
@@ -111,17 +111,17 @@ plane_image_example: # 12
   vote_cache: 3
   license: publicdomain
 
-rolf_profile_image: # 13
+rolf_profile_image:
   <<: *DEFAULTS
   when: 2013-09-08
   notes: NULL        # used in test_noteless_image
   copyright_holder: Rolf Singer
 
-query_first_image: # 14
+query_first_image:
   <<: *DEFAULTS
 
-query_second_image: # 15
+query_second_image:
   <<: *DEFAULTS
 
-locally_sequenced_obs_image: # 16
+locally_sequenced_obs_image:
   <<: *DEFAULTS

--- a/test/fixtures/interests.yml
+++ b/test/fixtures/interests.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-detailed_unknown_obs_interest: # 1
+detailed_unknown_obs_interest:
   updated_at: 2008-03-02 21:14:00
   user: junk
   target_type: Observation

--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -3,42 +3,42 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-english: # 1
+english:
   locale: en
   name: English
   order: English
   official: true
   beta: false
 
-french: # 2
+french:
   locale: fr
   name: Français
   order: Francais
   official: false
   beta: false
 
-greek: # 3
+greek:
   locale: el
   name: Ελληνικά
   order: Ellenika
   official: false
   beta: true
 
-russian: # 4
+russian:
   locale: ru
   name: Русский
   order: Russkii
   official: false
   beta: true
 
-spanish: # 5
+spanish:
   locale: es
   name: Español
   order: Espanol
   official: false
   beta: true
 
-portuguese: # 6
+portuguese:
   locale: pt
   name: Português
   order: Português

--- a/test/fixtures/licenses.yml
+++ b/test/fixtures/licenses.yml
@@ -3,7 +3,7 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-ccnc25: # 1
+ccnc25:
   # Do not autogenerate id
   # This is the default license for images.
   # That id is defined and hard-coded in the schema, in the image table.
@@ -15,19 +15,19 @@ ccnc25: # 1
   deprecated: true
   form_name: ccbyncsa25
 
-ccnc30: # 2
+ccnc30:
   display_name: Creative Commons Non-commercial v3.0
   url: http://creativecommons.org/licenses/by-nc-sa/3.0/
   deprecated: false
   form_name: ccbyncsa30
 
-ccwiki30: # 3
+ccwiki30:
   display_name: Creative Commons Wikipedia Compatible v3.0
   url: http://creativecommons.org/licenses/by-sa/3.0/
   deprecated: false
   form_name: ccbysa30
 
-publicdomain: # 4
+publicdomain:
   display_name: Public Domain
   url: http://wiki.creativecommons.org/Public_domain/
   deprecated: false

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -7,7 +7,7 @@ DEFAULTS: &DEFAULTS
   locked: false
 
 # no observations, 1 descsription and 2 versions all by rolf
-albion: # 1
+albion:
   <<: *DEFAULTS
   description: albion_desc
   created_at: 2007-12-27 06:41:20
@@ -25,7 +25,7 @@ albion: # 1
   rss_log: albion_rss_log
   notes: some notes & stuff... to test "unsafe" html
 
-burbank: # 2
+burbank:
   <<: *DEFAULTS
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
@@ -40,7 +40,7 @@ burbank: # 2
   high: 294.0
   low: 148.0
 
-mitrula_marsh: # 3
+mitrula_marsh:
   <<: *DEFAULTS
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
@@ -54,7 +54,7 @@ mitrula_marsh: # 3
   south: 39.5184
   rss_log: location_rss_log
 
-salt_point: # 4
+salt_point:
   <<: *DEFAULTS
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
@@ -70,7 +70,7 @@ salt_point: # 4
   low: 0.0
   notes: It's legal to collect in Salt Point (at least in 2010). Let's hope it stays that way!
 
-gualala: # 5
+gualala:
   <<: *DEFAULTS
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
@@ -85,7 +85,7 @@ gualala: # 5
   high: 100.0
   low: 0.0
 
-elgin_co: # 6
+elgin_co:
   <<: *DEFAULTS
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
@@ -98,7 +98,7 @@ elgin_co: # 6
   east: -80.8044
   south: 42.4701
 
-brett_woods: # 7
+brett_woods:
   <<: *DEFAULTS
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
@@ -111,7 +111,7 @@ brett_woods: # 7
   east: -73.3215
   south: 41.1939
 
-point_reyes: # 8
+point_reyes:
   <<: *DEFAULTS
   created_at: 2008-01-01 11:50:00
   updated_at: 2008-01-01 11:50:00
@@ -125,7 +125,7 @@ point_reyes: # 8
   south: 37.9255
   notes: Is it legal to collect in Point Reyes without a permit?
 
-howarth_park: # 9
+howarth_park:
   <<: *DEFAULTS
   created_at: 2008-01-01 15:24:18
   updated_at: 2008-01-01 15:24:18
@@ -138,7 +138,7 @@ howarth_park: # 9
   east: -122.6632
   south: 38.4496
 
-unknown_location: # 10
+unknown_location:
   <<: *DEFAULTS
   created_at: 2012-01-01 15:24:18
   updated_at: 2012-01-01 15:24:18
@@ -152,7 +152,7 @@ unknown_location: # 10
   south: -90
   locked: true
 
-nybg_location: # 11
+nybg_location:
   <<: *DEFAULTS
   created_at: 2012-10-21 06:50:00
   updated_at: 2012-10-21 06:50:00
@@ -167,7 +167,7 @@ nybg_location: # 11
 
 # Do not use this location for any object
   <<: *DEFAULTS
-unused_location: # 12
+unused_location:
   user_id: 0
   version: 1
   name: $LABEL
@@ -177,7 +177,7 @@ unused_location: # 12
   east: 180
   south: -90
 
-no_mushrooms_location: # 13
+no_mushrooms_location:
   <<: *DEFAULTS
   user_id: 0
   version: 1
@@ -188,7 +188,7 @@ no_mushrooms_location: # 13
   east: 180
   south: -90
 
-collection_location: # 14
+collection_location:
   <<: *DEFAULTS
   user_id: 0
   version: 1
@@ -199,7 +199,7 @@ collection_location: # 14
   east: 180
   south: -90
 
-display_location: # 15
+display_location:
   <<: *DEFAULTS
   user_id: 0
   version: 1
@@ -210,7 +210,7 @@ display_location: # 15
   east: 180
   south: -90
 
-sortable_observation_user_location: # 16
+sortable_observation_user_location:
   <<: *DEFAULTS
   user: sortable_observation_user
   version: 1
@@ -220,7 +220,7 @@ sortable_observation_user_location: # 16
   east: -73.878
   south: 40.866
 
-obs_default_location: # 17
+obs_default_location:
   <<: *DEFAULTS
   user: obs_default_location_user
   version: 1
@@ -230,7 +230,7 @@ obs_default_location: # 17
   east: -70.761
   south: 41.645
 
-california: # 18
+california:
   <<: *DEFAULTS
   created_at: 2017-12-18 14:39:23
   updated_at: 2017-12-18 14:39:23

--- a/test/fixtures/locations_versions.yml
+++ b/test/fixtures/locations_versions.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http_version_1://ar.rubyonrails.org/classes/Fixtures.html
 # location and user associations must be specified by id, not label
 
-albion_version_1: # 1
+albion_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:albion) %>
   updated_at: 2007-12-27 06:41:20
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -15,7 +15,7 @@ albion_version_1: # 1
   high: 100.0
   low: 0.0
 
-albion_version_2: # 2
+albion_version_2:
   location_id: <%= ActiveRecord::FixtureSet.identify(:albion) %>
   updated_at: 2007-12-27 06:41:20
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -29,7 +29,7 @@ albion_version_2: # 2
   high: 100.0
   low: 0.0
 
-burbank_version_1: # 3
+burbank_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:burbank) %>
   updated_at: 2007-12-27 06:47:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -43,7 +43,7 @@ burbank_version_1: # 3
   high: 294.0
   low: 148.0
 
-mitrula_marsh_version_1: # 4
+mitrula_marsh_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:mitrula_marsh) %>
   updated_at: 2007-12-27 06:47:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -55,7 +55,7 @@ mitrula_marsh_version_1: # 4
   east: -120.487
   south: 39.5184
 
-salt_point_version_1: # 5
+salt_point_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:salt_point) %>
   updated_at: 2007-12-27 06:47:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -69,7 +69,7 @@ salt_point_version_1: # 5
   high: 100.0
   low: 0.0
 
-gualala_version_1: # 6
+gualala_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:gualala) %>
   updated_at: 2007-12-27 06:47:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -83,7 +83,7 @@ gualala_version_1: # 6
   high: 100.0
   low: 0.0
 
-elgin_co_version_1: # 7
+elgin_co_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:elgin_co) %>
   updated_at: 2007-12-27 06:47:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -95,7 +95,7 @@ elgin_co_version_1: # 7
   east: -80.8044
   south: 42.4701
 
-brett_woods_version_1: # 8
+brett_woods_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:bretton_woods) %>
   updated_at: 2007-12-27 06:47:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -107,7 +107,7 @@ brett_woods_version_1: # 8
   east: -73.3215
   south: 41.1939
 
-point_reyes_version_1: # 9
+point_reyes_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:point_reyes) %>
   updated_at: 2008-01-01 11:50:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -119,7 +119,7 @@ point_reyes_version_1: # 9
   east: -122.7092
   south: 37.9255
 
-howarth_park_version_1: # 10
+howarth_park_version_1:
   location_id: <%= ActiveRecord::FixtureSet.identify(:howarth_park) %>
   updated_at: 2008-01-01 15:24:18
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -30,7 +30,7 @@ DEFAULTS: &DEFAULTS
   version:        1
   locked:         false
 
-fungi: # 1
+fungi:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Kingdom] %>
@@ -44,7 +44,7 @@ fungi: # 1
   updated_at: 2007-02-26 17:20:00
   locked: true
 
-coprinus: # 2
+coprinus:
   <<: *DEFAULTS
   description: coprinus_desc
   user: rolf
@@ -57,7 +57,7 @@ coprinus: # 2
   rank: <%= Name.ranks[:Genus] %>
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-coprinus_comatus: # 3
+coprinus_comatus:
   <<: *DEFAULTS
   description: coprinus_comatus_desc
   user: rolf
@@ -71,7 +71,7 @@ coprinus_comatus: # 3
   updated_at: 2007-02-27 20:48:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-stereum: # 4
+stereum:
   <<: *DEFAULTS
   text_name: Stereum
   display_name: '**__Stereum__**'
@@ -81,7 +81,7 @@ stereum: # 4
   updated_at: 2007-06-23 20:00:00
   rank: <%= Name.ranks[:Genus] %>
 
-stereum_hirsutum: # 5
+stereum_hirsutum:
   <<: *DEFAULTS
   text_name: Stereum hirsutum
   author: '(Willd.) Pers.'
@@ -91,7 +91,7 @@ stereum_hirsutum: # 5
   created_at: 2007-06-23 20:00:00
   updated_at: 2007-06-23 20:00:00
 
-tubaria: # 6
+tubaria:
   <<: *DEFAULTS
   text_name: Tubaria
   display_name: '**__Tubaria__**'
@@ -101,7 +101,7 @@ tubaria: # 6
   updated_at: 2007-06-23 20:00:00
   rank: <%= Name.ranks[:Genus] %>
 
-tubaria_furfuracea: # 7
+tubaria_furfuracea:
   <<: *DEFAULTS
   text_name: Tubaria furfuracea
   author: '(Pers.) Gillet'
@@ -111,7 +111,7 @@ tubaria_furfuracea: # 7
   created_at: 2007-06-23 20:00:00
   updated_at: 2007-06-23 20:00:00
 
-agaricus: # 8
+agaricus:
   <<: *DEFAULTS
   user: rolf
   text_name: Agaricus
@@ -123,7 +123,7 @@ agaricus: # 8
   rank: <%= Name.ranks[:Genus] %>
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-agaricus_campestris: # 9
+agaricus_campestris:
   <<: *DEFAULTS
   user: rolf
   text_name: Agaricus campestris
@@ -135,7 +135,7 @@ agaricus_campestris: # 9
   updated_at: 2007-03-19 17:20:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-conocybe: # 10
+conocybe:
   <<: *DEFAULTS
   user: rolf
   text_name: Conocybe
@@ -146,7 +146,7 @@ conocybe: # 10
   updated_at: 2007-03-19 15:51:00
   rank: <%= Name.ranks[:Genus] %>
 
-conocybe_filaris: # 11
+conocybe_filaris:
   <<: *DEFAULTS
   user: rolf
   text_name: Conocybe filaris
@@ -157,7 +157,7 @@ conocybe_filaris: # 11
   created_at: 2007-03-19 15:51:00
   updated_at: 2007-03-19 15:51:00
 
-amanita: # 12
+amanita:
   <<: *DEFAULTS
   user: rolf
   text_name: Amanita
@@ -168,7 +168,7 @@ amanita: # 12
   updated_at: 2007-04-09 08:53:30
   rank: <%= Name.ranks[:Genus] %>
 
-amanita_baccata_arora: # 13
+amanita_baccata_arora:
   <<: *DEFAULTS
   user: rolf
   text_name: Amanita baccata
@@ -179,7 +179,7 @@ amanita_baccata_arora: # 13
   created_at: 2007-04-09 08:53:30
   updated_at: 2007-04-09 08:53:30
 
-amanita_baccata_borealis: # 14
+amanita_baccata_borealis:
   <<: *DEFAULTS
   user: rolf
   text_name: Amanita baccata
@@ -190,7 +190,7 @@ amanita_baccata_borealis: # 14
   created_at: 2007-04-09 08:54:30
   updated_at: 2007-04-09 08:54:30
 
-lepiota: # 15
+lepiota:
   <<: *DEFAULTS
   user: rolf
   text_name: Lepiota
@@ -202,7 +202,7 @@ lepiota: # 15
   rank: <%= Name.ranks[:Genus] %>
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-lepiota_rachodes: # 16
+lepiota_rachodes:
   <<: *DEFAULTS
   user: rolf
   text_name: Lepiota rachodes
@@ -214,7 +214,7 @@ lepiota_rachodes: # 16
   updated_at: 2007-04-30 21:34:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-lepiota_rhacodes: # 17
+lepiota_rhacodes:
   <<: *DEFAULTS
   user: rolf
   text_name: Lepiota rhacodes
@@ -226,7 +226,7 @@ lepiota_rhacodes: # 17
   updated_at: 2007-04-30 21:34:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-macrolepiota: # 18
+macrolepiota:
   <<: *DEFAULTS
   user: rolf
   text_name: Macrolepiota
@@ -237,7 +237,7 @@ macrolepiota: # 18
   updated_at: 2007-04-30 21:34:00
   rank: <%= Name.ranks[:Genus] %>
 
-macrolepiota_rachodes: # 19
+macrolepiota_rachodes:
   <<: *DEFAULTS
   user: rolf
   text_name: Macrolepiota rachodes
@@ -250,7 +250,7 @@ macrolepiota_rachodes: # 19
   # later than rhacodes; used in test for best synonym
   updated_at: 2007-04-30 21:34:01
 
-macrolepiota_rhacodes: # 20
+macrolepiota_rhacodes:
   <<: *DEFAULTS
   user: mary
   text_name: Macrolepiota rhacodes
@@ -262,7 +262,7 @@ macrolepiota_rhacodes: # 20
   created_at: 2007-04-30 21:34:00
   updated_at: 2007-04-30 21:34:00
 
-chlorophyllum: # 21
+chlorophyllum:
   <<: *DEFAULTS
   user: rolf
   text_name: Chlorophyllum
@@ -274,7 +274,7 @@ chlorophyllum: # 21
   rank: <%= Name.ranks[:Genus] %>
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-chlorophyllum_rachodes: # 22
+chlorophyllum_rachodes:
   <<: *DEFAULTS
   user: rolf
   text_name: Chlorophyllum rachodes
@@ -287,7 +287,7 @@ chlorophyllum_rachodes: # 22
   updated_at: 2007-04-30 21:34:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-chlorophyllum_rhacodes: # 23
+chlorophyllum_rhacodes:
   <<: *DEFAULTS
   user: mary
   text_name: Chlorophyllum rhacodes
@@ -301,7 +301,7 @@ chlorophyllum_rhacodes: # 23
   updated_at: 2007-04-30 21:34:01
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-lactarius: # 24
+lactarius:
   <<: *DEFAULTS
   user: rolf
   text_name: Lactarius
@@ -312,7 +312,7 @@ lactarius: # 24
   updated_at: 2007-04-30 15:14:10
   rank: <%= Name.ranks[:Genus] %>
 
-lactarius_alpinus: # 25
+lactarius_alpinus:
   <<: *DEFAULTS
   user: rolf
   text_name: Lactarius alpinus
@@ -324,7 +324,7 @@ lactarius_alpinus: # 25
   created_at: 2007-04-30 15:14:10
   updated_at: 2007-04-30 15:14:10
 
-lactarius_alpigenes: # 26
+lactarius_alpigenes:
   <<: *DEFAULTS
   user: rolf
   text_name: Lactarius alpigenes
@@ -337,7 +337,7 @@ lactarius_alpigenes: # 26
   created_at: 2007-04-30 15:14:10
   updated_at: 2007-04-30 15:14:10
 
-lactarius_kuehneri: # 27
+lactarius_kuehneri:
   <<: *DEFAULTS
   user: rolf
   text_name: Lactarius kuehneri
@@ -350,7 +350,7 @@ lactarius_kuehneri: # 27
   created_at: 2007-04-30 15:14:10
   updated_at: 2007-04-30 15:14:10
 
-lactarius_subalpinus: # 28
+lactarius_subalpinus:
   <<: *DEFAULTS
   user: rolf
   text_name: Lactarius subalpinus
@@ -363,7 +363,7 @@ lactarius_subalpinus: # 28
   created_at: 2007-04-30 15:14:10
   updated_at: 2007-04-30 15:14:10
 
-psalliota: # 29
+psalliota:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Genus] %>
@@ -374,7 +374,7 @@ psalliota: # 29
   created_at: 2007-06-09 08:06:40
   updated_at: 2007-06-09 08:06:40
 
-agaricus_campestrus: # 30
+agaricus_campestrus:
   <<: *DEFAULTS
   user: rolf
   text_name: Agaricus campestrus
@@ -386,7 +386,7 @@ agaricus_campestrus: # 30
   updated_at: 2007-06-23 20:04:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-agaricus_campestras: # 31
+agaricus_campestras:
   <<: *DEFAULTS
   description: agaricus_campestras_desc
   user: rolf
@@ -399,7 +399,7 @@ agaricus_campestras: # 31
   updated_at: 2007-06-23 20:04:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-agaricus_campestros: # 32
+agaricus_campestros:
   <<: *DEFAULTS
   description: agaricus_campestros_desc
   user: rolf
@@ -412,7 +412,7 @@ agaricus_campestros: # 32
   updated_at: 2007-06-23 20:04:00
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
-coprinellus: # 33
+coprinellus:
   <<: *DEFAULTS
   user: rolf
   text_name: Coprinellus
@@ -423,7 +423,7 @@ coprinellus: # 33
   updated_at: 2007-06-24 12:45:55
   rank: <%= Name.ranks[:Genus] %>
 
-coprinellus_micaceus: # 34
+coprinellus_micaceus:
   <<: *DEFAULTS
   user: rolf
   version: 2
@@ -435,7 +435,7 @@ coprinellus_micaceus: # 34
   created_at: 2007-06-24 12:45:55
   updated_at: 2007-06-24 12:45:55
 
-coprinellus_micaceus_no_author: # 35
+coprinellus_micaceus_no_author:
   <<: *DEFAULTS
   user: rolf
   text_name: Coprinellus micaceus
@@ -445,7 +445,7 @@ coprinellus_micaceus_no_author: # 35
   created_at: 2007-06-24 12:45:55
   updated_at: 2007-06-24 12:45:55
 
-strobilurus: # 36
+strobilurus:
   <<: *DEFAULTS
   user: rolf
   text_name: Strobilurus
@@ -457,7 +457,7 @@ strobilurus: # 36
   rank: <%= Name.ranks[:Genus] %>
 
 # For testing when the author is added to a name that has an observation
-strobilurus_diminutivus_no_author: # 37
+strobilurus_diminutivus_no_author:
   <<: *DEFAULTS
   user: rolf
   text_name: Strobilurus diminutivus
@@ -467,7 +467,7 @@ strobilurus_diminutivus_no_author: # 37
   created_at: 2007-07-20 20:54:45
   updated_at: 2007-07-20 20:54:45
 
-pluteus: # 38
+pluteus:
   <<: *DEFAULTS
   user: rolf
   text_name: Pluteus
@@ -479,7 +479,7 @@ pluteus: # 38
   rank: <%= Name.ranks[:Genus] %>
 
 # For testing when there are both an approved and deprecated name with the same text name
-pluteus_petasatus_approved: # 39
+pluteus_petasatus_approved:
   <<: *DEFAULTS
   user: rolf
   text_name: Pluteus petasatus
@@ -491,7 +491,7 @@ pluteus_petasatus_approved: # 39
   updated_at: 2007-07-20 20:54:45
 
 # For testing the where the author is added when a name has an observation
-pluteus_petasatus_deprecated: # 40
+pluteus_petasatus_deprecated:
   <<: *DEFAULTS
   user: rolf
   text_name: Pluteus petasatus
@@ -503,7 +503,7 @@ pluteus_petasatus_deprecated: # 40
   created_at: 2007-07-20 21:12:45
   updated_at: 2007-07-20 21:12:45
 
-warnerbros: # 41
+warnerbros:
   <<: *DEFAULTS
   user: rolf
   text_name: Warnerbros
@@ -515,7 +515,7 @@ warnerbros: # 41
   rank: <%= Name.ranks[:Genus] %>
 
 # Two fake names with non-alphanumerics for severe stress-testing species lists.
-bugs_bunny_one: # 42
+bugs_bunny_one:
   <<: *DEFAULTS
   user: rolf
   author: One
@@ -526,7 +526,7 @@ bugs_bunny_one: # 42
   created_at: 2008-01-31 01:01:01
   updated_at: 2008-01-31 01:01:01
 
-bugs_bunny_two: # 43
+bugs_bunny_two:
   <<: *DEFAULTS
   user: rolf
   author: Two
@@ -537,7 +537,7 @@ bugs_bunny_two: # 43
   created_at: 2008-01-31 01:01:01
   updated_at: 2008-01-31 01:01:01
 
-russula: # 44
+russula:
   <<: *DEFAULTS
   user: rolf
   text_name: Russula
@@ -548,7 +548,7 @@ russula: # 44
   updated_at: 2008-03-10 22:31:27
   rank: <%= Name.ranks[:Genus] %>
 
-russula_brevipes_no_author: # 45
+russula_brevipes_no_author:
   <<: *DEFAULTS
   user: rolf
   text_name: Russula brevipes
@@ -558,7 +558,7 @@ russula_brevipes_no_author: # 45
   created_at: 2008-03-10 22:31:27
   updated_at: 2008-03-10 22:31:27
 
-russula_brevipes_author_notes: # 46
+russula_brevipes_author_notes:
   <<: *DEFAULTS
   description: russula_brevipes_author_notes_desc
   user: rolf
@@ -572,7 +572,7 @@ russula_brevipes_author_notes: # 46
   created_at: 2008-03-10 22:33:05
   updated_at: 2008-03-10 22:33:05
 
-russula_cremoricolor_no_author_notes: # 47
+russula_cremoricolor_no_author_notes:
   <<: *DEFAULTS
   description: russula_cremoricolor_no_author_notes_desc
   user: rolf
@@ -583,7 +583,7 @@ russula_cremoricolor_no_author_notes: # 47
   created_at: 2008-03-12 20:53:18
   updated_at: 2008-03-12 20:53:18
 
-russula_cremoricolor_author_notes: # 48
+russula_cremoricolor_author_notes:
   <<: *DEFAULTS
   description: russula_cremoricolor_author_notes_desc
   user: rolf
@@ -595,7 +595,7 @@ russula_cremoricolor_author_notes: # 48
   created_at: 2008-03-12 20:53:40
   updated_at: 2008-03-12 20:53:40
 
-lentinellus: # 49
+lentinellus:
   <<: *DEFAULTS
   user: rolf
   text_name: Lentinellus
@@ -606,7 +606,7 @@ lentinellus: # 49
   updated_at: 2008-03-19 08:35:37
   rank: <%= Name.ranks[:Genus] %>
 
-lentinellus_ursinus_author1: # 50
+lentinellus_ursinus_author1:
   <<: *DEFAULTS
   user: rolf
   text_name: Lentinellus ursinus
@@ -617,7 +617,7 @@ lentinellus_ursinus_author1: # 50
   created_at: 2008-03-19 08:35:37
   updated_at: 2008-03-19 08:35:37
 
-lentinellus_ursinus_author2: # 51
+lentinellus_ursinus_author2:
   <<: *DEFAULTS
   user: rolf
   text_name: Lentinellus ursinus
@@ -628,7 +628,7 @@ lentinellus_ursinus_author2: # 51
   created_at: 2008-03-19 08:35:37
   updated_at: 2008-03-19 08:35:37
 
-macrocybe: # 52
+macrocybe:
   <<: *DEFAULTS
   user: rolf
   text_name: Macrocybe
@@ -640,7 +640,7 @@ macrocybe: # 52
   rank: <%= Name.ranks[:Genus] %>
 
 # Genus with correct author
-macrocybe_pegler: # 53
+macrocybe_pegler:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Genus] %>
@@ -653,7 +653,7 @@ macrocybe_pegler: # 53
   updated_at: 2008-09-05 22:30:00
 
 # Genus with incorrect author
-macrocybe_titans: # 54
+macrocybe_titans:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Genus] %>
@@ -665,7 +665,7 @@ macrocybe_titans: # 54
   created_at: 2008-09-05 22:30:00
   updated_at: 2008-09-05 22:30:00
 
-boletus: # 55
+boletus:
   <<: *DEFAULTS
   text_name: Boletus
   display_name: '**__Boletus__**'
@@ -675,7 +675,7 @@ boletus: # 55
   updated_at: 2008-10-05 16:17:08
   rank: <%= Name.ranks[:Genus] %>
 
-boletus_edulis: # 56
+boletus_edulis:
   <<: *DEFAULTS
   text_name: Boletus edulis
   author: Bull.
@@ -686,7 +686,7 @@ boletus_edulis: # 56
   updated_at: 2008-10-05 16:17:08
   description: boletus_edulis_desc
 
-peltigera: # 57
+peltigera:
   <<: *DEFAULTS
   description: peltigera_desc
   user: rolf
@@ -704,7 +704,7 @@ peltigera: # 57
   updated_at: 2009-01-02 01:01:01
   lifeform: " lichen "
 
-petigera: # 58
+petigera:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Petigera
@@ -718,7 +718,7 @@ petigera: # 58
   updated_at: 2009-01-02 01:01:01
   lifeform: " lichen "
 
-suillus: # 59
+suillus:
   <<: *DEFAULTS
   description: suillus_desc
   rank: <%= Name.ranks[:Genus] %>
@@ -730,7 +730,7 @@ suillus: # 59
   created_at: 2009-10-12 21:30:01
   updated_at: 2009-10-12 21:30:01
 
-suillus_by_white: # 60
+suillus_by_white:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Suillus
@@ -742,7 +742,7 @@ suillus_by_white: # 60
   created_at: 2009-10-12 21:30:01
   updated_at: 2009-10-12 21:30:01
 
-suilus: # 61
+suilus:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Suilus
@@ -756,7 +756,7 @@ suilus: # 61
   created_at: 2009-10-12 21:30:01
   updated_at: 2009-10-12 21:30:01
 
-tremella: # 62
+tremella:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Genus] %>
@@ -769,7 +769,7 @@ tremella: # 62
   updated_at: 2010-10-18 21:30:01
   lifeform: " lichenicolous "
 
-tremella_mesenterica: # 63
+tremella_mesenterica:
   <<: *DEFAULTS
   user: rolf
   text_name: Tremella mesenterica
@@ -781,7 +781,7 @@ tremella_mesenterica: # 63
   updated_at: 2010-10-12 21:30:01
   lifeform: " lichenicolous "
 
-tremella_justpublished: # 64
+tremella_justpublished:
   <<: *DEFAULTS
   user: rolf
   text_name: Tremella justpublished
@@ -794,7 +794,7 @@ tremella_justpublished: # 64
   updated_at: 2010-12-18 21:30:01
   lifeform: " lichenicolous "
 
-hygrocybe: # 65
+hygrocybe:
   <<: *DEFAULTS
   user: rolf
   text_name: Hygrocybe
@@ -805,7 +805,7 @@ hygrocybe: # 65
   updated_at: 2011-02-18 21:30:01
   rank: <%= Name.ranks[:Genus] %>
 
-hygrocybe_russocoriacea_bad_author: # 66
+hygrocybe_russocoriacea_bad_author:
   <<: *DEFAULTS
   user: rolf
   text_name: Hygrocybe russocoriacea
@@ -817,7 +817,7 @@ hygrocybe_russocoriacea_bad_author: # 66
   created_at: 2011-02-18 21:30:01
   updated_at: 2011-02-18 21:30:01
 
-hygrocybe_russocoriacea_good_author: # 67
+hygrocybe_russocoriacea_good_author:
   <<: *DEFAULTS
   text_name: Hygrocybe russocoriacea
   search_name: Hygrocybe russocoriacea (Berk. & Jos.K. Mill.) P.D. Orton & Watling
@@ -827,7 +827,7 @@ hygrocybe_russocoriacea_good_author: # 67
   created_at: 2011-07-11 21:30:01
   updated_at: 2011-07-11 21:30:01
 
-lichen: # 68
+lichen:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Kingdom] %>
@@ -840,7 +840,7 @@ lichen: # 68
   updated_at: 2012-09-21 21:30:01
   lifeform: " lichen "
 
-abortiporus: # 69
+abortiporus:
   <<: *DEFAULTS
   text_name: Abortiporus
   display_name: '**__Abortiporus__**'
@@ -850,7 +850,7 @@ abortiporus: # 69
   updated_at: 2015-07-05 21:41:10
   rank: <%= Name.ranks[:Genus] %>
 
-abortiporus_biennis_for_eol: # 70
+abortiporus_biennis_for_eol:
   <<: *DEFAULTS
   text_name: Abortiporus biennis
   search_name: Abortiporus biennis (Bull.) Singer
@@ -860,7 +860,7 @@ abortiporus_biennis_for_eol: # 70
   created_at: 2015-07-05 21:41:10
   updated_at: 2015-07-05 21:41:10
 
-amanita_subgenus_lepidella: # 71
+amanita_subgenus_lepidella:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Subgenus] %>
   text_name: Amanita subgenus Lepidella
@@ -871,7 +871,7 @@ amanita_subgenus_lepidella: # 71
   created_at: 2015-09-17 21:30:01
   updated_at: 2015-09-17 21:30:01
 
-amanita_boudieri: # 72
+amanita_boudieri:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Species] %>
   text_name: Amanita boudieri
@@ -881,7 +881,7 @@ amanita_boudieri: # 72
   created_at: 2015-09-17 21:30:01
   updated_at: 2015-09-17 21:30:01
 
-amanita_boudieri_var_beillei: # 73
+amanita_boudieri_var_beillei:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Variety] %>
   text_name: Amanita boudieri var. beillei
@@ -891,7 +891,7 @@ amanita_boudieri_var_beillei: # 73
   created_at: 2015-09-17 21:30:01
   updated_at: 2015-09-17 21:30:01
 
-boletus_edulis_group: # 74
+boletus_edulis_group:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Group] %>
   text_name:         Boletus edulis group
@@ -901,7 +901,7 @@ boletus_edulis_group: # 74
   created_at: 2015-10-03 21:30:01
   updated_at: 2015-10-03 21:30:01
 
-imageless: # 75
+imageless:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Imageless
@@ -915,7 +915,7 @@ imageless: # 75
 # They are spellings suggested by lookup_name("Verpa").
 # NOTE: Verpa must not be used for any name, else the test will fail
 # because the lookup will find a match and not look for suggestions.
-suggested_by_verpa_authored: # 76
+suggested_by_verpa_authored:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Verpaa
@@ -926,7 +926,7 @@ suggested_by_verpa_authored: # 76
   created_at: 2016-08-23 21:30:01
   updated_at: 2016-08-23 21:30:01
 
-suggested_by_verpa_authorless: # 77
+suggested_by_verpa_authorless:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Verpaa
@@ -936,7 +936,7 @@ suggested_by_verpa_authorless: # 77
   created_at: 2016-09-01 21:30:01
   updated_at: 2016-09-01 21:30:01
 
-notification_but_no_observation: # 78
+notification_but_no_observation:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Genus] %>
   text_name: Mushroom
@@ -946,7 +946,7 @@ notification_but_no_observation: # 78
   created_at: 2016-09-03 21:30:01
   updated_at: 2016-09-03 21:30:01
 
-xa_genus: # 79
+xa_genus:
   <<: *DEFAULTS
   text_name:    Xa
   display_name: "**__Xa__**"
@@ -958,7 +958,7 @@ xa_genus: # 79
 
 # Next three Names for constructing an Observation with all Namings (and Votes)
 # for deprecated Names which are synonyms of same current Name
-namings_deprecated: # 80
+namings_deprecated:
   <<: *DEFAULTS
   text_name:    Xa current
   display_name: "**__Xa current__**"
@@ -968,7 +968,7 @@ namings_deprecated: # 80
   created_at:   2016-09-05 21:30:01
   updated_at:   2016-09-05 21:30:01
 
-namings_deprecated_1: # 81
+namings_deprecated_1:
   <<: *DEFAULTS
   text_name:    Xa deprecatedone
   display_name: "**__Xa deprecatedone__**"
@@ -979,7 +979,7 @@ namings_deprecated_1: # 81
   created_at:   2016-09-07 21:30:01
   updated_at:   2016-09-07 21:30:01
 
-namings_deprecated_2: # 82
+namings_deprecated_2:
   <<: *DEFAULTS
   text_name:    Xa deprecatedtwo
   display_name: "**__Xa deprecatedtwo__**"
@@ -991,7 +991,7 @@ namings_deprecated_2: # 82
   updated_at:   2016-09-09 21:30:01
 
 # For test of edit forcing creating of two ancestors
-two_ancestors: # 83
+two_ancestors:
   <<: *DEFAULTS
   rank:              <%= Name.ranks[:Variety] %>
   text_name:         Coprinellus micaceus var. phony
@@ -1001,7 +1001,7 @@ two_ancestors: # 83
   created_at:        2016-09-11 21:30:01
   updated_at:        2016-09-11 21:30:01
 
-mergeable_genus: # 84
+mergeable_genus:
   <<: *DEFAULTS
   text_name:         Mergeable
   search_name:       Mergeable
@@ -1011,7 +1011,7 @@ mergeable_genus: # 84
   updated_at:        2016-09-11 21:30:01
   rank:          <%= Name.ranks[:Genus] %>
 
-mergeable_no_notes: # 85
+mergeable_no_notes:
   <<: *DEFAULTS
   text_name:         Mergeable noteless
   search_name:       Mergeable noteless
@@ -1020,7 +1020,7 @@ mergeable_no_notes: # 85
   created_at:        2016-09-11 21:30:01
   updated_at:        2016-09-11 21:30:01
 
-mergeable_description_notes: # 86
+mergeable_description_notes:
   <<: *DEFAULTS
   text_name:         Mergeable description-notes
   search_name:       Mergeable description-notes
@@ -1030,7 +1030,7 @@ mergeable_description_notes: # 86
   created_at:        2016-09-11 21:30:01
   updated_at:        2016-09-11 21:30:01
 
-mergeable_second_description_notes: # 87
+mergeable_second_description_notes:
   <<: *DEFAULTS
   text_name:         Mergeable second-description-notes
   search_name:       Mergeable second-description-notes
@@ -1040,7 +1040,7 @@ mergeable_second_description_notes: # 87
   created_at:        2016-09-11 21:30:01
   updated_at:        2016-09-11 21:30:01
 
-mergeable_epithet_unauthored: # 88
+mergeable_epithet_unauthored:
   <<: *DEFAULTS
   text_name:         Mergeable epithet
   search_name:       Mergeable epithet
@@ -1049,7 +1049,7 @@ mergeable_epithet_unauthored: # 88
   created_at:        2016-09-11 21:30:01
   updated_at:        2016-09-11 21:30:01
 
-mergeable_epithet_authored: # 89
+mergeable_epithet_authored:
   <<: *DEFAULTS
   author:            Authored
   text_name:         Mergeable epithet
@@ -1059,7 +1059,7 @@ mergeable_epithet_authored: # 89
   created_at:        2016-09-11 21:30:01
   updated_at:        2016-09-11 21:30:01
 
-authored_with_naming: # 90
+authored_with_naming:
   <<: *DEFAULTS
   text_name:         Psalliota naming
   search_name:       Psalliota naming Authored
@@ -1068,7 +1068,7 @@ authored_with_naming: # 90
   created_at:        2017-01-11 21:30:01
   updated_at:        2017-01-11 21:30:01
 
-unauthored_with_naming: # 91
+unauthored_with_naming:
   <<: *DEFAULTS
   text_name:         Psalliota naming
   search_name:       Psalliota naming
@@ -1078,7 +1078,7 @@ unauthored_with_naming: # 91
   updated_at:        2017-01-11 21:30:01
 
 # dick owns the Name and Observation, but mary owns a Naming
-other_user_owns_naming_name: # 92
+other_user_owns_naming_name:
   <<: *DEFAULTS
   text_name:         Otheruserownsnaming
   search_name:       Otheruserownsnaming
@@ -1090,7 +1090,7 @@ other_user_owns_naming_name: # 92
   updated_at:        2017-03-11 21:30:01
 
 # dick owns the Name and Naming, but mary owns an Observation
-other_user_owns_observation: # 93
+other_user_owns_observation:
   <<: *DEFAULTS
   text_name:         Otheruserownsobs
   search_name:       Otheruserownsobs
@@ -1102,7 +1102,7 @@ other_user_owns_observation: # 93
   updated_at:        2017-03-11 21:30:01
 
 # dick owns the Name and the only Observation and Naming
-same_user_owns_naming_and_observation: # 94
+same_user_owns_naming_and_observation:
   <<: *DEFAULTS
   text_name:         Sameuserownsnamingandobservation
   search_name:       Sameuserownsnamingandobservation
@@ -1113,7 +1113,7 @@ same_user_owns_naming_and_observation: # 94
   created_at:        2017-04-03 21:30:01
   updated_at:        2017-04-03 21:30:01
 
-authored_group: # 95
+authored_group:
   <<: *DEFAULTS
   rank:              <%= Name.ranks[:Group] %>
   text_name:         Groupauthored group
@@ -1124,7 +1124,7 @@ authored_group: # 95
   created_at:        2017-05-03 21:30:01
   updated_at:        2017-05-03 21:30:01
 
-unauthored_group: # 96
+unauthored_group:
   <<: *DEFAULTS
   rank:              <%= Name.ranks[:Group] %>
   text_name:         Groupunauthored group
@@ -1134,7 +1134,7 @@ unauthored_group: # 96
   created_at:        2017-05-03 21:30:02
   updated_at:        2017-05-03 21:30:02
 
-basidiomycota: # 97
+basidiomycota:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Phylum] %>
@@ -1146,7 +1146,7 @@ basidiomycota: # 97
   updated_at: 2017-12-07 16:09:02
   classification: "Kingdom: _Fungi_"
 
-basidiomycetes: # 98
+basidiomycetes:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Class] %>
@@ -1158,7 +1158,7 @@ basidiomycetes: # 98
   updated_at: 2017-12-07 16:09:03
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_"
 
-agaricales: # 99
+agaricales:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Order] %>
@@ -1170,7 +1170,7 @@ agaricales: # 99
   updated_at: 2017-12-07 16:09:04
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_"
 
-agaricaceae: # 100
+agaricaceae:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Family] %>
@@ -1182,7 +1182,7 @@ agaricaceae: # 100
   updated_at: 2017-12-07 16:09:05
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_"
 
-ascomycota: # 101
+ascomycota:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Phylum] %>
@@ -1194,7 +1194,7 @@ ascomycota: # 101
   updated_at: 2017-12-07 16:09:06
   classification: "Kingdom: _Fungi_"
 
-ascomycetes: # 102
+ascomycetes:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Class] %>
@@ -1206,7 +1206,7 @@ ascomycetes: # 102
   updated_at: 2017-12-07 16:09:07
   classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_"
 
-lecanorales: # 103
+lecanorales:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Order] %>
@@ -1219,7 +1219,7 @@ lecanorales: # 103
   classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_"
   lifeform: " lichen "
 
-peltigeraceae: # 104
+peltigeraceae:
   <<: *DEFAULTS
   user: rolf
   rank: <%= Name.ranks[:Family] %>

--- a/test/fixtures/names_versions.yml
+++ b/test/fixtures/names_versions.yml
@@ -1,6 +1,6 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
-fungi_version_1: # 1
+fungi_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:fungi) %>
   updated_at: 2007-02-26 17:20:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -12,7 +12,7 @@ fungi_version_1: # 1
   sort_name: Fungi sp.
   citation: ''
 
-coprinus_comatus_version_1: # 2
+coprinus_comatus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:coprinus_comatus) %>
   updated_at: 2007-02-26 20:48:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -23,7 +23,7 @@ coprinus_comatus_version_1: # 2
   search_name: Coprinus comatus
   sort_name: Coprinus comatus
 
-coprinus_comatus_version_2: # 3
+coprinus_comatus_version_2:
   name_id: <%= ActiveRecord::FixtureSet.identify(:coprinus_comatus) %>
   updated_at: 2007-02-27 20:48:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -36,7 +36,7 @@ coprinus_comatus_version_2: # 3
   sort_name: Coprinus comatus (O.F. Müll.) Pers.
   citation: ''
 
-agaricus_campestris_version_1: # 4
+agaricus_campestris_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:agaricus_campestris) %>
   updated_at: 2007-03-19 17:20:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -49,7 +49,7 @@ agaricus_campestris_version_1: # 4
   sort_name: Agaricus campestris L.
   citation: ''
 
-conocybe_filaris_version_1: # 5
+conocybe_filaris_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:conocybe_filaris) %>
   updated_at: 2007-03-19 15:51:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -62,7 +62,7 @@ conocybe_filaris_version_1: # 5
   sort_name: Conocybe filaris
   citation: ''
 
-amanita_baccata_arora_version_1: # 6
+amanita_baccata_arora_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:amanita_baccata_arora) %>
   updated_at: 2007-04-09 08:53:30
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -75,7 +75,7 @@ amanita_baccata_arora_version_1: # 6
   sort_name: Amanita baccata sensu Arora
   citation: ''
 
-amanita_baccata_borealis_version_1: # 7
+amanita_baccata_borealis_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:amanita_baccata_borealis) %>
   updated_at: 2007-04-09 08:54:30
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -88,7 +88,7 @@ amanita_baccata_borealis_version_1: # 7
   sort_name: Amanita baccata sensu Borealis
   citation: ''
 
-lepiota_rachodes_version_1: # 8
+lepiota_rachodes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lepiota_rachodes) %>
   updated_at: 2007-04-30 21:34:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -101,7 +101,7 @@ lepiota_rachodes_version_1: # 8
   sort_name: Lepiota rachodes Vittad.
   citation: ''
 
-lepiota_rhacodes_version_1: # 9
+lepiota_rhacodes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lepiota_rhacodes) %>
   updated_at: 2007-04-30 21:34:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -114,7 +114,7 @@ lepiota_rhacodes_version_1: # 9
   sort_name: Lepiota rhacodes Vittad.
   citation: ''
 
-macrolepiota_rachodes_version_1: # 10
+macrolepiota_rachodes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:macrolepiota_rachodes) %>
   updated_at: 2007-04-30 21:34:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -127,7 +127,7 @@ macrolepiota_rachodes_version_1: # 10
   sort_name: Macrolepiota rachodes (Vittad.) Singer
   citation: ''
 
-macrolepiota_rhacodes_version_1: # 11
+macrolepiota_rhacodes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:macrolepiota_rhacodes) %>
   updated_at: 2007-04-30 21:34:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:mary) %>
@@ -140,7 +140,7 @@ macrolepiota_rhacodes_version_1: # 11
   sort_name: Macrolepiota rhacodes (Vittad.) Singer
   citation: ''
 
-chlorophyllum_rachodes_version_1: # 12
+chlorophyllum_rachodes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:chlorophyllum_rachodes) %>
   updated_at: 2007-04-30 21:34:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -153,7 +153,7 @@ chlorophyllum_rachodes_version_1: # 12
   sort_name: Chlorophyllum rachodes (Vittad.) Vellinga
   citation: ''
 
-chlorophyllum_rhacodes_version_1: # 13
+chlorophyllum_rhacodes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:chlorophyllum_rhacodes) %>
   updated_at: 2007-04-30 21:34:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:mary) %>
@@ -166,7 +166,7 @@ chlorophyllum_rhacodes_version_1: # 13
   sort_name: Chlorophyllum rhacodes (Vittad.) Vellinga
   citation: ''
 
-lactarius_alpinus_version_1: # 14
+lactarius_alpinus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lactarius_alpinus) %>
   updated_at: 2007-04-30 15:14:10
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -179,7 +179,7 @@ lactarius_alpinus_version_1: # 14
   sort_name: Lactarius alpinus Peck
   citation: ''
 
-lactarius_alpigenes_version_1: # 15
+lactarius_alpigenes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lactarius_alpigenes) %>
   updated_at: 2007-04-30 15:14:10
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -193,7 +193,7 @@ lactarius_alpigenes_version_1: # 15
   deprecated: 1
   citation: ''
 
-lactarius_kuehneri_version_1: # 16
+lactarius_kuehneri_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lactarius_kuehneri) %>
   updated_at: 2007-04-30 15:14:10
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -207,7 +207,7 @@ lactarius_kuehneri_version_1: # 16
   deprecated: 1
   citation: ''
 
-lactarius_subalpinus_version_1: # 17
+lactarius_subalpinus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lactarius_subalpinus) %>
   updated_at: 2007-04-30 15:14:10
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -221,7 +221,7 @@ lactarius_subalpinus_version_1: # 17
   deprecated: 1
   citation: ''
 
-psalliota_version_1: # 18
+psalliota_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:psalliota) %>
   updated_at: 2007-06-09 08:06:40
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -233,7 +233,7 @@ psalliota_version_1: # 18
   sort_name: Psalliota sp.
   citation: ''
 
-agaricus_version_1: # 19
+agaricus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:agaricus) %>
   updated_at: 2007-06-09 08:06:40
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -245,7 +245,7 @@ agaricus_version_1: # 19
   sort_name: Agaricus sp.
   citation: ''
 
-agaricus_campestrus_version_1: # 20
+agaricus_campestrus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:agaricus_campestrus) %>
   updated_at: 2007-06-23 20:04:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -258,7 +258,7 @@ agaricus_campestrus_version_1: # 20
   sort_name: Agaricus campestrus L.
   citation: ''
 
-agaricus_campestras_version_1: # 21
+agaricus_campestras_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:agaricus_campestras) %>
   updated_at: 2007-06-23 20:04:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -271,7 +271,7 @@ agaricus_campestras_version_1: # 21
   sort_name: Agaricus campestras L.
   citation: ''
 
-agaricus_campestros_version_1: # 22
+agaricus_campestros_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:agaricus_campestros) %>
   updated_at: 2007-06-23 20:04:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -284,7 +284,7 @@ agaricus_campestros_version_1: # 22
   sort_name: Agaricus campestros L.
   citation: ''
 
-coprinellus_micaceus_version_1: # 23
+coprinellus_micaceus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:coprinellus_micaceus) %>
   updated_at: 2007-06-24 12:45:55
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -295,7 +295,7 @@ coprinellus_micaceus_version_1: # 23
   search_name: Coprinellus micaceus
   sort_name: Coprinellus micaceus
 
-coprinellus_micaceus_version_2: # 24
+coprinellus_micaceus_version_2:
   name_id: <%= ActiveRecord::FixtureSet.identify(:coprinellus_micaceus) %>
   updated_at: 2007-06-24 12:45:55
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -308,7 +308,7 @@ coprinellus_micaceus_version_2: # 24
   sort_name: Coprinellus micaceus (Bull.) Vilgalys, Hopple & Jacq. Johnson
   citation: ''
 
-coprinellus_micaceus_no_author_version_1: # 25
+coprinellus_micaceus_no_author_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:coprinellus_micaceus_no_author) %>
   updated_at: 2007-06-24 12:45:55
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -321,7 +321,7 @@ coprinellus_micaceus_no_author_version_1: # 25
   sort_name: Coprinellus micaceus
   citation: ''
 
-strobilurus_diminutivus_no_author_version_1: # 26
+strobilurus_diminutivus_no_author_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:strobilurus_diminutivus_no_author) %>
   updated_at: 2007-07-20 20:54:45
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -333,7 +333,7 @@ strobilurus_diminutivus_no_author_version_1: # 26
   sort_name: Strobilurus diminutivus
   citation: ''
 
-pluteus_petasatus_approved_version_1: # 27
+pluteus_petasatus_approved_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:pluteus_petasatus_approved) %>
   updated_at: 2007-07-20 20:54:45
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -346,7 +346,7 @@ pluteus_petasatus_approved_version_1: # 27
   sort_name: Pluteus petasatus (Fr.) Gillet
   citation: ''
 
-pluteus_petasatus_deprecated_version_1: # 28
+pluteus_petasatus_deprecated_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:pluteus_petasatus_deprecated) %>
   updated_at: 2007-07-20 21:12:45
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -360,7 +360,7 @@ pluteus_petasatus_deprecated_version_1: # 28
   deprecated: 1
   citation: ''
 
-lepiota_version_1: # 29
+lepiota_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lepiota) %>
   updated_at: 2007-07-30 08:06:40
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -372,7 +372,7 @@ lepiota_version_1: # 29
   sort_name: Lepiota sp.
   citation: ''
 
-chlorophyllum_version_1: # 30
+chlorophyllum_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:chlorophyllum) %>
   updated_at: 2007-07-30 22:06:40
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -384,7 +384,7 @@ chlorophyllum_version_1: # 30
   sort_name: Chlorophyllum sp.
   citation: ''
 
-bugs_bunny_one_version_1: # 31
+bugs_bunny_one_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:bugs_bunny_one) %>
   updated_at: 2008-01-31 01:01:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -397,7 +397,7 @@ bugs_bunny_one_version_1: # 31
   sort_name: Warnerbros bugs-bunny One
   citation: ''
 
-bugs_bunny_two_version_1: # 32
+bugs_bunny_two_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:bugs_bunny_two) %>
   updated_at: 2008-01-31 01:01:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -410,7 +410,7 @@ bugs_bunny_two_version_1: # 32
   sort_name: Warnerbros bugs-bunny Two
   citation: ''
 
-russula_brevipes_no_author_version_1: # 33
+russula_brevipes_no_author_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:russula_brevipes_no_author) %>
   updated_at: 2008-03-10 22:31:27
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -422,7 +422,7 @@ russula_brevipes_no_author_version_1: # 33
   sort_name: Russula brevipes
   citation: ''
 
-russula_brevipes_author_notes_version_1: # 34
+russula_brevipes_author_notes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:russula_brevipes_author_notes) %>
   updated_at: 2008-03-10 22:33:05
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -435,7 +435,7 @@ russula_brevipes_author_notes_version_1: # 34
   sort_name: Russula brevipes Peck
   citation: ''
 
-russula_cremoricolor_no_author_notes_version_1: # 35
+russula_cremoricolor_no_author_notes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:russula_cremoricolor_no_author_notes) %>
   updated_at: 2008-03-12 20:53:18
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -447,7 +447,7 @@ russula_cremoricolor_no_author_notes_version_1: # 35
   sort_name: Russula cremoricolor
   citation: ''
 
-russula_cremoricolor_author_notes_version_1: # 36
+russula_cremoricolor_author_notes_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:russula_cremoricolor_author_notes) %>
   updated_at: 2008-03-12 20:53:40
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -460,7 +460,7 @@ russula_cremoricolor_author_notes_version_1: # 36
   sort_name: Russula cremoricolor Earle
   citation: ''
 
-lentinellus_ursinus_author1_version_1: # 37
+lentinellus_ursinus_author1_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lentinellus_ursinus_author1) %>
   updated_at: 2008-03-19 08:35:37
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -473,7 +473,7 @@ lentinellus_ursinus_author1_version_1: # 37
   sort_name: Lentinellus ursinus Kühner
   citation: ''
 
-lentinellus_ursinus_author2_version_1: # 38
+lentinellus_ursinus_author2_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:lentinellus_ursinus_author2) %>
   updated_at: 2008-03-19 08:35:37
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -486,7 +486,7 @@ lentinellus_ursinus_author2_version_1: # 38
   sort_name: Lentinellus ursinus Kuhner
   citation: ''
 
-macrocybe_pegler_version_1: # 39
+macrocybe_pegler_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:macrocybe_pegler) %>
   updated_at: 2008-09-05 22:30:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -499,7 +499,7 @@ macrocybe_pegler_version_1: # 39
   sort_name: Macrocybe sp.
   citation: ''
 
-macrocybe_titans_version_1: # 40
+macrocybe_titans_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:macrocybe_titans) %>
   updated_at: 2008-09-05 22:30:00
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -512,7 +512,7 @@ macrocybe_titans_version_1: # 40
   sort_name: Macrocybe sp. Titans
   citation: ''
 
-boletus_edulis_version_1: # 41
+boletus_edulis_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:boletus_edulis) %>
   updated_at: 2008-10-05 16:17:08
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
@@ -525,7 +525,7 @@ boletus_edulis_version_1: # 41
   sort_name: Boletus edulis Bull.
   citation: ''
 
-peltigera_version_1: # 42
+peltigera_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:peltigera) %>
   updated_at: 2009-01-01 01:01:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
@@ -537,7 +537,7 @@ peltigera_version_1: # 42
   sort_name: Petigera
   deprecated: 1
 
-peltigera_version_2: # 43
+peltigera_version_2:
   name_id: <%= ActiveRecord::FixtureSet.identify(:peltigera) %>
   updated_at: 2009-01-02 01:01:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
@@ -550,7 +550,7 @@ peltigera_version_2: # 43
   search_name: Peltigera sp. (Old) New Auth.
   sort_name: Peltigera sp. (Old) New Auth.
 
-petigera_version_1: # 44
+petigera_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:petigera) %>
   updated_at: 2009-01-02 01:01:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
@@ -564,7 +564,7 @@ petigera_version_1: # 44
   deprecated: true
   citation: ''
 
-suillus_version_1: # 45
+suillus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:suillus) %>
   updated_at: 2009-10-12 21:30:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
@@ -577,7 +577,7 @@ suillus_version_1: # 45
   sort_name: Suillus sp. Gray
   citation: ''
 
-suillus_by_white_version_1: # 46
+suillus_by_white_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:suillus_by_white) %>
   updated_at: 2009-10-12 21:30:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
@@ -590,7 +590,7 @@ suillus_by_white_version_1: # 46
   sort_name: Suillus sp. E.B. White
   citation: ''
 
-suilus_version_1: # 47
+suilus_version_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:suilus) %>
   updated_at: 2009-10-12 21:30:01
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
@@ -605,7 +605,7 @@ suilus_version_1: # 47
   deprecated: true
   citation: ''
 
-abortiporus_biennis_1: # 48
+abortiporus_biennis_1:
   name_id: <%= ActiveRecord::FixtureSet.identify(:abortiporus_biennis_for_eol) %>
   version: 1
   updated_at: 2015-07-05 21:41:10

--- a/test/fixtures/namings.yml
+++ b/test/fixtures/namings.yml
@@ -3,51 +3,51 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-minimal_unknown_naming: # 1
+minimal_unknown_naming:
   user: mary
   name: fungi
   observation: minimal_unknown_obs
 
-detailed_unknown_naming: # 2
+detailed_unknown_naming:
   user: mary
   name: fungi
   observation: detailed_unknown_obs
 
-coprinus_comatus_naming: # 3
+coprinus_comatus_naming:
   user: rolf
   name: coprinus_comatus
   observation: coprinus_comatus_obs
   vote_cache: 1
   reasons: "---\n1: Isn't it obvious?\n"
 
-agaricus_campestris_naming: # 4
+agaricus_campestris_naming:
   user: rolf
   name: agaricus_campestris
   observation: agaricus_campestris_obs
 
-agaricus_campestrus_naming: # 5
+agaricus_campestrus_naming:
   user: rolf
   name: agaricus_campestrus
   observation: agaricus_campestrus_obs
 
-agaricus_campestras_naming: # 6
+agaricus_campestras_naming:
   user: rolf
   name: agaricus_campestras
   observation: agaricus_campestras_obs
 
-agaricus_campestros_naming: # 7
+agaricus_campestros_naming:
   user: rolf
   name: agaricus_campestros
   observation: agaricus_campestros_obs
 
-strobilurus_diminutivus_naming: # 8
+strobilurus_diminutivus_naming:
   user: rolf
   name: strobilurus_diminutivus_no_author
   observation: strobilurus_diminutivus_obs
   vote_cache: 0
 
 # dates are hard-coded expects in AccountMailerTest test_name_proposal_email
-coprinus_comatus_other_naming: # 9
+coprinus_comatus_other_naming:
   created_at: 2007-02-28 20:20:00
   updated_at: 2007-02-28 20:21:00
   user: mary
@@ -55,53 +55,53 @@ coprinus_comatus_other_naming: # 9
   observation: coprinus_comatus_obs
   reasons: "---\n1: \"\"\n2: I asked *Uncle Herb*\n"
 
-boletus_edulis_naming: # 10
+boletus_edulis_naming:
   user: dick
   name: boletus_edulis
   observation: owner_only_favorite_eq_consensus
 
-tremella_naming: # 11
+tremella_naming:
   user: junk
   name: tremella
   observation: owner_only_favorite_ne_consensus
 
-tremella_mesenterica_naming: # 12
+tremella_mesenterica_naming:
   user: dick
   name: tremella_mesenterica
   observation: owner_only_favorite_ne_consensus
 
-owner_multiple_favorites_first_naming: # 13
+owner_multiple_favorites_first_naming:
   user: dick
   name: tremella
   observation: owner_multiple_favorites
 
-owner_multiple_favorites_second_naming: # 14
+owner_multiple_favorites_second_naming:
   user: dick
   name: tremella_mesenterica
   observation: owner_multiple_favorites
 
-owner_uncertain_favorite_naming: # 15
+owner_uncertain_favorite_naming:
   user: dick
   name: tremella_mesenterica
   observation: owner_uncertain_favorite
 
-unequal_positive_namings_top_naming: # 16
+unequal_positive_namings_top_naming:
   user: dick
   name: tremella_mesenterica
   observation: unequal_positive_namings_obs
 
-unequal_positive_namings_2nd_naming: # 17
+unequal_positive_namings_2nd_naming:
   user: dick
   name: tremella
   observation: unequal_positive_namings_obs
 
-all_namings_deprecated_winning_naming: # 18
+all_namings_deprecated_winning_naming:
   user:        dick
   observation: all_namings_deprecated_obs
   name:        namings_deprecated_1
   vote_cache:  <%= Vote.maximum_vote %>
 
-all_namings_deprecated_other_naming: # 19
+all_namings_deprecated_other_naming:
   # Manually set id low in order to improve test coverage of consensus_naming.
   # (This avoid Rails' generating the id via hashing the fixture label.)
   # Coverage is improved when this Naming appears before the winning one
@@ -113,34 +113,34 @@ all_namings_deprecated_other_naming: # 19
   name:        namings_deprecated_2
   vote_cache:  <%= Vote.next_best_vote %>
 
-authored_with_naming_obs_authored_naming: # 20
+authored_with_naming_obs_authored_naming:
   user:        rolf
   observation: authored_with_naming_obs
   name:        authored_with_naming
   vote_cache:  <%= Vote.maximum_vote %>
 
-authored_with_naming_obs_unauthored_naming: # 21
+authored_with_naming_obs_unauthored_naming:
   user:        dick
   observation: authored_with_naming_obs
   name:        unauthored_with_naming
   vote_cache:  <%= Vote.next_best_vote %>
 
 # dick owns the Name and Observation, but mary owns a Naming
-other_user_owns_naming: # 22
+other_user_owns_naming:
   user:        mary
   observation: other_user_owns_naming_obs
   name:        other_user_owns_naming_name
   vote_cache:  <%= Vote.next_best_vote %>
 
 # dick owns the Name and Naming, but mary owns an Observation
-other_user_owns_obs_naming: # 23
+other_user_owns_obs_naming:
   user:        dick
   observation: other_user_owns_obs
   name:        other_user_owns_observation
   vote_cache:  <%= Vote.next_best_vote %>
 
 # dick owns the Name and the only Observation and Naming
-same_user_owns_name_and_observation: # 24
+same_user_owns_name_and_observation:
   user:        dick
   observation: same_user_owns_name_and_naming_obs
   name:        same_user_owns_naming_and_observation

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -8,21 +8,21 @@ DEFAULTS: &DEFAULTS
   flavor: <%= Notification.flavors[:name] %>
   obj_id: <%= ActiveRecord::FixtureSet.identify(:agaricus_campestris) %>
 
-coprinus_comatus_notification: # 1
+coprinus_comatus_notification:
   <<: *DEFAULTS
   user: rolf
   obj_id: <%= ActiveRecord::FixtureSet.identify(:coprinus_comatus) %>
 
-agaricus_campestris_notification_with_note: # 2
+agaricus_campestris_notification_with_note:
   <<: *DEFAULTS
   user: mary
   note_template: A note about :observation for :observer. Please send to :mailing_address.
 
-agaricus_campestris_notification_without_note: # 3
+agaricus_campestris_notification_without_note:
   <<: *DEFAULTS
   user: katrina
 
-no_observation_notification: # 4
+no_observation_notification:
   <<: *DEFAULTS
   user: dick
   obj_id: <%= ActiveRecord::FixtureSet.identify(:notification_but_no_observation) %>

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -23,7 +23,7 @@ DEFAULTS: &DEFAULTS
   text_name: Boletus edulis
   classification: ""
 
-minimal_unknown_obs: # 1
+minimal_unknown_obs:
   <<: *DEFAULTS
   created_at: 2005-05-12 17:20:00
   updated_at: 2005-05-12 17:21:00
@@ -37,7 +37,7 @@ minimal_unknown_obs: # 1
   herbarium_records: interesting_unknown
   collection_numbers: minimal_unknown_coll_num
 
-detailed_unknown_obs: # 2
+detailed_unknown_obs:
   <<: *DEFAULTS
   created_at: 2006-05-12 17:20:00
   updated_at: 2006-05-12 17:21:00
@@ -57,7 +57,7 @@ detailed_unknown_obs: # 2
   herbarium_records: interesting_unknown, mycoflora_record
   collection_numbers: detailed_unknown_coll_num_one, detailed_unknown_coll_num_two
 
-coprinus_comatus_obs: # 3
+coprinus_comatus_obs:
   <<: *DEFAULTS
   created_at: 2007-02-27 20:20:00
   updated_at: 2007-02-27 20:21:00
@@ -78,7 +78,7 @@ coprinus_comatus_obs: # 3
   herbarium_records: coprinus_comatus_nybg_spec, coprinus_comatus_rolf_spec
   collection_numbers: coprinus_comatus_coll_num
 
-agaricus_campestris_obs: # 4
+agaricus_campestris_obs:
   <<: *DEFAULTS
   created_at: 2007-03-19 20:20:00
   updated_at: 2007-03-19 20:21:00
@@ -97,7 +97,7 @@ agaricus_campestris_obs: # 4
   herbarium_records: agaricus_campestris_spec
   collection_numbers: agaricus_campestris_coll_num
 
-agaricus_campestrus_obs: # 5
+agaricus_campestrus_obs:
   <<: *DEFAULTS
   created_at: 2007-06-23 20:00:00
   updated_at: 2007-06-23 20:00:00
@@ -111,7 +111,7 @@ agaricus_campestrus_obs: # 5
   notes:
     :Other: From somewhere else
 
-agaricus_campestras_obs: # 6
+agaricus_campestras_obs:
   <<: *DEFAULTS
   created_at: 2007-06-24 12:00:00
   updated_at: 2007-06-24 12:00:00
@@ -125,7 +125,7 @@ agaricus_campestras_obs: # 6
   notes:
     :Other: From somewhere else
 
-agaricus_campestros_obs: # 7
+agaricus_campestros_obs:
   <<: *DEFAULTS
   created_at: 2007-06-24 12:00:00
   updated_at: 2007-06-24 12:00:00
@@ -139,7 +139,7 @@ agaricus_campestros_obs: # 7
   notes:
     :Other: From somewhere else
 
-strobilurus_diminutivus_obs: # 8
+strobilurus_diminutivus_obs:
   <<: *DEFAULTS
   created_at: 2007-07-20 20:54:45
   updated_at: 2007-07-20 20:54:45
@@ -152,7 +152,7 @@ strobilurus_diminutivus_obs: # 8
   notes:
     :Other: From somewhere else
 
-stereum_hirsutum_1: # 9
+stereum_hirsutum_1:
   <<: *DEFAULTS
   when: 2017-06-23
   location: burbank
@@ -161,7 +161,7 @@ stereum_hirsutum_1: # 9
   name: stereum_hirsutum
   text_name: Stereum hirsutum
 
-stereum_hirsutum_2: # 10
+stereum_hirsutum_2:
   <<: *DEFAULTS
   when: 2017-06-24
   location: burbank
@@ -170,7 +170,7 @@ stereum_hirsutum_2: # 10
   name: stereum_hirsutum
   text_name: Stereum hirsutum
 
-tubaria_furfuracea_1: # 11
+tubaria_furfuracea_1:
   <<: *DEFAULTS
   when: 2017-06-23
   location: burbank
@@ -179,7 +179,7 @@ tubaria_furfuracea_1: # 11
   name: tubaria_furfuracea
   text_name: Tubaria furfuracea
 
-tubaria_furfuracea_2: # 12
+tubaria_furfuracea_2:
   <<: *DEFAULTS
   when: 2017-06-24
   location: burbank
@@ -188,7 +188,7 @@ tubaria_furfuracea_2: # 12
   name: tubaria_furfuracea
   text_name: Tubaria furfuracea
 
-unknown_with_no_naming: # 13
+unknown_with_no_naming:
   <<: *DEFAULTS
   when: 2008-09-23
   user: mary
@@ -197,7 +197,7 @@ unknown_with_no_naming: # 13
   name: fungi
   text_name: Fungi
 
-unknown_with_lat_long: # 14
+unknown_with_lat_long:
   <<: *DEFAULTS
   created_at: 2010-07-22 09:20:00
   updated_at: 2010-07-22 09:21:00
@@ -213,7 +213,7 @@ unknown_with_lat_long: # 14
   notes:
     :Other: 'unknown_with_lat_long'
 
-amateur_obs: # 15
+amateur_obs:
   <<: *DEFAULTS
   created_at: 2010-12-31 06:46:00
   when: 2010-12-30
@@ -229,7 +229,7 @@ amateur_obs: # 15
   lat: 34.1622
   long: -118.3521
 
-peltigera_obs: # 16
+peltigera_obs:
   <<: *DEFAULTS
   when: 2012-06-07
   user: rolf
@@ -250,7 +250,7 @@ peltigera_obs: # 16
   updated_at: 2014-04-04 04:04:03
   herbarium_records: field_museum_record
 
-peltigera_rolf_obs: # 17
+peltigera_rolf_obs:
   <<: *DEFAULTS
   when: 2013-09-08
   user: mary
@@ -269,7 +269,7 @@ peltigera_rolf_obs: # 17
   created_at: 2014-04-04 04:04:04
   updated_at: 2014-04-04 04:04:04
 
-fungi_obs: # 18
+fungi_obs:
   <<: *DEFAULTS
   when: 2013-09-15
   user: rolf
@@ -284,7 +284,7 @@ fungi_obs: # 18
   thumb_image: conic_image
   images: conic_image, plane_image_example
 
-boletus_edulis_obs: # 19
+boletus_edulis_obs:
   <<: *DEFAULTS
   when: 2014-04-21
   location:
@@ -297,44 +297,44 @@ boletus_edulis_obs: # 19
   vote_cache: 3
   species_lists: one_genus_three_species_list
 
-owner_only_favorite_eq_fungi: # 20
+owner_only_favorite_eq_fungi:
   <<: *DEFAULTS
 
-owner_only_favorite_eq_consensus: # 21
+owner_only_favorite_eq_consensus:
   <<: *DEFAULTS
 
-owner_only_favorite_ne_consensus: # 22
+owner_only_favorite_ne_consensus:
   <<: *DEFAULTS
   name: tremella
   text_name: Tremella
   lifeform: " lichenicolous "
 
-owner_multiple_favorites: # 23
+owner_multiple_favorites:
   <<: *DEFAULTS
 
-owner_uncertain_favorite: # 24
+owner_uncertain_favorite:
   <<: *DEFAULTS
 
-owner_accepts_general_questions: # 25
+owner_accepts_general_questions:
   <<: *DEFAULTS
   user: roy                      # roy has email_general_questions == true
 
-owner_refuses_general_questions: # 26
+owner_refuses_general_questions:
   <<: *DEFAULTS
   user: dick                     # dick has email_general_questions == false
 
-collected_at_obs: # 27
+collected_at_obs:
   <<: *DEFAULTS
   location: collection_location
   where: Collection Location
 
-displayed_at_obs: # 28
+displayed_at_obs:
   <<: *DEFAULTS
   location: display_location
   where: Display Location
   is_collection_location: false
 
-two_img_obs: # 29
+two_img_obs:
   <<: *DEFAULTS
   location: display_location
   where: Display Location
@@ -342,33 +342,33 @@ two_img_obs: # 29
   images: query_first_image, query_second_image
   thumb_image: query_first_image
 
-imageless_unvouchered_obs: # 30
+imageless_unvouchered_obs:
   <<: *DEFAULTS
   user: ignore_imageless_user
 
 # need >=2 imaged B edulis Obs's for filter tests
-imged_unvouchered_obs: # 31
+imged_unvouchered_obs:
   <<: *DEFAULTS
   images: query_first_image
   thumb_image: query_first_image
 
-vouchered_obs: # 32
+vouchered_obs:
   <<: *DEFAULTS
   specimen: 1
 
-vouchered_imged_obs: # 33
+vouchered_imged_obs:
   <<: *DEFAULTS
   specimen: 1
   images: query_first_image
   thumb_image: query_first_image
 
-updated_2013_obs: # 34
+updated_2013_obs:
   <<: *DEFAULTS
   when: 2013-09-08
   updated_at: 2013-09-08 17:21:00
 
 # Two Observations sortable by Name, Date, Date Posted, Time Last Modified
-sortable_obs_users_first_obs: # 35
+sortable_obs_users_first_obs:
   <<: *DEFAULTS
   created_at: 2016-01-10 17:20:00
   updated_at: 2016-01-11 17:20:00
@@ -380,7 +380,7 @@ sortable_obs_users_first_obs: # 35
   where: Sortable Observation User, New York, USA
   lifeform: " lichenicolous "
 
-sortable_obs_users_second_obs: # 36
+sortable_obs_users_second_obs:
   <<: *DEFAULTS
   created_at: 2017-01-10 17:20:00
   updated_at: 2017-01-11 17:20:00
@@ -392,7 +392,7 @@ sortable_obs_users_second_obs: # 36
   where: Sortable Observation User, New York, USA
   lifeform: " lichenicolous "
 
-unlisted_rolf_obs: # 37
+unlisted_rolf_obs:
   <<: *DEFAULTS
   location: point_reyes
   where: Point Reyes National Seashore, Marin Co., California, USA
@@ -400,102 +400,102 @@ unlisted_rolf_obs: # 37
 
 # default user (dick) has unequal positive namings
 # used for testing change vote
-unequal_positive_namings_obs: # 38
+unequal_positive_namings_obs:
   <<: *DEFAULTS
 
 # used for testing calc_consensus
-all_namings_deprecated_obs: # 39
+all_namings_deprecated_obs:
   <<: *DEFAULTS
   name: namings_deprecated
   text_name: Namings deprecated
 
 # Has 2 namings
 # Has two namings, which (under current rules) makes the Names unmergeable
-authored_with_naming_obs: # 40
+authored_with_naming_obs:
   <<: *DEFAULTS
   name: authored_with_naming
   text_name: Psalliota naming
 
 # dick owns the Name and Observation, but mary owns a Naming
-other_user_owns_naming_obs: # 41
+other_user_owns_naming_obs:
   <<: *DEFAULTS
   name: other_user_owns_naming_name
   text_name: Otheruserownsnaming
   user: dick
 
 # dick owns the Name and Naming, but mary owns an Observation
-other_user_owns_obs: # 42
+other_user_owns_obs:
   <<: *DEFAULTS
   name: other_user_owns_observation
   text_name: Otheruserownsobs
   user: mary
 
 # dick owns the Name and the only Observation and Naming
-same_user_owns_name_and_naming_obs: # 43
+same_user_owns_name_and_naming_obs:
   <<: *DEFAULTS
   name: same_user_owns_naming_and_observation
   text_name: Sameuserownsnamingandobservation
   user: dick
 
 # has Sequence which has not been deposited in an Archive
-locally_sequenced_obs: # 44
+locally_sequenced_obs:
   <<: *DEFAULTS
   rss_log: $LABEL_rss_log
   images: locally_sequenced_obs_image
   thumb_image: locally_sequenced_obs_image
 
 # has Sequence which is in GenBank
-genbanked_obs: # 45
+genbanked_obs:
   <<: *DEFAULTS
 
-substrate_notes_obs: # 46
+substrate_notes_obs:
   <<: *DEFAULTS
   notes:
     :substrate: soil
 
-substrate_and_other_notes_obs: # 47
+substrate_and_other_notes_obs:
   <<: *DEFAULTS
   notes:
     :substrate: soil
     :Other: slimy
 
-templater_noteless_obs: # 48
+templater_noteless_obs:
   <<: *DEFAULTS
   user: notes_templater
 
-templater_other_notes_obs: # 49
+templater_other_notes_obs:
   <<: *DEFAULTS
   notes:
     :Other: some notes
   user: notes_templater
 
-templater_orphaned_notes_obs: # 50
+templater_orphaned_notes_obs:
   <<: *DEFAULTS
   notes:
     :orphaned_caption: orphaned notes
   user: notes_templater
 
-template_only_obs: # 51
+template_only_obs:
   <<: *DEFAULTS
   notes:
     :Cap: red
   user: notes_templater
 
-template_and_other_notes_obs: # 52
+template_and_other_notes_obs:
   <<: *DEFAULTS
   notes:
     :Cap: red
     :Other: some notes
   user: notes_templater
 
-template_and_orphaned_notes_obs: # 53
+template_and_orphaned_notes_obs:
   <<: *DEFAULTS
   notes:
     :Cap: red
     :orphaned_caption: orphaned notes
   user: notes_templater
 
-template_and_orphaned_notes_scrambled_obs: # 54
+template_and_orphaned_notes_scrambled_obs:
   <<: *DEFAULTS
   notes:
     :Nearby_trees: pine
@@ -505,7 +505,7 @@ template_and_orphaned_notes_scrambled_obs: # 54
     :Cap: red
   user: notes_templater
 
-california_obs: # 55
+california_obs:
   <<: *DEFAULTS
   location: california
   where: California, USA

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -11,7 +11,7 @@ DEFAULTS: &DEFAULTS
 
 # admins: rolf (1), mary (2)
 # members: rolf (1), mary (2), katrina (5)
-eol_project: # 1
+eol_project:
   <<: *DEFAULTS
   user: rolf
   user_group: eol_users
@@ -26,7 +26,7 @@ eol_project: # 1
 # observations: 2 (detailed_unknown_obs - owned by mary)
 # images: 1 and 2 (detailed_unknown_obs's images - owned by mary)
 # species_lists: 3 (unknown_species_list - owned by mary)
-bolete_project: # 2
+bolete_project:
   <<: *DEFAULTS
   user_group: bolete_users
   admin_group: bolete_admins
@@ -38,7 +38,7 @@ bolete_project: # 2
   observations: detailed_unknown_obs
   species_lists: unknown_species_list
 
-empty_project: # 3
+empty_project:
   <<: *DEFAULTS
   user: mary
   user_group: mary_only
@@ -46,30 +46,30 @@ empty_project: # 3
   summary: No Images Observations or Lists
 
 # 2 lists, 0 observations, 0 images
-two_list_project: # 4
+two_list_project:
   <<: *DEFAULTS
   user: mary
   user_group: mary_only
   admin_group: mary_only
   species_lists: query_first_list, query_second_list
 
-obs_collected_and_displayed_project: # 5
+obs_collected_and_displayed_project:
   <<: *DEFAULTS
   observations: collected_at_obs, displayed_at_obs
 
-two_img_obs_project: # 6
+two_img_obs_project:
   <<: *DEFAULTS
   observations: two_img_obs
 
-rss_log_project: # 7
+rss_log_project:
   <<: *DEFAULTS
   rss_log: project_rss_log
 
-one_genus_two_species_project: # 8
+one_genus_two_species_project:
   <<: *DEFAULTS
   observations: peltigera_obs, agaricus_campestris_obs, boletus_edulis_obs
 
-news_articles_project: # 9
+news_articles_project:
   <<: *DEFAULTS
   title:       News Articles
   admin_group: article_writers

--- a/test/fixtures/publications.yml
+++ b/test/fixtures/publications.yml
@@ -3,21 +3,21 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one_pub: # 1
+one_pub:
   user: rolf
   full: MyText
   how_helped: MyText
   mo_mentioned: false
   peer_reviewed: false
 
-two_pub: # 2
+two_pub:
   user: rolf
   full: MyText
   how_helped: MyText
   mo_mentioned: false
   peer_reviewed: false
 
-spam_pub: # 3
+spam_pub:
   user: spammer
   full: This is spam
   how_helped: Spam spam spam

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -8,47 +8,47 @@
 
 # Some integration tests expect this to be at the top of the RSS Log.
 # Therefore insure that other Observation entries have earlier updated_at's.
-observation_rss_log: # 1
+observation_rss_log:
   observation: detailed_unknown_obs
   updated_at: 2006-03-02 21:14:00
   notes: "Updated Observation & Notes"
 
-imged_unvouchered_obs_rss_log: # 2
+imged_unvouchered_obs_rss_log:
   observation: imged_unvouchered_obs
   updated_at: 2005-03-02 21:14:00
   notes: "Updated Observation & Notes"
 
-locally_sequenced_obs_rss_log: # 3
+locally_sequenced_obs_rss_log:
   observation: locally_sequenced_obs
   updated_at:  2004-03-02 20:14:02
   notes:       ""
 
-species_list_rss_log: # 4
+species_list_rss_log:
   species_list: first_species_list
   updated_at: 2006-03-02 21:14:02
   notes: "Updated Species List"
 
-name_rss_log: # 5
+name_rss_log:
   name: fungi
   updated_at: 2006-03-02 21:14:03
   notes: "Updated Name"
 
-location_rss_log: # 6
+location_rss_log:
   location: mitrula_marsh
   updated_at: 2006-03-02 21:14:09
   notes: "Updated Location"
 
-albion_rss_log: # 7
+albion_rss_log:
   location: albion
   updated_at: 2007-12-27 06:41:20
   notes: "Updated Created"
 
-glossary_term_rss_log: # 8
+glossary_term_rss_log:
   glossary_term: conic_glossary_term
   updated_at: 2013-09-01 12:49:30
   notes: "Updated Glossary Term"
 
-project_rss_log: # 9
+project_rss_log:
   project: two_list_project
   updated_at: 2016-08-08 12:00:00
   notes: "Updated Project"

--- a/test/fixtures/sequences.yml
+++ b/test/fixtures/sequences.yml
@@ -10,7 +10,7 @@ DEFAULTS: &DEFAULTS
   accession:   $LABEL # Don't duplicate accessions for an Observation
   notes:       Notes about Sequence $LABEL
 
-local_sequence: # 1
+local_sequence:
   <<: *DEFAULTS
   observation: locally_sequenced_obs
   archive:     ""
@@ -18,32 +18,32 @@ local_sequence: # 1
   created_at:  2017-01-01 16:00:00
   updated_at:  2017-01-01 16:00:00
 
-deposited_sequence: # 2
+deposited_sequence:
   <<: *DEFAULTS
   accession:   KT968605
   bases:       ""
   created_at:  2017-01-01 17:00:00
   updated_at:  2017-01-01 17:00:00
 
-missing_archive_sequence: # 3
+missing_archive_sequence:
   <<: *DEFAULTS
   archive:     ""
   created_at:  2017-02-01 16:00:00
   updated_at:  2017-02-01 16:00:00
 
-missing_accession_sequence: # 4
+missing_accession_sequence:
   <<: *DEFAULTS
   accession:   ""
   created_at:  2017-02-02 16:00:00
   updated_at:  2017-02-02 16:00:00
 
-alternate_archive: # 5
+alternate_archive:
   <<: *DEFAULTS
   archive:     UNITE
   created_at:  2017-02-03 16:00:00
   updated_at:  2017-02-03 16:00:00
 
-fasta_formatted_sequence: # 6
+fasta_formatted_sequence:
   <<: *DEFAULTS
   # Use YAML literal style to retain newline characters
   # See http://www.yaml.org/spec/1.2/spec.html#id2760844
@@ -65,7 +65,7 @@ fasta_formatted_sequence: # 6
     TCTGTTTGTCCGCGAGGCGTTCCCGCCCACCGAACCCAATAAACCTTTCTCCTAGTTGACCTCGAATCAG
     GTGGGG
 
-bare_formatted_sequence: # 7
+bare_formatted_sequence:
   <<: *DEFAULTS
   # Differs from above by one letter
   # Use YAML literal style to retain newline characters
@@ -86,7 +86,7 @@ bare_formatted_sequence: # 7
     GTGGGG
     A
 
-bare_with_numbers_sequence: # 8
+bare_with_numbers_sequence:
   <<: *DEFAULTS
   # Differs from above by one letter
   # Use YAML literal style to retain newline chancters

--- a/test/fixtures/species_lists.yml
+++ b/test/fixtures/species_lists.yml
@@ -10,7 +10,7 @@ DEFAULTS: &DEFAULTS
   title:    $LABEL
 
 # has no obs
-first_species_list: # 1
+first_species_list:
   <<: *DEFAULTS
   created_at: 2006-03-01 21:14:00
   updated_at: 2006-03-01 21:14:00
@@ -21,7 +21,7 @@ first_species_list: # 1
   rss_log: species_list_rss_log
 
 # has no obs
-another_species_list: # 2
+another_species_list:
   <<: *DEFAULTS
   created_at: 2006-03-02 21:14:00
   updated_at: 2006-03-02 21:14:00
@@ -31,7 +31,7 @@ another_species_list: # 2
   notes: Got Skunked Again!
 
 # has: minimal_unknown_obs (1) and detailed_unknown_obs (2)
-unknown_species_list: # 3
+unknown_species_list:
   <<: *DEFAULTS
   created_at: 2006-03-09 21:14:00
   updated_at: 2006-03-09 21:14:00
@@ -40,14 +40,14 @@ unknown_species_list: # 3
   notes: Things I don't know
 
 # used by QueryTest
-query_first_list: # 4
+query_first_list:
   <<: *DEFAULTS
   created_at: 2007-03-01 21:14:00
   updated_at: 2007-03-01 21:14:00
   when: 2006-03-09
 
 # used by QueryTest
-query_second_list: # 5
+query_second_list:
   <<: *DEFAULTS
   created_at: 2007-03-02 21:14:00
   updated_at: 2007-03-02 21:14:00
@@ -55,7 +55,7 @@ query_second_list: # 5
 
 # used by QueryTest
 # has 1-word notes which is unique for SpeciesList
-query_notes_list: # 6
+query_notes_list:
   <<: *DEFAULTS
   created_at: 2008-04-03 21:14:00
   updated_at: 2008-04-03 21:14:00
@@ -63,7 +63,7 @@ query_notes_list: # 6
   notes: amazingraremushroom
 
 # used by QueryTest
-where_no_mushrooms_list: # 7
+where_no_mushrooms_list:
   <<: *DEFAULTS
   created_at: 2008-05-03 21:14:00
   updated_at: 2008-05-03 21:14:00
@@ -72,7 +72,7 @@ where_no_mushrooms_list: # 7
   location: no_mushrooms_location
 
 # used by QueryTest
-where_list: # 8
+where_list:
   <<: *DEFAULTS
   created_at: 2012-07-06 21:14:00
   updated_at: 2012-07-06 21:14:00
@@ -80,7 +80,7 @@ where_list: # 8
   where: wherenolocation  # 1-word where, unique for SpeciesList
   location: nil
 
-one_genus_three_species_list: # 9
+one_genus_three_species_list:
   <<: *DEFAULTS
   created_at: 2012-07-06 22:14:00
   updated_at: 2012-07-06 22:14:00

--- a/test/fixtures/synonyms.yml
+++ b/test/fixtures/synonyms.yml
@@ -3,20 +3,20 @@
 # if "id:" is included but left blank, the id is nil.
 # So use ActiveRecord to get the hashed id.
 
-macrolepiota_rachodes_synonym: # 1
+macrolepiota_rachodes_synonym:
   id: <%= ActiveRecord::FixtureSet.identify(:macrolepiota_rachodes_synonym) %>
 
-chlorophyllum_rachodes_synonym: # 2
+chlorophyllum_rachodes_synonym:
   id: <%= ActiveRecord::FixtureSet.identify(:chlorophyllum_rachodes_synonym) %>
 
-lactarius_alpinus_synonym: # 3
+lactarius_alpinus_synonym:
   id: <%= ActiveRecord::FixtureSet.identify(:lactarius_alpinus_synonym) %>
 
-peltigera_synonym: # 4
+peltigera_synonym:
   id: <%= ActiveRecord::FixtureSet.identify(:peltigera_synonym) %>
 
-namings_deprecated_synonym: # 5
+namings_deprecated_synonym:
   id: <%= ActiveRecord::FixtureSet.identify(:namings_deprecated_synonym) %>
 
-suillus_synonym: # 6
+suillus_synonym:
   id: <%= ActiveRecord::FixtureSet.identify(:suillus_synonym) %>

--- a/test/fixtures/translation_strings.yml
+++ b/test/fixtures/translation_strings.yml
@@ -10,7 +10,7 @@
 # 4 dick:  Greek:   one, two
 # (English "one" has changed since Mary translated it.)
 
-english_one: # 1
+english_one:
   version: 1
   language: english
   tag: one
@@ -18,7 +18,7 @@ english_one: # 1
   updated_at: 2012-05-30
   user_id: 0
 
-english_two: # 2
+english_two:
   version: 1
   language: english
   tag: two
@@ -26,7 +26,7 @@ english_two: # 2
   updated_at: 2012-05-24
   user_id: 0
 
-english_TWO: # 3
+english_TWO:
   version: 1
   language: english
   tag: TWO
@@ -34,7 +34,7 @@ english_TWO: # 3
   updated_at: 2012-05-24
   user_id: 0
 
-english_twos: # 4
+english_twos:
   version: 1
   language: english
   tag: twos
@@ -42,7 +42,7 @@ english_twos: # 4
   updated_at: 2012-05-24
   user_id: 0
 
-english_TWOS: # 5
+english_TWOS:
   version: 1
   language: english
   tag: TWOS
@@ -50,7 +50,7 @@ english_TWOS: # 5
   updated_at: 2012-05-24
   user_id: 0
 
-english_three: # 6
+english_three:
   version: 1
   language: english
   tag: three
@@ -58,7 +58,7 @@ english_three: # 6
   updated_at: 2012-05-24
   user_id: 0
 
-english_four: # 7
+english_four:
   version: 1
   language: english
   tag: four
@@ -66,7 +66,7 @@ english_four: # 7
   updated_at: 2012-05-24
   user_id: 0
 
-french_one: # 8
+french_one:
   version: 1
   language: french
   tag: one
@@ -74,7 +74,7 @@ french_one: # 8
   updated_at: 2012-05-24
   user: mary
 
-french_two: # 9
+french_two:
   version: 1
   language: french
   tag: two
@@ -82,7 +82,7 @@ french_two: # 9
   updated_at: 2012-05-24
   user: mary
 
-french_TWO: # 10
+french_TWO:
   version: 1
   language: french
   tag: TWO
@@ -90,7 +90,7 @@ french_TWO: # 10
   updated_at: 2012-05-24
   user: mary
 
-french_twos: # 11
+french_twos:
   version: 1
   language: french
   tag: twos
@@ -98,7 +98,7 @@ french_twos: # 11
   updated_at: 2012-05-30
   user: rolf
 
-french_TWOS: # 12
+french_TWOS:
   version: 1
   language: french
   tag: TWOS
@@ -106,7 +106,7 @@ french_TWOS: # 12
   updated_at: 2012-05-30
   user: rolf
 
-greek_one: # 13
+greek_one:
   version: 2
   language: greek
   tag: one
@@ -114,7 +114,7 @@ greek_one: # 13
   updated_at: 2012-05-31
   user: dick
 
-greek_two: # 14
+greek_two:
   version: 1
   language: greek
   tag: two
@@ -122,7 +122,7 @@ greek_two: # 14
   updated_at: 2012-05-31
   user: dick
 
-unknown_locations_string: # 15
+unknown_locations_string:
   version: 1
   language: english
   tag: unknown_locations
@@ -130,7 +130,7 @@ unknown_locations_string: # 15
   updated_at: 2012-05-31
   user_id: 0
 
-english_waiting_for_update: # 16
+english_waiting_for_update:
   version: 1
   language: english
   tag: all
@@ -138,7 +138,7 @@ english_waiting_for_update: # 16
   updated_at: 2012-05-30
   user_id: 0
 
-version_wizard: # 17
+version_wizard:
   version: 1
   language: russian
   tag: wizard
@@ -146,7 +146,7 @@ version_wizard: # 17
   updated_at: 2013-08-22
   user: roy
 
-french_app_contributors: # 18
+french_app_contributors:
   version: 1
   language: french
   tag: app_contributors

--- a/test/fixtures/translation_strings_versions.yml
+++ b/test/fixtures/translation_strings_versions.yml
@@ -1,7 +1,7 @@
 # For some reason we need to keep the ids in these fixtures.  Otherwise the
 # AJAX controller breaks.  Haven't looked into it in any depth. -JPH 20171117
 
-greek_one_version1: # 1
+greek_one_version1:
   id: 1
   version: 1
   translation_string_id: <%= ActiveRecord::FixtureSet.identify(:greek_one) %>
@@ -9,7 +9,7 @@ greek_one_version1: # 1
   updated_at: 2012-03-31
   user_id: <%= ActiveRecord::FixtureSet.identify(:mary) %>
 
-greek_one_version2: # 2
+greek_one_version2:
   id: 2
   version: 2
   translation_string_id: <%= ActiveRecord::FixtureSet.identify(:greek_one) %>
@@ -17,7 +17,7 @@ greek_one_version2: # 2
   updated_at: 2012-04-30
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
 
-version_wizard_version1: # 3
+version_wizard_version1:
   id: 3
   version: 1
   translation_string_id: <%= ActiveRecord::FixtureSet.

--- a/test/fixtures/triples.yml
+++ b/test/fixtures/triples.yml
@@ -3,37 +3,37 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-peltigera_is_a_lichen_triple: # 1
+peltigera_is_a_lichen_triple:
   subject: <%= "':name/" +
     ActiveRecord::FixtureSet.identify(:peltigera).to_s + "'"%>
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
-petigera_is_a_lichen_triple: # 2
+petigera_is_a_lichen_triple:
   subject: <%= "':name/" +
     ActiveRecord::FixtureSet.identify(:petigera).to_s + "'"%>
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
-tremella_mesenterica_is_a_lichen_triple: # 3
+tremella_mesenterica_is_a_lichen_triple:
   subject: <%= "':name/" +
     ActiveRecord::FixtureSet.identify(:tremella_mesenterica).to_s + "'"%>
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
-tremella_is_a_lichen_triple: # 4
+tremella_is_a_lichen_triple:
   subject: <%= "':name/" +
     ActiveRecord::FixtureSet.identify(:tremella).to_s + "'"%>
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
-tremella_justpublished_is_a_lichen_triple: # 5
+tremella_justpublished_is_a_lichen_triple:
   subject: <%= "':name/" +
     ActiveRecord::FixtureSet.identify(:tremella_justpublished).to_s + "'"%>
   predicate: ':lichenAuthority'
   object: '"http://www.ndsu.edu/pubweb/~esslinge/chcklst/chcklst7.htm"^^xsd:anyURI'
 
-aboritporus_biennis_eol_triple: # 6
+aboritporus_biennis_eol_triple:
   subject: <%= 'http://mushroomobserver.org/names/show_name/' +
     ActiveRecord::FixtureSet.identify(:abortiporus_biennis_for_eol).to_s %>
   predicate: ':eolName'

--- a/test/fixtures/user_groups.yml
+++ b/test/fixtures/user_groups.yml
@@ -3,47 +3,47 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-reviewers: # 1
+reviewers:
   name: reviewers
 
-eol_users: # 2
+eol_users:
   name: EOL Project
 
-eol_admins: # 3
+eol_admins:
   name: EOL Project.admin
 
-bolete_users: # 4
+bolete_users:
   name: Bolete Project
 
-bolete_admins: # 5
+bolete_admins:
   name: Bolete Project.admin
 
-all_users: # 6
+all_users:
   name: all users
 
-rolf_only: # 7
+rolf_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:rolf) %>
 
-mary_only: # 8
+mary_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:mary) %>
 
-junk_only: # 9
+junk_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:junk) %>
 
-dick_only: # 10
+dick_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:dick) %>
 
-katrina_only: # 11
+katrina_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:katrina) %>
 
-roy_only: # 12
+roy_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:roy) %>
 
-spammer_only: # 13
+spammer_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:spammer) %>
 
-article_writers: # 14
+article_writers:
   name: article writers
 
-thorsten_only: # 15
+thorsten_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:thorsten) %>

--- a/test/fixtures/votes.yml
+++ b/test/fixtures/votes.yml
@@ -9,7 +9,7 @@ DEFAULTS: &DEFAULTS
   value:    <%= Vote.maximum_vote %>
 
 # Rolf is pretty confident of his naming.
-coprinus_comatus_owner_vote: # 1
+coprinus_comatus_owner_vote:
   <<: *DEFAULTS
   user: rolf
   naming: coprinus_comatus_naming
@@ -17,7 +17,7 @@ coprinus_comatus_owner_vote: # 1
   observation: coprinus_comatus_obs
 
 # Mary is not so much.
-coprinus_comatus_other_vote: # 2
+coprinus_comatus_other_vote:
   <<: *DEFAULTS
   user: mary
   naming: coprinus_comatus_naming
@@ -25,7 +25,7 @@ coprinus_comatus_other_vote: # 2
   observation: coprinus_comatus_obs
 
 # Rolf hates Mary's naming.
-coprinus_comatus_other_naming_rolf_vote: # 3
+coprinus_comatus_other_naming_rolf_vote:
   <<: *DEFAULTS
   user: rolf
   naming: coprinus_comatus_other_naming
@@ -34,14 +34,14 @@ coprinus_comatus_other_naming_rolf_vote: # 3
   observation: coprinus_comatus_obs
 
 # Mary's absolutely positive, though.
-coprinus_comatus_other_naming_mary_vote: # 4
+coprinus_comatus_other_naming_mary_vote:
   <<: *DEFAULTS
   user: mary
   naming: coprinus_comatus_other_naming
   observation: coprinus_comatus_obs
 
 # Rolf has no opinion about his own naming.
-strobilurus_diminutivus_no_opinion_vote: # 5
+strobilurus_diminutivus_no_opinion_vote:
   <<: *DEFAULTS
   user: rolf
   naming: strobilurus_diminutivus_naming
@@ -49,50 +49,50 @@ strobilurus_diminutivus_no_opinion_vote: # 5
   favorite: false
   observation: strobilurus_diminutivus_obs
 
-amateur_vote: # 6
+amateur_vote:
   <<: *DEFAULTS
   user: katrina
   naming: detailed_unknown_naming
   value: <%= Vote.next_best_vote %>
   observation: amateur_obs
 
-owner_only_favorite_eq_fungi: # 7
+owner_only_favorite_eq_fungi:
   <<: *DEFAULTS
   naming: detailed_unknown_naming # Fungi
   observation: owner_only_favorite_eq_fungi # Boletus edulis
 
-owner_only_favorite_eq_consensus: # 8
+owner_only_favorite_eq_consensus:
   <<: *DEFAULTS
   naming: boletus_edulis_naming
   observation: owner_only_favorite_eq_consensus # Boletus edulis
 
-owner_only_favorite_ne_consensus: # 9
+owner_only_favorite_ne_consensus:
   <<: *DEFAULTS
   naming: tremella_mesenterica_naming
   observation: owner_only_favorite_ne_consensus # Tremella
 
-owner_multiple_favorites_first_vote: # 10
+owner_multiple_favorites_first_vote:
   <<: *DEFAULTS
   naming: owner_multiple_favorites_first_naming # Tremella
   observation: owner_multiple_favorites # Boletus edulis
 
-owner_multiple_favorites_second_vote: # 11
+owner_multiple_favorites_second_vote:
   <<: *DEFAULTS
   naming: owner_multiple_favorites_second_naming # Tremella mesenterica
   observation: owner_multiple_favorites # Boletus edulis
 
-owner_uncertain_favorite_vote: # 12
+owner_uncertain_favorite_vote:
   <<: *DEFAULTS
   naming: owner_uncertain_favorite_naming # Tremella mesenterica
   value: <%= Vote.min_neg_vote %>
   observation: owner_uncertain_favorite # Boletus edulis
 
-unequal_positive_namings_obs_top_vote: # 13
+unequal_positive_namings_obs_top_vote:
   <<: *DEFAULTS
   observation: unequal_positive_namings_obs
   naming:      unequal_positive_namings_top_naming
 
-unequal_positive_namings_obs_2nd_vote: # 14
+unequal_positive_namings_obs_2nd_vote:
   <<: *DEFAULTS
   favorite:    false
   observation: unequal_positive_namings_obs


### PR DESCRIPTION
Deletes fixture comments with phony IDs.

Delivers part of https://www.pivotaltracker.com/story/show/173463623