### PR TITLE
Recognize abbreviation "subgen"

### DIFF
--- a/app/classes/rank_matcher.rb
+++ b/app/classes/rank_matcher.rb
@@ -47,7 +47,7 @@ TEXT_NAME_MATCHERS = [
 
 # All abbrevisations for a given rank
 # Used by RANK_FROM_ABBREV_MATCHERS and in app/models/name/parse.rb
-SUBG_ABBR    = / subgenus | subg\.?                      /xi.freeze
+SUBG_ABBR    = / subgenus | subgen\.? | subg\.?          /xi.freeze
 SECT_ABBR    = / section | sect\.?                       /xi.freeze
 SUBSECT_ABBR = / subsection | subsect\.?                 /xi.freeze
 STIRPS_ABBR  = / stirps                                  /xi.freeze

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -398,6 +398,7 @@ class NameTest < UnitTestCase
     assert_name_match_author_optional(pat, "Amanita Subg. Vaginatae")
     assert_name_match_author_optional(pat, "Amanita subg Vaginatae")
     assert_name_match_author_optional(pat, '"Amanita subg. Vaginatae"')
+    assert_name_match_author_optional(pat, "Amanita subgen. Vaginatae")
   end
 
   def test_section_pat


### PR DESCRIPTION
This PR recognizes "subgen." as abbreviation of "subgenus"
(The code changes are trivial. )
Delivers [Pivotal #180830743](#180830743).

### Manual Test 
If you want to test them:
- Go to http://localhost:3000/name/create_name
- In the `Rank` pulldown menu, select `Subgenus`
- In the `Scientific Name` field, enter `Gyromitra subgen. Whatever`
- Click "Create"
Result:  Successfully created name ‘Gyromitra subg. Whatever’.