### PR TITLE
Rename `SessionExtensions#click` to `click_mo_link`

### DIFF
--- a/test/integration/admin_test.rb
+++ b/test/integration/admin_test.rb
@@ -7,7 +7,7 @@ class AdminTest < IntegrationTestCase
     rolf.admin = true
     rolf.save!
     login!(rolf)
-    click(href: /turn_admin_on/)
+    click_mo_link(href: /turn_admin_on/)
     get("/support/review_donations")
     open_form(&:submit)
     # If it fails it renders a simple text message.
@@ -19,16 +19,16 @@ class AdminTest < IntegrationTestCase
     rolf.save!
     login!(rolf)
     assert_equal(rolf.id, User.current_id)
-    click(href: /turn_admin_on/)
+    click_mo_link(href: /turn_admin_on/)
     assert_match(/DANGER: You are in administrator mode/, response.body)
-    click(href: /switch_users/)
+    click_mo_link(href: /switch_users/)
     open_form do |form|
       form.change("id", "mary")
       form.submit
     end
     assert_equal(mary.id, User.current_id)
     assert_match(/DANGER: You are currently logged in as mary/, response.body)
-    click(href: /logout_user/)
+    click_mo_link(href: /logout_user/)
     assert_equal(rolf.id, User.current_id)
     assert_match(/DANGER: You are in administrator mode/, response.body)
   end

--- a/test/integration/amateur_test.rb
+++ b/test/integration/amateur_test.rb
@@ -14,7 +14,7 @@ class AmateurTest < IntegrationTestCase
     get("/")
 
     # Login.
-    click(label: "Login", in: :left_panel)
+    click_mo_link(label: "Login", in: :left_panel)
     assert_template("account/login")
 
     # Try to login without a password.
@@ -52,14 +52,14 @@ class AmateurTest < IntegrationTestCase
     assert_flash_text(/success/i)
 
     # This should only be accessible if logged in.
-    click(label: "Preferences", in: :left_panel)
+    click_mo_link(label: "Preferences", in: :left_panel)
     assert_template("account/prefs")
 
     # Log out and try again.
-    click(label: "Logout", in: :left_panel)
+    click_mo_link(label: "Logout", in: :left_panel)
     assert_template("account/logout_user")
     assert_raises(MiniTest::Assertion) do
-      click(label: "Preferences", in: :left_panel)
+      click_mo_link(label: "Preferences", in: :left_panel)
     end
     get("/account/prefs")
     assert_template("account/login")
@@ -124,7 +124,7 @@ class AmateurTest < IntegrationTestCase
     # (Make sure there are no edit or destroy controls on existing comments.)
     assert_select("a[href*=edit_comment], a[href*=destroy_comment]", false)
 
-    click(label: "Add Comment")
+    click_mo_link(label: "Add Comment")
     assert_template("comment/add_comment")
 
     # (Make sure the form is for the correct object!)
@@ -157,7 +157,7 @@ class AmateurTest < IntegrationTestCase
     assert_select("a[href*='destroy_comment/#{com.id}']", 1)
 
     # Try changing it.
-    click(label: /edit/i, href: /edit_comment/)
+    click_mo_link(label: /edit/i, href: /edit_comment/)
     assert_template("comment/edit_comment")
     open_form do |form|
       form.assert_value("summary", summary)
@@ -183,7 +183,7 @@ class AmateurTest < IntegrationTestCase
     end
 
     # I grow weary of this comment.
-    click(label: /destroy/i, href: /destroy_comment/)
+    click_mo_link(label: /destroy/i, href: /destroy_comment/)
     assert_template("observer/show_observation")
     assert_objs_equal(obs, assigns(:observation))
     assert_nil(response.body.index(summary))
@@ -268,7 +268,7 @@ class AmateurTest < IntegrationTestCase
     assert_template("observer/show_observation")
     assert_select("div.thumbnail-map", 1)
 
-    click(label: "Hide thumbnail map.")
+    click_mo_link(label: "Hide thumbnail map.")
     assert_template("observer/show_observation")
     assert_select("div.thumbnail-map", 0)
 
@@ -302,14 +302,14 @@ class AmateurTest < IntegrationTestCase
   module UserDsl
     def run_test
       get("/admin/test_flash_redirection?tags=")
-      click(label: :app_edit_translations_on_page.t)
+      click_mo_link(label: :app_edit_translations_on_page.t)
       assert_no_flash
       assert_select("span.tag", text: "test_tag1:", count: 0)
       assert_select("span.tag", text: "test_tag2:", count: 0)
       assert_select("span.tag", text: "test_flash_redirection_title:", count: 1)
 
       get("/admin/test_flash_redirection?tags=test_tag1,test_tag2")
-      click(label: :app_edit_translations_on_page.t)
+      click_mo_link(label: :app_edit_translations_on_page.t)
       assert_no_flash
       assert_select("span.tag", text: "test_tag1:", count: 1)
       assert_select("span.tag", text: "test_tag2:", count: 1)
@@ -343,7 +343,7 @@ class AmateurTest < IntegrationTestCase
     def propose_then_login(namer, obs)
       get("/#{obs.id}")
       assert_template("observer/show_observation")
-      click(label: /login/i)
+      click_mo_link(label: /login/i)
       assert_template("account/login")
       open_form do |form|
         form.change("login", namer.login)
@@ -352,7 +352,7 @@ class AmateurTest < IntegrationTestCase
         form.submit("Login")
       end
       assert_select("a[href*='naming/edit'], a[href*='naming/destroy']", false)
-      click(label: /propose.*name/i)
+      click_mo_link(label: /propose.*name/i)
     end
 
     def create_name(obs, text_name)
@@ -417,7 +417,7 @@ class AmateurTest < IntegrationTestCase
       # Try changing it.
       author = "(Pers.) Grev."
       reason = "Test reason."
-      click(label: /edit/i, href: %r{naming/edit})
+      click_mo_link(label: /edit/i, href: %r{naming/edit})
       assert_template("naming/edit")
       open_form do |form|
         form.assert_value("name", text_name)
@@ -444,7 +444,7 @@ class AmateurTest < IntegrationTestCase
       # (Make sure reason shows up, too.)
       assert_match(reason, response.body)
 
-      click(label: /edit/i, href: %r{naming/edit})
+      click_mo_link(label: /edit/i, href: %r{naming/edit})
       assert_template("naming/edit")
       open_form do |form|
         form.assert_value("name", "#{text_name} #{author}")
@@ -455,17 +455,17 @@ class AmateurTest < IntegrationTestCase
         form.assert_unchecked("reason_3_check")
         form.assert_value("reason_3_notes", "")
       end
-      click(label: /cancel.*show/i)
+      click_mo_link(label: /cancel.*show/i)
       naming
     end
 
     def failed_delete(_obs)
-      click(label: /destroy/i, href: %r{naming/destroy})
+      click_mo_link(label: /destroy/i, href: %r{naming/destroy})
       assert_flash_text(/sorry/i)
     end
 
     def successful_delete(obs, naming, text_name, original_name)
-      click(label: /destroy/i, href: %r{naming/destroy})
+      click_mo_link(label: /destroy/i, href: %r{naming/destroy})
       assert_template("observer/show_observation")
       assert_objs_equal(obs, assigns(:observation))
       assert_flash_text(/success/i)

--- a/test/integration/curator_test.rb
+++ b/test/integration/curator_test.rb
@@ -17,7 +17,7 @@ class CuratorTest < IntegrationTestCase
     login!("mary", "testpassword", true)
     get("/#{obs.id}")
     assert_template("observer/show_observation")
-    click(label: :create_herbarium_record.t)
+    click_mo_link(label: :create_herbarium_record.t)
     assert_template("herbarium_record/create_herbarium_record")
     open_form do |form|
       form.submit("Add")
@@ -32,7 +32,7 @@ class CuratorTest < IntegrationTestCase
     obs = observations(:detailed_unknown_obs)
     rec = obs.herbarium_records.find { |r| r.can_edit?(mary) }
     get("/#{obs.id}")
-    click(href: "/herbarium_record/edit_herbarium_record/#{rec.id}")
+    click_mo_link(href: "/herbarium_record/edit_herbarium_record/#{rec.id}")
     assert_template("herbarium_record/edit_herbarium_record")
     open_form do |form|
       form.change("herbarium_name", "This Should Cause It to Reload Form")
@@ -48,11 +48,11 @@ class CuratorTest < IntegrationTestCase
     assert_match(%r{href="/observer/edit_observation/#{obs.id}},
                  response.body)
     go_back
-    click(label: "Cancel (Show Observation)")
+    click_mo_link(label: "Cancel (Show Observation)")
     assert_template("observer/show_observation")
     assert_match(%r{href="/observer/edit_observation/#{obs.id}},
                  response.body)
-    click(href: "/herbarium_record/remove_observation/#{rec.id}")
+    click_mo_link(href: "/herbarium_record/remove_observation/#{rec.id}")
     assert_template("observer/show_observation")
     assert_match(%r{href="/observer/edit_observation/#{obs.id}},
                  response.body)
@@ -64,9 +64,9 @@ class CuratorTest < IntegrationTestCase
     obs = observations(:detailed_unknown_obs)
     rec = obs.herbarium_records.find { |r| r.can_edit?(mary) }
     get("/#{obs.id}")
-    click(href: "/herbarium_record/show_herbarium_record/#{rec.id}")
+    click_mo_link(href: "/herbarium_record/show_herbarium_record/#{rec.id}")
     assert_template("herbarium_record/show_herbarium_record")
-    click(label: "Edit Fungarium Record")
+    click_mo_link(label: "Edit Fungarium Record")
     assert_template("herbarium_record/edit_herbarium_record")
     open_form do |form|
       form.change("herbarium_name", "This Should Cause It to Reload Form")
@@ -74,7 +74,7 @@ class CuratorTest < IntegrationTestCase
     end
     assert_template("herbarium_record/edit_herbarium_record")
     push_page
-    click(label: "Cancel (Show Fungarium Record)")
+    click_mo_link(label: "Cancel (Show Fungarium Record)")
     assert_template("herbarium_record/show_herbarium_record")
     go_back
     open_form do |form|
@@ -82,7 +82,7 @@ class CuratorTest < IntegrationTestCase
       form.submit("Save")
     end
     assert_template("herbarium_record/show_herbarium_record")
-    click(label: "Destroy Fungarium Record")
+    click_mo_link(label: "Destroy Fungarium Record")
     assert_template("herbarium_record/list_herbarium_records")
     assert_not(obs.reload.herbarium_records.include?(rec))
   end
@@ -92,9 +92,9 @@ class CuratorTest < IntegrationTestCase
     obs = observations(:detailed_unknown_obs)
     rec = obs.herbarium_records.find { |r| r.can_edit?(mary) }
     get(herbarium_path(rec.herbarium.id))
-    click(href: /herbarium_index/)
+    click_mo_link(href: /herbarium_index/)
     assert_template("herbarium_record/list_herbarium_records")
-    click(href: "/herbarium_record/edit_herbarium_record/#{rec.id}")
+    click_mo_link(href: "/herbarium_record/edit_herbarium_record/#{rec.id}")
     assert_template("herbarium_record/edit_herbarium_record")
     open_form do |form|
       form.change("herbarium_name", "This Should Cause It to Reload Form")
@@ -102,7 +102,7 @@ class CuratorTest < IntegrationTestCase
     end
     assert_template("herbarium_record/edit_herbarium_record")
     push_page
-    click(label: "Back to Fungarium Record Index")
+    click_mo_link(label: "Back to Fungarium Record Index")
     assert_template("herbarium_record/list_herbarium_records")
     go_back
     open_form do |form|
@@ -110,7 +110,7 @@ class CuratorTest < IntegrationTestCase
       form.submit("Save")
     end
     assert_template("herbarium_record/list_herbarium_records")
-    click(href: "/herbarium_record/destroy_herbarium_record/#{rec.id}")
+    click_mo_link(href: "/herbarium_record/destroy_herbarium_record/#{rec.id}")
     assert_template("herbarium_record/list_herbarium_records")
     assert_not(obs.reload.herbarium_records.include?(rec))
   end
@@ -132,7 +132,7 @@ class CuratorTest < IntegrationTestCase
     first_herbarium_path = herbaria_show_links.first.attributes["href"].value.
                            sub(/\?.*/, "") # strip query string
 
-    click(label: :sort_by_reverse.l)
+    click_mo_link(label: :sort_by_reverse.l)
     reverse_herbaria_show_links = assert_select("a:match('href', ?)",
                                                 herbarium_show_path_matcher)
     assert_equal(
@@ -146,7 +146,7 @@ class CuratorTest < IntegrationTestCase
     obs = observations(:minimal_unknown_obs)
     login!("mary", "testpassword", true)
     get("/herbarium_record/create_herbarium_record/#{obs.id}")
-    click(label: :herbarium_index.l)
+    click_mo_link(label: :herbarium_index.l)
 
     assert_select(
       "#title-caption", { text: :query_title_nonpersonal.l },
@@ -233,7 +233,7 @@ class CuratorTest < IntegrationTestCase
     assert_equal([], user.curated_herbaria)
     login!(user.login, "testpassword", true)
     get(herbaria_path(flavor: :all))
-    click(label: :create_herbarium.l)
+    click_mo_link(label: :create_herbarium.l)
 
     open_form("form[action^='#{herbaria_path}']") do |form|
       form.assert_value("[name]", "")
@@ -298,7 +298,7 @@ class CuratorTest < IntegrationTestCase
 
     login!("mary", "testpassword", true)
     get(herbarium_path(nybg))
-    click(label: :show_herbarium_curator_request.l)
+    click_mo_link(label: :show_herbarium_curator_request.l)
     assert_select("#title-caption").text.
       starts_with?(:show_herbarium_curator_request.l)
     open_form("form[action^='#{herbaria_curator_requests_path(id: nybg)}']",
@@ -319,7 +319,7 @@ class CuratorTest < IntegrationTestCase
 
     login!("mary", "testpassword", true)
     get(herbaria_path(flavor: :all))
-    click(href: herbaria_path(merge: fundis))
+    click_mo_link(href: herbaria_path(merge: fundis))
     form = open_form( # merge button
       "form[action *= 'dest=#{mary_herbarium.id}']"
     )

--- a/test/integration/expert_test.rb
+++ b/test/integration/expert_test.rb
@@ -189,7 +189,7 @@ class ExpertTest < IntegrationTestCase
     assert_true(obs.last.specimen)
 
     # Try making some edits, too.
-    click(href: /edit_species_list/)
+    click_mo_link(href: /edit_species_list/)
     new_member_notes = "New member notes."
     open_form do |form|
       form.assert_value("list_members", "")
@@ -277,7 +277,7 @@ class ExpertTest < IntegrationTestCase
     assert_equal(loc, obs.last.location)
 
     # Try adding a comment, just for kicks.
-    click(href: /add_comment/)
+    click_mo_link(href: /add_comment/)
     assert_template("comment/add_comment")
     assert_select("div#title", text: /#{spl.title}/)
     assert_select("a[href*='show_species_list/#{spl.id}']", text: /cancel/i)

--- a/test/integration/lurker_test.rb
+++ b/test/integration/lurker_test.rb
@@ -63,7 +63,8 @@ class LurkerTest < IntegrationTestCase
 
     # Check out location.
     get("/#{obs}")
-    click_mo_link(label: "Burbank, California") # Don't include USA due to <span>
+    # Don't include USA due to <span>
+    click_mo_link(label: "Burbank, California")
     assert_template("location/show_location")
 
     # Check out species list.

--- a/test/integration/lurker_test.rb
+++ b/test/integration/lurker_test.rb
@@ -11,33 +11,33 @@ class LurkerTest < IntegrationTestCase
     assert_template("rss_logs/index")
 
     # Click on first observation.
-    click(href: %r{^/\d+\?}, in: :results)
+    click_mo_link(href: %r{^/\d+\?}, in: :results)
     assert_template("observer/show_observation")
 
     # Click on prev/next
-    click(label: "Next »", in: :title)
-    click(label: "« Prev", in: :title)
+    click_mo_link(label: "Next »", in: :title)
+    click_mo_link(label: "« Prev", in: :title)
 
     # Click on the first image.
-    click(label: :image, href: /show_image/)
+    click_mo_link(label: :image, href: /show_image/)
 
     # Go back to observation and click on "About...".
-    click(label: "Show Observation")
-    click(href: /show_name/)
+    click_mo_link(label: "Show Observation")
+    click_mo_link(href: /show_name/)
     assert_template("name/show_name")
 
     # Take a look at the occurrence map.
-    click(label: "Occurrence Map")
+    click_mo_link(label: "Occurrence Map")
     assert_template("name/map")
 
     # Check out a few links from left-hand panel.
-    click(label: "How To Use",    in: :left_panel)
-    click(label: "Français",      in: :left_panel)
-    click(label: "Contributeurs", in: :left_panel)
-    click(label: "English",       in: :left_panel)
-    click(label: "Projects",      in: :left_panel)
-    click(label: "Comments",      in: :left_panel)
-    click(label: "Site Stats",    in: :left_panel)
+    click_mo_link(label: "How To Use", in: :left_panel)
+    click_mo_link(label: "Français", in: :left_panel)
+    click_mo_link(label: "Contributeurs", in: :left_panel)
+    click_mo_link(label: "English",       in: :left_panel)
+    click_mo_link(label: "Projects",      in: :left_panel)
+    click_mo_link(label: "Comments",      in: :left_panel)
+    click_mo_link(label: "Site Stats", in: :left_panel)
   end
 
   def test_show_observation
@@ -51,24 +51,24 @@ class LurkerTest < IntegrationTestCase
 
     # Check out the RSS log.
     save_path = path
-    click(label: "Show Log")
-    click(label: "Show Observation")
+    click_mo_link(label: "Show Log")
+    click_mo_link(label: "Show Observation")
     assert_equal(save_path, path,
                  "Went to RSS log and returned, expected to be the same.")
 
     # Mary has done several things to it (observation itself, naming, comment).
     assert_select("a[href^='/users/#{mary.id}']", minimum: 3)
-    click(label: "Mary Newbie")
+    click_mo_link(label: "Mary Newbie")
     assert_template("users/show")
 
     # Check out location.
     get("/#{obs}")
-    click(label: "Burbank, California") # Don't include USA due to <span>
+    click_mo_link(label: "Burbank, California") # Don't include USA due to <span>
     assert_template("location/show_location")
 
     # Check out species list.
     get("/#{obs}")
-    click(label: "List of mysteries")
+    click_mo_link(label: "List of mysteries")
     assert_template("species_list/show_species_list")
     # (Make sure detailed_unknown_obs is shown somewhere.)
     assert_select("a[href^='/#{obs}?']")
@@ -77,7 +77,7 @@ class LurkerTest < IntegrationTestCase
     get("/#{obs}")
     # (Should be at least two links to show the name Fungi.)
     assert_select("a[href^='/name/show_name/#{names(:fungi).id}']", minimum: 2)
-    click(label: /About.*Fungi/)
+    click_mo_link(label: /About.*Fungi/)
     # (Make sure the page contains create_name_description.)
     assert_select(
       "a[href^='/name/create_name_description/#{names(:fungi).id}']"
@@ -86,7 +86,7 @@ class LurkerTest < IntegrationTestCase
     # And lastly there are some images.
     get("/#{obs}")
     assert_select("a[href^='/image/show_image']", minimum: 2)
-    click(label: :image, href: /show_image/)
+    click_mo_link(label: :image, href: /show_image/)
     # (Make sure detailed_unknown_obs is shown somewhere.)
     assert_select("a[href^='/#{obs}']")
   end
@@ -162,16 +162,16 @@ class LurkerTest < IntegrationTestCase
     get("/name/map/#{names(:fungi).id}")
 
     # Get a list of locations shown on map. (One defined, one undefined.)
-    click(label: "Show Locations", in: :right_tabs)
+    click_mo_link(label: "Show Locations", in: :right_tabs)
     assert_template("location/list_locations")
 
     # Click on the defined location.
 
-    click(label: /Burbank/)
+    click_mo_link(label: /Burbank/)
     assert_template("location/show_location")
 
     # Get a list of observations from there.  (Several so goes to index.)
-    click(label: "Observations at this Location", in: :right_tabs)
+    click_mo_link(label: "Observations at this Location", in: :right_tabs)
     assert_template("observer/list_observations")
     save_results = get_links("div.results a:match('href',?)", %r{^/\d+})
 
@@ -183,19 +183,19 @@ class LurkerTest < IntegrationTestCase
     end
 
     # Try sorting differently.
-    click(label: "User", in: :sort_tabs)
+    click_mo_link(label: "User", in: :sort_tabs)
     results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
 
-    click(label: "Date", in: :sort_tabs)
+    click_mo_link(label: "Date", in: :sort_tabs)
     results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
 
-    click(label: "Reverse Order", in: :sort_tabs)
+    click_mo_link(label: "Reverse Order", in: :sort_tabs)
     results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
 
-    click(label: "Name", in: :sort_tabs)
+    click_mo_link(label: "Name", in: :sort_tabs)
     results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(save_results.length, results.length)
 
@@ -203,26 +203,26 @@ class LurkerTest < IntegrationTestCase
     query_params = parse_query_params(save_results.first.value)
 
     # Go to first observation, and try stepping back and forth.
-    click(href: %r{^/\d+\?}, in: :results)
+    click_mo_link(href: %r{^/\d+\?}, in: :results)
     save_path = @request.fullpath
     assert_equal(query_params, parse_query_params(save_path))
-    click(label: "« Prev", in: :title)
+    click_mo_link(label: "« Prev", in: :title)
     assert_flash_text(/there are no more observations/i)
     assert_equal(save_path, @request.fullpath)
     assert_equal(query_params, parse_query_params(save_path))
-    click(label: "Next »", in: :title)
+    click_mo_link(label: "Next »", in: :title)
     assert_no_flash
     assert_equal(query_params, parse_query_params(save_path))
     save_path = @request.fullpath
-    click(label: "Next »", in: :title)
+    click_mo_link(label: "Next »", in: :title)
     assert_no_flash
     assert_equal(query_params, parse_query_params(save_path))
-    click(label: "« Prev", in: :title)
+    click_mo_link(label: "« Prev", in: :title)
     assert_no_flash
     assert_equal(query_params, parse_query_params(save_path))
     assert_equal(save_path, @request.fullpath,
                  "Went next then prev, should be back where we started.")
-    click(label: "Index", href: /index/, in: :title)
+    click_mo_link(label: "Index", href: /index/, in: :title)
     results = get_links("div.results a:match('href',?)", %r{^/\d+})
     assert_equal(query_params, parse_query_params(results.first.value))
     assert_equal(save_results.map(&:value),

--- a/test/integration/name_description_integration_test.rb
+++ b/test/integration/name_description_integration_test.rb
@@ -102,7 +102,7 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
     user.save
     sess = open_session
     sess.login!(user)
-    sess.click(href: /turn_admin_on/)
+    sess.click_mo_link(href: /turn_admin_on/)
     teach_about_name_descriptions(sess)
     sess.user = user
     sess
@@ -277,7 +277,7 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
 
     def create_name_description
       get(show_name_uri)
-      click(href: /create_name_description/)
+      click_mo_link(href: /create_name_description/)
       # assert_template("name/create_name_description")
       open_form do |form|
         check_name_description_form_defaults(form)
@@ -355,7 +355,7 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
     end
 
     def check_edit_description_link_behavior
-      click(href: edit_name_description_uri)
+      click_mo_link(href: edit_name_description_uri)
       if edit_description_requires_login?
         assert_match(%r{account/login}, response.body)
       else

--- a/test/integration/post_observation_test.rb
+++ b/test/integration/post_observation_test.rb
@@ -3,12 +3,13 @@
 require("test_helper")
 
 class PostObservationTest < IntegrationTestCase
-  LOGIN_PAGE = "account/login"
-  SHOW_OBSERVATION_PAGE = "observer/show_observation"
-  CREATE_OBSERVATION_PAGE = "observer/create_observation"
-  EDIT_OBSERVATION_PAGE = "observer/edit_observation"
-  CREATE_LOCATION_PAGE = "location/create_location"
-  OBSERVATION_INDEX_PAGE = "observer/list_observations"
+  LOGIN_TEMPLATE = "account/login"
+  SHOW_OBSERVATION_TEMPLATE = "observations/show"
+  NEW_OBSERVATION_TEMPLATE = "observations/new"
+  CREATE_OBSERVATION_TEMPLATE = "observations"
+  EDIT_OBSERVATION_TEMPLATE = "observations/edit"
+  CREATE_LOCATION_TEMPLATE = "location/create_location"
+  OBSERVATION_INDEX_TEMPLATE = "observations/index"
 
   PASADENA_EXTENTS = {
     north: 34.251905,
@@ -34,16 +35,16 @@ class PostObservationTest < IntegrationTestCase
   end
 
   def open_create_observation_form
-    get("/#{CREATE_OBSERVATION_PAGE}")
-    assert_template(LOGIN_PAGE)
+    get(new_observation_path)
+    assert_template(LOGIN_TEMPLATE)
     login!(katrina)
-    assert_template(CREATE_OBSERVATION_PAGE)
+    assert_template(NEW_OBSERVATION_TEMPLATE)
     assert_form_has_correct_values(create_observation_form_defaults)
   end
 
   def submit_observation_form_with_errors
     submit_form_with_changes(create_observation_form_first_changes)
-    assert_template(CREATE_OBSERVATION_PAGE)
+    assert_template(NEW_OBSERVATION_TEMPLATE)
     assert_has_location_warning(/Unknown country/)
     assert_form_has_correct_values(
       create_observation_form_values_after_first_changes
@@ -55,14 +56,14 @@ class PostObservationTest < IntegrationTestCase
       submit_form_with_changes(create_observation_form_second_changes)
     end
     assert_flash_for_create_observation
-    assert_template(CREATE_LOCATION_PAGE)
+    assert_template(CREATE_LOCATION_TEMPLATE)
     assert_new_observation_is_correct(expected_values_after_create)
     assert_form_has_correct_values(create_location_form_defaults)
   end
 
   def submit_location_form_with_errors
     submit_form_with_changes(create_location_form_first_changes)
-    assert_template(CREATE_LOCATION_PAGE)
+    assert_template(CREATE_LOCATION_TEMPLATE)
     assert_has_location_warning(/County may not be required/)
     assert_form_has_correct_values(
       create_location_form_values_after_first_changes
@@ -72,22 +73,23 @@ class PostObservationTest < IntegrationTestCase
   def submit_location_form_without_errors
     submit_form_with_changes(create_location_form_second_changes)
     assert_flash_for_create_location
-    assert_template(SHOW_OBSERVATION_PAGE)
+    assert_template(SHOW_OBSERVATION_TEMPLATE)
     assert_new_location_is_correct(expected_values_after_location)
     assert_new_observation_is_correct(expected_values_after_location)
     assert_show_observation_page_has_important_info
   end
 
   def open_edit_observation_form
-    click(label: /edit/i, href: /edit_observation/)
-    assert_template(EDIT_OBSERVATION_PAGE)
+    new_obs = Observation.last
+    click_mo_link(label: /edit/i, href: /#{edit_observation_path(new_obs.id)}/)
+    assert_template(EDIT_OBSERVATION_TEMPLATE)
     assert_form_has_correct_values(edit_observation_form_initial_values)
   end
 
   def submit_observation_form_with_changes
     submit_form_with_changes(edit_observation_form_changes)
     assert_flash_for_edit_observation
-    assert_template(SHOW_OBSERVATION_PAGE)
+    assert_template(SHOW_OBSERVATION_TEMPLATE)
     assert_edit_observation_is_correct(expected_values_after_edit)
     assert_show_observation_page_has_important_info
   end
@@ -112,9 +114,11 @@ class PostObservationTest < IntegrationTestCase
   end
 
   def destroy_observation
-    click(label: /destroy/i, href: /destroy_observation/)
+    # puts(response.body)
+    assert_template(SHOW_OBSERVATION_TEMPLATE)
+    within("div#right_tabs") { click_mo_link("Destroy") }
     assert_flash_for_destroy_observation
-    assert_template(OBSERVATION_INDEX_PAGE)
+    assert_template(OBSERVATION_INDEX_TEMPLATE)
   end
 
   def make_sure_observation_is_in_main_index(obs)
@@ -207,7 +211,7 @@ class PostObservationTest < IntegrationTestCase
     end
     assert_match(new_obs.notes_show_formatted, response.body)
     assert_match(new_img.notes, response.body)
-    assert_no_link_exists_containing("observations_at_where")
+    assert_no_link_exists_containing("observations?where")
     assert_link_exists_containing("show_location/#{new_loc.id}")
     assert_link_exists_containing("show_image/#{new_img.id}")
   end
@@ -400,7 +404,7 @@ class PostObservationTest < IntegrationTestCase
       vote: Vote.next_best_vote,
       is_collection_location: false,
       specimen: true,
-      notes: "Notes for observation", # string displayed in show_observation
+      notes: "Notes for observation", # string displayed in observations/show
       image_notes: "Notes for image"
     }
   end
@@ -427,7 +431,7 @@ class PostObservationTest < IntegrationTestCase
       alt: 987,
       is_collection_location: true,
       specimen: false,
-      notes: "New notes for observation", # string displayed in show_observation
+      notes: "New notes for observation", # displayed in observations/show
       image_notes: "New notes for image"
     )
   end

--- a/test/integration/post_observation_test.rb
+++ b/test/integration/post_observation_test.rb
@@ -3,13 +3,12 @@
 require("test_helper")
 
 class PostObservationTest < IntegrationTestCase
-  LOGIN_TEMPLATE = "account/login"
-  SHOW_OBSERVATION_TEMPLATE = "observations/show"
-  NEW_OBSERVATION_TEMPLATE = "observations/new"
-  CREATE_OBSERVATION_TEMPLATE = "observations"
-  EDIT_OBSERVATION_TEMPLATE = "observations/edit"
-  CREATE_LOCATION_TEMPLATE = "location/create_location"
-  OBSERVATION_INDEX_TEMPLATE = "observations/index"
+  LOGIN_PAGE = "account/login"
+  SHOW_OBSERVATION_PAGE = "observer/show_observation"
+  CREATE_OBSERVATION_PAGE = "observer/create_observation"
+  EDIT_OBSERVATION_PAGE = "observer/edit_observation"
+  CREATE_LOCATION_PAGE = "location/create_location"
+  OBSERVATION_INDEX_PAGE = "observer/list_observations"
 
   PASADENA_EXTENTS = {
     north: 34.251905,
@@ -35,16 +34,16 @@ class PostObservationTest < IntegrationTestCase
   end
 
   def open_create_observation_form
-    get(new_observation_path)
-    assert_template(LOGIN_TEMPLATE)
+    get("/#{CREATE_OBSERVATION_PAGE}")
+    assert_template(LOGIN_PAGE)
     login!(katrina)
-    assert_template(NEW_OBSERVATION_TEMPLATE)
+    assert_template(CREATE_OBSERVATION_PAGE)
     assert_form_has_correct_values(create_observation_form_defaults)
   end
 
   def submit_observation_form_with_errors
     submit_form_with_changes(create_observation_form_first_changes)
-    assert_template(NEW_OBSERVATION_TEMPLATE)
+    assert_template(CREATE_OBSERVATION_PAGE)
     assert_has_location_warning(/Unknown country/)
     assert_form_has_correct_values(
       create_observation_form_values_after_first_changes
@@ -56,14 +55,14 @@ class PostObservationTest < IntegrationTestCase
       submit_form_with_changes(create_observation_form_second_changes)
     end
     assert_flash_for_create_observation
-    assert_template(CREATE_LOCATION_TEMPLATE)
+    assert_template(CREATE_LOCATION_PAGE)
     assert_new_observation_is_correct(expected_values_after_create)
     assert_form_has_correct_values(create_location_form_defaults)
   end
 
   def submit_location_form_with_errors
     submit_form_with_changes(create_location_form_first_changes)
-    assert_template(CREATE_LOCATION_TEMPLATE)
+    assert_template(CREATE_LOCATION_PAGE)
     assert_has_location_warning(/County may not be required/)
     assert_form_has_correct_values(
       create_location_form_values_after_first_changes
@@ -73,23 +72,22 @@ class PostObservationTest < IntegrationTestCase
   def submit_location_form_without_errors
     submit_form_with_changes(create_location_form_second_changes)
     assert_flash_for_create_location
-    assert_template(SHOW_OBSERVATION_TEMPLATE)
+    assert_template(SHOW_OBSERVATION_PAGE)
     assert_new_location_is_correct(expected_values_after_location)
     assert_new_observation_is_correct(expected_values_after_location)
     assert_show_observation_page_has_important_info
   end
 
   def open_edit_observation_form
-    new_obs = Observation.last
-    click_mo_link(label: /edit/i, href: /#{edit_observation_path(new_obs.id)}/)
-    assert_template(EDIT_OBSERVATION_TEMPLATE)
+    click_mo_link(label: /edit/i, href: /edit_observation/)
+    assert_template(EDIT_OBSERVATION_PAGE)
     assert_form_has_correct_values(edit_observation_form_initial_values)
   end
 
   def submit_observation_form_with_changes
     submit_form_with_changes(edit_observation_form_changes)
     assert_flash_for_edit_observation
-    assert_template(SHOW_OBSERVATION_TEMPLATE)
+    assert_template(SHOW_OBSERVATION_PAGE)
     assert_edit_observation_is_correct(expected_values_after_edit)
     assert_show_observation_page_has_important_info
   end
@@ -114,11 +112,9 @@ class PostObservationTest < IntegrationTestCase
   end
 
   def destroy_observation
-    # puts(response.body)
-    assert_template(SHOW_OBSERVATION_TEMPLATE)
-    within("div#right_tabs") { click_mo_link("Destroy") }
+    click_mo_link(label: /destroy/i, href: /destroy_observation/)
     assert_flash_for_destroy_observation
-    assert_template(OBSERVATION_INDEX_TEMPLATE)
+    assert_template(OBSERVATION_INDEX_PAGE)
   end
 
   def make_sure_observation_is_in_main_index(obs)
@@ -211,7 +207,7 @@ class PostObservationTest < IntegrationTestCase
     end
     assert_match(new_obs.notes_show_formatted, response.body)
     assert_match(new_img.notes, response.body)
-    assert_no_link_exists_containing("observations?where")
+    assert_no_link_exists_containing("observations_at_where")
     assert_link_exists_containing("show_location/#{new_loc.id}")
     assert_link_exists_containing("show_image/#{new_img.id}")
   end
@@ -404,7 +400,7 @@ class PostObservationTest < IntegrationTestCase
       vote: Vote.next_best_vote,
       is_collection_location: false,
       specimen: true,
-      notes: "Notes for observation", # string displayed in observations/show
+      notes: "Notes for observation", # string displayed in show_observation
       image_notes: "Notes for image"
     }
   end
@@ -431,7 +427,7 @@ class PostObservationTest < IntegrationTestCase
       alt: 987,
       is_collection_location: true,
       specimen: false,
-      notes: "New notes for observation", # displayed in observations/show
+      notes: "New notes for observation", # string displayed in show_observation
       image_notes: "New notes for image"
     )
   end

--- a/test/integration/random_test.rb
+++ b/test/integration/random_test.rb
@@ -6,7 +6,7 @@ class RandomTest < IntegrationTestCase
   test "pivotal tracker" do
     login(users(:zero_user))
     get("/")
-    click(label: "Feature Tracker")
+    click_mo_link(label: "Feature Tracker")
     assert_template("pivotal/index")
   end
 
@@ -36,13 +36,13 @@ class RandomTest < IntegrationTestCase
     assert_link_exists("/account/logout_user")
     assert_link_exists("/users/#{rolf.id}")
 
-    click(label: "Logout")
+    click_mo_link(label: "Logout")
     assert_template("account/logout_user")
     assert_link_exists("/account/login")
     assert_no_link_exists("/account/logout_user")
     assert_no_link_exists("/users/#{rolf.id}")
 
-    click(label: "Introduction")
+    click_mo_link(label: "Introduction")
     assert_template("info/intro")
     assert_link_exists("/account/login")
     assert_no_link_exists("/account/logout_user")

--- a/test/integration/student_test.rb
+++ b/test/integration/student_test.rb
@@ -44,10 +44,10 @@ class StudentTest < IntegrationTestCase
       end
       assert_no_match(/#{gen_desc}/, response.body)
       assert_select("a[href*=create_name_description]", 1)
-      click(href: /show_name_description/)
+      click_mo_link(href: /show_name_description/)
       assert_select("a[href*=edit_name_description]")
       assert_select("a[href*=destroy_name_description]")
-      click(href: /edit_name_description/)
+      click_mo_link(href: /edit_name_description/)
       open_form do |form|
         form.assert_value("source_type", "project")
         form.assert_value("source_name", project.title)
@@ -67,11 +67,11 @@ class StudentTest < IntegrationTestCase
     def create_draft(name, gen_desc, project)
       assert_nil(NameDescription.find_by(gen_desc: gen_desc))
       get("/")
-      click(label: "Names", in: :left_panel)
-      click(label: name.text_name)
+      click_mo_link(label: "Names", in: :left_panel)
+      click_mo_link(label: name.text_name)
       url = request.url
       assert_match(/there are no descriptions/i, response.body)
-      click(label: project.title)
+      click_mo_link(label: project.title)
       assert_match(:create_name_description_title.t(name: name.display_name),
                    response.body)
 
@@ -98,7 +98,7 @@ class StudentTest < IntegrationTestCase
 
       # Now give it some text to make sure it *can* (but doesn't) actually get
       # displayed (content, that is) on main show_name page.
-      click(href: /edit_name_description/)
+      click_mo_link(href: /edit_name_description/)
       open_form do |form|
         form.assert_value("source_type", :project)
         form.assert_value("source_name", project.title)
@@ -121,7 +121,7 @@ class StudentTest < IntegrationTestCase
     # Can view but not edit.
     def check_another_student(url)
       get(url)
-      click(href: /show_name_description/)
+      click_mo_link(href: /show_name_description/)
       assert_select("a[href*=edit_name_description]", 0)
       assert_select("a[href*=destroy_name_description]", 0)
     end
@@ -132,7 +132,7 @@ class StudentTest < IntegrationTestCase
     def check_another_user(url)
       get(url)
       assert_select("a[href*=show_name_description]", 1)
-      click(href: /show_name_description/)
+      click_mo_link(href: /show_name_description/)
       assert_flash_error
       assert_nil(assigns(:description))
     end

--- a/test/integration_test_case.rb
+++ b/test/integration_test_case.rb
@@ -13,7 +13,7 @@
 #      def test_simplest
 #        get('/controller/action?args=...')
 #        assert_template('controller/action')
-#        click(:label => 'Post Comment')
+#        click_mo_link(:label => 'Post Comment')
 #        open_form do |form|
 #          form.edit_field('message', 'This is a test.')
 #          form.submit('Post')

--- a/test/session_extensions.rb
+++ b/test/session_extensions.rb
@@ -242,10 +242,10 @@ module SessionExtensions
   # href::  URL starts with a String or matches a Regexp.
   # in::    Link contained in a given element type(s).
   # Sample use:
-  #   click(label: "Show Observation")
-  #   click(href: /show_name/)
-  #   click(label: "User", in: :sort_tabs)
-  def click(args = {})
+  #   click_mo_link(label: "Show Observation")
+  #   click_mo_link(href: /show_name/)
+  #   click_mo_link(label: "User", in: :sort_tabs)
+  def click_mo_link(args = {})
     select = "a[href]"
     sargs  = []
 


### PR DESCRIPTION
To provide access to the native Capybara method "click" which allows clicks on buttons, links, and inputs.

Desirable for the ObservationsController PR.