### PR TITLE
Unlock Capybara gem because we're on Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem("bundler")
 gem("railties", "~> 6.1")
 gem("sprockets-rails")
 
-gem("sprockets")
+# gem("sprockets")
 
 # security fix for CVE-2021-41817 regex denial of service vulnerability
 gem("date", ">= 3.2.1")
@@ -59,6 +59,9 @@ gem("jquery-rails")
 # gem("therubyracer", platforms: :ruby)
 
 # Use mini_racer as a substitute for therubyracer
+# If this is giving problems:
+# gem update --system
+# bundler update
 gem("mini_racer")
 
 # Use CoffeeScript for .js.coffee assets and views
@@ -247,7 +250,7 @@ end
 
 group :test do
   # Use capybara to simulate user-browser interaction
-  gem("capybara", "~> 3.36.0") # for ruby 2.6
+  gem("capybara") # , "~> 3.36.0" for ruby 2.6
 
   # allows test results to be reported back to test runner IDE's
   gem("minitest")
@@ -276,7 +279,7 @@ group :development do
   gem("web-console")
 
   # Use Rails DB to browse database at http://localhost:3000/rails/db/
-  # gem("rails_db", "~> 2.4.0")
+  # gem("rails_db", "~> 2.5.0", path: "../local_gems/rails_db")
 
   # Additional generators for input types, search objects, and mutations
   # gem("graphql-rails-generators")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     brakeman (5.2.3)
     browser (5.3.1)
     builder (3.2.4)
-    bullet (7.0.1)
+    bullet (7.0.2)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
@@ -102,7 +102,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    graphql (2.0.8)
+    graphql (2.0.9)
     graphql-batch (0.5.1)
       graphql (>= 1.10, < 3)
       promise.rb (~> 0.7.2)
@@ -273,7 +273,7 @@ DEPENDENCIES
   bullet
   bundler
   byebug
-  capybara (~> 3.36.0)
+  capybara
   coffee-rails
   cure_acts_as_versioned (>= 0.6.5)!
   date (>= 3.2.1)
@@ -305,7 +305,6 @@ DEPENDENCIES
   simple_enum
   simplecov
   simplecov-lcov
-  sprockets
   sprockets-rails
   uglifier
   unicorn (= 5.4.1)
@@ -317,4 +316,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.6
+   2.3.14


### PR DESCRIPTION
Also removes explicit listing of `sprockets` - it's a dependency of `sprockets-rails` and not necessary to include

(there's also a commented out version bump for possible rails_db update)