### PR TITLE
Add bullet_helper

### DIFF
--- a/test/bullet_helper.rb
+++ b/test/bullet_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # helper to integrate bullet gem with minitest
 # from https://github.com/flyerhzm/bullet/issues/442
 # Include this helper in any test file where you want to use the gem

--- a/test/bullet_helper.rb
+++ b/test/bullet_helper.rb
@@ -1,0 +1,19 @@
+# helper to integrate bullet gem with minitest
+# from https://github.com/flyerhzm/bullet/issues/442
+# Include this helper in any test file where you want to use the gem
+# Usage:
+#  class <YourTest> < <YourTestCase>
+#    include(BulletHelper)
+module BulletHelper
+  def before_setup
+    Bullet.start_request
+    super if defined?(super)
+  end
+
+  def after_teardown
+    super if defined?(super)
+
+    Bullet.perform_out_of_channel_notifications if Bullet.notification?
+    Bullet.end_request
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,8 @@ require("rails/test_help")
 require("mocha/minitest")
 
 %w[
+  bullet_helper
+
   general_extensions
   flash_extensions
   controller_extensions


### PR DESCRIPTION
This PR adds and requires a helper that can be included in any test in order to use the `bullet` gem in the test.
The objective is to use `bullet` to identify and fix n+1 issues in bite-sized chunks;  using `bullet` immediately in all tests
would expose ~142 alleged n+1 violations, some of which are difficult to fix, some of which are false positives.
See discussion starting at https://github.com/MushroomObserver/mushroom-observer/pull/868#issuecomment-1048147048

Suggested manual test:
- Add `include BulletHelper` to the test class of your choice (e.g., `test/controllers/observer_controller_test.rb`
- Run the test, e.g. `rails t test/controllers/observer_controller_test.rb`
Expected result: Test run displays potential n+1 errors similar to:
```ruby
ERROR["test_name_been_proposed", #<Minitest::Reporters::Suite:0x000055c8fa4488d8 @name="ObservationTest">, 1.943615176001913]
 test_name_been_proposed#ObservationTest (1.94s)
Minitest::UnexpectedError:         Bullet::Notification::UnoptimizedQueryError: user: vagrant
         
        USE eager loading detected
          Naming => [:name]
          Add to your query: .includes([:name])
        Call stack
          /vagrant/mushroom-observer/app/models/observation.rb:686:in `block in name_been_proposed?'
          /vagrant/mushroom-observer/app/models/observation.rb:686:in `name_been_proposed?'
          /vagrant/mushroom-observer/test/models/observation_test.rb:88:in `test_name_been_proposed'
        
        
            test/bullet_helper.rb:15:in `after_teardown'
```


