### PR TITLE
User — Fix memoization by adding a trivial method to shield query

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -597,10 +597,10 @@ class User < AbstractModel
   # Project that the User is a member of.
   def all_editable_species_lists(include: nil)
     @all_editable_species_lists ||=
-      calc_all_editable_species_lists(include: nil)
+      calc_all_editable_species_lists(include)
   end
 
-  def calc_all_editable_species_lists(include: nil)
+  def calc_all_editable_species_lists(include)
     return species_lists.includes(include) if projects_member.none?
 
     SpeciesList.includes(include).

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -596,13 +596,15 @@ class User < AbstractModel
   # Return an Array of SpeciesList's that User owns or that are attached to a
   # Project that the User is a member of.
   def all_editable_species_lists(include: nil)
-    @all_editable_species_lists ||= begin
-      return species_lists.includes(include) if projects_member.none?
+    @all_editable_species_lists ||= calc_all_editable_species_lists(include)
+  end
 
-      SpeciesList.includes(include).
-        where(SpeciesList[:user_id].eq(id).
-        or(SpeciesList[:id].in(species_lists_in_users_projects))).uniq
-    end
+  def calc_all_editable_species_lists(include: nil)
+    return species_lists.includes(include) if projects_member.none?
+
+    SpeciesList.includes(include).
+      where(SpeciesList[:user_id].eq(id).
+      or(SpeciesList[:id].in(species_lists_in_users_projects))).uniq
   end
 
   def species_lists_in_users_projects

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -596,7 +596,8 @@ class User < AbstractModel
   # Return an Array of SpeciesList's that User owns or that are attached to a
   # Project that the User is a member of.
   def all_editable_species_lists(include: nil)
-    @all_editable_species_lists ||= calc_all_editable_species_lists(include)
+    @all_editable_species_lists ||=
+      calc_all_editable_species_lists(include: nil)
   end
 
   def calc_all_editable_species_lists(include: nil)


### PR DESCRIPTION
For posterity, from @pellaea 👍

> I am concerned that this (*note: the method concerned*) will avoid setting `@all_editable_species_lists`, defeating the memoization. While I hate unnecessarily splitting methods up, this may be a "necessary" case. Consider moving the body into something like `calc_all_editable_species_lists`, and then make `all_editable_species_lists` a trivial memoized method: `@all_editable_species_lists ||= calc_all_editable_species_lists`. Then when your guard clause here returns early, it will still save the result in `@all_editable_species_lists` and not have to run `species_lists.includes(include)` multiple times if `all_editable_species_lists` is called multiple times.