### PR TITLE
Added safeguard to prevent RssLog notes from growing too large.

### DIFF
--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -156,6 +156,10 @@ class RssLog < AbstractModel
   belongs_to :project
   belongs_to :species_list
 
+  # Maximum allowed length (in bytes) of notes column.  Actually it should be
+  # 65535, I think, but let's mak sure there's a safe buffer.
+  MAX_LENGTH = 65_500
+
   # Override the default show_controller
   def self.show_controller
     :rss_logs
@@ -296,7 +300,7 @@ class RssLog < AbstractModel
   def add_with_date(tag, args = {})
     entry = encode(tag, relevant_args(args), args[:time] || Time.zone.now)
     RssLog.record_timestamps = false if args.key?(:touch) && !args[:touch]
-    self.notes = "#{entry}\n#{notes}"
+    add_entry(entry)
     save_without_our_callbacks unless args.key?(:save) && !args[:save]
     RssLog.record_timestamps = true
   end
@@ -315,7 +319,7 @@ class RssLog < AbstractModel
   def orphan(title, key, args = {})
     args = args.merge(save: false)
     add_with_date(key, args)
-    self.notes = "#{escape(title)}\n#{notes}"
+    add_entry(escape(title))
     clear_target_id
     save_without_our_callbacks
   end
@@ -450,5 +454,11 @@ class RssLog < AbstractModel
   # Reverse protection of special characters in string for log encoder/decoder.
   def unescape(str)
     str.to_s.gsub(/%(..)/) { Regexp.last_match(1).hex.chr }
+  end
+
+  # Add line to top of notes field, truncating it to keep it within the MySQL
+  # limit on TEXT field.
+  def add_entry(entry)
+    self.notes = "#{entry}\n#{notes}".truncate_bytes(MAX_LENGTH)
   end
 end

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -61,6 +61,20 @@ class RssLogTest < UnitTestCase
                  log.detail)
   end
 
+  def test_really_long_notes
+    max = RssLog::MAX_LENGTH
+    log = RssLog.first
+    log.notes = "test test " * (max / 10 - 1)
+    log.save
+    assert_operator(max, ">", log.notes.length)
+    assert_operator(max, "<", log.notes.length + 20)
+    log.add_with_date(:log_object_created_by_user,
+                      user: "make sure this is nice and long!",
+                      type: :OBSERVATION)
+    log.reload
+    assert_operator(max, ">", log.notes.length)
+  end
+
   # ---------- helpers ---------------------------------------------------------
 
   def normalized_rss_log_types


### PR DESCRIPTION
It just basically truncates the notes.  I wonder if we need to worry about the syntax of the last line getting corrupted by doing this?  Maybe it should truncate it to the last newline instead?