### PR TITLE
`RssLogsController` tab filters — use `GET` request instead of `POST`

### DIFF
--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -18,18 +18,13 @@ class RssLogsController < ApplicationController
   def index
     # POST requests with param `type` potentially show an array of types
     # of objects. The array comes from the checkboxes in tabset
-    if request.method == "POST"
+    if params[:type].present?
       types = Array(params[:type])
       types = RssLog.all_types.intersection(types)
       types = "all" if types.length == RssLog.all_types.length
       types = "none" if types.empty?
       types = types.map(&:to_s).join(" ") if types.is_a?(Array)
       query = find_or_create_query(:RssLog, type: types)
-    # GET requests with param `type` show a single type of object
-    # These come from simple links: the tabs in tabset
-    elsif params[:type].present?
-      types = params[:type].split & (["all"] + RssLog.all_types)
-      query = find_or_create_query(:RssLog, type: types.join(" "))
     # Previously saved query, incorporating type and other params
     elsif params[:q].present?
       query = find_query(:RssLog)

--- a/app/views/rss_logs/_rss_log_tabset.html.erb
+++ b/app/views/rss_logs/_rss_log_tabset.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(add_query_param(activity_logs_path)) %>
+<%= form_tag(add_query_param(activity_logs_path), { method: :get }) %>
   <div class="btn-group pad-bottom hidden-xs" style="white-space:nowrap">
     <%= content_tag(:span, :rss_show.t, class: "btn btn-xs disabled") %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -780,8 +780,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # These routes must go before resources, or it will try to match
   # "rss" to an rss_log
   get("/activity_logs/rss", to: "rss_logs#rss", as: "activity_logs_rss")
-  match("/activity_logs", to: "rss_logs#index", as: "activity_logs",
-                          via: %w[get post])
+  get("/activity_logs", to: "rss_logs#index", as: "activity_logs")
   get("/activity_logs/:id", to: "rss_logs#show", as: "activity_log")
 
   # ----- RssLogs: standard actions with aliases ------------------------------


### PR DESCRIPTION
This should leave functionality unchanged, it only changes the tab filters to make a `GET` request to the :index, instead of a `POST` request (which is the default form action).

Since the form does not create an rss_log, it's really a modified `GET` request.