### PR TITLE
EOL Darwin Core Archive

### DIFF
--- a/app/classes/report/darwin/observation_images.rb
+++ b/app/classes/report/darwin/observation_images.rb
@@ -3,7 +3,7 @@
 module Report
   module Darwin
     # Darwin Core Observations format.
-    class Images < Report::CSV
+    class ObservationImages < Report::CSV
       attr_accessor :observations, :query
 
       self.separator = "\t"

--- a/app/classes/report/darwin/observations.rb
+++ b/app/classes/report/darwin/observations.rb
@@ -4,13 +4,12 @@ module Report
   module Darwin
     # Darwin Core Observations format.
     class Observations < Report::CSV
-      attr_accessor :ids, :taxon_set
+      attr_accessor :ids
 
       self.separator = "\t"
 
       def initialize(args)
         super(args)
-        self.taxon_set = Set.new
         self.ids = []
       end
 
@@ -47,7 +46,6 @@ module Report
 
       # rubocop:disable Metrics/AbcSize
       def format_row(row)
-        taxon_set.add([row.name_id, row.name_text_name])
         ids.append(row.obs_id)
         [
           row.obs_id,
@@ -86,10 +84,6 @@ module Report
 
       def sort_after(rows)
         rows.sort_by { |row| row[0].to_i }
-      end
-
-      def taxa
-        taxon_set.to_a
       end
     end
   end

--- a/app/classes/report/darwin/taxa.rb
+++ b/app/classes/report/darwin/taxa.rb
@@ -14,10 +14,14 @@ module Report
       end
 
       def formatted_rows
-        query.select_rows(
+        @formatted_rows ||= query.select_rows(
           select: "DISTINCT names.id, names.text_name",
           join: [:names]
         )
+      end
+
+      def ids
+        formatted_rows.map { |row| row[0] }
       end
 
       def labels

--- a/app/classes/report/darwin/taxa.rb
+++ b/app/classes/report/darwin/taxa.rb
@@ -4,17 +4,20 @@ module Report
   module Darwin
     # Darwin Core Observations format.
     class Taxa < Report::CSV
-      attr_accessor :observations
+      attr_accessor :query
 
       self.separator = "\t"
 
       def initialize(args)
         super(args)
-        self.observations = args[:observations]
+        self.query = args[:query]
       end
 
       def formatted_rows
-        sort_after(observations.taxa)
+        query.select_rows(
+          select: "DISTINCT names.id, names.text_name",
+          join: [:names]
+        )
       end
 
       def labels
@@ -22,10 +25,6 @@ module Report
           taxonID
           scientificName
         ].freeze
-      end
-
-      def sort_after(rows)
-        rows.sort_by { |row| row[0].to_i }
       end
     end
   end

--- a/app/classes/report/darwin/taxon_images.rb
+++ b/app/classes/report/darwin/taxon_images.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+"""
+SELECT io.image_id
+FROM images_observations io, observations o
+WHERE o.name_id in (31753)
+AND io.observation_id = o.id
+AND o.vote_cache > 2.5;
+"""
+
+module Report
+  module Darwin
+    # Darwin Core Observations format.
+    class TaxonImages < Report::CSV
+      attr_accessor :taxa, :query
+
+      self.separator = "\t"
+
+      def initialize(args)
+        super(args)
+        self.taxa = args[:taxa]
+        initialize_query
+      end
+
+      def initialize_query
+        self.query = tables[:images]
+        add_joins
+        add_project
+      end
+
+      def tables
+        @tables ||= {
+          images: Image.arel_table,
+          images_observations: Arel::Table.new(:images_observations),
+          licenses: License.arel_table,
+          observations: Observation.arel_table,
+          users: User.arel_table
+        }
+      end
+
+      def add_joins
+        join_table(:images_observations, :image_id, attribute(:images, :id))
+        join_table(:observations, :id,
+                   attribute(:images_observations, :observation_id))
+        join_table(:licenses, :id, attribute(:images, :license_id))
+        join_table(:users, :id, attribute(:images, :user_id))
+      end
+
+      def join_table(join_name, join_field, attribute)
+        table = tables[join_name]
+        join_attribute = table[join_field]
+        self.query = query.join(table).on(join_attribute.eq(attribute))
+      end
+
+      def add_project
+        query.project(attribute(:images, :id),
+                      attribute(:observations, :name_id),
+                      attribute(:images, :when),
+                      attribute(:users, :name),
+                      attribute(:users, :login),
+                      attribute(:licenses, :url).as("license_url"),
+                      attribute(:images, :copyright_holder))
+      end
+
+      def attribute(table_name, field)
+        tables[table_name][field]
+      end
+
+      def formatted_rows
+        names_attr = tables[:observations][:name_id]
+        query.where(names_attr.in(taxa.ids))
+        vote_cache_attr = tables[:observations][:vote_cache]
+        query.where(vote_cache_attr.gt(2.5))
+
+        rows = ActiveRecord::Base.connection.exec_query(query.to_sql)
+        sort_after(rows.map { |row| format_image_row(row) })
+      end
+
+      def labels
+        %w[
+          identifier
+          type
+          format
+          accessURL
+          created
+          creator
+          license
+          rightsHolder
+        ]
+      end
+
+      def sort_after(rows)
+        rows.sort_by { |row| row[0].to_i }
+      end
+
+      private
+
+      def image_url(id)
+        "https://mushroomobserver.org/images/320/#{id}.jpg"
+      end
+
+      def format_image_row(row)
+        [row["name_id"].to_s,
+         "StillImage",
+         "image/jpeg",
+         image_url(row["id"]),
+         row["when"].to_s,
+         row["name"].to_s == "" ? row["login"] : row["name"],
+         row["license_url"],
+         row["copyright_holder"]]
+      end
+    end
+  end
+end

--- a/app/classes/report/dwca.rb
+++ b/app/classes/report/dwca.rb
@@ -9,7 +9,7 @@ module Report
       super(args)
       self.observations = Darwin::Observations.new(args)
       args[:observations] = observations
-      self.images = Darwin::Images.new(args)
+      self.images = Darwin::ObservationImages.new(args)
     end
 
     def filename

--- a/app/classes/report/eol.rb
+++ b/app/classes/report/eol.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Report
+  # Darwin Core Archive format.
+  class Eol < Report::ZipReport
+    attr_accessor :images, :observations, :taxa
+
+    def initialize(args)
+      super(args)
+      self.observations = Darwin::Observations.new(args)
+      args[:observations] = observations
+      self.taxa = Darwin::Taxa.new(args)
+      args[:taxa] = taxa
+      self.images = Darwin::TaxonImages.new(args)
+    end
+
+    def filename
+      "eol.#{extension}"
+    end
+
+    # generate CSV & meta.xml and bundle into a Zip
+    def render
+      filename = "#{::Rails.root}/public/dwca/eol_meta.xml"
+      content << ["meta.xml", File.open(filename).read]
+      content << ["taxa.csv", taxa.render]
+      content << ["multimedia.csv", images.render]
+      super
+    end
+  end
+end

--- a/app/classes/report/gbif.rb
+++ b/app/classes/report/gbif.rb
@@ -13,7 +13,7 @@ module Report
     end
 
     def filename
-      "dwca.#{extension}"
+      "gbif.#{extension}"
     end
 
     # generate CSV & meta.xml and bundle into a Zip

--- a/app/classes/report/gbif.rb
+++ b/app/classes/report/gbif.rb
@@ -2,7 +2,7 @@
 
 module Report
   # Darwin Core Archive format.
-  class Dwca < Report::ZipReport
+  class Gbif < Report::ZipReport
     attr_accessor :images, :observations
 
     def initialize(args)

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -288,6 +288,8 @@ class ObserverController
       Report::Adolf.new(args)
     when "darwin"
       Report::Dwca.new(args)
+    when "eol"
+      Report::Eol.new(args)
     when "symbiota"
       Report::Symbiota.new(args)
     when "fundis"

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -286,7 +286,7 @@ class ObserverController
       Report::Raw.new(args)
     when "adolf"
       Report::Adolf.new(args)
-    when "darwin"
+    when "gbif"
       Report::Gbif.new(args)
     when "eol"
       Report::Eol.new(args)

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -287,7 +287,7 @@ class ObserverController
     when "adolf"
       Report::Adolf.new(args)
     when "darwin"
-      Report::Dwca.new(args)
+      Report::Gbif.new(args)
     when "eol"
       Report::Eol.new(args)
     when "symbiota"

--- a/app/views/observer/download_observations.html.erb
+++ b/app/views/observer/download_observations.html.erb
@@ -19,8 +19,8 @@
       <%= :download_observations_adolf.t %>
     </li>
     <li>
-      <%= radio_button_tag(:format, :darwin, @format == "darwin") %>
-      <%= :download_observations_darwin.t %>
+      <%= radio_button_tag(:format, :gbif, @format == "gbif") %>
+      <%= :download_observations_gbif.t %>
       (<%= link_to(:download_observations_what_is_this.t, "http://rs.tdwg.org/dwc/index.htm",
                    target: "_new") %>)
     </li>

--- a/app/views/observer/download_observations.html.erb
+++ b/app/views/observer/download_observations.html.erb
@@ -25,6 +25,10 @@
                    target: "_new") %>)
     </li>
     <li>
+      <%= radio_button_tag(:format, :eol, @format == "eol") %>
+      <%= :download_observations_eol.t %>
+    </li>
+    <li>
       <%= radio_button_tag(:format, :symbiota, @format == "symbiota") %>
       <%= :download_observations_symbiota.t %>
     </li>

--- a/app/views/species_list/download.html.erb
+++ b/app/views/species_list/download.html.erb
@@ -50,8 +50,8 @@
       <%= :download_observations_adolf.t %>
     </li>
     <li>
-      <%= radio_button_tag(:format, :darwin, @format == "darwin") %>
-      <%= :download_observations_darwin.t %>
+      <%= radio_button_tag(:format, :gbif, @format == "gbif") %>
+      <%= :download_observations_gbif.t %>
       (<%= link_to(:download_observations_what_is_this.t, "http://rs.tdwg.org/dwc/index.htm",
                    target: "_new") %>)
     </li>

--- a/app/views/species_list/download.html.erb
+++ b/app/views/species_list/download.html.erb
@@ -56,6 +56,10 @@
                    target: "_new") %>)
     </li>
     <li>
+      <%= radio_button_tag(:format, :eol, @format == "eol") %>
+      <%= :download_observations_eol.t %>
+    </li>
+    <li>
       <%= radio_button_tag(:format, :symbiota, @format == "symbiota") %>
       <%= :download_observations_symbiota.t %>
     </li>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1379,8 +1379,8 @@
   download_observations_format: Choose format
   download_observations_raw: CSV spreadsheet
   download_observations_adolf: The Adolf Special™
-  download_observations_darwin: Darwin Core
-  download_observations_eol: Taxa for EOL
+  download_observations_gbif: Occurrence Darwin Core Archive for GBIF
+  download_observations_eol: Taxon Darwin Core Archive for EOL
   download_observations_symbiota: Symbiota
   download_observations_fundis: FunDiS
   download_observations_what_is_this: what is this?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1380,6 +1380,7 @@
   download_observations_raw: CSV spreadsheet
   download_observations_adolf: The Adolf Special™
   download_observations_darwin: Darwin Core
+  download_observations_eol: Taxa for EOL
   download_observations_symbiota: Symbiota
   download_observations_fundis: FunDiS
   download_observations_what_is_this: what is this?

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -3822,6 +3822,18 @@ class ObserverControllerTest < FunctionalTestCase
       :download_observations,
       params: {
         q: query.id.alphabetize,
+        format: "eol",
+        encoding: "UTF-8",
+        commit: "Download"
+      }
+    )
+    assert_no_flash
+    assert_response(:success)
+
+    post(
+      :download_observations,
+      params: {
+        q: query.id.alphabetize,
         format: "symbiota",
         encoding: "UTF-8",
         commit: "Download"

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -3810,7 +3810,7 @@ class ObserverControllerTest < FunctionalTestCase
       :download_observations,
       params: {
         q: query.id.alphabetize,
-        format: "darwin",
+        format: "gbif",
         encoding: "UTF-8",
         commit: "Download"
       }

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -83,9 +83,9 @@ class ReportTest < UnitTestCase
     do_csv_test(Report::Darwin::Observations, obs, expect, &:id)
   end
 
-  def test_dwca
+  def test_gbif
     expect = ["meta.xml", "observations.csv", "multimedia.csv"]
-    do_zip_test(Report::Dwca, expect)
+    do_zip_test(Report::Gbif, expect)
   end
 
   def test_taxa_report

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -83,6 +83,11 @@ class ReportTest < UnitTestCase
     do_csv_test(Report::Darwin::Observations, obs, expect, &:id)
   end
 
+  def test_eol
+    expect = ["meta.xml", "taxa.csv", "multimedia.csv"]
+    do_zip_test(Report::Eol, expect)
+  end
+
   def test_gbif
     expect = ["meta.xml", "observations.csv", "multimedia.csv"]
     do_zip_test(Report::Gbif, expect)


### PR DESCRIPTION
Implements the taxon based Darwin Core Archive (DwCA) that EOL expects.  Involves a bit of renaming and refactoring to differentiate between the two forms of DwCA.

To test:
- Go to a page where you can download a report (e.g., the Download link from a Species List page)
- Select the 'Taxon Darwin Core Archive for EOL' option
- Download and checkout the resulting zip file.
- Note that this is not expected to pass through the GBIF validator since it has no occurrence data.