### PR TITLE
Sometimes observations/print_labels is requested as a POST.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -655,6 +655,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
       get("download")
       post("download")
       get("print_labels")
+      post("print_labels")
     end
   end
 


### PR DESCRIPTION
This is a quick fix, no tests, etc.  This action (observations/print_labels) should go away completely.  It should be rewritten as

POST observations/download?submit=Print%20Labels&q=xxx

Probably easy to do, but for now, this is dead simple and gets the fix out ASAP.