### PR TITLE
Remove test_flash

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -39,7 +39,6 @@
 #
 #  ==== Testing
 #  test_autologin::     <tt>(L V .)</tt>
-#  test_flash::         <tt>(. . .)</tt>
 #
 ################################################################################
 class AccountController < ApplicationController
@@ -50,7 +49,6 @@ class AccountController < ApplicationController
     :reverify,
     :send_verify,
     :signup,
-    :test_flash,
     :verify,
     :welcome
   ]

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -823,22 +823,6 @@ class AccountController < ApplicationController
   # This is used to test the autologin feature.
   def test_autologin; end
 
-  # This is used to test the flash error mechanism in the unit tests.
-  def test_flash
-    notice   = params[:notice]
-    warning  = params[:warning]
-    error    = params[:error]
-    redirect = params[:redirect]
-    flash_notice(notice)   if notice
-    flash_warning(warning) if warning
-    flash_error(error)     if error
-    if redirect
-      redirect_to(redirect)
-    else
-      render(plain: "", layout: true)
-    end
-  end
-
   ##############################################################################
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,6 @@ ACTIONS = {
     signup: {},
     switch_users: {},
     test_autologin: {},
-    test_flash: {},
     turn_admin_off: {},
     turn_admin_on: {},
     verify: {},


### PR DESCRIPTION
This PR removes Account#test_flash (and its associated route).
It fixes a Brakeman unprotected redirect issue.
