### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
-dist: xenial # use Ubuntu 16.04
+os: linux
+dist: bionic # Ubuntu 18.04 (Bionic Beaver)
 services:
   - mysql
 
 language: ruby
 rvm:
   - "2.6.6"
-
-# make Travis use its legacy infrastructure
-sudo: true
 
 # uncomment this line if your project needs to run something other than `rake`:
 # script: bundle exec rake lang:update


### PR DESCRIPTION
- Explicitly specify os. (This avoids one Travis warning.)
- Remove `sudo` key. (It is obsolete.)
- Change Ubuntu distribution from Xenial to Bionic.
At the moment, we use Xenial (16.04) in production, Bionic (18.04) in development.
So Travis is guaranteed to be out of sync with one or the other.
I opted to have Travis use Bionic,  as we are planning to upgrade the production environment.
(It also might make Travis run slightly faster.)

There is no manual test script. (But perhaps look at the Travis build file to see if it's as expected.)

Delivers https://www.pivotaltracker.com/story/show/173998390