### PR TITLE
Fix small bug that was creating a bunch of "ghost" rss_logs.

### DIFF
--- a/app/models/name/resolve.rb
+++ b/app/models/name/resolve.rb
@@ -158,8 +158,10 @@ class Name < AbstractModel
 
     log ||= :log_name_updated
     args = { touch: altered? }.merge(args)
+    return false unless save
+
     log(log, args)
-    save
+    true
   end
 
   # A common mistake is capitalizing the species epithet. If the second word

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -872,6 +872,29 @@ class NameControllerTest < FunctionalTestCase
     assert_equal(10, rolf.reload.contribution)
   end
 
+  def test_create_name_icn_already_used
+    old_name = names(:coprinus_comatus)
+    assert_true(old_name.icn_id.present?)
+    name_count = Name.count
+    rss_log_count = RssLog.count
+    params = {
+      name: {
+        icn_id: old_name.icn_id.to_s,
+        text_name: "Something else",
+        author: "(Thank You) Why Not",
+        rank: :Species,
+        citation: "I'll pass"
+      }
+    }
+    login("mary")
+    post(:create_name, params: params)
+    assert_response(:success)
+    assert_equal(name_count, Name.count,
+                 "Shouldn't have created #{Name.last.search_name.inspect}.")
+    assert_equal(rss_log_count, RssLog.count,
+                 "Shouldn't have created an RSS log! #{RssLog.last.inspect}.")
+  end
+
   def test_create_name_matching_multiple_names
     desired_name = names(:coprinellus_micaceus_no_author)
     text_name = desired_name.text_name


### PR DESCRIPTION
Name#save_with_log would log the action before checking that it could actually save the changes (or in this case, the new record).