### PR TITLE
Disable Image Search UI

### DIFF
--- a/app/views/observer/advanced_search_form.html.erb
+++ b/app/views/observer/advanced_search_form.html.erb
@@ -16,7 +16,9 @@
       <span class="help"><%= :advanced_search_result_type_help.t %></span><br/>
       <%= select(:search, :model, [
                                     [:OBSERVATIONS.l, :observation],
-                                    [:IMAGES.l, :image],
+                                    # temporarily disabled for performance
+                                    # 2021-09-12 JDC
+                                    # [:IMAGES.l, :image],
                                     [:LOCATIONS.l, :location],
                                     [:NAMES.l, :name],
                                   ]) %>

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -15,7 +15,8 @@
             options = [
               [:COMMENTS.l, :comment],
               [:HERBARIA.l, :herbarium],
-              [:IMAGES.l, :image],
+              # Temporarily disabled for performance reasons. 2021-09-12 JDC
+              # [:IMAGES.l, :image],
               [:LOCATIONS.l, :location],
               [:NAMES.l, :name],
               [:OBSERVATIONS.l, :observation],

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2631,7 +2631,9 @@
   advanced_search_none_found: No matches found
   advanced_search_observer_help: Who observed the mushroom
   advanced_search_result_type: Result Type
-  advanced_search_result_type_help: Do you want [:observations], [:images], [:locations] or [:names]/[:descriptions]?
+  # Image search UI temporarily disabled for performance. 2021-09-12 JDC
+  # advanced_search_result_type_help: Do you want [:observations], [:images], [:locations] or [:names]/[:descriptions]?
+  advanced_search_result_type_help: Do you want [:observations], [:locations] or [:names]/[:descriptions]?
 
   advanced_search_filters: Search Filters
   advanced_search_filters_explain: Apply to this search only, overrides your normal preferred content filters

--- a/test/integration/lurker_test.rb
+++ b/test/integration/lurker_test.rb
@@ -107,13 +107,15 @@ class LurkerTest < IntegrationTestCase
     assert_match(%r{^/#{observations(:coprinus_comatus_obs).id}\?},
                  @request.fullpath)
 
+    # Image pattern searches temporarily disabled for performamce
+    # 2021-09-12 JDC
     # Search for images of the same thing.  (Still only one.)
-    form.select("type", "Images")
-    form.submit("Search")
-    assert_match(
-      %r{^/image/show_image/#{images(:connected_coprinus_comatus_image).id}},
-      @request.fullpath
-    )
+    # form.select("type", "Images")
+    # form.submit("Search")
+    # assert_match(
+    #   %r{^/image/show_image/#{images(:connected_coprinus_comatus_image).id}},
+    #   @request.fullpath
+    # )
 
     # There should be no locations of that name, though.
     form.select("type", "Locations")


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/179552557 

Image searches hog the server. 
Users (mostly or all anonymous) are disregarding our request to not use Image searches,
and instead searching for things like all Images in Australia (a real search).
So we've decided to disable the UI.


