### PR TITLE
Restore navbar links to articles, collection_numbers, observations, cleanup

### DIFF
--- a/app/helpers/rss_logs_helper.rb
+++ b/app/helpers/rss_logs_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Custom View Helpers for rss_log View (Activity Feed)
-#
+# NOTE: Not currently used by Bootstrap-4
 module RssLogsHelper
   # All types of RssLogs
   def types

--- a/app/views/application/_context_navbar.erb
+++ b/app/views/application/_context_navbar.erb
@@ -1,5 +1,5 @@
-<%# The top navbar. Auto-generated navbar "title" links to the index. %>
-<%# Tabs rendered in dropdown. %>
+<%# The top navbar. Navbar title usually links to the index. %>
+<%# Tabs can be rendered in a dropdown. %>
 
 <%= tag.div class: "navbar-nav w-100" do %>
 

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,6 +1,16 @@
 <% @title = edit_article_title(@article)
-   tabs = [link_to(:index_article.t, articles_path)]
-   @tabsets = { right: draw_tab_set(tabs) }
+   # tabs = [link_to(:index_article.t, articles_path)]
+   # @tabsets = { right: draw_tab_set(tabs) }
+
+   @navbar = {} # reset
+   @navbar[:title] = { title: :ARTICLES.t, url: articles_path }
+   # @navbar[:links] = [
+   #   { title: :cancel_and_show.t(type: :glossary_term),
+   #     url: glossary_term_path(@glossary_term.id), icon: "fa-backspace" }
+   # ]
 %>
 
-<%= render "articles/form" %>
+<div class="form-max-width mt-4">
+  <%= tag.h1 @title.humanize, class: "display-1" %>
+  <%= render "articles/form" %>
+</div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,8 +1,16 @@
 <%
   @title ||= :ARTICLES.t
   tabs = index_tabs + create_links(@links)
-  @tabsets = { right: draw_tab_set(tabs) }
+  # @tabsets = { right: draw_tab_set(tabs) }
 
+  @navbar = {} # reset
+  @navbar[:title] = { title: :ARTICLES.t, url: articles_path }
+  # @navbar[:links] = [
+  #   { title: :CREATE.t, url: new_observation_path, icon: "fa-plus" }
+  # ]
+  @navbar[:dropdowns] = [
+    { title: "Actions", links: tabs }
+  ]
   flash_error(@error) if @error && @objects.empty?
 %>
 

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,6 +1,11 @@
 <% @title = :create_article_title.l
-   tabs = [link_to(:index_article.t, articles_path)]
-   @tabsets = { right: draw_tab_set(tabs) }
+   # tabs = [link_to(:index_article.t, articles_path)]
+   # @tabsets = { right: draw_tab_set(tabs) }
+   @navbar = {} # reset
+   @navbar[:title] = { title: :ARTICLES.t, url: articles_path }
 %>
 
-<%= render "articles/form" %>
+<div class="form-max-width mt-4">
+  <%= tag.h1 @title.humanize, class: "display-1" %>
+  <%= render "articles/form" %>
+</div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,10 +1,17 @@
 <%
   @title = show_article_title(@article)
-  @tabsets = { right: draw_tab_set(show_article_tabs) }
+  # @tabsets = { right: draw_tab_set(show_article_tabs) }
+
+  @navbar = {} # reset
+  @navbar[:title] = { title: :ARTICLES.t, url: articles_path }
+  @navbar[:dropdowns] = [
+    { title: "Actions", links: show_article_tabs }
+  ]
 %>
 <div>
- <%= :BY.t %> <%= user_link(@article.user) %>,
- <%= tag.small @article.created_at.fancy_time %>
+  <%= tag.h1 @title.humanize, class: "display-1" %>
+  <%= :BY.t %> <%= user_link(@article.user) %>,
+  <%= tag.small @article.created_at.fancy_time %>
 </div>
 <div class="row mt-3">
   <div class="col-sm-12">

--- a/app/views/collection_numbers/edit.html.erb
+++ b/app/views/collection_numbers/edit.html.erb
@@ -1,27 +1,42 @@
 <%
   @title = :edit_collection_number_title.l(name: @collection_number.format_name)
 
-  tabs = []
-  if @back == "index"
-    tabs << link_to(:edit_collection_number_back_to_index.t,
-                    collection_numbers_index_collection_number_path(
-                      q: get_query_param))
-  else
-    tabs << link_to(:cancel_and_show.t(type: @back_object.type_tag),
-                    object_path(@back_object, q: get_query_param))
-  end
+  # tabs = []
+  # if @back == "index"
+  #   tabs << link_to(:edit_collection_number_back_to_index.t,
+  #                   collection_numbers_index_collection_number_path(
+  #                     q: get_query_param))
+  # else
+  #   tabs << link_to(:cancel_and_show.t(type: @back_object.type_tag),
+  #                   object_path(@back_object, q: get_query_param))
+  # end
 
-  @tabsets = { right: draw_tab_set(tabs) }
+  # @tabsets = { right: draw_tab_set(tabs) }
+
+  @navbar = {} # reset
+  @navbar[:title] = { title: :COLLECTION_NUMBERS.t,
+                      url: collection_numbers_path }
+  @navbar[:links] = []
+  if @back == "index"
+    @navbar[:links] << { title: :edit_collection_number_back_to_index.t,
+              url: collection_numbers_path(q: get_query_param)) }
+  else
+    @navbar[:links] << { title: :cancel_and_show.t(type: @back_object.type_tag),
+              url: object_path(@back_object, q: get_query_param) }
+  end
 %>
 
-<div class="row">
-  <div class="col-12 col-sm-7 max-width-text">
-    <%= render "collection_numbers/form", button: :SAVE %>
-  </div>
+<div class="form-max-width mt-4">
+  <%= tag.h1 @title.humanize, class: "display-1" %>
+  <div class="row">
+    <div class="col-12 col-sm-7 max-width-text">
+      <%= render "collection_numbers/form", button: :SAVE %>
+    </div>
 
-  <div class="col-12 col-sm-5 max-width-text">
-    <% @collection_number.observations.each do |obs| %>
-      <%= render "shared/log_item", object: obs.rss_log %>
-    <% end %>
+    <div class="col-12 col-sm-5 max-width-text">
+      <% @collection_number.observations.each do |obs| %>
+        <%= render "shared/log_item", object: obs.rss_log %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/collection_numbers/index.html.erb
+++ b/app/views/collection_numbers/index.html.erb
@@ -2,7 +2,14 @@
   @title ||= :list_collection_numbers_title.t
 
   tabs = create_links(@links)
-  @tabsets = { right: draw_tab_set(tabs) }
+  # @tabsets = { right: draw_tab_set(tabs) }
+
+  @navbar = {} # reset
+  @navbar[:title] = { title: :COLLECTION_NUMBERS.t,
+                      url: collection_numbers_path }
+  @navbar[:dropdowns] = [
+    { title: "Actions", links: tabs }
+  ]
 
   flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/collection_numbers/new.html.erb
+++ b/app/views/collection_numbers/new.html.erb
@@ -1,19 +1,31 @@
 <%
   @title = :create_collection_number_title.l
 
-  tabs = [
-    link_to(:cancel_and_show.t(type: :observation),
-            observation_path(@observation.id))
+  # tabs = [
+  #   link_to(:cancel_and_show.t(type: :observation),
+  #           observation_path(@observation.id))
+  # ]
+  # @tabsets = { right: draw_tab_set(tabs) }
+
+  @navbar = {} # reset
+  @navbar[:title] = { title: :COLLECTION_NUMBERS.t,
+                      url: collection_numbers_path }
+  @navbar[:links] = [
+    { title: :cancel_and_show.t(type: :observation),
+      url: observation_path(@observation.id),
+      icon: "fa-backspace" }
   ]
-  @tabsets = { right: draw_tab_set(tabs) }
 %>
 
-<div class="row">
-  <div class="col-12 col-sm-7 max-width-text">
-    <%= render "collection_numbers/form", button: :ADD %>
-  </div>
+<div class="form-max-width mt-4">
+  <%= tag.h1 @title.humanize, class: "display-1" %>
+  <div class="row">
+    <div class="col-12 col-sm-7 max-width-text">
+      <%= render "collection_numbers/form", button: :ADD %>
+    </div>
 
-  <div class="col-12 col-sm-5 max-width-text">
-    <%= render "shared/log_item", object: @observation.rss_log %>
+    <div class="col-12 col-sm-5 max-width-text">
+      <%= render "shared/log_item", object: @observation.rss_log %>
+    </div>
   </div>
 </div>

--- a/app/views/collection_numbers/show.html.erb
+++ b/app/views/collection_numbers/show.html.erb
@@ -15,8 +15,16 @@
 
   @tabsets = {
     pager_for: @collection_number,
-    right: draw_tab_set(tabs)
+    # right: draw_tab_set(tabs)
   }
+
+  @navbar = {} # reset
+  @navbar[:title] = { title: :COLLECTION_NUMBERS.t,
+                      url: collection_numbers_path }
+  @navbar[:dropdowns] = [
+    { title: "Actions", links: tabs }
+  ]
+
 %>
 
 <div class="max-width-text mt-3">

--- a/app/views/observations/change_banner.html.erb
+++ b/app/views/observations/change_banner.html.erb
@@ -1,6 +1,7 @@
 <% @title = :change_banner_title.t %>
 
 <div class="max-width-text">
+  <%= tag.h1 @title.humanize, class: "display-1" %>
   <%= form_tag(action: :change_banner) do %>
     <%= text_area_tag(:val, h(@val), rows: 5, class: "form-control") %>
     <%= submit_tag(:SUBMIT.l, class: "btn mx-auto mt-3") %>

--- a/app/views/observations/download_observations.html.erb
+++ b/app/views/observations/download_observations.html.erb
@@ -1,13 +1,11 @@
-<%# provide :context_navbar do
-  render "application/context_navbar"
-end %>
 <%
   @title = :download_observations_title.t
 
-  tabs = [
-    link_with_query(:download_observations_back.t, action: :index_observation)
-  ]
+  # tabs = [
+  #   link_with_query(:download_observations_back.t, action: :index_observation)
+  # ]
   @tabsets = { right: draw_tab_set(tabs) }
+  @navbar[:title] = { title: :OBSERVATIONS.t, url: observations_path }
 %>
 
 <%= form_tag(add_query_param({})) %>

--- a/app/views/observations/edit.html.erb
+++ b/app/views/observations/edit.html.erb
@@ -1,14 +1,18 @@
 <%
   @title = :edit_observation_title.t(name: @observation.unique_format_name)
 
-  tabs = [
-    link_to(:cancel_and_show.t(type: :observation),
-            observation_path(id: @observation.id, q: get_query_param))
-  ]
+  # tabs = [
+  #   link_to(:cancel_and_show.t(type: :observation),
+  #           observation_path(id: @observation.id, q: get_query_param))
+  # ]
   # @tabsets = { right: draw_tab_set(tabs) }
   @navbar = {} # reset
   @navbar[:title] = { title: :OBSERVATIONS.t, url: observations_path }
-  @navbar[:dropdowns] = [{ title: "Actions", links: tabs }]
+  @navbar[:links] = [
+    { title: :cancel_and_show.t(type: :observation),
+      url: observation_path(@observation.id, q: get_query_param),
+      icon: "fa-backspace" }
+  ]
 %>
 
 <%= tag.div class: "form-max-width mt-4" do %>

--- a/app/views/observations/map_observations.html.erb
+++ b/app/views/observations/map_observations.html.erb
@@ -1,13 +1,17 @@
-<% provide :context_navbar do
-  render "application/context_navbar"
-end %>
-
 <%
-  tabs = [
-    link_to_coerced_query(@query, Observation),
-    link_to_coerced_query(@query, Location)
+  # tabs = [
+  #   link_to_coerced_query(@query, Observation),
+  #   link_to_coerced_query(@query, Location)
+  # ]
+  # @tabsets = { right: draw_tab_set(tabs) }
+  @navbar[:title] = { title: :OBSERVATIONS.t, url: observations_path }
+  # TODO: NIMMO - check links below against coerced queries above
+  @navbar[:links] = [
+    { title: :show_objects.t(type: :observation),
+      url: observations_path(q: get_query_param) }
+    { title: :show_objects.t(type: :location),
+      url: locations_path(q: get_query_param) }
   ]
-  @tabsets = { right: draw_tab_set(tabs) }
 %>
 
 <br/>

--- a/app/views/observations/new.html.erb
+++ b/app/views/observations/new.html.erb
@@ -1,13 +1,16 @@
 <%
   @title = :create_observation_title.t
 
-  tabs = [
-    link_to(:create_herbarium.t, new_herbarium_path(q: get_query_param))
-  ]
+  # tabs = [
+  #   link_to(:create_herbarium.t, new_herbarium_path(q: get_query_param))
+  # ]
   # @tabsets = { right: draw_tab_set(tabs) }
   @navbar = {} # reset
   @navbar[:title] = { title: :OBSERVATIONS.t, url: observations_path }
-  @navbar[:dropdowns] = [{ title: "Actions", links: tabs }]
+  @navbar[:links] = [
+    { title: :create_herbarium.t,
+      url: new_herbarium_path(q: get_query_param) }
+  ]
 %>
 
 <%= tag.div class: "form-max-width mt-4" do %>

--- a/app/views/observations/suggestions.html.erb
+++ b/app/views/observations/suggestions.html.erb
@@ -3,11 +3,18 @@
   @title = show_obs_title(@observation)
   num_images = @observation.images.length
 
-  tabs = [
-    link_to :show_object.t(type: :observation),
-            observation_path(id: @observation.id, q: get_query_param)
+  # tabs = [
+  #   link_to :show_object.t(type: :observation),
+  #           observation_path(id: @observation.id, q: get_query_param)
+  # ]
+  # @tabsets = { right: draw_tab_set(tabs) }
+
+  @navbar[:title] = { title: :OBSERVATIONS.t, url: observations_path }
+  @navbar[:search] = 1
+  @navbar[:links] = [
+    { title: :show_object.t(type: :observation),
+      url: observation_path(id: @observation.id, q: get_query_param) },
   ]
-  @tabsets = { right: draw_tab_set(tabs) }
 %>
 
 <div class="row">

--- a/app/views/rss_logs/_context_search.erb
+++ b/app/views/rss_logs/_context_search.erb
@@ -1,3 +1,4 @@
+<%# NOTE: Needs to be integrated into Bootstrap-4 Activity Log Navbar %>
 <%= form_tag({controller: :search, action: :pattern_search},
              {class: "form-inline my-2 my-lg-0"}) do %>
 

--- a/app/views/rss_logs/_rss_log_tabset.html.erb
+++ b/app/views/rss_logs/_rss_log_tabset.html.erb
@@ -1,3 +1,4 @@
+<%# NOTE: Not currently used by Bootstrap-4 %>
 <%= form_with url: rss_logs_path(q: get_query_param) do |f| %>
   <div class="btn-group pb-2 d-none d-sm-block text-nowrap">
     <%= content_tag(:span, :rss_show.t, class: "btn btn-xs disabled") %>

--- a/app/views/rss_logs/_type.html.erb
+++ b/app/views/rss_logs/_type.html.erb
@@ -1,3 +1,4 @@
+<%# NOTE: Not currently used by Bootstrap-4 %>
 <!-- A single checkbox and tab in Activity Feed tabset -->
 <% checked = @types.include?(type) || @types == ['all'] %>
 <span class="btn btn-xs <%= "active" if @types == [type] %>"

--- a/app/views/rss_logs/index.html.erb
+++ b/app/views/rss_logs/index.html.erb
@@ -24,6 +24,7 @@
       { title: "Actions", links: create_links(@links) }
     ]
   end
+  # TODO: Maybe use context_search here instead - NIMMO
   @navbar[:search] = 1
   @navbar[:filter] = 1
 %>

--- a/app/views/shared/_sorter.html.erb
+++ b/app/views/shared/_sorter.html.erb
@@ -1,3 +1,4 @@
+<%# NOTE: Not currently used by Bootstrap-4 %>
 <% if @sorts %>
   <div class="d-print-none">
     <div class="pt-3">

--- a/app/views/shared/_tab_set.html.erb
+++ b/app/views/shared/_tab_set.html.erb
@@ -1,3 +1,4 @@
+<%# NOTE: Not currently used by Bootstrap-4 %>
 <% links ||= [] %>
 <small class="font-weight-bold">
   <% links.reject(&:nil?).each do |link| %>

--- a/app/views/shared/_title_and_tab_sets.html.erb
+++ b/app/views/shared/_title_and_tab_sets.html.erb
@@ -1,3 +1,4 @@
+<%# NOTE: Not currently used by Bootstrap-4 %>
 <%
   # This is a stop-gap measure until I/we figure out exactly how we want to
   # deal with tabsets moving foward.  I'm not sure that my current approach is


### PR DESCRIPTION
Restore navbar links to views for articles and collection numbers
Fix navbar links for observations views
Cleanup: add notes to retired templates in shared, rss_logs, observations