### PR TITLE
MO crashed if user tried to edit naming that they had no votes for.

### DIFF
--- a/app/controllers/naming_controller.rb
+++ b/app/controllers/naming_controller.rb
@@ -17,7 +17,7 @@ class NamingController < ApplicationController
     return default_redirect(naming.observation) unless check_permission!(naming)
 
     # TODO: Can this get moved into NamingParams#naming=
-    @params.vote = naming.first_vote
+    @params.vote = naming.owners_vote
     request.method == "POST" ? edit_post : @params.edit_init
   end
 

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -253,8 +253,10 @@ class Naming < AbstractModel
     result
   end
 
-  def first_vote
-    Vote.where(naming_id: id, user_id: user_id).first
+  # It is rare, but a single user can end up with multiple votes, for example,
+  # if two names are merged and a user had voted for both names.
+  def owners_vote
+    Vote.where(naming_id: id, user_id: user_id).order("value desc").first
   end
 
   ##############################################################################

--- a/app/views/naming/_form.html.erb
+++ b/app/views/naming/_form.html.erb
@@ -39,7 +39,7 @@
     <div class="form-group">
       <%= label_tag(:vote_value, :form_naming_confidence.t + ":") %><br>
       <%= select(:vote, :value,
-                 options_for_select(Vote.confidence_menu, vote.value),
+                 options_for_select(Vote.confidence_menu, vote&.value),
                  { include_blank: (action == :create ||
                                    action == :create_observation) } ,
                  class: "form-control",

--- a/test/controllers/naming_controller_test.rb
+++ b/test/controllers/naming_controller_test.rb
@@ -28,6 +28,13 @@ class NamingControllerTest < FunctionalTestCase
     )
   end
 
+  def test_edit_naming_no_votes
+    nam = namings(:minimal_unknown_naming)
+    assert_empty(nam.votes)
+    login(nam.user.login)
+    get(:edit, params: { id: nam.id })
+  end
+
   def test_update_observation_new_name
     login("rolf")
     nam = namings(:coprinus_comatus_naming)


### PR DESCRIPTION
Added test that reproduced the bug.

Fixed the bug.

Renamed Naming#first_vote to more descriptive Naming#owners_vote, and tweaked it so that it would return the user's most positive vote if they had multiple votes for the same name.  This case can rarely happen if two names are merged and a user voted for both names on the same observation.  Maybe.  Not actually 100% certain.  It may also result in two namings for the same name for the same observation, with one vote for each naming.  Whatever, just seemed worth making certain behavior is not random if the owner has multiple votes for a given naming.