### PR TITLE
Fix test_observations_by_known_user

### DIFF
--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -278,6 +278,8 @@ class ObserverControllerTest < FunctionalTestCase
     assert_nil(obs.rss_log_id)
     assert_not_nil(obs.thumb_image_id)
     url = Image.url(:small, obs.thumb_image_id)
+    test_show_owner_id_noone_logged_in
+    login
     get(:observations_by_user, params: { id: rolf.id })
     assert_template(:list_observations)
     assert_match(url, @response.body)


### PR DESCRIPTION
This test was broken by the merger of PR #858
(Post merger, users must login in order to GET `observations_by_user`.)