### PR TITLE
Fix Articles destroy links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,4 +293,17 @@ module ApplicationHelper
       action_name.tr("_", " ").titleize
     end
   end
+
+  # button to destroy object
+  # Used instead of link because DESTROY link requires js
+  # Sample usage:
+  #   destroy_button(object: article)
+  #   destroy_button(object: term, name: :destroy_glossary_term)
+  def destroy_button(object:, name: :DESTROY)
+    button_to(
+      name.t,
+      { action: "destroy", id: object.id },
+      method: :delete, data: { confirm: "Are you sure?" }
+    )
+  end
 end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -19,9 +19,7 @@ module ArticlesHelper
 
     tabs.push(link_to(:create_article_title.t, new_article_path),
               link_to(:EDIT.t, edit_article_path(article.id)),
-              # Fix link_to DESTROY
-              # https://www.pivotaltracker.com/story/show/174524961
-              link_to(:DESTROY.t, action: :destroy, id: article.id))
+              destroy_button(object: article))
   end
 
   # Can user modify all articles

--- a/app/helpers/glossary_terms_helper.rb
+++ b/app/helpers/glossary_terms_helper.rb
@@ -2,11 +2,7 @@
 
 # View Helpers for GlossaryTerms
 module GlossaryTermsHelper
-  def destroy_button(term)
-    button_to(
-      :destroy_glossary_term.t,
-      { action: "destroy", id: term.id },
-      method: :delete, data: { confirm: "Are you sure?" }
-    )
+  def glossary_term_destroy_button(term)
+    destroy_button(object: term, name: :destroy_glossary_term)
   end
 end

--- a/app/views/glossary_terms/index.html.erb
+++ b/app/views/glossary_terms/index.html.erb
@@ -21,7 +21,7 @@
         <%= term.description.tpl %>
       </td>
       <td>
-        <%= destroy_button(term) if in_admin_mode? %>
+        <%= glossary_term_destroy_button(term) if in_admin_mode? %>
         <%= if term&.thumb_image_id&.nonzero?
           thumbnail(term.thumb_image, votes: true)
         end %>

--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -6,7 +6,7 @@
     link_to(:create_glossary_term.t, new_glossary_term_path),
     link_to(:edit_glossary_term.t, edit_glossary_term_path(@glossary_term.id))
   ]
-  tabs << destroy_button(@glossary_term) if in_admin_mode?
+  tabs << glossary_term_destroy_button(@glossary_term) if in_admin_mode?
 
 
   @tabsets = { right: draw_tab_set(tabs) }

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -51,7 +51,8 @@ class ArticlesControllerTest < FunctionalTestCase
     get(:show, params: { id: article.id })
     assert_select("a", text: :create_article_title.l)
     assert_select("a", text: :EDIT.l)
-    assert_select("a", text: :DESTROY.l)
+    assert_select("form input[value='Destroy']", true,
+                  "Page is missing Destroy button")
 
     # Prove that trying to show non-existent article provokes error & redirect
     get(:show, params: { id: 0 })

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -42,6 +42,16 @@ class GlossaryTermsControllerTest < FunctionalTestCase
                   "Page should have link to prior version")
   end
 
+  def test_show_admin_delete
+    term = glossary_terms(:square_glossary_term)
+    login
+    make_admin
+    get(:show, params: { id: term.id })
+
+    assert_select("form input[value='delete']", { count: 1 },
+                  "Page is missing a way for admin to destroy glossary term")
+  end
+
   # ---------- Test actions that Display forms -- (new, edit, etc.) ------------
 
   # ***** new *****


### PR DESCRIPTION
Change `Articles` destroy links to buttons

`destroy` links don't work because they require js,
so use button instead.

- Promote and refactor `destroy_button` method
- Use button instead of link to destroy `article`
- Revise GlossaryTermsHelper and view to work with promoted method

Delivers https://www.pivotaltracker.com/story/show/174524961

Suggested manual test script:
- Go into admin mode
- Create an article. 
  Result: The show_article page should have a "Destroy" link
- Click it.
Result: The article should be destroyed.
- Create a GlossaryTerm
  Result: The show_glossary_term page should have a "Destroy Glossary Term" link
- Click it
  Result: The term should be destroyed.
