### PR TITLE
config/application.rb — Only load Rails components we actually use

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,8 +1,23 @@
 # frozen_string_literal: true
 
-require(File.expand_path("boot", __dir__))
+require_relative "boot"
 
-require("rails/all")
+# require("rails/rails")
+
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+# require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+# require "action_mailbox/engine"
+require "action_text/engine"
+require "action_view/railtie"
+# require "action_cable/engine"
+# require "sprockets/railtie"
+require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-require_relative "boot"
+require_relative("boot")
 
 # require("rails/rails")
 
-require "rails"
+require("rails")
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-# require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-# require "action_mailbox/engine"
-require "action_text/engine"
-require "action_view/railtie"
-# require "action_cable/engine"
-# require "sprockets/railtie"
-require "rails/test_unit/railtie"
+require("active_model/railtie")
+require("active_job/railtie")
+require("active_record/railtie")
+# require("active_storage/engine")
+require("action_controller/railtie")
+require("action_mailer/railtie")
+# require("action_mailbox/engine")
+require("action_text/engine")
+require("action_view/railtie")
+# require("action_cable/engine")
+# require("sprockets/railtie")
+require("rails/test_unit/railtie")
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
This gets rid of a warning in Rails 6.1 that ActiveStorage is not set up. But also eliminates other unused components!
https://andycroll.com/ruby/turn-off-the-bits-of-rails-you-dont-use/