### PR TITLE
Herbaria redirects 179048565

### DIFF
--- a/app/controllers/herbaria/merges_controller.rb
+++ b/app/controllers/herbaria/merges_controller.rb
@@ -29,7 +29,7 @@ module Herbaria
       result = perform_or_request_merge(src, dest) || return
 
       # redirect_to_herbarium_index(result)
-      redirect_with_query(herbaria_path(id: result.try(&:id)))
+      redirect_with_query(herbarium_path(result.try(&:id)))
     end
 
     ############################################################################

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -22,7 +22,7 @@
 
 # Table: legacy Herbariums actions vs updated Herbaria actions
 #
-# legacy Herbarium action (method)  upddated Herbaria action (method)
+# legacy Herbarium action (method)  updated Herbaria action (method)
 # --------------------------------  ---------------------------------
 # create_herbarium (get)            new (get)
 # create_herbarium (post)           create (post)
@@ -142,7 +142,7 @@ class HerbariaController < ApplicationController
     if user_can_destroy_herbarium?
       @herbarium.destroy
       redirect_to_referrer ||
-        redirect_with_query(herbaria_path(id: @herbarium.try(&:id)))
+        redirect_with_query(herbarium_path(@herbarium.try(&:id)))
     else
       flash_error(:permission_denied.t)
       redirect_to_referrer || redirect_with_query(herbarium_path(@herbarium))

--- a/test/controllers/herbaria/merges_controller_test.rb
+++ b/test/controllers/herbaria/merges_controller_test.rb
@@ -54,7 +54,7 @@ module Herbaria
         post(:create, params: { src: src.id, dest: dest.id })
       end
       assert_flash_success
-      assert_redirected_to(herbaria_path(id: dest.id))
+      assert_redirected_to(herbarium_path(dest))
       assert_equal(
         dest.personal_user_id, mary.id,
         "Destination Herbarium should remain Mary's personal Herbarium"
@@ -65,7 +65,7 @@ module Herbaria
       make_admin("mary")
       post(:create, params: { src: nybg.id, dest: field_museum.id })
       assert_flash_success
-      assert_redirected_to(herbaria_path(id: field_museum))
+      assert_redirected_to(herbarium_path(field_museum))
     end
 
     def test_merge_no_login

--- a/test/integration/curator_test.rb
+++ b/test/integration/curator_test.rb
@@ -317,6 +317,6 @@ class CuratorTest < IntegrationTestCase
     form.submit("#{mary.name} (#{mary.login}): Personal Fungarium")
 
     assert_response(:success) # Rails follows the redirect
-    assert_select("#title-caption", text: :herbarium_index.l)
+    assert_select("#title-caption", text: mary_herbarium.format_name, count: 1)
   end
 end


### PR DESCRIPTION
Redirects 2 action to an individual herbarium (fungarium) instead of the index.
-Delivers https://www.pivotaltracker.com/story/show/179048565

*** Suggested Manual Test ***
- Create a herbarium. (For convenience, I suggest Naming it something that starts with "aaa" so that it appears at the top of the index.
- Go to the Fungarium index
- Go into admin mode.
- Merge the newly created herbarium into your personal herbarium
Result: Displays your personal herbarium.

