### PR TITLE
Make "Earth" the default unknown_location_name a constant, also use in tests

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -243,9 +243,10 @@ class Location < AbstractModel
 
   # Get an instance of the Location whose name means "unknown".
   def self.unknown
-    raise("There is no \"unknown\" location!") if names_for_unknown.empty?
+    raise("There is no \"unknown_location_name\" configured!") if
+      MO.unknown_location_name.blank?
 
-    Location.find_by(Location[:name].matches_any(names_for_unknown))
+    Location.find_by(name: MO.unknown_location_name)
   end
 
   # Is this one of the names we recognize for the "unknown" location?

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -113,6 +113,7 @@ MushroomObserver::Application.configure do
   config.location_states_file    = "#{location_path}states.yml"
   config.location_prefixes_file  = "#{location_path}prefixes.yml"
   config.location_bad_terms_file = "#{location_path}bad_terms.yml"
+  config.unknown_location_name = "Earth"
 
   # Limit the number of objects we draw on a google map.
   config.max_map_objects = 100

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -124,14 +124,14 @@ class Api2ControllerTest < FunctionalTestCase
   end
 
   def test_post_minimal_observation
-    params = { api_key: api_keys(:rolfs_api_key).key, location: "Unknown" }
+    params = { api_key: api_keys(:rolfs_api_key).key, location: "Earth" }
     post(:observations, params: params)
     assert_no_api_errors
     obs = Observation.last
     assert_users_equal(rolf, obs.user)
     assert_equal(Time.zone.today.web_date, obs.when.web_date)
     assert_objs_equal(Location.unknown, obs.location)
-    assert_equal("Unknown", obs.where)
+    assert_equal("Earth", obs.where)
     assert_names_equal(names(:fungi), obs.name)
     assert_equal(1, obs.namings.length)
     assert_equal(1, obs.votes.length)

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -126,13 +126,13 @@ class ApiControllerTest < FunctionalTestCase
   def test_post_minimal_observation
     post(:observations,
          api_key: api_keys(:rolfs_api_key).key,
-         location: "Unknown")
+         location: "Earth")
     assert_no_api_errors
     obs = Observation.last
     assert_users_equal(rolf, obs.user)
     assert_equal(Time.zone.today.web_date, obs.when.web_date)
     assert_objs_equal(Location.unknown, obs.location)
-    assert_equal("Unknown", obs.where)
+    assert_equal("Earth", obs.where)
     assert_names_equal(names(:fungi), obs.name)
     assert_equal(1, obs.namings.length)
     assert_equal(1, obs.votes.length)

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -725,7 +725,7 @@ class LocationControllerTest < FunctionalTestCase
     post(:edit_location, params)
     location.reload
     assert_true(location.locked)
-    assert_equal("Unknown", location.name)
+    assert_equal("Earth", location.name)
     assert_equal(90, location.north)
     assert_equal(-90, location.south)
     assert_equal(180, location.east)

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -3,7 +3,8 @@
 # in a fixture on the opposite side of the association.
 # See https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-DEFAULTS: &DEFAULTS
+DEFAULTS:
+  &DEFAULTS
   locked: false
   user: rolf
   version: 1
@@ -44,7 +45,7 @@ mitrula_marsh:
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
   name: '"Mitrula Marsh", Sand Lake, Bassetts, Yuba Co., California, USA'
-  scientific_name: 'USA, California, Yuba Co., Bassetts, Sand Lake'
+  scientific_name: "USA, California, Yuba Co., Bassetts, Sand Lake"
   north: 39.7184
   west: -120.687
   east: -120.487
@@ -128,8 +129,8 @@ unknown_location:
   created_at: 2012-01-01 15:24:18
   updated_at: 2012-01-01 15:24:18
   user_id: 0
-  name: Unknown
-  scientific_name: Unknown
+  name: Earth
+  scientific_name: Earth
   north: 90
   west: -180
   east: 180
@@ -147,7 +148,7 @@ nybg_location:
   east: -73.878
   south: 40.866
 
-# Do not use this location for any object
+  # Do not use this location for any object
   <<: *DEFAULTS
 unused_location:
   user_id: 0


### PR DESCRIPTION
Add unknown_location_name in config/consts.rb
Change the "Unknown" location fixture to "Earth"
Change the tests that match for this name
Note: "Unknown" remains a recognized "unknown" location. It's just that we're "hardcoding" "Earth" as the default.