### PR TITLE
Tweaks to API POST observation

### DIFF
--- a/app/views/api2/_user.json.builder
+++ b/app/views/api2/_user.json.builder
@@ -10,6 +10,8 @@ json.last_login(object.last_login.try(&:utc))
 json.last_activity(object.last_activity.try(&:utc))
 json.contribution(object.contribution) if object.contribution.present?
 json.notes(object.notes.to_s.tpl_nodiv) if object.notes.present?
+json.notes_template(object.notes_template_parts) \
+  if object.notes_template.present?
 json.mailing_address(object.mailing_address.to_s) \
   if object.mailing_address.present?
 if !detail

--- a/app/views/api2/_user.xml.builder
+++ b/app/views/api2/_user.xml.builder
@@ -14,6 +14,12 @@ xml.tag!(
   xml_datetime(xml, :last_activity, object.last_activity)
   xml_integer(xml, :contribution, object.contribution)
   xml_html_string(xml, :notes, object.notes.to_s.tpl_nodiv)
+  if object.notes_template.present?
+    fields = object.notes_template_parts
+    xml.tag!(:notes_template, length: fields.length) do
+      fields.each { |field| xml_string(xml, :field, field) }
+    end
+  end
   xml_string(xml, :mailing_address,
              object.mailing_address.to_s.tpl_nodiv.html_to_ascii)
   if !detail

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -224,6 +224,19 @@ class Api2Test < UnitTestCase
     assert_in_delta(Time.zone.now, naming.updated_at, 1.minute)
     assert_equal(1, naming.votes.length)
     assert_objs_equal(vote, naming.votes.first)
+    assert_last_reasons_correct(naming) if @reasons
+  end
+
+  def assert_last_reasons_correct(naming)
+    naming.get_reasons.each do |reason|
+      expect = @reasons[reason.num]
+      if expect.nil?
+        assert_false(reason.used?)
+      else
+        assert_true(reason.used?)
+        assert_equal(expect.to_s, reason.notes.to_s)
+      end
+    end
   end
 
   def assert_last_observation_correct
@@ -2322,6 +2335,12 @@ class Api2Test < UnitTestCase
       Stipe: "smooth",
       Other: "These are notes.\nThey look like this."
     }
+    @reasons = {
+      1 => "because I say",
+      2 => "",
+      3 => nil,
+      4 => "K+ paisley"
+    }
     @vote = 2.0
     @specimen = true
     @is_col_loc = true
@@ -2344,6 +2363,9 @@ class Api2Test < UnitTestCase
       altitude: "50m",
       has_specimen: "yes",
       name: "Coprinus comatus",
+      reason_1: @reasons[1],
+      reason_2: @reasons[2],
+      reason_4: @reasons[4],
       vote: "2",
       projects: @proj.id,
       species_lists: @spl.id,

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -3359,9 +3359,8 @@ class Api2Test < UnitTestCase
 
   def test_getting_users
     params = { method: :get, action: :user }
-    user = User.all.sample
-    assert_api_pass(params.merge(id: user.id))
-    assert_api_results([user])
+    assert_api_pass(params.merge(detail: :low))
+    assert_api_results(User.all)
   end
 
   def test_posting_minimal_user


### PR DESCRIPTION
Added ability to set naming reasons when POSTing observations.

Added user's custom notes_template to the output of GET users so that the mobile app can know which custom notes fields to provide.