### PR TITLE
Fix image form html closing div `(partial: "project")`

### DIFF
--- a/app/views/image/_project.html.erb
+++ b/app/views/image/_project.html.erb
@@ -4,4 +4,4 @@
                 checked: @project_checks[project.id],
                 disabled: @image.user != @user && !project.is_member?(@user),
                 class: "form-control") %>
-</div
+</div>


### PR DESCRIPTION
Fixes an issue found by Nathan in the wild. 