### PR TITLE
Herbaria #Records reversed

### DIFF
--- a/app/classes/query/image_advanced_search.rb
+++ b/app/classes/query/image_advanced_search.rb
@@ -31,12 +31,8 @@ class Query::ImageAdvancedSearch < Query::ImageBase
     # [Sorry, yes, this is a mess. But I don't expect this type of search
     # to survive much longer. Image searches are in desperate need of
     # critical revision for performance concerns, anyway. -JPH 20210809]
-    args2 = args.dup
-    args2.delete(:select)
-    args2.delete(:order)
-    args2.delete(:group)
-    params2 = params.dup
-    params2.delete(:by)
+    args2 = args.except(:select, :order, :group)
+    params2 = params.except(:by)
     ids = Query.lookup(:Observation, flavor, params2).result_ids(args2)
     ids = clean_id_set(ids)
     args2 = args.dup

--- a/app/classes/query/image_advanced_search.rb
+++ b/app/classes/query/image_advanced_search.rb
@@ -28,8 +28,13 @@ class Query::ImageAdvancedSearch < Query::ImageBase
   end
 
   def execute_content_search(args)
+    # [Sorry, yes, this is a mess. But I don't expect this type of search
+    # to survive much longer. Image searches are in desperate need of
+    # critical revision for performance concerns, anyway. -JPH 20210809]
     args2 = args.dup
     args2.delete(:select)
+    args2.delete(:order)
+    args2.delete(:group)
     params2 = params.dup
     params2.delete(:by)
     ids = Query.lookup(:Observation, flavor, params2).result_ids(args2)

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -110,13 +110,15 @@ module Query::Modules::HighLevelQueries
 
   # Make sure we requery if we change the letter field.
   def need_letters=(letters)
-    if !letters.is_a?(String)
+    unless letters.is_a?(String)
       raise("You must pass a SQL expression to 'need_letters'.")
-    elsif need_letters != letters
-      @result_ids = nil
-      @num_results = nil
-      @need_letters = letters
     end
+
+    return if need_letters == letters
+
+    @result_ids = nil
+    @num_results = nil
+    @need_letters = letters
   end
 
   # Returns a subset of the results (as ids).  Optional arguments:

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -43,11 +43,7 @@ module Query::Modules::HighLevelQueries
       else
         rows = select_rows(args.merge(select: "count(*)"))
         begin
-          # Herbaria by records returns multiple rows -- 1 row/herbarium --
-          # where each row is the number of records for that herbarium
-          # The number of results is the number of rows,
-          # NOT the number of herbarium_records for the 1st herbarium
-          rows.size > 1 ? rows.size : rows[0][0].to_i
+          rows[0][0].to_i
         rescue StandardError
           0
         end

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -43,7 +43,11 @@ module Query::Modules::HighLevelQueries
       else
         rows = select_rows(args.merge(select: "count(*)"))
         begin
-          rows[0][0].to_i
+          # Herbaria by records returns multiple rows -- 1 row/herbarium --
+          # where each row is the number of records for that herbarium
+          # The number of results is the number of rows,
+          # NOT the number of herbarium_records for the 1st herbarium
+          rows.size > 1 ? rows.size : rows[0][0].to_i
         rescue StandardError
           0
         end

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -41,7 +41,12 @@ module Query::Modules::HighLevelQueries
       if @result_ids
         @result_ids.count
       else
-        rows = select_rows(args.merge(select: "count(*)"))
+        # Explicitly disable GROUP BY and ORDER clauses for the purposes of
+        # simply counting the number of results.  This is important because
+        # GROUP BY in particular will mess up the COUNT(*) spec.  Passing in
+        # empty strings for group and order will tell it to explicitly override
+        # anything in self.group and self.order.
+        rows = select_rows(args.merge(select: "COUNT(*)", group: "", order: ""))
         begin
           rows[0][0].to_i
         rescue StandardError

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -291,6 +291,27 @@ class HerbariaControllerTest < FunctionalTestCase
     )
   end
 
+  def test_reverse_records
+    get(:index, params: { by: "reverse_records" })
+
+    assert_response(:success)
+    assert_select(
+      "#title-caption",
+      { text: "#{:HERBARIA.l} #{:by.l} #{:sort_by_records.l}" },
+      "Displayed title should be #{:HERBARIA.l} #{:by.l} #{:sort_by_records.l}"
+    )
+    assert_select(
+      "#sorts", true,
+      "Fungaria by #Records Reversed is missing sort tabs"
+    )
+    Herbarium.find_each do |herbarium|
+      assert_select(
+        "a[href *= '#{herbarium_path(herbarium)}']", true,
+        "Fungaria by reverse #Records missing link to #{herbarium.format_name})"
+      )
+    end
+  end
+
   # ---------- Actions to Display forms -- (new, edit, etc.) -------------------
 
   def test_new


### PR DESCRIPTION
Fixes a bug in Herbaria by #Records reversed
- Delivers https://www.pivotaltracker.com/story/show/176833509
- The bug was that sorting links were not displayed.
- The links were not displayed because `Query#num_results` returned the wrong value (1) for #Records reversed. (It also returned the wrong value for #Records not reversed.

#### Suggested Manual Test ###
- http://localhost:3000/herbarium or http://localhost:3000/herbaria?flavor=all
- Sort by: #Records
- Sort by: Reverse Order
**Expected Result**: Page includes sort tabs

This works, but seems like a kluge.
It feels like the correction should be made somewhere in one of the Query Herbaria modules.
But I can't figure out where or how.