### PR TITLE
AbstractModelTest - be sure that arel-helpers are included

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -67,9 +67,6 @@
 
 class AbstractModel < ApplicationRecord
   self.abstract_class = true
-  require "arel-helpers"
-  include ArelHelpers::ArelTable
-  include ArelHelpers::JoinAssociation
 
   def self.acts_like_model?
     true

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -458,4 +458,15 @@ class AbstractModelTest < UnitTestCase
     obj = model.first
     assert_equal("#{domain}/#{path}/#{obj.id}", obj.show_url)
   end
+
+  # -------------------------------------------------------------------------
+  #  Checks that arel-helpers are included (from the gem) in ApplicationRecord.
+  #  In the test below, the brackets in User[:login] referring to table column
+  #  will throw  NoMethodError: undefined method `[]' for #<Class>
+  #  if arel-helpers not included. Error could be mystifying at first.
+  # -------------------------------------------------------------------------
+  def test_arel_helpers_included
+    arel_find_user = User.find_by(User[:login].eq(rolf.login))
+    assert_equal(arel_find_user.login, rolf.login)
+  end
 end


### PR DESCRIPTION
Test could be valuable in the future, because *not* including the Arel-helpers will throw an error 
```
NoMethodError: undefined method `[]' for #<Class:0x0000562c259b2998>
```
in the innocuous-looking code `User[:login]` — it might be hard to comprehend at first.

Also - removes the require/include arel-helpers from AbstractModel, because that class, in turn, inherits from ApplicationRecord, which already includes the arel-helpers via the previous PR. @JoeCohen Sorry i didn't notice that when committing that PR!