### PR TITLE
Language.calculate_users_contribution — Fixes latent code formatting issue for 6.1

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -71,7 +71,8 @@ class Language < AbstractModel
   # It counts paragraphs, actually, and weights them according to length.
   def self.calculate_users_contribution(user)
     lines = 0
-    get_user_translation_contributions_overall(user).each do |text|
+    contributions = get_user_translation_contributions_overall(user)
+    contributions.pluck(:text).each do |text|
       lines += score_lines(text)
     end
     lines
@@ -82,14 +83,14 @@ class Language < AbstractModel
     TranslationString::Version.
       where(v[:user_id].eq(user.id)).
       group(v[:translation_string_id]).
-      select(v[:text].group_concat("\n", order: [v[:text].asc])).
-      pluck(v[:text])
+      select(v[:text].group_concat("\n", order: [v[:text].asc]))
   end
 
   # For one language (instance method)
   def calculate_users_contribution(user)
     lines = 0
-    get_user_translation_contributions(user).each do |text|
+    contributions = get_user_translation_contributions(user)
+    contributions.pluck(:text).each do |text|
       lines += Language.score_lines(text)
     end
     lines
@@ -102,8 +103,7 @@ class Language < AbstractModel
       where(TranslationString[:language_id].eq(id)).
       where(v[:user_id].eq(user.id)).
       group(TranslationString[:id]).
-      select(v[:text].group_concat("\n", order: [v[:text].asc])).
-      pluck(v[:text])
+      select(v[:text].group_concat("\n", order: [v[:text].asc]))
   end
 
   def self.score_lines(text)

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -568,9 +568,9 @@ class AjaxControllerTest < FunctionalTestCase
   def build_name_primer_item(name)
     { id: name.id,
       text_name: name.text_name,
+      author: name.author,
       deprecated: name.deprecated,
-      synonym_id: name.synonym_id,
-      author: name.author }.to_json
+      synonym_id: name.synonym_id }.to_json
   end
 
   def test_location_primer

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -568,9 +568,9 @@ class AjaxControllerTest < FunctionalTestCase
   def build_name_primer_item(name)
     { id: name.id,
       text_name: name.text_name,
-      author: name.author,
       deprecated: name.deprecated,
-      synonym_id: name.synonym_id }.to_json
+      synonym_id: name.synonym_id,
+      author: name.author }.to_json
   end
 
   def test_location_primer


### PR DESCRIPTION
In Language, the plucks in the two `get_contributions` methods were confusing to future Rails 6.1. I just moved them to the `calculate` methods. Very minor refactor.

~In AjaxControllerTest, the method build_name_primer_item built the hash in an order different from expected. (Could have to do with tightened behavior for kwargs?) Anyway this small change solves it.~ Must wait for 6.1, doesn't pass here

