### PR TITLE
fix bootstrap4 Description Query

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -224,6 +224,7 @@
 #  initialized?::       Has this query been initialized?
 #  coerce::             Coerce a query for one model into a query for another.
 #  coercable?::         Check if +coerce+ will work (but don't actually do it).
+#  title::              Translated title, used by views
 #
 #  ==== Sequence operators
 #  first::              Go to first result.

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -24,7 +24,11 @@ module Query
     include Query::Modules::Validation
 
     def flavor
-      self.class.to_s.sub(/^.*::/, "")[model.to_s.length..-1].underscore.to_sym
+      class_name_minus_model_name.underscore.to_sym
+    end
+
+    def class_name_minus_model_name
+      self.class.name.sub(/^.*::/, "")[model.name.gsub("::","").length..-1]
     end
 
     def parameter_declarations

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -28,7 +28,7 @@ module Query
     end
 
     def class_name_minus_model_name
-      self.class.name.sub(/^.*::/, "")[model.name.gsub("::","").length..-1]
+      self.class.to_s.sub(/^.*::/, "")[model.to_s.remove("::").length..-1]
     end
 
     def parameter_declarations

--- a/app/classes/query/modules/titles.rb
+++ b/app/classes/query/modules/titles.rb
@@ -9,12 +9,9 @@ module Query
 
       def initialize_title
         @title_tag = "query_title_#{flavor}".to_sym
-        @title_args = {
-          type: model.to_s.underscore.
-                # for namespaced models, convert paths to underscore separation
-                gsub("/", "_").
-                to_sym
-        }
+        @title_args = { type: model.to_s.underscore.
+                      tr("/", "_"). # for namespaced models
+                      to_sym }
       end
 
       # translated title, used by views

--- a/app/classes/query/modules/titles.rb
+++ b/app/classes/query/modules/titles.rb
@@ -9,9 +9,15 @@ module Query
 
       def initialize_title
         @title_tag = "query_title_#{flavor}".to_sym
-        @title_args = { type: model.to_s.underscore.to_sym }
+        @title_args = {
+          type: model.to_s.underscore.
+                # for namespaced models, convert paths to underscore separation
+                gsub("/", "_").
+                to_sym
+        }
       end
 
+      # translated title, used by views
       def title
         initialize_query unless initialized?
         @title_tag.t(params.merge(@title_args))

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -283,6 +283,20 @@ class QueryTest < UnitTestCase
     assert_equal(7, QueryRecord.count)
   end
 
+  def test_flavor
+=begin
+    assert_equal(:all,
+                 Query.lookup(:Observation, :all, by: :id).flavor,
+                 "Wrong Query flavor for one-word model")
+    assert_equal(:all,
+                 Query.lookup(:HerbariumRecord, :all, by: :id).flavor,
+                 "Wrong Query flavor for multiple-word model")
+=end
+    assert_equal(:all,
+                 Query.lookup(:NameDescription, :all, by: :id).flavor,
+                 "Wrong Query flavor for namespaced model")
+  end
+
   def test_title
     assert_equal("Observation Index",
                  Query.lookup(:Observation).title,

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -284,14 +284,12 @@ class QueryTest < UnitTestCase
   end
 
   def test_flavor
-=begin
     assert_equal(:all,
                  Query.lookup(:Observation, :all, by: :id).flavor,
                  "Wrong Query flavor for one-word model")
     assert_equal(:all,
                  Query.lookup(:HerbariumRecord, :all, by: :id).flavor,
                  "Wrong Query flavor for multiple-word model")
-=end
     assert_equal(:all,
                  Query.lookup(:NameDescription, :all, by: :id).flavor,
                  "Wrong Query flavor for namespaced model")
@@ -2381,7 +2379,8 @@ class QueryTest < UnitTestCase
   end
 
   def test_name_with_descriptions
-    expect = Name::Description.distinct(:name_id).order(:name_id).pluck(:name_id)
+    expect = Name::Description.distinct(:name_id).order(:name_id).
+             pluck(:name_id)
     assert_query(expect, :Name, :with_descriptions, by: :id)
   end
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -283,6 +283,18 @@ class QueryTest < UnitTestCase
     assert_equal(7, QueryRecord.count)
   end
 
+  def test_title
+    assert_equal("Observation Index",
+                 Query.lookup(:Observation).title,
+                 "Wrong Query title for one-word model")
+    assert_equal("Herbarium Record Index",
+                 Query.lookup(:HerbariumRecord).title,
+                 "Wrong Query title for multiple-word model")
+    assert_equal("Name Descriptions by ID",
+                 Query.lookup(:NameDescription, :all, by: :id).title,
+                 "Wrong Query title for namespaced model")
+  end
+
   ##############################################################################
   #
   #  :section: Query Mechanics


### PR DESCRIPTION
Makes Query work with namespaced models: `Location::Description`, `Name::Description`

Delivers https://www.pivotaltracker.com/story/show/173999735


