### PR TITLE
Fix "Locate on map" button submitting form prematurely on Observation form

### DIFF
--- a/app/views/observations/_form_observations.html.erb
+++ b/app/views/observations/_form_observations.html.erb
@@ -53,7 +53,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <button class="map-locate btn btn-default mt-3">Locate on Map</button>
+    <span class="map-locate map-btn btn btn-default mt-3">Locate on Map</span>
     <div class="well well-sm mt-3 help-block position-relative">
       <div class="arrow-up hidden-xs"></div>
       <%= :form_observations_locate_on_map_help.t %>
@@ -85,8 +85,8 @@
     <%= tag.label("#{:GEOLOCATION.t}: (#{:optional.t})") %>
     <div id="observationFormMap" class="form-observation-map hidden"></div>
     <div>
-      <span class="map-open map-btn"><%= :form_observations_open_map.t %></span>
-      <span class="map-clear map-btn btn-default hidden"><%= :form_observations_clear_map.t %></span>
+      <span class="map-open map-btn btn btn-default"><%= :form_observations_open_map.t %></span>
+      <span class="map-clear map-btn btn btn-default hidden"><%= :form_observations_clear_map.t %></span>
     </div>
   </div>
   <div class="col-sm-6">

--- a/app/views/observations/_form_observations.html.erb
+++ b/app/views/observations/_form_observations.html.erb
@@ -53,7 +53,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <span class="map-locate btn btn-default mt-3">Locate on Map</span>
+    <button type="button" class="map-locate btn btn-default mt-3">Locate on Map</button>
     <div class="well well-sm mt-3 help-block position-relative">
       <div class="arrow-up hidden-xs"></div>
       <%= :form_observations_locate_on_map_help.t %>
@@ -85,8 +85,8 @@
     <%= tag.label("#{:GEOLOCATION.t}: (#{:optional.t})") %>
     <div id="observationFormMap" class="form-observation-map hidden"></div>
     <div>
-      <span class="map-open btn btn-default"><%= :form_observations_open_map.t %></span>
-      <span class="map-clear btn btn-default hidden"><%= :form_observations_clear_map.t %></span>
+      <button type="button" class="map-open btn btn-default"><%= :form_observations_open_map.t %></button>
+      <button type="button" class="map-clear btn btn-default hidden"><%= :form_observations_clear_map.t %></button>
     </div>
   </div>
   <div class="col-sm-6">

--- a/app/views/observations/_form_observations.html.erb
+++ b/app/views/observations/_form_observations.html.erb
@@ -53,7 +53,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <span class="map-locate map-btn btn btn-default mt-3">Locate on Map</span>
+    <span class="map-locate btn btn-default mt-3">Locate on Map</span>
     <div class="well well-sm mt-3 help-block position-relative">
       <div class="arrow-up hidden-xs"></div>
       <%= :form_observations_locate_on_map_help.t %>
@@ -85,8 +85,8 @@
     <%= tag.label("#{:GEOLOCATION.t}: (#{:optional.t})") %>
     <div id="observationFormMap" class="form-observation-map hidden"></div>
     <div>
-      <span class="map-open map-btn btn btn-default"><%= :form_observations_open_map.t %></span>
-      <span class="map-clear map-btn btn btn-default hidden"><%= :form_observations_clear_map.t %></span>
+      <span class="map-open btn btn-default"><%= :form_observations_open_map.t %></span>
+      <span class="map-clear btn btn-default hidden"><%= :form_observations_clear_map.t %></span>
     </div>
   </div>
   <div class="col-sm-6">


### PR DESCRIPTION
Urgent fix.

Seems that my making the "Locate on map" button a `<button>` element, even though it is not `type="submit"`, makes it submit the form. 

~There may be an MO script involved, but reverting the button to being a `<span>` seems to fix the submit problem. This is a simple reversion and should be safe to deploy immediately.~

While making it a `<span>` works, `<button>` is the proper HTML element to use here. The solution is to declare the type attribute `<button type="button">`.

Incidentally, GMaps does not load for me locally in any case, so this form is hard to troubleshoot.
```
Google Maps JavaScript API error: RefererNotAllowedMapError
https://developers.google.com/maps/documentation/javascript/error-messages#referer-not-allowed-map-error
Your site URL to be authorized: http://localhost:3000/observations/new
```