### PR TITLE
Tweak "Switch Users" admin funtion to accept email address as well as login name

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -677,7 +677,7 @@ class AccountController < ApplicationController
     elsif str.match?(/^\d+$/)
       User.safe_find(str)
     else
-      User.find_by_login(str.sub(/ <.*>$/, ""))
+      User.find_by_login(str) || User.find_by_email(str.sub(/ <.*>$/, ""))
     end
   end
 

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -827,5 +827,7 @@ class AccountControllerTest < FunctionalTestCase
     assert_users_equal(mary, User.current)
     post(:switch_users, params: { id: dick.login })
     assert_users_equal(dick, User.current)
+    post(:switch_users, params: { id: mary.email })
+    assert_users_equal(mary, User.current)
   end
 end


### PR DESCRIPTION
Tired of having to lookup users' login name in order to use this function!  The typical use case is a user writes us saying they can't remember their password.  I would like to copy and paste their email address into the Switch Users login field so that I can login as them and change their password.  Presently I need to look up their login name first, which is painfully difficult on my slow internet.

No review necessary.  Just celebrating finally having a working dev VM again after several months. :)