### PR TITLE
Account for login state when asserting search controller redirects

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -38,7 +38,7 @@ class SearchController < ApplicationController
       return
     else
       flash_error(:runtime_invalid.t(type: :search, value: type.inspect))
-      redirect_back_or_default(:root)
+      redirect_back_or_default(observations_path)
       return
     end
     # If pattern is blank, this would devolve into a very expensive index.
@@ -58,7 +58,7 @@ class SearchController < ApplicationController
 
   def site_google_search(pattern)
     if pattern.blank?
-      redirect_to(:root)
+      redirect_to observations_path
     else
       search = URI.encode_www_form(q: "site:#{MO.domain} #{pattern}")
       redirect_to("https://google.com/search?#{search}")

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -69,19 +69,21 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern_search, params)
     assert_redirected_to(target)
 
+    # note, due to :root for non-logged-in users being "observations#index",
+    # the path literal works, but not the controller/action hash! Mysterious -AN
     params = { search: { pattern: "", type: :google } }
     get(:pattern_search, params)
-    assert_redirected_to(:root)
+    assert_redirected_to("/observations")
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
     get(:pattern_search, params)
-    assert_redirected_to(:root)
+    assert_redirected_to("/observations")
 
     params = { search: { pattern: "", type: :all } }
     get(:pattern_search, params)
-    assert_redirected_to(:root)
+    assert_redirected_to("/observations")
 
-    # logged in users have a different :root, so check this goes to observations
+    # logged in users have a different :root, so use controller/action
     login("rolf")
     params = { search: { pattern: "", type: :observation } }
     get(:pattern_search, params)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -81,9 +81,10 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern_search, params)
     assert_redirected_to(:root)
 
+    # logged in users have a different :root, so check this goes to observations
     login("rolf")
     params = { search: { pattern: "", type: :observation } }
     get(:pattern_search, params)
-    assert_redirected_to(:root)
+    assert_redirected_to(controller: :observations, action: :index)
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -73,15 +73,15 @@ class SearchControllerTest < FunctionalTestCase
     # the path literal works, but not the controller/action hash! Mysterious -AN
     params = { search: { pattern: "", type: :google } }
     get(:pattern_search, params)
-    assert_redirected_to("/observations")
+    assert_redirected_to observations_path
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
     get(:pattern_search, params)
-    assert_redirected_to("/observations")
+    assert_redirected_to observations_path
 
     params = { search: { pattern: "", type: :all } }
     get(:pattern_search, params)
-    assert_redirected_to("/observations")
+    assert_redirected_to observations_path
 
     # logged in users have a different :root, so use controller/action
     login("rolf")


### PR DESCRIPTION
This attempts to clear up confusion with the new dual :root behavior (observations_path being the new root for not-logged-in users).

The somewhat confusing Rails behavior can be researched another time, but I hope this is a practical workaround. It only applies to the observations controller index.

Inside a controller, `redirect_to(observations_path)` apparently still generates `"/observations"`, not `"/"`. I _believe_ this is because `observations_path` is itself a stored object, independent of and not yet processed by the routes.rb ":root" setting, within the controller.

So in a test for not-logged-in activity, `assert_redirected_to("/observations")` or `assert_redirected_to observations_path` will work, _even though this is the root path_, but `assert_redirected_to(controller: :observations, action: :index)` will not. I _believe_ this is because when you use the controller/action hash, Rails seems to process that route through all rules in routes.rb, and generates the :root path ("/").

For logged in users, on the contrary, you apparently _should_ use the controller/action hash, because Rails knows you're logged in at that point, and will correctly generate the path. 

See comments also in the test.