### PR TITLE
Start server with Rails.application

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require(::File.expand_path("../config/environment", __FILE__))
-run(MushroomObserver::Application)
+run(Rails.application)


### PR DESCRIPTION
Fixes deprecation warning which we overlooked in the Rails 5,2 upgrade

Delivers https://www.pivotaltracker.com/story/show/176830091

### Manual Test
- Empty/delete log/development.log
- Start the server in dev mode
Result: log should _not_ begin with:
```sh
DEPRECATION WARNING: Using `Rails::Application` subclass to start the server is deprecated and will be removed in Rails 6.0. Please change `run MushroomObserver::Application` to `run Rails.application` in config.ru. (called from require at bin/rails:6)
```
