### PR TITLE
No admin email when ICN id unchanged

### DIFF
--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -255,7 +255,7 @@ class NameController
 
   def icn_id_conflict?(new_icn_id)
     new_icn_id && @name.icn_id &&
-      new_icn_id != @name.icn_id
+      new_icn_id != @name.icn_id.to_s
   end
 
   def just_adding_author?

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1762,6 +1762,34 @@ class NameControllerTest < FunctionalTestCase
     assert_no_emails
   end
 
+  def test_update_icn_id_unchanged
+    name = names(:coprinus_comatus)
+    assert(name.icn_id, "Test needs a fixture with an icn_id")
+    params = {
+      id: name.id,
+      name: {
+        version: name.version,
+        text_name: name.text_name,
+        author: name.author,
+        sort_name: name.sort_name,
+        rank: name.rank,
+        citation: name.citation,
+        deprecated: (name.deprecated ? "true" : "false"),
+        icn_id: name.icn_id,
+        notes: "A zillion synonyms and other stuff copied from Index Fungorum"
+      }
+    }
+    user = name.user
+    login(user.login)
+
+    assert_difference("name.versions.count", 1) do
+      post(:edit_name, params: params)
+    end
+    assert_flash_success
+    assert_redirected_to(action: :show_name, id: name.id)
+    assert_no_emails
+  end
+
   def test_update_icn_id_invalid
     name = names(:authored_group)
     params = {


### PR DESCRIPTION
When comparing existing `icn_id` to `params[:name][;icn_id]`, convert existing ID to string.

Otherwise ICN ID always appears to change, and an admin email is sent (to webmaster).
That's what happens when you compare 5 apples to 5 oranges and expect them to be equal.

Delivers https://www.pivotaltracker.com/story/show/175158610

