### PR TITLE
Nimmo rails db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,5 +161,5 @@ group :development do
   gem "web-console"
 
   # Use Rails DB to browse database at http://localhost:3000/rails/db/
-  gem "rails_db"
+  gem "rails_db", "2.2.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -161,5 +161,5 @@ group :development do
   gem "web-console"
 
   # Use Rails DB to browse database at http://localhost:3000/rails/db/
-  gem "rails_db", "2.2.1"
+  gem "rails_db", "~> 2.3.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -108,9 +108,6 @@ gem("rubyzip")
 # Use byebug as debugging gem
 gem("byebug", group: [:development, :test])
 
-# Calling `console` creates irb session in the browser (instead of the terminal)
-gem("web-console", group: :development)
-
 # Use built-in Ruby coverage to generate html coverage file
 gem("simplecov", require: false)
 # generate lcov file to send to Coveralls by Github Actions
@@ -155,4 +152,12 @@ group :test do
   # Stub and set expectations on HTTP requests in test mode
   # Allow selective disabling of internet
   gem "webmock"
+end
+
+group :development do
+  # Calling `console` creates irb session in the browser (instead of the terminal)
+  gem "web-console"
+
+  # Use Rails DB to browse database at http://localhost:3000/rails/db/
+  gem "rails_db"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ group :test do
 end
 
 group :development do
-  # Calling `console` creates irb session in the browser (instead of the terminal)
+  # Calling `console` creates irb session in the browser (instead of terminal)
   gem "web-console"
 
   # Use Rails DB to browse database at http://localhost:3000/rails/db/

--- a/Gemfile
+++ b/Gemfile
@@ -105,9 +105,6 @@ gem("rubyzip")
 
 ########## Development, Testing, and Analysis ##################################
 
-# Use byebug as debugging gem
-gem("byebug", group: [:development, :test])
-
 # Use built-in Ruby coverage to generate html coverage file
 gem("simplecov", require: false)
 # generate lcov file to send to Coveralls by Github Actions
@@ -130,6 +127,11 @@ gem("rubocop-rails")
 
 # use mry to support safe updating of .rubocop.yml
 gem("mry", require: false)
+
+group :test, :development do
+  # Use byebug as debugging gem
+  gem "byebug"
+end
 
 group :test do
   # Use capybara to simulate user-browser interaction

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,11 +195,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_db (2.2.1)
+    rails_db (2.3.1)
       activerecord
       kaminari
       rails (>= 5.0.0)
-      ransack
+      ransack (>= 2.3.2)
       simple_form (>= 5.0.1)
       terminal-table
     railties (5.2.6)
@@ -324,7 +324,7 @@ DEPENDENCIES
   mysql2
   rails (~> 5.2.2)
   rails-controller-testing
-  rails_db (= 2.2.1)
+  rails_db (~> 2.3.0)
   rtf
   rubocop (= 0.89)
   rubocop-performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,18 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-slick-rails (1.9.0)
       railties (>= 3.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     kgio (2.11.3)
     libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-linux)
@@ -183,6 +195,13 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_db (2.2.1)
+      activerecord
+      kaminari
+      rails (>= 5.0.0)
+      ransack
+      simple_form (>= 5.0.1)
+      terminal-table
     railties (5.2.6)
       actionpack (= 5.2.6)
       activesupport (= 5.2.6)
@@ -192,6 +211,10 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.3)
+    ransack (2.5.0)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     regexp_parser (1.7.1)
     rexml (3.2.5)
     rtf (0.3.3)
@@ -225,6 +248,9 @@ GEM
       tilt
     simple_enum (2.3.2)
       activesupport (>= 4.0.0)
+    simple_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -239,6 +265,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -296,6 +324,7 @@ DEPENDENCIES
   mysql2
   rails (~> 5.2.2)
   rails-controller-testing
+  rails_db (= 2.2.1)
   rtf
   rubocop (= 0.89)
   rubocop-performance
@@ -313,4 +342,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   2.2.27
+   2.2.29


### PR DESCRIPTION
This PR proposes adding Rails DB, a convenient browser interface for the working database. 
Allows you to check and query real data without command line while developing.

It does however install some dependencies, and these need to be reviewed.
kaminari
ransack
simple-form
terminal-table

If any of these these are a dealbreaker, i'm happy to drop the PR and just use it locally myself.

Also - How do gem dependencies work? If Rails DB is only loaded in the development environment, **are its dependencies also only loaded in development**?