### PR TITLE
Update refresh_sitemap

### DIFF
--- a/script/refresh_sitemap
+++ b/script/refresh_sitemap
@@ -115,6 +115,9 @@ ROBOTS_HEADER = <<~"TXT"
   User-agent: AdsBot-Google
   User-agent: AdsBot-Google-Mobile
   User-agent: AdsBot-Google-Mobile-Apps
+  # This bot must be named explicity, else it follows GoogleBot rules
+  # https://developers.facebook.com/docs/sharing/bot/
+  User-agent: FacebookBot
   User-agent: Facebot # Unofficial Facebook bots (subset of facebookexternalhit)
   User-agent: * # Block everything else not whitelisted below
   Disallow: /
@@ -138,8 +141,8 @@ ROBOTS_HEADER = <<~"TXT"
   Disallow: /name/show_name
 
 TXT
-# The rest of #write_robots_file mjust follow immeediately
-# abd aookues to the group of whitelisted user agents immediatelyu above.
+# The rest of #write_robots_file must follow immediately
+# after the rules for whitelisted crawlers/user agents.
 ROBOTS_FOOTER = <<"TXT"
 TXT
 


### PR DESCRIPTION
- Block FacebookBot, an official bot for improving language models for Facebook's speech recognition technology. 
This bot must be blocked explicitly, else it uses Googlebot's rules.
- Fix weird typos

Delivers https://www.pivotaltracker.com/story/show/181237582