### PR TITLE
Herbaria by Code

### DIFF
--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -148,7 +148,6 @@ module Query::Modules::Ordering
       "collection_numbers.name ASC, collection_numbers.number ASC"
 
     when "code"
-      where << "herbaria.code != ''"
       "herbaria.code ASC"
 
     when "code_then_name"

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1450,6 +1450,11 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Herbarium, :all, by: :records)
   end
 
+  def test_herbarium_by_code
+    expect = Herbarium.all.sort_by(&:code)
+    assert_query(expect, :Herbarium, :all, by: :code)
+  end
+
   def test_herbarium_in_set
     expect = [
       herbaria(:dick_herbarium),


### PR DESCRIPTION
Keep all hits when sorting Herbaria by Code
- Delivers https://www.pivotaltracker.com/story/show/176751952

### Suggested Manual Test and Comparison###
- For comparison purposes, start with the current behavior in the production server
  - https://mushroomobserver.org/herbaria?flavor=nonpersonal
  - click the Code sort tab
**Result** The sort makes some hits disappear (i.e., the non-personal herbaria with a blank Code).
- Now do the same thing in this branch:
  - http://localhost:3000/herbaria?flavor=nonpersonal
  - click the Code sort tab
 **Result** The sort includes all hits from the prior search.
  