### PR TITLE
NameTest: Fix kwarg deprecation warning

### DIFF
--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -16,8 +16,8 @@ class NameTest < UnitTestCase
   end
 
   # Parse a string, with detailed error message.
-  def do_name_parse_test(str, expects, deprecated: false)
-    parse = Name.parse_name(str, deprecated: deprecated)
+  def do_name_parse_test(str, expects)
+    parse = Name.parse_name(str, deprecated: expects[:deprecated])
     assert(parse, "Expected #{str.inspect} to parse!")
     any_errors = false
     msg = ["Name is wrong; expected -vs- actual:"]
@@ -576,7 +576,8 @@ class NameTest < UnitTestCase
       display_name: "**__Lecania ryaniana__** van den Boom",
       parent_name: "Lecania",
       rank: :Species,
-      author: "van den Boom"
+      author: "van den Boom",
+      deprecated: false
     )
   end
 
@@ -591,7 +592,8 @@ class NameTest < UnitTestCase
       display_name: "**__Lecania__** van den Boom",
       parent_name: nil,
       rank: :Genus,
-      author: "van den Boom"
+      author: "van den Boom",
+      deprecated: false
     )
   end
 
@@ -606,7 +608,8 @@ class NameTest < UnitTestCase
       display_name: "**__Lecania ryaniana__** de Hoog",
       parent_name: "Lecania",
       rank: :Species,
-      author: "de Hoog"
+      author: "de Hoog",
+      deprecated: false
     )
   end
 
@@ -621,7 +624,8 @@ class NameTest < UnitTestCase
       display_name: "**__Lecania__** de Hoog",
       parent_name: nil,
       rank: :Genus,
-      author: "de Hoog"
+      author: "de Hoog",
+      deprecated: false
     )
   end
 
@@ -636,7 +640,8 @@ class NameTest < UnitTestCase
       display_name: "**__Synchytrium__** subg. **__Endochytrium__** du Plessis",
       parent_name: "Synchytrium",
       rank: :Subgenus,
-      author: "du Plessis"
+      author: "du Plessis",
+      deprecated: false
     )
   end
 
@@ -651,7 +656,8 @@ class NameTest < UnitTestCase
       display_name: "**__Lecidea sanguineoatra__** sensu Nyl",
       parent_name: "Lecidea",
       rank: :Species,
-      author: "sensu Nyl"
+      author: "sensu Nyl",
+      deprecated: false
     )
   end
 
@@ -666,7 +672,8 @@ class NameTest < UnitTestCase
       display_name: "**__Acarospora squamulosa__** sensu Th. Fr.",
       parent_name: "Acarospora",
       rank: :Species,
-      author: "sensu Th. Fr."
+      author: "sensu Th. Fr.",
+      deprecated: false
     )
   end
 
@@ -685,7 +692,8 @@ class NameTest < UnitTestCase
         "f. **__decolorans__** auct.",
       parent_name: "Cladina portentosa subsp. pacifica",
       rank: :Form,
-      author: "auct."
+      author: "auct.",
+      deprecated: false
     )
   end
 
@@ -700,7 +708,8 @@ class NameTest < UnitTestCase
       display_name: "**__Japewia tornoënsis__** Somloë",
       parent_name: "Japewia",
       rank: :Species,
-      author: "Somloë"
+      author: "Somloë",
+      deprecated: false
     )
   end
 
@@ -715,7 +724,8 @@ class NameTest < UnitTestCase
       display_name: '**__Micarea globularis__** "(Ach. ex Nyl.) Hedl."',
       parent_name: "Micarea",
       rank: :Species,
-      author: '"(Ach. ex Nyl.) Hedl."'
+      author: '"(Ach. ex Nyl.) Hedl."',
+      deprecated: false
     )
   end
 
@@ -730,7 +740,8 @@ class NameTest < UnitTestCase
       display_name: '**__Synechoblastus aggregatus__** ("Ach.") Th. Fr.',
       parent_name: "Synechoblastus",
       rank: :Species,
-      author: '("Ach.") Th. Fr.'
+      author: '("Ach.") Th. Fr.',
+      deprecated: false
     )
   end
 
@@ -745,7 +756,8 @@ class NameTest < UnitTestCase
       display_name: '**__"Toninia"__**',
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -760,7 +772,8 @@ class NameTest < UnitTestCase
       display_name: '**__"Toninia"__**',
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -775,7 +788,8 @@ class NameTest < UnitTestCase
       display_name: '**__"Toninia" squalescens__**',
       parent_name: '"Toninia"',
       rank: :Species,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -790,7 +804,8 @@ class NameTest < UnitTestCase
       display_name: '**__Anaptychia "leucomelaena"__** auct.',
       parent_name: "Anaptychia",
       rank: :Species,
-      author: "auct."
+      author: "auct.",
+      deprecated: false
     )
   end
 
@@ -805,7 +820,8 @@ class NameTest < UnitTestCase
       display_name: "**__Anema__**",
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -820,7 +836,8 @@ class NameTest < UnitTestCase
       display_name: "**__Anema__**",
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -835,7 +852,8 @@ class NameTest < UnitTestCase
       display_name: "**__Anema__**",
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -850,7 +868,8 @@ class NameTest < UnitTestCase
       display_name: "**__Anema__** Nyl. ex Forss.",
       parent_name: nil,
       rank: :Genus,
-      author: "Nyl. ex Forss."
+      author: "Nyl. ex Forss.",
+      deprecated: false
     )
   end
 
@@ -865,7 +884,8 @@ class NameTest < UnitTestCase
       display_name: "**__Anema__** Nyl. ex Forss.",
       parent_name: nil,
       rank: :Genus,
-      author: "Nyl. ex Forss."
+      author: "Nyl. ex Forss.",
+      deprecated: false
     )
   end
 
@@ -880,7 +900,8 @@ class NameTest < UnitTestCase
       display_name: "**__Anema__** Nyl. ex Forss.",
       parent_name: nil,
       rank: :Genus,
-      author: "Nyl. ex Forss."
+      author: "Nyl. ex Forss.",
+      deprecated: false
     )
   end
 
@@ -895,7 +916,8 @@ class NameTest < UnitTestCase
       display_name: "**__Japewia tornoënsis__** var. **__tornoënsis__**",
       parent_name: "Japewia tornoënsis",
       rank: :Variety,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -911,7 +933,8 @@ class NameTest < UnitTestCase
                     "var. **__happen__** f. **__for__** Real?",
       parent_name: "Does this subsp. ever var. happen",
       rank: :Form,
-      author: "Real?"
+      author: "Real?",
+      deprecated: false
     )
   end
 
@@ -926,7 +949,8 @@ class NameTest < UnitTestCase
       display_name: "**__Boletus rex-veris__** Arora & Simonini",
       parent_name: "Boletus",
       rank: :Species,
-      author: "Arora & Simonini"
+      author: "Arora & Simonini",
+      deprecated: false
     )
   end
 
@@ -941,7 +965,8 @@ class NameTest < UnitTestCase
       display_name: '**__Amanita "quoted"__**',
       parent_name: "Amanita",
       rank: :Species,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -956,7 +981,8 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita__**",
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -971,7 +997,8 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita__** sect. **__Vaginatae__** (L.) Ach.",
       parent_name: "Amanita",
       rank: :Section,
-      author: "(L.) Ach."
+      author: "(L.) Ach.",
+      deprecated: false
     )
   end
 
@@ -986,7 +1013,8 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita__** stirps **__Vaginatae__** Ach. & Fr.",
       parent_name: "Amanita",
       rank: :Stirps,
-      author: "Ach. & Fr."
+      author: "Ach. & Fr.",
+      deprecated: false
     )
   end
 
@@ -1002,7 +1030,8 @@ class NameTest < UnitTestCase
         "**__Amanita__** subg. **__Vaginatae__** stirps **__Vaginatae__**",
       parent_name: "Amanita subg. Vaginatae",
       rank: :Stirps,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -1017,7 +1046,8 @@ class NameTest < UnitTestCase
       display_name: '**__Amanita "sp-S01"__**',
       parent_name: "Amanita",
       rank: :Species,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -1032,7 +1062,8 @@ class NameTest < UnitTestCase
       display_name: '**__Amanita "sp-S01"__** Tulloss',
       parent_name: "Amanita",
       rank: :Species,
-      author: "Tulloss"
+      author: "Tulloss",
+      deprecated: false
     )
   end
 
@@ -1047,7 +1078,8 @@ class NameTest < UnitTestCase
       display_name: '**__Amanita__** "Wrong Author"',
       parent_name: nil,
       rank: :Genus,
-      author: '"Wrong Author"'
+      author: '"Wrong Author"',
+      deprecated: false
     )
   end
 
@@ -1062,7 +1094,8 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita vaginata__**",
       parent_name: "Amanita",
       rank: :Species,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -1078,7 +1111,8 @@ class NameTest < UnitTestCase
         "**__Pleurotus djamor__** (Fr.) Boedijn var. **__djamor__**",
       parent_name: "Pleurotus djamor",
       rank: :Variety,
-      author: "(Fr.) Boedijn"
+      author: "(Fr.) Boedijn",
+      deprecated: false
     )
   end
 
@@ -1093,7 +1127,8 @@ class NameTest < UnitTestCase
       display_name: '**__Pleurotus "sp-T44"__** Tulloss',
       parent_name: "Pleurotus",
       rank: :Species,
-      author: "Tulloss"
+      author: "Tulloss",
+      deprecated: false
     )
   end
 
@@ -1108,7 +1143,8 @@ class NameTest < UnitTestCase
       display_name: "**__Xylaria__**",
       parent_name: nil,
       rank: :Genus,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -1123,7 +1159,8 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita__** Pers. sect. **__Amanita__**",
       parent_name: "Amanita",
       rank: :Section,
-      author: "Pers."
+      author: "Pers.",
+      deprecated: false
     )
   end
 
@@ -1138,7 +1175,8 @@ class NameTest < UnitTestCase
       display_name: "**__Amanita__** Pers. sect. **__Amanita__**",
       parent_name: "Amanita",
       rank: :Section,
-      author: "Pers."
+      author: "Pers.",
+      deprecated: false
     )
   end
 
@@ -1160,7 +1198,8 @@ class NameTest < UnitTestCase
         "sect. **__Amidella__** stirps **__Amidella__**",
       parent_name: "Amanita subg. Amidella sect. Amidella",
       rank: :Stirps,
-      author: "Singer"
+      author: "Singer",
+      deprecated: false
     )
   end
 
@@ -1175,7 +1214,8 @@ class NameTest < UnitTestCase
       display_name: "**__Podoscyphaceae__** sensu Reid",
       parent_name: nil,
       rank: :Family,
-      author: "sensu Reid"
+      author: "sensu Reid",
+      deprecated: false
     )
   end
 
@@ -1190,7 +1230,8 @@ class NameTest < UnitTestCase
       display_name: "**__Fossil-Ascomycetes__**",
       parent_name: nil,
       rank: :Class,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -1205,7 +1246,8 @@ class NameTest < UnitTestCase
       display_name: "**__Fossil-Fungi__**",
       parent_name: nil,
       rank: :Phylum,
-      author: ""
+      author: "",
+      deprecated: false
     )
   end
 
@@ -1220,7 +1262,8 @@ class NameTest < UnitTestCase
       display_name: "**__Armillaria mellea__** D.C.",
       parent_name: "Armillaria",
       rank: :Species,
-      author: "D.C."
+      author: "D.C.",
+      deprecated: false
     )
   end
 
@@ -1235,7 +1278,8 @@ class NameTest < UnitTestCase
       display_name: "**__Sebacina schweinitzii__** comb. prov.",
       parent_name: "Sebacina",
       rank: :Species,
-      author: "comb. prov."
+      author: "comb. prov.",
+      deprecated: false
     )
   end
 
@@ -1250,7 +1294,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus__** group",
       parent_name: "",
       rank: :Group,
-      author: ""
+      author: "",
+      deprecated: false
     )
     do_name_parse_test( # binomial, no author
       "Agaricus campestris group",
@@ -1262,7 +1307,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** group",
       parent_name: "Agaricus",
       rank: :Group,
-      author: ""
+      author: "",
+      deprecated: false
     )
     do_name_parse_test( # monomial, with author
       "Agaricus group Author",
@@ -1274,7 +1320,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus__** group Author",
       parent_name: "",
       rank: :Group,
-      author: "Author"
+      author: "Author",
+      deprecated: false
     )
     do_name_parse_test( # binomial, author
       "Agaricus campestris group Author",
@@ -1286,7 +1333,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** group Author",
       parent_name: "Agaricus",
       rank: :Group,
-      author: "Author"
+      author: "Author",
+      deprecated: false
     )
     do_name_parse_test( # binomial with author, "group" at end
       "Agaricus campestris Author group",
@@ -1298,7 +1346,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** group Author",
       parent_name: "Agaricus",
       rank: :Group,
-      author: "Author"
+      author: "Author",
+      deprecated: false
     )
     do_name_parse_test( # binomial, sensu author
       "Agaricus campestris group sensu Author",
@@ -1310,7 +1359,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** group sensu Author",
       parent_name: "Agaricus",
       rank: :Group,
-      author: "sensu Author"
+      author: "sensu Author",
+      deprecated: false
     )
     do_name_parse_test( # species with Tulloss form of sp. nov.
       "Pleurotus sp. T44 group Tulloss",
@@ -1322,7 +1372,8 @@ class NameTest < UnitTestCase
       display_name: '**__Pleurotus "sp-T44"__** group Tulloss',
       parent_name: "Pleurotus",
       rank: :Group,
-      author: "Tulloss"
+      author: "Tulloss",
+      deprecated: false
     )
     do_name_parse_test( # subgenus group, with author
       "Amanita subg. Vaginatae group (L.) Ach.",
@@ -1335,7 +1386,8 @@ class NameTest < UnitTestCase
         "**__Amanita__** subg. **__Vaginatae__** group (L.) Ach.",
       parent_name: "Amanita",
       rank: :Group,
-      author: "(L.) Ach."
+      author: "(L.) Ach.",
+      deprecated: false
     )
     do_name_parse_test( # stirps group, with sub-genus parent
       "Amanita subgenus Vaginatae stirps Vaginatae group",
@@ -1350,7 +1402,8 @@ class NameTest < UnitTestCase
         "**__Vaginatae__** group",
       parent_name: "Amanita subg. Vaginatae",
       rank: :Group,
-      author: ""
+      author: "",
+      deprecated: false
     )
     do_name_parse_test( # binomial, "group" part of epithet
       "Agaricus grouperi group Author",
@@ -1362,7 +1415,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus grouperi__** group Author",
       parent_name: "Agaricus",
       rank: :Group,
-      author: "Author"
+      author: "Author",
+      deprecated: false
     )
     do_name_parse_test( # author duplicates a word in the taxon
       "Agaricus group Agaricus",
@@ -1374,7 +1428,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus__** group Agaricus",
       parent_name: "",
       rank: :Group,
-      author: "Agaricus"
+      author: "Agaricus",
+      deprecated: false
     )
   end
 
@@ -1389,7 +1444,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus__** clade",
       parent_name: "",
       rank: :Group,
-      author: ""
+      author: "",
+      deprecated: false
     )
     do_name_parse_test( # binomial, no author
       "Agaricus campestris clade",
@@ -1401,7 +1457,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** clade",
       parent_name: "Agaricus",
       rank: :Group,
-      author: ""
+      author: "",
+      deprecated: false
     )
     do_name_parse_test( # binomial, sensu author
       "Agaricus campestris clade sensu Author",
@@ -1413,7 +1470,8 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** clade sensu Author",
       parent_name: "Agaricus",
       rank: :Group,
-      author: "sensu Author"
+      author: "sensu Author",
+      deprecated: false
     )
     do_name_parse_test( # binomial with author, "clade" at end
       "Agaricus campestris Author clade",
@@ -1425,54 +1483,49 @@ class NameTest < UnitTestCase
       display_name: "**__Agaricus campestris__** clade Author",
       parent_name: "Agaricus",
       rank: :Group,
-      author: "Author"
+      author: "Author",
+      deprecated: false
     )
   end
 
   def test_name_parse_deprecated
     do_name_parse_test(
       "Lecania ryaniana van den Boom",
-      {
-        text_name: "Lecania ryaniana",
-        real_text_name: "Lecania ryaniana",
-        search_name: "Lecania ryaniana van den Boom",
-        real_search_name: "Lecania ryaniana van den Boom",
-        sort_name: "Lecania ryaniana  van den Boom",
-        display_name: "__Lecania ryaniana__ van den Boom",
-        parent_name: "Lecania",
-        rank: :Species,
-        author: "van den Boom"
-      },
+      text_name: "Lecania ryaniana",
+      real_text_name: "Lecania ryaniana",
+      search_name: "Lecania ryaniana van den Boom",
+      real_search_name: "Lecania ryaniana van den Boom",
+      sort_name: "Lecania ryaniana  van den Boom",
+      display_name: "__Lecania ryaniana__ van den Boom",
+      parent_name: "Lecania",
+      rank: :Species,
+      author: "van den Boom",
       deprecated: true
     )
     do_name_parse_test( # binomial, no author, deprecated
       "Agaricus campestris group",
-      {
-        text_name: "Agaricus campestris group",
-        real_text_name: "Agaricus campestris group",
-        search_name: "Agaricus campestris group",
-        real_search_name: "Agaricus campestris group",
-        sort_name: "Agaricus campestris   group",
-        display_name: "__Agaricus campestris__ group",
-        parent_name: "Agaricus",
-        rank: :Group,
-        author: ""
-      },
+      text_name: "Agaricus campestris group",
+      real_text_name: "Agaricus campestris group",
+      search_name: "Agaricus campestris group",
+      real_search_name: "Agaricus campestris group",
+      sort_name: "Agaricus campestris   group",
+      display_name: "__Agaricus campestris__ group",
+      parent_name: "Agaricus",
+      rank: :Group,
+      author: "",
       deprecated: true
     )
     do_name_parse_test( # binomial, sensu author, deprecated
       "Agaricus campestris group sensu Author",
-      {
-        text_name: "Agaricus campestris group",
-        real_text_name: "Agaricus campestris group",
-        search_name: "Agaricus campestris group sensu Author",
-        real_search_name: "Agaricus campestris group sensu Author",
-        sort_name: "Agaricus campestris   group  sensu Author",
-        display_name: "__Agaricus campestris__ group sensu Author",
-        parent_name: "Agaricus",
-        rank: :Group,
-        author: "sensu Author"
-      },
+      text_name: "Agaricus campestris group",
+      real_text_name: "Agaricus campestris group",
+      search_name: "Agaricus campestris group sensu Author",
+      real_search_name: "Agaricus campestris group sensu Author",
+      sort_name: "Agaricus campestris   group  sensu Author",
+      display_name: "__Agaricus campestris__ group sensu Author",
+      parent_name: "Agaricus",
+      rank: :Group,
+      author: "sensu Author",
       deprecated: true
     )
   end


### PR DESCRIPTION
Just passing `:deprecated` to do_name_parse_test along with all the other kwargs clears up the warning (coming in Ruby 2.7)