### PR TITLE
Fix ApplicationController#coerced_query_link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1052,8 +1052,10 @@ class ApplicationController < ActionController::Base
 
     [
       :show_objects.t(type: model.type_tag),
-      add_query_param({ controller: "/#{model.show_controller}",
-                        action: :index }, query)
+      # add_query_param({ controller: "/#{model.show_controller}",
+      #                   action: :index }, query)
+      "/#{model.show_controller}/#{model.index_action}/" \
+      "#{params[:id]}?q=#{get_query_param}"
     ]
   end
   helper_method :coerced_query_link


### PR DESCRIPTION
1. The action that lists the results of a search has changed between `master` to `bootstrap4`
2. `add_query_param` no longer works because
- There's no route to `.../index_action` + params id: id. So I've appended `/id` to the path.
- And I have to append the query to that.

Note also that there's no helper path to index_action(/:id)

(cherry picked from commit 955070ba984802a79d2dfc6832291273b4e6f9f1)