### PR TITLE
Prevent bad punctuation in Author and Citation

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -462,7 +462,7 @@ class Name < AbstractModel
   end
 
   def citation_start
-    # Should not end with punctuation other than:
+    # Should not start with punctuation other than:
     # quotes, period, close paren, close bracket
     # question mark (used for Textile italics)
     # underscore (previously used for Textile italics)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -377,6 +377,7 @@ class Name < AbstractModel
   validate :icn_id_unique
 
   validate :author_ending
+  validate :citation_start
 
   # Notify webmaster that a new name was created.
   after_create do |name|
@@ -458,5 +459,16 @@ class Name < AbstractModel
     )
 
     errors.add(:base, :name_error_field_end.t(field: :AUTHOR.t, end: punct))
+  end
+
+  def citation_start
+    # Should not end with punctuation
+    # other than quotes, period, close paren, close bracket
+    return unless (
+      start = %r{\A[\s!#%&)*+,\-./:;<=>?@\[\]^_{|}~]+}.match(citation)
+    )
+
+    errors.add(:base,
+               :name_error_field_start.t(field: :CITATION.t, start: start))
   end
 end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -376,6 +376,8 @@ class Name < AbstractModel
   validate :icn_id_registrable
   validate :icn_id_unique
 
+  validate :author_ending
+
   # Notify webmaster that a new name was created.
   after_create do |name|
     user    = User.current || User.admin
@@ -446,5 +448,15 @@ class Name < AbstractModel
 
   def other_names_with_same_icn_id
     Name.where(icn_id: icn_id).where.not(id: id)
+  end
+
+  def author_ending
+    # Should not end with punctuation
+    # other than quotes, period, close paren, close bracket
+    return unless (
+      punct = %r{[\s!#%&(*+,\-/:;<=>?@\[^_{|}~]+\Z}.match(author)
+    )
+
+    errors.add(:base, :name_error_field_end.t(field: :AUTHOR.t, end: punct))
   end
 end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -462,11 +462,12 @@ class Name < AbstractModel
   end
 
   def citation_start
-    # Should not end with punctuation
-    # other than quotes, period, close paren, close bracket
+    # Should not end with punctuation other than:
+    # quotes, period, close paren, close bracket
     # question mark (used for Textile italics)
+    # underscore (previously used for Textile italics)
     return unless (
-      start = %r{\A[\s!#%&)*+,\-./:;<=>@\[\]^_{|}~]+}.match(citation)
+      start = %r{\A[\s!#%&)*+,\-./:;<=>@\[\]^{|}~]+}.match(citation)
     )
 
     errors.add(:base,

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -464,8 +464,9 @@ class Name < AbstractModel
   def citation_start
     # Should not end with punctuation
     # other than quotes, period, close paren, close bracket
+    # question mark (used for Textile italics)
     return unless (
-      start = %r{\A[\s!#%&)*+,\-./:;<=>?@\[\]^_{|}~]+}.match(citation)
+      start = %r{\A[\s!#%&)*+,\-./:;<=>@\[\]^_{|}~]+}.match(citation)
     )
 
     errors.add(:base,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1507,6 +1507,8 @@
   form_names_refs_help: Each line is considered a separate reference, but no other formatting is enforced.
   name_error_unregistrable: The [rank] '[name]' is not eligible for an ICN identifier.
   name_error_icn_id_in_use: An ICN identifier number may be used by only one Name. '[number]' is already used by '[name]'.
+  name_error_field_start: "'[field] must not start with '[start]'."
+  name_error_field_end: "[field] must not end with '[end]'."
 
   # observer/_form_naming
   form_naming_confidence: Confidence
@@ -4229,4 +4231,3 @@
   system_status_gc: GC
   system_status_textile_name_size: Textile name cache size
   system_status_title: Server Status
-

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1507,7 +1507,7 @@
   form_names_refs_help: Each line is considered a separate reference, but no other formatting is enforced.
   name_error_unregistrable: The [rank] '[name]' is not eligible for an ICN identifier.
   name_error_icn_id_in_use: An ICN identifier number may be used by only one Name. '[number]' is already used by '[name]'.
-  name_error_field_start: "'[field] must not start with '[start]'."
+  name_error_field_start: "[field] must not start with '[start]'."
   name_error_field_end: "[field] must not end with '[end]'."
 
   # observer/_form_naming

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1063,7 +1063,7 @@ class NameControllerTest < FunctionalTestCase
     assert_form_action(action: "create_name")
   end
 
-  def test_create_name_bad_author_punctuation
+  def test_create_name_author_trailing_comma
     text_name = "Inocybe magnifolia"
     name = Name.find_by(text_name: text_name)
     punct = "!"
@@ -1079,11 +1079,34 @@ class NameControllerTest < FunctionalTestCase
 
     assert_no_difference(
       "Name.count",
-      "A Name should not be created when Author ends wtih #{punct}"
+      "A Name should not be created when Author ends with #{punct}"
     ) do
       post(:create_name, params: params)
     end
     assert_flash_error(:name_error_field_end.l)
+  end
+
+  def test_create_name_citation_leading_commma
+    text_name = "Coprinopsis nivea"
+    name = Name.find_by(text_name: text_name)
+    assert_nil(name)
+    params = {
+      name: {
+        text_name: text_name,
+        author: "(Pers.) Redhead, Vilgalys & Moncalvo",
+        citation: ", in Redhead, Taxon 50(1): 229 (2001)",
+        rank: :Species
+      }
+    }
+    login("rolf")
+
+    assert_no_difference(
+      "Name.count",
+      "A Name should not be created when Citation starts with ','"
+    ) do
+      post(:create_name, params: params)
+    end
+    assert_flash_error(:name_error_field_start.l)
   end
 
   def test_create_name_author_limit

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -1063,6 +1063,29 @@ class NameControllerTest < FunctionalTestCase
     assert_form_action(action: "create_name")
   end
 
+  def test_create_name_bad_author_punctuation
+    text_name = "Inocybe magnifolia"
+    name = Name.find_by(text_name: text_name)
+    punct = "!"
+    assert_nil(name)
+    params = {
+      name: {
+        text_name: text_name,
+        author: "Matheny, Aime & T.W. Henkel,",
+        rank: :Species
+      }
+    }
+    login("rolf")
+
+    assert_no_difference(
+      "Name.count",
+      "A Name should not be created when Author ends wtih #{punct}"
+    ) do
+      post(:create_name, params: params)
+    end
+    assert_flash_error(:name_error_field_end.l)
+  end
+
   def test_create_name_author_limit
     # Prove author :limit is number of characters, not bytes
     text_name = "Max-size-author"


### PR DESCRIPTION
Prevents most punctuation at the end of Author and the start of Citation.
There are Names whose Authors ends in a comma or whose Citation starts with a comma.[1]
This PR gives an appropriate flash warning when a user tries to Save/Update a Name with one of those problems.

Follows-up on now-closed PR #1037 
Re-delivers https://www.pivotaltracker.com/story/show/182508428

#### Manual Test
Try to create a Name with an Author ending in a comma, and a citation beginning with a comma. E.g.:

Scientific Name:Boletus test
Author: TryToEndInComma,
Citation: , TryToStartWithComma
Expected result: User is returned to form with a flash message describing the mistake.

-----
1. I think this typically results from copying and pasting too many characters from Index Fungorum.