### PR TITLE
Fix Rails 6.1 deprecation warning for ExternalSite.name validation

### DIFF
--- a/app/models/external_site.rb
+++ b/app/models/external_site.rb
@@ -16,7 +16,8 @@ class ExternalSite < AbstractModel
   has_many   :observations, through: :external_links
 
   validates :project, presence: true
-  validates :name,    presence: true, length: { maximum: 100 }, uniqueness: true
+  validates :name,    presence: true, length: { maximum: 100 },
+                      uniqueness: { case_sensitive: false }
 
   def member?(user)
     user.in_group?(project.user_group)

--- a/test/models/external_site_test.rb
+++ b/test/models/external_site_test.rb
@@ -10,6 +10,13 @@ class ExternalSiteTest < UnitTestCase
     )
     assert_not_nil(site)
     assert_empty(site.errors)
+
+    assert_raises("Name has already been taken") do
+      ExternalSite.create!(
+        name: "genbank",
+        project: Project.first
+      )
+    end
   end
 
   def test_create_missing_attributes


### PR DESCRIPTION
Passes new "case_sensitive" param to the uniqueness validator for ExternalSite.name. 
This PR proposes setting `case-sensitive: false` because domains, at least, are not case sensitive, even if we write them "MycoPortal.org" we don't want to add a second "mycoportal.org"

Please let me know if this seems OK. It's our only deprecation warning(?!)