### PR TITLE
Refactor Herbaria merge parameters

### DIFF
--- a/app/controllers/herbaria/merges_controller.rb
+++ b/app/controllers/herbaria/merges_controller.rb
@@ -18,15 +18,15 @@ module Herbaria
 
     # ---------- Actions to Modify data: (create, update, destroy, etc.) -------
 
-    # Merges :this into :that Herbarium if user has sufficient privileges
+    # Merge :src into :dest Herbarium if user has sufficient privileges
     # Otherwise sends an email to the webmaster requesting a merger
     def create
-      this = find_or_goto_index(Herbarium, params[:this]) || return
-      that = find_or_goto_index(Herbarium, params[:that]) || return
+      src = find_or_goto_index(Herbarium, params[:src]) || return
+      dest = find_or_goto_index(Herbarium, params[:dest]) || return
 
       # Calls shared private methods that are also used by
       # Herbaria#create and Herbaria#update
-      result = perform_or_request_merge(this, that) || return
+      result = perform_or_request_merge(src, dest) || return
 
       # redirect_to_herbarium_index(result)
       redirect_with_query(herbaria_path(id: result.try(&:id)))

--- a/app/controllers/herbaria/shared_private_methods.rb
+++ b/app/controllers/herbaria/shared_private_methods.rb
@@ -21,29 +21,29 @@ module Herbaria::SharedPrivateMethods
 
   # Used by create, edit and HerbariaMerges
 
-  def perform_or_request_merge(this, that)
-    if in_admin_mode? || this.can_merge_into?(that)
-      perform_merge(this, that)
+  def perform_or_request_merge(src, dest)
+    if in_admin_mode? || src.can_merge_into?(dest)
+      perform_merge(src, dest)
     else
-      request_merge(this, that)
+      request_merge(src, dest)
     end
   end
 
-  def perform_merge(this, that)
-    old_name = this.name_was
-    result = this.merge(that)
+  def perform_merge(src, dest)
+    old_name = src.name_was
+    result = dest.merge(src)
     flash_notice(
       :runtime_merge_success.t(
-        type: :herbarium, this: old_name, that: result.name
+        type: :herbarium, src: old_name, dest: result.name
       )
     )
     result
   end
 
-  def request_merge(this, that)
+  def request_merge(src, dest)
     redirect_with_query(
       observer_email_merge_request_path(
-        type: :Herbarium, old_id: this.id, new_id: that.id
+        type: :Herbarium, old_id: src.id, new_id: dest.id
       )
     )
     false

--- a/app/controllers/herbaria/shared_private_methods.rb
+++ b/app/controllers/herbaria/shared_private_methods.rb
@@ -1,51 +1,53 @@
 # frozen_string_literal: true
 
 # private methods shared by HerbariaController and subcontrollers
-module Herbaria::SharedPrivateMethods
-  private
+module Herbaria
+  module SharedPrivateMethods
+    private
 
-  # ---------- Filters ---------------------------------------------------------
+    # ---------- Filters -------------------------------------------------------
 
-  def keep_track_of_referrer
-    @back = params[:back] || request.referer
-  end
-
-  def redirect_to_referrer
-    return false if @back.blank?
-
-    redirect_to(@back)
-    true
-  end
-
-  # ---------- Merges ----------------------------------------------------------
-
-  # Used by create, edit and HerbariaMerges
-
-  def perform_or_request_merge(src, dest)
-    if in_admin_mode? || src.can_merge_into?(dest)
-      perform_merge(src, dest)
-    else
-      request_merge(src, dest)
+    def keep_track_of_referrer
+      @back = params[:back] || request.referer
     end
-  end
 
-  def perform_merge(src, dest)
-    old_name = src.name_was
-    result = dest.merge(src)
-    flash_notice(
-      :runtime_merge_success.t(
-        type: :herbarium, src: old_name, dest: result.name
-      )
-    )
-    result
-  end
+    def redirect_to_referrer
+      return false if @back.blank?
 
-  def request_merge(src, dest)
-    redirect_with_query(
-      observer_email_merge_request_path(
-        type: :Herbarium, old_id: src.id, new_id: dest.id
+      redirect_to(@back)
+      true
+    end
+
+    # ---------- Merges --------------------------------------------------------
+
+    # Used by Herbaria#create, Herbaria#edit, HerbariaMerges#create
+
+    def perform_or_request_merge(src, dest)
+      if in_admin_mode? || src.can_merge_into?(dest)
+        perform_merge(src, dest)
+      else
+        request_merge(src, dest)
+      end
+    end
+
+    def perform_merge(src, dest)
+      old_name = src.name_was
+      result = dest.merge(src)
+      flash_notice(
+        :runtime_merge_success.t(
+          type: :herbarium, src: old_name, dest: result.name
+        )
       )
-    )
-    false
+      result
+    end
+
+    def request_merge(src, dest)
+      redirect_with_query(
+        observer_email_merge_request_path(
+          type: :Herbarium, old_id: src.id, new_id: dest.id
+        )
+      )
+      false
+    end
   end
 end

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -313,8 +313,8 @@ class HerbariaController < ApplicationController
     return false if user.personal_herbarium.blank?
 
     flash_error(:edit_herbarium_user_already_has_personal_herbarium.t(
-      user: user.login, herbarium: user.personal_herbarium.name
-    ))
+                  user: user.login, herbarium: user.personal_herbarium.name
+                ))
     true
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -312,9 +312,11 @@ class HerbariaController < ApplicationController
   def flash_personal_herbarium?(user)
     return false if user.personal_herbarium.blank?
 
-    flash_error(:edit_herbarium_user_already_has_personal_herbarium.t(
-                  user: user.login, herbarium: user.personal_herbarium.name
-                ))
+    flash_error(
+      :edit_herbarium_user_already_has_personal_herbarium.t(
+        user: user.login, herbarium: user.personal_herbarium.name
+      )
+    )
     true
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -241,14 +241,14 @@ class HerbariaController < ApplicationController
       return false
     end
 
-    other = Herbarium.where(name: @herbarium.name).first
-    return true if !other || other == @herbarium
+    dest = Herbarium.where(name: @herbarium.name).first
+    return true if !dest || dest == @herbarium
 
     if !@herbarium.id # i.e. in create mode
       flash_error(:create_herbarium_duplicate_name.t(name: @herbarium.name))
       false
     else
-      @herbarium = perform_or_request_merge(@herbarium, other)
+      @herbarium = perform_or_request_merge(@herbarium, dest)
     end
   end
 

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -118,47 +118,47 @@ class Herbarium < AbstractModel
     "#{:HERBARIUM.l} ##{id}: #{name} [#{num_cur} curators, #{num_rec} records]"
   end
 
-  def merge(that)
-    return that if that == self
+  def merge(src)
+    return src if src == self
 
-    this = self
+    dest = self
     [:code, :location, :email, :mailing_address].each do |var|
-      this.merge_field(that, var)
+      dest.merge_field(src, var)
     end
-    this.merge_notes(that)
-    this.personal_user_id ||= that.personal_user_id
-    this.save
-    this.merge_associatied_records(that)
-    that.destroy
-    this
+    dest.merge_notes(src)
+    dest.personal_user_id ||= src.personal_user_id
+    dest.save
+    dest.merge_associated_records(src)
+    src.destroy
+    dest
   end
 
-  def merge_field(that, var)
-    this = self
-    val1 = this.send(var)
-    val2 = that.send(var)
+  def merge_field(src, var)
+    dest = self
+    val1 = dest.send(var)
+    val2 = src.send(var)
     return if val1.present?
 
-    this.send(:"#{var}=", val2)
+    dest.send(:"#{var}=", val2)
   end
 
-  def merge_notes(that)
-    this   = self
-    notes1 = this.description
-    notes2 = that.description
+  def merge_notes(src)
+    dest   = self
+    notes1 = dest.description
+    notes2 = src.description
     if notes1.blank?
-      this.description = notes2
+      dest.description = notes2
     elsif notes2.present?
-      this.description = "#{notes1}\n\n" \
+      dest.description = "#{notes1}\n\n" \
                          "[Merged at #{Time.now.utc.web_time}]\n\n" +
                          notes2
     end
   end
 
-  def merge_associatied_records(that)
-    this = self
-    this.curators          += that.curators - this.curators
-    this.herbarium_records += that.herbarium_records - this.herbarium_records
+  def merge_associated_records(src)
+    dest = self
+    dest.curators          += src.curators - dest.curators
+    dest.herbarium_records += src.herbarium_records - dest.herbarium_records
   end
 
   # Look at the most recent HerbariumRecord's the current User has created.

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -49,8 +49,8 @@
                 <%# Cannot POST from a link without js; Use buttons instead %>
                 <%= post_button(
                       name: herbarium.name.t,
-                      path: herbaria_merges_path(this: @merge.id,
-                                                 that: herbarium.id),
+                      path: herbaria_merges_path(src: @merge.id,
+                                                 dest: herbarium.id),
                       confirm: :are_you_sure.t
                     ) %>
               <% else %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3640,7 +3640,7 @@
   runtime_invalid: "[Type] is invalid: '[value]'"
   runtime_lat_long_error: "Latitude and longitude must be real numbers between -90 and 90, and -180 and 180 respectively. Use decimal notation or degrees/minutes/seconds. Examples:\n-123.4567\n123.4567 N\n123 27.402 N\n123 24 24.12 N\n123° 24’ 24.12” N\n123deg 24min 24.12sec N"
   runtime_altitude_error: "Elevation must be real number in feet or meters.  Feet will be converted to meters (default).  Examples:\n1234\n1234m\n4049'\n4049 ft."
-  runtime_merge_success: Successfully merged [type] [this] into [that].
+  runtime_merge_success: Successfully merged [type] [src] into [dest].
   runtime_missing: Missing [field].
   runtime_no_changes: No changes made.
   runtime_no_create: Unable to create [type].
@@ -3760,7 +3760,7 @@
   runtime_edit_location_success: "[:runtime_updated_id(type=:location,value=id)]"
   runtime_edit_name_description_no_change: "[:runtime_no_changes]"
   runtime_edit_name_description_success: "[:runtime_updated_id(type=:name_description,value=id)]"
-  runtime_edit_name_merge_success: "[:runtime_merge_success(type=:name,this=this,that=that)]"
+  runtime_edit_name_merge_success: "[:runtime_merge_success(type=:name,src=this,dest=that)]"
   runtime_edit_name_no_change: "[:runtime_no_changes]"
   runtime_edit_name_success: "[:runtime_updated_name(type=:name,value=name)]"
   runtime_edit_observation_success: "[:runtime_updated_id(type=:observation,value=id)]"
@@ -3788,7 +3788,7 @@
   runtime_location_description_success: "[:runtime_created_id(type=:location_description,value=id)]"
   runtime_location_descriptions_by_author_error: "[:runtime_user_hasnt_authored(type=:location_description)]"
   runtime_location_descriptions_by_editor_error: "[:runtime_user_hasnt_edited(type=:location_description)]"
-  runtime_location_merge_success: "[:runtime_merge_success(type=:location,this=this,that=that)]"
+  runtime_location_merge_success: "[:runtime_merge_success(type=:location,src=this,dest=that)]"
   runtime_location_success: "[:runtime_created_id(type=:location,value=id)]"
   runtime_merge_locations_warning: "[:runtime_merge_warning(type=:location)]"
   runtime_merge_names_warning: "[:runtime_merge_warning(type=:name)]"

--- a/test/controllers/herbaria/merges_controller_test.rb
+++ b/test/controllers/herbaria/merges_controller_test.rb
@@ -43,33 +43,41 @@ module Herbaria
       # records at fundis, randomly enough, so if we create a personal
       # herbarium for her, she should be able to merge fundis into it.
       assert_true(fundis.owns_all_records?(mary))
-      marys = mary.create_personal_herbarium
+      src = fundis
+      dest = mary.create_personal_herbarium
+      # dest_old_name = dest.name
       login("mary")
-      post(:create, params: { this: fundis.id, that: marys.id })
 
+      assert_no_changes(
+        "dest.name", "Destination Herbarium should retain its name"
+      ) do
+        post(:create, params: { src: src.id, dest: dest.id })
+      end
       assert_flash_success
-      # fundis ends up being the destination because it is older.
-      assert_redirected_to(herbaria_path(id: fundis))
+      assert_redirected_to(herbaria_path(id: dest.id))
+      assert_equal(
+        dest.personal_user_id, mary.id,
+        "Destination Herbarium should remain Mary's personal Herbarium"
+      )
     end
 
     def test_merge_admin
       make_admin("mary")
-      post(:create, params: { this: nybg.id, that: field_museum.id })
+      post(:create, params: { src: nybg.id, dest: field_museum.id })
       assert_flash_success
-      # nybg survives because it is older.
-      assert_redirected_to(herbaria_path(id: nybg))
+      assert_redirected_to(herbaria_path(id: field_museum))
     end
 
     def test_merge_no_login
       marys = mary.create_personal_herbarium
-      post(:create, params: { this: fundis.id, that: marys.id })
+      post(:create, params: { src: fundis.id, dest: marys.id })
       assert_redirected_to(account_login_path)
     end
 
     def test_merge_by_record_nonowner
       marys = mary.create_personal_herbarium
       login("rolf")
-      post(:create, params: { this: fundis.id, that: marys.id })
+      post(:create, params: { src: fundis.id, dest: marys.id })
 
       assert_redirected_to(
         observer_email_merge_request_path(
@@ -87,25 +95,25 @@ module Herbaria
     def test_merge_personal_herbarium_into_itself
       marys = mary.create_personal_herbarium
       login("mary")
-      post(:create, params: { this: marys.id, that: marys.id })
+      post(:create, params: { src: marys.id, dest: marys.id })
       assert_no_flash
     end
 
     def test_merge_non_existent_merge_source
       login("mary")
-      post(:create, params: { this: 666 })
+      post(:create, params: { src: 666 })
       assert_flash_error
     end
 
     def test_merge_non_existent_merge_target
       login("mary")
-      post(:create, params: { this: fundis.id, that: 666 })
+      post(:create, params: { src: fundis.id, dest: 666 })
       assert_flash_error
     end
 
     def test_merge_identical_non_personal_herbaria
       login("mary")
-      post(:create, params: { this: nybg.id, that: nybg.id })
+      post(:create, params: { src: nybg.id, dest: nybg.id })
 
       assert_redirected_to(
         observer_email_merge_request_path(
@@ -116,7 +124,7 @@ module Herbaria
 
     def test_merge_valid_source_into_non_personal_target
       login("mary")
-      post(:create, params: { this: fundis.id, that: nybg.id })
+      post(:create, params: { src: fundis.id, dest: nybg.id })
       assert_redirected_to(
         observer_email_merge_request_path(
           type: :Herbarium, old_id: fundis.id, new_id: nybg.id

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -200,10 +200,10 @@ class HerbariaControllerTest < FunctionalTestCase
     login("rolf")
     get(:index, params: { flavor: :all, merge: source.id })
 
-    assert_select("form[action *= 'that=#{source.id}']", count: 0)
-    assert_select("form[action *= 'that=#{nybg.id}']", count: 1)
-    assert_select("form[action *= 'that=#{fundis.id}']", count: 1)
-    assert_select("form[action *= 'that=#{dicks_personal.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{source.id}']", count: 0)
+    assert_select("form[action *= 'dest=#{nybg.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{fundis.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{dicks_personal.id}']", count: 1)
   end
 
   def test_index_all_merge_target_buttons_presence_dick
@@ -214,10 +214,10 @@ class HerbariaControllerTest < FunctionalTestCase
 
     login("dick")
     get(:index, params: { flavor: :all, merge: source.id })
-    assert_select("form[action *= 'that=#{source.id}']", count: 0)
-    assert_select("form[action *= 'that=#{nybg.id}']", count: 1)
-    assert_select("form[action *= 'that=#{fundis.id}']", count: 1)
-    assert_select("form[action *= 'that=#{dicks_personal.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{source.id}']", count: 0)
+    assert_select("form[action *= 'dest=#{nybg.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{fundis.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{dicks_personal.id}']", count: 1)
   end
 
   def test_index_all_merge_target_buttons_presence_admin
@@ -225,10 +225,10 @@ class HerbariaControllerTest < FunctionalTestCase
     make_admin("zero")
     get(:index, params: { flavor: :all, merge: source.id })
 
-    assert_select("form[action *= 'that=#{source.id}']", count: 0)
-    assert_select("form[action *= 'that=#{nybg.id}']", count: 1)
-    assert_select("form[action *= 'that=#{fundis.id}']", count: 1)
-    assert_select("form[action *= 'that=#{dicks_personal.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{source.id}']", count: 0)
+    assert_select("form[action *= 'dest=#{nybg.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{fundis.id}']", count: 1)
+    assert_select("form[action *= 'dest=#{dicks_personal.id}']", count: 1)
   end
 
   def test_index_all_merge_target_buttons_presence_no_login
@@ -583,14 +583,16 @@ class HerbariaControllerTest < FunctionalTestCase
   end
 
   def test_update_with_duplicate_name_by_owner_of_all_records
-    other = herbaria(:rolf_herbarium)
-    params = herbarium_params.merge(name: other.name)
-    # Rolf can both edit and does own all the records.  Should merge.
+    dest = herbaria(:rolf_herbarium)
+    params = herbarium_params.merge(name: dest.name)
+    # Rolf can both edit and does own all the records.
+    # When he changes nybg's name == Rolf's personal herbarium name,
+    # Should merge nybg into Rolf's personal herbarium.
     login("rolf")
     patch(:update, params: { herbarium: params, id: nybg.id })
 
-    assert_nil(Herbarium.safe_find(other.id))
-    assert_not_nil(Herbarium.safe_find(nybg.id))
+    assert_not_nil(Herbarium.safe_find(dest.id))
+    assert_nil(Herbarium.safe_find(nybg.id))
   end
 
   def test_update_with_nonexisting_place_name

--- a/test/integration/curator_test.rb
+++ b/test/integration/curator_test.rb
@@ -312,7 +312,7 @@ class CuratorTest < IntegrationTestCase
     get(herbaria_path(flavor: :all))
     click(href: herbaria_path(merge: fundis))
     form = open_form( # merge button
-      "form[action *= 'that=#{mary_herbarium.id}']"
+      "form[action *= 'dest=#{mary_herbarium.id}']"
     )
     form.submit("#{mary.name} (#{mary.login}): Personal Fungarium")
 


### PR DESCRIPTION
- `this` => `src`, `that` => `dest`
- supply correct arguments to HerbariaMerges#create

Fixes the bug described in https://www.pivotaltracker.com/story/show/177597433, 
which bug existed before updating HerbariaController (#740)

#### Manual Test
- Create a new institutional Fungarium. I suggest naming it `!test institutional` so it sorts first.
- Click **Fungarum Index** (or go to http://localhost:3000/herbaria?flavor=nonpersonal)
- In the resulting List of Institutional Fungaria, next to the Fungarium you just created, click **Merge**
- Click the letter and page number links, until you get to a page that includes your personal herbarium
- Click on the name of your personal Herbarium
Result: Flash success message
- Review the list of Institutional Fungaria, http://localhost:3000/herbaria?flavor=nonpersonal
Result: The Fungarium you created at the beginning of the test should not exist; it was merged into your personal Fungarium.
