### PR TITLE
Add Spring, spring-watcher-listen, and Listen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,6 +166,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the
   # background. Read more: https://github.com/rails/spring
   gem "spring", "~> 3.1.0"
+
   # Temporary: use a fork of spring-watcher-listen that allows using spring 3
   # https://github.com/rails/spring-watcher-listen/pull/26
   gem "spring-watcher-listen", github: "timdorr/spring-watcher-listen"

--- a/Gemfile
+++ b/Gemfile
@@ -162,4 +162,14 @@ group :development do
 
   # Use Rails DB to browse database at http://localhost:3000/rails/db/
   gem "rails_db", "~> 2.3.0"
+
+  # Spring speeds up development by keeping your application running in the
+  # background. Read more: https://github.com/rails/spring
+  gem "spring", "~> 3.1.0"
+  # Temporary: use a fork of spring-watcher-listen that allows using spring 3
+  # https://github.com/rails/spring-watcher-listen/pull/26
+  gem "spring-watcher-listen", github: "timdorr/spring-watcher-listen"
+
+  # Listen for file changes in development
+  gem "listen", ">= 3.0.5", "< 3.2"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -172,5 +172,5 @@ group :development do
   gem "spring-watcher-listen", github: "timdorr/spring-watcher-listen"
 
   # Listen for file changes in development
-  gem "listen", ">= 3.0.5", "< 3.2"
+  gem "listen", ">= 3.3.0", "< 4.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
     docile (1.4.0)
     erubi (1.10.0)
     execjs (2.7.0)
-    ffi (1.12.2)
+    ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -143,10 +143,9 @@ GEM
     kgio (2.11.3)
     libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-linux)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -251,7 +250,6 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
-    ruby_dep (1.5.0)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sassc (2.3.0)
@@ -331,7 +329,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-slick-rails
-  listen (>= 3.0.5, < 3.2)
+  listen (>= 3.3.0, < 4.0)
   mail (= 2.7.0)
   mimemagic
   mini_racer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
     cure_acts_as_versioned (0.6.3)
       activerecord (>= 3.0.9)
 
+GIT
+  remote: https://github.com/timdorr/spring-watcher-listen.git
+  revision: d61ae74ac8462aef863592eea0e417d3ca31d6af
+  specs:
+    spring-watcher-listen (2.0.1)
+      listen (>= 2.7, < 4.0)
+      spring (>= 1.2, < 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -135,6 +143,10 @@ GEM
     kgio (2.11.3)
     libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-linux)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -215,6 +227,9 @@ GEM
       activerecord (>= 5.2.4)
       activesupport (>= 5.2.4)
       i18n
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     regexp_parser (1.7.1)
     rexml (3.2.5)
     rtf (0.3.3)
@@ -236,6 +251,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
+    ruby_dep (1.5.0)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sassc (2.3.0)
@@ -258,6 +274,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.3)
+    spring (3.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -314,6 +331,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-slick-rails
+  listen (>= 3.0.5, < 3.2)
   mail (= 2.7.0)
   mimemagic
   mini_racer
@@ -334,6 +352,8 @@ DEPENDENCIES
   simple_enum
   simplecov
   simplecov-lcov
+  spring (~> 3.1.0)
+  spring-watcher-listen!
   sprockets
   uglifier
   unicorn (= 5.4.1)


### PR DESCRIPTION
Another development-only tool that i'm finding helpful. 

[Spring](https://github.com/rails/spring) is a Rails-maintained application preloader. _"It speeds up development by keeping your application running in the background, so you don't need to boot it every time you run a test, rake task or migration."_

[Listen](https://github.com/guard/listen) allows Spring to [work more efficiently](https://github.com/rails/spring#watching-files-and-directories) by sending it notifications of directory changes. It can also be used independently, but this PR does not implement it outside of Spring.

[spring-watcher-listen](https://github.com/rails/spring-watcher-listen/pull/26) connects the two.

Versions of all three locked to work with Rails 5.2 and each other.

Spring (v4) is, bundled and active by default in Rails 6 (this PR is for Spring v3, the last version that works with Rails 5). It's back to inactive by default in Rails 7 (because "computers are faster" they say), but it's still bundled with Rails 7 currently. 

If anyone objects for any reason, no problem. I'm open to using it local-only.