### PR TITLE
Fix Publications link in left navbar

### DIFF
--- a/app/views/shared/_nav_left.html.erb
+++ b/app/views/shared/_nav_left.html.erb
@@ -134,7 +134,7 @@
               { class: "list-group-item indent" }) %>
   <%= link_to(:translators_note_title.t, observer_translators_note_path,
               { class: "list-group-item indent" }) %>
-  <%= link_to(:app_publications.t, publications_index_path,
+  <%= link_to(:app_publications.t, publications_path,
               { class: "list-group-item indent" }) %>
 
   <% unless browser.bot?%>


### PR DESCRIPTION
Publications link in left navbar currently throws an error.
This PR corrects the link `href`.

Delivers https://www.pivotaltracker.com/story/show/178420299