### PR TITLE
Fix instructions for adding synonyms

### DIFF
--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1590,7 +1590,7 @@
   form_synonyms_deprecate_synonyms: Deprecate Synonyms
   form_synonyms_deprecate_synonyms_help: If checked all listed synonyms become deprecated names.  Otherwise, they are left as they are with new names created as not deprecated.
   form_synonyms_missing_names: The following names could not be found.
-  form_synonyms_missing_names_help: Click 'Add' to create these names.  If you want to correct any names, do so in the area below and click 'Add' to re-evaluate the list.
+  form_synonyms_missing_names_help: Click [:name_change_synonyms_submit] to create these names.  If you want to correct any names, do so in the area below and click [:name_change_synonyms_submit] to re-evaluate the list.
 
   # image/add_image
   image_set_default: Set as default thumbnail


### PR DESCRIPTION
Corrects the name of the button to fix.

Delivers https://www.pivotaltracker.com/story/show/61089358

#### Manual test
- Go to any Name page (e.g. http://localhost:3000/name/show_name/800
- Click `Change Synonyms`
- In the "Names" box, type at least one Name that doesn't exist in MO, e.g., `Uttercompletegarbage`
- Submit Changes
- **Expected Result**: page is redisplayed with flash:
> "Click **Submit Changes** .... If you want to correct any names ... click **Submit Changes** ...." (boldface added).