### PR TITLE
Made show_project robust w/resp. to possible description.name being nil.

### DIFF
--- a/app/views/project/show_project.html.erb
+++ b/app/views/project/show_project.html.erb
@@ -86,7 +86,7 @@
         <%= @drafts.any? ? @drafts.length : :NONE.t %><br/>
         <div style="margin-left:1em">
           <% @drafts.each do |draft| %>
-            <%= link_with_query(draft.name.display_name.t,
+            <%= link_with_query(draft.name&.display_name&.t,
                                 { controller: :name,
                                   action: :show_name_description,
                                   id: draft.id }) %>


### PR DESCRIPTION
Not sure why this would happen, but I don't want to see it crash if it does.