### PR TITLE
Add mailing address to Donate page

### DIFF
--- a/app/views/shared/_nav_left.html.erb
+++ b/app/views/shared/_nav_left.html.erb
@@ -6,6 +6,7 @@
   <%= link_to(:app_intro.t, {controller: :observer, action: :intro}, {class: "list-group-item"}) %>
   <%= link_to(:app_how_to_use.t, {controller: :observer, action: :how_to_use}, {class: "list-group-item"}) %>
   <%= link_to(:app_privacy_policy.t, {controller: :policy, action: :privacy}, {class: "list-group-item"}) %>
+  <%= link_to(:app_donate.t, {controller: :support, action: :donate}, {class: "list-group-item"}) %>
 
   <% if in_admin_mode? %>
     <div class="list-group-item disabled bold">
@@ -81,7 +82,6 @@
     <%= :app_more.t %>
   </div>
   <%= link_to(:app_how_to_help.t, {controller: :observer, action: :how_to_help}, {class: "list-group-item indent"}) %>
-  <%= link_to(:app_donate.t, {controller: :support, action: :donate}, {class: "list-group-item indent"}) %>
   <%= link_to(:app_feature_tracker.t, {controller: :pivotal, action: :index}, {class: "list-group-item indent"}) %>
   <%= link_to(:app_send_a_comment.t, {controller: :observer, action: :ask_webmaster_question}, {class: "list-group-item indent"}) %>
   <%= link_to(:app_contributors.t, {controller: :observer, action: :users_by_contribution}, {class: "list-group-item indent"}) %>

--- a/app/views/support/confirm.html.erb
+++ b/app/views/support/confirm.html.erb
@@ -6,7 +6,7 @@
   <%= :confirm_text.tp %>
 
   <p>
-    <%= :confirm_amount.t %>: <%= @donation.amount.to_s %><br/>
+    <%= :confirm_amount.t %>: $<%= sprintf("%0.2f", @donation.amount) %><br/>
     <%= :confirm_recurring.t %>: <%= @donation.recurring ? :YEP.t : :NOPE.t %><br/>
     <% if @donation.anonymous %>
       <%= :donate_anonymous.t %><br/>
@@ -15,7 +15,7 @@
       <%= :donate_email.t %>: <%= @donation.email %><br/>
     <% end %>
   </p>
-   
+
   <div class="text-center">
     <form id="donate_form" name="_xclick" action="https://www.paypal.com/cgi-bin/webscr" method="post">
       <input type="hidden" name="business" value="<%= MO.donation_business %>">
@@ -38,4 +38,3 @@
     </form>
   </div>
 </div>
-

--- a/app/views/support/confirm.html.erb
+++ b/app/views/support/confirm.html.erb
@@ -6,7 +6,7 @@
   <%= :confirm_text.tp %>
 
   <p>
-    <%= :confirm_amount.t %>: $<%= sprintf("%0.2f", @donation.amount) %><br/>
+    <%= :confirm_amount.t %>: $<%= sprintf("%0.2f", @donation.amount || 0) %><br/>
     <%= :confirm_recurring.t %>: <%= @donation.recurring ? :YEP.t : :NOPE.t %><br/>
     <% if @donation.anonymous %>
       <%= :donate_anonymous.t %><br/>

--- a/app/views/support/donate.html.erb
+++ b/app/views/support/donate.html.erb
@@ -69,5 +69,6 @@
       <br/><br/>
     <% end %>
   </div>
+  <%= :donate_snail_mail.tp %>
   <%= :donate_fine_print.tp %>
 </div>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2560,13 +2560,13 @@
   donate_email: Email (to ensure uniqueness)
   donate_confirm: Confirm
   donors_order: The donors names are ordered based first on the total amount donated and then by who has donated the most recently.
-  donate_snail_mail: Donors who wish to donate by check instead of PayPal should make the check payable to "Mushroom Observer, Inc." and mail it to our registered corporate address:\nMushroom Observer, Inc. \n68 Bay Rd. \nNorth Falmouth, MA 02556-2404
+  donate_snail_mail: Donors who wish to donate by check should make the check payable to "Mushroom Observer, Inc." and mail it to our registered corporate address:\nMushroom Observer, Inc. \n68 Bay Rd. \nNorth Falmouth, MA 02556-2404
   donors_title: The Mushroom Observer Community Thanks Our Donors
   donors_tab: Show Donors
   donate_thanks: Thank you for your interest in donating to Mushroom Observer!
-  donate_explanation: "Tax deductible donations can be made in any amount through PayPal using most common credit cards or a PayPal account by clicking on the \"Confirm\" button below\n\nDonors are normally acknowledged by name on the \"Mushroom Observer Donors Page\":/support/donors once the funds are received.  If you would like special arrangements for your acknowledgement please \"send us a comment\":/observer/ask_webmaster_question."
+  donate_explanation: "A donation can be made in any amount. There are two ways: via PayPal or by check. We encourage you to send a check for donations of $200 or more. \n\nPayPal donations can be made with most credit cards (no PayPal account needed) or via a PayPal account by clicking on the \"Confirm\" button below. \n\nFor donations by check see below. \n\nDonors are normally acknowledged by name on the \"Mushroom Observer Donors Page\":/support/donors. If you would like special arrangements for your acknowledgement please \"send us a comment\":/observer/ask_webmaster_question."
 
-  donate_fine_print: "\"http://www.mushroomobserver.org\":/ is operated by \"Mushroom Observer, Inc.\":/support/governance for educational purposes. Mushroom Observer, Inc. is a public charity described under section ==501(c)(3)== of the Internal Revenue Code (see \"IRS Determination Letter\":/doc/mo-determination.pdf). Donations to Mushroom Observer, Inc. are allowable as itemized deductions for federal income tax purposes.  To substantiate the amount of your deductible donation, you will receive an email acknowledgement from Mushroom Observer, Inc. of the amount and date of your donation."
+  donate_fine_print: "\"http://www.mushroomobserver.org\":/ is operated by \"Mushroom Observer, Inc.\":/support/governance for educational purposes. Mushroom Observer, Inc. is a public charity described under section ==501(c)(3)== of the Internal Revenue Code (see \"IRS Determination Letter\":/doc/mo-determination.pdf). Donations to Mushroom Observer, Inc. are eligible to be deducted for federal income tax purposes.  To substantiate the amount of your deductible donation, you will receive an email acknowledgement from Mushroom Observer, Inc. of the amount and date of your donation."
 
   # support/confirm
   confirm_title: Donation Confirmation

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2560,6 +2560,7 @@
   donate_email: Email (to ensure uniqueness)
   donate_confirm: Confirm
   donors_order: The donors names are ordered based first on the total amount donated and then by who has donated the most recently.
+  donate_snail_mail: Donors who wish to donate by check instead of PayPal should make the check payable to "Mushroom Observer, Inc." and mail it to our registered corporate address:\nMushroom Observer, Inc. \n68 Bay Rd. \nNorth Falmouth, MA 02556-2404
   donors_title: The Mushroom Observer Community Thanks Our Donors
   donors_tab: Show Donors
   donate_thanks: Thank you for your interest in donating to Mushroom Observer!


### PR DESCRIPTION
- For people who prefer to donate with checks rather than via PayPal
- Delivers https://www.pivotaltracker.com/story/show/176837190

Also makes some changes suggested by John Harper, including:
- Donate link moved to near top of left navbar
- Change language re deductibility
- Clarify that PayPal donations do not require PayPal account
- Encourage checks for donations >= $200
- Fix formatting of amount on confirmation page. (Add dollar sign, display 2 decimal places.)


#### Manual Test Script
Go to  http://localhost:3000/support/donate (or Click "Donate" in the left navbar.)
Result: `Donate` is near the top of the left navbar
Page should include instructions for donating by check, including mailing address
Click $100 radio button
Click Confirm button
Result: "Amount" should display `$100.00` (as opposed to `100.0`
