### PR TITLE
MimeMagic 3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)


### PR DESCRIPTION
Update MimeMagic to 3.10

- Fixes the Travis CI  build failure which was caused by MimeMagic yanking the version that was in Gemfile.lock
- Delivers https://www.pivotaltracker.com/story/show/177518956.

 