### PR TITLE
Change CSV separator and column ordering for Darwin Core CSV export

### DIFF
--- a/app/classes/observation_report/base.rb
+++ b/app/classes/observation_report/base.rb
@@ -3,13 +3,13 @@
 module ObservationReport
   # base class
   class Base
-    attr_accessor :query
-    attr_accessor :encoding
+    attr_accessor :encoding, :query
 
     class_attribute :default_encoding
     class_attribute :mime_type
     class_attribute :extension
     class_attribute :header
+    class_attribute :separator
 
     def initialize(args)
       self.query    = args[:query]

--- a/app/classes/observation_report/csv.rb
+++ b/app/classes/observation_report/csv.rb
@@ -9,9 +9,10 @@ module ObservationReport
     self.mime_type = "text/csv"
     self.extension = "csv"
     self.header = { header: :present }
+    self.separator = ","
 
     def render
-      ::CSV.generate do |csv|
+      ::CSV.generate(col_sep: separator) do |csv|
         csv << labels
         formatted_rows.each { |row| csv << row }
       end.force_encoding("UTF-8")

--- a/app/classes/observation_report/darwin.rb
+++ b/app/classes/observation_report/darwin.rb
@@ -3,12 +3,16 @@
 module ObservationReport
   # Darwin format.
   class Darwin < ObservationReport::CSV
+    self.separator = "\t"
+
     def labels
       %w[
+        CatalogNumber
+        OccurrenceID
+        BasisOfRecord
         DateLastModified
         InstitutionCode
         CollectionCode
-        CatalogNumber
         ScientificName
         ScientificNameAuthor
         ScientificNameRank
@@ -35,12 +39,15 @@ module ObservationReport
     # rubocop:disable Metrics/AbcSize
     def format_row(row)
       [
+        row.obs_id,
+        "#{MO.http_domain}/#{row.obs_id}",
+        "HumanObservation",
         row.obs_updated_at,
         "MushroomObserver",
         nil,
-        row.obs_id,
+        # row.obs_id,
         row.name_text_name,
-        row.name_author,
+        clean_value(row.name_author),
         row.name_rank,
         row.genus,
         row.species,
@@ -58,12 +65,16 @@ module ObservationReport
         row.best_long,
         row.best_low,
         row.best_high,
-        row.obs_notes
+        clean_value(row.obs_notes)
       ]
     end
 
+    def clean_value(value)
+      value&.tr("\t", " ")&.gsub("\n", "  ")&.gsub("\r", "  ")
+    end
+
     def sort_after(rows)
-      rows.sort_by { |row| row[3].to_i }
+      rows.sort_by { |row| row[0].to_i }
     end
   end
 end

--- a/test/models/observation_report_test.rb
+++ b/test/models/observation_report_test.rb
@@ -7,7 +7,7 @@ class ObservationReportTest < UnitTestCase
     query = Query.lookup(:Observation, :all)
     report = report_type.new(query: query).body
     assert_not_empty(report)
-    table = CSV.parse(report)
+    table = CSV.parse(report, col_sep: report_type.separator)
     assert_equal(query.num_results + 1, table.count)
     idx = query.results.sort_by(&block).index(obs)
     assert_equal(expect, table[idx + 1])
@@ -75,10 +75,12 @@ class ObservationReportTest < UnitTestCase
   def test_darwin
     obs = observations(:detailed_unknown_obs)
     expect = [
+      obs.id.to_s,
+      "#{MO.http_domain}/#{obs.id}",
+      "HumanObservation",
       "2006-05-12 17:21:00 UTC",
       "MushroomObserver",
       nil,
-      obs.id.to_s,
       "Fungi",
       nil,
       "Kingdom",


### PR DESCRIPTION
This allows the CSV to be included in a complete Darwin Core Archive including the attached meta.xml file.  Note: GitHub required that it end with .txt.
[meta.xml.txt](https://github.com/MushroomObserver/mushroom-observer/files/5580147/meta.xml.txt)

To test:
- Download a Darwin Core CSV (simplest way I've found is to go to a species list, then click 'Downloads, Reports, Print Labels'.  Select 'Darwin Core'.  Click 'Download'.
- Rename the downloaded file 'observations.txt'
- Download the attached meta.xml.txt and rename to just 'meta.xml'.
- Create a zip file with `zip dwca.zip meta.xml observations.txt`.
- This should create a file called `dwca.zip`.
- Go to the GBIF validator: https://www.gbif.org/tools/data-validator
- Click 'SELECT FILE' and verify that the dwca.zip file is considered valid.
