### PR TITLE
Validate glossary terms

### DIFF
--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -37,19 +37,19 @@ class GlossaryTermsController < ApplicationController
   # ---------- Actions to Modify data: (create, update, destroy, etc.) ---------
 
   def create
-    @glossary_term = \
-      GlossaryTerm.new(user: @user, name: params[:glossary_term][:name],
-                       description: params[:glossary_term][:description])
+    @glossary_term = GlossaryTerm.new(
+      user: @user,
+      name: params[:glossary_term][:name],
+      description: params[:glossary_term][:description]
+  )
 
     if params[:glossary_term][:upload_image]
       @glossary_term.add_image(process_image(image_args))
     end
 
-    unless @glossary_term.save
-      return reload_form("new")
-    else
-      redirect_to(glossary_term_path(@glossary_term.id))
-    end
+    return reload_form("new") unless @glossary_term.save
+
+    redirect_to(glossary_term_path(@glossary_term.id))
   end
 
   def update
@@ -58,11 +58,9 @@ class GlossaryTermsController < ApplicationController
                                 permit(:name, :description)
     @glossary_term.user = @user
 
-    unless @glossary_term.save
-      return reload_form("edit")
-    else
-      redirect_to(glossary_term_path(@glossary_term.id))
-    end
+    return reload_form("edit") unless @glossary_term.save
+
+    redirect_to(glossary_term_path(@glossary_term.id))
   end
 
   def destroy

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -136,7 +136,9 @@ class GlossaryTermsController < ApplicationController
     return if @glossary_term.save # happy path
 
     # term failed, so clean up the orphaned (unassociated) image
-    added_image.try(:destroy)
+    # and its flash notice ("Successfully uploaded image ...")
+    saved_image.try(:destroy)
+    flash_clear
     false
   end
 

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -115,8 +115,8 @@ class GlossaryTermsController < ApplicationController
   end
 
   def add_glossary_term_error_messages_to_flash
-    @glossary_term.errors.messages.values.each do |val|
-      # flash_error takes a string; val is a hash, e.g. ["message"]
+    @glossary_term.errors.messages.each_value do |val|
+      # flash_error takes a string; val is an array of size 1, e.g. ["message"]
       flash_error(val.first)
     end
   end

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -109,23 +109,20 @@ class GlossaryTermsController < ApplicationController
   end
 
   def reload_form(form)
-    flash_error(format_model_error_messages)
+    add_glossary_term_error_messages_to_flash
     init_image_form_instance_variables
     render(form)
   end
 
-  # Convert model error messages to a form expected by #flash_error
-  # The model supplies messages like `["message"]``
-  # Change these to "<p>1st message</p><p>2nd message</p>"
-  def format_model_error_messages
-    flash_string = ""
+  def add_glossary_term_error_messages_to_flash
     @glossary_term.errors.messages.values.each do |val|
-      flash_string = flash_string + "<p>#{val.first}</p>"
+      # flash_error takes a string; val is a hash, e.g. ["message"]
+      flash_error(val.first)
     end
-    flash_string
   end
 
-  # Process any image with @glossary_term, returning truthy if neither fails
+  # Process any image together with @glossary_term,
+  # returning truthy if neither fails
   # They must be processed together to correctly validate GlossaryTerm and
   # allow backing out Image if GlossaryTerm is invalid
   def image_and_term_saves_smooth?

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -27,7 +27,7 @@ class GlossaryTermsController < ApplicationController
 
   def new
     @glossary_term = GlossaryTerm.new
-    init_image_form_instance_variables
+    assign_image_form_ivars
   end
 
   def edit
@@ -98,19 +98,17 @@ class GlossaryTermsController < ApplicationController
 
   # --------- Other private methods
 
-  def init_image_form_instance_variables
-    @copyright_holder ||= @user.name
-    @copyright_year ||= Time.now.utc.year
-    @upload_license_id ||= @user.license_id
-    # rubocop:disable Naming/MemoizedInstanceVariableName
-    # RuboCop wants to name the ivar "@update_image_form_instance_variables"
-    @licenses ||= License.current_names_and_ids(@user.license)
-    # rubocop:enable Naming/MemoizedInstanceVariableName
+  def assign_image_form_ivars
+    @copyright_holder = params[:copyright_holder] || @user.name
+    @copyright_year = params.dig(:date, :copyright_year)&.to_i ||
+                      Time.now.utc.year
+    @licenses = License.current_names_and_ids(@user.license)
+    @upload_license_id = params.dig(:upload, :license_id) || @user.license_id
   end
 
   def reload_form(form)
     add_glossary_term_error_messages_to_flash
-    init_image_form_instance_variables
+    assign_image_form_ivars
     render(form)
   end
 

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -43,13 +43,21 @@ class GlossaryTermsController < ApplicationController
       description: params[:glossary_term][:description]
     )
 
-    if params[:glossary_term][:upload_image]
-      @glossary_term.add_image(process_image(image_args))
+    # rubocop:disable Style/IfUnlessModifier
+    # RuboCop gives false positive -- modifier if doesn't fit on one line.
+    added_image = if params[:glossary_term][:upload_image]
+                    process_image(image_args)
+                  end
+    # rubocop:enable Style/IfUnlessModifier
+
+    @glossary_term.add_image(added_image)
+
+    if @glossary_term.save
+      redirect_to(glossary_term_path(@glossary_term.id))
+    else
+      added_image.try(:destroy)
+      reload_form("new")
     end
-
-    return reload_form("new") unless @glossary_term.save
-
-    redirect_to(glossary_term_path(@glossary_term.id))
   end
 
   def update

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -105,18 +105,15 @@ class GlossaryTermsController < ApplicationController
 
   # --------- Other private methods
 
-  def reload_form(form = "new")
-    add_validation_errors_to_flash
+  def reload_form(form)
+    add_model_error_messages_to_flash
     init_image_form_instance_variables
     render(form)
   end
 
-  def add_validation_errors_to_flash
-    errors = ""
-    @glossary_term.errors.messages.each_value do |v|
-      errors = errors + "#{v.first}\n"
-    end
-    flash_error(errors)
+  def add_model_error_messages_to_flash
+    model_error_messages = @glossary_term.errors.messages.values.join("\n")
+    flash_error(model_error_messages)
   end
 
   def init_image_form_instance_variables
@@ -141,9 +138,10 @@ class GlossaryTermsController < ApplicationController
     }
   end
 
+  # Remove "permitted: false" from this param so that model can mass assign it
+  # Do this only in test environment
   def permit_upload_image_param
     args = strong_upload_image_param
-    # Remove "permitted: false" from this param so that model can mass assign it
     args[:image] = params[:glossary_term][:upload_image][:image]
     args
   end

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -26,6 +26,7 @@ class GlossaryTermsController < ApplicationController
   # ---------- Actions to Display forms -- (new, edit, etc.) -------------------
 
   def new
+    @glossary_term = GlossaryTerm.new
     init_image_form_instance_variables
   end
 
@@ -36,31 +37,31 @@ class GlossaryTermsController < ApplicationController
   # ---------- Actions to Modify data: (create, update, destroy, etc.) ---------
 
   def create
-    glossary_term = \
+    @glossary_term = \
       GlossaryTerm.new(user: @user, name: params[:glossary_term][:name],
                        description: params[:glossary_term][:description])
 
     if params[:glossary_term][:upload_image]
-      glossary_term.add_image(process_image(image_args))
+      @glossary_term.add_image(process_image(image_args))
     end
 
-    unless glossary_term.save
-      return reload_form(term: glossary_term, form: "new")
+    unless @glossary_term.save
+      return reload_form("new")
     else
-      redirect_to(glossary_term_path(glossary_term.id))
+      redirect_to(glossary_term_path(@glossary_term.id))
     end
   end
 
   def update
-    glossary_term = GlossaryTerm.find(params[:id].to_s)
-    glossary_term.attributes = params[:glossary_term].
-                               permit(:name, :description)
-    glossary_term.user = @user
+    @glossary_term = GlossaryTerm.find(params[:id].to_s)
+    @glossary_term.attributes = params[:glossary_term].
+                                permit(:name, :description)
+    @glossary_term.user = @user
 
-    unless glossary_term.save
-      return reload_edit_form(term: glossary_term)
+    unless @glossary_term.save
+      return reload_form("edit")
     else
-      redirect_to(glossary_term_path(glossary_term.id))
+      redirect_to(glossary_term_path(@glossary_term.id))
     end
   end
 
@@ -104,26 +105,15 @@ class GlossaryTermsController < ApplicationController
 
   # --------- Other private methods
 
-  def reload_form(term:, form:)
-    flash_validation_errors(term)
-    @name = params[:glossary_term][:name]
-    @description = params[:glossary_term][:description]
+  def reload_form(form = "new")
+    add_validation_errors_to_flash
     init_image_form_instance_variables
     render(form)
   end
 
-  def reload_edit_form(term:)
-    flash_validation_errors(term)
-    @glossary_term = term
-    @glossary_term.name = params[:glossary_term][:name]
-    @glossary_term.description = params[:glossary_term][:description]
-    init_image_form_instance_variables
-    render("edit")
-  end
-
-  def flash_validation_errors(term)
+  def add_validation_errors_to_flash
     errors = ""
-    term.errors.messages.each_value do |v|
+    @glossary_term.errors.messages.each_value do |v|
       errors = errors + "#{v.first}\n"
     end
     flash_error(errors)

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -127,7 +127,7 @@ class GlossaryTermsController < ApplicationController
   # allow backing out Image if GlossaryTerm is invalid
   def image_and_term_saves_smooth?
     # If no upload file specified, only issue is the term
-    return @glossary_term.save unless upload?
+    return @glossary_term.save unless upload_specified?
 
     # return false if image processing fails
     return unless (saved_image = process_upload(image_args))
@@ -142,7 +142,7 @@ class GlossaryTermsController < ApplicationController
     false
   end
 
-  def upload?
+  def upload_specified?
     params[:glossary_term][:upload_image]
   end
 

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -41,7 +41,7 @@ class GlossaryTermsController < ApplicationController
       user: @user,
       name: params[:glossary_term][:name],
       description: params[:glossary_term][:description]
-  )
+    )
 
     if params[:glossary_term][:upload_image]
       @glossary_term.add_image(process_image(image_args))
@@ -118,7 +118,10 @@ class GlossaryTermsController < ApplicationController
     @copyright_holder ||= @user.name
     @copyright_year ||= Time.now.utc.year
     @upload_license_id ||= @user.license_id
+    # rubocop:disable Naming/MemoizedInstanceVariableName
+    # RuboCop wants to name the ivar "@update_image_form_instance_variables"
     @licenses ||= License.current_names_and_ids(@user.license)
+    # rubocop:enable Naming/MemoizedInstanceVariableName
   end
 
   # Permit mass assignment of image arguments for testing purposes

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -15,11 +15,11 @@ class GlossaryTerm < AbstractModel
   # Add before_save validity check(s)
   # See https://www.pivotaltracker.com/story/show/174606044
   validates :name, presence: {
-    message: proc { :glossary_error_name_blank.t }
+    message: :glossary_error_name_blank.t
   }
   validates :name, uniqueness: {
     case_sensitive: false,
-    message: proc { :glossary_error_duplicate_name.t }
+    message: :glossary_error_duplicate_name.t
   }
   validate :must_have_description_or_image
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -12,17 +12,17 @@ class GlossaryTerm < AbstractModel
   belongs_to :rss_log
   has_and_belongs_to_many :images, -> { order "vote_cache DESC" }
 
-  # rubocop disable:Rails/UniqueValidationWithoutIndex
-  # It's not worth indexing :name in the db;
-  # Uniqueness of this attribute is nice, but not critical
   validates :name, presence: {
     message: proc { :glossary_error_name_blank.t }
   }
-  # rubocop enable:Rails/UniqueValidationWithoutIndex
+  # rubocop disable:Rails/UniqueValidationWithoutIndex
+  # It's not worth indexing :name in the db;
+  # Uniqueness of this attribute is nice, but not critical
   validates :name, uniqueness: {
     case_sensitive: false,
     message: proc { :glossary_error_duplicate_name.t }
   }
+  # rubocop enable:Rails/UniqueValidationWithoutIndex
   validate :must_have_description_or_image
 
   after_destroy(:destroy_unused_images)

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -15,11 +15,11 @@ class GlossaryTerm < AbstractModel
   # Add before_save validity check(s)
   # See https://www.pivotaltracker.com/story/show/174606044
   validates :name, presence: {
-    message: :glossary_error_name_blank.t
+    message: proc { :glossary_error_name_blank.t }
   }
   validates :name, uniqueness: {
     case_sensitive: false,
-    message: :glossary_error_duplicate_name.t
+    message: proc { :glossary_error_duplicate_name.t }
   }
   validate :must_have_description_or_image
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Glossary of mycological terms, with illustrations
 class GlossaryTerm < AbstractModel
   require "acts_as_versioned"
 
@@ -14,11 +15,11 @@ class GlossaryTerm < AbstractModel
   # Add before_save validity check(s)
   # See https://www.pivotaltracker.com/story/show/174606044
   validates :name, presence: {
-    message: ->(object, data) { :glossary_error_name_blank.t }
+    message: Proc.new { :glossary_error_name_blank.t }
   }
   validates :name, uniqueness: {
     case_sensitive: false,
-    message: ->(object, data) { :glossary_error_duplicate_name.t }
+    message: Proc.new { :glossary_error_duplicate_name.t }
   }
   validate :must_have_description_or_image
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -12,11 +12,13 @@ class GlossaryTerm < AbstractModel
   belongs_to :rss_log
   has_and_belongs_to_many :images, -> { order "vote_cache DESC" }
 
-  # Add before_save validity check(s)
-  # See https://www.pivotaltracker.com/story/show/174606044
+  # rubocop disable:Rails/UniqueValidationWithoutIndex
+  # It's not worth indexing :name in the db;
+  # Uniqueness of this attribute is nice, but not critical
   validates :name, presence: {
     message: proc { :glossary_error_name_blank.t }
   }
+  # rubocop enable:Rails/UniqueValidationWithoutIndex
   validates :name, uniqueness: {
     case_sensitive: false,
     message: proc { :glossary_error_duplicate_name.t }

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -13,6 +13,16 @@ class GlossaryTerm < AbstractModel
 
   # Add before_save validity check(s)
   # See https://www.pivotaltracker.com/story/show/174606044
+  validates :name, presence: {
+    message: ->(object, data) { :glossary_error_name_blank.t }
+  }
+  validates :name, uniqueness: {
+    case_sensitive: false,
+    message: ->(object, data) do
+      :glossary_error_duplicate_name.t(name: %{value})
+    end
+  }
+  validate :must_have_description_or_image
 
   after_destroy(:destroy_unused_images)
 
@@ -87,6 +97,12 @@ class GlossaryTerm < AbstractModel
   ##############################################################################
 
   private
+
+  def must_have_description_or_image
+    return if description.present? || thumb_image.present?
+
+    errors[:base] << :glossary_error_description_or_image.t
+  end
 
   def destroy_unused_images
     all_images.each do |image|

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -15,14 +15,14 @@ class GlossaryTerm < AbstractModel
   validates :name, presence: {
     message: proc { :glossary_error_name_blank.t }
   }
-  # rubocop disable:Rails/UniqueValidationWithoutIndex
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
   # It's not worth indexing :name in the db;
   # Uniqueness of this attribute is nice, but not critical
   validates :name, uniqueness: {
     case_sensitive: false,
     message: proc { :glossary_error_duplicate_name.t }
   }
-  # rubocop enable:Rails/UniqueValidationWithoutIndex
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
   validate :must_have_description_or_image
 
   after_destroy(:destroy_unused_images)

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -18,9 +18,7 @@ class GlossaryTerm < AbstractModel
   }
   validates :name, uniqueness: {
     case_sensitive: false,
-    message: ->(object, data) do
-      :glossary_error_duplicate_name.t(name: %{value})
-    end
+    message: ->(object, data) { :glossary_error_duplicate_name.t }
   }
   validate :must_have_description_or_image
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -15,11 +15,11 @@ class GlossaryTerm < AbstractModel
   # Add before_save validity check(s)
   # See https://www.pivotaltracker.com/story/show/174606044
   validates :name, presence: {
-    message: Proc.new { :glossary_error_name_blank.t }
+    message: proc { :glossary_error_name_blank.t }
   }
   validates :name, uniqueness: {
     case_sensitive: false,
-    message: Proc.new { :glossary_error_duplicate_name.t }
+    message: proc { :glossary_error_duplicate_name.t }
   }
   validate :must_have_description_or_image
 

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: @glossary_term, html: { multipart: true } do |f| %>
+
+  <div class="form-group push-down">
+    <%= f.label(:name, "#{:glossary_term_name.t}:") %>
+    <%= f.text_field :name, class: "form-control" %>
+  </div>
+
+  <div class="form-group push-down">
+    <%= f.label :description, "#{:glossary_term_description.t}:" %>
+    <%= f.text_area :description, rows: 20, class: "form-control" %>
+  </div>
+  <%# Form should have link to Textile sandbox
+      See https://www.pivotaltracker.com/story/show/124382351 %>
+
+  <%# Let calling view add more if needed %>
+  <%= yield f %>
+
+  <%= f.submit(:SAVE.t, class: "btn center-block push-down") %>
+
+<% end %>

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -10,8 +10,6 @@
     <%= f.text_area(:description, rows: 16, class: "form-control") %>
     <%= :field_textile_link.t %>
   </div>
-  <%# Form should have link to Textile sandbox
-      See https://www.pivotaltracker.com/story/show/124382351 %>
 
   <%= yield f %>
 

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -2,17 +2,17 @@
 
   <div class="form-group push-down">
     <%= f.label(:name, "#{:glossary_term_name.t}:") %>
-    <%= f.text_field :name, class: "form-control" %>
+    <%= f.text_field(:name, class: "form-control") %>
   </div>
 
   <div class="form-group push-down">
-    <%= f.label :description, "#{:glossary_term_description.t}:" %>
-    <%= f.text_area :description, rows: 20, class: "form-control" %>
+    <%= f.label(:description, "#{:glossary_term_description.t}:") %>
+    <%= f.text_area(:description, rows: 16, class: "form-control") %>
+    <%= :field_textile_link.t %>
   </div>
   <%# Form should have link to Textile sandbox
       See https://www.pivotaltracker.com/story/show/124382351 %>
 
-  <%# Let calling view add more if needed %>
   <%= yield f %>
 
   <%= f.submit(:SAVE.t, class: "btn center-block push-down") %>

--- a/app/views/glossary_terms/edit.html.erb
+++ b/app/views/glossary_terms/edit.html.erb
@@ -15,23 +15,5 @@
     See https://www.pivotaltracker.com/story/show/174608605 %>
 
 <div class="max-width-text">
-  <%= form_for(@glossary_term,
-               url: { action: "update" },
-               method: :put) do |form| %>
-    <div class="form-group push-down">
-      <%= label_tag(:glossary_name, "#{:glossary_term_name.t}:") %>
-      <%= form.text_field(:name, class: "form-control") %>
-    </div>
-
-    <div class="form-group push-down">
-      <%= label_tag(:glossary_description,
-                    "#{:glossary_term_description.t}:") %>
-      <%= form.text_area(:description, rows: 15, class: "form-control") %>
-    </div>
-    <%# Form should have link to Textile sandbox
-        See https://www.pivotaltracker.com/story/show/124382351 %>
-
-    <%= submit_tag(:edit_glossary_term_save.t,
-                   class: "btn center-block push-down") %>
-  <% end %>
+  <%= render "form" %>
 </div>

--- a/app/views/glossary_terms/edit.html.erb
+++ b/app/views/glossary_terms/edit.html.erb
@@ -11,9 +11,6 @@
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 
-<%# Combine "new" and "edit" forms
-    See https://www.pivotaltracker.com/story/show/174608605 %>
-
 <div class="max-width-text">
   <%= render "form" %>
 </div>

--- a/app/views/glossary_terms/new.html.erb
+++ b/app/views/glossary_terms/new.html.erb
@@ -17,14 +17,14 @@
                html: {multipart: true}) do |form| %>
     <div class="form-group push-down">
       <%= label_tag(:glossary_name, "#{:glossary_term_name.t}:") %>
-      <%= form.text_field(:name, value: @name,
+      <%= form.text_field(:name, value: @glossary_term.name,
                           class: "form-control") %>
     </div>
 
     <div class="form-group push-down">
       <%= label_tag(:glossary_description,
                     "#{:glossary_term_description.t}:") %>
-      <%= form.text_area(:description, value: @description,
+      <%= form.text_area(:description, value: @glossary_term.description,
                          rows: 20, class: "form-control") %>
     </div>
     <%# Form should have link to Textile sandbox

--- a/app/views/glossary_terms/new.html.erb
+++ b/app/views/glossary_terms/new.html.erb
@@ -12,23 +12,8 @@
 <%# Combine "new" and "edit" forms
     See https://www.pivotaltracker.com/story/show/174608605 %>
 <div class="max-width-text">
-  <%= form_for(:glossary_term,
-               url: { action: :create },
-               html: {multipart: true}) do |form| %>
-    <div class="form-group push-down">
-      <%= label_tag(:glossary_name, "#{:glossary_term_name.t}:") %>
-      <%= form.text_field(:name, value: @glossary_term.name,
-                          class: "form-control") %>
-    </div>
 
-    <div class="form-group push-down">
-      <%= label_tag(:glossary_description,
-                    "#{:glossary_term_description.t}:") %>
-      <%= form.text_area(:description, value: @glossary_term.description,
-                         rows: 20, class: "form-control") %>
-    </div>
-    <%# Form should have link to Textile sandbox
-        See https://www.pivotaltracker.com/story/show/124382351 %>
+  <%= render "form", button_name: :edit_glossary_term_save do |f| %>
 
     <div class="form-group push-down">
       <%= label_tag(:glossary_term_upload_image, "#{:Image.t}:") %>
@@ -51,7 +36,5 @@
       <p class="help_block">(<%= :glossary_term_copyright_warning.t %>)</p>
     </div>
 
-    <%= submit_tag(:edit_glossary_term_save.t,
-                   class: "btn center-block push-down") %>
   <% end %>
 </div>

--- a/app/views/glossary_terms/new.html.erb
+++ b/app/views/glossary_terms/new.html.erb
@@ -12,17 +12,20 @@
 <%# Combine "new" and "edit" forms
     See https://www.pivotaltracker.com/story/show/174608605 %>
 <div class="max-width-text">
-  <%= form_for(:glossary_term, url: { action: :create },
+  <%= form_for(:glossary_term,
+               url: { action: :create },
                html: {multipart: true}) do |form| %>
     <div class="form-group push-down">
-      <%= label_tag(:glossary_name, :glossary_term_name.t + ":") %>
-      <%= form.text_field(:name, class: "form-control") %>
+      <%= label_tag(:glossary_name, "#{:glossary_term_name.t}:") %>
+      <%= form.text_field(:name, value: @name,
+                          class: "form-control") %>
     </div>
 
     <div class="form-group push-down">
       <%= label_tag(:glossary_description,
                     "#{:glossary_term_description.t}:") %>
-      <%= form.text_area(:description, rows: 20, class: "form-control") %>
+      <%= form.text_area(:description, value: @description,
+                         rows: 20, class: "form-control") %>
     </div>
     <%# Form should have link to Textile sandbox
         See https://www.pivotaltracker.com/story/show/124382351 %>

--- a/app/views/glossary_terms/new.html.erb
+++ b/app/views/glossary_terms/new.html.erb
@@ -9,8 +9,6 @@
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 
-<%# Combine "new" and "edit" forms
-    See https://www.pivotaltracker.com/story/show/174608605 %>
 <div class="max-width-text">
 
   <%= render "form", button_name: :edit_glossary_term_save do |f| %>
@@ -21,18 +19,22 @@
     </div>
 
     <div class="form-group push-down form-inline">
+
       <%= label_tag(:copyright_holder,
                     "#{:glossary_term_copyright_holder.t}:") %><br/>
       <%= text_field_tag(:copyright_holder, @copyright_holder,
                          class: "form-control") %>
+
       <%= select_year(@copyright_year,
                       { field_name: :copyright_year,
                         start_year: 1980,
                         end_year: Time.zone.now.year },
                       { class: "form-control" }) %><br/>
+
       <%= select(:upload, :license_id, @licenses,
                  selected: @upload_license_id,
                  class: "form-control") %>
+
       <p class="help_block">(<%= :glossary_term_copyright_warning.t %>)</p>
     </div>
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2268,7 +2268,7 @@
 
   # glossary_term save errors
   glossary_error_name_blank: Name cannot be blank.
-  glossary_error_duplicate_name: "Name must be unique; [name] already in use."
+  glossary_error_duplicate_name: "Name must be unique; (Name is already in use.)"
   glossary_error_description_or_image: Glossary term needs description or image.
 
   # news article fields

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2266,6 +2266,11 @@
   # glossary_term#destroy
   destroy_glossary_term: "[:destroy_object(type=:glossary_term)]"
 
+  # glossary_term save errors
+  glossary_error_name_blank: Name cannot be blank.
+  glossary_error_duplicate_name: "Name must be unique; [name] already in use."
+  glossary_error_description_or_image: Glossary term needs description or image.
+
   # news article fields
   article_title: Title
   article_body: Body

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2266,7 +2266,7 @@
   # glossary_term#destroy
   destroy_glossary_term: "[:destroy_object(type=:glossary_term)]"
 
-  # glossary_term save errors
+  # glossary_term errors
   glossary_error_name_blank: Name cannot be blank.
   glossary_error_duplicate_name: Name must be unique.
   glossary_error_description_or_image: Glossary term must have a description or image.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2268,8 +2268,8 @@
 
   # glossary_term save errors
   glossary_error_name_blank: Name cannot be blank.
-  glossary_error_duplicate_name: "Name must be unique; (Name is already in use.)"
-  glossary_error_description_or_image: Glossary term needs description or image.
+  glossary_error_duplicate_name: Name must be unique.
+  glossary_error_description_or_image: Glossary term must have a description or image.
 
   # news article fields
   article_title: Title

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -53,9 +53,11 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     assert_title(:create_glossary_term_title.l)
 
     ESSENTIAL_ATTRIBUTES.each do |attr|
-      assert_select("form #glossary_term_#{attr}", { count: 1 },
-                    "Form is missing field for #{attr}")
+      assert_select("form [name='glossary_term[#{attr}]']", { count: 1 },
+                    "Form should have one field for #{attr}")
     end
+    assert_select("input#glossary_term_upload_image", { count: 1 },
+                  "Form should include upload image field")
   end
 
   def test_new_no_login
@@ -73,17 +75,23 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     assert_response(:success)
     assert_title(:edit_glossary_term_title.l(name: term.name))
 
+
     assert_select(
-      "form #glossary_term_name[value='#{term.name}']", { count: 1 },
-      "Form lacks Name field that defaults to glossary term name"
-    )
+      "form [name='glossary_term[name]']", { count: 1 },
+      "Form should have one field for Name"
+    ) do
+      assert_select(
+        "[value='#{term.name}']", true,
+        "Name field should default to glossary term name"
+      )
+    end
     assert_select(
-      "form #glossary_term_description",
+      "form [name='glossary_term[description]']",
       { text: /#{term.description}/, count: 1 },
       "Form lacks Description field that defaults to glossary term description"
     )
-    assert_select("input#upload_image", false,
-                  "Edit GlossaryTerm form should omit image input form")
+    assert_select("input#glossary_term_upload_image", false,
+                  "Edit GlossaryTerm form should omit upload image field")
   end
 
   def test_edit_no_login

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -197,10 +197,30 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     params[:glossary_term][:name] = ""
     login
 
-    assert_no_difference("GlossaryTerm.count") do
-      post(:create, params: params)
-    end
+    post(:create, params: params)
     assert_flash(/#{:glossary_error_name_blank.t}/)
+  end
+
+  def test_update_no_description_or_image
+    params = changes_to_conic.merge
+    params[:glossary_term][:description] = ""
+    login
+
+    post(:create, params: params)
+    assert_flash(/#{:glossary_error_description_or_image.t}/)
+  end
+
+  def test_update_duplicate_name
+    existing_name = GlossaryTerm.where.not(name:"Conic").first.name
+    params = changes_to_conic.merge
+    params[:glossary_term][:name] = existing_name
+    login
+
+    post(:update, params: params)
+    assert_flash(
+      # Must be quoted because it contains Regexp metacharacters "(" and ")"
+      Regexp.new(Regexp.quote(:glossary_error_duplicate_name.t))
+    )
   end
 
   # ***** destroy *****

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -75,7 +75,6 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     assert_response(:success)
     assert_title(:edit_glossary_term_title.l(name: term.name))
 
-
     assert_select(
       "form [name='glossary_term[name]']", { count: 1 },
       "Form should have one field for Name"
@@ -219,7 +218,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   end
 
   def test_update_duplicate_name
-    existing_name = GlossaryTerm.where.not(name:"Conic").first.name
+    existing_name = GlossaryTerm.where.not(name: "Conic").first.name
     params = changes_to_conic.merge
     params[:glossary_term][:name] = existing_name
     login

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -167,6 +167,19 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_create_invalid_name_with_image
+    params = term_with_image_params
+    params[:glossary_term][:name] = ""
+    login
+
+    assert_no_difference("GlossaryTerm.count") do
+      assert_no_difference("Image.count") do
+        post(:create, params: params)
+      end
+    end
+    assert_flash(/#{:glossary_error_name_blank.t}/)
+  end
+
   def test_create_image_save_failure
     login
     # Simulate image.save failure.

--- a/test/models/glossary_term_test.rb
+++ b/test/models/glossary_term_test.rb
@@ -119,6 +119,18 @@ class GlossaryTermTest < UnitTestCase
     assert_equal(images_length, glossary_term.images.length)
   end
 
+  def test_validations
+    term = GlossaryTerm.new(name: nil, description: "xxx")
+    assert(term.invalid?, "GlossaryTerm must have a name")
+
+    term = GlossaryTerm.new(name: GlossaryTerm.first.name,
+                            description: "xxx")
+    assert(term.invalid?, "GlossaryTerm name must be unique")
+
+    term = GlossaryTerm.new(name: "xxx", description: nil, thumb_image: nil)
+    assert(term.invalid?, "GlossaryTerm must have description or image")
+  end
+
   # Remove an image from images
   # Remove nil
   # Remove an image that is not associated with this glossary_term


### PR DESCRIPTION
Prevents saving a GlossaryTerm if
- the Name is blank
- the Name is not unique
- the Term lacks both a Description and an Image.

**Suggested Manual Test**
Try to create (and/or edit) a GlossaryTerm with:
1. a blank Name;
2. a name that duplicates the Name of an existing term (e.g. "Acrid", "Lichen");
3. neither Description nor Image.
Expected result: 
You are returned to the form, with appropriate red flash error(s).

Delivers https://www.pivotaltracker.com/story/show/174606044
Also incidentally delivers:
- https://www.pivotaltracker.com/story/show/174608605 (Use single form for `new` and `edit` forms)
- https://www.pivotaltracker.com/story/show/124382351 (Edit and Create GlossaryTerm should have link to Textile sandbox)