### PR TITLE
Title and logo — HTML classes and ids

### DIFF
--- a/app/assets/javascripts/vote_popup.js.erb
+++ b/app/assets/javascripts/vote_popup.js.erb
@@ -77,7 +77,7 @@ function VotePopupModule(translations) {
               var title = html.children().eq(0);
               var div   = html.children().eq(1);
               document.title = title.attr("title");
-              $("#title-caption").html(title.html());
+              $("#title").html(title.html());
               $("#naming_partial").html(div.html());
               attach_bindings();
               if (typeof SuggestionModule !== "undefined")

--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -7,13 +7,6 @@
   padding-bottom: 5em;
 }
 
-#title,
-.sub-caption,
-.owner-id {
-  font-size: 170%;
-  margin-top: 5px;
-}
-
 //
 // specialized stuff for print view
 // --------------------------------------------------

--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -7,7 +7,7 @@
   padding-bottom: 5em;
 }
 
-#title-caption,
+#title,
 .sub-caption,
 .owner-id {
   font-size: 170%;

--- a/app/assets/stylesheets/mo/_logo.scss
+++ b/app/assets/stylesheets/mo/_logo.scss
@@ -2,56 +2,13 @@
 // Mushroom Observer logo
 // --------------------------------------------------
 
-#logo-trim {
+.logo-trim {
   max-width: 100%;
   height: auto;
   padding-top: 10px;
   padding-bottom: 10px;
 }
 
-#logo-link:hover {
+#logo_link:hover {
   background-color: transparent;
-}
-
-#navigation {
-  #logo {
-    background-color: $LOGO_BG_COLOR;
-    border-width: 0px;
-    border-bottom-width: $LOGO_BORDER_WIDTH;
-    border-color: $LOGO_BORDER_COLOR;
-    border-style: $LOGO_BORDER_STYLE;
-    border-radius: 0px;
-    @if $LEFT_BAR_ITEM_BORDER_WIDTH == 0px {
-      margin-bottom: 5px;
-    }
-
-    padding-top: 5px;
-    padding-bottom: 5px;
-    font: small-caps 25px/25px "Times New Roman", serif;
-    text-align: center;
-    white-space: nowrap;
-    text-overflow: clip;
-    overflow: hidden;
-  }
-
-  #logo #logo-text,
-  #logo:visited #logo-text {
-    color: $LOGO_FG_COLOR;
-    background-color: transparent;
-    text-decoration: none;
-  }
-
-  #logo:hover,
-  #logo:hover div,
-  #logo:hover #logo-text {
-    color: $LOGO_HOVER_FG_COLOR;
-    background-color: $LOGO_HOVER_BG_COLOR;
-    text-decoration: none;
-  }
-
-  @if $LOGO_BORDER_STYLE == outset {
-    #logo:active div {
-      border-style: inset;
-    }
-  }
 }

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -27,14 +27,14 @@
     </div>
   <% end %>
   <div>
-    <div class="sub-caption">
+    <div class="h3">
       <%= :login_create_account_caption.tp %>
     </div>
     <%= :login_no_account.tp %>
     (<%= :login_explain_login_requirement.t %>)
   </div>
   <div>
-    <div class="sub-caption">
+    <div class="h3">
       <%= :login_data_without_login_caption.tp %>
     </div>
     <div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,9 +93,9 @@
 
   <div class="row row-offcanvas row-offcanvas-left">
 
-    <!--NAVIGATION-->
+    <!--LOGO AND NAVIGATION-->
     <div class="col-xs-8 col-lg-2 col-sm-2 sidebar-offcanvas hidden-print">
-      <a id="logo-link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
+      <a id="logo_link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
         <img class="logo-trim" alt="MO Logo" src="/logo-trim.png"/>
       </a>
       <div id="navigation">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -139,7 +139,7 @@
                 when 2; "alert-danger"
               end
               content_tag(:div, flash_get_notices,
-                          id: "flash-notices",
+                          id: "flash_notices",
                           class: "alert mt-3 #{klass}")
             %>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -96,7 +96,7 @@
     <!--NAVIGATION-->
     <div class="col-xs-8 col-lg-2 col-sm-2 sidebar-offcanvas hidden-print">
       <a id="logo-link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
-        <img id="logo-trim" alt="MO Logo" src="/logo-trim.png"/>
+        <img class="logo-trim" alt="MO Logo" src="/logo-trim.png"/>
       </a>
       <div id="navigation">
         <%= render(partial: "/shared/nav_left") %>
@@ -151,9 +151,9 @@
         <% unless @user&.verified? %>
           <div class="max-width-text">
             <p class="text-center hidden-sm hidden-md hidden-lg">
-              <img id="logo-trim" alt="MO Logo" src="/logo-trim.png">
+              <img class="logo-trim" alt="MO Logo" src="/logo-trim.png">
             </p>
-            <p class="sub-caption text-center">Mushroom Observer (MO)</p>
+            <h2 class="h3 text-center">Mushroom Observer (MO)</h2>
             <p><%= :login_layout_description.t %></p>
           </div>
         <% end %>

--- a/app/views/shared/_title_and_tab_sets.html.erb
+++ b/app/views/shared/_title_and_tab_sets.html.erb
@@ -7,10 +7,10 @@
 %>
 
   <!-- Push down pager, title on small, xs screens so buttons do not block -->
-  <%= content_tag(:div, safe_nbsp, class: "hidden-print visible-xs visible-sm
-                                           mt-4") %>
+  <%= content_tag(:div, safe_nbsp,
+                  class: "hidden-print visible-xs visible-sm mt-4") %>
 
-  <div class="col-xs-<%= @tabsets[:right] ? 8 : 12 %>" id="title">
+  <div class="col-xs-<%= @tabsets[:right] ? 8 : 12 %>" id="title_bar">
     <!-- Pager -->
     <%= content_tag(:div, class: "hidden-print") do
           if @tabsets[:pager_for]
@@ -21,13 +21,13 @@
 
     <!-- Title Caption -->
     <!-- e.g. "Observation 5"; Can be multiple lines, e.g., with Observer ID -->
-    <%= content_tag(:span, @title, id: "title-caption") -%>
+    <%= content_tag(:h1, @title, class: "h3", id: "title") -%>
     <%= if @any_content_filters_applied
           add_context_help(content_tag(:span, "(#{:filtered.t})",
                                        class: "context-help"),
                            :rss_filtered_mouseover.t)
         end -%>
-    <%= content_tag_if(@owner_id, :div, @owner_id, class: "owner-id") %>
+    <%= content_tag_if(@owner_id, :div, @owner_id, class: "h3", id: "owner_id") %>
   </div>
 
   <!-- Tabsets -->

--- a/app/views/shared/_title_and_tab_sets.html.erb
+++ b/app/views/shared/_title_and_tab_sets.html.erb
@@ -27,7 +27,7 @@
                                        class: "context-help"),
                            :rss_filtered_mouseover.t)
         end -%>
-    <%= content_tag_if(@owner_id, :div, @owner_id, class: "h3", id: "owner_id") %>
+    <%= content_tag_if(@owner_id, :h3, @owner_id, id: "owner_id") %>
   </div>
 
   <!-- Tabsets -->

--- a/test/controllers/emails_controller_test.rb
+++ b/test/controllers/emails_controller_test.rb
@@ -233,7 +233,7 @@ class EmailsControllerTest < FunctionalTestCase
 
     get(:name_change_request, params: params)
     assert_select(
-      "#title-caption", text: :email_name_change_request_title.l, count: 1
+      "#title", text: :email_name_change_request_title.l, count: 1
     )
   end
 

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -53,7 +53,7 @@ class HerbariaControllerTest < FunctionalTestCase
     login("mary")
     get(:show, params: { id: herbarium.id })
 
-    assert_select("#title-caption", text: herbarium.format_name, count: 1)
+    assert_select("#title", text: herbarium.format_name, count: 1)
     assert_select(
       "a[href^='#{new_herbaria_curator_request_path(id: herbarium)}']",
       { text: :show_herbarium_curator_request.l },
@@ -67,7 +67,7 @@ class HerbariaControllerTest < FunctionalTestCase
     login("rolf")
     get(:show, params: { id: herbarium.id })
 
-    assert_select("#title-caption", text: herbarium.format_name)
+    assert_select("#title", text: herbarium.format_name)
     assert_select("form[action^='#{herbarium_path(herbarium)}']") do
       assert_select("input[value='delete']", true,
                     "Show Herbarium page is missing a destroy herbarium button")
@@ -124,7 +124,7 @@ class HerbariaControllerTest < FunctionalTestCase
     get(:index, params: { flavor: :all })
 
     assert_response(:success)
-    assert_select("#title-caption", { text: "#{:HERBARIA.l} by Name" },
+    assert_select("#title", { text: "#{:HERBARIA.l} by Name" },
                   "index should display #{:HERBARIA.l} by Name")
     Herbarium.find_each do |herbarium|
       assert_select(
@@ -247,7 +247,7 @@ class HerbariaControllerTest < FunctionalTestCase
     login
     get(:index, params: { flavor: :nonpersonal })
 
-    assert_select("#title-caption", text: :query_title_nonpersonal.l)
+    assert_select("#title", text: :query_title_nonpersonal.l)
     Herbarium.where(personal_user_id: nil).each do |herbarium|
       assert_select(
         "a[href ^= '#{herbarium_path(herbarium)}']", true,
@@ -269,7 +269,7 @@ class HerbariaControllerTest < FunctionalTestCase
     login
     get(:index, params: { pattern: pattern })
 
-    assert_select("#title-caption").text.start_with?(
+    assert_select("#title").text.start_with?(
       :query_title_pattern_search.l(types: :HERBARIA.l, pattern: pattern)
     )
     Herbarium.where.not(personal_user_id: nil).each do |herbarium|
@@ -304,7 +304,7 @@ class HerbariaControllerTest < FunctionalTestCase
 
     assert_response(:success)
     assert_select(
-      "#title-caption",
+      "#title",
       { text: "#{:HERBARIA.l} #{:by.l} #{:sort_by_records.l}" },
       "Displayed title should be #{:HERBARIA.l} #{:by.l} #{:sort_by_records.l}"
     )
@@ -347,7 +347,7 @@ class HerbariaControllerTest < FunctionalTestCase
     get(:edit, params: { id: herbarium.id })
 
     assert_response(:success)
-    assert_select("#title-caption", text: :edit_herbarium_title.l, count: 1)
+    assert_select("#title", text: :edit_herbarium_title.l, count: 1)
   end
 
   def test_edit_with_curators_by_non_curator
@@ -364,7 +364,7 @@ class HerbariaControllerTest < FunctionalTestCase
     login("rolf")
     get(:edit, params: { id: nybg.id })
     assert_response(:success)
-    assert_select("#title-caption", text: :edit_herbarium_title.l, count: 1)
+    assert_select("#title", text: :edit_herbarium_title.l, count: 1)
   end
 
   def test_edit_with_curators_by_admin
@@ -373,7 +373,7 @@ class HerbariaControllerTest < FunctionalTestCase
     get(:edit, params: { id: nybg.id })
 
     assert_response(:success)
-    assert_select("#title-caption", text: :edit_herbarium_title.l, count: 1)
+    assert_select("#title", text: :edit_herbarium_title.l, count: 1)
   end
 
   # ---------- Actions to Modify data: (create, update, destroy, etc.) ---------

--- a/test/controllers/image_controller_test.rb
+++ b/test/controllers/image_controller_test.rb
@@ -714,8 +714,7 @@ class ImageControllerTest < FunctionalTestCase
     Image.any_instance.stubs(:save).returns(false)
     post(:edit_image, params: params)
 
-    assert(assert_select("span#title-caption").
-             text.start_with?("Editing Image"),
+    assert(assert_select("#title").text.start_with?("Editing Image"),
            "It should return to form if image save fails")
   end
 

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -707,7 +707,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login(user_with_view_owner_id_true)
     obs = observations(:owner_only_favorite_ne_consensus)
     get(:show, params: { id: obs.id })
-    assert_select("div[class *= 'owner-id']",
+    assert_select("#owner_id",
                   { text: /#{obs.owner_preference.text_name}/,
                     count: 1 },
                   "Observation should show Observer ID")
@@ -715,7 +715,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(
       :show, params: { id: observations(:owner_multiple_favorites).id }
     )
-    assert_select("div[class *= 'owner-id']",
+    assert_select("#owner_id",
                   { text: /#{:show_observation_no_clear_preference.t}/,
                     count: 1 },
                   "Observation should show lack of Observer preference")
@@ -726,7 +726,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(
       :show, params: { id: observations(:owner_only_favorite_ne_consensus).id }
     )
-    assert_select("div[class *= 'owner-id']", { count: 0 },
+    assert_select("#owner_id", { count: 0 },
                   "Do not show Observer ID when user has not opted for it")
   end
 
@@ -735,7 +735,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(
       :show, params: { id: observations(:owner_only_favorite_ne_consensus).id }
     )
-    assert_select("div[class *= 'owner-id']", { count: 0 },
+    assert_select("#owner_id", { count: 0 },
                   "Do not show Observer ID when nobody logged in")
   end
 

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -37,7 +37,7 @@ class SequencesControllerTest < FunctionalTestCase
     get(:index, params: { flavor: :all })
 
     assert_response(:success)
-    assert_select("#title-caption", { text: "#{:SEQUENCE.l} Index" },
+    assert_select("#title", { text: "#{:SEQUENCE.l} Index" },
                   "index should display #{:SEQUENCES.l} Index")
     Sequence.find_each do |sequence|
       assert_select(

--- a/test/integration/curator_test.rb
+++ b/test/integration/curator_test.rb
@@ -149,7 +149,7 @@ class CuratorTest < IntegrationTestCase
     click_mo_link(label: :herbarium_index.l)
 
     assert_select(
-      "#title-caption", { text: :query_title_nonpersonal.l },
+      "#title", { text: :query_title_nonpersonal.l },
       "Clicking #{:herbarium_index.l} should display " \
       "#{:query_title_nonpersonal.l} by Name"
     )
@@ -164,7 +164,7 @@ class CuratorTest < IntegrationTestCase
       form.submit("Search")
     end
     assert_select(
-      "#title-caption",
+      "#title",
       { text: herbaria(:nybg_herbarium).format_name },
       "Fungaria pattern search with a single hit should land on " \
       "the show page for that Fungarium"
@@ -180,7 +180,7 @@ class CuratorTest < IntegrationTestCase
       form.submit("Search")
     end
     assert_select(
-      "#title-caption",
+      "#title",
       { text: "Fungaria Matching ‘Personal’" },
       "Fungaria pattern search with multiple hits should land on " \
       "an index page for those Fungaria"
@@ -197,7 +197,7 @@ class CuratorTest < IntegrationTestCase
     end
     assert_template("herbarium_record/list_herbarium_records")
     assert_select(
-      "#title-caption",
+      "#title",
       { text: "#{:HERBARIUM_RECORDS.l} Matching ‘Coprinus comatus’" },
       "Fungarium Record pattern search should display " \
       "#{:HERBARIUM_RECORDS.l} Matching ‘Coprinus comatus’"
@@ -222,7 +222,7 @@ class CuratorTest < IntegrationTestCase
 
     assert_equal(new_code, herbarium.reload.code)
     assert_select(
-      "#title-caption",
+      "#title",
       { text: herbarium.format_name },
       "Changing Fungarium code should land on page for that Fungarium"
     )
@@ -252,7 +252,7 @@ class CuratorTest < IntegrationTestCase
     assert_not_empty(user.curated_herbaria)
 
     assert_select(
-      "#title-caption", { text: "Mary’s Herbarium" }, # smart apostrophe
+      "#title", { text: "Mary’s Herbarium" }, # smart apostrophe
       "Creating a Fungarium should show the new Fungarium"
     )
 
@@ -261,7 +261,7 @@ class CuratorTest < IntegrationTestCase
       form.submit(:destroy_object.t(type: :herbarium))
     end
     assert_select(
-      "#title-caption", { text: :herbarium_index.l },
+      "#title", { text: :herbarium_index.l },
       "Destroying a Fungarium should display #{:herbarium_index.l}"
     )
   end
@@ -299,14 +299,14 @@ class CuratorTest < IntegrationTestCase
     login!("mary", "testpassword", true)
     get(herbarium_path(nybg))
     click_mo_link(label: :show_herbarium_curator_request.l)
-    assert_select("#title-caption").text.
+    assert_select("#title").text.
       starts_with?(:show_herbarium_curator_request.l)
     open_form("form[action^='#{herbaria_curator_requests_path(id: nybg)}']",
               &:submit)
 
     assert_flash_text(:show_herbarium_request_sent.t)
     assert_select(
-      "#title-caption", { text: nybg.format_name },
+      "#title", { text: nybg.format_name },
       "Submitting a curator request should return to herbarium page"
     )
   end
@@ -326,6 +326,6 @@ class CuratorTest < IntegrationTestCase
     form.submit("#{mary.name} (#{mary.login}): Personal Fungarium")
 
     assert_response(:success) # Rails follows the redirect
-    assert_select("#title-caption", text: mary_herbarium.format_name, count: 1)
+    assert_select("#title", text: mary_herbarium.format_name, count: 1)
   end
 end

--- a/test/integration/expert_test.rb
+++ b/test/integration/expert_test.rb
@@ -262,7 +262,7 @@ class ExpertTest < IntegrationTestCase
     end
     assert_flash_success
     assert_template("species_list/show_species_list")
-    assert_select("div#title", text: /#{spl.title}/)
+    assert_select("#title", text: /#{spl.title}/)
     assert_select("a[href*='edit_species_list/#{spl.id}']", text: /edit/i)
 
     loc = Location.last

--- a/test/integration/expert_test.rb
+++ b/test/integration/expert_test.rb
@@ -279,7 +279,7 @@ class ExpertTest < IntegrationTestCase
     # Try adding a comment, just for kicks.
     click_mo_link(href: /add_comment/)
     assert_template("comment/add_comment")
-    assert_select("div#title", text: /#{spl.title}/)
+    assert_select("#title", text: /#{spl.title}/)
     assert_select("a[href*='show_species_list/#{spl.id}']", text: /cancel/i)
     open_form do |form|
       form.change("comment_summary", "Slartibartfast")
@@ -288,7 +288,7 @@ class ExpertTest < IntegrationTestCase
     end
     assert_flash_success
     assert_template("species_list/show_species_list")
-    assert_select("div#title", text: /#{spl.title}/)
+    assert_select("#title", text: /#{spl.title}/)
     assert_select("div.comment", text: /Slartibartfast/)
     assert_select("div.comment", text: /Steatopygia/)
   end

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -29,8 +29,7 @@ class FilterTest < IntegrationTestCase
       /#{:app_title.l}: Observations Matching ‘#{obs.name.text_name}/,
       page.title, "Wrong page"
     )
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_text(:filtered.t)
+    page.find("#title_bar").assert_text(:filtered.t)
     results = page.find("#results")
     # Number of hits should == number of **imaged** Observations of obs.name
     results.assert_text(obs.name.text_name, count: imged_obss.size)
@@ -39,13 +38,11 @@ class FilterTest < IntegrationTestCase
 
     # Show Locations should be filtered
     click_link("Show Locations")
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_text(:filtered.t)
+    page.find("#title_bar").assert_text(:filtered.t)
 
     # And mapping them should also be filtered.
     click_link("Map Locations")
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_text(:filtered.t)
+    page.find("#title_bar").assert_text(:filtered.t)
 
     ### Now prove that turning filter off stops filtering ###
     # Prove that preference page UI works
@@ -74,8 +71,7 @@ class FilterTest < IntegrationTestCase
     page.select("Observations", from: :search_type)
     click_button("Search")
 
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_no_text(:filtered.t)
+    page.find("#title_bar").assert_no_text(:filtered.t)
 
     results = page.find("#results")
     # Number of hits should == **total** Observations of obs.name
@@ -117,8 +113,7 @@ class FilterTest < IntegrationTestCase
     page.select("Observations", from: :search_type)
 
     click_button("Search")
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_text(:filtered.t)
+    page.find("#title_bar").assert_text(:filtered.t)
 
     results = page.find("#results")
     vouchered_obss = Observation.where(name: obs.name).where(specimen: true)
@@ -141,7 +136,7 @@ class FilterTest < IntegrationTestCase
 
     # Verfy Advanced Search form
     click_on("Advanced Search", match: :first)
-    within("div#advanced_search_filters") do
+    within("#advanced_search_filters") do
       # Verify Labels.
       assert_text(:advanced_search_filters.t)
       assert_text(:advanced_search_filter_has_images.t)
@@ -157,8 +152,7 @@ class FilterTest < IntegrationTestCase
     first(:button, :advanced_search_submit.l).click
 
     # Advance Search Filters should override user's { has_images: "yes" }
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_no_text(:filtered.t)
+    page.find("#title_bar").assert_no_text(:filtered.t)
 
     results = page.find("#results")
     # Number of hits should == **total** Observations of obs.name
@@ -173,7 +167,7 @@ class FilterTest < IntegrationTestCase
 
     # Verify additional parts of Advanced Search form
     click_on("Advanced Search", match: :first)
-    filters = page.find("div#advanced_search_filters")
+    filters = page.find("#advanced_search_filters")
     within(filters) do
       assert(find("#content_filter_has_images_yes").checked?)
       assert(find("#content_filter_has_specimen_").checked?)
@@ -188,8 +182,7 @@ class FilterTest < IntegrationTestCase
 
     # Advance Search Filters should override user content_filter so hits
     #   should == vouchered Observations of obs.name, both imaged and imageless
-    page.find_by_id("title"). # rubocop:disable Rails/DynamicFindBy
-      assert_no_text(:filtered.t)
+    page.find("#title_bar").assert_no_text(:filtered.t)
     expect = Observation.where(name: obs.name).where(specimen: true)
     results = page.find("#results")
     results.assert_text(obs.name.text_name, count: expect.size)

--- a/test/integration/observations_controller_supplemental_test.rb
+++ b/test/integration/observations_controller_supplemental_test.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# This cop doesn't understand that find_by_id is not being called on an
-# ActiveRecord instance, and therefore is not a rails dynamic finder.
-# rubocop:disable Rails/DynamicFindBy
-
 require("test_helper")
 
 # Tests which supplement controller/observations_controller_test.rb
@@ -34,7 +30,7 @@ class ObservationsControllerSupplementalTest < IntegrationTestCase
     visit("/name/map/#{name.id}")
     click_link("Show Observations")
     click_link("Show Map")
-    title = page.find_by_id("title")
+    title = page.find("#title")
     title.assert_text("Map of Observation Index")
   end
 
@@ -59,7 +55,7 @@ class ObservationsControllerSupplementalTest < IntegrationTestCase
     within("div#right_tabs") { click_button("Destroy") }
 
     # MO should show next Observation.
-    page.find_by_id("title")
+    page.find("#title")
     assert_match(/#{:app_title.l}: Observation #{next_obs.id}/, page.title,
                  "Wrong page")
   end
@@ -130,10 +126,8 @@ class ObservationsControllerSupplementalTest < IntegrationTestCase
       fill_in("fr:mo.ask_user_question_subject", with: "Bonjour!")
       fill_in("fr:mo.ask_user_question_message:", with: "Ça va?")
       click_button("fr:mo.SEND")
-      notices = page.find_by_id("flash-notices")
+      notices = page.find("#flash-notices")
       notices.assert_text("fr:mo.runtime_ask_user_question_success")
     end
   end
 end
-
-# rubocop:enable Rails/DynamicFindBy

--- a/test/integration/observations_controller_supplemental_test.rb
+++ b/test/integration/observations_controller_supplemental_test.rb
@@ -126,7 +126,7 @@ class ObservationsControllerSupplementalTest < IntegrationTestCase
       fill_in("fr:mo.ask_user_question_subject", with: "Bonjour!")
       fill_in("fr:mo.ask_user_question_message:", with: "Ça va?")
       click_button("fr:mo.SEND")
-      notices = page.find("#flash-notices")
+      notices = page.find("#flash_notices")
       notices.assert_text("fr:mo.runtime_ask_user_question_success")
     end
   end

--- a/test/integration/query_supplemental_test.rb
+++ b/test/integration/query_supplemental_test.rb
@@ -24,7 +24,7 @@ class QuerySupplementalTest < IntegrationTestCase
     click_link("Show Locations")
     click_link("Map Locations")
 
-    title = page.find_by_id("title") # rubocop:disable Rails/DynamicFindBy
+    title = page.find("#title")
     title.assert_text("‘#{obs.name.text_name}’")
   end
 end

--- a/test/session_extensions.rb
+++ b/test/session_extensions.rb
@@ -355,7 +355,7 @@ module SessionExtensions
     when :results
       "#results"
     when :title
-      "#title"
+      "#title_bar"
     else
       arg
     end


### PR DESCRIPTION
Part of a series of PRs to generate more predictable page elements for test refactoring.

- Clean up logo classes and ids, currently somewhat confusing. One `id` was not unique on the page
- Eliminate unused CSS `#navigation .logo` style block (logo moved out of #navigation when logo changed, apparently)
- Refactor page title bar and title "caption" to use an `h1` element, and rename the ids and classes used there.
- Change "#title" to "#title_bar" and "#title_caption" to "#title"
- Change ".owner-id" to "#owner_id" and "#flash-notices" to "#flash_notices"
- Adjust tests to find the new ids, removes element tag names from selectors ("div#title" to "#title_bar"

Curiously, MO does not currently generate a machine-readable page heading (generally, that would be an `h1` element). It doesn't have to be styled like an h1... Bootstrap allows for restyling headings like so, keeping the same appearance we have currently: 

`<h1 class="h3" id="title"><%= @title %></h1>`
