### PR TITLE
Pending layout cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,9 +61,12 @@ AllCops:
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationleadingspace
 Layout/LineContinuationLeadingSpace: #`new in 1.31.1
   Enabled: true
-
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinecontinuationspacing
 Layout/LineContinuationSpacing: #`new in 1.31.1
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceBeforeBrackets: # new in 1.7
   Enabled: true
 
 Lint/AmbiguousAssignment: # new in 1.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,7 +65,11 @@ Layout/LineContinuationLeadingSpace: #`new in 1.31.1
 Layout/LineContinuationSpacing: #`new in 1.31.1
   Enabled: true
 Layout/LineEndStringConcatenationIndentation: # new in 1.18
-  Enabled: true
+  # We most consistently align the start of the continued line
+  # with the start of the string on the previous line.
+  # This does not correspond to any available EnforcedStyle.
+  Enabled: false
+
 Layout/SpaceBeforeBrackets: # new in 1.7
   Enabled: true
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -491,9 +491,9 @@ class LocationTest < UnitTestCase
     loc = locations(:east_lt_west_location)
     centrum = { lat: loc.south + loc.north_south_distance / 2,
                 lon: loc.east - loc.east_west_distance / 2 }
-    assert_true(loc.lat_long_close?(centrum[:lat], centrum [:lon]),
+    assert_true(loc.lat_long_close?(centrum[:lat], centrum[:lon]),
                 "Location's centrum should be 'close' to Location.")
-    assert_false(loc.lat_long_close?(centrum[:lat], centrum [:lon] + 180),
+    assert_false(loc.lat_long_close?(centrum[:lat], centrum[:lon] + 180),
                  "Opposite side of globe should not be 'close' to Location.")
   end
 end


### PR DESCRIPTION
Sets up the pending cops in the Layout department:
- Explicitly enables/disables them;
- Fixes any offenses

Delivers the final part of https://www.pivotaltracker.com/story/show/182027741