### PR TITLE
Create 20220126211212_add_created_at_to_rss_logs.rb

### DIFF
--- a/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
+++ b/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
@@ -1,0 +1,12 @@
+class AddCreatedAtToRssLogs < ActiveRecord::Migration[5.2]
+
+  def up
+    add_column :rss_logs, :created_at, :datetime
+    change_column_null :rss_logs, :created_at, false
+  end
+
+  def down
+    remove_column :rss_logs, :created_at
+  end
+
+end

--- a/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
+++ b/db/migrate/20220126211212_add_created_at_to_rss_logs.rb
@@ -2,7 +2,6 @@ class AddCreatedAtToRssLogs < ActiveRecord::Migration[5.2]
 
   def up
     add_column :rss_logs, :created_at, :datetime
-    change_column_null :rss_logs, :created_at, false
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_17_194852) do
+ActiveRecord::Schema.define(version: 2022_01_26_211212) do
 
   create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at"
@@ -565,6 +565,7 @@ ActiveRecord::Schema.define(version: 2021_04_17_194852) do
     t.integer "project_id"
     t.integer "glossary_term_id"
     t.integer "article_id"
+    t.datetime "created_at"
   end
 
   create_table "sequences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|


### PR DESCRIPTION
Note: This migration doesn't seem to work yet. When i run `rake db:migrate` for the simple migration i get

Mysql2::Error: Duplicate column name 'created_at': ALTER TABLE `rss_logs` ADD `created_at` datetime

Here’s my migration:
```ruby
class AddCreatedAtToRssLogs < ActiveRecord::Migration[5.2]

  def up
    add_column :rss_logs, :created_at, :datetime
    change_column_null :rss_logs, :created_at, false
  end

  def down
    remove_column :rss_logs, :created_at
  end

end
```