### PR TITLE
Remove legacy redirects of form routes from routes and `RedirectTests`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -614,7 +614,9 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
 
   # ----- Articles: standard actions --------------------------------------
   resources :articles, id: /\d+/
-  redirect_legacy_actions(old_controller: "article")
+  redirect_legacy_actions(
+    old_controller: "article", actions: [:controller, :show, :list, :index]
+  )
 
   # ----- Authors: no resources, just forms ------------------------------------
   match("authors/email_request(/:id)",
@@ -682,7 +684,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   end
   redirect_legacy_actions(
     old_controller: "glossary", new_controller: "glossary_terms",
-    actions: LEGACY_CRUD_ACTIONS - [:destroy] + [:show_past]
+    actions: [:controller, :show, :list, :index, :show_past]
   )
 
   # ----- Herbaria: standard actions -------------------------------------------
@@ -696,50 +698,13 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # Herbaria: standard redirects of Herbarium legacy actions
   redirect_legacy_actions(
     old_controller: "herbarium", new_controller: "herbaria",
-    actions: LEGACY_CRUD_ACTIONS - [:controller, :index, :show_past]
+    actions: [:controller, :show, :list, :index]
   )
   # Herbaria: non-standard redirects of legacy Herbarium actions
   # Rails routes currently accept only template tokens
-  # rubocop:disable Style/FormatStringToken
   get("/herbarium/herbarium_search", to: redirect(path: "herbaria"))
   get("/herbarium/index", to: redirect(path: "herbaria"))
   get("/herbarium/list_herbaria", to: redirect(path: "herbaria?flavor=all"))
-  get("/herbarium/request_to_be_curator/:id",
-      to: redirect(path: "herbaria/curator_requests/new?id=%{id}"))
-
-  # Herbaria: complicated redirects of legacy Herbarium actions
-  # Actions needing two routes in order to successfully redirect
-  #
-  # The next two routes combine to redirect
-  #   GET herbarium/delete_curator
-  #   DELETE herbaria/curators
-  # The "match" redirects
-  #   GET("/herbarium/delete_curator/nnn?user=uuu") and
-  #   POST("/herbarium/delete_curator/nnn?user=uuu")
-  # to
-  #   GET("/herbaria/curators/nnn?user=uuu")
-  # which would throw: No route matches [GET] "/herbaria/curators/nnnnn"
-  # absent the following get
-  match("/herbarium/delete_curator/:id",
-        to: redirect(path: "/herbaria/curators/%{id}"),
-        via: [:get, :post])
-  get("/herbaria/curators/:id", to: "herbaria/curators#destroy", id: /\d+/)
-
-  # The next post and get combine to redirect the legacy
-  #   POST /herbarium/request_to_be_curator to
-  #   POST herbaria/curator_requests#create
-  post("/herbarium/request_to_be_curator/:id",
-       to: redirect(path: "/herbaria/curator_requests?id=%{id}"))
-  get("/herbaria/curator_requests",
-      to: "herbaria/curator_requests#create", id: /\d+/)
-
-  # The next post and get combine to redirect
-  #   POST /herbarium/show_herbarium/:id to
-  #   POST herbaria/curators#create
-  post("/herbarium/show_herbarium", to: redirect(path: "herbaria/curators"))
-  get("/herbaria/curators", to: "herbaria/curators#create", id: /\d+/)
-
-  # rubocop:enable Style/FormatStringToken
 
   # Herbaria: non-standard redirect
   # Must be the final route in order to give the others priority

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -532,7 +532,7 @@ end
 
 # Disable cop until there's time to reexamine block length
 # Maybe we could define methods for logical chunks of this.
-MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
+MushroomObserver::Application.routes.draw do
   if Rails.env.development?
     mount(GraphiQL::Rails::Engine, at: "/graphiql",
                                    graphql_path: "/graphql#execute")
@@ -698,17 +698,15 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # Herbaria: standard redirects of Herbarium legacy actions
   redirect_legacy_actions(
     old_controller: "herbarium", new_controller: "herbaria",
-    actions: [:controller, :show, :list, :index]
+    actions: [:show, :list, :index]
   )
   # Herbaria: non-standard redirects of legacy Herbarium actions
   # Rails routes currently accept only template tokens
-  get("/herbarium/herbarium_search", to: redirect(path: "herbaria"))
-  get("/herbarium/index", to: redirect(path: "herbaria"))
-  get("/herbarium/list_herbaria", to: redirect(path: "herbaria?flavor=all"))
-
-  # Herbaria: non-standard redirect
+  get("/herbarium/herbarium_search", to: redirect("/herbaria"))
+  get("/herbarium/index", to: redirect("/herbaria"))
+  get("/herbarium/list_herbaria", to: redirect("/herbaria?flavor=all"))
   # Must be the final route in order to give the others priority
-  get("/herbarium", to: redirect(path: "herbaria?flavor=nonpersonal"))
+  get("/herbarium", to: redirect("/herbaria?flavor=nonpersonal"))
 
   # ----- Info: no resources, just forms and pages ----------------------------
   get("info/how_to_help", to: "info#how_to_help")

--- a/test/integration/redirects_test.rb
+++ b/test/integration/redirects_test.rb
@@ -54,57 +54,6 @@ class RedirectsTest < IntegrationTestCase
                  @response.request.fullpath)
   end
 
-  def test_create_article_get
-    login("article_writer", "testpassword", true)
-    get("/article/create_article")
-    assert_equal(new_article_path,
-                 @response.request.fullpath)
-  end
-
-  def test_create_article_post
-    login("article_writer", "testpassword", true)
-    post("/article/create_article")
-    assert_equal(new_article_path,
-                 @response.request.fullpath)
-  end
-
-  def test_edit_article_get
-    login("article_writer", "testpassword", true)
-    get("/article/edit_article/#{Article.first.id}")
-    assert_equal(edit_article_path(Article.first.id),
-                 @response.request.fullpath)
-  end
-
-  def test_edit_article_post
-    login("article_writer", "testpassword", true)
-    post("/article/edit_article/#{Article.first.id}")
-    assert_equal(edit_article_path(Article.first.id),
-                 @response.request.fullpath)
-  end
-
-  def test_destroy_article_post
-    login("article_writer", "testpassword", true)
-    post("/article/destroy_article/#{Article.first.id}")
-    assert_equal(article_path(Article.first.id),
-                 @response.request.fullpath)
-  end
-
-  def test_destroy_article_patch
-    login("article_writer", "testpassword", true)
-    patch("/article/destroy_article/#{Article.first.id}")
-    # Rails sends patch/put to intermediate page, not the "to:" location
-    assert_equal(article_url(Article.first.id),
-                 @response.header["Location"])
-  end
-
-  def test_destroy_article_put
-    login("article_writer", "testpassword", true)
-    put("/article/destroy_article/#{Article.first.id}")
-    # Rails sends patch/put to intermediate page, not the "to:" location
-    assert_equal(article_url(Article.first.id),
-                 @response.header["Location"])
-  end
-
   # Glossary to GlossaryTerms --------------------------------------------------
 
   def test_controller_glossary
@@ -133,36 +82,6 @@ class RedirectsTest < IntegrationTestCase
     login
     get("/glossary/show_glossary_term/#{term.id}")
     assert_equal(glossary_term_path(term.id),
-                 @response.request.fullpath)
-  end
-
-  def test_create_glossary_get
-    login(users(:rolf).login)
-    get("/glossary/create_glossary_term")
-    assert_equal(new_glossary_term_path,
-                 @response.request.fullpath)
-  end
-
-  def test_create_glossary_post
-    login(users(:rolf).login)
-    post("/glossary/create_glossary_term")
-    assert_equal(new_glossary_term_path,
-                 @response.request.fullpath)
-  end
-
-  def test_edit_glossary_get
-    login(users(:rolf).login)
-    term = glossary_terms(:conic_glossary_term)
-    get("/glossary/edit_glossary_term/#{term.id}")
-    assert_equal(edit_glossary_term_path(term.id),
-                 @response.request.fullpath)
-  end
-
-  def test_edit_glossary_post
-    login(users(:rolf).login)
-    term = glossary_terms(:conic_glossary_term)
-    post("/glossary/edit_glossary_term/#{term.id}")
-    assert_equal(edit_glossary_term_path(term.id),
                  @response.request.fullpath)
   end
 
@@ -198,67 +117,6 @@ class RedirectsTest < IntegrationTestCase
   # * == legacy action is not redirected
   # See https://tinyurl.com/ynapvpt7
 
-  def test_create_herbarium_get
-    login(rolf)
-    assert_old_url_redirects_to_new_path(
-      :get, "/herbarium/create_herbarium", new_herbarium_path
-    )
-  end
-
-  def test_create_herbarium_post
-    login(rolf)
-    assert_old_url_redirects_to_new_path(
-      :post, "/herbarium/create_herbarium", new_herbarium_path
-    )
-  end
-
-  def test_delete_herbarium_curator_post
-    nybg = herbaria(:nybg_herbarium)
-    # make sure nobody messed up the fixtures
-    assert(nybg.curator?(rolf))
-    assert(nybg.curator?(roy))
-
-    login(rolf)
-
-    # Test the results of the redirect because
-    # There is no way to test the redirect directly (unlike other actions).
-    # Due to the routing scheme, Rails actually follows the redirect.
-    assert_old_url_redirects_to_new_path(
-      :post,
-      "/herbarium/delete_curator/#{nybg.id}?user=#{roy.id}",
-      herbarium_path(nybg)
-    )
-    assert_response(:success)
-    assert_not(nybg.reload.curator?(roy))
-  end
-
-  def test_destroy_herbarium
-    login(rolf)
-    assert_old_url_redirects_to_new_path(
-      :post,
-      "/herbarium/destroy_herbarium/#{herbaria(:rolf_herbarium).id}",
-      herbarium_path(herbaria(:rolf_herbarium))
-    )
-  end
-
-  def test_edit_herbarium_get
-    login(rolf)
-    assert_old_url_redirects_to_new_path(
-      :get,
-      "/herbarium/edit_herbarium/#{herbaria(:rolf_herbarium).id}",
-      edit_herbarium_path(herbaria(:rolf_herbarium))
-    )
-  end
-
-  def test_edit_herbarium_post
-    login(rolf)
-    assert_old_url_redirects_to_new_path(
-      :post,
-      "/herbarium/edit_herbarium/#{herbaria(:rolf_herbarium).id}",
-      edit_herbarium_path(herbaria(:rolf_herbarium))
-    )
-  end
-
   def test_herbarium_search
     login
     assert_old_url_redirects_to_new_path(
@@ -287,43 +145,11 @@ class RedirectsTest < IntegrationTestCase
     )
   end
 
-  def test_request_to_be_herbarium_curator_get
-    nybg = herbaria(:nybg_herbarium)
-    login("mary")
-
-    assert_old_url_redirects_to_new_path(
-      :get, "/herbarium/request_to_be_curator/#{nybg.id}",
-      new_herbaria_curator_request_path(id: nybg)
-    )
-  end
-
-  def test_request_to_be_herbarium_curator_post
-    nybg = herbaria(:nybg_herbarium)
-    email_count = ActionMailer::Base.deliveries.count
-    login("mary")
-    post("/herbarium/request_to_be_curator/#{nybg.id}")
-
-    # Rails seems to follow the redirect, instead of just redirecting
-    assert_equal(herbarium_path(nybg), @response.request.fullpath)
-    assert_equal(email_count + 1, ActionMailer::Base.deliveries.count)
-  end
-
   def test_show_herbarium_get
     nybg = herbaria(:nybg_herbarium)
     login
     assert_old_url_redirects_to_new_path(
       :get, "/herbarium/show_herbarium/#{nybg.id}", herbarium_path(nybg)
     )
-  end
-
-  def test_show_herbarium_post
-    nybg = herbaria(:nybg_herbarium)
-    assert(nybg.curators.include?(rolf))
-    curator_count = nybg.curators.count
-    login("rolf")
-    post("/herbarium/show_herbarium?id=#{nybg.id}&add_curator=#{mary.login}")
-
-    assert_equal(herbarium_path(nybg), @response.request.fullpath)
-    assert_equal(curator_count + 1, nybg.reload.curators.count)
   end
 end


### PR DESCRIPTION
Per discussion with @pellaea and @JoeCohen, form routes wouldn't be bookmarked anywhere and don't need redirects from the old URLs. People needing the forms should be able to find them from the redirected :show, :index pages and their generated (updated) links.

This also removes the RedirectTests for those routes.