### PR TITLE
Make api accept upload from multipart form

### DIFF
--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -126,7 +126,7 @@ class API2
         upload_length: @upload.content_length,
         upload_type: @upload.content_type,
         upload_md5sum: @upload.content_md5
-      }
+      }.compact
     end
   end
 end

--- a/app/classes/api2/results.rb
+++ b/app/classes/api2/results.rb
@@ -47,7 +47,7 @@ class API2
   end
 
   def result_ids
-    @result_ids ||= query.paginate_ids(paginator)
+    @result_ids ||= query&.paginate_ids(paginator)
   end
 
   def num_results

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -90,7 +90,11 @@ class Api2Controller < ApplicationController
     args = params_to_api_args(type)
 
     if request.method == "POST"
-      args[:upload] = upload_api if upload_present?
+      if args[:upload].present?
+        args[:upload] = upload_from_multipart_form_data(args[:upload])
+      elsif is_request_body_an_upload?
+        args[:upload] = upload_from_request_body
+      end
       # Special exception to let caller who creates new user to see that user's
       # new API keys.  Otherwise there is no way to get that info via the API.
       @show_api_keys_for_new_user = true if type == :user
@@ -108,32 +112,25 @@ class Api2Controller < ApplicationController
     args
   end
 
-  def upload_present?
-    (upload_length.positive? &&
-     upload_type.present? &&
-     upload_type != "application/x-www-form-urlencoded" &&
-     upload_data.present?)
+  def upload_from_multipart_form_data(data)
+    API2::Upload.new(data: data)
   end
 
-  def upload_api
+  def is_request_body_an_upload?
+    (request.content_length.positive? &&
+     request.media_type.present? &&
+     request.media_type != "application/x-www-form-urlencoded" &&
+     request.media_type != "multipart/form-data" &&
+     request.body.present?)
+  end
+
+  def upload_from_request_body
     API2::Upload.new(
-      data: upload_data,
-      length: upload_length,
-      content_type: upload_type,
+      data: request.body,
+      length: request.content_length,
+      content_type: request.media_type,
       checksum: request.headers["CONTENT_MD5"].to_s
     )
-  end
-
-  def upload_length
-    request.content_length
-  end
-
-  def upload_type
-    request.media_type
-  end
-
-  def upload_data
-    request.body
   end
 
   def render_api_results(args)

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -92,6 +92,7 @@ class Api2Controller < ApplicationController
     if request.method == "POST"
       if args[:upload].present?
         args[:upload] = upload_from_multipart_form_data(args[:upload])
+        logger.warn("API UPLOAD: #{args[:upload].inspect}")
       elsif is_request_body_an_upload?
         args[:upload] = upload_from_request_body
       end

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -216,6 +216,18 @@ class Api2ControllerTest < FunctionalTestCase
     assert_obj_list_equal([], img.observations)
   end
 
+  def test_post_minimal_image_via_multipart_form_data
+    setup_image_dirs
+    count = Image.count
+    file = "#{::Rails.root}/test/images/sticky.jpg"
+    File.stub(:rename, false) do
+      post(:images, api_key: api_keys(:rolfs_api_key).key,
+                    upload: Rack::Test::UploadedFile.new(file, "image/jpeg"))
+    end
+    assert_no_api_errors
+    assert_equal(count + 1, Image.count)
+  end
+
   def test_post_maximal_image
     setup_image_dirs
     file = "#{::Rails.root}/test/images/Coprinus_comatus.jpg"


### PR DESCRIPTION
Before, the API would only accept an upload as the entire body of the request (any parameters would have to be encoded instead in the URL).  But these days people prefer to use multipart forms to pass in both parameters and one or more files.  Well, this only allows a single uploaded file (always as the parameter "upload"), but it's a start in the right direction.

Also, this PR cleans up the method names associated with uploads in the Api2 controller.  And it adds a temporary diagnostic to help Olivia troubleshoot how Rails is receiving her upload.