### PR TITLE
Added scripts to check for and correct a few screwy cases in the database

### DIFF
--- a/script/check_for_orphaned_thumbnails
+++ b/script/check_for_orphaned_thumbnails
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -e
 source $(dirname "$0")/bash_include
+
 run_mysql "SELECT id, thumb_image_id, 'thumbnail image doesnt exist' \
            FROM observations WHERE \
            thumb_image_id IS NOT NULL AND \
            thumb_image_id NOT IN \
            (SELECT DISTINCT image_id FROM images_observations)" | grep -v thumb
+
+run_mysql "UPDATE observations SET thumb_image_id = NULL WHERE \
+           thumb_image_id IS NOT NULL AND \
+           thumb_image_id NOT IN \
+           (SELECT DISTINCT image_id FROM images_observations)"

--- a/script/check_for_orphaned_thumbnails
+++ b/script/check_for_orphaned_thumbnails
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+source $(dirname "$0")/bash_include
+run_mysql "SELECT id, thumb_image_id, 'thumbnail image doesnt exist' \
+           FROM observations WHERE \
+           thumb_image_id IS NOT NULL AND \
+           thumb_image_id NOT IN \
+           (SELECT DISTINCT image_id FROM images_observations)" | grep -v thumb

--- a/script/check_rss_logs
+++ b/script/check_rss_logs
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+source $(dirname "$0")/bash_include
+
+config_file=$app_root/config/mysql-$RAILS_ENV.cnf
+mysql="mysql --defaults-extra-file=$config_file -q -s"
+
+all_types="article glossary_term location name observation project \
+           species_list"
+
+for type in $all_types; do
+  types="$type"s
+  type_id="$type"_id
+
+
+
+  # echo orphans with $types...
+  cat <<EOB | $mysql
+    SELECT id, "orphan with $type", $type_id FROM rss_logs WHERE
+      notes NOT REGEXP '^[0-9]{14}' AND $type_id IS NOT NULL
+EOB
+
+  cat <<EOB | $mysql
+    UPDATE rss_logs SET $type_id = NULL WHERE
+      notes NOT REGEXP '^[0-9]{14}' AND $type_id IS NOT NULL
+EOB
+
+
+
+  # echo nonorphans with bogus $types...
+  cat <<EOB | $mysql
+    SELECT id, "nonorphan with bogus $type", $type_id FROM rss_logs WHERE
+      notes REGEXP '^[0-9]{14}' AND
+      $type_id IS NOT NULL AND
+      $type_id NOT IN (SELECT id FROM $types)
+EOB
+
+  cat <<EOB | $mysql
+    DELETE FROM rss_logs WHERE
+      notes REGEXP '^[0-9]{14}' AND
+      $type_id IS NOT NULL AND
+      $type_id NOT IN (SELECT id FROM $types)
+EOB
+
+done
+
+
+
+# echo ghosts...
+cat <<EOB | $mysql
+  SELECT id, "ghost" FROM rss_logs WHERE
+    notes REGEXP '^[0-9]{14}' AND
+    article_id IS NULL AND
+    glossary_term_id IS NULL AND
+    location_id IS NULL AND
+    name_id IS NULL AND
+    observation_id IS NULL AND
+    project_id IS NULL AND
+    species_list_id IS NULL
+EOB
+
+cat <<EOB | $mysql
+  DELETE FROM rss_logs WHERE
+    notes REGEXP '^[0-9]{14}' AND
+    article_id IS NULL AND
+    glossary_term_id IS NULL AND
+    location_id IS NULL AND
+    name_id IS NULL AND
+    observation_id IS NULL AND
+    project_id IS NULL AND
+    species_list_id IS NULL
+EOB
+
+
+
+exit 0


### PR DESCRIPTION
The latter has already been running on the server, and I think it's a good idea to make it official and keep it running.  Every so often, for reasons which are still not clear, observations end up with a nonexistent image declared as the thumbnail.  I think that will actually break things.  Right now it just reports the state, but it should probably clear observations.thumb_image_id for those cases to ensure at least that the site continues to run.  I'll do that in a minute...

The other script is meant to complement work done to clean up rss_logs in several other recent PRs.  There appear to be a whole host of reasons why rss_logs become messy:

1) Logs that have been orphaned but still point to the deleted object (which no longer exists!) was very common, but should no longer occur.  This script will simply null out the target id.

2) Logs that are not orphaned but point to nonexistent targets (surprisingly common among name logs, to the tune of 40,000 or so!); this seems pretty serious, and this script summarily deletes all of those logs.  One recent case proved to be a race condition from a name starting to get created but because of problems with the ICN number was unable to be created.  The stranded half-created log was totally superfluous and should be deleted.

3) logs that don't point to any target, but also don't have an orphan title.  Very rare, so I'm just going to summarily delete them.

Any reason not to delete the messed up logs in cases 2 and 3?  Without serious detective work there is probably no way to dig up what the original target was, and they're kinda useless without that data.