### PR TITLE
Stop images_observations.csv from expanding every time the script is run

### DIFF
--- a/script/update_snapshots
+++ b/script/update_snapshots
@@ -6,10 +6,8 @@ source $(dirname $0)/bash_include
 config_file=$app_root/config/mysql-$RAILS_ENV.cnf
 public=$app_root/public
 
-echo "image_id	observation_id" > $public/observation_images.csv
-mysql --defaults-extra-file=$config_file -q -s -e 'select image_id, observation_id from observation_images' >> $public/observation_images.csv
-# Maintain a copy of the old file for backwards compatibility.
-cp $public/observation_images.csv $public/images_observations.csv
+echo "image_id	observation_id" > $public/images_observations.csv
+mysql --defaults-extra-file=$config_file -q -s -e 'select image_id, observation_id from observation_images' >> $public/images_observations.csv
 
 echo "id	name	north	south	east	west	high	low" > $public/locations.csv
 mysql --defaults-extra-file=$config_file -q -s -e 'select id, name, north, south, east, west, high, low from locations' >> $public/locations.csv

--- a/script/update_snapshots
+++ b/script/update_snapshots
@@ -7,7 +7,8 @@ config_file=$app_root/config/mysql-$RAILS_ENV.cnf
 public=$app_root/public
 
 echo "image_id	observation_id" > $public/observation_images.csv
-mysql --defaults-extra-file=$config_file -q -s -e 'select image_id, observation_id from observation_images' >> $public/images_observations.csv
+mysql --defaults-extra-file=$config_file -q -s -e 'select image_id, observation_id from observation_images' >> $public/observation_images.csv
+cp $public/observation_images.csv $public/images_observations.csv
 
 echo "id	name	north	south	east	west	high	low" > $public/locations.csv
 mysql --defaults-extra-file=$config_file -q -s -e 'select id, name, north, south, east, west, high, low from locations' >> $public/locations.csv

--- a/script/update_snapshots
+++ b/script/update_snapshots
@@ -8,6 +8,7 @@ public=$app_root/public
 
 echo "image_id	observation_id" > $public/observation_images.csv
 mysql --defaults-extra-file=$config_file -q -s -e 'select image_id, observation_id from observation_images' >> $public/observation_images.csv
+# Maintain a copy of the old file for backwards compatibility.
 cp $public/observation_images.csv $public/images_observations.csv
 
 echo "id	name	north	south	east	west	high	low" > $public/locations.csv


### PR DESCRIPTION
I noticed that the file /var/web/mo/public/images_observations.csv had become unreasonably large (41 million lines) and had a huge amount of duplication.  Traced it down to some recent changes in script/update_snapshots.  I believe this fix will now correctly create both observation_images.csv and images_observations.csv.  I'm assuming we want to maintain the original name (images_observations.csv) since folks might be downloading from that URL while also enabling the now more correctly named observation_images.csv.  This should also clean up the current mess once this fix gets deployed.