### PR TITLE
Fix sect_agaricus fixture

### DIFF
--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -1249,6 +1249,8 @@ eukarya:
 # This should actually be section Leucoagaricus, but I was too lazy to add the genus Leucoagaricus!
 sect_agaricus:
   <<: *DEFAULTS
+  created_at: 2007-06-23 20:04:00
+  updated_at: 2007-06-23 20:04:00
   rank: <%= Name.ranks[:Section] %>
   text_name:    "Agaricus sect. Agaricus"
   search_name:  "Agaricus sect. Agaricus"


### PR DESCRIPTION
Add explicit timestamps to name.yml `sect_agaricus`
The lack of explicit timestamps made CacheTest#test_propagate_lifeform fail under some circumstances.

```ruby
vagrant@ubuntu-focal /vagrant/mushroom-observer (master)
$ rails t test/models/cache_test.rb -n test_propagate_lifeform
Started with run options -n test_propagate_lifeform --seed 63341

 FAIL CacheTest#test_propagate_lifeform (0.72s)
        Expected Mon, 18 Jul 2022 23:21:38.000000000 EDT -04:00 to be < Mon, 18 Jul 2022 23:20:38.481509038 EDT -04:00.
        test/models/cache_test.rb:107:in `block in test_propagate_lifeform'
        test/models/cache_test.rb:105:in `test_propagate_lifeform'
```