### PR TITLE
Fix confusion about whether Image#glossary_terms includes the thumbnail.

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -400,20 +400,6 @@ class Image < AbstractModel
     size == :original ? original_extension : "jpg"
   end
 
-  def has_size?(size)
-    max = width.to_i > height.to_i ? width.to_i : height.to_i
-    case size.to_s
-    when "thumbnail" then true
-    when "small" then max > 160
-    when "medium" then max > 320
-    when "large" then max > 640
-    when "huge" then max > 960
-    when "full_size" then max > 1280
-    when "original" then true
-    else; false
-    end
-  end
-
   # Calculate the approximate dimensions of the image of the given size.
   def size(size)
     w = width

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -247,17 +247,14 @@ class Image < AbstractModel
   after_update :track_copyright_changes
   before_destroy :update_thumbnails
 
-  def all_glossary_terms
-    best_glossary_terms + glossary_terms
-  end
-
-  def get_subjects
-    observations + subjects + best_glossary_terms + glossary_terms
+  # Array of all observations, users and glossary terms using this image.
+  def all_subjects
+    observations + subjects + glossary_terms
   end
 
   # Is image used by an object other than obj
   def other_subjects?(obj)
-    (get_subjects - [obj]).present?
+    (all_subjects - [obj]).present?
   end
 
   # Create plain-text title for image from observations, appending image id to
@@ -268,7 +265,7 @@ class Image < AbstractModel
   #   "Agaricus campestris L. & Agaricus californicus Peck. (3)"
   #
   def unique_text_name
-    title = get_subjects.map(&:text_name).uniq.sort.join(" & ")
+    title = all_subjects.map(&:text_name).uniq.sort.join(" & ")
     if title.blank?
       :image.l + " ##{id || "?"}"
     else
@@ -284,7 +281,7 @@ class Image < AbstractModel
   #   "**__Agaricus campestris__** L. & **__Agaricus californicus__** Peck. (3)"
   #
   def unique_format_name
-    title = get_subjects.map(&:format_name).uniq.sort.join(" & ")
+    title = all_subjects.map(&:format_name).uniq.sort.join(" & ")
     if title.blank?
       :image.l + " ##{id || "?"}"
     else

--- a/app/views/image/show_image.html.erb
+++ b/app/views/image/show_image.html.erb
@@ -173,7 +173,7 @@
             <%= link_with_query(user.format_name.t, user.show_link_args) %>
           </div>
         <% end %>
-        <% @image.all_glossary_terms.each do |glossary_term| %>
+        <% @image.glossary_terms.each do |glossary_term| %>
           <div>
             <%= :GLOSSARY_TERM.t %>:
             <%= link_with_query(glossary_term.format_name.t, glossary_term.show_link_args) %>

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -29,7 +29,7 @@ plane_glossary_term:
   name: Plane
   description: Three points define a plane & be sure to test unsafe html
   thumb_image: plane_image_thumb
-  images: plane_image_example
+  images: plane_image_thummb, plane_image_example
 
 square_glossary_term:
   <<: *DEFAULTS
@@ -43,4 +43,4 @@ no_images_glossary_term:
 unused_thumb_and_used_image_glossary_term:
   <<: *DEFAULTS
   thumb_image: unused_image # not used elsewhere
-  images: conic_image # used elsewhere (conic_glossary_term)
+  images: conic_image, unused_image # used elsewhere (conic_glossary_term)

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -150,4 +150,16 @@ class ImageTest < UnitTestCase
       end
     end
   end
+
+  def test_glossary_terms
+    img1  = images(:conic_image)
+    img2  = images(:unused_image)
+    term1 = glossary_terms(:conic_glossary_term)
+    term2 = glossary_terms(:unused_thumb_and_used_image_glossary_term)
+    assert_obj_list_equal([term1, term2].sort_by(&:id),
+                          img1.glossary_terms.sort_by(&:id))
+    assert_obj_list_equal([term1], img1.best_glossary_terms)
+    assert_obj_list_equal([term2], img2.glossary_terms)
+    assert_obj_list_equal([term2], img2.best_glossary_terms)
+  end
 end


### PR DESCRIPTION
Answer is: it should.  That's how observation thumbnails work, so it really should work the same for glossary terms.  I'll make sure the database reflects this.  If not, we might need to do some more work on this PR.

Therefore I removed the now-redundant Image#all_glossary_terms, and I fixed the fixtures (only one glossary term was affected, I think).

Also, I changed Image#get_subjects to all_subjects because I think rubocop doesn't like methods with the prefix "get_".  I wish there were a better name for this to disambiguate it with respect to Image#subjects which refers exclusively to users who use this image for their profile.  Maybe we can change Image#subjects to profile_users?  Then use just plain old generic "subjects" for what used to be "get_subjects" (and is now at least temporarily called "all_subjects").