### PR TITLE
Replace byebug gem with debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -252,8 +252,9 @@ gem("graphql-batch")
 #
 
 group :test, :development do
-  # Use byebug as debugging gem
-  gem("byebug")
+  # https://github.com/ruby/debug
+  # NOTE: Remove this upon upgrade to Ruby 3.1. (It's included with Ruby 3.1)
+  gem "debug", ">= 1.0.0"
 
   # GraphiQL for GraphQL development
   # Makes an IDE available to test graphql queries at '/graphiql/'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
     bullet (7.0.2)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     capybara (3.36.0)
       addressable
       matrix
@@ -96,6 +95,9 @@ GEM
       rexml
     crass (1.0.6)
     date (3.2.2)
+    debug (1.5.0)
+      irb (>= 1.3.6)
+      reline (>= 0.2.7)
     docile (1.4.0)
     erubi (1.10.0)
     execjs (2.8.1)
@@ -112,6 +114,9 @@ GEM
     hashdiff (1.0.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -177,6 +182,8 @@ GEM
     rake (13.0.6)
     rbtree (0.4.5)
     regexp_parser (2.5.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rtf (0.3.3)
     rubocop (1.30.1)
@@ -275,10 +282,10 @@ DEPENDENCIES
   browser
   bullet
   bundler
-  byebug
   capybara
   coffee-rails
   date (>= 3.2.1)
+  debug (>= 1.0.0)
   graphiql-rails!
   graphql
   graphql-batch


### PR DESCRIPTION
Replaces the `byebug` gem with the `debug` gem.
Byebug is incompatible with Zeitwerk. 
`debug` is the new default Ruby debugger, included in Ruby 3.1 and Rails 7.
(So we can remove the gem once we upgrade to Ruby 3.1.)

Delivers https://www.pivotaltracker.com/story/show/182558784