### PR TITLE
Fixes bug in create/edit_naming.

### DIFF
--- a/app/models/name/create.rb
+++ b/app/models/name/create.rb
@@ -52,7 +52,7 @@ class Name < AbstractModel
   end
 
   def self.set_author(names, author, fill_in_authors)
-    return unless author.blank? && fill_in_authors && names.length == 1
+    return unless author.present? && fill_in_authors && names.length == 1
 
     names.first.change_author(author)
     names.first.save

--- a/app/models/name/create.rb
+++ b/app/models/name/create.rb
@@ -36,8 +36,10 @@ class Name < AbstractModel
     results = name_search(finder.where("text_name = :name",
                                        { name: parse.text_name }),
                           ignore_deprecated)
-    set_author(results, parse.author, fill_in_authors)
+    return results if parse.author.blank?
+    return [] if results.any? { |n| n.author.present? }
 
+    set_author(results, parse.author, fill_in_authors)
     results
   end
 
@@ -50,7 +52,7 @@ class Name < AbstractModel
   end
 
   def self.set_author(names, author, fill_in_authors)
-    return unless author.present? && fill_in_authors && names.length == 1
+    return unless author.blank? && fill_in_authors && names.length == 1
 
     names.first.change_author(author)
     names.first.save

--- a/app/models/name/resolve.rb
+++ b/app/models/name/resolve.rb
@@ -167,7 +167,6 @@ class Name < AbstractModel
   # interpreted as an author, and it *is* recognized if changed to lowercase,
   # this method changes the second word to lowercase.  Returns fixed string.
   def self.fix_capitalized_species_epithet(str)
-
     # Is second word capitalized?
     return str unless str.match?(/^\S+ [A-Z]/)
 
@@ -175,13 +174,13 @@ class Name < AbstractModel
     return str if Name.find_by_search_name(str).present?
 
     # Try converting second word to lowercase.
-    str2 = str.sub(/ [A-Z]/) { |match| match.downcase }
+    str2 = str.sub(/ [A-Z]/, &:downcase)
 
     # Return corrected name if that name exists, else keep original name.
     if Name.where("search_name = ? OR text_name = ?", str2, str2).present?
-      return str2
+      str2
     else
-      return str
+      str
     end
   end
 end

--- a/test/controllers/naming_controller_test.rb
+++ b/test/controllers/naming_controller_test.rb
@@ -606,4 +606,28 @@ class NamingControllerTest < FunctionalTestCase
                     _show_images
                   ])
   end
+
+  def test_automatic_author_bug
+    obs = observations(:minimal_unknown_obs)
+    name = names(:peltigera)
+    assert_equal(:Genus, name.rank)
+    assert_not_empty(name.author)
+    name.locked = true
+    name.save!
+    old_author = name.author
+
+    params = {
+      id: obs.id,
+      name: {
+        name: "#{name.text_name} Seneca #{name.author}",
+        approved_name: "#{name.text_name} #{name.author}"
+      }
+    }
+    login("dick")
+    post(:create, params)
+
+    name.reload
+    assert_equal(old_author, name.author)
+    assert_response(:success, "Was expecting it to re-serve the form because the name wasn't recognized.")
+  end
 end

--- a/test/controllers/naming_controller_test.rb
+++ b/test/controllers/naming_controller_test.rb
@@ -625,8 +625,8 @@ class NamingControllerTest < FunctionalTestCase
     name.reload
     assert_equal(old_author, name.author)
     assert_flash_error
-    assert_response(:success, "Was expecting it to re-serve the form because "
-                              "the name wasn't recognized.")
+    assert_response(:success, "Was expecting it to re-serve the form " \
+                              "because the name wasn't recognized.")
   end
 
   def test_automatic_case_correction

--- a/test/controllers/naming_controller_test.rb
+++ b/test/controllers/naming_controller_test.rb
@@ -625,7 +625,8 @@ class NamingControllerTest < FunctionalTestCase
     name.reload
     assert_equal(old_author, name.author)
     assert_flash_error
-    assert_response(:success, "Was expecting it to re-serve the form because the name wasn't recognized.")
+    assert_response(:success, "Was expecting it to re-serve the form because "
+                              "the name wasn't recognized.")
   end
 
   def test_automatic_case_correction

--- a/test/controllers/naming_controller_test.rb
+++ b/test/controllers/naming_controller_test.rb
@@ -612,22 +612,33 @@ class NamingControllerTest < FunctionalTestCase
     name = names(:peltigera)
     assert_equal(:Genus, name.rank)
     assert_not_empty(name.author)
-    name.locked = true
-    name.save!
     old_author = name.author
 
     params = {
       id: obs.id,
-      name: {
-        name: "#{name.text_name} Seneca #{name.author}",
-        approved_name: "#{name.text_name} #{name.author}"
-      }
+      name: { name: "#{name.text_name} Seneca #{name.author}" },
+      approved_name: "#{name.text_name} #{name.author}"
     }
     login("dick")
     post(:create, params)
 
     name.reload
     assert_equal(old_author, name.author)
+    assert_flash_error
     assert_response(:success, "Was expecting it to re-serve the form because the name wasn't recognized.")
+  end
+
+  def test_automatic_case_correction
+    obs = observations(:minimal_unknown_obs)
+    name = names(:coprinus_comatus)
+    params = {
+      id: obs.id,
+      name: { name: "Coprinus Comatus" }
+    }
+    login("dick")
+    post(:create, params)
+    assert_flash_success
+    naming = obs.namings.where(user: dick).first
+    assert_names_equal(name, naming.name)
   end
 end


### PR DESCRIPTION
The bug is that if you create or edit a naming, and enter an existing genus that currently has a single version, but fill in a different author, it will change the author.  It should only fill in the author if the existing name has no author.  For example, propose the name "Psilocybe Azurescens".  Psilocybe already has an author, "(Fr.) Kumm.".  After the naming is created, it will change the author to "Azurescens".  (Even if the name is locked!)

So far, all I've done is write a test that reproduces the bug.