### PR TITLE
Fix ContextNavbar partial

### DIFF
--- a/app/views/application/_context_navbar.erb
+++ b/app/views/application/_context_navbar.erb
@@ -11,13 +11,17 @@
 
   <%= tag.div class: "ml-auto d-flex flex-column flex-md-row justify-content-between" do %>
 
-    <%= link_to({ controller: controller.controller_name, action: :new },
-                { class: "mx-4 mr-lg-5 btn nav-item nav-link btn-link",
-                  id: "create_link" }) do -%>
-          <%= tag.span class: "text-nowrap" do -%>
-            <%= tag.span :CREATE.t, class: "mr-2" -%>
-            <%= tag.span class: "fas fa-edit" -%>
-          <% end %>
+    <% if Rails.application.routes.url_helpers.method_defined?(
+            "new_#{controller.controller_name.singularize}_path"
+    ) %>
+      <%= link_to({ controller: controller.controller_name, action: :new },
+                  { class: "mx-4 mr-lg-5 btn nav-item nav-link btn-link",
+                    id: "create_link" }) do -%>
+            <%= tag.span class: "text-nowrap" do -%>
+              <%= tag.span :CREATE.t, class: "mr-2" -%>
+              <%= tag.span class: "fas fa-edit" -%>
+            <% end %>
+      <% end %>
     <% end %>
 
     <%= form_with url: search_pattern_search_path,


### PR DESCRIPTION
Prevent partial from throwing  error for a Controller that lacks a `new` path, e.g.:
```ruby
ERROR["test_index_user", #<Minitest::Reporters::Suite:0x000055eb10914988 @name="UsersControllerTest">, 13.45352479396388]
 test_index_user#UsersControllerTest (13.45s)
Minitest::UnexpectedError:         ActionView::Template::Error: No route matches {:action=>"new", :controller=>"users"}
```
Cherry-picked from #fec2653