### PR TITLE
Display site banner on small screens

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
 <div id="main_container" class="container-fluid">
 
   <!--CALLOUT_BANNER-->
-  <div class="row hidden-xs hidden-print">
+  <div class="row hidden-print">
     <div class="col-xs-12">
       <% if in_admin_mode? %>
         <div class="Admin">


### PR DESCRIPTION
Stop hiding the banner on screens smaller than tablet, e.g., mobile phones
As a result mobile users (there are plenty of them) were not seeing important messages, e.g.:
- Don't click while waiting for page to load
- Donation appeal

### Manual Test
- Clear mushroomobserver cookies
- Open MO
- Use developer mode in your browser
- Try different screen sizes
