### PR TITLE
Admin utility to let admins switch to another user (and back)

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -22,3 +22,4 @@
 //= link BlackOnWhite.css
 //= link Cantharellaceae.css
 //= link Hygrocybe.css
+//= link Sudo.css

--- a/app/assets/stylesheets/Sudo.scss
+++ b/app/assets/stylesheets/Sudo.scss
@@ -1,0 +1,39 @@
+@import "defaults";
+
+$BODY_BG_COLOR:               #DD7700;
+
+$LOGO_BORDER_COLOR:           black;
+$LOGO_BORDER_WIDTH:           2px;
+$LOGO_FG_COLOR:               black;
+$LOGO_BG_COLOR:               #66FF44;
+$LOGO_HOVER_FG_COLOR:         #DD7700;
+$LOGO_HOVER_BG_COLOR:         #66FF44;
+
+$LEFT_BAR_BORDER_COLOR:       gray;
+$LEFT_BAR_BORDER_RADIUS:      0px;
+$LEFT_BAR_HEADER_FG_COLOR:    black;
+$LEFT_BAR_HEADER_BG_COLOR:    #66FF44;
+$LEFT_BAR_FG_COLOR:           #DD7700;
+$LEFT_BAR_BG_COLOR:           #66FF44;
+$LEFT_BAR_HOVER_FG_COLOR:     #66FF44;
+$LEFT_BAR_HOVER_BG_COLOR:     #DD7700;
+
+$TOP_BAR_BG_COLOR:            #DD7700;
+
+$TOP_BAR_BORDER_COLOR:        none;
+$TOP_BAR_BORDER_WIDTH:        0;
+$TOP_BAR_BORDER_STYLE:        none;
+$TOP_BAR_BORDER_RADIUS:       0;
+$TOP_BAR_FG_COLOR:            $BODY_FG_COLOR;
+$TOP_BAR_BG_COLOR:            $BODY_BG_COLOR;
+
+$VOTE_METER_FG_COLOR:         #000000;
+
+@import "mushroom_observer";
+
+.Admin {
+  font-size: 26px;
+  font-weight: bold;
+  text-align: center;
+  padding: 7px;
+}

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -191,8 +191,9 @@ class AccountController < ApplicationController
   end
 
   def logout_user
-    if session[:real_user_id]
-      new_user = User.safe_find(session[:real_user_id])
+    if session[:real_user_id].present? &&
+       (new_user = User.safe_find(session[:real_user_id])) &&
+       new_user.admin
       switch_to_user(new_user)
       redirect_back_or_default(controller: :observer, action: :index)
     else
@@ -647,9 +648,7 @@ class AccountController < ApplicationController
   ##############################################################################
 
   def turn_admin_on
-    if (@user&.admin || session[:real_user_id].present?) && !in_admin_mode?
-      session[:admin] = true
-    end
+    session[:admin] = true if @user&.admin && !in_admin_mode?
     redirect_back_or_default(controller: :observer, action: :index)
   end
 

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -31,6 +31,7 @@
 #  ==== Admin utilities
 #  turn_admin_on::      <tt>(R . .)</tt>
 #  turn_admin_off::     <tt>(R . .)</tt>
+#  sudo::               <tt>(R V .)</tt>
 #  add_user_to_group::  <tt>(R V .)</tt>
 #  create_alert::       <tt>(R V .)</tt>
 #  destroy_user::       <tt>(R . .)</tt>
@@ -190,10 +191,16 @@ class AccountController < ApplicationController
   end
 
   def logout_user
-    @user = nil
-    User.current = nil
-    session_user_set(nil)
-    clear_autologin_cookie
+    if session[:real_user_id]
+      new_user = User.safe_find(session[:real_user_id])
+      switch_to_user(new_user)
+      redirect_back_or_default(controller: :observer, action: :index)
+    else
+      @user = nil
+      User.current = nil
+      session_user_set(nil)
+      clear_autologin_cookie
+    end
   end
 
   # ========= private Login section methods ==========
@@ -410,7 +417,7 @@ class AccountController < ApplicationController
       # Check if we need to upload an image.
       upload = params["user"]["upload_image"]
       if upload.present?
-        date = Date.parse(params["date"]["copyright_year"].to_s + "0101")
+        date = Date.parse("#{params["date"]["copyright_year"]}0101")
         license = License.safe_find(params["upload"]["license_id"])
         holder = params["copyright_holder"]
         image = Image.new(
@@ -618,21 +625,19 @@ class AccountController < ApplicationController
   end
 
   def edit_api_key
-    if (@key = find_or_goto_index(ApiKey, params[:id].to_s))
-      if check_permission!(@key)
-        if request.method == "POST"
-          if params[:commit] == :UPDATE.l
-            @key.update!(params[:key].permit!)
-            flash_notice(:account_api_keys_updated.t)
-          end
-          redirect_to(action: :api_keys)
-        end
-      else
-        redirect_to(action: :api_keys)
-      end
-    end
+    return unless @key = find_or_goto_index(ApiKey, params[:id].to_s)
+    return redirect_to(action: :api_keys) unless check_permission!(@key)
+    return if request.method != "POST"
+
+    update_api_key if params[:commit] == :UPDATE.l
+    redirect_to(action: :api_keys)
   rescue StandardError => e
     flash_error(e.to_s)
+  end
+
+  def update_api_key
+    @key.update!(params[:key].permit(:notes))
+    flash_notice(:account_api_keys_updated.t)
   end
 
   ##############################################################################
@@ -642,13 +647,48 @@ class AccountController < ApplicationController
   ##############################################################################
 
   def turn_admin_on
-    session[:admin] = true if @user&.admin && !in_admin_mode?
+    if (@user&.admin || session[:real_user_id].present?) && !in_admin_mode?
+      session[:admin] = true
+    end
     redirect_back_or_default(controller: :observer, action: :index)
   end
 
   def turn_admin_off
     session[:admin] = nil
     redirect_back_or_default(controller: :observer, action: :index)
+  end
+
+  def sudo
+    @id = params[:id].to_s
+    new_user = find_user_by_id_login_or_email(@id)
+    if !@user&.admin && session[:real_user_id].blank?
+      redirect_back_or_default(controller: :observer, action: :index)
+    elsif new_user.present?
+      switch_to_user(new_user)
+      redirect_back_or_default(controller: :observer, action: :index)
+    end
+  end
+
+  def find_user_by_id_login_or_email(str)
+    if str.blank?
+      nil
+    elsif str.match?(/^\d+$/)
+      User.safe_find(str)
+    else
+      User.where(login: str).first
+    end
+  end
+
+  def switch_to_user(new_user)
+    if session[:real_user_id].blank?
+      session[:real_user_id] = User.current_id
+      session[:admin] = nil
+    elsif session[:real_user_id] == new_user.id
+      session[:real_user_id] = nil
+      session[:admin] = true
+    end
+    User.current = new_user
+    session_user_set(new_user)
   end
 
   def add_user_to_group
@@ -689,6 +729,10 @@ class AccountController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # I think this is as good as it gets: just a simple switch statement of
+  # one-line commands.  Breaking this up doesn't make sense to me.
+  # -JPH 2020-10-09
   def process_blocked_ips_commands
     if validate_ip!(params[:add_okay])
       IpStats.add_okay_ips([params[:add_okay]])
@@ -706,6 +750,7 @@ class AccountController < ApplicationController
       @ip = params[:report]
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def validate_ip!(ip)
     return false if ip.blank?

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -200,6 +200,7 @@ class AccountController < ApplicationController
       @user = nil
       User.current = nil
       session_user_set(nil)
+      session[:admin] = false
       clear_autologin_cookie
     end
   end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -31,7 +31,7 @@
 #  ==== Admin utilities
 #  turn_admin_on::      <tt>(R . .)</tt>
 #  turn_admin_off::     <tt>(R . .)</tt>
-#  sudo::               <tt>(R V .)</tt>
+#  switch_users::       <tt>(R V .)</tt>
 #  add_user_to_group::  <tt>(R V .)</tt>
 #  create_alert::       <tt>(R V .)</tt>
 #  destroy_user::       <tt>(R . .)</tt>
@@ -658,7 +658,7 @@ class AccountController < ApplicationController
     redirect_back_or_default(controller: :observer, action: :index)
   end
 
-  def sudo
+  def switch_users
     @id = params[:id].to_s
     new_user = find_user_by_id_login_or_email(@id)
     if !@user&.admin && session[:real_user_id].blank?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -499,7 +499,7 @@ class ApplicationController < ActionController::Base
   # Is the current User in admin mode?  Returns true or false.  (*NOTE*: this
   # is available to views.)
   def in_admin_mode?
-    @user&.admin && session[:admin]
+    session[:admin]
   end
   helper_method :in_admin_mode?
 

--- a/app/views/account/sudo.html.erb
+++ b/app/views/account/sudo.html.erb
@@ -1,0 +1,11 @@
+<%
+  @title = "Login as Another User"
+%>
+
+<div class="max-width-text">
+  <%= form_tag({}, { class: "push-down pad-bottom-2x"}) %>
+    <big>ID, login or email:</big><br/>
+    <%= text_field_tag(:id, @id, size: 40, data: {autofocus: true}, class: "form-control") %><br/>
+    <%= submit_tag("SUDO", class: "btn", style: "margin-left: 1em") %>
+  </form>
+</div>

--- a/app/views/account/switch_users.html.erb
+++ b/app/views/account/switch_users.html.erb
@@ -1,11 +1,11 @@
 <%
-  @title = "Login as Another User"
+  @title = :app_switch_users.l
 %>
 
 <div class="max-width-text">
   <%= form_tag({}, { class: "push-down pad-bottom-2x"}) %>
-    <big>ID, login or email:</big><br/>
+    <big><%= :LOGIN_NAME.t %>:</big><br/>
     <%= text_field_tag(:id, @id, size: 40, data: {autofocus: true}, class: "form-control") %><br/>
-    <%= submit_tag("SUDO", class: "btn", style: "margin-left: 1em") %>
+    <%= submit_tag(:SUBMIT.t, class: "btn", style: "margin-left: 1em") %>
   </form>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,8 @@
     css = MO.default_theme
     if in_admin_mode?
       css = "Admin"
+    elsif session[:real_user_id].present? 
+      css = "Sudo"
     elsif browser.bot?
       css = MO.default_theme
     elsif MO.themes.member?(controller.action_name)
@@ -46,6 +48,10 @@
       <% if in_admin_mode? %>
         <div class="Admin">
           DANGER: You are in administrator mode. Proceed with caution.
+        </div>
+      <% elsif session[:real_user_id].present? %>
+        <div class="Admin">
+          DANGER: You are currently logged in as <%= User.current.login %>.
         </div>
       <% end
 

--- a/app/views/shared/_nav_left.html.erb
+++ b/app/views/shared/_nav_left.html.erb
@@ -12,6 +12,7 @@
       <%= :app_admin.t %>:
     </div>
     <%= link_to(:app_blocked_ips.t, {controller: :account, action: :blocked_ips}, {class: "list-group-item list-group-item-danger indent"}) %>
+    <%= link_to("SUDO", {controller: :account, action: :sudo}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:app_users.t, {controller: :observer, action: :users_by_name}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:change_banner_title.t, {controller: :observer, action: :change_banner}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:app_email_all_users.t, {controller: :observer, action: :email_features}, {class: "list-group-item list-group-item-danger indent"}) %>

--- a/app/views/shared/_nav_left.html.erb
+++ b/app/views/shared/_nav_left.html.erb
@@ -12,7 +12,7 @@
       <%= :app_admin.t %>:
     </div>
     <%= link_to(:app_blocked_ips.t, {controller: :account, action: :blocked_ips}, {class: "list-group-item list-group-item-danger indent"}) %>
-    <%= link_to("SUDO", {controller: :account, action: :sudo}, {class: "list-group-item list-group-item-danger indent"}) %>
+    <%= link_to(:app_switch_users.t, {controller: :account, action: :switch_users}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:app_users.t, {controller: :observer, action: :users_by_name}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:change_banner_title.t, {controller: :observer, action: :change_banner}, {class: "list-group-item list-group-item-danger indent"}) %>
     <%= link_to(:app_email_all_users.t, {controller: :observer, action: :email_features}, {class: "list-group-item list-group-item-danger indent"}) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1258,6 +1258,7 @@
   app_logout: Logout
   app_admin: Admin
   app_blocked_ips: Blocked IPs
+  app_switch_users: Switch Users
   app_users: "[:list_objects(type=:user)]"
   app_email_all_users: Email All Users
   app_add_to_group: Add to Group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ ACTIONS = {
     reverify: {},
     send_verify: {},
     signup: {},
+    sudo: {},
     test_autologin: {},
     test_flash: {},
     turn_admin_off: {},

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ ACTIONS = {
     reverify: {},
     send_verify: {},
     signup: {},
-    sudo: {},
+    switch_users: {},
     test_autologin: {},
     test_flash: {},
     turn_admin_off: {},

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -820,5 +820,10 @@ class AccountControllerTest < FunctionalTestCase
     rolf.save!
     get(:switch_users)
     assert_response(:success)
+    assert_users_equal(rolf, User.current)
+    post(:switch_users, params: { id: mary.id })
+    assert_users_equal(mary, User.current)
+    post(:switch_users, params: { id: dick.login })
+    assert_users_equal(dick, User.current)
   end
 end

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -821,6 +821,8 @@ class AccountControllerTest < FunctionalTestCase
     get(:switch_users)
     assert_response(:success)
     assert_users_equal(rolf, User.current)
+    post(:switch_users, params: { id: "Frosted Flake" })
+    assert_users_equal(rolf, User.current)
     post(:switch_users, params: { id: mary.id })
     assert_users_equal(mary, User.current)
     post(:switch_users, params: { id: dick.login })

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -795,4 +795,30 @@ class AccountControllerTest < FunctionalTestCase
     assert_no_flash
     assert_false(IpStats.blocked?(new_ip))
   end
+
+  def test_turn_admin_on
+    get(:turn_admin_on)
+    assert_false(session[:admin])
+    login(:rolf)
+    get(:turn_admin_on)
+    assert_false(session[:admin])
+    rolf.admin = true
+    rolf.save!
+    get(:turn_admin_on)
+    assert_true(session[:admin])
+    get(:turn_admin_off)
+    assert_false(session[:admin])
+  end
+
+  def test_switch_users
+    get(:switch_users)
+    assert_response(:redirect)
+    login(:rolf)
+    get(:switch_users)
+    assert_response(:redirect)
+    rolf.admin = true
+    rolf.save!
+    get(:switch_users)
+    assert_response(:success)
+  end
 end

--- a/test/integration/admin_test.rb
+++ b/test/integration/admin_test.rb
@@ -14,14 +14,14 @@ class AdminTest < IntegrationTestCase
     assert_select("form")
   end
 
-  def test_sudo
+  def test_switch_users
     rolf.admin = true
     rolf.save!
     login!(rolf)
     assert_equal(rolf.id, User.current_id)
     click(href: /turn_admin_on/)
     assert_match(/DANGER: You are in administrator mode/, response.body)
-    click(href: /sudo/)
+    click(href: /switch_users/)
     open_form do |form|
       form.change("id", "mary")
       form.submit

--- a/test/integration/admin_test.rb
+++ b/test/integration/admin_test.rb
@@ -13,4 +13,23 @@ class AdminTest < IntegrationTestCase
     # If it fails it renders a simple text message.
     assert_select("form")
   end
+
+  def test_sudo
+    rolf.admin = true
+    rolf.save!
+    login!(rolf)
+    assert_equal(rolf.id, User.current_id)
+    click(href: /turn_admin_on/)
+    assert_match(/DANGER: You are in administrator mode/, response.body)
+    click(href: /sudo/)
+    open_form do |form|
+      form.change("id", "mary")
+      form.submit
+    end
+    assert_equal(mary.id, User.current_id)
+    assert_match(/DANGER: You are currently logged in as mary/, response.body)
+    click(href: /logout_user/)
+    assert_equal(rolf.id, User.current_id)
+    assert_match(/DANGER: You are in administrator mode/, response.body)
+  end
 end


### PR DESCRIPTION
Workflow:

turn on admin mode
click on "Switch Users" (left nav bar)
enter login name or id of other user and submit
you are now logged in as that user (and no longer in admin mode)

Note that the page colors change to goldenrod and avocado green, and there is a big banner at the top warning that you are logged in as the other user.  When you are done:

click on logout
you are back to yourself and in admin mode again

I didn't do any serious testing, just the basics (e.g., that you have to be logged in and in admin mode, and that a simple integration session works as expected).