### PR TITLE
Fix Name page links to SF synonymy records

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -90,9 +90,16 @@ module ObjectLinkHelper
       "#{name.text_name.tr(" ", "+")}"
   end
 
-  # url of SF page with "official" synonyms
+  # url of SF page with "official" synonyms by category
+  # works for species, infra-specific ranks
   def species_fungorum_gsd_synonymy(record_id)
     "http://www.speciesfungorum.org/Names/GSDspecies.asp?RecordID=#{record_id}"
+  end
+
+  # url of SF page with "official" synonyms in alpha order
+  # works for species, genus, family
+  def species_fungorum_sf_synonymy(record_id)
+    "http://www.speciesfungorum.org/Names/SynSpecies.asp?RecordID=#{record_id}"
   end
 
   # ----------------------------------------------------------------------------

--- a/app/views/name/_nomenclature.html.erb
+++ b/app/views/name/_nomenclature.html.erb
@@ -24,8 +24,15 @@
           <p><%= link_to("[##{name.icn_id}]",
                          mycobank_record_url(name.icn_id)) %>
              MycoBank</p>
-          <p><%= link_to(:gsd_species_synonymy.t,
-                         species_fungorum_gsd_synonymy(name.icn_id)) %></p>
+          <p>
+            <% if name.at_or_below_species? %>
+              <%= link_to(:gsd_species_synonymy.t,
+                          species_fungorum_gsd_synonymy(name.icn_id)) %>
+            <% elsif [:Genus, :Family].include?(name.rank) %>
+              <%= link_to(:sf_species_synonymy.t,
+                          species_fungorum_sf_synonymy(name.icn_id)) %>
+            <% end %>
+          </p>
        <% elsif name.registrable? %>
           <p><%= :ICN_ID.t %>: <em><%= :show_name_icn_id_missing.t %></em></p>
           <p><%= link_to(:index_fungorum_search.t,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2040,6 +2040,7 @@
   mycobank: MycoBank
   mycobank_search: MycoBank search
   gsd_species_synonymy: GSD Species Synonymy
+  sf_species_synonymy: SF Species Synonymy
 
   # name/show_name - links to observations
   show_name_observations: More [:OBSERVATIONS]

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -262,7 +262,7 @@ class NameControllerTest < FunctionalTestCase
     assert_template(:show_name, partial: "_name")
   end
 
-  def test_show_name_icn_id_info
+  def test_show_name_species_with_icn_id
     # Name's icn_id is filled in
     name = names(:coprinus_comatus)
     get(:show_name, params: { id: name.id })
@@ -276,7 +276,17 @@ class NameControllerTest < FunctionalTestCase
     )
     assert_select(
       "body a[href='#{species_fungorum_gsd_synonymy(name.icn_id)}']", true,
-      "Page is missing a link to SF GSD Species Synonymy record"
+      "Page is missing a link to GSD Synonymy record"
+    )
+  end
+
+  def test_show_name_genus_with_icn_id
+    # Name's icn_id is filled in
+    name = names(:tubaria)
+    get(:show_name, params: { id: name.id })
+    assert_select(
+      "body a[href='#{species_fungorum_sf_synonymy(name.icn_id)}']", true,
+      "Page is missing a link to SF Synonymy record"
     )
   end
 

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -103,6 +103,7 @@ tubaria:
   created_at: 2007-06-23 20:00:00
   updated_at: 2007-06-23 20:00:00
   rank: <%= Name.ranks[:Genus] %>
+  icn_id: 18686
 
 tubaria_furfuracea:
   <<: *DEFAULTS


### PR DESCRIPTION
- For ranks <= Species use GSD synonymy
- For Genus, Family use SF synonymy (GSD not available)
- For other ranks, no such links (they don't work)

Delivers https://www.pivotaltracker.com/story/show/175528452

### Manual Test
- Edit a Species by adding its ICN identifier (e.g., 148667 for _Coprinus comatus_) 
Result: Nomenclature section should have a link to GSD Species Synonymy
- Edit an infraspecific Name by adding its ICN identifier (e.g., 362067 for _Boletus edulis var. arcticus_) 
Result: Nomenclature section should have a link to GSD Species Synonymy
- Edit a Genus by adding its ICN identifier (e.g., 18686 for _Tubaria_) 
Result: Nomenclature section should have a link to SF Species Synonymy
- Edit a Family by adding its ICN identifier (e.g., 505549 for _Mycenaceae_) 
Result: Nomenclature section should have a link to SF Species Synonymy

