### PR TITLE
Fix a few nil bugs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -353,3 +353,6 @@ Style/StringLiteralsInInterpolation:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
+# We skip validations all the time.  I'm tired of disabling this cop.
+Rails/SkipsModelValidations:
+  Enabled: false

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -769,13 +769,8 @@ class ImageController < ApplicationController
       update_licenses_history(images_to_update, row[:old_holder], row[:old_id])
 
       # Update the license info in the images
-      # Disable cop because we want to update all relevant records with
-      # a single SELECT. Otherwise license updating would take too long
-      # for users with many (e.g. thousands) of images
-      # rubocop:disable Rails/SkipsModelValidations
       images_to_update.update_all(license_id: row[:new_id],
                                   copyright_holder: row[:new_holder])
-      # rubocop:enable Rails/SkipsModelValidations
     end
   end
 

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -659,7 +659,7 @@ class AbstractModel < ApplicationRecord
   #
   def log(tag, args = {})
     init_rss_log unless rss_log
-    touch unless new_record? || # rubocop:disable Rails/SkipsModelValidations
+    touch unless new_record? ||
                  args[:touch] == false
     rss_log.add_with_date(tag, args)
   end

--- a/app/models/name/merge.rb
+++ b/app/models/name/merge.rb
@@ -22,8 +22,6 @@ class Name < AbstractModel
   def merge(old_name)
     return if old_name == self
 
-    xargs = {}
-
     # Move all observations over to the new name.
     old_name.observations.each do |obs|
       obs.name = self
@@ -77,14 +75,7 @@ class Name < AbstractModel
     end
 
     # Move over any remaining descriptions.
-    old_name.descriptions.each do |desc|
-      xargs = {
-        id: desc,
-        set_name: self
-      }
-      desc.name_id = id
-      desc.save
-    end
+    NameDescription.where(name_id: old_name.id).update_all(name_id: id)
 
     # Log the action.
     old_name.rss_log&.orphan(old_name.display_name, :log_name_merged,

--- a/app/models/name/propagate_generic_classifications.rb
+++ b/app/models/name/propagate_generic_classifications.rb
@@ -80,15 +80,12 @@ class Name < AbstractModel
     end
 
     def execute_bundled_propagation_fixes(bundles, dry_run)
-      # Deliberately skip validations
-      # rubocop:disable Rails/SkipsModelValidations
       bundles.each_with_object([]) do |bundle, msgs|
         classification, ids = bundle
         msgs << "Setting classifications for #{ids.join(",")}"
         Name.where(id: ids).update_all(classification: classification) \
           unless dry_run
       end
-      # rubocop:enable Rails/SkipsModelValidations
     end
 
     def describe_propagation_fix(name, old_class, new_class)

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -176,10 +176,7 @@ class Name < AbstractModel
            map do |id, text_name, author|
              "Name ##{id} #{text_name} #{author} was a misspelling of itself."
            end
-    # Deliberately skip validations
-    # rubocop:disable Rails/SkipsModelValidations
     Name.where("correct_spelling_id = id").update_all(correct_spelling_id: nil)
-    # rubocop:enable Rails/SkipsModelValidations
     msgs
   end
 end

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -507,7 +507,6 @@ class Name < AbstractModel
       if rank != :Genus
 
     # Deliberately skip validations
-    # rubocop:disable Rails/SkipsModelValidations
     subtaxa = subtaxa_whose_classification_needs_to_be_changed
     Name.where(id: subtaxa).
       update_all(classification: classification)
@@ -515,7 +514,6 @@ class Name < AbstractModel
       update_all(classification: classification)
     Observation.where(name_id: subtaxa).
       update_all(classification: classification)
-    # rubocop:enable Rails/SkipsModelValidations
   end
 
   # Get list of subtaxa whose classification doesn't match (and therefore
@@ -537,14 +535,11 @@ class Name < AbstractModel
   # This is meant to be run nightly to ensure that all the classification
   # caches are up to date.  It only pays attention to genera or higher.
   def self.refresh_classification_caches
-    # Deliberately skip validations
-    # rubocop:disable Rails/SkipsModelValidations
     Name.where(rank: 0..Name.ranks[:Genus]).
       joins(:description).
       where("name_descriptions.classification != names.classification").
       where("COALESCE(name_descriptions.classification, '') != ''").
       update_all("names.classification = name_descriptions.classification")
-    # rubocop:enable Rails/SkipsModelValidations
     []
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -836,6 +836,7 @@ class User < AbstractModel
   # Blank out any references in public records.
   private_class_method def self.blank_out_public_references(id)
     [
+      [:herbaria,                       :personal_user_id],
       [:location_descriptions,          :user_id],
       [:location_descriptions_versions, :user_id],
       [:locations,                      :user_id],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -507,9 +507,7 @@ class User < AbstractModel
   #   user.change_password('new_password')
   #
   def change_password(pass)
-    # rubocop:disable Rails/SkipsModelValidations
     update_attribute("password", self.class.sha1(pass)) if pass.present?
-    # rubocop:enable Rails/SkipsModelValidations
   end
 
   # Mark a User account as "verified".

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -32,7 +32,7 @@
               <%= herbarium.herbarium_records.length %>
             </td>
             <td>
-              <%= if herbarium.personal_user_id.present? && !@no_user_column
+              <%= if !@no_user_column && herbarium.personal_user.present?
                     tag.span(user_link(herbarium.personal_user),
                              title: herbarium.personal_user.unique_text_name)
               end %>

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -933,4 +933,14 @@ class HerbariaControllerTest < FunctionalTestCase
       "Attempt to destroy non-existent herbarium should redirect to index"
     )
   end
+
+  # This was a bug found in the wild, presumably from a user which was deleted
+  # but the corresponding personal_user_id was not cleared and therefore then
+  # referred to a nonexistent user.  It caused the herbarium index to crash.
+  def test_herbarium_personal_user_id_corrupt
+    # Intentionally "break" the user link for Rolf's personal herbarium.
+    herbaria(:rolf_herbarium).update(personal_user_id: -1)
+    login("mary")
+    get(:index)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -229,12 +229,15 @@ class UserTest < UnitTestCase
     num_name_descriptions = NameDescription.count
     assert(user.name_descriptions.length > 1)
     sample_name_description_id = user.name_descriptions.first.id
+    herbarium = user.personal_herbarium
+    assert_not_nil(herbarium.personal_user)
     User.erase_user(user.id)
     assert_equal(num_comments - 1, Comment.count)
     assert_raises(ActiveRecord::RecordNotFound) { Comment.find(comment_id) }
     assert_equal(num_name_descriptions, NameDescription.count)
     desc = NameDescription.find(sample_name_description_id)
     assert_equal(0, desc.user_id)
+    assert_equal(0, herbarium.reload.personal_user_id)
   end
 
   def test_erase_user_with_observation


### PR DESCRIPTION
User.erase_user was neglecting to deal with herbaria whose personal_user pointed to the dead user.  Wrote a test to expose this behavior and fixed it.

Similarly, something was happening in name merges that was causing name_descriptions to get orphaned.  It looked like it should have worked.  I don't know why it wasn't.  But it was old code and messy and could be reduced to a single line, so I did that.  Hopefully this version is more robust?

Lastly, I have noticed a *ton* of bogus requests for /images/facebook_icon.png, each of which causes rails to throw a routing error.  Not a hugely expensive drain on resources, but wholly unnecessary.  I just created an empty static file in /public/images/facebook_icon.png.  This should cause nginx to serve the (empty) file instead of punting the request to rails.