### PR TITLE
Include new text_name in name-change request email

### DIFF
--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -105,7 +105,7 @@ class ObserverController
 
   def email_name_change_request
     @name = Name.safe_find(params[:name_id])
-    @new_name = params[:new_name]
+    @new_text_name = params[:new_name]
     unless @name && @name.text_name != @new_text_name
       redirect_back_or_default(action: :index)
       return


### PR DESCRIPTION
- Fixes a typo in `ObserverController#email_name_change_request`
- Delivers https://www.pivotaltracker.com/story/show/176784457

The typo caused these emails to omit the proposed new text_name