### PR TITLE
Switch to Rails native `enum` for `Notification`

### DIFF
--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1145,7 +1145,7 @@ class NameController < ApplicationController
       note_template = params[:notification][:note_template]
       note_template = nil if note_template.blank?
       if @notification.nil?
-        @notification = Notification.new(flavor: :name,
+        @notification = Notification.new(flavor: "name",
                                          user: @user,
                                          obj_id: name_id,
                                          note_template: note_template)

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -86,6 +86,16 @@ class AbstractModel < ApplicationRecord
     self.class.name.underscore.to_sym
   end
 
+  # Default value (as a symbol) for an enum attribute
+  def self.enum_default_value(attr)
+    send(attr.to_s.pluralize).hash.key(default_cardinal(attr)).to_sym
+  end
+
+  # number (or nil) that is the default value for attr
+  def self.default_cardinal(attr)
+    column_defaults[attr.to_s]
+  end
+
   ##############################################################################
   #
   #  :section: "Find" Extensions

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -86,16 +86,6 @@ class AbstractModel < ApplicationRecord
     self.class.name.underscore.to_sym
   end
 
-  # Default value (as a symbol) for an enum attribute
-  def self.enum_default_value(attr)
-    send(attr.to_s.pluralize).hash.key(default_cardinal(attr)).to_sym
-  end
-
-  # number (or nil) that is the default value for attr
-  def self.default_cardinal(attr)
-    column_defaults[attr.to_s]
-  end
-
   ##############################################################################
   #
   #  :section: "Find" Extensions

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -55,7 +55,7 @@ class Notification < AbstractModel
   #   naming::    Naming that triggered this email.
   #
   def calc_note(args)
-    return nil unless (template = note_template) && flavor == :name
+    return nil unless (template = note_template) && flavor == "name"
 
     tracker  = user
     observer = args[:user]

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -32,19 +32,19 @@
 class Notification < AbstractModel
   belongs_to :user
 
-  # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
-  as_enum(:flavor,
-          { name: 1,
-            observation: 2,
-            user: 3,
-            all_comments: 4 },
-          source: :flavor,
-          accessor: :whiny)
+  enum flavor:
+       {
+         name: 1,
+         observation: 2,
+         user: 3,
+         all_comments: 4
+       },
+       _suffix: :flavor
 
-  # List of all available flavors (Symbol's).
+        # List of all available flavors (strings).
   def self.all_flavors
-    [:name]
+    ["name"]
   end
 
   # Create body of the email we're about to send.  Each flavor requires a
@@ -77,12 +77,12 @@ class Notification < AbstractModel
   # name::   Name that User is tracking.
   #
   def target
-    @target ||= flavor == :name ? Name.find(obj_id) : nil
+    @target ||= flavor == "name" ? Name.find(obj_id) : nil
   end
 
   # Return a string summarizing what this Notification is about.
   def summary
-    if flavor == :name
+    if flavor == "name"
       "#{:TRACKING.l} #{:name.l}: #{target ? target.display_name : "?"}"
     else
       "Unrecognized notification flavor"
@@ -96,7 +96,7 @@ class Notification < AbstractModel
   #
   def link_params
     result = {}
-    if flavor == :name
+    if flavor == "name"
       result[:controller] = :name
       result[:action] = :email_tracking
       result[:id] = obj_id


### PR DESCRIPTION
Note: This PR is based on the Zeitwerk branch, to avoid excessive re-refactoring.
**The big difference here is that Rails native enums return a string rather than a symbol.** 
In other words, with the current `simple_enum` gem,
```
notification.flavor
=> :name
```
**with Rails enum**,
```
notification.flavor
=> “name"
```
Tests must therefore compare results to strings. 