### PR TITLE
Stop defaulting Observation lat lon alt

### DIFF
--- a/app/controllers/observer_controller/create_and_edit_observation.rb
+++ b/app/controllers/observer_controller/create_and_edit_observation.rb
@@ -66,8 +66,7 @@ class ObserverController
                        order(:created_at).last
     return unless last_observation && last_observation.created_at > 1.hour.ago
 
-    %w[when where location lat long alt
-       is_collection_location gps_hidden].each do |attr|
+    %w[when where location is_collection_location gps_hidden].each do |attr|
       @observation.send("#{attr}=", last_observation.send(attr))
     end
     last_observation.projects.each do |project|


### PR DESCRIPTION
Make the default lat lon & alt all blank.

- Delivers https://www.pivotaltracker.com/story/show/179516419
- Observation lat, lon, alt defaulted to those of the User's previously-created Observation (_provided_ the prior Observation was created less than an hour ago).
This is hard to notice and is rarely correct. The result has been some Observations with incorrect geolocations.
-See https://www.pivotaltracker.com/story/show/179516419,
Comments at https://mushroomobserver.org/observer/show_observation/467868
- Solution: simply remove the defualts.

