### PR TITLE
Unlock mail gem version, fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,10 +99,7 @@ gem("simple_enum")
 gem("jquery-slick-rails")
 
 # email generation, parsing and sending
-# version locked to prevent test failures caused by added "=0D" at the
-# end of line in the body of plaintext emails.
-# See https://www.pivotaltracker.com/story/show/172299270/comments/213574631
-gem("mail", "= 2.7.0")
+gem("mail")
 
 # for detecting file type of uploaded images
 gem("mimemagic")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-slick-rails
-  mail (= 2.7.0)
+  mail
   mimemagic
   mini_racer
   minitest
@@ -368,4 +368,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   2.3.13
+   2.3.5

--- a/config/initializers/mail_patch.rb
+++ b/config/initializers/mail_patch.rb
@@ -1,4 +1,5 @@
-# config/initializers/mail_patch.rb
+# frozen_string_literal: true
+
 # Resolves an issue in mail 2.7.1 and above, where newlines are inserted
 # in mail body every x characters. This allows tests to pass
 module Mail

--- a/config/initializers/mail_patch.rb
+++ b/config/initializers/mail_patch.rb
@@ -1,0 +1,10 @@
+# config/initializers/mail_patch.rb
+# Resolves an issue in mail 2.7.1 and above, where newlines are inserted
+# in mail body every x characters. This allows tests to pass
+module Mail
+  module Utilities
+    def self.safe_for_line_ending_conversion?(string)
+      string.ascii_only?
+    end
+  end
+end


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/172299270/comments/213574631

Gem `mail` version had been locked to prevent test failures caused by a new behavior in version 2.7.1, where the gem adds Unix-style newlines `"=0D"` at the end of lines in the body of plaintext emails. The behavior is [not going away](https://stackoverflow.com/a/52910806/3357635), though, because it's part of email spec (RFC 5322, 2822, 822)

This new config/initializers/mail_patch.rb strips the newlines out, allows for checking the contents of mail in tests without including the newlines, and gets the tests passing with current mail. In my local environment, it's the only gem blocking MO from moving to Rails 6.0, which I have working and passing tests locally.

Discussion of issue and solution here: https://github.com/mikel/mail/issues/1325
