### PR TITLE
Cover HerbariumController

### DIFF
--- a/test/controllers/herbarium_controller_test.rb
+++ b/test/controllers/herbarium_controller_test.rb
@@ -375,6 +375,47 @@ class HerbariumControllerTest < FunctionalTestCase
     )
   end
 
+  def test_create_post_invalid_personal_user
+    params = herbarium_params.merge(
+      name: "My Herbarium",
+      personal: "1",
+      personal_user_name: "non-user"
+    )
+    login("rolf")
+    make_admin("rolf")
+    post(:create_herbarium, herbarium: params)
+
+    assert_response(
+      :success,
+      "Response to :create_herbarium with invalid personal_user_name " \
+      "should be 'success' (re-displaying form), not redirect to new herbarium"
+    )
+    assert_flash_error(
+      ":create_herbarium with invalid personal_user_name should flash error"
+    )
+  end
+
+  def test_create_post_second_personal_herbarium
+    params = herbarium_params.merge(
+      name: "My Herbarium",
+      personal: "1",
+      personal_user_name: "dick"
+    )
+    login("rolf")
+    make_admin("rolf")
+    assert_nil(mary.personal_herbarium)
+    post(:create_herbarium, herbarium: params)
+
+    assert_response(
+      :success,
+      "Response to creating second personal herbarium for user " \
+      "should be 'success' (re-displaying form), not redirect to new herbarium"
+    )
+    assert_flash_error(
+      "Trying to create second personal herbarium for user should flash error"
+    )
+  end
+
   def test_edit_herbarium_without_curators
     nybg = herbaria(:nybg_herbarium)
     nybg.curators.delete(rolf)


### PR DESCRIPTION
- Achieve 100% coverage of HerbariumController;
- Also fixes all RuboCop offenses in HerbariumController.

Manual Test: check Coveralls or SimpleCov to confirm 100% coverage of `app/controllers/herbarium_controller.rb`

This is the first step in "normalizing" HerbariumController. See https://www.pivotaltracker.com/story/show/174310149. 
I thought I should get this step into `master` because it's independently useful and I don't know how long that Story will take.