### PR TITLE
Allow more user Name changes

### DIFF
--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -113,7 +113,7 @@ class NameController
 
   def update
     @parse = parse_name
-    if @name.dependents? && !in_admin_mode?
+    if !minor_change? && @name.dependents? && !in_admin_mode?
       redirect_with_query(
         controller: :observer, action: :email_name_change_request,
         name_id: @name.id, new_name: @parse.search_name

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -5,7 +5,11 @@ class Name < AbstractModel
 
   # Is this Name misspelled?
   def is_misspelling?
-    correct_spelling_id.present?
+    !correctly_spelt?
+  end
+
+  def correctly_spelt?
+    correct_spelling_id.blank?
   end
 
   # Do some simple queries to try to find alternate spellings of the given

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -555,7 +555,7 @@ class Name < AbstractModel
   def approved_synonym_of_correctly_spelt_proposed_name?
     !deprecated &&
       Naming.joins(:name).where(name: other_synonyms).
-      merge(Name.with_correct_spelling).any?
+        merge(Name.with_correct_spelling).any?
   end
 
   def ancestor_of_correctly_spelled_name?

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -543,7 +543,7 @@ class Name < AbstractModel
 
   # Does another Name "depend" on this Name?
   def dependents?
-    approved_synonym_of_proposed_name? ||
+    approved_synonym_of_correctly_spelt_proposed_name? ||
       correctly_spelled_ancestor_of_proposed_name? ||
       ancestor_of_correctly_spelled_name?
   end
@@ -552,8 +552,10 @@ class Name < AbstractModel
 
   private
 
-  def approved_synonym_of_proposed_name?
-    !deprecated && Naming.where(name: other_synonyms).any?
+  def approved_synonym_of_correctly_spelt_proposed_name?
+    !deprecated &&
+      Naming.joins(:name).where(name: other_synonyms).
+      merge(Name.with_correct_spelling).any?
   end
 
   def ancestor_of_correctly_spelled_name?

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1762,6 +1762,38 @@ class NameControllerTest < FunctionalTestCase
     )
   end
 
+  def test_update_minor_change_to_ancestor
+    name = names(:boletus)
+    assert(name.children.present? &&
+           name.icn_id.blank? && name.author.blank? && name.citation.blank?,
+           "Test needs different fixture: " \
+           "Name with a child, and without icn_id, author, or citation")
+    params = {
+      id: name.id,
+      name: {
+        text_name: name.text_name,
+        rank: name.rank,
+        # adding these should be a minor change
+        icn_id: "17175",
+        author: "L.",
+        citation: "Sp. pl. 2: 1176 (1753)"
+      }
+    }
+
+    login(name.user.login)
+    post(:edit_name, params: params)
+
+    assert_flash_success(
+      "User should be able to make minor changes to Name that has offspring"
+    )
+    # assert_redirected_to(action: :show_name, id: name.id)
+    assert_no_emails
+    name.reload
+    assert_equal(params[:name][:icn_id], name.icn_id.to_s)
+    assert_equal(params[:name][:author], name.author)
+    assert_equal(params[:name][:citation], name.citation)
+  end
+
   def test_update_change_text_name_of_approved_synonym
     approved_synonym = names(:lactarius_alpinus)
     deprecated_name = names(:lactarius_alpigenes)

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1786,7 +1786,6 @@ class NameControllerTest < FunctionalTestCase
     assert_flash_success(
       "User should be able to make minor changes to Name that has offspring"
     )
-    # assert_redirected_to(action: :show_name, id: name.id)
     assert_no_emails
     name.reload
     assert_equal(params[:name][:icn_id], name.icn_id.to_s)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2866,18 +2866,42 @@ class NameTest < UnitTestCase
   def test_approved_synonym_of_proposed_name_has_dependents
     approved_synonym = names(:lactarius_alpinus)
     deprecated_name = names(:lactarius_alpigenes)
+    assert(!approved_synonym.deprecated &&
+           deprecated_name.synonym == approved_synonym.synonym &&
+           deprecated_name.correctly_spelt?,
+           "Test needs different fixture(s): " \
+           "an Approved Name, with a Deprecated Synonym" \
+           "the Deprecated Name being correctly spelt")
     Naming.create(user: mary,
                   name: deprecated_name,
                   observation: observations(:minimal_unknown_obs))
-    assert(!approved_synonym.deprecated &&
-           deprecated_name.synonym == approved_synonym.synonym,
-           "Test needs different fixture: " \
-           "an Approved Name, with a Synonym having Naming(s)")
 
     assert(
       approved_synonym.dependents?,
       "`dependents?` should be true for an approved synonym " \
-      "(#{approved_synonym}) of a Proposed Name (#deprecated_name)"
+      "(#{approved_synonym.text_name}) of " \
+      "a correctly spelt Proposed Name (#{deprecated_name.text_name})"
+    )
+  end
+
+  def test_approved_synonym_of_mispelt_name_has_no_dependents
+    approved_synonym = names(:peltigera)
+    deprecated_name = names(:petigera)
+    assert(!approved_synonym.deprecated &&
+           deprecated_name.synonym == approved_synonym.synonym &&
+           deprecated_name.is_misspelling?,
+           "Test needs different fixture(s): " \
+           "an Approved Name, with a Deprecated Synonym" \
+           "the Deprecated Name being misspelt")
+    Naming.create(user: mary,
+                  name: deprecated_name,
+                  observation: observations(:minimal_unknown_obs))
+
+    assert_not(
+      approved_synonym.dependents?,
+      "`dependents?` should be false for an approved synonym " \
+      "(#{approved_synonym.text_name}) of " \
+      "a misspelt Proposed Name (#{deprecated_name.text_name})"
     )
   end
 


### PR DESCRIPTION
Fixes some problems caused by PR #704, which just went into production.
That PR was overzealous in requiring admin approval for Name changes.
This PR:
- Allows "minor" changes -- regardless of dependencies -- without admin approval;
- Relaxes the definition of dependency. 

As this is essentially a bug fix, I will merge it and put it into production as soon as it passes.