### PR TITLE
Remove mass_insert gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,11 +45,6 @@ gem("mysql2")
 gem("arel_extensions")
 gem("arel-helpers")
 
-# Add method `mass_insert` for bulk db inserts in ActiveRecord.
-# Same basic syntax as upcoming Rails 6 `insert_all`
-# If upgrading to Rails 6, we can disable the gem and switch methods
-gem("mass_insert")
-
 # Use bootstrap style generator
 gem("bootstrap-sass")
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mass_insert (1.0.0)
-      activerecord (>= 5.2)
     matrix (0.4.2)
     method_source (1.0.0)
     mimemagic (0.4.3)
@@ -288,7 +286,6 @@ DEPENDENCIES
   jquery-rails
   jquery-slick-rails
   mail
-  mass_insert
   mimemagic
   mini_racer
   minitest

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -973,8 +973,7 @@ class Image < AbstractModel
            pluck(:id, Image[:when].year, :license_id)
     return unless data.any?
 
-    # The gem `mass_insert` anticipates Rails 6 method `insert_all`, same args
-    CopyrightChange.mass_insert(copyright_change_new_rows(data, old_name, user))
+    CopyrightChange.insert_all(copyright_change_new_rows(data, old_name, user))
 
     Image.where(user_id: user.id, copyright_holder: old_name).
       update_all(copyright_holder: new_name)

--- a/app/models/synonym.rb
+++ b/app/models/synonym.rb
@@ -46,8 +46,8 @@ class Synonym < AbstractModel
       # For mass_insert when setting the id, need to set `primary_key: true`
       # Also, id in hash apparently needs a string (to check exists already?)
       # but stores an integer. The above not necessary with Rails 6 insert_all
-      missing = missing.map { |m| Hash[id: m.to_s] }
-      Synonym.mass_insert(missing, primary_key: true)
+      missing = missing.map { |m| Hash[id: m] }
+      Synonym.insert_all(missing)
       msgs << "Restoring #{missing.count} missing synonyms: #{missing.inspect}"
     end
     msgs

--- a/app/models/synonym.rb
+++ b/app/models/synonym.rb
@@ -43,9 +43,6 @@ class Synonym < AbstractModel
       msgs << "Deleting #{unused.count} unused synonyms: #{unused.inspect}"
     end
     if missing.any?
-      # For mass_insert when setting the id, need to set `primary_key: true`
-      # Also, id in hash apparently needs a string (to check exists already?)
-      # but stores an integer. The above not necessary with Rails 6 insert_all
       missing = missing.map { |m| Hash[id: m] }
       Synonym.insert_all(missing)
       msgs << "Restoring #{missing.count} missing synonyms: #{missing.inspect}"


### PR DESCRIPTION
This PR removes `mass_insert` gem, replacing its `mass_insert` method with Rails' native `insert_all` (which became available in Rails 6.0).

There is no manual test.
