### PR TITLE
Fungarium Record Notes

### DIFF
--- a/app/controllers/observer_controller/create_and_edit_observation.rb
+++ b/app/controllers/observer_controller/create_and_edit_observation.rb
@@ -191,8 +191,9 @@ class ObserverController
 
     herbarium_record = lookup_herbarium_record(herbarium, accession_number)
     if !herbarium_record
-      herbarium_record = create_herbarium_record(herbarium, initial_det,
-                                                 accession_number, herbarium_record_notes)
+      herbarium_record = create_herbarium_record(
+        herbarium, initial_det, accession_number, herbarium_record_notes
+      )
     elsif herbarium_record.can_edit?
       flash_warning(:create_herbarium_record_already_used.t) if
         herbarium_record.observations.any?
@@ -261,8 +262,8 @@ class ObserverController
     ).first
   end
 
-  def create_herbarium_record(herbarium, initial_det, accession_number, 
-  														herbarium_record_notes)
+  def create_herbarium_record(herbarium, initial_det, accession_number,
+                              herbarium_record_notes)
     HerbariumRecord.create(
       herbarium: herbarium,
       initial_det: initial_det,

--- a/app/controllers/observer_controller/create_and_edit_observation.rb
+++ b/app/controllers/observer_controller/create_and_edit_observation.rb
@@ -185,14 +185,14 @@ class ObserverController
   end
 
   def save_herbarium_record(obs, params)
-    herbarium, initial_det, accession_number =
+    herbarium, initial_det, accession_number, herbarium_record_notes =
       normalize_herbarium_record_params(obs, params)
     return if not_creating_record?(obs, herbarium, accession_number)
 
     herbarium_record = lookup_herbarium_record(herbarium, accession_number)
     if !herbarium_record
       herbarium_record = create_herbarium_record(herbarium, initial_det,
-                                                 accession_number)
+                                                 accession_number, herbarium_record_notes)
     elsif herbarium_record.can_edit?
       flash_warning(:create_herbarium_record_already_used.t) if
         herbarium_record.observations.any?
@@ -225,7 +225,8 @@ class ObserverController
     init_det  = initial_determination(obs)
     accession = params2[:herbarium_id].to_s.strip_html.strip_squeeze
     accession = default_accession_number(obs, params) if accession.blank?
-    [herbarium, init_det, accession]
+    notes = params2[:herbarium_record_notes]
+    [herbarium, init_det, accession, notes]
   end
 
   def initial_determination(obs)
@@ -260,11 +261,13 @@ class ObserverController
     ).first
   end
 
-  def create_herbarium_record(herbarium, initial_det, accession_number)
+  def create_herbarium_record(herbarium, initial_det, accession_number, 
+  														herbarium_record_notes)
     HerbariumRecord.create(
       herbarium: herbarium,
       initial_det: initial_det,
-      accession_number: accession_number
+      accession_number: accession_number,
+      notes: herbarium_record_notes
     )
   end
 

--- a/app/views/observer/_form_observations.html.erb
+++ b/app/views/observer/_form_observations.html.erb
@@ -185,6 +185,11 @@
           <%= label_tag(:herbarium_record_herbarium_id, :herbarium_record_accession_number.t + ":") %>
           <%= text_field(:herbarium_record, :herbarium_id, value: @herbarium_id, class: "form-control") %>
         </div>
+        <div class="form-group">
+          <%= label_tag(:herbarium_record_notes, "#{:herbarium_record_notes.t}:") %>
+          <%= text_field(:herbarium_record, :herbarium_record_notes, 
+          		value: "", class: "form-control") %>
+        </div>
       </div>
       <div class="col-sm-6">
         <div class="well well-sm ">

--- a/app/views/observer/_form_observations.html.erb
+++ b/app/views/observer/_form_observations.html.erb
@@ -187,8 +187,8 @@
         </div>
         <div class="form-group">
           <%= label_tag(:herbarium_record_notes, "#{:herbarium_record_notes.t}:") %>
-          <%= text_field(:herbarium_record, :herbarium_record_notes, 
-          		value: "", class: "form-control") %>
+          <%= text_field(:herbarium_record, :herbarium_record_notes,
+                         value: "", class: "form-control") %>
         </div>
       </div>
       <div class="col-sm-6">

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2483,6 +2483,7 @@
   herbarium_record_initial_det: Initial Determination
   herbarium_record_accession_number: Accession Number
   herbarium_record_user: Record Creator
+  herbarium_record_notes: Fungarium Record Notes
 
   # herbarium_record/create_herbarium_record
   create_herbarium_record: Add Fungarium Record

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2488,7 +2488,7 @@
   # herbarium_record/create_herbarium_record
   create_herbarium_record: Add Fungarium Record
   create_herbarium_record_title: Add Fungarium Record
-  create_herbarium_record_accession_number_help: "Must be a unique identifier for this fungarium.  If you do not know the accession number, or there isn't one yet, use the observation number or your own collection number.  Examples:\n&nbsp;&nbsp;BRY-L-0025845\n&nbsp;&nbsp;MO 174623\n&nbsp;&nbsp;Joe Smith 17-013."
+  create_herbarium_record_accession_number_help: "Must be a unique identifier for this fungarium.  If you do not know the accession number, or there isn't one yet, use the observation number or your own collection number.  Examples:\n&nbsp;&nbsp;12419 \n&nbsp;&nbsp;BRY-L-0025845 \n&nbsp;&nbsp;MO 174623 \n&nbsp;&nbsp;Joe Smith 17-013"
   create_herbarium_separately: The fungarium you entered doesn't exist. Please create it separately and then add the fungarium record to your observation.
   create_herbarium_record_missing_herbarium_name: Missing fungarium name.
   create_herbarium_record_already_used: This fungarium record already exists. We've added this observation to it. If that isn't correct, remove it from your observation, then add the correct fungarium record.


### PR DESCRIPTION
Let User enter Fungarium Record Notes when creating Obs

- Allows this to be done in one step (as opposed to first creating the Obs, then editing the Record).
- Delivers https://www.pivotaltracker.com/story/show/178512407