### PR TITLE
Glossary image fix

### DIFF
--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -565,9 +565,13 @@ class ImageController < ApplicationController
     pass_query_params
     @object = GlossaryTerm.safe_find(params[:id])
     image = look_for_image(request.method, params)
-    if image
-      redirect_to(@object.process_image_reuse(image, query_params))
+    if image &&
+       @object.add_image(image) &&
+       @object.save
+      @object.log_reuse_image(image)
+      redirect_with_query(glossary_term_path(@object.id))
     else
+      flash_error(:runtime_no_save.t(:glossary_term)) if image
       serve_reuse_form(params)
     end
   end

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -806,17 +806,6 @@ class AbstractModel < ApplicationRecord
     save
   end
 
-  def process_image_reuse(image, query_params)
-    add_image(image)
-    log_reuse_image(image)
-    {
-      controller: show_controller,
-      action: show_action,
-      id: id,
-      q: query_params[:q]
-    }
-  end
-
   def can_edit?(user = User.current)
     !respond_to?("user") || (user && (self.user == user))
   end

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -68,10 +68,11 @@ class GlossaryTerm < AbstractModel
   end
 
   def add_image(image)
-    return unless image
+    return false unless image
+    return false if images.include?(image)
 
-    self.thumb_image = image if thumb_image.nil?
-    images.push(image) unless images.include?(image)
+    self.thumb_image = image if thumb_image.empty?
+    images.push(image)
   end
 
   def all_images

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -71,7 +71,7 @@ class GlossaryTerm < AbstractModel
     return false unless image
     return false if images.include?(image)
 
-    self.thumb_image = image if thumb_image.empty?
+    self.thumb_image = image if thumb_image.nil?
     images.push(image)
   end
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -70,11 +70,8 @@ class GlossaryTerm < AbstractModel
   def add_image(image)
     return unless image
 
-    if thumb_image.nil?
-      self.thumb_image = image
-    else
-      images.push(image)
-    end
+    self.thumb_image = image if thumb_image.nil?
+    images.push(image) unless images.include?(image)
   end
 
   def all_images

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -572,7 +572,7 @@ class ImageControllerTest < FunctionalTestCase
       img_id: image.id.to_s
     }
     login("mary")
-    get_with_dump(:reuse_image_for_glossary_term, params)
+    get(:reuse_image_for_glossary_term, params)
     assert_redirected_to(glossary_term_path(glossary_term.id))
     assert(glossary_term.reload.images.member?(image))
     assert_objs_equal(image, glossary_term.thumb_image)

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -562,6 +562,22 @@ class ImageControllerTest < FunctionalTestCase
     assert(glossary_term.reload.images.member?(image))
   end
 
+  def test_reuse_image_for_glossary_term_post_without_thumbnail
+    glossary_term = glossary_terms(:convex_glossary_term)
+    image = images(:commercial_inquiry_image)
+    assert_empty(glossary_term.images)
+    assert_nil(glossary_term.thumb_image)
+    params = {
+      id: glossary_term.id.to_s,
+      img_id: image.id.to_s
+    }
+    login("mary")
+    get_with_dump(:reuse_image_for_glossary_term, params)
+    assert_redirected_to(glossary_term_path(glossary_term.id))
+    assert(glossary_term.reload.images.member?(image))
+    assert_objs_equal(image, glossary_term.thumb_image)
+  end
+
   def test_upload_image
     setup_image_dirs
     obs = observations(:coprinus_comatus_obs)

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -578,6 +578,23 @@ class ImageControllerTest < FunctionalTestCase
     assert_objs_equal(image, glossary_term.thumb_image)
   end
 
+  def test_reuse_image_for_glossary_term_add_image_fails
+    GlossaryTerm.any_instance.stubs(:add_image).returns(false)
+    glossary_term = glossary_terms(:convex_glossary_term)
+    image = images(:commercial_inquiry_image)
+    assert_empty(glossary_term.images)
+    assert_nil(glossary_term.thumb_image)
+    params = {
+      id: glossary_term.id.to_s,
+      img_id: image.id.to_s
+    }
+    login("mary")
+    get(:reuse_image_for_glossary_term, params)
+    assert_form_action(action: "reuse_image_for_glossary_term",
+                       id: glossary_term.id)
+    assert_flash_error
+  end
+
   def test_upload_image
     setup_image_dirs
     obs = observations(:coprinus_comatus_obs)

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -14,6 +14,7 @@ conic_glossary_term:
   name: Conic # Want to support translations, so this should be a symbol
   description: Cute little cone head. # This should be a symbol
   thumb_image: conic_image # The image for the index
+  images: conic_image # all thumb_images should also be in images
 
 convex_glossary_term:
   <<: *DEFAULTS

--- a/test/models/glossary_term_test.rb
+++ b/test/models/glossary_term_test.rb
@@ -23,10 +23,10 @@ class GlossaryTermTest < UnitTestCase
     image = glossary_term.thumb_image
     images = glossary_term.images
     assert(image)
-    assert_equal([], images)
+    assert_equal(1, images.length)
     glossary_term.add_image(nil)
     assert_equal(image, glossary_term.thumb_image)
-    assert_equal(images, glossary_term.images)
+    assert_equal(1, glossary_term.images.length)
   end
 
   def test_add_image_additional
@@ -49,18 +49,18 @@ class GlossaryTermTest < UnitTestCase
     first_image = images(:convex_image)
     glossary_term.add_image(first_image)
     assert_equal(first_image, glossary_term.thumb_image)
-    assert_equal(0, glossary_term.images.length)
+    assert_equal(1, glossary_term.images.length)
   end
 
   def test_add_image_second
     glossary_term = glossary_terms(:conic_glossary_term)
     thumb = glossary_term.thumb_image
     assert(thumb)
-    assert_equal(0, glossary_term.images.length)
+    assert_equal(1, glossary_term.images.length)
     second_image = images(:convex_image)
     glossary_term.add_image(second_image)
     assert_equal(thumb, glossary_term.thumb_image)
-    assert_equal(1, glossary_term.images.length)
+    assert_equal(2, glossary_term.images.length)
     assert(glossary_term.images.member?(second_image))
   end
 


### PR DESCRIPTION
The old way glossary terms worked, the first time you went to add an image, it would set the thumbnail but not actually add the image to the glossary term.  This was creating a lot of confusion.  The fix was, well, just to fix that.

It probably wasn't noticed at first because the show page shows the thumbnail separately, then shows the images attached to the term later.  So you would see the first image attached right away in the thumbnail section, even though it wasn't showing it in the full images section.  But ever since I cleared out the corrupted images from the database, there are now a bunch of glossary terms with images but no thumbnail selected.  This shouldn't be a problem, but what happens when someone goes to add an additional image to a glossary term without a thumbnail is that it tries to set the thumbnail but doesn't actually either save the change or add the image to the term, so nothing happened.  (See email complaint from user on 2021-09-10.)

(Actually, come to think of it, I'm not sure how image/reuse_image_for_glossary_term ever worked for the first image added to a glossary term, because of this problem.  Maybe it was actually saving the change to the thumbnail somewhere automagically...  Well, whatever, it now saves it explicitly, and even checks for an error if it fails.)