### PR TITLE
Changed RssLog#target_simply_deleted? to be a more generally useful R…

### DIFF
--- a/app/classes/api/image_api.rb
+++ b/app/classes/api/image_api.rb
@@ -96,14 +96,14 @@ class API
 
     def after_create(img)
       strip = @observations.any?(&:gps_hidden)
-      img.process_image(strip) || raise(ImageUploadFailed.new(img))
+      img.process_image(strip: strip) || raise(ImageUploadFailed.new(img))
       @observations.each do |obs|
         obs.update(thumb_image_id: img.id) unless obs.thumb_image_id
-        obs.log_create_image(img)
+        img.log_create_for(obs)
       end
       return unless @vote
 
-      img.change_vote(@user, @vote, (@user.votes_anonymous == :yes))
+      img.change_vote(@user, @vote, anon: @user.votes_anonymous == :yes)
     end
 
     ############################################################################

--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -95,14 +95,14 @@ class API2
 
     def after_create(img)
       strip = @observations.any?(&:gps_hidden)
-      img.process_image(strip) || raise(ImageUploadFailed.new(img))
+      img.process_image(strip: strip) || raise(ImageUploadFailed.new(img))
       @observations.each do |obs|
         obs.update(thumb_image_id: img.id) unless obs.thumb_image_id
-        obs.log_create_image(img)
+        img.log_create_for(obs)
       end
       return unless @vote
 
-      img.change_vote(@user, @vote, (@user.votes_anonymous == :yes))
+      img.change_vote(@user, @vote, anon: @user.votes_anonymous == :yes)
     end
 
     ############################################################################

--- a/app/controllers/ajax_controller/vote.rb
+++ b/app/controllers/ajax_controller/vote.rb
@@ -9,9 +9,10 @@ class AjaxController
   # value:: Value of vote.
   def vote
     @user = session_user!
-    if @type == "naming"
+    case @type
+    when "naming"
       cast_naming_vote(@id, @value)
-    elsif @type == "image"
+    when "image"
       cast_image_vote(@id, @value)
     end
   end
@@ -40,7 +41,7 @@ class AjaxController
 
     value = value == "0" ? nil : Image.validate_vote(value)
     anon = (@user.votes_anonymous == :yes)
-    image.change_vote(@user, value, anon)
+    image.change_vote(@user, value, anon: anon)
     render(partial: "image/image_vote_links", locals: { image: image })
   end
 end

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -158,16 +158,14 @@ class ImageController < ApplicationController
     @links << coerced_query_link(query, Observation)
 
     # Paginate by letter if sorting by user.
-    if (query.params[:by] == "user") ||
-       (query.params[:by] == "reverse_user")
+    case query.params[:by]
+    when "user", "reverse_user"
       args[:letters] = "users.login"
     # Paginate by letter if sorting by copyright holder.
-    elsif (query.params[:by] == "copyright_holder") ||
-          (query.params[:by] == "reverse_copyright_holder")
+    when "copyright_holder", "reverse_copyright_holder"
       args[:letters] = "images.copyright_holder"
     # Paginate by letter if sorting by name.
-    elsif (query.params[:by] == "name") ||
-          (query.params[:by] == "reverse_name")
+    when "name", "reverse_name"
       args[:letters] = "names.sort_name"
     end
 
@@ -226,7 +224,7 @@ class ImageController < ApplicationController
       cur = @image.users_vote
       if cur != val
         anon = @user.votes_anonymous == :yes
-        @image.change_vote(@user, val, anon)
+        @image.change_vote(@user, val, anon: anon)
       end
 
       # Advance to next image automatically if "next" parameter set.
@@ -344,14 +342,14 @@ class ImageController < ApplicationController
     @image.original_name = "" if @user.keep_filenames == :toss
     return flash_object_errors(@image) unless @image.save
 
-    if !@image.process_image(@observation.gps_hidden)
+    if !@image.process_image(strip: @observation.gps_hidden)
       name = @image.original_name
       name = "???" if name.empty?
       flash_error(:runtime_image_invalid_image.t(name: name))
       flash_object_errors(@image)
     else
       @observation.add_image(@image)
-      @observation.log_create_image(@image)
+      @image.log_create_for(@observation)
       name = @image.original_name
       name = "##{@image.id}" if name.empty?
       flash_notice(:runtime_image_uploaded_image.t(name: name))
@@ -531,7 +529,7 @@ class ImageController < ApplicationController
       flash_error(:runtime_image_remove_missing.t(id: @image.id))
     else
       @observation.remove_image(@image)
-      @observation.log_remove_image(@image)
+      @image.log_remove_from(@observation)
       flash_notice(:runtime_image_remove_success.t(id: @image.id))
     end
     redirect_with_query(controller: "observer",
@@ -567,7 +565,7 @@ class ImageController < ApplicationController
     if image &&
        @object.add_image(image) &&
        @object.save
-      @object.log_reuse_image(image)
+      image.log_reuse_for(@object)
       redirect_with_query(glossary_term_path(@object.id))
     else
       flash_error(:runtime_no_save.t(:glossary_term)) if image
@@ -616,7 +614,7 @@ class ImageController < ApplicationController
       elsif @mode == :observation
         # Add image to observation.
         @observation.add_image(image)
-        @observation.log_reuse_image(image)
+        image.log_reuse_for(@observation)
         if @observation.gps_hidden
           error = image.strip_gps!
           flash_error(:runtime_failed_to_strip_gps.t(msg: error)) if error
@@ -677,7 +675,7 @@ class ImageController < ApplicationController
           next unless (image = Image.safe_find(image_id))
 
           @object.remove_image(image)
-          @object.log_remove_image(image)
+          image.log_remove_from(@object)
           flash_notice(:runtime_image_remove_success.t(id: image_id))
         end
         redirect_with_query(controller: target_class.show_controller,
@@ -700,13 +698,14 @@ class ImageController < ApplicationController
     return unless image
 
     if check_permission!(image)
-      if params[:op] == "rotate_left"
+      case params[:op]
+      when "rotate_left"
         image.transform(:rotate_left)
         flash_notice(:image_show_transform_note.t)
-      elsif params[:op] == "rotate_right"
+      when "rotate_right"
         image.transform(:rotate_right)
         flash_notice(:image_show_transform_note.t)
-      elsif params[:op] == "mirror"
+      when "mirror"
         image.transform(:mirror)
         flash_notice(:image_show_transform_note.t)
       else

--- a/app/controllers/observer_controller/create_and_edit_observation.rb
+++ b/app/controllers/observer_controller/create_and_edit_observation.rb
@@ -650,7 +650,7 @@ class ObserverController
           if !image.save
             bad_images.push(image)
             flash_object_errors(image)
-          elsif !image.process_image(observation.gps_hidden)
+          elsif !image.process_image(strip: observation.gps_hidden)
             name_str = name ? "'#{name}'" : "##{image.id}"
             flash_notice(:runtime_no_upload_image.t(name: name_str))
             bad_images.push(image)
@@ -717,7 +717,7 @@ class ObserverController
     images.each do |image|
       unless observation.image_ids.include?(image.id)
         observation.add_image(image)
-        observation.log_create_image(image)
+        image.log_create_for(observation)
       end
     end
   end

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -662,7 +662,6 @@ class AbstractModel < ApplicationRecord
     touch unless new_record? || # rubocop:disable Rails/SkipsModelValidations
                  args[:touch] == false
     rss_log.add_with_date(tag, args)
-    rss_log
   end
 
   # Add message to RssLog if you're about to destroy this object, creating new
@@ -674,7 +673,6 @@ class AbstractModel < ApplicationRecord
   def orphan_log(*args)
     rss_log = init_rss_log(orphan: true)
     rss_log.orphan(format_name, *args)
-    rss_log
   end
 
   # Callback that logs creation.
@@ -689,10 +687,7 @@ class AbstractModel < ApplicationRecord
 
   # Callback that logs destruction.
   def autolog_destroyed
-    return unless rss_log = autolog_event(:destroyed, orphan: true)
-
-    rss_log.send("#{type_tag}_id=", nil)
-    rss_log.save
+    autolog_event(:destroyed, orphan: true)
   end
 
   # Do we log this event? and how?

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -688,6 +688,8 @@ class AbstractModel < ApplicationRecord
   # Callback that logs destruction.
   def autolog_destroyed
     autolog_event(:destroyed, orphan: true)
+    rss_log.send("#{type_tag}_id=", nil)
+    rss_log.save
   end
 
   # Do we log this event? and how?
@@ -721,10 +723,9 @@ class AbstractModel < ApplicationRecord
     rss_log
   end
 
+  # Point object to its new RssLog and save the object unless we are sure
+  # it will be saved later.
   def attach_rss_log_first_step(rss_log)
-
-    # Point object to its new rss_log and save the object unless we are sure
-    # it will be saved later.
     will_save_later = new_record? || changed?
     self.rss_log_id = rss_log.id
     self.rss_log    = rss_log

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -662,6 +662,7 @@ class AbstractModel < ApplicationRecord
     touch unless new_record? || # rubocop:disable Rails/SkipsModelValidations
                  args[:touch] == false
     rss_log.add_with_date(tag, args)
+    rss_log
   end
 
   # Add message to RssLog if you're about to destroy this object, creating new
@@ -673,6 +674,7 @@ class AbstractModel < ApplicationRecord
   def orphan_log(*args)
     rss_log = init_rss_log(orphan: true)
     rss_log.orphan(format_name, *args)
+    rss_log
   end
 
   # Callback that logs creation.
@@ -687,7 +689,8 @@ class AbstractModel < ApplicationRecord
 
   # Callback that logs destruction.
   def autolog_destroyed
-    autolog_event(:destroyed, orphan: true)
+    return unless rss_log = autolog_event(:destroyed, orphan: true)
+
     rss_log.send("#{type_tag}_id=", nil)
     rss_log.save
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -908,14 +908,14 @@ class Image < AbstractModel
 
   # Log update in associated observations, glossary terms, etc.
   def log_update
-    [glossary_terms + observations].each do |object|
+    (glossary_terms + observations).each do |object|
       object.log(:log_image_updated, name: log_name, touch: false)
     end
   end
 
   # Log destruction in associated observations, glossary terms, etc.
   def log_destroy
-    [glossary_terms + observations].each do |object|
+    (glossary_terms + observations).each do |object|
       object.log(:log_image_destroyed, name: log_name, touch: true)
     end
   end

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -389,7 +389,7 @@ class RssLog < AbstractModel
 
   # Has target been destroyed (orphaning this log)?
   def orphan?
-    !target_type || notes !~ /^\d{14}/
+    !target_type || !notes.match?(/\A\d{14}/)
   end
 
   ##############################################################################

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -374,7 +374,7 @@ class RssLog < AbstractModel
   def detail
     log = parse_log
     latest_tag, latest_args, latest_time = log.first
-    if target_simply_destroyed?
+    if orphan?
       :rss_destroyed.t(type: :object)
     elsif target_combined?(latest_tag)
       :rss_destroyed.t(type: target_type)
@@ -385,6 +385,11 @@ class RssLog < AbstractModel
     end
   rescue StandardError
     ""
+  end
+
+  # Has target been destroyed (orphaning this log)?
+  def orphan?
+    !target_type || notes !~ /^\d{14}/
   end
 
   ##############################################################################
@@ -446,10 +451,6 @@ class RssLog < AbstractModel
   #############################################################################
 
   private
-
-  def target_simply_destroyed?
-    !target_type
-  end
 
   def target_combined?(tag)
     !target_id || tag.to_s.match?(/^log_#{target_type}_(merged|destroyed)/)

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -439,7 +439,7 @@ class RssLog < AbstractModel
 
   # Protect special characters (whitespace) in string for log encoder/decoder.
   def escape(str)
-    str.to_s.gsub(/[%\s]/) { |m| "%%%02X" % m.ord }
+    str.to_s.gsub(/[%\s]/) { |m| format("%%%<code>02X", code: m.ord) }
   end
 
   # Reverse protection of special characters in string for log encoder/decoder.

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -194,6 +194,13 @@ class RssLog < AbstractModel
     nil
   end
 
+  # Clear association with target.
+  def clear_target_id
+    RssLog.all_types.each do |type|
+      send("#{type}_id=", nil)
+    end
+  end
+
   # Handy for prev/next handler.  Any object that responds to rss_log has an
   # attached RssLog.  In this case, it *is* the RssLog itself, meaning it is
   # an orphan log for a deleted object.
@@ -309,6 +316,7 @@ class RssLog < AbstractModel
     args = args.merge(save: false)
     add_with_date(key, args)
     self.notes = "#{escape(title)}\n#{notes}"
+    clear_target_id
     save_without_our_callbacks
   end
 

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -143,32 +143,33 @@ class Sequence < AbstractModel
   end
 
   ##############################################################################
-
-  protected
-
-  ##############################################################################
   #
   #  :section: Logging
   #
   ##############################################################################
 
-  # Callbacks to log Sequence modifications in associated Observation
+  protected
 
   def log_add_sequence
-    observation.log_add_sequence(self)
+    observation.log(:log_sequence_added, name: log_name, touch: true)
   end
 
   def log_update_sequence
     if accession_added?
-      # Log accession and put at top of RSS feed
-      observation.log_accession_sequence(self)
+      observation.log(:log_sequence_accessioned, name: log_name, touch: true)
     else
-      observation.log_update_sequence(self)
+      observation.log(:log_sequence_updated, name: log_name, touch: false)
     end
   end
 
   def log_destroy_sequence
-    observation.log_destroy_sequence(self)
+    observation.log(:log_sequence_destroyed, name: log_name, touch: true)
+  end
+
+  private
+
+  def log_name
+    "#{:SEQUENCE.t} ##{id || "?"}"
   end
 
   def accession_added?
@@ -188,6 +189,8 @@ class Sequence < AbstractModel
   #  :section: Validation
   #
   ##############################################################################
+
+  protected
 
   # Validations, in order that error messages should appear in flash
   validates :locus, :observation, :user, presence: true

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -464,9 +464,8 @@ class ImageControllerTest < FunctionalTestCase
     assert(obs.reload.rss_log)
     assert(obs.rss_log.notes.include?("log_image_updated"))
     assert(obs.rss_log.notes.include?("user #{obs.user.login}"))
-    image_num = RssLog.escape("Image ##{image.id}")
     assert(
-      obs.rss_log.notes.include?("name #{image_num}")
+      obs.rss_log.notes.include?("name Image%20##{image.id}")
     )
     assert_equal(new_name, image.reload.original_name)
   end
@@ -748,10 +747,10 @@ class ImageControllerTest < FunctionalTestCase
   def test_bulk_image_vote_anonymity_thingy
     img1 = images(:in_situ_image)
     img2 = images(:commercial_inquiry_image)
-    img1.change_vote(mary, 1, false)
-    img2.change_vote(mary, 2, true)
-    img1.change_vote(rolf, 3, true)
-    img2.change_vote(rolf, 4, false)
+    img1.change_vote(mary, 1, anon: false)
+    img2.change_vote(mary, 2, anon: true)
+    img1.change_vote(rolf, 3, anon: true)
+    img2.change_vote(rolf, 4, anon: false)
 
     assert_not(ImageVote.find_by(image_id: img1.id, user_id: mary.id).anonymous)
     assert(ImageVote.find_by(image_id: img2.id, user_id: mary.id).anonymous)

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -12,58 +12,58 @@ observation_rss_log:
   observation: detailed_unknown_obs
   updated_at: 2006-03-02 21:14:00
   created_at: 2006-03-02 21:13:05
-  notes: "20060302211400 log_image_created user ignatz\n20060302211305 log_observation_created user ignatz"
+  notes: "20060302211400 log_image_created user mary\n20060302211305 log_observation_created user mary"
 
 imged_unvouchered_obs_rss_log:
   observation: imged_unvouchered_obs
   updated_at: 2005-03-02 21:14:00
   created_at: 2005-03-01 15:25:02
-  notes: "Updated Observation & Notes"
+  notes: "20050301152502 log_observation_created user dick\n"
 
 locally_sequenced_obs_rss_log:
   observation: locally_sequenced_obs
   updated_at: 2004-03-02 20:14:02
   created_at: 2004-03-02 20:13:05
-  notes: ""
+  notes: "20040302201305 log_observation_created user dick\n"
 
 species_list_rss_log:
   species_list: first_species_list
   updated_at: 2006-03-02 21:14:02
   created_at: 2006-03-02 21:13:05
-  notes: "Updated Species List"
+  notes: "20060302211305 log_species_list_created user rolf\n"
 
 name_rss_log:
   name: fungi
   updated_at: 2006-03-02 21:14:03
   created_at: 2006-03-02 21:13:05
-  notes: "Updated Name"
+  notes: "20060302211305 log_name_created user rolf\n"
 
 location_rss_log:
   location: mitrula_marsh
   updated_at: 2006-03-02 21:14:09
   created_at: 2006-03-01 15:25:02
-  notes: "Updated Location"
+  notes: "20060301152502 log_location_created user rolf\n"
 
 albion_rss_log:
   location: albion
   updated_at: 2007-12-27 06:41:20
   created_at: 2006-03-01 15:25:02
-  notes: "Updated Created"
+  notes: "20060301152502 log_location_created user rolf\n"
 
 glossary_term_rss_log:
   glossary_term: conic_glossary_term
   updated_at: 2013-09-01 12:49:30
   created_at: 2010-09-01 15:25:02
-  notes: "Updated Glossary Term"
+  notes: "20100901152502 log_glossary_term_created user rolf\n"
 
 project_rss_log:
   project: two_list_project
   updated_at: 2016-08-08 12:00:00
   created_at: 2016-08-07 15:25:02
-  notes: "Updated Project"
+  notes: "20160807152502 log_project_created user mary\n"
 
 article_rss_log:
   article: premier_article
   updated_at: 2016-08-08 12:00:01
   created_at: 2016-08-08 08:25:02
-  notes: "Updated Article"
+  notes: "20160808082502 log_article_created user rolf\n"

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -207,7 +207,7 @@ class AbstractModelTest < UnitTestCase
     assert_rss_log_has_tag(:log_location_merged, rss_log)
     assert(rss_log.updated_at > time)
     assert_nil(Location.safe_find(loc_id))
-    assert_equal(:location, rss_log.target_type)
+    assert_nil(rss_log.target_type)
   end
 
   def test_name_rss_log_life_cycle
@@ -254,7 +254,7 @@ class AbstractModelTest < UnitTestCase
     assert_rss_log_has_tag(:log_name_merged, rss_log)
     assert(rss_log.updated_at > time)
     assert_nil(Name.safe_find(name_id))
-    assert_equal(:name, rss_log.target_type)
+    assert_nil(rss_log.target_type)
   end
 
   def test_observation_rss_log_life_cycle
@@ -301,7 +301,7 @@ class AbstractModelTest < UnitTestCase
     assert_rss_log_has_tag(:log_observation_destroyed, rss_log)
     # assert_in_delta(time, rss_log.updated_at, 1.second)
     assert_nil(Observation.safe_find(obs_id))
-    assert_equal(:observation, rss_log.target_type)
+    assert_nil(rss_log.target_type)
   end
 
   def test_project_rss_log_life_cycle
@@ -353,7 +353,7 @@ class AbstractModelTest < UnitTestCase
     assert_rss_log_has_tag(:log_project_destroyed, rss_log)
     assert(proj.rss_log.updated_at > time)
     assert_nil(Project.safe_find(proj_id))
-    assert_equal(:project, rss_log.target_type)
+    assert_nil(rss_log.target_type)
   end
 
   def test_species_list_rss_log_life_cycle
@@ -394,7 +394,7 @@ class AbstractModelTest < UnitTestCase
     assert_rss_log_lines(5, rss_log)
     assert_rss_log_has_tag(:log_species_list_destroyed, rss_log)
     assert_nil(SpeciesList.safe_find(spl_id))
-    assert_equal(:species_list, rss_log.target_type)
+    assert_nil(rss_log.target_type)
   end
 
   # -------------------------------------------------------------------

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -18,20 +18,20 @@ class ImageTest < UnitTestCase
     assert_nil(img.users_vote(rolf))
     assert_false(img.image_votes.first.anonymous)
 
-    img.change_vote(rolf, 4, :anon)
+    img.change_vote(rolf, 4, anon: true)
     assert_equal(2, img.num_votes)
     assert_equal(3, img.vote_cache)
     assert_equal(2, img.users_vote(mary))
     assert_equal(4, img.users_vote(rolf))
 
-    img.change_vote(mary)
+    img.change_vote(mary, nil)
     assert_equal(1, img.num_votes)
     assert_equal(4, img.vote_cache)
     assert_equal(4, img.users_vote(rolf))
     assert_nil(img.users_vote(mary))
     assert_true(img.image_votes.first.anonymous)
 
-    img.change_vote(rolf)
+    img.change_vote(rolf, nil)
     assert_nil(img.users_vote(mary))
     assert_nil(img.users_vote(rolf))
   end

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -19,20 +19,46 @@ class RssLogTest < UnitTestCase
 
   def test_orphan_title
     log = rss_logs(:location_rss_log)
-    assert_equal(log.notes, log.orphan_title)
-
-    # replace normal top line of log with yyyymmddhhmmss
-    log.notes = Time.zone.now.strftime("%Y%m%d%I%M%S")
+    # If log doesn't look orphaned, it should return generic "deleted item".
     assert_equal(:rss_log_of_deleted_item.l, log.orphan_title)
+
+    # When it is orphaned, it should put the target title in the first line
+    # of the log, and that's what orphan_title should return.
+    log.update(notes: "Target Title\n#{log.notes}")
+    assert_equal("Target Title", log.orphan_title)
   end
 
-  def test_details
+  def test_detail_for_complexly_created_observation
+    # Observation is created then an image is immediately uploaded.
+    # We want it to return "observation created" not "image added".
     log = rss_logs(:observation_rss_log)
     detail = log.detail
     log_decode = RssLog.decode(log.notes)
     assert_equal(:rss_created_at.t(type: :observation), detail)
     # Check that it's still getting the most recent updated time
     assert_equal(Time.parse("20060302211400").in_time_zone, log_decode[2])
+  end
+
+  def test_detail_for_destroyed_object
+    obs = observations(:detailed_unknown_obs)
+    log = obs.rss_log
+    assert_not_nil(log)
+    assert_false(log.orphan?)
+    obs.destroy!
+    log.reload
+    assert_true(log.orphan?)
+    assert_equal(:rss_destroyed.t(type: :object), log.detail)
+  end
+
+  def test_detail_for_merged_location
+    loc1 = locations(:albion)
+    loc2 = locations(:mitrula_marsh)
+    log = loc1.rss_log
+    assert_false(log.orphan?)
+    loc2.merge(loc1)
+    log.reload
+    assert_true(log.orphan?)
+    assert_equal(:rss_destroyed.t(type: :object), log.detail)
   end
 
   # ---------- helpers ---------------------------------------------------------

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -12,7 +12,7 @@ class RssLogTest < UnitTestCase
       rss_log = create_rss_log(type)
       id = rss_log.target_id
 
-      assert(rss_log.url.starts_with?("#{model(type).show_controller}/#{id}"),
+      assert(rss_log.url.include?("#{model(type).show_controller}/#{id}"),
              "rss_log.url incorrect for #{model(type)}")
     end
   end
@@ -33,10 +33,7 @@ class RssLogTest < UnitTestCase
     # We want it to return "observation created" not "image added".
     log = rss_logs(:observation_rss_log)
     detail = log.detail
-    log_decode = RssLog.decode(log.notes)
     assert_equal(:rss_created_at.t(type: :observation), detail)
-    # Check that it's still getting the most recent updated time
-    assert_equal(Time.parse("20060302211400").in_time_zone, log_decode[2])
   end
 
   def test_detail_for_destroyed_object


### PR DESCRIPTION
…ssLog#orphan? and fixed it to account for more pathological cases found in the wild of improperly-orphaned logs -- that is, orphaned logs that still point to a nonexistent target and for which target_type would mistakenly return non-nil.