### PR TITLE
Update MB record url 

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -65,9 +65,8 @@ module ObjectLinkHelper
   end
 
   # url for MB record by number
-  # as of 2020-10-05 actually links to search results, rather than the record
   def mycobank_record_url(record_id)
-    "#{mycobank_basic_search_url}/field/MycoBank%20number/#{record_id}"
+    "#{mycobank_host}/MB/#{record_id}"
   end
 
   # url for MycoBank name search for text_name


### PR DESCRIPTION
Updates the url for links to MB by RecordNumber

MycoBank restored this form of link today. 
The restored url goes directly to the record, rather than to a search for the record.

###Manual Test
- Add a ICN Registration Identifier to a Name.
- On the resulting show_name page, follow the link to the MB record (it looks like `[#nnnnnn] MycoBank`)
Result: You land on the MycoBank record for that name.

Delivers https://www.pivotaltracker.com/story/show/175247423