### PR TITLE
Fix icn validation flash messages

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -429,8 +429,9 @@ class Name < AbstractModel
   def icn_id_registrable
     return if icn_id.blank? || registrable?
 
-    errors.add(:base, :name_error_unregistrable.t,
-               rank: rank.to_s, name: real_search_name)
+    errors.add(:base, :name_error_unregistrable.t(
+                        rank: rank.to_s, name: real_search_name
+                      ))
   end
 
   # Require icn_id to be unique
@@ -440,8 +441,9 @@ class Name < AbstractModel
     return if icn_id.nil?
     return if (conflicting_name = other_names_with_same_icn_id.first).blank?
 
-    errors.add(:base, :name_error_icn_id_in_use.t,
-               number: icn_id, name: conflicting_name.real_search_name)
+    errors.add(:base, :name_error_icn_id_in_use.t(
+                        number: icn_id, name: conflicting_name.real_search_name
+                      ))
   end
 
   def other_names_with_same_icn_id


### PR DESCRIPTION
The messages said things like
>An ICN identifier number may be used by only one Name. ‘[number]’ is already used by ‘[name]’.

because I had neglected to make `number` and `name` into arguments.

Delivers https://www.pivotaltracker.com/story/show/182531179

NOTE: I didn't add a test; I don't think it's worth it.

