### PR TITLE
Fix most bootstrap4 SearchController issues

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -38,13 +38,9 @@ class SearchController < ApplicationController
       return
     else
       flash_error(:runtime_invalid.t(type: :search, value: type.inspect))
-      redirect_back_or_default(
-        controller: :observations,
-        action: :index
-      )
+      redirect_back_or_default(:root)
       return
     end
-
     # If pattern is blank, this would devolve into a very expensive index.
     if pattern.blank?
       redirect_to(
@@ -62,11 +58,7 @@ class SearchController < ApplicationController
 
   def site_google_search(pattern)
     if pattern.blank?
-      # redirect_to(
-      #   controller: :observations,
-      #   action: :index
-      # )
-      redirect_to observations_path
+      redirect_to(:root)
     else
       search = URI.encode_www_form(q: "site:#{MO.domain} #{pattern}")
       redirect_to("https://google.com/search?#{search}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -394,6 +394,7 @@ ACTIONS = {
   #   show: {}
   # },
   observations: {
+    advanced_search: {},
     # create_observation: {}, # aliased only
     # destroy_observation: {}, # aliased only
     download_observations: {},
@@ -742,7 +743,7 @@ MushroomObserver::Application.routes.draw do
 
   # namespace :names do
   #   resources :descriptions
-  # end 
+  # end
 
   resources :names do
     resources :descriptions, module: :names

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -70,15 +70,16 @@ class SearchControllerTest < FunctionalTestCase
 
     params = { search: { pattern: "", type: :google } }
     get(:pattern_search, params)
-    assert_redirected_to(controller: :rss_logs, action: :list_rss_logs)
+    assert_redirected_to(observations_path)
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
     get(:pattern_search, params)
-    assert_redirected_to(controller: :rss_logs, action: :list_rss_logs)
+    assert_redirected_to(:root)
 
+    login("rolf")
     params = { search: { pattern: "", type: :observation } }
     get(:pattern_search, params)
-    assert_redirected_to(controller: :observations, action: :list_observations)
+    assert_redirected_to(observations_path)
   end
 
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SearchControllerTest < FunctionalTestCase
-
   def test_advanced_search_form
     [Name, Image, Observation].each do |model|
       post(
@@ -70,16 +71,19 @@ class SearchControllerTest < FunctionalTestCase
 
     params = { search: { pattern: "", type: :google } }
     get(:pattern_search, params)
-    assert_redirected_to(observations_path)
+    assert_redirected_to(:root)
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
+    get(:pattern_search, params)
+    assert_redirected_to(:root)
+
+    params = { search: { pattern: "", type: :all } }
     get(:pattern_search, params)
     assert_redirected_to(:root)
 
     login("rolf")
     params = { search: { pattern: "", type: :observation } }
     get(:pattern_search, params)
-    assert_redirected_to(observations_path)
+    assert_redirected_to(:root)
   end
-
 end


### PR DESCRIPTION
- Add missing route
- Conform test expectations to new routes
- Revise redirect target in event of pattern_search invalid type.
(Goes to :root, which should vary depending on whether user is logged in.)

Fixes test Errors and all but one failure:

```ruby
$ rails t test/controllers/search_controller_test.rb
Started with run options --seed 59011

 FAIL["test_pattern_search", #<Minitest::Reporters::Suite:0x0000555db916e718 @name="SearchControllerTest">, 2.1695715410023695]
 test_pattern_search#SearchControllerTest (2.17s)
        Expected response to be a redirect to <http://test.host/observations> but was a redirect to <http://test.host/>.
        Expected "http://test.host/observations" to be === "http://test.host/".
        test/controllers/search_controller_test.rb:73:in `test_pattern_search'

  2/2: [========================================================================] 100% Time: 00:00:02, Time: 00:00:02

Finished in 2.17259s
2 tests, 28 assertions, 1 failures, 0 errors, 0 skips
```