### PR TITLE
Fix link_to_object typo

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -232,7 +232,7 @@ module ObjectLinkHelper
   def link_to_object(object, name = nil)
     return nil unless object
 
-    link_to(name || object.title.t, object_path(object.id))
+    link_to(name || object.title.t, object_path(object))
   end
 
   # Output path helpers. Useful when:


### PR DESCRIPTION
Fix typo in ObjectLinkHelper#link_to_object
Cherry picks #1b0070a47
Joe Cohen <jdcohenesq@gmail.com>	Jun 29, 2020 at 09:20