### PR TITLE
Fix name description layout from last PR, also longstanding lack of tabset

### DIFF
--- a/app/views/name/show_name_description.html.erb
+++ b/app/views/name/show_name_description.html.erb
@@ -1,6 +1,8 @@
 <%
   @title ||= @description.format_name.t
-  show_description_tab_set(@description)
+  tabs = show_description_tab_set(@description)
+  @tabsets = { right: draw_tab_set(tabs) }
+  @container = :wide
 %>
 
 <table cellpadding="5" width="100%">


### PR DESCRIPTION
This restores the intended layout for name descriptions (inadvertently changed in the big CSS PR), and adds the tabset that was intended but incorrectly coded in the template, and thus didn't appear (as far as I can tell, maybe ever).