### PR TITLE
Update Rubocop to v1.33

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       io-console (~> 0.5)
     rexml (3.2.5)
     rtf (0.3.3)
-    rubocop (1.32.0)
+    rubocop (1.33.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)


### PR DESCRIPTION
Updates Rubocop to v1.33.
(There are no new cops; just bug fixes, refactors, 1 new autocorrect.
https://github.com/rubocop/rubocop/releases/tag/v1.33.0)
NOTE: CI continues to use v1.31 -- the highest available channel on Codeclimate.
