### PR TITLE
Temporarily block bots from show_name

### DIFF
--- a/script/refresh_sitemap
+++ b/script/refresh_sitemap
@@ -127,6 +127,7 @@ ROBOTS_HEADER = <<~"TXT"
   Disallow: */index*user_locale=*
   Disallow: */lookup*user_locale=*
   Disallow: /*?*q= # block urls having the q parameter
+  Disallow: /name/show_name
 TXT
 ROBOTS_FOOTER = <<"TXT"
 TXT


### PR DESCRIPTION
`show_name` adds a huge load to an already slow site
Blocking robots from those pages may help a bit.
For more details see discussion starting at https://groups.google.com/g/mo-developers/c/nMRihKG70hw/m/Pfcvc197AQAJ