### PR TITLE
Turn Style/FormatStringToken cop again

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -377,13 +377,11 @@ Style/AsciiComments:
 Style/DateTime:
   Enabled: false
 
-# This doesn't apply in routes.rb because Rails routes don't accept annotated
-# tokens (at least yet).  Also, enabling this produce a ton of new errors.
-# Let's talk about this before we enable it, I guess.
+# This doesn't work for redirect in config/routes.rb.
 Style/FormatStringToken:
-  Enabled: false
-  Exclude:
-    - "config/routes.rb"
+  Enabled: true
+  IgnoredMethods:
+    - "redirect"
 
 # Rubocop does not enable this cop by default
 # MO uses parentheses

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -456,7 +456,9 @@ def redirect_legacy_actions(old_controller: "",
     to_url = format(data[:to],
                     new_controller: new_controller,
                     model: model,
-                    id: "%{id}")
+                    # This is going to be used in a redirect which rubocop
+                    # has been instructed to ignore, but doesn't realize it.
+                    id: "%{id}") # rubocop:disable Style/FormatStringToken
 
     match(format(data[:from], old_controller: old_controller, model: model),
           to: redirect(path: to_url),


### PR DESCRIPTION
I changed the configuration to ignore the redirect method instead of skipping the entire config/routes.rb file.

I cannot reproduce the offenses that it was finding in the scripts directory earlier.

We have now officially gone 360° and returned almost precisely to where we were before I turned this silly cop off.  I'm so confused.