### PR TITLE
Propagate generic classifications2

### DIFF
--- a/app/controllers/name_controller/classification.rb
+++ b/app/controllers/name_controller/classification.rb
@@ -19,9 +19,9 @@ class NameController
     return unless make_sure_name_below_genus!(name)
     return unless make_sure_genus_has_classification!(name)
 
-    name.update(classification: name.genus.classification)
+    name.update(classification: name.accepted_genus.classification)
     desc = name.description
-    desc&.update(classification: name.genus.classification)
+    desc&.update(classification: name.accepted_genus.classification)
     redirect_with_query(name.show_link_args)
   end
 
@@ -96,7 +96,7 @@ class NameController
   end
 
   def make_sure_genus_has_classification!(name)
-    return true if name.genus&.classification.present?
+    return true if name.accepted_genus&.classification.present?
 
     flash_error(:edit_name_fill_in_classification_for_genus_first.t)
     redirect_with_query(name.show_link_args)

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -54,7 +54,7 @@ class ObserverController
     names = Name.where(id: name_str).to_a
     names = Name.where(search_name: name_str).to_a if names.empty?
     names = Name.where(text_name: name_str).to_a if names.empty?
-    names.map(&:parents).flatten.map(&:id).uniq
+    names.map { |name| name.approved_name.parents }.flatten.map(&:id).uniq
   end
 
   # Displays matrix of User's Observation's, by date.

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -286,6 +286,7 @@ class Name < AbstractModel
   require_dependency "name/notify"
   require_dependency "name/parse"
   require_dependency "name/primer"
+  require_dependency "name/propagate_generic_classifications"
   require_dependency "name/resolve"
   require_dependency "name/synonymy"
   require_dependency "name/taxonomy"

--- a/app/models/name/propagate_generic_classifications.rb
+++ b/app/models/name/propagate_generic_classifications.rb
@@ -4,7 +4,7 @@ class Name < AbstractModel
   class << self
     # This is used only by script/refresh_caches.  I have placed it here in
     # order to make it easily accessible to unit testing.  As a separate file,
-    # it should ever be loaded by the web server, so it's safe from causing
+    # it should never be loaded by the web server, so it's safe from causing
     # even more unnecessary bloat.  I think. -JPH 20210814
     def propagate_generic_classifications(dry_run: false)
       fixes = []
@@ -26,14 +26,14 @@ class Name < AbstractModel
 
     def old_classification(name)
       str = name.classification
-      str.present? && str.strip
+      str.present? && str.strip || nil
     end
 
     def new_classification(name, accepted_names, classifications)
       accepted_text_name = accepted_names[name.synonym_id] || name.text_name
       genus = accepted_text_name.split.first
       str = classifications[genus]
-      str.present? && str.strip
+      str.present? && str.strip || nil
     end
 
     def build_accepted_names_lookup_table
@@ -88,8 +88,6 @@ class Name < AbstractModel
     def execute_bundled_propagation_fixes(bundles, dry_run)
       msgs = []
       bundles.each do |classification, ids|
-        next if classification.blank?
-
         msgs << "Setting classifications for #{ids.join(",")}"
         next if dry_run
 
@@ -108,7 +106,7 @@ class Name < AbstractModel
         "Filling in classification for #{name.text_name}"
       else
         "Fixing classification of #{name.text_name}: " \
-          "#{changesin_classification_string(old_class, new_class)}"
+          "#{changes_in_classification_string(old_class, new_class)}"
       end
     end
 

--- a/app/models/name/propagate_generic_classifications.rb
+++ b/app/models/name/propagate_generic_classifications.rb
@@ -37,31 +37,25 @@ class Name < AbstractModel
     end
 
     def build_accepted_names_lookup_table
-      accepted_names = {}
-      Name.select(:synonym_id, :text_name).
-        where(rank: 0..Name.ranks[:Genus], deprecated: false).
+      Name.where(rank: 0..Name.ranks[:Genus], deprecated: false).
         where.not(synonym_id: nil).
-        each do |name|
-          accepted_names[name.synonym_id] = name.text_name
-        end
-      accepted_names
+        pluck(:synonym_id, :text_name).
+        to_h
     end
 
     def accepted_generic_classification_strings
-      classifications = {}
-      Name.select(:text_name, :classification).
-        where(rank: Name.ranks[:Genus], deprecated: false).
+      Name.where(rank: Name.ranks[:Genus], deprecated: false).
         where("author NOT LIKE 'sensu lato%'").
-        each do |name|
-          next if name.classification.blank?
-
-          if classifications[name.text_name].present?
+        where("LENGTH(classification) > 2").
+        pluck(:text_name, :classification).
+        each_with_object({}) do |vals, classifications|
+          text_name, classification = vals
+          if classifications[text_name].present?
             warn("Multiple accepted non-sensu lato genera for #{text_name}!")
           else
-            classifications[name.text_name] = name.classification
+            classifications[text_name] = classification
           end
         end
-      classifications
     end
 
     def hash_of_names_with_observations
@@ -75,28 +69,26 @@ class Name < AbstractModel
     def execute_propagation_fixes(fixes, dry_run)
       bundles = {}
       used_names = hash_of_names_with_observations
-      msgs = fixes.map do |name, old_class, new_class|
+      fixes.each_with_object([]) do |fix, msgs|
+        name, old_class, new_class = fix
         bundles[new_class] = [] if bundles[new_class].blank?
         bundles[new_class] << name.id
         next unless used_names[name.text_name]
 
-        describe_propagation_fix(name, old_class, new_class)
-      end
-      msgs.reject(&:nil?) + execute_bundled_propagation_fixes(bundles, dry_run)
+        msgs << describe_propagation_fix(name, old_class, new_class)
+      end + execute_bundled_propagation_fixes(bundles, dry_run)
     end
 
     def execute_bundled_propagation_fixes(bundles, dry_run)
-      msgs = []
-      bundles.each do |classification, ids|
+      # Deliberately skip validations
+      # rubocop:disable Rails/SkipsModelValidations
+      bundles.each_with_object([]) do |bundle, msgs|
+        classification, ids = bundle
         msgs << "Setting classifications for #{ids.join(",")}"
-        next if dry_run
-
-        # Deliberately skip validations
-        # rubocop:disable Rails/SkipsModelValidations
-        Name.where(id: ids).update_all(classification: classification)
-        # rubocop:enable Rails/SkipsModelValidations
+        Name.where(id: ids).update_all(classification: classification) \
+          unless dry_run
       end
-      msgs
+      # rubocop:enable Rails/SkipsModelValidations
     end
 
     def describe_propagation_fix(name, old_class, new_class)
@@ -111,13 +103,11 @@ class Name < AbstractModel
     end
 
     def changes_in_classification_string(old_class, new_class)
-      msgs = []
-      Name.all_ranks.each do |rank|
+      Name.all_ranks.each_with_object([]) do |rank, msgs|
         old_name = grab_name_from_classification_string(old_class, rank)
         new_name = grab_name_from_classification_string(new_class, rank)
         msgs << "#{old_name} => #{new_name}" if old_name != new_name
-      end
-      msgs.join(", ")
+      end.join(", ")
     end
 
     def grab_name_from_classification_string(str, rank)

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -177,11 +177,11 @@ class Name < AbstractModel
     )).map do |id, text_name, author|
       "Name ##{id} #{text_name} #{author} was a misspelling of itself."
     end
-    Name.connection.execute %(
+    Name.connection.execute(%(
       UPDATE names
       SET correct_spelling_id = null
       WHERE correct_spelling_id = id
-    )
+    ))
     msgs
   end
 end

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -172,11 +172,10 @@ class Name < AbstractModel
   # name merges?  Whatever.  This fixes it and will run nightly. -JPH 20210812
   def self.fix_self_referential_misspellings
     msgs = Name.select(:id, :text_name, :author).
-                where("correct_spelling_id = id").
-                map do |id, text_name, author|
-                  "Name ##{id} #{text_name} #{author} was a misspelling of " \
-                  "itself."
-                end
+           where("correct_spelling_id = id").
+           map do |id, text_name, author|
+             "Name ##{id} #{text_name} #{author} was a misspelling of itself."
+           end
     # Deliberately skip validations
     # rubocop:disable Rails/SkipsModelValidations
     Name.where("correct_spelling_id = id").update_all(correct_spelling_id: nil)

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -38,6 +38,12 @@ class Name < AbstractModel
     approved_synonyms - [self]
   end
 
+  # Returns the first approved synonym unless the name itself is approved.
+  # If no synonyms are approved, it just returns itself.
+  def approved_name
+    deprecated && approved_synonyms.first || self
+  end
+
   # Returns an Array of approved Synonym Name's and an Array of deprecated
   # Synonym Name's, including misspellings, but _NOT_ including itself.
   #

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -510,8 +510,7 @@ class Name < AbstractModel
     raise("Name#propagate_classification only works on genera for now.") \
       if rank != :Genus
 
-    # Rubocop complains that update_all skips validations.
-    # Well, duh, that's why I'm using it, Sherlock! :)
+    # Deliberately skip validations
     # rubocop:disable Rails/SkipsModelValidations
     subtaxa = subtaxa_whose_classification_needs_to_be_changed
     Name.where(id: subtaxa).
@@ -547,7 +546,10 @@ class Name < AbstractModel
       joins(:description).
       where("name_descriptions.classification != names.classification").
       where("COALESCE(name_descriptions.classification, '') != ''").
+      # Deliberately skip validations
+      # rubocop:disable Rails/SkipsModelValidations
       update_all("names.classification = name_descriptions.classification")
+      # rubocop:enable Rails/SkipsModelValidations
     []
   end
 

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -200,7 +200,7 @@ class Name < AbstractModel
   # Beyond that it just chooses the first one arbitrarily.
   def genus
     @genus ||= begin
-      accepted   = deprecated && approved_synonyms.first || self
+      accepted = deprecated && approved_synonyms.first || self
       return unless accepted.text_name.include?(" ")
 
       genus_name = accepted.text_name.split(" ", 2).first
@@ -506,13 +506,17 @@ class Name < AbstractModel
     raise("Name#propagate_classification only works on genera for now.") \
       if rank != :Genus
 
+    # Rubocop complains that update_all skips validations.
+    # Well, duh, that's why I'm using it, Sherlock! :)
+    # rubocop:disable Rails/SkipsModelValidations
     subtaxa = subtaxa_whose_classification_needs_to_be_changed
     Name.where(id: subtaxa).
-         update_all(classification: classification)
+      update_all(classification: classification)
     NameDescription.where(name_id: subtaxa).
-                    update_all(classification: classification)
+      update_all(classification: classification)
     Observation.where(name_id: subtaxa).
-                update_all(classification: classification)
+      update_all(classification: classification)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   # Get list of subtaxa whose classification doesn't match (and therefore

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -200,9 +200,10 @@ class Name < AbstractModel
   # Beyond that it just chooses the first one arbitrarily.
   def genus
     @genus ||= begin
-      return unless text_name.include?(" ")
+      accepted   = deprecated ? approved_synonyms.first : self
+      return unless accepted.text_name.include?(" ")
 
-      genus_name = text_name.split(" ", 2).first
+      genus_name = accepted.text_name.split(" ", 2).first
       genera     = Name.with_correct_spelling.where(text_name: genus_name)
       accepted   = genera.reject(&:deprecated)
       genera     = accepted if accepted.any?

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -464,7 +464,7 @@ class Name < AbstractModel
   # This is called before a name is created to let us populate things like
   # classification and lifeform from the parent (if infrageneric only).
   def inherit_stuff
-    return unless at_or_below_genus?
+    return unless accepted_genus
 
     self.classification ||= accepted_genus.classification
     self.lifeform       ||= accepted_genus.lifeform

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -542,14 +542,12 @@ class Name < AbstractModel
   # This is meant to be run nightly to ensure that all the classification
   # caches are up to date.  It only pays attention to genera or higher.
   def self.refresh_classification_caches
-    Name.connection.execute(%(
-      UPDATE names n, name_descriptions nd
-      SET n.classification = nd.classification
-      WHERE nd.id = n.description_id
-        AND n.`rank` <= #{Name.connection.quote(Name.ranks[:Genus])}
-        AND nd.classification != n.classification
-        AND COALESCE(nd.classification, "") != ""
-    ))
+    Name.
+      where(rank: 0..Name.ranks[:Genus]).
+      joins(:description).
+      where("name_descriptions.classification != names.classification").
+      where("COALESCE(name_descriptions.classification, '') != ''").
+      update_all("names.classification = name_descriptions.classification")
     []
   end
 

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -162,7 +162,7 @@ class Naming < AbstractModel
 
       # Send email to people interested in this name.
       @initial_name_id = name_id
-      taxa = name.all_parents
+      taxa = name.approved_name.all_parents
       taxa.push(name)
       taxa.push(Name.find_by_text_name("Lichen")) if name.is_lichen?
       done_user = {}

--- a/app/views/name/_classification.html.erb
+++ b/app/views/name/_classification.html.erb
@@ -1,10 +1,14 @@
-<% parents = @name.approved_name.all_parents.select(&:above_genus?) %>
-<% if parents.any? %>
+<% approved_name = @name.approved_name %>
+<% parents = approved_name.all_parents %>
+<% if approved_name.classification.present? && parents.any? %>
   <div style="margin-bottom:0.5em">
-    <% parents.reverse.each do |n| %>
+    <% ([approved_name] + parents).reverse.each do |n| %>
       <p>
         <%= rank_as_string(n.rank) %>:
         <i><%= link_with_query(n.text_name.t, n.show_link_args) %></i>
+        <% if n == approved_name && approved_name != @name %>
+          <br/>&nbsp;&nbsp;(= <i><%= @name.text_name.t %></i>)
+        <% end %>
       </p>
     <% end %>
   </div>
@@ -14,7 +18,7 @@
   <p><%= link_to(:show_object.t(type: @name.at_or_below_genus? && !@name.at_or_below_species? ? :rank_species : :show_subtaxa_obss),
                  add_query_param({ action: :index_name }, @children_query)) %></p>
 <% end %>
-<% if @name.below_genus? && @name.genus.try(&:classification).to_s.strip != @name.classification.to_s.strip %>
+<% if @name.below_genus? && @name.accepted_genus.try(&:classification).to_s.strip != @name.classification.to_s.strip %>
   <p><%= link_with_query(:show_name_refresh_classification.t,
                          controller: :name, action: :refresh_classification,
                          id: @name.id) %></p>

--- a/app/views/name/_classification.html.erb
+++ b/app/views/name/_classification.html.erb
@@ -1,4 +1,4 @@
-<% parents = @name.all_parents %>
+<% parents = @name.approved_name.all_parents.select(&:above_genus?) %>
 <% if parents.any? %>
   <div style="margin-bottom:0.5em">
     <% parents.reverse.each do |n| %>
@@ -14,7 +14,7 @@
   <p><%= link_to(:show_object.t(type: @name.at_or_below_genus? && !@name.at_or_below_species? ? :rank_species : :show_subtaxa_obss),
                  add_query_param({ action: :index_name }, @children_query)) %></p>
 <% end %>
-<% if @name.below_genus? && @name.genus.try(&:classification) != @name.classification %>
+<% if @name.below_genus? && @name.genus.try(&:classification).to_s.strip != @name.classification.to_s.strip %>
   <p><%= link_with_query(:show_name_refresh_classification.t,
                          controller: :name, action: :refresh_classification,
                          id: @name.id) %></p>

--- a/app/views/name/edit_classification.html.erb
+++ b/app/views/name/edit_classification.html.erb
@@ -13,7 +13,7 @@
       <%= label_tag(:classification, :"form_names_classification".t + ":") %>
       <p class="help-block" style="margin-top:0">
         <%= rank = rank_as_lower_string(@name.rank)
-        :"form_names_classification_help".l(rank: rank) %>
+        :form_names_classification_help.l(rank: rank) %>
       </p>
       <%= text_area_tag(:classification, @name.classification,
                         rows: 10, class: "form-control",

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1505,7 +1505,7 @@
   form_names_citation_help: Citation for the publication of this name.
   form_names_citation_textilize_note: Citations can be formatted using the <a href="/observer/textile" target="_new">Textile markup system</a>.
   form_names_misspelling_note: If this name is misspelt, please check the box and enter the correct spelling. *NOTE:* Please do not use this to deprecate correctly-spelled synonyms.
-  form_names_classification_help: "List the higher taxa containing this [rank], one name per rank.  Example:<br/> Domain: _Eukarya_<br/> Kingdom: _Fungi_<br/> Phylum: _Basidiomycota_<br/> Class: _Agaricomycetes_<br/> Order: _Agaricales_<br/> Family: _Agaricaceae_<br/>"
+  form_names_classification_help: "List the higher taxa containing this [rank], one name per rank. Do not include genus or lower ranks. Example:<br/> Domain: _Eukarya_<br/> Kingdom: _Fungi_<br/> Phylum: _Basidiomycota_<br/> Class: _Agaricomycetes_<br/> Order: _Agaricales_<br/> Family: _Agaricaceae_<br/>"
   form_names_gen_desc_help: Describe the general appearance of this taxon.
   form_names_diag_desc_help: Describe what distinguishes this taxon from closely related taxa.
   form_names_look_alikes_help: What other taxa look similar to this one?

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -32,12 +32,13 @@ def propagate_generic_classifications(dry_run: false)
   accepted_names = build_accepted_names_lookup_table
   classifications = accepted_generic_classification_strings
   Name.select(:id, :synonym_id, :text_name, :classification).
-    where(rank: 0..Name.ranks[:Genus] - 1).
-    each do |id, synonym_id, text_name, classification|
-      genus = (accepted_names[synonym_id] || text_name).split.first
-      next if (classification = clean(classification)) == classifications[genus]
+    where(rank: 0..(Name.ranks[:Genus] - 1)).
+    each do |name|
+      genus = (accepted_names[name.synonym_id] || name.text_name).split.first
+      classification = clean(name.classification)
+      next if classification == classifications[genus]
 
-      fixes << [id, text_name, classification, classifications[genus]]
+      fixes << [name, classification, classifications[genus]]
     end
   execute_fixes(fixes, dry_run)
 end
@@ -51,8 +52,8 @@ def build_accepted_names_lookup_table
   Name.select(:synonym_id, :text_name).
     where(rank: 0..Name.ranks[:Genus], deprecated: false).
     where.not(synonym_id: nil).
-    each do |synonym_id, text_name|
-      accepted_names[synonym_id] = text_name
+    each do |name|
+      accepted_names[name.synonym_id] = name.text_name
     end
   accepted_names
 end
@@ -62,13 +63,13 @@ def accepted_generic_classification_strings
   Name.select(:text_name, :classification).
     where(rank: Name.ranks[:Genus], deprecated: false).
     where("author NOT LIKE 'sensu lato%'").
-    each do |text_name, classification|
-      next if classification.blank?
+    each do |name|
+      next if name.classification.blank?
 
-      if classifications[text_name].present?
+      if classifications[name.text_name].present?
         warn("Multiple accepted non-sensu lato genera for #{text_name}!")
       else
-        classifications[text_name] = classification.strip
+        classifications[name.text_name] = name.classification.strip
       end
     end
   classifications
@@ -85,17 +86,17 @@ end
 def execute_fixes(fixes, dry_run)
   bundles = {}
   used_names = hash_of_names_with_observations
-  msgs = fixes.map do |id, text_name, old_class, new_class|
+  msgs = fixes.map do |name, old_class, new_class|
     bundles[new_class] = [] if bundles[new_class].blank?
-    bundles[new_class] << id
-    next unless used_names[text_name]
+    bundles[new_class] << name.id
+    next unless used_names[name.text_name]
 
     if new_class.blank?
-      "Stripping classification from #{text_name}"
+      "Stripping classification from #{name.text_name}"
     elsif old_class.blank?
-      "Filling in classification for #{text_name}"
+      "Filling in classification for #{name.text_name}"
     else
-      "Fixing classification of #{text_name}: #{changes(old_class, new_class)}"
+      "Fixing classification of #{name.text_name}: #{changes(old_class, new_class)}"
     end
   end
   msgs.reject(&:nil?) + execute_bundled_fixes(bundles, dry_run)

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -34,17 +34,25 @@ def propagate_generic_classifications(dry_run: false)
   Name.select(:id, :synonym_id, :text_name, :classification).
     where(rank: 0..(Name.ranks[:Genus] - 1)).
     each do |name|
-      genus = (accepted_names[name.synonym_id] || name.text_name).split.first
-      classification = clean(name.classification)
-      next if classification == classifications[genus]
+      old_class = old_classification(name)
+      new_class = new_classification(name, accepted_names, classifications)
+      next if old_class == new_class
 
-      fixes << [name, classification, classifications[genus]]
+      fixes << [name, old_class, new_class]
     end
   execute_fixes(fixes, dry_run)
 end
 
-def clean(classification)
-  classification.strip if classification.present?
+def old_classification(name)
+  str = name.classification
+  str.present? && str.strip
+end
+
+def new_classification(name, accepted_names, classifications)
+  accepted_text_name = accepted_names[name.synonym_id] || name.text_name
+  genus = accepted_text_name.split.first
+  str = classifications[genus]
+  str.present? && str.strip
 end
 
 def build_accepted_names_lookup_table
@@ -69,7 +77,7 @@ def accepted_generic_classification_strings
       if classifications[name.text_name].present?
         warn("Multiple accepted non-sensu lato genera for #{text_name}!")
       else
-        classifications[name.text_name] = name.classification.strip
+        classifications[name.text_name] = name.classification
       end
     end
   classifications
@@ -91,15 +99,20 @@ def execute_fixes(fixes, dry_run)
     bundles[new_class] << name.id
     next unless used_names[name.text_name]
 
-    if new_class.blank?
-      "Stripping classification from #{name.text_name}"
-    elsif old_class.blank?
-      "Filling in classification for #{name.text_name}"
-    else
-      "Fixing classification of #{name.text_name}: #{changes(old_class, new_class)}"
-    end
+    describe_fix(name, old_class, new_class)
   end
   msgs.reject(&:nil?) + execute_bundled_fixes(bundles, dry_run)
+end
+
+def describe_fix(name, old_class, new_class)
+  if new_class.blank?
+    "Stripping classification from #{name.text_name}"
+  elsif old_class.blank?
+    "Filling in classification for #{name.text_name}"
+  else
+    "Fixing classification of #{name.text_name}: " \
+      "#{changes(old_class, new_class)}"
+  end
 end
 
 def execute_bundled_fixes(bundles, dry_run)

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -95,17 +95,17 @@ def execute_fixes(fixes, dry_run)
   msgs = fixes.map do |id, text_name, author, old_class, genus, new_class|
     bundles[new_class] = [] unless bundles[new_class].present?
     bundles[new_class] << id
+    next unless used_names[text_name]
+
     if new_class.blank?
       "Please fill in classification for #{genus}: #{old_class.inspect}"
     elsif old_class.blank?
       "Filling in classification for #{text_name}"
-    elsif used_names[text_name]
-      "Fixing classification of #{text_name}: #{changes(old_class, new_class)}"
     else
-      "Fixing classification of unused name #{text_name}: #{changes(old_class, new_class)}"
+      "Fixing classification of #{text_name}: #{changes(old_class, new_class)}"
     end
   end
-  msgs + execute_bundled_fixes(bundles, dry_run)
+  msgs.reject(&:nil?) + execute_bundled_fixes(bundles, dry_run)
 end
 
 def execute_bundled_fixes(bundles, dry_run)

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-#
+
 #  USAGE::
 #
 #    script/refresh_caches
@@ -30,21 +30,22 @@ require(File.expand_path("../config/environment.rb", __dir__))
 def propagate_generic_classifications(dry_run: false)
   fixes = []
   accepted_names = build_accepted_names_lookup_table
-  classifications = get_accepted_generic_classification_strings
+  classifications = accepted_generic_classification_strings
   Name.connection.select_rows(%(
-    SELECT id, synonym_id, text_name, author, `rank`, classification
+    SELECT id, synonym_id, text_name, classification
     FROM names
     WHERE `rank` < #{Name.ranks[:Genus]}
-  )).each do |id, synonym_id, text_name, author, rank, classification|
+  )).each do |id, synonym_id, text_name, classification|
     genus = (accepted_names[synonym_id] || text_name).split.first
-    classification = nil if classification.blank?
-    classification.strip! if classification
-    next if classification == classifications[genus]
+    next if (classification = clean(classification)) == classifications[genus]
 
-    fixes << [id, text_name, author, classification, genus,
-              classifications[genus]]
+    fixes << [id, text_name, classification, classifications[genus]]
   end
   execute_fixes(fixes, dry_run)
+end
+
+def clean(classification)
+  classification.strip if classification.present?
 end
 
 def build_accepted_names_lookup_table
@@ -61,7 +62,7 @@ def build_accepted_names_lookup_table
   accepted_names
 end
 
-def get_accepted_generic_classification_strings
+def accepted_generic_classification_strings
   classifications = {}
   Name.connection.select_rows(%(
     SELECT text_name, classification
@@ -73,7 +74,7 @@ def get_accepted_generic_classification_strings
     next if classification.blank?
 
     if classifications[text_name].present?
-      warn "Multiple accepted non-sensu lato genera for #{text_name}!"
+      warn("Multiple accepted non-sensu lato genera for #{text_name}!")
     else
       classifications[text_name] = classification.strip
     end
@@ -81,7 +82,7 @@ def get_accepted_generic_classification_strings
   classifications
 end
 
-def get_hash_of_names_with_observations
+def hash_of_names_with_observations
   Hash[
     Observation.distinct.pluck(:text_name).collect do |text_name|
       [text_name, true]
@@ -91,14 +92,14 @@ end
 
 def execute_fixes(fixes, dry_run)
   bundles = {}
-  used_names = get_hash_of_names_with_observations
-  msgs = fixes.map do |id, text_name, author, old_class, genus, new_class|
-    bundles[new_class] = [] unless bundles[new_class].present?
+  used_names = hash_of_names_with_observations
+  msgs = fixes.map do |id, text_name, old_class, new_class|
+    bundles[new_class] = [] if bundles[new_class].blank?
     bundles[new_class] << id
     next unless used_names[text_name]
 
     if new_class.blank?
-      "Please fill in classification for #{genus}: #{old_class.inspect}"
+      "Stripping classification from #{text_name}"
     elsif old_class.blank?
       "Filling in classification for #{text_name}"
     else
@@ -113,15 +114,15 @@ def execute_bundled_fixes(bundles, dry_run)
   bundles.each do |classification, ids|
     next if classification.blank?
 
-    id_list = ids.map {|id| Name.connection.quote(id)}.join(",")
+    id_list = ids.map { |id| Name.connection.quote(id) }.join(",")
     msgs << "Setting classifications for #{id_list}"
     next if dry_run
 
-    Name.connection.execute %(
+    Name.connection.execute(%(
       UPDATE names
       SET classification = #{Name.connection.quote(classification)}
       WHERE id IN (#{id_list})
-    )
+    ))
   end
   msgs
 end
@@ -149,22 +150,22 @@ ARGV.each do |flag|
   when "-n", "--dry-run"
     dry_run = true
   else
-    puts "USAGE: script/refresh_caches [-n|--dry-run]"
-    exit 1
+    puts("USAGE: script/refresh_caches [-n|--dry-run]")
+    exit(1)
   end
 end
 
 msgs = if dry_run
-  propagate_generic_classifications(dry_run: true)
-else
-  Synonym.make_sure_all_referenced_synonyms_exist +
-  Name.fix_self_referential_misspellings +
-  Name.make_sure_names_are_bolded_correctly +
-  Name.refresh_classification_caches +
-  propagate_generic_classifications +
-  Observation.make_sure_no_observations_are_misspelled +
-  Observation.refresh_content_filter_caches
-end
+         propagate_generic_classifications(dry_run: true)
+       else
+         Synonym.make_sure_all_referenced_synonyms_exist +
+           Name.fix_self_referential_misspellings +
+           Name.make_sure_names_are_bolded_correctly +
+           Name.refresh_classification_caches +
+           propagate_generic_classifications +
+           Observation.make_sure_no_observations_are_misspelled +
+           Observation.refresh_content_filter_caches
+       end
 warn(msgs.join("\n")) if msgs.any?
 
 exit(0)

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -32,14 +32,13 @@ def propagate_generic_classifications(dry_run: false)
   accepted_names = build_accepted_names_lookup_table
   classifications = accepted_generic_classification_strings
   Name.select(:id, :synonym_id, :text_name, :classification).
-       where(rank: 0..Name.ranks[:Genus] - 1).
-       each do |id, synonym_id, text_name, classification|
-         genus = (accepted_names[synonym_id] || text_name).split.first
-         next if (classification = clean(classification)) == 
-                 classifications[genus]
+    where(rank: 0..Name.ranks[:Genus] - 1).
+    each do |id, synonym_id, text_name, classification|
+      genus = (accepted_names[synonym_id] || text_name).split.first
+      next if (classification = clean(classification)) == classifications[genus]
 
-         fixes << [id, text_name, classification, classifications[genus]]
-       end
+      fixes << [id, text_name, classification, classifications[genus]]
+    end
   execute_fixes(fixes, dry_run)
 end
 
@@ -50,28 +49,28 @@ end
 def build_accepted_names_lookup_table
   accepted_names = {}
   Name.select(:synonym_id, :text_name).
-       where(rank: 0..Name.ranks[:Genus], deprecated: false).
-       where.not(synonym_id: nil).
-       each do |synonym_id, text_name|
-         accepted_names[synonym_id] = text_name
-       end
+    where(rank: 0..Name.ranks[:Genus], deprecated: false).
+    where.not(synonym_id: nil).
+    each do |synonym_id, text_name|
+      accepted_names[synonym_id] = text_name
+    end
   accepted_names
 end
 
 def accepted_generic_classification_strings
   classifications = {}
   Name.select(:text_name, :classification).
-       where(rank: Name.ranks[:Genus], deprecated: false).
-       where("author NOT LIKE 'sensu lato%'").
-       each do |text_name, classification|
-         next if classification.blank?
-      
-         if classifications[text_name].present?
-           warn("Multiple accepted non-sensu lato genera for #{text_name}!")
-         else
-           classifications[text_name] = classification.strip
-         end
-       end
+    where(rank: Name.ranks[:Genus], deprecated: false).
+    where("author NOT LIKE 'sensu lato%'").
+    each do |text_name, classification|
+      next if classification.blank?
+    
+      if classifications[text_name].present?
+        warn("Multiple accepted non-sensu lato genera for #{text_name}!")
+      else
+        classifications[text_name] = classification.strip
+      end
+    end
   classifications
 end
 

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -22,132 +22,6 @@
 require(File.expand_path("../config/boot.rb", __dir__))
 require(File.expand_path("../config/environment.rb", __dir__))
 
-# -----------------------------------------------------------------------------
-
-# I was going to put this in Name, but it's such a specialized and complicated
-# operation that I decided I'd rather not pollute the main code with it unless
-# other folks disagree strongly with me. -JPH 20210812
-def propagate_generic_classifications(dry_run: false)
-  fixes = []
-  accepted_names = build_accepted_names_lookup_table
-  classifications = accepted_generic_classification_strings
-  Name.select(:id, :synonym_id, :text_name, :classification).
-    where(rank: 0..(Name.ranks[:Genus] - 1)).
-    each do |name|
-      old_class = old_classification(name)
-      new_class = new_classification(name, accepted_names, classifications)
-      next if old_class == new_class
-
-      fixes << [name, old_class, new_class]
-    end
-  execute_fixes(fixes, dry_run)
-end
-
-def old_classification(name)
-  str = name.classification
-  str.present? && str.strip
-end
-
-def new_classification(name, accepted_names, classifications)
-  accepted_text_name = accepted_names[name.synonym_id] || name.text_name
-  genus = accepted_text_name.split.first
-  str = classifications[genus]
-  str.present? && str.strip
-end
-
-def build_accepted_names_lookup_table
-  accepted_names = {}
-  Name.select(:synonym_id, :text_name).
-    where(rank: 0..Name.ranks[:Genus], deprecated: false).
-    where.not(synonym_id: nil).
-    each do |name|
-      accepted_names[name.synonym_id] = name.text_name
-    end
-  accepted_names
-end
-
-def accepted_generic_classification_strings
-  classifications = {}
-  Name.select(:text_name, :classification).
-    where(rank: Name.ranks[:Genus], deprecated: false).
-    where("author NOT LIKE 'sensu lato%'").
-    each do |name|
-      next if name.classification.blank?
-
-      if classifications[name.text_name].present?
-        warn("Multiple accepted non-sensu lato genera for #{text_name}!")
-      else
-        classifications[name.text_name] = name.classification
-      end
-    end
-  classifications
-end
-
-def hash_of_names_with_observations
-  Hash[
-    Observation.distinct.pluck(:text_name).collect do |text_name|
-      [text_name, true]
-    end
-  ]
-end
-
-def execute_fixes(fixes, dry_run)
-  bundles = {}
-  used_names = hash_of_names_with_observations
-  msgs = fixes.map do |name, old_class, new_class|
-    bundles[new_class] = [] if bundles[new_class].blank?
-    bundles[new_class] << name.id
-    next unless used_names[name.text_name]
-
-    describe_fix(name, old_class, new_class)
-  end
-  msgs.reject(&:nil?) + execute_bundled_fixes(bundles, dry_run)
-end
-
-def describe_fix(name, old_class, new_class)
-  if new_class.blank?
-    "Stripping classification from #{name.text_name}"
-  elsif old_class.blank?
-    "Filling in classification for #{name.text_name}"
-  else
-    "Fixing classification of #{name.text_name}: " \
-      "#{changes(old_class, new_class)}"
-  end
-end
-
-def execute_bundled_fixes(bundles, dry_run)
-  msgs = []
-  bundles.each do |classification, ids|
-    next if classification.blank?
-
-    msgs << "Setting classifications for #{ids.join(",")}"
-    next if dry_run
-
-    # Deliberately skip validations
-    # rubocop:disable Rails/SkipsModelValidations
-    Name.where(id: ids).update_all(classification: classification)
-    # rubocop:enable Rails/SkipsModelValidations
-  end
-  msgs
-end
-
-def changes(old_classification, new_classification)
-  msgs = []
-  Name.all_ranks.each do |rank|
-    old_name = parse_classification(old_classification, rank)
-    new_name = parse_classification(new_classification, rank)
-    msgs << "#{old_name} => #{new_name}" if old_name != new_name
-  end
-  msgs.join(", ")
-end
-
-def parse_classification(str, rank)
-  match = str.to_s.match(/#{rank}: _([^_]+)_/)
-  match ? match[1] : "-"
-end
-
-# -----------------------------------------------------------------------------
-
 dry_run = false
 ARGV.each do |flag|
   case flag
@@ -160,13 +34,13 @@ ARGV.each do |flag|
 end
 
 msgs = if dry_run
-         propagate_generic_classifications(dry_run: true)
+         Name.propagate_generic_classifications(dry_run: true)
        else
          Synonym.make_sure_all_referenced_synonyms_exist +
            Name.fix_self_referential_misspellings +
            Name.make_sure_names_are_bolded_correctly +
            Name.refresh_classification_caches +
-           propagate_generic_classifications +
+           Name.propagate_generic_classifications +
            Observation.make_sure_no_observations_are_misspelled +
            Observation.refresh_content_filter_caches
        end

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-
 #
 #  USAGE::
 #
@@ -23,13 +22,149 @@
 require(File.expand_path("../config/boot.rb", __dir__))
 require(File.expand_path("../config/environment.rb", __dir__))
 
-msgs =
+# -----------------------------------------------------------------------------
+
+# I was going to put this in Name, but it's such a specialized and complicated
+# operation that I decided I'd rather not pollute the main code with it unless
+# other folks disagree strongly with me. -JPH 20210812
+def propagate_generic_classifications(dry_run: false)
+  fixes = []
+  accepted_names = build_accepted_names_lookup_table
+  classifications = get_accepted_generic_classification_strings
+  Name.connection.select_rows(%(
+    SELECT id, synonym_id, text_name, author, `rank`, classification
+    FROM names
+    WHERE `rank` < #{Name.ranks[:Genus]}
+  )).each do |id, synonym_id, text_name, author, rank, classification|
+    genus = (accepted_names[synonym_id] || text_name).split.first
+    classification = nil if classification.blank?
+    classification.strip! if classification
+    next if classification == classifications[genus]
+
+    fixes << [id, text_name, author, classification, genus,
+              classifications[genus]]
+  end
+  execute_fixes(fixes, dry_run)
+end
+
+def build_accepted_names_lookup_table
+  accepted_names = {}
+  Name.connection.select_rows(%(
+    SELECT synonym_id, text_name
+    FROM names
+    WHERE `rank` <= #{Name.ranks[:Genus]}
+      AND deprecated IS FALSE
+      AND synonym_id IS NOT NULL
+  )).each do |synonym_id, text_name|
+    accepted_names[synonym_id] = text_name
+  end
+  accepted_names
+end
+
+def get_accepted_generic_classification_strings
+  classifications = {}
+  Name.connection.select_rows(%(
+    SELECT text_name, classification
+    FROM names
+    WHERE `rank` = #{Name.ranks[:Genus]}
+      AND deprecated IS FALSE
+      AND author NOT LIKE "sensu lato%"
+  )).each do |text_name, classification|
+    next if classification.blank?
+
+    if classifications[text_name].present?
+      warn "Multiple accepted non-sensu lato genera for #{text_name}!"
+    else
+      classifications[text_name] = classification.strip
+    end
+  end
+  classifications
+end
+
+def get_hash_of_names_with_observations
+  Hash[
+    Observation.distinct.pluck(:text_name).collect do |text_name|
+      [text_name, true]
+    end
+  ]
+end
+
+def execute_fixes(fixes, dry_run)
+  bundles = {}
+  used_names = get_hash_of_names_with_observations
+  msgs = fixes.map do |id, text_name, author, old_class, genus, new_class|
+    bundles[new_class] = [] unless bundles[new_class].present?
+    bundles[new_class] << id
+    if new_class.blank?
+      "Please fill in classification for #{genus}: #{old_class.inspect}"
+    elsif old_class.blank?
+      "Filling in classification for #{text_name}"
+    elsif used_names[text_name]
+      "Fixing classification of #{text_name}: #{changes(old_class, new_class)}"
+    else
+      "Fixing classification of unused name #{text_name}: #{changes(old_class, new_class)}"
+    end
+  end
+  msgs + execute_bundled_fixes(bundles, dry_run)
+end
+
+def execute_bundled_fixes(bundles, dry_run)
+  msgs = []
+  bundles.each do |classification, ids|
+    next if classification.blank?
+
+    id_list = ids.map {|id| Name.connection.quote(id)}.join(",")
+    msgs << "Setting classifications for #{id_list}"
+    next if dry_run
+
+    Name.connection.execute %(
+      UPDATE names
+      SET classification = #{Name.connection.quote(classification)}
+      WHERE id IN (#{id_list})
+    )
+  end
+  msgs
+end
+
+def changes(old_classification, new_classification)
+  msgs = []
+  Name.all_ranks.each do |rank|
+    old_name = parse_classification(old_classification, rank)
+    new_name = parse_classification(new_classification, rank)
+    msgs << "#{old_name} => #{new_name}" if old_name != new_name
+  end
+  msgs.join(", ")
+end
+
+def parse_classification(str, rank)
+  match = str.to_s.match(/#{rank}: _([^_]+)_/)
+  match ? match[1] : "-"
+end
+
+# -----------------------------------------------------------------------------
+
+dry_run = false
+ARGV.each do |flag|
+  case flag
+  when "-n", "--dry-run"
+    dry_run = true
+  else
+    puts "USAGE: script/refresh_caches [-n|--dry-run]"
+    exit 1
+  end
+end
+
+msgs = if dry_run
+  propagate_generic_classifications(dry_run: true)
+else
   Synonym.make_sure_all_referenced_synonyms_exist +
+  Name.fix_self_referential_misspellings +
   Name.make_sure_names_are_bolded_correctly +
   Name.refresh_classification_caches +
-  Name.propagate_generic_classifications +
-  Observation.refresh_content_filter_caches +
-  Observation.make_sure_no_observations_are_misspelled
+  propagate_generic_classifications +
+  Observation.make_sure_no_observations_are_misspelled +
+  Observation.refresh_content_filter_caches
+end
 warn(msgs.join("\n")) if msgs.any?
 
 exit(0)

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -31,16 +31,15 @@ def propagate_generic_classifications(dry_run: false)
   fixes = []
   accepted_names = build_accepted_names_lookup_table
   classifications = accepted_generic_classification_strings
-  Name.connection.select_rows(%(
-    SELECT id, synonym_id, text_name, classification
-    FROM names
-    WHERE `rank` < #{Name.ranks[:Genus]}
-  )).each do |id, synonym_id, text_name, classification|
-    genus = (accepted_names[synonym_id] || text_name).split.first
-    next if (classification = clean(classification)) == classifications[genus]
+  Name.select(:id, :synonym_id, :text_name, :classification).
+       where(rank: 0..Name.ranks[:Genus] - 1).
+       each do |id, synonym_id, text_name, classification|
+         genus = (accepted_names[synonym_id] || text_name).split.first
+         next if (classification = clean(classification)) == 
+                 classifications[genus]
 
-    fixes << [id, text_name, classification, classifications[genus]]
-  end
+         fixes << [id, text_name, classification, classifications[genus]]
+       end
   execute_fixes(fixes, dry_run)
 end
 
@@ -50,35 +49,29 @@ end
 
 def build_accepted_names_lookup_table
   accepted_names = {}
-  Name.connection.select_rows(%(
-    SELECT synonym_id, text_name
-    FROM names
-    WHERE `rank` <= #{Name.ranks[:Genus]}
-      AND deprecated IS FALSE
-      AND synonym_id IS NOT NULL
-  )).each do |synonym_id, text_name|
-    accepted_names[synonym_id] = text_name
-  end
+  Name.select(:synonym_id, :text_name).
+       where(rank: 0..Name.ranks[:Genus], deprecated: false).
+       where.not(synonym_id: nil).
+       each do |synonym_id, text_name|
+         accepted_names[synonym_id] = text_name
+       end
   accepted_names
 end
 
 def accepted_generic_classification_strings
   classifications = {}
-  Name.connection.select_rows(%(
-    SELECT text_name, classification
-    FROM names
-    WHERE `rank` = #{Name.ranks[:Genus]}
-      AND deprecated IS FALSE
-      AND author NOT LIKE "sensu lato%"
-  )).each do |text_name, classification|
-    next if classification.blank?
-
-    if classifications[text_name].present?
-      warn("Multiple accepted non-sensu lato genera for #{text_name}!")
-    else
-      classifications[text_name] = classification.strip
-    end
-  end
+  Name.select(:text_name, :classification).
+       where(rank: Name.ranks[:Genus], deprecated: false).
+       where("author NOT LIKE 'sensu lato%'").
+       each do |text_name, classification|
+         next if classification.blank?
+      
+         if classifications[text_name].present?
+           warn("Multiple accepted non-sensu lato genera for #{text_name}!")
+         else
+           classifications[text_name] = classification.strip
+         end
+       end
   classifications
 end
 
@@ -114,15 +107,13 @@ def execute_bundled_fixes(bundles, dry_run)
   bundles.each do |classification, ids|
     next if classification.blank?
 
-    id_list = ids.map { |id| Name.connection.quote(id) }.join(",")
-    msgs << "Setting classifications for #{id_list}"
+    msgs << "Setting classifications for #{ids.join(',')}"
     next if dry_run
 
-    Name.connection.execute(%(
-      UPDATE names
-      SET classification = #{Name.connection.quote(classification)}
-      WHERE id IN (#{id_list})
-    ))
+    # Deliberately skip validations
+    # rubocop:disable Rails/SkipsModelValidations
+    Name.where(id: ids).update_all(classification: classification)
+    # rubocop:enable Rails/SkipsModelValidations
   end
   msgs
 end

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -64,7 +64,7 @@ def accepted_generic_classification_strings
     where("author NOT LIKE 'sensu lato%'").
     each do |text_name, classification|
       next if classification.blank?
-    
+
       if classifications[text_name].present?
         warn("Multiple accepted non-sensu lato genera for #{text_name}!")
       else
@@ -106,7 +106,7 @@ def execute_bundled_fixes(bundles, dry_run)
   bundles.each do |classification, ids|
     next if classification.blank?
 
-    msgs << "Setting classifications for #{ids.join(',')}"
+    msgs << "Setting classifications for #{ids.join(",")}"
     next if dry_run
 
     # Deliberately skip validations

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3046,22 +3046,6 @@ class NameTest < UnitTestCase
     assert_equal(good, name.description.reload.classification)
   end
 
-  # def test_propagate_generic_classifications
-  #   msgs = Name.propagate_generic_classifications
-  #   assert_empty(msgs, msgs.join("\n"))
-  #
-  #   a = names(:agaricus)
-  #   ac = names(:agaricus_campestris)
-  #   ac.update_attributes(classification: "")
-  #   msgs = Name.propagate_generic_classifications
-  #   assert_equal(["Updating Agaricus campestris"], msgs)
-  #   assert_equal(a.classification, ac.reload.classification)
-  #
-  #   a.destroy
-  #   msgs = Name.propagate_generic_classifications
-  #   assert(msgs.include?("Missing genus Agaricus"))
-  # end
-
   def test_changing_classification_propagates_to_subtaxa
     name  = names(:coprinus)
     child = names(:coprinus_comatus)
@@ -3216,5 +3200,17 @@ class NameTest < UnitTestCase
       "Old name (#{old_name.text_name}) interests " \
       "were not moved to target (#{target.text_name})"
     )
+  end
+
+  def test_fix_self_referential_misspellings
+    msgs = Name.fix_self_referential_misspellings
+    assert_empty(msgs)
+
+    name = names(:coprinus)
+    name.update_attributes(correct_spelling_id: name.id)
+    msgs = Name.fix_self_referential_misspellings
+    assert_equal(1, msgs.length)
+    name.reload
+    assert_nil(name.correct_spelling_id)
   end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3213,4 +3213,11 @@ class NameTest < UnitTestCase
     name.reload
     assert_nil(name.correct_spelling_id)
   end
+
+  def test_genus_of_synonym
+    names(:coprinus_comatus).merge_synonyms(names(:stereum_hirsutum))
+    names(:coprinus_comatus).update(deprecated: true)
+    assert_names_equal(names(:stereum), names(:coprinus_comatus).genus)
+    assert_names_equal(names(:stereum), names(:stereum_hirsutum).genus)
+  end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3217,7 +3217,7 @@ class NameTest < UnitTestCase
   def test_genus_of_synonym
     names(:coprinus_comatus).merge_synonyms(names(:stereum_hirsutum))
     names(:coprinus_comatus).update(deprecated: true)
-    assert_names_equal(names(:stereum), names(:coprinus_comatus).genus)
-    assert_names_equal(names(:stereum), names(:stereum_hirsutum).genus)
+    assert_names_equal(names(:stereum), names(:coprinus_comatus).accepted_genus)
+    assert_names_equal(names(:stereum), names(:stereum_hirsutum).accepted_genus)
   end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3207,7 +3207,7 @@ class NameTest < UnitTestCase
     assert_empty(msgs)
 
     name = names(:coprinus)
-    name.update_attributes(correct_spelling_id: name.id)
+    name.update(correct_spelling_id: name.id)
     msgs = Name.fix_self_referential_misspellings
     assert_equal(1, msgs.length)
     name.reload

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3220,4 +3220,74 @@ class NameTest < UnitTestCase
     assert_names_equal(names(:stereum), names(:coprinus_comatus).accepted_genus)
     assert_names_equal(names(:stereum), names(:stereum_hirsutum).accepted_genus)
   end
+
+  def test_propagate_generic_classifications
+    # This should result in the classification of Coprinus being copied to
+    # Chlorophyllum rachodes.
+    c_rachodes = names(:chlorophyllum_rachodes)
+    c_comatus = names(:coprinus_comatus)
+    c_rachodes.merge_synonyms(c_comatus)
+    c_rachodes.update(deprecated: true)
+    c_comatus.update(deprecated: false)
+    wrong_class = c_rachodes.classification.sub(/Agaricaceae/, "Boletaceae")
+    c_rachodes.update(classification: wrong_class)
+    c_rachodes.reload
+    c_comatus.reload
+    assert_not_empty(c_rachodes.observations)
+    assert_not_equal(c_rachodes.classification, names(:coprinus).classification)
+
+    # This should result in the species in Agaricus having their
+    # classifications stripped.  (Presently, I'm deeming this safer than
+    # trusting old classifications which cannot even be seen on the website
+    # anymore. It should be impossible to set a species's classification
+    # to be different from the genus deliberately these days.)
+    a_campestris = names(:agaricus_campestris)
+    observations(:agaricus_campestrus_obs).destroy
+    observations(:agaricus_campestras_obs).destroy
+    observations(:agaricus_campestros_obs).destroy
+    names(:agaricus).update(classification: nil)
+    assert_not_empty(a_campestris.observations)
+
+    # It should fill these in from Lepiota.
+    l_rachodes = names(:lepiota_rachodes)
+    l_rhacodes = names(:lepiota_rhacodes)
+    l_rachodes.update(classification: nil)
+    l_rhacodes.update(classification: "")
+    observations(:minimal_unknown_obs).update(
+      name: l_rhacodes,
+      text_name: l_rhacodes.text_name
+    )
+    assert_empty(l_rachodes.observations)
+    assert_not_empty(l_rhacodes.observations)
+
+    # Make sure observations.text_name mirror is fully populated!
+    Observation.refresh_content_filter_caches
+
+    msgs = Name.propagate_generic_classifications
+
+    # Should be, in any order:
+    #   Fixing classification for C... rachodes: Boletaceae => Agaricaceae
+    #   Stripping classification from Agaricus campestris
+    #   Filling in classification for Lepiota rhacodes
+    #   Setting classifications for blah,blah,blah.
+    #   Setting classifications for blah,blah,blah,blah.
+    assert(
+      msgs.include?("Fixing classification of Chlorophyllum rachodes: " \
+                    "Boletaceae => Agaricaceae") &&
+        msgs.include?("Filling in classification for Lepiota rhacodes") &&
+        msgs.include?("Stripping classification from Agaricus campestris") &&
+        !msgs.include?("Filling in classification for Lepiota rachodes") &&
+        !msgs.include?("Stripping classification from Agaricus campestras"),
+      "Messages wrong.  Got this:\n#{msgs.inspect}\n"
+    )
+
+    # Make sure reported changes were actually made...
+    assert_equal(c_comatus.classification, c_rachodes.reload.classification)
+    assert_nil(a_campestris.reload.classification)
+    assert_nil(names(:agaricus_campestrus).classification)
+    assert_equal(names(:lepiota).classification,
+                 l_rachodes.reload.classification)
+    assert_equal(names(:lepiota).classification,
+                 l_rhacodes.reload.classification)
+  end
 end


### PR DESCRIPTION
This script finally completes the suite of maintenance tasks to be performed regularly (nightly?) that will keep our database of names, classifications, and mirrored columns in observations table accurate and complete.

Initially I was going to write this as a class method of Name, but it is sufficiently complex and specialized, that I changed my mind and have retained it in scripts/refresh_caches, the only place it will likely ever be used.  Feel free to convince me otherwise.

It basically follows from the argument that our users really shouldn't be forced to fill in the classification strings of taxa below genus, since the parent is clearly present right there in the name(!)  Of course, choosing which particular version of the genus to grab the classification from, especially when dealing with synonymy and multiple versions of genera, can be challenging, so I've written this to be very conservative, and with lots of feedback so we can keep an eye on how many errors it is catching and correcting and exactly what those corrections are.

The process isn't as complicated as I expected, so I think the code is solid.  But the first time it is run it catches *a lot* of errors.  It will be some time before I go through and spot check enough of those errors to be fully confident that I haven't missed any strange pathological cases.

However, once this goes live, it is exciting, because it means the ability to search by higher classification units (e.g., search for everything in Pilocarpaceae) will finally work fully.  (Right now, many members of Pilocarpaceae do not have their classification string filled in at all, and many more are placed in the wrong family, and often there is a great deal of conflict within the species within the same genus.)

This will also make it possible for the new version of the FunDiS report, which contains phylum, class, order and family, to work properly.  Right now, those columns are mostly blank.  (The new FunDiS report is in a separate PR, and I'm having trouble creating it because of internet issues, so don't be concerned if you do not see it.)

And just in general, this will ensure that the mirrored columns observations.text_name, life_form and classification are kept accurate.  Redundant data inevitably drifts, as Nathan has argued many times, and this is no exception.  My hope is that this nightly cronjob will limit and minimize that drift to the point where it is essentially no longer an issue.
