### PR TITLE
Rubocop documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,7 +41,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
 
-  ###################### Excluded files ########################################
+  ########################### Excluded files ###################################
   # Completely ignore the following
   Exclude:
     - .codeclimate.yml
@@ -59,133 +59,53 @@ AllCops:
     - script/perf_monitor
     - "tmp/**/*"
 
-###################### Global Enables #########################################
-# Enable pending cops added by recent RuboCop versions
+# ------------------------------------------------------------------------------
 
-# (0.83)
+#####  Individual Cops
+
+# Use RuboCop's default configuration, except as specified below
+# Note: pending cops have no default, so must be explicitly specified
+
+# Rubocop supports multiple options and MO uses a non-default
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+# (0.83) pending cop
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 
-# (0.82)
+# Repeat the default because Codeclimate ignores it as of 2019-07-09
+Layout/HashAlignment:
+  EnforcedColonStyle: key
+
+# Rubocop supports multiple options and MO uses a non-default
+Layout/LineLength:
+  # RuboCop default is 120 as of 0.84
+  Max: 80
+
+# (0.82) pending cop
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
-# (0.84)
+# (0.84) pending cop
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
-# (0.88)
+# (0.88) pending cop
 Lint/DuplicateElsifCondition:
   Enabled: true
 
-# (0.85)
+# (0.85) pending cop
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
-# (0.81)
+# (0.81) pending cop
 Lint/RaiseException:
   Enabled: true
 
-# (0.81)
+# (0.81) pending cop
 Lint/StructNewOverride:
   Enabled: true
-
-# (0.87)
-Style/AccessorGrouping:
-  Enabled: true
-
-# (0.88)
-Style/ArrayCoercion:
-  Enabled: true
-
-# (0.87)
-Style/BisectedAttrAccessor:
-  Enabled: true
-
-# (0.88)
-# Unsafe -- although the 0.88 documentation says "Safe"
-# The edge case is an if-elsif with a regex,
-# where the following code depends on $1 being something other than true/false,
-# e.g., where it uses a named capture group.
-# This has been reported https://github.com/rubocop-hq/rubocop/issues/8541
-Style/CaseLikeIf:
-  Enabled: true
-
-# (0.82)
-Style/ExponentialNotation:
-  Enabled: true
-
-# (0.88)
-Style/HashAsLastArrayItem:
-  Enabled: true
-
-# (0.80)
-Style/HashEachMethods:
-  Enabled: true
-
-# (0.88)
-Style/HashLikeCase:
-  Enabled: true
-
-# (0.80)
-Style/HashTransformKeys:
-  Enabled: true
-
-# (0.80)
-Style/HashTransformValues:
-  Enabled: true
-
-# (0.87)
-Style/RedundantAssignment:
-  Enabled: true
-
-# (0.86)
-Style/RedundantFetchBlock:
-  Enabled: true
-
-# (0.88)
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-
-# (0.85)
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-# (0.85)
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-# (0.83)
-Style/SlicingWithRange:
-  Enabled: true
-
-###################### Global Disables, Enables ################################
-
-# Disable because it does not work with Unicode in Ruby 2.4
-# Cop supports --auto-correct.
-Performance/Casecmp:
-  Enabled: false
-
-# MO uses HABTM extensively; RuboCop prefers the newer has_many through
-# Switching would require a migration process, detailed here:
-# http://chrisrolle.com/en/blog/migration-path-from-habtm-to-has_many-through
-# It's not worth the effort
-Rails/HasAndBelongsToMany:
-  Enabled: false
-
-# Allow non-ascii characters in comments; we need to use accented chars
-Style/AsciiComments:
-  Enabled: false
-
-# Repeat the RuboCop default because CodeClimate silently overrides it
-Style/DateTime:
-  Enabled: false
-
-# When the cop is enabled, the default is require_parentheses.
-Style/MethodCallWithArgsParentheses:
-  Enabled: true
-
-###################### Options #################################################
 
 Metrics/AbcSize:
 # Can we try relaxing this one?  Even short simple methods sometimes exceed
@@ -237,18 +157,10 @@ Metrics/PerceivedComplexity:
     # This Cop makes less sense in tests, we regularly ignore it.
     - "test//**/*"
 
-# Repeat the default because Codeclimate ignores it as of 2019-07-09
-Layout/HashAlignment:
-  EnforcedColonStyle: key
-
-# Rubocop supports multiple options and MO uses a non-default
-Layout/DotPosition:
-  EnforcedStyle: trailing
-
-# Rubocop supports multiple options and MO uses a non-default
-Layout/LineLength:
-  # RuboCop default is 120 as of 0.84
-  Max: 80
+# Disable because it does not work with Unicode in Ruby 2.4
+# Cop supports --auto-correct.
+Performance/Casecmp:
+  Enabled: false
 
 Performance/RegexpMatch:
   # Autocorrect changes "something.match(regexp)" to "something.match?(regexp)".
@@ -258,15 +170,80 @@ Performance/RegexpMatch:
   AutoCorrect: false
 
 # Causes test failures when used with Rubocop auto-correct
+# Could we get autocorrect to work by configuring the Whitelist parameter
 Rails/DynamicFindBy:
   AutoCorrect: false
 
+# MO uses HABTM extensively; RuboCop prefers the newer has_many through
+# Switching would require a migration process, detailed here:
+# http://chrisrolle.com/en/blog/migration-path-from-habtm-to-has_many-through
+# It's not worth the effort
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+# (0.87) pending cop
+Style/AccessorGrouping:
+  Enabled: true
+
+# (0.88) pending cop
+Style/ArrayCoercion:
+  Enabled: true
+
+# Allow non-ascii characters in comments; we need to use accented chars
+Style/AsciiComments:
+  Enabled: false
+
+# (0.87) pending cop
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+# (0.88) pending cop
+# Unsafe -- although the 0.88 documentation says "Safe"
+# The edge case is an if-elsif with a regex,
+# where the following code depends on $1 being something other than true/false,
+# e.g., where it uses a named capture group.
+# This has been reported https://github.com/rubocop-hq/rubocop/issues/8541
+Style/CaseLikeIf:
+  Enabled: true
+
+# Repeat the RuboCop default because CodeClimate silently overrides it
+# Is this still true? JDC 2020-08-17
+Style/DateTime:
+  Enabled: false
+
+# (0.82) pending cop
+Style/ExponentialNotation:
+  Enabled: true
+
+# (0.88) pending cop
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+# (0.80) pending cop
+Style/HashEachMethods:
+  Enabled: true
+
+# (0.88) pending cop
+Style/HashLikeCase:
+  Enabled: true
+
+# (0.80) pending cop
+Style/HashTransformKeys:
+  Enabled: true
+
+# (0.80) pending cop
+Style/HashTransformValues:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
-  # When it's auto-corrected in Ruby 2.4, our test suite won't run.
-  # We get: "can't modify frozen String" error
   AutoCorrect: true
 
-# Repeat the RuboCop defaults because CodeClimate silently overrides them
+# When the cop is enabled, the default is require_parentheses.
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+
+# Repeat the RuboCop defaults because Codeclimate silently overrides them
+# Is that still true? JDC 2020-08-17?
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: "()"
@@ -275,6 +252,34 @@ Style/PercentLiteralDelimiters:
     '%r':    "{}"
     '%w':    "[]"
     '%W':    "[]"
+
+# I can't figure out how to get exploded to work with API.
+Style/RaiseArgs:
+  EnforcedStyle: compact
+
+# (0.87) pending cop
+Style/RedundantAssignment:
+  Enabled: true
+
+# (0.86) pending cop
+Style/RedundantFetchBlock:
+  Enabled: true
+
+# (0.88) pending cop
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
+# (0.85) pending cop
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+# (0.85) pending cop
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+# (0.83) pending cop
+Style/SlicingWithRange:
+  Enabled: true
 
 # Rubocop supports multiple options and MO uses a non-default
 Style/StringLiterals:
@@ -288,6 +293,3 @@ Style/StringLiteralsInInterpolation:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# I can't figure out how to get exploded to work with API.
-Style/RaiseArgs:
-  EnforcedStyle: compact

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,18 +4,44 @@ require:
 
 inherit_from: .rubocop_todo.yml
 
-# RuboCop configuration
-# Uses Rubcop's default configuration, except as specified below
-# For more info, see http://rubocop.readthedocs.io/en/latest/configuration/
-
-# WARNING: .codeclimate.yml can specify the RuboCop version ('channel') used
+# ------------------------------------------------------------------------------
+#
+# UPDATING RUBOCOP in MushroomObserver
+# Please use the following procedure or equivalent in order to:
+# - Avoid discrepancies between RuboCop locally vs in continuous integration;
+# - Prevent increases in the number of offenses.
+#
+# *** Update the Codeclimate channel
+# .codeclimate.yml specifies the RuboCop version ('channel') used
 # by Code Climate, which can be different than the version in Gemfile.lock
 # See docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions
-# Therefore .codeclimate.yml should be updated whenever we update RuboCop
+# Therefore .codeclimate.yml should be updated whenever updating RuboCop
+#
+# *** Update the RuboCop configuration (this file)
+# - Run "rubocop --auto-gen-config" BUT DON'T COMMIT .rubocop_todo.yml
+# - Add any new cops to .rubocop.yml (this file) if the output so indicates.
+#
+# *** Fix any new offenses caused by the update
+# - Iteratively do the following steps until all new offenses are fixed:
+#   - Again run "rubocop --auto-gen-config" BUT DON'T COMMIT .rubocop_todo.yml
+#   - Compare the newly generated and existing versions of .rubocop_todo.yml
+#   - Fix any new offenses.
+# (The initial new offenses will have been caused by new or updated cops.
+#  Fixing those offenses may cause new offenses. And so forth.)
+#
+# *** Prune the todo list
+# Compare the new and existing versions of .rubocop_todo.yml (the todo list)
+# Accept any changes that reduce the todo list.
+#
+# ------------------------------------------------------------------------------
+
+# RuboCop configuration
+# Uses Rubcop's default configuration, except as specified below
+# For more info, see https://docs.rubocop.org/rubocop/configuration.html
 
 AllCops:
 
-  ###################### Exclusions ############################################
+  ###################### Excluded files ########################################
   # Completely ignore the following
   Exclude:
     - .codeclimate.yml

--- a/Gemfile
+++ b/Gemfile
@@ -107,14 +107,9 @@ gem("coveralls", require: false)
 gem("brakeman", require: false)
 
 # Use rubocop and associated gems for code quality control
-# WARNING: Whenever updating RuboCop, also:
-#   - Update .codeclimate.yml's RuboCop channel whenever we update RuboCop.
-#       docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions
-#   - Run `rubocop --auto-gen-config` to regenerate .rubocop_todo.yml
-#       For more information about autoconfiguration
-#       go to https://docs.rubocop.org/,
-#       enter Automatically Generated Configuration in the Rubocop search bar.
-#   - Add any added-but-unconfigured cops to .rubocop.yml and re-autoconfigure
+#
+# WARNING:
+# When upgrading RuboCop, please use the procedure specified in .rubocop.yml
 #
 # Temporarily lock RuboCop version while we are working our way through
 # auto-correctable offenses


### PR DESCRIPTION
- Improves MO's documentation about upgrading RuboCop
(By not following the newly documented procedure, 
I've ended up adding to the todo list, which is already way too large.
I hope this will help me and others to avoid that in the future.)
- Reorganizes RuboCop config file.
New organization is simpler and like that of the RuboCop generated todo list.

There is no manual test.
Delivers https://www.pivotaltracker.com/story/show/174361719