### PR TITLE
Revert change to `.help-block` position, add `.position-relative` where tooltips are needed

### DIFF
--- a/app/assets/stylesheets/mo/_help_tooltips.scss
+++ b/app/assets/stylesheets/mo/_help_tooltips.scss
@@ -15,7 +15,6 @@ $help-block-max-width: 600px;
 .help-block {
   color: $WELL_FG_COLOR;
   max-width: $help-block-max-width;
-  position: relative
 }
 
 .tooltip-inner {

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -112,6 +112,11 @@
   margin: 1em !important;
 }
 
+.my-2 {
+  margin-top: 0.5em !important;
+  margin-bottom: 0.5em !important;
+}
+
 .my-3 {
   margin-top: 1em !important;
   margin-bottom: 1em !important;

--- a/app/views/account/profile.html.erb
+++ b/app/views/account/profile.html.erb
@@ -11,10 +11,11 @@
 %>
 
 <div class="max-width-text">
-  <%= form_for(:user, url: { action: :profile }, html: { multipart: true })
-        do |form| %>
+  <%= form_for(:user, url: { action: :profile },
+               html: { multipart: true }) do |form| %>
 
-    <%= submit_tag(:profile_button.l, class: "btn btn-default center-block mt-3") %>
+    <%= submit_tag(:profile_button.l,
+                   class: "btn btn-default center-block mt-3") %>
 
     <div class="form-group mt-3">
       <%= label_tag(:user_name, :profile_name.t + ":") %>
@@ -23,7 +24,8 @@
 
     <div class="form-group mt-3">
       <%= label_tag(:user_place_name, :profile_location.t + ":") %> (33%)
-      <%= text_field(:user, :place_name, value: @place_name, class: "form-control") %>
+      <%= text_field(:user, :place_name,
+                     value: @place_name, class: "form-control") %>
       <% turn_into_location_auto_completer("user_place_name") %>
     </div>
 
@@ -45,7 +47,8 @@
       <%= label_tag(:copyright_holder, :profile_copyright_holder.t + ":") %>
       <div class="row">
         <div class="col-xs-8">
-          <%= text_field_tag(:copyright_holder, @copyright_holder, class: "form-control") %>
+          <%= text_field_tag(:copyright_holder, @copyright_holder,
+                             class: "form-control") %>
         </div>
         <div class="col-xs-4">
           <%= select_year(@copyright_year,

--- a/app/views/account/profile.html.erb
+++ b/app/views/account/profile.html.erb
@@ -11,7 +11,8 @@
 %>
 
 <div class="max-width-text">
-  <%= form_for(:user, url: {action: :profile}, html: {multipart: true}) do |form| %>
+  <%= form_for(:user, url: { action: :profile }, html: { multipart: true })
+        do |form| %>
 
     <%= submit_tag(:profile_button.l, class: "btn btn-default center-block mt-3") %>
 
@@ -33,9 +34,10 @@
 
     <div class="form-group mt-3">
       <%= label_tag(:user_upload_image, (@user.image_id ? :profile_image_change.t : :profile_image_create.t) + ":") %> (33%)
-      <%= link_to(:profile_image_reuse.t, controller: :image, action: :reuse_image, mode: :profile) %>
-      <%= link_to(:profile_image_remove.t, {action: :remove_image},
-                  {data: {confirm: :are_you_sure.l}}) if @user.image %>
+      <%= link_to(:profile_image_reuse.t,
+                  controller: :image, action: :reuse_image, mode: :profile) %>
+      <%= link_to(:profile_image_remove.t, { action: :remove_image },
+                  { data: { confirm: :are_you_sure.l } }) if @user.image %>
       <%= custom_file_field(:user, :upload_image) %>
     </div>
 
@@ -53,7 +55,9 @@
         </div>
       </div>
       <div class="mt-3">
-        <%= select(:upload, :license_id, @licenses, {selected: @upload_license_id}, {class: "form-control"}) %>
+        <%= select(:upload, :license_id, @licenses,
+                   { selected: @upload_license_id },
+                   { class: "form-control" }) %>
       </div>
       <div class="help-block">(<%= :profile_copyright_warning.t %>)</div>
     </div>
@@ -63,7 +67,8 @@
       <%= form.text_area(:mailing_address, rows: 5, class: "form-control") %>
     </div>
 
-    <%= submit_tag(:profile_button.l, class: "btn btn-default center-block mt-3") %>
+    <%= submit_tag(:profile_button.l,
+                   class: "btn btn-default center-block mt-3") %>
 
   <% end %>
 </div>

--- a/app/views/herbaria/_form.html.erb
+++ b/app/views/herbaria/_form.html.erb
@@ -25,7 +25,7 @@
          <% turn_into_user_auto_completer(:herbarium_personal_user_name) %>
         </div>
         <% if button_name != :CREATE %>
-          <div class="well well-sm mt-3 help-block">
+          <div class="well well-sm mt-3 help-block position-relative">
             <div class="arrow-up mt-2"></div>
             <% top_users = herbarium_top_users(@herbarium)
                top_users.each do |name, login, count| %>
@@ -55,7 +55,7 @@
             <%= f.check_box(:personal, class: "form-control-xxx") %>
             <%= f.label(:personal, :create_herbarium_personal.t) %>
           </div>
-          <div class="well well-sm mt-3 help-block">
+          <div class="well well-sm mt-3 help-block position-relative">
             <div class="arrow-up"></div>
             <%= :create_herbarium_personal_help.t(
                   name: @user.personal_herbarium_name
@@ -74,7 +74,7 @@
           <%= f.text_field(:code, size: 8, class: "form-control") %>
           <span class="HelpNote">(<%= :optional.t %>)</span>
         </div>
-        <div class="well well-sm mt-3 help-block">
+        <div class="well well-sm mt-3 help-block position-relative">
           <div class="arrow-up mt-2"></div>
           <%= :create_herbarium_code_help.t %>
         </div>

--- a/app/views/herbaria/_form.html.erb
+++ b/app/views/herbaria/_form.html.erb
@@ -95,7 +95,7 @@
   <div class="row form-group">
     <div class="col-xs-12">
       <%= f.label(:herbarium_email, "#{:create_herbarium_email.t}:") %>
-     <span class="HelpNote">(<%= :optional.t %>)</span>
+      <span class="HelpNote">(<%= :optional.t %>)</span>
       <%= f.text_field(:email, class: "form-control") %>
     </div>
   </div>

--- a/app/views/herbarium_record/_form.html.erb
+++ b/app/views/herbarium_record/_form.html.erb
@@ -15,7 +15,8 @@
     <div class="form-group">
       <%= label_tag(:herbarium_record_herbarium_name, :NAME.t + ":") %>
       <span class="HelpNote">(<%= :required.t %>)</span>
-      <%= text_field(:herbarium_record, :herbarium_name, class: "form-control") %>
+      <%= text_field(:herbarium_record, :herbarium_name,
+                     class: "form-control") %>
       <% turn_into_herbarium_auto_completer(:herbarium_record_herbarium_name) %>
     </div>
   </div>
@@ -34,8 +35,10 @@
 <div class="row">
   <div class="col-xs-12">
     <div class="form-inline">
-      <%= label_tag(:herbarium_record_accession_number, :herbarium_record_accession_number.t + ":") %>
-      <%= text_field(:herbarium_record, :accession_number, class:"form-control") %>
+      <%= label_tag(:herbarium_record_accession_number,
+                    :herbarium_record_accession_number.t + ":") %>
+      <%= text_field(:herbarium_record, :accession_number,
+                     class:"form-control") %>
       <span class="HelpNote">(<%= :required.t %>)</span>
     </div>
     <div class="well well-sm mt-3 help-block position-relative">
@@ -50,7 +53,8 @@
     <div class="form-group">
       <%= label_tag(:herbarium_record_notes, :NOTES.t + ":") %>
       <span class="HelpNote">(<%= :optional.t %>)</span>
-      <%= text_area(:herbarium_record, :notes, class: "form-control", rows: 6) %>
+      <%= text_area(:herbarium_record, :notes,
+                    class: "form-control", rows: 6) %>
     </div>
   </div>
 </div>

--- a/app/views/herbarium_record/_form.html.erb
+++ b/app/views/herbarium_record/_form.html.erb
@@ -38,7 +38,7 @@
       <%= text_field(:herbarium_record, :accession_number, class:"form-control") %>
       <span class="HelpNote">(<%= :required.t %>)</span>
     </div>
-    <div class="well well-sm mt-3 help-block">
+    <div class="well well-sm mt-3 help-block position-relative">
       <div class="arrow-up"></div>
       <%= :create_herbarium_record_accession_number_help.t %>
     </div>

--- a/app/views/naming/_form.html.erb
+++ b/app/views/naming/_form.html.erb
@@ -38,9 +38,9 @@
   </div>
 
   <div class="col-sm-6">
-    <div class="well well-sm">
+    <div class="well well-sm help-block position-relative">
       <div class="arrow-left hidden-xs"></div>
-      <%= tag.p(:form_naming_name_help.t, class: "help-block mb-3") %>
+      <%= tag.p(:form_naming_name_help.t) %>
     </div>
   </div>
 

--- a/app/views/observations/_form_multi_image_upload.html.erb
+++ b/app/views/observations/_form_multi_image_upload.html.erb
@@ -6,9 +6,9 @@
     <input type="file" multiple id="multiple_images_button" accept="image/*" class="mt-3"/>
   </div>
   <div class="col-sm-6">
-    <div class="well well-sm max-width-text">
+    <div class="well well-sm max-width-text help-block position-relative">
       <div class="arrow-left hidden-xs"></div>
-      <p class="help-block">
+      <p class="">
         <%= :form_observations_upload_help_multi_select.t %>
       </p>
     </div>

--- a/app/views/observations/_form_observation_notes.html.erb
+++ b/app/views/observations/_form_observation_notes.html.erb
@@ -14,10 +14,10 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-6 max-width-text">
-        <div class="well well-sm" id="notes_help">
+        <div class="well well-sm help-block position-relative" id="notes_help">
           <div class="arrow-left hidden-xs"></div>
           <%= content_tag(:p, :form_observations_notes_help.t,
-                          class: "help-block pt-0 mt-0") %>
+                          class: "pt-0 mt-0") %>
           <%= render(partial: "shared/textilize_help") %>
         </div>
       </div>

--- a/app/views/observations/_form_observations.html.erb
+++ b/app/views/observations/_form_observations.html.erb
@@ -39,7 +39,7 @@
     </div>
   </div>
   <div class="col-xs-12 col-sm-6">
-    <div class="well well-sm max-width-text help-block">
+    <div class="well well-sm max-width-text help-block position-relative">
       <div class="arrow-left hidden-xs"></div>
       <%=
         loc1 = "Albion, Mendocino Co., California, USA"
@@ -56,7 +56,7 @@
 <div class="row">
   <div class="col-xs-12 col-sm-6 max-width-text">
     <span class="map-locate map-btn">Locate on Map</span>
-    <div class="well well-sm mt-3 max-width-text help-block">
+    <div class="well well-sm mt-3 max-width-text help-block position-relative">
       <div class="arrow-up hidden-xs"></div>
       <%= :form_observations_locate_on_map_help.t %>
     </div>
@@ -71,7 +71,7 @@
       <%= check_box(:observation, :is_collection_location, class: "form-control-xxx") %>
       <%= label_tag(:observation_is_collection_location, :form_observations_is_collection_location.t) %>
     </div>
-    <div class="well well-sm mt-3 max-width-text help-block">
+    <div class="well well-sm mt-3 max-width-text help-block position-relative">
       <div class="arrow-up hidden-xs"></div>
       <%= :form_observations_is_collection_location_help.t %>
     </div>
@@ -90,7 +90,7 @@
     </div>
   </div>
   <div class="col-sm-6">
-    <div class="well well-sm help-block">
+    <div class="well well-sm help-block position-relative">
       <div class="arrow-left hidden-xs"></div>
       <%= :form_observations_lat_long_help.t %>
     </div>
@@ -148,7 +148,7 @@
       <%= check_box(:observation, :specimen, class: "form-control-xxx") %>
       <%= label_tag(:observation_specimen, :form_observations_specimen_available.t) %>
     </div>
-    <div class="well well-sm mt-3 max-width-text help-block">
+    <div class="well well-sm mt-3 max-width-text help-block position-relative">
       <div class="arrow-up"></div>
       <%= :form_observations_specimen_available_help.t %>
     </div>
@@ -178,7 +178,7 @@
         </div>
       </div>
       <div class="col-sm-6">
-        <div class="well well-sm help-block">
+        <div class="well well-sm help-block position-relative">
           <div class="arrow-left hidden-xs"></div>
           <%= :form_observations_collection_number_help.t %>
         </div>
@@ -202,7 +202,7 @@
         </div>
       </div>
       <div class="col-sm-6">
-        <div class="well well-sm help-block">
+        <div class="well well-sm help-block position-relative">
           <div class="arrow-left hidden-xs"></div>
           <%= :form_observations_herbarium_record_help.t %>
         </div>
@@ -381,7 +381,7 @@
   <div class="row mt-3">
     <div class="col-xs-12 max-width-text-times-two">
       <div class="col-xs-12 col-sm-6 pull-right">
-        <div class="well well-sm max-width-text help-block">
+        <div class="well well-sm max-width-text help-block position-relative">
           <div class="arrow-left hidden-xs"></div>
           <%= :form_observations_project_help.t %>
         </div>
@@ -403,7 +403,7 @@
   <div class="row mt-3">
     <div class="col-xs-12 max-width-text-times-two">
       <div class="col-xs-12 col-sm-6 pull-right">
-        <div class="well well-sm max-width-text help-block">
+        <div class="well well-sm max-width-text help-block position-relative">
           <div class="arrow-left hidden-xs"></div>
           <%= :form_observations_list_help.t %>
         </div>

--- a/app/views/observations/_form_observations.html.erb
+++ b/app/views/observations/_form_observations.html.erb
@@ -68,8 +68,10 @@
 <div class="row">
   <div class="col-xs-12 max-width-text">
     <div class="form-inline">
-      <%= check_box(:observation, :is_collection_location, class: "form-control-xxx") %>
-      <%= label_tag(:observation_is_collection_location, :form_observations_is_collection_location.t) %>
+      <%= check_box(:observation, :is_collection_location,
+                    class: "form-control-xxx") %>
+      <%= label_tag(:observation_is_collection_location,
+                    :form_observations_is_collection_location.t) %>
     </div>
     <div class="well well-sm mt-3 max-width-text help-block position-relative">
       <div class="arrow-up hidden-xs"></div>
@@ -121,7 +123,8 @@
       <div class="col-xs-12 col-sm-12">
         <div class="form-inline">
           <%= check_box(:observation, :gps_hidden, class: "form-control-xxx") %>
-          <%= label_tag(:observation_gps_hidden, :form_observations_gps_hidden.t) %>
+          <%= label_tag(:observation_gps_hidden,
+                        :form_observations_gps_hidden.t) %>
         </div>
       </div>
     </div>
@@ -146,7 +149,8 @@
   <div class="col-xs-12 mt-3 max-width-text">
     <div class="form-inline">
       <%= check_box(:observation, :specimen, class: "form-control-xxx") %>
-      <%= label_tag(:observation_specimen, :form_observations_specimen_available.t) %>
+      <%= label_tag(:observation_specimen,
+                    :form_observations_specimen_available.t) %>
     </div>
     <div class="well well-sm mt-3 max-width-text help-block position-relative">
       <div class="arrow-up"></div>
@@ -169,12 +173,16 @@
     <div class="row mb-3">
       <div class="col-sm-6 max-width-text">
         <div class="form-group">
-          <%= label_tag(:collection_number_name, :collection_number_name.t + ":") %>
-          <%= text_field(:collection_number, :name, value: @collectors_name, class: "form-control") %>
+          <%= label_tag(:collection_number_name,
+                        :collection_number_name.t + ":") %>
+          <%= text_field(:collection_number, :name,
+                         value: @collectors_name, class: "form-control") %>
         </div>
         <div class="form-group">
-          <%= label_tag(:collection_number_number, :collection_number_number.t + ":") %>
-          <%= text_field(:collection_number, :number, value: @collectors_number, class: "form-control") %>
+          <%= label_tag(:collection_number_number,
+                        :collection_number_number.t + ":") %>
+          <%= text_field(:collection_number, :number,
+                         value: @collectors_number, class: "form-control") %>
         </div>
       </div>
       <div class="col-sm-6">
@@ -187,13 +195,19 @@
     <div class="row mb-3">
       <div class="col-sm-6 max-width-text">
         <div class="form-group">
-          <%= label_tag(:herbarium_record_herbarium_name, :herbarium_record_herbarium_name.t + ":") %>
-          <%= text_field(:herbarium_record, :herbarium_name, value: @herbarium_name, class: "form-control") %>
-          <% turn_into_herbarium_auto_completer(:herbarium_record_herbarium_name) %>
+          <%= label_tag(:herbarium_record_herbarium_name,
+                        :herbarium_record_herbarium_name.t + ":") %>
+          <%= text_field(:herbarium_record, :herbarium_name,
+                         value: @herbarium_name, class: "form-control") %>
+          <% turn_into_herbarium_auto_completer(
+               :herbarium_record_herbarium_name
+             ) %>
         </div>
         <div class="form-group">
-          <%= label_tag(:herbarium_record_herbarium_id, :herbarium_record_accession_number.t + ":") %>
-          <%= text_field(:herbarium_record, :herbarium_id, value: @herbarium_id, class: "form-control") %>
+          <%= label_tag(:herbarium_record_herbarium_id,
+                        :herbarium_record_accession_number.t + ":") %>
+          <%= text_field(:herbarium_record, :herbarium_id,
+                         value: @herbarium_id, class: "form-control") %>
         </div>
         <div class="form-group">
           <%= label_tag(:herbarium_record_notes, "#{:herbarium_record_notes.t}:") %>
@@ -255,48 +269,68 @@
                 <%= radio_button(:observation, :thumb_image_id, image.id) %>
               </div>
               <div class="col-xs-11 col-sm-3">
-                <%= thumbnail(image, border: 0, obs: @observation.id, votes: true) %>
+                <%= thumbnail(image, border: 0,
+                              obs: @observation.id, votes: true) %>
               </div>
               <div class="col-xs-12 col-sm-8">
                 <% if check_permission(image) %>
                   <table class="table-observation-form">
                     <tr>
                       <td>
-                        <%= label_tag("image_#{image.id}_notes", :NOTES.t + ":") %>
+                        <%= label_tag("image_#{image.id}_notes",
+                                      :NOTES.t + ":") %>
                       </td>
                       <td>
-                        <%= text_area(:good_image, :notes, value: image.notes, index: image.id,
-                                       rows: 1, class: "form-control form-control-sm") %>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <%= label_tag("image_#{image.id}_original_name", :form_observations_original_name.t + ":") %>
-                      </td>
-                      <td>
-                        <%= text_field(:good_image, :original_name, value: image.original_name, index: image.id,
-                                       size: 40, class: "form-control form-control-sm") %>
+                        <%= text_area(:good_image, :notes,
+                                      value: image.notes,
+                                      index: image.id,
+                                      rows: 1,
+                                      class: "form-control form-control-sm") %>
                       </td>
                     </tr>
                     <tr>
                       <td>
-                        <%= label_tag("image_#{image.id}_copyright_holder", "#{:form_images_copyright_holder.t}:") %>
+                        <%= label_tag(
+                              "image_#{image.id}_original_name",
+                              :form_observations_original_name.t + ":"
+                            ) %>
                       </td>
                       <td>
-                        <%= text_field(:good_image, :copyright_holder, value: image.copyright_holder, index: image.id, class: "form-control form-control-sm") %>
+                        <%= text_field(:good_image, :original_name,
+                                       value: image.original_name,
+                                       index: image.id,
+                                       size: 40,
+                                       class: "form-control form-control-sm") %>
                       </td>
                     </tr>
                     <tr>
                       <td>
-                        <%= label_tag("image_#{image.id}_when_1i", :form_images_when_taken.t + ":") %>
+                        <%= label_tag("image_#{image.id}_copyright_holder",
+                                      "#{:form_images_copyright_holder.t}:") %>
+                      </td>
+                      <td>
+                        <%= text_field(:good_image, :copyright_holder,
+                                       value: image.copyright_holder,
+                                       index: image.id,
+                                       class: "form-control form-control-sm") %>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <%= label_tag("image_#{image.id}_when_1i",
+                                      :form_images_when_taken.t + ":") %>
                       </td>
                       <td>
                         <div class="form-inline">
-                          <%= date_select(:good_image, :when, date_select_opts(image).
-                                          merge(object: image, index: image.id),
-                                          {class: "form-control form-control-sm",
-                                          onchange: "CHANGED_DATES[#{image.id}] = true"}) %>
-                          <% turn_into_year_auto_completer("good_image_#{image.id}_when_1i") %>
+                          <%= date_select(:good_image, :when,
+                                date_select_opts(image).merge(object: image,
+                                                              index: image.id),
+                                { class: "form-control form-control-sm",
+                                  onchange:
+                                  "CHANGED_DATES[#{image.id}] = true"}) %>
+                          <% turn_into_year_auto_completer(
+                               "good_image_#{image.id}_when_1i"
+                             ) %>
                         </div>
                       </td>
                     </tr>
@@ -305,8 +339,11 @@
                         <%= label_tag("image_#{image.id}_license_id", :form_images_select_license.t + ":") %>
                       </td>
                       <td>
-                        <%= select(:good_image, :license_id, License.current_names_and_ids(image.license),
-                                   {selected: image.license_id, index: image.id}, {class: "form-control form-control-sm"}) %>
+                        <%= select(:good_image, :license_id,
+                                   License.current_names_and_ids(image.license),
+                                   { selected: image.license_id,
+                                     index: image.id },
+                                   { class: "form-control form-control-sm" }) %>
                       </td>
                     </tr>
                   </table>
@@ -345,7 +382,12 @@
               <% i += 1 %>
             <% end %>
           </div>
-          <input id="new_image_button" onclick="image_new();" type="button" value="<%= :form_observations_upload_another.t %>" class="btn btn-default"/>
+          <input
+            id="new_image_button"
+            onclick="image_new();"
+            type="button"
+            value="<%= :form_observations_upload_another.t %>"
+            class="btn btn-default"/>
           <% javascript_include("single_image_uploader") %>
           <%= javascript_tag %(
             var x = String.fromCharCode(60);
@@ -389,8 +431,10 @@
       <strong><%= :PROJECTS.t %>:</strong>
       <% @projects.each do |project| %>
         <div class="form-inline max-width-text">
-          <%= check_box(:project, "id_#{project.id}", checked: @project_checks[project.id],
-                        disabled: @observation.user != @user && !project.is_member?(@user),
+          <%= check_box(:project, "id_#{project.id}",
+                        checked: @project_checks[project.id],
+                        disabled: @observation.user != @user &&
+                          !project.is_member?(@user),
                         class: "form-control-xxx") %>
           <%= link_to_object(project) %>
         </div>
@@ -411,8 +455,10 @@
       <strong><%= :SPECIES_LISTS.t %>:</strong>
       <% @lists.each do |list| %>
         <div class="form-inline max-width-text">
-          <%= check_box(:list, "id_#{list.id}", checked: @list_checks[list.id],
-                        disabled: !check_permission(list), class: "form-control-xxx") %>
+          <%= check_box(:list, "id_#{list.id}",
+                        checked: @list_checks[list.id],
+                        disabled: !check_permission(list),
+                        class: "form-control-xxx") %>
           <%= link_to_object(list) %>
         </div>
       <% end %>

--- a/app/views/sequences/_form.html.erb
+++ b/app/views/sequences/_form.html.erb
@@ -9,7 +9,7 @@
         <%= form.text_area(:locus, rows: 1, class:"form-control", style:"width: 100%;" ) %>
     </div>
     <div class="col-xs-12 col-sm-6">
-      <div class="well well-sm max-width-text help-block">
+      <div class="well well-sm max-width-text help-block position-relative">
         <div class="arrow-left hidden-xs"></div>
         <%= :form_sequence_locus_help.t(locus_width: Sequence.locus_width) %>
       </div>
@@ -55,7 +55,7 @@
       <%= form.text_field(:accession, class: "form-control") %>
     </div>
     <div class="col-xs-12 col-md-6">
-      <div class="well well-sm max-width-text help-block">
+      <div class="well well-sm max-width-text help-block position-relative">
         <div class="arrow-left hidden-xs"></div>
         <%= :form_sequence_accession_help.t %>
       </div>
@@ -70,7 +70,7 @@
       <%= form.text_area(:notes, rows: 3, class: "form-control") %>
     </div>
     <div class="col-xs-12 col-md-6">
-      <div class="well well-sm max-width-text help-block mt-4">
+      <div class="well well-sm max-width-text help-block position-relative mt-4">
         <div class="arrow-left hidden-xs"></div>
         <%= :field_textile_link.t %>
       </div>


### PR DESCRIPTION
To make the positioning of "tooltip-arrows" more predictable, I had added `position: relative` to the class `.help-block`. This had the unintended consequence of blocking clicks on **links in nested, floated divs** such as the one for "Propose a name". 

This PR reverts that change and adds  the class `.position-relative` only to help-blocks with tooltips, which (i checked) do not have nested button links.