### PR TITLE
Whitelist robots instead of blacklisting

### DIFF
--- a/script/refresh_sitemap
+++ b/script/refresh_sitemap
@@ -93,30 +93,32 @@ LOCALES = Language.connection.select_values(%(
 ))
 
 ROBOTS_HEADER = <<~"TXT"
+  # Control behavior of crowlers that follow robots.txt rules
   # For documentation, see:
   # https://developers.google.com/search/docs/advanced/robots/robots_txt
   # http://www.robotstxt.org
+
+  # Other ways for MO to block/control robots include:
+  # - Manually block ip address ranges at the firewall
+  # - Automatically block in Rails an anonymous user (including robots)
+  #   that's hogging the webserver. See script/update_ip_stats.rb
+  # - Automatically block in Rails a fake GoogleBot.
+  #    See script/update_googlebots.rb
+  # - Manually block in Rails an anonymous user via the Admin UI
+  # - Limit them via browser gem and #bot? method
+
   Sitemap: #{SITEMAP_URL.sub("NAME", "index")}
 
-  # Completely disallowed bots
-  User-agent: ltx71
-  User-agent: AdsBot-Google
-  User-agent: AhrefsBot
-  User-agent: Applebot
-  User-agent: DAUM
-  User-agent: MauiBot
-  User-agent: MJ12bot
-  User-agent: SpiderLing
-  User-agent: spbot
-  Disallow: /
-
   # Rules applying to some allowed bots
+  # Whitelist Common Crawler (used by WayBack Machine)
   User-agent: CCBot
   Crawl-Delay: 30
 
-  # Rules applying to all alloed bots
-  # (Note: the rest of #write_robots_file output follows this immeediately.)
-  User-agent: *
+  # Rules applying to all other allowed bots
+  # Whitelist Bing, Google, Facebook
+  User-agent: bingbot
+  User-agent: GoogleBot
+  User-agent: Facebot
   Crawl-Delay: 15
   Disallow: *page=*
   Disallow: *letter=*
@@ -128,6 +130,17 @@ ROBOTS_HEADER = <<~"TXT"
   Disallow: */lookup*user_locale=*
   Disallow: /*?*q= # block urls having the q parameter
   Disallow: /name/show_name
+
+  # (Note: the rest of #write_robots_file output follows this immeediately.)
+  # Completely block all robots that are not whitelisted above
+  User-agent: *
+  # Google AdBot crawlers must be named explicitly
+  # https://developers.google.com/search/docs/advanced/robots/create-robots-txt
+  User-agent: AdsBot-Google
+  User-agent: AdsBot-Google-Mobile
+  User-agent: AdsBot-Google-Mobile-Apps
+  Disallow: /
+
 TXT
 ROBOTS_FOOTER = <<"TXT"
 TXT


### PR DESCRIPTION
Block non-whitelisted robots that obey `robots.txt`.

Delivers https://www.pivotaltracker.com/story/show/179791971
See https://groups.google.com/g/mo-developers/c/qh3r9h5nXoU/m/oEgrj4IjAgAJ.