### PR TITLE
Fix image float-right in comments

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -44,6 +44,14 @@
   display: flex !important;
 }
 
+.float-right {
+  float: right !important;
+}
+
+.float-left {
+  float: left !important;
+}
+
 .align-middle {
   vertical-align: middle !important;
 }


### PR DESCRIPTION
In my previous SCSS refactor moving inline styles to Bootstrap-4-syntax utility classes, I forgot to define the classes for `float-right` and `float-left`, although I used `float-right` in the comment markup. 

This defines the classes and fixes the layout.