### PR TITLE
Fix deprecation warnings about enumerating or adding to ActiveModel::Errors

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -315,13 +315,15 @@ class AbstractModel < ApplicationRecord
   #   obj.errors.add(:attr, "message").
   def formatted_errors
     out = []
-    errors.each do |attr, msg|
-      if /^[A-Z]/.match?(msg)
-        out << msg
+    errors.each do |error|
+      attribute = error.attribute
+      message = error.message
+      if /^[A-Z]/.match?(message)
+        out << message
       else
-        name = attr.to_s.to_sym.l
+        name = attribute.to_s.to_sym.l
         obj = type_tag.to_s.upcase_first.to_sym.l
-        out << "#{obj} #{name} #{msg}."
+        out << "#{obj} #{name} #{message}."
       end
     end
     out

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -100,7 +100,7 @@ class GlossaryTerm < AbstractModel
   def must_have_description_or_image
     return if description.present? || thumb_image.present?
 
-    errors[:base] << :glossary_error_description_or_image.t
+    errors.add(:base, :glossary_error_description_or_image.t)
   end
 
   def destroy_unused_images

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -427,9 +427,8 @@ class Name < AbstractModel
   def icn_id_registrable
     return if icn_id.blank? || registrable?
 
-    errors[:base] << :name_error_unregistrable.t(
-      rank: rank.to_s, name: real_search_name
-    )
+    errors.add(:base, :name_error_unregistrable.t,
+               { rank: rank.to_s, name: real_search_name })
   end
 
   # Require icn_id to be unique
@@ -439,9 +438,8 @@ class Name < AbstractModel
     return if icn_id.nil?
     return if (conflicting_name = other_names_with_same_icn_id.first).blank?
 
-    errors[:base] << :name_error_icn_id_in_use.t(
-      number: icn_id, name: conflicting_name.real_search_name
-    )
+    errors.add(:base, :name_error_icn_id_in_use.t,
+               { number: icn_id, name: conflicting_name.real_search_name })
   end
 
   def other_names_with_same_icn_id


### PR DESCRIPTION
Fixes two deprecation warnings about how ActiveModel::Errors are handled.

DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:

person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end

You are passing a block expecting two parameters,
so the old hash behavior is simulated. As this is deprecated,
this will result in an ArgumentError in Rails 7.0.

DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from must_have_description_or_image at /home/runner/work/mushroom-observer/mushroom-observer/app/models/glossary_term.rb:103)