### PR TITLE
Add ActiveStorage tables to Rails 6.1

### DIFF
--- a/db/migrate/20220528213936_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220528213936_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,17 +2,45 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_28_202651) do
+ActiveRecord::Schema.define(version: 2022_05_28_213235) do
 
-  create_table "api_keys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "api_keys", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "last_used"
     t.integer "num_uses", default: 0
@@ -22,7 +50,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "verified"
   end
 
-  create_table "articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "articles", id: :integer, charset: "latin1", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.integer "user_id"
@@ -31,7 +59,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_numbers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "collection_numbers", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "user_id"
@@ -39,12 +67,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.string "number"
   end
 
-  create_table "collection_numbers_observations", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "collection_numbers_observations", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "collection_number_id"
     t.integer "observation_id"
   end
 
-  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "comments", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.integer "user_id"
     t.string "summary", limit: 100
@@ -54,7 +82,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at"
   end
 
-  create_table "copyright_changes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "copyright_changes", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "updated_at", null: false
     t.string "target_type", limit: 30, null: false
@@ -64,7 +92,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "license_id"
   end
 
-  create_table "donations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "donations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.decimal "amount", precision: 12, scale: 2
     t.string "who", limit: 100
     t.string "email", limit: 100
@@ -76,7 +104,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.boolean "recurring", default: false
   end
 
-  create_table "external_links", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "external_links", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "user_id"
@@ -85,12 +113,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.string "url", limit: 100
   end
 
-  create_table "external_sites", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "external_sites", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "name", limit: 100
     t.integer "project_id"
   end
 
-  create_table "glossary_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "glossary_terms", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.integer "user_id"
     t.string "name", limit: 1024
@@ -101,12 +129,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at"
   end
 
-  create_table "glossary_terms_images", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "glossary_terms_images", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "image_id"
     t.integer "glossary_term_id"
   end
 
-  create_table "glossary_terms_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "glossary_terms_versions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "glossary_term_id"
     t.integer "version"
     t.integer "user_id"
@@ -115,7 +143,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.text "description"
   end
 
-  create_table "herbaria", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "herbaria", id: :integer, charset: "utf8", force: :cascade do |t|
     t.text "mailing_address"
     t.integer "location_id"
     t.string "email", limit: 80, default: "", null: false
@@ -127,12 +155,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "personal_user_id"
   end
 
-  create_table "herbaria_curators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "herbaria_curators", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
     t.integer "herbarium_id", default: 0, null: false
   end
 
-  create_table "herbarium_records", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "herbarium_records", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "herbarium_id", null: false
     t.text "notes"
     t.datetime "created_at"
@@ -142,12 +170,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.string "accession_number", limit: 80, null: false
   end
 
-  create_table "herbarium_records_observations", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "herbarium_records_observations", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "observation_id", default: 0, null: false
     t.integer "herbarium_record_id", default: 0, null: false
   end
 
-  create_table "image_votes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "image_votes", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "value", null: false
     t.boolean "anonymous", default: false, null: false
     t.integer "user_id"
@@ -156,7 +184,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.index ["user_id"], name: "index_image_votes_on_user_id"
   end
 
-  create_table "images", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "images", id: { type: :integer, unsigned: true }, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "content_type", limit: 100
@@ -176,18 +204,18 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.boolean "gps_stripped", default: false, null: false
   end
 
-  create_table "images_observations", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "images_observations", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "image_id", default: 0, null: false
     t.integer "observation_id", default: 0, null: false
     t.index ["observation_id"], name: "index_images_observations_on_observation_id"
   end
 
-  create_table "images_projects", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "images_projects", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "image_id", null: false
     t.integer "project_id", null: false
   end
 
-  create_table "interests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "interests", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "target_type", limit: 30
     t.integer "target_id"
     t.integer "user_id"
@@ -195,7 +223,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at"
   end
 
-  create_table "languages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "languages", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "locale", limit: 40
     t.string "name", limit: 100
     t.string "order", limit: 100
@@ -203,7 +231,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.boolean "beta", null: false
   end
 
-  create_table "licenses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "licenses", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "display_name", limit: 80
     t.string "url", limit: 200
     t.boolean "deprecated", default: false, null: false
@@ -211,7 +239,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at"
   end
 
-  create_table "location_descriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -234,27 +262,27 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "project_id"
   end
 
-  create_table "location_descriptions_admins", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions_admins", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "location_description_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_descriptions_authors", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions_authors", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "location_description_id", default: 0, null: false
     t.integer "user_id", default: 0, null: false
   end
 
-  create_table "location_descriptions_editors", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions_editors", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "location_description_id", default: 0, null: false
     t.integer "user_id", default: 0, null: false
   end
 
-  create_table "location_descriptions_readers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions_readers", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "location_description_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_descriptions_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions_versions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "location_description_id"
     t.integer "version"
     t.datetime "updated_at"
@@ -268,12 +296,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.text "refs"
   end
 
-  create_table "location_descriptions_writers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "location_descriptions_writers", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "location_description_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "locations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -295,7 +323,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.boolean "locked", default: false, null: false
   end
 
-  create_table "locations_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "locations_versions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "location_id"
     t.integer "version"
     t.datetime "updated_at"
@@ -311,7 +339,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.string "scientific_name", limit: 1024
   end
 
-  create_table "name_descriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -341,27 +369,27 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "project_id"
   end
 
-  create_table "name_descriptions_admins", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions_admins", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "name_description_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_descriptions_authors", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions_authors", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "name_description_id", default: 0, null: false
     t.integer "user_id", default: 0, null: false
   end
 
-  create_table "name_descriptions_editors", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions_editors", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "name_description_id", default: 0, null: false
     t.integer "user_id", default: 0, null: false
   end
 
-  create_table "name_descriptions_readers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions_readers", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "name_description_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_descriptions_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions_versions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "name_description_id"
     t.integer "version"
     t.datetime "updated_at"
@@ -379,12 +407,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.text "classification"
   end
 
-  create_table "name_descriptions_writers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "name_descriptions_writers", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "name_description_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "names", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "names", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -411,7 +439,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "icn_id"
   end
 
-  create_table "names_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "names_versions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "name_id"
     t.integer "version"
     t.datetime "updated_at"
@@ -430,13 +458,13 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "icn_id"
   end
 
-  create_table "naming_reasons", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "naming_reasons", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "naming_id"
     t.integer "reason"
     t.text "notes"
   end
 
-  create_table "namings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "namings", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "observation_id"
@@ -446,7 +474,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.text "reasons"
   end
 
-  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "notifications", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
     t.integer "flavor"
     t.integer "obj_id"
@@ -455,13 +483,13 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.boolean "require_specimen", default: false, null: false
   end
 
-  create_table "observation_views", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "observation_views", charset: "utf8", force: :cascade do |t|
     t.integer "observation_id"
     t.integer "user_id"
     t.datetime "last_view"
   end
 
-  create_table "observations", id: :integer, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date "when"
@@ -486,17 +514,17 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.boolean "gps_hidden", default: false, null: false
   end
 
-  create_table "observations_projects", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "observations_projects", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "observation_id", null: false
     t.integer "project_id", null: false
   end
 
-  create_table "observations_species_lists", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "observations_species_lists", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "observation_id", default: 0, null: false
     t.integer "species_list_id", default: 0, null: false
   end
 
-  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "projects", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
     t.integer "admin_group_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
@@ -507,12 +535,12 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "rss_log_id"
   end
 
-  create_table "projects_species_lists", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "projects_species_lists", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "project_id", null: false
     t.integer "species_list_id", null: false
   end
 
-  create_table "publications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "publications", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "user_id"
     t.text "full"
     t.string "link"
@@ -523,31 +551,31 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at"
   end
 
-  create_table "query_records", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "query_records", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "updated_at"
     t.integer "access_count"
     t.text "description"
     t.integer "outer_id"
   end
 
-  create_table "queued_email_integers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "queued_email_integers", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "queued_email_id", default: 0, null: false
     t.string "key", limit: 100
     t.integer "value", default: 0, null: false
   end
 
-  create_table "queued_email_notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "queued_email_notes", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "queued_email_id", default: 0, null: false
     t.text "value"
   end
 
-  create_table "queued_email_strings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "queued_email_strings", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "queued_email_id", default: 0, null: false
     t.string "key", limit: 100
     t.string "value", limit: 100
   end
 
-  create_table "queued_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "queued_emails", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "user_id"
     t.datetime "queued"
     t.integer "num_attempts"
@@ -555,7 +583,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "to_user_id"
   end
 
-  create_table "rss_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "rss_logs", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "observation_id"
     t.integer "species_list_id"
     t.datetime "updated_at"
@@ -568,7 +596,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "created_at", null: false
   end
 
-  create_table "sequences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "sequences", id: :integer, charset: "latin1", force: :cascade do |t|
     t.integer "observation_id"
     t.integer "user_id"
     t.text "locus"
@@ -580,7 +608,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "species_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "species_lists", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date "when"
@@ -592,10 +620,10 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "location_id"
   end
 
-  create_table "synonyms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "synonyms", id: :integer, charset: "utf8", force: :cascade do |t|
   end
 
-  create_table "translation_strings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "translation_strings", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.integer "language_id", null: false
     t.string "tag", limit: 100
@@ -604,7 +632,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "user_id"
   end
 
-  create_table "translation_strings_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "translation_strings_versions", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "version"
     t.integer "translation_string_id"
     t.text "text"
@@ -612,25 +640,25 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.integer "user_id"
   end
 
-  create_table "triples", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "triples", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "subject", limit: 1024
     t.string "predicate", limit: 1024
     t.string "object", limit: 1024
   end
 
-  create_table "user_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "user_groups", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "meta", default: false
   end
 
-  create_table "user_groups_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "user_groups_users", id: false, charset: "utf8", force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
     t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "login", limit: 80, default: "", null: false
     t.string "password", limit: 40, default: "", null: false
     t.string "email", limit: 80, default: "", null: false
@@ -685,7 +713,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.text "notes_template"
   end
 
-  create_table "votes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "votes", id: :integer, charset: "utf8", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "naming_id"
@@ -695,4 +723,6 @@ ActiveRecord::Schema.define(version: 2022_01_28_202651) do
     t.float "value"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
Note that Rails (not my autoformatter!) automatically reformatted schema.rb. But our options are all there.