### PR TITLE
Api2Controller fix `require_dependency "api2"` (not `"api"`)

### DIFF
--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -13,7 +13,7 @@
 #
 class Api2Controller < ApplicationController
   require "xmlrpc/client"
-  require_dependency "api"
+  require_dependency "api2"
 
   disable_filters
 


### PR DESCRIPTION
This fixes a longstanding (and until now, inconsequential) oversight, which would become consequential if we deleted the original API. Anyway, "api2" is obviously the intended require_dependency.

I'd like to merge today if it's OK.