### PR TITLE
Handle improper add_comment request without crashing.

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -191,7 +191,9 @@ class CommentController < ApplicationController
   def add_comment
     pass_query_params
     @target = Comment.find_object(params[:type], params[:id].to_s)
-    if !allowed_to_see!(@target)
+    if !@target
+      redirect_back_or_default("/")
+    elsif !allowed_to_see!(@target)
       # redirected already
     elsif request.method == "GET"
       @comment = Comment.new

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -32,6 +32,12 @@ class CommentControllerTest < FunctionalTestCase
     assert_form_action(action: "add_comment", id: obs_id, type: "Observation")
   end
 
+  def test_add_comment_no_id
+    login("dick")
+    get(:add_comment)
+    assert_response(:redirect)
+  end
+
   def test_add_comment_to_name_with_synonyms
     name_id = names(:chlorophyllum_rachodes).id
     requires_login(:add_comment, id: name_id, type: "Name")


### PR DESCRIPTION
We got a whole string of error messages from someone requesting add_comment without an id.  Simple patch to handle this case without crashing.  Just have it redirect back or to the main page.