### PR TITLE
Fix some routes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -378,9 +378,10 @@ Style/DateTime:
   Enabled: false
 
 # This doesn't apply in routes.rb because Rails routes don't accept annotated
-# tokens (at least yet).
+# tokens (at least yet).  Also, enabling this produce a ton of new errors.
+# Let's talk about this before we enable it, I guess.
 Style/FormatStringToken:
-  Enabled: true
+  Enabled: false
   Exclude:
     - "config/routes.rb"
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -377,6 +377,13 @@ Style/AsciiComments:
 Style/DateTime:
   Enabled: false
 
+# This doesn't apply in routes.rb because Rails routes don't accept annotated
+# tokens (at least yet).
+Style/FormatStringToken:
+  Enabled: true
+  Exclude:
+    - "config/routes.rb"
+
 # Rubocop does not enable this cop by default
 # MO uses parentheses
 Style/MethodCallWithArgsParentheses:

--- a/app/assets/javascripts/multi_image_upload.js.erb
+++ b/app/assets/javascripts/multi_image_upload.js.erb
@@ -555,25 +555,26 @@ function MultiImageUploader(localized_text) {
           }
         };
 
-        update = function() {
-          var req = new XMLHttpRequest();
-          req.open("GET", _progressUri, 1);
-          req.setRequestHeader("X-Progress-ID", _this.uuid);
-          req.onreadystatechange = function () {
-            if (req.readyState == 4 && req.status == 200) {
-              var upload = eval(req.responseText);
-              if (upload.state == "done" || upload.state == "uploading") {
-                _this.incrementProgressBar(upload.received / upload.size);
-                progress = window.setTimeout(update, 1000);
-              } else {
-                window.clearTimeout(progress);
-                progress = null;
-              }
-            }
-          };
-          req.send(null);
-        };
-        progress = window.setTimeout(update, 1000);
+        // This is currently disabled in nginx, so no sense making the request.
+        // update = function() {
+        //   var req = new XMLHttpRequest();
+        //   req.open("GET", _progressUri, 1);
+        //   req.setRequestHeader("X-Progress-ID", _this.uuid);
+        //   req.onreadystatechange = function () {
+        //     if (req.readyState == 4 && req.status == 200) {
+        //       var upload = eval(req.responseText);
+        //       if (upload.state == "done" || upload.state == "uploading") {
+        //         _this.incrementProgressBar(upload.received / upload.size);
+        //         progress = window.setTimeout(update, 1000);
+        //       } else {
+        //         window.clearTimeout(progress);
+        //         progress = null;
+        //       }
+        //     }
+        //   };
+        //   req.send(null);
+        // };
+        // progress = window.setTimeout(update, 1000);
 
         // Note: You need to add the event listeners before calling open()
         // on the request.

--- a/app/classes/mo_paginator.rb
+++ b/app/classes/mo_paginator.rb
@@ -162,13 +162,10 @@ class MOPaginator
   end
 
   # Validate +used_letters+ array.  Force them all to uppercase, and remove
-  # duplicates and non-letters.  (Set to +nil+ to mean assume all letters have
-  # results.)
+  # duplicates and non-letters.
   def used_letters=(list)
-    @used_letters = if list
-                      list.map { |l| l.to_s[0, 1].upcase }.uniq.
-                        select { |l| l.match(/[A-Z]/) }.sort
-                    end
+    @used_letters = list.map { |l| l.to_s[0, 1].upcase }.uniq.
+                    select { |l| l.match(/[A-Z]/) }.sort
   end
 
   # Number of pages of results available.

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -28,7 +28,7 @@ module ObservationsController::Index
       observations_at_where and return
     elsif params[:project].present?
       observations_for_project and return
-    elsif params[:by].present? || params[:q].present?
+    elsif params[:by].present? || params[:q].present? || params[:id].present?
       index_observation and return
     else
       list_observations and return

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -27,7 +27,7 @@ module PaginationHelper
   #   def action
   #     query = create_query(:Name)
   #     @pages = paginate_letters(:letter, :page, 50)
-  #     @names = query.paginate(@pages, letter_field: 'names.sort_name')
+  #     @names = query.paginate(@pages)
   #   end
   #
   #   # In view:
@@ -41,7 +41,7 @@ module PaginationHelper
     args[:params] = (args[:params] || {}).dup
     args[:params][pages.number_arg] = nil
     str = LETTERS.map do |letter|
-      if !pages.used_letters || pages.used_letters.include?(letter)
+      if pages.used_letters.include?(letter)
         pagination_link(letter, letter, pages.letter_arg, args)
       else
         content_tag(:li, content_tag(:span, letter), class: "disabled")
@@ -55,7 +55,7 @@ module PaginationHelper
 
     pages.letter_arg &&
       (pages.letter || pages.num_total > pages.num_per_page) &&
-      (!pages.used_letters || pages.used_letters.length > 1)
+      (pages.used_letters && pages.used_letters.length > 1)
   end
 
   # Insert numbered pagination links.  I've thrown out the Rails plugin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -663,6 +663,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
     collection do
       get("map")
       get("download")
+      post("download")
       get("print_labels")
     end
   end
@@ -723,14 +724,14 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   get("/observer/checklist", to: redirect("/checklist"))
 
   # ----- Emails: legacy action redirects
-  get("/observer/ask_observation_question",
-      to: redirect(path: "/emails/ask_observation_question"))
-  get("/observer/ask_user_question",
-      to: redirect(path: "/emails/ask_user_question"))
+  get("/observer/ask_observation_question/:id",
+      to: redirect(path: "/emails/ask_observation_question/%{id}"))
+  get("/observer/ask_user_question/:id",
+      to: redirect(path: "/emails/ask_user_question/%{id}"))
   get("/observer/ask_webmaster_question",
       to: redirect(path: "/emails/ask_webmaster_question"))
-  get("/observer/commercial_inquiry",
-      to: redirect(path: "/emails/commercial_inquiry"))
+  get("/observer/commercial_inquiry/:id",
+      to: redirect(path: "/emails/commercial_inquiry/%{id}"))
   get("/observer/email_features",
       to: redirect(path: "/emails/features"))
   get("/observer/email_merge_request",
@@ -753,7 +754,11 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # ----- Herbaria: nonstandard legacy action redirects
   get("/herbarium/herbarium_search", to: redirect("/herbaria"))
   get("/herbarium/index", to: redirect("/herbaria"))
+  get("/herbarium/index_herbarium/:id", to: redirect("/herbaria?id=%{id}"))
+  get("/herbarium/index_herbarium", to: redirect("/herbaria"))
   get("/herbarium/list_herbaria", to: redirect("/herbaria?flavor=all"))
+  get("/herbarium/request_to_be_curator/:id",
+      to: redirect("/herbaria/curator_requests/new?id=%{id}"))
   # Must be the final route in order to give the others priority
   get("/herbarium", to: redirect("/herbaria?flavor=nonpersonal"))
 
@@ -768,75 +773,61 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   get("/observer/textile_sandbox", to: redirect("/info/textile_sandbox"))
   get("/observer/translators_note", to: redirect("/info/translators_note"))
 
+  # ----- Javascript: legacy action redirects ----------------------------
+  get("/observer/hide_thumbnail_map/:id",
+      to: redirect("/javascript/hide_thumbnail_map?id=%{id}"))
+
   # ----- Observations: legacy action redirects ----------------------------
+  get("/observer/create_observation", to: redirect("/observations/new"))
   get("/observer/observation_search", to: redirect("/observations"))
   get("/observer/advanced_search", to: redirect("/observations"))
+  get("/observer/index_observation/:id", to: redirect("/observations?id=%{id}"))
   get("/observer/index_observation", to: redirect("/observations"))
   get("/observer/list_observations", to: redirect("/observations"))
-  get("/observer/observations_of_look_alikes(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?name=#{req.params[:id]}&look_alikes=1"
-      end)
-  get("/observer/observations_of_related_taxa(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?name=#{req.params[:id]}&related_taxa=1"
-      end)
-  get("/observer/observations_of_name(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?name=#{req.params[:id]}"
-      end)
-  get("/observer/observations_by_user(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?user=#{req.params[:id]}"
-      end)
-  get("/observer/observations_at_location(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?location=#{req.params[:id]}"
-      end)
-  get("/observer/observations_at_where(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?where=#{req.params[:id]}"
-      end)
-  get("/observer/observations_for_project(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations?project=#{req.params[:id]}"
-      end)
-  get("/observer/show_observation(/:id)",
-      to: redirect do |_path_params, req|
-        "/observations/#{req.params[:id]}"
-      end)
+  get("/observer/map_observation/:id", to: redirect("/observations/%{id}/map"))
+  get("/observer/map_observations", to: redirect("/observations/map"))
+  get("/observer/next_observation/:id",
+      to: redirect("/observations/%{id}?flow=next"))
+  get("/observer/prev_observation/:id",
+      to: redirect("/observations/%{id}?flow=prev"))
+  get("/observer/observations_of_look_alikes/:id",
+      to: redirect("/observations?name=%{id}&look_alikes=1"))
+  get("/observer/observations_of_related_taxa/:id",
+      to: redirect("/observations?name=%{id}&related_taxa=1"))
+  get("/observer/observations_of_name/:id",
+      to: redirect("/observations?name=%{id}"))
+  get("/observer/observations_by_user/:id",
+      to: redirect("/observations?user=%{id}"))
+  get("/observer/observations_at_location/:id",
+      to: redirect("/observations?location=%{id}"))
+  get("/observer/observations_at_where/:id",
+      to: redirect("/observations?where=%{id}"))
+  get("/observer/observations_for_project/:id",
+      to: redirect("/observations?project=%{id}"))
+  get("/observer/show_observation/:id",
+      to: redirect("/observations/%{id]}"))
 
   # ----- RssLogs: legacy action redirects ------------------------------
   get("/observer/index", to: redirect("/activity_logs"))
   get("/observer/list_rss_logs", to: redirect("/activity_logs"))
-  get("/observer/index_rss_logs", to: redirect("/activity_logs"))
-  get("/observer/show_rss_log(/:id)",
-      to: redirect do |_path_params, req|
-        "/activity_logs/#{req.params[:id]}"
-      end)
+  get("/observer/index_rss_log/:id", to: redirect("/activity_logs?id=%{id}"))
+  get("/observer/index_rss_log", to: redirect("/activity_logs"))
+  get("/observer/show_rss_log/:id", to: redirect("/activity_logs/%{id}"))
   get("/observer/rss", to: redirect("/activity_logs/rss"))
 
   # ----- Users: legacy action redirects  ----------------------------------
   get("/observer/user_search", to: redirect(path: "/users"))
+  get("/observer/index_user/:id", to: redirect(path: "/users?id=%{id}"))
   get("/observer/index_user", to: redirect(path: "/users"))
   get("/observer/list_users", to: redirect(path: "/users"))
-  get("/observer/users_by_contribution",
-      to: redirect(path: "/contributors"))
+  get("/observer/users_by_contribution", to: redirect(path: "/contributors"))
   get("/observer/users_by_name", to: redirect("/users?by=name"))
-  get("/observer/show_user(/:id)",
-      to: redirect do |_path_params, req|
-        "/users/#{req.params[:id]}"
-      end)
-  get("/observer/change_user_bonuses(/:id)",
-      to: redirect do |_path_params, req|
-        "/users/#{req.params[:id]}/edit"
-      end)
+  get("/observer/show_user/:id", to: redirect("/users/%{id}"))
+  get("/observer/change_user_bonuses/:id", to: redirect("/users/%{id}/edit"))
 
   # ----- Search: legacy action redirects ---------------------------------
-  get("/observer/pattern_search",
-      to: redirect("/search/pattern"))
-  get("/observer/advanced_search_form",
-      to: redirect("/search/advanced"))
+  get("/observer/pattern_search", to: redirect("/search/pattern"))
+  get("/observer/advanced_search_form", to: redirect("/search/advanced"))
 
   ###
   ###

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -456,8 +456,7 @@ def redirect_legacy_actions(old_controller: "",
     to_url = format(data[:to],
                     new_controller: new_controller,
                     model: model,
-                    # Rails routes currently only accept template tokens
-                    id: "%{id}") # rubocop:disable Style/FormatStringToken
+                    id: "%{id}")
 
     match(format(data[:from], old_controller: old_controller, model: model),
           to: redirect(path: to_url),

--- a/test/models/mo_paginator_test.rb
+++ b/test/models/mo_paginator_test.rb
@@ -79,8 +79,6 @@ class MOPaginatorTest < UnitTestCase
     assert_raises(RuntimeError) { pages.num_per_page = 0 }
     assert_raises(RuntimeError) { pages.num_per_page = "str" }
 
-    pages.used_letters = nil
-    assert_nil(pages.used_letters)
     pages.used_letters = []
     assert_equal([], pages.used_letters)
     pages.used_letters = [1, 2, 3]

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -558,7 +558,7 @@ class QueryTest < UnitTestCase
       @query.paginate_ids(@pages).map { |id| name_ids.index(id) + 1 }
     )
     assert_equal(@names.size, @pages.num_total)
-    assert_equal(@names[from_nth..to_nth], @query.paginate(@pages))
+    assert_name_list_equal(@names[from_nth..to_nth], @query.paginate(@pages))
   end
 
   def test_paginate_start
@@ -592,7 +592,7 @@ class QueryTest < UnitTestCase
     assert(@ells.length >= 9)
     assert_equal(@ells[3..5].map(&:id), @query.paginate_ids(@pages))
     assert_equal(@letters, @pages.used_letters.sort)
-    assert_equal(@ells[3..5], @query.paginate(@pages))
+    assert_name_list_equal(@ells[3..5], @query.paginate(@pages))
   end
 
   def test_eager_instantiator


### PR DESCRIPTION
I noticed a profusion of "no routes exist" errors in the log file after deploying Nimmo's observer controller refactor.  I tried to fix them all.

Also there was no route for POSTing /observations/download ... probably should write a test for that one!

Lastly, I accidentally uncovered an old bug in query pagination where it was literally loading and instantiating *every* observation in certain cases.  (Click on an observation, then click on "Index" between "« Prev" and "Next »".)  I simplified and cleaned up that code to ensure nothing like that happens again.