### PR TITLE
Rails 6.1/Ruby 2.7 - update not-yet-mandatory things

### DIFF
--- a/app/classes/eol_data.rb
+++ b/app/classes/eol_data.rb
@@ -232,7 +232,7 @@ class EolData
   end
 
   def image_id_to_names
-    make_list_hash_from_pairs(name_images_list.sum)
+    make_list_hash_from_pairs(name_images_list.sum([]))
   end
 
   def name_images_list

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -410,7 +410,7 @@ class ApplicationController < ActionController::Base
   def track_last_page_request_by_user
     if @user && (
         !@user.last_activity ||
-        @user.last_activity.to_fs("%Y%m%d%H") != Time.current.to_fs("%Y%m%d%H"))
+        @user.last_activity.to_s("%Y%m%d%H") != Time.current.to_s("%Y%m%d%H"))
       @user.last_activity = Time.current
       @user.save
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -410,7 +410,7 @@ class ApplicationController < ActionController::Base
   def track_last_page_request_by_user
     if @user && (
         !@user.last_activity ||
-        @user.last_activity.to_s("%Y%m%d%H") != Time.current.to_s("%Y%m%d%H"))
+        @user.last_activity.to_fs("%Y%m%d%H") != Time.current.to_fs("%Y%m%d%H"))
       @user.last_activity = Time.current
       @user.save
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,6 +69,9 @@ module MushroomObserver
     # Still validating 5.2 deploy and want to allow rollback
     # TODO: Remove this once we are satisfied with 5.2 deplay.
     config.action_dispatch.use_authenticated_cookie_encryption = false
+
+    # Rails 6.1+
+    config.active_record.legacy_connection_handling = false
   end
 end
 


### PR DESCRIPTION
Two lines of code change in this PR.

A new Rails config, to switch to the new ActiveRecord connection handler that _can_ handle multiple database connections, [does not change anything in our app](https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling), but the config needs to be present for later updates. 

The method `Enumerable#sum` will in Ruby 3.0 require an initial value. The value is the default and should match the type of the sum (`array` / `string` / `hash`). This one seems to be an array.