### PR TITLE
Two small tweaks

### DIFF
--- a/app/assets/stylesheets/Amanita.scss
+++ b/app/assets/stylesheets/Amanita.scss
@@ -129,3 +129,8 @@ $DANGER_FG_COLOR:                   black;
 .list-group-item {
   border: 0px !important;
 }
+
+// Some error messages are invisible!
+div.alert p.help-block {
+  color: black !important;
+}

--- a/app/views/name/show_name.html.erb
+++ b/app/views/name/show_name.html.erb
@@ -160,16 +160,12 @@
 
     <% if !@best_description.blank? %>
       <strong><%= :show_name_brief_description.t %>:</strong>
-      <div>
-        <span class="pull-right">
-          <%= link_with_query(:show_name_see_more.t, controller: :name,
+        [<%= link_with_query(:show_name_see_more.t, controller: :name,
                               action: :show_name_description,
                               id: @name.description.id) %> |
           <%= link_with_query(:EDIT.t, controller: :name,
                               action: :edit_name_description,
-                              id: @name.description.id) %>
-        </span>
-      </div>
+                              id: @name.description.id) %>]
       <div class="list-group">
         <div class="list-group-item">
           <%= @best_description.tpl %>


### PR DESCRIPTION
The "Show More" and "Edit" links for the Brief Description on show_name page were not showing up, not sure why.  Anyway, I moved them to beside the section header to be like all the rest of the sections.  Works now.

Also, some error messages on the observation page were white-on-white and thus invisible in the Amanita theme.  Overrode this and made the text black for that one specific case.