### PR TITLE
Relax api restrictions

### DIFF
--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -54,7 +54,7 @@ class IpStats
       update_one_stat(hash, vals, weight, do_activity)
     end
 
-    def update_one_stat(hash, vals, weight)
+    def update_one_stat(hash, vals, weight, do_activity)
       time, ip, user, load, controller, action, api_key = *vals
       hash[:ip] = ip
       hash[:user] ||= user.to_i if user.to_s != ""

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -234,6 +234,7 @@ class ApplicationController < ActionController::Base
       time: Time.current,
       controller: params[:controller],
       action: params[:action],
+      api_key: params[:api_key],
       robot: browser.bot? ? "robot" : "user",
       ip: request.try(&:remote_ip),
       url: request.try(&:url),

--- a/app/views/account/_ip_stats.html.erb
+++ b/app/views/account/_ip_stats.html.erb
@@ -3,6 +3,11 @@
 <% if user_id = @stats[@ip][:user] %>
   User: <%= user_link(User.safe_find(user_id) || user_id) %><br/>
 <% end %>
+<% if api_key_str = @stats[@ip][:api_key]
+  api_key = ApiKey.find_by_key(api_key_str) %>
+  API key: <%= api_key_str %> (<%= api_key ? user_link(api_key.user) :
+                                             "bogus!" %>)<br/>
+<% end %>
 Rate: <%= (@stats[@ip][:rate].to_f * 60).round(2) %> / minute
       = 1 every <%= (1.0 / @stats[@ip][:rate]).round(2) %> seconds<br/>
 Load: <%= (@stats[@ip][:load].to_f * 100).round(2) %>% of one worker<br/>

--- a/app/views/account/_ip_summary.html.erb
+++ b/app/views/account/_ip_summary.html.erb
@@ -15,7 +15,16 @@
         [<%= link_to("Block", { controller: :account, action: :blocked_ips,
                                 add_bad: ip }) %>]
       <% end %></td>
-      <td><%= @stats[ip][:user].present? ? user_link(@stats[ip][:user]) : "—" %></td>
+      <td>
+        <% if user_id = @stats[ip][:user] %>
+          User: <%= user_link(User.safe_find(user_id) || user_id) %><br/>
+        <% end %>
+        <% if api_key_str = @stats[ip][:api_key]
+          api_key = ApiKey.find_by_key(api_key_str) %>
+          API key: <%= api_key_str %> (<%= api_key ? user_link(api_key.user) :
+                                                     "bogus!" %>)<br/>
+        <% end %>
+      </td>
       <td><%= (@stats[ip][:rate] * 60).round(2) %></td>
       <td><%= (@stats[ip][:load] * 100).round(2) %></td>
     </tr>

--- a/script/update_ip_stats.rb
+++ b/script/update_ip_stats.rb
@@ -72,6 +72,7 @@ end
 def report_user(stats)
   id = stats[:user]
   puts("User ##{id} is hogging the server!")
+  puts("  API key: #{stats[:api_key]}") if stats[:api_key].to_s != ""
   puts("  https://mushroomobserver.org/observer/show_user/#{id}")
   puts("  request rate: #{(stats[:rate] * 60).round(2)} requests / minute")
   puts("  request rate: 1 every #{(1.0 / stats[:rate]).round(2)} seconds")

--- a/script/update_ip_stats.rb
+++ b/script/update_ip_stats.rb
@@ -54,7 +54,7 @@ abort(<<"HELP") if ARGV.any? { |arg| ["-h", "--help"].include?(arg) }
 HELP
 
 def bad_ip?(stats)
-  if stats[:user].to_s != ""
+  if stats[:user].to_s != "" || stats[:api_key].to_d != ""
     report_user(stats) if stats[:rate] * 60  >= 30 || # requests per minute
                           stats[:load] * 100 >= 100   # pct use of one worker
   elsif stats[:rate] * 60  > 20 || # requests per minute

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -766,6 +766,15 @@ class AccountControllerTest < FunctionalTestCase
   def test_blocked_ips
     new_ip = "5.4.3.2"
     IpStats.remove_blocked_ips([new_ip])
+    # make sure there is an API key logged to test that part of view
+    api_key = api_keys(:rolfs_api_key)
+    IpStats.log_stats({
+      ip:         "3.14.15.9",
+      time:       Time.now,
+      controller: "api",
+      action:     "observations",
+      api_key:    api_key.key
+    })
     assert_false(IpStats.blocked?(new_ip))
 
     login(:rolf)
@@ -775,6 +784,7 @@ class AccountControllerTest < FunctionalTestCase
     make_admin
     get(:blocked_ips)
     assert_response(:success)
+    assert_includes(@response.body, api_key.key)
 
     get(:blocked_ips, add_bad: "garbage")
     assert_flash_error

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -768,13 +768,11 @@ class AccountControllerTest < FunctionalTestCase
     IpStats.remove_blocked_ips([new_ip])
     # make sure there is an API key logged to test that part of view
     api_key = api_keys(:rolfs_api_key)
-    IpStats.log_stats({
-      ip:         "3.14.15.9",
-      time:       Time.now,
-      controller: "api",
-      action:     "observations",
-      api_key:    api_key.key
-    })
+    IpStats.log_stats({ ip: "3.14.15.9",
+                        time: Time.zone.now,
+                        controller: "api",
+                        action: "observations",
+                        api_key: api_key.key })
     assert_false(IpStats.blocked?(new_ip))
 
     login(:rolf)


### PR DESCRIPTION
1. Reduces weight given to API requests when calculating rate and load stats for an IP.
2. Treats any request including an API key as logged in (and therefore even more relaxed rate and load restrictions apply).