### PR TITLE
Set up pending Naming cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,6 +121,9 @@ Lint/UnmodifiedReduceAccumulator: # new in 1.1
 Lint/UselessRuby2Keywords: # new in 1.23
   Enabled: true
 
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+
 Performance/AncestorsInclude: # new in 1.7
   Enabled: true
 Performance/BigDecimalWithNumericArgument: # new in 1.7


### PR DESCRIPTION
Configures Naming department cops which are pending in Rubocop 1.31.1

(There's just one cop and there are no current offenses, so it's just a matter of explicitly enabling it.)