### PR TITLE
Bump Rubocop to 1.36

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       io-console (~> 0.5)
     rexml (3.2.5)
     rtf (0.3.3)
-    rubocop (1.35.1)
+    rubocop (1.36.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)


### PR DESCRIPTION
Upgrades Rubocop from 1.35 to 1.36
(There are no new cops; mostly bug fixes, plus some improvements to existing cops.)