### PR TITLE
Oops, by "fixing" the API last week, I actually not only didn't fix anything...

### DIFF
--- a/app/views/api2/results.json.jbuilder
+++ b/app/views/api2/results.json.jbuilder
@@ -14,6 +14,8 @@ unless @api.errors.any?(&:fatal)
 
   if @api.detail == :none
     json.results(@api.result_ids)
+  elsif @api.results.empty?
+    json.results([])
   else
     type = @api.results.first.class.type_tag
     json.results(@api.results,

--- a/app/views/api2/results.xml.builder
+++ b/app/views/api2/results.xml.builder
@@ -14,12 +14,16 @@ xml.response(xmlns: "#{MO.http_domain}/response.xsd") do
       xml_integer(xml, :page_number, @api.page_number)
     end
 
-    xml.results(number: @api.result_ids.length) do
-      if @api.detail == :none
+    if @api.detail == :none
+      xml.results(number: @api.result_ids.length) do
         @api.result_ids.each do |result_id|
           xml_minimal_object(xml, :result, @api.model.type_tag, result_id)
         end
-      else
+      end
+    elsif @api.results.empty?
+      xml.results(number: 0) {}
+    else
+      xml.results(number: @api.results.length) do
         xml.target! << render(
           partial: @api.results.first.class.type_tag.to_s,
           collection: @api.results,

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -351,4 +351,11 @@ class Api2ControllerTest < FunctionalTestCase
     get(:observations, id: obs.id, detail: :high, format: :xml)
     assert_no_match(/34.1622|118.3521/, @response.body)
   end
+
+  def test_get_empty_results
+    get(:observations, date: "2100-01-01", format: :json, detail: :none)
+    get(:observations, date: "2100-01-01", format: :json, detail: :high)
+    get(:observations, date: "2100-01-01", format: :xml, detail: :none)
+    get(:observations, date: "2100-01-01", format: :xml, detail: :high)
+  end
 end


### PR DESCRIPTION
but I broke it in precisely the opposite way I was trying to fix it!  I'm fairly certain there's a Greek tragedy with this very plot somewhere...

Decoded: the change I made last week resulted in API2 rendering API1 results in JSON format (not XML format).  I've fixed this.

Additionally, I tried completely removing API1(!) and running the tests.  I figured that would once and for all remove all doubt about whether any API1 results were ever being rendered for API2.  We're safe now, I think. :)