### PR TITLE
Fixed translations of the Activity Log checkbox items.

### DIFF
--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -517,15 +517,6 @@ class String
     strip.squeeze(" ")
   end
 
-  # Uncamelizes and converts string to pluralized title. E.g.:
-  # "Observation"  => "Observations"
-  # "SpeciesList"  => "Species Lists"
-  # "GlossaryTerm" => "Glossary Terms"
-  # "good dog"     => "Good Dogs"
-  def pluralized_title
-    pluralize.underscore.humanize.titleize
-  end
-
   # Generate a string of random characters of length +len+.  By default it
   # chooses from among the lowercase letters and digits, however you can give
   # it an arbitrary set of characters to choose from.  (And they don't have to

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -194,7 +194,7 @@ module ObjectLinkHelper
     count = obs.herbarium_records.count
     if count.positive?
       
-      link_to(count == 1 ? :herbarium_record.t : :herbarium_records.t),
+      link_to((count == 1 ? :herbarium_record.t : :herbarium_records.t),
               controller: :herbarium_record, action: :observation_index,
               id: obs.id)
     else

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -193,7 +193,7 @@ module ObjectLinkHelper
   def observation_herbarium_record_link(obs)
     count = obs.herbarium_records.count
     if count.positive?
-      
+
       link_to((count == 1 ? :herbarium_record.t : :herbarium_records.t),
               controller: :herbarium_record, action: :observation_index,
               id: obs.id)

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -193,7 +193,8 @@ module ObjectLinkHelper
   def observation_herbarium_record_link(obs)
     count = obs.herbarium_records.count
     if count.positive?
-      link_to(pluralize(count, :herbarium_record.t),
+      
+      link_to(count == 1 ? :herbarium_record.t : :herbarium_records.t),
               controller: :herbarium_record, action: :observation_index,
               id: obs.id)
     else

--- a/app/helpers/rss_log_helper.rb
+++ b/app/helpers/rss_log_helper.rb
@@ -18,7 +18,7 @@ module RssLogHelper
 
   # A single tab in Activity Feed tabset
   def tab_for_type(type)
-    label = :rss_one.t(type: type.classify.constantize.rss_log_tab_label)
+    label = :"rss_one_#{type}".t
     link = { action: :index_rss_log, type: type }
     help = { title: :rss_one_help.t(type: type.to_sym) }
     @types == [type] ? label : link_with_query(label, link, help)

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -738,12 +738,6 @@ class AbstractModel < ApplicationRecord
     rss_log.save
   end
 
-  # The label which is displayed for the model's tab in the RssLog tabset
-  # e.g. "Names", "Species Lists"
-  def self.rss_log_tab_label
-    to_s.pluralized_title
-  end
-
   # Add a note to the notes field with paragraph break between different notes.
   def add_note(note)
     self.notes = notes.present? ? "\n\n#{note}" : note

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,7 +19,6 @@
 #  display_name::       name boldfaced
 #  format_name          name
 #  text_name            name without formatting
-#  rss_log_tab_label    label displayed in the RssLog tabset
 #  unique_format_name   name + id
 #  unique_text_name     name + id without formatting
 #
@@ -58,11 +57,6 @@ class Article < AbstractModel
   # used by RSS feed
   def unique_text_name
     text_name + " (#{id || "?"})"
-  end
-
-  # The label which is displayed for this model's tab in the RssLog tabset
-  def self.rss_log_tab_label
-    "News"
   end
 
   # wrapper around class method of same name

--- a/app/views/herbaria/_curator_table.html.erb
+++ b/app/views/herbaria/_curator_table.html.erb
@@ -4,7 +4,7 @@
   <thead>
     <tr>
       <th colspan="<%= can_delete ? 2 : 1 %>">
-        <%= "#{pluralize(herbarium.curators.length, :herbarium_curator.t)}:" %>
+        <%= "#{herbarium.curators.length == 1 ? :herbarium_curator.t : :herbarium_curators.t}:" %>
       </th>
     </tr>
   </thead>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2428,6 +2428,7 @@
 
   # herbarium fields
   herbarium_curator: Curator
+  herbarium_curators: Curators
   herbarium_mailing_address: Mailing Address
   herbarium_code: Code
   user_personal_herbarium: "[name]: Personal Fungarium"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1925,7 +1925,13 @@
   rss_hide: "Hide:"
   rss_all: Everything
   rss_all_help: Show all object types.
-  rss_one: "[TYPES]"
+  rss_one_observation: "[:OBSERVATIONS]"
+  rss_one_name: "[:NAMES]"
+  rss_one_location: "[:LOCATIONS]"
+  rss_one_species_list: "[:SPECIES_LISTS]"
+  rss_one_project: "[:PROJECTS]"
+  rss_one_glossary_term: "[:GLOSSARY]"
+  rss_one_article: "[:NEWS]"
   rss_one_help: Show only [types].
   rss_make_default: Make This My Default
   rss_this_is_default: This Is Your Default

--- a/test/models/string_extensions_test.rb
+++ b/test/models/string_extensions_test.rb
@@ -4,13 +4,6 @@ require("test_helper")
 
 # test extensions to Ruby and Rails String Class
 class StringExtensionsTest < UnitTestCase
-  def test_pluralized_title
-    assert_equal("Good Dogs", "good dog".pluralized_title)
-    assert_equal("Observations", "Observation".pluralized_title)
-    assert_equal("Glossary Terms", "GlossaryTerm".pluralized_title)
-    assert_equal("Species Lists", "SpeciesList".pluralized_title)
-  end
-
   def test_dealphabetize
     # convert_base62_to_decimal
     assert_equal(0, "0".dealphabetize)


### PR DESCRIPTION
The checkboxes at the top of the Activity Log had gotten all messed up.  It was doing

  :observation.classify.constantize.to_s.pluralized_title

This does:

  :observation -> "Observation" -> Observation -> "Observation" -> "Observations" (!!) 

This does not get translated.  Instead do:

  :observation.to_s.pluralize.upcase.to_sym.t

This does:

  :observation -> "observation" -> "observations" -> "OBSERVATIONS" -> :OBSERVATIONS -> "Observaciones"

Or better yet, let the translator deal with it!

  :"rss_one_#{:observation}"
    -> :rss_one_observation -> [:OBSERVATIONS] -> "Observaciones"

This latter approach requires a bunch of aliases in the translation file, but it let us override individual choices. For example, we can choose to change "Glossary Terms" to just "Glossary" and "Articles" to "News".  And it makes the code much more readable.

Note that these extra translations are all just aliases, so there is no need for translators to do anything.  But it does let them override our choices. What works best in English isn't necessarily what's best in Urdu. :)