### PR TITLE
Add FunctionalIntegrationTestCase class and extensions, plus example articles_controller_integration_test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,6 +98,7 @@ class ApplicationController < ActionController::Base
   require "login_system"
   require "csv"
   include LoginSystem
+  include ObjectLinkHelper
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,6 +221,11 @@ class ApplicationController < ActionController::Base
 
   # Catch errors for integration tests, and report stats re completed request.
   def catch_errors_and_log_request_stats
+    if Rails.env.test? && @test_session_changes.present?
+      session.merge!(@test_session_changes)
+    #   @test_session_changes.each { |k, v| session[key] = val }
+    #   @test_session_changes = nil
+    end
     clear_user_globals
     stats = request_stats
     yield

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -45,6 +45,8 @@ class ArticlesController < ApplicationController
   end
 
   def edit
+    puts "-" * 100 
+    puts "rendering edit"
     @article = find_or_goto_index(Article, params[:id])
   end
 
@@ -64,8 +66,10 @@ class ArticlesController < ApplicationController
 
   def update
     @article = Article.find(params[:id])
+    puts "updating"
     return render(:edit) if flash_missing_title?
-
+    puts "-" * 90
+    puts "still going"
     @article.title = params[:article][:title]
     @article.body = params[:article][:body]
 

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -135,8 +135,65 @@ module ObjectLinkHelper
   def link_to_object(object, name = nil)
     return nil unless object
 
-    link_to(name || object.title.t, object.show_link_args)
+    link_to(name || object.title.t, object_path(object))
   end
+
+  # Output path helpers. Useful when:
+  # - code permits different classes of objects, e.g., @back_object
+  # - can save space: object_path(@project) vs project_path(@project.id)
+  # - can accept params: object_path(@project, q: get_query_param)
+  def object_path(obj, params = {})
+    objroute = object_route_s(obj)
+    add_object_path_params(obj, params)
+    send("#{objroute}_path", params)
+  end
+
+  def edit_object_path(obj, params = {})
+    objroute = object_route_s(obj)
+    # params[:id] = obj.id
+    add_object_path_params(obj, params)
+    send("edit_#{objroute}_path", params)
+  end
+
+  def new_object_path(obj, params = {})
+    objroute = object_route_s(obj)
+    # params[:id] = obj.id
+    add_object_path_params(obj, params)
+    send("new_#{objroute}_path", params)
+  end
+
+  def object_action_path(obj, action, params = {})
+    objroute = object_route_p(obj)
+    # params[:id] = obj.id
+    add_object_path_params(obj, params)
+    send("#{route}_#{action.to_s}_path", params)
+  end
+
+  # This is a replacement for model#show_controller
+  def model_index_path(model, params = {})
+    objroute = object_route_p(model)
+    send("#{objroute}_path", params)
+  end
+
+  # This is a replacement for model#show_controller
+  def model_show_path(model, params = {})
+    objroute = object_route_s(model)
+    send("#{objroute}_path", params)
+  end
+
+  # Note: could be dicey! Assumes plural controller name and default resources
+  def controller_index_path(controller, params)
+    send("#{controller.controller_name}_path", params)
+  end
+
+  def object_route_s(obj)
+    obj.model_name.singular_route_key
+  end
+
+  def object_route_p(obj)
+    obj.model_name.route_key
+  end
+
 
   # Wrap description title in link to show_description.
   #

--- a/test/controller_integration_extensions.rb
+++ b/test/controller_integration_extensions.rb
@@ -1,0 +1,772 @@
+# frozen_string_literal: true
+
+#
+#  = Controller Test Helpers
+#
+#  Methods in this class are available to all the functional tests.
+#
+#  == Request helpers
+#  reget::                      Resets request and calls +get+.
+#  login::                      Login a user.
+#  logout::                     Logout current user.
+#  make_admin::                 Make current user an admin & turn on admin mode.
+#  get_with_dump::              Send GET, no login required.
+#  requires_login::             Send GET, login required.
+#  requires_user::              Send GET, certain user must be logged in.
+#  post_with_dump::             Send POST, no login required.
+#  post_requires_login::        Send POST, login required.
+#  post_requires_user::         Send POST, certain user must be logged in.
+#  html_dump::                  Dump response body to file for W3C validation.
+#  save_response::              Dump response body to public/test.html
+#                               for debugging.
+#  get_without_clearing_flash::  Wrapper: calls +get+
+#                                without clearing flash errors.
+#  post_without_clearing_flash:: Wrapper: calls +post+
+#                                without clearing flash errors.
+#
+#  == HTML Helpers
+#  url_for::                    Get URL for +link_to+ style Hash of args.
+#  extract_links::              Get Array of show_object links on page.
+#  extract_error_from_body::    Extract error and stacktrace
+#                               from 500 response body.
+#
+#  == HTML Assertions
+#  assert_link_in_html::        A given link exists.
+#  assert_image_link_in_html::  A given link with an image
+#                               instead of text exists#
+#  assert_form_action::         A form posting to a given action exists.
+#  assert_response_equal_file:: Response body is same as copy in a file.
+#  assert_request::             Check heuristics of an arbitrary request.
+#  assert_response::            Check that last request resulted in a
+#                               given redirect.
+#  assert_action_partials::     Check that each of the given partials were
+#                               rendered(?)
+#  assert_redirect_match::      Check that last request resulted in a given
+#                               redirect(?)
+#  assert_input_value::         Check default value of a form field.
+#  assert_checkbox_state::      Check state of checkbox.
+#  assert_textarea_value::      Check value of textarea.
+#
+################################################################################
+
+module ControllerIntegrationExtensions
+  ##############################################################################
+  #
+  #  :section: Request helpers
+  #
+  ##############################################################################
+
+  def get(*args, &block)
+    args = check_for_params(args)
+    super(*args, &block)
+    check_for_unsafe_html!
+  end
+
+  def post(*args, &block)
+    args = extract_body(check_for_params(args))
+    super(*args, &block)
+    check_for_unsafe_html!
+  end
+
+  def put(*args, &block)
+    args = check_for_params(args)
+    super(*args, &block)
+    check_for_unsafe_html!
+  end
+
+  def patch(*args, &block)
+    args = check_for_params(args)
+    super(*args, &block)
+    check_for_unsafe_html! # Disabling, invalidates fixtures in forms -AN 8/20
+  end
+
+  def delete(*args, &block)
+    args = check_for_params(args)
+    super(*args, &block)
+    check_for_unsafe_html!
+  end
+
+  def check_for_params(args)
+    return args if (args.length < 2) || args[1][:params]
+
+    [args[0], { params: args[1] }] + args[2..]
+  end
+
+  def extract_body(args)
+    if args.length >= 2
+      params = args[1][:params]
+      args[1][:body] = params.delete(:body).read if params.member?(:body)
+    end
+    args
+  end
+
+  # Second "get" won't update fullpath, so we must reset the request.
+  def reget(*args)
+    @request = @request.class.new
+    get(*args)
+  end
+
+  # Call +get+ without clearing the flash (which we do by default).
+  def get_without_clearing_flash(*args)
+    @without_clearing_flash = true
+    get(*args)
+  end
+
+  # Call +post+ without clearing the flash (which we do by default).
+  def post_without_clearing_flash(*args)
+    @without_clearing_flash = true
+    post(*args)
+  end
+
+  # Log a user in (affects session only).
+  def login(user = "rolf", password = "testpassword")
+    user = User.authenticate(user, password)
+    assert(user, "Failed to authenticate user <#{user}> " \
+                 "with password <#{password}>.")
+    # new 8/20 AN, note it has to be user.login not just user (fixture)
+    post account_login_path,
+         params: { user: { login: user.login, password: password, remember_me: 1 } }
+    @request.session[:user_id] = user.id
+    session[:user_id] = user.id
+    User.current = user
+    # check welcome page? - AN 08/20
+  end
+
+  # Log a user out (affects session only).
+  def logout
+    post account_logout_user_path, params: { id: :user_id }
+    @request.session[:user_id] = nil
+    @request.session[:admin] = nil
+    User.current = nil
+  end
+
+  # Make the logged-in user admin and turn on admin mode.
+  def make_admin(user = "rolf", password = "testpassword")
+    user = login(user, password)
+    unless user.admin
+      user.admin = 1
+      user.save
+    end
+    # @request.session[:admin] = true
+    post account_turn_admin_on_path, params: { id: :user_id } # new 8/20 AN
+    user
+  end
+
+  # Send a GET request, and save the result in a file for w3c validation.
+  #
+  #   # Send request, but ignore response.
+  #   get(:action, params)
+  #
+  #   # Send request, and save response in ../html/action_0.html.
+  #   get_with_dump(:action, params)
+  #
+  def get_with_dump(page, params = {})
+    get(page, params: params)
+    html_dump(page, @response.body, params)
+  end
+
+  # Send a POST request, and save the result in a file for w3c validation.
+  #
+  #   # Send request, but ignore response.
+  #   post(:action, params)
+  #
+  #   # Send request, and save response in ../html/action_0.html.
+  #   post_with_dump(:action, params)
+  #
+  def post_with_dump(page, params = {})
+    post(page, params: params)
+    html_dump(page, @response.body, params)
+  end
+
+  # Send GET request to a page that should require login.
+  #
+  #   # Make sure only logged-in users get to see this page.
+  #   requires_login(:edit_name, id: 1)
+  #
+  def requires_login(page, *args)
+    either_requires_either(:get, page, nil, *args)
+  end
+
+  # Send POST request to a page that should require login.
+  #
+  #   # Make sure only logged-in users get to post this page.
+  #   post_requires_login(:edit_name, id: 1)
+  #
+  def post_requires_login(page, *args)
+    either_requires_either(:post, page, nil, *args)
+  end
+
+  # Send GET request to a page that should require a specific user.
+  #
+  #   # Make sure only reviewers can see this page (non-reviewers get
+  #   # redirected to "show_location").
+  #   requires_user(:review_authors, :show_location, id: 1)
+  #   requires_user(:review_authors, [:location, :show_location], id: 1)
+  #
+  def requires_user(*args)
+    either_requires_either(:get, *args)
+  end
+
+  # Send POST request to a page that should require login.
+  #
+  #   # Make sure only owner can edit observation (non-owners get
+  #   # redirected to "show_observation").
+  #   post_requires_user(:edit_obs, :show_obs, notes: 'new notes')
+  #   post_requires_user(:edit_obs, [:observer, :show_obs],
+  #                      notes: 'new notes')
+  #
+  def post_requires_user(*args)
+    either_requires_either(:post, *args)
+  end
+
+  # Helper used by the blah_requires_blah methods.
+  # method::        [Request method: "GET" or "POST".
+  #                 - Supplied automatically by all four "public" methods.]
+  # page::          Name of action.
+  # altpage::       [Name of page redirected to if user wrong.
+  #                 - Only include in +requires_user+ and +post_requires_user+.]
+  # params::        Hash of parameters for action.
+  # stay_on_page::  Does it render template of same name as action if succeeds?
+  # username::      Which user should be logged in (default is "rolf").
+  # password::      Which password should it try to use
+  #                 (default is "testpassword").
+  #
+  #   # Make sure only logged-in users get to see this page, and that it
+  #   # renders the template of the same name when it succeeds.
+  #   requires_login(:edit_name, id: 1)
+  #
+  #   # Make sure only logged-in users get to post this page, but that it
+  #   # renders the template of a different name (or redirects) on success.
+  #   post_requires_login(:edit_name, id: 1, false)
+  #
+  #   # Make sure only reviewers can see this page (non-reviewers get
+  #   # redirected to "show_location"), and that it renders
+  #   # the template of the same name when it succeeds.
+  #   requires_user(:review_authors, {id: 1}, :show_location)
+  #
+  #   # Make sure only owner can edit observation (non-owners get
+  #   # redirected to "show_observation"), and that it redirects to
+  #   # "show_observation" when it succeeds (last argument).
+  #   post_requires_user(:edit_observation, {notes: 'new notes'},
+  #     :show_observation, [:show_observation])
+  #
+  #   # Even more general case where second case renders a template:
+  #   post_requires_user(:action, params,
+  #     {controller: controller1, action: :access_denied, ...},
+  #     :success_template)
+  #
+  #   # Even more general case where both cases redirect:
+  #   post_requires_user(:action, params,
+  #     {controller: controller1, action: :access_denied, ...},
+  #     {controller: controller2, action: :succeeded, ...})
+  #
+  def either_requires_either(method, page, altpage, params = {},
+                             username = "rolf", password = "testpassword")
+    assert_request(
+      method: method,
+      action: page,
+      params: params,
+      user: (params[:username] || username),
+      password: (params[:password] || password),
+      require_login: :login,
+      require_user: altpage ? [altpage].flatten : nil
+    )
+  end
+
+  # The whole purpose of this is to create a directory full of sample HTML
+  # files that we can run the W3C validator on -- this has nothing to do with
+  # debugging!  This happens automatically if following directory exists:
+  #
+  #   ::Rails.root.to_s/../html
+  #
+  # Files are created:
+  #
+  #   show_user_0.html
+  #   show_user_1.html
+  #   show_user_2.html
+  #   etc.
+  #
+  def html_dump(label, html, _params)
+    html_dir = "../html"
+    return unless File.directory?(html_dir) && html[0..11] != "<html><body>"
+
+    file_name = "#{html_dir}/#{label}.html"
+    count = 0
+    while File.exist?(file_name)
+      file_name = "#{html_dir}/#{label}_#{count}.html"
+      count += 1
+      next unless count > 100
+
+      raise(RangeError.new(
+        "More than 100 files found with a label of '#{label}'"
+      ))
+    end
+    print("Creating html_dump file: #{file_name}\n")
+    file = File.new(file_name, "w")
+    # show_params(file, params, "params")
+    file.write(html)
+    file.close
+  end
+
+  # Add the hash of parameters to the dump file for diagnostics.
+  def show_params(file, hash, prefix)
+    if hash.is_a?(Hash)
+      hash.each { |k, v| show_params(file, v, "#{prefix}[#{k}]") }
+    else
+      file.write("#{prefix} = [#{hash}]<br>\n")
+    end
+  end
+
+  # This writes @response.body to the given file
+  # (relative to <tt>::Rails.root.to_s</tt>).
+  def save_response(file = "public/test.html")
+    File.open("#{::Rails.root}/#{file}", "w:utf-8") do |fh|
+      fh.write(@response.body)
+    end
+  end
+
+  def get_query_param(query = nil)
+    if query
+      query.save unless query.id
+      query.id.alphabetize
+    end
+  end
+
+  ##############################################################################
+  #
+  #  :section: HTML Helpers
+  #
+  ##############################################################################
+
+  # Return URL for +link_to+ style Hash of parameters.
+  def url_for(args = {})
+    # By default expect relative links.  Allow caller to override by
+    # explicitly setting only_path: false.
+    args[:only_path] = true unless args.key?(:only_path)
+    URI.decode_www_form_component(@controller.url_for(args))
+  end
+
+  # Extract error message and backtrace from Rails's 500 response.  This should
+  # be obsolete now that all the test controllers re-raise exceptions.  But
+  # just in case, here it is...
+  def extract_error_from_body
+    str = @response.body
+    str.gsub!(/<pre>.*?<.pre>/m) { |x| x.gsub(/\s*\n/, "<br>") }
+    str.sub!(/^.*?<p>/m, "")
+    str.sub!(/<.div>.*/m, "")
+    str.sub!(/<div.*<div.*?>/m, "")
+    str.sub!(/<p><code>RAILS.*?<.p>/, "")
+    str.gsub!(/<p><.p>/m, "")
+    str.gsub!(/\s+/m, " ")
+    str.gsub!("<br>", "\n")
+    str.gsub!("</p>", "\n\n")
+    str.gsub!(": <pre>", "\n")
+    str.gsub!(/<.*?>/, "")
+    str.gsub!(/^ */, "")
+    str.gsub!(/\n\n+/, "\n\n")
+    str.sub!(/\A\s*/, "\n")
+    str.sub!(/\s*\Z/, "\n")
+  end
+
+  ##############################################################################
+  #
+  #  :section: HTML assertions
+  #
+  ##############################################################################
+
+  def raise_params(opts)
+    if opts.member?(:params)
+      result = opts.clone
+      result.delete(:params)
+      result.merge(opts[:params])
+    else
+      opts
+    end
+  end
+
+  # Assert the existence of a given link in the response body, and check
+  # that it points to the right place.
+  def assert_link_in_html(label, url_opts, _msg = nil)
+    revised_opts = raise_params(url_opts)
+    url = url_for(revised_opts)
+    assert_select("a[href='#{url}']", text: label)
+  end
+
+  def assert_image_link_in_html(img_src, url_opts, _msg = nil)
+    revised_opts = raise_params(url_opts)
+    url = url_for(revised_opts)
+    assert_select("a[href = '#{url}']>img") do
+      assert_select(":match('src', ?)", img_src)
+    end
+  end
+
+  # Assert that a form exists which posts to the given url.
+  def assert_form_action(url_opts, msg = nil)
+    url_opts[:only_path] = true if url_opts[:only_path].nil?
+    url = @controller.url_for(url_opts)
+    url.force_encoding("UTF-8") if url.respond_to?(:force_encoding)
+    url = URI.decode_www_form_component(url)
+    # Find each occurrance of <form action="blah" method="post">.
+    found_it = false
+    found = {}
+    @response.body.split(/<form [^<>]*action/).each do |str|
+      next unless str =~ /^="([^"]*)" [^>]*method="post"/
+
+      url2 = URI.decode_www_form_component(Regexp.last_match(1)).gsub("&amp;",
+                                                                      "&")
+      if url == url2
+        found_it = true
+        break
+      end
+      found[url2] = 1
+    end
+    return pass if found_it
+
+    if found.keys
+      flunk(build_message(msg,
+                          "Expected HTML to contain form that posts to " \
+                          "<#{url}>, but only found these: " \
+                          "<#{found.keys.sort.join(">, <")}>."))
+    else
+      flunk(build_message(msg,
+                          "Expected HTML to contain form that posts to " \
+                          "<#{url}>, but found nothing at all."))
+    end
+  end
+
+  # Assert that a response body is same as contents of a given file.
+  #   get(:action, params)
+  #   assert_response_equal_file("#{path}/file")
+  #
+  # Assert that a response body is same as contents of a given file,
+  # where file has given encoding. This is a work-around for a Net::HTTP issue
+  # that causes response-body encoding to be set incorrectly.
+  #   get(:action, params)
+  #   assert_response_equal_file(["#{path}/file", "ISO-8859-1"])
+  #
+  # Pass in a block to use as a filter on both contents of response and file.
+  #   get(:action, params)
+  #   assert_response_equal_file(
+  #     "#{path}/expected_response.html",
+  #     "#{path}/alternate_expected_response.html") do |str|
+  #     str.strip_squeeze.downcase
+  #   end
+  #
+  def assert_response_equal_file(*files, &block)
+    body = @response.body_parts.join("\n")
+    body = fix_encoding(body, files) if encoding_included?(files)
+    assert_string_equal_file(body, *files, &block)
+  end
+
+  def encoding_included?(files)
+    files.first.is_a?(Array)
+  end
+
+  # Work-around for Net::HTTP issue that causes incorrect response-body encoding
+  def fix_encoding(body, files)
+    encoding = files.first.second
+    body.force_encoding(encoding)
+  end
+
+  # Send a general request of any type.  Check login_required and check_user
+  # heuristics if appropriate.  Check that the resulting redirection or
+  # rendered template is correct.
+  #
+  # method::        HTTP request method.  Defaults to "GET".
+  # action::        Action/page requested, e.g., :show_observation.
+  # params::        Hash of parameters to pass in.  Defaults to {}.
+  # user::          User name.  Defaults to "rolf" (user #1, a reviewer).
+  # password::      Password.  Defaults to "testpassword".
+  # alt_user::      Alternate user name.  Defaults to "rolf" or "mary",
+  #                 whichever is different.
+  # alt_password::  Password for alt user.  Defaults to "testpassword".
+  # require_login:: Check result if no user logged in.
+  # require_user::  Check result if wrong user logged in.
+  # result::        Expected result if everything is correct.
+  #
+  #   # POST the edit_name form: requires standard login; redirect to
+  #   # show_name if it succeeds.
+  #   assert_request(
+  #     method: "POST",
+  #     action: "edit_name",
+  #     params: params,
+  #     require_login: :login,
+  #     result: ["show_name"]
+  #   )
+  #
+  #   # Make sure only logged-in users get to post this page, and that it
+  #   # render the template of the same name when it succeeds.
+  #   post_requires_login(:edit_name, id: 1)
+  #
+  def assert_request(args)
+    method       = args[:method] || :get
+    action       = args[:action] || raise("Missing action!")
+    params       = args[:params] || {}
+    user         = args[:user] || "rolf"
+    password     = args[:password] || "testpassword"
+    alt_user     = args[:alt_user] || (user == "mary" ? "rolf" : "mary")
+    alt_password = args[:alt_password] || "testpassword"
+
+    logout
+
+    # Make sure it fails if not logged in at all.
+    if (result = args[:require_login])
+      result = :login if result == true
+      send(method, action, params: params)
+      assert_response(result, "No user: ")
+    end
+
+    # Login alternate user, and make sure that also fails.
+    if (result = args[:require_user])
+      login(alt_user, alt_password)
+      send(method, action, params: params)
+      assert_response(result, "Wrong user (#{alt_user}): ")
+    end
+
+    # Finally, login correct user and let it do its thing.
+    login(user, password)
+    send("#{method}_with_dump", action, params)
+    assert_response(args[:result])
+  end
+
+  # Check response of a request.  There are several different types:
+  #
+  #   # The old style continues to work.
+  #   assert_response(200)
+  #   assert_response(:success)
+  #
+  #   # Expect it to render a given template (success).
+  #   assert_response("template")
+  #
+  #   # Expect a redirect to particular observation
+  #   assert_response( {controller: observer, action: show_observation, id: 1 })
+  #   assert_response( {action: show_observation, id: 1 })
+  #
+  #   # Expect a redirection to site index.
+  #   assert_response(controller: "observer", action: "index")
+  #
+  #   # These also expect a redirection to site index.
+  #   assert_response(["index"])
+  #   assert_response(["observer", "index"])
+  #
+  #   # Short-hand for common redirects:
+  #   assert_response(:index)   => /observer/list_rss_logs
+  #   assert_response(:login)   => /account/login
+  #   assert_response(:welcome) => /account/welcome
+  #
+  #   # Lastly, expect redirect to full explicit URL.
+  #   assert_response("http://bogus.com")
+  #
+  def assert_response(arg, msg = "")
+    return unless arg
+
+    if arg == :success || arg == :redirect || arg.is_a?(Integer)
+      super
+    else
+      # Put together good error message telling us exactly what happened.
+      code = @response.response_code
+      if @response.successful?
+        got = ", got #{code} rendered <#{@request.fullpath}>."
+      elsif @response.not_found?
+        got = ", got #{code} missing (?)"
+      elsif @response.redirect?
+        url = @response.redirect_url.sub(/^http:..test.host/, "")
+        got = ", got #{code} redirect to <#{url}>."
+      else
+        got = ", got #{code} body is <#{extract_error_from_body}>."
+      end
+
+      # Add flash notice to potential error message.
+      flash_notice = get_last_flash.to_s.strip_squeeze
+      if flash_notice != ""
+        got += "\nFlash message: <#{flash_notice[1..].html_to_ascii}>."
+      end
+
+      # Now check result.
+      if arg.is_a?(Array)
+        if arg.length == 1
+          if arg[0].is_a?(Hash)
+            msg += "Expected redirect to <#{url_for(arg[0])}>" + got
+            assert_redirected_to(url_for(arg[0]), msg)
+          else
+            controller = @controller.controller_name
+            msg += "Expected redirect to <#{controller}/#{arg[0]}>" + got
+            # assert_redirected_to({action: arg[0]}, msg)
+            assert_redirected_to(%r{/#{controller}/#{arg[0]}}, msg)
+          end
+        else
+          msg += "Expected redirect to <#{arg[0]}/#{arg[1]}}>" + got
+          # assert_redirected_to({ controller: arg[0], action: arg[1] }, msg)
+          assert_redirected_to(%r{/#{arg[0]}/#{arg[1]}}, msg)
+        end
+      elsif arg.is_a?(Hash)
+        url = @controller.url_for(arg).sub(/^http:..test.host./, "")
+        msg += "Expected redirect to <#{url}>" + got
+        # assert_redirect_match(arg, @response, @controller, msg)
+        assert_redirected_to(arg, msg)
+      elsif arg.is_a?(String) && arg.match(%r{^\w+://})
+        msg += "Expected redirect to <#{arg}>" + got
+        assert_equal(arg, @response.redirect_url, msg)
+      elsif arg.is_a?(String)
+        controller = @controller.controller_name
+        msg += "Expected it to render <#{controller}/#{arg}>" + got
+        super(:success, msg)
+        assert_template(arg.to_s, msg)
+      elsif arg == :index
+        msg += "Expected redirect to <observer/list_rss_logs>" + got
+        assert_redirected_to({ controller: "observer",
+                               action: "list_rss_logs" }, msg)
+      elsif arg == :login
+        msg += "Expected redirect to <account/login>" + got
+        assert_redirected_to({ controller: "account", action: "login" }, msg)
+      elsif arg == :welcome
+        msg += "Expected redirect to <account/welcome>" + got
+        assert_redirected_to({ controller: "account", action: "login" }, msg)
+      else
+        raise("Invalid response type expected: [#{arg.class}: #{arg}]\n")
+      end
+    end
+  end
+
+  def assert_action(action, partials)
+    if partials
+      if partials.is_a?(Array)
+        assert_action_partials(action, partials)
+      else
+        assert_redirected_to(action: action, partial: partials)
+      end
+    else
+      assert_redirected_to(action: action)
+    end
+  end
+
+  def assert_action_partials(action, partials)
+    partials.each do |p|
+      assert_template(action, partial: p)
+    end
+  end
+
+  def assert_redirect_match(partial, response, controller, _msg)
+    mismatches = find_mismatches(partial, response.redirect_url)
+    if mismatches[:controller].to_s == controller.controller_name.to_s
+      mismatches.delete(:controller)
+    elsif mismatches.member?(:controller)
+      print("assert_redirect_match: #{partial}\n")
+      print("assert_redirect_match: #{response.redirect_url}\n")
+    end
+    assert_equal({}, mismatches, "Mismatched partial hash: #{mismatches}")
+  end
+
+  def find_mismatches(partial, full)
+    mismatches = {}
+    partial.each do |k, v|
+      f = full[k] || full[k.to_s]
+      f = full[k.to_sym] if f.nil? && k.respond_to?(:to_sym)
+      mismatches[k] = v if f.to_s != v.to_s
+    end
+    mismatches
+  end
+
+  # Check default value of a form field.
+  def assert_input_value(id, expect_val)
+    message = "Didn't find any inputs '#{id}'."
+    assert_select("input##{id}, select##{id}") do |elements|
+      if elements.length > 1
+        message = "Found more than one input '#{id}'."
+      elsif elements.length == 1
+        message = if elements.first.to_s.start_with?("<select")
+                    check_select_value(elements.first, expect_val, id)
+                  else
+                    check_input_value(elements.first.to_s, expect_val, id)
+                  end
+      end
+    end
+    assert(message.nil?, message)
+  end
+
+  def check_select_value(elem, expect_val, id)
+    if expect_val.nil?
+      assert_select(elem, "option[selected]", { count: 0 },
+                    "Expected :#{id} not to have any options selected")
+      nil
+    else
+      assert_select(elem, "option[selected]", { count: 1 },
+                    "Expected :#{id} to have one option selected") do |opts|
+        return check_input_value(opts.first.to_s, expect_val, id)
+      end
+    end
+  end
+
+  def check_input_value(elem, expect_val, id)
+    match = elem.match(/value=('[^']*'|"[^"]*")/)
+    actual_val = match ? CGI.unescapeHTML(match[1].sub(/^.(.*).$/, '\\1')) : ""
+    actual_val = "" if elem =~ /type=['"]?checkbox/ && elem !~ / checked[ >]/
+    return if actual_val == expect_val.to_s
+
+    "Input '#{id}' has wrong value, " \
+    "expected <#{expect_val}>, got <#{actual_val}>"
+  end
+
+  # Check existence and value of a texarea
+  def assert_textarea_value(id, expect_val)
+    message = "Didn't find any inputs '#{id}'."
+    assert_select("textarea##{id}") do |elements|
+      if elements.length > 1
+        message = "Found more than one input '#{id}'."
+      elsif elements.length == 1
+        actual_val = CGI.unescapeHTML(elements.first.children.map(&:to_s).
+                         join("")).strip
+        message = if actual_val != expect_val.to_s
+                    "Input '#{id}' has wrong value, " \
+                    "expected <#{expect_val}>, got <#{actual_val}>"
+                  end
+      end
+    end
+    assert(message.nil?, message)
+  end
+
+  # Check the state of a checkbox.  Parameters: +id+ is element id,
+  # +state+ can be:
+  #
+  #   :no_field
+  #   :checked
+  #   :unchecked
+  #   :checked_but_disabled
+  #   :unchecked_but_disabled
+  #
+  def assert_checkbox_state(id, state)
+    case state
+    when :checked_but_disabled
+      assert_select("input##{id}", 1)
+      assert_select("input##{id}[checked=checked]", 1)
+      assert_select("input##{id}[disabled=disabled]", 1)
+    when :unchecked_but_disabled
+      assert_select("input##{id}", 1)
+      assert_select("input##{id}[checked=checked]", 0)
+      assert_select("input##{id}[disabled=disabled]", 1)
+    when :checked, true
+      assert_select("input##{id}", 1)
+      assert_select("input##{id}[checked=checked]", 1)
+      assert_select("input##{id}[disabled=disabled]", 0)
+    when :unchecked, false
+      assert_select("input##{id}", 1)
+      assert_select("input##{id}[checked=checked]", 0)
+      assert_select("input##{id}[disabled=disabled]", 0)
+    when :no_field
+      assert_select("input##{id}", 0)
+    else
+      raise("Invalid state in check_project_checks: #{state.inspect}")
+    end
+  end
+
+  # Check presence and value of notes textareas.  Example:
+  #   assert_page_has_correct_notes( expect_areas: { Cap: "red", Other: "" } )
+  #   assert_page_has_correct_notes( klass: Species_list,
+  #                                  expect_areas: { Other: "" })
+  def assert_page_has_correct_notes_areas(klass: Observation, expect_areas: {})
+    expect_areas.each do |key, val|
+      id = klass.notes_part_id(key.to_s.tr(" ", "_"))
+      assert_textarea_value(id, val)
+    end
+  end
+end

--- a/test/controller_integration_extensions.rb
+++ b/test/controller_integration_extensions.rb
@@ -139,8 +139,9 @@ module ControllerIntegrationExtensions
     }
     # new 8/20 AN, note it has to be user.login not just user (fixture)
     post(account_login_path(params))
-    @request.session[:user_id] = user.id
-    session[:user_id] = user.id
+    @test_session_changes[:user_id] = user.id
+    # @request.session[:user_id] = user.id
+    # session[:user_id] = user.id
     User.current = user
     # check welcome page? - AN 08/20
   end
@@ -148,8 +149,10 @@ module ControllerIntegrationExtensions
   # Log a user out (affects session only).
   def logout
     post(account_logout_user_path, params: { id: :user_id })
-    @request.session[:user_id] = nil
-    @request.session[:admin] = nil
+    @test_session_changes[:user_id] = nil
+    @test_session_changes[:admin] = nil
+    # @request.session[:user_id] = nil
+    # @request.session[:admin] = nil
     User.current = nil
   end
 
@@ -160,6 +163,7 @@ module ControllerIntegrationExtensions
       user.admin = 1
       user.save
     end
+    @test_session_changes[:admin] = true
     # @request.session[:admin] = true
     post(account_turn_admin_on_path, params: { id: :user_id }) # new 8/20 AN
     user

--- a/test/controller_integration_extensions.rb
+++ b/test/controller_integration_extensions.rb
@@ -139,7 +139,6 @@ module ControllerIntegrationExtensions
     }
     # new 8/20 AN, note it has to be user.login not just user (fixture)
     post(account_login_path(params))
-    @test_session_changes[:user_id] = user.id
     # @request.session[:user_id] = user.id
     # session[:user_id] = user.id
     User.current = user
@@ -149,8 +148,6 @@ module ControllerIntegrationExtensions
   # Log a user out (affects session only).
   def logout
     post(account_logout_user_path, params: { id: :user_id })
-    @test_session_changes[:user_id] = nil
-    @test_session_changes[:admin] = nil
     # @request.session[:user_id] = nil
     # @request.session[:admin] = nil
     User.current = nil
@@ -163,7 +160,6 @@ module ControllerIntegrationExtensions
       user.admin = 1
       user.save
     end
-    @test_session_changes[:admin] = true
     # @request.session[:admin] = true
     post(account_turn_admin_on_path, params: { id: :user_id }) # new 8/20 AN
     user

--- a/test/controllers/articles_controller_integration_test.rb
+++ b/test/controllers/articles_controller_integration_test.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Controller tests for news articles
+class ArticlesControllerIntegrationTest < FunctionalIntegrationTestCase
+  ############ test Actions that Display data (index, show, etc.)
+
+  def test_index
+    # get(:index)
+    get(articles_path)
+    assert(:success, "Any user should be able to see article index")
+    Article.find_each do |article|
+      assert_select(
+        "a[href *= '#{article_path(article.id)}']", true,
+        "full Article Index missing link to #{article.title} (##{article.id})"
+      )
+    end
+  end
+
+  def test_index_filtered
+    article = Article.first
+    query = Query.lookup(:Article, :in_set, ids: [article.id])
+
+    # params = @controller.query_params(query) # controller method not available
+    # params[:q] = get_query_param(query)
+    # get(:index, params: params)
+    get(articles_path(q: get_query_param(query)))
+    assert_select("a:match('href',?)", %r{/articles/\d+}, { count: 1 },
+                  "filtered Article Index has wrong number of entries")
+    assert_select(
+      "a[href *= '#{article_path(article.id)}']", true,
+      "filtered Article Index missing link to #{article.title} (##{article.id})"
+    )
+  end
+
+  def test_index_links_to_create
+    login(users(:article_writer).login)
+    # get(:index)
+    get(articles_path)
+    assert_select("a", { text: :create_article_title.l },
+                  "Privileged user should get link to Create Article")
+  end
+
+  def test_show
+    # Prove that an actual article gets shown
+    article = articles(:premier_article)
+    # get(:show, params: { id: article.id })
+    get(article_path(id: article.id))
+    # assert_response(:success)
+    # assert_template(:show)
+    assert_equal(article_path(id: article.id), path)
+    assert(/#{article.body}/ =~ @response.body,
+           "Page is missing article body")
+
+    # Prove privileged user gets extra links
+    login(users(:article_writer).login)
+    # get(:show, params: { id: article.id })
+    get(article_path(id: article.id))
+    assert_select("a", text: :create_article_title.l)
+    assert_select("a", text: :EDIT.l)
+    assert_select("a", text: :DESTROY.l)
+
+    # Prove that trying to show non-existent article provokes error & redirect
+    # get(:show, params: { id: 0 })
+    get(article_path(id: 0))
+    assert_flash_error
+    # assert_response(:redirect) # Probably not. get always follow_redirects!
+    # where should it get redirected to? Guessing the index - AN
+    assert_equal(articles_path, path)
+  end
+
+  ############ test Actions that Display forms -- (new, edit, etc.)
+
+  def test_new
+    # Prove unathorized user cannot see create_article form
+    login(users(:zero_user).login)
+    # get(:new)
+    get(new_article_path)
+    assert_flash_text(:permission_denied.l)
+    # assert_redirected_to(articles_path)
+    assert_equal(articles_path, path)
+
+    # Prove authorized user can go to create_article form
+    login(users(:article_writer).login)
+    make_admin
+    # get(:new)
+    get(new_article_path)
+    assert_form_action(action: :create) # "new" form posts to :create action
+
+    # Prove that if News Articles project doesn't exist, there's no error.
+    Project.destroy(Article.news_articles_project.id)
+    # get(:new)
+    get(new_article_path)
+    assert_flash_text(:permission_denied.l)
+    # assert_redirected_to(articles_path)
+    assert_equal(articles_path, path)
+  end
+
+  def test_edit
+    # Prove unauthorized user cannot see edit form
+    article = articles(:premier_article)
+    params = { id: article.id }
+
+    login(users(:zero_user).login)
+    # get(:edit, params: params)
+    get(edit_article_path(params))
+    assert_flash_text(:permission_denied.l)
+    # assert_redirected_to(articles_path)
+    assert_equal(articles_path, path)
+
+    # Prove authorized user can create article
+    login(users(:article_writer).login)
+    make_admin
+    # get(:edit, params: params)
+    get(edit_article_path(params))
+    assert_form_action(action: :update) # "edit" form posts to :update action
+  end
+
+  ############ test Actions to Modify data: (create, update, destroy, etc.)
+
+  def test_create
+    user   = users(:article_writer)
+    title  = "Test article"
+    body   = "The body of a new test article."
+    params = {
+      article: { title: title, body: body }
+    }
+
+    # Prove unauthorized user cannot create Article
+    login(users(:zero_user).login)
+    assert_no_difference("Article.count") do
+      # post(:create, params: params)
+      post(articles_path, params: params)
+    end
+    assert_flash_text(:permission_denied.l)
+    # assert_redirected_to(articles_path)
+    assert_equal(articles_path, path)
+
+    # Prove authorized user cannot create title-less Article
+    login(user.login)
+    make_admin
+    params = {
+      article: { title: "", body: body }
+    }
+    assert_no_difference("Article.count") do
+      # post(:create, params: params)
+      post(articles_path, params: params)
+    end
+    assert_flash_text(:article_title_required.l)
+    # assert_template(:new)
+    # NOTE: This does not seemingly go to the new article form.
+    # Path is now articles_path, because we posted. However, form action works.
+    assert_equal(articles_path, path)
+    assert_form_action(action: :create) # "new" form
+
+    # Prove authorized user can create Article
+    params = {
+      article: { title: title, body: body }
+    }
+    assert_difference("Article.count", 1) do
+      # post(:create, params: params)
+      post(articles_path, params: params)
+    end
+    article = Article.last
+    assert_equal(body, article.body)
+    assert_equal(title, article.title)
+    # assert_redirected_to(article_path(article.id))
+    # follow_redirect!
+    assert_equal(article_path(article.id), path)
+    assert_not_nil(article.rss_log, "Failed to create rss_log entry")
+  end
+
+  def test_update
+    # Prove unauthorized user cannot edit article
+    article = articles(:premier_article)
+    new_title = "Edited Article Title"
+    new_body = "Edited body"
+    params = {
+      id: article.id,
+      article: { title: new_title, body: new_body }
+    }
+    login(users(:zero_user).login)
+    # post(:update, params: params)
+    patch(article_path(params))
+    assert_flash_text(:permission_denied.l)
+    assert_redirected_to(articles_path)
+    # assert_equal(articles_path, path)
+
+    # Prove authorized user can edit article
+    login(users(:article_writer).login)
+    make_admin
+    # post(:update, params: params)
+    patch(article_path(params))
+    article.reload
+
+    assert_flash_success
+    # assert_redirected_to(article_path(article.id))
+    assert_equal(article_path(article.id), path)
+    assert_equal(new_title, article.title)
+    assert_equal(new_body, article.body)
+
+    # Prove that saving without changes provokes warning
+    # save it again without changes
+    # post(:update, params: params)
+    patch(article_path(params))
+    article.reload
+    assert_flash_warning
+    # assert_redirected_to(article_path(article.id))
+    assert_equal(article_path(article.id), path)
+
+    # Prove removing title provokes warning
+    params[:article][:title] = ""
+    # post(:update, params: params)
+    patch(article_path(params))
+    # NOTE: The flash text is perplexing! It seems to give a Both/And!
+    # <p>Successfully updated article #788338338.</p><p>No changes made.</p><p>Title Required</p>
+    assert_flash_text(:article_title_required.l)
+    # assert_template(:edit)
+    assert_equal(edit_article_path(params), path)
+    assert_form_action(action: :update) # "edit" form
+  end
+
+  def test_destroy
+    article = articles(:premier_article)
+    params  = { id: article.id }
+
+    # Prove unauthorized user cannot destroy article
+    login(users(:zero_user).login)
+    # delete(:destroy, params: params)
+    delete(article_path(params))
+    assert_flash_text(:permission_denied.l)
+    assert(Article.exists?(article.id))
+
+    # Prove authorized user can destroy article
+    login(article.user.login)
+    make_admin
+    # delete(:destroy, params: params)
+    delete(article_path(params))
+    assert_not(Article.exists?(article.id),
+               "Failed to destroy Article #{article.id}, '#{article.title}'")
+  end
+
+  ############ test Public methods (unrouted)
+end

--- a/test/controllers/articles_controller_integration_test.rb
+++ b/test/controllers/articles_controller_integration_test.rb
@@ -182,8 +182,20 @@ class ArticlesControllerIntegrationTest < FunctionalIntegrationTestCase
     }
     login(users(:zero_user).login)
     # post(:update, params: params)
-    patch(article_path(params))
+    # patch(article_path(params))
+    puts "-" * 80
+    puts '@controller.instance_variable_get("@last_notice")'
+    pp @controller.instance_variable_get("@last_notice")
+    puts '@controller.instance_variable_get(:@last_notice)'
+    pp @controller.instance_variable_get(:@last_notice)
+    puts '@controller.view_assigns[:@last_notice])'
+    pp @controller.view_assigns[:@last_notice]
+    puts '@controller.view_assigns["@last_notice"])'
+    pp @controller.view_assigns["@last_notice"]
+    byebug
     assert_flash_text(:permission_denied.l)
+    # byebug
+    # assert_equal(:permission_denied.l, session[:notice])
     assert_redirected_to(articles_path)
     # assert_equal(articles_path, path)
 
@@ -216,6 +228,7 @@ class ArticlesControllerIntegrationTest < FunctionalIntegrationTestCase
     # NOTE: The flash text is perplexing! It seems to give a Both/And!
     # <p>Successfully updated article #788338338.</p><p>No changes made.</p><p>Title Required</p>
     assert_flash_text(:article_title_required.l)
+    # assert_equal(:article_title_required.l, flash[:notice])
     # assert_template(:edit)
     assert_equal(edit_article_path(params), path)
     assert_form_action(action: :update) # "edit" form

--- a/test/controllers/articles_controller_integration_test.rb
+++ b/test/controllers/articles_controller_integration_test.rb
@@ -181,56 +181,50 @@ class ArticlesControllerIntegrationTest < FunctionalIntegrationTestCase
       article: { title: new_title, body: new_body }
     }
     login(users(:zero_user).login)
-    # post(:update, params: params)
-    # patch(article_path(params))
-    puts "-" * 80
-    puts '@controller.instance_variable_get("@last_notice")'
-    pp @controller.instance_variable_get("@last_notice")
-    puts '@controller.instance_variable_get(:@last_notice)'
-    pp @controller.instance_variable_get(:@last_notice)
-    puts '@controller.view_assigns[:@last_notice])'
-    pp @controller.view_assigns[:@last_notice]
-    puts '@controller.view_assigns["@last_notice"])'
-    pp @controller.view_assigns["@last_notice"]
-    byebug
-    assert_flash_text(:permission_denied.l)
-    # byebug
-    # assert_equal(:permission_denied.l, session[:notice])
+    patch(article_path(params))
+    assert_flash(:permission_denied.l)
     assert_redirected_to(articles_path)
-    # assert_equal(articles_path, path)
 
     # Prove authorized user can edit article
     login(users(:article_writer).login)
     make_admin
-    # post(:update, params: params)
     patch(article_path(params))
     article.reload
 
     assert_flash_success
-    # assert_redirected_to(article_path(article.id))
     assert_equal(article_path(article.id), path)
     assert_equal(new_title, article.title)
     assert_equal(new_body, article.body)
 
     # Prove that saving without changes provokes warning
     # save it again without changes
-    # post(:update, params: params)
     patch(article_path(params))
+    puts "session[:notice]"
+    pp session[:notice]
     article.reload
+    puts "session[:notice] after reload"
+    pp session[:notice]
     assert_flash_warning
-    # assert_redirected_to(article_path(article.id))
     assert_equal(article_path(article.id), path)
 
     # Prove removing title provokes warning
     params[:article][:title] = ""
-    # post(:update, params: params)
+    puts "session[:notice] before removing title"
+    pp session[:notice]
     patch(article_path(params))
-    # NOTE: The flash text is perplexing! It seems to give a Both/And!
-    # <p>Successfully updated article #788338338.</p><p>No changes made.</p><p>Title Required</p>
+    puts "session[:notice] after removing title"
+    pp session[:notice]
+
+    # For some reason THIS one doesn't get any got.
+    # New form already rendered, so...
+    # Flash has been flash_clear'ed and is printed in response.body
+    # div class="alert push-down..."
     assert_flash_text(:article_title_required.l)
-    # assert_equal(:article_title_required.l, flash[:notice])
-    # assert_template(:edit)
-    assert_equal(edit_article_path(params), path)
+    # assert_match(:article_title_required.l, @response.body)
+    follow_redirect!
+    byebug
+    # This is not getting the form
+    assert_equal(edit_article_path(article), path)
     assert_form_action(action: :update) # "edit" form
   end
 

--- a/test/flash_integration_extensions.rb
+++ b/test/flash_integration_extensions.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#
+#  = Flash Test Helpers
+#
+#  Methods in this class are available to all the functional and integration
+#  tests.
+#
+#  get_last_flash::       Retrieve current list of errors or last set rendered.
+#  assert_flash::         Assert an error was rendered or is pending.
+#  assert_no_flash::      Assert there was no notice, warning or error.
+#  assert_flash_success:: Assert there was a notice but no warning or error.
+#  assert_flash_warning:: Assert there was a warning but no error.
+#  assert_flash_error::   Assert there was an error.
+#  assert_flash_text::    Assert flash has particular text
+#
+################################################################################
+
+module FlashIntegrationExtensions
+  # Get the errors rendered in the last request, or current set of errors if
+  # redirected.
+  def get_last_flash
+    @test_session_changes[:@last_notice] || session[:notice]
+  end
+
+  # Assert that there was no notice, warning or error.
+  def assert_no_flash(msg = "")
+    assert_flash(nil, msg)
+  end
+
+  # Assert that there was a notice but no warning or error.
+  def assert_flash_success(msg = "Should be flash success (level 0).")
+    assert_flash(0, msg)
+  end
+
+  # Assert that there was warning but no error.
+  def assert_flash_warning(
+    msg = "Should be a flash warning but no error (level 1)"
+  )
+    assert_flash(1, msg)
+  end
+
+  # Assert that there was a error.
+  def assert_flash_error(msg = "Should be a flash error (level 2).")
+    assert_flash(2, msg)
+  end
+
+  # Assert that an error was rendered or is pending.
+  def assert_flash(expect, msg = "")
+    if (got = get_last_flash)
+      lvl = got[0, 1].to_i
+      got = got[1..].gsub(/(\n|<br.?>)+/, "\n")
+    end
+    msg&.sub(/\n*$/, "\n")
+    if !expect && got
+      assert(got.nil?,
+             "#{msg} Shouldn't have been any flash errors. Got #{got.inspect}.")
+    elsif expect && !got
+      assert(expect.nil?, "#{msg} Expected a flash error.  Got nothing.")
+    elsif expect.is_a?(Integer)
+      assert(expect == lvl,
+             "#{msg} Wrong flash error level. "\
+             "Message: level #{lvl}, #{got.inspect}.")
+    elsif expect.is_a?(Regexp)
+      assert(got.match(expect),
+             "#{msg} Got the wrong flash error(s). " \
+             "Expected: #{expect.inspect}.  Got: #{got.inspect}.")
+    else
+      assert(got == expect,
+             "#{msg} Got the wrong flash error(s). " \
+             "Expected: #{expect.inspect}.  Got: #{got.inspect}.")
+    end
+    # @controller.instance_variable_set("@last_notice", nil)
+    @test_session_changes["@last_notice"] = nil
+    session[:notice] = nil
+  end
+
+  # Assert that a flash was rendered or is pending with the expected text.
+  def assert_flash_text(expect, msg = "Flash text incorrect")
+    got = get_last_flash
+    got = got[1..].gsub(/(\n|<br.?>)+/, "\n") if got.present?
+    if expect.is_a?(Regexp)
+      assert_match(expect, got, msg)
+    else
+      assert_equal("<p>#{expect}</p>", got, msg)
+    end
+
+    # @controller.instance_variable_set("@last_notice", nil)
+    @test_session_changes[:@last_notice] = nil
+    session[:notice] = nil
+  end
+end

--- a/test/flash_integration_extensions.rb
+++ b/test/flash_integration_extensions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-#  = Flash Test Helpers
+#  = Flash Integration Test Helpers
 #
 #  Methods in this class are available to all the functional and integration
 #  tests.
@@ -19,17 +19,62 @@
 module FlashIntegrationExtensions
   # Get the errors rendered in the last request, or current set of errors if
   # redirected.
+  def get_full_flash
+    # puts "-" * 80
+    # puts "We are in flash_extensions get_full_flash"
+    # puts "@last_notice"
+    # pp @controller.instance_variable_get("@last_notice")
+    # puts "session[:notice]"
+    # pp session[:notice]
+    # puts "-" * 80
+    got = session[:notice]
+    # if needed: ActionController::Base.helpers.strip_tags(string)
+    # session[:notice]
+  end
+
+  def get_flash_level
+    got = session[:notice]
+    if got
+      got[0, 1].to_i
+    end
+  end
+
+  # This is necessary because the session[:notice] never gets cleared by test,
+  # even though it is cleared by our flash_clear in layouts/application
   def get_last_flash
-    @test_session_changes[:@last_notice] || session[:notice]
+    # if !got.present?
+    got = session[:notice]
+    # end
+    if got.present?
+      # puts "unprocessed got"
+      # pp got
+      # This regex gets the contents of the last paragraph tag
+      got = got.match(/.*<p>([^<]*)<\/p>/)
+      # puts "processed got"
+      # pp got
+      # byebug
+      got = got[1]
+      # puts "got[1]"
+      # pp got
+    end
+    got
+    # if needed: ActionController::Base.helpers.strip_tags(string)
+    # session[:notice]
   end
 
   # Assert that there was no notice, warning or error.
   def assert_no_flash(msg = "")
+    puts "-" * 80
+    puts "We are in flash_extensions assert_no_flash"
+    puts "-" * 80
     assert_flash(nil, msg)
   end
 
   # Assert that there was a notice but no warning or error.
   def assert_flash_success(msg = "Should be flash success (level 0).")
+    puts "-" * 80
+    puts "We are in flash_extensions assert_flash_success"
+    puts "-" * 80
     assert_flash(0, msg)
   end
 
@@ -37,19 +82,31 @@ module FlashIntegrationExtensions
   def assert_flash_warning(
     msg = "Should be a flash warning but no error (level 1)"
   )
+    puts "-" * 80
+    puts "We are in flash_extensions assert_flash_warning"
+    puts "-" * 80
     assert_flash(1, msg)
   end
 
   # Assert that there was a error.
   def assert_flash_error(msg = "Should be a flash error (level 2).")
+    puts "-" * 80
+    puts "We are in flash_extensions assert_flash_error"
+    puts "-" * 80
     assert_flash(2, msg)
   end
 
   # Assert that an error was rendered or is pending.
+  # Regex is here (<p>[^<p>]+<\/p>$)
   def assert_flash(expect, msg = "")
-    if (got = get_last_flash)
-      lvl = got[0, 1].to_i
-      got = got[1..].gsub(/(\n|<br.?>)+/, "\n")
+    puts "-" * 80
+    puts "We are in flash_extensions assert_flash"
+    puts "-" * 80
+    if (session[:notice])
+      # lvl = got[0, 1].to_i
+      lvl = get_flash_level
+      # got = got[1..].gsub(/(\n|<br.?>)+/, "\n")
+      got = get_last_flash
     end
     msg&.sub(/\n*$/, "\n")
     if !expect && got
@@ -71,22 +128,35 @@ module FlashIntegrationExtensions
              "Expected: #{expect.inspect}.  Got: #{got.inspect}.")
     end
     # @controller.instance_variable_set("@last_notice", nil)
-    @test_session_changes["@last_notice"] = nil
-    session[:notice] = nil
+    # session[:notice] = nil
   end
 
+  # Seems to be a duplicate. Delete?
   # Assert that a flash was rendered or is pending with the expected text.
   def assert_flash_text(expect, msg = "Flash text incorrect")
+    puts "-" * 80
+    puts "We are in flash_extensions assert_flash_text"
+    puts "-" * 80
+    # got = get_full_flash
+    # got = got[1..] if got.present?
+    # got = got[1..].gsub(/(\n|<br.?>)+/, "\n") if got.present?
+    # got = got[1..].match(/(<p>[^<p>]+<\/p>$)/) if got.present?
+    # got = got[1];
+    # got = get_last_flash(got) if got.present?
+    # puts "got"
+    # pp got
+    # byebug
     got = get_last_flash
-    got = got[1..].gsub(/(\n|<br.?>)+/, "\n") if got.present?
+
     if expect.is_a?(Regexp)
       assert_match(expect, got, msg)
     else
-      assert_equal("<p>#{expect}</p>", got, msg)
+      # assert_equal("<p>#{expect}</p>", got, msg)
+      # Now that we're grabbing the contents of the <p>
+      assert_equal(expect, got, msg)
     end
 
     # @controller.instance_variable_set("@last_notice", nil)
-    @test_session_changes[:@last_notice] = nil
-    session[:notice] = nil
+    # session[:notice] = nil
   end
 end

--- a/test/functional_integration_test_case.rb
+++ b/test/functional_integration_test_case.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#
+#  = Functional Test Case
+#
+#  The test case class that all functional tests currently derive from.
+#  Includes:
+#
+#  1. Some general-purpose helpers and assertions from GeneralExtensions.
+#  2. Some controller-related helpers and assertions from ControllerExtensions.
+#  3. A few helpers that encapsulate testing the flash error mechanism.
+#
+################################################################################
+
+class FunctionalIntegrationTestCase < ActionDispatch::IntegrationTest
+  include GeneralExtensions
+  include SessionExtensions
+  include FlashExtensions
+  include CheckForUnsafeHtml
+  include ControllerIntegrationExtensions
+
+  # temporarily silence deprecation warnings
+  # ActiveSupport::Deprecation.silenced = true
+
+  def setup
+    # Note: Disabling the forgery_protection CSRF stuff.
+    # This breaks cookies and sessions in integration tests - JH, AN 8/20
+    # ApplicationController.allow_forgery_protection = true
+
+    # This should be automatically removed at the beginning of each test,
+    # but for some reason it is not nil before the very first test run.
+    # If it is not removed, then all sessions opened in your test will have
+    # the identical session instance, breaking some tests. This is probably
+    # a bug in rails, but as of 20190101 it is required.
+    @integration_session = nil
+
+    # Treat Rails html requests as coming from non-robots.
+    # If it's a bot, controllers often do not serve the expected content.
+    # The requester looks like a bot to the `browser` gem because the User Agent
+    # in the request is blank. I don't see an easy way to change that. -JDC
+    Browser::Generic.any_instance.stubs(:bot?).returns(false)
+  end
+
+  def teardown
+    # ApplicationController.allow_forgery_protection = false
+  end
+end

--- a/test/functional_integration_test_case.rb
+++ b/test/functional_integration_test_case.rb
@@ -16,7 +16,7 @@
 class FunctionalIntegrationTestCase < ActionDispatch::IntegrationTest
   include GeneralExtensions
   # include SessionExtensions # - These are for Capybara style tests - JH 09/20
-  include FlashExtensions
+  include FlashIntegrationExtensions
   include CheckForUnsafeHtml
   include ControllerIntegrationExtensions
 

--- a/test/functional_integration_test_case.rb
+++ b/test/functional_integration_test_case.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 #
-#  = Functional Test Case
+#  = Functional Integration Test Case
 #
 #  The test case class that all functional tests currently derive from.
+#  Adapted from previous controller test case
 #  Includes:
 #
 #  1. Some general-purpose helpers and assertions from GeneralExtensions.
@@ -14,7 +15,7 @@
 
 class FunctionalIntegrationTestCase < ActionDispatch::IntegrationTest
   include GeneralExtensions
-  include SessionExtensions
+  # include SessionExtensions # - These are for Capybara style tests - JH 09/20
   include FlashExtensions
   include CheckForUnsafeHtml
   include ControllerIntegrationExtensions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,7 @@ require("mocha/minitest")
   general_extensions
   flash_extensions
   controller_extensions
+  controller_integration_extensions
   integration_extensions
   language_extensions
   session_extensions
@@ -58,6 +59,7 @@ require("mocha/minitest")
 
   unit_test_case
   functional_test_case
+  functional_integration_test_case
   integration_test_case
 ].each do |file|
   require File.expand_path(File.dirname(__FILE__) + "/#{file}")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,7 @@ require("mocha/minitest")
 %w[
   general_extensions
   flash_extensions
+  flash_integration_extensions
   controller_extensions
   controller_integration_extensions
   integration_extensions


### PR DESCRIPTION
This PR aims to create a parallel new class for our functional tests that inherits from `ActionDispatch::IntegrationTest` instead of `ActionController::TestCase`. 

It also includes an example integration-style controller test, for Articles, which attempts to exactly duplicate the existing controller test, in parallel. It's called `articles_controller_integration_test.rb`

Here are the new files added:
```
- test
-- functional_integration_test_case.rb
-- controller_integration_extensions.rb
-- controllers
--- articles_controller_integration_test.rb
```
Revised files
```
- app
-- controllers
--- application_controller.rb (adding a line to include ObjectLinkHelper at the top)
-- helpers
--- object_link_helper.rb (adding the new object link methods)
- test
-- test_helper.rb (requiring the new files above in the list of test cases and extensions)
```
So far, so good. (The integration-controller test runs in 8 seconds, just like the controller test it's based on!)
All tests in the new `articles_controller_integration_test` are green in this branch, except one assertion in `test_update`.
Here's that part of the revised method. 
```
    # Prove removing title provokes warning
    params[:article][:title] = ""
    patch(article_path(params))
    # NOTE: The flash text seems to give all possible messages at once.
    # <p>Successfully updated article #788338338.</p><p>No changes made.</p><p>Title Required</p>
    assert_flash_text(:article_title_required.l)
    assert_equal(edit_article_path(params), path)
    assert_form_action(action: :update) # "edit" form
```
(Note that with CRUD resources/paths, you PUT or PATCH to the article_path(params) to update the article, as shown in rake routes for articles currently.)
Here's the error message:
```
        Flash text incorrect.
        --- expected
        +++ actual
        @@ -1 +1 @@
        -"<p>Title Required</p>"
        +"<p>Successfully updated article #788338338.</p><p>No changes made.</p><p>Title Required</p>"
        test/flash_extensions.rb:84:in `assert_flash_text'
        test/controllers/articles_controller_test.rb:220:in `test_update'
```
I wonder if maybe the integration test is reporting the actual response accurately?

Maybe someone who is an actual admin can try removing the title of an article, and see what flash response you get in the wild.
