### PR TITLE
Update CI Rubocop to 1.30.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -124,7 +124,7 @@ plugins:
     # Specify RuboCop version so that we're not stuck with Code Climate's
     # default, which can be different than what's in Gemfile.lock. See
     # docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions
-    channel: rubocop-1-23-0
+    channel: rubocop-1-30-0
 
 # scss style checker
   scss-lint:


### PR DESCRIPTION
Updates Codeclimate's Rubocop "channel" to the highest number available (1.30.0).

This gets us very close to the Rubocop version currently in Gemlock (1.30.1), which is also the latest release.

(I think I'm seeing at least one discrepancy between 1.23. and 1.30.1. I hope this will fix that issue, so I probably will merge this immediately.)