### PR TITLE
Fix broken link to MB number

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -127,7 +127,8 @@ module ObjectLinkHelper
 
     title = users.count > 1 ? title.to_s.pluralize.to_sym.t : title.t
     links = users.map { |u| user_link(u, u.legal_name) }
-    "#{title}: #{links.safe_join(", ")}".html_safe
+    # sanitize because interpolation makes the string html unsafe
+    sanitize("#{title}: #{links.safe_join(", ")}")
   end
 
   # Wrap object's name in link to the object, return nil if no object

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -127,8 +127,10 @@ module ObjectLinkHelper
 
     title = users.count > 1 ? title.to_s.pluralize.to_sym.t : title.t
     links = users.map { |u| user_link(u, u.legal_name) }
-    # sanitize because interpolation makes the string html unsafe
-    sanitize("#{title}: #{links.safe_join(", ")}")
+    # interpolation would require `sanitize` or similar
+    # rubocop:disable Style/StringConcatenation
+    title + ": " + links.safe_join(", ")
+    # rubocop:enable Style/StringConcatenation
   end
 
   # Wrap object's name in link to the object, return nil if no object

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -127,7 +127,8 @@ module ObjectLinkHelper
 
     title = users.count > 1 ? title.to_s.pluralize.to_sym.t : title.t
     links = users.map { |u| user_link(u, u.legal_name) }
-    # interpolation would require `sanitize` or similar
+    # interpolating would require inefficient #sanitize
+    # or dangerous #html_safe
     # rubocop:disable Style/StringConcatenation
     title + ": " + links.safe_join(", ")
     # rubocop:enable Style/StringConcatenation

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -43,7 +43,7 @@ module ObjectLinkHelper
   #
   def name_link(name, str = nil)
     if name.is_a?(Integer)
-      str ||= :NAME.t + " #" + name.to_s
+      str ||= "#{:NAME.t} ##{name}"
       link_to(str, Name.show_link_args(name))
     else
       str ||= name.display_name_brief_authors.t
@@ -53,21 +53,9 @@ module ObjectLinkHelper
 
   # ----- links to names and records at external websites ----------------------
 
-  # Create link for name to MyCoPortal website.
-  def mycoportal_url(name)
-    "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
-      "#{name.text_name.tr(" ", "+")}"
-  end
-
   # url for IF record
   def index_fungorum_record_url(record_id)
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"
-  end
-
-  # url for MB record
-  def mycobank_record_url(record_id)
-    "#{mycobank_host}page/Basic%20names%20search/field/MycoBank%20%23/" \
-      "#{record_id}"
   end
 
   # url for Index Fungorum search. This is a general search.
@@ -76,13 +64,17 @@ module ObjectLinkHelper
     "http://www.indexfungorum.org/Names/Names.asp"
   end
 
+  # url for MB record by number
+  # as of 2020-10-05 actually links to search results, rather than the record
+  def mycobank_record_url(record_id)
+    "#{mycobank_basic_search_url}/field/MycoBank%20number/#{record_id}"
+  end
+
   # url for MycoBank name search for text_name
   def mycobank_name_search_url(name)
-    unescaped_str = "#{mycobank_basic_search_url}/field/Taxon%20name/" \
-                    "#{name.text_name}"
-    # CGI::escape.html(unescaped_str) should work, but throws error
-    #   ActionView::Template::Error: wrong number of arguments (0 for 1)
-    unescaped_str.gsub(" ", "%20")
+    "#{mycobank_basic_search_url}/field/Taxon%20name/#{
+      name.text_name.gsub(" ", "%20")
+    }"
   end
 
   def mycobank_basic_search_url
@@ -91,6 +83,12 @@ module ObjectLinkHelper
 
   def mycobank_host
     "https://www.mycobank.org/"
+  end
+
+  # url for name search on MyCoPortal
+  def mycoportal_url(name)
+    "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
+      "#{name.text_name.tr(" ", "+")}"
   end
 
   # ----------------------------------------------------------------------------
@@ -105,7 +103,7 @@ module ObjectLinkHelper
   #
   def user_link(user, name = nil)
     if user.is_a?(Integer)
-      name ||= :USER.t + " #" + user.to_s
+      name ||= "#{:USER.t} ##{user}"
       link_to(name, User.show_link_args(user))
     elsif user
       name ||= user.unique_text_name
@@ -129,7 +127,7 @@ module ObjectLinkHelper
 
     title = users.count > 1 ? title.to_s.pluralize.to_sym.t : title.t
     links = users.map { |u| user_link(u, u.legal_name) }
-    title + ": " + links.safe_join(", ")
+    "#{title}: #{links.safe_join(", ")}".html_safe
   end
 
   # Wrap object's name in link to the object, return nil if no object

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -14,7 +14,7 @@ class ObjectLinkHelperTest < ActionView::TestCase
 
     link_text = name.display_name_brief_authors.t
     assert_equal(expected_link(path, obj, link_text), name_link(name))
-end
+  end
 
   def test_link_if_object
     # link to project, name not supplied

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -4,6 +4,18 @@ require("test_helper")
 
 # test helper for links in views
 class ObjectLinkHelperTest < ActionView::TestCase
+  def test_name_link
+    name = names(:suillus)
+    path = "#{name_show_name_path}/"
+    obj = name
+
+    link_text = "#{:NAME.l} ##{name.id}"
+    assert_equal(expected_link(path, obj, link_text), name_link(name.id))
+
+    link_text = name.display_name_brief_authors.t
+    assert_equal(expected_link(path, obj, link_text), name_link(name))
+end
+
   def test_link_if_object
     # link to project, name not supplied
     # pre  = '<a href="/project/show_project/'
@@ -28,6 +40,10 @@ class ObjectLinkHelperTest < ActionView::TestCase
     assert_nil(link_to_object(nil, "Nada"),
                "Non-existent object should lack link.")
   end
+
+  ##############################################################################
+
+  private
 
   def expected_link(path, obj, link_text)
     "<a href=\"#{path}#{obj.id}\">#{link_text}</a>"

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -41,9 +41,7 @@ class ObjectLinkHelperTest < ActionView::TestCase
                "Non-existent object should lack link.")
   end
 
-  ##############################################################################
-
-  private
+  # - Helper Methods -----------------------------------------------------------
 
   def expected_link(path, obj, link_text)
     "<a href=\"#{path}#{obj.id}\">#{link_text}</a>"


### PR DESCRIPTION
- Fix url for taxon by MB number
- Reorganize ObjectLinkHelper: group url methods by host
- Some RuboCopping

MB had incorrectly documented how to create a link to MB by taxon number.
See https://www.pivotaltracker.com/story/show/175129131

Manual Test:
- Edit any Name
- Add the ICN Identifier and Save
- On the resulting Name page, follow the link to the MycoBank record
Result: It should land on MB, on a page showing the search results for that ICN identifier. (You may have to scroll down to see the unique hit. And clicking on that hit should pop up a window for the record.)

Delivers https://www.pivotaltracker.com/story/show/175129131