### PR TITLE
Bump acts_as_versioned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem("xmlrpc")
 
 # Simple versioning
 # Use our own fork, which stores enum attrs as integers in the db
-gem("cure_acts_as_versioned",
+gem("cure_acts_as_versioned", ">= 0.6.5",
     git: "https://github.com/MushroomObserver/acts_as_versioned/")
 
 # In Rails 4.0, use simple_enum to replace enum_column3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/MushroomObserver/acts_as_versioned/
-  revision: 59a408816683875d14e1cce66b0feb493ab06747
+  revision: 57b2b4bfc9050c4ae5cef414a18d8ff475f97bfa
   specs:
-    cure_acts_as_versioned (0.6.3)
+    cure_acts_as_versioned (0.6.5)
       activerecord (>= 3.0.9)
 
 GIT
@@ -341,7 +341,7 @@ DEPENDENCIES
   byebug
   capybara (~> 3.36.0)
   coffee-rails
-  cure_acts_as_versioned!
+  cure_acts_as_versioned (>= 0.6.5)!
   date (>= 3.2.1)
   graphiql-rails!
   graphql


### PR DESCRIPTION
Specifies a version that fixes the  "last argument as keyword parameters is deprecated" warning
Fixes deprecation warning when using Ruby 2.7