### PR TITLE
Fix Brakeman RCEs

### DIFF
--- a/app/classes/query/comment_for_target.rb
+++ b/app/classes/query/comment_for_target.rb
@@ -17,7 +17,7 @@ class Query::CommentForTarget < Query::CommentBase
   end
 
   def target_instance
-    type = params[:type].to_s.constantize
+    type = Comment.all_types.find { |model| model.name == params[:type] }
     unless type.reflect_on_association(:comments)
       raise("The model #{params[:type].inspect} does not support comments!")
     end

--- a/app/classes/query/comment_for_target.rb
+++ b/app/classes/query/comment_for_target.rb
@@ -17,8 +17,7 @@ class Query::CommentForTarget < Query::CommentBase
   end
 
   def target_instance
-    type = Comment.all_types.find { |model| model.name == params[:type] }
-    unless type.reflect_on_association(:comments)
+    unless (type = Comment.safe_model_from_name(params[:type]))
       raise("The model #{params[:type].inspect} does not support comments!")
     end
 

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -100,7 +100,8 @@ class CommentController < ApplicationController
   # "and more..." thingy at the bottom of truncated embedded comment lists.)
   def show_comments_for_target
     model = begin
-              params[:type].to_s.constantize
+              Comment.all_types.
+                      select {|model| model.name == params[:type]}.first
             rescue StandardError
               nil
             end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -100,8 +100,7 @@ class CommentController < ApplicationController
   # "and more..." thingy at the bottom of truncated embedded comment lists.)
   def show_comments_for_target
     model = begin
-              Comment.all_types.
-                      select {|model| model.name == params[:type]}.first
+              Comment.all_types.find { |m| m.name == params[:type] }
             rescue StandardError
               nil
             end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -99,7 +99,7 @@ class CommentController < ApplicationController
   # Shows comments for a given object, most recent first. (Linked from the
   # "and more..." thingy at the bottom of truncated embedded comment lists.)
   def show_comments_for_target
-    model = safe_model_from_param_type
+    model = Comment.safe_model_from_name(params[:type])
     if !model
       flash_error(:runtime_invalid.t(type: '"type"',
                                      value: params[:type].to_s))
@@ -316,9 +316,5 @@ class CommentController < ApplicationController
     redirect_with_query(controller: target.show_controller,
                         action: target.show_action, id: target.id)
     false
-  end
-
-  def safe_model_from_param_type
-    Comment.all_types.find { |m| m.name == params[:type] }
   end
 end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -104,7 +104,7 @@ class CommentController < ApplicationController
             rescue StandardError
               nil
             end
-    if !model || !model.acts_like?(:model)
+    if !model
       flash_error(:runtime_invalid.t(type: '"type"',
                                      value: params[:type].to_s))
       redirect_back_or_default(action: :list_comments)

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -319,10 +319,8 @@ class CommentController < ApplicationController
   end
 
   def safe_model_from_param_type
-    begin
-      Comment.all_types.find { |m| m.name == params[:type] }
-    rescue StandardError
-      nil
-    end
+    Comment.all_types.find { |m| m.name == params[:type] }
+  rescue StandardError
+    nil
   end
 end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -320,7 +320,5 @@ class CommentController < ApplicationController
 
   def safe_model_from_param_type
     Comment.all_types.find { |m| m.name == params[:type] }
-  rescue StandardError
-    nil
   end
 end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -99,11 +99,7 @@ class CommentController < ApplicationController
   # Shows comments for a given object, most recent first. (Linked from the
   # "and more..." thingy at the bottom of truncated embedded comment lists.)
   def show_comments_for_target
-    model = begin
-              Comment.all_types.find { |m| m.name == params[:type] }
-            rescue StandardError
-              nil
-            end
+    model = safe_model_from_param_type
     if !model
       flash_error(:runtime_invalid.t(type: '"type"',
                                      value: params[:type].to_s))
@@ -320,5 +316,13 @@ class CommentController < ApplicationController
     redirect_with_query(controller: target.show_controller,
                         action: target.show_action, id: target.id)
     false
+  end
+
+  def safe_model_from_param_type
+    begin
+      Comment.all_types.find { |m| m.name == params[:type] }
+    rescue StandardError
+      nil
+    end
   end
 end

--- a/app/controllers/observer_controller/other.rb
+++ b/app/controllers/observer_controller/other.rb
@@ -2,6 +2,9 @@
 
 # TODO: where does this stuff belong?
 module ObserverController::Other
+  EXPORTABLE_MODELS = [Image, Location, LocationDescription, NameDescription,
+                         Name].freeze
+
   def test_flash_redirection
     tags = params[:tags].to_s.split(",")
     if tags.any?
@@ -92,13 +95,12 @@ module ObserverController::Other
     id    = params[:id].to_s
     type  = params[:type].to_s
     value = params[:value].to_s
-    model_class = type.camelize.safe_constantize
+    model_class = EXPORTABLE_MODELS.find { |m| m.name.downcase == type }
+
     if !reviewer?
       flash_error(:runtime_admin_only.t)
       redirect_back_or_default("/")
-    elsif !model_class ||
-          !model_class.respond_to?(:column_names) ||
-          model_class.column_names.exclude?("ok_for_export")
+    elsif !model_class
       flash_error(:runtime_invalid.t(type: '"type"', value: type))
       redirect_back_or_default("/")
     elsif !value.match(/^[01]$/)

--- a/app/controllers/observer_controller/search_controller.rb
+++ b/app/controllers/observer_controller/search_controller.rb
@@ -55,6 +55,8 @@ module ObserverController::SearchController
     end
   end
 
+  ADVANCED_SEARCHABLE_MODELS = [Image, Location, Name, Observation].freeze
+
   # Advanced search form.  When it posts it just redirects to one of several
   # "foreign" search actions:
   #   image/advanced_search
@@ -65,7 +67,8 @@ module ObserverController::SearchController
     @filter_defaults = users_content_filters || {}
     return unless request.method == "POST"
 
-    model = params[:search][:model].to_s.camelize.constantize
+    model = ADVANCED_SEARCHABLE_MODELS.
+            find { |m| m.name.downcase == params[:search][:model] }
     query_params = {}
     add_filled_in_text_fields(query_params)
     add_applicable_filter_parameters(query_params, model)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -145,6 +145,12 @@ class Comment < AbstractModel
     target.log(:log_comment_destroyed, summary: summary, touch: false)
   end
 
+  # Return model if params[:type] is the name of a commentable model
+  # Else nil
+  def self.safe_model_from_name(name)
+    all_types.find { |m| m.name == name }
+  end
+
   ############################################################################
 
   protected

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -30,6 +30,43 @@ class CommentControllerTest < FunctionalTestCase
                          params: @controller.query_params(QueryRecord.last))
   end
 
+  def test_show_comments_for_target_with_comments
+    target = observations(:minimal_unknown_obs)
+    params = { type: target.class.name, id: target.id }
+    comments = Comment.where(target_type: target.class.name, target: target)
+
+    login
+    get(:show_comments_for_target, params: params)
+    assert_select("div[class *='list-group comment']", count: comments.size)
+  end
+
+  def test_show_comments_for_valid_target_without_comments
+    target = names(:conocybe_filaris)
+    params = { type: target.class.name, id: target.id }
+
+    login
+    get(:show_comments_for_target, params: params)
+    assert_flash_text(:runtime_no_matches.l(types: "comments"))
+  end
+
+  def test_show_comments_for_invalid_target_type
+    target = api_keys(:rolfs_api_key)
+    params = { type: target.class.name, id: target.id }
+
+    login
+    get(:show_comments_for_target, params: params)
+    assert_flash_text(:runtime_invalid.t(type: '"type"',
+                      value: params[:type].to_s))
+  end
+
+  def test_show_comments_for_non_model
+    params = { type: "Hacker", id: 666 }
+
+    login
+    get(:show_comments_for_target, params: params)
+    assert_flash_text(:runtime_invalid.t(type: '"type"',
+                      value: params[:type].to_s))
+  end
   def test_add_comment
     obs_id = observations(:minimal_unknown_obs).id
     requires_login(:add_comment, id: obs_id, type: "Observation")

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -67,6 +67,7 @@ class CommentControllerTest < FunctionalTestCase
     assert_flash_text(:runtime_invalid.t(type: '"type"',
                       value: params[:type].to_s))
   end
+
   def test_add_comment
     obs_id = observations(:minimal_unknown_obs).id
     requires_login(:add_comment, id: obs_id, type: "Observation")

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -745,6 +745,9 @@ class API2Test < UnitTestCase
     obs = observations(:minimal_unknown_obs)
     assert_api_pass(params.merge(target: "observation ##{obs.id}"))
     assert_api_results(obs.comments.sort_by(&:id))
+
+    # APIKeys don't have comments
+    assert_api_fail(params.merge(type: APIKey.name))
   end
 
   def test_posting_comments


### PR DESCRIPTION
This PR fixes the Remote Code Execution issues flagged by Brakeman.
Instead of constantizing user params, it compares the param to a list of known good models.
See [The Safest Way to Constantize…](http://gavinmiller.io/2016/the-safesty-way-to-constantize/) (2016)
[Ruby Unsafe Reflection Vulnerabilities - Praetorian](https://www.praetorian.com/blog/ruby-unsafe-reflection-vulnerabilities/)
[Insecure Use of Dangerous Function | GuardRails](https://docs.guardrails.io/docs/vulnerabilities/ruby/insecure_use_of_dangerous_function#option-b-using-constantize-safely) (2022)

Delivers https://www.pivotaltracker.com/story/show/182567331