### PR TITLE
Fixes for the clean.sql script

### DIFF
--- a/README_DATABASE_INSTALL
+++ b/README_DATABASE_INSTALL
@@ -79,6 +79,7 @@ root> mysql -u root -p
   # For each remote user:
   create user 'mo'@'$WEB_SERVER' identified by '$DB_PASSWORD';
   grant all privileges on mo_production.* to 'mo'@'$WEB_SERVER' with grant option;
+  GRANT PROCESS, SELECT, LOCK TABLES ON *.* TO 'mo'@'$WEB_SERVER';
 root> service mysql restart
 
 # Configure on remote machine:

--- a/db/clean.sql
+++ b/db/clean.sql
@@ -4,12 +4,13 @@ update donations set email = 'webmaster@mushroomobserver.org';
 update donations set who = 'anonymous' where anonymous = true;
 
 update herbaria set email = 'webmaster@mushroomobserver.org';
+update collection_numbers set name = 'xxx';
 
 update image_votes set user_id = 0 where anonymous = true;
 
 update images set original_name = 'xxx';
 
-update observations set lat = null, long = null where gps_hidden = true;
+update observations set `lat` = null, `long` = null where `gps_hidden` = true;
 
 # delete from interests;
 


### PR DESCRIPTION
To test:

   `mysql -u root -p mo_development < db/clean.sql`

should not report any errors.  This is the script that takes a production database to a point where it doesn't have any publicly available identifying information.  There will still be some emails addresses in things like comments, but since these are already publicly available I don't think we need to worry about them.