### PR TITLE
Create brakeman_test.rb

### DIFF
--- a/test/brakeman_test.rb
+++ b/test/brakeman_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BrakemanTest < ActiveSupport::TestCase
+  require 'brakeman'
+
+  test 'no brakeman errors or warnings' do
+    result = Brakeman.run Rails.root.to_s
+    assert_equal([], result.errors)
+    assert_equal([], result.warnings)
+  end
+end


### PR DESCRIPTION
Inspired by https://www.briankephart.com/adding-code-quality-checks-to-your-ruby-test-suite

However, the result printed from `assert_equal` is not very legible. It's an array of hashes like this:

```
+[{:exception=>#<Racc::ParseError: app/views/observer/test.html.erb:13 :: parse error on value "link_to" (tIDENTIFIER)
 +Could not parse app/views/observer/test.html.erb>, :error=>"app/views/observer/test.html.erb:13 :: parse error on value \"link_to\" (tIDENTIFIER) Could not parse app/views/observer/test.html.erb", :backtrace=>["Could not parse /vagrant/mushroom-observer/app/views/observer/test.html.erb"]}, {:exception=>#<Racc::ParseError: app/views/shared/_merge_descriptions.html.erb:28 :: parse error on value "|" (tPIPE)
 +Could not parse app/views/shared/_merge_descriptions.html.erb>, :error=>"app/views/shared/_merge_descriptions.html.erb:28 :: parse error on value \"|\" (tPIPE) Could not parse app/views/shared/_merge_descriptions.html.erb", :backtrace=>["Could not parse /vagrant/mushroom-observer/app/views/shared/_merge_descriptions.html.erb"]}]
```

I don't know enough about minitest to prettify that result.