### PR TITLE
Name merger log

### DIFF
--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -323,12 +323,10 @@ class NameController
     end
     survivor.change_deprecated(deprecation) unless deprecation.nil?
 
-
     survivor.merge(@name) # move associations to survivor, destroy @name
 
     send_merger_messages(destroyed_real_search_name: destroyed_real_search_name,
                          survivor: survivor)
-
     @name = survivor
     @name.save
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -65,9 +65,8 @@ module ObjectLinkHelper
   end
 
   # url for MB record by number
-  # as of 2020-10-05 actually links to search results, rather than the record
   def mycobank_record_url(record_id)
-    "#{mycobank_basic_search_url}/field/MycoBank%20number/#{record_id}"
+    "#{mycobank_host}/MB/#{record_id}"
   end
 
   # url for MycoBank name search for text_name

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -65,8 +65,9 @@ module ObjectLinkHelper
   end
 
   # url for MB record by number
+  # as of 2020-10-05 actually links to search results, rather than the record
   def mycobank_record_url(record_id)
-    "#{mycobank_host}/MB/#{record_id}"
+    "#{mycobank_basic_search_url}/field/MycoBank%20number/#{record_id}"
   end
 
   # url for MycoBank name search for text_name

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2721,10 +2721,10 @@ class NameControllerTest < FunctionalTestCase
     assert_equal(208_785, survivor.reload.icn_id)
 
     expect = "log_name_merged" \
-      # change spaces to %20 because display_name in the log is URI escaped
-      " that #{survivor.display_name.gsub(" ", "%20")}" \
-      " this #{destroyed_display_name.gsub(" ", "%20")}".
-        gsub("*", "\*") # escape regex metacharacters
+    # change spaces to %20 because display_name in the log is URI escaped
+    " that #{survivor.display_name.gsub(" ", "%20")}" \
+    " this #{destroyed_display_name.gsub(" ", "%20")}".
+      tr("*", "\*") # escape regex metacharacters
     assert_match(expect, RssLog.last.notes, "Merger was logged incorrectly")
   end
 

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2711,19 +2711,21 @@ class NameControllerTest < FunctionalTestCase
     end
 
     assert_redirected_to(action: :show_name, id: survivor.id)
-    assert_flash_text(/Successfully merged name #{destroyed_real_search_name}/,
-                      "Flash should include destroyed name")
+
+    expect = "Successfully merged name #{destroyed_real_search_name} " \
+             "into #{survivor.real_search_name}"
+    assert_flash_text(/#{expect}/, "Merger success flash is incorrect")
+
     assert_no_emails
     assert_not(Name.exists?(edited_name.id))
     assert_equal(208_785, survivor.reload.icn_id)
-
 
     expect = "log_name_merged" \
       # change spaces to %20 because display_name in the log is URI escaped
       " that #{survivor.display_name.gsub(" ", "%20")}" \
       " this #{destroyed_display_name.gsub(" ", "%20")}".
         gsub("*", "\*") # escape regex metacharacters
-    assert_match(expect, RssLog.last.notes, "Merger logged incorrectly")
+    assert_match(expect, RssLog.last.notes, "Merger was logged incorrectly")
   end
 
   def test_update_name_reverse_merge_add_identifier

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2690,7 +2690,10 @@ class NameControllerTest < FunctionalTestCase
     assert_nil(edited_name.icn_id, "Test needs fixtures without icn_id")
     assert_nil(survivor.icn_id, "Test needs fixtures without icn_id")
 
+    edited_name.log("create edited_name log")
+
     destroyed_real_search_name = edited_name.real_search_name
+    destroyed_display_name = edited_name.display_name
 
     params = {
       id: edited_name.id,
@@ -2713,6 +2716,14 @@ class NameControllerTest < FunctionalTestCase
     assert_no_emails
     assert_not(Name.exists?(edited_name.id))
     assert_equal(208_785, survivor.reload.icn_id)
+
+
+    expect = "log_name_merged" \
+      # change spaces to %20 because display_name in the log is URI escaped
+      " that #{survivor.display_name.gsub(" ", "%20")}" \
+      " this #{destroyed_display_name.gsub(" ", "%20")}".
+        gsub("*", "\*") # escape regex metacharacters
+    assert_match(expect, RssLog.last.notes, "Merger logged incorrectly")
   end
 
   def test_update_name_reverse_merge_add_identifier


### PR DESCRIPTION
Fixes a bug in how Name mergers were logged:
- Shows the destroyed Name (rather than the surviving Name) In the "Name Destroyed" log entry.

Delivers https://www.pivotaltracker.com/story/show/175219034