### PR TITLE
Remove redundant ICN Identifier from Nomenclature

### DIFF
--- a/app/views/name/_nomenclature.html.erb
+++ b/app/views/name/_nomenclature.html.erb
@@ -18,7 +18,6 @@
 
       <div class="col-sm-5 name-section">
         <% if name.icn_id? %>
-          <p><%= :ICN_ID.t %>:</p>
           <p><%= link_to("[##{name.icn_id}]",
                          index_fungorum_record_url(name.icn_id)) %>
              Index Fungorum</p>

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -266,10 +266,6 @@ class NameControllerTest < FunctionalTestCase
     # Name's icn_id is filled in
     name = names(:coprinus_comatus)
     get(:show_name, params: { id: name.id })
-    assert(
-      /#{:ICN_ID.l}.*#{name.icn_id}/m =~ @response.body,
-      "Page lacks ICN identifier label and/or number"
-    )
     assert_select(
       "body a[href='#{index_fungorum_record_url(name.icn_id)}']", true,
       "Page is missing a link to IF record"


### PR DESCRIPTION
A two-line code change (actually a minus two-line code change) to simplify the Nomenclature section of the Name page for Names that have ICN identifiers.

**Manual test script**
- View any Name that has an ICN identifier.
Result: The Nomenclature section should **not** display "ICN Identifier" in the RH column.
I.e., it should look like this:
![Screen Shot 2020-10-29 at 06 42 03](https://user-images.githubusercontent.com/45460/97581566-f8435480-19b1-11eb-9bc1-8be758897a31.jpg)
_Not_ like this:
![Screen Shot 2020-10-29 at 06 43 30](https://user-images.githubusercontent.com/45460/97581708-20cb4e80-19b2-11eb-8389-ae563998b7d6.jpg)

Delivers https://www.pivotaltracker.com/story/show/175478011