### PR TITLE
ApplicationHelper: Allow for an array of refactored controllers in link_next/prev

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,8 +93,8 @@ module ApplicationHelper
 
   # link to next object in query results
   def link_next(object)
-    path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag}_path", { object.id, flow: "next" })
+    path = if REFACTORED_CONTROLLERS.include?(object.type_tag)
+             send("#{object.type_tag}_path", object.id, flow: "next")
            else
              { controller: object.show_controller,
                action: object.next_action, id: object.id }
@@ -104,8 +104,8 @@ module ApplicationHelper
 
   # link to previous object in query results
   def link_prev(object)
-    path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag}_path", { object.id, flow: "prev" })
+    path = if REFACTORED_CONTROLLERS.include?(object.type_tag)
+             send("#{object.type_tag}_path", object.id, flow: "prev")
            else
              { controller: object.show_controller,
                action: object.prev_action, id: object.id }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,13 +87,13 @@ module ApplicationHelper
     link_to(*link)
   end
 
-  REFACTORED_CONTROLLERS = [
+  REFACTORED_CONTROLLERS_WITH_FLOW = [
     :herbarium
   ].freeze
 
   # link to next object in query results
   def link_next(object)
-    path = if REFACTORED_CONTROLLERS.include?(object.type_tag)
+    path = if REFACTORED_CONTROLLERS_WITH_FLOW.include?(object.type_tag)
              send("#{object.type_tag}_path", object.id, flow: "next")
            else
              { controller: object.show_controller,
@@ -104,7 +104,7 @@ module ApplicationHelper
 
   # link to previous object in query results
   def link_prev(object)
-    path = if REFACTORED_CONTROLLERS.include?(object.type_tag)
+    path = if REFACTORED_CONTROLLERS_WITH_FLOW.include?(object.type_tag)
              send("#{object.type_tag}_path", object.id, flow: "prev")
            else
              { controller: object.show_controller,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,7 +94,7 @@ module ApplicationHelper
   # link to next object in query results
   def link_next(object)
     path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag}_path", (object.id, flow: "next"))
+             send("#{object.type_tag}_path", { object.id, flow: "next" })
            else
              { controller: object.show_controller,
                action: object.next_action, id: object.id }
@@ -105,7 +105,7 @@ module ApplicationHelper
   # link to previous object in query results
   def link_prev(object)
     path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag}_path", (object.id, flow: "prev"))
+             send("#{object.type_tag}_path", { object.id, flow: "prev" })
            else
              { controller: object.show_controller,
                action: object.prev_action, id: object.id }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,7 +94,7 @@ module ApplicationHelper
   # link to next object in query results
   def link_next(object)
     path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag.to_s}_path", object.id, flow: "next")
+             send("#{object.type_tag}_path", object.id, flow: "next")
            else
              { controller: object.show_controller,
                action: object.next_action, id: object.id }
@@ -105,7 +105,7 @@ module ApplicationHelper
   # link to previous object in query results
   def link_prev(object)
     path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag.to_s}_path", object.id, flow: "prev")
+             send("#{object.type_tag}_path", object.id, flow: "prev")
            else
              { controller: object.show_controller,
                action: object.prev_action, id: object.id }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,12 +89,12 @@ module ApplicationHelper
 
   REFACTORED_CONTROLLERS = [
     :herbarium
-  ]
+  ].freeze
 
   # link to next object in query results
   def link_next(object)
     path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag}_path", object.id, flow: "next")
+             send("#{object.type_tag}_path", (object.id, flow: "next"))
            else
              { controller: object.show_controller,
                action: object.next_action, id: object.id }
@@ -105,7 +105,7 @@ module ApplicationHelper
   # link to previous object in query results
   def link_prev(object)
     path = if REFACTORED_CONTROLLERS.include? object.type_tag
-             send("#{object.type_tag}_path", object.id, flow: "prev")
+             send("#{object.type_tag}_path", (object.id, flow: "prev"))
            else
              { controller: object.show_controller,
                action: object.prev_action, id: object.id }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,10 +87,14 @@ module ApplicationHelper
     link_to(*link)
   end
 
+  REFACTORED_CONTROLLERS = [
+    :herbarium
+  ]
+
   # link to next object in query results
   def link_next(object)
-    path = if object.type_tag == :herbarium
-             herbarium_path(object.id, flow: "next")
+    path = if REFACTORED_CONTROLLERS.include? object.type_tag
+             send("#{object.type_tag.to_s}_path", object.id, flow: "next")
            else
              { controller: object.show_controller,
                action: object.next_action, id: object.id }
@@ -100,8 +104,8 @@ module ApplicationHelper
 
   # link to previous object in query results
   def link_prev(object)
-    path = if object.type_tag == :herbarium
-             herbarium_path(object.id, flow: "prev")
+    path = if CONVERTED_CONTROLLERS.include? object.type_tag
+             send("#{object.type_tag.to_s}_path", object.id, flow: "prev")
            else
              { controller: object.show_controller,
                action: object.prev_action, id: object.id }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -104,7 +104,7 @@ module ApplicationHelper
 
   # link to previous object in query results
   def link_prev(object)
-    path = if CONVERTED_CONTROLLERS.include? object.type_tag
+    path = if REFACTORED_CONTROLLERS.include? object.type_tag
              send("#{object.type_tag.to_s}_path", object.id, flow: "prev")
            else
              { controller: object.show_controller,


### PR DESCRIPTION
This PR doesn't change much, it just allows for adding other controllers to an array of `REFACTORED_CONTROLLERS` that will accept a `flow` `next`/`prev` `param`. The goal here is to start allowing for other controllers to emulate  @JoeCohen 's refactor of `HerbariaController`. That moves routes to default `resources` routes like `show` and `index`, and provides redirects for the old routes. 

Routes in a potential GraphQL app would ideally follow a similar regular pattern, so I'm thinking refactoring the controllers and updating paths ahead of time would "clear the paths" for minimal eventual URL disruption in the future. Hopefully it'll get easier following Joe's example. 