### PR TITLE
Add integration n+1 test

### DIFF
--- a/app/controllers/sequence_controller.rb
+++ b/app/controllers/sequence_controller.rb
@@ -147,7 +147,7 @@ class SequenceController < ApplicationController
 
   def show_selected_sequences(query, args = {})
     args = { action: :list_sequences,
-             include: [:observation, { observation: :name }, :user],
+             include: [{ observation: :name }, :user],
              letters: "sequences.locus",
              num_per_page: 50 }.merge(args)
     @links ||= []

--- a/app/controllers/sequence_controller.rb
+++ b/app/controllers/sequence_controller.rb
@@ -147,6 +147,7 @@ class SequenceController < ApplicationController
 
   def show_selected_sequences(query, args = {})
     args = { action: :list_sequences,
+             include: [:observation, { observation: :name }, :user],
              letters: "sequences.locus",
              num_per_page: 50 }.merge(args)
     @links ||= []

--- a/test/integration/n_plus_1_test.rb
+++ b/test/integration/n_plus_1_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Discover potential n+1 issues by running some requests with bullet gem
+class NPlusOneTest < IntegrationTestCase
+  include BulletHelper
+
+  def test_api2
+    get("/api2/observations?detail=high&format=xml")
+    get("/api2/locations?detail=high&format=xml")
+    get("/api2/names?detail=high&format=xml")
+    get("/api2/images?detail=high&format=xml")
+  end
+
+  def test_indexes
+    login
+    get("/articles")
+    get("/comment/list_comments")
+    get("/herbaria?flavor=all")
+    get("/location/list_locations")
+    get("/name/list_names")
+    get("/image/list_images")
+    get("/observer/list_observations")
+    get("/observer/list_rss_logs")
+    get("/project/list_projects")
+    get("/publications")
+    get("/sequence/list_sequences")
+    get("/species_list/list_species_lists")
+  end
+
+  def test_download_observations
+    login
+    get("/observer/download_observations")
+  end
+
+  def test_show_site_stats
+    login
+    get("/observer/show_site_stats")
+  end
+end


### PR DESCRIPTION
This PR adds an integration test designed to catch some potential n+1 queries for some actions.
It also fixes the only n+1 issue which was disclosed by the test.
