### PR TITLE
Delete bad route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -374,7 +374,6 @@ ACTIONS = {
     turn_javascript_nil: {},
     turn_javascript_off: {},
     turn_javascript_on: {},
-    update_whitelisted_observation_attributes: {},
     user_search: {},
     users_by_contribution: {},
     users_by_name: {},


### PR DESCRIPTION
`update_whitelisted_observation_attributes` was part of a skeleton #01276fcce2893daf675191d6b9b326550e19f787
but never caught, so it found its way into the final routes