### PR TITLE
Fix Useless Assignments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -120,10 +120,6 @@ Lint/UselessAccessModifier:
     - 'app/models/rss_log.rb'
     - 'app/models/vote.rb'
 
-# Offense count: 61
-Lint/UselessAssignment:
-  Enabled: false
-
 # Offense count: 9
 # Configuration parameters: CheckForMethodsWithNoSideEffects.
 Lint/Void:

--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -113,10 +113,10 @@ class Checklist
     Name.connection.select_rows(query).each do |text_name, syn_id, deprecated|
       if syn_id && deprecated == 1
         # wait until we find an accepted synonym
-        text_name = synonyms[syn_id] ||= nil
+        synonyms[syn_id] ||= nil
       elsif syn_id
         # use the first accepted synonym we encounter
-        text_name = synonyms[syn_id] ||= text_name
+        synonyms[syn_id] ||= text_name
       else
         # count non-synonyms immediately
         count_species(text_name)

--- a/app/classes/eol_data.rb
+++ b/app/classes/eol_data.rb
@@ -111,7 +111,7 @@ class EolData
       synonyms[name.synonym_id] << name if name.synonym_id
     end
     names_to_keep = {}
-    synonyms.each do |synonym_id, name_list|
+    synonyms.each do |_synonym_id, name_list|
       name = most_desirable_name(name_list)
       names_to_keep[name.id] = true
     end

--- a/app/classes/eol_data.rb
+++ b/app/classes/eol_data.rb
@@ -111,7 +111,7 @@ class EolData
       synonyms[name.synonym_id] << name if name.synonym_id
     end
     names_to_keep = {}
-    for synonym_id, name_list in synonyms
+    synonyms.each do |name_list|
       name = most_desirable_name(name_list)
       names_to_keep[name.id] = true
     end

--- a/app/classes/eol_data.rb
+++ b/app/classes/eol_data.rb
@@ -111,7 +111,7 @@ class EolData
       synonyms[name.synonym_id] << name if name.synonym_id
     end
     names_to_keep = {}
-    synonyms.each do |name_list|
+    synonyms.each do |synonym_id, name_list|
       name = most_desirable_name(name_list)
       names_to_keep[name.id] = true
     end

--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -47,7 +47,7 @@ class IpStats
     end
 
     def add_one_line_to_stats(data, vals, now, do_activity)
-      time, ip, controller = *vals
+      time, ip, _user, _load, controller, _action, _api_key = *vals
       hash = data[ip] ||= { load: 0, activity: [], rate: 0 }
       weight = calc_weight(now, Time.parse(time).utc)
       weight /= 2 if controller.to_s == "api"

--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -47,7 +47,7 @@ class IpStats
     end
 
     def add_one_line_to_stats(data, vals, now, do_activity)
-      time, ip, user, load, controller, action, api_key = *vals
+      time, ip, controller = *vals
       hash = data[ip] ||= { load: 0, activity: [], rate: 0 }
       weight = calc_weight(now, Time.parse(time).utc)
       weight /= 2 if controller.to_s == "api"

--- a/app/classes/query/modules/lookup_names.rb
+++ b/app/classes/query/modules/lookup_names.rb
@@ -80,10 +80,7 @@ module Query
           if /^\d+$/.match?(val.to_s)
             result << minimal_name_data(Name.safe_find(val))
           else
-            # rubocop:disable Lint/UselessAssignment
-            # cop generates a false positive
-            result += find_matching_names(val)
-            # rubocop:enable Lint/UselessAssignment
+            result + find_matching_names(val)
           end
         end.uniq.reject(&:nil?)
       end

--- a/app/classes/query/modules/lookup_names.rb
+++ b/app/classes/query/modules/lookup_names.rb
@@ -80,8 +80,10 @@ module Query
           if /^\d+$/.match?(val.to_s)
             result << minimal_name_data(Name.safe_find(val))
           else
-            # Cop appears to generate false positive
+            # rubocop:disable Lint/UselessAssignment
+            # cop generates a false positive
             result += find_matching_names(val)
+            # rubocop:enable Lint/UselessAssignment
           end
         end.uniq.reject(&:nil?)
       end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -203,7 +203,6 @@ class CommentController < ApplicationController
       if !@comment.save
         flash_object_errors(@comment)
       else
-        type = @target.type_tag
         @comment.log_create
         flash_notice(:runtime_form_comments_create_success.t(id: @comment.id))
         redirect_with_query(controller: @target.show_controller,

--- a/app/controllers/description_controller_helpers.rb
+++ b/app/controllers/description_controller_helpers.rb
@@ -231,9 +231,6 @@ module DescriptionControllerHelpers
     if draft = find_description(params[:id].to_s)
       parent = draft.parent
       old = parent.description
-      type = parent.type_tag
-      old_partial   = old.unique_partial_format_name if old
-      draft_partial = draft.unique_partial_format_name
 
       # Must be admin on the draft in order for this to work.  (Must be able
       # to delete the draft after publishing it.)

--- a/app/controllers/project_controller.rb
+++ b/app/controllers/project_controller.rb
@@ -321,8 +321,6 @@ class ProjectController < ApplicationController
         flash_error(:change_member_status_denied.t)
         redirect_with_query(action: :show_project, id: @project.id)
       elsif request.method == "POST"
-        user_group = @project.user_group
-        admin_group = @project.admin_group
         admin = member = :remove
         case params[:commit]
         when :change_member_status_make_admin.l

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -571,7 +571,7 @@ class String
       i = alphabet.index(char)
       raise("Character not in alphabet: '#{char}'") if i.nil?
 
-      num = num * len + i
+      num * len + i
     end
   end
 

--- a/app/helpers/description_helper.rb
+++ b/app/helpers/description_helper.rb
@@ -111,7 +111,6 @@ module DescriptionHelper
 
     # Turn each into a link to show_description, and add optional controls.
     list.map! do |desc|
-      any = true
       item = description_link(desc)
       writer = is_writer?(desc)
       admin  = is_admin?(desc)
@@ -174,7 +173,6 @@ module DescriptionHelper
     head += link_with_query(:show_name_create_description.t,
                             controller: obj.show_controller,
                             action: "create_#{type}_description", id: obj.id)
-    any = false
 
     # Add title and maybe "no descriptions", wrapping it all up in paragraph.
     list = list_descriptions(obj).map { |link| indent + link }

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -85,7 +85,6 @@ module FooterHelper
   #
   def show_object_footer(obj)
     html = []
-    type = obj.type_tag
     num_versions = obj.respond_to?(:version) ? obj.versions.length : 0
 
     # Old version of versioned object.
@@ -137,6 +136,6 @@ module FooterHelper
     end
 
     html = html.safe_join(safe_br)
-    html = content_tag(:p, html, class: "small")
+    content_tag(:p, html, class: "small")
   end
 end

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -136,6 +136,6 @@ module FooterHelper
     end
 
     html = html.safe_join(safe_br)
-    content_tag(:p, html, class: "small")
+    tag.p(html, class: "small")
   end
 end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -89,7 +89,6 @@ module MapHelper
   end
 
   def mapset_marker_title(set)
-    result = ""
     strings = map_location_strings(set.objects)
     result = if strings.length > 1
                "#{strings.length} #{:locations.t}"

--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -111,7 +111,7 @@ module VersionHelper
     end
 
     table = make_table(table, style: "margin-left:20px")
-    content_tag(:p, :VERSIONS.t) + table + safe_br
+    "#{tag.p(:VERSIONS.t)}#{table}#{safe_br}"
   end
 
   ##############################################################################

--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -14,7 +14,6 @@ module VersionHelper
   #   Previous Version: N-1<br/>
   #
   def show_previous_version(obj)
-    type = obj.type_tag
     html = "#{:VERSION.t}: #{obj.version}".html_safe
     latest_version = obj.versions.latest
     if latest_version.respond_to?(:merge_source_id) &&
@@ -112,7 +111,7 @@ module VersionHelper
     end
 
     table = make_table(table, style: "margin-left:20px")
-    html = content_tag(:p, :VERSIONS.t) + table + safe_br
+    content_tag(:p, :VERSIONS.t) + table + safe_br
   end
 
   ##############################################################################

--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -111,7 +111,7 @@ module VersionHelper
     end
 
     table = make_table(table, style: "margin-left:20px")
-    "#{tag.p(:VERSIONS.t)}#{table}#{safe_br}"
+    tag.p(:VERSIONS.t) + table + safe_br
   end
 
   ##############################################################################

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -39,10 +39,7 @@ class ApiKey < AbstractModel
 
   def self.new_key
     result = String.random(KEY_LENGTH)
-    # rubocop:disable Lint/UselessAssignment:
-    # RuboCop gives false positive
-    key = String.random(KEY_LENGTH) while find_by(key: result)
-    # rubocop:enable Lint/UselessAssignment:
+    result = String.random(KEY_LENGTH) while find_by(key: result)
     result
   end
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -41,7 +41,7 @@ class ApiKey < AbstractModel
     result = String.random(KEY_LENGTH)
     # rubocop:disable Lint/UselessAssignment:
     # RuboCop gives false positive
-    key = String.random(KEY_LENGTH) while find_by_key(result)
+    key = String.random(KEY_LENGTH) while find_by(key: result)
     # rubocop:enable Lint/UselessAssignment:
     result
   end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -39,7 +39,10 @@ class ApiKey < AbstractModel
 
   def self.new_key
     result = String.random(KEY_LENGTH)
+    # rubocop:disable Lint/UselessAssignment:
+    # RuboCop gives false positive
     key = String.random(KEY_LENGTH) while find_by_key(result)
+    # rubocop:enable Lint/UselessAssignment:
     result
   end
 

--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -238,7 +238,7 @@ class Description < AbstractModel
   #
   def note_status
     fieldCount = sizeCount = 0
-    for (k, v) in all_notes
+    all_notes.each_value do |v|
       if v.present?
         fieldCount += 1
         sizeCount += v.strip_squeeze.length

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -671,10 +671,6 @@ class Location < AbstractModel
 
     # Move over any remaining descriptions.
     old_loc.descriptions.each do |desc|
-      xargs = {
-        id: desc,
-        set_location: self
-      }
       desc.location_id = id
       desc.save
     end

--- a/app/models/name/change.rb
+++ b/app/models/name/change.rb
@@ -34,7 +34,6 @@ class Name < AbstractModel
   def change_author(new_author)
     return if rank == :Group
 
-    old_author = author
     new_author2 = new_author.blank? ? "" : " " + new_author
     self.author = new_author.to_s
     self.search_name  = text_name + new_author2

--- a/app/models/name/parse.rb
+++ b/app/models/name/parse.rb
@@ -201,7 +201,7 @@ class Name < AbstractModel
   end
 
   def self.parse_group(str, deprecated = false)
-    return unless (match = GROUP_PAT.match(str))
+    return unless GROUP_PAT.match(str)
 
     result = parse_name(str_without_group(str),
                         rank: :Group, deprecated: deprecated)

--- a/app/models/name_parse.rb
+++ b/app/models/name_parse.rb
@@ -73,8 +73,6 @@ class NameParse
   #   <synonym_search_name>
   #   <synonym_rank> <synonym_search_name>
   def initialize(spl_line)
-    result = []
-    name_str = ""
     @line_str = spl_line.strip_squeeze
     equal_pos = @line_str.index("=")
     if equal_pos

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -218,7 +218,7 @@ class Naming < AbstractModel
   # clear naming.observation -- otherwise it will recalculate the consensus for
   # each deleted naming, and send a bunch of bogus emails.)
   def log_destruction
-    if (user = User.current) &&
+    if User.current &&
        (obs = observation)
       obs.log(:log_naming_destroyed, name: format_name)
       obs.calc_consensus

--- a/app/models/observation/consensus_calculator.rb
+++ b/app/models/observation/consensus_calculator.rb
@@ -217,7 +217,6 @@ class Observation
       return names.first if names.length == 1
       return best if names.blank?
 
-      synonyms = names.map(&:id).join(", ")
       votes = process_votes_for_synonyms
       find_best_synonym(names, votes)
     end

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -213,7 +213,7 @@ class RssLog < AbstractModel
     name = notes.to_s.split("\n", 2).first
     if /^\d{14}/.match?(name)
       # This is an occasional error, when a log wasn't orphaned properly.
-      tag, args, time = parse_log.first
+      _tag, args, _time = parse_log.first
       args[:this] || :rss_log_of_deleted_item.l
     else
       RssLog.unescape(name)

--- a/lib/tasks/jason.rake
+++ b/lib/tasks/jason.rake
@@ -9,8 +9,6 @@ namespace :jason do
   task(check_for_special_characters: :environment) do
     print "Writing file \"y\"...\n"
     out = ""
-    cd = Iconv.new("ISO-8859-1", "UTF-8")
-    # for name in Name.find(:all) # Rails 3
     for name in Name.all
       str = [
         name.id.to_s,

--- a/script/make_eol_xml
+++ b/script/make_eol_xml
@@ -63,7 +63,7 @@ def test_host(host, port)
       http.use_ssl = true if port == 443
       result = true
     end
-  rescue Exception => e
+  rescue Exception
   end
   result
 end

--- a/script/mushroom_mapper.rb
+++ b/script/mushroom_mapper.rb
@@ -77,7 +77,7 @@ name_data.
     names[id] = [text_name, rank, deprecated]
     if ids[text_name]
       id2 = ids[text_name]
-      text_name2, rank2, deprecated2 = names[id2]
+      _text_name2, _rank2, deprecated2 = names[id2]
       if !deprecated && !deprecated2
         warn("Multiple accepted names match #{text_name}: #{id2}, #{id}")
       elsif !deprecated && deprecated2

--- a/script/refresh_sitemap
+++ b/script/refresh_sitemap
@@ -281,7 +281,7 @@ def write_sitemap_xml(name, pages)
   file = SITEMAP_FILE.sub("NAME", name)
   File.open(file, "w") do |fh|
     fh.write(SITEMAP_LEAF_HEADER)
-    for str, path, time in pages
+    pages.each do |_str, path, time|
       fh.puts("<url><loc>#{DOMAIN}/#{path}</loc>#{time}</url>")
     end
     fh.write(SITEMAP_LEAF_FOOTER)
@@ -292,7 +292,7 @@ def write_sitemap_html(name, pages)
   file = INDEX_FILE.sub("NAME", name)
   File.open(file, "w") do |fh|
     fh.write(INDEX_HEADER)
-    for str, path, time in pages
+    pages.each do |str, path, _time|
       fh.puts("<a href=\"/#{path}\">#{str}</a><br/>")
     end
     fh.write(INDEX_FOOTER)
@@ -314,7 +314,6 @@ def write_index_xml(sitemaps)
 end
 
 def write_index_html(sitemaps)
-  now = get_current_time
   file = INDEX_FILE.sub("NAME", "index")
   File.open(file, "w") do |fh|
     fh.write(INDEX_HEADER)
@@ -369,10 +368,10 @@ end
 
 def deduce_allowed_actions
   actions = {}
-  for table, type, path in OBJECT_TYPES
+  OBJECT_TYPES.each do |_table, _type, path|
     add_action(actions, path)
   end
-  for str, path, freq in STATIC_PAGES
+  STATIC_PAGES.each do |_str, path, _freq|
     add_action(actions, path)
   end
   actions

--- a/script/slowest_pages
+++ b/script/slowest_pages
@@ -41,7 +41,7 @@ end
 for path, rec in data
   sum, ssq, num = *rec
   rec[0] = avg = sum / num
-  rec[1] = sig = Math.sqrt(ssq / num - avg * avg)
+  rec[1] = Math.sqrt(ssq / num - avg * avg)
 end
 
 n = 0

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -523,7 +523,7 @@ class AjaxControllerTest < FunctionalTestCase
 
   def test_exif_parser
     fixture = "#{MO.root}/test/images/geotagged.jpg"
-    result, status = Open3.capture2e("exiftool", fixture)
+    result, _status = Open3.capture2e("exiftool", fixture)
     unstripped = @controller.test_parse_exif_data(result, false)
     assert_not_empty(unstripped.select do |key, _val|
                        key.match(/latitude|longitude|gps/i)

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -213,7 +213,6 @@ class LocationControllerTest < FunctionalTestCase
   end
 
   def test_location_descriptions_by_author
-    descs = LocationDescription.all
     desc = location_descriptions(:albion_desc)
     get_with_dump(:location_descriptions_by_author, id: rolf.id)
     assert_redirected_to(

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -949,7 +949,7 @@ class NameControllerTest < FunctionalTestCase
     post(:create_name, params)
     assert_redirected_to(action: :show_name,
                          id: Name.find_by(text_name: text_name2).id)
-    assert(name = Name.find_by(text_name: text_name2))
+    assert(Name.find_by(text_name: text_name2)
     assert_equal(count + 5, Name.count)
   end
 

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -949,7 +949,7 @@ class NameControllerTest < FunctionalTestCase
     post(:create_name, params)
     assert_redirected_to(action: :show_name,
                          id: Name.find_by(text_name: text_name2).id)
-    assert(Name.find_by(text_name: text_name2)
+    assert(Name.find_by(text_name: text_name2))
     assert_equal(count + 5, Name.count)
   end
 

--- a/test/controllers/sequence_controller_test.rb
+++ b/test/controllers/sequence_controller_test.rb
@@ -456,7 +456,6 @@ class SequenceControllerTest < FunctionalTestCase
     old_count = Sequence.count
     sequence = sequences(:local_sequence)
     obs      = sequence.observation
-    observer = obs.user
 
     # Prove admin can destroy Sequence
     make_admin("zero")

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -336,7 +336,7 @@ module GeneralExtensions
   #
   def assert_xml_exists(key, msg = nil)
     assert(@doc, "XML response is nil!")
-    result = key.sub(%r{^/}, "").split("/").inject(@doc) do |elem, key|
+    key.sub(%r{^/}, "").split("/").inject(@doc) do |elem, key|
       elem = elem.elements[/^\d+$/.match?(key) ? key.to_i : key]
       assert(nil, msg || "XML response should have \"#{key}\".") unless elem
       elem

--- a/test/integration/random_test.rb
+++ b/test/integration/random_test.rb
@@ -49,7 +49,6 @@ class RandomTest < IntegrationTestCase
 
   test "sessions" do
     rolf_session = open_session
-    app = rolf_session.app
     rolf_session.login(rolf)
     mary_session = open_session
     mary_session.login(mary)

--- a/test/integration/student_test.rb
+++ b/test/integration/student_test.rb
@@ -15,7 +15,6 @@ class StudentTest < IntegrationTestCase
     project = projects(:eol_project)
     project.admin_group.users.delete(mary)
 
-    app = open_session.app
     rolf_session    = open_session.extend(AdminDsl)
     mary_session    = open_session.extend(CreatorDsl)
     katrina_session = open_session.extend(StudentDsl)

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -1150,12 +1150,12 @@ class ApiTest < UnitTestCase
     )
     assert_api_results(imgs)
 
-    # Agaricus is an existing autonym
+    agaricus = Name.where(text_name: "Agaricus").first # (an existing autonym)
     agaricus_img = Image.create(
       # add notes to avoid breaking later, brittle assertion
       notes: "Agaricus image", user: rolf
     )
-    agaricus_obs = Observation.create(
+    Observation.create(
       name: agaricus, images: [agaricus_img], thumb_image: agaricus_img,
       user: rolf
     )

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -1150,7 +1150,7 @@ class ApiTest < UnitTestCase
     )
     assert_api_results(imgs)
 
-    agaricus = Name.where(text_name: "Agaricus").first # (an existing autonym)
+    # Agaricus is an existing autonym
     agaricus_img = Image.create(
       # add notes to avoid breaking later, brittle assertion
       notes: "Agaricus image", user: rolf
@@ -1265,7 +1265,7 @@ class ApiTest < UnitTestCase
     assert_equal(2, Name.where(text_name: "Agaricus").count)
 
     agaricus_img = Image.create(user: rolf)
-    agaricus_obs = Observation.create(
+    Observation.create(
       name: agaricus, images: [agaricus_img], thumb_image: agaricus_img,
       user: rolf
     )
@@ -1489,7 +1489,6 @@ class ApiTest < UnitTestCase
       low: @low,
       notes: @notes
     }
-    name = params[:name]
     assert_api_pass(params)
     assert_last_location_correct
     assert_api_fail(params)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2401,13 +2401,15 @@ class NameTest < UnitTestCase
   def test_mysql_sort_order
     return unless sql_collates_accents?
 
-    # RuboCop gives false positives
+    # rubocop:disable Lint/UselessAssignment
+    # cop gives false positives
     n1 = create_test_name("Agaricus Aehou")
     n2 = create_test_name("Agaricus Aeiou")
     n3 = create_test_name("Agaricus Aeiøu")
     n4 = create_test_name("Agaricus Aëiou")
     n5 = create_test_name("Agaricus Aéiou")
     n6 = create_test_name("Agaricus Aejou")
+    # rubocop:enable Lint/UselessAssignment
     n5.update(author: "aÉIOU")
 
     x = Name.where(id: n1.id..n6.id).order(:author).pluck(:author)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2401,18 +2401,17 @@ class NameTest < UnitTestCase
   def test_mysql_sort_order
     return unless sql_collates_accents?
 
-    # rubocop:disable Lint/UselessAssignment
-    # cop gives false positives
-    n1 = create_test_name("Agaricus Aehou")
-    n2 = create_test_name("Agaricus Aeiou")
-    n3 = create_test_name("Agaricus Aeiøu")
-    n4 = create_test_name("Agaricus Aëiou")
-    n5 = create_test_name("Agaricus Aéiou")
-    n6 = create_test_name("Agaricus Aejou")
-    # rubocop:enable Lint/UselessAssignment
-    n5.update(author: "aÉIOU")
+    names = [
+      create_test_name("Agaricus Aehou"),
+      create_test_name("Agaricus Aeiou"),
+      create_test_name("Agaricus Aeiøu"),
+      create_test_name("Agaricus Aëiou"),
+      create_test_name("Agaricus Aéiou"),
+      create_test_name("Agaricus Aejou")
+    ]
+    names[4].update(author: "aÉIOU")
 
-    x = Name.where(id: n1.id..n6.id).order(:author).pluck(:author)
+    x = Name.where(id: names.map(&:id)).order(:author).pluck(:author)
     assert_equal(%w[Aehou Aeiou Aëiou aÉIOU Aeiøu Aejou], x)
   end
 

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -16,6 +16,15 @@ class RssLogTest < UnitTestCase
     end
   end
 
+  def test_orphan_title
+    log = rss_logs(:location_rss_log)
+    assert_equal(log.notes, log.orphan_title)
+
+    # replace normal top line of log with yyyymmddhhmmss
+    log.notes = Time.zone.now.strftime("%Y%m%d%I%M%S")
+    assert_equal(:rss_log_of_deleted_item.l, log.orphan_title)
+  end
+
   # ---------- helpers ---------------------------------------------------------
 
   def normalized_rss_log_types

--- a/test/session_extensions.rb
+++ b/test/session_extensions.rb
@@ -130,7 +130,7 @@ module SessionExtensions
   # Get string representing (our) query from the given URL.  Defaults to the
   # current page's URL.  (In practice, for now, this is just the Query id.)
   def parse_query_params(url = path)
-    path, query = url.split("?")
+    _path, query = url.split("?")
     params = CGI.parse(query)
     params["q"]
   end


### PR DESCRIPTION
Re-enables the Lint/UselessAssignment cop without creating a backlog of offenses
- Manually fix all current offenses;
- Remove the cop from the todo list.

Notes:
- I have only one particular question. See https://github.com/MushroomObserver/mushroom-observer/pull/664#discussion_r486648331
- This is an older cop.
- I think we'd all agree it's a desirable cop. Useless assignments are at best dead code and may signal a problem elsewhere in the code, so we'd like to get notice of potential problems.
- The cop was silently disabled, thereby hiding and accumulating new offenses.
- I re-enabled the cop by removing it from the todo list. 
- I also fixed all the outstanding offenses so that we wouldn't suddenly see a batch of 60 new things to fix.
- The fixes are manual because there's no autocorrect feature. (Indeed there were a few false positives, which I "fixed" by disabling the cop in the source code.)

There is no manual test.
Delivers https://www.pivotaltracker.com/story/show/174567330