### PR TITLE
View templates: fix `form.select` syntax (with class)

### DIFF
--- a/app/assets/stylesheets/Agaricus.scss
+++ b/app/assets/stylesheets/Agaricus.scss
@@ -11,20 +11,22 @@ $xanthodermus_stain:   #D4A833;
 $polyozellus_light:    #a5bffa;
 $polyozellus_dark:     #5167b2;
 
+$BUTTON_FG_COLOR:             $cupreobrunneus_gills;
+
 $BODY_FG_COLOR:               $cupreobrunneus_gills;
 $BODY_BG_COLOR:               $campestris_cap;
-                             
+
 $LINK_FG_COLOR:               $brasiliensis_gills_1;
 $LINK_VISITED_FG_COLOR:       $cupreobrunneus_gills;
 $LINK_HOVER_FG_COLOR:         $brasiliensis_gills_2;
 $LINK_HOVER_BG_COLOR:         $campestris_cap;
-                             
+
 $LOGO_BORDER_COLOR:           $cupreobrunneus_gills;
 $LOGO_FG_COLOR:               $cupreobrunneus_gills;
 $LOGO_BG_COLOR:               $semotus_cap;
 $LOGO_HOVER_FG_COLOR:         $brasiliensis_gills_2;
 $LOGO_HOVER_BG_COLOR:         $campestris_cap;
-                             
+
 $LEFT_BAR_BORDER_COLOR:       $augustus_cap;
 $LEFT_BAR_HEADER_FG_COLOR:    $cupreobrunneus_gills;
 $LEFT_BAR_HEADER_BG_COLOR:    $augustus_cap;
@@ -48,13 +50,13 @@ $LIST_BG_COLOR:               mix($campestris_cap, white, 50%);
 
 $TOOLTIP_FG_COLOR:            $campestris_cap;
 $TOOLTIP_BG_COLOR:            $cupreobrunneus_gills;
-                             
+
 $PAGER_FG_COLOR:              $cupreobrunneus_gills;
 $PAGER_HOVER_FG_COLOR:        $brasiliensis_gills_2;
 $PAGER_HOVER_BG_COLOR:        $campestris_cap;
 $PAGER_ACTIVE_FG_COLOR:       $campestris_cap;
 $PAGER_ACTIVE_BG_COLOR:       $brasiliensis_gills_2;
-                             
+
 $MENU_BORDER_COLOR:           $brasiliensis_gills_2;
 $MENU_FG_COLOR:               black;
 $MENU_BG_COLOR:               white;

--- a/app/assets/stylesheets/Amanita.scss
+++ b/app/assets/stylesheets/Amanita.scss
@@ -23,6 +23,8 @@ $pachycolea_dark_brown:           #60412d;
 $polyozellus_light:               #a5bffa;
 $polyozellus_dark:                #5167b2;
 
+$BUTTON_FG_COLOR:             $pachycolea_background;
+
 $BODY_FG_COLOR:               $pachycolea_foreground;
 $BODY_BG_COLOR:               $pachycolea_background;
 

--- a/app/assets/stylesheets/Cantharellaceae.scss
+++ b/app/assets/stylesheets/Cantharellaceae.scss
@@ -19,20 +19,22 @@ $cornucopioides_bright_margin:  #e6c987;
 $polyozellus_light:             #a5bffa;
 $polyozellus_dark:              #5167b2;
 
+$BUTTON_FG_COLOR:             $cornucopioides_dark_hymenium;
+
 $BODY_FG_COLOR:               $cornucopioides_dark_hymenium;
 $BODY_BG_COLOR:               $californicus_stipe;
-                             
+
 $LINK_FG_COLOR:               $cinnabarinus_light_cap;
 $LINK_VISITED_FG_COLOR:       $cinnabarinus_dark_cap;
 $LINK_HOVER_FG_COLOR:         $cinnabarinus_light_cap;
 $LINK_HOVER_BG_COLOR:         $californicus_cap;
-                             
+
 $LOGO_BORDER_COLOR:           $cornucopioides_dark_hymenium;
 $LOGO_FG_COLOR:               $cornucopioides_dark_hymenium;
 $LOGO_BG_COLOR:               $californicus_cap;
 $LOGO_HOVER_FG_COLOR:         $cornucopioides_dark_hymenium;
 $LOGO_HOVER_BG_COLOR:         $californicus_stipe;
-                             
+
 $LEFT_BAR_BORDER_COLOR:       $californicus_cap;
 $LEFT_BAR_HEADER_FG_COLOR:    $cornucopioides_dark_hymenium;
 $LEFT_BAR_HEADER_BG_COLOR:    $californicus_cap;
@@ -56,20 +58,20 @@ $LIST_BG_COLOR:               mix($californicus_stipe, white, 50%);
 
 $TOOLTIP_FG_COLOR:            $californicus_stipe;
 $TOOLTIP_BG_COLOR:            $cornucopioides_dark_hymenium;
-                             
+
 $VOTE_METER_FG_COLOR:         $cornucopioides_dark_hymenium;
 $VOTE_METER_BG_COLOR:         $californicus_cap;
-                             
+
 $PROGRESS_BG_COLOR:           $californicus_stipe;
 $PROGRESS_FG_COLOR:           $cornucopioides_dark_hymenium;
 $PROGRESS_BAR_COLOR:          $cinnabarinus_light_cap;
-                             
+
 $PAGER_FG_COLOR:              $cornucopioides_dark_hymenium;
 $PAGER_HOVER_FG_COLOR:        $cornucopioides_dark_hymenium;
 $PAGER_HOVER_BG_COLOR:        $californicus_cap;
 $PAGER_ACTIVE_FG_COLOR:       $californicus_stipe;
 $PAGER_ACTIVE_BG_COLOR:       $cornucopioides_dark_hymenium;
-                             
+
 $MENU_BORDER_COLOR:           $cornucopioides_dark_hymenium;
 $MENU_FG_COLOR:               black;
 $MENU_BG_COLOR:               white;

--- a/app/assets/stylesheets/Hygrocybe.scss
+++ b/app/assets/stylesheets/Hygrocybe.scss
@@ -20,20 +20,22 @@ $punicea_light_stipe:   #e9e3af;
 $polyozellus_light:     #a5bffa;
 $polyozellus_dark:      #5167b2;
 
+$BUTTON_FG_COLOR:             $conica_stain;
+
 $BODY_FG_COLOR:               $conica_stain;
 $BODY_BG_COLOR:               $punicea_light_stipe;
-                             
+
 $LINK_FG_COLOR:               $psittacina_cap_green;
 $LINK_VISITED_FG_COLOR:       $psittacina_cap_orange;
 $LINK_HOVER_FG_COLOR:         $psittacina_cap_green;
 $LINK_HOVER_BG_COLOR:         $psittacina_gill_color;
-                             
+
 $LOGO_BORDER_COLOR:           $conica_stain;
 $LOGO_FG_COLOR:               $conica_stain;
 $LOGO_BG_COLOR:               $punicea_cap_light;
 $LOGO_HOVER_FG_COLOR:         $conica_stain;
 $LOGO_HOVER_BG_COLOR:         $punicea_cap_light;
-                             
+
 $LEFT_BAR_BORDER_COLOR:       $miniata_cap_yellow;
 $LEFT_BAR_HEADER_FG_COLOR:    $psittacina_cap_green;
 $LEFT_BAR_HEADER_BG_COLOR:    $miniata_cap_yellow;
@@ -55,13 +57,13 @@ $LIST_FG_COLOR:               $conica_stain;
 $LIST_BG_COLOR:               mix($punicea_light_stipe, white, 50%);
 
 $TOOLTIP_BG_COLOR:            $punicea_cap_light;
-                             
+
 $PAGER_FG_COLOR:              $punicea_cap_dark;
 $PAGER_HOVER_FG_COLOR:        $punicea_light_stipe;
 $PAGER_HOVER_BG_COLOR:        $punicea_cap_light;
 $PAGER_ACTIVE_FG_COLOR:       $punicea_light_stipe;
 $PAGER_ACTIVE_BG_COLOR:       $punicea_cap_dark;
-                             
+
 $MENU_BORDER_COLOR:           $miniata_gill_margin;
 $MENU_FG_COLOR:               black;
 $MENU_BG_COLOR:               white;

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -1597,6 +1597,10 @@ form.button_to {
     font-family: monospace
 }
 
+.mb-1 {
+  margin-bottom: 0.25em;
+}
+
 .push-down {
     margin-top: 1em;
 }

--- a/app/assets/stylesheets/mushroom_observer.scss
+++ b/app/assets/stylesheets/mushroom_observer.scss
@@ -236,9 +236,11 @@ blockquote {
 }
 
 .form-control {
+    color: $BUTTON_FG_COLOR;
     border-width: $INPUT_BORDER_WIDTH;
     border-style: $INPUT_BORDER_STYLE;
     border-radius: $INPUT_BORDER_RADIUS;
+    border-color: $BUTTON_FG_COLOR;
     padding: 4px 8px 3px 8px;
 }
 

--- a/app/views/account/_prefs_appearance.html.erb
+++ b/app/views/account/_prefs_appearance.html.erb
@@ -8,20 +8,20 @@
   <%= form.select(:hide_authors,
                   [[:prefs_hide_authors_none.l, "none"],
                    [:prefs_hide_authors_above_species.l, "above_species"]],
-                  class: "form-control") %><br/>
+                  {}, { class: "form-control" }) %><br/>
 
   <%= label_tag(:user_location_format, :prefs_location_format.t + ":") %>
   <%= form.select(:location_format,
                   [[:prefs_location_format_postal.l, "postal"],
                    [:prefs_location_format_scientific.l, "scientific"]],
-                  class: "form-control") %><br/>
+                  {}, { class: "form-control" }) %><br/>
 
   <%= label_tag(:user_theme, :prefs_theme.t + ":") %>
   <%= form.select(:theme,
                   [
                    [:theme_random.l, "NULL"]
                   ] + MO.themes.map { |t| [t.to_sym.l, t] },
-                  class: "form-control") %>
+                  {}, { class: "form-control" }) %>
   <%= link_to(:prefs_themes_about.t, controller: :theme,
                                      action: :color_themes) %><br/>
 
@@ -31,7 +31,7 @@
                   name += " (beta)" if lang.beta
                   [name, lang.locale]
                 end
-      form.select(:locale, locales, class: "form-control") %><br/>
+      form.select(:locale, locales, {}, { class: "form-control" }) %><br/>
 
   <%= form.check_box(:thumbnail_maps, class: "form-control") %>
 

--- a/app/views/account/_prefs_appearance.html.erb
+++ b/app/views/account/_prefs_appearance.html.erb
@@ -3,19 +3,21 @@
   <%= :prefs_appearance.t %>
 </div>
 
-<div class="form-group push-down form-inline">
+<div class="form-group mb-1 form-inline">
   <%= label_tag(:user_hide_authors, :prefs_hide_authors.t + ":") %>
   <%= form.select(:hide_authors,
                   [[:prefs_hide_authors_none.l, "none"],
                    [:prefs_hide_authors_above_species.l, "above_species"]],
                   {}, { class: "form-control" }) %><br/>
-
+</div>
+<div class="form-group mb-1 form-inline">
   <%= label_tag(:user_location_format, :prefs_location_format.t + ":") %>
   <%= form.select(:location_format,
                   [[:prefs_location_format_postal.l, "postal"],
                    [:prefs_location_format_scientific.l, "scientific"]],
                   {}, { class: "form-control" }) %><br/>
-
+</div>
+<div class="form-group mb-1 form-inline">
   <%= label_tag(:user_theme, :prefs_theme.t + ":") %>
   <%= form.select(:theme,
                   [
@@ -24,7 +26,8 @@
                   {}, { class: "form-control" }) %>
   <%= link_to(:prefs_themes_about.t, controller: :theme,
                                      action: :color_themes) %><br/>
-
+</div>
+<div class="form-group mb-1 form-inline">
   <%= label_tag(:user_locale, :prefs_locale.t + ":") %>
   <%= locales = Language.all.map do |lang|
                   name = lang.name
@@ -32,17 +35,17 @@
                   [name, lang.locale]
                 end
       form.select(:locale, locales, {}, { class: "form-control" }) %><br/>
-
+</div>
+<div class="form-group mb-1 form-inline">
   <%= form.check_box(:thumbnail_maps, class: "form-control") %>
-
   <%= label_tag(:user_thumbnail_maps, :prefs_thumbnail_maps.t) %><br/>
-
-  <div>
-    <%= form.check_box(:view_owner_id, class: "form-control") %>
-    <%= add_context_help(label_tag(:user_view_owner_id, :prefs_view_owner_id.t),
-                        :prefs_view_owner_id_help.t) %>
-  </div>
-
+</div>
+<div class="form-group mb-1 form-inline">
+  <%= form.check_box(:view_owner_id, class: "form-control") %>
+  <%= add_context_help(label_tag(:user_view_owner_id, :prefs_view_owner_id.t),
+                      :prefs_view_owner_id_help.t) %>
+</div>
+<div class="form-group push-down form-inline">
   <%= label_tag(:layout_count, :prefs_layout_count.t + ":") %>
   <%= form.number_field(:layout_count, class: "form-control", min: 1) %>
 </div>

--- a/app/views/account/_prefs_filter_radiobox.html.erb
+++ b/app/views/account/_prefs_filter_radiobox.html.erb
@@ -7,6 +7,7 @@
         filter.prefs_vals.map do |val|
           [ :"prefs_filters_#{filter.sym}_#{val}".t, val ]
         end
-      form.select(filter.sym, options, class: "form-control",
-                  selected: @user.content_filter[filter.sym]) %>
+      form.select(filter.sym, options,
+                  { selected: @user.content_filter[filter.sym] },
+                  { class: "form-control" }) %>
 <% end %>

--- a/app/views/account/_prefs_filters.html.erb
+++ b/app/views/account/_prefs_filters.html.erb
@@ -5,18 +5,20 @@
 </div>
 
 <% ContentFilter.all.each do |filter| %>
-  <% if filter.type == :boolean && filter.prefs_vals.count == 1 %>
-    <%= render partial: "prefs_filter_checkbox",
-               locals: { filter: filter, form: form } %>
-  <% elsif filter.type == :boolean && filter.prefs_vals.count > 1 %>
-    <%= render partial: "prefs_filter_radiobox",
-               locals: { filter: filter, form: form } %>
-  <% elsif filter.type == [:string] %>
-    <%= render partial: "prefs_filter_text_field",
-               locals: { filter: filter, form: form } %>
-  <% else %>
-    <% raise "unrecognized content filter type #{filter.type.inspect}" %>
-  <% end %>
+  <div class="form-group mb-1 form-inline">
+    <% if filter.type == :boolean && filter.prefs_vals.count == 1 %>
+      <%= render partial: "prefs_filter_checkbox",
+                locals: { filter: filter, form: form } %>
+    <% elsif filter.type == :boolean && filter.prefs_vals.count > 1 %>
+      <%= render partial: "prefs_filter_radiobox",
+                locals: { filter: filter, form: form } %>
+    <% elsif filter.type == [:string] %>
+      <%= render partial: "prefs_filter_text_field",
+                locals: { filter: filter, form: form } %>
+    <% else %>
+      <% raise "unrecognized content filter type #{filter.type.inspect}" %>
+    <% end %>
+  </div>
 <% end %>
 
 <%= submit_tag(:SAVE_EDITS.l, class: "btn center-block push-down") %>

--- a/app/views/account/_prefs_privacy.html.erb
+++ b/app/views/account/_prefs_privacy.html.erb
@@ -15,7 +15,7 @@
       if @user.created_at && @user.created_at < Time.zone.parse(MO.vote_cutoff)
         values << [:prefs_votes_anonymous_old.l(cutoff: MO.vote_cutoff), :old]
       end
-      form.select(:votes_anonymous, values, class: "form-control") %>
+      form.select(:votes_anonymous, values, {}, { class: "form-control" }) %>
   <span class="HelpNote">
     <%= link_to(:prefs_change_image_vote_anonymity.t,
                 controller: :image,
@@ -33,7 +33,7 @@
                      "keep_but_hide"],
                     [:prefs_keep_image_filenames_keep_and_show.l,
                      "keep_and_show"]],
-                  class: "form-control") %>
+                  {}, { class: "form-control" }) %>
   <span class="HelpNote">
     <%= link_to(:prefs_bulk_filename_purge.t,
                  { controller: :image,
@@ -46,7 +46,7 @@
 <div class="form-group push-down">
   <%= label_tag(:user_license_id, :License.t + ":") %>
   <span class="HelpNote">(<%= :prefs_license_note.t %>)</span><br/>
-  <%= form.select(:license_id, @licenses, class: "form-control") %>
+  <%= form.select(:license_id, @licenses, {}, { class: "form-control" }) %>
   <span class="HelpNote">
     <%= link_to(:bulk_license_link.t, controller: :image,
                                       action: :license_updater) %>

--- a/app/views/account/_prefs_privacy.html.erb
+++ b/app/views/account/_prefs_privacy.html.erb
@@ -15,7 +15,7 @@
       if @user.created_at && @user.created_at < Time.zone.parse(MO.vote_cutoff)
         values << [:prefs_votes_anonymous_old.l(cutoff: MO.vote_cutoff), :old]
       end
-      form.select(:votes_anonymous, values, {}, { class: "form-control" }) %>
+      form.select(:votes_anonymous, values, {}, { class: "form-control input-sm", style: "display: inline-block; width: auto; margin-right: 1em;" }) %>
   <span class="HelpNote">
     <%= link_to(:prefs_change_image_vote_anonymity.t,
                 controller: :image,
@@ -33,7 +33,7 @@
                      "keep_but_hide"],
                     [:prefs_keep_image_filenames_keep_and_show.l,
                      "keep_and_show"]],
-                  {}, { class: "form-control" }) %>
+                  {}, { class: "form-control input-sm", style: "display: inline-block; width: auto; margin-right: 1em;" }) %>
   <span class="HelpNote">
     <%= link_to(:prefs_bulk_filename_purge.t,
                  { controller: :image,
@@ -46,7 +46,7 @@
 <div class="form-group push-down">
   <%= label_tag(:user_license_id, :License.t + ":") %>
   <span class="HelpNote">(<%= :prefs_license_note.t %>)</span><br/>
-  <%= form.select(:license_id, @licenses, {}, { class: "form-control" }) %>
+  <%= form.select(:license_id, @licenses, {}, { class: "form-control input-sm", style: "display: inline-block; width: auto; margin-right: 1em;" }) %>
   <span class="HelpNote">
     <%= link_to(:bulk_license_link.t, controller: :image,
                                       action: :license_updater) %>

--- a/app/views/sequences/_form.html.erb
+++ b/app/views/sequences/_form.html.erb
@@ -47,7 +47,8 @@
     </div>
     <div class="col-xs-5 col-md-2">
       <%= form.label(:sequence_archive, :ARCHIVE.t) %>
-      <%= form.select(:archive, archive_dropdown, { include_blank: true }) %>
+      <%= form.select(:archive, archive_dropdown,
+                      { include_blank: true }, { class: "form-control" }) %>
     </div>
     <div class="col-xs-6 col-md-3">
       <span class="bold"><%= :form_sequence_accession.t %></span>

--- a/app/views/shared/_form_description.html.erb
+++ b/app/views/shared/_form_description.html.erb
@@ -21,14 +21,14 @@
         [:form_description_source_project.l, "project"],
         [:form_description_source_source.l,  "source"],
         [:form_description_source_user.l,    "user"],
-      ], class: "form-control") %>
+      ], {}, { class: "form-control" }) %>
     <% elsif new_record && ["public", "source", "user"].include?(type) %>
       <% need_help = true %>
       <%= form.select(:source_type, [
         [:form_description_source_public.l, "public"],
         [:form_description_source_source.l, "source"],
         [:form_description_source_user.l,   "user"],
-      ], class: "form-control") %>
+      ], {}, { class: "form-control" }) %>
     <% else %>
       <%= form.hidden_field(:source_type, value: type) %>
       <%= :"form_description_source_#{type}".l %>
@@ -65,7 +65,7 @@
 
   <div class="form-group">
     <%= label_tag(:description_license_id, :License.t + ":") %>
-    <%= form.select(:license_id, @licenses, class: "form-control") %>
+    <%= form.select(:license_id, @licenses, {}, { class: "form-control" }) %>
     <p class="help-block"><%= :form_description_license_help.t %></p>
   </div>
 


### PR DESCRIPTION
To reproduce: go to your account preferences, select the Amanita theme, and reload the page. Preference selects are not really very legible; insufficient contrast.

Diagnosis:
In the view templates, form selects (in user prefs and elsewhere) correctly specify the Bootstrap `class: "form-control"`, but the class attribute is not created in the HTML, due to incorrect syntax in the erb tag. Result: the select options are not very legible; the text color is incorrectly inherited from the parent element.

Fix: The `form.select` helper requires two options hashes. The `class` has to be in the second hash, rather unintuitively. (Someone seems to have discovered this already, because `views/name/form_name.html.erb` already had the correct syntax.)