### PR TITLE
Remove merge_source_id code

### DIFF
--- a/app/controllers/description_controller_helpers.rb
+++ b/app/controllers/description_controller_helpers.rb
@@ -693,13 +693,6 @@ module DescriptionControllerHelpers
         dest.send("#{f}=", val) if val.present?
       end
 
-      # Store where merge came from in new version of destination.
-      dest.merge_source_id = begin
-                               src.versions.latest.id
-                             rescue StandardError
-                               nil
-                             end
-
       # Save changes to destination.
       dest.save
 

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -441,23 +441,7 @@ class LocationController < ApplicationController
     return unless @description
 
     @location = @description.location
-    if params[:merge_source_id].blank?
-      @description.revert_to(params[:version].to_i)
-    else
-      @merge_source_id = params[:merge_source_id]
-      version = LocationDescription::Version.find(@merge_source_id)
-      @old_parent_id = version.location_description_id
-      subversion = params[:version]
-      if subversion.present? &&
-         (version.version != subversion.to_i)
-        version = LocationDescription::Version.
-                  find_by(
-                    version: params[:version],
-                    location_description_id: @old_parent_id
-                  )
-      end
-      @description.clone_versioned_model(version, @description)
-    end
+    @description.revert_to(params[:version].to_i)
   end
 
   # Go to next location: redirects to show_location.

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -784,7 +784,6 @@ class LocationController < ApplicationController
         if (params[:delete_after] == "true") &&
            (old_desc = LocationDescription.safe_find(params[:old_desc_id]))
           v = @description.versions.latest
-          v.merge_source_id = old_desc.versions.latest.id
           v.save
           if !in_admin_mode? && !old_desc.is_admin?(@user)
             flash_warning(:runtime_description_merge_delete_denied.t)

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -420,23 +420,8 @@ class NameController < ApplicationController
     return unless @description
 
     @name = @description.name
-    if params[:merge_source_id].blank?
-      @description.revert_to(params[:version].to_i)
-    else
-      @merge_source_id = params[:merge_source_id]
-      version = NameDescription::Version.find(@merge_source_id)
-      @old_parent_id = version.name_description_id
-      subversion = params[:version]
-      if subversion.present? &&
-         (version.version != subversion.to_i)
-        version = NameDescription::Version.find_by(
-          version: params[:version],
-          name_description_id: @old_parent_id
-        )
-      end
-      @description.clone_versioned_model(version, @description)
+    @description.revert_to(params[:version].to_i)
     end
-  end
 
   # Go to next name: redirects to show_name.
   def next_name
@@ -583,7 +568,6 @@ class NameController < ApplicationController
         if (params[:delete_after] == "true") &&
            (old_desc = NameDescription.safe_find(params[:old_desc_id]))
           v = @description.versions.latest
-          v.merge_source_id = old_desc.versions.latest.id
           v.save
           if !in_admin_mode? && !old_desc.is_admin?(@user)
             flash_warning(:runtime_description_merge_delete_denied.t)

--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -421,7 +421,7 @@ class NameController < ApplicationController
 
     @name = @description.name
     @description.revert_to(params[:version].to_i)
-    end
+  end
 
   # Go to next name: redirects to show_name.
   def next_name

--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -16,10 +16,6 @@ module VersionHelper
   def show_previous_version(obj)
     html = "#{:VERSION.t}: #{obj.version}".html_safe
     latest_version = obj.versions.latest
-    if latest_version.respond_to?(:merge_source_id) &&
-       latest_version.merge_source_id
-      html += indent(1) + get_version_merge_link(obj, latest_version)
-    end
     html += safe_br
     return html unless latest_version
 
@@ -27,10 +23,6 @@ module VersionHelper
       str = :show_name_previous_version.t + " " + previous_version.version.to_i
       html += link_with_query(str, action: obj.show_past_action, id: obj.id,
                                    version: previous_version.version)
-      if previous_version.respond_to?(:merge_source_id) &&
-         previous_version.merge_source_id
-        html += indent(1) + get_version_merge_link(obj, previous_version)
-      end
       html += safe_br
     end
     html

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -15,7 +15,8 @@
 #  updated_at::       (V) Date/time it was last updated.
 #  user::             (V) User that created it.
 #  version::          (V) Version number.
-#  merge_source_id::  (V) Tracks of descriptions that were merged into this one.
+#  merge_source_id::  (V) Obsolete
+#    Track of descriptions that were merged into this one.
 #    Primarily useful in the past versions: stores id of latest version of the
 #    Description merged into this one at the time of the merge.
 #

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -15,7 +15,8 @@
 #  updated_at::       (V) Date/time it was last updated.
 #  user::             (V) User that created it.
 #  version::          (V) Version number.
-#  merge_source_id::  (V) Used to keep track of descriptions that were merged
+#  merge_source_id::  (V) Obsolete
+#    Used to keep track of descriptions that were merged
 #    into this one. Primarily useful in the past versions: stores id of latest
 #    version of the Description merged into this one at the time of the merge.
 #


### PR DESCRIPTION
Removes all code related to unused attributes `LocationDescription.merge_source_id` and  `NameDescription.merge_source_id`
(Does not  remove the columns themselves. That will be handled by a later migration.)

Delivers the code portion of https://www.pivotaltracker.com/story/show/182778592