### PR TITLE
Configure pending Gemspec & Security cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,10 @@ Lint/ConstantOverwrittenInRescue:
 
 # cops for which MO uses a non-default configuration
 
+# Not relevent (MO is not a gem)
+Gemspec:
+  Enabled: false
+
 # Default: align "end" with **start of the line** that includes "begin"
 # MO: align with "begin". This is how we've almost always done it.
 # And it's consistent with Layout/EndAlignment for other keywords.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,24 +53,21 @@ AllCops:
 
 ########### Pending Cops
 # https://docs.rubocop.org/rubocop/versioning.html#pending-cops
-# Once Rubocop removes pending status for these cops,
+# NOTE: Once Rubocop removes pending status for these cops,
 # our configuration should be:
 #   deleted, if our configuration is the same as Rubocop's default, or
-#   moved to the Individual Resolved (Non-Pending) Cops area
+#   moved to the Resolved (Non-Pending) Cops area
 
-# Pending in Rubocop 1.31.1
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationleadingspace
-Layout/LineContinuationLeadingSpace:
+Layout/LineContinuationLeadingSpace: #`new in 1.31.1
   Enabled: true
 
-# Pending in Rubocop 1.31.1
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationspacing
-Layout/LineContinuationSpacing:
+Layout/LineContinuationSpacing: #`new in 1.31.1
   Enabled: true
 
-# Pending in Rubocop 1.31.1
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintconstantoverwritteninrescue
-Lint/ConstantOverwrittenInRescue:
+Lint/ConstantOverwrittenInRescue: #`new in 1.31.1
   Enabled: true
 
 ########### Resolved (Non-Pending) Cops

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,11 +51,7 @@ AllCops:
 
 # ------------------------------------------------------------------------------
 
-########### Individual Cops
-
-# Use RuboCop's default configuration, except as specified below
-
-########### Individual Pending Cops
+########### Pending Cops
 # https://docs.rubocop.org/rubocop/versioning.html#pending-cops
 # Once Rubocop removes pending status for these cops,
 # our configuration should be:
@@ -77,7 +73,7 @@ Layout/LineContinuationSpacing:
 Lint/ConstantOverwrittenInRescue:
   Enabled: true
 
-########### Individual Resolved (Non-Pending) Cops
+########### Resolved (Non-Pending) Cops
 
 # cops for which MO uses a non-default configuration
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,12 @@ Layout/LineContinuationSpacing: #`new in 1.31.1
 Lint/ConstantOverwrittenInRescue: #`new in 1.31.1
   Enabled: true
 
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+
+Security/IoMethods: # new in 1.22
+  Enabled: true
+
 ########### Resolved (Non-Pending) Cops
 
 # cops for which MO uses a non-default configuration

--- a/app/classes/country_counter.rb
+++ b/app/classes/country_counter.rb
@@ -41,9 +41,9 @@ class CountryCounter
     Observation.where.not(location: nil).pluck(:where).reject(&:nil?)
   end
 
-  def self.load_param_hash(file)
+  private_class_method def self.load_param_hash(file)
     File.open(file, "r:utf-8") do |fh|
-      YAML.load(fh)
+      YAML.safe_load(fh)
     end
   end
 

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -189,7 +189,7 @@ module LanguageExporter
 
   def read_export_file
     File.open(export_file, "r:utf-8") do |fh|
-      YAML.safe_load(fh)
+      YAML.safe_load(fh, permitted_classes: [Symbol])
     end
   end
 

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -175,7 +175,7 @@ module LanguageExporter
 
   def read_localization_file
     File.open(localization_file, "r:utf-8") do |fh|
-      YAML.load(fh)[locale][MO.locale_namespace]
+      YAML.safe_load(fh)[locale][MO.locale_namespace]
     end
   end
 
@@ -189,7 +189,7 @@ module LanguageExporter
 
   def read_export_file
     File.open(export_file, "r:utf-8") do |fh|
-      YAML.load(fh)
+      YAML.safe_load(fh)
     end
   end
 

--- a/test/models/image_script_test.rb
+++ b/test/models/image_script_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 class ScriptTest < UnitTestCase
-  DATABASE_CONFIG = YAML.safe_load(IO.
+  DATABASE_CONFIG = YAML.safe_load(File.
     read("#{::Rails.root}/config/database.yml"))["test"]
 
   def script_file(cmd)


### PR DESCRIPTION
This PR 
- configures Gemspec cops, disabling them
- configures pending Security cops, enabling them and fixing offenses

(Pending cops are those that are introduced or significantly modified between major versions. They have a special Pending status and will generate a warning when Rubcop is run, unless explicitly enabled or disabled. 
See https://docs.rubocop.org/rubocop/versioning.html#pending-cops.