### PR TITLE
Replace coveralls gem with coveralls_reborn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,10 @@ gem("byebug", group: [:development, :test])
 gem("web-console", group: :development)
 
 # Automatically track code test coverage
-gem("coveralls", require: false)
+# Use coveralls_reborn gem instead of coveralls gem
+# With `coveralls` Travis CI runnning with Ubuntu focal gets an SSLError
+# when Travis submits the coverage report to Coveralls
+gem("coveralls_reborn", "~> 0.20.0", require: false)
 
 # Brakeman static analysis security scanner
 # See http://brakemanscanner.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,16 +98,15 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls_reborn (0.20.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    docile (1.3.2)
+    docile (1.3.4)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -125,7 +124,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-slick-rails (1.9.0)
       railties (>= 3.1)
-    json (2.3.0)
     kgio (2.11.3)
     libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-linux)
@@ -226,11 +224,12 @@ GEM
       tilt
     simple_enum (2.3.2)
       activesupport (>= 4.0.0)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -244,7 +243,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.25.0)
+    tins (1.27.1)
       sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -284,7 +283,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails
-  coveralls
+  coveralls_reborn (~> 0.20.0)
   cure_acts_as_versioned!
   i18n
   jbuilder


### PR DESCRIPTION
Makes Travis CI-Coveralls integration work again.
A side effect is that a few other germs are updated.

Delivers https://www.pivotaltracker.com/story/show/175663051

There is no manual test script.