### PR TITLE
Fix GeneralExtensions#fixture_label

### DIFF
--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -261,7 +261,7 @@ module GeneralExtensions
   def fixture_label(obj)
     return "" if obj.nil?
 
-    table = obj.class.table_name
+    table = obj.class.name.tableize
     if @loaded_fixtures
       @loaded_fixtures[table].fixtures.each do |name, fixture|
         return "<#{name}>" if fixture["id"] == obj.id


### PR DESCRIPTION
-  Cherry picks #66f4cfc5
- `GeneralExtensions#fixture_label` worked fine in `master` but threw an error with  bootstrap-4's namespaced fixtures, like Name/Descriptions.