### PR TITLE
Add token-based authentication to API

### DIFF
--- a/README_API_HELP_MESSAGES.txt
+++ b/README_API_HELP_MESSAGES.txt
@@ -1,6 +1,7 @@
 POST api_key
   app:	string (identifier used to help user distinguish which api key belongs to which app)
   for_user:	user (user you are creating api key for)
+  password:	string (password of the user you are creating an API key for)
 
 GET comment
   content_has:	string (search within body)

--- a/app/classes/api2/errors.rb
+++ b/app/classes/api2/errors.rb
@@ -289,6 +289,10 @@ class API2
   class CantAddHerbariumRecord < Error
   end
 
+  # Tried to create api key for user with incorrect password.
+  class PasswordIncorrect < Error
+  end
+
   ##############################################################################
 
   # Request requires upload.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3938,6 +3938,7 @@
   api_help_message: "Usage: [help]"
   api_herbarium_record_already_exists: There is already a record for [number] at [herbarium].
   api_image_upload_failed: "Failed to upload image: [error]"
+  api_incorrect_password: Incorrect password.
   api_lat_long_must_both_be_set: Must supply both latitude and longitude, or neither.
   api_location_already_exists: The location "[location]" already exists.
   api_missing_method: Missing "method" parameter.
@@ -4021,6 +4022,7 @@
   api_help_obs_notes_has: search within observation notes
   api_help_observer: observer
   api_help_original_name: original file name or other private identifier
+  api_help_password: password of the user you are creating an API key for
   api_help_postal: in postal format with country last regardless of user preference
   api_help_region: matches locations which end in this, e.g. "California, USA"
   api_help_set_correct_spelling: mark this as misspelt and deprecated and synonymize with the correct spelling

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3985,6 +3985,7 @@
   api_help_accession_number: unique fungarium id
   api_help_accession_number_has: search within accession number
   api_help_any_date: this date can mean anything you want
+  api_help_api_key_password: password of the user you are creating an API key for
   api_help_api_key_user: user you are creating api key for
   api_help_app: identifier used to help user distinguish which api key belongs to which app
   api_help_author_has: search within author
@@ -4022,7 +4023,6 @@
   api_help_obs_notes_has: search within observation notes
   api_help_observer: observer
   api_help_original_name: original file name or other private identifier
-  api_help_password: password of the user you are creating an API key for
   api_help_postal: in postal format with country last regardless of user preference
   api_help_region: matches locations which end in this, e.g. "California, USA"
   api_help_set_correct_spelling: mark this as misspelt and deprecated and synonymize with the correct spelling

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -428,7 +428,7 @@ class Api2Test < UnitTestCase
       app: @app
     }
     api = API2.execute(params)
-    assert_no_errors(api, "Errors while posting image")
+    assert_no_errors(api, "Errors while posting api key")
     assert_obj_list_equal([ApiKey.last], api.results)
     assert_last_api_key_correct
     assert_api_fail(params.remove(:api_key))
@@ -436,7 +436,7 @@ class Api2Test < UnitTestCase
     assert_equal(email_count, ActionMailer::Base.deliveries.size)
   end
 
-  def test_posting_api_key_for_another_user
+  def test_posting_api_key_for_another_user_without_password
     email_count = ActionMailer::Base.deliveries.size
     @for_user = katrina
     @app = "  Mushroom  Mapper  "
@@ -449,7 +449,7 @@ class Api2Test < UnitTestCase
       for_user: @for_user.id
     }
     api = API2.execute(params)
-    assert_no_errors(api, "Errors while posting image")
+    assert_no_errors(api, "Errors while posting api key")
     assert_obj_list_equal([ApiKey.last], api.results)
     assert_last_api_key_correct
     assert_api_fail(params.remove(:api_key))
@@ -457,6 +457,27 @@ class Api2Test < UnitTestCase
     assert_api_fail(params.merge(app: ""))
     assert_api_fail(params.merge(for_user: 123_456))
     assert_equal(email_count + 1, ActionMailer::Base.deliveries.size)
+  end
+
+  def test_posting_api_key_for_another_user_with_password
+    email_count = ActionMailer::Base.deliveries.size
+    @for_user = katrina
+    @app = "  Mushroom  Mapper  "
+    @verified = true
+    params = {
+      method: :post,
+      action: :api_key,
+      api_key: @api_key.key,
+      app: @app,
+      for_user: @for_user.id,
+      password: "testpassword"
+    }
+    api = API2.execute(params)
+    assert_no_errors(api, "Errors while posting api key")
+    assert_obj_list_equal([ApiKey.last], api.results)
+    assert_last_api_key_correct
+    assert_api_fail(params.merge(password: "bogus"))
+    assert_equal(email_count, ActionMailer::Base.deliveries.size)
   end
 
   def test_patching_api_keys
@@ -3363,7 +3384,7 @@ class Api2Test < UnitTestCase
       password: "secret"
     }
     api = API2.execute(params)
-    assert_no_errors(api, "Errors while posting image")
+    assert_no_errors(api, "Errors while posting user")
     assert_obj_list_equal([User.last], api.results)
     assert_last_user_correct
     assert_api_fail(params)
@@ -3404,7 +3425,7 @@ class Api2Test < UnitTestCase
       create_key: @new_key
     }
     api = API2.execute(params)
-    assert_no_errors(api, "Errors while posting image")
+    assert_no_errors(api, "Errors while posting user")
     assert_obj_list_equal([User.last], api.results)
     assert_last_user_correct
     params[:login] = "miles"


### PR DESCRIPTION
In support of mobile app.

First draft, as discussed in general email, is simply to allow app to pass in the user's password when creating an API key.  If the password is correct, it verifies the API key immediately, and it functions -- so far as I can tell -- identically to a normal token.

We can discuss additional features, such as having API keys automatically expire after a certain amount of time.  And whether we want certain apps to be considered "trusted" and exactly what that means.  (At the moment, I can't think of anything a "trusted" app would be able to do that I'm not comfortable giving every app the ability to do!)

Consider this the opening of a dialog about implementation details...