### PR TITLE
Prevent commas at start and end of some Name fields

### DIFF
--- a/app/controllers/name_controller/create_and_edit_name.rb
+++ b/app/controllers/name_controller/create_and_edit_name.rb
@@ -95,7 +95,8 @@ class NameController
   def set_unparsed_attrs
     set_locked_if_admin
     set_icn_id_if_unlocked_or_admin
-    @name.citation = params[:name][:citation].to_s.strip_squeeze
+    @name.citation = params[:name][:citation].to_s.
+                     strip_squeeze.strip_bad_chars_at_ends
     @name.notes    = params[:name][:notes].to_s.strip
   end
 

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -520,8 +520,8 @@ class String
 
   # Strip leading and trailing whitespace and some punctuation chars
   def strip_bad_chars_at_ends
-    gsub(/\A[\s\,;-]+/, "").
-      gsub(/[\s\,;-]+\Z/, "")
+    gsub(/\A[\s,;-]+/, "").
+      gsub(/[\s,;-]+\Z/, "")
   end
 
   # Generate a string of random characters of length +len+.  By default it

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -518,6 +518,12 @@ class String
     strip.squeeze(" ")
   end
 
+  # Strip leading and trailing whitespace and some punctuation chars
+  def strip_bad_chars_at_ends
+    gsub(/\A[\s\,;-]+/, "").
+      gsub(/[\s\,;-]+\Z/, "")
+  end
+
   # Generate a string of random characters of length +len+.  By default it
   # chooses from among the lowercase letters and digits, however you can give
   # it an arbitrary set of characters to choose from.  (And they don't have to

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -438,7 +438,8 @@ class String
   # tags.  If greater than +max+, truncates to <tt>max - 1</tt> and adds "..."
   # to the end (inside any formatting tags open at that point).  Assumes the
   # String is well-formatted HTML with properly-nested tags.
-  def truncate_html(max)
+  # Disable cop because no easy way to improve
+  def truncate_html(max) # rubocop:disable Metrics/AbcSize
     result = ""
     # make str mutable because it will be modified in place with sub!
     str = String.new(self)
@@ -599,7 +600,8 @@ class String
 
   # This definition copied from Rails::Generators, Which is based directly on
   # the Text gem implementation.
-  def levenshtein_distance(str1, str2)
+  # Disable cop because no easy way to improve
+  def levenshtein_distance(str1, str2) # rubocop:disable Metrics/AbcSize
     s = str1
     t = str2
     n = s.length

--- a/app/models/name/parse.rb
+++ b/app/models/name/parse.rb
@@ -463,7 +463,7 @@ class Name < AbstractModel
           sub(/(?<=comb. |nom. ) ?#{NOV_ABBR}/,  "nov. ").
           sub(/(?<=comb. |nom. ) ?#{PROV_ABBR}/, "prov. ").
           strip_squeeze
-    squeeze_author(str)
+    squeeze_author(str).strip_bad_chars_at_ends
   end
 
   # Squeeze "A. H. Smith" into "A.H. Smith".

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1194,6 +1194,28 @@ class NameControllerTest < FunctionalTestCase
     assert(Name.find_by(text_name: "Pleurotus"))
   end
 
+  def test_create_name_clear_bordering_bad_chars
+    text_name = "Amanita velosa"
+    assert_not(Name.find_by(text_name: text_name))
+    author = "(Peck) Lloyd"
+    citation = "??Mycol. Writ.?? (Cincinnati) 1(7): 9, 15 (1898)"
+    params = {
+      name: {
+        text_name: text_name,
+        author: "#{author},",
+        rank: :Species,
+        citation: ", #{citation}"
+      }
+    }
+
+    post_requires_login(:create_name, params)
+
+    assert(name = Name.find_by(text_name: text_name))
+    assert_equal(author, name.author, "Failed to strip trailing comma")
+    assert_equal(citation, name.citation, "Failed strip leading comma, space")
+  end
+
+
   # ----------------------------
   #  Edit name -- without merge
   # ----------------------------

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1215,7 +1215,6 @@ class NameControllerTest < FunctionalTestCase
     assert_equal(citation, name.citation, "Failed strip leading comma, space")
   end
 
-
   # ----------------------------
   #  Edit name -- without merge
   # ----------------------------


### PR DESCRIPTION
This PR prevents (going forward) Names from having: (a) Authors ending in a comma, and (b) Citations starting with a comma. These are mistakes that we sometimes see and can be easily prevented.
The PR operates by stripping combinations of space(s), comma(s), and som other punctuation from the start and end of the entered Author and Citation fields before saving them.

Delivers https://www.pivotaltracker.com/story/show/182508428

####Manual Test
Try to create a Name with an Author ending in a comma, and a citation beginning with a comma. E.g.:
- Scientific Name:`Boletus test`
- Author: `TryToEndInComma,` 
- Citation: `, TryToStartWithComma`
Expected result: The Name is created without those commas.
