### PR TITLE
Update date gem per CVE-2021-41817

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 
 source("https://rubygems.org")
 
+# security fix for CVE-2021-41817 regex denial of service vulnerability
+gem("date", ">= 3.2.1")
+
 gem("sprockets")
 
 # To bundle edge Rails instead: gem "rails", github: "rails/rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    date (3.2.1)
     docile (1.4.0)
     erubi (1.10.0)
     execjs (2.7.0)
@@ -280,6 +281,7 @@ DEPENDENCIES
   capybara
   coffee-rails
   cure_acts_as_versioned!
+  date (>= 3.2.1)
   i18n
   jbuilder
   jquery-rails


### PR DESCRIPTION
Fixes regular expression denial of service vulnerability (ReDoS).
See [CVE-2021-41817: Regular Expression Denial of Service Vunlerability of Date Parsing Methods](https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/).