### PR TITLE
De-SQL Tests

### DIFF
--- a/test/controllers/project_controller_test.rb
+++ b/test/controllers/project_controller_test.rb
@@ -198,10 +198,6 @@ class ProjectControllerTest < FunctionalTestCase
     assert_raises(ActiveRecord::RecordNotFound) do
       admin_group = UserGroup.find(admin_group.id)
     end
-    n = Name.connection.select_value(%(
-      SELECT COUNT(*) FROM name_description_admins
-      WHERE user_group_id IN (#{admin_group.id}, #{user_group.id})
-    ))
     n = NameDescriptionAdmin.
         where(user_group: [admin_group.id, user_group.id]).count
     assert_equal(

--- a/test/controllers/project_controller_test.rb
+++ b/test/controllers/project_controller_test.rb
@@ -202,24 +202,22 @@ class ProjectControllerTest < FunctionalTestCase
       SELECT COUNT(*) FROM name_description_admins
       WHERE user_group_id IN (#{admin_group.id}, #{user_group.id})
     ))
+    n = NameDescriptionAdmin.
+        where(user_group: [admin_group.id, user_group.id]).count
     assert_equal(
       0, n,
       "Project admin/user group has been destroyed, " \
       "no name descriptions should refer to it to set admin privileges."
     )
-    n = Name.connection.select_value(%(
-      SELECT COUNT(*) FROM name_description_writers
-      WHERE user_group_id IN (#{admin_group.id}, #{user_group.id})
-    ))
+    n = NameDescriptionWriter.
+        where(user_group: [admin_group.id, user_group.id]).count
     assert_equal(
       0, n,
       "Project admin/user group has been destroyed, " \
       "no name descriptions should refer to it to set write permissions."
     )
-    n = Name.connection.select_value(%(
-      SELECT COUNT(*) FROM name_description_readers
-      WHERE user_group_id IN (#{admin_group.id}, #{user_group.id})
-    ))
+    n = NameDescriptionReader.
+        where(user_group: [admin_group.id, user_group.id]).count
     assert_equal(
       0, n,
       "Project admin/user group has been destroyed, " \

--- a/test/controllers/species_list_controller_test.rb
+++ b/test/controllers/species_list_controller_test.rb
@@ -1845,11 +1845,11 @@ class SpeciesListControllerTest < FunctionalTestCase
 
   def test_post_add_remove_double_observations
     spl = species_lists(:unknown_species_list)
-    old_obs_list = SpeciesList.connection.select_values(%(
-      SELECT observation_id FROM species_list_observations
-      WHERE species_list_id = #{spl.id}
-      ORDER BY observation_id ASC
-    ))
+    old_obs_list =
+      SpeciesListObservation.select(:observation_id).
+      where(species_list: spl.id).
+      order(observation_id: :asc).
+      map(&:observation_id)
     dup_obs = spl.observations.first
     new_obs = (Observation.all - spl.observations).first
     ids = [dup_obs.id, new_obs.id]
@@ -1862,11 +1862,11 @@ class SpeciesListControllerTest < FunctionalTestCase
     post(:post_add_remove_observations, params: params)
     assert_response(:redirect)
     assert_flash_success
-    new_obs_list = SpeciesList.connection.select_values(%(
-      SELECT observation_id FROM species_list_observations
-      WHERE species_list_id = #{spl.id}
-      ORDER BY observation_id ASC
-    ))
+    new_obs_list =
+      SpeciesListObservation.select(:observation_id).
+      where(species_list: spl.id).
+      order(observation_id: :asc).
+      map(&:observation_id)
     assert_equal(new_obs_list.length, old_obs_list.length + 1)
     assert_equal((new_obs_list - old_obs_list).first, new_obs.id)
   end


### PR DESCRIPTION
Changes test suite SQL to AR queries, except `QueryTest`.
(`QueryTest` is an exception because the tested `Query` methods generate SQL fragments; 
the tests check whether those fragments comprise the correct SQL.)