### PR TITLE
Several small things

### DIFF
--- a/app/views/image/show_image.html.erb
+++ b/app/views/image/show_image.html.erb
@@ -131,7 +131,7 @@
               <tr>
                 <td>
                   <%= chgs[-1].updated_at.web_date %> &rarr;
-                  <%= @image.updated_at.web_date %>
+                  <%= Time.zone.now.web_date %>
                 </td>
                 <td>
                   <%= link_to(@image.license.display_name.t, @image.license.url) %>

--- a/db/clean.sql
+++ b/db/clean.sql
@@ -75,6 +75,7 @@ delete from queued_email_strings;
 delete from queued_emails;
 
 update users set email = 'webmaster@mushroomobserver.org';
+# Set all passwords to just "password".
 update users set password = 'ae98587c6f1599fbdcc800e66db6874a8fa0e713';
 
 update votes

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -21,6 +21,15 @@ marys_api_key:
   key: aSFGWQWER14kjhdfasd134k1dxASrfh
   notes: Doesn't get used very often.
 
+rolfs_mo_app_api_key:
+  created_at: 2021-02-09 01:23:45
+  verified: 2021-02-09 01:23:45
+  last_used: 2021-11-05 22:41:27
+  num_uses: 10
+  user: rolf
+  key: aSDfkljJsdfglkDJSwEarLKjkerADGl
+  notes: MO App
+
 # The next 3 fixtures are used to test whether sql collates accented letters.
 # Has nothing to do with APIs; This is just a convenient spot to add fixtures.
 api_key_u_1:

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -493,6 +493,33 @@ class Api2Test < UnitTestCase
     assert_equal(email_count, ActionMailer::Base.deliveries.size)
   end
 
+  def test_posting_api_key_where_key_already_exists
+    email_count = ActionMailer::Base.deliveries.size
+    api_key = api_keys(:rolfs_mo_app_api_key)
+    @for_user = rolf
+    @app = api_key.notes
+    @verified = true
+    params = {
+      method: :post,
+      action: :api_key,
+      api_key: @api_key.key,
+      app: @app,
+      for_user: @for_user.id,
+      password: "testpassword"
+    }
+    api = API2.execute(params)
+    assert_no_errors(api, "Errors while posting api key")
+    assert_obj_list_equal([api_key], api.results)
+    assert_api_fail(params.merge(password: "bogus"))
+    assert_equal(email_count, ActionMailer::Base.deliveries.size)
+
+    api_key.update(verified: nil)
+    assert_nil(api_key.reload.verified)
+    api = API2.execute(params)
+    assert_no_errors(api, "Errors while posting api key")
+    assert_not_nil(api_key.reload.verified)
+  end
+
   def test_patching_api_keys
     params = {
       method: :patch,


### PR DESCRIPTION
1. added comment to db/clean.sql to record what the password is for the stripped db snapshot
2. fixed bug in how image license history is displayed, in particular make sure the last date is "now"
3. fixed API2 POST api_keys to return the app's existing api_key for that user if one already exists (and if the password is provided and is correct)

Item 3 should address the proliferation of api keys for the MO app.  Each time we reinstall the app it has to get a new api key.  Might as well reuse the existing one if one exists.  No changes to the MO app should be required.  The request is the same, and it should return the api key just as before.  It just returns the existing one instead of a new one.