### PR TITLE
Restore expected rss_log messages without causing n+1 queries in RssLog#detail

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -762,6 +762,7 @@ class AbstractModel < ApplicationRecord
       result = rss_log
     else
       rss_log = RssLog.new
+      rss_log.created_at = created_at unless new_record?
       # Don't attach to object if about to destroy.
       if !orphan
         rss_log.send("#{type_tag}_id=", id) if id

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -379,10 +379,10 @@ class RssLog < AbstractModel
     end
     if !target_type
       :rss_destroyed.t(type: :object)
-    elsif !target ||
+    elsif !target_id ||
           tag.to_s.match?(/^log_#{target_type}_(merged|destroyed)/)
       :rss_destroyed.t(type: target_type)
-    elsif !time
+    elsif !time || time < created_at + 1.minute
       :rss_created_at.t(type: target_type)
     else
       tag.t(args)

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -459,7 +459,7 @@ class RssLog < AbstractModel
     !time || time < created_at + 1.minute
   end
 
-  def creation_message(tag, args, time)
+  def creation_message(tag, args)
     if [:observation, :species_list].include?(target_type)
       :rss_created_at.t(type: target_type) # user would be redundant
     else

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -372,14 +372,14 @@ class RssLog < AbstractModel
 
   # Figure out a message for most recent update.
   def detail
-    parse = parse_log
-    latest_tag, latest_args, latest_time = parse.first
+    log = parse_log
+    latest_tag, latest_args, latest_time = log.first
     if target_simply_destroyed?
       :rss_destroyed.t(type: :object)
     elsif target_combined?(latest_tag)
       :rss_destroyed.t(type: target_type)
     elsif target_recently_created?(latest_time)
-      creation_message(parse.first)
+      creation_message(log)
     else
       latest_tag.t(latest_args)
     end
@@ -459,10 +459,11 @@ class RssLog < AbstractModel
     !time || time < created_at + 1.minute
   end
 
-  def creation_message(tag, args)
+  def creation_message(log)
     if [:observation, :species_list].include?(target_type)
       :rss_created_at.t(type: target_type) # user would be redundant
     else
+      tag, args = log.last
       tag.t(args)
     end
   end

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -378,13 +378,10 @@ class RssLog < AbstractModel
       :rss_destroyed.t(type: :object)
     elsif target_combined?(latest_tag)
       :rss_destroyed.t(type: target_type)
-    elsif !target_recently_created?(latest_time)
-      latest_tag.t(latest_args)
-    elsif [:observation, :species_list].include?(target_type)
-      :rss_created_at.t(type: target_type) # user would be redundant
+    elsif target_recently_created?(latest_time)
+      creation_message(parse.first)
     else
-      first_tag, first_args, first_time = parse.last
-      first_tag.t(first_args)
+      latest_tag.t(latest_args)
     end
   rescue StandardError
     ""
@@ -450,12 +447,6 @@ class RssLog < AbstractModel
 
   private
 
-  def number_of_objects_changed?(tag, time)
-    target_simply_destroyed? ||
-      target_combined?(tag) ||
-      target_recently_created?(time)
-  end
-
   def target_simply_destroyed?
     !target_type
   end
@@ -466,5 +457,13 @@ class RssLog < AbstractModel
 
   def target_recently_created?(time)
     !time || time < created_at + 1.minute
+  end
+
+  def creation_message(tag, args, time)
+    if [:observation, :species_list].include?(target_type)
+      :rss_created_at.t(type: target_type) # user would be redundant
+    else
+      tag.t(args)
+    end
   end
 end

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -118,6 +118,8 @@
 #  == Attributes
 #
 #  id::                 Locally unique numerical id, starting at 1.
+#  created_at::         Date/time log or object was created.
+#                       See AbstractModel#init_rss_log
 #  updated_at::         Date/time it was last updated.
 #  notes::              Log of changes.
 #  location::           Owning Location (or nil).
@@ -149,8 +151,6 @@
 #
 #  None.
 #
-################################################################################
-
 class RssLog < AbstractModel
   belongs_to :location
   belongs_to :name
@@ -315,7 +315,7 @@ class RssLog < AbstractModel
                           relevant_args(args),
                           args[:time] || Time.zone.now)
     RssLog.record_timestamps = false if args.key?(:touch) && !args[:touch]
-    self.notes = entry + "\n" + notes.to_s
+    self.notes = "#{entry}\n#{notes}"
     # self.updated_at = args[:time] if args[:touch]
     save_without_our_callbacks unless args.key?(:save) && !args[:save]
     RssLog.record_timestamps = true
@@ -340,7 +340,7 @@ class RssLog < AbstractModel
   def orphan(title, key, args = {})
     args = args.merge(save: false)
     add_with_date(key, args)
-    self.notes = RssLog.escape(title) + "\n" + notes.to_s
+    self.notes = "#{RssLog.escape(title)}\n#{notes}"
     save_without_our_callbacks
   end
 
@@ -354,7 +354,7 @@ class RssLog < AbstractModel
   def parse_log(cutoff_time = nil)
     first = true
     results = []
-    for line in notes.to_s.split("\n")
+    notes.to_s.split("\n").each do |line|
       if first && !line.match(/^\d{14}/)
         tag  = :log_orphan
         args = { title: self.class.unescape(line) }
@@ -377,15 +377,14 @@ class RssLog < AbstractModel
     rescue StandardError
       []
     end
-    if !target_type
+    return tag.t(args) unless number_of_objects_changed?(tag, time)
+
+    if target_simply_destroyed?
       :rss_destroyed.t(type: :object)
-    elsif !target_id ||
-          tag.to_s.match?(/^log_#{target_type}_(merged|destroyed)/)
+    elsif target_combined?(tag)
       :rss_destroyed.t(type: target_type)
-    elsif !time || time < created_at + 1.minute
-      :rss_created_at.t(type: target_type)
-    else
-      tag.t(args)
+    else # it must have been recently created
+      creation_detail(args)
     end
   end
 
@@ -443,5 +442,36 @@ class RssLog < AbstractModel
   # Reverse protection of special characters in string for log encoder/decoder.
   def self.unescape(str)
     str.to_s.gsub(/%(..)/) { Regexp.last_match(1).hex.chr }
+  end
+
+  #############################################################################
+
+  private
+
+  def number_of_objects_changed?(tag, time)
+    target_simply_destroyed? ||
+      target_combined?(tag) ||
+      target_recently_created?(time)
+  end
+
+  def target_simply_destroyed?
+    !target_type
+  end
+
+  def target_combined?(tag)
+    !target_id || tag.to_s.match?(/^log_#{target_type}_(merged|destroyed)/)
+  end
+
+  def target_recently_created?(time)
+    !time || time < created_at + 1.minute
+  end
+
+  def creation_detail(args)
+    if [:observation, :species_list].include?(target_type) ||
+       args[:user].blank?
+      :rss_created_at.t(type: target_type) # user would be redundant
+    else
+      "#{:rss_created_at.t(type: target_type)} by #{args[:user]}"
+    end
   end
 end

--- a/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
+++ b/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
@@ -1,5 +1,5 @@
 class AddCreatedAtToRssLogs < ActiveRecord::Migration[5.2]
   def change
-    add_column(:rss_logs, :created_at, :datetime, null: false)
+    add_column(:rss_logs, :created_at, :datetime)
   end
 end

--- a/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
+++ b/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
@@ -1,0 +1,11 @@
+class AddCreatedAtToRssLogs < ActiveRecord::Migration[5.2]
+
+  def up
+    add_column :rss_logs, :created_at, :datetime
+  end
+
+  def down
+    remove_column :rss_logs, :created_at
+  end
+
+end

--- a/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
+++ b/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
@@ -1,11 +1,5 @@
 class AddCreatedAtToRssLogs < ActiveRecord::Migration[5.2]
-
-  def up
-    add_column :rss_logs, :created_at, :datetime
+  def change
+    add_column(:rss_logs, :created_at, :datetime, null: false)
   end
-
-  def down
-    remove_column :rss_logs, :created_at
-  end
-
 end

--- a/db/migrate/20220128202651_change_column_null_rss_logs_created_at.rb
+++ b/db/migrate/20220128202651_change_column_null_rss_logs_created_at.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNullRssLogsCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null(:rss_logs, :created_at, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_17_194852) do
+ActiveRecord::Schema.define(version: 2022_01_26_211212) do
 
   create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at"
@@ -565,6 +565,7 @@ ActiveRecord::Schema.define(version: 2021_04_17_194852) do
     t.integer "project_id"
     t.integer "glossary_term_id"
     t.integer "article_id"
+    t.datetime "created_at"
   end
 
   create_table "sequences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_211212) do
+ActiveRecord::Schema.define(version: 2022_01_28_202651) do
 
   create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at"
@@ -565,7 +565,7 @@ ActiveRecord::Schema.define(version: 2022_01_26_211212) do
     t.integer "project_id"
     t.integer "glossary_term_id"
     t.integer "article_id"
-    t.datetime "created_at"
+    t.datetime "created_at", null: false
   end
 
   create_table "sequences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -11,49 +11,59 @@
 observation_rss_log:
   observation: detailed_unknown_obs
   updated_at: 2006-03-02 21:14:00
-  notes: "20090722075918 log_observation_created user ignatz"
+  created_at: 2006-03-02 21:13:05
+  notes: "20060302211400 log_image_created user ignatz\n20060302211305 log_observation_created user ignatz"
 
 imged_unvouchered_obs_rss_log:
   observation: imged_unvouchered_obs
   updated_at: 2005-03-02 21:14:00
+  created_at: 2005-03-01 15:25:02
   notes: "Updated Observation & Notes"
 
 locally_sequenced_obs_rss_log:
   observation: locally_sequenced_obs
-  updated_at:  2004-03-02 20:14:02
-  notes:       ""
+  updated_at: 2004-03-02 20:14:02
+  created_at: 2004-03-02 20:13:05
+  notes: ""
 
 species_list_rss_log:
   species_list: first_species_list
   updated_at: 2006-03-02 21:14:02
+  created_at: 2006-03-02 21:13:05
   notes: "Updated Species List"
 
 name_rss_log:
   name: fungi
   updated_at: 2006-03-02 21:14:03
+  created_at: 2006-03-02 21:13:05
   notes: "Updated Name"
 
 location_rss_log:
   location: mitrula_marsh
   updated_at: 2006-03-02 21:14:09
+  created_at: 2006-03-01 15:25:02
   notes: "Updated Location"
 
 albion_rss_log:
   location: albion
   updated_at: 2007-12-27 06:41:20
+  created_at: 2006-03-01 15:25:02
   notes: "Updated Created"
 
 glossary_term_rss_log:
   glossary_term: conic_glossary_term
   updated_at: 2013-09-01 12:49:30
+  created_at: 2010-09-01 15:25:02
   notes: "Updated Glossary Term"
 
 project_rss_log:
   project: two_list_project
   updated_at: 2016-08-08 12:00:00
+  created_at: 2016-08-07 15:25:02
   notes: "Updated Project"
 
 article_rss_log:
   article: premier_article
   updated_at: 2016-08-08 12:00:01
+  created_at: 2016-08-08 08:25:02
   notes: "Updated Article"

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -30,8 +30,9 @@ class RssLogTest < UnitTestCase
     log = rss_logs(:observation_rss_log)
     detail = log.detail
     log_decode = RssLog.decode(log.notes)
-    assert_equal(:log_observation_created.t(user: "ignatz"), detail)
-    assert_equal(Time.parse("20090722075918").in_time_zone, log_decode[2])
+    assert_equal(:rss_created_at.t(type: :observation), detail)
+    # Check that it's still getting the most recent updated time
+    assert_equal(Time.parse("20060302211400").in_time_zone, log_decode[2])
   end
 
   # ---------- helpers ---------------------------------------------------------


### PR DESCRIPTION
In models/rss_log.rb#detail, restores check: If the most recent message is within one minute of target.created_at time, just print the "Object Created" message.

This PR should fix issue #830