### PR TITLE
Improved flash for expired Advanced Search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1100,6 +1100,17 @@ class ApplicationController < ActionController::Base
     result
   end
 
+  # Handle advanced_search actions with an invalid q param,
+  # so that they get just one flash msg if the query has expired.
+  # This method avoids a call to find_safe, which would add
+  # "undefined method `id' for nil:NilClass" if there's no QueryRecord for q
+  def handle_advanced_search_invalid_q_param?
+    return unless invalid_q_param?
+
+    flash_error(:advanced_search_bad_q_error.t)
+    redirect_to(controller: "observer", action: "advanced_search")
+  end
+
   private ##########
 
   def map_past_bys(args)
@@ -1178,6 +1189,11 @@ class ApplicationController < ActionController::Base
 
   def query_needs_update?(new_args, query)
     new_args.any? { |_arg, val| query.params[:arg] != val }
+  end
+
+  def invalid_q_param?
+    params && params[:q] &&
+      !QueryRecord.where(id: params[:q].dealphabetize).exists?
   end
 
   public ##########

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1108,7 +1108,7 @@ class ApplicationController < ActionController::Base
     return unless invalid_q_param?
 
     flash_error(:advanced_search_bad_q_error.t)
-    redirect_to(controller: "observer", action: "advanced_search")
+    redirect_to(observer_advanced_search_form_path)
   end
 
   private ##########

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -114,6 +114,8 @@ class ImageController < ApplicationController
 
   # Displays matrix of advanced search results.
   def advanced_search
+    return if handle_advanced_search_invalid_q_param?
+
     query = find_query(:Image)
     show_selected_images(query)
   rescue StandardError => e

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -112,6 +112,8 @@ class LocationController < ApplicationController
 
   # Displays matrix of advanced search results.
   def advanced_search
+    return if handle_advanced_search_invalid_q_param?
+
     query = find_query(:Location)
     show_selected_locations(query, link_all_sorts: true)
   rescue StandardError => e

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -208,6 +208,8 @@ class NameController < ApplicationController
 
   # Displays list of advanced search results.
   def advanced_search
+    return if handle_advanced_search_invalid_q_param?
+
     query = find_query(:Name)
     show_selected_names(query)
   rescue StandardError => e

--- a/app/controllers/observer_controller/search_controller.rb
+++ b/app/controllers/observer_controller/search_controller.rb
@@ -102,6 +102,8 @@ class ObserverController
       search[:search_location_notes] = params[:search_location_notes].present?
       query = create_query(:Observation, :advanced_search, search)
     else
+      return if handle_advanced_search_invalid_q_param?
+
       query = find_query(:Observation)
     end
     show_selected_observations(query)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3871,6 +3871,9 @@
   pattern_search_bad_rank_range_error: Invalid value for [term], [value], expected rank or range of ranks, e.g., "genus" or "species-form".
   pattern_search_user_me_not_logged_in_error: The term '[:search_term_user]:[:search_value_me]' doesn't make sense unless you are logged in!
 
+  # Advanced search error messages
+  advanced_search_bad_q_error: Search expired or cannot be found. Please re-enter search criteria.
+
   # content for html header title tag,
   # used when there are no hits for a list or search
   title_for_comment_search: Comment Search

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -269,6 +269,13 @@ class ImageControllerTest < FunctionalTestCase
     assert_template("list_images")
   end
 
+  def test_advanced_search_invalid_q_param
+    get(:advanced_search, params: { q: "xxxxx" })
+
+    assert_flash_text(:advanced_search_bad_q_error.l)
+    assert_redirected_to(observer_advanced_search_path)
+  end
+
   def test_add_image
     requires_login(:add_image, id: observations(:coprinus_comatus_obs).id)
     assert_form_action(action: "add_image",

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -273,7 +273,7 @@ class ImageControllerTest < FunctionalTestCase
     get(:advanced_search, params: { q: "xxxxx" })
 
     assert_flash_text(:advanced_search_bad_q_error.l)
-    assert_redirected_to(observer_advanced_search_path)
+    assert_redirected_to(observer_advanced_search_form_path)
   end
 
   def test_add_image


### PR DESCRIPTION
"Search expired or cannot be found. Please re-enter search criteria."
instead of 
"undefined method 'id' for nil:NilClass"

Delivers https://www.pivotaltracker.com/story/show/24489297

#### Suggest manual test
- Go to http://localhost:3000/observer/advanced_search?q=xxxxx
- Result: Advanced Search form with flash: "Search expired or cannot be found. Please re-enter search criteria."