### PR TITLE
Use mini_racer instead of therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,12 @@ gem("sassc-rails")
 # Use jquery as the JavaScript library
 gem("jquery-rails")
 
-# Use thebuyracer as JavaScript runtime for ExecJS
+# Use therubyracer as JavaScript runtime for ExecJS
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem("therubyracer", platforms: :ruby)
+# gem("therubyracer", platforms: :ruby)
+
+# Use mini_racer as a substitute for therubyracer
+gem("mini_racer")
 
 # Use CoffeeScript for .js.coffee assets and views
 gem("coffee-rails")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       railties (>= 3.1)
     json (2.3.0)
     kgio (2.11.3)
-    libv8 (3.16.14.19)
+    libv8 (8.4.255.0)
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -134,6 +134,8 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minitest (5.14.2)
     minitest-reporters (1.4.2)
       ansi
@@ -185,7 +187,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
-    ref (2.0.0)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rtf (0.3.3)
@@ -234,9 +235,6 @@ GEM
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -287,6 +285,7 @@ DEPENDENCIES
   jquery-slick-rails
   mail (= 2.7.0)
   mimemagic
+  mini_racer
   minitest
   minitest-reporters
   mocha
@@ -302,7 +301,6 @@ DEPENDENCIES
   sassc-rails
   simple_enum
   sprockets
-  therubyracer
   uglifier
   unicorn (= 5.4.1)
   web-console


### PR DESCRIPTION
- Hopefully solves Travis `libv8` install failure. See https://www.pivotaltracker.com/story/show/176132861
- Uses a more modern gem. In particular note it's using liv8 which is 5 major versions ahead of that used by `therubyracer`.
- And is more lightweight than `therubyracer`.

I have manually tested create_observation, but don't know how else, or what else to do, to test js.

