### PR TITLE
Allow http in questions to webmaster from logged-in user

### DIFF
--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -32,7 +32,7 @@ class ObserverController
     elsif @content.blank?
       flash_error(:runtime_ask_webmaster_need_content.t)
     elsif !@user &&
-            (/http:/ =~ @content || %r{<[/a-zA-Z]+>} =~ @content ||
+            (/https?:/ =~ @content || %r{<[/a-zA-Z]+>} =~ @content ||
             !@content.include?(" "))
       flash_error(:runtime_ask_webmaster_antispam.t)
     else

--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -31,8 +31,9 @@ class ObserverController
       @email_error = true
     elsif @content.blank?
       flash_error(:runtime_ask_webmaster_need_content.t)
-    elsif /http:/ =~ @content || %r{<[/a-zA-Z]+>} =~ @content ||
-          !@content.include?(" ")
+    elsif !@user &&
+            (/http:/ =~ @content || %r{<[/a-zA-Z]+>} =~ @content ||
+            !@content.include?(" "))
       flash_error(:runtime_ask_webmaster_antispam.t)
     else
       WebmasterEmail.build(@email, @content).deliver_now

--- a/app/controllers/observer_controller/email_controller.rb
+++ b/app/controllers/observer_controller/email_controller.rb
@@ -21,19 +21,12 @@ class ObserverController
   end
 
   def ask_webmaster_question
-    init_webmaster_question_instance_vars
-    if @email.blank? || @email.index("@").nil?
-      flash_error(:runtime_ask_webmaster_need_address.t)
-      @email_error = true
-    elsif @content.blank?
-      flash_error(:runtime_ask_webmaster_need_content.t)
-    elsif non_user_potential_spam?
-      flash_error(:runtime_ask_webmaster_antispam.t)
-    else
-      WebmasterEmail.build(@email, @content).deliver_now
-      flash_notice(:runtime_ask_webmaster_success.t)
-      redirect_to(action: "list_rss_logs")
-    end
+    @email = params.dig(:user, :email)
+    @content = params.dig(:question, :content)
+    @email_error = false
+    return create_webmaster_question if request.method == "POST"
+
+    @email = @user.email if @user
   end
 
   def ask_user_question
@@ -122,19 +115,27 @@ class ObserverController
 
   private
 
-  def init_webmaster_question_instance_vars
-    @email = params.dig(:user, :email)
-    @content = params.dig(:question, :content)
-    @email_error = false
-    return if request.method == "POST"
-
-    @email = @user.email if @user
+  def create_webmaster_question
+    if @email.blank? || @email.index("@").nil?
+      flash_error(:runtime_ask_webmaster_need_address.t)
+      @email_error = true
+    elsif @content.blank?
+      flash_error(:runtime_ask_webmaster_need_content.t)
+    elsif non_user_potential_spam?
+      flash_error(:runtime_ask_webmaster_antispam.t)
+    else
+      WebmasterEmail.build(@email, @content).deliver_now
+      flash_notice(:runtime_ask_webmaster_success.t)
+      redirect_to(action: "list_rss_logs")
+    end
   end
 
   def non_user_potential_spam?
-    !@user &&
-      (/https?:/ =~ @content || %r{<[/a-zA-Z]+>} =~ @content ||
-       !@content.include?(" "))
+    !@user && (
+      /https?:/.match?(@content) ||
+      %r{<[/a-zA-Z]+>}.match?(@content) ||
+      !@content.include?(" ")
+    )
   end
 
   def validate_merge_model!(val)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -821,6 +821,17 @@ class ObserverControllerTest < FunctionalTestCase
                        flash: :runtime_ask_webmaster_antispam.t)
   end
 
+  def test_send_webmaster_question_antispam_logged_in
+    disable_unsafe_html_filter
+    user = users(:rolf)
+    login(user.login)
+    ask_webmaster_test(user.email,
+                       content: "https://",
+                       response: :redirect,
+                       flash: :runtime_delivered_message.t)
+  end
+
+
   def ask_webmaster_test(email, args)
     response = args[:response] || :success
     flash = args[:flash]

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -831,7 +831,6 @@ class ObserverControllerTest < FunctionalTestCase
                        flash: :runtime_delivered_message.t)
   end
 
-
   def ask_webmaster_test(email, args)
     response = args[:response] || :success
     flash = args[:flash]


### PR DESCRIPTION
Allow http in questions to webmaster from logged-in user
Fixes a bug causing the flash error "To cut down on robot spam, questions from unregistered users cannot contain ‘http:’ or HTML markup" when a logged-in user asks a question with `http:` or HTML markup.

Dellivers https://www.pivotaltracker.com/story/show/179308945

### Suggested Manual Test ###
- Login
- http://localhost:3000/observer/ask_webmaster_question
- enter "http:" in the Question or Comment field
- Save
Expected result: "Successfully delivered message."
- Logout
- http://localhost:3000/observer/ask_webmaster_question
- enter  an email address in the "Your email address" field
- enter "http:" in the "Question or Comment" field
- Save
Expected result: "To cut down on robot spam, questions from unregistered users cannot contain ‘http:’ or HTML markup."
