### PR TITLE
Fix small synonym-related bug

### DIFF
--- a/app/views/api/_name.json.builder
+++ b/app/views/api/_name.json.builder
@@ -15,7 +15,7 @@ json.ok_for_export   object.ok_for_export ? true : false
 if !detail
   json.synonym_id object.synonym_id if object.synonym_id
 else
-  if object.synonym_id
+  if object.synonym
     json.synonyms((object.synonym.names - [object]).map do |synonym|
       {
         id:         synonym.id,

--- a/app/views/api/_name.xml.builder
+++ b/app/views/api/_name.xml.builder
@@ -20,7 +20,7 @@ xml.tag!(tag,
       xml_minimal_object_old(xml, :synonym, Synonym, object.synonym_id)
     end
   else
-    if object.synonym_id
+    if object.synonym
       xml.synonyms(number: object.synonym.names.length - 1) do
         for synonym in object.synonym.names - [object]
           xml_detailed_object_old(xml, :synonym, synonym)


### PR DESCRIPTION
Somehow or another we have gotten a bunch of name with a synonym_id but no corresponding entry in the synonym table.  Even though this shouldn't matter at all, it causes name.synonyms to return nil when name.synonym_id does not.

I have fixed the database (removed all unused synonyms, added missing synonyms).

This fixes a case in the API which calls name.synonym.names to make it more robust for this sort of failure.

No review or anything should be required here.  Very trivial change.