### PR TITLE
Fix bug in pattern search.

### DIFF
--- a/app/controllers/observer_controller/search_controller.rb
+++ b/app/controllers/observer_controller/search_controller.rb
@@ -37,7 +37,7 @@ class ObserverController
 
     # If pattern is blank, this would devolve into a very expensive index.
     if pattern.blank?
-      redirect_to(controller: ctrlr, action: "list_#{type}s")
+      redirect_to(controller: ctrlr, action: "list_#{type.to_s.pluralize}")
     else
       redirect_to(controller: ctrlr, action: "#{type}_search",
                   pattern: pattern)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -590,6 +590,11 @@ class ObserverControllerTest < FunctionalTestCase
     params = { search: { pattern: "", type: :observation } }
     get_with_dump(:pattern_search, params)
     assert_redirected_to(controller: :observer, action: :list_observations)
+
+    # Make sure this redirects correctly to list_herbaria not list_herariums.
+    params = { search: { pattern: "", type: :herbarium } }
+    get(:pattern_search, params)
+    assert_redirected_to(controller: :herbarium, action: :list_herbaria)
   end
 
   def test_observation_search_help


### PR DESCRIPTION
If the pattern string is empty it redirects to list_xxx to get full listing of all objects. But it was not pluralizing "herbarium" correctly and failing for that object type.

Again, just a trivial bug fix and simple corresponding test.  Review not really required.  But I am going to wait for Travis to run the tests for me.  My laptop is too busy with other intensive jobs right now to run them myself.