### PR TITLE
Fixed bug in string content filters, and added test to ensure it actually works.

### DIFF
--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -257,10 +257,6 @@ module Query
         @params_cache[arg]
       end
 
-      # ------------------------------------------------------------------------
-
-      private
-
       def validate_value(arg_type, arg_sym, val)
         if arg_type.is_a?(Array)
           array_validate(arg_sym, val, arg_type.first)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1525,7 +1525,8 @@ class ApplicationController < ActionController::Base
       # in user's content filter?
       next unless fltr.on?(filters[key])
 
-      query.params[key] = filters[key]
+      query.params[key] = query.validate_value(fltr.type, fltr.sym,
+                                               filters[key].to_s)
       @any_content_filters_applied = true
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1525,6 +1525,11 @@ class ApplicationController < ActionController::Base
       # in user's content filter?
       next unless fltr.on?(filters[key])
 
+      # This is a "private" method used by Query#validate_params.
+      # It would be better to add these parameters before the query is
+      # instantiated. Or alternatively, make query validation lazy so
+      # we can continue to add parameters up until we first ask it to
+      # execute the query.
       query.params[key] = query.validate_value(fltr.type, fltr.sym,
                                                filters[key].to_s)
       @any_content_filters_applied = true

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -785,6 +785,14 @@ class ObserverControllerTest < FunctionalTestCase
            "No results should be lichens")
   end
 
+  def test_observations_with_region_filter
+    login(users(:californian).name)
+    get(:list_observations)
+    expect = Observation.where("`where` LIKE '%California, USA'").to_a
+    results = @controller.instance_variable_get("@objects")
+    assert_obj_list_equal(expect.sort_by(&:id), results.sort_by(&:id))
+  end
+
   def test_send_webmaster_question
     ask_webmaster_test("rolf@mushroomobserver.org",
                        response: { controller: :observer,

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -139,3 +139,7 @@ antilichenologist:
   <<: *DEFAULTS
   content_filter: <%= { lichen: "no" }.to_yaml.inspect %>
 
+californian:
+  <<: *DEFAULTS
+  content_filter: <%= { region: "California, USA" }.to_yaml.inspect %>
+


### PR DESCRIPTION
Apparently we never actually tested to see if the region and clade content filters work.  I broke them a few weeks ago while enabling multiple values for the "region" parameter in Query.  It is now fixed and nominally tested.

I'm not fully satisfied with the solution.  The problem has to do with ApplicationController#apply_content_filters bypassing Query's validation process and assigning the filter values directly to query.params.  This PR fixes this problem.

But, the correct solution would probably be to apply the content filters to the parameters *before* instantiating the query, then validation will happen automatically.  Alternatively, we could make validation in Query lazy, so that we're allowed to continue to add values to query.params until we finally ask it to execute the query.  For now, I'm just calling a "private" method used by Query#validate_params.  This is technically fine, but probably not the safest long-term solution.  (I'd better add a comment to that bit of code to make sure this doesn't get forgotten.)

The problem is this is actually affecting real-life users, so I don't want to delay this while tinkering with Query internals.  I have too many other more important things I must get to right away.  I just wanted to get this quick fix out first.

May not be worth reviewing, but I'll leave the PR up for a day or so just in case someone has time and interest in looking at it.