### PR TITLE
Fixes the language the success notice is displayed in

### DIFF
--- a/app/models/account_mailer.rb
+++ b/app/models/account_mailer.rb
@@ -6,7 +6,11 @@ class AccountMailer < ActionMailer::Base
 
   def setup_user(user)
     @user = user
-    I18n.locale = @user.try(&:locale) || MO.default_locale
+    @old_locale = I18n.locale
+    new_locale = @user.try(&:locale) || MO.default_locale
+    # Setting I18n.locale used to incur a significant performance penalty,
+    # avoid doing so if not required.  Not sure if this is still the case.
+    I18n.locale = new_locale if I18n.locale != new_locale
   end
 
   def mo_mail(title, headers = {})
@@ -19,6 +23,7 @@ class AccountMailer < ActionMailer::Base
          from: from,
          reply_to: reply_to,
          content_type: "text/#{content_style}")
+    I18n.locale = @old_locale if I18n.locale != @old_locale
   end
 
   def debug_log(template, from, to, objects = {})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -139,6 +139,7 @@
                 when 2; "alert-danger"
               end
               content_tag(:div, flash_get_notices,
+                          id: "flash-notices",
                           class: "alert push-down #{klass}")
             %>
           </div>

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -1471,30 +1471,6 @@ class ObserverControllerTest < FunctionalTestCase
     assert_flash_text(:runtime_ask_user_question_success.t)
   end
 
-  def test_ask_foreign_user_gives_english_success_message
-    I18n.locale = :fr
-    rolf.update(locale: "fr")
-    assert_equal("fr", rolf.reload.locale)
-    assert_equal("en", mary.locale)
-    login("rolf")
-    str = "Question posée avec succès."
-    TranslationString.create!(
-      language_id: languages(:french).id,
-      tag: "runtime_ask_user_question_success",
-      text: str
-    )
-    params = {
-      id: mary.id,
-      email: {
-        subject: "Bonjour!",
-        content: "Ça va?"
-      }
-    }
-    post(:ask_user_question, params)
-    assert_flash_text(str)
-    assert_equal(:fr, I18n.locale)
-  end
-
   def test_email_merge_request
     name1 = Name.all.sample
     name2 = Name.all.sample

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -1472,6 +1472,7 @@ class ObserverControllerTest < FunctionalTestCase
   end
 
   def test_ask_foreign_user_gives_english_success_message
+    I18n.locale = :fr
     rolf.update(locale: "fr")
     assert_equal("fr", rolf.reload.locale)
     assert_equal("en", mary.locale)

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -1471,6 +1471,29 @@ class ObserverControllerTest < FunctionalTestCase
     assert_flash_text(:runtime_ask_user_question_success.t)
   end
 
+  def test_ask_foreign_user_gives_english_success_message
+    rolf.update(locale: "fr")
+    assert_equal("fr", rolf.reload.locale)
+    assert_equal("en", mary.locale)
+    login("rolf")
+    str = "Question posée avec succès."
+    TranslationString.create!(
+      language_id: languages(:french).id,
+      tag: "runtime_ask_user_question_success",
+      text: str
+    )
+    params = {
+      id: mary.id,
+      email: {
+        subject: "Bonjour!",
+        content: "Ça va?"
+      }
+    }
+    post(:ask_user_question, params)
+    assert_flash_text(str)
+    assert_equal(:fr, I18n.locale)
+  end
+
   def test_email_merge_request
     name1 = Name.all.sample
     name2 = Name.all.sample

--- a/test/integration/observer_controller_supplemental_test.rb
+++ b/test/integration/observer_controller_supplemental_test.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+# This cop doesn't understand that find_by_id is not being called on an
+# ActiveRecord instance, and therefore is not a rails dynamic finder.
+# rubocop:disable Rails/DynamicFindBy
+
 require("test_helper")
 
 # Tests which supplement controller/observer_controller_test.rb
 class ObserverControllerSupplementalTest < IntegrationTestCase
-
   def login(user = users(:zero_user))
     visit("/account/login")
     fill_in("User name or Email address:", with: user.login)
@@ -113,7 +116,11 @@ class ObserverControllerSupplementalTest < IntegrationTestCase
     # Makes it very easy to test which language is being used!
     # But note that the standard login helper won't work because it is
     # expecting the English translations to work correctly.
-    I18n.stub(:t, lambda {|*args| "#{I18n.locale}:#{args.first}"}) do
+    translator = lambda do |*args|
+      "#{I18n.locale}:#{args.first}"
+    end
+
+    I18n.stub(:t, translator) do
       visit("/account/login")
       fill_in("en:mo.login_user:", with: sender.login)
       fill_in("en:mo.login_password:", with: "testpassword")
@@ -127,3 +134,5 @@ class ObserverControllerSupplementalTest < IntegrationTestCase
     end
   end
 end
+
+# rubocop:enable Rails/DynamicFindBy

--- a/test/integration/observer_controller_supplemental_test.rb
+++ b/test/integration/observer_controller_supplemental_test.rb
@@ -4,6 +4,16 @@ require("test_helper")
 
 # Tests which supplement controller/observer_controller_test.rb
 class ObserverControllerSupplementalTest < IntegrationTestCase
+
+  def login(user = users(:zero_user))
+    visit("/account/login")
+    fill_in("User name or Email address:", with: user.login)
+    fill_in("Password:", with: "testpassword")
+    click_button("Login")
+  end
+
+  # ------------------------------------------------------------
+
   # Prove that when a user "Tests" the text entered in the Textile Sandbox,
   # MO displays what the entered text looks like.
   def test_post_textile
@@ -90,10 +100,30 @@ class ObserverControllerSupplementalTest < IntegrationTestCase
     assert_not_includes(species_list.observations, observation)
   end
 
-  def login(user = users(:zero_user))
-    visit("/account/login")
-    fill_in("User name or Email address:", with: user.login)
-    fill_in("Password:", with: "testpassword")
-    click_button("Login")
+  def test_locales_when_sending_email_question
+    sender = users(:rolf)
+    receiver = users(:mary)
+    sender.update(locale: "fr")
+    assert_equal("fr", sender.locale)
+    assert_equal("en", receiver.locale)
+
+    # I have no clue how to ensure translations are set any particular way.
+    # This stub causes every single translation to be simply:
+    #   "locale:mo.tag"
+    # Makes it very easy to test which language is being used!
+    # But note that the standard login helper won't work because it is
+    # expecting the English translations to work correctly.
+    I18n.stub(:t, lambda {|*args| "#{I18n.locale}:#{args.first}"}) do
+      visit("/account/login")
+      fill_in("en:mo.login_user:", with: sender.login)
+      fill_in("en:mo.login_password:", with: "testpassword")
+      click_button("en:mo.login_login")
+      visit("/observer/ask_user_question/#{receiver.id}")
+      fill_in("fr:mo.ask_user_question_subject", with: "Bonjour!")
+      fill_in("fr:mo.ask_user_question_message:", with: "Ça va?")
+      click_button("fr:mo.SEND")
+      notices = page.find_by_id("flash-notices")
+      notices.assert_text("fr:mo.runtime_ask_user_question_success")
+    end
   end
 end


### PR DESCRIPTION
when sending an email to another user.  Just needed to restore the I18n.locale after sending the email.  But testing this turned out to be a huge pain in the tuckus.  Arg.