### PR TITLE
Added table to keep track of the last time each user saw each observation.

### DIFF
--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -118,12 +118,17 @@ module FooterHelper
         end
       end
       if obj.respond_to?(:num_views) && obj.last_view
-        times = if obj.num_views == 1
+        times = if obj.old_num_views == 1
                   :one_time.l
                 else
-                  :many_times.l(num: obj.num_views)
+                  :many_times.l(num: obj.old_num_views)
                 end
-        html << :footer_viewed.t(date: obj.last_view.web_time, times: times)
+        date = obj.old_last_view&.web_time || :footer_never.l
+        html << :footer_viewed.t(date: date, times: times)
+      end
+      if User.current && obj.respond_to?(:last_viewed_by)
+        time = obj.old_last_viewed_by(User.current)&.web_time || :footer_never.l
+        html << :footer_last_you_viewed.t(date: time)
       end
     end
 
@@ -136,6 +141,6 @@ module FooterHelper
     end
 
     html = html.safe_join(safe_br)
-    tag.p(html, class: "small")
+    tag.p(html, class: "small footer-view-stats")
   end
 end

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -271,14 +271,27 @@ class AbstractModel < ApplicationRecord
   # *NOTE*: this turns off timestamp updating for this class and avoids touching
   # any RssLog, because it uses +save_without_our_callbacks+.
   #
+  # *NOTE*: this saves the old stats for the page footer of show_observation,
+  # show_name, etc. otherwise the footer will always show the last view as now!
+  #
   def update_view_stats
     return unless respond_to?("num_views=") || respond_to?("last_view=")
 
+    @old_num_views = num_views
+    @old_last_view = last_view
     self.class.record_timestamps = false
     self.num_views = (num_views || 0) + 1 if respond_to?("num_views=")
     self.last_view = Time.zone.now        if respond_to?("last_view=")
     save_without_our_callbacks
     self.class.record_timestamps = true
+  end
+
+  def old_num_views
+    @old_num_views.to_i
+  end
+
+  def old_last_view
+    @old_last_view
   end
 
   ##############################################################################

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -290,9 +290,7 @@ class AbstractModel < ApplicationRecord
     @old_num_views.to_i
   end
 
-  def old_last_view
-    @old_last_view
-  end
+  attr_reader :old_last_view
 
   ##############################################################################
   #

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -164,8 +164,11 @@ class Observation < AbstractModel
                                           before_remove: :remove_spl_callback
   has_and_belongs_to_many :collection_numbers
   has_and_belongs_to_many :herbarium_records
-  before_destroy { destroy_orphaned_collection_numbers }
+  has_many :observation_views
+  has_many :viewers, class_name: "User", through: :observation_views,
+           source: :user
 
+  before_destroy { destroy_orphaned_collection_numbers }
   before_save :cache_content_filter_data
   after_update :notify_users_after_change
   before_destroy :notify_species_lists
@@ -277,6 +280,23 @@ class Observation < AbstractModel
       WHERE o.name_id = n.id AND n.correct_spelling_id IS NOT NULL
     ))
     msgs
+  end
+
+  def update_view_stats
+    super
+    return if User.current.blank?
+
+    @old_last_viewed_by ||= {}
+    @old_last_viewed_by[User.current_id] = last_viewed_by(User.current)
+    ObservationView.touch(self, User.current)
+  end
+
+  def last_viewed_by(user)
+    observation_views.where(user: user).first&.last_view
+  end
+
+  def old_last_viewed_by(user)
+    @old_last_viewed_by && @old_last_viewed_by[user&.id]
   end
 
   ##############################################################################

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -165,8 +165,9 @@ class Observation < AbstractModel
   has_and_belongs_to_many :collection_numbers
   has_and_belongs_to_many :herbarium_records
   has_many :observation_views
-  has_many :viewers, class_name: "User", through: :observation_views,
-           source: :user
+  has_many :viewers, class_name: "User",
+                     through: :observation_views,
+                     source: :user
 
   before_destroy { destroy_orphaned_collection_numbers }
   before_save :cache_content_filter_data
@@ -288,11 +289,11 @@ class Observation < AbstractModel
 
     @old_last_viewed_by ||= {}
     @old_last_viewed_by[User.current_id] = last_viewed_by(User.current)
-    ObservationView.touch(self, User.current)
+    ObservationView.update_view_stats(self, User.current)
   end
 
   def last_viewed_by(user)
-    observation_views.where(user: user).first&.last_view
+    observation_views.find_by(user: user)&.last_view
   end
 
   def old_last_viewed_by(user)

--- a/app/models/observation_view.rb
+++ b/app/models/observation_view.rb
@@ -8,7 +8,7 @@ class ObservationView < AbstractModel
   def self.update_view_stats(observation, user)
     return if observation.blank? || user.blank?
 
-    if view = find_by(observation: observation, user: user)
+    if (view = find_by(observation: observation, user: user))
       view.update!(last_view: Time.zone.now)
     else
       create!(observation: observation, user: user, last_view: Time.zone.now)

--- a/app/models/observation_view.rb
+++ b/app/models/observation_view.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Keep track of when each user last viewed each observation.
+class ObservationView < AbstractModel
+  belongs_to :observation
+  belongs_to :user
+
+  def self.touch(observation, user)
+    return if observation.blank? || user.blank?
+
+    if view = where(observation: observation, user: user).first
+      view.update_attributes!(last_view: Time.zone.now)
+    else
+      create!(observation: observation, user: user, last_view: Time.zone.now)
+    end
+  end
+end

--- a/app/models/observation_view.rb
+++ b/app/models/observation_view.rb
@@ -5,7 +5,7 @@ class ObservationView < AbstractModel
   belongs_to :observation
   belongs_to :user
 
-  def self.touch(observation, user)
+  def self.update_view_stats(observation, user)
     return if observation.blank? || user.blank?
 
     if view = where(observation: observation, user: user).first

--- a/app/models/observation_view.rb
+++ b/app/models/observation_view.rb
@@ -8,8 +8,8 @@ class ObservationView < AbstractModel
   def self.update_view_stats(observation, user)
     return if observation.blank? || user.blank?
 
-    if view = where(observation: observation, user: user).first
-      view.update_attributes!(last_view: Time.zone.now)
+    if view = find_by(observation: observation, user: user)
+      view.update!(last_view: Time.zone.now)
     else
       create!(observation: observation, user: user, last_view: Time.zone.now)
     end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -854,6 +854,8 @@
   footer_last_updated_at: "*Last [:modified]:* [date]"
   footer_last_updated_by: "*Last [:modified]:* [date] *by* [user]"
   footer_viewed: "*[:Viewed]:* [times], *last [:viewed]:* [date]"
+  footer_last_you_viewed: "*Last viewed by you:* [date]"
+  footer_never: never
   footer_version_out_of: "*[:Version]:* [num] *of* [total]"
 
   # Taxonomic ranks.

--- a/db/migrate/20201011132400_create_observation_views.rb
+++ b/db/migrate/20201011132400_create_observation_views.rb
@@ -1,13 +1,9 @@
 class CreateObservationViews < ActiveRecord::Migration[5.2]
-  def up
+  def change
     create_table :observation_views, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
       t.integer  :observation_id
       t.integer  :user_id
       t.datetime :last_view
     end
-  end
-
-  def down
-    drop_table :observation_views
   end
 end

--- a/db/migrate/20201011132400_create_observation_views.rb
+++ b/db/migrate/20201011132400_create_observation_views.rb
@@ -1,0 +1,13 @@
+class CreateObservationViews < ActiveRecord::Migration[5.2]
+  def up
+    create_table :observation_views, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+      t.integer  :observation_id
+      t.integer  :user_id
+      t.datetime :last_view
+    end
+  end
+
+  def down
+    drop_table :observation_views
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_11_183059) do
+ActiveRecord::Schema.define(version: 2020_10_11_132400) do
 
   create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at"
@@ -453,6 +453,12 @@ ActiveRecord::Schema.define(version: 2020_09_11_183059) do
     t.text "note_template"
     t.datetime "updated_at"
     t.boolean "require_specimen", default: false, null: false
+  end
+
+  create_table "observation_views", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "observation_id"
+    t.integer "user_id"
+    t.datetime "last_view"
   end
 
   create_table "observations", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -144,7 +144,7 @@ class ObserverControllerTest < FunctionalTestCase
     end
 
     last_view = 1.hour.ago
-    obs.update_attributes!(last_view: last_view)
+    obs.update!(last_view: last_view)
     login("dick")
     get(:show_observation, params: { id: obs.id })
     assert_equal(1, ObservationView.where(observation: obs).count)
@@ -156,9 +156,8 @@ class ObserverControllerTest < FunctionalTestCase
     end
 
     last_view = 2.months.ago
-    obs.update_attributes!(last_view: last_view)
-    obs.observation_views.where(user: dick).first.
-        update_attributes!(last_view: last_view)
+    obs.update!(last_view: last_view)
+    obs.observation_views.where(user: dick).first.update!(last_view: last_view)
     get(:show_observation, params: { id: obs.id })
     assert_equal(1, ObservationView.where(observation: obs).count)
     assert_operator(obs.last_viewed_by(dick), :>=, 2.seconds.ago)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -83,17 +83,6 @@ class ObserverControllerTest < FunctionalTestCase
     )
   end
 
-  def test_create_observation_with_unrecognized_name
-    text_name = "Elfin saddle"
-    params = { name: { name: text_name },
-               user: rolf,
-               where: locations.first.name }
-    post_requires_login(:create_observation, params)
-
-    assert_select("div[id='name_messages']",
-                  /MO does not recognize the name.*#{text_name}/)
-  end
-
   ##############################################################################
 
   # ----------------------------
@@ -142,6 +131,43 @@ class ObserverControllerTest < FunctionalTestCase
     get(:show_obs,
         params: { id: obs.id })
     assert_redirected_to(action: :show_observation, id: obs.id)
+  end
+
+  def test_show_obs_view_stats
+    obs = observations(:minimal_unknown_obs)
+    assert_empty(ObservationView.where(observation: obs))
+    get(:show_observation, params: { id: obs.id })
+    assert_empty(ObservationView.where(observation: obs))
+    assert_select("p.footer-view-stats") do |p|
+      assert_includes(p.to_s, :footer_viewed.t(date: :footer_never.l,
+                                               times: :many_times.l(num: 0)))
+    end
+
+    last_view = 1.hour.ago
+    obs.update_attributes!(last_view: last_view)
+    login("dick")
+    get(:show_observation, params: { id: obs.id })
+    assert_equal(1, ObservationView.where(observation: obs).count)
+    assert_operator(obs.last_viewed_by(dick), :>=, 2.seconds.ago)
+    assert_select("p.footer-view-stats") do |p|
+      assert_includes(p.to_s, :footer_viewed.t(date: last_view.web_time,
+                                               times: :one_time.l))
+      assert_includes(p.to_s, :footer_last_you_viewed.t(date: :footer_never.l))
+    end
+
+    last_view = 2.months.ago
+    obs.update_attributes!(last_view: last_view)
+    obs.observation_views.where(user: dick).first.
+        update_attributes!(last_view: last_view)
+    get(:show_observation, params: { id: obs.id })
+    assert_equal(1, ObservationView.where(observation: obs).count)
+    assert_operator(obs.last_viewed_by(dick), :>=, 2.seconds.ago)
+    assert_select("p.footer-view-stats") do |p|
+      assert_includes(p.to_s, :footer_viewed.t(date: last_view.web_time,
+                                               times: :many_times.l(num: 2)))
+      assert_includes(p.to_s,
+                      :footer_last_you_viewed.t(date: last_view.web_time))
+    end
   end
 
   def test_page_loads
@@ -1710,6 +1736,17 @@ class ObserverControllerTest < FunctionalTestCase
     users(:rolf).update(location_format: :scientific)
     get(:create_observation)
     assert_true(@response.body.include?("California, Mendocino Co., Albion"))
+  end
+
+  def test_create_observation_with_unrecognized_name
+    text_name = "Elfin saddle"
+    params = { name: { name: text_name },
+               user: rolf,
+               where: locations.first.name }
+    post_requires_login(:create_observation, params)
+
+    assert_select("div[id='name_messages']",
+                  /MO does not recognize the name.*#{text_name}/)
   end
 
   def test_construct_observation_approved_place_name

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1014,9 +1014,8 @@ class ObservationTest < UnitTestCase
     assert_nil(obs.old_last_viewed_by(dick))
 
     time = 1.day.ago
-    obs.update_attributes!(last_view: time)
-    obs.observation_views.where(user: dick).first.
-        update_attributes!(last_view: time)
+    obs.update!(last_view: time)
+    obs.observation_views.where(user: dick).first.update!(last_view: time)
     # Make sure this is a totally fresh instance.
     obs = Observation.find(obs.id)
 

--- a/test/models/observation_view_test.rb
+++ b/test/models/observation_view_test.rb
@@ -6,7 +6,7 @@ class ObservationViewTest < UnitTestCase
   def test_basic_stuff
     obs = observations(:minimal_unknown_obs)
     assert_empty(ObservationView.where(observation: obs, user: dick))
-    ObservationView.touch(obs, dick)
+    ObservationView.update_view_stats(obs, dick)
     assert_equal(1, ObservationView.where(observation: obs, user: dick).count)
     assert_operator(obs.last_viewed_by(dick), :>=, 2.seconds.ago)
   end

--- a/test/models/observation_view_test.rb
+++ b/test/models/observation_view_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ObservationViewTest < UnitTestCase
+  def test_basic_stuff
+    obs = observations(:minimal_unknown_obs)
+    assert_empty(ObservationView.where(observation: obs, user: dick))
+    ObservationView.touch(obs, dick)
+    assert_equal(1, ObservationView.where(observation: obs, user: dick).count)
+    assert_operator(obs.last_viewed_by(dick), :>=, 2.seconds.ago)
+  end
+end


### PR DESCRIPTION
It is maintained solely by show_observation.  No automagic callbacks or anything.

Also fixed bug in footer of show_observation page to make it display the *previous* time the page was displayed, not *this* time.  That must have been there for years!

I'll do queries and other follow-on features as separate PRs.

I might also attempt to populate the table using the logs.  I can go back to beginning of 2019 on the server.  If it is worthwhile, maybe Nathan would be willing to run a script for me on the archived logs from < 2019?  Not sure when we started logging the user id with requests.  Maybe > 2019?

Probably need to do some rubocop work.  This should be considered a draft for the moment.