### PR TITLE
Fix column null migration

### DIFF
--- a/db/migrate/20220128202651_change_column_null_rss_logs_created_at.rb
+++ b/db/migrate/20220128202651_change_column_null_rss_logs_created_at.rb
@@ -1,5 +1,6 @@
 class ChangeColumnNullRssLogsCreatedAt < ActiveRecord::Migration[5.2]
   def change
-    change_column_null(:rss_logs, :created_at, false)
+    change_column_null(:rss_logs, :created_at, false, Time.now)
+    RssLog.update_all("created_at = updated_at")
   end
 end


### PR DESCRIPTION
Provide a default value when making created_at column non-null and then populate created_at based on existing updated_at data.