### PR TITLE
Convert `get_with_dump` to `get`, use named params hash everywhere

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -42,9 +42,9 @@ class AdminController < ApplicationController
     time = Time.zone.now
     Language.all.each do |lang|
       if (str = lang.translation_strings.where(tag: "app_banner_box")[0])
-        update_string(str, time)
+        update_banner_string(str, time)
       else
-        str = create_string(lang, time)
+        str = create_banner_string(lang, time)
       end
       str.update_localization
       str.language.update_localization_file
@@ -52,14 +52,14 @@ class AdminController < ApplicationController
     end
   end
 
-  def update_string(str, time)
+  def update_banner_string(str, time)
     str.update!(
       text: @val,
       updated_at: (str.language.official ? time : time - 1.minute)
     )
   end
 
-  def create_string(lang, time)
+  def create_banner_string(lang, time)
     lang.translation_strings.create!(
       tag: "app_banner_box",
       text: @val,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -564,7 +564,6 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   match("/admin/change_banner", to: "admin#change_banner", via: [:get, :post])
   match("/admin/test_flash_redirection",
         to: "admin#test_flash_redirection", via: [:get, :post])
-  get("/admin/w3c_tests", to: "admin#w3c_tests")
 
   # ----- Articles: standard actions --------------------------------------
   resources :articles, id: /\d+/

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -10,15 +10,10 @@
 #  login::                      Login a user.
 #  logout::                     Logout current user.
 #  make_admin::                 Make current user an admin & turn on admin mode.
-#  get_with_dump::              Send GET, no login required.
 #  requires_login::             Send GET, login required.
 #  requires_user::              Send GET, certain user must be logged in.
-#  post_with_dump::             Send POST, no login required.
 #  post_requires_login::        Send POST, login required.
 #  post_requires_user::         Send POST, certain user must be logged in.
-#  html_dump::                  Dump response body to file for W3C validation.
-#  save_response::              Dump response body to public/test.html
-#                               for debugging.
 #  get_without_clearing_flash::  Wrapper: calls +get+
 #                                without clearing flash errors.
 #  post_without_clearing_flash:: Wrapper: calls +post+
@@ -99,42 +94,6 @@ module ControllerExtensions
       user.save
     end
     user
-  end
-
-  # Send a GET request, and save the result in a file for w3c validation.
-  #
-  #   # Send request, but ignore response.
-  #   get(:action, params: params)
-  #
-  #   # Send request, and save response in ../html/action_0.html.
-  #   get_with_dump(:action, params: params)
-  #
-  def get_with_dump(page, params = {})
-    get(page, **params)
-    html_dump(page, @response.body, params)
-  end
-
-  # Send a POST request, and save the result in a file for w3c validation.
-  #
-  #   # Send request, but ignore response.
-  #   post(:action, params: params)
-  #
-  #   # Send request, and save response in ../html/action_0.html.
-  #   post_with_dump(:action, params: params)
-  #
-  def post_with_dump(page, params = {})
-    post(page, **params)
-    html_dump(page, @response.body, params)
-  end
-
-  def put_with_dump(page, params = {})
-    put(page, **params)
-    html_dump(page, @response.body, params)
-  end
-
-  def patch_with_dump(page, params = {})
-    patch(page, **params)
-    html_dump(page, @response.body, params)
   end
 
   # Send GET request to a page that should require login.
@@ -246,58 +205,6 @@ module ControllerExtensions
       require_login: :login,
       require_user: altpage ? [altpage].flatten : nil
     )
-  end
-
-  # The whole purpose of this is to create a directory full of sample HTML
-  # files that we can run the W3C validator on -- this has nothing to do with
-  # debugging!  This happens automatically if following directory exists:
-  #
-  #   ::Rails.root.to_s/../html
-  #
-  # Files are created:
-  #
-  #   show_user_0.html
-  #   show_user_1.html
-  #   show_user_2.html
-  #   etc.
-  #
-  def html_dump(label, html, _params)
-    html_dir = "../html"
-    return unless File.directory?(html_dir) && html[0..11] != "<html><body>"
-
-    file_name = "#{html_dir}/#{label}.html"
-    count = 0
-    while File.exist?(file_name)
-      file_name = "#{html_dir}/#{label}_#{count}.html"
-      count += 1
-      next unless count > 100
-
-      raise(
-        RangeError.new("More than 100 files found with a label of '#{label}'")
-      )
-    end
-    print("Creating html_dump file: #{file_name}\n")
-    file = File.new(file_name, "w")
-    # show_params(file, params, "params")
-    file.write(html)
-    file.close
-  end
-
-  # Add the hash of parameters to the dump file for diagnostics.
-  def show_params(file, hash, prefix)
-    if hash.is_a?(Hash)
-      hash.each { |k, v| show_params(file, v, "#{prefix}[#{k}]") }
-    else
-      file.write("#{prefix} = [#{hash}]<br>\n")
-    end
-  end
-
-  # This writes @response.body to the given file
-  # (relative to <tt>::Rails.root.to_s</tt>).
-  def save_response(file = "public/test.html")
-    File.open("#{::Rails.root}/#{file}", "w:utf-8") do |fh|
-      fh.write(@response.body)
-    end
   end
 
   ##############################################################################
@@ -499,7 +406,7 @@ module ControllerExtensions
 
     # Finally, login correct user and let it do its thing.
     login(user, password)
-    send("#{method}_with_dump", action, params: params)
+    send(method, action, params: params)
     assert_response(args[:result])
   end
 

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -110,7 +110,7 @@ module ControllerExtensions
   #   get_with_dump(:action, params)
   #
   def get_with_dump(page, params = {})
-    get(page, params: params)
+    get(page, **params)
     html_dump(page, @response.body, params)
   end
 
@@ -123,17 +123,17 @@ module ControllerExtensions
   #   post_with_dump(:action, params)
   #
   def post_with_dump(page, params = {})
-    post(page, params: params)
+    post(page, **params)
     html_dump(page, @response.body, params)
   end
 
   def put_with_dump(page, params = {})
-    put(page, params: params)
+    put(page, **params)
     html_dump(page, @response.body, params)
   end
 
   def patch_with_dump(page, params = {})
-    patch(page, params: params)
+    patch(page, **params)
     html_dump(page, @response.body, params)
   end
 

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -104,10 +104,10 @@ module ControllerExtensions
   # Send a GET request, and save the result in a file for w3c validation.
   #
   #   # Send request, but ignore response.
-  #   get(:action, params)
+  #   get(:action, params: params)
   #
   #   # Send request, and save response in ../html/action_0.html.
-  #   get_with_dump(:action, params)
+  #   get_with_dump(:action, params: params)
   #
   def get_with_dump(page, params = {})
     get(page, **params)
@@ -117,10 +117,10 @@ module ControllerExtensions
   # Send a POST request, and save the result in a file for w3c validation.
   #
   #   # Send request, but ignore response.
-  #   post(:action, params)
+  #   post(:action, params: params)
   #
   #   # Send request, and save response in ../html/action_0.html.
-  #   post_with_dump(:action, params)
+  #   post_with_dump(:action, params: params)
   #
   def post_with_dump(page, params = {})
     post(page, **params)
@@ -499,7 +499,7 @@ module ControllerExtensions
 
     # Finally, login correct user and let it do its thing.
     login(user, password)
-    send("#{method}_with_dump", action, params)
+    send("#{method}_with_dump", action, params: params)
     assert_response(args[:result])
   end
 

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -621,7 +621,7 @@ class AccountControllerTest < FunctionalTestCase
     }
     File.stub(:rename, false) do
       login("rolf", "testpassword")
-      post_with_dump(:profile, params)
+      post_with_dump(:profile, params: params)
     end
     assert_redirected_to(user_path(rolf.id))
     assert_flash_success

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -621,7 +621,7 @@ class AccountControllerTest < FunctionalTestCase
     }
     File.stub(:rename, false) do
       login("rolf", "testpassword")
-      post_with_dump(:profile, params: params)
+      post(:profile, params: params)
     end
     assert_redirected_to(user_path(rolf.id))
     assert_flash_success

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -4,15 +4,6 @@ require("test_helper")
 
 # Controller tests for info pages
 class AdminControllerTest < FunctionalTestCase
-  # Prove w3c_tests renders html, with all content within the <body>
-  # (and therefore without MO's layout).
-  def test_w3c_tests
-    login
-    expect_start = "<html><head></head><body>"
-    get(:w3c_tests)
-    assert_equal(expect_start, @response.body[0..(expect_start.size - 1)])
-  end
-
   def test_change_banner
     use_test_locales do
       # Oops!  One of these tags actually exists now!

--- a/test/controllers/collection_number_controller_test.rb
+++ b/test/controllers/collection_number_controller_test.rb
@@ -13,7 +13,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     obs = observations(:minimal_unknown_obs)
     assert_equal(1, obs.collection_numbers.count)
     login
-    get_with_dump(:observation_index, id: obs.id)
+    get_with_dump(:observation_index, params: { id: obs.id })
     assert_template(:list_collection_numbers)
     assert_no_flash
   end
@@ -22,7 +22,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     obs = observations(:detailed_unknown_obs)
     assert_operator(obs.collection_numbers.count, :>, 1)
     login
-    get_with_dump(:observation_index, id: obs.id)
+    get_with_dump(:observation_index, params: { id: obs.id })
     assert_template(:list_collection_numbers)
     assert_no_flash
   end
@@ -31,7 +31,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     obs = observations(:strobilurus_diminutivus_obs)
     assert_empty(obs.collection_numbers)
     login
-    get_with_dump(:observation_index, id: obs.id)
+    get_with_dump(:observation_index, params: { id: obs.id })
     assert_template(:list_collection_numbers)
     assert_flash_text(/no matching collection numbers found/i)
   end
@@ -58,7 +58,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     numbers = CollectionNumber.where("name like '%neighbor%'")
     assert_equal(1, numbers.count)
     login
-    get_with_dump(:collection_number_search, pattern: "neighbor")
+    get_with_dump(:collection_number_search, params: { pattern: "neighbor" })
     query_record = QueryRecord.last
     assert_redirected_to(action: :show_collection_number,
                          id: numbers.first.id, q: query_record.id.alphabetize)
@@ -82,7 +82,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     get(:show_collection_number, params: { id: "bogus" })
 
     number = collection_numbers(:detailed_unknown_coll_num_two)
-    get_with_dump(:show_collection_number, id: number.id)
+    get_with_dump(:show_collection_number, params: { id: number.id })
   end
 
   def test_next_and_prev_collection_number
@@ -113,7 +113,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:create_collection_number, id: obs.id)
+    get_with_dump(:create_collection_number, params: { id: obs.id })
     assert_response(:success)
     assert_template("create_collection_number", partial: "_rss_log")
     assert(assigns(:collection_number))
@@ -251,7 +251,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:edit_collection_number, id: number.id)
+    get_with_dump(:edit_collection_number, params: { id: number.id })
     assert_response(:success)
     assert_template("edit_collection_number", partial: "_rss_log")
     assert_objs_equal(number, assigns(:collection_number))

--- a/test/controllers/collection_number_controller_test.rb
+++ b/test/controllers/collection_number_controller_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class CollectionNumberControllerTest < FunctionalTestCase
   def test_collection_index
     login
-    get_with_dump(:list_collection_numbers)
+    get(:list_collection_numbers)
     assert_template(:list_collection_numbers)
   end
 
@@ -13,7 +13,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     obs = observations(:minimal_unknown_obs)
     assert_equal(1, obs.collection_numbers.count)
     login
-    get_with_dump(:observation_index, params: { id: obs.id })
+    get(:observation_index, params: { id: obs.id })
     assert_template(:list_collection_numbers)
     assert_no_flash
   end
@@ -22,7 +22,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     obs = observations(:detailed_unknown_obs)
     assert_operator(obs.collection_numbers.count, :>, 1)
     login
-    get_with_dump(:observation_index, params: { id: obs.id })
+    get(:observation_index, params: { id: obs.id })
     assert_template(:list_collection_numbers)
     assert_no_flash
   end
@@ -31,7 +31,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     obs = observations(:strobilurus_diminutivus_obs)
     assert_empty(obs.collection_numbers)
     login
-    get_with_dump(:observation_index, params: { id: obs.id })
+    get(:observation_index, params: { id: obs.id })
     assert_template(:list_collection_numbers)
     assert_flash_text(/no matching collection numbers found/i)
   end
@@ -58,7 +58,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     numbers = CollectionNumber.where("name like '%neighbor%'")
     assert_equal(1, numbers.count)
     login
-    get_with_dump(:collection_number_search, params: { pattern: "neighbor" })
+    get(:collection_number_search, params: { pattern: "neighbor" })
     query_record = QueryRecord.last
     assert_redirected_to(action: :show_collection_number,
                          id: numbers.first.id, q: query_record.id.alphabetize)
@@ -82,7 +82,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     get(:show_collection_number, params: { id: "bogus" })
 
     number = collection_numbers(:detailed_unknown_coll_num_two)
-    get_with_dump(:show_collection_number, params: { id: number.id })
+    get(:show_collection_number, params: { id: number.id })
   end
 
   def test_next_and_prev_collection_number
@@ -113,7 +113,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:create_collection_number, params: { id: obs.id })
+    get(:create_collection_number, params: { id: obs.id })
     assert_response(:success)
     assert_template("create_collection_number", partial: "_rss_log")
     assert(assigns(:collection_number))
@@ -251,7 +251,7 @@ class CollectionNumberControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:edit_collection_number, params: { id: number.id })
+    get(:edit_collection_number, params: { id: number.id })
     assert_response(:success)
     assert_template("edit_collection_number", partial: "_rss_log")
     assert_objs_equal(number, assigns(:collection_number))

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -12,7 +12,7 @@ class CommentControllerTest < FunctionalTestCase
   def test_show_comment
     login
     get_with_dump(:show_comment,
-                  id: comments(:minimal_unknown_obs_comment_1).id)
+                  params: { id: comments(:minimal_unknown_obs_comment_1).id })
     assert_template("show_comment")
   end
 

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -18,13 +18,13 @@ class CommentControllerTest < FunctionalTestCase
 
   def test_show_comments_for_user
     login
-    get_with_dump(:show_comments_for_user, id: rolf.id)
+    get_with_dump(:show_comments_for_user, params: { id: rolf.id })
     assert_template("list_comments")
   end
 
   def test_show_comments_by_user
     login
-    get_with_dump(:show_comments_by_user, id: rolf.id)
+    get_with_dump(:show_comments_by_user, params: { id: rolf.id })
     assert_redirected_to(action: "show_comment",
                          id: comments(:minimal_unknown_obs_comment_1).id,
                          params: @controller.query_params(QueryRecord.last))

--- a/test/controllers/comment_controller_test.rb
+++ b/test/controllers/comment_controller_test.rb
@@ -5,26 +5,26 @@ require("test_helper")
 class CommentControllerTest < FunctionalTestCase
   def test_list_comments
     login
-    get_with_dump(:list_comments)
+    get(:list_comments)
     assert_template("list_comments")
   end
 
   def test_show_comment
     login
-    get_with_dump(:show_comment,
-                  params: { id: comments(:minimal_unknown_obs_comment_1).id })
+    get(:show_comment,
+        params: { id: comments(:minimal_unknown_obs_comment_1).id })
     assert_template("show_comment")
   end
 
   def test_show_comments_for_user
     login
-    get_with_dump(:show_comments_for_user, params: { id: rolf.id })
+    get(:show_comments_for_user, params: { id: rolf.id })
     assert_template("list_comments")
   end
 
   def test_show_comments_by_user
     login
-    get_with_dump(:show_comments_by_user, params: { id: rolf.id })
+    get(:show_comments_by_user, params: { id: rolf.id })
     assert_redirected_to(action: "show_comment",
                          id: comments(:minimal_unknown_obs_comment_1).id,
                          params: @controller.query_params(QueryRecord.last))

--- a/test/controllers/contributors_controller_test.rb
+++ b/test/controllers/contributors_controller_test.rb
@@ -9,7 +9,7 @@ require("test_helper")
 class ContributorsControllerTest < FunctionalTestCase
   def test_page_load
     login
-    get_with_dump(:index)
+    get(:index)
     assert_template("contributors/_contributor")
   end
 end

--- a/test/controllers/emails_controller_test.rb
+++ b/test/controllers/emails_controller_test.rb
@@ -122,7 +122,7 @@ class EmailsControllerTest < FunctionalTestCase
     assert_flash_text(/denied|only.*admin/i)
 
     make_admin("rolf")
-    post_with_dump(page, params)
+    post_with_dump(page, params: params)
     assert_redirected_to(users_path(by: "name"))
   end
 
@@ -191,7 +191,7 @@ class EmailsControllerTest < FunctionalTestCase
     get(:merge_request, params: params.merge(new_id: -456))
     assert_response(:redirect)
 
-    get_with_dump(:merge_request, params)
+    get_with_dump(:merge_request, params: params)
     assert_response(:success)
     assert_names_equal(name1, assigns(:old_obj))
     assert_names_equal(name2, assigns(:new_obj))

--- a/test/controllers/emails_controller_test.rb
+++ b/test/controllers/emails_controller_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class EmailsControllerTest < FunctionalTestCase
   def test_page_loads
     login
-    get_with_dump(:ask_webmaster_question)
+    get(:ask_webmaster_question)
     assert_template(:ask_webmaster_question)
     assert_form_action(action: :ask_webmaster_question)
   end
@@ -24,7 +24,7 @@ class EmailsControllerTest < FunctionalTestCase
       assert_flash_text(/denied|only.*admin/i)
 
       make_admin("rolf")
-      get_with_dump(page, params)
+      get(page, params: params)
       assert_template(response) # 1
     end
   end
@@ -122,7 +122,7 @@ class EmailsControllerTest < FunctionalTestCase
     assert_flash_text(/denied|only.*admin/i)
 
     make_admin("rolf")
-    post_with_dump(page, params: params)
+    post(page, params: params)
     assert_redirected_to(users_path(by: "name"))
   end
 
@@ -191,7 +191,7 @@ class EmailsControllerTest < FunctionalTestCase
     get(:merge_request, params: params.merge(new_id: -456))
     assert_response(:redirect)
 
-    get_with_dump(:merge_request, params: params)
+    get(:merge_request, params: params)
     assert_response(:success)
     assert_names_equal(name1, assigns(:old_obj))
     assert_names_equal(name2, assigns(:new_obj))

--- a/test/controllers/herbarium_record_controller_test.rb
+++ b/test/controllers/herbarium_record_controller_test.rb
@@ -17,13 +17,15 @@ class HerbariumRecordControllerTest < FunctionalTestCase
 
   def test_herbarium_index
     login
-    get_with_dump(:herbarium_index, id: herbaria(:nybg_herbarium).id)
+    get_with_dump(:herbarium_index,
+                  params: { id: herbaria(:nybg_herbarium).id })
     assert_template(:list_herbarium_records)
   end
 
   def test_herbarium_with_no_herbarium_records_index
     login
-    get_with_dump(:herbarium_index, id: herbaria(:dick_herbarium).id)
+    get_with_dump(:herbarium_index,
+                  params: { id: herbaria(:dick_herbarium).id })
     assert_template(:list_herbarium_records)
     assert_flash_text(/No matching fungarium records found/)
   end
@@ -31,14 +33,14 @@ class HerbariumRecordControllerTest < FunctionalTestCase
   def test_observation_index
     login
     get_with_dump(:observation_index,
-                  id: observations(:coprinus_comatus_obs).id)
+                  params: { id: observations(:coprinus_comatus_obs).id })
     assert_template(:list_herbarium_records)
   end
 
   def test_observation_with_no_herbarium_records_index
     login
     get_with_dump(:observation_index,
-                  id: observations(:strobilurus_diminutivus_obs).id)
+                  params: { id: observations(:strobilurus_diminutivus_obs).id })
     assert_template(:list_herbarium_records)
     assert_flash_text(/No matching fungarium records found/)
   end
@@ -57,7 +59,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
   def test_herbarium_record_search_with_one_herbarium_record_index
     login
     get_with_dump(:herbarium_record_search,
-                  pattern: herbarium_records(:interesting_unknown).id)
+                  params: { pattern: herbarium_records(:interesting_unknown).id })
     assert_response(:redirect)
     assert_no_flash
   end
@@ -75,7 +77,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
     herbarium_record = herbarium_records(:coprinus_comatus_nybg_spec)
     assert(herbarium_record)
     login
-    get_with_dump(:show_herbarium_record, id: herbarium_record.id)
+    get_with_dump(:show_herbarium_record, params: { id: herbarium_record.id })
     assert_template(:show_herbarium_record)
     assert_template("shared/_matrix_box")
   end
@@ -84,7 +86,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
     herbarium_record = herbarium_records(:interesting_unknown)
     assert(herbarium_record)
     login
-    get_with_dump(:show_herbarium_record, id: herbarium_record.id)
+    get_with_dump(:show_herbarium_record, params: { id: herbarium_record.id })
     assert_template(:show_herbarium_record)
     assert_template("shared/_matrix_box")
   end
@@ -111,7 +113,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
 
     login("rolf")
     get_with_dump(:create_herbarium_record,
-                  id: observations(:coprinus_comatus_obs).id)
+                  params: { id: observations(:coprinus_comatus_obs).id })
     assert_template("create_herbarium_record")
     assert_template("shared/_matrix_box")
     assert(assigns(:herbarium_record))
@@ -215,20 +217,20 @@ class HerbariumRecordControllerTest < FunctionalTestCase
 
   def test_edit_herbarium_record
     nybg = herbarium_records(:coprinus_comatus_nybg_spec)
-    get_with_dump(:edit_herbarium_record, id: nybg.id)
+    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
     assert_response(:redirect)
 
     login("mary") # Non-curator
-    get_with_dump(:edit_herbarium_record, id: nybg.id)
+    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
     assert_flash_text(/permission denied/i)
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:edit_herbarium_record, id: nybg.id)
+    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
     assert_template(:edit_herbarium_record)
 
     make_admin("mary") # Non-curator, but an admin
-    get_with_dump(:edit_herbarium_record, id: nybg.id)
+    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
     assert_template(:edit_herbarium_record)
   end
 

--- a/test/controllers/herbarium_record_controller_test.rb
+++ b/test/controllers/herbarium_record_controller_test.rb
@@ -17,30 +17,30 @@ class HerbariumRecordControllerTest < FunctionalTestCase
 
   def test_herbarium_index
     login
-    get_with_dump(:herbarium_index,
-                  params: { id: herbaria(:nybg_herbarium).id })
+    get(:herbarium_index,
+        params: { id: herbaria(:nybg_herbarium).id })
     assert_template(:list_herbarium_records)
   end
 
   def test_herbarium_with_no_herbarium_records_index
     login
-    get_with_dump(:herbarium_index,
-                  params: { id: herbaria(:dick_herbarium).id })
+    get(:herbarium_index,
+        params: { id: herbaria(:dick_herbarium).id })
     assert_template(:list_herbarium_records)
     assert_flash_text(/No matching fungarium records found/)
   end
 
   def test_observation_index
     login
-    get_with_dump(:observation_index,
-                  params: { id: observations(:coprinus_comatus_obs).id })
+    get(:observation_index,
+        params: { id: observations(:coprinus_comatus_obs).id })
     assert_template(:list_herbarium_records)
   end
 
   def test_observation_with_no_herbarium_records_index
     login
-    get_with_dump(:observation_index,
-                  params: { id: observations(:strobilurus_diminutivus_obs).id })
+    get(:observation_index,
+        params: { id: observations(:strobilurus_diminutivus_obs).id })
     assert_template(:list_herbarium_records)
     assert_flash_text(/No matching fungarium records found/)
   end
@@ -59,7 +59,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
   def test_herbarium_record_search_with_one_herbarium_record_index
     login
     params = { pattern: herbarium_records(:interesting_unknown).id }
-    get_with_dump(:herbarium_record_search, params: params)
+    get(:herbarium_record_search, params: params)
     assert_response(:redirect)
     assert_no_flash
   end
@@ -77,7 +77,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
     herbarium_record = herbarium_records(:coprinus_comatus_nybg_spec)
     assert(herbarium_record)
     login
-    get_with_dump(:show_herbarium_record, params: { id: herbarium_record.id })
+    get(:show_herbarium_record, params: { id: herbarium_record.id })
     assert_template(:show_herbarium_record)
     assert_template("shared/_matrix_box")
   end
@@ -86,7 +86,7 @@ class HerbariumRecordControllerTest < FunctionalTestCase
     herbarium_record = herbarium_records(:interesting_unknown)
     assert(herbarium_record)
     login
-    get_with_dump(:show_herbarium_record, params: { id: herbarium_record.id })
+    get(:show_herbarium_record, params: { id: herbarium_record.id })
     assert_template(:show_herbarium_record)
     assert_template("shared/_matrix_box")
   end
@@ -112,8 +112,8 @@ class HerbariumRecordControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:create_herbarium_record,
-                  params: { id: observations(:coprinus_comatus_obs).id })
+    get(:create_herbarium_record,
+        params: { id: observations(:coprinus_comatus_obs).id })
     assert_template("create_herbarium_record")
     assert_template("shared/_matrix_box")
     assert(assigns(:herbarium_record))
@@ -217,20 +217,20 @@ class HerbariumRecordControllerTest < FunctionalTestCase
 
   def test_edit_herbarium_record
     nybg = herbarium_records(:coprinus_comatus_nybg_spec)
-    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
+    get(:edit_herbarium_record, params: { id: nybg.id })
     assert_response(:redirect)
 
     login("mary") # Non-curator
-    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
+    get(:edit_herbarium_record, params: { id: nybg.id })
     assert_flash_text(/permission denied/i)
     assert_response(:redirect)
 
     login("rolf")
-    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
+    get(:edit_herbarium_record, params: { id: nybg.id })
     assert_template(:edit_herbarium_record)
 
     make_admin("mary") # Non-curator, but an admin
-    get_with_dump(:edit_herbarium_record, params: { id: nybg.id })
+    get(:edit_herbarium_record, params: { id: nybg.id })
     assert_template(:edit_herbarium_record)
   end
 

--- a/test/controllers/herbarium_record_controller_test.rb
+++ b/test/controllers/herbarium_record_controller_test.rb
@@ -58,8 +58,8 @@ class HerbariumRecordControllerTest < FunctionalTestCase
 
   def test_herbarium_record_search_with_one_herbarium_record_index
     login
-    get_with_dump(:herbarium_record_search,
-                  params: { pattern: herbarium_records(:interesting_unknown).id })
+    params = { pattern: herbarium_records(:interesting_unknown).id }
+    get_with_dump(:herbarium_record_search, params: params)
     assert_response(:redirect)
     assert_no_flash
   end

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -772,7 +772,7 @@ class ImageControllerTest < FunctionalTestCase
                          id: obs.id)
 
     login("rolf", "testpassword")
-    send(:get_with_dump, :reuse_image, params)
+    send(:get_with_dump, :reuse_image, params: params)
     assert_response(:success)
     assert_form_action(action: :reuse_image, mode: "observation",
                        obs_id: obs.id)
@@ -829,7 +829,7 @@ class ImageControllerTest < FunctionalTestCase
     assert_not(obs.reload.images.member?(image))
 
     login(owner)
-    get_with_dump(:reuse_image, params)
+    get_with_dump(:reuse_image, params: params)
     # assert_template(controller: :observations, action: :show)
     assert_redirected_to(controller: :observations, action: :show,
                          id: obs.id)
@@ -846,7 +846,7 @@ class ImageControllerTest < FunctionalTestCase
       img_id: image.id.to_s
     }
     login("mary")
-    get_with_dump(:reuse_image_for_glossary_term, params)
+    get_with_dump(:reuse_image_for_glossary_term, params: params)
     assert_redirected_to(glossary_term_path(glossary_term.id))
     assert(glossary_term.reload.images.member?(image))
   end
@@ -929,7 +929,7 @@ class ImageControllerTest < FunctionalTestCase
     }
     File.stub(:rename, false) do
       login("rolf", "testpassword")
-      post_with_dump(:add_image, params)
+      post_with_dump(:add_image, params: params)
     end
     assert_equal(20, rolf.reload.contribution)
     assert(obs.reload.images.size == (img_count + 1))

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class ImageControllerTest < FunctionalTestCase
   def test_list_images
     login
-    get_with_dump(:list_images)
+    get(:list_images)
     assert_template("list_images", partial: "_image")
   end
 
@@ -19,7 +19,7 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_images_by_user
     login
-    get_with_dump(:images_by_user, params: { id: rolf.id })
+    get(:images_by_user, params: { id: rolf.id })
     assert_template("list_images", partial: "_image")
   end
 
@@ -44,14 +44,14 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_images_for_project
     login
-    get_with_dump(:images_for_project,
-                  params: { id: projects(:bolete_project).id })
+    get(:images_for_project,
+        params: { id: projects(:bolete_project).id })
     assert_template("list_images", partial: "_image")
   end
 
   def test_next_image
     login
-    get_with_dump(:next_image, params: { id: images(:turned_over_image).id })
+    get(:next_image, params: { id: images(:turned_over_image).id })
     # Default sort order is inverse chronological (created_at DESC, id DESC).
     # So here, "next" image is one created immediately previously.
     assert_redirected_to(%r{show_image/#{images(:in_situ_image).id}[\b|?]})
@@ -156,7 +156,7 @@ class ImageControllerTest < FunctionalTestCase
   def test_prev_image
     login
     # oldest image
-    get_with_dump(:prev_image, params: { id: images(:in_situ_image).id })
+    get(:prev_image, params: { id: images(:in_situ_image).id })
     # so "prev" is the 2nd oldest
     assert_redirected_to(%r{show_image/#{images(:turned_over_image).id}[\b|?]})
   end
@@ -222,7 +222,7 @@ class ImageControllerTest < FunctionalTestCase
   def test_show_original
     img_id = images(:in_situ_image).id
     login
-    get_with_dump(:show_original, params: { id: img_id })
+    get(:show_original, params: { id: img_id })
     assert_redirected_to(action: "show_image", size: "full_size", id: img_id)
   end
 
@@ -371,12 +371,12 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_image_search
     login
-    get_with_dump(:image_search, params: { pattern: "Notes" })
+    get(:image_search, params: { pattern: "Notes" })
     assert_template("list_images", partial: "_image")
     assert_equal(:query_title_pattern_search.t(types: "Images",
                                                pattern: "Notes"),
                  @controller.instance_variable_get(:@title))
-    get_with_dump(:image_search, params: { pattern: "Notes", page: 2 })
+    get(:image_search, params: { pattern: "Notes", page: 2 })
     assert_template("list_images")
     assert_equal(:query_title_pattern_search.t(types: "Images",
                                                pattern: "Notes"),
@@ -385,14 +385,14 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_image_search_next
     login
-    get_with_dump(:image_search, params: { pattern: "Notes" })
+    get(:image_search, params: { pattern: "Notes" })
     assert_template("list_images", partial: "_image")
   end
 
   def test_image_search_by_number
     img_id = images(:commercial_inquiry_image).id
     login
-    get_with_dump(:image_search, params: { pattern: img_id })
+    get(:image_search, params: { pattern: img_id })
     assert_redirected_to(action: "show_image", id: img_id)
   end
 
@@ -434,8 +434,8 @@ class ImageControllerTest < FunctionalTestCase
     assert_form_action(action: "add_image",
                        id: observations(:coprinus_comatus_obs).id)
     # Check that image cannot be added to an observation the user doesn't own.
-    get_with_dump(:add_image,
-                  params: { id: observations(:minimal_unknown_obs).id })
+    get(:add_image,
+        params: { id: observations(:minimal_unknown_obs).id })
     assert_redirected_to(controller: :observations, action: :show)
   end
 
@@ -772,7 +772,7 @@ class ImageControllerTest < FunctionalTestCase
                          id: obs.id)
 
     login("rolf", "testpassword")
-    send(:get_with_dump, :reuse_image, params: params)
+    send(:get, :reuse_image, params: params)
     assert_response(:success)
     assert_form_action(action: :reuse_image, mode: "observation",
                        obs_id: obs.id)
@@ -829,7 +829,7 @@ class ImageControllerTest < FunctionalTestCase
     assert_not(obs.reload.images.member?(image))
 
     login(owner)
-    get_with_dump(:reuse_image, params: params)
+    get(:reuse_image, params: params)
     # assert_template(controller: :observations, action: :show)
     assert_redirected_to(controller: :observations, action: :show,
                          id: obs.id)
@@ -846,7 +846,7 @@ class ImageControllerTest < FunctionalTestCase
       img_id: image.id.to_s
     }
     login("mary")
-    get_with_dump(:reuse_image_for_glossary_term, params: params)
+    get(:reuse_image_for_glossary_term, params: params)
     assert_redirected_to(glossary_term_path(glossary_term.id))
     assert(glossary_term.reload.images.member?(image))
   end
@@ -929,7 +929,7 @@ class ImageControllerTest < FunctionalTestCase
     }
     File.stub(:rename, false) do
       login("rolf", "testpassword")
-      post_with_dump(:add_image, params: params)
+      post(:add_image, params: params)
     end
     assert_equal(20, rolf.reload.contribution)
     assert(obs.reload.images.size == (img_count + 1))

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -19,7 +19,7 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_images_by_user
     login
-    get_with_dump(:images_by_user, id: rolf.id)
+    get_with_dump(:images_by_user, params: { id: rolf.id })
     assert_template("list_images", partial: "_image")
   end
 
@@ -44,13 +44,14 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_images_for_project
     login
-    get_with_dump(:images_for_project, id: projects(:bolete_project).id)
+    get_with_dump(:images_for_project,
+                  params: { id: projects(:bolete_project).id })
     assert_template("list_images", partial: "_image")
   end
 
   def test_next_image
     login
-    get_with_dump(:next_image, id: images(:turned_over_image).id)
+    get_with_dump(:next_image, params: { id: images(:turned_over_image).id })
     # Default sort order is inverse chronological (created_at DESC, id DESC).
     # So here, "next" image is one created immediately previously.
     assert_redirected_to(%r{show_image/#{images(:in_situ_image).id}[\b|?]})
@@ -154,7 +155,8 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_prev_image
     login
-    get_with_dump(:prev_image, id: images(:in_situ_image).id) # oldest image
+    # oldest image
+    get_with_dump(:prev_image, params: { id: images(:in_situ_image).id })
     # so "prev" is the 2nd oldest
     assert_redirected_to(%r{show_image/#{images(:turned_over_image).id}[\b|?]})
   end
@@ -220,7 +222,7 @@ class ImageControllerTest < FunctionalTestCase
   def test_show_original
     img_id = images(:in_situ_image).id
     login
-    get_with_dump(:show_original, id: img_id)
+    get_with_dump(:show_original, params: { id: img_id })
     assert_redirected_to(action: "show_image", size: "full_size", id: img_id)
   end
 
@@ -369,12 +371,12 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_image_search
     login
-    get_with_dump(:image_search, pattern: "Notes")
+    get_with_dump(:image_search, params: { pattern: "Notes" })
     assert_template("list_images", partial: "_image")
     assert_equal(:query_title_pattern_search.t(types: "Images",
                                                pattern: "Notes"),
                  @controller.instance_variable_get(:@title))
-    get_with_dump(:image_search, pattern: "Notes", page: 2)
+    get_with_dump(:image_search, params: { pattern: "Notes", page: 2 })
     assert_template("list_images")
     assert_equal(:query_title_pattern_search.t(types: "Images",
                                                pattern: "Notes"),
@@ -383,14 +385,14 @@ class ImageControllerTest < FunctionalTestCase
 
   def test_image_search_next
     login
-    get_with_dump(:image_search, pattern: "Notes")
+    get_with_dump(:image_search, params: { pattern: "Notes" })
     assert_template("list_images", partial: "_image")
   end
 
   def test_image_search_by_number
     img_id = images(:commercial_inquiry_image).id
     login
-    get_with_dump(:image_search, pattern: img_id)
+    get_with_dump(:image_search, params: { pattern: img_id })
     assert_redirected_to(action: "show_image", id: img_id)
   end
 
@@ -432,7 +434,8 @@ class ImageControllerTest < FunctionalTestCase
     assert_form_action(action: "add_image",
                        id: observations(:coprinus_comatus_obs).id)
     # Check that image cannot be added to an observation the user doesn't own.
-    get_with_dump(:add_image, id: observations(:minimal_unknown_obs).id)
+    get_with_dump(:add_image,
+                  params: { id: observations(:minimal_unknown_obs).id })
     assert_redirected_to(controller: :observations, action: :show)
   end
 

--- a/test/controllers/info_controller_test.rb
+++ b/test/controllers/info_controller_test.rb
@@ -6,22 +6,22 @@ require("test_helper")
 class InfoControllerTest < FunctionalTestCase
   def test_page_loads
     login
-    get_with_dump(:how_to_help)
+    get(:how_to_help)
     assert_template(:how_to_help)
 
-    get_with_dump(:how_to_use)
+    get(:how_to_use)
     assert_template(:how_to_use)
 
-    get_with_dump(:intro)
+    get(:intro)
     assert_template(:intro)
 
     get(:search_bar_help)
     assert_response(:success)
 
-    get_with_dump(:news)
+    get(:news)
     assert_template(:news)
 
-    get_with_dump(:textile_sandbox)
+    get(:textile_sandbox)
     assert_template(:textile_sandbox)
   end
 

--- a/test/controllers/interest_controller_test.rb
+++ b/test/controllers/interest_controller_test.rb
@@ -11,7 +11,7 @@ class InterestControllerTest < FunctionalTestCase
                     user: rolf, state: true)
     Interest.create(target: names(:agaricus_campestris), user: rolf,
                     state: true)
-    get_with_dump(:list_interests)
+    get(:list_interests)
     assert_template("list_interests")
   end
 

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -92,7 +92,7 @@ class LocationControllerTest < FunctionalTestCase
   ##############################################################################
 
   def test_location_help
-    get_with_dump(:help)
+    get(:help)
   end
 
   def test_show_location
@@ -100,7 +100,7 @@ class LocationControllerTest < FunctionalTestCase
     updated_at = location.updated_at
     log_updated_at = location.rss_log.updated_at
     login
-    get_with_dump(:show_location, params: { id: location.id })
+    get(:show_location, params: { id: location.id })
     assert_template("show_location")
     assert_template("location/_location")
     assert_template("comment/_show_comments")
@@ -115,26 +115,26 @@ class LocationControllerTest < FunctionalTestCase
     login("mary")
     make_admin("mary")
     location = locations(:albion)
-    get_with_dump(:show_location, params: { id: location.id })
+    get(:show_location, params: { id: location.id })
   end
 
   def test_show_past_location
     location = locations(:albion)
     login
-    get_with_dump(:show_past_location,
-                  params: { id: location.id, version: location.version - 1 })
+    get(:show_past_location,
+        params: { id: location.id, version: location.version - 1 })
     assert_template("show_past_location", partial: "_location")
   end
 
   def test_show_past_location_no_version
     location = locations(:albion)
-    get_with_dump(:show_past_location, params: { id: location.id })
+    get(:show_past_location, params: { id: location.id })
     assert_response(:redirect)
   end
 
   def test_list_locations
     login
-    get_with_dump(:list_locations)
+    get(:list_locations)
     assert_template("list_locations")
   end
 
@@ -175,19 +175,19 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_list_countries
     login
-    get_with_dump(:list_countries)
+    get(:list_countries)
     assert_template("list_countries")
   end
 
   def test_list_by_country
     login
-    get_with_dump(:list_by_country, params: { country: "USA" })
+    get(:list_by_country, params: { country: "USA" })
     assert_template("list_locations")
   end
 
   def test_list_by_country_with_quote
     login
-    get_with_dump(:list_by_country, params: { country: "Cote d'Ivoire" })
+    get(:list_by_country, params: { country: "Cote d'Ivoire" })
     assert_template("list_locations")
   end
 
@@ -233,13 +233,13 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_locations_by_user
     login
-    get_with_dump(:locations_by_user, params: { id: rolf.id })
+    get(:locations_by_user, params: { id: rolf.id })
     assert_template("list_locations")
   end
 
   def test_locations_by_editor
     login
-    get_with_dump(:locations_by_editor, params: { id: rolf.id })
+    get(:locations_by_editor, params: { id: rolf.id })
     assert_template("list_locations")
   end
 
@@ -250,14 +250,14 @@ class LocationControllerTest < FunctionalTestCase
       location_id: burbank.id,
       source_type: "public"
     )
-    get_with_dump(:list_location_descriptions)
+    get(:list_location_descriptions)
     assert_template("list_location_descriptions")
   end
 
   def test_location_descriptions_by_author
     desc = location_descriptions(:albion_desc)
     login
-    get_with_dump(:location_descriptions_by_author, params: { id: rolf.id })
+    get(:location_descriptions_by_author, params: { id: rolf.id })
     assert_redirected_to(
       %r{/location/show_location_description/#{desc.id}}
     )
@@ -265,7 +265,7 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_location_descriptions_by_editor
     login
-    get_with_dump(:location_descriptions_by_editor, params: { id: rolf.id })
+    get(:location_descriptions_by_editor, params: { id: rolf.id })
     assert_template("list_location_descriptions")
   end
 
@@ -273,7 +273,7 @@ class LocationControllerTest < FunctionalTestCase
     # happy path
     desc = location_descriptions(:albion_desc)
     login
-    get_with_dump(:show_location_description, params: { id: desc.id })
+    get(:show_location_description, params: { id: desc.id })
     assert_template("show_location_description")
     assert_template("location/_location_description")
 
@@ -282,7 +282,7 @@ class LocationControllerTest < FunctionalTestCase
 
     # description is private and belongs to a project
     desc = location_descriptions(:bolete_project_private_location_desc)
-    get_with_dump(:show_location_description, params: { id: desc.id })
+    get(:show_location_description, params: { id: desc.id })
     assert_flash_error
     assert_redirected_to(controller: :project, action: :show_project,
                          id: desc.project.id)
@@ -290,13 +290,13 @@ class LocationControllerTest < FunctionalTestCase
     # description is private, for a project, project doesn't exist
     # but project doesn't existb
     desc = location_descriptions(:non_ex_project_private_location_desc)
-    get_with_dump(:show_location_description, params: { id: desc.id })
+    get(:show_location_description, params: { id: desc.id })
     assert_flash_error
     assert_redirected_to(action: :show_location, id: desc.location_id)
 
     # description is private, not for a project
     desc = location_descriptions(:user_private_location_desc)
-    get_with_dump(:show_location_description, params: { id: desc.id })
+    get(:show_location_description, params: { id: desc.id })
     assert_flash_error
     assert_redirected_to(action: :show_location, id: desc.location_id)
   end
@@ -309,7 +309,7 @@ class LocationControllerTest < FunctionalTestCase
     desc.reload
     new_versions = desc.versions.length
     assert(new_versions > old_versions)
-    get_with_dump(:show_past_location_description, params: { id: desc.id })
+    get(:show_past_location_description, params: { id: desc.id })
     assert_template("show_past_location_description",
                     partial: "_location_description")
   end
@@ -350,7 +350,7 @@ class LocationControllerTest < FunctionalTestCase
     loc = locations(:albion)
     user = login(users(:spammer).name)
     assert_false(user.successful_contributor?)
-    get_with_dump(:create_location_description, params: { id: loc.id })
+    get(:create_location_description, params: { id: loc.id })
     assert_response(:redirect)
   end
 
@@ -690,7 +690,7 @@ class LocationControllerTest < FunctionalTestCase
     past_descs_to_go = 0
 
     make_admin("rolf")
-    post_with_dump(:edit_location, params: params)
+    post(:edit_location, params: params)
 
     # assert_template(action: "show_location")
     assert_redirected_to(action: :show_location, id: to_stay.id)
@@ -843,15 +843,15 @@ class LocationControllerTest < FunctionalTestCase
   def test_map_locations
     login
     # test_map_locations - map everything
-    get_with_dump(:map_locations)
+    get(:map_locations)
     assert_template("map_locations")
 
     # test_map_locations_empty - map nothing
-    get_with_dump(:map_locations, params: { pattern: "Never Never Land" })
+    get(:map_locations, params: { pattern: "Never Never Land" })
     assert_template("map_locations")
 
     # test_map_locations_some - map something
-    get_with_dump(:map_locations, params: { pattern: "California" })
+    get(:map_locations, params: { pattern: "California" })
     assert_template("map_locations")
   end
 

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -356,7 +356,7 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_edit_location_description
     desc = location_descriptions(:albion_desc)
-    requires_login(:edit_location_description, params: { id: desc.id })
+    requires_login(:edit_location_description, { id: desc.id })
     assert_form_action(action: :edit_location_description, id: desc.id)
   end
 
@@ -690,7 +690,7 @@ class LocationControllerTest < FunctionalTestCase
     past_descs_to_go = 0
 
     make_admin("rolf")
-    post_with_dump(:edit_location, params)
+    post_with_dump(:edit_location, params: params)
 
     # assert_template(action: "show_location")
     assert_redirected_to(action: :show_location, id: to_stay.id)

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -100,7 +100,7 @@ class LocationControllerTest < FunctionalTestCase
     updated_at = location.updated_at
     log_updated_at = location.rss_log.updated_at
     login
-    get_with_dump(:show_location, id: location.id)
+    get_with_dump(:show_location, params: { id: location.id })
     assert_template("show_location")
     assert_template("location/_location")
     assert_template("comment/_show_comments")
@@ -115,20 +115,20 @@ class LocationControllerTest < FunctionalTestCase
     login("mary")
     make_admin("mary")
     location = locations(:albion)
-    get_with_dump(:show_location, id: location.id)
+    get_with_dump(:show_location, params: { id: location.id })
   end
 
   def test_show_past_location
     location = locations(:albion)
     login
-    get_with_dump(:show_past_location, id: location.id,
-                                       version: location.version - 1)
+    get_with_dump(:show_past_location,
+                  params: { id: location.id, version: location.version - 1 })
     assert_template("show_past_location", partial: "_location")
   end
 
   def test_show_past_location_no_version
     location = locations(:albion)
-    get_with_dump(:show_past_location, id: location.id)
+    get_with_dump(:show_past_location, params: { id: location.id })
     assert_response(:redirect)
   end
 
@@ -181,13 +181,13 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_list_by_country
     login
-    get_with_dump(:list_by_country, country: "USA")
+    get_with_dump(:list_by_country, params: { country: "USA" })
     assert_template("list_locations")
   end
 
   def test_list_by_country_with_quote
     login
-    get_with_dump(:list_by_country, country: "Cote d'Ivoire")
+    get_with_dump(:list_by_country, params: { country: "Cote d'Ivoire" })
     assert_template("list_locations")
   end
 
@@ -233,13 +233,13 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_locations_by_user
     login
-    get_with_dump(:locations_by_user, id: rolf.id)
+    get_with_dump(:locations_by_user, params: { id: rolf.id })
     assert_template("list_locations")
   end
 
   def test_locations_by_editor
     login
-    get_with_dump(:locations_by_editor, id: rolf.id)
+    get_with_dump(:locations_by_editor, params: { id: rolf.id })
     assert_template("list_locations")
   end
 
@@ -257,7 +257,7 @@ class LocationControllerTest < FunctionalTestCase
   def test_location_descriptions_by_author
     desc = location_descriptions(:albion_desc)
     login
-    get_with_dump(:location_descriptions_by_author, id: rolf.id)
+    get_with_dump(:location_descriptions_by_author, params: { id: rolf.id })
     assert_redirected_to(
       %r{/location/show_location_description/#{desc.id}}
     )
@@ -265,7 +265,7 @@ class LocationControllerTest < FunctionalTestCase
 
   def test_location_descriptions_by_editor
     login
-    get_with_dump(:location_descriptions_by_editor, id: rolf.id)
+    get_with_dump(:location_descriptions_by_editor, params: { id: rolf.id })
     assert_template("list_location_descriptions")
   end
 
@@ -273,7 +273,7 @@ class LocationControllerTest < FunctionalTestCase
     # happy path
     desc = location_descriptions(:albion_desc)
     login
-    get_with_dump(:show_location_description, id: desc.id)
+    get_with_dump(:show_location_description, params: { id: desc.id })
     assert_template("show_location_description")
     assert_template("location/_location_description")
 
@@ -282,7 +282,7 @@ class LocationControllerTest < FunctionalTestCase
 
     # description is private and belongs to a project
     desc = location_descriptions(:bolete_project_private_location_desc)
-    get_with_dump(:show_location_description, id: desc.id)
+    get_with_dump(:show_location_description, params: { id: desc.id })
     assert_flash_error
     assert_redirected_to(controller: :project, action: :show_project,
                          id: desc.project.id)
@@ -290,13 +290,13 @@ class LocationControllerTest < FunctionalTestCase
     # description is private, for a project, project doesn't exist
     # but project doesn't existb
     desc = location_descriptions(:non_ex_project_private_location_desc)
-    get_with_dump(:show_location_description, id: desc.id)
+    get_with_dump(:show_location_description, params: { id: desc.id })
     assert_flash_error
     assert_redirected_to(action: :show_location, id: desc.location_id)
 
     # description is private, not for a project
     desc = location_descriptions(:user_private_location_desc)
-    get_with_dump(:show_location_description, id: desc.id)
+    get_with_dump(:show_location_description, params: { id: desc.id })
     assert_flash_error
     assert_redirected_to(action: :show_location, id: desc.location_id)
   end
@@ -309,7 +309,7 @@ class LocationControllerTest < FunctionalTestCase
     desc.reload
     new_versions = desc.versions.length
     assert(new_versions > old_versions)
-    get_with_dump(:show_past_location_description, id: desc.id)
+    get_with_dump(:show_past_location_description, params: { id: desc.id })
     assert_template("show_past_location_description",
                     partial: "_location_description")
   end
@@ -350,13 +350,13 @@ class LocationControllerTest < FunctionalTestCase
     loc = locations(:albion)
     user = login(users(:spammer).name)
     assert_false(user.successful_contributor?)
-    get_with_dump(:create_location_description, id: loc.id)
+    get_with_dump(:create_location_description, params: { id: loc.id })
     assert_response(:redirect)
   end
 
   def test_edit_location_description
     desc = location_descriptions(:albion_desc)
-    requires_login(:edit_location_description, id: desc.id)
+    requires_login(:edit_location_description, params: { id: desc.id })
     assert_form_action(action: :edit_location_description, id: desc.id)
   end
 
@@ -847,11 +847,11 @@ class LocationControllerTest < FunctionalTestCase
     assert_template("map_locations")
 
     # test_map_locations_empty - map nothing
-    get_with_dump(:map_locations, pattern: "Never Never Land")
+    get_with_dump(:map_locations, params: { pattern: "Never Never Land" })
     assert_template("map_locations")
 
     # test_map_locations_some - map something
-    get_with_dump(:map_locations, pattern: "California")
+    get_with_dump(:map_locations, params: { pattern: "California" })
     assert_template("map_locations")
   end
 

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -607,7 +607,7 @@ class NameControllerTest < FunctionalTestCase
     desc = name_descriptions(:peltigera_desc)
     params = { "id" => desc.id.to_s }
     login
-    get_with_dump(:show_name_description, params)
+    get_with_dump(:show_name_description, params: params)
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -239,7 +239,7 @@ class NameControllerTest < FunctionalTestCase
 
   def test_observation_index_by_letter
     login
-    get_with_dump(:observation_index, letter: "A")
+    get_with_dump(:observation_index, params: { letter: "A" })
     assert_template(:list_names)
   end
 
@@ -252,7 +252,7 @@ class NameControllerTest < FunctionalTestCase
   def test_show_name
     assert_equal(0, QueryRecord.count)
     login
-    get_with_dump(:show_name, id: names(:coprinus_comatus).id)
+    get_with_dump(:show_name, params: { id: names(:coprinus_comatus).id })
     assert_template(:show_name)
     # Creates three for children and all four observations sections,
     # but one never used.
@@ -386,34 +386,34 @@ class NameControllerTest < FunctionalTestCase
   def test_show_name_locked
     name = Name.where(locked: true).first
     login
-    get_with_dump(:show_name, id: name.id)
+    get_with_dump(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     login("rolf")
-    get_with_dump(:show_name, id: name.id)
+    get_with_dump(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     make_admin("mary")
-    get_with_dump(:show_name, id: name.id)
+    get_with_dump(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 1)
     assert_select("a[href*=change_synonyms]", count: 1)
 
     Name.update(name.id, deprecated: true)
     logout
-    get_with_dump(:show_name, id: name.id)
+    get_with_dump(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     login("rolf")
-    get_with_dump(:show_name, id: name.id)
+    get_with_dump(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     make_admin("mary")
-    get_with_dump(:show_name, id: name.id)
+    get_with_dump(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 1)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 1)
@@ -421,13 +421,13 @@ class NameControllerTest < FunctionalTestCase
 
   def test_show_past_name
     login
-    get_with_dump(:show_past_name, id: names(:coprinus_comatus).id)
+    get_with_dump(:show_past_name, params: { id: names(:coprinus_comatus).id })
     assert_template(:show_past_name)
   end
 
   def test_show_past_name_with_misspelling
     login
-    get_with_dump(:show_past_name, id: names(:petigera).id)
+    get_with_dump(:show_past_name, params: { id: names(:petigera).id })
     assert_template(:show_past_name)
   end
 
@@ -503,13 +503,13 @@ class NameControllerTest < FunctionalTestCase
 
   def test_names_by_user
     login
-    get_with_dump(:names_by_user, id: rolf.id)
+    get_with_dump(:names_by_user, params: { id: rolf.id })
     assert_template(:list_names)
   end
 
   def test_names_by_editor
     login
-    get_with_dump(:names_by_editor, id: rolf.id)
+    get_with_dump(:names_by_editor, params: { id: rolf.id })
     assert_template(:list_names)
   end
 
@@ -521,13 +521,13 @@ class NameControllerTest < FunctionalTestCase
 
   def test_name_descriptions_by_author
     login
-    get_with_dump(:name_descriptions_by_author, id: rolf.id)
+    get_with_dump(:name_descriptions_by_author, params: { id: rolf.id })
     assert_template(:list_name_descriptions)
   end
 
   def test_name_descriptions_by_editor
     login
-    get_with_dump(:name_descriptions_by_editor, id: rolf.id)
+    get_with_dump(:name_descriptions_by_editor, params: { id: rolf.id })
     assert_redirected_to(action: :show_name_description,
                          id: name_descriptions(:coprinus_comatus_desc).id,
                          params: @controller.query_params)
@@ -536,19 +536,19 @@ class NameControllerTest < FunctionalTestCase
   def test_name_search
     id = names(:agaricus).id
     login
-    get_with_dump(:name_search, pattern: id)
+    get_with_dump(:name_search, params: { pattern: id })
     assert_redirected_to(action: :show_name, id: id)
   end
 
   def test_name_search_help
     login
-    get_with_dump(:name_search, pattern: "help:me")
+    get_with_dump(:name_search, params: { pattern: "help:me" })
     assert_match(/unexpected term/i, @response.body)
   end
 
   def test_name_search_with_spelling_correction
     login
-    get_with_dump(:name_search, pattern: "agaricis campestrus")
+    get_with_dump(:name_search, params: { pattern: "agaricis campestrus" })
     assert_template(:list_names)
     assert_select("div.alert-warning", 1)
     assert_select("a[href*='show_name/#{names(:agaricus_campestrus).id}']",
@@ -620,7 +620,7 @@ class NameControllerTest < FunctionalTestCase
     desc.reload
     new_versions = desc.versions.length
     assert(new_versions > old_versions)
-    get_with_dump(:show_past_name_description, id: desc.id)
+    get_with_dump(:show_past_name_description, params: { id: desc.id })
     assert_template(:show_past_name_description)
     assert_template("name/_name_description")
   end
@@ -851,21 +851,21 @@ class NameControllerTest < FunctionalTestCase
   # name with Observations that have Locations
   def test_map
     login
-    get_with_dump(:map, id: names(:agaricus_campestris).id)
+    get_with_dump(:map, params: { id: names(:agaricus_campestris).id })
     assert_template(:map)
   end
 
   # name with Observations that don't have Locations
   def test_map_no_loc
     login
-    get_with_dump(:map, id: names(:coprinus_comatus).id)
+    get_with_dump(:map, params: { id: names(:coprinus_comatus).id })
     assert_template(:map)
   end
 
   # name with no Observations
   def test_map_no_obs
     login
-    get_with_dump(:map, id: names(:conocybe_filaris).id)
+    get_with_dump(:map, params: { id: names(:conocybe_filaris).id })
     assert_template(:map)
   end
 
@@ -4379,7 +4379,7 @@ class NameControllerTest < FunctionalTestCase
     login("rolf")
 
     # No interest in this name yet.
-    get_with_dump(:show_name, id: peltigera.id)
+    get_with_dump(:show_name, params: { id: peltigera.id })
     assert_response(:success)
     assert_image_link_in_html(/watch\d*.png/,
                               controller: "interest", action: "set_interest",
@@ -4390,7 +4390,7 @@ class NameControllerTest < FunctionalTestCase
 
     # Turn interest on and make sure there is an icon linked to delete it.
     Interest.create(target: peltigera, user: rolf, state: true)
-    get_with_dump(:show_name, id: peltigera.id)
+    get_with_dump(:show_name, params: { id: peltigera.id })
     assert_response(:success)
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: "interest", action: "set_interest",
@@ -4402,7 +4402,7 @@ class NameControllerTest < FunctionalTestCase
     # Destroy that interest, create new one with interest off.
     Interest.where(user_id: rolf.id).last.destroy
     Interest.create(target: peltigera, user: rolf, state: false)
-    get_with_dump(:show_name, id: peltigera.id)
+    get_with_dump(:show_name, params: { id: peltigera.id })
     assert_response(:success)
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: "interest", action: "set_interest",
@@ -4420,7 +4420,7 @@ class NameControllerTest < FunctionalTestCase
   def test_show_draft
     draft = name_descriptions(:draft_coprinus_comatus)
     login(draft.user.login)
-    get_with_dump(:show_name_description, id: draft.id)
+    get_with_dump(:show_name_description, params: { id: draft.id })
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -4430,7 +4430,7 @@ class NameControllerTest < FunctionalTestCase
     draft = name_descriptions(:draft_coprinus_comatus)
     assert_not_equal(draft.user, mary)
     login(mary.login)
-    get_with_dump(:show_name_description, id: draft.id)
+    get_with_dump(:show_name_description, params: { id: draft.id })
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -4440,7 +4440,7 @@ class NameControllerTest < FunctionalTestCase
     draft = name_descriptions(:draft_agaricus_campestris)
     assert_not_equal(draft.user, katrina)
     login(katrina.login)
-    get_with_dump(:show_name_description, id: draft.id)
+    get_with_dump(:show_name_description, params: { id: draft.id })
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -4452,7 +4452,7 @@ class NameControllerTest < FunctionalTestCase
     assert(draft.belongs_to_project?(project))
     assert_not(project.is_member?(dick))
     login(dick.login)
-    get_with_dump(:show_name_description, id: draft.id)
+    get_with_dump(:show_name_description, params: { id: draft.id })
     assert_redirected_to(project.show_link_args)
   end
 
@@ -4931,7 +4931,7 @@ class NameControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     # Make sure it doesn't crash if id is bogus.
-    get_with_dump(:inherit_classification, id: name.id)
+    get_with_dump(:inherit_classification, params: { id: name.id })
     assert_no_flash
     assert_response(:success)
     assert_template("inherit_classification")
@@ -5046,7 +5046,7 @@ class NameControllerTest < FunctionalTestCase
     assert_textarea_value(:classification, "")
 
     name = names(:agaricus_campestris)
-    get_with_dump(:edit_classification, id: name.id)
+    get_with_dump(:edit_classification, params: { id: name.id })
     assert_response(:success)
     assert_template(:edit_classification)
     assert_textarea_value(:classification, name.classification)

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -209,50 +209,50 @@ class NameControllerTest < FunctionalTestCase
 
   def test_index_name
     login
-    get_with_dump(:index_name)
+    get(:index_name)
     assert_template(:list_names)
   end
 
   def test_name_index
     login
-    get_with_dump(:list_names)
+    get(:list_names)
     assert_template(:list_names)
   end
 
   def test_name_description_index
     login
-    get_with_dump(:list_name_descriptions)
+    get(:list_name_descriptions)
     assert_template(:list_name_descriptions)
   end
 
   def test_index_description_index
     login
-    get_with_dump(:index_name_description)
+    get(:index_name_description)
     assert_template(:list_name_descriptions)
   end
 
   def test_observation_index
     login
-    get_with_dump(:observation_index)
+    get(:observation_index)
     assert_template(:list_names)
   end
 
   def test_observation_index_by_letter
     login
-    get_with_dump(:observation_index, params: { letter: "A" })
+    get(:observation_index, params: { letter: "A" })
     assert_template(:list_names)
   end
 
   def test_authored_names
     login
-    get_with_dump(:authored_names)
+    get(:authored_names)
     assert_template(:list_names)
   end
 
   def test_show_name
     assert_equal(0, QueryRecord.count)
     login
-    get_with_dump(:show_name, params: { id: names(:coprinus_comatus).id })
+    get(:show_name, params: { id: names(:coprinus_comatus).id })
     assert_template(:show_name)
     # Creates three for children and all four observations sections,
     # but one never used.
@@ -386,34 +386,34 @@ class NameControllerTest < FunctionalTestCase
   def test_show_name_locked
     name = Name.where(locked: true).first
     login
-    get_with_dump(:show_name, params: { id: name.id })
+    get(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     login("rolf")
-    get_with_dump(:show_name, params: { id: name.id })
+    get(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     make_admin("mary")
-    get_with_dump(:show_name, params: { id: name.id })
+    get(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 1)
     assert_select("a[href*=change_synonyms]", count: 1)
 
     Name.update(name.id, deprecated: true)
     logout
-    get_with_dump(:show_name, params: { id: name.id })
+    get(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     login("rolf")
-    get_with_dump(:show_name, params: { id: name.id })
+    get(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 0)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 0)
     make_admin("mary")
-    get_with_dump(:show_name, params: { id: name.id })
+    get(:show_name, params: { id: name.id })
     assert_select("a[href*=approve_name]", count: 1)
     assert_select("a[href*=deprecate_name]", count: 0)
     assert_select("a[href*=change_synonyms]", count: 1)
@@ -421,13 +421,13 @@ class NameControllerTest < FunctionalTestCase
 
   def test_show_past_name
     login
-    get_with_dump(:show_past_name, params: { id: names(:coprinus_comatus).id })
+    get(:show_past_name, params: { id: names(:coprinus_comatus).id })
     assert_template(:show_past_name)
   end
 
   def test_show_past_name_with_misspelling
     login
-    get_with_dump(:show_past_name, params: { id: names(:petigera).id })
+    get(:show_past_name, params: { id: names(:petigera).id })
     assert_template(:show_past_name)
   end
 
@@ -503,31 +503,31 @@ class NameControllerTest < FunctionalTestCase
 
   def test_names_by_user
     login
-    get_with_dump(:names_by_user, params: { id: rolf.id })
+    get(:names_by_user, params: { id: rolf.id })
     assert_template(:list_names)
   end
 
   def test_names_by_editor
     login
-    get_with_dump(:names_by_editor, params: { id: rolf.id })
+    get(:names_by_editor, params: { id: rolf.id })
     assert_template(:list_names)
   end
 
   def test_needed_descriptions
     login
-    get_with_dump(:needed_descriptions)
+    get(:needed_descriptions)
     assert_template(:list_names)
   end
 
   def test_name_descriptions_by_author
     login
-    get_with_dump(:name_descriptions_by_author, params: { id: rolf.id })
+    get(:name_descriptions_by_author, params: { id: rolf.id })
     assert_template(:list_name_descriptions)
   end
 
   def test_name_descriptions_by_editor
     login
-    get_with_dump(:name_descriptions_by_editor, params: { id: rolf.id })
+    get(:name_descriptions_by_editor, params: { id: rolf.id })
     assert_redirected_to(action: :show_name_description,
                          id: name_descriptions(:coprinus_comatus_desc).id,
                          params: @controller.query_params)
@@ -536,19 +536,19 @@ class NameControllerTest < FunctionalTestCase
   def test_name_search
     id = names(:agaricus).id
     login
-    get_with_dump(:name_search, params: { pattern: id })
+    get(:name_search, params: { pattern: id })
     assert_redirected_to(action: :show_name, id: id)
   end
 
   def test_name_search_help
     login
-    get_with_dump(:name_search, params: { pattern: "help:me" })
+    get(:name_search, params: { pattern: "help:me" })
     assert_match(/unexpected term/i, @response.body)
   end
 
   def test_name_search_with_spelling_correction
     login
-    get_with_dump(:name_search, params: { pattern: "agaricis campestrus" })
+    get(:name_search, params: { pattern: "agaricis campestrus" })
     assert_template(:list_names)
     assert_select("div.alert-warning", 1)
     assert_select("a[href*='show_name/#{names(:agaricus_campestrus).id}']",
@@ -607,7 +607,7 @@ class NameControllerTest < FunctionalTestCase
     desc = name_descriptions(:peltigera_desc)
     params = { "id" => desc.id.to_s }
     login
-    get_with_dump(:show_name_description, params: params)
+    get(:show_name_description, params: params)
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -620,7 +620,7 @@ class NameControllerTest < FunctionalTestCase
     desc.reload
     new_versions = desc.versions.length
     assert(new_versions > old_versions)
-    get_with_dump(:show_past_name_description, params: { id: desc.id })
+    get(:show_past_name_description, params: { id: desc.id })
     assert_template(:show_past_name_description)
     assert_template("name/_name_description")
   end
@@ -677,7 +677,7 @@ class NameControllerTest < FunctionalTestCase
 
   def test_eol_preview
     login
-    get_with_dump("eol_preview")
+    get("eol_preview")
   end
 
   def ids_from_links(links)
@@ -851,21 +851,21 @@ class NameControllerTest < FunctionalTestCase
   # name with Observations that have Locations
   def test_map
     login
-    get_with_dump(:map, params: { id: names(:agaricus_campestris).id })
+    get(:map, params: { id: names(:agaricus_campestris).id })
     assert_template(:map)
   end
 
   # name with Observations that don't have Locations
   def test_map_no_loc
     login
-    get_with_dump(:map, params: { id: names(:coprinus_comatus).id })
+    get(:map, params: { id: names(:coprinus_comatus).id })
     assert_template(:map)
   end
 
   # name with no Observations
   def test_map_no_obs
     login
-    get_with_dump(:map, params: { id: names(:conocybe_filaris).id })
+    get(:map, params: { id: names(:conocybe_filaris).id })
     assert_template(:map)
   end
 
@@ -4379,7 +4379,7 @@ class NameControllerTest < FunctionalTestCase
     login("rolf")
 
     # No interest in this name yet.
-    get_with_dump(:show_name, params: { id: peltigera.id })
+    get(:show_name, params: { id: peltigera.id })
     assert_response(:success)
     assert_image_link_in_html(/watch\d*.png/,
                               controller: "interest", action: "set_interest",
@@ -4390,7 +4390,7 @@ class NameControllerTest < FunctionalTestCase
 
     # Turn interest on and make sure there is an icon linked to delete it.
     Interest.create(target: peltigera, user: rolf, state: true)
-    get_with_dump(:show_name, params: { id: peltigera.id })
+    get(:show_name, params: { id: peltigera.id })
     assert_response(:success)
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: "interest", action: "set_interest",
@@ -4402,7 +4402,7 @@ class NameControllerTest < FunctionalTestCase
     # Destroy that interest, create new one with interest off.
     Interest.where(user_id: rolf.id).last.destroy
     Interest.create(target: peltigera, user: rolf, state: false)
-    get_with_dump(:show_name, params: { id: peltigera.id })
+    get(:show_name, params: { id: peltigera.id })
     assert_response(:success)
     assert_image_link_in_html(/halfopen\d*.png/,
                               controller: "interest", action: "set_interest",
@@ -4420,7 +4420,7 @@ class NameControllerTest < FunctionalTestCase
   def test_show_draft
     draft = name_descriptions(:draft_coprinus_comatus)
     login(draft.user.login)
-    get_with_dump(:show_name_description, params: { id: draft.id })
+    get(:show_name_description, params: { id: draft.id })
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -4430,7 +4430,7 @@ class NameControllerTest < FunctionalTestCase
     draft = name_descriptions(:draft_coprinus_comatus)
     assert_not_equal(draft.user, mary)
     login(mary.login)
-    get_with_dump(:show_name_description, params: { id: draft.id })
+    get(:show_name_description, params: { id: draft.id })
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -4440,7 +4440,7 @@ class NameControllerTest < FunctionalTestCase
     draft = name_descriptions(:draft_agaricus_campestris)
     assert_not_equal(draft.user, katrina)
     login(katrina.login)
-    get_with_dump(:show_name_description, params: { id: draft.id })
+    get(:show_name_description, params: { id: draft.id })
     assert_template(:show_name_description)
     assert_template("name/_name_description")
   end
@@ -4452,7 +4452,7 @@ class NameControllerTest < FunctionalTestCase
     assert(draft.belongs_to_project?(project))
     assert_not(project.is_member?(dick))
     login(dick.login)
-    get_with_dump(:show_name_description, params: { id: draft.id })
+    get(:show_name_description, params: { id: draft.id })
     assert_redirected_to(project.show_link_args)
   end
 
@@ -4931,7 +4931,7 @@ class NameControllerTest < FunctionalTestCase
     assert_response(:redirect)
 
     # Make sure it doesn't crash if id is bogus.
-    get_with_dump(:inherit_classification, params: { id: name.id })
+    get(:inherit_classification, params: { id: name.id })
     assert_no_flash
     assert_response(:success)
     assert_template("inherit_classification")
@@ -5046,7 +5046,7 @@ class NameControllerTest < FunctionalTestCase
     assert_textarea_value(:classification, "")
 
     name = names(:agaricus_campestris)
-    get_with_dump(:edit_classification, params: { id: name.id })
+    get(:edit_classification, params: { id: name.id })
     assert_response(:success)
     assert_template(:edit_classification)
     assert_textarea_value(:classification, name.classification)

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -94,12 +94,12 @@ class ObservationsControllerTest < FunctionalTestCase
     img = images(:rolf_profile_image)
     assert_nil(img.notes)
     assert(obs.images.member?(img))
-    get_with_dump(:show, id: obs.id)
+    get_with_dump(:show, params: { id: obs.id })
   end
 
   def test_show_observation_noteful_image
     obs = observations(:detailed_unknown_obs)
-    get_with_dump(:show, id: obs.id)
+    get_with_dump(:show, params: { id: obs.id })
   end
 
   def test_show_observation_change_thumbnail_size
@@ -422,14 +422,14 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_observation_search_help
     login
-    get_with_dump(:index, pattern: "help:me")
+    get_with_dump(:index, params: { pattern: "help:me" })
     assert_match(/unexpected term/i, @response.body)
   end
 
   def test_observation_search1
     login
     pattern = "Boletus edulis"
-    get_with_dump(:index, pattern: pattern)
+    get_with_dump(:index, params: { pattern: pattern })
     assert_template(:index)
     assert_equal(
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
@@ -441,7 +441,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_observation_search2
     login
     pattern = "Boletus edulis"
-    get_with_dump(:index, pattern: pattern, page: 2)
+    get_with_dump(:index, params: { pattern: pattern, page: 2 })
     assert_template(:index)
     assert_equal(
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
@@ -455,7 +455,7 @@ class ObservationsControllerTest < FunctionalTestCase
     # When there are no hits, no title is displayed, there's no rh tabset, and
     # html <title> contents are the action name
     pattern = "no hits"
-    get_with_dump(:index, pattern: pattern)
+    get_with_dump(:index, params: { pattern: pattern })
     assert_template(:index)
 
     # Change 2022/07 : Now setting @title explicitly for refactored indexes
@@ -469,7 +469,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
     # If pattern is id of a real Observation, go directly to that Observation.
     obs = Observation.first
-    get_with_dump(:index, pattern: obs.id)
+    get_with_dump(:index, params: { pattern: obs.id })
     assert_redirected_to(action: :show, id: Observation.first.id)
   end
 
@@ -631,7 +631,7 @@ class ObservationsControllerTest < FunctionalTestCase
     num_views = obs.num_views
     last_view = obs.last_view
     # obs.update_view_stats
-    get_with_dump(:show, id: obs.id)
+    get_with_dump(:show, params: { id: obs.id })
     obs.reload
     assert_equal(num_views + 1, obs.num_views)
     assert_not_equal(last_view, obs.last_view)
@@ -654,27 +654,27 @@ class ObservationsControllerTest < FunctionalTestCase
 
     # Test it on obs with no namings first.
     obs_id = observations(:unknown_with_no_naming).id
-    get_with_dump(:show, id: obs_id)
+    get_with_dump(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings (Rolf's and Mary's), but no one logged in.
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get_with_dump(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings, with owner logged in.
     login("rolf")
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get_with_dump(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings, with non-owner logged in.
     login("mary")
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get_with_dump(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
@@ -694,11 +694,11 @@ class ObservationsControllerTest < FunctionalTestCase
     obs = observations(:coprinus_comatus_obs)
     user = login(users(:public_voter).name)
 
-    get_with_dump(:show, id: obs.id, go_private: 1)
+    get_with_dump(:show, params: { id: obs.id, go_private: 1 })
     user.reload
     assert_equal("yes", user.votes_anonymous)
 
-    get_with_dump(:show, id: obs.id, go_public: 1)
+    get_with_dump(:show, params: { id: obs.id, go_public: 1 })
     user.reload
     assert_equal("no", user.votes_anonymous)
   end
@@ -706,14 +706,15 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_show_owner_id
     login(user_with_view_owner_id_true)
     obs = observations(:owner_only_favorite_ne_consensus)
-    get_with_dump(:show, id: obs.id)
+    get_with_dump(:show, params: { id: obs.id })
     assert_select("div[class *= 'owner-id']",
                   { text: /#{obs.owner_preference.text_name}/,
                     count: 1 },
                   "Observation should show Observer ID")
 
-    get_with_dump(:show,
-                  id: observations(:owner_multiple_favorites).id)
+    get_with_dump(
+      :show, params: { id: observations(:owner_multiple_favorites).id }
+    )
     assert_select("div[class *= 'owner-id']",
                   { text: /#{:show_observation_no_clear_preference.t}/,
                     count: 1 },
@@ -722,16 +723,18 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_show_owner_id_view_owner_id_false
     login(user_with_view_owner_id_false)
-    get_with_dump(:show,
-                  id: observations(:owner_only_favorite_ne_consensus).id)
+    get_with_dump(
+      :show, params: { id: observations(:owner_only_favorite_ne_consensus).id }
+    )
     assert_select("div[class *= 'owner-id']", { count: 0 },
                   "Do not show Observer ID when user has not opted for it")
   end
 
   def test_show_owner_id_noone_logged_in
     logout
-    get_with_dump(:show,
-                  id: observations(:owner_only_favorite_ne_consensus).id)
+    get_with_dump(
+      :show, params: { id: observations(:owner_only_favorite_ne_consensus).id }
+    )
     assert_select("div[class *= 'owner-id']", { count: 0 },
                   "Do not show Observer ID when nobody logged in")
   end
@@ -747,7 +750,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_observation_external_links_exist
     login
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, id: obs_id)
+    get_with_dump(:show, params: { id: obs_id })
 
     assert_select("a[href *= 'images.google.com']")
     assert_select("a[href *= 'mycoportal.org']")

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -513,7 +513,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_where_search_next_page
     login
     params = { place_name: "Burbank", page: 2 }
-    get_with_dump(:index, params)
+    get_with_dump(:index, params: params)
     assert_template(:index)
   end
 
@@ -522,7 +522,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_where_search_pattern
     login
     params = { place_name: "Burbank" }
-    get_with_dump(:index, params)
+    get_with_dump(:index, params: params)
     assert_template("shared/_matrix_box")
   end
 

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -94,12 +94,12 @@ class ObservationsControllerTest < FunctionalTestCase
     img = images(:rolf_profile_image)
     assert_nil(img.notes)
     assert(obs.images.member?(img))
-    get_with_dump(:show, params: { id: obs.id })
+    get(:show, params: { id: obs.id })
   end
 
   def test_show_observation_noteful_image
     obs = observations(:detailed_unknown_obs)
-    get_with_dump(:show, params: { id: obs.id })
+    get(:show, params: { id: obs.id })
   end
 
   def test_show_observation_change_thumbnail_size
@@ -174,7 +174,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_page_loads
     login
-    get_with_dump(:index)
+    get(:index)
     assert_template("shared/_matrix_box")
 
     # Test again, this time specifying page number via an observation id.
@@ -186,7 +186,7 @@ class ObservationsControllerTest < FunctionalTestCase
         params: { project: projects(:bolete_project).id })
     assert_template("shared/_matrix_box")
 
-    get_with_dump(:index, params: { by: "name" })
+    get(:index, params: { by: "name" })
     assert_template("shared/_matrix_box")
 
     get(:index,
@@ -203,10 +203,10 @@ class ObservationsControllerTest < FunctionalTestCase
                   name: names(:tremella_mesenterica).text_name })
     assert_template(:index)
 
-    get_with_dump(:index, params: { user: rolf.id })
+    get(:index, params: { user: rolf.id })
     assert_template("shared/_matrix_box")
 
-    # get_with_dump(:login)
+    # get(:login)
     # assert_redirected_to(controller: :account, action: :login)
   end
 
@@ -422,14 +422,14 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_observation_search_help
     login
-    get_with_dump(:index, params: { pattern: "help:me" })
+    get(:index, params: { pattern: "help:me" })
     assert_match(/unexpected term/i, @response.body)
   end
 
   def test_observation_search1
     login
     pattern = "Boletus edulis"
-    get_with_dump(:index, params: { pattern: pattern })
+    get(:index, params: { pattern: pattern })
     assert_template(:index)
     assert_equal(
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
@@ -441,7 +441,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_observation_search2
     login
     pattern = "Boletus edulis"
-    get_with_dump(:index, params: { pattern: pattern, page: 2 })
+    get(:index, params: { pattern: pattern, page: 2 })
     assert_template(:index)
     assert_equal(
       :query_title_pattern_search.t(types: "Observations", pattern: pattern),
@@ -455,7 +455,7 @@ class ObservationsControllerTest < FunctionalTestCase
     # When there are no hits, no title is displayed, there's no rh tabset, and
     # html <title> contents are the action name
     pattern = "no hits"
-    get_with_dump(:index, params: { pattern: pattern })
+    get(:index, params: { pattern: pattern })
     assert_template(:index)
 
     # Change 2022/07 : Now setting @title explicitly for refactored indexes
@@ -469,7 +469,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
     # If pattern is id of a real Observation, go directly to that Observation.
     obs = Observation.first
-    get_with_dump(:index, params: { pattern: obs.id })
+    get(:index, params: { pattern: obs.id })
     assert_redirected_to(action: :show, id: Observation.first.id)
   end
 
@@ -513,7 +513,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_where_search_next_page
     login
     params = { place_name: "Burbank", page: 2 }
-    get_with_dump(:index, params: params)
+    get(:index, params: params)
     assert_template(:index)
   end
 
@@ -522,7 +522,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_where_search_pattern
     login
     params = { place_name: "Burbank" }
-    get_with_dump(:index, params: params)
+    get(:index, params: params)
     assert_template("shared/_matrix_box")
   end
 
@@ -547,7 +547,7 @@ class ObservationsControllerTest < FunctionalTestCase
   # Prove that lichen content_filter works on observations
   def test_observations_with_lichen_filter
     login(users(:lichenologist).name)
-    get_with_dump(:index)
+    get(:index)
     results = @controller.instance_variable_get(:@objects)
 
     assert(results.count.positive?)
@@ -555,7 +555,7 @@ class ObservationsControllerTest < FunctionalTestCase
            "All results should be lichen-ish")
 
     login(users(:antilichenologist).name)
-    get_with_dump(:index)
+    get(:index)
     results = @controller.instance_variable_get(:@objects)
 
     assert(results.count.positive?)
@@ -631,7 +631,7 @@ class ObservationsControllerTest < FunctionalTestCase
     num_views = obs.num_views
     last_view = obs.last_view
     # obs.update_view_stats
-    get_with_dump(:show, params: { id: obs.id })
+    get(:show, params: { id: obs.id })
     obs.reload
     assert_equal(num_views + 1, obs.num_views)
     assert_not_equal(last_view, obs.last_view)
@@ -654,27 +654,27 @@ class ObservationsControllerTest < FunctionalTestCase
 
     # Test it on obs with no namings first.
     obs_id = observations(:unknown_with_no_naming).id
-    get_with_dump(:show, params: { id: obs_id })
+    get(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings (Rolf's and Mary's), but no one logged in.
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, params: { id: obs_id })
+    get(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings, with owner logged in.
     login("rolf")
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, params: { id: obs_id })
+    get(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
     # Test it on obs with two namings, with non-owner logged in.
     login("mary")
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, params: { id: obs_id })
+    get(:show, params: { id: obs_id })
     assert_show_observation
     assert_form_action(controller: :vote, action: :cast_votes, id: obs_id)
 
@@ -694,11 +694,11 @@ class ObservationsControllerTest < FunctionalTestCase
     obs = observations(:coprinus_comatus_obs)
     user = login(users(:public_voter).name)
 
-    get_with_dump(:show, params: { id: obs.id, go_private: 1 })
+    get(:show, params: { id: obs.id, go_private: 1 })
     user.reload
     assert_equal("yes", user.votes_anonymous)
 
-    get_with_dump(:show, params: { id: obs.id, go_public: 1 })
+    get(:show, params: { id: obs.id, go_public: 1 })
     user.reload
     assert_equal("no", user.votes_anonymous)
   end
@@ -706,13 +706,13 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_show_owner_id
     login(user_with_view_owner_id_true)
     obs = observations(:owner_only_favorite_ne_consensus)
-    get_with_dump(:show, params: { id: obs.id })
+    get(:show, params: { id: obs.id })
     assert_select("div[class *= 'owner-id']",
                   { text: /#{obs.owner_preference.text_name}/,
                     count: 1 },
                   "Observation should show Observer ID")
 
-    get_with_dump(
+    get(
       :show, params: { id: observations(:owner_multiple_favorites).id }
     )
     assert_select("div[class *= 'owner-id']",
@@ -723,7 +723,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_show_owner_id_view_owner_id_false
     login(user_with_view_owner_id_false)
-    get_with_dump(
+    get(
       :show, params: { id: observations(:owner_only_favorite_ne_consensus).id }
     )
     assert_select("div[class *= 'owner-id']", { count: 0 },
@@ -732,7 +732,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_show_owner_id_noone_logged_in
     logout
-    get_with_dump(
+    get(
       :show, params: { id: observations(:owner_only_favorite_ne_consensus).id }
     )
     assert_select("div[class *= 'owner-id']", { count: 0 },
@@ -750,7 +750,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_observation_external_links_exist
     login
     obs_id = observations(:coprinus_comatus_obs).id
-    get_with_dump(:show, params: { id: obs_id })
+    get(:show, params: { id: obs_id })
 
     assert_select("a[href *= 'images.google.com']")
     assert_select("a[href *= 'mycoportal.org']")

--- a/test/controllers/pivotal_controller_test.rb
+++ b/test/controllers/pivotal_controller_test.rb
@@ -7,7 +7,7 @@ class PivotalControllerTest < FunctionalTestCase
     login
     enabled = MO.pivotal_enabled
     MO.pivotal_enabled = false
-    get_with_dump(:index)
+    get(:index)
     assert_response("index")
     MO.pivotal_enabled = enabled
   end
@@ -48,7 +48,7 @@ class PivotalControllerTest < FunctionalTestCase
                   headers: {})
     enabled = MO.pivotal_enabled
     MO.pivotal_enabled = true
-    get_with_dump(:index)
+    get(:index)
     assert_response("index")
     MO.pivotal_enabled = enabled
   end

--- a/test/controllers/project_controller_test.rb
+++ b/test/controllers/project_controller_test.rb
@@ -72,7 +72,7 @@ class ProjectControllerTest < FunctionalTestCase
   def test_show_project
     login("zero") # NOt the owner of eol_project
     p_id = projects(:eol_project).id
-    get_with_dump(:show_project, params: { id: p_id })
+    get(:show_project, params: { id: p_id })
     assert_template("show_project")
     assert_select("a[href*='admin_request/#{p_id}']")
     assert_select("a[href*='edit_project/#{p_id}']", count: 0)
@@ -83,7 +83,7 @@ class ProjectControllerTest < FunctionalTestCase
   def test_show_project_logged_in
     p_id = projects(:eol_project).id
     requires_login(:add_project)
-    get_with_dump(:show_project, params: { id: p_id })
+    get(:show_project, params: { id: p_id })
     assert_template("show_project")
     assert_select("a[href*='admin_request/']")
     assert_select("a[href*='edit_project/#{p_id}']")
@@ -93,7 +93,7 @@ class ProjectControllerTest < FunctionalTestCase
 
   def test_list_projects
     login
-    get_with_dump(:list_projects)
+    get(:list_projects)
     assert_template("list_projects")
   end
 

--- a/test/controllers/project_controller_test.rb
+++ b/test/controllers/project_controller_test.rb
@@ -72,7 +72,7 @@ class ProjectControllerTest < FunctionalTestCase
   def test_show_project
     login("zero") # NOt the owner of eol_project
     p_id = projects(:eol_project).id
-    get_with_dump(:show_project, id: p_id)
+    get_with_dump(:show_project, params: { id: p_id })
     assert_template("show_project")
     assert_select("a[href*='admin_request/#{p_id}']")
     assert_select("a[href*='edit_project/#{p_id}']", count: 0)
@@ -83,7 +83,7 @@ class ProjectControllerTest < FunctionalTestCase
   def test_show_project_logged_in
     p_id = projects(:eol_project).id
     requires_login(:add_project)
-    get_with_dump(:show_project, id: p_id)
+    get_with_dump(:show_project, params: { id: p_id })
     assert_template("show_project")
     assert_select("a[href*='admin_request/']")
     assert_select("a[href*='edit_project/#{p_id}']")

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -3,17 +3,17 @@
 class RssLogsControllerTest < FunctionalTestCase
   def test_page_loads
     login
-    get_with_dump(:index)
+    get(:index)
     assert_template("shared/_matrix_box")
     assert_link_in_html(:app_intro.t, controller: :info, action: :intro)
 
-    get_with_dump(:index)
+    get(:index)
     assert_template("shared/_matrix_box")
 
-    get_with_dump(:rss)
+    get(:rss)
     assert_template(:rss)
 
-    get_with_dump(:show, params: { id: rss_logs(:observation_rss_log).id })
+    get(:show, params: { id: rss_logs(:observation_rss_log).id })
     assert_template(:show)
   end
 

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -13,7 +13,7 @@ class RssLogsControllerTest < FunctionalTestCase
     get_with_dump(:rss)
     assert_template(:rss)
 
-    get_with_dump(:show, id: rss_logs(:observation_rss_log).id)
+    get_with_dump(:show, params: { id: rss_logs(:observation_rss_log).id })
     assert_template(:show)
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -72,38 +72,38 @@ class SearchControllerTest < FunctionalTestCase
   def test_pattern_search
     login
     params = { search: { pattern: "12", type: :observation } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :observations, action: :index,
                          pattern: "12")
 
     params = { search: { pattern: "34", type: :image } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :image, action: :image_search,
                          pattern: "34")
 
     params = { search: { pattern: "56", type: :name } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :name, action: :name_search,
                          pattern: "56")
 
     params = { search: { pattern: "78", type: :location } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :location, action: :location_search,
                          pattern: "78")
 
     params = { search: { pattern: "90", type: :comment } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :comment, action: :comment_search,
                          pattern: "90")
 
     params = { search: { pattern: "12", type: :species_list } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :species_list,
                          action: :species_list_search,
                          pattern: "12")
 
     params = { search: { pattern: "34", type: :user } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(users_path(pattern: "34"))
 
     stub_request(:any, /google.com/)
@@ -111,19 +111,19 @@ class SearchControllerTest < FunctionalTestCase
     params = { search: { pattern: pattern, type: :google } }
     target =
       "https://google.com/search?q=site%3Amushroomobserver.org+#{pattern}"
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(target)
 
     params = { search: { pattern: "", type: :google } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to("/")
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to("/")
 
     params = { search: { pattern: "", type: :observation } }
-    get_with_dump(:pattern, params)
+    get_with_dump(:pattern, params: params)
     assert_redirected_to(controller: :observations, action: :index)
 
     # Make sure this redirects to the index that lists all herbaria,

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -72,38 +72,38 @@ class SearchControllerTest < FunctionalTestCase
   def test_pattern_search
     login
     params = { search: { pattern: "12", type: :observation } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :observations, action: :index,
                          pattern: "12")
 
     params = { search: { pattern: "34", type: :image } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :image, action: :image_search,
                          pattern: "34")
 
     params = { search: { pattern: "56", type: :name } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :name, action: :name_search,
                          pattern: "56")
 
     params = { search: { pattern: "78", type: :location } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :location, action: :location_search,
                          pattern: "78")
 
     params = { search: { pattern: "90", type: :comment } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :comment, action: :comment_search,
                          pattern: "90")
 
     params = { search: { pattern: "12", type: :species_list } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :species_list,
                          action: :species_list_search,
                          pattern: "12")
 
     params = { search: { pattern: "34", type: :user } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(users_path(pattern: "34"))
 
     stub_request(:any, /google.com/)
@@ -111,19 +111,19 @@ class SearchControllerTest < FunctionalTestCase
     params = { search: { pattern: pattern, type: :google } }
     target =
       "https://google.com/search?q=site%3Amushroomobserver.org+#{pattern}"
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(target)
 
     params = { search: { pattern: "", type: :google } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to("/")
 
     params = { search: { pattern: "x", type: :nonexistent_type } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to("/")
 
     params = { search: { pattern: "", type: :observation } }
-    get_with_dump(:pattern, params: params)
+    get(:pattern, params: params)
     assert_redirected_to(controller: :observations, action: :index)
 
     # Make sure this redirects to the index that lists all herbaria,

--- a/test/controllers/support_controller_test.rb
+++ b/test/controllers/support_controller_test.rb
@@ -13,20 +13,15 @@ class SupportControllerTest < FunctionalTestCase
       :wrapup_2011,
       :wrapup_2012
     ].each do |template|
-      assert_template_with_dump(template)
-      get_with_dump(template)
+      get(template)
       assert_template(template)
     end
   end
 
-  def assert_template_with_dump(template)
-    get_with_dump(template)
-    assert_template(template)
-  end
-
   def test_donate
     login("rolf")
-    assert_template_with_dump(:donate)
+    get(:donate)
+    assert_template(:donate)
     assert_select("form input[value=\"#{users(:rolf).name}\"]")
   end
 
@@ -89,7 +84,8 @@ class SupportControllerTest < FunctionalTestCase
     get(:create_donation)
     assert_response(:redirect)
     make_admin
-    assert_template_with_dump(:create_donation)
+    get(:create_donation)
+    assert_template(:create_donation)
   end
 
   def test_create_donation_post
@@ -113,7 +109,8 @@ class SupportControllerTest < FunctionalTestCase
     get(:review_donations)
     assert_response(:redirect)
     make_admin
-    assert_template_with_dump(:review_donations)
+    get(:review_donations)
+    assert_template(:review_donations)
   end
 
   def test_review_donations_post

--- a/test/controllers/translation_controller_test.rb
+++ b/test/controllers/translation_controller_test.rb
@@ -178,7 +178,7 @@ class TranslationControllerTest < FunctionalTestCase
 
   def test_edit_translation_form_get_tag_two
     login("rolf")
-    get_with_dump(:edit_translations, locale: "en", tag: "two")
+    get_with_dump(:edit_translations, params: { locale: "en", tag: "two" })
     assert_no_flash
     assert_response(:success)
     assert_select("input[type=submit][value=#{:SAVE.l}]", 1)

--- a/test/controllers/translation_controller_test.rb
+++ b/test/controllers/translation_controller_test.rb
@@ -178,7 +178,7 @@ class TranslationControllerTest < FunctionalTestCase
 
   def test_edit_translation_form_get_tag_two
     login("rolf")
-    get_with_dump(:edit_translations, params: { locale: "en", tag: "two" })
+    get(:edit_translations, params: { locale: "en", tag: "two" })
     assert_no_flash
     assert_response(:success)
     assert_select("input[type=submit][value=#{:SAVE.l}]", 1)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -14,7 +14,7 @@ class UsersControllerTest < FunctionalTestCase
 
   def test_page_loads
     login
-    get_with_dump(:show, id: rolf.id)
+    get_with_dump(:show, params: { id: rolf.id })
     assert_template(:show)
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -14,7 +14,7 @@ class UsersControllerTest < FunctionalTestCase
 
   def test_page_loads
     login
-    get_with_dump(:show, params: { id: rolf.id })
+    get(:show, params: { id: rolf.id })
     assert_template(:show)
   end
 
@@ -32,7 +32,7 @@ class UsersControllerTest < FunctionalTestCase
   #     assert_flash_text(/denied|only.*admin/i)
 
   #     make_admin("rolf")
-  #     get_with_dump(page, params)
+  #     get(page, params)
   #     assert_template(response) # 1
   #   end
   # end

--- a/test/controllers/vote_controller_test.rb
+++ b/test/controllers/vote_controller_test.rb
@@ -141,7 +141,9 @@ class VoteControllerTest < FunctionalTestCase
   def test_show_votes
     login
     # First just make sure the page displays.
-    get_with_dump(:show_votes, id: namings(:coprinus_comatus_naming).id)
+    get_with_dump(
+      :show_votes, params: { id: namings(:coprinus_comatus_naming).id }
+    )
     assert_template(:show_votes)
     assert_template("vote/_show_votes")
 

--- a/test/controllers/vote_controller_test.rb
+++ b/test/controllers/vote_controller_test.rb
@@ -141,7 +141,7 @@ class VoteControllerTest < FunctionalTestCase
   def test_show_votes
     login
     # First just make sure the page displays.
-    get_with_dump(
+    get(
       :show_votes, params: { id: namings(:coprinus_comatus_naming).id }
     )
     assert_template(:show_votes)


### PR DESCRIPTION
When we updated to Rails 6/Ruby 2.7, and then on to Ruby 3.0, if I recall correctly, there was a new requirement that when a hash is the last argument in any method call, it must be **named**. No more automatic conversion of keyword arguments. So in the case of `FunctionalTestCase` methods `get`, `post`,  `put`, and `patch` which modify the `super` methods with the same names, it became necessary to change them to send a named `params: params` hash. 

In other words, no more `get(:action, params)`; it seems it has to be `get(:action, params: params)`.

> _(Note: I _believe_ this change was necessary, but I am not 100% sure. There is a chance I misunderstood the requirement, but I seem to remember trying various less intrusive changes to the methods in functional test case, and I couldn't get any of them to work. With the changes I did implement, I also had to change quite a few test method calls to send that named `params` hash.)_
> Check [this discussion](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) of the change to Ruby.
> _If anyone feels that my changes to FunctionalTestCase made the test code unnecessarily verbose, or is aware that I missed something obvious about Ruby, please speak up now! Even if a few months ago might have been more convenient. :)_

So. This PR extends the same expectation/behavior to MO's other methods descended from `get` et al: the `ControllerExtensions` methods `get_with_dump`, `post_with_dump`... It brings their syntax in line with the format used in functional test case's `get` et al. All methods now expect a hash named `params`, and the method splats the hash. 

If this doesn't make sense, just check the code in the PR, it should be obvious at a glance. **New positive outcome**: test calls to `get_with_dump` now have the same syntax as calls to `get`, as you will notice from the changes in the PR. There may be other test methods that will need a syntax change, like `requires_login` maybe, but I believe not. 

Reason for this PR: `get_with_dump` was throwing a lot of errors when it was called with the extra "parent_id"  parameter that is necessary for route nesting on the `NamesController` / `NameDescriptionsController` branch. 

`names/:name_id/descriptions/:desc_id`

This issue with `get_with_dump` seemed to have a separate scope from the refactoring in that controller, so I wanted to tackle it separately.