### PR TITLE
Fix guess name bug

### DIFF
--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -78,8 +78,8 @@ class Name < AbstractModel
     patterns = []
 
     # Restrict search to names close in length.
-    a = name.length - 2
-    b = name.length + 2
+    min_len = Name.connection.quote((name.length - 2).to_s)
+    max_len = Name.connection.quote((name.length + 2).to_s)
 
     # Create a bunch of SQL "like" patterns.
     name = name.gsub(/ \w+\. /, " % ")
@@ -105,8 +105,8 @@ class Name < AbstractModel
     conds = patterns.map do |pat|
       "text_name LIKE #{Name.connection.quote(pat)}"
     end.join(" OR ")
-    all_conds = "(LENGTH(text_name) BETWEEN #{a} AND #{b}) AND (#{conds}) " \
-                "AND correct_spelling_id IS NULL"
+    all_conds = "(LENGTH(text_name) BETWEEN #{min_len} AND #{max_len}) " \
+                "AND (#{conds}) AND correct_spelling_id IS NULL"
     names = where(all_conds).limit(10).to_a
 
     names

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -105,15 +105,9 @@ class Name < AbstractModel
     conds = patterns.map do |pat|
       "text_name LIKE #{Name.connection.quote(pat)}"
     end.join(" OR ")
-    all_conds = "(LENGTH(text_name) BETWEEN :a AND :b) AND (#{conds}) " \
+    all_conds = "(LENGTH(text_name) BETWEEN #{a} AND #{b}) AND (#{conds}) " \
                 "AND correct_spelling_id IS NULL"
-    names = where(all_conds, a: a, b: b).limit(10).to_a
-
-    # Screen out ones way too different.
-    names = names.reject do |x|
-      (x.text_name.length < a) ||
-        (x.text_name.length > b)
-    end
+    names = where(all_conds).limit(10).to_a
 
     names
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2961,8 +2961,8 @@ class NameTest < UnitTestCase
   # The ":Fr" in this used to raise an ActiveRecord error because it was
   # interpreting it as a named variable.
   def test_guess_name_with_colon_in_pattern
-    assert_nothing_raised do
-      Name.guess_with_errors("Crepidotus applanatus(Pers.:Fr.)Kummer", 1)
-    end
+    # Apparently assert_nothing_raised hides debug information but gives
+    # nothing useful in return.
+    Name.guess_with_errors("Crepidotus applanatus(Pers.:Fr.)Kummer", 1)
   end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2957,4 +2957,12 @@ class NameTest < UnitTestCase
     assert(name.searchable_in_registry?,
            "Protozoa should be searchable in registry")
   end
+
+  # The ":Fr" in this used to raise an ActiveRecord error because it was
+  # interpreting it as a named variable.
+  def test_guess_name_with_colon_in_pattern
+    assert_nothing_raised do
+      Name.guess_with_errors("Crepidotus applanatus(Pers.:Fr.)Kummer", 1)
+    end
+  end
 end


### PR DESCRIPTION
Small, rare bug seen when looking up names spelled slightly differently than, for example:

    "Crepidotus applanatus(Pers.:Fr.)Kummer"

The :Fr was confusing ActiveRecord.  I just removed the other two named parameters, and now ActiveRecord no longer looks for magic in the condition string.