### PR TITLE
Fix edit location highest

### DIFF
--- a/app/views/location/_form_location.html.erb
+++ b/app/views/location/_form_location.html.erb
@@ -89,7 +89,7 @@
               </center>
             </div>
           </div>
-        </div>    
+        </div>
         <div class="col-sm-4">
           <center>
             <div class="form-group push-down">
@@ -128,8 +128,8 @@
       <%= content_tag(:b, :EAST.t) %>: <%= @location.east %>°<br/>
       <%= content_tag(:b, :WEST.t) %>: <%= @location.west %>°<br/>
       <% if @location.high.present? && @location.low.present? %>
-        <%= content_tag(:b, show_location_highest.t) %>: <%= @location.high %> m<br/>
-        <%= content_tag(:b, show_location_lowest.t) %>: <%= @location.low %> m<br/>
+        <%= content_tag(:b, :show_location_highest.t) %>: <%= @location.high %> m<br/>
+        <%= content_tag(:b, :show_location_lowest.t) %>: <%= @location.low %> m<br/>
       <% end %>
       <div class="help-block"><%= :show_location_locked.tp %></div>
       <%= hidden_field(:location, :display_name, value: @display_name) %>

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -457,6 +457,17 @@ class LocationControllerTest < FunctionalTestCase
     assert_input_value(:location_display_name, loc.display_name)
   end
 
+  def test_edit_locked_location
+    location = locations(:albion)
+    location.update(locked: true)
+    login(mary.login)
+
+    get(:edit_location, params: { id: location.id })
+
+    assert_select("input#location_display_name[type='text']", { count: 0 })
+    assert_select("input#location_display_name[type='hidden']", { count: 1 })
+  end
+
   def test_edit_unknown_location
     loc = locations(:unknown_location)
     old_loc_display_name = loc.display_name

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -467,7 +467,7 @@ class LocationControllerTest < FunctionalTestCase
     assert_select(
       "input:match('name', ?)", /location/, { minimum: 2 },
       "Location form for locked Location should have location input fields"
-      ) do |location_input_fields|
+    ) do |location_input_fields|
       location_input_fields.each do |field|
         assert_equal(
           "hidden", field["type"],

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -464,8 +464,17 @@ class LocationControllerTest < FunctionalTestCase
 
     get(:edit_location, params: { id: location.id })
 
-    assert_select("input#location_display_name[type='text']", { count: 0 })
-    assert_select("input#location_display_name[type='hidden']", { count: 1 })
+    assert_select(
+      "input:match('name', ?)", /location/, { minimum: 2 },
+      "Location form for locked Location should have location input fields"
+      ) do |location_input_fields|
+      location_input_fields.each do |field|
+        assert_equal(
+          "hidden", field["type"],
+          "Location input fields should be hidden for locked Locations"
+        )
+      end
+    end
   end
 
   def test_edit_unknown_location


### PR DESCRIPTION
Fix Location form typo that throws an Error

Location form throws an error when a non-admin tries to edit a locked Location that has a `high` or `low`. Examples:
```sh
1,2d0
< F, [2020-12-29T04:51:08.206032 #2737760] FATAL -- : ActionView::Template::Error (undefined local variable or method `show_location_highest' for #<#<Class:0x000055e794beba78>:0x000055e7a3d7d850>
< F, [2020-12-29T04:51:46.642451 #2737768] FATAL -- : ActionView::Template::Error (undefined local variable or method `show_location_highest' for #<#<Class:0x000055e797c4d518>:0x000055e798a94b08>

3d2
< F, [2020-12-29T04:53:23.889060 #2737768] FATAL -- : ActionView::Template::Error (undefined local variable or method `show_location_highest' for #<#<Class:0x000055e797c4d518>:0x000055e79ed3c670>
```
