### PR TITLE
Pattern Search end-of-month

### DIFF
--- a/app/classes/pattern_search/term/dates.rb
+++ b/app/classes/pattern_search/term/dates.rb
@@ -10,13 +10,15 @@ module PatternSearch
         when /^\d{4}$/
           yyyymmdd([a, 1, 1], [a, 12, 31])
         when /^\d{4}-\d\d?$/
-          yyyymmdd([a, b, 1], [a, b, 31])
+          # yyyymmdd([a, b, 1], [a, b, 31])
+          yyyymmdd([a, b, 1], [a, b, end_of_month(a, b)])
         when /^\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [a, b, c])
         when /^\d{4}-\d{4}$/
           yyyymmdd([a, 1, 1], [b, 12, 31])
         when /^\d{4}-\d\d?-\d{4}-\d\d?$/
-          yyyymmdd([a, b, 1], [c, d, 31])
+          # yyyymmdd([a, b, 1], [c, d, 31])
+          yyyymmdd([a, b, 1], [c, d, end_of_month(c, d)])
         when /^\d{4}-\d\d?-\d\d?-\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [d, e, f])
         when /^\d\d?$/
@@ -41,6 +43,10 @@ module PatternSearch
       def mmdd(from, to)
         [format("%02d-%02d", from.first.to_i, from.second.to_i),
          format("%02d-%02d", to.first.to_i, to.second.to_i)]
+      end
+
+      def end_of_month(year, month)
+        Date.new(year.to_i, month.to_i).end_of_month.strftime("%d")
       end
 
       def parse_date_words

--- a/app/classes/pattern_search/term/dates.rb
+++ b/app/classes/pattern_search/term/dates.rb
@@ -2,6 +2,7 @@
 
 module PatternSearch
   class Term
+    # parse the date variable in pattern searches
     module Dates
       def parse_date_range
         val = parse_date_words
@@ -10,14 +11,13 @@ module PatternSearch
         when /^\d{4}$/
           yyyymmdd([a, 1, 1], [a, 12, 31])
         when /^\d{4}-\d\d?$/
-          # yyyymmdd([a, b, 1], [a, b, end_of_month(a, b)])
           yyyymmdd([a, b, 1], [a, b, 31])
         when /^\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [a, b, c])
         when /^\d{4}-\d{4}$/
           yyyymmdd([a, 1, 1], [b, 12, 31])
         when /^\d{4}-\d\d?-\d{4}-\d\d?$/
-          yyyymmdd([a, b, 1], [c, d, end_of_month(c, d)])
+          yyyymmdd([a, b, 1], [c, d, 31])
         when /^\d{4}-\d\d?-\d\d?-\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [d, e, f])
         when /^\d\d?$/
@@ -31,21 +31,27 @@ module PatternSearch
         end
       end
 
+      ##########################################################################
+
       private
 
       def yyyymmdd(from, to)
-        [format("%04d-%02d-%02d", from.first, from.second.to_i,
-                from.third.to_i),
-         format("%04d-%02d-%02d", to.first, to.second.to_i,
-                [to.third.to_i, end_of_month(to.first, to.second).to_i].min)]
+        [format("%04<year>d-%02<month>d-%02<day>d",
+                year: from.first, month: from.second.to_i,
+                day: from.third.to_i),
+         format("%04<year>d-%02<month>d-%02<day>d",
+                year: to.first, month: to.second.to_i,
+                day: [to.third.to_i, eom(to.first, to.second).to_i].min)]
       end
 
       def mmdd(from, to)
-        [format("%02d-%02d", from.first.to_i, from.second.to_i),
-         format("%02d-%02d", to.first.to_i, to.second.to_i)]
+        [format("%02<year>d-%02<month>d",
+                year: from.first.to_i, month: from.second.to_i),
+         format("%02<year>d-%02<month>d",
+                year: to.first.to_i, month: to.second.to_i)]
       end
 
-      def end_of_month(year, month)
+      def eom(year, month)
         Date.new(year.to_i, month.to_i).end_of_month.strftime("%d")
       end
 

--- a/app/classes/pattern_search/term/dates.rb
+++ b/app/classes/pattern_search/term/dates.rb
@@ -10,7 +10,8 @@ module PatternSearch
         when /^\d{4}$/
           yyyymmdd([a, 1, 1], [a, 12, 31])
         when /^\d{4}-\d\d?$/
-          yyyymmdd([a, b, 1], [a, b, end_of_month(a, b)])
+          # yyyymmdd([a, b, 1], [a, b, end_of_month(a, b)])
+          yyyymmdd([a, b, 1], [a, b, 31])
         when /^\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [a, b, c])
         when /^\d{4}-\d{4}$/
@@ -35,7 +36,8 @@ module PatternSearch
       def yyyymmdd(from, to)
         [format("%04d-%02d-%02d", from.first, from.second.to_i,
                 from.third.to_i),
-         format("%04d-%02d-%02d", to.first, to.second.to_i, to.third.to_i)]
+         format("%04d-%02d-%02d", to.first, to.second.to_i,
+                [to.third.to_i, end_of_month(to.first, to.second).to_i].min)]
       end
 
       def mmdd(from, to)

--- a/app/classes/pattern_search/term/dates.rb
+++ b/app/classes/pattern_search/term/dates.rb
@@ -10,14 +10,12 @@ module PatternSearch
         when /^\d{4}$/
           yyyymmdd([a, 1, 1], [a, 12, 31])
         when /^\d{4}-\d\d?$/
-          # yyyymmdd([a, b, 1], [a, b, 31])
           yyyymmdd([a, b, 1], [a, b, end_of_month(a, b)])
         when /^\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [a, b, c])
         when /^\d{4}-\d{4}$/
           yyyymmdd([a, 1, 1], [b, 12, 31])
         when /^\d{4}-\d\d?-\d{4}-\d\d?$/
-          # yyyymmdd([a, b, 1], [c, d, 31])
           yyyymmdd([a, b, 1], [c, d, end_of_month(c, d)])
         when /^\d{4}-\d\d?-\d\d?-\d{4}-\d\d?-\d\d?$/
           yyyymmdd([a, b, c], [d, e, f])

--- a/test/models/pattern_search_test.rb
+++ b/test/models/pattern_search_test.rb
@@ -301,8 +301,12 @@ class PatternSearchTest < UnitTestCase
     assert_raises(PatternSearch::TooManyValuesError) { x.parse_date_range }
     x.vals = ["2010"]
     assert_equal(%w[2010-01-01 2010-12-31], x.parse_date_range)
+    # Thirty days hath September ....
+    # Otherwise, mySQL says Mysql2::Error: Incorrect DATE value: '2020-09-31'
     x.vals = ["2010-9"]
-    assert_equal(%w[2010-09-01 2010-09-31], x.parse_date_range)
+    assert_equal(%w[2010-09-01 2010-09-30], x.parse_date_range)
+    x.vals = ["2010-10"]
+    assert_equal(%w[2010-10-01 2010-10-31], x.parse_date_range)
     x.vals = ["2010-9-5"]
     assert_equal(%w[2010-09-05 2010-09-05], x.parse_date_range)
     x.vals = ["2010-09-05"]
@@ -311,6 +315,8 @@ class PatternSearchTest < UnitTestCase
     assert_equal(%w[2010-01-01 2012-12-31], x.parse_date_range)
     x.vals = ["2010-3-2010-5"]
     assert_equal(%w[2010-03-01 2010-05-31], x.parse_date_range)
+    x.vals = ["2010-3-2010-6"]
+    assert_equal(%w[2010-03-01 2010-06-30], x.parse_date_range)
     x.vals = ["2010-3-12-2010-5-1"]
     assert_equal(%w[2010-03-12 2010-05-01], x.parse_date_range)
     x.vals = ["6"]


### PR DESCRIPTION
Prevent Observation pattern searches from throwing an Error
when `date` is specified as 
(a) yyyy-mm, or 
(b) a range ending in yyyy-mm
where m  has fewer than 31 days. 

Delivers https://www.pivotaltracker.com/story/show/177297260