### PR TITLE
Subg follow-up

### DIFF
--- a/app/classes/rank_matcher.rb
+++ b/app/classes/rank_matcher.rb
@@ -32,9 +32,7 @@ TEXT_NAME_MATCHERS = [
   RankMatcher.new(:Stirps,     / stirps /),
   RankMatcher.new(:Subsection, / subsect\. /),
   RankMatcher.new(:Section,    / sect\. /),
-  # TODO: Can delete "subgenus" from the next line
-  # after all subgenus Names are converted to "subg."
-  RankMatcher.new(:Subgenus,   / (sub\.|subgenus) /),
+  RankMatcher.new(:Subgenus,   / subg\. /),
   RankMatcher.new(:Species,    / /),
   RankMatcher.new(:Family,     /^\S+aceae$/),
   RankMatcher.new(:Family,     /^\S+ineae$/),     # :Suborder

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2714,7 +2714,7 @@ class NameTest < UnitTestCase
     assert_equal(:Subsection, Name.guess_rank("Amanita subsect. Amanita"))
     assert_equal(:Section, Name.guess_rank("Amanita sect. Amanita"))
     assert_equal(:Section, Name.guess_rank("Hygrocybe sect. Coccineae"))
-    assert_equal(:Subgenus, Name.guess_rank("Amanita subgenus Amanita"))
+    assert_equal(:Subgenus, Name.guess_rank("Amanita subg. Amanita"))
     assert_equal(:Family, Name.guess_rank("Amanitaceae"))
     assert_equal(:Family, Name.guess_rank("Peltigerineae"))
     assert_equal(:Order, Name.guess_rank("Peltigerales"))


### PR DESCRIPTION
Resolves TODO created in #782 in app/classes/rank_matcher.rb
Delivers https://www.pivotaltracker.com/story/show/179551893

- Update regex used to map `text_name` to  the rank Subgenus
- Update test

 After #86389186 (including a manual update to the db),  only "subg." in text_name maps to Subgenus.

PS: I've confirmed that there are no Names in the db matching "sub.":
```ruby
2.6.6 :002 > Name.where("text_name LIKE '%sub.%'").count
 => 0
2.6.6 :003 > Name.where("search_name LIKE '%sub.%'").count
 => 0
2.6.6 :004 > Name.where("display_name LIKE '%sub.%'").count
 => 0
2.6.6 :005 > Name.where("sort_name LIKE '%sub.%'").count
 => 0
```