### PR TITLE
Api2Test — SQL -> AR/Arel

### DIFF
--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -550,13 +550,11 @@ class Api2Test < UnitTestCase
   def test_getting_collection_numbers
     params = { method: :get, action: :collection_number }
 
-    # nums = CollectionNumber.where("year(created_at) = 2006")
     nums = CollectionNumber.where(CollectionNumber[:created_at].year == 2006)
     assert_not_empty(nums)
     assert_api_pass(params.merge(created_at: "2006"))
     assert_api_results(nums)
 
-    # nums = CollectionNumber.where("year(updated_at) = 2005")
     nums = CollectionNumber.where(CollectionNumber[:updated_at].year == 2005)
     assert_not_empty(nums)
     assert_api_pass(params.merge(updated_at: "2005"))
@@ -578,7 +576,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(collector: "Mary Newbie"))
     assert_api_results(nums)
 
-    # nums = CollectionNumber.where("name LIKE '%mary%'")
     nums = CollectionNumber.where(CollectionNumber[:name].matches("%mary%"))
     assert_not_empty(nums)
     assert_api_pass(params.merge(collector_has: "Mary"))
@@ -929,7 +926,6 @@ class Api2Test < UnitTestCase
       method: :get,
       action: :external_site
     }
-    # sites = ExternalSite.where("name like '%inat%'")
     sites = ExternalSite.where(ExternalSite[:name].matches("%inat%"))
     assert_not_empty(sites)
     assert_api_pass(params.merge(name: "inat"))
@@ -947,7 +943,6 @@ class Api2Test < UnitTestCase
     }
 
     herbs = Herbarium.where(
-      # "date(created_at) = '2012-10-21'"
       Herbarium[:created_at].format("%Y-%m-%d") == "2012-10-21"
     )
     assert_not_empty(herbs)
@@ -964,19 +959,16 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(code: "NY"))
     assert_api_results(herbs)
 
-    # herbs = Herbarium.where("name like '%personal%'")
     herbs = Herbarium.where(Herbarium[:name].matches("%personal%"))
     assert_not_empty(herbs)
     assert_api_pass(params.merge(name: "personal"))
     assert_api_results(herbs)
 
-    # herbs = Herbarium.where("description like '%awesome%'")
     herbs = Herbarium.where(Herbarium[:description].matches("%awesome%"))
     assert_not_empty(herbs)
     assert_api_pass(params.merge(description: "awesome"))
     assert_api_results(herbs)
 
-    # herbs = Herbarium.where("mailing_address like '%New York%'")
     herbs = Herbarium.where(Herbarium[:mailing_address].matches("%New York%"))
     assert_not_empty(herbs)
     assert_api_pass(params.merge(address: "New York"))
@@ -990,13 +982,11 @@ class Api2Test < UnitTestCase
   def test_getting_herbarium_records
     params = { method: :get, action: :herbarium_record }
 
-    # recs = HerbariumRecord.where("year(created_at) = 2012")
     recs = HerbariumRecord.where(HerbariumRecord[:created_at].year == 2012)
     assert_not_empty(recs)
     assert_api_pass(params.merge(created_at: "2012"))
     assert_api_results(recs)
 
-    # recs = HerbariumRecord.where("year(updated_at) = 2017")
     recs = HerbariumRecord.where(HerbariumRecord[:updated_at].year == 2017)
     assert_not_empty(recs)
     assert_api_pass(params.merge(updated_at: "2017"))
@@ -1019,19 +1009,16 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(observation: obs.id))
     assert_api_results(recs)
 
-    # recs = HerbariumRecord.where("notes LIKE '%dried%'")
     recs = HerbariumRecord.where(HerbariumRecord[:notes].matches("%dried%"))
     assert_not_empty(recs)
     assert_api_pass(params.merge(notes_has: "dried"))
     assert_api_results(recs)
 
-    # recs = HerbariumRecord.where("COALESCE(notes, '') = ''")
     recs = HerbariumRecord.where(HerbariumRecord[:notes].blank)
     assert_not_empty(recs)
     assert_api_pass(params.merge(has_notes: "no"))
     assert_api_results(recs)
 
-    # recs = HerbariumRecord.where("CONCAT(notes, '') != ''")
     recs = HerbariumRecord.where(HerbariumRecord[:notes].not_blank)
     assert_not_empty(recs)
     assert_api_pass(params.merge(has_notes: "yes"))
@@ -1042,7 +1029,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(initial_det: "Coprinus comatus"))
     assert_api_results(recs)
 
-    # recs = HerbariumRecord.where("initial_det LIKE '%coprinus%'")
     recs = HerbariumRecord.where(
       HerbariumRecord[:initial_det].matches("%coprinus%")
     )
@@ -1055,7 +1041,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(accession_number: "1234"))
     assert_api_results(recs)
 
-    # recs = HerbariumRecord.where("accession_number LIKE '%23%'")
     recs = HerbariumRecord.where(
       HerbariumRecord[:accession_number].matches("%23%")
     )
@@ -1210,17 +1195,14 @@ class Api2Test < UnitTestCase
     assert_api_results([img])
 
     assert_api_pass(params.merge(created_at: "2006"))
-    # assert_api_results(Image.where("year(created_at) = 2006"))
     assert_api_results(Image.where(Image[:created_at].year == 2006))
 
     assert_api_pass(params.merge(updated_at: "2006-05-22"))
-    # assert_api_results(Image.where('date(updated_at) = "2006-05-22"'))
     assert_api_results(Image.where(
                          Image[:updated_at].format("%Y-%m-%d") == "2006-05-22"
                        ))
 
     assert_api_pass(params.merge(date: "2007-03"))
-    # assert_api_results(Image.where("year(`when`) = 2007 and month(`when`) = 3"))
     assert_api_results(Image.where((Image[:when].year == 2007).
                              and(Image[:when].month == 3)))
 
@@ -1293,10 +1275,8 @@ class Api2Test < UnitTestCase
     # assert_api_pass(params.merge(has_observation: "no"))
     # assert_api_results(unattached)
 
-    # imgs = Image.where("width >= 1280 || height >= 1280")
     imgs = Image.where((Image[:width] >= 1280).or(Image[:height] >= 1280))
     assert_empty(imgs)
-    # imgs = Image.where("width >= 960 || height >= 960")
     imgs = Image.where((Image[:width] >= 960).or(Image[:height] >= 960))
     assert_not_empty(imgs)
     assert_api_pass(params.merge(size: "huge"))
@@ -1317,12 +1297,10 @@ class Api2Test < UnitTestCase
     assert_api_results([pretty_img])
 
     assert_api_pass(params.merge(copyright_holder_has: "Insil Choi"))
-    # assert_api_results(Image.where("copyright_holder like '%insil choi%'"))
     assert_api_results(Image.where(
                          Image[:copyright_holder].matches("%insil choi%")
                        ))
     assert_api_pass(params.merge(copyright_holder_has: "Nathan"))
-    # assert_api_results(Image.where("copyright_holder like '%nathan%'"))
     assert_api_results(Image.where(
                          Image[:copyright_holder].matches("%nathan%")
                        ))
@@ -1332,19 +1310,15 @@ class Api2Test < UnitTestCase
     assert_api_results(Image.where(license: pd))
 
     assert_api_pass(params.merge(has_votes: "yes"))
-    # assert_api_results(Image.where("vote_cache IS NOT NULL"))
     assert_api_results(Image.where(Image[:vote_cache].not_eq(nil)))
     assert_api_pass(params.merge(has_votes: "no"))
-    # assert_api_results(Image.where("vote_cache IS NULL"))
     assert_api_results(Image.where(Image[:vote_cache].eq(nil)))
 
     assert_api_pass(params.merge(quality: "2-3"))
-    # assert_api_results(Image.where("vote_cache > 2.0"))
     assert_api_results(Image.where(Image[:vote_cache] > 2.0))
     assert_api_pass(params.merge(quality: "1-2"))
     assert_api_results([])
 
-    # imgs = Observation.where("vote_cache >= 2.0").map(&:images).flatten
     imgs = Observation.where(Observation[:vote_cache] >= 2.0).
            map(&:images).flatten
     assert_not_empty(imgs)
@@ -1542,14 +1516,12 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: loc.id))
     assert_api_results([loc])
 
-    # locs = Location.where("year(created_at) = 2008")
     locs = Location.where(Location[:created_at].year == 2008)
     assert_not_empty(locs)
     assert_api_pass(params.merge(created_at: "2008"))
     assert_api_results(locs)
 
-    # locs = Location.where("date(created_at) = '2012-01-01'")
-    # Nimmo Note: I believe this should be updated_at
+    # Nimmo Note: I believe this should be updated_at, not created_at
     locs = Location.where(
       Location[:updated_at].format("%Y-%m-%d") == "2012-01-01"
     )
@@ -1562,8 +1534,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(user: "rolf"))
     assert_api_results(locs)
 
-    # locs = Location.where("south >= 39 and north <= 40 and
-    #                        west >= -124 and east <= -123 and west <= east")
     locs = Location.where(
       (Location[:south] >= 39).and(Location[:north] <= 40).
       and(Location[:west] >= -124).and(Location[:east] <= -123).
@@ -1747,14 +1717,12 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: name.id))
     assert_api_results([name])
 
-    # names = Name.where("year(created_at) = 2008").
     names = Name.where(Name[:created_at].year == 2008).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(created_at: "2008"))
     assert_api_results(names)
 
-    # names = Name.where("date(updated_at) = '2008-09-05'").
     names = Name.where(Name[:updated_at].format("%Y-%m-%d") == "2008-09-05").
             reject(&:correct_spelling_id)
     assert_not_empty(names)
@@ -1785,10 +1753,8 @@ class Api2Test < UnitTestCase
     )
     assert_api_results(names)
 
-    # names = Name.where("classification like '%Fungi%'").map do |n|
     names = Name.where(Name[:classification].matches("%Fungi%")).map do |n|
       genus = n.text_name.split.first
-      # Name.where("text_name like '#{genus} %'") + [n]
       Name.where(Name[:text_name].matches("#{genus} %")) + [n]
     end.flatten.uniq.sort_by(&:id).reject(&:correct_spelling_id)
     assert_not_empty(names)
@@ -1803,7 +1769,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(is_deprecated: "true"))
     assert_api_results(names)
 
-    # names = Name.where("date(updated_at) = '2009-10-12'")
     names = Name.where(Name[:updated_at].format("%Y-%m-%d") == "2009-10-12")
     goods = names.reject(&:correct_spelling_id)
     bads  = names.select(&:correct_spelling_id)
@@ -1850,10 +1815,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(rank: "variety"))
     assert_api_results(names)
 
-    # with    = Name.where.not("author is null or author = ''").
     with    = Name.where.not(Name[:author].blank).
               reject(&:correct_spelling_id)
-    # without = Name.where("author is null or author = ''").
     without = Name.where(Name[:author].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
@@ -1863,10 +1826,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_author: "no"))
     assert_api_results(without)
 
-    # with    = Name.where.not("citation is null or citation = ''").
     with    = Name.where.not(Name[:citation].blank).
               reject(&:correct_spelling_id)
-    # without = Name.where("citation is null or citation = ''").
     without = Name.where(Name[:citation].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
@@ -1876,10 +1837,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_citation: "no"))
     assert_api_results(without)
 
-    # with    = Name.where.not("classification is null or classification = ''").
     with    = Name.where.not(Name[:classification].blank).
               reject(&:correct_spelling_id)
-    # without = Name.where("classification is null or classification = ''").
     without = Name.where(Name[:classification].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
@@ -1889,10 +1848,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_classification: "no"))
     assert_api_results(without)
 
-    # with    = Name.where.not("notes is null or notes = ''").
     with    = Name.where.not(Name[:notes].blank).
               reject(&:correct_spelling_id)
-    # without = Name.where("notes is null or notes = ''").
     without = Name.where(Name[:notes].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
@@ -1919,42 +1876,36 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_description: "no"))
     assert_api_results(without)
 
-    # names = Name.where("text_name like '%bunny%'").
     names = Name.where(Name[:text_name].matches("%bunny%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(text_name_has: "bunny"))
     assert_api_results(names)
 
-    # names = Name.where("author like '%peck%'").
     names = Name.where(Name[:author].matches("%peck%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(author_has: "peck"))
     assert_api_results(names)
 
-    # names = Name.where("citation like '%lichenes%'").
     names = Name.where(Name[:citation].matches("%lichenes%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(citation_has: "lichenes"))
     assert_api_results(names)
 
-    # names = Name.where("classification like '%lecanorales%'").
     names = Name.where(Name[:classification].matches("%lecanorales%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(classification_has: "lecanorales"))
     assert_api_results(names)
 
-    # names = Name.where("notes like '%known%'").
     names = Name.where(Name[:notes].matches("%known%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(notes_has: "known"))
     assert_api_results(names)
 
-    # names = Comment.where("target_type = 'Name' and comment like '%mess%'").
     names = Comment.where(
       Comment[:target_type].eq("name").and(Comment[:comment].matches("%mess%"))
     ).map(&:target).uniq.sort_by(&:id).reject(&:correct_spelling_id)
@@ -2205,13 +2156,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: obs.id))
     assert_api_results([obs])
 
-    # obses = Observation.where("year(created_at) = 2010")
     obses = Observation.where(Observation[:created_at].year == 2010)
     assert_not_empty(obses)
     assert_api_pass(params.merge(created_at: "2010"))
     assert_api_results(obses)
 
-    # obses = Observation.where("date(updated_at) = '2007-06-24'")
     obses = Observation.where(
       Observation[:updated_at].format("%Y-%m-%d") == "2007-06-24"
     )
@@ -2219,7 +2168,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(updated_at: "20070624"))
     assert_api_results(obses)
 
-    # obses = Observation.where("year(`when`) >= 2012 and year(`when`) <= 2014")
     obses = Observation.where(
       (Observation[:when].year >= 2012).and(Observation[:when].year <= 2014)
     )
@@ -2324,7 +2272,6 @@ class Api2Test < UnitTestCase
 
     genus = Name.ranks[:Genus]
     group = Name.ranks[:Group]
-    # names = Name.where("`rank` <= #{genus} or `rank` = #{group}")
     names = Name.where((Name[:rank] <= genus).or(Name[:rank] == group))
     with = Observation.where(name: names)
     without = Observation.where.not(name: names)
@@ -2364,7 +2311,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_notes: "no"))
     assert_api_results(without)
 
-    # obses = Observation.where("notes like '%:substrate:%'").
     obses = Observation.where(
       Observation[:notes].matches("%:substrate:%")
     ).reject { |o| o.notes[:substrate].blank? }
@@ -2372,13 +2318,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_notes_field: "substrate"))
     assert_api_results(obses)
 
-    # obses = Observation.where("notes like '%orphan%'")
     obses = Observation.where(Observation[:notes].matches("%orphan%"))
     assert(obses.length > 1)
     assert_api_pass(params.merge(notes_has: "orphan"))
     assert_api_results(obses)
 
-    # obses = Comment.where("concat(summary, comment) like \"%let's%\"").
     obses = Comment.where(
       Comment[:summary].concat(Comment[:comment]).matches("%let's%")
     ).map(&:target).uniq.sort_by(&:id)
@@ -2386,10 +2330,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(comments_has: "let's"))
     assert_api_results(obses)
 
-    # obses = Observation.where("`lat` >= 34 and `lat` <= 35 and
-    #                            `long` >= -119 and `long` <= -118")
-    # locs  = Location.where("south >= 34 and north <= 35 and west >= -119 and
-    #                         east <= -118 and west <= east")
     obses = Observation.where(
       (Observation[:lat] >= 34).and(Observation[:lat] <= 35).
       and(Observation[:long] >= -119).and(Observation[:long] <= -118)
@@ -2409,8 +2349,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(north: 35, south: 34, east: -118, west: -119))
     assert_api_results(obses)
 
-    # obses = Observation.where("`where` like '%, California, USA' OR " \
-    #                           "`where` = 'California, USA'")
     obses = Observation.where(
       Observation[:where].matches("%, California, USA").
       or(Observation[:where].matches("California, USA"))
@@ -2772,14 +2710,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: proj.id))
     assert_api_results([proj])
 
-    # projs = Project.where("year(created_at) = 2008")
     projs = Project.where(Project[:created_at].year == 2008)
     assert_not_empty(projs)
     assert_api_pass(params.merge(created_at: "2008"))
     assert_api_results(projs)
 
-    # projs = Project.where("year(updated_at) = 2008 and
-    #                        month(updated_at) = 9")
     projs = Project.where(
       (Project[:updated_at].year == 2008).and(Project[:updated_at].month == 9)
     )
@@ -2813,8 +2748,6 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_comments: "yes"))
     assert_api_results(projs)
 
-    # with    = Project.where("summary is not null and summary != ''")
-    # without = Project.where("summary is null or summary = ''")
     with    = Project.where(Project[:summary].not_blank)
     without = Project.where(Project[:summary].blank)
     assert_not_empty(with)
@@ -2824,13 +2757,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_summary: "no"))
     assert_api_results(without)
 
-    # projs = Project.where("title like '%bolete%'")
     projs = Project.where(Project[:title].matches("%bolete%"))
     assert_not_empty(projs)
     assert_api_pass(params.merge(title_has: "bolete"))
     assert_api_results(projs)
 
-    # projs = Project.where("summary like '%article%'")
     projs = Project.where(Project[:summary].matches("%article%"))
     assert_not_empty(projs)
     assert_api_pass(params.merge(summary_has: "article"))

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -1549,8 +1549,9 @@ class Api2Test < UnitTestCase
     assert_api_results(locs)
 
     # locs = Location.where("date(created_at) = '2012-01-01'")
+    # Nimmo Note: I believe this should be updated_at
     locs = Location.where(
-      Location[:created_at].format("%Y-%m-%d") == "2012-01-01"
+      Location[:updated_at].format("%Y-%m-%d") == "2012-01-01"
     )
     assert_not_empty(locs)
     assert_api_pass(params.merge(updated_at: "2012-01-01"))
@@ -1746,13 +1747,15 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: name.id))
     assert_api_results([name])
 
-    names = Name.where("year(created_at) = 2008").
+    # names = Name.where("year(created_at) = 2008").
+    names = Name.where(Name[:created_at].year == 2008).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(created_at: "2008"))
     assert_api_results(names)
 
-    names = Name.where("date(updated_at) = '2008-09-05'").
+    # names = Name.where("date(updated_at) = '2008-09-05'").
+    names = Name.where(Name[:updated_at].format("%Y-%m-%d") == "2008-09-05").
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(updated_at: "2008-09-05"))
@@ -1782,9 +1785,11 @@ class Api2Test < UnitTestCase
     )
     assert_api_results(names)
 
-    names = Name.where("classification like '%Fungi%'").map do |n|
+    # names = Name.where("classification like '%Fungi%'").map do |n|
+    names = Name.where(Name[:classification].matches("%Fungi%")).map do |n|
       genus = n.text_name.split.first
-      Name.where("text_name like '#{genus} %'") + [n]
+      # Name.where("text_name like '#{genus} %'") + [n]
+      Name.where(Name[:text_name].matches("#{genus} %")) + [n]
     end.flatten.uniq.sort_by(&:id).reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(children_of: "Fungi"))
@@ -1798,7 +1803,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(is_deprecated: "true"))
     assert_api_results(names)
 
-    names = Name.where("date(updated_at) = '2009-10-12'")
+    # names = Name.where("date(updated_at) = '2009-10-12'")
+    names = Name.where(Name[:updated_at].format("%Y-%m-%d") == "2009-10-12")
     goods = names.reject(&:correct_spelling_id)
     bads  = names.select(&:correct_spelling_id)
     assert_not_empty(names)
@@ -1844,9 +1850,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(rank: "variety"))
     assert_api_results(names)
 
-    with    = Name.where.not("author is null or author = ''").
+    # with    = Name.where.not("author is null or author = ''").
+    with    = Name.where.not(Name[:author].blank).
               reject(&:correct_spelling_id)
-    without = Name.where("author is null or author = ''").
+    # without = Name.where("author is null or author = ''").
+    without = Name.where(Name[:author].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
     assert_not_empty(without)
@@ -1855,9 +1863,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_author: "no"))
     assert_api_results(without)
 
-    with    = Name.where.not("citation is null or citation = ''").
+    # with    = Name.where.not("citation is null or citation = ''").
+    with    = Name.where.not(Name[:citation].blank).
               reject(&:correct_spelling_id)
-    without = Name.where("citation is null or citation = ''").
+    # without = Name.where("citation is null or citation = ''").
+    without = Name.where(Name[:citation].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
     assert_not_empty(without)
@@ -1866,9 +1876,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_citation: "no"))
     assert_api_results(without)
 
-    with    = Name.where.not("classification is null or classification = ''").
+    # with    = Name.where.not("classification is null or classification = ''").
+    with    = Name.where.not(Name[:classification].blank).
               reject(&:correct_spelling_id)
-    without = Name.where("classification is null or classification = ''").
+    # without = Name.where("classification is null or classification = ''").
+    without = Name.where(Name[:classification].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
     assert_not_empty(without)
@@ -1877,9 +1889,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_classification: "no"))
     assert_api_results(without)
 
-    with    = Name.where.not("notes is null or notes = ''").
+    # with    = Name.where.not("notes is null or notes = ''").
+    with    = Name.where.not(Name[:notes].blank).
               reject(&:correct_spelling_id)
-    without = Name.where("notes is null or notes = ''").
+    # without = Name.where("notes is null or notes = ''").
+    without = Name.where(Name[:notes].blank).
               reject(&:correct_spelling_id)
     assert_not_empty(with)
     assert_not_empty(without)
@@ -1905,39 +1919,45 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_description: "no"))
     assert_api_results(without)
 
-    names = Name.where("text_name like '%bunny%'").
+    # names = Name.where("text_name like '%bunny%'").
+    names = Name.where(Name[:text_name].matches("%bunny%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(text_name_has: "bunny"))
     assert_api_results(names)
 
-    names = Name.where("author like '%peck%'").
+    # names = Name.where("author like '%peck%'").
+    names = Name.where(Name[:author].matches("%peck%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(author_has: "peck"))
     assert_api_results(names)
 
-    names = Name.where("citation like '%lichenes%'").
+    # names = Name.where("citation like '%lichenes%'").
+    names = Name.where(Name[:citation].matches("%lichenes%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(citation_has: "lichenes"))
     assert_api_results(names)
 
-    names = Name.where("classification like '%lecanorales%'").
+    # names = Name.where("classification like '%lecanorales%'").
+    names = Name.where(Name[:classification].matches("%lecanorales%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(classification_has: "lecanorales"))
     assert_api_results(names)
 
-    names = Name.where("notes like '%known%'").
+    # names = Name.where("notes like '%known%'").
+    names = Name.where(Name[:notes].matches("%known%")).
             reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(notes_has: "known"))
     assert_api_results(names)
 
-    names = Comment.where("target_type = 'Name' and comment like '%mess%'").
-            map(&:target).uniq.sort_by(&:id).
-            reject(&:correct_spelling_id)
+    # names = Comment.where("target_type = 'Name' and comment like '%mess%'").
+    names = Comment.where(
+      Comment[:target_type].eq("name").and(Comment[:comment].matches("%mess%"))
+    ).map(&:target).uniq.sort_by(&:id).reject(&:correct_spelling_id)
     assert_not_empty(names)
     assert_api_pass(params.merge(comments_has: "mess"))
     assert_api_results(names)
@@ -2185,17 +2205,24 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: obs.id))
     assert_api_results([obs])
 
-    obses = Observation.where("year(created_at) = 2010")
+    # obses = Observation.where("year(created_at) = 2010")
+    obses = Observation.where(Observation[:created_at].year == 2010)
     assert_not_empty(obses)
     assert_api_pass(params.merge(created_at: "2010"))
     assert_api_results(obses)
 
-    obses = Observation.where("date(updated_at) = '2007-06-24'")
+    # obses = Observation.where("date(updated_at) = '2007-06-24'")
+    obses = Observation.where(
+      Observation[:updated_at].format("%Y-%m-%d") == "2007-06-24"
+    )
     assert_not_empty(obses)
     assert_api_pass(params.merge(updated_at: "20070624"))
     assert_api_results(obses)
 
-    obses = Observation.where("year(`when`) >= 2012 and year(`when`) <= 2014")
+    # obses = Observation.where("year(`when`) >= 2012 and year(`when`) <= 2014")
+    obses = Observation.where(
+      (Observation[:when].year >= 2012).and(Observation[:when].year <= 2014)
+    )
     assert_not_empty(obses)
     assert_api_pass(params.merge(date: "2012-2014"))
     assert_api_results(obses)
@@ -2297,7 +2324,8 @@ class Api2Test < UnitTestCase
 
     genus = Name.ranks[:Genus]
     group = Name.ranks[:Group]
-    names = Name.where("`rank` <= #{genus} or `rank` = #{group}")
+    # names = Name.where("`rank` <= #{genus} or `rank` = #{group}")
+    names = Name.where((Name[:rank] <= genus).or(Name[:rank] == group))
     with = Observation.where(name: names)
     without = Observation.where.not(name: names)
     assert(with.length > 1)
@@ -2322,9 +2350,11 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_specimen: "no"))
     assert_api_results(without)
 
-    no_notes = Observation.no_notes_persisted
-    with = Observation.where("notes != ?", no_notes)
-    without = Observation.where("notes = ?", no_notes)
+    # no_notes = Observation.no_notes_persisted
+    # with = Observation.where("notes != ?", no_notes)
+    # without = Observation.where("notes = ?", no_notes)
+    with = Observation.where(Observation[:notes] != Observation.no_notes)
+    without = Observation.where(Observation[:notes] == Observation.no_notes)
     assert(with.length > 1)
     assert(without.length > 1)
     assert_api_pass(params.merge(has_notes: "yes"))
@@ -2332,27 +2362,42 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_notes: "no"))
     assert_api_results(without)
 
-    obses = Observation.where("notes like '%:substrate:%'").
-            reject { |o| o.notes[:substrate].blank? }
+    # obses = Observation.where("notes like '%:substrate:%'").
+    obses = Observation.where(
+      Observation[:notes].matches("%:substrate:%")
+    ).reject { |o| o.notes[:substrate].blank? }
     assert(obses.length > 1)
     assert_api_pass(params.merge(has_notes_field: "substrate"))
     assert_api_results(obses)
 
-    obses = Observation.where("notes like '%orphan%'")
+    # obses = Observation.where("notes like '%orphan%'")
+    obses = Observation.where(Observation[:notes].matches("%orphan%"))
     assert(obses.length > 1)
     assert_api_pass(params.merge(notes_has: "orphan"))
     assert_api_results(obses)
 
-    obses = Comment.where("concat(summary, comment) like \"%let's%\"").
-            map(&:target).uniq.sort_by(&:id)
+    # obses = Comment.where("concat(summary, comment) like \"%let's%\"").
+    obses = Comment.where(
+      Comment[:summary].concat(Comment[:comment]).matches("%let's%")
+    ).map(&:target).uniq.sort_by(&:id)
     assert(obses.length > 1)
     assert_api_pass(params.merge(comments_has: "let's"))
     assert_api_results(obses)
 
-    obses = Observation.where("`lat` >= 34 and `lat` <= 35 and
-                               `long` >= -119 and `long` <= -118")
-    locs  = Location.where("south >= 34 and north <= 35 and west >= -119 and
-                            east <= -118 and west <= east")
+    # obses = Observation.where("`lat` >= 34 and `lat` <= 35 and
+    #                            `long` >= -119 and `long` <= -118")
+    # locs  = Location.where("south >= 34 and north <= 35 and west >= -119 and
+    #                         east <= -118 and west <= east")
+    obses = Observation.where(
+      (Observation[:lat] >= 34).and(Observation[:lat] <= 35).
+      and(Observation[:long] >= -119).and(Observation[:long] <= -118)
+    )
+    locs = Location.where(
+      (Location[:south] >= 34).and(Location[:north] <= 35).
+      and(Location[:west] >= -119).and(Location[:east] <= -118).
+      and(Location[:west] <= Location[:east])
+    )
+
     obses = (obses + locs.map(&:observations)).flatten.uniq.sort_by(&:id)
     assert_not_empty(obses)
     assert_api_fail(params.merge(south: 34, east: -118, west: -119))
@@ -2362,8 +2407,12 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(north: 35, south: 34, east: -118, west: -119))
     assert_api_results(obses)
 
-    obses = Observation.where("`where` like '%, California, USA' OR " \
-                              "`where` = 'California, USA'")
+    # obses = Observation.where("`where` like '%, California, USA' OR " \
+    #                           "`where` = 'California, USA'")
+    obses = Observation.where(
+      Observation[:where].matches("%, California, USA").
+      or(Observation[:where].matches("California, USA"))
+    )
     assert_not_empty(obses)
     assert_api_pass(params.merge(region: "California, USA"))
     assert_api_results(obses)
@@ -2721,13 +2770,17 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: proj.id))
     assert_api_results([proj])
 
-    projs = Project.where("year(created_at) = 2008")
+    # projs = Project.where("year(created_at) = 2008")
+    projs = Project.where(Project[:created_at].year == 2008)
     assert_not_empty(projs)
     assert_api_pass(params.merge(created_at: "2008"))
     assert_api_results(projs)
 
-    projs = Project.where("year(updated_at) = 2008 and
-                           month(updated_at) = 9")
+    # projs = Project.where("year(updated_at) = 2008 and
+    #                        month(updated_at) = 9")
+    projs = Project.where(
+      (Project[:updated_at].year == 2008).and(Project[:updated_at].month == 9)
+    )
     assert_not_empty(projs)
     assert_api_pass(params.merge(updated_at: "2008-09"))
     assert_api_results(projs)
@@ -2758,8 +2811,10 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_comments: "yes"))
     assert_api_results(projs)
 
-    with    = Project.where("summary is not null and summary != ''")
-    without = Project.where("summary is null or summary = ''")
+    # with    = Project.where("summary is not null and summary != ''")
+    # without = Project.where("summary is null or summary = ''")
+    with    = Project.where(Project[:summary].not_blank)
+    without = Project.where(Project[:summary].blank)
     assert_not_empty(with)
     assert_not_empty(without)
     assert_api_pass(params.merge(has_summary: "yes"))
@@ -2767,12 +2822,14 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_summary: "no"))
     assert_api_results(without)
 
-    projs = Project.where("title like '%bolete%'")
+    # projs = Project.where("title like '%bolete%'")
+    projs = Project.where(Project[:title].matches("%bolete%"))
     assert_not_empty(projs)
     assert_api_pass(params.merge(title_has: "bolete"))
     assert_api_results(projs)
 
-    projs = Project.where("summary like '%article%'")
+    # projs = Project.where("summary like '%article%'")
+    projs = Project.where(Project[:summary].matches("%article%"))
     assert_not_empty(projs)
     assert_api_pass(params.merge(summary_has: "article"))
     assert_api_results(projs)
@@ -2971,7 +3028,7 @@ class Api2Test < UnitTestCase
     end
 
     obses = Observation.where(
-      Observation[:when].year.gteq(2012).and(Observation[:when].year.lteq(2014))
+      (Observation[:when].year >= 2012).and(Observation[:when].year <= 2014)
     )
     assert_not_empty(obses)
     assert_api_pass(params.merge(obs_date: "2012-2014"))

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -550,12 +550,14 @@ class Api2Test < UnitTestCase
   def test_getting_collection_numbers
     params = { method: :get, action: :collection_number }
 
-    nums = CollectionNumber.where("year(created_at) = 2006")
+    # nums = CollectionNumber.where("year(created_at) = 2006")
+    nums = CollectionNumber.where(CollectionNumber[:created_at].year == 2006)
     assert_not_empty(nums)
     assert_api_pass(params.merge(created_at: "2006"))
     assert_api_results(nums)
 
-    nums = CollectionNumber.where("year(updated_at) = 2005")
+    # nums = CollectionNumber.where("year(updated_at) = 2005")
+    nums = CollectionNumber.where(CollectionNumber[:updated_at].year == 2005)
     assert_not_empty(nums)
     assert_api_pass(params.merge(updated_at: "2005"))
     assert_api_results(nums)
@@ -576,7 +578,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(collector: "Mary Newbie"))
     assert_api_results(nums)
 
-    nums = CollectionNumber.where("name LIKE '%mary%'")
+    # nums = CollectionNumber.where("name LIKE '%mary%'")
+    nums = CollectionNumber.where(CollectionNumber[:name].matches("%mary%"))
     assert_not_empty(nums)
     assert_api_pass(params.merge(collector_has: "Mary"))
     assert_api_results(nums)
@@ -586,7 +589,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(number: "174"))
     assert_api_results(nums)
 
-    nums = CollectionNumber.where("number LIKE '%17%'")
+    # nums = CollectionNumber.where("number LIKE '%17%'")
+    nums = CollectionNumber.where(CollectionNumber[:number].matches("%17%"))
     assert_not_empty(nums)
     assert_api_pass(params.merge(number_has: "17"))
     assert_api_results(nums)
@@ -925,7 +929,8 @@ class Api2Test < UnitTestCase
       method: :get,
       action: :external_site
     }
-    sites = ExternalSite.where("name like '%inat%'")
+    # sites = ExternalSite.where("name like '%inat%'")
+    sites = ExternalSite.where(ExternalSite[:name].matches("%inat%"))
     assert_not_empty(sites)
     assert_api_pass(params.merge(name: "inat"))
     assert_api_results(sites)
@@ -941,7 +946,10 @@ class Api2Test < UnitTestCase
       action: :herbarium
     }
 
-    herbs = Herbarium.where("date(created_at) = '2012-10-21'")
+    herbs = Herbarium.where(
+      # "date(created_at) = '2012-10-21'"
+      Herbarium[:created_at].format("%Y-%m-%d") == "2012-10-21"
+    )
     assert_not_empty(herbs)
     assert_api_pass(params.merge(created_at: "2012-10-21"))
     assert_api_results(herbs)
@@ -956,17 +964,20 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(code: "NY"))
     assert_api_results(herbs)
 
-    herbs = Herbarium.where("name like '%personal%'")
+    # herbs = Herbarium.where("name like '%personal%'")
+    herbs = Herbarium.where(Herbarium[:name].matches("%personal%"))
     assert_not_empty(herbs)
     assert_api_pass(params.merge(name: "personal"))
     assert_api_results(herbs)
 
-    herbs = Herbarium.where("description like '%awesome%'")
+    # herbs = Herbarium.where("description like '%awesome%'")
+    herbs = Herbarium.where(Herbarium[:description].matches("%awesome%"))
     assert_not_empty(herbs)
     assert_api_pass(params.merge(description: "awesome"))
     assert_api_results(herbs)
 
-    herbs = Herbarium.where("mailing_address like '%New York%'")
+    # herbs = Herbarium.where("mailing_address like '%New York%'")
+    herbs = Herbarium.where(Herbarium[:mailing_address].matches("%New York%"))
     assert_not_empty(herbs)
     assert_api_pass(params.merge(address: "New York"))
     assert_api_results(herbs)
@@ -979,12 +990,14 @@ class Api2Test < UnitTestCase
   def test_getting_herbarium_records
     params = { method: :get, action: :herbarium_record }
 
-    recs = HerbariumRecord.where("year(created_at) = 2012")
+    # recs = HerbariumRecord.where("year(created_at) = 2012")
+    recs = HerbariumRecord.where(HerbariumRecord[:created_at].year == 2012)
     assert_not_empty(recs)
     assert_api_pass(params.merge(created_at: "2012"))
     assert_api_results(recs)
 
-    recs = HerbariumRecord.where("year(updated_at) = 2017")
+    # recs = HerbariumRecord.where("year(updated_at) = 2017")
+    recs = HerbariumRecord.where(HerbariumRecord[:updated_at].year == 2017)
     assert_not_empty(recs)
     assert_api_pass(params.merge(updated_at: "2017"))
     assert_api_results(recs)
@@ -1006,17 +1019,20 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(observation: obs.id))
     assert_api_results(recs)
 
-    recs = HerbariumRecord.where("notes LIKE '%dried%'")
+    # recs = HerbariumRecord.where("notes LIKE '%dried%'")
+    recs = HerbariumRecord.where(HerbariumRecord[:notes].matches("%dried%"))
     assert_not_empty(recs)
     assert_api_pass(params.merge(notes_has: "dried"))
     assert_api_results(recs)
 
-    recs = HerbariumRecord.where("COALESCE(notes, '') = ''")
+    # recs = HerbariumRecord.where("COALESCE(notes, '') = ''")
+    recs = HerbariumRecord.where(HerbariumRecord[:notes].blank)
     assert_not_empty(recs)
     assert_api_pass(params.merge(has_notes: "no"))
     assert_api_results(recs)
 
-    recs = HerbariumRecord.where("CONCAT(notes, '') != ''")
+    # recs = HerbariumRecord.where("CONCAT(notes, '') != ''")
+    recs = HerbariumRecord.where(HerbariumRecord[:notes].not_blank)
     assert_not_empty(recs)
     assert_api_pass(params.merge(has_notes: "yes"))
     assert_api_results(recs)
@@ -1026,7 +1042,10 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(initial_det: "Coprinus comatus"))
     assert_api_results(recs)
 
-    recs = HerbariumRecord.where("initial_det LIKE '%coprinus%'")
+    # recs = HerbariumRecord.where("initial_det LIKE '%coprinus%'")
+    recs = HerbariumRecord.where(
+      HerbariumRecord[:initial_det].matches("%coprinus%")
+    )
     assert_not_empty(recs)
     assert_api_pass(params.merge(initial_det_has: "coprinus"))
     assert_api_results(recs)
@@ -1036,7 +1055,10 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(accession_number: "1234"))
     assert_api_results(recs)
 
-    recs = HerbariumRecord.where("accession_number LIKE '%23%'")
+    # recs = HerbariumRecord.where("accession_number LIKE '%23%'")
+    recs = HerbariumRecord.where(
+      HerbariumRecord[:accession_number].matches("%23%")
+    )
     assert_not_empty(recs)
     assert_api_pass(params.merge(accession_number_has: "23"))
     assert_api_results(recs)
@@ -1188,13 +1210,19 @@ class Api2Test < UnitTestCase
     assert_api_results([img])
 
     assert_api_pass(params.merge(created_at: "2006"))
-    assert_api_results(Image.where("year(created_at) = 2006"))
+    # assert_api_results(Image.where("year(created_at) = 2006"))
+    assert_api_results(Image.where(Image[:created_at].year == 2006))
 
     assert_api_pass(params.merge(updated_at: "2006-05-22"))
-    assert_api_results(Image.where('date(updated_at) = "2006-05-22"'))
+    # assert_api_results(Image.where('date(updated_at) = "2006-05-22"'))
+    assert_api_results(Image.where(
+                         Image[:updated_at].format("%Y-%m-%d") == "2006-05-22"
+                       ))
 
     assert_api_pass(params.merge(date: "2007-03"))
-    assert_api_results(Image.where("year(`when`) = 2007 and month(`when`) = 3"))
+    # assert_api_results(Image.where("year(`when`) = 2007 and month(`when`) = 3"))
+    assert_api_results(Image.where((Image[:when].year == 2007).
+                             and(Image[:when].month == 3)))
 
     assert_api_pass(params.merge(user: "#{mary.id},#{katrina.id}"))
     assert_api_results(Image.where(user: [mary, katrina]))
@@ -1265,9 +1293,11 @@ class Api2Test < UnitTestCase
     # assert_api_pass(params.merge(has_observation: "no"))
     # assert_api_results(unattached)
 
-    imgs = Image.where("width >= 1280 || height >= 1280")
+    # imgs = Image.where("width >= 1280 || height >= 1280")
+    imgs = Image.where((Image[:width] >= 1280).or(Image[:height] >= 1280))
     assert_empty(imgs)
-    imgs = Image.where("width >= 960 || height >= 960")
+    # imgs = Image.where("width >= 960 || height >= 960")
+    imgs = Image.where((Image[:width] >= 960).or(Image[:height] >= 960))
     assert_not_empty(imgs)
     assert_api_pass(params.merge(size: "huge"))
     assert_api_results([])
@@ -1287,25 +1317,36 @@ class Api2Test < UnitTestCase
     assert_api_results([pretty_img])
 
     assert_api_pass(params.merge(copyright_holder_has: "Insil Choi"))
-    assert_api_results(Image.where("copyright_holder like '%insil choi%'"))
+    # assert_api_results(Image.where("copyright_holder like '%insil choi%'"))
+    assert_api_results(Image.where(
+                         Image[:copyright_holder].matches("%insil choi%")
+                       ))
     assert_api_pass(params.merge(copyright_holder_has: "Nathan"))
-    assert_api_results(Image.where("copyright_holder like '%nathan%'"))
+    # assert_api_results(Image.where("copyright_holder like '%nathan%'"))
+    assert_api_results(Image.where(
+                         Image[:copyright_holder].matches("%nathan%")
+                       ))
 
     pd = licenses(:publicdomain)
     assert_api_pass(params.merge(license: pd.id))
     assert_api_results(Image.where(license: pd))
 
     assert_api_pass(params.merge(has_votes: "yes"))
-    assert_api_results(Image.where("vote_cache IS NOT NULL"))
+    # assert_api_results(Image.where("vote_cache IS NOT NULL"))
+    assert_api_results(Image.where(Image[:vote_cache].not_eq(nil)))
     assert_api_pass(params.merge(has_votes: "no"))
-    assert_api_results(Image.where("vote_cache IS NULL"))
+    # assert_api_results(Image.where("vote_cache IS NULL"))
+    assert_api_results(Image.where(Image[:vote_cache].eq(nil)))
 
     assert_api_pass(params.merge(quality: "2-3"))
-    assert_api_results(Image.where("vote_cache > 2.0"))
+    # assert_api_results(Image.where("vote_cache > 2.0"))
+    assert_api_results(Image.where(Image[:vote_cache] > 2.0))
     assert_api_pass(params.merge(quality: "1-2"))
     assert_api_results([])
 
-    imgs = Observation.where("vote_cache >= 2.0").map(&:images).flatten
+    # imgs = Observation.where("vote_cache >= 2.0").map(&:images).flatten
+    imgs = Observation.where(Observation[:vote_cache] >= 2.0).
+           map(&:images).flatten
     assert_not_empty(imgs)
     assert_api_pass(params.merge(confidence: "2-3"))
     assert_api_results(imgs)
@@ -1501,12 +1542,16 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(id: loc.id))
     assert_api_results([loc])
 
-    locs = Location.where("year(created_at) = 2008")
+    # locs = Location.where("year(created_at) = 2008")
+    locs = Location.where(Location[:created_at].year == 2008)
     assert_not_empty(locs)
     assert_api_pass(params.merge(created_at: "2008"))
     assert_api_results(locs)
 
-    locs = Location.where("date(created_at) = '2012-01-01'")
+    # locs = Location.where("date(created_at) = '2012-01-01'")
+    locs = Location.where(
+      Location[:created_at].format("%Y-%m-%d") == "2012-01-01"
+    )
     assert_not_empty(locs)
     assert_api_pass(params.merge(updated_at: "2012-01-01"))
     assert_api_results(locs)
@@ -1516,8 +1561,14 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(user: "rolf"))
     assert_api_results(locs)
 
-    locs = Location.where("south >= 39 and north <= 40 and
-                           west >= -124 and east <= -123 and west <= east")
+    # locs = Location.where("south >= 39 and north <= 40 and
+    #                        west >= -124 and east <= -123 and west <= east")
+    locs = Location.where(
+      (Location[:south] >= 39).and(Location[:north] <= 40).
+      and(Location[:west] >= -124).and(Location[:east] <= -123).
+      and(Location[:west] <= Location[:east])
+    )
+
     assert_not_empty(locs)
     assert_api_fail(params.merge(south: 39, east: -123, west: -124))
     assert_api_fail(params.merge(north: 40, east: -123, west: -124))

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -2353,6 +2353,8 @@ class Api2Test < UnitTestCase
     # no_notes = Observation.no_notes_persisted
     # with = Observation.where("notes != ?", no_notes)
     # without = Observation.where("notes = ?", no_notes)
+    # Nimmo note: Observation.no_notes_persisted is just no_notes.to_yaml
+    # Observation.no_notes, not the above, works for comparison in Arel here.
     with = Observation.where(Observation[:notes] != Observation.no_notes)
     without = Observation.where(Observation[:notes] == Observation.no_notes)
     assert(with.length > 1)
@@ -3164,8 +3166,8 @@ class Api2Test < UnitTestCase
     assert_api_pass(params.merge(has_specimen: "no"))
     assert_api_results(without.map(&:sequences).flatten.sort_by(&:id))
 
-    # Nimmo note: no_notes_persisted is just no_notes.to_yaml
-    # no_notes, rather than above, is what works for comparison in Arel here.
+    # Nimmo note: Observation.no_notes_persisted is just no_notes.to_yaml
+    # Observation.no_notes, not the above, works for comparison in Arel here.
     with = Observation.where(Observation[:notes] != Observation.no_notes)
     without = Observation.where(Observation[:notes] == Observation.no_notes)
 


### PR DESCRIPTION
Rewrites SQL strings in AR or Arel. Mostly where clauses testing query results.

Note the convenient [arel-extensions methods](https://github.com/Faveod/arel-extensions) `blank` and `not_blank` here  💅 that generate null-coalescing SQL