### PR TITLE
Supplement ICN id

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -91,6 +91,11 @@ module ObjectLinkHelper
       "#{name.text_name.tr(" ", "+")}"
   end
 
+  # url for IF record
+  def species_fungorum_gsd_synonymy(record_id)
+    "http://www.speciesfungorum.org/Names/GSDspecies.asp?RecordID=#{record_id}"
+  end
+
   # ----------------------------------------------------------------------------
 
   # Wrap user name in link to show_user.

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -91,7 +91,7 @@ module ObjectLinkHelper
       "#{name.text_name.tr(" ", "+")}"
   end
 
-  # url for IF record
+  # url of SF page with "official" synonyms
   def species_fungorum_gsd_synonymy(record_id)
     "http://www.speciesfungorum.org/Names/GSDspecies.asp?RecordID=#{record_id}"
   end

--- a/app/views/name/_nomenclature.html.erb
+++ b/app/views/name/_nomenclature.html.erb
@@ -25,6 +25,8 @@
           <p><%= link_to("[##{name.icn_id}]",
                          mycobank_record_url(name.icn_id)) %>
              MycoBank</p>
+          <p><%= link_to(:gsd_species_synonymy.t,
+                         species_fungorum_gsd_synonymy(name.icn_id)) %></p>
        <% elsif name.registrable? %>
           <p><%= :ICN_ID.t %>: <em><%= :show_name_icn_id_missing.t %></em></p>
           <p><%= link_to(:index_fungorum_search.t,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2028,6 +2028,7 @@
   index_fungorum_search: Index Fungorum search
   mycobank: MycoBank
   mycobank_search: MycoBank search
+  gsd_species_synonymy: GSD Species Synonymy
 
   # name/show_name - links to observations
   show_name_observations: More [:OBSERVATIONS]

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -277,6 +277,10 @@ class NameControllerTest < FunctionalTestCase
       "body a[href='#{mycobank_record_url(name.icn_id)}']", true,
       "Page is missing a link to MB record"
     )
+    assert_select(
+      "body a[href='#{species_fungorum_gsd_synonymy(name.icn_id)}']", true,
+      "Page is missing a link to SF GSD Species Synonymy record"
+    )
   end
 
   def test_show_name_icn_id_missing

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2691,7 +2691,6 @@ class NameControllerTest < FunctionalTestCase
     assert_nil(survivor.icn_id, "Test needs fixtures without icn_id")
 
     destroyed_real_search_name = edited_name.real_search_name
-    survivor_old_version = survivor.version
 
     params = {
       id: edited_name.id,

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2680,8 +2680,39 @@ class NameControllerTest < FunctionalTestCase
     )
   end
 
-  def test_update_name_merge_identifier_was_blank
+  def test_update_name_merge_add_identifier
+    edited_name = names(:amanita_boudieri_var_beillei)
+    survivor = names(:amanita_boudieri)
+    assert_nil(edited_name.icn_id, "Test needs fixtures without icn_id")
+    assert_nil(survivor.icn_id, "Test needs fixtures without icn_id")
+
+    destroyed_real_search_name = edited_name.real_search_name
+    survivor_old_version = survivor.version
+
+    params = {
+      id: edited_name.id,
+      name: {
+        icn_id: 208_785,
+        text_name: survivor.text_name,
+        author: edited_name.author,
+        rank: survivor.rank,
+        deprecated: (survivor.deprecated ? "true" : "false")
+      }
+    }
+    login("rolf")
     post(:edit_name, params: params)
+
+    assert_redirected_to(action: :show_name, id: survivor.id)
+    assert_flash_text(/Successfully merged name #{destroyed_real_search_name}/,
+                      "Flash should include destroyed name")
+    assert_no_emails
+    assert_not(Name.exists?(edited_name.id))
+    assert_equal(208_785, survivor.reload.icn_id)
+    assert_equal(survivor_old_version + 1, survivor.version,
+                 "Name version should incrememt upon merger")
+  end
+
+  def test_update_name_reverse_merge_add_identifier
     edited_name = names(:coprinus_comatus)
     merged_name = names(:stereum_hirsutum) # has empty icn_id
     assert_nil(merged_name.icn_id, "Test needs a fixture without icn_id")

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2681,6 +2681,7 @@ class NameControllerTest < FunctionalTestCase
   end
 
   def test_update_name_merge_identifier_was_blank
+    post(:edit_name, params: params)
     edited_name = names(:coprinus_comatus)
     merged_name = names(:stereum_hirsutum) # has empty icn_id
     assert_nil(merged_name.icn_id, "Test needs a fixture without icn_id")

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2704,7 +2704,9 @@ class NameControllerTest < FunctionalTestCase
       }
     }
     login("rolf")
-    post(:edit_name, params: params)
+    assert_difference("survivor.versions.count", 1) do
+      post(:edit_name, params: params)
+    end
 
     assert_redirected_to(action: :show_name, id: survivor.id)
     assert_flash_text(/Successfully merged name #{destroyed_real_search_name}/,
@@ -2712,8 +2714,6 @@ class NameControllerTest < FunctionalTestCase
     assert_no_emails
     assert_not(Name.exists?(edited_name.id))
     assert_equal(208_785, survivor.reload.icn_id)
-    assert_equal(survivor_old_version + 1, survivor.version,
-                 "Name version should incrememt upon merger")
   end
 
   def test_update_name_reverse_merge_add_identifier


### PR DESCRIPTION
- Fixes two more bugs (found in the wild) related to PR #669:
  - corrects text of flash after successful merger
  - Doesn't send spurious email to webmaster when icn_id is added via merger
- Adds SF GSD species synonymy link to names where icn_id is present

Manual test
- Edit a Name to add an ICN identifier. 
Result: Nomenclature section of the show-name page should have a link to GSD Species Synonymy
- Edit a Name that has no ICN id to be the same as another Name without an identifier, but add an ICN identifier in the Edit form.
Result: Green flash success message saying that the destroyed name has been merged into the other name.  

Delivers:
- https://www.pivotaltracker.com/story/show/175216008
- https://www.pivotaltracker.com/story/show/175216117
- https://www.pivotaltracker.com/story/show/175216189
 