### PR TITLE
Fix Location pattern_search with id

### DIFF
--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -97,11 +97,17 @@ class LocationController < ApplicationController
 
   # Displays a list of locations matching a given string.
   def location_search
-    query = create_query(
-      :Location, :pattern_search,
-      pattern: Location.user_name(@user, params[:pattern].to_s)
-    )
-    show_selected_locations(query, link_all_sorts: true)
+    pattern = params[:pattern].to_s
+    loc = Location.safe_find(pattern) if /^\d+$/.match?(pattern)
+    if loc
+      redirect_to(action: "show_location", id: loc.id)
+    else
+      query = create_query(
+        :Location, :pattern_search,
+        pattern: Location.user_name(@user, pattern)
+      )
+      show_selected_locations(query, link_all_sorts: true)
+    end
   end
 
   # Displays matrix of advanced search results.

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -112,6 +112,13 @@ class LocationControllerTest < FunctionalTestCase
     assert_template("list_locations")
   end
 
+  def test_location_pattern_search_id
+    loc = locations(:salt_point)
+
+    get(:location_search, params: { pattern: loc.id.to_s })
+    assert_redirected_to("#{location_show_location_path}/#{loc.id}")
+  end
+
   def test_location_advanced_search
     query = Query.lookup_and_save(:Location, :advanced_search,
                                   location: "California")


### PR DESCRIPTION
- Redirect to Location when a Location `pattern_search` pattern is Location id.
- Makes Location pattern search work like other types of pattern_search

Delivers https://www.pivotaltracker.com/story/show/176286532

#### Manual test
- Do a Location-type pattern search for `14656` (or the id of any other Location)
- Expected result: Displays that Location
