### PR TITLE
Add missing destroy_location action (and test thereof)

### DIFF
--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -480,7 +480,7 @@ class LocationController < ApplicationController
 
   ##############################################################################
   #
-  #  :section: Create/Edit Location
+  #  :section: Create/Edit/Destroy Location
   #
   ##############################################################################
   def create_location
@@ -634,6 +634,16 @@ class LocationController < ApplicationController
     else
       post_edit_location_change(db_name)
     end
+  end
+
+  def destroy_location
+    return unless in_admin_mode?
+    return unless (@location = find_or_goto_index(Location, params[:id].to_s))
+
+    if @location.destroy
+      flash_notice(:runtime_destroyed_id.t(type: Location, value: params[:id]))
+    end
+    redirect_to(location_list_locations_path)
   end
 
   # Merge this location with another.

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -707,6 +707,22 @@ class LocationControllerTest < FunctionalTestCase
     assert_equal(10, location.low)
   end
 
+  def test_destroy_location
+    location = locations(:california)
+    params = { id: location.id }
+
+    login(location.user.login)
+    delete(:destroy_location, params: params)
+    assert(Location.exists?(location.id),
+           "Location should be destroyable only if user is in admin mode")
+
+    make_admin
+    delete(:destroy_location, params: params)
+    assert_redirected_to(location_list_locations_path)
+    assert_not(Location.exists?(location.id),
+               "Failed to destroy Location #{location.id}, '#{location.name}'")
+  end
+
   def test_list_merge_options
     albion = locations(:albion)
 


### PR DESCRIPTION
Prevents admin mode `Destroy Location` from throwing an Error

Delivers https://www.pivotaltracker.com/story/show/178706675