### PR TITLE
Fixed minor bug in Name#display_name_without_authors.

### DIFF
--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -62,7 +62,8 @@ module Name::Format
       display_name.sub(/ #{Regexp.quote(author)}$/, "")
     else
       # Remove author and preceding space after markup
-      display_name.sub(/(\*+|_+) #{Regexp.quote(author)}/, "\\1")
+      display_name.sub(/(\*+|_+) #{Regexp.quote(author)}/, "\\1 ").
+                   strip_squeeze
     end
   end
 

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -63,7 +63,7 @@ module Name::Format
     else
       # Remove author and preceding space after markup
       display_name.sub(/(\*+|_+) #{Regexp.quote(author)}/, "\\1 ").
-                   strip_squeeze
+        strip_squeeze
     end
   end
 

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -702,7 +702,7 @@ class NameControllerTest < FunctionalTestCase
     assert_template(:list_names)
     name_links = css_select(".table a")
     assert_equal(10, name_links.length)
-    expected = Name.all.order("text_name, author").limit(10).to_a
+    expected = Name.all.order("sort_name, author").limit(10).to_a
     assert_equal(expected.map(&:id), ids_from_links(name_links))
     # assert_equal(@controller.url_with_query(action: "show_name",
     #  id: expected.first.id, only_path: true), name_links.first.url)

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -1245,3 +1245,13 @@ eukarya:
   search_name:       Eukarya
   sort_name:         Eukarya
   display_name: "**__Eukarya_**"
+
+# This should actually be section Leucoagaricus, but I was too lazy to add the genus Leucoagaricus!
+sect_agaricus:
+  <<: *DEFAULTS
+  rank: <%= Name.ranks[:Section] %>
+  text_name:    "Agaricus sect. Agaricus"
+  search_name:  "Agaricus sect. Agaricus"
+  display_name: "**__Agaricus__** sect. **__Agaricus__**"
+  sort_name:    "Agaricus  {2sect.  !Agaricus"
+  classification: "Domain: _Eukarya_\r\nKingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2595,6 +2595,10 @@ class NameTest < UnitTestCase
     # group with author
     assert_equal("**__Groupauthored__** group",
                  names(:authored_group).display_name_without_authors)
+
+    # Autonym
+    assert_equal("**__Agaricus__** sect. **__Agaricus__**",
+                 names(:sect_agaricus).display_name_without_authors)
   end
 
   def test_format_autonym

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1723,11 +1723,14 @@ class NameTest < UnitTestCase
     assert_name_list_equal(
       [], names(:agaricus_campestris).children
     )
-    assert_name_list_equal([names(:agaricus_campestras),
+    assert_name_list_equal([names(:sect_agaricus)],
+                           names(:agaricus).children(all: false), :sort)
+    assert_name_list_equal([names(:sect_agaricus),
+                            names(:agaricus_campestras),
                             names(:agaricus_campestris),
                             names(:agaricus_campestros),
                             names(:agaricus_campestrus)],
-                           names(:agaricus).children, :sort)
+                           names(:agaricus).children(all: true), :sort)
   end
 
   def test_ancestors_2

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -463,7 +463,8 @@ class QueryTest < UnitTestCase
                   names(:agaricus).id.to_s,
                   names(:agaricus_campestrus).id.to_s,
                   names(:agaricus_campestras).id.to_s,
-                  names(:agaricus_campestros).id.to_s].sort,
+                  names(:agaricus_campestros).id.to_s,
+                  names(:sect_agaricus).id.to_s].sort,
                  query.select_values(where: 'text_name LIKE "Agaricus%"').
                        map(&:to_s).sort)
 
@@ -479,8 +480,10 @@ class QueryTest < UnitTestCase
     assert_equal({ "id" => Name.first.id }, query.select_one)
 
     assert_equal([Name.first], query.find_by_sql(limit: 1))
-    assert_equal(@agaricus.children.sort_by(&:id),
-                 query.find_by_sql(where: 'text_name LIKE "Agaricus %"'))
+    assert_name_list_equal(
+      @agaricus.children(all: true).sort_by(&:id),
+      query.find_by_sql(where: 'text_name LIKE "Agaricus %"')
+    )
   end
 
   def test_tables_used


### PR DESCRIPTION
This method wasn't working on autonyms.  For example, for `__**Leucoagaricus**__ sect. __**Leucoagaricus**__` it would remove the space before `sect.` resulting in RedCloth not interpreting the mark-up correctly.