### PR TITLE
Add mass-insert gem for insert_all functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,11 @@ gem("mysql2")
 gem("arel_extensions")
 gem("arel-helpers")
 
+# Add method `mass_insert` for bulk db inserts in ActiveRecord.
+# Same basic syntax as upcoming Rails 6 `insert_all`
+# If upgrading to Rails 6, we can disable the gem and switch methods
+gem("mass_insert")
+
 # Use bootstrap style generator
 gem("bootstrap-sass")
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    mass_insert (1.0.0)
+      activerecord (>= 5.2)
     matrix (0.4.2)
     method_source (1.0.0)
     mimemagic (0.4.3)
@@ -339,6 +341,7 @@ DEPENDENCIES
   jquery-rails
   jquery-slick-rails
   mail (= 2.7.0)
+  mass_insert
   mimemagic
   mini_racer
   minitest
@@ -368,4 +371,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   2.3.13
+   2.3.5


### PR DESCRIPTION
The gem adds a `mass_insert` method, modeled on Rails 6's `insert_all`, that allows for bulk inserts in a single ActiveRecord statement. 

It takes an identically-formatted argument: an *array of hashes containing the values for each row inserted to the table*. (`mass_insert` also has a couple of useful optional arguments that we don't need yet.) 

When we get to Rails 6, it should be easy to swap the method names out and delete the gem.

(I will now remove this commit from the Image SQL PR. Made a separate PR because I also need `mass_insert` to simplify a method in `Synonym`, and get it passing locally for Rails 6.)
If no objections, I'd like to merge this today.