### PR TITLE
Add two new `User` validations: email format and content_filter[:region]

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,13 +15,9 @@ ActionMailer::Base.raise_delivery_errors = false
 
 #  Base class for mailers for each type of email
 class ApplicationMailer < ActionMailer::Base
-  # This more or less follows RFC-5321 rules, minus the ridiculous quoting.
-  DOT_ATOM = %r{[0-9A-Za-z_!$&*\-=\\^`|~#%‘+/?{}]+}
-  DOT_ATOMS = /#{DOT_ATOM}(\.#{DOT_ATOM})*/
-  VALID_EMAIL_REGEXP = /^#{DOT_ATOMS}@#{DOT_ATOMS}$/
-
+  # Use native Ruby URI::MailTo class
   def self.valid_email_address?(address)
-    address.to_s.match?(VALID_EMAIL_REGEXP)
+    address.to_s.match?(URI::MailTo::EMAIL_REGEXP)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1167,13 +1167,19 @@ class User < AbstractModel
 
   validate :user_requirements
   validate :check_password, on: :create
+  # `if` accounts for existing invalid entries; otherwise users cannot update
+  validate :user_email_requirements, if: proc { |c|
+    c.new_record? || c.email_changed?
+  }
   validate :notes_template_forbid_other
   validate :notes_template_forbid_duplicates
+  validate :check_content_filter_region, if: proc { |c|
+    c.new_record? || c.content_filter_changed?
+  }
 
   def user_requirements
     user_login_requirements
     user_password_requirements
-    user_email_requirements
     user_other_requirements
   end
 
@@ -1198,7 +1204,7 @@ class User < AbstractModel
   end
 
   def user_email_requirements
-    if email.to_s.blank?
+    if email.to_s.blank? || !ApplicationMailer.valid_email_address?(email.to_s)
       errors.add(:email, :validate_user_email_missing.t)
     elsif email.size > 80
       errors.add(:email, :validate_user_email_too_long.t)
@@ -1258,5 +1264,15 @@ class User < AbstractModel
 
   def notes_other_translations
     %w[andere altro altra autre autres otra otras otro otros outros]
+  end
+
+  # Check if region is provided and is in fact a valid region with locations,
+  # i.e. the end of a location name string
+  def check_content_filter_region
+    return if content_filter[:region].blank?
+    return if Location.in_region(content_filter[:region]).any?
+
+    # If we're here, there are no MO locations in that region.
+    errors.add(:region, :advanced_search_filter_region.t)
   end
 end

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -438,7 +438,7 @@ class AccountControllerTest < FunctionalTestCase
     has_images: "1",
     has_specimen: "1",
     lichen: "yes",
-    region: "California",
+    region: "California, USA",
     clade: "Ascomycota"
   }
 
@@ -505,7 +505,7 @@ class AccountControllerTest < FunctionalTestCase
     assert_input_value(:user_has_images, "1")
     assert_input_value(:user_has_specimen, "1")
     assert_input_value(:user_lichen, "yes")
-    assert_input_value(:user_region, "California")
+    assert_input_value(:user_region, "California, USA")
     assert_input_value(:user_clade, "Ascomycota")
 
     # Try a bogus email address
@@ -554,7 +554,7 @@ class AccountControllerTest < FunctionalTestCase
     assert_equal("yes", user.content_filter[:has_images])
     assert_equal("yes", user.content_filter[:has_specimen])
     assert_equal("yes", user.content_filter[:lichen])
-    assert_equal("California", user.content_filter[:region])
+    assert_equal("California, USA", user.content_filter[:region])
     assert_equal("Ascomycota", user.content_filter[:clade])
 
     # Prove user cannot pick "Other" as a notes_template heading

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -443,6 +443,9 @@ class AccountControllerTest < FunctionalTestCase
   }
 
   def test_edit_prefs
+    # licenses fixture only available within test??
+    params = PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s })
+
     # First make sure it can serve the form to start with.
     requires_login(:prefs)
     Language.all.each do |lang|

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -400,7 +400,7 @@ class AccountControllerTest < FunctionalTestCase
     assert_flash_success
   end
 
-  PARAMS = {
+  GOOD_PARAMS = {
     login: "rolf",
     password: "new_password",
     password_confirmation: "new_password",
@@ -444,7 +444,7 @@ class AccountControllerTest < FunctionalTestCase
 
   def test_edit_prefs
     # licenses fixture only available within test??
-    params = PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s })
+    params = GOOD_PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s })
 
     # First make sure it can serve the form to start with.
     requires_login(:prefs)
@@ -589,8 +589,8 @@ class AccountControllerTest < FunctionalTestCase
 
   def test_edit_prefs_user_with_bogus_email
     # licenses fixture only available within test??
-    params = PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s,
-                            login: "flintstone" })
+    params = GOOD_PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s,
+                                 login: "flintstone" })
 
     user = users(:flintstone)
     login("flintstone")
@@ -608,8 +608,8 @@ class AccountControllerTest < FunctionalTestCase
 
   def test_edit_prefs_user_with_invalid_region
     # licenses fixture only available within test??
-    params = PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s,
-                            login: "nonregional" })
+    params = GOOD_PARAMS.merge({ license_id: licenses(:publicdomain).id.to_s,
+                                 login: "nonregional" })
 
     user = users(:nonregional)
     login("nonregional")

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -440,7 +440,7 @@ class AccountControllerTest < FunctionalTestCase
     lichen: "yes",
     region: "California, USA",
     clade: "Ascomycota"
-  }
+  }.freeze
 
   def test_edit_prefs
     # licenses fixture only available within test??

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -85,7 +85,7 @@ class AccountControllerTest < FunctionalTestCase
            assigns("new_user").dump_errors)
 
     # Invalid email
-    post(:create, params: { new_user: params.merge(email: "wrong") })
+    post(:signup, params: { new_user: params.merge(email: "wrong") })
     assert_flash_error
     assert_response(:success)
     assert(assigns("new_user").errors[:email].any?,
@@ -595,12 +595,12 @@ class AccountControllerTest < FunctionalTestCase
     user = users(:flintstone)
     login("flintstone")
 
-    get(:edit)
+    get(:prefs)
     assert_input_value(:user_login, "flintstone")
     assert_input_value(:user_email, "bogus")
 
     # I don't know if we need all the PARAMS, but
-    patch(:update, params: { user: params })
+    post(:prefs, params: { user: params })
 
     assert_flash_text(:runtime_prefs_success.t)
     assert_equal("new@email.com", user.reload.email)
@@ -614,12 +614,12 @@ class AccountControllerTest < FunctionalTestCase
     user = users(:nonregional)
     login("nonregional")
 
-    get(:edit)
+    get(:prefs)
     assert_input_value(:user_login, "nonregional")
     assert_input_value(:user_region, "Massachusetts")
 
     # I don't know if we need all the PARAMS, but
-    patch(:update, params: { user: params })
+    post(:prefs, params: { user: params })
 
     assert_flash_text(:runtime_prefs_success.t)
     assert_equal("California, USA", user.reload.content_filter[:region])

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -505,6 +505,14 @@ class AccountControllerTest < FunctionalTestCase
     assert_input_value(:user_region, "California")
     assert_input_value(:user_clade, "Ascomycota")
 
+    # Try a bogus email address
+    post(:prefs, params: { user: params.merge(email: "bogus") })
+    assert_flash_error
+
+    # Try an incomplete region
+    post(:prefs, params: { user: params.merge(region: "California") })
+    assert_flash_error
+
     # Now do it correctly, and make sure changes were made.
     post(:prefs, params: { user: params })
     assert_flash_text(:runtime_prefs_success.t)

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -84,6 +84,13 @@ class AccountControllerTest < FunctionalTestCase
     assert(assigns("new_user").errors[:email].any?,
            assigns("new_user").dump_errors)
 
+    # Invalid email
+    post(:create, params: { new_user: params.merge(email: "wrong") })
+    assert_flash_error
+    assert_response(:success)
+    assert(assigns("new_user").errors[:email].any?,
+           assigns("new_user").dump_errors)
+
     # Email doesn't match.
     post(:signup,
          params: { new_user: params.merge(email_confirmation: "wrong") })

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -154,3 +154,14 @@ unverified:
 admin:
   <<: *DEFAULTS
   admin: true
+
+# User with existing email that won't pass new validations
+flintstone:
+  <<: *DEFAULTS
+  email: "bogus"
+
+# User with existing content_filter[:region] that won't pass new validations
+nonregional:
+  <<: *DEFAULTS
+  email: "bogus"
+  content_filter: <%= { region: "Massachusetts" }.to_yaml.inspect %>


### PR DESCRIPTION
This adds two new validators for the `User` model:
- `email` format `address@service.tld`
checks the `email` format against the same regex used in `ApplicationMailer`. This doesn't ensure that someone has entered a valid working email address, but at least it catches typos and deliberate non-addresses. (The PR also updates Jason's recently-added regex to use the Ruby native library `URI::MailTo` regex.)

- `region` format `maybe place, province, country`
checks if the content_filter text string `region` is a valid MO region, i.e. if MO has any locations in that region. It uses the `Location.in_region` scope to check if the string matches the end of any existing Location strings. If not, it won't validate.

### Dev note ###
**I discovered a major Rails gotcha with adding new validations to existing records**: if you add a normal Rails model attribute validation _without conditions_, and if our existing records have _newly-invalid_ data (ours certainly do), users and admins will not be able to update (correct) the invalid fields. Not even in the console! 

**Solution**: You **must** add an `if` `new_record?` or `email_changed?` condition to the validator, so it works as expected and doesn't block updates.

#### Further solutions for users who deliberately enter invalid email addresses after signup ####
Jason and I are working out other ideas to help satisfy people who don't want any emails, and to alert them to provide a valid and verifiable email address.
