### PR TITLE
Propagate generic classifications

### DIFF
--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -148,7 +148,6 @@ module Query::Modules::Ordering
       "collection_numbers.name ASC, collection_numbers.number ASC"
 
     when "code"
-      where << "herbaria.code != ''"
       "herbaria.code ASC"
 
     when "code_then_name"

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-
 #
 #  USAGE::
 #
@@ -23,13 +22,138 @@
 require(File.expand_path("../config/boot.rb", __dir__))
 require(File.expand_path("../config/environment.rb", __dir__))
 
-msgs =
+# -----------------------------------------------------------------------------
+
+# I was going to put this in Name, but it's such a specialized and complicated
+# operation that I decided I'd rather not pollute the main code with it unless
+# other folks disagree strongly with me. -JPH 20210812
+def propagate_generic_classifications(dry_run: false)
+  fixes = []
+  accepted_names = build_accepted_names_lookup_table
+  classifications = get_accepted_generic_classification_strings
+  Name.connection.select_rows(%(
+    SELECT id, synonym_id, text_name, author, `rank`, classification
+    FROM names
+    WHERE `rank` < #{Name.ranks[:Genus]}
+  )).each do |id, synonym_id, text_name, author, rank, classification|
+    genus = (accepted_names[synonym_id] || text_name).split.first
+    classification = nil if classification.blank?
+    classification.strip! if classification
+    next if classification == classifications[genus]
+
+    fixes << [id, text_name, author, classification, genus,
+              classifications[genus]]
+  end
+  execute_fixes(fixes, dry_run)
+end
+
+def build_accepted_names_lookup_table
+  accepted_names = {}
+  Name.connection.select_rows(%(
+    SELECT synonym_id, text_name
+    FROM names
+    WHERE `rank` <= #{Name.ranks[:Genus]}
+      AND deprecated IS FALSE
+      AND synonym_id IS NOT NULL
+  )).each do |synonym_id, text_name|
+    accepted_names[synonym_id] = text_name
+  end
+  accepted_names
+end
+
+def get_accepted_generic_classification_strings
+  classifications = {}
+  Name.connection.select_rows(%(
+    SELECT text_name, classification
+    FROM names
+    WHERE `rank` = #{Name.ranks[:Genus]}
+      AND deprecated IS FALSE
+      AND author NOT LIKE "sensu lato%"
+  )).each do |text_name, classification|
+    next if classification.blank?
+
+    if classifications[text_name].present?
+      warn "Multiple accepted non-sensu lato genera for #{text_name}!"
+    else
+      classifications[text_name] = classification.strip
+    end
+  end
+  classifications
+end
+
+def execute_fixes(fixes, dry_run)
+  bundles = {}
+  msgs = fixes.map do |id, text_name, author, old_class, genus, new_class|
+    bundles[new_class] = [] unless bundles[new_class].present?
+    bundles[new_class] << id
+    if new_class.blank?
+      "Please fill in classification for #{genus}: #{old_class.inspect}"
+    elsif old_class.present?
+      "Fixing classification of #{text_name}: #{changes(old_class, new_class)}"
+    else
+      "Filling in classification for #{text_name}"
+    end
+  end
+  msgs + execute_bundled_fixes(bundles, dry_run)
+end
+
+def execute_bundled_fixes(bundles, dry_run)
+  msgs = []
+  bundles.each do |classification, ids|
+    next if classification.blank?
+
+    id_list = ids.map {|id| Name.connection.quote(id)}.join(",")
+    msgs << "Setting classifications for #{id_list}"
+    next if dry_run
+
+    Name.connection.execute %(
+      UPDATE names
+      SET classification = #{Name.connection.quote(classification)}
+      WHERE id IN (#{id_list})
+    )
+  end
+  msgs
+end
+
+def changes(old_classification, new_classification)
+  msgs = []
+  Name.all_ranks.each do |rank|
+    old_name = parse_classification(old_classification, rank)
+    new_name = parse_classification(new_classification, rank)
+    msgs << "#{old_name} => #{new_name}" if old_name != new_name
+  end
+  msgs.join(", ")
+end
+
+def parse_classification(str, rank)
+  match = str.to_s.match(/#{rank}: _([^_]+)_/)
+  match ? match[1] : "-"
+end
+
+# -----------------------------------------------------------------------------
+
+dry_run = false
+ARGV.each do |flag|
+  case flag
+  when "-n", "--dry-run"
+    dry_run = true
+  else
+    puts "USAGE: script/refresh_caches [-n|--dry-run]"
+    exit 1
+  end
+end
+
+msgs = if dry_run
+  propagate_generic_classifications(dry_run: true)
+else
   Synonym.make_sure_all_referenced_synonyms_exist +
+  Name.fix_self_referential_misspellings +
   Name.make_sure_names_are_bolded_correctly +
   Name.refresh_classification_caches +
-  Name.propagate_generic_classifications +
-  Observation.refresh_content_filter_caches +
-  Observation.make_sure_no_observations_are_misspelled
+  propagate_generic_classifications +
+  Observation.make_sure_no_observations_are_misspelled +
+  Observation.refresh_content_filter_caches
+end
 warn(msgs.join("\n")) if msgs.any?
 
 exit(0)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3046,22 +3046,6 @@ class NameTest < UnitTestCase
     assert_equal(good, name.description.reload.classification)
   end
 
-  # def test_propagate_generic_classifications
-  #   msgs = Name.propagate_generic_classifications
-  #   assert_empty(msgs, msgs.join("\n"))
-  #
-  #   a = names(:agaricus)
-  #   ac = names(:agaricus_campestris)
-  #   ac.update_attributes(classification: "")
-  #   msgs = Name.propagate_generic_classifications
-  #   assert_equal(["Updating Agaricus campestris"], msgs)
-  #   assert_equal(a.classification, ac.reload.classification)
-  #
-  #   a.destroy
-  #   msgs = Name.propagate_generic_classifications
-  #   assert(msgs.include?("Missing genus Agaricus"))
-  # end
-
   def test_changing_classification_propagates_to_subtaxa
     name  = names(:coprinus)
     child = names(:coprinus_comatus)
@@ -3216,5 +3200,17 @@ class NameTest < UnitTestCase
       "Old name (#{old_name.text_name}) interests " \
       "were not moved to target (#{target.text_name})"
     )
+  end
+
+  def test_fix_self_referential_misspellings
+    msgs = Name.fix_self_referential_misspellings
+    assert_empty(msgs)
+
+    name = names(:coprinus)
+    name.update_attributes(correct_spelling_id: name.id)
+    msgs = Name.fix_self_referential_misspellings
+    assert_equal(1, msgs.length)
+    name.reload
+    assert_nil(name.correct_spelling_id)
   end
 end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1450,6 +1450,11 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Herbarium, :all, by: :records)
   end
 
+  def test_herbarium_by_code
+    expect = Herbarium.all.sort_by(&:code)
+    assert_query(expect, :Herbarium, :all, by: :code)
+  end
+
   def test_herbarium_in_set
     expect = [
       herbaria(:dick_herbarium),


### PR DESCRIPTION
This script finally completes the suite of maintenance tasks to be performed regularly (nightly?) that will keep our database of names, classifications, and mirrored columns in observations table accurate and complete.

Initially I was going to write this as a class method of Name, but it is sufficiently complex and specialized, that I changed my mind and have retained it in scripts/refresh_caches, the only place it will likely ever be used.  Feel free to convince me otherwise.

It basically follows from the argument that our users really shouldn't be forced to fill in the classification strings of taxa below genus, since the parent is clearly present right there in the name(!)  Of course, choosing which particular version of the genus to grab the classification from, especially when dealing with synonymy and multiple versions of genera, can be challenging, so I've written this to be very conservative, and with lots of feedback so we can keep an eye on how many errors it is catching and correcting and exactly what those corrections are.

The process isn't as complicated as I expected, so I think the code is solid.  But the first time it is run it catches *a lot* of errors.  It will be some time before I go through and spot check enough of those errors to be fully confident that I haven't missed any strange pathological cases.

However, once this goes live, it is exciting, because it means the ability to search by higher classification units (e.g., search for everything in Pilocarpaceae) will finally work fully.  (Right now, many members of Pilocarpaceae do not have their classification string filled in at all, and many more are placed in the wrong family, and often there is a great deal of conflict within the species within the same genus.)

This will also make it possible for the new version of the FunDiS report, which contains phylum, class, order and family, to work properly.  Right now, those columns are mostly blank.  (The new FunDiS report is in a separate PR, and I'm having trouble creating it because of internet issues, so don't be concerned if you do not see it.)

And just in general, this will ensure that the mirrored columns observations.text_name, life_form and classification are kept accurate.  Redundant data inevitably drifts, as Nathan has argued many times, and this is no exception.  My hope is that this nightly cronjob will limit and minimize that drift to the point where it is essentially no longer an issue.