### PR TITLE
Herbaria by #Records

### DIFF
--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -6,13 +6,13 @@ module Query::Modules::Ordering
     # Let queries define custom order spec in "order", but have explicitly
     # passed-in "by" parameter take precedence.  If neither is given, then
     # fall back on the "default_order" finally.
-    if by || order.blank?
-      by ||= default_order
-      by = by.dup
-      reverse = !!by.sub!(/^reverse_/, "")
-      result = initialize_order_specs(by)
-      self.order = reverse ? reverse_order(result) : result
-    end
+    return unless by || order.blank?
+
+    by ||= default_order
+    by = by.dup
+    reverse = !!by.sub!(/^reverse_/, "")
+    result = initialize_order_specs(by)
+    self.order = reverse ? reverse_order(result) : result
   end
 
   def initialize_order_specs(by)
@@ -155,7 +155,8 @@ module Query::Modules::Ordering
       "IF(herbaria.code = '', '~', herbaria.code) ASC, herbaria.name ASC"
 
     when "records"
-      add_join(:herbarium_records)
+      # outer_join needed to show herbaria with no records
+      add_join(:herbarium_records!)
       self.group = "herbaria.id"
       "count(herbarium_records.id) DESC"
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -9,7 +9,7 @@ class QueryTest < UnitTestCase
     expect = expect.to_a unless expect.respond_to?(:map!)
     query = Query.lookup(*args)
     actual = test_ids ? query.result_ids : query.results
-    msg = "Query results are wrong. SQL is:\n" + query.last_query
+    msg = "Query results are wrong. SQL is:\n#{query.last_query}"
     if test_ids
       assert_equal(expect.sort, actual.sort, msg)
     else
@@ -1438,6 +1438,16 @@ class QueryTest < UnitTestCase
   def test_herbarium_all
     expect = Herbarium.all.sort_by(&:name)
     assert_query(expect, :Herbarium, :all)
+  end
+
+  def test_herbarium_by_records
+    expect = Herbarium.
+             left_joins(:herbarium_records).
+             group(:id).
+             # Wrap known safe argument in Arel
+             # to prevent "Dangerous query method" Deprecation Warning
+             order(Arel.sql("COUNT(herbarium_records.id) DESC"))
+    assert_query(expect, :Herbarium, :all, by: :records)
   end
 
   def test_herbarium_in_set


### PR DESCRIPTION
Include empty herbaria in sort by #Records

- Delivers https://www.pivotaltracker.com/story/show/176833561
(a pre-existing issue that was imported into updated HerbariaController).

### Manual Test
- Go to http://localhost:3000/herbaria?flavor=nonpersonal
- Click `#Records` in sort tabs
- Go to last page if there are > 1 page of results
#### Expected Result: Includes Fungaria with 0 records