### PR TITLE
Exclude ApiControllerTest from Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,7 @@ AllCops:
     - app/controllers/api_controller.rb
     - app/helpers/api_helper.rb
     - "app/views/api/**/*"
+    - test/controllers/api_controller_test.rb
     - test/models/api_test.rb
     - "db/**/*"
     - "log/**/*"


### PR DESCRIPTION
This was overlooked in #990