### PR TITLE
Adjust fancy_time for dst-to-standard change

### DIFF
--- a/app/extensions/time_extensions.rb
+++ b/app/extensions/time_extensions.rb
@@ -90,13 +90,10 @@ class ActiveSupport::TimeWithZone
   private
 
   def diff_corrected_for_dst_change(ref)
-    if dst? && !ref.dst?
-      ref - self - 1.hour
-    elsif !dst? && ref.dst?
-      ref - self + 1.hour
-    else
-      ref - self
-    end
+    return ref - self - 1.hour if dst? && !ref.dst?
+    return ref - self + 1.hour if !dst? && ref.dst?
+
+    ref - self
   end
 end
 

--- a/app/extensions/time_extensions.rb
+++ b/app/extensions/time_extensions.rb
@@ -56,7 +56,7 @@ class ActiveSupport::TimeWithZone
 
   # Format time as "5 days ago", etc.
   def fancy_time(ref = Time.zone.now)
-    diff = ref - self
+    diff = diff_corrected_for_dst_change(ref)
     if -diff > 1.minute
       web_time
     elsif diff < 1.minute
@@ -82,6 +82,20 @@ class ActiveSupport::TimeWithZone
       :"time_one_#{unit}_ago".l(date: web_date)
     else
       :"time_#{unit}s_ago".l(n: n, date: web_date)
+    end
+  end
+
+  ##############################################################################
+
+  private
+
+  def diff_corrected_for_dst_change(ref)
+    if dst? && !ref.dst?
+      ref - self - 1.hour
+    elsif !dst? && ref.dst?
+      ref - self + 1.hour
+    else
+      ref - self
     end
   end
 end


### PR DESCRIPTION
Fixes this bug:
```sh
 FAIL["test_fancy_time", #<Minitest::Reporters::Suite:0x000055db6acfa940 @name="TimeExtensionsTest">, 2.8948509150000064]
 test_fancy_time#TimeExtensionsTest (2.89s)
        Expected: "last week, 2021-03-10"
          Actual: "6 days ago, 2021-03-10"
        test/models/time_extensions_test.rb:98:in `assert_fancy_time'
        test/models/time_extensions_test.rb:87:in `test_fancy_time'
```

Delivers https://www.pivotaltracker.com/story/show/177378817