### PR TITLE
Change icn_id dependencies

### DIFF
--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -119,7 +119,8 @@ class NameController
         params: {
           name_id: @name.id,
           # Auricularia Bull. [#17132]
-          new_name_with_icn_id: "#{@parse.search_name} [##{params[:name][:icn_id]}]"
+          new_name_with_icn_id: "#{@parse.search_name} " \
+                                "[##{params[:name][:icn_id]}]"
         }
       )
       return

--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -114,9 +114,15 @@ class NameController
   def update
     @parse = parse_name
     if !minor_change? && @name.dependents? && !in_admin_mode?
+      # Auricularia Bull. [#17132]
+      @new_name_with_icn_id = "#{@parse.search_name} [##{params[:name][:icn_id]}]"
       redirect_with_query(
         controller: :observer, action: :email_name_change_request,
-        name_id: @name.id, new_name: @parse.search_name
+        params: {
+          name_id: @name.id,
+          # Auricularia Bull. [#17132]
+          new_name_with_icn_id: "#{@parse.search_name} [##{params[:name][:icn_id]}]"
+        }
       )
       return
     end

--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -114,8 +114,6 @@ class NameController
   def update
     @parse = parse_name
     if !minor_change? && @name.dependents? && !in_admin_mode?
-      # Auricularia Bull. [#17132]
-      @new_name_with_icn_id = "#{@parse.search_name} [##{params[:name][:icn_id]}]"
       redirect_with_query(
         controller: :observer, action: :email_name_change_request,
         params: {

--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -107,7 +107,7 @@ class ObserverController
     @name = Name.safe_find(params[:name_id])
     @new_name = params[:new_name]
 
-    unless @name && @name.search_name != @new_name
+    if @name&.search_name == @new_name
       redirect_back_or_default(action: :index)
       return
     end

--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -116,9 +116,11 @@ class ObserverController
       redirect_back_or_default(action: :index)
       return
     end
+
+    @new_name_with_icn_id = params[:new_name_with_icn_id]
     return unless request.method == "POST"
 
-    send_name_change_request(name_with_icn_id, params[:new_name_with_icn_id])
+    send_name_change_request(name_with_icn_id, @new_name_with_icn_id)
   end
 
   ##########

--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -103,16 +103,20 @@ class ObserverController
     send_request if request.method == "POST"
   end
 
+  # get email_name_change_request(
+  #   params: { name_id: 1258, new_name_with_icn_id: "Auricularia Bull. [#17132]" }
+  # )
   def email_name_change_request
     @name = Name.safe_find(params[:name_id])
-    @new_name = params[:new_name]
+    name_with_icn_id = "#{@name.search_name} [##{@name.icn_id}]"
 
-    if @name&.search_name == @new_name
+    if name_with_icn_id == params[:new_name_with_icn_id]
       redirect_back_or_default(action: :index)
       return
     end
+    return unless request.method == "POST"
 
-    send_name_change_request if request.method == "POST"
+    send_name_change_request(name_with_icn_id, params[:new_name_with_icn_id])
   end
 
   ##########
@@ -151,14 +155,14 @@ class ObserverController
     redirect_to(@old_obj.show_link_args)
   end
 
-  def send_name_change_request
+  def send_name_change_request(name_with_icn_id, new_name_with_icn_id)
     change_locale_if_needed(MO.default_locale)
     subject = "Request to change Name having dependents"
     content = :email_name_change_request.l(
       user: @user.login,
-      name: @name.search_name,
+      name: name_with_icn_id,
       name_url: @name.show_url,
-      new_name: @new_name,
+      new_name: new_name_with_icn_id,
       notes: params[:notes].to_s.strip_html.strip_squeeze
     )
     WebmasterEmail.build(@user.email, content, subject).deliver_now

--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -104,7 +104,9 @@ class ObserverController
   end
 
   # get email_name_change_request(
-  #   params: { name_id: 1258, new_name_with_icn_id: "Auricularia Bull. [#17132]" }
+  #   params: {
+  #     name_id: 1258, new_name_with_icn_id: "Auricularia Bull. [#17132]"
+  #   }
   # )
   def email_name_change_request
     @name = Name.safe_find(params[:name_id])

--- a/app/views/observer/email_name_change_request.html.erb
+++ b/app/views/observer/email_name_change_request.html.erb
@@ -13,16 +13,19 @@
     <div class="form-group push-down">
       <%= label_tag(:name, :NAME.t) %>:
           <%= @name.unique_search_name %>
+          [#<%= @name.icn_id.to_s %>]
     </div>
 
     <div class="form-group push-down">
-      <%= label_tag(:new_name.t) %>: <%= @new_name %>
+      <%= label_tag(:new_name.t) %>: <%= @new_name_with_icn_id %>
+      <%# pass this thru to the Update side of the action %>
+      <%= hidden_field_tag(:new_name_with_icn_id, @new_name_with_icn_id) %>
     </div>
 
     <div class="form-group push-down">
       <%= label_tag(:notes, "#{:Notes.t}:") %>
       <%= text_area_tag(:notes, "", rows: 10, class: "form-control",
-                        data: {autofocus: true}) %>
+                        data: { autofocus: true }) %>
     </div>
 
     <%= submit_tag(:SEND.l, class: "btn center-block push-down") %>

--- a/app/views/observer/email_name_change_request.html.erb
+++ b/app/views/observer/email_name_change_request.html.erb
@@ -18,7 +18,7 @@
 
     <div class="form-group push-down">
       <%= label_tag(:new_name.t) %>: <%= @new_name_with_icn_id %>
-      <%# pass this thru to the Update side of the action %>
+      <%# pass it back to the action, else it's clobbered there %>
       <%= hidden_field_tag(:new_name_with_icn_id, @new_name_with_icn_id) %>
     </div>
 

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1757,7 +1757,7 @@ class NameControllerTest < FunctionalTestCase
 
     assert_redirected_to(
       { controller: :observer, action: :email_name_change_request,
-        name_id: name.id, new_name: "Superboletus" },
+        name_id: name.id, new_name_with_icn_id: "Superboletus [#]" },
       "User should be unable to change text_name of Name with dependents"
     )
   end
@@ -1908,8 +1908,10 @@ class NameControllerTest < FunctionalTestCase
     post(:edit_name, params: params)
     assert_redirected_to(
       { controller: :observer, action: :email_name_change_request,
-        params: { name_id: name.id,
-                  new_name: name.search_name, new_icn_id: name.icn_id + 1 } },
+        params: {
+          name_id: name.id,
+          new_name_with_icn_id: "#{name.search_name} [##{name.icn_id + 1}]"
+        } },
       "Editing icn_id of Name with dependents should ask webmaster to make change"
     )
   end

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1886,7 +1886,7 @@ class NameControllerTest < FunctionalTestCase
 
   def test_update_change_icn_id_name_with_dependents
     name = names(:lactarius)
-    assert((old_icn_id = name.icn_id), "Test needs a fixture with an icn_id")
+    assert(name.icn_id, "Test needs a fixture with an icn_id")
     assert(name.dependents?, "Test needs a fixture with dependents")
     params = {
       id: name.id,
@@ -1912,7 +1912,7 @@ class NameControllerTest < FunctionalTestCase
           name_id: name.id,
           new_name_with_icn_id: "#{name.search_name} [##{name.icn_id + 1}]"
         } },
-      "Editing icn_id of Name with dependents should ask webmaster to make change"
+      "Editing icn_id of Name with dependents should ask admin to make change"
     )
   end
 
@@ -3648,6 +3648,7 @@ class NameControllerTest < FunctionalTestCase
         existing_synonyms[n.id.to_s] = "1" # Check the rest
       end
     end
+
     split_version = split_name.version
     kept_version = kept_name.version
     params = {

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1884,6 +1884,36 @@ class NameControllerTest < FunctionalTestCase
     assert_no_emails
   end
 
+  def test_update_change_icn_id_name_with_dependents
+    name = names(:lactarius)
+    assert((old_icn_id = name.icn_id), "Test needs a fixture with an icn_id")
+    assert(name.dependents?, "Test needs a fixture with dependents")
+    params = {
+      id: name.id,
+      name: {
+        version: name.version,
+        text_name: name.text_name,
+        author: name.author,
+        sort_name: name.sort_name,
+        rank: name.rank,
+        citation: name.citation,
+        deprecated: (name.deprecated ? "true" : "false"),
+        icn_id: name.icn_id + 1,
+        notes: name.notes
+      }
+    }
+    user = name.user
+    login(user.login)
+
+    post(:edit_name, params: params)
+    assert_redirected_to(
+      { controller: :observer, action: :email_name_change_request,
+        params: { name_id: name.id,
+                  new_name: name.search_name, new_icn_id: name.icn_id + 1 } },
+      "Editing icn_id of Name with dependents should ask webmaster to make change"
+    )
+  end
+
   def test_update_icn_id_unregistrable
     name = names(:authored_group)
     params = {

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1912,7 +1912,7 @@ class NameControllerTest < FunctionalTestCase
           name_id: name.id,
           new_name_with_icn_id: "#{name.search_name} [##{name.icn_id + 1}]"
         } },
-      "Editing icn_id of Name with dependents should ask admin to make change"
+      "Editing id# of Name w/dependents should show Name Change Request form"
     )
   end
 

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -1502,6 +1502,39 @@ class ObserverControllerTest < FunctionalTestCase
     assert_match(/SHAZAM/, ActionMailer::Base.deliveries.last.to_s)
   end
 
+  def test_email_name_change_request_get
+    name = names(:lactarius)
+    assert(name.icn_id, "Test needs a fixture with an icn_id")
+    assert(name.dependents?, "Test needs a fixture with dependents")
+    params = {
+      name_id: name.id,
+      new_name_with_icn_id: "#{name.search_name} [#777]"
+    }
+    login("mary")
+
+    get(:email_name_change_request, params: params)
+    assert_select(
+      "#title-caption", text: :email_name_change_request_title.l, count: 1
+    )
+  end
+
+  def test_email_name_change_request_post
+    name = names(:lactarius)
+    assert(name.icn_id, "Test needs a fixture with an icn_id")
+    assert(name.dependents?, "Test needs a fixture with dependents")
+    params = {
+      name_id: name.id,
+      new_name_with_icn_id: "#{name.search_name} [#777]"
+    }
+    login("mary")
+
+    post(:email_name_change_request, params: params)
+    assert_redirected_to(
+      "#{name_show_name_path}/#{name.id}",
+      "Sending Name Change Request should redirect to Name page"
+    )
+  end
+
   def test_show_notifications
     # First, create a naming notification email, making sure it has a template,
     # and making sure the person requesting the notifcation is not the same
@@ -2793,8 +2826,8 @@ class ObserverControllerTest < FunctionalTestCase
   def test_edit_observation_with_non_image
     obs = observations(:minimal_unknown_obs)
     file = Rack::Test::UploadedFile.new(
-      Rails.root.join("test", "fixtures", "projects.yml").to_s, "text/plain"
-    )
+      Rails.root.join("test/fixtures/projects.yml").to_s, "text/plain"
+   )
     params = {
       id: obs.id,
       observation: {

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2827,7 +2827,7 @@ class ObserverControllerTest < FunctionalTestCase
     obs = observations(:minimal_unknown_obs)
     file = Rack::Test::UploadedFile.new(
       Rails.root.join("test/fixtures/projects.yml").to_s, "text/plain"
-   )
+    )
     params = {
       id: obs.id,
       observation: {

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -315,6 +315,7 @@ lactarius:
   created_at: 2007-04-30 15:14:10
   updated_at: 2007-04-30 15:14:10
   rank: <%= Name.ranks[:Genus] %>
+  icn_id: 17895
 
 lactarius_alpinus:
   <<: *DEFAULTS


### PR DESCRIPTION
Enable sending admin an email when user changes identifier of a Name that has dependencies.
- Delivers https://www.pivotaltracker.com/story/show/178233771
- Fixes a bug which occurs when user tries to change `icn_id` of a Name having dependencies:
MO would simply re-display the Edit form without any changes.

### Suggested Manual Test ###
- Edit a Name that has both dependencies and an icn_id. [_Hydnum_
](https://mushroomobserver.org/name/show_past_name/805) should work.
- Change the ICN id
- Save changes
**Expected result**: Send Name Change Request form
- Send
**Expected result**: redirected to show_name page with flash success message
