### PR TITLE
Make it so non-logged in users can see glossary.

### DIFF
--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -2,7 +2,7 @@
 
 # create and edit Glossary terms
 class GlossaryTermsController < ApplicationController
-  before_action :login_required # except: [:index, :show, :show_past]
+  before_action :login_required, except: [:index, :show, :show_past]
   before_action :store_location, except: [:create, :update, :destroy]
 
   # ---------- Actions to Display data (index, show, etc.) ---------------------


### PR DESCRIPTION
Next installment in my series of one-line PRs!

The glossary is so rarely used I believe this cannot possibly cause a drain on performance.  Since I think at least some visitors encountering pages that require login are finding MO to be unwelcoming, it doesn't seem worth doing so for the glossary.  Site stats?  User summaries?  Yes, those are expensive pages, I'm fine with requiring login.  But the glossary is different.

Feel free to disagree and veto this PR.  It's not like I worked hard on it. :)