### PR TITLE
Fix Observation#check_time

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1174,9 +1174,9 @@ class Observation < AbstractModel
   end
 
   def check_date
-    return true unless self.when.is_a?(Date) && self.when > Date.today + 1.day
+    return true unless self.when.is_a?(Date) && self.when > Time.zone.tomorrow
 
-    errors.add(:when, when_message("Date.today=#{Date.today}"))
+    errors.add(:when, when_message("Time.zone.today=#{Time.zone.today}"))
     errors.add(:when, :validate_observation_future_time.t)
     false
   end


### PR DESCRIPTION
Fixes intermittent time-related bug in `Observation#check_time`
Example:
https://travis-ci.org/github/MushroomObserver/mushroom-observer/builds/717764885

For solution, see https://docs.rubocop.org/rubocop-rails/2.7/cops_rails.html#railsdate