### PR TITLE
Softened block message, and made blocked IPs permanent.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -163,7 +163,10 @@ class ApplicationController < ActionController::Base
     logger.warn("BLOCKED #{request.remote_ip}")
     msg = "We have noticed an excessive amount of server-intensive " \
           "traffic from this IP address (#{request.remote_ip}). " \
-          "Please contact the webmaster (#{MO.webmaster_email_address})."
+          "Please contact the webmaster (#{MO.webmaster_email_address}) " \
+          "so that we can see if there is a better way to do what you are " \
+          "trying to do.  If you believe you have been mistakenly blocked, " \
+          "please contact us so that we can remove the block."
     render(plain: msg,
            status: :too_many_requests,
            layout: false)

--- a/script/update_ip_stats.rb
+++ b/script/update_ip_stats.rb
@@ -94,6 +94,6 @@ bad_ips = data.keys.select { |ip| bad_ip?(data[ip]) }
 # Removing then re-adding has effect of updating the time stamp on each bad IP.
 IpStats.remove_blocked_ips(bad_ips)
 IpStats.add_blocked_ips(bad_ips)
-IpStats.clean_blocked_ips # remove old blocked ips after a day
+# IpStats.clean_blocked_ips # remove old blocked ips after a day
 
 exit(0)


### PR DESCRIPTION
This is in response to the jokers who we finally defeated a few months ago after weeks and weeks of battle, and who have now returned now that their IPs have been automatically cleared after a period of no use.  Apparently, we need to keep those IPs permanently on the block list.  Too bad I didn't keep a copy of the original list.