### PR TITLE
Switch to Rails native `enum` for `User`

### DIFF
--- a/app/classes/api2/core/base.rb
+++ b/app/classes/api2/core/base.rb
@@ -276,12 +276,12 @@ module API2::Base
 
   def clear_user
     User.current = self.user = nil
-    User.current_location_format = :postal
+    User.current_location_format = "postal"
   end
 
   def login_user(key)
     User.current = self.user = key.user
-    User.current_location_format = :postal
+    User.current_location_format = "postal"
     # (that overrides user pref in order to make it more consistent for apps)
     key.touch!
     self.api_key = key

--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -99,7 +99,7 @@ class API2
       end
       return unless @vote
 
-      img.change_vote(@user, @vote, anon: @user.votes_anonymous == :yes)
+      img.change_vote(@user, @vote, anon: @user.votes_anonymous == "yes")
     end
 
     ############################################################################
@@ -123,7 +123,7 @@ class API2
       # sure it doesn't accidentally explicitly set the original_name even if
       # the user has requested not to save it.  I'm not sure the mobile app
       # has access to that preference.
-      return nil if User.current&.keep_filenames == :toss
+      return nil if User.current&.keep_filenames == "toss"
 
       val
     end

--- a/app/classes/api2/location_api.rb
+++ b/app/classes/api2/location_api.rb
@@ -30,7 +30,7 @@ class API2
 
     def create_params
       {
-        display_name: parse(:string, :name, limit: 1024, help: :postal),
+        display_name: parse(:string, :name, limit: 1024, help: "postal"),
         north: parse(:latitude, :north),
         south: parse(:longitude, :south),
         east: parse(:longitude, :east),
@@ -45,7 +45,7 @@ class API2
     def update_params
       {
         display_name: parse(:string, :set_name, limit: 1024, not_blank: true,
-                                                help: :postal),
+                                                help: "postal"),
         north: parse(:latitude, :set_north),
         south: parse(:longitude, :set_south),
         east: parse(:longitude, :set_east),

--- a/app/classes/minimal_map_location.rb
+++ b/app/classes/minimal_map_location.rb
@@ -15,7 +15,7 @@ class MinimalMapLocation
   include BoxMethods
 
   def display_name
-    if User.current_location_format == :scientific
+    if User.current_location_format == "scientific"
       Location.reverse_name(name)
     else
       name

--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -39,7 +39,7 @@ module Query::Modules::Ordering
         self.group = "images.id"
         "MIN(names.sort_name) ASC, images.when DESC"
       elsif model == Location
-        if User.current_location_format == :scientific
+        if User.current_location_format == "scientific"
           "locations.scientific_name ASC"
         else
           "locations.name ASC"
@@ -77,7 +77,7 @@ module Query::Modules::Ordering
       if columns.include?("location_id")
         # Join Users with null locations, else join records with locations
         model == User ? add_join(:locations!) : add_join(:locations)
-        if User.current_location_format == :scientific
+        if User.current_location_format == "scientific"
           "locations.scientific_name ASC"
         else
           "locations.name ASC"

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -350,7 +350,7 @@ class AccountController < ApplicationController
       when :string  then update_pref(pref, val.to_s)
       when :integer then update_pref(pref, val.to_i)
       when :boolean then update_pref(pref, val == "1")
-      when :enum    then update_pref(pref, val || User.enum_default_value(pref))
+      when :enum    then update_pref(pref, val)
       when :content_filter then update_content_filter(pref, val)
       end
     end

--- a/app/controllers/ajax_controller/upload_image.rb
+++ b/app/controllers/ajax_controller/upload_image.rb
@@ -68,7 +68,7 @@ module AjaxController::UploadImage
   end
 
   def image_original_name(args)
-    return nil if @user.keep_filenames == :toss
+    return nil if @user.keep_filenames == "toss"
 
     args[:original_name].to_s
   end

--- a/app/controllers/ajax_controller/vote.rb
+++ b/app/controllers/ajax_controller/vote.rb
@@ -42,7 +42,7 @@ module AjaxController::Vote
     raise("Bad value.") if value != "0" && !Image.validate_vote(value)
 
     value = value == "0" ? nil : Image.validate_vote(value)
-    anon = (@user.votes_anonymous == :yes)
+    anon = (@user.votes_anonymous == "yes")
     image.change_vote(@user, value, anon: anon)
     render(partial: "image/image_vote_links", locals: { image: image })
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1776,7 +1776,7 @@ class ApplicationController < ActionController::Base
       @user.thumbnail_size
     else
       session[:thumbnail_size]
-    end || :thumbnail
+    end || "thumbnail"
   end
   helper_method :default_thumbnail_size
 

--- a/app/controllers/image_controller.rb
+++ b/app/controllers/image_controller.rb
@@ -341,7 +341,7 @@ class ImageController < ApplicationController
     # The 1st save (or !save) puts the image's original filename in the db,
     # whether or not the user wants it.  So if we don't want it,
     # we must empty it and save a 2nd time.
-    @image.original_name = "" if @user.keep_filenames == :toss
+    @image.original_name = "" if @user.keep_filenames == "toss"
     return flash_object_errors(@image) unless @image.save
 
     if !@image.process_image(strip: @observation.gps_hidden)

--- a/app/helpers/autocomplete_helper.rb
+++ b/app/helpers/autocomplete_helper.rb
@@ -38,7 +38,7 @@ module AutocompleteHelper
 
   # Make text_field auto-complete for Location display name.
   def turn_into_location_auto_completer(id, opts = {})
-    format = if @user && @user.location_format == :scientific
+    format = if @user && @user.location_format == "scientific"
                "?format=scientific"
              else
                ""

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -6,8 +6,6 @@
 #  == Methods
 #
 #  type_tag::           Language tag, e.g., :observation, :rss_log, etc.
-#  enum_default_value   Default value (as a Symbol) of an enum attribute
-#                       Ex: User.enum_default_value(:image_size) => :medium
 #
 #  ==== Extensions to "find"
 #  safe_find::          Same as <tt>find(id)</tt> but return nil if not found.
@@ -84,16 +82,6 @@ class AbstractModel < ApplicationRecord
   # Language tag for name, e.g. :observation, :rss_log, etc.
   def type_tag
     self.class.name.underscore.to_sym
-  end
-
-  # Default value (as a symbol) for an enum attribute
-  def self.enum_default_value(attr)
-    send(attr.to_s.pluralize).hash.key(default_cardinal(attr)).to_sym
-  end
-
-  # number (or nil) that is the default value for attr
-  def self.default_cardinal(attr)
-    column_defaults[attr.to_s]
   end
 
   ##############################################################################

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -626,7 +626,7 @@ class Image < AbstractModel
     # name = '(uploaded at %s)' % Time.now.web_time if name.empty?
     name = name.truncate(120)
     return unless name.present? && User.current &&
-                  User.current.keep_filenames != :toss
+                  User.current.keep_filenames != "toss"
 
     self.original_name = name
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -259,11 +259,11 @@ class Location < AbstractModel
   end
 
   def display_name
-    User.current_location_format == :scientific ? scientific_name : name
+    User.current_location_format == "scientific" ? scientific_name : name
   end
 
   def display_name=(val)
-    if User.current_location_format == :scientific
+    if User.current_location_format == "scientific"
       self.name = Location.reverse_name(val)
       self.scientific_name = val
     else
@@ -341,7 +341,7 @@ class Location < AbstractModel
     #   ORDER BY observations.updated_at DESC
     #   LIMIT 100
     # )).sort
-    # if User.current_location_format == :scientific
+    # if User.current_location_format == "scientific"
     #   result.map! { |n| Location.reverse_name(n) }
     # end
     # result
@@ -382,7 +382,7 @@ class Location < AbstractModel
   end
 
   def self.user_name(user, name)
-    if user && (user.location_format == :scientific)
+    if user && (user.location_format == "scientific")
       Location.reverse_name(name)
     else
       name

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -10,7 +10,7 @@ module Name::Format
   def display_name
     str = self[:display_name]
     if User.current &&
-       User.current.hide_authors == :above_species &&
+       User.current.hide_authors == "above_species" &&
        Name.ranks_above_species.include?(rank)
       str = str.sub(/^(\**__.*__\**).*/, '\\1')
     end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -289,11 +289,11 @@ class Observation < AbstractModel
 
   # Abstraction over +where+ and +location.display_name+.  Returns Location
   # name as a string, preferring +location+ over +where+ wherever both exist.
-  # Also applies the location_format of the current user (defaults to :postal).
+  # Also applies the location_format of the current user (defaults to "postal").
   def place_name
     if location
       location.display_name
-    elsif User.current_location_format == :scientific
+    elsif User.current_location_format == "scientific"
       Location.reverse_name(where)
     else
       where
@@ -305,7 +305,7 @@ class Observation < AbstractModel
   # Adjusts for the current user's location_format as well.
   def place_name=(place_name)
     place_name = place_name.strip_squeeze
-    where = if User.current_location_format == :scientific
+    where = if User.current_location_format == "scientific"
               Location.reverse_name(place_name)
             else
               place_name

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -149,11 +149,11 @@ class SpeciesList < AbstractModel
 
   # Abstraction over +where+ and +location.display_name+.  Returns Location
   # name as a string, preferring +location+ over +where+ wherever both exist.
-  # Also applies the location_format of the current user (defaults to :postal).
+  # Also applies the location_format of the current user (defaults to "postal").
   def place_name
     if location
       location.display_name
-    elsif User.current_location_format == :scientific
+    elsif User.current_location_format == "scientific"
       Location.reverse_name(where)
     else
       where
@@ -164,7 +164,7 @@ class SpeciesList < AbstractModel
   # the given +display_name+.  (Fills the other in with +nil+.)
   # Adjusts for the current user's location_format as well.
   def place_name=(place_name)
-    where = if User.current_location_format == :scientific
+    where = if User.current_location_format == "scientific"
               Location.reverse_name(place_name)
             else
               place_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,54 +203,59 @@ class User < AbstractModel
   # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
   # first value is the default
-  as_enum(:thumbnail_size,
-          {
-            thumbnail: 1,
-            small: 2
-          },
-          source: :thumbnail_size,
-          accessor: :whiny)
-  as_enum(:image_size,
-          {
-            thumbnail: 1,
-            small: 2,
-            medium: 3,
-            large: 4,
-            huge: 5,
-            full_size: 6
-          },
-          source: :image_size,
-          accessor: :whiny)
-  as_enum(:votes_anonymous,
-          {
-            no: 1,
-            yes: 2,
-            old: 3
-          },
-          source: :votes_anonymous,
-          accessor: :whiny)
-  as_enum(:location_format,
-          {
-            postal: 1,
-            scientific: 2
-          },
-          source: :location_format,
-          accessor: :whiny)
-  as_enum(:hide_authors,
-          {
-            none: 1,
-            above_species: 2
-          },
-          source: :hide_authors,
-          accessor: :whiny)
-  as_enum(:keep_filenames,
-          {
-            toss: 1,
-            keep_but_hide: 2,
-            keep_and_show: 3
-          },
-          source: :keep_filenames,
-          accessor: :whiny)
+  enum thumbnail_size:
+       {
+         thumbnail: 1,
+         small: 2
+       },
+       _prefix: :thumb_size,
+       _default: "thumbnail"
+
+  enum image_size:
+       {
+         thumbnail: 1,
+         small: 2,
+         medium: 3,
+         large: 4,
+         huge: 5,
+         full_size: 6
+       },
+       _prefix: true,
+        _default: "medium"
+
+  enum votes_anonymous:
+       {
+         no: 1,
+         yes: 2,
+         old: 3
+       },
+       _prefix: :votes_anon,
+       _default: "no"
+
+  enum location_format:
+       {
+         postal: 1,
+         scientific: 2
+       },
+       _prefix: true,
+       _default: "postal"
+
+  enum hide_authors:
+       {
+         none: 1,
+         above_species: 2
+       },
+       _prefix: true,
+       _default: "none"
+
+  enum keep_filenames:
+       {
+         toss: 1,
+         keep_but_hide: 2,
+         keep_and_show: 3
+       },
+       _suffix: :filenames,
+       _default: "toss"
 
   has_many :api_keys, dependent: :destroy
   has_many :comments
@@ -372,7 +377,7 @@ class User < AbstractModel
   # Tell User model which User is currently logged in (if any).  This is used
   # by the +autologin+ filter and API authentication.
   def self.current=(val)
-    @@location_format = val ? val.location_format : :postal
+    @@location_format = val ? val.location_format : "postal"
     @@user = val
   end
 
@@ -381,7 +386,7 @@ class User < AbstractModel
   #   location_format = User.current_location_format
   #
   def self.current_location_format
-    @@location_format = :postal unless defined?(@@location_format)
+    @@location_format = "postal" unless defined?(@@location_format)
     @@location_format
   end
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -222,7 +222,7 @@ class Vote < AbstractModel
   # This is the first step: abstracting it as a method on Vote instance.
   # Now we are free to change the implementation later.
   def anonymous?
-    (user.votes_anonymous == :yes) ||
+    (user.votes_anonymous == "yes") ||
       (user.votes_anonymous == :old &&
        updated_at <= Time.zone.parse(MO.vote_cutoff))
   end

--- a/app/views/account/_prefs_appearance.html.erb
+++ b/app/views/account/_prefs_appearance.html.erb
@@ -6,14 +6,14 @@
 <div class="form-group push-down form-inline">
   <%= label_tag(:user_hide_authors, :prefs_hide_authors.t + ":") %>
   <%= form.select(:hide_authors,
-                  [[:prefs_hide_authors_none.l, :none],
-                   [:prefs_hide_authors_above_species.l, :above_species]],
+                  [[:prefs_hide_authors_none.l, "none"],
+                   [:prefs_hide_authors_above_species.l, "above_species"]],
                   class: "form-control") %><br/>
 
   <%= label_tag(:user_location_format, :prefs_location_format.t + ":") %>
   <%= form.select(:location_format,
-                  [[:prefs_location_format_postal.l, :postal],
-                   [:prefs_location_format_scientific.l, :scientific]],
+                  [[:prefs_location_format_postal.l, "postal"],
+                   [:prefs_location_format_scientific.l, "scientific"]],
                   class: "form-control") %><br/>
 
   <%= label_tag(:user_theme, :prefs_theme.t + ":") %>

--- a/app/views/account/_prefs_privacy.html.erb
+++ b/app/views/account/_prefs_privacy.html.erb
@@ -28,11 +28,11 @@
   <%= label_tag(:user_keep_filenames,
                 :prefs_keep_image_filenames.t + ":") %><br/>
   <%= form.select(:keep_filenames,
-                   [[:prefs_keep_image_filenames_toss.l, :toss],
+                   [[:prefs_keep_image_filenames_toss.l, "toss"],
                     [:prefs_keep_image_filenames_keep_but_hide.l,
-                     :keep_but_hide],
+                     "keep_but_hide"],
                     [:prefs_keep_image_filenames_keep_and_show.l,
-                     :keep_and_show]],
+                     "keep_and_show"]],
                   class: "form-control") %>
   <span class="HelpNote">
     <%= link_to(:prefs_bulk_filename_purge.t,

--- a/app/views/image/_image_thumbnail.html.erb
+++ b/app/views/image/_image_thumbnail.html.erb
@@ -22,7 +22,7 @@
       img_tag = image_tag(size_url, title: notes, style: style, class: img_class,
                           data: {toggle: "tooltip", placement: "bottom"}) %>
       <%= link_with_query(img_tag, link, html_options) %>
-      <%= 
+      <%=
         lightbox_id = is_set ? "observation-set" : SecureRandom.uuid
         show_orig = "<a href='#{orig_url}' target='_blank' class='lightbox_link'>#{:image_show_original.t}</a>"
         show_exif = "<a href='javascript:popup_exif(#{image_id})' class='lightbox_link'>#{:image_show_exif.t}</a>"
@@ -35,7 +35,7 @@
           <%= render(partial: "image/image_vote_links", locals: {image: image}) %>
         <% end %>
         <% if original && image && !image.original_name.blank? &&
-              (check_permission(image) || image.user && image.user.keep_filenames == :keep_and_show) %>
+              (check_permission(image) || image.user && image.user.keep_filenames == "keep_and_show") %>
           <center>
             <span><%= image.original_name %></span>
           </center>

--- a/app/views/image/show_image.html.erb
+++ b/app/views/image/show_image.html.erb
@@ -91,7 +91,7 @@
             <%= render(partial: "image/image_vote_links", locals: {image: @image}) %>
           <% end %>
           <% if !@image.original_name.blank? &&
-                (check_permission(@image) || @image.user && @image.user.keep_filenames == :keep_and_show) %>
+                (check_permission(@image) || @image.user && @image.user.keep_filenames == "keep_and_show") %>
             <%= @image.original_name %>
           <% end %>
         </div>

--- a/app/views/location/list_locations.html.erb
+++ b/app/views/location/list_locations.html.erb
@@ -50,7 +50,7 @@
       <%= paginate_block(@undef_pages) do %>
         <div class="list-group">
           <% @undef_data.each do |location, count|
-            if @undef_location_format == :scientific
+            if @undef_location_format == "scientific"
               location = Location.reverse_name(location)
             end %>
             <div class="list-group-item">

--- a/app/views/observer/_form_observations.html.erb
+++ b/app/views/observer/_form_observations.html.erb
@@ -44,7 +44,7 @@
       <%=
         loc1 = "Albion, Mendocino Co., California, USA"
         loc2 = "Hotel Parque dos Coqueiros, Aracaju, Sergipe, Brazil"
-        if User.current_location_format == :scientific
+        if User.current_location_format == "scientific"
           loc1 = Location.reverse_name(loc1)
           loc2 = Location.reverse_name(loc2)
         end

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -437,17 +437,17 @@ class AccountControllerTest < FunctionalTestCase
       email_observations_all: "",
       email_observations_consensus: "1",
       email_observations_naming: "1",
-      hide_authors: :above_species,
-      keep_filenames: :keep_but_hide,
+      hide_authors: "above_species",
+      keep_filenames: "keep_but_hide",
       license_id: licenses(:publicdomain).id.to_s,
       layout_count: "100",
       locale: "el",
-      location_format: :scientific,
+      location_format: "scientific",
       notes_template: "Collector's #",
       theme: "Agaricus",
       thumbnail_maps: "",
       view_owner_id: "",
-      votes_anonymous: :yes,
+      votes_anonymous: "yes",
       has_images: "1",
       has_specimen: "1",
       lichen: "yes",
@@ -481,17 +481,17 @@ class AccountControllerTest < FunctionalTestCase
     assert_input_value(:user_email_observations_all, "")
     assert_input_value(:user_email_observations_consensus, "1")
     assert_input_value(:user_email_observations_naming, "1")
-    assert_input_value(:user_hide_authors, :above_species)
-    assert_input_value(:user_keep_filenames, :keep_but_hide)
+    assert_input_value(:user_hide_authors, "above_species")
+    assert_input_value(:user_keep_filenames, "keep_but_hide")
     assert_input_value(:user_license_id, licenses(:publicdomain).id.to_s)
     assert_input_value(:user_layout_count, "100")
     assert_input_value(:user_locale, "el")
-    assert_input_value(:user_location_format, :scientific)
+    assert_input_value(:user_location_format, "scientific")
     assert_textarea_value(:user_notes_template, "Collector's #")
     assert_input_value(:user_theme, "Agaricus")
     assert_input_value(:user_thumbnail_maps, "")
     assert_input_value(:user_view_owner_id, "")
-    assert_input_value(:user_votes_anonymous, :yes)
+    assert_input_value(:user_votes_anonymous, "yes")
     assert_input_value(:user_has_images, "1")
     assert_input_value(:user_has_specimen, "1")
     assert_input_value(:user_lichen, "yes")
@@ -522,17 +522,17 @@ class AccountControllerTest < FunctionalTestCase
     assert_equal(false, user.email_observations_all)
     assert_equal(true, user.email_observations_consensus)
     assert_equal(true, user.email_observations_naming)
-    assert_equal(:above_species, user.hide_authors)
-    assert_equal(:keep_but_hide, user.keep_filenames)
+    assert_equal("above_species", user.hide_authors)
+    assert_equal("keep_but_hide", user.keep_filenames)
     assert_equal(100, user.layout_count)
     assert_equal(licenses(:publicdomain), user.license)
     assert_equal("el", user.locale)
-    assert_equal(:scientific, user.location_format)
+    assert_equal("scientific", user.location_format)
     assert_equal("Collector's #", user.notes_template)
     assert_equal("Agaricus", user.theme)
     assert_equal(false, user.thumbnail_maps)
     assert_equal(false, user.view_owner_id)
-    assert_equal(:yes, user.votes_anonymous)
+    assert_equal("yes", user.votes_anonymous)
     assert_equal("yes", user.content_filter[:has_images])
     assert_equal("yes", user.content_filter[:has_specimen])
     assert_equal("yes", user.content_filter[:lichen])

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -271,7 +271,7 @@ class API2ControllerTest < FunctionalTestCase
 
   def test_post_maximal_image
     setup_image_dirs
-    rolf.update(keep_filenames: :keep_and_show)
+    rolf.update(keep_filenames: "keep_and_show")
     rolf.reload
     file = "#{::Rails.root}/test/images/Coprinus_comatus.jpg"
     proj = rolf.projects_member.first
@@ -430,7 +430,7 @@ class API2ControllerTest < FunctionalTestCase
 
   def test_vote_anonymity
     obs = observations(:coprinus_comatus_obs)
-    rolf.update!(votes_anonymous: :yes)
+    rolf.update!(votes_anonymous: "yes")
     rolfs_key = api_keys(:rolfs_api_key)
     marys_key = api_keys(:marys_api_key)
     rolfs_vote = obs.votes.find_by(user: rolf)

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -795,34 +795,34 @@ class ImageControllerTest < FunctionalTestCase
     img_id = images(:agaricus_campestris_image).id
     login("mary")
 
-    rolf.keep_filenames = :toss
+    rolf.keep_filenames = "toss"
     rolf.save
     get(:show_image, params: { id: img_id })
     assert_false(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_but_hide
+    rolf.keep_filenames = "keep_but_hide"
     rolf.save
     get(:show_image, params: { id: img_id })
     assert_false(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_and_show
+    rolf.keep_filenames = "keep_and_show"
     rolf.save
     get(:show_image, params: { id: img_id })
     assert_true(@response.body.include?("áč€εиts"))
 
     login("rolf")
 
-    rolf.keep_filenames = :toss
+    rolf.keep_filenames = "toss"
     rolf.save
     get(:show_image, params: { id: img_id })
     assert_true(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_but_hide
+    rolf.keep_filenames = "keep_but_hide"
     rolf.save
     get(:show_image, params: { id: img_id })
     assert_true(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_and_show
+    rolf.keep_filenames = "keep_and_show"
     rolf.save
     get(:show_image, params: { id: img_id })
     assert_true(@response.body.include?("áč€εиts"))

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -610,7 +610,7 @@ class LocationControllerTest < FunctionalTestCase
   end
 
   def test_update_location_with_scientific_names
-    rolf.update(location_format: :scientific)
+    rolf.update(location_format: "scientific")
     rolf.reload
     login("rolf")
     loc = locations(:burbank)
@@ -825,7 +825,7 @@ class LocationControllerTest < FunctionalTestCase
       notes: "new observation"
     )
     assert_nil(obs.location)
-    assert_equal(:scientific, roy.location_format)
+    assert_equal("scientific", roy.location_format)
     params = {
       where: where,
       location: albion.id
@@ -901,7 +901,7 @@ class LocationControllerTest < FunctionalTestCase
     }
 
     login("rolf")
-    assert_equal(:postal, rolf.location_format)
+    assert_equal("postal", rolf.location_format)
     postal_name = "Missoula, Montana, USA"
     scientific_name = "USA, Montana, Missoula"
     params[:location][:display_name] = postal_name
@@ -913,7 +913,7 @@ class LocationControllerTest < FunctionalTestCase
     assert_equal(scientific_name, loc.scientific_name)
 
     login("roy")
-    assert_equal(:scientific, roy.location_format)
+    assert_equal("scientific", roy.location_format)
     postal_name = "Santa Fe, New Mexico, USA"
     scientific_name = "USA, New Mexico, Santa Fe"
     params[:location][:display_name] = scientific_name

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -106,9 +106,9 @@ class ObserverControllerTest < FunctionalTestCase
     user = users(:small_thumbnail_user)
     login(user.name)
     get(:show_observation,
-        params: { set_thumbnail_size: :thumbnail })
+        params: { set_thumbnail_size: "thumbnail" })
     user.reload
-    assert_equal(:thumbnail, user.thumbnail_size)
+    assert_equal("thumbnail", user.thumbnail_size)
   end
 
   def test_show_observation_hidden_gps
@@ -974,11 +974,11 @@ class ObserverControllerTest < FunctionalTestCase
 
     get_with_dump(:show_observation, id: obs.id, go_private: 1)
     user.reload
-    assert_equal(:yes, user.votes_anonymous)
+    assert_equal("yes", user.votes_anonymous)
 
     get_with_dump(:show_observation, id: obs.id, go_public: 1)
     user.reload
-    assert_equal(:no, user.votes_anonymous)
+    assert_equal("no", user.votes_anonymous)
   end
 
   def test_show_owner_id
@@ -1754,34 +1754,34 @@ class ObserverControllerTest < FunctionalTestCase
     login("mary")
     obs_id = observations(:agaricus_campestris_obs).id
 
-    rolf.keep_filenames = :toss
+    rolf.keep_filenames = "toss"
     rolf.save
     get(:show_observation, params: { id: obs_id })
     assert_false(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_but_hide
+    rolf.keep_filenames = "keep_but_hide"
     rolf.save
     get(:show_observation, params: { id: obs_id })
     assert_false(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_and_show
+    rolf.keep_filenames = "keep_and_show"
     rolf.save
     get(:show_observation, params: { id: obs_id })
     assert_true(@response.body.include?("áč€εиts"))
 
     login("rolf") # owner
 
-    rolf.keep_filenames = :toss
+    rolf.keep_filenames = "toss"
     rolf.save
     get(:show_observation, params: { id: obs_id })
     assert_true(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_but_hide
+    rolf.keep_filenames = "keep_but_hide"
     rolf.save
     get(:show_observation, params: { id: obs_id })
     assert_true(@response.body.include?("áč€εиts"))
 
-    rolf.keep_filenames = :keep_and_show
+    rolf.keep_filenames = "keep_and_show"
     rolf.save
     get(:show_observation, params: { id: obs_id })
     assert_true(@response.body.include?("áč€εиts"))
@@ -1802,7 +1802,7 @@ class ObserverControllerTest < FunctionalTestCase
                        users(:rolf).preferred_herbarium_name)
     assert_input_value(:herbarium_record_herbarium_id, "")
     assert_true(@response.body.include?("Albion, Mendocino Co., California"))
-    users(:rolf).update(location_format: :scientific)
+    users(:rolf).update(location_format: "scientific")
     get(:create_observation)
     assert_true(@response.body.include?("California, Mendocino Co., Albion"))
   end

--- a/test/integration/expert_test.rb
+++ b/test/integration/expert_test.rb
@@ -122,7 +122,7 @@ class ExpertTest < IntegrationTestCase
     newer_location_reverse = "USA, California, Somewhere Else"
 
     # Good opportunity to test scientific location notation!
-    dick.location_format = :scientific
+    dick.location_format = "scientific"
     dick.save
 
     # First attempt at creating a list.

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -1395,7 +1395,7 @@ class API2Test < UnitTestCase
       upload_file: "#{::Rails.root}/test/images/sticky.jpg",
       original_name: "strip_this"
     }
-    assert_equal(:toss, @user.keep_filenames)
+    assert_equal("toss", @user.keep_filenames)
     File.stub(:rename, true) do
       File.stub(:chmod, true) do
         api = API2.execute(params)
@@ -1408,7 +1408,7 @@ class API2Test < UnitTestCase
 
   def test_posting_maximal_image
     setup_image_dirs
-    rolf.update(keep_filenames: :keep_and_show)
+    rolf.update(keep_filenames: "keep_and_show")
     rolf.reload
     @user   = rolf
     @proj   = projects(:eol_project)
@@ -1476,7 +1476,7 @@ class API2Test < UnitTestCase
   end
 
   def test_patching_images
-    rolf.update(keep_filenames: :keep_and_show)
+    rolf.update(keep_filenames: "keep_and_show")
     rolf.reload
     rolfs_img = images(:rolf_profile_image)
     marys_img = images(:in_situ_image)
@@ -2519,7 +2519,7 @@ class API2Test < UnitTestCase
       action: :observation,
       api_key: @api_key.key
     }
-    assert_equal(:postal, rolf.location_format)
+    assert_equal("postal", rolf.location_format)
 
     params[:location] = "New Place, California, USA"
     api = API2.execute(params)
@@ -2539,8 +2539,8 @@ class API2Test < UnitTestCase
     # is supposed to make it more consistent for apps.  It would be a real
     # problem because apps don't have access to the user's prefs, so they have
     # no way of knowing how to pass in locations on the behalf of the user.
-    User.update(rolf.id, location_format: :scientific)
-    assert_equal(:scientific, rolf.reload.location_format)
+    User.update(rolf.id, location_format: "scientific")
+    assert_equal("scientific", rolf.reload.location_format)
 
     # params[:location] = "USA, California, Somewhere Else"
     params[:location] = "Somewhere Else, California, USA"

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -413,13 +413,13 @@ class LocationTest < UnitTestCase
     loc = Location.first
 
     User.current = rolf
-    assert_equal(:postal, User.current_location_format)
+    assert_equal("postal", User.current_location_format)
     loc.update_attribute(:display_name, "One, Two, Three")
     assert_equal("One, Two, Three", loc.name)
     assert_equal("Three, Two, One", loc.scientific_name)
 
     User.current = roy
-    assert_equal(:scientific, User.current_location_format)
+    assert_equal("scientific", User.current_location_format)
     loc.update_attribute(:display_name, "Un, Deux, Trois")
     assert_equal("Trois, Deux, Un", loc.name)
     assert_equal("Un, Deux, Trois", loc.scientific_name)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2209,8 +2209,8 @@ class NameTest < UnitTestCase
   end
 
   def test_hiding_authors
-    dick.hide_authors = :above_species
-    mary.hide_authors = :none
+    dick.hide_authors = "above_species"
+    mary.hide_authors = "none"
 
     name = names(:agaricus_campestris)
     User.current = mary

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -509,7 +509,7 @@ class QueryTest < UnitTestCase
       Set.new([rolf.id, mary.id, junk.id, dick.id, katrina.id, roy.id]) -
         query.result_ids
     )
-    assert_equal(roy.location_format, :scientific)
+    assert_equal(roy.location_format, "scientific")
     assert_equal(
       Set.new,
       Set.new([rolf, mary, junk, dick, katrina, roy]) - query.results
@@ -3198,12 +3198,12 @@ class QueryTest < UnitTestCase
     elgin_co = locations(:elgin_co)
 
     User.current = rolf
-    assert_equal(:postal, User.current_location_format)
+    assert_equal("postal", User.current_location_format)
     assert_query([albion, elgin_co], :Location, :in_set,
                  ids: [albion.id, elgin_co.id], by: :name)
 
     User.current = roy
-    assert_equal(:scientific, User.current_location_format)
+    assert_equal("scientific", User.current_location_format)
     assert_query([elgin_co, albion], :Location, :in_set,
                  ids: [albion.id, elgin_co.id], by: :name)
 
@@ -3213,12 +3213,12 @@ class QueryTest < UnitTestCase
     obs2.update(location: elgin_co)
 
     User.current = rolf
-    assert_equal(:postal, User.current_location_format)
+    assert_equal("postal", User.current_location_format)
     assert_query([obs1, obs2], :Observation, :in_set,
                  ids: [obs1.id, obs2.id], by: :location)
 
     User.current = roy
-    assert_equal(:scientific, User.current_location_format)
+    assert_equal("scientific", User.current_location_format)
     assert_query([obs2, obs1], :Observation, :in_set,
                  ids: [obs1.id, obs2.id], by: :location)
   end


### PR DESCRIPTION
Note: This PR is based on the Zeitwerk branch, to avoid excessive re-refactoring.
**The big difference here is that Rails native enums return a string rather than a symbol.** 
In other words, with the current `simple_enum` gem,
```
user.keep_filenames
=> :toss
```
**with Rails enum**,
```
user.keep_filenames
=> “toss"
```
Tests must therefore compare results to strings. 