### PR TITLE
bundle update --conservative mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)


### PR DESCRIPTION
Updates mimemagic to 0.3.5
Delivers [Pivotal #17747704](https://www.pivotaltracker.com/story/show/177477041), 
fixing Travis CI build Error documented therein.