### PR TITLE
Serve images over https

### DIFF
--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -130,10 +130,10 @@ http {
     }
 
     # serve old originals from digitalocean object store
-    rewrite "^/images/orig/((\d{1,4}|[1-7]\d\d\d\d\d)\.\w+)$" http://mushroomobserver.nyc3.digitaloceanspaces.com/orig/$1?;
+    rewrite "^/images/orig/((\d{1,4}|[1-7]\d\d\d\d\d)\.\w+)$" https://mushroomobserver.nyc3.digitaloceanspaces.com/orig/$1?;
 
     # serve all the rest of the images from Alan's image server
-    rewrite "^/images/(.*)/(.*)$" http://images.mushroomobserver.org/$1/$2?;
+    rewrite "^/images/(.*)/(.*)$" https://images.mushroomobserver.org/$1/$2?;
 
     # serve non-thumbnails only from image server
     # rewrite "^/images/640/(.*)$" http://images.mushroomobserver.org/640/$1?;
@@ -142,7 +142,7 @@ http {
     # rewrite "^/images/orig/(.*)$" http://images.mushroomobserver.org/orig/$1?;
 
     # Chris Parrish's site.
-    rewrite "^/lichens/(.*)$" http://lichens.mushroomobserver.org/$1?;
+    rewrite "^/lichens/(.*)$" https://lichens.mushroomobserver.org/$1?;
   }
 }
 


### PR DESCRIPTION
Serves images over https rather than http
- Fixes the intermittent 504 timeout discussed in
https://groups.google.com/g/mo-developers/c/M4fNCQQoEr0/m/0xpv4q_3GQAJ  and
https://groups.google.com/g/mo-developers/c/M4fNCQQoEr0/m/knkmzx1eCQAJ