### PR TITLE
Abbreviate subgenus

### DIFF
--- a/app/classes/rank_matcher.rb
+++ b/app/classes/rank_matcher.rb
@@ -11,8 +11,7 @@
 #   end
 #
 class RankMatcher
-  attr_reader :rank
-  attr_reader :pattern
+  attr_reader :pattern, :rank
 
   def initialize(rank, pattern)
     @rank = rank

--- a/app/classes/rank_matcher.rb
+++ b/app/classes/rank_matcher.rb
@@ -33,7 +33,9 @@ TEXT_NAME_MATCHERS = [
   RankMatcher.new(:Stirps,     / stirps /),
   RankMatcher.new(:Subsection, / subsect\. /),
   RankMatcher.new(:Section,    / sect\. /),
-  RankMatcher.new(:Subgenus,   / subgenus /),
+  # TODO: Can delete "subgenus" from the next line
+  # after all subgenus Names are converted to "subg."
+  RankMatcher.new(:Subgenus,   / (sub\.|subgenus) /),
   RankMatcher.new(:Species,    / /),
   RankMatcher.new(:Family,     /^\S+aceae$/),
   RankMatcher.new(:Family,     /^\S+ineae$/),     # :Suborder

--- a/app/models/name/parse.rb
+++ b/app/models/name/parse.rb
@@ -435,7 +435,7 @@ class Name < AbstractModel
                  elsif /^stirps/i.match?(words[i])
                    "stirps"
                  elsif /^subg/i.match?(words[i])
-                   "subgenus"
+                   "subg."
                  elsif /^subsect/i.match?(words[i])
                    "subsect."
                  else
@@ -498,7 +498,7 @@ class Name < AbstractModel
           gsub(/_+/, " "). # put genus at the top
           sub(/ "(sp[\-\.])/, ' {\1'). # put "sp-1" at end
           gsub(/"([^"]*")/, '\1'). # collate "baccata" with baccata
-          sub(" subgenus ", " {1subgenus ").
+          sub(" subg. ", " {1subg. ").
           sub(" sect. ",    " {2sect. ").
           sub(" subsect. ", " {3subsect. ").
           sub(" stirps ",   " {4stirps ").

--- a/app/models/name/parse.rb
+++ b/app/models/name/parse.rb
@@ -421,23 +421,29 @@ class Name < AbstractModel
     end
   end
 
+  # matches to ranks that are included in the name proper
+  # subspecies is not included because it's the catchall default
+  RANK_START_MATCHER = /^(f|sect|stirps|subg|subsect|v)/i.freeze
+
+  # convert rank start_match to standard form of rank
+  # subspecies is not included because it's the catchall default
+  STANDARD_SECONDARY_RANKS = {
+    f: "f.",
+    sect: "sect.",
+    stirps: "stirps",
+    subg: "subg.",
+    subsect: "subsect.",
+    v: "var."
+  }.freeze
+
   def self.standardize_name(str)
     words = str.split(" ")
     # every other word, starting next-from-last, is an abbreviation
     i = words.length - 2
     while i.positive?
-      words[i] = if /^f/i.match?(words[i])
-                   "f."
-                 elsif /^v/i.match?(words[i])
-                   "var."
-                 elsif /^sect/i.match?(words[i])
-                   "sect."
-                 elsif /^stirps/i.match?(words[i])
-                   "stirps"
-                 elsif /^subg/i.match?(words[i])
-                   "subg."
-                 elsif /^subsect/i.match?(words[i])
-                   "subsect."
+      words[i] = if (match_start_of_rank = RANK_START_MATCHER.match(words[i]))
+                   start_of_rank = match_start_of_rank[0]
+                   STANDARD_SECONDARY_RANKS[start_of_rank.downcase.to_sym]
                  else
                    "subsp."
                  end

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -452,10 +452,6 @@ class Name < AbstractModel
     notes&.match(/\S/)
   end
 
-  def text_before_rank
-    text_name.split(" #{rank.to_s.downcase}").first
-  end
-
   # This is called before a name is created to let us populate things like
   # classification and lifeform from the parent (if infrageneric only).
   def inherit_stuff

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -2753,9 +2753,9 @@ class NameControllerTest < FunctionalTestCase
     login("rolf")
     syn = Synonym.create
     name1 = Name.create!(
-      text_name: "Cortinarius subgenus Sericeocybe",
-      search_name: "Cortinarius subgenus Sericeocybe",
-      sort_name: "Cortinarius subgenus Sericeocybe",
+      text_name: "Cortinarius subg. Sericeocybe",
+      search_name: "Cortinarius subg. Sericeocybe",
+      sort_name: "Cortinarius subg. Sericeocybe",
       display_name: "**__Cortinarius__** subg. **__Sericeocybe__**",
       author: "",
       rank: :Subgenus,
@@ -2794,7 +2794,7 @@ class NameControllerTest < FunctionalTestCase
     assert(name1.reload)
     assert_not(name1.correct_spelling)
     assert_not(name1.deprecated)
-    assert_equal("Cortinarius subgenus Sericeocybe", name1.text_name)
+    assert_equal("Cortinarius subg. Sericeocybe", name1.text_name)
     assert_equal("", name1.author)
   end
 

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -868,10 +868,10 @@ abortiporus_biennis_for_eol:
 amanita_subgenus_lepidella:
   <<: *DEFAULTS
   rank: <%= Name.ranks[:Subgenus] %>
-  text_name: Amanita subgenus Lepidella
-  search_name: Amanita subgenus Lepidella (E.-J. Gilbert) Veselý emend. Corner & Bas
-  sort_name: Amanita subgenus Lepidella  (E.-J. Gilbert) Veselý emend. Corner & Bas
-  display_name: '**__Amanita__ subgenus __Lepidella__** (E.-J. Gilbert) Veselý emend. Corner & Bas'
+  text_name: Amanita subg. Lepidella
+  search_name: Amanita subg. Lepidella (E.-J. Gilbert) Veselý emend. Corner & Bas
+  sort_name: Amanita subg. Lepidella  (E.-J. Gilbert) Veselý emend. Corner & Bas
+  display_name: '**__Amanita__ subg. __Lepidella__** (E.-J. Gilbert) Veselý emend. Corner & Bas'
   author: '(E.-J. Gilbert) Veselý emend. Corner & Bas'
   created_at: 2015-09-17 21:30:01
   updated_at: 2015-09-17 21:30:01

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1648,17 +1648,6 @@ class NameTest < UnitTestCase
     assert(name.at_or_below_species?)
   end
 
-  def test_text_before_rank
-    name_above_genus = names(:fungi)
-    assert_equal("Fungi", name_above_genus.text_before_rank)
-
-    name_between_genus_and_species = names(:amanita_subgenus_lepidella)
-    assert_equal("Amanita", name_between_genus_and_species.text_before_rank)
-
-    variety_name = names(:amanita_boudieri_var_beillei)
-    assert_equal("Amanita boudieri var. beillei", variety_name.text_before_rank)
-  end
-
   # ------------------------------
   #  Test ancestors and parents.
   # ------------------------------

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -201,7 +201,7 @@ class NameTest < UnitTestCase
     assert_equal("Amanita stirps Vaginatae",
                  Name.standardize_name("Amanita Stirps Vaginatae"))
     assert_equal(
-      "Amanita subgenus One sect. Two stirps Three",
+      "Amanita subg. One sect. Two stirps Three",
       Name.standardize_name("Amanita Subg One Sect Two Stirps Three")
     )
     assert_equal("Amanita vaginata", Name.standardize_name("Amanita vaginata"))
@@ -627,13 +627,13 @@ class NameTest < UnitTestCase
 
   def test_name_parse_1d
     do_name_parse_test(
-      "Synchytrium subgenus Endochytrium du Plessis",
-      text_name: "Synchytrium subgenus Endochytrium",
-      real_text_name: "Synchytrium subgenus Endochytrium",
-      search_name: "Synchytrium subgenus Endochytrium du Plessis",
-      real_search_name: "Synchytrium subgenus Endochytrium du Plessis",
-      sort_name: "Synchytrium  {1subgenus  Endochytrium  du Plessis",
-      display_name: "**__Synchytrium__** subgenus **__Endochytrium__** du Plessis", # rubocop:disable Layout/LineLength
+      "Synchytrium subg. Endochytrium du Plessis",
+      text_name: "Synchytrium subg. Endochytrium",
+      real_text_name: "Synchytrium subg. Endochytrium",
+      search_name: "Synchytrium subg. Endochytrium du Plessis",
+      real_search_name: "Synchytrium subg. Endochytrium du Plessis",
+      sort_name: "Synchytrium  {1subg.  Endochytrium  du Plessis",
+      display_name: "**__Synchytrium__** subg. **__Endochytrium__** du Plessis", # rubocop:disable Layout/LineLength
       parent_name: "Synchytrium",
       rank: :Subgenus,
       author: "du Plessis"
@@ -993,14 +993,14 @@ class NameTest < UnitTestCase
   def test_name_parse_26
     do_name_parse_test(
       "Amanita subgenus Vaginatae stirps Vaginatae",
-      text_name: "Amanita subgenus Vaginatae stirps Vaginatae",
-      real_text_name: "Amanita subgenus Vaginatae stirps Vaginatae",
-      search_name: "Amanita subgenus Vaginatae stirps Vaginatae",
-      real_search_name: "Amanita subgenus Vaginatae stirps Vaginatae",
-      sort_name: "Amanita  {1subgenus  Vaginatae  {4stirps  !Vaginatae",
+      text_name: "Amanita subg. Vaginatae stirps Vaginatae",
+      real_text_name: "Amanita subg. Vaginatae stirps Vaginatae",
+      search_name: "Amanita subg. Vaginatae stirps Vaginatae",
+      real_search_name: "Amanita subg. Vaginatae stirps Vaginatae",
+      sort_name: "Amanita  {1subg.  Vaginatae  {4stirps  !Vaginatae",
       display_name:
-        "**__Amanita__** subgenus **__Vaginatae__** stirps **__Vaginatae__**",
-      parent_name: "Amanita subgenus Vaginatae",
+        "**__Amanita__** subg. **__Vaginatae__** stirps **__Vaginatae__**",
+      parent_name: "Amanita subg. Vaginatae",
       rank: :Stirps,
       author: ""
     )
@@ -1145,20 +1145,20 @@ class NameTest < UnitTestCase
   def test_name_parse_37
     do_name_parse_test(
       "Amanita subg. Amidella Singer sect. Amidella stirps Amidella",
-      text_name: "Amanita subgenus Amidella sect. Amidella stirps Amidella",
+      text_name: "Amanita subg. Amidella sect. Amidella stirps Amidella",
       real_text_name:
-        "Amanita subgenus Amidella sect. Amidella stirps Amidella",
+        "Amanita subg. Amidella sect. Amidella stirps Amidella",
       search_name:
-        "Amanita subgenus Amidella sect. Amidella stirps Amidella Singer",
+        "Amanita subg. Amidella sect. Amidella stirps Amidella Singer",
       real_search_name:
-        "Amanita subgenus Amidella Singer sect. Amidella stirps Amidella",
+        "Amanita subg. Amidella Singer sect. Amidella stirps Amidella",
       sort_name:
-        "Amanita  {1subgenus  Amidella  {2sect.  !Amidella  {4stirps  " \
+        "Amanita  {1subg.  Amidella  {2sect.  !Amidella  {4stirps  " \
         "!Amidella  Singer",
       display_name:
-        "**__Amanita__** subgenus **__Amidella__** Singer " \
+        "**__Amanita__** subg. **__Amidella__** Singer " \
         "sect. **__Amidella__** stirps **__Amidella__**",
-      parent_name: "Amanita subgenus Amidella sect. Amidella",
+      parent_name: "Amanita subg. Amidella sect. Amidella",
       rank: :Stirps,
       author: "Singer"
     )
@@ -1326,29 +1326,29 @@ class NameTest < UnitTestCase
     )
     do_name_parse_test( # subgenus group, with author
       "Amanita subg. Vaginatae group (L.) Ach.",
-      text_name: "Amanita subgenus Vaginatae group",
-      real_text_name: "Amanita subgenus Vaginatae group",
-      search_name: "Amanita subgenus Vaginatae group (L.) Ach.",
-      real_search_name: "Amanita subgenus Vaginatae group (L.) Ach.",
-      sort_name: "Amanita  {1subgenus  Vaginatae   group  (L.) Ach.",
+      text_name: "Amanita subg. Vaginatae group",
+      real_text_name: "Amanita subg. Vaginatae group",
+      search_name: "Amanita subg. Vaginatae group (L.) Ach.",
+      real_search_name: "Amanita subg. Vaginatae group (L.) Ach.",
+      sort_name: "Amanita  {1subg.  Vaginatae   group  (L.) Ach.",
       display_name:
-        "**__Amanita__** subgenus **__Vaginatae__** group (L.) Ach.",
+        "**__Amanita__** subg. **__Vaginatae__** group (L.) Ach.",
       parent_name: "Amanita",
       rank: :Group,
       author: "(L.) Ach."
     )
     do_name_parse_test( # stirps group, with sub-genus parent
       "Amanita subgenus Vaginatae stirps Vaginatae group",
-      text_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
-      real_text_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
-      search_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
-      real_search_name: "Amanita subgenus Vaginatae stirps Vaginatae group",
+      text_name: "Amanita subg. Vaginatae stirps Vaginatae group",
+      real_text_name: "Amanita subg. Vaginatae stirps Vaginatae group",
+      search_name: "Amanita subg. Vaginatae stirps Vaginatae group",
+      real_search_name: "Amanita subg. Vaginatae stirps Vaginatae group",
       sort_name:
-        "Amanita  {1subgenus  Vaginatae  {4stirps  !Vaginatae   group",
+        "Amanita  {1subg.  Vaginatae  {4stirps  !Vaginatae   group",
       display_name:
-        "**__Amanita__** subgenus **__Vaginatae__** stirps " \
+        "**__Amanita__** subg. **__Vaginatae__** stirps " \
         "**__Vaginatae__** group",
-      parent_name: "Amanita subgenus Vaginatae",
+      parent_name: "Amanita subg. Vaginatae",
       rank: :Group,
       author: ""
     )

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -633,7 +633,7 @@ class NameTest < UnitTestCase
       search_name: "Synchytrium subg. Endochytrium du Plessis",
       real_search_name: "Synchytrium subg. Endochytrium du Plessis",
       sort_name: "Synchytrium  {1subg.  Endochytrium  du Plessis",
-      display_name: "**__Synchytrium__** subg. **__Endochytrium__** du Plessis", # rubocop:disable Layout/LineLength
+      display_name: "**__Synchytrium__** subg. **__Endochytrium__** du Plessis",
       parent_name: "Synchytrium",
       rank: :Subgenus,
       author: "du Plessis"

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -190,8 +190,12 @@ class NameTest < UnitTestCase
 
   def test_standardize_name
     assert_equal("Amanita", Name.standardize_name("Amanita"))
-    assert_equal("Amanita subgenus Vaginatae",
+    assert_equal("Amanita subg. Vaginatae",
+                 Name.standardize_name("Amanita subgenus Vaginatae"))
+    assert_equal("Amanita subg. Vaginatae",
                  Name.standardize_name("Amanita SUBG. Vaginatae"))
+    assert_equal("Amanita subg. Vaginatae",
+                 Name.standardize_name("Amanita subgen. Vaginatae"))
     assert_equal("Amanita subsect. Vaginatae",
                  Name.standardize_name("Amanita subsect Vaginatae"))
     assert_equal("Amanita stirps Vaginatae",


### PR DESCRIPTION
Abbreviate "subgenus" to "subg."

- Delivers https://www.pivotaltracker.com/story/show/86389186
- Stores and displays subgenera as _Xxx_ subg. _Yyy_.

### Suggested Manual Test ###
* CreateName Aaa subg. Bbb
Expected result: "Successfully created name ‘Aaa subg. Bbb’."
* CreateName Bbb subgenus Ccc
Expected result: "Successfully created name ‘Bbb subg. Ccc’." (saves using the abbreviation)
* Edit any old Name that still uses "subgenus",  Save **without making any changes**.
Expected result: "Successfully updated name ‘_X_. subg. _Y_’." (i.e. automatically updates when the Name is touched)

* Pattern Search for "rank:subgenus"
Expected result: List includes both "subgenus" and  "subg." Names