### PR TITLE
Fix bug introduced when normalizing ArticlesController

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -381,26 +381,6 @@ class AbstractModel < ApplicationRecord
     self.class.show_action
   end
 
-  # Return the path of the "show_<object>" action
-  #
-  #   # normalized controller
-  #   Article.index_action => "articles/12"
-  #
-  #   # unnormalized controller
-  #   Name.show_url(12) => "http://mushroomobserver.org/name/show_name/12"
-  #   name.show_url     => "http://mushroomobserver.org/name/show_name/12"	  #
-  def self.show_path(id)
-    if controller_normalized?(name)
-      "/#{show_controller}/#{id}"
-    else
-      "/#{show_controller}/#{show_action}/#{id}"
-    end
-  end
-
-  def show_path
-    self.class.show_url(id)
-  end
-
   # Return the URL of the "show_<object>" action
   #
   #   # normalized controller

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -381,18 +381,24 @@ class AbstractModel < ApplicationRecord
     self.class.show_action
   end
 
-  # Return the name of the "show_past_<object>" action
-  # JDC 2020-08-22: This should be refactored once all tne show_past_<objects>
-  # actions are normalized.
-  # See https://www.pivotaltracker.com/story/show/174440291
-  def self.show_past_action
-    return "show_past" if controller_normalized?(name) # Rails standard
-
-    "show_past_#{name.underscore}" # Old MO style
+  # Return the path of the "show_<object>" action
+  #
+  #   # normalized controller
+  #   Article.index_action => "articles/12"
+  #
+  #   # unnormalized controller
+  #   Name.show_url(12) => "http://mushroomobserver.org/name/show_name/12"
+  #   name.show_url     => "http://mushroomobserver.org/name/show_name/12"	  #
+  def self.show_path(id)
+    if controller_normalized?(name)
+      "/#{show_controller}/#{id}"
+    else
+      "/#{show_controller}/#{show_action}/#{id}"
+    end
   end
 
-  def show_past_action
-    self.class.show_past_action
+  def show_path
+    self.class.show_url(id)
   end
 
   # Return the URL of the "show_<object>" action
@@ -414,6 +420,20 @@ class AbstractModel < ApplicationRecord
 
   def show_url
     self.class.show_url(id)
+  end
+
+  # Return the name of the "show_past_<object>" action
+  # JDC 2020-08-22: This should be refactored once all tne show_past_<objects>
+  # actions are normalized.
+  # See https://www.pivotaltracker.com/story/show/174440291
+  def self.show_past_action
+    return "show_past" if controller_normalized?(name) # Rails standard
+
+    "show_past_#{name.underscore}" # Old MO style
+  end
+
+  def show_past_action
+    self.class.show_past_action
   end
 
   # Return the link_to args of the "show_<object>" action

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -284,7 +284,7 @@ class RssLog < AbstractModel
       format("/observer/show_species_list/%d?time=%d", species_list_id,
              updated_at.tv_sec)
     elsif glossary_term_id
-      format("/glossary_term/%d?time=%d", glossary_term_id, updated_at.tv_sec)
+      format("/glossary_terms/%d?time=%d", glossary_term_id, updated_at.tv_sec)
     elsif article_id
       format("/articles/%d?time=%d", article_id, updated_at.tv_sec)
     else

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -286,7 +286,7 @@ class RssLog < AbstractModel
     elsif glossary_term_id
       format("/glossary_term/%d?time=%d", glossary_term_id, updated_at.tv_sec)
     elsif article_id
-      format("/article/%d?time=%d", article_id, updated_at.tv_sec)
+      format("/articles/%d?time=%d", article_id, updated_at.tv_sec)
     else
       format("/observer/show_rss_log/%d?time=%d", id, updated_at.tv_sec)
     end

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -52,3 +52,8 @@ project_rss_log:
   project: two_list_project
   updated_at: 2016-08-08 12:00:00
   notes: "Updated Project"
+
+article_rss_log:
+  article: premier_article
+  updated_at: 2016-08-08 12:00:00
+  notes: "Updated Article"

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -3,6 +3,10 @@
 require("test_helper")
 
 class RssLogTest < UnitTestCase
+  # Alert developer if normalization changes the path of an RssLogg'ed object
+  # The test should be deleted once controllers for all RssLog'ged objects are
+  # normalized.
+  # See https://www.pivotaltracker.com/story/show/174685402
   def test_url_for_normalized_controllers
     normalized_rss_log_types.each do |type|
       rss_log = create_rss_log(type)

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -34,10 +34,6 @@ class RssLogTest < UnitTestCase
     rss_log
   end
 
-  def target_id(rss_log)
-    rss_log.target_id
-  end
-
   def type_normalized_show_path(type, id)
     %r{/#{model(type).show_controller}/#{id}}
   end

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class RssLogTest < UnitTestCase
   def test_url_for_normalized_controllers
     normalized_rss_log_types.each do |type|
-      rss_log = rss_log_for_type(type)
+      rss_log = create_rss_log(type)
       id = rss_log.target_id
       assert_match(type_normalized_show_path(type, id), rss_log.url,
                    "rss_log.url incorrect for #{model(type)}")
@@ -25,7 +25,7 @@ class RssLogTest < UnitTestCase
   end
 
   # rss_log factory
-  def rss_log_for_type(type)
+  def create_rss_log(type)
     # Target must have id; use an existing object to avoid hitting db
     target = model(type).first
     rss_log = RssLog.new

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -3,4 +3,42 @@
 require("test_helper")
 
 class RssLogTest < UnitTestCase
+  def test_url_for_normalized_controllers
+    normalized_rss_log_types.each do |type|
+      rss_log = rss_log_for_type(type)
+      id = rss_log.target_id
+      assert_match(type_normalized_show_path(type, id), rss_log.url,
+                   "rss_log.url incorrect for #{model(type)}")
+    end
+  end
+
+  # ---------- helpers ---------------------------------------------------------
+
+  def normalized_rss_log_types
+    RssLog.all_types.each_with_object([]) do |type, ary|
+      ary << type if model(type).controller_normalized?(model(type).name)
+    end
+  end
+
+  def model(type)
+    type.camelize.constantize
+  end
+
+  # rss_log factory
+  def rss_log_for_type(type)
+    # Target must have id; use an existing object to avoid hitting db
+    target = model(type).first
+    rss_log = RssLog.new
+    rss_log["#{type}_id".to_sym] = target.id
+    rss_log.updated_at = Time.zone.now
+    rss_log
+  end
+
+  def target_id(rss_log)
+    rss_log.target_id
+  end
+
+  def type_normalized_show_path(type, id)
+    %r{/#{model(type).show_controller}/#{id}}
+  end
 end


### PR DESCRIPTION
Fix RssLog#url for articles

- Test rss_log.url for normalized controllers
- Add AbstractArticle#show_path
- Correct rss_log.url for article. (This was overlooked in #629.)
- Add rss_log article fixture (just in case).
- Delivers https://www.pivotaltracker.com/story/show/174394837

**This is a re-do of closed PR #641. See conversation there for some Comments.**

There is no manual test.