### PR TITLE
Rubocop 1.35.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       io-console (~> 0.5)
     rexml (3.2.5)
     rtf (0.3.3)
-    rubocop (1.35.0)
+    rubocop (1.35.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)


### PR DESCRIPTION
Bumps rubocop to v1.35.1.
(The changes are all bug fixes -- no new cops. https://github.com/rubocop/rubocop/releases/tag/v1.35.1)