### PR TITLE
`Observer#map_observations` Set up benchmark `pluck` vs `map`

### DIFF
--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -247,8 +247,8 @@ module ObserverController::Indexes
       #   locations[id] = MinimalMapLocation.new(id, *the_rest)
       # end
       Location.where(id: locations.keys).map do |loc|
-        locations[id] = MinimalMapLocation.new(
-          id, loc.name, loc.north, loc.south, loc.east, loc.west
+        locations[loc.id] = MinimalMapLocation.new(
+          loc.id, loc.name, loc.north, loc.south, loc.east, loc.west
         )
       end
 

--- a/app/controllers/observer_controller/indexes.rb
+++ b/app/controllers/observer_controller/indexes.rb
@@ -238,13 +238,20 @@ module ObserverController::Indexes
       end
 
     unless locations.empty?
+      # NIMMO NOTE: Benchmark these two:
       # Eager-load corresponding locations.
-      @locations = Location.
-                   where(id: locations.keys.sort).
-                   pluck(:id, :name, :north, :south, :east, :west).
-                   map do |id, *the_rest|
-        locations[id] = MinimalMapLocation.new(id, *the_rest)
+      # @locations = Location.
+      #              where(id: locations.keys.sort).
+      #              pluck(:id, :name, :north, :south, :east, :west).
+      #              map do |id, *the_rest|
+      #   locations[id] = MinimalMapLocation.new(id, *the_rest)
+      # end
+      Location.where(id: locations.keys).map do |loc|
+        locations[id] = MinimalMapLocation.new(
+          id, loc.name, loc.north, loc.south, loc.east, loc.west
+        )
       end
+
       @observations.each do |obs|
         obs.location = locations[obs.location_id] if obs.location_id
       end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -61,6 +61,8 @@ class SearchesController < ApplicationController
     end
   end
 
+  ADVANCED_SEARCHABLE_MODELS = [Image, Location, Name, Observation].freeze
+
   # Advanced search form.  When it posts it just redirects to one of several
   # "foreign" search actions:
   #   image/advanced_search
@@ -71,7 +73,8 @@ class SearchesController < ApplicationController
     @filter_defaults = users_content_filters || {}
     return unless request.method == "POST"
 
-    model = params[:search][:model].to_s.camelize.constantize
+    model = ADVANCED_SEARCHABLE_MODELS.
+            find { |m| m.name.downcase == params[:search][:model] }
     query_params = {}
     add_filled_in_text_fields(query_params)
     add_applicable_filter_parameters(query_params, model)


### PR DESCRIPTION
via @pellaea 
> Naturally I don't have the capacity to benchmark this, but from what Nimmo and I were seeing not too long ago in a not-altogether-different case, it is actually a good deal faster these days to instantiate all of the locations, and then grab the columns you need from the instances. Admittedly, though, this could be huge. I mean, for example, it is entirely possible that folks will try to map every single location in our database(!) So it might be a good idea to benchmark this one properly. And pay attention to memory use, as well as system/user time, this time around.
> 
> For clarity, I'm recommending comparing what you've written with:

```ruby
Location.where(id: locations.keys).map do |loc| 
  locations[id] = MinimalMapLocation.new(
    id, loc.name, loc.north, loc.south, loc.east, loc.west
  ) 
end
```
> (Note that there is no reason to sort locations.keys... I don't think. I guess it depends what mysql does on the database end. Maybe if dbserver time is more precious than webserver time it really is better to sort it however mysql wants it sorted on the webserver end. But how would we know what will make mysql's life easiest? In the absence of any information, it stands to reason we should do nothing -- that is, leave locations.keys unsorted until we have some benchmark or documentation proving that it is better to sort it somehow.)