### PR TITLE
Add yet another email preference to opt out of all emails.

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -305,6 +305,7 @@ class AccountController < ApplicationController
       [:locale, :string],
       [:location_format, :enum],
       [:login, :string],
+      [:no_emails, :boolean],
       [:notes_template, :string],
       [:theme, :string],
       [:thumbnail_maps, :boolean],

--- a/app/helpers/observation_tabs_helper.rb
+++ b/app/helpers/observation_tabs_helper.rb
@@ -36,6 +36,7 @@ module ObservationTabsHelper
   end
 
   def general_questions_link(obs, user)
+    return if obs.user.no_emails
     return unless obs.user.email_general_question && obs.user != user
 
     link_with_query(:show_observation_send_question.t,

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -47,8 +47,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def mo_mail(title, headers = {})
-    to = calc_email(headers[:to])
-    return unless ApplicationMailer.valid_email_address?(to)
+    return unless (to = to_address(headers[:to]))
 
     content_style = calc_content_style(headers)
     from = calc_email(headers[:from]) || MO.news_email_address
@@ -82,5 +81,16 @@ class ApplicationMailer < ActionMailer::Base
 
   def calc_email(user)
     user.respond_to?(:email) ? user.email : user
+  end
+
+  def to_address(user)
+    # I just want to be extra certain that we don't accidentally send email
+    # to anyone who has opted out of all email.
+    return nil if user.is_a?(User) && user.no_emails
+
+    address = calc_email(user)
+    return nil unless ApplicationMailer.valid_email_address?(address)
+
+    address
   end
 end

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -84,6 +84,8 @@ class HerbariumRecord < AbstractModel
     return if recipients.member?(sender)
 
     recipients.each do |recipient|
+      next if recipient.no_emails
+
       email_klass = QueuedEmail::AddHerbariumRecordNotCurator
       email_klass.create_email(sender, recipient, self)
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -811,6 +811,9 @@ class Location < AbstractModel
       end
     end
 
+    # Remove users who have opted out of all emails.
+    recipients.reject!(&:no_emails)
+
     # Send notification to all except the person who triggered the change.
     (recipients.uniq - [sender]).each do |recipient|
       QueuedEmail::LocationChange.create_email(sender, recipient, self)

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -167,6 +167,9 @@ class LocationDescription < Description
       end
     end
 
+    # Remove users who have opted out of all emails.
+    recipients.reject!(&:no_emails)
+
     # Send notification to all except the person who triggered the change.
     (recipients.uniq - [sender]).each do |recipient|
       QueuedEmail::LocationChange.create_email(

--- a/app/models/name/notify.rb
+++ b/app/models/name/notify.rb
@@ -50,6 +50,9 @@ module Name::Notify
       end
     end
 
+    # Remove users who have opted out of all emails.
+    recipients.reject!(&:no_emails)
+
     # Send notification to all except the person who triggered the change.
     (recipients.uniq - [sender]).each do |recipient|
       QueuedEmail::NameChange.create_email(sender, recipient, self, nil, false)

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -281,6 +281,9 @@ class NameDescription < Description
         end
       end
 
+      # Remove users who have opted out of all emails.
+      recipients.reject!(&:no_emails)
+
       # Send notification to all except the person who triggered the change.
       (recipients.uniq - [sender]).each do |recipient|
         QueuedEmail::NameChange.create_email(sender, recipient, name, self,

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -172,6 +172,7 @@ class Naming < AbstractModel
         find_each do |n|
         next unless (n.user_id != user.id) && !done_user[n.user_id] &&
                     (!n.require_specimen || observation.specimen)
+        next if n.user.no_emails
 
         QueuedEmail::NameTracking.create_email(n, self)
         done_user[n.user_id] = true
@@ -206,6 +207,9 @@ class Naming < AbstractModel
         recipients.push(interest.user) if interest.state
       end
     end
+
+    # Remove users who have opted out of all emails.
+    recipients.reject!(&:no_emails)
 
     # Send to everyone (except the person who created the naming!)
     (recipients.uniq - [sender]).each do |recipient|

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1301,7 +1301,7 @@ class Observation < AbstractModel
 
     # Send notification to all except the person who triggered the change.
     recipients.uniq.each do |recipient|
-      next if !recipient || recipient == sender
+      next if !recipient || recipient == sender || recipient.no_emails
 
       case action
       when :destroy
@@ -1343,6 +1343,9 @@ class Observation < AbstractModel
         recipients.delete(interest.user)
       end
     end
+
+    # Remove users who have opted out of all emails.
+    recipients.reject!(&:no_emails)
 
     # Send notification to all except the person who triggered the change.
     (recipients.uniq - [sender]).each do |recipient|

--- a/app/models/queued_email/feature.rb
+++ b/app/models/queued_email/feature.rb
@@ -16,6 +16,7 @@ class QueuedEmail::Feature < QueuedEmail
   end
 
   def deliver_email
+    return if to_user.no_emails
     return unless to_user.email_general_feature # Make sure it hasn't changed
 
     FeaturesMailer.build(to_user, content).deliver_now

--- a/app/views/account/_prefs_email.html.erb
+++ b/app/views/account/_prefs_email.html.erb
@@ -4,6 +4,8 @@
 </div>
 
 <div class="form-group form-inline">
+  <%= form.check_box(:no_emails, class: "form-control") %>
+  <%= label_tag(:user_no_emails, :prefs_no_emails.t) %><br/>
   <%= form.check_box(:email_html, class: "form-control") %>
   <%= label_tag(:user_email_html, :prefs_email_html.t) %>
 </div>

--- a/app/views/image/show_image.html.erb
+++ b/app/views/image/show_image.html.erb
@@ -26,7 +26,7 @@
                       data: {confirm: :are_you_sure.l})
     ]
   end
-  if @image.user.email_general_commercial
+  if @image.user.email_general_commercial && !@image.user.no_emails
     tabs << link_with_query(:image_show_inquiry.t, controller: :emails,
                             action: :commercial_inquiry, id: @image.id)
   end

--- a/config/locales/be.txt
+++ b/config/locales/be.txt
@@ -1,0 +1,4221 @@
+#
+#  Be sure to rake lang:update and restart your server if you modify this file.
+#
+################################################################################
+#
+#  Rails Comments
+#
+#  Files in the config/locales directory are used for internationalization
+#  and are automatically loaded by Rails. If you want to use locales other
+#  than English, add the necessary files in this directory.
+#
+#  To use the locales, use `I18n.t`:
+#
+#      I18n.t 'hello'
+#
+#  In views, this is aliased to just `t`:
+#
+#      <%= t('hello') %>
+#
+#  To use a different locale, set it with `I18n.locale`:
+#
+#      I18n.locale = :es
+#
+#  This would use the information in config/locales/es.yml.
+#
+#  To learn more, please read the Rails Internationalization guide
+#  available at http://guides.rubyonrails.org/i18n.html.
+#
+################################################################################
+#
+#  MO Differences
+#
+#  In MO, locales files are created and modified differently.  One should never
+#  change the locale.yml files by hand.  And further, how to change the
+#  translations is different for English (the "official" language) than the
+#  other languages.
+#
+#  English:  ""
+#
+#  Change and check in en.txt (not en.yml!), and run "rake lang:update"
+#  both locally and on the production server to pick up the changes.
+#  This should be the *only* way we make changes to the English "translations".
+#  Any other method will get clobbered next time someone runs "rake lang:update".
+#
+#  Other languages:
+#
+#  Option one: "Export" a .txt file, e.g., es.txt ("rake lang:export:es"),
+#  change the exported file, then import that on the server into the live
+#  database ("rake lang:import:es").
+#
+#  Option two: Change the translations on the live, running site via the "Edit
+#  Translations on This Page" link at the bottom of the page while viewing the
+#  page in the desired language.  Any changes made here will be stored in the
+#  live database, and will propagate automatically to all other currently
+#  running instances immediately.
+#
+#  rake lang:update:
+#
+#  This command clobbers es.txt and es.yml, and recreates them fresh from the
+#  strings stored in the database.  It does NOT clobber en.txt, making an
+#  exception for that one case.  This is critical because we need to be able to
+#  check this in to git.  The foreign translations are not checked into git,
+#  they are considered "data" at present.  Instead, MO "imports" en.txt each
+#  time "rake lang:update" is run, and syncs the English translations in the
+#  database with the current data in en.txt.  Furthermore, en.txt is special in
+#  one additional way: it is used as the template for the other "export" files,
+#  es.txt, fr.txt, etc.  It preserves comments, order, etc. exactly like it
+#  appears in en.txt.)
+#
+################################################################################
+#
+#  How to Create and Import a New Language:
+#
+#  First create the language in the database:
+#
+#    INSERT INTO languages (`locale`, `name`, `order`, `beta`)
+#      VALUES (
+#        "jp",          # locale, e.g. "pt" for Portuguese
+#        "日本語",      # name of the language *in that language*
+#        "Nihongo",     # transliteration of the above (so it sorts right)
+#        1              # beta=1 means it won't appear in site's language menu
+#      );
+#
+#  Create stub language files:
+#
+#    mo$ rake lang:update
+#    mo$ rake lang:export:jp
+#
+#  You should now have an import/export file called config/locales/jp.txt.
+#  Once you're done editing this file -- remembering to remove the extra space
+#  between "tag:" and "value"!! -- test if it's valid:
+#
+#    mo$ ruby -e "require 'yaml'; YAML.load_file('config/locales/jp.txt')"
+#
+#  Sorry, it doesn't always tell you where the syntax errors are. Look for
+#  things like "tag: [..." or "tag: blah: ..."  That should be the cause of
+#  most of the grief.  Just protect those strings in quotes, remembering to
+#  backslash-protect embedded quotes when you do so.
+#
+#  Now you should be ready to import the file.  Note that this can be redone
+#  as many times as necessary if you see problems when you test it.  This is
+#  why it's good to keep new languages beta!!
+#
+#    mo$ cp config/locales/jp.txt config/locales/jp.txt.bak
+#    mo$ rake user_id=1234 lang:import:jp
+#    mo$ rake lang:update
+#    mo$ uni reload
+#
+#  You need to supply user_id to lang:import because it needs to know who
+#  created each translation_string.  You can give "user_name=xxx" instead.
+#  If that works, then you should be able to test it on the server.  Note
+#  that the new language is still "beta" so it doesn't show up as a publically
+#  available option.  Instead add "?user_locale=jp" to the end of any URL:
+#
+#    http:  ""
+#
+#  It should stay in Japanese now until you tell it to switch to another.
+#  If you need to re-import, it's safest to purge the old strings first:
+#
+#    DELETE FROM translation_strings WHERE language_id = xxx;
+#
+#  Note that it's important to backup the original import file, because
+#  rake lang:update will clobber it.  Looking at the new jp.txt can help
+#  identify problems with the import file, too.  You may even be able to
+#  diff the two, depending how the translator does their work.
+#
+#  Once you're satisfied, repeat all this on the live server, and clear the
+#  beta flag in the languages table.
+#
+#    UPDATE languages SET beta=0 WHERE language_id=xxx;
+#
+#  -Jason 20180320
+#
+################################################################################
+#
+#  Hints about the entries.
+#
+#  Each entry is a *one-line* string. It must not contain a carriage return or
+#  line feed. To display a new line, use: \n, <br>, or <\br>.
+#  Example:  ""
+#    entry:  ""
+#  will display as
+#    1st line
+#    2nd line
+#
+#  The string can include html (without newline characters).
+#  Examples:  ""
+#    entry:  ""
+#    entry:  ""
+#
+#  The string can incorporate other entries by including those entries' labels.
+#  An entry which includes other labels must be dumbquoted.
+#  Example:  ""
+#    quoted_entry:  ""
+#    quoting_entry:  ""
+#
+#  Then in the code,
+#    quoting_entry.t
+#  will display as:
+#    Hello there.
+#
+#  Within a dumbquoted entry, dumbquotes must be escaped: \"
+#  (Smartquotes must *not* be escaped.)
+#  Example
+#    entry:  ""
+#  will display as
+#    "dumbquoted" “smartquoted”.
+#
+#  - Joe Cohen 20170312
+#
+################################################################################
+
+  all_months: Студзень Люты Сакавік Красавік Май Чэрвень Ліпень Жнівень Верасень Кастрычнік Лістапад Снежань
+  all_month_abbrs: Студзень Люты Сакавік Красавік Май Чэрвень Ліпень Жнівень Верасень Кастрычнік Лістапад Снеж
+
+  # Important examples:
+  hello: Прывітанне Сусвет
+  they_flew_by: "[they] праляцелі"
+  they_fly: "[THEY] лётаць"
+  quote_test: Гэта "цытаты"
+  quote_them: Гэта мае "[THEM]"
+  one: адзін
+
+  # Yes and No are apparently broken
+  YEP: Tак
+  yep: так
+  NOPE: He
+  nope: he
+
+  # Test with new lines
+  with_newlines: "Гэта\nмае\nновыя\nрадкі"
+
+  # Test with a link
+  with_a_link: "\"Глядзіце гэтую спасылку\n\":https://mushroomobserver.org"
+
+  ##############################################################################
+  #
+  #  Overview of File
+  #
+  #  Translations are presented roughly in order of decreasing importance,
+  #  starting with things that are seen on every page, progressing through
+  #  commonly-used to rarely-used pages, to emails, error messages, and finally
+  #  administrative and debugging messages. Sections:
+  #
+  #    COMMON WORDS AND PHRASES
+  #    ENUMERATED SETS OF VALUES
+  #    APPLICATION LAYOUT
+  #    MOST POPULAR PAGES
+  #    LESS POPULAR PAGES
+  #    ADMIN-TYPE PAGES
+  #    EMAIL MESSAGES
+  #    INTRO PAGE
+  #    HOW TO HELP PAGE
+  #    HOW TO USE PAGE (COMMON TASKS)
+  #    HOW TO USE PAGE (GLOSSARY)
+  #    LOCATION HELP PAGE
+  #    ERROR MESSAGES
+  #    LESS IMPORTANT ENUMERATED SETS OF VALUES
+  #    DEBUGGING STUFF
+  #
+  ##############################################################################
+
+  # COMMON WORDS AND PHRASES
+
+  # Object titles, all nouns.
+  API_KEY:  API Key
+  api_key:  API key
+  API_KEYS:  API Keys
+  api_keys:  API keys
+  ARTICLE: Aртыкул
+  article: артыкул
+  ARTICLES: Aртыкулы
+  articles: артыкулы
+  COLLECTION_NUMBER: Hумар Kалекцыі
+  collection_number: нумар калекцыі
+  COLLECTION_NUMBERS: Kалекцыйныя Hумары
+  collection_numbers: калекцыйныя нумары
+  COMMENT: Kаментар
+  comment: каментар
+  COMMENTS: Kаментарыі
+  comments: каментарыі
+  DESCRIPTION: Aпісанне
+  description: апісанне
+  DESCRIPTIONS: Aпісання
+  descriptions: апісання
+  DRAFT: Nраект
+  draft: праект
+  DRAFTS: чарнавікі
+  drafts: чарнавікі
+  EXTERNAL_LINK: знешняя спасылка
+  external_link: знешняя спасылка
+  EXTERNAL_LINKS: знешнія спасылкі
+  external_links: знешнія спасылкі
+  EXTERNAL_SITE: знешні сайт
+  external_site: знешні сайт
+  EXTERNAL_SITES: знешнія сайты
+  external_sites: знешнія сайты
+  IMAGE: Mалюнак
+  image: малюнак
+  IMAGES: выявы
+  images: bыявы
+  ignore: ігнараваць
+  IGNORE: Iгнараваць
+  GEOLOCATION: Rеолокация
+  geolocation: геолокация
+  GLOSSARY: Rласарый
+  glossary: гласарый
+  GLOSSARY_TERM: Cлоўнікавы Tэрмін
+  glossary_term: слоўнікавы тэрмін
+  GLOSSARY_TERMS: Tэрміны Cлоўніка
+  glossary_terms: тэрміны слоўніка
+  HERBARIUM_RECORD: запіс фунгарыя
+  herbarium_record: запіс фунгарыя
+  HERBARIUM_RECORDS: запісы фунгарыя
+  herbarium_records: запісы фунгарыя
+  HERBARIA: фунгарыя
+  herbaria: фунгарыя
+  HERBARIUM: фунгарыум
+  herbarium: фунгарыум
+  HERBARIUMS: фунгарыя
+  herbariums: фунгарыя
+  LICENSE: Ліцэнзія
+  license: ліцэнзія
+  LICENSES: Ліцэнзіі
+  licenses: ліцэнзіі
+  LOCATION: Pазмяшчэнне
+  location: размяшчэнне
+  LOCATIONS: Mесцы
+  locations: месцы
+  LOCATION_DESCRIPTION: Апісанне месцазнаходжання
+  location_description: апісанне месцазнаходжання
+  LOCATION_DESCRIPTIONS: Апісанне месцазнаходжання
+  location_descriptions: апісання месцазнаходжання
+  LOG: часопіс
+  log: часопіс
+  LOGS: бярвення
+  logs: бярвення
+  MAP: Kарта
+  map: карта
+  MAPS: Kарты
+  maps: карты
+  NAME: Iмя
+  name: імя
+  NAMES: Iмёны
+  names: імёны
+  NAME_DESCRIPTION: Назва Апісанне
+  name_description: апісанне імя
+  NAME_DESCRIPTIONS: Апісанне назвы
+  name_descriptions: назвы апісання
+  NAMING: Nрапанаванае Iмя
+  naming: прапанаванае імя
+  NAMINGS: прапанаваныя імёны
+  namings: прапанаваныя імёны
+  NEWS: Hавіны
+  news: навіны
+  NOTIFICATION: Апавяшчэнне
+  notification: апавяшчэнне
+  NOTIFICATIONS: Апавяшчэнні
+  notifications: апавяшчэнні
+  # generic object
+  OBJECT: Аб'ект
+  object: аб'ект
+  OBJECTS: Аб'екты
+  objects: аб'ектаў
+  OBSERVATION: Hазіранне
+  observation: назіранне
+  OBSERVATIONS: Hазіранні
+  observations: назіранні
+  PAST_LOCATION: Змена месцазнаходжання
+  past_location: змена месцазнаходжання
+  PAST_LOCATIONS: Змены месцазнаходжання
+  past_locations: змены месцазнаходжання
+  PAST_NAME: Змена назвы
+  past_name: змена імя
+  PAST_NAMES: Змены імя
+  past_names: змены назвы
+  PROJECT: Nраект
+  project: праект
+  PROJECTS: Nраектаў
+  projects: праектаў
+  PUBLICATION: Nублікацыі
+  publication: публікацыі
+  PUBLICATIONS: Nублікацыі
+  publications: публікацыі
+  RSS_LOG: Часопіс Aктыўнасці
+  rss_log: Часопіс актыўнасці
+  RSS_LOGS: часопісы дзейнасці
+  rss_logs: часопісы дзейнасці
+  SEQUENCE: Nаслядоўнасць
+  sequence: паслядоўнасць
+  SEQUENCES: Nаслядоўнасці
+  sequences: паслядоўнасці
+  SOURCE: Крыніца
+  source: крыніца
+  SOURCES: Крыніцы
+  sources: крыніцы
+  SPECIES_LIST: Cпіс Bідаў
+  species_list: спіс відаў
+  SPECIES_LISTS: Bідавыя Cпісы
+  species_lists: відавыя спісы
+  SPECIMEN: Aсобнік
+  specimen: асобнік
+  SPECIMENS: Aсобнікі
+  specimens: асобнікі
+  USER: Kарыстальнік
+  user: карыстальнік
+  USERS: Kарыстальнікаў
+  users: карыстальнікаў
+  USER_GROUP:  User Group
+  user_group:  user group
+  USER_GROUPS:  User Groups
+  user_groups:  user groups
+  VOTE: Rаласаваць
+  vote: галасаваць
+  VOTES: Rаласоў
+  votes: галасоў
+
+  # Other common nouns.
+  ACCESSION:  Accession
+  ACCESSIONS:  Accessions
+  accession:  accession
+  accessions:  accessions
+  ACCOUNT: Pахунак
+  account: рахунак
+  ACCOUNTS: Pахункі
+  accounts: рахункі
+  ADMIN:  Admin
+  admin:  admin
+  ADMINS:  Admins
+  admins:  admins
+  ADMIN_GROUP:  Admin Group
+  admin_group:  admin group
+  ADMIN_GROUPS:  Admin Groups
+  admin_groups:  admin groups
+  # ("Author" is person(s) who wrote a book, description, or news Article.)
+  AUTHOR: Aўтар
+  author: аўтар
+  AUTHORS: Aўтараў
+  authors: аўтараў
+  # ("Authority" is authority on a scientific name.)
+  ALTITUDE: ўзвышэнне
+  altitude: ўзвышэнне
+  # online database with nucleotide Sequence data
+  ARCHIVE:  Archive
+  archive:  archive
+  AUTHORITY: Aўтар
+  authority: аўтар
+  AUTHORITYS: Aўтараў
+  authoritys: аўтараў
+  # nucleotide bases of Sequences
+  BASES:  Bases
+  bases:  bases
+  CHANGE:  Change
+  change:  change
+  CHANGES:  Changes
+  changes:  changes
+  CITATION: цытаванне
+  citation: цытаванне
+  CITATIONS: цытавання
+  citations: цытавання
+  CONFIDENCE_LEVEL: ўзровень даверу
+  confidence_level: ўзровень даверу
+  CONFIDENCE_LEVELS: ўзроўні даверу
+  confidence_levels: ўзроўні даверу
+  COPYRIGHT_HOLDER: Праваўладальнік
+  copyright_holder: праваўладальнік
+  COPYRIGHT_HOLDERS: Праваўладальнікі
+  copyright_holders: праваўладальнікі
+  CORRECT_SPELLING:  Correct Spelling
+  correct_spelling:  correct spelling
+  CORRECT_SPELLINGS:  Correct Spellings
+  correct_spellings:  correct spellings
+  CONSENSUS: Кансэнсус
+  DATE: Стварыць спіс
+  date: cтварыць спіс
+  DATES: Даты
+  dates: даты
+  # deposit of Sequence Bases in an Archive
+  DEPOSIT:  Deposit
+  deposit:  deposit
+  EDITOR:  Editor
+  editor:  editor
+  EDITORS:  Editors
+  editors:  editors
+  EMAIL: электронная пошта
+  email: электронная пошта
+  EMAILS: электронныя лісты
+  emails: электронныя лісты
+  EMAIL_ADDRESS: адрас электроннай пошты
+  email_address: адрас электроннай пошты
+  EMAIL_ADDRESSS: адрасы электроннай пошты
+  email_addresss: адрасы электроннай пошты
+  FULL_NAME: поўнае імя
+  full_name: поўнае імя
+  FULL_NAMES: поўныя імёны
+  full_names: поўныя імёны
+  ICN_ID: ICN Ідэнтыфікатар
+  icn_id: ICN Ідэнтыфікатар
+  ID:  ID
+  id:  ID
+  IDS:  IDs
+  ids:  IDs
+  IDENTIFIER: Ідэнтыфікатар
+  identifier: Ідэнтыфікатар
+  IDENTIFIERS: Ідэнтыфікатары
+  identifiers: Ідэнтыфікатары
+  INDEX: Iндэкс
+  index: індэкс
+  INDEXES: Iндэксы
+  indexes: індэксы
+  LATITUDE: шырата
+  latitude: шырата
+  LATITUDES: шыроты
+  latitudes: шыроты
+  LOCUS:  Locus
+  locus:  locus
+  LOGIN_NAME: імя для ўваходу
+  login_name: імя для ўваходу
+  LOGIN_NAMES: імёны для ўваходу
+  login_names: імёны для ўваходу
+  LONGITUDE: даўгата
+  longitude: даўгата
+  LONGITUDES: даўгот
+  longitudes: даўгот
+  MEMBER:  Member
+  member:  member
+  MEMBERS:  Members
+  members:  members
+  MESSAGE: Nаведамленне
+  message: паведамленне
+  MESSAGES: Nаведамленні
+  messages: паведамленні
+  NOTE:  Note
+  note:  note
+  NOTES:  Notes
+  notes:  notes
+  OBSERVER: Hазіральнік
+  observer: назіральнік
+  OBSERVERS: Hазіральнікі
+  observers: назіральнікі
+  OWNER: Yладальнік
+  owner: уладальнік
+  OWNERS: Yладальнікаў
+  owners: уладальнікаў
+  PASSWORD: пароль
+  password: пароль
+  PASSWORDS: паролі
+  passwords: паролі
+  PREFERENCES: Nеравагі
+  preferences: перавагі
+  PREFERRED_NAME: пажаданае імя
+  preferred_name: пажаданае імя
+  PREFERRED_NAMES: пераважныя імёны
+  preferred_names: пераважныя імёны
+  PROFILE: Nрофіль
+  profile: профіль
+  PROFILES: Nрофілі
+  profiles: профілі
+  QUALITY: якасць
+  quality: якасць
+  RANK: Pанг
+  rank: ранг
+  RANKS: Званні
+  ranks: чыны
+  REVIEWER:  Reviewer
+  reviewer:  reviewer
+  REVIEWERS:  Reviewers
+  reviewers:  reviewers
+  SIZE:  Size
+  size:  size
+  STATUS: Cтатус
+  status: статус
+  STATUSS: Cтатусы
+  statuss: статусы
+  SUBJECT:  Subject
+  subject:  subject
+  SUBJECTS:  Subjects
+  subjects:  subjects
+  SUMMARY: Pэзюмэ
+  summary: рэзюмэ
+  SUMMARYS: зводкі
+  summarys: зводкі
+  # ("Tag" refers to a keyword, will be used to tag names and images.)
+  TAG:  Tag
+  tag:  tag
+  TAGS:  Tags
+  tags:  tags
+  TIME:  Time
+  time:  time
+  TIMES:  Times
+  times:  times
+  TITLE:  Title
+  title:  title
+  TITLES:  Titles
+  titles:  titles
+  VERSION: Версія
+  version: версія
+  VERSIONS: Версіі
+  versions: версіі
+
+  # (Only used by validation errors, I think.)
+  email_confirmation: пацвярджэнне па электроннай пошце
+  password_confirmation: пацвярджэнне пароля
+
+  # Common nouns/adjectives used as labels, never pluralized.
+  ALL:  All
+  all:  all
+  NONE:  None
+  none:  none
+  HIGH:  High
+  high:  high
+  LOW:  Low
+  low:  low
+  LESS:  Less
+  less:  less
+  MORE: больш
+  more: больш
+  PREV: папярэдні
+  prev: папярэдні
+  NEXT: Hаступны
+  next: наступны
+  BACK: папярэдні
+  back: папярэдні
+  FORWARD: Hаступны
+  forward: наступны
+  EAST:  East
+  east:  east
+  NORTH:  North
+  north:  north
+  SOUTH:  South
+  south:  south
+  WEST:  West
+  west:  west
+
+  # Labels for fields answering: "What did you observe?", "When did you observe
+  # it?", "Where did you observe it?", and "Who observed it?".
+  WHAT: Hавуковая Hазва
+  what: навуковая назва
+  WHEN: Kалі
+  when: калі
+  WHERE: Mясцовасць
+  where: мясцовасць
+  WHO: Сусветная арганізацыя па ахове здароўя
+  who: Сусветная арганізацыя па ахове здароўя
+
+  # Common verbs/actions used as button labels.
+  ADD: дадаць
+  add: дадаць
+  # activate an API key
+  ACTIVATE:  Activate
+  activate:  activate
+  # approve a name
+  APPROVE:  Approve
+  approve:  approve
+  # attach an observation to a project
+  ATTACH:  Attach
+  attach:  attach
+  CANCEL: Aдмяніць
+  cancel: адмяніць
+  # close a popup window
+  CLOSE: блізка
+  close: блізка
+  CREATE: Cтвараць
+  create: ствараць
+  DELETE:  Delete
+  delete:  delete
+  # deprecate a name
+  DEPRECATE:  Deprecate
+  deprecate:  deprecate
+  # destroy an observation or other object
+  DESTROY: Знішчыць
+  destroy: знішчыць
+  DISABLE:  Disable
+  disable:  disable
+  download:  download
+  DOWNLOAD:  Download
+  EDIT: Pэдагаваць
+  edit: рэдагаваць
+  ENABLE:  Enable
+  enable:  enable
+  # merge one object into another
+  MERGE:  Merge
+  merge:  merge
+  OKAY:  Okay
+  okay:  okay
+  # reload a form
+  RELOAD: Nеразагрузіць
+  reload: перазагрузіць
+  # remove an image from an observation, or an observation from a project
+  REMOVE: выдаліць
+  remove: выдаліць
+  SAVE: захаваць
+  save: захаваць
+  SAVE_CHANGES:  Save Changes
+  save_changes:  save changes
+  SAVE_EDITS: захаваць праўкі
+  save_edits: захаваць праўкі
+  SEARCH: Nошук
+  search: пошук
+  SEARCHES: Пошукі
+  SEND: Aдправіць
+  send: адправіць
+  SHOW: Nаказаць
+  show: паказаць
+  # submit a form
+  SUBMIT: Nрадставіць
+  submit: прадставіць
+  UPDATE: Aбнаўленне
+  update: абнаўленне
+  # upload an image or checklist
+  UPLOAD: загрузіць
+  upload: загрузіць
+
+  # Common adjectives.
+  ANONYMOUS: Aнанімны
+  anonymous: ананімны
+  BY: па
+  by: па
+  CREATED: Cтвораны
+  created: створаны
+  CREATED_AT: Cтвораны пры
+  created_at: створаны пры
+  DESTROYED: Pазбураны
+  destroyed: разбураны
+  FILTERED: фільтруюць
+  filtered: фільтруюць
+  MODIFIED:  Modified
+  modified:  modified
+  OPTIONAL:  Optional
+  optional:  optional
+  REQUIRED: Nатрабуецца
+  required: патрабуецца
+  WATCHING: Глядзець
+  watching: назіраючы
+  IGNORING: Irнараванне
+  ignoring: ігнараванне
+  TRACKING: Aдсочванне
+  tracking: адсочванне
+  UPDATED: Aбноўлены
+  updated: абноўлены
+  UPDATED_AT: Aбноўлены на
+  updated_at: абноўлены на
+  VIEWED: Nрагледжана
+  viewed: прагледжана
+
+  # Common adjectives describing species names. (Note: "approved" seems to be
+  # interchangeable with "accepted" in our site -- both indicate that the
+  # scientific community accepts this name as correct.  "Reviewed" on the
+  # other hand indicates that a user in the "reviewers" group has looked at
+  # an object and didn't see any obvious mistakes.)
+  APPROVED: Зацверджаны
+  approved: зацверджаны
+  ACCEPTED: Прынята
+  accepted: прынята
+  DEPRECATED: Састарэла
+  deprecated: састарэў
+  MISSPELLED:  Misspelt
+  misspelled:  misspelt
+  NOT_MISSPELLED:  Spelled Correctly
+  not_misspelled:  spelled correctly
+  REVIEWED:  Reviewed
+  reviewed:  reviewed
+  UNKNOWN:  Unknown
+  unknown:  unknown
+
+  # Permission states: restricted means access is restricted but the current user
+  # has access; private means the current user does not have access; default means
+  # this is the default description that shows up on the show_name/location page
+  # (synonyms that might work better are "principle" or "main" or "official").
+  PRIVATE: Прыватны
+  private: прыватны
+  PUBLIC: Грамадскі
+  public: грамадскасць
+  RESTRICTED:  Restricted
+  restricted:  restricted
+  DEFAULT: Nа змаўчанні
+  default: па змаўчанні
+
+  # Common verbs/actions with objects.
+  add_object: Дадаць [TYPE]
+  add_objects: Дадаць [TYPES]
+  all_objects:  All [TYPES]
+  cancel_and_show:  Cancel (Show [TYPE])
+  create_object: Ствараць [TYPE]
+  destroy_object: Знішчыць [TYPE]
+  edit_object: Рэдагаваць [TYPE]
+  list_objects:  List [TYPES]
+  remove_object:  Remove [TYPE]
+  remove_objects:  Remove [TYPES]
+  show_all: Паказаць усе
+  map_all: Карта ўсіх
+  show_location: Паказаць [LOCATION]
+  show_location_description: Паказаць [DESCRIPTION]
+  show_name: Аб [NAME]
+  show_name_description: Паказаць [DESCRIPTION]
+  show_object: Паказаць [TYPE]
+  show_objects: Паказаць [TYPES]
+  sort_by_object: "Сартаваць па\n[TYPE]"
+
+  # Other generic phrases.
+  added_to_list: "Дададзена назіранне\n\"[list]\"."
+  attached_to_project:  Attached [object] to "[project]".
+  and_num_more:  And [num] more...
+  are_you_sure: Вы ўпэўнены?
+  click_for_map: Націсніце для карты
+  CREATED_BY: Створана
+  EDITING:  Editing
+  google_images: Google Малюнкі
+  MAXIMUM:  Maximum
+  show_on_map: Паказаць на карце
+  many_times: "[num] разы"
+  one_time:  once
+  permission_denied:  Permission denied.
+  removed_from_list:  Removed observation from "[list]".
+  removed_from_project:  Removed [object] from "[project]".
+  select_file: Выберыце файл...
+  no_file_selected: Файл не выбраны.
+  "YES": Tак
+  "NO": Hяма
+  "yes": так
+  "no": няма
+
+  ##############################################################################
+
+  # ENUMERATED SETS OF VALUES
+
+  # Units.
+  units_meters: метраў
+
+  # Names we recognize for the "unknown" location: comma-separated list.
+  unknown_locations:  Unknown, Earth, World, Worldwide, Anywhere, Everywhere
+
+  # Quality values.
+  image_vote_long_0: Без меркавання.
+  image_vote_long_1: "**Добра**, але не так карысна."
+  image_vote_long_2: "**Карысна** для ідэнтыфікацыі."
+  image_vote_long_3: "**Добра** дастаткова для палявога гіда."
+  image_vote_long_4: "**Выдатна!** За межамі працы смяротных."
+  image_vote_help_0: Без меркавання.
+  image_vote_help_1: Добра, але не так карысна.
+  image_vote_help_2: Карысна для ідэнтыфікацыі.
+  image_vote_help_3: Дастаткова добра для палявога гіда.
+  image_vote_help_4: Выдатна! Па-за працай смяротных.
+  image_vote_short_0: Без рэйтынгу
+  image_vote_short_1: Добра
+  image_vote_short_2: Карысна
+  image_vote_short_3: Добра
+  image_vote_short_4: Выдатна
+
+  # Review statuses. (Note: "unvetted" means it's been looked at but the reviewer
+  # doesn't feel comfortable declaring it "accurate"; thus "unvetted" means
+  # "reviewed" and "vetted" means "approved".  Sorry, we inherited these odd
+  # terms from EOL; they weren't my choice!)
+  review_unreviewed:  Unreviewed
+  review_unvetted:  Reviewed
+  review_vetted:  Approved
+  review_inaccurate:  Inaccurate/Incomplete
+  review_no_export:  Not for Export
+  review_ok_for_export:  Okay for Export
+  review_no_ml:  Not for Machine Learning
+  review_ok_for_ml:  Okay for Machine Learning
+
+  # Naming reasons.
+  naming_reason_label_1: Пазналі з выгляду
+  naming_reason_label_2: Выкарыстаная літаратура
+  naming_reason_label_3: Заснаваны на мікраскапічных прыкметах
+  naming_reason_label_4: Заснаваны на хімічных прыкметах
+
+  # Name/location description types.  These are used as page title and in index
+  # results -- must include both the type of description and the title of the
+  # object ([object]) they're describing.
+  description_full_title_public:  Public [:DESCRIPTION] of [object]
+  description_full_title_foreign:  "[:DESCRIPTION] of [object] from [text]"
+  description_full_title_project: Draft of [object] for [text] па [user]
+  description_full_title_source:  "[:DESCRIPTION] of [object] from [text]"
+  description_full_title_user:  "[USER]'s [:DESCRIPTION] of [object]"
+
+  # Name/location description types.  These are used when listing the available
+  # descriptions in the show_name page.
+  description_part_title_public:  Public [:DESCRIPTION]
+  description_part_title_user:  "[USER]'s [:DESCRIPTION]"
+
+  # Name/location description types.  These are used when listing the available
+  # descriptions in the show_name page, but this time the optional text field was
+  # filled in.  Note that the text field is not optional for half of the source
+  # types.
+  description_part_title_public_with_text:  "[TEXT]"
+  description_part_title_foreign_with_text:  "[:DESCRIPTION] From [TEXT]"
+  description_part_title_project_with_text: Draft for [TEXT] па [USER]
+  description_part_title_source_with_text:  "[:DESCRIPTION] From [TEXT]"
+  description_part_title_user_with_text: "[TEXT] па [USER]"
+
+  # Footers -- "Created: [date]", "By: [user]", "Obs Created: 2008-11-03", etc.
+  footer_created_at:  "*[:Created]:* [date]"
+  footer_created_by: "*[:Created]:* [date] *па* [user]"
+  footer_updated_at:  "*[:Modified]:* [date]"
+  footer_updated_by: "*[:Modified]:* [date] *па* [user]"
+  footer_last_updated_at: "*Апошні [:modified]:* [date]"
+  footer_last_updated_by: "*Апошні [:modified]:* [date] *па* [user]"
+  footer_viewed:  "*[:Viewed]:* [times], *last [:viewed]:* [date]"
+  footer_last_you_viewed: "*Апошні раз прагледжаны вамі\n:* [date]"
+  footer_never: ніколі
+  footer_version_out_of:  "*[:Version]:* [num] *of* [total]"
+
+  # Taxonomic ranks.
+  RANK_DOMAIN: Дамен
+  rank_domain: дамен
+  RANK_PLURAL_DOMAIN:  Domain
+  rank_plural_domain:  domain
+  RANK_KINGDOM: Каралеўства
+  rank_kingdom: каралеўства
+  RANK_PLURAL_KINGDOM:  Kingdoms
+  rank_plural_kingdom:  kingdoms
+  RANK_PHYLUM: Тып
+  rank_phylum: тып
+  RANK_PLURAL_PHYLUM:  Phyla
+  rank_plural_phylum:  phyla
+  RANK_CLASS: Kлас
+  rank_class: клас
+  RANK_PLURAL_CLASS:  Classes
+  rank_plural_class:  classes
+  RANK_ORDER: Nарадак
+  rank_order: парадак
+  RANK_PLURAL_ORDER:  Orders
+  rank_plural_order:  orders
+  RANK_FAMILY: Сям'я
+  rank_family: сям'я
+  RANK_PLURAL_FAMILY:  Families
+  rank_plural_family:  families
+  RANK_GENUS: Род
+  rank_genus: роду
+  RANK_PLURAL_GENUS:  Genera
+  rank_plural_genus:  genera
+  RANK_SUBGENUS: Падрод
+  rank_subgenus: падрод
+  RANK_PLURAL_SUBGENUS:  Subgenera
+  rank_plural_subgenus:  subgenera
+  RANK_SECTION: Раздзел
+  rank_section: раздзел
+  RANK_PLURAL_SECTION:  Sections
+  rank_plural_section:  sections
+  RANK_SUBSECTION:  Subsection
+  rank_subsection:  subsection
+  RANK_PLURAL_SUBSECTION:  Subsections
+  rank_plural_subsection:  subsections
+  RANK_STIRPS:  Stirps
+  rank_stirps:  stirps
+  RANK_PLURAL_STIRPS:  Stirpes
+  rank_plural_stirps:  stirpes
+  RANK_SPECIES: Віды
+  rank_species: віды
+  RANK_PLURAL_SPECIES:  Species
+  rank_plural_species:  species
+  RANK_SUBSPECIES:  Subspecies
+  rank_subspecies:  subspecies
+  RANK_PLURAL_SUBSPECIES:  Subspecies
+  rank_plural_subspecies:  subspecies
+  RANK_VARIETY:  Variety
+  rank_variety:  variety
+  RANK_PLURAL_VARIETY:  Varieties
+  rank_plural_variety:  varieties
+  RANK_FORM:  Form
+  rank_form:  form
+  RANK_PLURAL_FORM:  Forms
+  rank_plural_form:  forms
+  RANK_GROUP:  Group or Clade
+  rank_group:  group or clade
+  RANK_PLURAL_GROUP:  Groups or Clades
+  rank_plural_group:  groups or clades
+
+  # These two are used when parsing rank, e.g., in name pattern search.
+  rank_alt_phylum:  phylum, division
+  rank_alt_group:  group, clade, complex
+
+  # User statistics field names.
+  user_stats_comments:  "[:COMMENTS]"
+  user_stats_contributing_users:  ""
+  user_stats_images:  "[:IMAGES]"
+  user_stats_location_description_authors: "[:LOCATION_DESCRIPTIONS] Аўтар"
+  user_stats_location_description_editors: "[:LOCATION_DESCRIPTIONS] Адрэдагавана"
+  user_stats_locations: "[:LOCATIONS] Стварылі"
+  user_stats_locations_versions: "[:LOCATIONS] Адрэдагавана"
+  user_stats_name_description_authors: "[:NAME_DESCRIPTIONS] Аўтар"
+  user_stats_name_description_editors: "[:NAME_DESCRIPTIONS] Адрэдагавана"
+  user_stats_names: "[:NAMES] Стварылі"
+  user_stats_names_versions: "[:NAMES] Адрэдагавана"
+  user_stats_namings: Прапанаваныя ідэнтыфікатары
+  user_stats_observations:  "[:OBSERVATIONS]"
+  user_stats_observations_with_voucher:  Observations with Specimen, Notes and Images
+  user_stats_observations_without_voucher:  All Other Observations
+  user_stats_sequences:  ""
+  user_stats_sequenced_observations:  ""
+  user_stats_species_list_entries:  "[:SPECIES_LIST] Entries"
+  user_stats_species_lists:  "[:SPECIES_LISTS]"
+  user_stats_users:  ""
+  user_stats_votes:  "[:VOTES]"
+
+  # Site statistics field names.
+  site_stats_comments:  "[:COMMENTS]"
+  site_stats_contributing_users: Карыстальнікі, якія ўдзельнічаюць
+  site_stats_images:  "[:IMAGES]"
+  site_stats_listed_taxa: Пералічаныя таксоны
+  site_stats_location_description_authors:  Authored [:LOCATION_DESCRIPTIONS]
+  site_stats_location_description_editors:  ""
+  site_stats_locations:  Defined [:LOCATIONS]
+  site_stats_locations_versions:  ""
+  site_stats_name_description_authors:  Authored [:NAME_DESCRIPTIONS]
+  site_stats_name_description_editors:  ""
+  site_stats_names:  ""
+  site_stats_names_versions:  ""
+  site_stats_namings: Прапанаваныя ідэнтыфікатары
+  site_stats_observations:  "[:OBSERVATIONS]"
+  site_stats_observations_with_voucher:  Observations with Full Data
+  site_stats_observations_without_voucher:  Other Observations
+  site_stats_observed_taxa: Назіраныя таксоны
+  site_stats_sequences:  "[:SEQUENCES]"
+  site_stats_sequenced_observations:  Sequenced Observations
+  site_stats_species_list_entries:  "[:SPECIES_LIST] Entries"
+  site_stats_species_lists:  "[:SPECIES_LISTS]"
+  site_stats_users:  Members
+  site_stats_votes:  "[:VOTES]"
+
+  # Vote descriptions.
+  vote_no_opinion: Без меркавання
+  vote_confidence_100: Я б назваў гэта так
+  vote_confidence_80: Перспектыўны
+  vote_confidence_60: Можа быць
+  vote_confidence_40: Сумнеўна
+  vote_confidence_20: Неверагодна
+  vote_confidence_0: Як быццам!
+  vote_agreement_100:  I'd Call It That
+  vote_agreement_80:  Promising
+  vote_agreement_60:  Could Be
+  vote_agreement_40:  Doubtful
+  vote_agreement_20:  Not Likely
+  vote_agreement_0:  As If!
+
+  # Time quantities.
+  time_just_seconds_ago: секунд таму
+  time_one_minute_ago: хвіліну таму
+  time_minutes_ago: "[n] хвілін таму"
+  time_one_hour_ago: гадзіну таму
+  time_hours_ago: "[n] гадзін таму"
+  time_one_day_ago: учора
+  time_days_ago: "[n] дзён таму,\n[date]"
+  time_one_week_ago: "на мінулым тыдні\n, [date]"
+  time_weeks_ago:  "[n] weeks ago, [date]"
+  time_one_month_ago: "апошні месяц\n, [date]"
+  time_months_ago:  "[n] months ago, [date]"
+  time_one_year_ago:  last year, [date]
+  time_years_ago:  "[n] years ago, [date]"
+
+  # Lifeform "tags".
+  lifeform_basidiolichen:  Basidiolichen
+  lifeform_lichen:  Lichen
+  lifeform_lichen_ally:  Lichen Ally
+  lifeform_lichenicolous:  Lichenicolous
+  lifeform_help_basidiolichen:  Lichen-forming fungus with a mushroom fruiting body.
+  lifeform_help_lichen:  Lichen-forming fungus which grows a specialized thallus when in symbiosis with one or more green algae or cyanobacteria.
+  lifeform_help_lichen_ally:  Fungus related to lichens and often studied by lichenologists despite being nonlichenized.
+  lifeform_help_lichenicolous:  Fungus which often or exclusively grows on or within a lichen.
+
+  # These are the search terms we look for, e.g. "date" in "date:today".
+  search_term_author:  author
+  search_term_citation: цытаванне
+  search_term_classification:  classification
+  search_term_comments:  comments
+  search_term_confidence:  confidence
+  search_term_created:  created
+  search_term_date:  date
+  search_term_deprecated:  deprecated
+  search_term_east:  east
+  search_term_exclude_consensus:  exclude_consensus
+  search_term_has_author:  has_author
+  search_term_has_citation:  has_citation
+  search_term_has_classification:  has_classification
+  search_term_has_comments:  has_comments
+  search_term_has_description:  has_description
+  search_term_has_field:  has_field
+  search_term_has_location:  has_location
+  search_term_has_name:  has_name
+  search_term_has_notes:  has_notes
+  search_term_has_observations:  has_observations
+  search_term_has_synonyms:  has_synonyms
+  search_term_herbarium:  herbarium
+  search_term_images:  images
+  search_term_include_all_name_proposals:  include_all_name_proposals
+  search_term_include_misspellings:  include_misspellings
+  search_term_include_subtaxa:  include_subtaxa
+  search_term_include_synonyms:  include_synonyms
+  search_term_is_collection_location:  is_collection_location
+  search_term_lichen:  lichen
+  search_term_list:  list
+  search_term_location:  location
+  search_term_modified:  modified
+  search_term_name:  name
+  search_term_north:  north
+  search_term_notes:  notes
+  search_term_project:  project
+  search_term_project_lists:  project_lists
+  search_term_rank:  rank
+  search_term_region:  region
+  search_term_sequence:  sequence
+  search_term_south:  south
+  search_term_specimen:  specimen
+  search_term_user:  user
+  search_term_west:  west
+
+  # Words recognized in search bar.
+  # e.g. "user:me"
+  search_value_me:  me
+  # e.g. "has_images:yes"
+  search_value_true:  yes|true
+  # e.g. "has_specimen:no"
+  search_value_false:  no|false
+  # e.g. "include_misspellings:either" meaning include both correctly and incorrectly spelled names
+  search_value_both:  both|either
+  # e.g. "date:last month-today"
+  search_value_today:  today
+  search_value_yesterday:  yesterday
+  search_value_days_ago:  N days ago
+  search_value_this_week:  this week
+  search_value_last_week:  last week
+  search_value_weeks_ago:  N weeks ago
+  search_value_this_month:  this month
+  search_value_last_month:  last month
+  search_value_months_ago:  N months ago
+  search_value_this_year:  this year
+  search_value_last_year:  last year
+  search_value_years_ago:  N years ago
+
+  # Rss log messages.
+  log_ancient:  "[String]"
+  log_approved_by: Зацверджаны [user].
+  log_approved_by_with_comment:  "[:log_approved_by] [comment]"
+  log_consensus_changed: "Кансенсус зменены з:\n[old]."
+  log_consensus_created:  Initial name [name].
+  log_consensus_created_at:  "[:log_consensus_created]"
+  log_consensus_reached: "Дасягнуты кансенсус: [name]"
+  log_deprecated_by: "Састарэў\n[user]."
+  log_deprecated_by_with_comment:  "[:log_deprecated_by] [comment]"
+  log_changed_default_description:  Default description changed to [name] by [user].
+  log_changed_permissions:  "Permissions modified by [user]: [name]"
+  log_name_approved: Зацверджаны [user] над [other].
+  log_name_approved_with_comment:  "[:log_name_approved] [comment]"
+  log_name_deprecated: "Састарэў [user] на карысць\n[other]."
+  log_name_deprecated_with_comment:  "[:log_name_deprecated] [comment]"
+  log_object_accessioned: "[name] далучаны а\n[user]"
+  log_object_added_by_user: "[Type] дадаў\n[user]."
+  log_object_added_by_user_with_name: "[Type] дадаў\n[user]: [name]"
+  log_object_created_by_user: "[Type] створаны [user]."
+  log_object_created_by_user_with_name: "[Type] створаны [user]: [name]"
+  log_object_destroyed_by_user: "[Type] разбураны а\n[user]."
+  log_object_destroyed_by_user_with_name:  "[Type] destroyed by [user]: [name]"
+  log_object_merged_by_user:  "[Type] merged into [that] by [user]."
+  log_object_moved_by_user:  "[Type] moved to [to] by [user]."
+  log_object_removed_by_user: "[Type] выдалена [user]."
+  log_object_removed_by_user_with_name: "[Type] выдалена [user]: [name]"
+  log_object_removed_no_user: "[Type] выдалены."
+  log_object_updated_by_user: "[Type] абноўлена [user]."
+  log_object_updated_by_user_with_name: "[Type] абноўлена [user]: [name]"
+  log_orphan:  "[Title]"
+  log_published_description:  "Description published by [user]: [name]"
+  log_updated_by: абноўлена [user].
+
+  # These should not need any translation.
+  log_article_created:  "[:log_object_created_by_user(type=:article)]"
+  log_article_created_at:  "[:log_object_created_by_user(type=:article)]"
+  log_article_destroyed:  "[:log_object_destroyed_by_user(type=:article)]"
+  log_article_updated:  "[:log_object_updated_by_user(type=:article)]"
+  log_article_updated_at:  "[:log_object_updated_by_user(type=:article)]"
+  log_collection_number_added:  "[:log_object_added_by_user_with_name(type=:collection_number)]"
+  log_collection_number_updated:  "[:log_object_updated_by_user_with_name(type=:collection_number)]"
+  log_collection_number_updated_at:  "[:log_object_updated_by_user_with_name(type=:collection_number)]"
+  log_collection_number_removed:  "[:log_object_removed_by_user_with_name(type=:collection_number)]"
+  log_comment_added:  "[:log_object_added_by_user_with_name(type=:comment,name=summary)]"
+  log_comment_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:comment,name=summary)]"
+  log_comment_updated:  "[:log_object_updated_by_user_with_name(type=:comment,name=summary)]"
+  log_comment_updated_at:  "[:log_object_updated_by_user_with_name(type=:comment,name=summary)]"
+  log_description_created:  "[:log_object_created_by_user_with_name(type=:description)]"
+  log_description_created_at:  "[:log_object_created_by_user_with_name(type=:description)]"
+  log_description_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:description)]"
+  log_description_updated:  "[:log_object_updated_by_user_with_name(type=:description)]"
+  log_description_updated_at:  "[:log_object_updated_by_user_with_name(type=:description)]"
+  log_glossary_term_created:  "[:log_object_created_by_user(type=:glossary_term)]"
+  log_glossary_term_created_at:  "[:log_object_created_by_user(type=:glossary_term)]"
+  log_glossary_term_updated:  "[:log_object_updated_by_user(type=:glossary_term)]"
+  log_glossary_term_updated_at:  "[:log_object_updated_by_user(type=:glossary_term)]"
+  log_herbarium_record_added:  "[:log_object_added_by_user_with_name(type=:herbarium_record)]"
+  log_herbarium_record_moved:  "[:log_object_moved_by_user(type=:specimen)]"
+  log_herbarium_record_updated:  "[:log_object_updated_by_user_with_name(type=:herbarium_record)]"
+  log_herbarium_record_updated_at:  "[:log_object_updated_by_user_with_name(type=:herbarium_record)]"
+  log_herbarium_record_removed:  "[:log_object_removed_by_user_with_name(type=:herbarium_record)]"
+  log_image_created:  "[:log_object_added_by_user_with_name(type=:image)]"
+  log_image_created_at:  "[:log_object_added_by_user_with_name(type=:image)]"
+  log_image_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:image)]"
+  log_image_removed:  "[:log_object_removed_by_user_with_name(type=:image)]"
+  log_image_reused:  "[:log_object_added_by_user_with_name(type=:image)]"
+  log_image_updated:  "[:log_object_updated_by_user_with_name(type=:image)]"
+  log_image_updated_at:  "[:log_object_updated_by_user_with_name(type=:image)]"
+  log_location_created:  "[:log_object_created_by_user(type=:location)]"
+  log_location_created_at:  "[:log_object_created_by_user(type=:location)]"
+  log_location_destroyed:  "[:log_object_destroyed_by_user(type=:location)]"
+  log_location_merged:  "[:log_object_merged_by_user(type=:location)]"
+  log_location_updated:  "[:log_object_updated_by_user(type=:location)]"
+  log_location_updated_at:  "[:log_object_updated_by_user(type=:location)]"
+  log_name_created:  "[:log_object_created_by_user(type=:name)]"
+  log_name_created_at:  "[:log_object_created_by_user(type=:name)]"
+  log_name_destroyed:  "[:log_object_destroyed_by_user(type=:name)]"
+  log_name_merged:  "[:log_object_merged_by_user(type=:name)]"
+  log_name_updated:  "[:log_object_updated_by_user(type=:name)]"
+  log_name_updated_at:  "[:log_object_updated_by_user(type=:name)]"
+  log_naming_created:  "[:log_object_created_by_user_with_name(type=:naming)]"
+  log_naming_created_at:  "[:log_object_created_by_user_with_name(type=:naming)]"
+  log_naming_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:naming)]"
+  log_naming_updated:  "[:log_object_updated_by_user_with_name(type=:naming)]"
+  log_naming_updated_at:  "[:log_object_updated_by_user_with_name(type=:naming)]"
+  log_observation_created:  "[:log_object_created_by_user(type=:observation)]"
+  log_observation_created_at:  "[:log_object_created_by_user(type=:observation)]"
+  log_observation_destroyed2:  "[:log_object_destroyed_by_user_with_name(type=:observation)]"
+  log_observation_destroyed:  "[:log_object_destroyed_by_user(type=:observation)]"
+  log_observation_updated:  "[:log_object_updated_by_user(type=:observation)]"
+  log_observation_updated_at:  "[:log_object_updated_by_user(type=:observation)]"
+  log_project_added_admin:  "[:log_object_added_by_user_with_name(type=:admin)]"
+  log_project_added_member:  "[:log_object_added_by_user_with_name(type=:member)]"
+  log_project_created:  "[:log_object_created_by_user(type=:project)]"
+  log_project_created_at:  "[:log_object_created_by_user(type=:project)]"
+  log_project_destroyed:  "[:log_object_destroyed_by_user(type=:project)]"
+  log_project_removed_admin:  "[:log_object_removed_by_user_with_name(type=:admin)]"
+  log_project_removed_member:  "[:log_object_removed_by_user_with_name(type=:member)]"
+  log_project_updated:  "[:log_object_updated_by_user(type=:project)]"
+  log_project_updated_at:  "[:log_object_updated_by_user(type=:project)]"
+  log_species_list_created:  "[:log_object_created_by_user(type=:species_list)]"
+  log_species_list_created_at:  "[:log_object_created_by_user(type=:species_list)]"
+  log_species_list_destroyed:  "[:log_object_destroyed_by_user(type=:species_list)]"
+  log_species_list_updated:  "[:log_object_updated_by_user(type=:species_list)]"
+  log_species_list_updated_at:  "[:log_object_updated_by_user(type=:species_list)]"
+  log_sequence_added: "[name] дадаў\n[user]"
+  log_sequence_accessioned:  "[:log_object_accessioned(type=:sequence)]"
+  log_sequence_destroyed:  "[:log_object_destroyed_by_user(type=:sequence)]"
+  log_specimen_added:  "[:log_object_added_by_user_with_name(type=:herbarium_record)]"
+  log_object_added:  "[:log_object_added_by_user]"
+  log_object_created:  "[:log_object_created_by_user]"
+  log_object_created_at:  "[:log_object_created_by_user]"
+  log_object_destroyed:  "[:log_object_destroyed_by_user]"
+  log_object_removed:  "[:log_object_removed_by_user]"
+  log_object_updated:  "[:log_object_updated_by_user]"
+  log_object_updated_at:  "[:log_object_updated_by_user]"
+
+  ##############################################################################
+
+  # APPLICATION LAYOUT -- this stuff appears on every single page
+
+  # This goes in the title bar of the browser.  You don't need to translate this,
+  # it's up to you.
+  app_title:  Mushroom Observer
+
+  # This goes in a box at the top of the page.
+  app_banner_box: "**MO Тавар!!! Праверце гэта ў  \"MO Крама далей Etsy\":https://www.etsy.com/shop/MushroomObsMerch!**<br>\nДзякуй Ханне і Эн за тое, што гэта адбылося!"
+
+  # These are the controls/links in the left-hand panel.
+  app_intro: Уводзіны
+  app_how_to_use: Як выкарыстоўваць
+  app_how_to_help: Як дапамагчы
+  app_privacy_policy: Палітыка прыватнасці
+  app_donate: Ахвяраваць
+  app_send_a_comment: Адправіць каментар
+  app_index_a_z:  "[:INDEXES]: [:NAMES]"
+  app_list_locations:  "[:list_objects(type=:location)]"
+  app_list_projects:  "[:list_objects(type=:project)]"
+  app_latest: Апошні
+  app_latest_changes: Змены карыстальнікамі
+  app_newest_images:  "[:IMAGES]"
+  app_comments:  "[:COMMENTS]"
+  app_observations_left:  "[:OBSERVATIONS]"
+  app_create_observation:  "[:create_object(type=:observation)]"
+  app_sort_by_date_obs:  "[:sort_by_object(type=:date)]"
+  app_sort_by:  "[:sort_by_object(type=order)]"
+  app_species_list:  "[:SPECIES_LISTS]"
+  app_create_list: Стварыць спіс
+  app_sort_by_date_spl:  "[:sort_by_object(type=:date)]"
+  app_sort_by_title:  "[:sort_by_object(type=:title)]"
+  app_account: Рахунак
+  app_login: Увайсці
+  app_create_account: Стварыць уліковы запіс
+  app_current_user: Бягучы карыстальнік
+  app_comments_for_you: Каментары для вас
+  app_your_observations: Вашы назіранні
+  app_your_lists: Вашы спісы
+  app_your_interests: Вашы інтарэсы
+  app_your_summary: Ваша рэзюмэ
+  app_preferences: Прэферэнцыі
+  app_life_list: Жыццёвы спіс
+  app_checklist:  Checklist
+  app_join_mailing_list:  Join Mailing List
+  app_logout: Выйсці з сістэмы
+  app_admin:  Admin
+  app_blocked_ips:  Blocked IPs
+  app_switch_users:  Switch Users
+  app_users:  "[:list_objects(type=:user)]"
+  app_email_all_users:  Email All Users
+  app_add_to_group:  Add to Group
+  app_turn_admin_on:  Turn on Admin Mode
+  app_turn_admin_off:  Turn off Admin Mode
+  app_languages: Мовы
+  app_contributors: Укладальнікі
+  app_site_stats: Статыстыка сайта
+  app_colors_from:  Colors from [theme]
+  app_powered_by:  Powered by
+  app_preferred_browser:  Preferred browser
+  app_feature_tracker: Функцыя Tracker
+  app_publications: Публікацыі
+  app_more: больш
+  app_other: Іншае
+
+  # This is for the search bar at the top of every page.
+  app_find: Знайсці
+  app_search: Пошук
+  app_search_google: Сайт (праз Google)
+  app_advanced_search: Пашыраны пошук
+  app_timer: "час:  [seconds] сек"
+  app_index_timer: "[num] вынікі ў [seconds] сек"
+
+  # This shows up at the bottom of every page.  We recommend something like: \n
+  # "Translated into <Language> by _user your-login_"
+  app_translators_credit: На беларускую мову пераклаў
+  app_translators_credit_and_others:  and others
+  app_edit_translations: Рэдагаваць усе пераклады
+  app_edit_translations_on_page: Рэдагаваць пераклады на гэтай старонцы
+
+  # These are general alerts that appear near the top of the page.
+  app_no_ajax:  Your Browser Is Out of Date
+  app_no_browser:  We Don't Recognize Your Browser
+  app_no_javascript:  Javascript Is Disabled
+  app_no_session:  You Have Cookies Disabled
+
+  # Title of the RSS auto-discovery link in the HTML header section.
+  app_rss:  "[:app_title] RSS"
+
+  ##############################################################################
+
+  # MOST POPULAR PAGES
+
+  # emails/ask_observation_question
+  ask_observation_question_title: "Пытанне аб\n[name]"
+  ask_observation_question_label:  Enter your question below.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this observation as well as your email address.
+
+  # emails/ask_user_question
+  ask_user_question_title: "Паведамленне па электроннай пошце для\n[user]"
+  ask_user_question_label: "Увядзіце сваё пытанне ніжэй. Пры ўдары\n\"[:SEND]\" ён будзе адпраўлены па электроннай пошце\n[user].  Электронны адрас будзе ўключаць ваш адрас электроннай пошты ў якасці адраса \"Адказаць\"."
+  ask_user_question_message:  "[:Message]"
+  ask_user_question_subject:  "[:Subject]"
+
+  # emails/ask_webmaster_question
+  ask_webmaster_title: Адправіць пытанне або каментарый па электроннай пошце
+  ask_webmaster_your_email: Ваш электронны адрас
+  ask_webmaster_question: Пытанне або каментар
+  ask_webmaster_note:  "Thanks for your interest in the Mushroom Observer website.  This website was first launched in mid-2006.  The site is owned by the non-profit \"Mushroom Observer, Inc.\":/support/governance and administered by a group of volunteer developers and maintainers.  We welcome any questions you might have about using the site or comments on how the site might be improved.  Please have a look at our \"feature tracker\":/pivotal/index or our \"account on Pivotal Tracker\":https://www.pivotaltracker.com/projects/224629 to see what we have planned.  You can vote and comment on all the various suggestions for future development there.  However, they are only rough guides, subject to bugs or others issues that may come up and, of course, the availability of our own time to work on the site.\n\nThe Mushroom Observer Team"
+
+  # comment/add_comment
+  comment_add_title: "Дадаць каментарый да\n[name]"
+  comment_add_create:  "[:CREATE]"
+
+  # comment/edit_comment
+  comment_edit_title:  Edit Comment on [name]
+
+  # comment/list_comments (This is used to describe the object the comment is
+  # about if the object has been deleted, orphaning the comment.)
+  comment_list_deleted:  object deleted
+
+  # comment/show_comment
+  comment_show_title:  Comment on [Name]
+  comment_show_created_at:  "[:Created]"
+  comment_show_by:  "[:By]"
+  comment_show_summary:  "[:Summary]"
+  comment_show_comment:  "[:Comment]"
+  comment_show_show:  "[:show_object]"
+  comment_show_edit:  "[:EDIT]"
+  comment_show_destroy:  "[:DESTROY]"
+
+  # emails/commercial_inquiry
+  commercial_inquiry_title:  Commercial Inquiry About [name]
+  commercial_inquiry_header:  Enter your commercial inquiry about this image.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this image as well as your email address.
+
+  # location/create_location_description
+  create_location_description_title:  "[:create_name_description_title]"
+
+  # location/create_location
+  create_location_title:  "[:create_object(type=:location)]"
+
+  # name/create_name_description
+  create_name_description_title:  Create Description for [name]
+
+  # name/create_name
+  create_name_title:  "[:create_object(type=:name)]"
+  create_name_multiple_names_match:  There are already multiple names matching "[str]".
+  create_name_duplicate_identifier:  is used by another Name
+
+  # naming/create
+  create_naming_title: "Прапанаваць імя для назірання #\n[id]"
+  create_new_naming_warn:  Sorry, someone else has given this a positive vote, so we had to create a new Naming to accomodate your changes."
+
+  # observer/create_observation
+  create_observation_title:  "[:create_object(type=:observation)]"
+
+  # observation/download_observations
+  download_observations_title: Спампаваць Назіранні
+  download_observations_back:  Cancel (Back to Index)
+  download_observations_format: Выберыце фармат
+  download_observations_raw:  CSV spreadsheet
+  download_observations_adolf:  The Adolf Special™
+  download_observations_darwin:  Darwin Core
+  download_observations_symbiota:  Symbiota
+  download_observations_fundis:  FunDiS
+  download_observations_what_is_this:  what is this?
+  download_observations_encoding:  Choose character encoding
+  download_observations_ascii:  ASCII (no accents)
+  download_observations_windows:  WINDOWS-1252 (best for Excel)
+  download_observations_utf8:  UTF-8 (most universal)
+  download_observations_utf16:  UTF-16 (best for Windows 7 and up)
+  download_observations_print_labels_header:  Or you can print labels for the selected observations
+  download_observations_print_labels: Друк этыкетак
+
+  # location/edit_location
+  edit_location_title:  "[:edit_object(type=:location)]"
+
+  # location/edit_location_description
+  edit_location_description_title:  Edit [name]
+
+  # name/edit_name_description
+  edit_name_description_title:  Edit [name]
+
+  # name/edit_name
+  edit_name_title:  Edit Name [name]
+  edit_name_multiple_names_match:  "Multiple names match \"[str]\".  If you want to get rid of this name, please choose one of the following names to merge it with: [matches]"
+  edit_name_fill_in_classification_for_genus_first:  You need to fill in a classification for the genus first.
+  edit_lifeform_title:  Edit Lifeform of [name]
+  edit_lifeform_help:  Check boxes of all categories which apply to this taxon.
+  edit_lifeform_save:  "[:SAVE]"
+  propagate_lifeform_title:  Propagate Lifeform to Subtaxa of [name]
+  propagate_lifeform_add:  Check boxes of categories to add to all subtaxa.
+  propagate_lifeform_remove:  Check boxes of categories to remove from all subtaxa.
+  propagate_lifeform_apply:  Apply
+
+  # observer/edit_naming
+  edit_naming_title:  "Edit [:NAMING] for Observation #[id]"
+
+  # observations/edit
+  edit_observation_title:  "[:edit_object(type=:observation)]: [name]"
+  edit_observation_turn_off_specimen_with_records_present:  You just told us there is no longer a specimen available.  Don't forget to remove the corresponding collection numbers, fungarium records and/or sequences below, too, if you need to.
+
+  # account/email_new_password
+  email_new_password_title: Новы пароль па электроннай пошце
+  email_new_password_login: Увайсці
+
+  # observer/email_merge_request
+  email_merge_request_title:  Send [TYPE] Merge Request
+  email_merge_request_help:  By changing the name of a [type] to be the same as the name of another [type] you are effectively requesting that we merge two [types].  If this is really what you want to do, please take a minute to explain why you think this is the right thing to do.  This will send a request to the admins, and if we agree with you, we will perform the merge.  Note that merging two [types] cannot be undone. It will implicitly affect all [:observations] or other objects attached to the two [types].
+  email_merge_request_success:  Your request has been sent.  Thank you!
+
+  # emails/name_change_request
+  email_name_change_request_title:  Send Name Change Request
+  email_name_change_request_help:  "Changing this Name will indirectly affect other Names that depend on this Name. For instance, another Name may: include this Name as part of its Classification; or have this Name as an approved synonym. If you really want to change this Name, please explain why. This will send a request to the admins, and if we agree with you, we will make the change."
+  new_name:  New Name
+  email_change_name_request_success:  Your request has been sent. Thank you!
+
+  # observer/_form_comments
+  form_comments_comment:  "[:Comment]"
+  form_comments_summary:  "[:Summary]"
+
+  # shared/_form_description
+  form_description_source:  "[:SOURCE]"
+  form_description_source_public: Грамадскі [:app_title] Апісанне
+  form_description_source_foreign:  From Another [:app_title] Server
+  form_description_source_project:  "[:PROJECT]"
+  form_description_source_source:  Independent Source
+  form_description_source_user:  "[:USER]"
+  form_description_permissions:  Permissions
+  form_description_public_writable:  Modifiable by the general public.
+  form_description_public_readable:  Visible to the general public.
+  form_description_source_help:  "There are three kinds of descriptions you can create:\n1. *Public:* These are wikipedia-style documents that are editable by everyone on the site.  The default title is \"[:description_part_title_public]\". Use the text field above to customize this.\n2. *Source:* These descriptions come from a third-party source, and typically are not meant to be modifiable.  Enter the name of the source in the text field above.  Note, if you are posting a description that derives from copyrighted material, please be sure to rewrite it in your own words.\n3. *User:* Use this to create your own personalized description.  The default title will be \"[:description_part_title_user(user=:name)]\".  Use the text field above to customize this.  In both this and the 'Source' type above, you will have exclusive rights to choose who can view and modify this description (see the check-boxes below)."
+  form_description_permissions_help:  Is the general public is allowed to view or make modifications to this description?  If you wish to have more control over read, write and admin permissions, please use the '[:show_description_adjust_permissions]' link above.
+  form_description_license_help:  Please select "license":/info/how_to_use#license you want to use for this description.
+
+  # observations/_form_images
+  form_images_when_taken: Калі гэта было зроблена
+  form_images_when_help: Дата стварэння фатаграфіі або малюнка.
+  form_images_notes_help: Увядзіце нататкі, характэрныя для гэтага відарыса.
+  form_images_copyright_holder:  "[:COPYRIGHT_HOLDER]"
+  form_images_original_name: Арыгінальная назва файла
+  form_images_select_license:  Select a "License":/info/how_to_use#license
+  form_images_license_help:  Select "license":/info/how_to_use#license you want to give for this image.
+  form_images_project_help: Адзначце любыя праекты, да якіх вы хочаце далучыць гэты відарыс.
+  form_images_camera_date: Дата камеры
+
+  # observer/_form_list_feedback
+  form_list_feedback_missing_names:  The following names could not be found.
+  form_list_feedback_missing_names_help:  Click 'Save'/'Update' to create these names.  If you want to correct any you entered by hand, do so in the area below and click 'Save' to re-evaluate the list.  If the names came from an uploaded species list, create a correct file and select it for upload.
+
+  # location/_form_location
+  form_locations_locked:  Lock this location so users cannot change the name or coordinates?
+  form_locations_gen_desc: Агульнае апісанне
+  form_locations_ecology:  Habitat Description
+  form_locations_species:  Interesting Species
+  form_locations_notes:  "[:Notes]"
+  form_locations_refs:  "[:form_names_refs]"
+  form_locations_refs_help:  "[:form_names_refs_help]"
+  form_locations_help:  "<a href=\"/location/help\" target=\"_new\">Help</a>"
+  form_locations_find_on_map: "Знайсці на карце\n=>"
+  form_locations_lat_long_help:  All values should be in decimal degrees.
+  form_locations_license_help:  Select "license":/info/how_to_use#license you want to give for the above text.
+  form_locations_gen_desc_help:  Describe the geographical location of this location.
+  form_locations_ecology_help:  Summarize the climate, geology, ecology, plant communities, etc.
+  form_locations_species_help:  List the common, rare, or otherwise interesting species found here.
+  form_locations_notes_help:  Enter notes that are specific to this particular location.  For example, whether it is private or public, whether permits are required, driving directions, etc.
+  form_locations_dubious_help: Адпраўце яшчэ раз, каб выкарыстоўваць гэтую назву месца, або адрэдагуйце тэкст ніжэй, каб выправіць памылку друку.
+
+  # observer/_form_name
+  form_names_locked:  Lock this name so users cannot change name, author or rank?
+  form_names_text_name: Навуковая назва
+  form_names_icn_id:  "ICN Identifier #"
+  form_names_identifier_help:  Index Fungorum or MycoBank registration number, if known.
+  form_names_misspelling:  This name is misspelt.
+  form_names_misspelling_it_should_be:  It should be
+  form_names_taxonomic_notes: Нататкі па сістэматыцы
+  form_names_taxonomic_notes_warning:  Please avoid duplicating information from <a href=\"http://www.indexfungorum.org/\">Index Fungorum</a> (IF) or  <a href=\"https://www.mycobank.org/\">MycoBank</a> (MB) in the [:form_names_taxonomic_notes]. Instead, enter the Index Fungorum Registration Identifier or the MycoBank number in the [:form_names_icn_id] field above. This will automatically create links to both IF and MB.
+  form_names_classification:  Taxonomic Classification
+  form_names_gen_desc: Агульнае апісанне
+  form_names_diag_desc:  Diagnostic Description
+  form_names_look_alikes: Паглядзіце падобныя
+  form_names_habitat:  Habitat
+  form_names_distribution:  Distribution
+  form_names_uses:  Uses
+  form_names_notes: Заўвагі
+  form_names_refs:  References
+  form_names_text_name_help:  "Unformatted taxon name <i>without</i> author info or status info. E.g.: <br>&nbsp;&nbsp; Amanita muscaria var. flavivolvata <br>For a <b>group or clade</b>, select <b>[:RANK]</b> “[:RANK_GROUP]” above, and add either “group” or “clade” at the end of <b>[:form_names_text_name]</b>. E.g.: <br>&nbsp;&nbsp; Amanita muscaria group <br>&nbsp;&nbsp; Morchella elata clade"
+  form_names_author_help:  "Include the author using <a href=\"http://www.iapt-taxon.org/nomen/main.php?page=art46\" target=\"_new\">ICN</a> format. <b>[:Authority]</b> may also include “sensu” and/or status information. E.g.: <br>&nbsp;&nbsp; (Singer) Jenkins <br>&nbsp;&nbsp; sensu Ginns <br>&nbsp;&nbsp; N. Siegel & C.F. Schwarz nom. prov."
+  form_names_citation_help:  Citation for the publication of this name.
+  form_names_citation_textilize_note:  Citations can be formatted using the <a href="/info/textile_sandbox" target="_new">Textile markup system</a>.
+  form_names_misspelling_note:  If this name is misspelt, please check the box and enter the correct spelling. *NOTE:* Please do not use this to deprecate correctly-spelled synonyms.
+  form_names_classification_help:  "List the higher taxa containing this [rank], one name per rank. Do not include genus or lower ranks. Example:<br/> Domain: _Eukarya_<br/> Kingdom: _Fungi_<br/> Phylum: _Basidiomycota_<br/> Class: _Agaricomycetes_<br/> Order: _Agaricales_<br/> Family: _Agaricaceae_<br/>"
+  form_names_gen_desc_help:  Describe the general appearance of this taxon.
+  form_names_diag_desc_help:  Describe what distinguishes this taxon from closely related taxa.
+  form_names_look_alikes_help:  What other taxa look similar to this one?
+  form_names_habitat_help:  What habitats has taxon has been found in?
+  form_names_distribution_help:  Where geographically has this taxon been found and where is it expected to occur?
+  form_names_uses_help:  How has this taxon been used by people?
+  form_names_notes_help:  Please include notes about the validity of this name, common misuses of the name, and more appropriate names to be used when applicable.
+  form_names_refs_help:  Each line is considered a separate reference, but no other formatting is enforced.
+  name_error_unregistrable:  The [rank] '[name]' is not eligible for an ICN identifier.
+  name_error_icn_id_in_use:  An ICN identifier number may be used by only one Name. '[number]' is already used by '[name]'.
+  name_error_field_start:  "[field] must not start with '[start]'."
+  name_error_field_end:  "[field] must not end with '[end]'."
+
+  # observer/_form_naming
+  form_naming_confidence: Упэўненасць
+  form_naming_valid_synonyms:  Valid synonyms are
+  form_naming_deprecated:  The name '[name]' is deprecated.
+  form_naming_not_recognized:  MO does not recognize the name '[name]'.
+  form_naming_parent_deprecated:  The [rank] [parent] is deprecated.
+  form_naming_name_help: "**Навуковая назва** (без аўтара), якая ідэнтыфікуе гэта назіранне. **Пакіньце гэта поле пустым, калі вы не ведаеце навуковай назвы.**"
+  form_naming_deprecated_help:  Select a valid name or click '[button]' to use '[name]'.
+  form_naming_correct_help:  Did you mean one of the following names? [:form_naming_deprecated_help]
+  form_naming_not_recognized_help:  "To proceed: Edit the name to be a valid, correctly spelled, scientific name\n(or -- if you are creating an Observation -- erase the name).\nThen click '[button]'."
+  form_naming_multiple_names:  Multiple names match '[name]'.  Select the one you intended.
+  form_naming_multiple_names_help:  The number after each name is how many observations are currently using that name.
+  form_naming_confidence_help: Наколькі вы ўпэўнены ў гэтай ідэнтыфікацыі? Калі ласка, таксама абгрунтуйце, як вы прыйшлі да свайго рашэння ў палях ніжэй.
+
+  # observer/_form_observations
+  form_observations_specimen_available: Даступны ўзор
+  form_observations_is_collection_location: Гэта месца, дзе ён быў сабраны?
+  form_observations_gps_hidden: Схаваць дакладныя каардынаты?
+  form_observations_original_name: Арыгінальная назва файла
+  form_observations_upload_images: Загрузіць выявы
+  form_observations_uploading_images:  Uploading Images
+  form_observations_upload_another: Загрузіць іншы...
+  form_observations_creating_observation: Стварэнне назірання
+  form_observations_edit_image:  Edit Image
+  form_observations_remove_image: Выдаліць малюнак
+  form_observations_lat_long_help: "Дадатковае месцазнаходжанне GPS у межах\n**[:WHERE]**. Шырата павінна быць ад -90,0 да 90,0; даўгата павінна быць ад -180,0 да 180,0. Вышыня будзе пераўтворана ў метры. Калі вы вырашылі прадаставіць гэтыя даныя, зрабіце іх максімальна дакладнымі. Прыклады:\n\"34.1164\" = \"34°6&apos;59&quot;N\", \"-118.1459\" = \"118 8.754 W\", \"239 m\" = \"784 ft.\""
+  form_observations_log_change: Змена часопіса
+  form_observations_is_collection_location_help: Праверце, калі гэта месца, дзе рос грыб. Зніміце сцяжок, калі ён знаходзіцца толькі там, дзе грыб быў заўважаны (напрыклад, грыбны кірмаш, прадуктовы магазін, табліца ідэнтыфікатараў набегаў, дзе месца збору невядомае і г.д.).
+  form_observations_open_map: Адкрыйце інтэрактыўную карту
+  form_observations_clear_map: Ачысціць карту
+  form_observations_notes_help: Калі ласка, уключыце любую дадатковую інфармацыю, якую вы можаце прыдумаць аб гэтым назіранні, якая не зразумелая з фатаграфій, напрыклад, асяроддзе пражывання, субстрат або бліжэйшыя дрэвы; адметная кансістэнцыя, водар, густ, плямы або сінякі; вынікі хімічных або мікраскапічных аналізаў і інш.
+  form_observations_remove_image_confirm: Вы ўпэўнены, што хочаце выдаліць гэту выяву? Гэта толькі выдаліць гэты відарыс з гэтага назірання. Калі ён далучаны да іншых назіранняў, ён застанецца прывязаным да іх.
+  form_observations_specimen_available_help: Праверце, калі ёсць захаваны ўзор, даступны для далейшага вывучэння.
+  form_observations_upload_help: Выкарыстоўвайце сцяжкі злева, каб выбраць выяву, якую вы хочаце выкарыстоўваць у якасці мініяцюры для гэтага назірання.
+  form_observations_upload_help_multi_select: Выкарыстоўвайце сцяжкі злева, каб выбраць выяву, якую вы хочаце выкарыстоўваць у якасці мініяцюры для гэтага назірання. У дыялогавым акне выбару файла вы можаце выбраць некалькі малюнкаў адначасова. Вы таксама можаце працягнуць дадаваць дадатковыя выявы, націснуўшы кнопку ніжэй.
+  form_observations_where_help: "Месца, дзе было зроблена назіранне. **У ЗША гэта павінна быць прынамсі такім жа дакладным, як і акруга.** Уключыце адміністрацыйныя аддзелы ў парадку ад найменшага да самага вялікага, заканчваючы поўнай назвай краіны, за выключэннем выкарыстання «ЗША» для Злучаных Штатаў Амерыкі. Прыклады:\n\n&nbsp;&nbsp; [loc1]\n&nbsp;&nbsp; [loc2]"
+  form_observations_locate_on_map_help: Каб паказаць гэтае месцазнаходжанне на карце, выкарыстоўвайце кнопку Знайсці на карце. Затым націсніце, каб дадаць маркер, і перацягніце яго на пэўную шырыню і даўгату.
+  form_observations_dubious_help:  Click '[button]' to use this location name or edit the text below to correct any typo.
+  form_observations_project_help: Адзначце любыя праекты, да якіх вы хочаце далучыць гэтае назіранне. Усе выявы, якія вы загружаеце, таксама будуць аўтаматычна далучаны да гэтых праектаў.
+  form_observations_list_help: Праверце ўсе спісы відаў, у якія вы хочаце дадаць гэтае назіранне.
+  form_observations_edit_specimens_help:  Please add, edit and remove specimen data from the main observation page.
+  form_observations_use_date: Выкарыстоўвайце гэтую дату
+  form_observations_date_warning: "Заўвага: дата камеры на некаторых вашых фотаздымках не супадае з датай назірання, якую вы ўвялі."
+  form_observations_gps_info: Нам удалося выявіць каардынаты GPS на далучаных вамі відарысах. Выберыце адну з каардынат і націсніце "абнавіць", каб прымяніць каардынаты да вашага назірання.
+  form_observations_set_observation_date_to: Усталюйце дату назірання
+  form_observations_set_image_dates_to: Усталюйце даты выявы
+  form_observations_image_too_big:  This image is too large. Images must be less than [max]Mb in file size.
+  form_observations_upload_error:  Something went wrong while uploading image. Skipping it for now. You can try uploading it again later after we've created the observation.
+  form_observations_collection_number_help:  Enter the collector's full name and their record identifier.  The identifier can be anything.  It's whatever you use to keep track of your specimens, and it is typically written on the specimen label.  This is most commonly a sequential number starting at 1 for your first specimen, and working up over your life time.  Another common format is a year or date along with a collection number for that date, e.g., "17-034".  But it can be anything you like, including letters and punctuation.
+  form_observations_herbarium_record_help:  If you've sent a specimen to a fungarium, you can enter that here, along with their accession number if you know it.  Otherwise let it default to your personal fungarium and leave the accession number blank.
+  form_observations_there_is_a_problem_with_location:  There is a problem with the location. "+See message below.+":#location_messages
+  form_observations_there_is_a_problem_with_name:  There is a problem with the name. "+See message below.+":#name_messages
+
+  # observer/_form_species_list
+  form_species_lists_title:  Title
+  form_species_lists_species_to_add: Выберыце віды для дадання
+  form_species_lists_write_in_species:  "Write-In Species: (enter a name on each line)"
+  form_species_lists_list_notes: Заўвагі да спісу відаў
+  form_species_lists_member_notes:  Notes for each new member
+  form_species_lists_confidence:  Confidence in identifications
+  form_species_lists_deprecated:  The following names are deprecated
+  form_species_lists_deprecated_help:  Select any names you would prefer to use.  If you prefer a name you entered then don't select one of the suggested synonyms.
+  form_species_lists_multiple_names:  Multiple names match each of the following entries
+  form_species_lists_multiple_names_help:  In each case, select the intended name.  The number after each name is how many observations are currently using that name.
+  form_species_lists_project_help:  Check any projects you wish to attach this species list to.  Any observations you create for this species list will also automatically be attached to these projects, too.  (But not pre-existing observations.)
+
+  # observer/_form_synonyms
+  form_synonyms_names:  Names
+  form_synonyms_names_help:  List the names you want to be synonymized with [name].
+  form_synonyms_current_synonyms:  Current Synonyms
+  form_synonyms_current_synonyms_help:  Unchecked items will no longer be synonymized with this name, but will remain synonymized with each other.
+  form_synonyms_proposed_synonyms:  Proposed Synonyms
+  form_synonyms_proposed_synonyms_help:  Unchecked items will no longer be synonymized with this name, but will retain their relationships with each other.
+  form_synonyms_deprecate_synonyms:  Deprecate Synonyms
+  form_synonyms_deprecate_synonyms_help:  If checked all listed synonyms become deprecated names.  Otherwise, they are left as they are with new names created as not deprecated.
+  form_synonyms_missing_names:  The following names could not be found.
+  form_synonyms_missing_names_help:  Click [:name_change_synonyms_submit] to create these names.  If you want to correct any names, do so in the area below and click [:name_change_synonyms_submit] to re-evaluate the list.
+
+  # image/add_image
+  image_set_default: Усталяваць мініяцюру па змаўчанні
+  image_add_title:  Add an Image for [name]
+  image_add_edit:  "[:edit_object(type=:observation)]"
+  image_add_default: Мініяцюра па змаўчанні
+  image_add_image:  "[:Image]"
+  image_add_optional:  "[:optional]"
+  image_add_upload:  "[:UPLOAD]"
+  image_add_warning:  Please only upload images that you created or which you own the copyright of. By uploading images you are giving us permission to distribute this image to other users ("legalese":http://creativecommons.org/licenses/by-nc-sa/2.5/). You are also giving us permission to display this image along side advertisements or other fund-raising tools that may be used to support this site.
+
+  # image/reuse_image_for_user
+  image_reuse_all_users:  Include other users' images.
+  image_reuse_just_yours:  Only show your images.
+
+  # image/edit_image
+  image_edit_title:  "Editing Image: [name]"
+
+  # image/remove_images
+  image_remove_edit:  "[:edit_object(type=:observation)]"
+  image_remove_remove: Зняць
+  image_remove_title:  Remove Images from [name]
+
+  # image/reuse_images
+  image_reuse_title:  Reuse Image for [name]
+  image_reuse_edit:  "[:edit_object(type=:observation)]"
+  image_reuse_id:  Image ID
+  image_reuse_reuse: Паўторнае выкарыстанне
+  image_reuse_id_help:  Either click one of the images below, or if you know the image ID, just enter it here and click '[:image_reuse_reuse]'.
+
+  # image/show_image
+  image_show_title:  "[:IMAGE]: [name]"
+  image_show_inquiry: Адправіць камерцыйны запыт
+  image_show_rotate_left:  Rotate Left
+  image_show_rotate_right:  Rotate Right
+  image_show_mirror:  Mirror
+  image_show_edit:  "[:EDIT]"
+  image_show_destroy:  "[:DESTROY]"
+  image_show_when:  "[:WHEN]"
+  image_show_notes:  "[:NOTES]"
+  image_show_copyright: Аўтарскае права
+  image_show_public_domain: Грамадскі набытак ад
+  image_show_quality: Якасць
+  image_show_your_vote: Ваш голас
+  image_show_vote_and_next:  Vote & [:NEXT]
+  image_show_comments:  "[num] comment(s)"
+  image_show_observations:  "[:OBSERVATIONS]"
+  image_show_thumbnail:  Thumbnail
+  image_show_small:  Small
+  image_show_medium:  Medium
+  image_show_large:  Large
+  image_show_huge:  Huge
+  image_show_full_size:  Full Size
+  image_show_original: Паказаць зыходны відарыс
+  image_show_exif: Паказаць загаловак EXIF
+  image_show_original_name: Арыгінальная назва файла
+  image_show_make_default: Зрабіце гэта памерам па змаўчанні
+  image_show_transform_note:  Image is being processed. This may take several seconds.
+
+  # observation/list_observations
+  list_observations_location_all:  All Locations
+  list_observations_location_define: Вызначце гэта месцазнаходжанне
+  list_observations_location_merge:  Merge With A Defined Location
+  list_observations_alternate_spellings:  Maybe you meant one of the following names?
+  list_observations_suggestions:  Other Links
+  list_observation_name:  "[:NAME]"
+  list_observation_observations:  Observations of
+  list_observations_add_to_list:  Add To / Remove From Species List
+  list_observations_download_as_csv:  Download Observations
+
+  # location/list_place_names (list_locations)
+  list_place_names_known:  Known Locations
+  list_place_names_known_order:  "(by name)"
+  list_place_names_map:  Map Locations
+  list_place_names_merge:  Merge
+  list_place_names_parenthetical:  Number in parentheses shows Observation count.
+  list_place_names_popularity:  "\"[:sort_by_num_views]\" means how many times the page was visited."
+  list_place_names_undef:  Undefined Locations
+  list_place_names_undef_order:  "(by frequency)"
+
+  # location/list_countries
+  list_countries:  Country List
+  list_countries_known: Краіны з назіраннямі
+  list_countries_title:  Countries and Other Localities
+  list_countries_unknown:  Other Localities With Observations
+  list_countries_missing:  Countries Without Observations
+
+  # _location (RSS log display)
+  location_change:  Change to Location
+
+  # model/location
+  location_dubious_ambiguous_country:  Ambiguous country or state, '[country]'
+  location_dubious_bad_char:  Contains unexpected character '[char]'
+  location_dubious_bad_term:  For consistency, we prefer '[good]' instead of '[bad]'.
+  location_dubious_commas:  All commas should be followed by a space and another word
+  location_dubious_empty:  Empty location given
+  location_dubious_redundant_county:  County may not be required in this name; for greatest consistency we prefer that you not include the county for towns and cities.
+  location_dubious_redundant_state:  Both '[state]' and '[country]' are on the list of countries and continents.  A common mistake is to include the continent in addition to the country; this is unnecessary.
+  location_dubious_unknown_country: "Невядомая краіна\n'[country]'"
+  location_dubious_unknown_state:  Unrecognized state or province '[state]' for '[country]'.
+
+  # account/login
+  login_please_login: Калі ласка, увайдзіце
+  login_login: Увайсці
+  login_user: Імя карыстальніка або адрас электроннай пошты
+  login_password: Пароль
+  login_remember_me: Запомні мяне на гэтым кампутары.
+  login_forgot_password: "Я забыў свой пароль. \"Напішыце мне новы.\"\n:/account/email_new_password"
+  login_no_account: "У мяне няма акаўнта. «Стварыце новы ўліковы запіс\n.\":/account/signup"
+  login_having_problems: "Калі ў вас узніклі праблемы з уваходам у ваш уліковы запіс, адпраўце «электронны ліст вэб-майстру»\n:/emails/ask_webmaster_question."
+  email_new_password_help: Калі вы запоўніце гэту старонку і націснеце «Адправіць», мы вышлем вам электронны ліст з інфармацыяй праверкі.
+  email_spam_notice: Калі вы не бачыце электроннага ліста ў паштовай скрыні, праверце папку са спамам. Калі ён знаходзіцца ў вашай папцы са спамам, калі ласка, (1) паведаміце свайму пастаўшчыку электроннай пошты, што гэта не спам, і (2) занясіце ў белы спіс «mushroomobserver.org». Гэта можа прадухіліць трапленне электронных лістоў MO ў вашы папкі са спамам ці іншых карыстальнікаў.
+  login_layout_description: Вэб-сайт для запісу назіранняў за грыбамі, дапамогі людзям ідэнтыфікаваць незнаёмыя грыбы і пашырэння супольнасці вакол навуковага даследавання грыбоў (мікалогія).
+  login_create_account_caption: Стварыце бясплатны рахунак
+  login_explain_login_requirement: Каб аўтаматызаваныя праграмы не спажывалі занадта шмат нашых рэсурсаў, мы абмяжоўваем выкарыстанне вэб-сайта зарэгістраванымі карыстальнікамі.
+  login_data_without_login_caption:  Get MO Data Without Logging In
+  login_images_without_login:  Get "MO Images for Machine Learning":/articles/20.
+  login_data_without_login:  Get "MO Data":https://github.com/MushroomObserver/mushroom-observer/blob/master/README_API.md#csv-files.
+
+  # account/logout
+  logout_title: Выйсці з сістэмы
+  logout_note: "Вы выйшлі з сістэмы\n[:app_title] сайт. Функцыі рэдагавання адключаны."
+
+  # location/map_locations
+  map_locations_title:  Map of [locations]
+  map_locations_global_map:  Global Map
+
+  # name/approve_name
+  name_approve_title:  Approve [name]
+  name_approve_comment_summary:  "[:Approved]"
+  name_approve_comments:  "[:Comments]"
+  name_approve_comments_help:  "Please include any notes about why this name has been approved.\nThis will be added to the notes for [name]."
+  name_approve_deprecate:  Deprecate the following synonyms
+  name_approve_deprecate_help:  If you want to split up a set of synonyms, click 'Approve' or 'Cancel' and then click the 'Change Synonyms' link.
+
+  # name/change_synonyms
+  name_change_synonyms_title:  Synonyms for [name]
+  name_change_synonyms_submit:  Submit Changes
+  name_change_synonyms_confirm:  Please confirm that this is what you intended.
+
+  # name/deprecate_name
+  name_deprecate_title:  Deprecate [name]
+  name_deprecate_preferred:  Preferred name
+  name_deprecate_comment_summary:  "[:Deprecated]"
+  name_deprecate_comments:  "[:Comments]"
+  name_deprecate_submit:  "[:SUBMIT]"
+  name_deprecate_preferred_help:  Enter the preferred name. Author citation is recommended but not required.
+  name_deprecate_comments_help:  "Please say why this Name has been deprecated (e.g, a link to Index Fungorum).\nThis will be added to the Comments for [name]."
+
+  # name/name_index (and other actions using same view)
+  name_index_add_name:  Add Name
+  name_index_bulk_edit:  "[:name_bulk_title]"
+
+  # name/map
+  name_map_title: "Карта ўзнікнення для\n[name]"
+  name_map_about:  "[:show_name]"
+  name_map_no_maps:  No observations of [name] have mappable location information.
+
+  # info/news
+  news_title:  "Latest Release: April 17, 2017"
+  news_header:  This page provides notes on the latest releases and changes to [:app_title].
+  news_content:  "[:news_content_pr_306]\n\n[:news_content_pr_301]\n\n[:news_content_pr_294]\n\n[:news_content_pr_291]\n\n[:news_content_pr_293]\n\n[:news_content_pr_276]\n\n[:news_content_pr_261]\n\n[:news_content_pr_258]\n\n[:news_content_pr_256]\n\n[:news_content_pr_249]\n\n[:news_content_pr_248]\n\n[:news_content_pr_247]\n\n[:news_content_pr_246]\n\n[:news_content_commit_efa11ea]\n\n[:news_content_pr_241]\n\n[:news_content_pr_240]\n\n[:news_content_pr_238]\n\n[:news_content_commit_22deee6]\n\n[:news_content_commit_33639d5]\n\n[:news_content_commit_96e27e9]\n\n[:news_content_pr_236]\n\n[:news_content_pr_235]\n\n[:news_content_pr_233]\n\n[:news_content_pr_232]\n\n[:news_content_pr_231]\n\n[:news_content_pr_230]\n\n[:news_content_pr_226]\n\n[:news_content_pr_224]\n\n[:news_content_pr_223]\n\n[:news_content_pr_221]\n\n[:news_content_pr_220]\n\n[:news_content_pr_219]\n\n[:news_content_pr_217]\n\n[:news_content_pr_216]\n\n[:news_content_pr_215]\n\n[:news_content_pr_213]\n\n[:news_content_pr_212]\n\n[:news_content_pr_208]"
+
+  # info/news individual updates
+  news_content_pr_306:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/306\" target=\"_new\">PR #306</a> (April 17, 2017) Allow removal of author from Name; allow Group or Clade authored/unauthored Name pairs."
+  news_content_pr_301:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/301\" target=\"_new\">PR #301</a> (April 1, 2017) Add google map inset to observation form to help users enter good lat/long and elevation for observatons."
+  news_content_pr_294:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/294\" target=\"_new\">PR #294</a> (March 19, 2017) Add support for clade names. These are just like group names, but use “clade” instead of “group”. Clarify and expand instructions on the Create Name and Edit Name pages."
+  news_content_pr_291:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/291\" target=\"_new\">PR #291</a> (March 18, 2017) Improve group names: allow “group” to be appended to any ICN valid Scientific Name, requiring “group” to be in the Scientific Name field."
+  news_content_pr_293:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/293\">PR #293</a> (March 16, 2017) Fixed bug which caused loss of “Big Eyes” next to a Proposed Name and caused incorrect calculation of Observer Preference."
+  news_content_pr_276:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/276\">PR #276</a> (January 24, 2017) Revived pages explaining color themes. See https://mushroomobserver.org/theme/color_themes. Moved theme actions to a new controller."
+  news_content_pr_261:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/261\">PR #261</a> (January 7, 2017) Added prototype ability to create \"external links\" between observations and corresponding records on external websites, such as MycoPortal and GenBank."
+  news_content_pr_258:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/258\">PR #258</a> (December 27, 2016) Add - via user preferences - persistent filters giving user the option to exclude imageless observations and/or observations without specimens from Activity Feed and other displays of observations."
+  news_content_pr_256:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/256\">PR #256</a> (December 25, 2016) Made it so users who have only proposed a name for an observation will get comment response notifications, instead of requiring users to comment in order to get comment response notifications."
+  news_content_pr_249:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/249\">PR #249</a> (December 24, 2016) Re-enabled donations through paypal  MO, Inc. can now officially accept tax-free donations!"
+  news_content_pr_248:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/248\">PR #248</a> (December 22, 2016) You can now notify users by mentioning them in comments with the usual notations: \"_user john_\" or \"@john\".  If a user's login contains non-alphanumeric characters (like dashes, periods, spaces), then use this format: \"@John Doe@\"."
+  news_content_pr_247:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/247\">PR #247</a> (December 22, 2016) The vote pull-down menus on observation pages now automatically save without requiring an additional page load."
+  news_content_pr_246:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/246\">PR #246</a> (December 22, 2016) Added ability to add (or remove) results of an observation query to (from) an existing species list.  Look for link in upper right corner of any observation index page."
+  news_content_commit_efa11ea:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/efa11ea\">Commit #efa11ea</a> (December 20, 2016) Added support for already-existing query capabilities via the search bar.  Search for observations matching \"help:me\" to see full list of new capabilites."
+  news_content_pr_241:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/241\">PR #241</a> (September 15, 2016) Extensive refactor of Query model in preparation for user filters."
+  news_content_pr_240:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/240\">PR #240</a> (September 11, 2016) Allows 'comb.' e.g., comb. nov., in author field.  Standardize 'comb.' and similar status indicators in future Name edits and creates."
+  news_content_pr_238:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/238\">PR #238</a> (September 9, 2016) Fixes bug in email tracking which caused uploader's mailing address to be used in place of the person who wants the notifications."
+  news_content_commit_22deee6:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/22deee6\">Commit #22deee6</a> (Aug 16, 2016) Fix errors cause by corrupted RSS log. Make failures more graceful if log gets corrupted in the future."
+  news_content_commit_33639d5:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/33639d5\">Commit #33639d5</a> (Aug 10, 2016) Letter to MO Community stating policy on abuse, community openness.  Block user account."
+  news_content_commit_96e27e9:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/96e27e9\">Commit #96e27e9</a> (Aug 7, 2016) Add basic documentation of API to GitHub."
+  news_content_pr_236:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/236\">PR #236</a> (July 28, 2016) Prevent use of the Name \"Imageless\"."
+  news_content_pr_235:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/235\">PR #235</a> (July 28, 2016) Improve link to MycoBank for taxa at the Group rank."
+  news_content_pr_233:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/233\">PR #233</a> (July 28, 2016) Restore padding of tables created with Textile. Reduce size of Textile quoted paragraphs."
+  news_content_pr_232:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/232\">PR #232</a> (July 28, 2016) Wrap long words (to prevent them from extending into other windows)."
+  news_content_pr_231:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/230\">PR #231</a> (July 28, 2016) Improve test coverage of extensions."
+  news_content_pr_230:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/230\">PR #230</a> (July 28, 2016) Refactor fixtures and tests to use Advanced Fixtures."
+  news_content_pr_226:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/226\">PR #226</a> (May 30, 2016) Fix intermittent testing bug (in export_round_trip)."
+  news_content_pr_224:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/224\">PR #224</a> (May 7, 2016) Prevent changes to the \"Unknown\" Location."
+  news_content_pr_223:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/221\">PR #223</a> (April 24, 2016) Expand Show RSS Log page so it is easier to read."
+  news_content_pr_221:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/221\">PR #221</a> (April 24, 2016) Fix bug where weakened confidence level vote sometimes caused mistaken calculation of Observer's favorite."
+  news_content_pr_220:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/220\">PR #220</a> (February 1, 2016) Allow creation of Observations with observation date more than 20 years old."
+  news_content_pr_219:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/219\">PR #219</a> (January 16, 2016) Create Vote Controller."
+  news_content_pr_217:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/217\">PR #217</a> (January 15, 2016) Make \"Textile markup system\" a link everywhere on edit_name form."
+  news_content_pr_216:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/216\">PR #216</a> (January 15, 2016) Remove IP address blocking from Rails code."
+  news_content_pr_215:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/215\">PR #215</a> (January 15, 2016) Always show Observer Preference line in Observations if user checks \"View Observer’s Preferred ID?\"."
+  news_content_pr_213:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/213\">PR #213</a> (January 14, 2016) Add Capybara gem and counterparts of 2 older integration tests."
+  news_content_pr_212:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/212\">PR #212</a> (January 14, 2016) Enable web console in development mode on the VM."
+  news_content_pr_208:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/208\">PR #208</a> (December 13, 2015) <u>Rails 4.2.5</u>\n\nAt long last the Mushroom Observer website is up to date with the latest stable version of Ruby on Rails (4.2.5). This has not been true since at least March of 2009.  The upgrade process started last August when we were still using the 2.1.1 version of Ruby on Rails.\n\nThis has been a huge team effort by all the volunteer developers on the project. Thanks to every one of you for helping to make this happen.\n\nFor those who are interested in the technical low-down of this specific release, we got to 4.1 last month and the biggest change between 4.1 and 4.2 was a new HTML parsing library that required many minor code changes throughout out code base. There have also been some changes to how email is handled and a variety of other small changes to the code base.  You should see no new changes in the site due to this latest upgrade, but of course <a href=\"/emails/ask_webmaster_question\">send us a note</a> if you see anything wrong."
+
+  # shared/_observation_list
+  observation_made_confidence:  Community confidence
+
+  # account/prefs
+  prefs_title:  Change Preferences
+  prefs_link:  Edit Preferences
+  prefs_login:  Login
+  prefs_email:  Email address
+  prefs_password_new:  New password
+  prefs_password_confirm:  Confirm new password
+
+  prefs_appearance:  Appearance Settings
+  prefs_theme:  Preferred theme
+  prefs_themes_about:  About Themes
+  prefs_locale:  Language
+  prefs_location_format:  Location Format
+  prefs_location_format_postal:  Postal (New York, USA)
+  prefs_location_format_scientific:  Scientific (USA, New York)
+  prefs_hide_authors:  "[:AUTHORITYS]"
+  prefs_hide_authors_none:  show author for all ranks (default)
+  prefs_hide_authors_above_species:  hide author for genus and higher ranks
+  prefs_thumbnail_size:  Thumbnail size
+  prefs_thumbnail_small:  "[:image_show_small]"
+  prefs_thumbnail_large:  "[:image_show_large]"
+  prefs_thumbnail_maps:  View thumbnail map on Observation page?
+  prefs_image_size:  Image size
+  prefs_image_size_help:  Size shown when you click on an image.
+  prefs_image_small:  "[:image_show_small] (320 x 320)"
+  prefs_image_medium:  "[:image_show_medium] (640 x 640)"
+  prefs_image_large:  "[:image_show_large] (960 x 960)"
+  prefs_image_huge:  "[:image_show_huge] Huge (1280 x 1280)"
+  prefs_image_full_size:  "[:image_show_full_size]"
+  prefs_layout_count:  List page items
+  prefs_layout_title:  List page layout
+  prefs_rows_by:  rows ×
+  prefs_columns:  columns
+  prefs_alt_col_colors:  Alternate column colors.
+  prefs_alt_row_colors:  Alternate row colors.
+  prefs_text_below_images:  Put text below images.
+  prefs_view_owner_id: Праглядзець пажаданы ідэнтыфікатар назіральніка?
+  prefs_view_owner_id_help: Прагляд пераважнага ідэнтыфікатара назіральніка для назірання (у дадатак да кансенсуснага ідэнтыфікатара)
+
+  prefs_content_filters:  Content Filters
+  prefs_content_filters_explanation:  Control content visibility site-wide.
+  prefs_filters_has_images:  Hide observations with no images
+  prefs_filters_has_specimen:  Hide observations with no specimens
+  prefs_filters_lichen:  Filter observations of lichens
+  prefs_filters_lichen_yes:  Show only lichens
+  prefs_filters_lichen_no:  Hide lichens
+  prefs_filters_region:  Show only observations and locations within this region
+  prefs_filters_region_help:  Must match the end of the location name, e.g., "Thailand" and "California, USA".
+  prefs_filters_clade:  Show only observations within this taxonomic clade
+  prefs_filters_clade_help:  Any taxonomic level is okay, e.g., "Agaricales", "Amanitaceae" and "Cortinarius".
+  prefs_filter_off:  filter off
+
+  prefs_notes_template:  Observation Notes Template
+  notes_template:  "[:prefs_notes_template]"
+  prefs_notes_template_explanation:  Comma-separated list of Notes sub-headings for the Create Observation page.
+  prefs_notes_template_no_other:  must not include a heading named “[part]”
+  prefs_notes_template_no_dups:  contains duplicate heading “[part]”
+  prefs_privacy:  Privacy Settings
+  prefs_votes_anonymous:  Votes on proposed names and images
+  prefs_votes_anonymous_no:  Always public
+  prefs_votes_anonymous_yes:  Always anonymous
+  prefs_votes_anonymous_old:  Public after [cutoff]
+  prefs_keep_image_filenames:  Keep original file name of uploaded images?
+  prefs_keep_image_filenames_toss:  remove from database completely
+  prefs_keep_image_filenames_keep_but_hide:  save but keep them private
+  prefs_keep_image_filenames_keep_and_show:  save and make them public
+  prefs_bulk_filename_purge:  Purge All Filenames from Database
+  prefs_bulk_filename_purge_confirm:  Are you sure you want to purge all image filenames from our database? This action cannot be undone.  Please note that no one but you is able to see these filenames, anyway.
+  prefs_bulk_filename_purge_success:  Successfully purged all image filenames from our database.
+  prefs_change_image_vote_anonymity:  Change Image Vote Anonymity
+  prefs_license_note:  Default "license":/info/how_to_use#license you want for new images.
+
+  prefs_email_please_notify:  Please notify me when...
+  prefs_email_general:  General Email
+  prefs_email_general_commercial:  someone is interested in using an image of mine for commercial purposes.
+  prefs_email_general_features:  new features come out.
+  prefs_email_general_questions:  someone wants to send me a question about my observations, etc.
+  prefs_email_comments:  "[:Comment] Email"
+  prefs_email_comments_all:  anyone comments on anything.
+  prefs_email_comments_owner:  someone comments on my observations, names, etc.
+  prefs_email_comments_response:  someone posts responses to my comments.
+  prefs_email_locations:  "[:Location] Email"
+  prefs_email_locations_all:  anyone changes any location.
+  prefs_email_locations_admin:  someone changes a location I administrate.
+  prefs_email_locations_author:  someone changes a location I'm author on.
+  prefs_email_locations_editor:  someone changes a location I've edited.
+  prefs_email_observations:  "[:Observation] Email"
+  prefs_email_observations_all:  anything happens to any observation.
+  prefs_email_observations_consensus:  consensus name changes for one of my observations.
+  prefs_email_observations_naming:  someone proposes a name for one of my observations.
+  prefs_email_names:  "[:Name] Email"
+  prefs_email_names_all:  anyone changes any name.
+  prefs_email_names_admin:  someone changes a name I administrate.
+  prefs_email_names_author:  someone changes a name I'm author on.
+  prefs_email_names_editor:  someone changes a name I've edited.
+  prefs_email_names_reviewer:  someone changes a name I've reviewed.
+  prefs_email_prefs:  Email preferences
+  prefs_email_html:  It's okay to use HTML in my emails.
+  prefs_email_digest_daily:  Send me summary at the end of the day.
+  prefs_email_digest_immediate:  Notify me of events as they happen.
+  prefs_email_digest_weekly:  Send me summary at the end of the week.
+  prefs_email_note:  Note that none of these email features will cause your email address to be displayed on a webpage or allow the person who wants to contact you to obtain your email address.  You will be sent an email from news at mushroomobserver.org that will contain the contact information for the person who wants to contact you.  It will be entirely up to you if you want to respond to them.
+
+  # account/profile
+  profile_title:  "[:edit_object(type=:profile)]"
+  profile_link:  "[:edit_object(type=:profile)]"
+  profile_button:  "[:SAVE_CHANGES]"
+  profile_name:  "[:Name]"
+  profile_notes: Пра сябе
+  profile_location: Асноўнае размяшчэнне
+  profile_mailing_address: Паштовы адрас для калекцый
+  profile_image_create: Загрузіць фота
+  profile_image_change: Загрузіць новае фота
+  profile_image_remove: "(Выдаліць фота.)"
+  profile_image_reuse: "(Паўторнае выкарыстанне іншага фота.)"
+  profile_copyright_holder: Уладальнік аўтарскіх правоў і ліцэнзіі на гэты відарыс
+  profile_copyright_warning: Калі ласка, загружайце толькі той відарыс, які вы стварылі або аўтарскім правам на які вы валодаеце.
+
+  # account/reverify
+  reverify_welcome: Праверце ўліковы запіс
+  reverify_link: Пераправерыць
+  reverify_note: "Ваш рахунак,\n[user], яшчэ не праверана.\n\n\nПраверце сваю электронную пошту на наяўнасць URL-адраса спраўджання або націсніце на спасылку ніжэй, каб паўторна адправіць ліст спраўджання."
+
+  # rss_logs/rss
+  rss_description:  List of changes to [:app_title] as they happen.
+  rss_log_of_deleted_item: Выдалены элемент
+  rss_log_title: Часопіс актыўнасці
+  rss_by: па [user]
+  rss_title:  "[:app_title]"
+  rss_filtered_mouseover: "[:app_title] прымяніў фільтр(ы) на аснове вашых пераваг."
+  rss_show: "Паказаць:"
+  rss_hide: "Схаваць:"
+  rss_all: Yсё
+  rss_all_help: Паказаць усе тыпы аб'ектаў.
+  rss_one_observation:  "[:OBSERVATIONS]"
+  rss_one_name:  "[:NAMES]"
+  rss_one_location:  "[:LOCATIONS]"
+  rss_one_species_list:  "[:SPECIES_LISTS]"
+  rss_one_project:  "[:PROJECTS]"
+  rss_one_glossary_term:  "[:GLOSSARY]"
+  rss_one_article:  "[:NEWS]"
+  rss_one_help: "Толькі паказаць\n[types]."
+  rss_make_default: Зрабіць гэта маім стандартным
+  rss_this_is_default: Гэта ваш стандарт
+  rss_created_at: "[TYPE] Стварылі"
+  rss_changed: "[TYPE] Зменены"
+  rss_destroyed: "[TYPE] Разбураны"
+  rss_consensus_reached: Дасягнуты кансенсус
+
+  # shared/_textile_help
+  general_textile_link:  Can be formatted with <a href="/info/textile_sandbox" target="_new">Textile</a>.
+  shared_textile_link: Падрабязней тут.
+  shared_textile_help: "Нататкі можна адфарматаваць з дапамогай\n<a href=\"/info/textile_sandbox\" target=\"_new\">Textile markup system</a>.<br/> _Amanita ocreata_, _A. ocreata_ ---> <u><b><i>Amanita ocreata</i></b></u> (linked to name description)<br/> __italic__, **bold** ---> <i>italic</i>, <b>bold</b><br/>"
+
+  field_textile_link:  This field can be formatted with <a href="/info/textile_sandbox" target="_new">Textile</a>.
+
+  # comment/_show_comments
+  show_comments_add_comment:  "[:add_object(type=:comment)]"
+  show_comments_no_comments_yet: Ніхто пакуль не каментаваў.
+  show_comments_and_more:  And [num] more...
+
+  # observation/_show_consensus
+  show_consensus_species:  Species in [name]
+
+  # name/show_name_description or location/show_location_description
+  show_description_empty:  Nothing has been written for this description yet.
+  show_description_destroy:  "[:DESTROY]"
+  show_description_edit:  "[:EDIT]"
+  show_description_clone:  Clone
+  show_description_merge:  Merge With Another
+  show_description_publish:  Publish
+  show_description_make_default:  Make Default
+  show_description_adjust_permissions:  Adjust Permissions
+  show_description_read_permissions:  View
+  show_description_write_permissions:  Edit
+  show_description_clone_help:  Create your own description based on this description.
+  show_description_merge_help:  Merge this description into another, then remove this one.
+  show_description_publish_help:  Publish this draft and make it the default public description.
+  show_description_make_default_help:  Make this the default description that is shown on the main '[:show_name(name=:name)]' page.
+  show_description_adjust_permissions_help:  Change the set of users who are allowed to view, modify or administrate this description.
+
+  # observer/_show_images
+  show_images_small_thumbs:  "(small thumbnails)"
+  show_images_large_thumbs:  "(large thumbnails)"
+
+  # observer/_show_lists
+  show_lists_header:  "[:SPECIES_LISTS]"
+
+  # location/show_location
+  show_location_title:  "[:LOCATION]: [name]"
+  show_location_create:  "[:create_object(type=:location)]"
+  show_location_edit:  "[:edit_object(type=:location)]"
+  show_location_destroy:  "[:destroy_object(type=:location)]"
+  show_location_observations:  Observations at this Location
+  show_location_highest:  Highest Elevation
+  show_location_lowest:  Lowest Elevation
+  show_location_no_descriptions:  There are no descriptions for this location yet.
+  show_location_create_description:  "[:CREATE]"
+  show_location_creator:  User who defined this location
+  show_location_editor:  "[:Editors]"
+  show_location_editors:  "[:Editors]"
+  show_location_reverse:  Reverse Location
+  show_location_locked:  This location is locked. If you want to change the location of your observation, please edit the observation instead.  Changing a location name or coordinates implicitly changes all the observations at that location, too.
+
+  # name/show_name
+  show_name_title:  "[:NAME]: [name]"
+  show_name_add_name:  "[:add_object(type=:name)]"
+  show_name_edit_name:  "[:edit_object(type=:name)]"
+  show_name_bulk_name_edit:  "[:name_bulk_title]"
+  show_name_distribution_map: Карта ўзнікнення
+  show_name_change_synonyms:  Change Synonyms
+  show_name_email_tracking:  Email Tracking
+  show_name_create_description:  "[:CREATE]"
+  show_name_synonyms:  Synonym(s)
+  show_name_preferred_synonyms: Пераважныя сінонімы
+  show_name_deprecated_synonyms:  Deprecated Synonyms
+  show_name_misspelled_synonyms:  Misspellings
+  show_name_misspelling:  This name is misspelled.
+  show_name_misspelling_correct:  "[:CORRECT_SPELLING]"
+  show_name_refresh_classification:  Refresh from Genus
+  show_name_propagate_classification:  Propagate to Subtaxa
+  show_name_lifeform:  Lifeform
+  show_name_propagate_lifeform:  Propagate to Subtaxa
+  show_name_notes:  "[:form_names_taxonomic_notes]"
+  show_name_descriptions: "[:DESCRIPTIONS]"
+  show_name_create_draft: Стварыць новы чарнавік для
+  show_name_no_descriptions:  There are no descriptions for this name yet.
+  show_name_description_author:  "[:Description] author"
+  show_name_description_authors:  "[:Description] authors"
+  show_name_description_editor:  "[:Description] editor"
+  show_name_description_editors:  "[:Description] editors"
+  show_name_author_request:  Request Authorship Credit
+  show_name_content_status:  Description status
+  show_name_latest_review:  "Latest review: [date] by [user]"
+  show_name_most_confident: Самыя ўпэўненыя назіранні
+  show_name_previous_version: Папярэдняя версія
+  show_name_other_versions:  Other Versions
+  show_name_creator: Першы чалавек, які выкарыстаў гэтае імя ў MO
+  show_name_editor:  "[:Editors]"
+  show_name_editors:  "[:Editors]"
+  show_name_other_observations_notes:  "(Someone proposed [name] for these observations, but consensus hasn't accepted it.  Confidence value is for __this__ name, not the consensus name.)"
+  show_name_nomenclature:  Nomenclature
+  show_name_classification: Класіфікацыя
+  show_name_brief_description: Кароткае апісанне
+  show_name_see_more:  See More
+  show_name_icn_id_missing:  missing
+  index_fungorum:  Index Fungorum
+  index_fungorum_search:  Index Fungorum search
+  mycobank:  MycoBank
+  mycobank_search:  MycoBank search
+  gsd_species_synonymy:  GSD Species Synonymy
+  sf_species_synonymy:  SF Species Synonymy
+
+  # name/show_name - links to observations
+  show_name_observations: больш [:OBSERVATIONS]
+  show_name_observations_of: "больш [:OBSERVATIONS] з\n[name]"
+  show_name_all_observations:  More [:OBSERVATIONS] (all synonyms)
+  show_name_synonym_observations:  Synonym [:OBSERVATIONS]
+  show_name_other_observations:  Similar [:OBSERVATIONS]
+  show_observations_of:  "[:OBSERVATIONS] of:"
+  obss_of_this_name: гэтае імя
+  obss_of_taxon: гэты таксон, любая назва
+  taxon_obss_other_names: гэты таксон, іншыя назвы
+  obss_name_proposed: любы таксон, прапанаваная гэтая назва
+  obss_taxon_proposed: іншыя таксоны, прапанаваныя гэтым таксонам
+  show_subtaxa_obss: Падтаксоны
+  show_name_locked:  This name is locked. If you want to change the name of your observation, please propose a new name for your observation and vote on it, instead.  If you change a name record on MO, it implicitly changes all the observations of that name.
+  show_name_inherit_classification:  Copy from parent.
+  edit_classification_title:  Edit Classification of [name]
+  inherit_classification_title:  Copy Classification from Parent of [name]
+  inherit_classification_parent_name:  Name of Parent
+  inherit_classification_parent_blank:  Parent has no classification, either!
+  inherit_classification_no_matches:  No names match.
+  inherit_classification_alt_spellings:  No names match.  Maybe you meant one of these?
+  inherit_classification_multiple_matches:  Multiple names match.  Which did you mean?
+  inherit_classification_parent_lower_rank:  Parent must be higher rank than [rank].
+  show_name_num_notifications:  "*Number of users interested in this name:* [num]"
+
+  # observer/_show_namings
+  show_namings_proposed_name:  "[:NAMING]"
+  show_namings_proposed_names:  "[:NAMINGS]"
+  show_namings_no_names_yet: Імёны пакуль не прапаноўваліся.
+  show_namings_propose_new_name: Прапануйце іншую назву
+  show_namings_eye_help: Выбар назіральніка
+  show_namings_eyes_help: Бягучы кансенсус
+  show_namings_community_favorite: Гэта фаварыт супольнасці.
+  show_namings_consensus: Галасаванне супольнасці
+  show_namings_no_votes: няма галасоў
+  show_namings_your_vote: Ваш голас
+  show_namings_update_votes: Абнавіць галасы
+  show_namings_suggest_names: Прапановы назваў
+  show_namings_cast:  Cast Vote
+  show_namings_user:  "[:User]"
+  show_namings_consensus_help: "Для кожнай назвы, пералічанай вышэй, выберыце сваё меркаванне аб тым, наколькі гэтае імя адносіцца да гэтага назірання. Выберыце\n'[:show_namings_propose_new_name]' калі вы хочаце прапанаваць іншы варыянт. Глядзіце\n\"How to Use\":/info/how_to_use#voting старонка для больш падрабязнай інфармацыі аб тым, як падлічваюцца галасы."
+  show_namings_lose_changes:  You must click '[:show_namings_update_votes]' to save any changes you've made to your votes.
+  show_namings_please_login:  Please login to propose your own names and vote on existing names.
+  show_namings_saving:  Saving
+
+  # observer/show_observation
+  show_observation_title:  "[:OBSERVATION]: [name]"
+  show_observation_header:  "[:OBSERVATION]"
+  show_observation_site_id: Ідэнтыфікатар сайта
+  show_observation_owner_id: Перавага назіральніка
+  show_observation_no_clear_preference:  no clear preference
+  show_observation_edit_observation:  "[:edit_object(type=:observation)]"
+  show_observation_propose_new_name:  "[:show_namings_propose_new_name]"
+  show_observation_debug_consensus:  Debug Consensus
+  show_observation_alternative_names:  Alternative Name(s)
+  show_observation_preferred_names: Пераважныя назвы
+  show_observation_observation_created_at:  Observation created
+  # This is used if this is the location where the thing was growing.
+  show_observation_collection_location: Месца збору
+  # This is used if this is NOT the location where the thing was growing.
+  show_observation_seen_at: Бачылі на
+  show_observation_gps_hidden: каардынаты схаваныя ад грамадскасці
+  show_observation_specimen_available: Узор даступны
+  show_observation_specimen_not_available: Няма даступных узораў
+  show_observation_remove_images:  "[:remove_objects(type=:image)]"
+  show_observation_reuse_image: Паўторнае выкарыстанне выявы
+  show_observation_add_images:  "[:add_objects(type=:image)]"
+  show_observation_species_lists:  "[:SPECIES_LISTS]"
+  show_observation_manage_species_lists: Кіраванне спісамі відаў
+  show_observation_send_question: Адправіць назіральніку пытанне
+  show_observation_view_notifications:  View Notifications
+  show_observation_hide_map: Схаваць мініяцюру карты.
+  show_observation_thumbnail_map_hidden:  Thumbnail map hidden.  To re-enable this feature, go to your "[:app_preferences]":/account/prefs page.
+  show_observation_add_link_dialog:  "Enter full URL, including \"http://\":"
+  show_observation_edit_link_dialog:  "[:show_observation_add_link_dialog]"
+  show_observation_remove_link_dialog:  Are you sure you want to remove this link?
+  show_observation_no_collection_numbers:  No [:collection_numbers]
+  show_observation_no_herbarium_records:  No [:herbarium_records]
+  show_observation_add_sequence:  Add [:SEQUENCE]
+  show_observation_no_sequences:  No [:sequences]
+  show_observation_archive_link:  Show Archive Record
+  show_observation_blast_link: Бегчы BLAST®
+  show_observation_more_like_this: Больш падобнага
+  show_observation_look_alikes: Двойнікі
+  show_observation_related_taxa: Роднасныя таксоны
+  map_observation_title: "Карта назірання\n#[ID]"
+
+  # observer/suggestions
+  suggestions_title:  Confident Suggestions
+  suggestions_title_others:  Wild Guesses
+  suggestions_already_proposed:  already proposed
+  suggestions_propose_name: Прапанаваць гэта імя
+  suggestions_confidence:  Confidence
+  suggestions_max:  Max
+  suggestions_avg:  Avg
+  suggestions_excellent:  excellent
+  suggestions_good:  good
+  suggestions_fair:  fair
+  suggestions_poor:  poor
+  suggestions_processing_images:  Loading images
+  suggestions_processing_image:  Analyzing image
+  suggestions_processing_results:  Processing results
+  suggestions_error:  Something went wrong, sorry!
+
+  # location/show_past_location
+  show_past_location_title:  "[:VERSION] [num]: [name]"
+  show_past_location_other_versions:  Other Versions
+  show_past_location_no_version:  No version specified
+
+  # location/show_past_location_description
+  show_past_location_description_title:  "[:VERSION] [num]: [name]"
+
+  # name/show_past_name
+  show_past_name_title:  "[:VERSION] [num]: [name]"
+
+  # name/show_past_name_description
+  show_past_name_description_title:  "[:VERSION] [num]: [name]"
+
+  # object/show_past_versions
+  show_past_version_merged_with:  "(merged with #[id])"
+
+  # observer/show_rss_log
+  show_rss_log_title: "Увайсці для\n[title]"
+
+  # info/site_stats
+  show_site_stats_title: Статыстыка сайта
+
+  # observer/_show_votes
+  show_votes_title:  Show Votes for [name]
+  show_votes_users:  "[:Users]"
+  show_votes_vote:  "[:Vote]"
+  show_votes_weight: Вага
+  show_votes_average: Сярэдні
+  show_votes_score: Ацэнка
+  show_votes_go_public: Зрабіць усе мае галасы агульнадаступнымі.
+  show_votes_go_private: Зрабіць усе мае галасы ананімнымі.
+  show_votes_total:  "Overall Score\nsum(score * weight) /\n(total weight + 1)"
+  show_votes_descript:  User's votes are weighted by their contribution to the site (log<small>10</small> contribution). In addition, the user who created the observation gets an extra vote.
+  show_votes_go_public_confirm: Гэта зробіць усе вашыя галасы за ўсе назіранні публічнымі, а не толькі ваш голас за гэтае імя. Гэта тое, што вы хочаце зрабіць?
+  show_votes_go_private_confirm: Гэта зробіць усе вашыя галасы за ўсе назіранні ананімнымі, а не толькі ваш голас за гэтае імя. Гэта тое, што вы хочаце зрабіць?
+  show_votes_gone_public:  Thank you!  Your preferences have been updated.  Other users can now see your votes.
+  show_votes_gone_private:  Your preferences have been updated.  Other users can no longer see your votes.
+
+  # users/show
+  show_user_title: "Рэзюмэ ўкладу для\n[user]"
+  show_user_contributors:  "[:app_contributors]"
+  show_user_observations_by: "Назіранні па\n[name]"
+  show_user_your_observations: Вашы назіранні
+  show_user_comments_for: "Каментары для\n[name]"
+  show_user_comments_for_you: Каментары для вас
+  show_user_your_notifications: Вашы абвесткі па электроннай пошце
+  show_user_edit_profile: Рэдагаваць профіль
+  show_user_email_to: "Электронная пошта\n[name]"
+  show_user_joined: Далучыўся
+  show_user_mailing_address: Паштовы адрас для калекцый
+  show_user_primary_location: Асноўнае размяшчэнне
+  show_user_personal_herbarium: Асабісты фунгарыум
+  show_user_total: Усяго
+  show_user_language_contribution: "Пераклады: [name]"
+  show_user_life_list: "\"Жыццёвы спіс\n\":[url]: [species] віды ў [genera] роды"
+
+  # sequence
+  sequence_edit_title: Рэдагаванне [name]
+
+  # account/signup
+  signup_title: Рэгістрацыя акаўнта
+  signup_name: Імя (неабавязкова)
+  signup_login: Пажаданы лагін
+  signup_email_address: Адрас электроннай пошты
+  signup_email_confirmation: Пацвердзіце электронную пошту
+  signup_choose_password: Выбраць пароль
+  signup_confirm_password: Пацвердзіце пароль
+  signup_preferred_theme: Пераважная тэма (неабавязкова)
+  signup_random: Выпадковы
+  signup_button: Зарэгістравацца
+  signup_email_help: Для праверкі ўліковага запісу патрабуецца працоўны адрас электроннай пошты. Гэта дапамагае нам не дапускаць спамераў. Пасля пацверджання ўліковага запісу вы можаце змяніць адрас электроннай пошты на старонцы налад уліковага запісу. Мы вельмі асцярожныя, каб ніколі не паказваць ваш адрас электроннай пошты на вэб-старонцы, да якой іншыя маюць доступ. Мы ніколі не прададзім ваш адрас электроннай пошты. Мы перадамо ваш адрас электроннай пошты, толькі калі вы папросіце нас аб гэтым (напрыклад, калі вы адправіце электронны ліст іншаму ўдзельніку, ён убачыць ваш электронны ліст). Па змаўчанні ваш адрас электроннай пошты будзе выкарыстоўвацца для адпраўкі вам інфармацыі аб зменах на сайце, а таксама паведамленняў, звязаных з вашым укладам у сайт. Вы можаце адмовіцца ад гэтага выкарыстання, змяніўшы свае налады. Калі вы запоўніце гэтую старонку і націснеце «Зарэгістравацца», мы вышлем вам электронны ліст з інфармацыяй для праверкі ўліковага запісу.
+
+  # species_list/create_species_list
+  species_list_create_title:  "[:create_object(type=:species_list)]"
+
+  # species_list/edit_species_list
+  species_list_edit_title:  "[:edit_object(type=:species_list)]: [name]"
+
+  # species_list/add_remove_observations
+  species_list_add_remove_title:  Add or Remove Observations from Species List
+  species_list_add_remove_cancel:  Cancel (back to observation index)
+  species_list_add_remove_body:  Adding or removing [num] observation(s) to/from species list. Enter title or id of target species list. Don't worry, it will ignore observations already added or removed from the list.
+  species_list_add_remove_label:  Target species list
+  species_list_add_remove_add_success:  Successfully added [num] observation(s) to species list.
+  species_list_add_remove_remove_success:  Successfully removed [num] observation(s) from species list.
+  species_list_add_remove_no_query:  Missing observation query results, or query has expired.
+  species_list_add_remove_bad_name:  "Unrecognized species list id or title: [name]"
+
+  # species_list/manage_species_lists
+  species_list_manage_title:  Manage Species Lists for [name]
+  species_list_manage_belongs_to:  This observation belongs to
+  species_list_manage_doesnt_contain:  Lists you own that do not contain this observation
+
+  # species_list/manage_projects
+  species_list_projects_title:  Manage Projects for [List]
+  species_list_projects_which_objects:  Which objects?
+  species_list_projects_which_projects:  Which projects?
+  species_list_projects_this_list:  this species list
+  species_list_projects_observations:  observations in this list
+  species_list_projects_images:  images in this list
+  species_list_projects_no_add_to_project:  You do not have permission to attach objects to the project "[proj]".
+  species_list_projects_help:  "This form allows you to either attach this list or its observations or images to one or more projects, or remove them from one or more projects.  Choose which objects you wish to attach or remove, then choose the project or projects you wish to attach them to or remove them from, then click on \"Attach\" or \"Remove\" to perform the operation.  Note: It will only allow you to attach or remove objects which you have permission to edit."
+
+  # species_list/show_species_list
+  species_list_show_title:  "[:SPECIES_LIST]: [name]"
+  species_list_show_download: Спампоўкі, справаздачы, друк этыкетак
+  species_list_show_save_as_txt:  Save as Plain Text
+  species_list_show_save_as_rtf:  Save as Rich Text
+  species_list_show_save_as_csv:  Save as Spreadsheet
+  species_list_show_print_labels:  Print Labels
+  species_list_show_set_source:  Save This List for Later
+  species_list_show_set_source_help:  Save this list for the next time you create or edit a species list. It will display a list of the species in this list for you to choose from.
+  species_list_show_clone_list: Зрабіце копію гэтага спісу
+  species_list_show_add_remove_from_another_list:  Add To / Remove From Another List
+  species_list_show_manage_projects:  Manage Projects
+  species_list_show_manage_projects_help:  Change which projects this list and its observations and images are attached to.
+  species_list_show_manage_observations_too:  If you would like to attach/remove observations or images, too, please use the "[:species_list_show_manage_projects]" link.
+  species_list_show_edit:  Edit This List
+  species_list_show_clear_list:  Clear This List
+  species_list_show_destroy:  Destroy This List
+  species_list_show_members:  Members
+  species_list_show_no_members:  This list contains no observations.
+  species_list_show_regular_index:  Regular Index
+  species_list_show_regular_index_help:  Show observations in the "regular" index as a table of thumbnails.
+
+  # species_list/species_lists_by_title
+  species_list_by_title_title:  "[:SPECIES_LISTS] by Title"
+  species_list_by_title_created_at:  "[:Created]"
+  species_list_by_title_list_name:  List Name
+  species_list_by_title_owner:  Owner
+  species_list_by_title_size:  Size
+
+  # species_list/upload_species_list
+  species_list_upload_title:  "[:UPLOAD] [:SPECIES_LIST]"
+  species_list_upload_label:  "[:UPLOAD] [:SPECIES_LIST]"
+  species_list_upload_help:  A species list can either be a simple text file with each name on its own line, or the 'list' format generated by the Name species listing program.
+
+  # species_list/download
+  species_list_download_title:  Species List Reports and Downloads
+  species_list_download_back:  Back to Species List
+  species_list_labels_header:  Print Labels for Observation
+  species_list_labels_button:  Print Labels
+  species_list_report_header:  Save a Checklist of Names
+  species_list_report_button:  Save Names
+  species_list_download_header:  Download Observation Data
+
+  # sequence/add_sequence
+  sequence_add_title:  Add [:SEQUENCE]
+  sequence_add_edit:  "[:image_add_edit]"
+  sequence_add_owner_id:  "[:show_observation_owner_id]"
+
+  # sequence/form_sequence
+  form_sequence_locus_help:  "Start with a short abbreviation (because the [:OBSERVATION] displays only the first [locus_width] characters). Examples:\n&nbsp;&nbsp;ITS\n&nbsp;&nbsp;multi-locus\n&nbsp;&nbsp;LSU large subunit ribosomal RNA gene, partial sequence"
+  form_sequence_both_required:  "[:BASES] and/or both [:ARCHIVE]/[:ACCESSION] required"
+  form_sequence_bases_format:  "<a href=[help_url]>FASTA or Bare Sequence format</a>"
+  form_sequence_archive_help:  On-line, public database with [:sequence] data for this [:OBSERVATION].
+  form_sequence_accession:  "[:ACCESSION] number/code"
+  form_sequence_accession_help:  "Examples:\n&nbsp;&nbsp;KT968655\n&nbsp;&nbsp;UDB024324"
+  form_sequence_valid_deposit:  "[:deposit] requires both [:archive] and [:accession]"
+  form_sequence_bases_or_deposit_required:  bases and/or deposit required
+
+  # users/by_contribution
+  users_by_contribution_title:  List of Contributors
+  users_by_contribution_2a:  "[:images]"
+  users_by_contribution_2b:  "[:name]"
+  users_by_contribution_2c:  "[:observation]"
+  users_by_contribution_2d:  "[:naming]"
+  users_by_contribution_2e:  "[:vote]"
+  users_by_contribution_2f:  points
+  users_by_contribution_1:  "The order is currently based on an automated estimation of what each person has contributed to the site.  The purpose of creating this order is to recognize the individual contributions of the members of the [:app_title] community.\n\nThe current formula is a weighted sum of each contribution.  The current weighting is:"
+  users_by_contribution_2:  "Thus an observation of a species not previously in the site with three images would count as:"
+  users_by_contribution_3:  These weights or the overall method of ranking is likely to change over time based on feedback from the members of the community.
+
+  # account/verify
+  verify_note: "Ваш уліковы запіс правераны... Цяпер вы павінны мець магчымасць публікаваць назіранні, загружаць выявы, рэдагаваць апісанні імёнаў, вызначаць новыя месцы, дадаваць каментарыі, а таксама прапаноўваць і галасаваць за ідэнтыфікацыі на\n\"[:app_title]\":[domain].\n\nДзякуй за далучэнне!"
+
+  # account/choose_password
+  account_choose_password_title: Праверка вашага ўліковага запісу
+  account_choose_password_warning: Вы павінны выбраць пароль, перш чым мы зможам спраўдзіць ваш уліковы запіс.
+
+  # account/welcome
+  welcome_no_user_title:  User not set in session
+  welcome_logout_link: Выйсці з сістэмы
+  welcome_no_user_note:  If you are not a spammer, please report this as an error.
+  welcome_note:  You are now logged into the system...
+
+  # semantic_vernacular/delete
+  delete_svd_not_allowed:  Only admins can delete components of Semantic Vernacular Descriptions
+  semantic_vernacular_index:  Go to all Semantic Vernacular Descriptions
+  semantic_vernacular_proposed:  Proposed by [name] at [date_time]
+  semantic_vernacular_delete:  Delete
+  semantic_vernacular_title:  "SVD Detail: [name]"
+
+  # glossary term fields
+  glossary_term_created_at: Створана Ат
+  glossary_term_updated_at: Абноўлены At
+  glossary_term_name:  Name
+  glossary_term_description:  Description
+  glossary_term_copyright_holder:  Copyright holder and license for this image
+  glossary_term_copyright_warning: Калі ласка, загружайце толькі той відарыс, які вы стварылі або аўтарскім правам на які вы валодаеце.
+
+  # glossary_term#show
+  show_glossary_term: Паказаць тэрмін Гласарыя
+  show_glossary_term_title:  "Glossary Term: [name]"
+  show_glossary_term_reuse_image:  Add Example
+  show_glossary_term_remove_image:  Remove Examples
+
+  # glossary_term#show_past_glossary_term
+  show_past_glossary_term_title:  "[:VERSION] [num]: [name]"
+  show_past_glossary_term_no_version:  No version specified
+
+  # glossary_term#create_glossary_term
+  create_glossary_term:  Create New Glossary Term
+  create_glossary_term_add:  Add Glossary Term
+  create_glossary_term_title:  Create New Glossary Term
+
+  # glossary_term#index
+  glossary_term_index: Гласарый
+  glossary_term_index_title: Слоўнік мікалагічных тэрмінаў
+  glossary_term_index_intro:  "In collaboration with the Rhode Island School of Design, students from Jean Blackburn's Scientific Illustration class to create high-quality Creative Commons licensed scientific illustrations of fungal anatomy terms. To share these works, this new glossary feature for Mushroom Observer was created.\nThis release provides the bare minimum of functionality to be able to discover and view these illustrations. New glossary terms can also be created by anyone in the community. Currently these terms are illustrated by single images, but my intent is to add support for multiple images including both scientific illustrations and example photographs. There will also be a search feature, the ability to add links to terms as part of any Mushroom Observer markup. A particular feature that needs discussion is how best to handle translations of these terms and their definitions. Discussion of these features including additional desired terms are welcome on either the Mushroom Observer mailing list (<a href=\"https://groups.google.com/forum/?fromgroups=#!forum/mo-general\">mo-general@googlegroups.com</a>) or the <a href=\"https://www.facebook.com/groups/105230049528087/\">unofficial Mushroom Observer Facebook page</a>."
+
+  # glossary_term#edit
+  edit_glossary_term:  "[:edit_object(type=:glossary_term)]"
+  edit_glossary_term_title:  "Editing Glossary Term: [name]"
+  edit_glossary_term_save:  Save
+  edit_glossary_term_not_allowed:  Only admins can edit glossary terms
+
+  # glossary_term errors
+  glossary_error_name_blank:  Name cannot be blank.
+  glossary_error_duplicate_name:  Name must be unique.
+  glossary_error_description_or_image:  Glossary term must have a description or image.
+
+  # news article fields
+  article_title:  Title
+  article_body:  Body
+
+  # article/create_article
+  create_article_title:  "[:create_object(type=:article)]"
+  article_body_required:  "[:article_body] [:REQUIRED]"
+  article_title_required:  "[:article_title] [:REQUIRED]"
+  form_article_title_help:  This field will appear in the Activity Feed.
+
+  # article/show_article
+  show_article:  "[:show_object(type=:article)]"
+
+  # article/index_article
+  index_article:  "[:ARTICLE] Index"
+
+  # publication fields
+  publication_full:  Full Reference
+  publication_link:  Link
+  publication_peer_reviewed:  Publication was peer reviewed
+  publication_how_helped:  How did Mushroom Observer help with this publication?
+  publication_mo_mentioned:  Mushroom Observer is mentioned or referenced in the publication
+
+  # publication/index
+  publication_index: Спіс публікацый
+  publication_index_title: Спіс усіх публікацый
+  publication_index_intro:  This is a list of all known publications that benefitted in some way by the existence of the Mushroom Observer. If you are aware of an article that should be added to this list please "add it":/publications/new. If you find an error, please add the correct citation and "send us a note":/emails/ask_webmaster_question.
+  publication_full_help:  When possible please use the other citations as a model for how to format new ones and specifically start the citation with the family name of the lead author.
+  publication_legend:  "*P* indicates that it is a scientific, peer-reviewed article.\n*M* indicates that the article explicitly mentions or references the Mushroom Observer."
+  publication_citation:  "We encourage you to cite Mushroom Observer this way:\n\nWilson, N., Hollinger, J., et al. 2006-present. Mushroom Observer. https://mushroomobserver.org\n\nHowever, your publisher may restrict how or whether websites can be cited. If you need a published reference the best current citation we are aware of is:"
+
+  # publication/edit
+  edit_publication:  Edit
+  edit_publication_title:  Editing Publication
+
+  # publication/create_event
+  create_publication:  Add Publication
+  create_publication_title:  Create New Publication
+
+  # publication/show
+  show_publication_title: Публікацыя
+  show_publication_added_by: дадаў
+
+
+
+  # herbarium fields
+  herbarium_curator:  Curator
+  herbarium_curators:  Curators
+  herbarium_mailing_address: Паштовы адрас
+  herbarium_code:  Code
+  user_personal_herbarium:  "[name]: Personal Fungarium"
+
+  # herbaria/show
+  show_herbarium_herbarium_record_count:  This fungarium contains [count] fungarium record(s).
+  show_herbarium_add_curator: Дадаць куратара
+  show_herbarium_no_user: "Немагчыма знайсці карыстальніка\n'[login]'."
+  show_herbarium_curator_request:  Request to be a Curator
+  show_herbarium_curator_help:  When you press send below, you will send a note to the admins requesting to be made an admin of this fungarium.  When we add curators to an MO fungarium, those curators are given exclusive rights to edit the fungarium's addresses and notes.  Curators are also allowed to create fungarium records for other users' observations.  For example, when a fungarium accessions a contributor's specimen, the fungarium can create a record attached to the contributor's observation on MO noting that the specimen resides at your fungarium and what its accession number is.  Please ask how MO can help your fungarium IT people automate this process via our API.
+  show_herbarium_request_sent:  Request has been sent to admins.  We'll get back to you as soon as possible.
+
+  # herbaria/create
+  create_herbarium: Стварыце новы фунгарыум
+  create_herbarium_title: Стварыце новы фунгарыум
+  create_herbarium_personal: Адзначце гэты сцяжок, калі гэта ваш асабісты фунгарыум
+  create_herbarium_personal_help: "Кожны карыстальнік можа мець адзін асабісты фунгарыум, для якога ён мае прывілеі куратара. Па змаўчанні гэта называецца\n\"[name]\", але вы можаце змяніць гэтае імя на любое, якое заўгодна."
+  create_herbarium_code:  Standard Abbreviation
+  create_herbarium_code_help:  Look up the standard abbreviation for a fungarium at "Index Herbariorum":http://sweetgum.nybg.org/science/ih/.
+  create_herbarium_email: Адрас электроннай пошты
+  create_herbarium_mailing_address: Паштовы адрас
+  create_herbarium_duplicate_name:  Fungarium called '[name]' already exists.
+  create_herbarium_personal_already_exists:  You've already created a personal fungarium called '[name]'.
+  create_herbarium_must_define_location:  You must define this location before we can use it for this fungarium. Any other information you provided has been saved.
+  create_herbarium_name_blank: Поле для назвы гербарыя не павінна быць пустым.
+
+  # herbaria/edit
+  edit_herbarium: Рэдагаваць Fungarium
+  edit_herbarium_title:  Editing Fungarium
+  edit_herbarium_this_is_personal_herbarium:  This is your personal fungarium. You are only allowed one personal fungarium. If you would like to change which fungarium is your personal fungarium, please contact the admins and explain the situation.
+  edit_herbarium_cant_make_personal:  You can't make this your personal fungarium because you don't own all the fungarium records. You will need to have an admin do this for you. Please send us a message explaining what's going on.
+  edit_herbarium_admin_make_personal:  Make this the personal fungarium for
+  edit_herbarium_user_records:  User "[name]" has [num] records in this fungarium.
+  edit_herbarium_no_herbarium_records:  No fungarium records for this fungarium.
+  edit_herbarium_user_already_has_personal_herbarium:  User "[user]" already has a personal fungarium called "[herbarium]".
+  edit_herbarium_successfully_made_personal:  Successfully made this the personal fungarium of "[user]".
+  edit_herbarium_successfully_made_nonpersonal:  Successfully made this nobody's personal fungarium.
+
+  # herbaria/index
+  herbarium_index:  Fungarium Index
+  herbarium_index_list_all_herbaria:  List All Fungaria
+  herbarium_index_nonpersonal_herbaria:  List Institutional Fungaria
+  herbarium_index_records:  Records
+  herbarium_index_merge_help:  Click on the fungarium below that you would like to merge "[name]" into.  This will cause "[name]" to be deleted and all of its records and curators to be transferred into the new fungarium.  If you do not have permission to perform the merge, it will send a request to the admins.  ("+Cancel merge.+":[url])
+
+  # herbaria/filtered
+  list_herbaria_title:  "[:list_objects(type=:herbarium)]"
+
+
+  # herbarium record fields
+  herbarium_record_herbarium_name:  Fungarium Name
+  herbarium_record_initial_det:  Initial Determination
+  herbarium_record_accession_number:  Accession Number
+  herbarium_record_user:  Record Creator
+  herbarium_record_notes:  Fungarium Record Notes
+
+  # herbarium_record/create_herbarium_record
+  create_herbarium_record: Дадаць запіс Fungarium
+  create_herbarium_record_title: Дадаць запіс Fungarium
+  create_herbarium_record_accession_number_help:  "Must be a unique identifier for this fungarium.  If you do not know the accession number, or there isn't one yet, use the observation number or your own collection number.  Examples:\n&nbsp;&nbsp;12419\n&nbsp;&nbsp;BRY-L-0025845\n&nbsp;&nbsp;MO 174623\n&nbsp;&nbsp;Joe Smith 17-013"
+  create_herbarium_separately:  The fungarium you entered doesn't exist. Please create it separately and then add the fungarium record to your observation.
+  create_herbarium_record_missing_herbarium_name:  Missing fungarium name.
+  create_herbarium_record_already_used:  This fungarium record already exists. We've added this observation to it. If that isn't correct, remove it from your observation, then add the correct fungarium record.
+  create_herbarium_record_already_used_by_someone_else:  This accession number has already been recorded by someone else for [herbarium_name]. Try adding your initials to the accession number to distinguish labels.
+  create_herbarium_record_only_curator_or_owner:  Only curators can add fungarium records to other users' observations.
+
+  # herbarium_record/edit_herbarium_record
+  edit_herbarium_record:  Edit Fungarium Record
+  edit_herbarium_record_title:  Edit Fungarium Record [herbarium_label]
+  edit_herbarium_record_back_to_index:  Back to Fungarium Record Index
+  edit_herbarium_record_cant_add_or_remove:  Only curators or the observer can add or remove an observation to or from a fungarium record.
+  edit_herbarium_record_already_used:  This fungarium record already exists. If you want to merge records, move the observations from this record to the other, then delete this record.
+  edit_affects_multiple_observations:  The changes you make here will affect all of the observations shown.  If you wish to change a single observation, go to that observation, remove the incorrect [type] from it, then add the correct one.  That will leave the [type] unchanged for any other observations associated with it.
+
+  # herbarium_record/destroy_herbarium_record
+  delete_herbarium_record:  Destroy Fungarium Record
+
+  # herbarium_record/herbarium_record_index (not a real page)
+  herbarium_record_index_title:  "[subject] Fungarium Record Index"
+
+  # herbarium_record/list_herbarium_records
+  list_herbarium_records_title:  "[:list_objects(type=:herbarium_record)]"
+
+
+
+  # collection number fields
+  collection_number_name: Імя калекцыянера
+  collection_number_number:  Collector's Number
+  collection_number_user:  Record Creator
+
+  # collection_number/create_collection_number
+  create_collection_number: Дадайце нумар калекцыі
+  create_collection_number_title: Дадайце нумар калекцыі
+  create_collection_number_missing_name:  Missing collector's name.
+  create_collection_number_missing_number:  Missing collector's number.
+
+  # collection_number/edit_collection_number
+  edit_collection_number:  Edit Collection Number
+  edit_collection_number_title:  Edit Collection Number [name]
+  edit_collection_number_back_to_index:  Back to Collection Number Index
+  edit_collection_number_cant_add_or_remove:  Only the observer can add or remove a collection number to or from an observation.
+  edit_collection_number_already_used:  This collection number is shared with another observation. If you need to fix it, remove it from your observation, then add the correct one.
+  edit_collection_numbers_merged:  Merged [this] into [that]. If this was not what you meant to do, remove the collection number from one of the observations, then add the correct one.
+
+  # collection_number/destroy_collection_number
+  delete_collection_number:  Destroy Collection Number
+
+  # collection_number/collection_number_index (not a real page)
+  collection_number_index_title:  "[subject] Collection Number Index"
+
+  # collection_number/list_collection_numbers
+  list_collection_numbers_title:  "[:list_objects(type=:collection_number)]"
+
+
+
+  # support/donate
+  donate_title: Ахвяруйце Mushroom Observer, Inc.
+  donate_tab: Ахвяраваць
+  donate_other:  Other Amount
+  donate_anonymous:  Anonymous donation
+  donate_recurring:  Monthly recurring donation
+  donate_who:  Name for Donors Page
+  donate_email:  Email (to ensure uniqueness)
+  donate_confirm:  Confirm
+  donors_order:  The donors names are ordered based first on the total amount donated and then by who has donated the most recently.
+  donate_snail_mail:  "Donors who wish to donate by check should make the check payable to \"Mushroom Observer, Inc.\" and mail it to our registered corporate address:\nMushroom Observer, Inc.\n68 Bay Rd.\nNorth Falmouth, MA 02556-2404"
+  donors_title:  The Mushroom Observer Community Thanks Our Donors
+  donors_tab:  Show Donors
+  donate_thanks:  Thank you for your interest in donating to Mushroom Observer!
+  donate_explanation:  "A donation can be made in any amount. There are two ways: via PayPal or by check. We encourage you to send a check for donations of $200 or more.\n\nPayPal donations can be made with most credit cards (no PayPal account needed) or via a PayPal account by clicking on the \"Confirm\" button below.\n\nFor donations by check see below.\n\nDonors are normally acknowledged by name on the \"Mushroom Observer Donors Page\":/support/donors. If you would like special arrangements for your acknowledgement please \"send us a comment\":/emails/ask_webmaster_question."
+
+  donate_fine_print:  "\"https://www.mushroomobserver.org\":/ is operated by \"Mushroom Observer, Inc.\":/support/governance for educational purposes. Mushroom Observer, Inc. is a public charity described under section ==501(c)(3)== of the Internal Revenue Code (see \"IRS Determination Letter\":/doc/mo-determination.pdf). Donations to Mushroom Observer, Inc. are eligible to be deducted for federal income tax purposes.  To substantiate the amount of your deductible donation, you will receive an email acknowledgement from Mushroom Observer, Inc. of the amount and date of your donation."
+
+  # support/confirm
+  confirm_title:  Donation Confirmation
+  confirm_amount:  Amount
+  confirm_text:  Thank you for offering to make the following donation.  To complete this transaction using PayPal, click the button below.
+  confirm_positive_number_error:  Other Amount must be a number greater than zero
+  confirm_recurring:  Recurring monthly
+
+  # support/governance
+  governance_title:  Governance of the Mushroom Observer
+  governance:  "The \"Mushroom Observer website\":/ is owned and operated by the Massachusetts based non-profit, Mushroom Observer, Inc. - specifically the domain, mushroomobserver.org, as well as all relevant source code copyrights are owned by Mushroom Observer, Inc. The images and user entered text on the site are owned by their respective authors and are licensed for use under Creative Commons licenses as described on the \"Introduction\":/info/intro page.\n\nMushroom Observer, Inc. was organized based on its \"articles of organization\":/doc/mo-articles.pdf and operates under its \"bylaws\":/doc/mo-bylaws.pdf which may be revised from time to by its Board of Directors. Mushroom Observer, Inc. has been \"recognized as a section ==501(c)(3)== public charity\":/doc/mo-determination.pdf serving educational purposes. If you have questions about the governance of the site or need to get in touch with members of the Board of Directors please \"send us a comment\":/emails/ask_webmaster_question."
+
+  # support/thanks
+  thanks_title:  Thanks for Your Support!
+  thanks_note:  "Thank you for helping to support the Mushroom Observer.  Your support is greatly appreciated and will help Mushroom Observer continue its mission.\n\nYour donation will be acknowledged by name on the \"Mushroom Observer Donors Page\":/support/donors once the funds are received unless you have requested special arrangements for your acknowledgement.  Examples of special arrangements might be to make the donation anonymously or to leave it in someone else's name.  If you would like special arrangements for your acknowledgement please \"send us a comment\":/emails/ask_webmaster_question."
+
+  # support/letter
+  letter_title:  Open Letter to the Community
+  letter_body:  "To the Mushroom Observer Community,\n\nIt has been an amazing year for us.  This year we hit some major milestones: 100,000 images, 50,000 observations and 2,000 registered users.  This means we have essentially been doubling every year.  While Jason has achieved some minor miracles in his volunteer efforts to keep things going with the bare bones server configuration we are using, it is becoming clear that we will soon need more memory and more processors to support our continued growth.\n\nUnfortunately, this means our server expenses will be going up.  So far I have been happy to support the Mushroom Observer server needs out of my own pocket, but those expenses have also been essentially doubling every year and I will soon not be able to afford it.  As a result, I would like to start asking for donations from the community.  Those of you who have gotten a lot out of the site and want to see it continue to grow and expand, now is your chance to give a little back and help with the financial support of the site.\n\nTo that end, we have setup a \"donation page\":/support/donate that can securely accept money from a PayPal account or a regular credit card.\n\nI would like to raise at least $2000 to cover basic server costs.  The more we get, the more we can expand our capacity for traffic and growth.  And the fewer times you will encounter server down time and failed uploads.\n\nWhen you make a donation, your name by default will be added to our \"donors page\":/support/donors as soon as we confirm the donation.  If you would prefer to donate anonymously or make other special arrangements for your acknowledgement, \"send a comment\":/emails/ask_webmaster_question after you make your donation.\n\nPlease help support this active internet community of people who enjoy sharing and learning more about the mushrooms around us.\n\nThanks,\n-Nathan"
+
+  # support/wrapup_2011
+  wrapup_2011_title:  2011 Wrapup to the Mushroom Observer Community
+  wrapup_2011_body:  "To the Mushroom Observer Community,\n\n2011 has been a relatively quiet year for Mushroom Observer at least from the perspective of new development.  I have personally been working overtime on a new version of the Encyclopedia of Life and Jason has been working hard on a new lichen related website and book.\n\nEven so the site has continued to grow.  We now have over 180,000 images, 80,000 observations and we are very close to 3,000 registered users.  This continues our trend of nearly doubling every year.  Fortunately, due to generous donations from all of you, Jason was able to substantially upgrade our server configuration and to the best of our knowledge the system has been working very well despite the ever growing demand.  While we still have some money in the bank, we will continue to need \"additional donations\":/support/donate to keep the system going.\n\nAs was true last year, the donations are made through a not-for-profit corporation called The Consortium for Digital Mycology Resources (CDMR).  The CDMR is recognized as a non-profit by the state of California, but is still not an official federal ==501(c)(3)== non-profit.  However, the application process has moved forward and for now we continue to act as a non-profit and donations are tax deductible.  For anyone interested in the details of that process please visit the \"CDMR website\":http://digitalmycology.org.\n\nThere have been a few notable new features added to Mushroom Observer over the last year.  Jason did a great job developing the \"MO Feature Tracker\":/pivotal/index interface that interacts with our new freely accessible \"Pivotal Tracker account\":https://www.pivotaltracker.com/projects/224629 for tracking bugs and feature requests.  In addition, I have been working quite a bit behind the scenes to prepare for a roughly 10 fold increase in the number of Mushroom Observer images that will be sharable with the broader biodiversity community and EOL in particular.\n\nAlong with this note, we are also releasing the newly developed \"Black on White\":/observer/BlackOnWhite color theme.  With this theme I am trying to provide a more current and professional look for the site. \"Feedback on the theme or suggestions for improvements\":/emails/ask_webmaster_question are very welcome.\n\nWhile there have not been a lot of new features released this year, there have been a number of important discussions going on about potential future development. These have included discussions of better ways of managing naming and voting so they align better with standard herbarium practices, improving the expressiveness of the voting system, rearranging the interface to be more workflow driven, and expanding the role of projects to encourage more focused collaboration within MO.\n\nWhich brings us to the biggest news.  I have begun doing some of my own research with the data from the Mushroom Observer and I have received several inquiries from other scientists interested in either using Mushroom Observer as it is to support their own research or to support additional development of the Mushroom Observer to expand the connections between Mushroom Observer and the scientific community.\n\nMy own research has included some preliminary analysis of the data in the Mushroom Observer database.  The most interesting finding has been that \"users who collect in the Western US on average find more species there than users who collect in the Eastern US\":/images/fungal_biogeography.png. I am currently in the process of developing funding and collaborators to more fully pursue this and other interesting questions that can be answered using our data.  Another area of research development has been with some of the computer scientists at Rensselaer Polytechnic Institute.  The group I am working with are focused on the emerging \"semantic web\":http://en.wikipedia.org/wiki/Semantic_web. We are developing a system for creating a new naming system for amateur/citizen mycologists. It will include a global, web-based registration system for names that are then associated with rigorous definitions that computers can reason about.  We have plans to support a summer internship through the EOL to help develop this idea.\n\nIn addition, as many of you are aware Tom Bruns at UC Berkeley has already been using Mushroom Observer to catalog the collections his collaborators (including many of you) have been finding in Yosemite National Park.  He and I have also begun discussions of what features would be valuable to add Mushroom Observer to support his call for developing a \"North American Mycoflora\":http://msafungi.org/wp-content/uploads/Inoculum/62(4).pdf. Another promising development was being asked to write a letter of support for a proposal that Barabara Thiers and Roy Haling have submitted to digitize the fungal herbaria throughout the US.  If that gets funded, they are interested in making their data available through the Mushroom Observer.\n\nFinally, through connections at the EOL, I was able to participate in a workshop focused on citizen science biodiversity observation systems.  The workshop was held in October outside of London and included representatives from \"iSpot\":http://www.ispot.org.uk/ and \"iNaturalist\":http://inaturalist.org along with several other significant global projects.  I went to the workshop not only to represent the technical side of the EOL, but also the Mushroom Observer.  As a result the group of projects involved in the workshop, including Mushroom Observer, are participating in a competition called \"Badges for Lifelong Learning\":http://www.dmlcompetition.net/Competition/4/badges-competition-cfp.php. We have already successfully passed the first stage of the competition and are working on our application for the second stage.\n\nWhile many of these projects promise exciting developments for MO over the next year and some may even include financial support for the development of new Mushroom Observer features, the on-going support for the site relies on \"donations\":/support/donate from you our users. Please help support this active internet community of people who enjoy sharing and learning more about the mushrooms around us.\n\nThanks for all your contributions to the Mushroom Observer,\n-Nathan"
+
+  # support/wrapup_2012
+  wrapup_2012_title:  2012 Wrapup for the Mushroom Observer Community
+  wrapup_2012_body:  "2012 was a busy year for Mushroom Observer.  Many notable new features were added.  Highlights include:\n\n* Substantial revisions to the <a href=\"/name/show_name/383\">Show Name</a> and <a href=\"/image/show_image/267480?size=medium\">Show Image</a> pages\n* Data downloads from observation searches\n* Support for <a href=\"/herbarium\">Herbarium</a> and Specimen pages\n* Interactive support for translators\n* <a href=\"/users/checklist?user_id=1093\">Life Lists</a> from user summary pages\n* Substantial increase in data shared with EOL\n* Reciprocal links with <a href=\"http://mycoportal.org/\">MyCoPortal</a>\n\nMore details available on the <a href=\"/info/news\">Features and Fixes</a> page.\n\nOne of the goals of this work has been to increase the scientific value of the site for research. The support for Herbarium and Specimen pages as well as the reciprocal links with MyCoPortal are recent steps towards this goal. This work is directly related to a new effort to digitize fungal herbaria throughout the US led by Barbara Thiers. I continue to work with Tom Bruns at UC Berkeley and Deborah McGuinness at Rensselaer Polytechnic Institute (RPI) to find funding to directly support improvements to the Mushroom Observer.  These projects continue to promise exciting developments for MO in the future.\n\nIn addition, the site has continued to grow.  We now have over 300,000 images, 100,000 observations, and over 3800 registered users.  This not only indicates the greatest number of images we've received in a year (106,000), but is a greater growth rate than the previous year (56% vs. 49%).\n\nFortunately, due to generous donations from all of you, we have continued to be able to improve the site configuration.  While we do have a few more tricks up our sleeves that we expect to implement soon, it is increasingly clear that more substantial improvements are needed.  Historically, we have run the site off a single server.  To achieve the next level of performance we would like to separate the database from the application server, and add an additional application server along with a small load balancer.  We expect this to roughly triple the monthly costs of running the site to around $200/month.\n\nI am also excited by a recent surge in the number of folks interested in contributing their time to the Mushroom Observer development effort.  We had a summer intern, Han Wang, from RPI create a prototype system for describing Fungi using semantic web technology (references at the end of the letter).  I presented on this work at the 2012 Mycological Society of America annual meeting.  Another RPI student, Katie Chastain, has recently joined the team and is interested in working on data provenance and developing a workflow for species discovery.  Alan Rockefeller has begun looking into improving site performance and Joe Cohen has started exploring upgrading our software stack.  If you want to join the party, sign up for the new <a href=\"https://groups.google.com/forum/?fromgroups=#!forum/mo-developers\">mo-developers@googlegroups.com</a> mailing list.  One of the significant enabling pieces for this is a new simpler system for setting up a development environment.  You can find out more at the <a href=\"https://github.com/MushroomObserver/developer-startup\">developer-startup GitHub Project</a>.\n\nHowever, this year has not been entirely good news. The Consortium for Digital Mycology Resources (CDMR), was organized in 2009 to support online digital mycology resources such as Mushroom Observer, and it applied for federal tax exempt status under section ==501(c)(3)== so that it could receive deductible donations from interested users.  This ruling is still pending in the IRS.  Beginning in 2012, Mushroom Observer member John Harper, a tax lawyer with Morrison & Foerster, noticed that CDMR’s exemption application had been pending with the IRS for an unusually long time, and volunteered to help CDMR on a pro-bono basis in its attempt to attempt to obtain recognition of a section ==501(c)(3)== status for CDMR.  Since then he has briefed the IRS on the issues that the IRS has raised, and had a conference with the IRS to discuss the ruling request.  CDMR’s case is currently under review in the National Office of the IRS.\n\nIn light of CDMR’s unsettled tax status, CDMR’s board decided not to solicit donations at the end of last year.  However, the CDMR board of directors is committed to creating or joining a recognized tax-exempt non-profit that can receive deductible donations to support online mycological resources such as the Mushroom Observer.  Exactly what form this will take and how soon it will happen is still up in the air.\n\nWithout financial support from CDMR, I have been personally paying to support Mushroom Observer largely out of my own pocket over the last few months. I would very much appreciate any <a href=\"https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2TGUG7TNXYF7Q\">personal gifts</a> that you all would be willing to send to contribute to the cost of keeping Mushroom Observer online during this interim period. This will be especially important before we can attempt to improve the level of performance by adding more servers. Any gifts I receive will be used to cover costs directly associated with running the Mushroom Observer and such donations will continue to be recognized on the Mushroom Observer donors page. Unfortunately, you will not be able to count them as tax deductible donations.  You can make your gifts with a credit card through <a href=\"https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2TGUG7TNXYF7Q\">PayPal</a>\n\n\nThanks for all your contributions to the Mushroom Observer,\n-Nathan"
+
+  ##############################################################################
+
+  # LESS POPULAR PAGES
+
+  # account/api_keys
+  account_api_keys_link:  API Key Manager
+  account_api_keys_title:  API Key Manager
+  account_api_keys_last_used_column_label:  Last Used
+  account_api_keys_num_uses_column_label:  Uses
+  account_api_keys_notes_label:  "Enter the name or a brief description of the application that will use this key:"
+  account_api_keys_remove_button:  Remove the Selected Keys
+  account_api_keys_create_button:  Create a New Key
+  account_api_keys_help:  "API Keys are used by third-party applications to access the Mushroom Observer database directly.  You may request as many API Keys as you like, and no restrictions are placed on these keys.\n\nEach key is attached to a single user.  When posting observations or images, for example, your application will send this API Key in lieu of logging in. Therefore you should take some care to prevent other people or malicious agents from using your API Keys.\n\nNote that no key is required if you are only interested in _reading_ data; keys are only required if you wish to post or modify data."
+  account_api_keys_create_success:  Sucessfully created a new API Key.
+  account_api_keys_create_failed:  "Failed to create a new API Key:"
+  account_api_keys_removed_some:  Successfully removed [num] selected API Key(s).
+  account_api_keys_removed_none:  No API Keys were selected.
+  account_api_keys_updated:  Successfully updated API Key notes.
+  account_api_keys_activated:  Successfully activated key for [notes].
+  account_api_keys_no_notes:  You left name/description field empty.
+
+  # description/adjust_permissions
+  adjust_permissions_user_header:  User or Group
+  adjust_permissions_reader_header:  View
+  adjust_permissions_writer_header:  "[:EDIT]"
+  adjust_permissions_admin_header:  "[:ADMIN]"
+  adjust_permissions_all_users:  All Users
+  adjust_permissions_site_admin:  site admin
+
+  # search/advanced
+  advanced_search_at_least_one:  Please provide at least one search parameter
+  advanced_search_caveat:  "Advanced search has somewhat limited options because of performance issues that result in timeouts.  Please \"email the webmaster\":/emails/ask_webmaster_question if you experience timeouts or if there are particular types of searches you would like to have added.\n\nHints : It's okay to leave some of the fields blank, e.g., if you leave 'Observer' blank, it will return results by all [:users]. It matches the exact string given.  Use \"OR\" (all caps) to tell it to match one of several possible strings, e.g. \"Xanthoria OR Xanthomendoza\".  Use a star as a wildcard, e.g. \"Wells Gray*Canada\" will match \"Wells Gray, Canada\", \"Wells Gray Park, Canada\", and \"Wells Gray Provincial Park, Canada\".  (See notes under 'Content', too.)"
+  advanced_search_content:  Content
+  advanced_search_content_help:  Text contained in [:observation] notes or [:comments]
+  advanced_search_content_notes:  "Content search supports full Google syntax, including \"OR\", double quotes, and negation:\naaa bbb -> contains \"aaa\" and \"bbb\" in any order\n\"aaa bbb\" -> contains \"aaa\" followed immediately by \"bbb\"\naaa OR bbb -> contains either \"aaa\" or \"bbb\"\n-aaa -bbb -> reject anything that contains \"aaa\" or \"bbb\""
+  advanced_search_location_help:  Where was the mushroom found
+  advanced_search_name_help:  Name of the mushroom
+  advanced_search_none_found:  No matches found
+  advanced_search_observer_help:  Who observed the mushroom
+  advanced_search_result_type:  Result Type
+  # Image search UI temporarily disabled for performance. 2021-09-12 JDC
+  # advanced_search_result_type_help:  Do you want [:observations], [:locations] or [:names]/[:descriptions]?
+  advanced_search_result_type_help:  Do you want [:observations], [:locations] or [:names]/[:descriptions]?
+
+  advanced_search_filters:  Search Filters
+  advanced_search_filters_explain:  Apply to this search only, overrides your normal preferred content filters
+  advanced_search_filter_has_images:  Filter observations based on whether they have images
+  advanced_search_filter_has_images_off:  Include both imaged and imageless observations
+  advanced_search_filter_has_images_yes:  Exclude imageless observations
+  advanced_search_filter_has_images_no:  Exclude imaged observations
+  advanced_search_filter_has_specimen:  Filter observations based on whether they have specimens
+  advanced_search_filter_has_specimen_off:  Include both observations with and without specimens
+  advanced_search_filter_has_specimen_yes:  Exclude observations without specimens
+  advanced_search_filter_has_specimen_no:  Exclude observations with specimens
+  advanced_search_filter_lichen:  Filter observations based on whether they are lichens
+  advanced_search_filter_lichen_off:  Include both lichens and nonlichens
+  advanced_search_filter_lichen_yes:  Include only lichen-forming, lichenicolous and allied fungi
+  advanced_search_filter_lichen_no:  Exclude lichen-forming fungi
+  advanced_search_filter_region:  Restrict observations and locations to a region, e.g., "California, USA" or "Europe"
+  advanced_search_filter_clade:  Restrict observations to a taxonomic clade, e.g., "Ascomycota" or "Agaricales"
+  advanced_search_submit:  Submit Advanced Search
+
+  # observer/license_updater
+  bulk_license_link:  Bulk License Updater
+
+  # checklists
+  checklist_for_site_title:  Checklist for Mushroom Observer
+  checklist_for_user_title:  Checklist for [user]
+  checklist_for_project_title:  Checklist for [project]
+  checklist_for_species_list_title:  Checklist for [list]
+  checklist_summary:  "Summary: [species] species in [genera] genera"
+
+  # theme/color_themes
+  color_themes_text:  "**General Concept:** The [:app_title] website provides a number of color themes, some based on different groups of mushrooms.  By default the simple clean \"Black on White\" theme is used.  However, a [:user] can choose to use a particular theme throughout the site by selecting the theme on the [:user] preference page.\n\nThe idea of using mushrooms for color follows in the tradition of using mushrooms to dye fabrics.  Each color in a mushroom theme was pulled from a photograph included in the site from the given group.  The colors attempt to express the characteristic colors of the group.  In a few cases, the [:images] were adjusted using an automatic color balance operation in order to get a more characteristic color.\n\nThe following links describe each of the available themes including links to the [:images] the colors were extracted from:"
+  color_themes_title:  Color Themes
+
+  # name/email_tracking
+  email_tracking_enabled_only_for:  Enabled only for [name] -- contained taxa not yet supported for [rank].
+  email_tracking_help:  If you enable tracking then a note will be sent to the email address you have provided whenever this name is applied to an [:observation].  A link to this page will be given in each tracking email.  You can save your mailing address for collections in "your profile":/account/profile.
+  email_tracking_no_longer_tracking:  No longer tracking [name].
+  email_tracking_note:  Template for notifying an observer
+  email_tracking_note_help:  Provide a note template that will be sent as an email or shown to the observer when this name is applied to an [:observation].  If you leave it blank, then the observer will not be notified.
+  email_tracking_note_template:  "Dear :observer,\n\nI am currently doing research related to [species_name].\n\nIf possible, please make a dried specimen of any of the mushrooms described in :observation and send them to:\n\n[mailing_address]\n\nThanks,\n\n[users_name]"
+  email_tracking_now_tracking:  Now tracking [name].
+  email_tracking_title:  Email Tracking for [name]
+  email_tracking_updated_messages:  Updated tracking messages.
+
+  # name/eol_expanded_review
+  eol_expanded_review_title:  EOL Name List
+  eol_expanded_review_count:  "[count] names"
+  eol_expanded_review_total_image_count:  "[count] images"
+  eol_expanded_review_total_description_count:  "[count] descriptions"
+  eol_expanded_review_image_count:  "Images: [count]"
+  eol_expanded_review_description_count:  "Descriptions: [count]"
+
+  # name/eol_preview
+  eol_preview_name_count:  "[count] description(s)"
+  eol_preview_image_count:  "[count] image(s)"
+  eol_preview_title:  EOL Preview
+  eol_preview_explanation:  "This page provides links to or shows the content that is currently scheduled for delivery to the \"Encyclopedia of Life\":http://eol.org (EOL).  The features related to this effort are still very new and far from polished since it has been implemented quickly to meet the immediate needs to develop the fungus related content on the EOL.  The content delivered from [:app_title] to the EOL will be credited both as coming from the [:app_title] website and the individual content providers.\n\nOn this page each section represents one taxon.  The descriptive paragraphs for each listed taxon will be sent with the exception of any paragraphs marked 'Notes'.  Both the taxa and the images that are being sent have been at least quickly reviewed by expert members of the [:app_title] community.\n\nThe review status of a specific taxon is given on the page for that taxon and can only be set by a designated expert.  Images are selected based on the voting history of specific observations and their quality.  Currently only designated experts can set the quality level of an image, but this is expected to become a open voting process for the entire [:app_title] community in the near future.\n\nCurrently the designated experts are either mycology professors that are teaching classes that are planning to provide data to EOL through the [:app_title] or individuals in the [:app_title] community who have shown dedication to the site and are recognized experts in mushroom or fungal identification.  All aspect of the process of providing data to EOL are under discussion and open to change so please send any questions or comments you have to the [:app_title] webmaster.\n\nThe best way to participate in this amazing opportunity is to find a taxon you care about and work to expand the descriptive paragraphs for this taxon."
+
+  # image/license_updater
+  image_updater_count:  Count
+  image_updater_license:  "[:LICENSE]"
+  image_updater_holder:  "[:COPYRIGHT_HOLDER]"
+  image_updater_title:  Updating Licenses for [user]
+  image_updater_update:  "[:UPDATE]"
+  image_updater_help:  Listed below are all the different licenses you've posted images under, along with the number of your images which use that license.  Make any changes you want to the license or the name listed as the copyright holder, then click "[:UPDATE]" to submit changes.
+
+  # image/vote_anonymity
+  image_vote_anonymity_title:  Change Anonymity of Your Image Votes
+  image_vote_anonymity_num_anonymous:  Number of anonymous votes
+  image_vote_anonymity_num_public:  Number of public votes
+  image_vote_anonymity_make_anonymous:  Make all votes anonymous
+  image_vote_anonymity_make_public:  Make all votes public
+  image_vote_anonymity_made_anonymous:  Made all of your image votes anonymous.  Please also check your vote preference below to ensure that future votes are also anonymous.
+  image_vote_anonymity_made_public:  Made all of your image votes public.  Please also check your vote preference below to ensure that future votes are also public.
+  image_vote_anonymity_invalid_submit_button:  Invalid submit button "[label]", please "contact us":/emails/ask_webmaster_question for help.
+
+  # interest-related controls in name/show_name, observation/show_observation, etc.
+  interest_watch:  Watch
+  interest_ignore:  Ignore
+  interest_watch_help:  Click here if you want us to send you email whenever there is a change in this [object].
+  interest_ignore_help:  Click here if you want to stop getting any emails about this [object].
+  interest_default_help:  Click here if you want to go back to the default -- having your account preferences determine whether you get email about this [object].
+  interest_watching:  You have told us to email you about changes in this [object].  Click one of the small icons below to change.
+  interest_ignoring:  You have told us never to email you about changes in this [object].  Click one of the small icons below to change.
+
+  # interest/list_interests
+  list_interests_title:  Your Notification Requests
+  list_interests_turn_on:  Change to Watch
+  list_interests_turn_off:  Change to Ignore
+
+  # location/list_merge_options
+  list_merge_are_you_sure:  Do merge?  This cannot be undone.
+  list_merge_options_near_matches:  Near Matches
+  list_merge_options_others:  Other Available [:locations]
+  list_merge_options_title:  Merge Options for [where]
+
+  # observer/list_notifications
+  list_notifications_title:  Email Alerts for [user]
+
+  # observer/list_users
+  list_users_joined:  Joined
+  list_users_contribution:  Contribution
+
+  # species_list/make_report
+  make_report_not_supported:  We don't support report filetype *.[type].
+
+  # description/merge_descriptions
+  merge_descriptions_title:  Merge [object]
+  merge_descriptions_merge_header:  Merge with another description
+  merge_descriptions_move_header:  Move / copy to a synonym
+  merge_descriptions_merge:  "[:MERGE]"
+  merge_descriptions_move:  Move / Copy
+  merge_descriptions_merge_or_move:  Merge / Move / Copy
+  merge_descriptions_no_others:  "(there are no other descriptions)"
+  merge_descriptions_delete_after:  Delete old description after merge?
+  merge_descriptions_merge_help:  This will copy any non-blank sections from the source description into the description you select below.  If the target description already has text in any of those fields, you will be given an editing form with the text from both descriptions.  This will allow you to reconcile any conflicts by hand before saving the form and making the merger official.
+  merge_descriptions_move_help:  This will move the source description into a synonym.  It will just copy it if you elect not to delete the old description.  If you wish to merge with an existing description in the other name, you must first move your description into that name, then select [:show_description_merge] again from there.
+
+  # name/bulk_name_edit
+  name_bulk_help:  "Each line indicates a set of changes.\n\np(bulk_text). To ensure a name is in the database, just list the name.  E.g.,\n\np(bulk_pre). Agaricus bisporus\n\np(bulk_text). To ensure a name exists with a particular author, give the name followed by the author.  E.g.,\n\np(bulk_pre). Agaricus bisporus (J.E. Lange) Pilát\n\np(bulk_text). To add a taxon above the species level, give the rank followed by the name.  E.g.,\n\np(bulk_pre). Order Agaricales\n\np(bulk_text). To make a name a deprecated synonym of another name, follow the valid name with the deprecated synonym.  E.g.,\n\np(bulk_pre). Agaricus bisporus (J.E. Lange) Pilát = Agaricus hortensis (Cke.) Imai\n\nThe changes are cumulative, so the last example by itself would ensure that the names **__@Agaricus bisporus@__** @(J.E. Lange) Pilát@ and __@Agaricus hortensis@__ @(Cke.) Imai@ exist, as well as making __@A. hortensis@__ a deprecated synononym of **__@A. bisporus@__**.  If a name exists with no author and you provide an author, then the existing name is updated. Otherwise, if the author is given and it does not match the current author, a new name is created.\n\np(bulk_text). You may include an optional one-line comment by inserting it after either the accepted or deprecated name, enclosed in square brackets. This will be saved in the notes when the name is created.\n\np(bulk_pre). Herpothallon Tobler [[citation:Aptroot, A, G Thor, ...]]"
+  name_bulk_label:  Name Edits
+  name_bulk_success:  All names are now in the database.
+  name_bulk_title:  Bulk Name Edit
+
+  # species_list/name_lister
+  name_lister_bad_browser:  This page will not work on your browser, sorry!
+  name_lister_bad_submit:  Invalid commit button '[button]'.
+  name_lister_charset:  Character Encoding
+  name_lister_charset_help:  "(Try changing this if authors get garbled.)"
+  name_lister_classic:  Classic [:SPECIES_LIST] Generator
+  name_lister_genera:  Genera
+  name_lister_help:  "*Create List:* Click a genus in the first column to pull up a list of species in that genus.  Select any of these taxa and press return or double-click to add species to your list.  Accepted names are in boldface; deprecated names are followed by one or more accepted alternatives.  You may choose any.  To remove a name, select it in the third column, and press delete or double-click.  (You may also use arrows to navigate, or type partial names to search within a column.)\n\n*Save List:* When you are finished, click any of the buttons at the bottom of the page.  \"Create [:species_list]\" takes you back to the old creation form, where you will be able to enter date, location, notes, etc. before saving the list.\n\n*Reports :* The plain text report gives you a simple list of taxa with no formatting.  Rich text can be used to import the list into Microsoft Word complete with authors and all the formatting intact.  Spreadsheet produces a CSV file, with name, author, citation, and accepted columns.  Common names are not available yet.  Reports should automatically download in a separate tab or window; if not, go to your browser's File menu and click 'Save As'."
+  name_lister_names:  Selected
+  name_lister_no_js:  This page will not work if javascript is disabled.
+  name_lister_species:  Species
+  name_lister_submit_csv:  Save as Spreadsheet
+  name_lister_submit_rtf:  Save as Rich Text
+  name_lister_submit_spl:  Create [:species_list]
+  name_lister_submit_txt:  Save as Plain Text
+  name_lister_title:  Name List Generator
+
+  # name/needed_descriptions
+  needed_descriptions_help:  The following species names are the ones that have the most [:observations], but do not have a general description in the [:app_title].  Adding a general description to these common species would be a big help.
+  needed_descriptions_title:  Top 100 Needed Species [:descriptions]
+
+  # observer/no_ajax
+  no_ajax_body:  It looks like your browser is out of date.  You still have access to all of the capabilities of this site, however unless you upgrade your browser we will not be able to make use of some very useful javascript features that modern browsers support.  This includes dynamic forms, auto-completion of scientific names and locations, the new version of the [:species_list] creator, and more.
+  no_ajax_browsers:  "Browsers that we recommend (and test the site on regularly) are:\n\n* Firefox / Iceweasel 1.0 or higher\n\n* Internet Explorer 5.5 or higher\n\n* Netscape 7.0 or higher\n\n* Safari 1.2 or higher\n\n* Opera (we know 8.0 works)\n\n* Chrome\n\nIf you know that your browser supports AJAX but it's not listed here, please \"send us an e-mail\":/emails/ask_webmaster_question."
+  no_ajax_dont_care:  If you don't care and you're tired of seeing the "Your Browser is Out of Date" tab at the top of every page, "please click here":/javascript/turn_javascript_off.  (Login and go to preferences to re-enable auto-detection.)
+  no_ajax_title:  Your Browser is Out of Date
+
+  # observer/no_browser
+  no_browser_body:  "We have not seen your browser before.  This means we don't know if it supports the full capabilities of this site.  Since there are pages that won't work if we guess wrong (like voting on [:observation] names), we have to assume the worst.  However this means that a number of useful features are not available, like dynamic forms, auto-completion of scientific names and locations, the new version of the [:species_list] creator, and more.\n\nIf you would like to override this decision, \"click here to turn javascript on\":/javascript/turn_javascript_on.  If you are tired of seeing the \"We Don't Recognize Your Browser\" tab at the top of every page, please \"click here to turn javascript off\":/javascript/turn_javascript_off.  (Login and go to preferences to re-enable auto-detection.)"
+  no_browser_title:  We Don't Recognize Your Browser
+
+  # account/no_email
+  no_email_how_to_reenable:  Go to your "Preferences":/account/prefs page to re-enable this feature.
+  no_email_some_maybe_queued:  "Note: For the next few minutes you may continue to receive emails that have already been queued."
+  no_email_comments_owner_note:  You will no longer receive email notifications when other [:users] of the [:app_title] website post [:comments] about your [:observations], names, etc.
+  no_email_comments_response_note:  You will no longer receive email notifications when other [:users] of the [:app_title] website post responses to your [:comments].
+  no_email_comments_all_note:  You will no longer receive email notifications of all [:comments].
+  no_email_observations_consensus_note:  You will no longer receive email notifications when the names of your [:observations] change.
+  no_email_observations_naming_note:  You will no longer receive email notifications when other [:users] of the [:app_title] website propose names for your [:observations].
+  no_email_observations_all_note:  You will no longer receive email notifications whenenver [:observations] change.
+  no_email_names_admin_note:  You will no longer receive email notifications when other [:users] make changes to name descriptions you administrate.
+  no_email_names_author_note:  You will no longer receive email notifications when other [:users] make changes to descriptions you have written.
+  no_email_names_editor_note:  You will no longer receive email notifications when other [:users] make changes to descriptions you have edited.
+  no_email_names_reviewer_note:  You will no longer receive email notifications when other [:users] make changes to descriptions you have reviewed.
+  no_email_names_all_note:  You will no longer receive email notifications about all name changes.
+  no_email_locations_admin_note:  You will no longer receive email notifications when other [:users] make changes to location descriptions you administrate.
+  no_email_locations_author_note:  You will no longer receive email notifications when other [:users] make changes to [:locations] you have created.
+  no_email_locations_editor_note:  You will no longer receive email notifications when other [:users] make changes to [:locations] you have edited.
+  no_email_locations_all_note:  You will no longer receive email notifications about all location changes.
+  no_email_general_feature_note:  Automated email about new features has been disabled for your account.
+  no_email_general_commercial_note:  Other [:users] of the [:app_title] website can no longer send you commercial inquiries about your [:images].
+  no_email_general_question_note:  Other [:users] of the [:app_title] website can no longer send you questions about your [:observations].
+  no_email_comments_owner_success:  "[:comment] notifications disabled for [name]."
+  no_email_comments_response_success:  "[:comment] response notifications disabled for [name]."
+  no_email_comments_all_success:  "[:comment] notifications disabled for [name]."
+  no_email_observations_consensus_success:  Consensus change notifications disabled for [name].
+  no_email_observations_naming_success:  Name proposal notifications disabled for [name].
+  no_email_observations_all_success:  "[:observation] notifications disabled for [name]."
+  no_email_names_admin_success:  Admin name change notifications disabled for [name].
+  no_email_names_author_success:  Author name change notifications disabled for [name].
+  no_email_names_editor_success:  Editor name change notifications disabled for [name].
+  no_email_names_reviewer_success:  Reviewer name change notifications disabled for [name].
+  no_email_names_all_success:  All name change notifications disabled for [name].
+  no_email_locations_admin_success:  Admin location change notifications disabled for [name].
+  no_email_locations_author_success:  Author location change notifications disabled for [name].
+  no_email_locations_editor_success:  Editor location change notifications disabled for [name].
+  no_email_locations_all_success:  All location change notifications disabled for [name].
+  no_email_general_feature_success:  Automated feature email disabled for [name].
+  no_email_general_commercial_success:  Commercial inquiries disabled for [name].
+  no_email_general_question_success:  Question email disabled for [name].
+
+  # observer/no_javascript
+  no_javascript_body:  "It looks like you have javascript disabled on your browser.  You will still have access to all of the capabilities of this site, however unless you enable javascript we will not be able to make use of some very useful features that modern browsers support.  This includes dynamic forms, auto-completion of scientific names and locations, the new version of the [:species_list] creator, and more.\n\nIf you would like to turn Javascript on, but aren't sure how, try looking it up on google with this search: \"How do I enable JavaScript in my browser?\":http://www.google.com/search?hl=en&q=How+do+I+enable+Javascript+in+my+browser%3F&btnG=Google+Search"
+  no_javascript_dont_care:  If you *do* have javascript enabled, but our auto-detection algorithm is failing to detect it correctly, "please click here":/javascript/turn_javascript_on.  If you don't care and you're tired of seeing the "Javascript Disabled" tab at the top of every page, "please click here":/javascript/turn_javascript_off. (Login and go to preferences to re-enable auto-detection.)
+  no_javascript_title:  You Have Javascript Disabled
+
+  # observer/no_session
+  no_session_body:  "It looks like your browser is refusing cookies.  Without cookies, our site has no way of remembering who you are from one page to the next.  This means that you will not be able to create an account and login, and therefore you will not be able to create [:observations], upload [:images], make [:comments], and much more.  You will still be able to view everything that the general public has access to, but you will just be an observer, you will not be able to participate actively.\n\nAll we will do is store a big long number on your computer.  Next time you go to our site, we will look up that number and use it to keep track of who you are.  (We get multiple requests every second from around the world -- without this ID we wouldn't stand a chance of keeping everyone straight!)  This ID is encrypted and keeps no sensitive information in it.\n\nIf you would like to turn cookies on, but aren't sure how, try looking it up on google with this search: \"How do I enable cookies in my browser?\":http://www.google.com/search?hl=en&q=How+do+I+enable+cookies+on+my+browser%3F&btnG=Google+Search Note that most browsers will let you enable cookies for individual sites, allowing you to protect your privacy everywhere else.  For example, in Firefox, go into Edit -> Preferences -> Privacy Tab -> Exceptions."
+  no_session_title:  You Have Cookies Disabled
+
+  # pivotal/index
+  pivotal_index_title:  Directions for Future Development
+  pivotal_post_comment:  Post Comment
+  pivotal_index_header:  Use this page to browse through the many features requested by users and developers.  Some are very specific bug fixes or requests for new capabilities.  Others are just general areas people are interested in seeing Mushroom Observer grow.  Features are organized by use of the following set of labels.  Click on a label to see a list of features with that label. Click on a feature to see more detail and discussion.  If you are logged in, you will be able to vote features up or down, and you can add your own comments to the discussion.  If you would like to request a new feature, for now we request that you "send us an email":/emails/ask_webmaster_question describing what it is you'd like to do.  Please try to be as detailed as possible; concrete examples are generally the best.
+  pivotal_vote_failed:  "We were unable to process your vote.\nIf the problem persists please notify to admins.\nSorry for the inconvenience!"
+  pivotal_story_failed:  "We were unable to get the story you requested.\nIf the problem persists please notify to admins.\nSorry for the inconvenience!"
+  pivotal_comment_failed:  "We were unable to post your comment.\nIf the problem persists please notify to admins.\nSorry for the inconvenience!"
+  pivotal_story_loading:  Loading story details...
+  pivotal_posting_comment:  Posting comment...
+  pivotal_posted_by:  Posted by
+  pivotal_state_unscheduled:  unscheduled
+  pivotal_state_unstarted:  in the queue
+  pivotal_state_started:  in progress
+  pivotal_head_critical:  serious bugs or mission-critical work
+  pivotal_head_bottleneck:  stuff required by lots of other things
+  pivotal_head_open:  areas we are actively soliciting feedback
+  pivotal_head_started:  areas developers are actively working
+  pivotal_head_unstarted:  scheduled for work soon
+  pivotal_head_unscheduled:  for the indefinite future
+  pivotal_head_day:  has comments within last day
+  pivotal_head_week:  has comments within last week
+  pivotal_head_month:  has comments within last month
+  pivotal_head_none:  has no recent comments
+  pivotal_head_all:  show everything
+  pivotal_head_other:  uncategorized
+  pivotal_label_critical:  critical
+  pivotal_label_bottleneck:  bottleneck
+  pivotal_label_open:  open
+  pivotal_label_day:  day
+  pivotal_label_week:  week
+  pivotal_label_month:  month
+  pivotal_label_none:  none
+  pivotal_label_unscheduled:  "[:pivotal_state_unscheduled]"
+  pivotal_label_unstarted:  "[:pivotal_state_unstarted]"
+  pivotal_label_started:  "[:pivotal_state_started]"
+  pivotal_label_all:  "[:all]"
+  pivotal_label_other:  other
+
+  pivotal_head_api:  programmatic interface
+  pivotal_head_comments:  commenting on observations, names, etc.
+  pivotal_head_descriptions:  species descriptions and drafts
+  pivotal_head_email:  email notifications
+  pivotal_head_i18n:  translating site into other languages
+  pivotal_head_images:  image information, manipulation
+  pivotal_head_lists:  species lists, checklists
+  pivotal_head_locations:  location names, geocoding
+  pivotal_head_maps:  how observations are mapped
+  pivotal_head_names:  taxonomy, synonymy, etc.
+  pivotal_head_observations:  observation fields and interface
+  pivotal_head_performance:  site performance
+  pivotal_head_projects:  working on group projects
+  pivotal_head_search:  search capabilities and data mining
+  pivotal_head_specimen:  how fungarium specimens are documented
+  pivotal_head_voting:  voting on observation names and images
+
+  pivotal_label_api:  API
+  pivotal_label_comments:  "[:comments]"
+  pivotal_label_descriptions:  "[:descriptions]"
+  pivotal_label_email:  email
+  pivotal_label_i18n:  translations
+  pivotal_label_images:  "[:images]"
+  pivotal_label_lists:  lists
+  pivotal_label_locations:  "[:locations]"
+  pivotal_label_maps:  "[:maps]"
+  pivotal_label_names:  "[:names]"
+  pivotal_label_observations:  "[:observations]"
+  pivotal_label_performance:  performance
+  pivotal_label_projects:  "[:projects]"
+  pivotal_label_search:  search
+  pivotal_label_specimen:  "[:specimens]"
+  pivotal_label_voting:  voting
+
+  # info/textile
+  sandbox_enter:  Enter Textile you wish to test here
+  sandbox_header:  This page let's you play with the textile markup language.  Click 'Test' to see what your markup looks like.  You will need to copy the results from this page to where ever you want to use it.
+  sandbox_link4:  The RedCloth manual
+  sandbox_link5:  The old hobix.com tutorial
+  sandbox_link6:  Cheatsheet courtesy warpedivisions.org
+  sandbox_look_like:  This is what it will look like
+  sandbox_more_help:  Gotchas, more examples
+  sandbox_quick_ref:  Quick Reference
+  sandbox_sample:  "??italics??        trademark(tm)\n**boldface**       copyright(c)\n+underline+        registered(r)\n^superscript^      1.6 &amp;&#109;icro;m  ->  1.6 &micro;m\n~subscript~        34&amp;&#100;eg;17' N  ->  34&deg;17' N\n\n\"External Link\":http://google.com or !http://random.com/image.jpg!\n\nInternal links:\n_name 371_, _Amanita ocreata_, or _A. ocreata_\n_location 382_, _location Mt. Wilson_\n_user 252_, _user jason_\n_observation 12345_\n_image 12345_, !image 12345!, or !image 640/12345!\n\nInclude footnote[[1]] references after any word[[2]].\n\nfn1. And then define the footnote at the bottom.\n\nfn2. Be sure to leave blank lines around these \"xx.\" directives.\n\nh1. Header\n\nbq. Block quote\n\n* bullet list item 1\n* bullet list item 2\n\n# numbered list item 1\n# numbered list item 2\n\nTables are useful for comparing species:\n| Species 1 | value 1.1 | value 1.2 |\n| Species 2 | value 2.1 | value 2.2 |\n| Species 3 | value 3.1 | value 3.2 |"
+  sandbox_test:  Test
+  sandbox_test_codes:  Show HTML
+  sandbox_title:  Textile Sandbox
+  sandbox_web_refs:  Web References
+
+  # interest/set_interest
+  set_interest_already_deleted:  You have expressed no interest in [name].
+  set_interest_already_off:  You have already told us to ignore [name].
+  set_interest_already_on:  You have already told us to watch [name].
+  set_interest_bad_object:  "Object [type] #[id] doesn't exist."
+  set_interest_failure:  Could not save changes.  Please try again or report this to the webmaster.
+  set_interest_success_was_off:  Cancelled your ban on emails about [name].
+  set_interest_success_was_on:  Cancelled your request for emails about [name].
+  set_interest_success_off:  We will now ignore any changes in [name].
+  set_interest_success_on:  You will now be notified of any changes in [name].
+  set_interest_user_mismatch:  Another [:user] is logged on at this machine.  Please log them off, log back in as you, and try again.
+
+  # observer/show_notifications
+  show_notifications_title:  New Notifications for [user]
+
+  # species_list/bulk_editor
+  species_list_bulk_editor_title:  Species List Bulk Editor
+  species_list_bulk_editor_another:  Another
+  species_list_bulk_editor_reuse:  Reuse
+  species_list_bulk_editor_success:  Successfully updated [n] observation(s).
+  species_list_bulk_editor_you_own_no_observations:  You don't own any observations in this species list.
+  species_list_bulk_editor_ambiguous_namings:  "The proposed names are confusing for observation [id]: [name]. Please \"go to that observation\":/[id] and make your changes there."
+  species_list_bulk_editor_help:  "Hold your mouse over any of the fields in the table below to see what the field is supposed to be.  The text fields are, in order: notes (top right), date, location, latitude, longitude, elevation (second row).  Check boxes indicate, respectively, if location is where collected, and specimen.  All links open in new tabs."
+
+  # observer/<Theme>
+  theme_agaricus:  _Agaricus_ Theme
+  theme_agaricus_augustus:  "[link] is used for the left-hand panel's background color."
+  theme_agaricus_campestris:  "[link] is used for the primary background and the default link hover background color."
+  theme_agaricus_cupreobrunneus:  "[link] is used for the default text color and the visited link color."
+  theme_agaricus_lilaceps:  "[link] is used for the background color for the some rows on the list pages and the unvisited link color for the other rows."
+  theme_agaricus_semotus:  "[link] is used for the banner background color."
+  theme_agaricus_subrufescens:  "[link] is used for most unvisited links."
+  theme_agaricus_xanthodermus:  "[link] is used for the background color for some rows on the list pages and the unvisited link color for the other rows."
+  theme_amanita:  _Amanita_ Theme
+  theme_amanita_calyptroderma:  "[link] is used for all the colors of half the rows on the list pages."
+  theme_amanita_muscaria:  "[link] is used for the banner background and text, the default visited link and link hover colors as well as the text for the left-hand panel."
+  theme_amanita_pachycolea:  "[link] is used for the primary background, the default text and default unvisited links."
+  theme_amanita_phalloides:  "[link] is used for all the colors of the other half of the rows on the list pages."
+  theme_amanita_velosa:  "[link] is used for the left-hand panel's background color and the left-hand panel's visited and unvisited link colors."
+  theme_cantharellaceae:  _Cantharellaceae_ Theme
+  theme_cantharellaceae_californicus:  "[link] is used for the primary, banner and left-hand panel backgrounds."
+  theme_cantharellaceae_cinnabarinus:  "[link] is used for the default link and visited link colors."
+  theme_cantharellaceae_cornucopioides:  "[link] is used for the default text and all the colors of half the rows on the list pages."
+  theme_cantharellaceae_tubaeformis:  "[link] is used for all the colors of the other half of the rows on the list pages."
+  theme_hygrocybe:  _Hygrocybe_ Theme
+  theme_hygrocybe_conica:  "[link] is used for the default text and all the colors of half the rows on the list pages."
+  theme_hygrocybe_miniata:  "[link] is used for the left-hand panel background and link text colors."
+  theme_hygrocybe_pittacina:  "[link] is used for the default link text colors."
+  theme_hygrocybe_punicea:  "[link] is used for the default background color, the banner background color, and all the colors of the other half of the rows on the list pages."
+  theme_random:  Random
+  theme_list:  List of Themes
+  theme_black_on_white:  Black on White Theme
+  theme_black_on_white_description:  This is a simple Black on White theme that attempts to be as readable and clean as possible. The logo colors come from the [link] theme.
+  theme_switch:  To select this as your theme, go to your "preferences":/account/prefs and select [theme] as your Preferred Theme
+
+  # Theme names.
+  Agaricus:  Agaricus
+  Amanita:  Amanita
+  Cantharellaceae:  Cantharellaceae
+  Hygrocybe:  Hygrocybe
+  BlackOnWhite:  Black on White
+
+  # info/translators_note
+  translators_note:  "Please help us make this website available around the world!  It's easy.\n\nThere are approximately 3000 lines with 25000 words of text on this site at the moment, but don't let that scare you.  We've organized it so someone with limited time can concentrate on the most important text.  Then as time and energy permits, they or someone else can continue working down the list until one day it is all finished.\n\nThere are several ways to get started.  You can pick up a copy of the entire \"translation file\":[repo] and start translating it into any language you wish.  \"Send us an email\":/emails/ask_webmaster_question to learn more about this approach.\n\nIt's even easier to work on existing translations.  Just look for \"[:app_edit_translations]\" at the bottom of any page.  You can see immediately how your changes look in the context of the page.  If your language is not available, \"send us an email\":/emails/ask_webmaster_question and we can create a \"beta\" version for you to work on.\n\nYou will, of course, receive credit and contribution bonus for each line you translate, in addition to the gratitude of countless users."
+  translators_note_title: Заўвага перакладчыка
+
+  # translation/edit_translations
+  edit_translations_title: Рэдагаваць пераклады
+  edit_translations_bad_locale:  "Invalid locale code: [locale]"
+  edit_translations_login_required:  Must be logged in to edit translations.
+  edit_translations_reviewer_required:  Only reviewers have permission to edit the English translations.
+  edit_translations_created_at:  Created translation for [tag].
+  edit_translations_changed:  Changed translation for [tag].
+  edit_translations_no_changes:  Nothing changed.
+  edit_translations_saving:  Saving...
+  edit_translations_loading:  Loading...
+  edit_translations_will_lose_changes:  There are unsaved changes. Would you like to continue anyway?
+  edit_translations_switch_language: Пераключыць мову
+  edit_translations_original_text: Арыгінальны Tэкст
+  edit_translations_old_versions: Старыя версіі
+  edit_translations_full_text:  full text
+  edit_translations_no_versions:  No old versions.
+  edit_translations_singular: форма адзіночнага ліку
+  edit_translations_plural: форма множнага ліку
+  edit_translations_lowercase: усё ў малым рэгістры, як у канцы прапановы
+  edit_translations_uppercase: усе вялікія літары, як для назвы
+  edit_translations_page_expired:  The page you were working on has expired.  Please go back and reload it, then click on "[:app_edit_translations_on_page]" again.
+  edit_translations_help: Злева знаходзіцца спіс радкоў перакладу, упарадкаваных тэматычна ў адпаведнасці з тым, як яны з'яўляюцца ў галоўным файле перакладу. Калі вы націснеце на адну з падкрэсленых этыкетак, гэта дазволіць вам адрэдагаваць адпаведны радок на панэлі справа. Націсніце "[:SAVE]", каб захаваць змены.
+
+  # observer/turn_javascript_nil
+  turn_javascript_nil_body:  We will resume auto-detection of the state of javascript.
+  turn_javascript_nil_title:  Auto-Detect Javascript
+
+  # observer/turn_javascript_off
+  turn_javascript_off_body:  We will now ignore javascript.
+  turn_javascript_off_title:  Turn Javascript Off
+
+  # observer/turn_javascript_on
+  turn_javascript_on_body:  We will now assume javascript is on.
+  turn_javascript_on_title:  Turn Javascript On
+
+  ##############################################################################
+
+  # ADMIN-TYPE PAGES
+
+  # project/add_members
+  add_members_change_status:  Change Status
+  add_members_denied:  "Permission denied: only admins for a project can add new members."
+  add_members_title:  Add [:users] to [title]
+  add_members_not_found:  User "<str>" not found.
+  add_members_added_admin:  Successfully added [user] to admins.
+  add_members_added_member:  Successfully added [user] to members.
+  add_members_removed_admin:  Successfully removed [user] from admins.
+  add_members_removed_member:  Successfully removed [user] from members.
+  add_members_already_added_admin:  Already added [user] to admins.
+  add_members_already_added_member:  Already added [user] to members.
+  add_members_already_removed_admin:  Already removed [user] from admins.
+  add_members_already_removed_member:  Already removed [user] from members.
+
+  # project/add_project
+  add_project_already_exists:  A project named '[title]' already exists.
+  add_project_group_exists:  Unable to create project because a [:user_group] named '[group]' already exists.
+  add_project_need_title:  Projects must have a title.
+  add_project_success:  Project was successfully created.
+  add_project_title:  Create New Project
+
+  # account/add_user_to_group
+  add_user_to_group_already:  "[user] is already a member of [group]."
+  add_user_to_group_group:  Group name
+  add_user_to_group_no_group:  Unable to find the group, '[group]'.
+  add_user_to_group_no_user:  Unable to find the [:user], '[user]'.
+  add_user_to_group_success:  "[user] added to [group]."
+  add_user_to_group_title:  Add [:user] to Group
+  add_user_to_group_user:  "[:user] name"
+
+  # admin_request/author_request emails
+  admin_request_change_member_status:  Change [:user]'s status
+  admin_request_success:  Successfully sent admin request for [title]
+  admin_request_title:  Admin Request for [title]
+  admin_request_note:  Enter your request below.  When you hit "[:SEND]" it will be emailed to to project admins.  The email will include your email address so that they can respond to your request.
+  author_request_add_author:  Make sender an author
+  author_request_title:  Authorship Request for [title]
+  author_request_note:  "[:admin_request_note]"
+  request_message:  Message
+  request_show_user:  Show details on sender
+  request_subject:  Subject
+  request_success:  Delivered email.
+
+  # info/change_banner
+  change_banner_title: Змена банера сайта
+
+  # project/change_member_status
+  change_member_status_admins:  Current Project Admins
+  change_member_status_change_status:  Change Status
+  change_member_status_edit:  Edit Project
+  change_member_status_make_admin:  Make Admin
+  change_member_status_make_admin_help:  Make Admin - Allows [:user] to perform admin functions.  They will be able to add or remove members, change the ability for other members to perform admin functions, and edit any draft names for this project.  [:user] is also made a member of the project if they are not already.
+  change_member_status_make_member:  Make Regular Member
+  change_member_status_make_member_help:  Make Regular Member - Ensures that [:user] is a member of the project, but not in the admin group. Afterwords the [:user] will be able to view and create draft names for this project.  They will be the only non-admin members able to edit their drafts.
+  change_member_status_members:  Current Project Members
+  change_member_status_remove_member:  Remove Member
+  change_member_status_remove_member_help:  Remove Member - Removes all member and admin privileges for a project.  [:user] will no longer be able view or create draft names for this project.  They will not be able to perform any admin functions.
+  change_member_status_denied:  Only the admins for a project can change member permissions.
+  change_member_status_title:  Changing [:user] Status of [name] for [title]
+
+  # users/bonuses
+  change_user_bonuses_title:  Contribution Bonuses for [user]
+  change_user_bonuses:  Award Bonus
+  change_user_bonuses_help:  "List one bonus per line, each specifying a number of points and reason, like this:\n\n10000 German translations\n50000 Expert in hypogeous fungi\n\n\nThese will appear on the show_user page below the usual contribution scores. Keep the reasons short or it might mess up the formatting of the table on that page."
+
+  # project/destroy_project
+  destroy_project_failed:  Failed to destroy project.
+  destroy_project_success:  Project destroyed.
+
+  # project/edit_project
+  edit_project_destroy:  "[:destroy_object(type=:project)]"
+  edit_project_title:  "[:edit_object(type=:project)]: [title]"
+
+  # project/_form_projects
+  form_projects_title:  "[:Title]"
+
+  # project/list_projects
+  list_projects_title:  "[:list_objects(type=:project)]"
+  list_projects_add_project:  "[:add_object(type=:project)]"
+
+  # draft/publish_draft
+  publish_draft_denied:  "Permission denied: Only the creator of a draft or a project admin can publish a draft."
+
+  # observer/refresh_vote_cache
+  refresh_vote_cache:  Refreshed vote caches.
+
+  # project/review_authors
+  review_authors_add_author:  Add
+  review_authors_authors:  Current [:description] Authors
+  review_authors_denied:  Only existing authors and reviewers can change the description authors.
+  review_authors_note:  This page changes the recorded author(s) of a taxon description on the [:app_title] website.  This is in no direct way related to the original publishing author of the taxon.
+  review_authors_review_authors:  Review Authors
+  review_authors_other_users:  Other [:users]
+  review_authors_remove_author:  Remove
+  review_authors_title:  Reviewing Author(s) for [name]
+
+  # observer/send_feature_email
+  send_feature_email_success:  Delivered feature mail.
+  send_feature_email_denied:  Only the admin can send feature mail.
+
+  # project/show_project
+  show_project_add_members:  Add Members
+  show_project_admin_group:  Admin Group
+  show_project_admin_request:  Admin Request
+  show_project_by:  Owned By
+  show_project_created_at:  Created
+  show_project_destroy:  Destroy Project
+  show_project_drafts:  Drafts
+  show_project_edit:  Edit Project
+  show_project_published:  Reviewed Published Names
+  show_project_summary:  Summary
+  show_project_title:  "Project: [title]"
+  show_project_user_group:  User Group
+
+  # users/by_name
+  users_by_name_title:  Users by Name
+  users_by_name_created_at:  Created
+  users_by_name_groups:  Groups
+  users_by_name_id:  ID
+  users_by_name_last_login:  Last login
+  users_by_name_login:  Login
+  users_by_name_name:  Name
+  users_by_name_theme:  Theme
+  users_by_name_verified:  Verified
+
+  # support/create_donation
+  create_donation_title:  Record Mushroom Observer Donation
+  create_donation_not_allowed:  Only admins can record donations
+  create_donation_add:  Add
+  create_donation_tab:  Record Donation
+
+  # support/review_donations
+  review_donations_title:  Review All Donations
+  review_donations_not_allowed:  Only admins can review donations
+  review_donations_update:  Update
+  review_donations_tab:  Review Donations
+  review_reviewed:  Reviewed
+  review_id:  Id
+  review_who:  Who
+  review_anon:  Anon
+  review_amount:  Amount
+  review_email:  Email
+
+  ##############################################################################
+
+  # EMAIL MESSAGES
+
+  # Subject lines.
+  email_subject_add_herbarium_record_not_curator:  Fungarium Record Added to [herbarium_name]
+  email_subject_comment:  "[:COMMENT] About [name]"
+  email_subject_commercial_inquiry:  Commercial Inquiry About [Name]
+  email_subject_consensus_change: "Кансенсус зменены з\n[old] каб [new]"
+  email_subject_denied:  "[:USER] Creation Blocked"
+  email_subject_features:  New [:app_title] Features
+  email_subject_location_change:  "[name] Has Been Changed"
+  email_subject_naming_for_observer:  Research Request
+  email_subject_naming_for_tracker:  Naming Notification - [name]
+  email_subject_name_change:  "[name] Has Been Changed"
+  email_subject_name_proposal:  "[:OBSERVATION] #[id] May Be [name]"
+  email_subject_new_password:  New Password
+  email_subject_observation_change:  "[:OBSERVATION] Changed, [name]"
+  email_subject_observation_destroy:  "[:OBSERVATION] Destroyed, [name]"
+  email_subject_observation_question:  Question About [name]
+  email_subject_publish_name:  Name Published
+  email_subject_registration:  "[name] Registration Verification"
+  email_subject_update_registration:  "[name] Registration Update"
+  email_subject_verify:  Email Verification
+  email_subject_verify_api_key:  Activate API Key
+  email_subject_webmaster_question: Пытанне ад [user]
+
+  # Field labels in the "object_change" emails.
+  email_field_added_images:  Added image(s)
+  email_field_changed_thumbnail:  Changed thumbnail
+  email_field_collection_location: Узор _быў_ сабраны ў гэтым месцы
+  email_field_collection_not_location:  Specimen _was not_ collected at this location
+  email_field_east:  "[:East] edge"
+  email_field_image_count:  "[:Image] count"
+  email_field_new_name:  New [:name]
+  email_field_no_specimen_available:  Specimen is no longer available
+  email_field_north:  "[:North] edge"
+  email_field_old_name:  Old [:name]
+  email_field_published:  Published by
+  email_field_removed_images:  Removed image(s)
+  email_field_south:  "[:South] edge"
+  email_field_specimen_available:  Specimen is now available
+  email_field_west:  "[:West] edge"
+
+  # This is used like this: "<Label>: <old_value> changed to <new_value>"
+  email_field_is_now:  changed to
+
+  # "Helpful" links at the bottom of the email.
+  email_links_change_prefs: Змяніце свае перавагі
+  email_links_disable_tracking:  Disable tracking for this [type]
+  email_links_email_publisher:  Send email to the publisher
+  email_links_latest_changes:  Latest changes at [:app_title]
+  email_links_not_interested: Мяне гэта не цікавіць [type]
+  email_links_post_comment:  Post a [:comment]
+  email_links_show_object:  Show this [type]
+  email_links_show_user:  Show [:user]'s profile
+  email_links_show_observer:  Show [:observer]'s profile
+  email_links_show_identifier:  Show [:identifier]'s profile
+  email_links_stop_sending:  Stop sending me email like this
+  email_links_your_interests:  Review your [:notifications]
+
+  # Some other common phrases and sections.
+  email_can_respond:  It is entirely up to you whether you want to reply to [name] ([email]) by replying directly to this email.
+  email_handy_links: "Вось некалькі карысных спасылак:"
+  email_no_respond: Калі ласка, не адказвайце на гэты ліст!
+  email_naming_for_observation_warning:  "WARNING: We've heard that some people have mis-used this notification feature in the past, claiming it's for research but not using specimens for that purpose. You may want to take a moment to look at their user profile on MO and perhaps google them to verify that they are actually active mycologists before going to the effort of packaging and sending them any specimens."
+  email_report_abuse:  "If you feel this user is abusing this service please forward this entire email message to: [email]"
+  email_respond_via_comment: Скарыстайцеся спасылкай ніжэй, каб адказаць праз уласны публічны каментар.
+  email_welcome: "Сардэчна запрашаем,\n[user]"
+
+  # Main message contents.
+  email_admin_request_intro:  "h2. *Admin Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following request to you regarding [project]:"
+  email_author_request_intro:  "h2. *Author Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following request to you regarding [object]:"
+  email_comment_intro_other:  "h2. *Comment on [Type]*\n\nThe following comment was posted on the [:app_title] website regarding the [type] <u>[name]</u>:"
+  email_comment_intro_response:  "h2. *Comment Response*\n\nThe following comment was posted on the [:app_title] website in response to your comment regarding the [type] <u>[name]</u>:"
+  email_comment_intro_to_owner:  "h2. *Comment on Your [Type]*\n\nThe following comment was posted on the [:app_title] website regarding your [type] <u>[name]</u>:"
+  email_commercial_intro:  "h2. *Commercial Inquiry*\n\n[user] ([email]) asked the [:app_title] website to forward the following commercial inquiry to you about your image [image]:"
+  email_consensus_change_intro: "h2. *Змена кансенсусу\n*\n\nКансенсус зменены для назірання\n#[id]:"
+  email_add_herbarium_record_not_curator_intro:  "h2. *Fungarium Record Added By Non-Curator*\n\nThe user, [login], added the fungarium record, [herbarium_label], to the fungarium, [herbarium_name], which you curate."
+  email_features_intro: "h2. *Новыя функцыі\n*\n\nНаступныя новыя функцыі былі выпушчаныя на\n[:app_title] сайт:"
+  email_name_change:  "User made nontrivial change to a name:\n\nuser : [user]\nold identifier : [old_identifier]\nnew identifier : [new_identifier]\nold name : [old]\nnew name : [new]\nobservations : [observations]\nnamings : [namings]\nshow name : [show_url]\nedit name : [edit_url]"
+  email_location_change:  "User made nontrivial change to a location:\n\nuser : [user]\nold name : [old]\nnew name : [new]\nobservations : [observations]\nshow location : [show_url]\nedit location : [edit_url]"
+  email_merger_icn_id_conflict:  "User merged names; one icn_id discarded:\n\nname : [name]\nsurviving icn_id : [surviving_icn_id]\ndeleted icn_id : [deleted_icn_id]\nuser : [user]\nshow url : [show_url]\nedit url : [edit_url]"
+  email_merge_objects:  "User wants to merge two [types]:\n\nuser : [user]\nthis : [this]\ninto : [that]\nshow this : [show_this_url]\nedit this : [edit_this_url]\nshow that : [show_that_url]\nedit that : [edit_that_url]\nnotes : [notes]"
+  email_name_change_request:  "User wants to change Name having dependents:\n\nuser : [user]\nold name : [old_name]\nnew name : [new_name]\nshow url : [show_url]\nedit url : [edit_url]\nnotes : [notes]"
+  email_name_proposal_intro:  "h2. *Name Proposal*\n\nA name was proposed for observation #[id]:"
+  email_naming_for_observer_intro:  "h2. *Research Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following message to you about your [type] <u>[name]</u>:"
+  email_naming_for_tracker_intro:  "h2. *Tracking Alert*\n\nAn [obs] on the [:app_title] website has been given the name [name], which you are currently tracking.  You can contact either the [:observer] or the [:identifier] by going to the appropriate link below and clicking the email link near the top of the page."
+  email_new_password_intro: "h2. *Новы пароль*\n\nВаш новы\n[:app_title] пароль:"
+  email_new_password_what_now: "Пасля таго, як вы ўвайшлі ў сістэму, вы павінны змяніць свой пароль на пароль, які лягчэй запомніць, перайшоўшы на старонку\n'[:app_preferences]' старонка."
+  email_object_change_intro:  "h2. *[Type] was Changed*\n\nThere were change(s) made to the [type] <u>[name]</u>:"
+  email_object_new_intro:  "h2. *[Type] was Created*\n\nThe [type] <u>[name]</u> was created."
+  email_object_change_reason_all:  You received this email because you have requested to be notified when any [type] changes.
+  email_object_change_reason_admin:  You received this email because you are an admin for a description of the changed [type].
+  email_object_change_reason_editor:  You received this email because you have edited a description of the changed [type].
+  email_object_change_reason_author:  You received this email because you are an author of a description of the changed [type].
+  email_object_change_reason_reviewer:  You received this email because you reviewed a description of this [type].
+  email_object_change_reason_interest:  You received this email because you expressed interest in this [type].
+  email_observation_destroyed_intro:  h2. *Observation Destroyed*
+  email_observation_question_intro:  "h2. *Question from Another User*\n\n[user] ([email]) asked the [:app_title] website to forward the following question to you about your observation <u>[name]</u>:"
+  email_publish_name_intro:  "h2. *Draft of Name Has Been Published*\n\nA description of a name has been published on the [:app_title] website. You are receiving this email since you are listed as either an author for this taxon or as a reviewer on the site."
+  email_registration_intro:  "h2. *Hello [user]*\n\nPlease click the following link to verify that you received this email and intended to register [how_many] attendee(s) for the [name]:\n\n[link]"
+  email_update_registration_intro:  "h2. *Hello [user]*\n\nYour registration for the [name] has been updated from\n\n[before]\n\n\nto\n\n\n[after]"
+  email_user_question_intro:  "h2. *Question from Another User*\n\n[user] ([email]) asked the [:app_title] website to forward the following email to you:"
+  email_verify_intro:  "h2. *Hello [user]*\n\nPlease click the following link to verify that you received this email and activate your [:app_title] account:\n\n[link]"
+  email_verify_api_key_intro:  "h2. *Hello [user]*\n\nThe application \"[app]\" (associated with user \"[other_user]\") has requested access to your [:app_title] account.  If you recognize this application and wish to give them permission to post observations, etc. in your name, all you have to do is click on the activation link below to activate the API key they just created.  Note that you can review your list of API keys at any time by visiting the [:account_api_keys_title] from your \"[:app_preferences]\" page.\n\nActivate Key: [activate_link]\n[:account_api_keys_link]: [manager_link]\n\nTo report a suspicious access request, just respond to this email."
+
+  ##############################################################################
+
+  # HELP PAGES
+
+  # info/intro
+  intro_title: Уводзіны
+  intro_purpose:  "*Purpose&#58;* The purpose of this site is to record observations about mushrooms, help people identify mushrooms they aren't familiar with, and expand the community around the scientific exploration of mushrooms (mycology).  Some have asked what counts as a mushroom.  This site takes a very broad view.  While the emphasis is on the large fleshy fungi, other fungi such as lichens, rust and molds as well as fungus-like organisms such as slime-molds are all welcome.  Ultimately, I hope this site will become a valuable resource for both amateur and professional mycologists.  I like to think of it as a living field guide for mushrooms or a collaborative mushroom field journal.\n\nFor those new to mycology, there is a huge amount of basic research that still needs to be done.  By some estimates less than 5% of the world's species of fungi are known to science.  While things are slightly better for the large fleshy fungi known as mushrooms, it is still a common experience to come across a mushroom that cannot be easily identified in the available books or which doesn't really fit the definition of any recognized species. This site is intended to address that gap by creating a place for us to talk about and record what we've found, as well as connect to the existing literature about mushrooms.  Please do not feel intimidated by the scientific bent of the site.  Everyone is welcome to dive in and add their own mushroom observations, upload mushroom photos and make [:comments] on other people's observations."
+  intro_image_sharing:  "*Image Sharing:* This site follows the principles of cooperative sharing pioneered by the \"Free Software Foundation\":http://fsf.org, further expressed by the \"Open Source software movement\":http://opensource.org, and expanded to other creative efforts by the \"Creative Commons\":http://creativecommons.org. Consequently all images are made available under one of the Creative Commons licenses or are in the public domain.  In short this means that when anyone uploads one of their images to the site, they are giving others explicit permission to use those images under certain \"conditions\":/info/how_to_use#license in perpetuity.  This type of permission is very important for basic research.  It allows future researchers to freely use these data to expand our understanding of mushrooms.  It also significantly increases the likelihood that the data will continue to be available into the distant future.\n\nIf you upload your own images, this license does not mean you are giving up your copyright or your ability to make money off your images.  Depending on which license you choose, you can still require that anyone who wishes to use any of these images for commercial purposes get in touch with the copyright holder and work out the conditions for that use.  The site includes special links on the image pages to help create those relationships."
+  intro_source_code:  "*Source Code:* Source code for the site is available at: \"[repo]\":[repo] and is licensed under the \"Open Source MIT License\":http://www.opensource.org/licenses/mit-license.php.  Source code contributions are welcome (\"README\":[readme]). Here's a list of \"planned features\":[todo_list]. All suggestions and comments are welcome.  If you would like to contribute, please send mail to *webmaster @ mushroomobserver.org* so we can coordinate our efforts."
+  intro_governance:  "*Governance:* This site is owned and operated by \"Mushroom Observer, Inc.\":/support/governance."
+  intro_note:  "*Note:* The administrators of this site reserve the right to remove any material they deem inappropriate or not in keeping with the purpose of this site."
+
+  # info/how_to_help
+  how_help_title:  How to Help Make [:app_title] Better
+  how_help_intro:  This page provides a list of skills that we could really use some help with. If you're interested in helping out just "send an email":/emails/ask_webmaster_question and let us know what you want to do.
+  how_help_contributors:  "h4. 1. Contributors\n\np(normal).  Beyond adding pictures and descriptions of mushrooms that you've seen, you can make a big difference to the site by \"describing species\":/info/how_to_use#describing_species or \"defining locations\":/info/how_to_use#defining_locations."
+  how_help_scientists:  "h4. 2. Scientists\n\np(normal).  Mention Mushroom Observer in your publications and \"add references to your publications\":/publications."
+  how_help_developers:  "h4. 3. Developers\n\np(normal).  We have \"lots of ideas\":[todo_list] about how to improve the site.  The framework, Ruby on Rails, is really easy to pick up and we are more than happy to mentor anyone who wants to dive in."
+  how_help_translators:  "h4. 4. Translators\n\np(normal). The site is set up to support foreign languages.  All we need is someone to do the translations."
+  how_help_donors:  "h4. 5. Donors\n\np(normal). Help support our server costs by \"donating\":/support/donate to the Mushroom Observer."
+  how_help_business_planning:  "h4. 6. Business Planning\n\np(normal).  So far [:app_title] has been an entirely volunteer effort, after some time consuming false starts, we are now in the process of creating a new non-profit focused solely on Mushroom Observer. This is just getting going so let us know if you want to get involved or have any business related advice."
+
+  # info/how_to_use
+  how_title: Як выкарыстоўваць [:app_title]
+  how_common_tasks:  Common Tasks
+  how_glossary:  Concepts Glossary
+  how_intro:  This page provides some short descriptions of common uses of this website followed by an overview of the basic concepts used.
+  how_keeping_up:  "*Keeping Up with Changes* - The default page for [:app_title] is the '[:rss_log_title]', it is also accessible through the '\"Latest Changes\":/' link in the left-hand panel.  This page shows you the most recent changes on the site.  It lists new \"Observations\":#observation and \"Species Lists\":#species_list as well as significant changes to any already existing ones.  Additions of \"Images\":#image and \"Comments\":#comment are considered significant changes to the relevant observations.  Changes to \"Names\":#name are also listed.  Click the page numbers at the top and bottom of the page to browse through older changes.  Observations and names created as a side effect of other changes are not listed separately.\n\nNote : The latest changes can be tracked using our \"RSS feed\":/activity_logs/rss. See this \"wikipedia article\":http://en.wikipedia.org/wiki/Rss for more information about RSS feeds."
+  how_searching:  "*Searching* - There are several interesting ways to search for information on the site.  The simplest is to type a search string into the search box near the top of each page and click one of the buttons next to it.  This will give you a list of all the \"Observations\":#observation, \"Images\":#image, \"Names\":#name or \"Locations\":#location that contain fields matching the given string.  If you need a little more control over the search, try clicking '[:app_advanced_search]'.\n\nYou may also browse the site using the links in the left-hand panel.  For example, clicking on 'Names' under 'Indexes' on the left of the page shows all the species that have observations, listed alphabetically.  You can page through this list, or skip directly to the letter of a name you are interested in by clicking the appropriate page number or letter along the top or bottom of the list.  Click a name from this list to see a description of the species and a list of observations of that species.  If you click a genus like 'Agaricus', it will also show a list of species in that genus.  Note, however, that in this case it will only show observations that have been identified to the genus level, not ones that have been identified as a species in that genus.  On the other hand, if two names are considered synonyms, you will see observations for either name on this page.  (*NOTE*: If you do a search on 'Agaricus', it _will_ show all the observations whose name contains that string, so you get all the observations that belong to that genus.)\n\nWhenever you click an observation or other result on an index page, it will take you to a page showing that result.  At the top of the page you will see '[:PREV]', '[:NEXT]', and '[:INDEX]' links.  These let you browse forward or backward through the results or return to the index.  At the top of the index page you will often see links allowing you to sort the results by different criteria, such as by date, name or user.  In the same place you will sometimes find links that let you turn an index of observations into an index of names or images of those same observations.  For example, if you click '[:app_your_observations]', it will show you a list of observations you have posted.  Click '[:show_objects(types=:names)]' at the top of the page to see a list of the species you have seen, or click '[:show_objects(types=:locations)]' to see a list of all the locations you've gone mushrooming in.\n\nPower users may also be interested in our new API providing direct access to our database back-end.  This can be used to mine our database for images or species descriptions for inclusion in wikipedia or other public websites. You can also use it to upload observations and images and much more.  Please contact the webmaster for more information."
+  how_unknown_help:  "*Getting Help with an Unknown* - In order to get help with an unknown, you need to have a user account.  These can be created easily by selecting '[:app_create_account]' from the left-hand panel.  See the discussion of \"Users\":#user below for more details.\n\nOnce you are logged in, create a new \"Observation\":#observation by selecting '[:app_create_observation]' in the left-hand panel.  Enter all the details you can into the resulting form.  You can leave the '[:WHAT]' field blank call it '[:unknown]', or if you think you know the genus or family or other group, give that \"Name\":#name followed by 'sp.', e.g., 'Russula sp.'. In the '[:NOTES]' field provide information about habitat, odor, smell and anything else not clear from the photos.  Once the form is as complete as you can make it, click '[:CREATE]'.\n\nYou should now be looking at a page showing you the information you just entered.  However, if you used a name that is not currently in the database, you will be asked if you want to add the name.  This also gives you a chance to catch and fix typos.  In addition, if you use a name that is considered deprecated, you will be given the option of using a preferred synonym.\n\nOnce you have created the new observation, you can upload any \"Images\":#image you have by selecting the '[:show_observation_add_images]' link on the right-side of the page.  It is very important either that it be an image you took or that you have the explicit permission of the person who created the image to upload it to the site.  If you did not take the image, please update the '[:form_images_copyright_holder]' field to reflect the actual owner.  This page also allows you to select the \"License\":#license you want to release the image under.\n\nWhen you add unknowns, the community will generally \"propose one or more names\":#proposing_names for it within 24-hours.  If you find any of the suggested names compelling, you should not hesitate to revisit your observation and \"Vote\":#vote on them.  Please see the discussion below on \"voting\":#voting, as well.  Members of the community may also post feedback via \"Comments\":#comment.  By default your account is set up to deliver comments posted about your observations to you by email.  If you are asked to provide more details on the collection, we prefer that you select '[:show_observation_edit_observation]' (at the top of the observation page) and add them to the '[:NOTES]' field than to just post another comment."
+  how_adding_observations:  "*Adding Observations You Have Identified* - Use the same process as \"Getting Help with an Unknown\":#unknown_help, except this time provide your identification in the '[:WHAT]' field.  You are strongly encouraged to say something about how you arrived at the identification.  We've provided a small set of checkboxes to make this easy ('[:naming_reason_label_1]', '[:naming_reason_label_3]', etc.), but you are encouraged to elaborate on them in the provided text fields (e.g., list the references you used, or enter 'sequenced the DNA and compared it against the data in GenBank'!). Community members will often post \"Comments\":#comment if there is some question about the collection or if they would like clarification as to why you ruled out other \"Names\":#name.  Roy Halling has provided beautifully illustrated presentations describing <a href=\"https://mushroomobserver.org/pdf/macro-features.pdf\">macroscopic</a> and <a href=\"https://mushroomobserver.org/pdf/micro-features.pdf\">microscopic</a> features. More documentation on creating scientifically valuable collections is available from the <a href=\"http://mycoportal.org/portal/misc/links.php\">MycoPortal Links Page</a>."
+  how_proposing_names:  "*Proposing Names* - Any member of the community can propose \"Names\":#name for any \"Observations\":#observation.  Click an observation (e.g., from the '[:rss_log_title]' page) and scroll down below the observation notes.  There should be a list of \"Proposed Names\":#proposed_name enclosed in a thin outlined box.  Most observations will already have at least one proposed name (by the owner).  From here you may either click '[:show_namings_propose_new_name]' or \"Vote\":#voting on existing names.  In either case you will have to log in before you are allowed to do so.\n\nWhen you click '[:show_namings_propose_new_name]' you will be presented with a form much like the one used to create an observation.  In addition to the name, you are required to choose a confidence level.  This is your \"Vote\":#vote, and you may change it on the '[:show_object(type=:observation)]' page at any time you like.  As with creating an observation, you are strongly encouraged to give some explanation as to why you think your Name applies to this Observation (and why other names don't).  When you are finished, click '[:CREATE]'.  You will be given a chance to correct typos or to choose an accepted name if you entered a deprecated one.\n\nUsers are not allowed to propose a name if someone else has already done so. The only reason to do so would be to describe alternative reasons for reaching the same conclusion.  Instead use the discussion forum provided by comments to do this."
+  how_voting:  "*Voting on Proposed Names* - Click an \"Observation\":#observation, e.g., from the '[:rss_log_title]' page, and scroll down to the '[:show_namings_proposed_names]' box.  Note that you must login before you can see or change any of your \"Votes\":#vote.  Once you have logged in, you should see pulldown menus next to each \"Proposed Name\":#proposed_name.  Your vote expresses the degree of confidence or agreement you have with placing that name on that observation.  Everything above '[min_neg_vote]' is considered a positive vote, everything below '[min_pos_vote]' negative. Choose '[no_opinion]' to tell it to delete your vote.  When you've changed all the votes you want to, be sure to click '[:show_namings_update_votes]' to record your votes.  Don't worry, if you forget and try to navigate away without casting your votes it will complain (unless you have Javascript disabled).\n\nRoughly speaking, votes for a name are weighted, summed and then divided by the number of votes for that name.  The name with the highest score wins, and that name will be applied to that observation throughout the site.  In the case where multiple synonyms are proposed for an observation it lumps the votes together, choosing each user's strongest vote within that group of synonyms.  In the end, assuming that group of synonyms wins, the currently accepted name is used as the community consensus.  If there is still debate in the scientific community about which name is appropriate for a given taxon, then it will use votes the best it can to decide between multiple accepted names.  Note that the owner's vote automatically carries a little more weight, as do the votes of users who have made a large \"Contribution\":#contribution to [:app_title] or who are considered experts.  Click '[:app_contributors]' or click a user's name to see the contribution and expert status.  (We use the log base 10 of users' contributions.)"
+  how_adding_comments:  "*Adding Comments* - When you are looking at an \"Observation\":#observation, if you would like to post or respond to a \"Comment\":#comment, select the '[:show_comments_add_comment]' link near the top of the page.  If you are not currently logged in to a \"User\":#user account, you will be asked to log in.  Once you are logged in, you will be given a form asking for a summary and your comment.  Note that you can do some simple formatting in the comment section.  This is briefly documented below the text field with a link to detailed documentation.  You can also add links within a comment using standard HTML formatting.  The HTML gets automatically cleaned to avoid security problems like script injection, so try not to get too fancy."
+  how_tracking_species:  "*Tracking a Particular Species or Genus Through Email* - [:app_title] allows you to request an email any time a particular \"Name\":#name is given to an \"Observation\":#observation.  If that name is a genus or species it will also send you an email whenever a species or subspecies is observed.  To turn this feature on, go to the page for a Name you are interested in (see \"Searching\":#searching) and click '[:show_name_email_tracking]'.  You can configure it so that the person who made the observation that was given that name will be sent a customized email to let them know you are interested in their observation.  If you don't provide any instructions, they will not be sent an email.  If the observer gives the name at the time the observation is created, they will be shown your message immediately through the website. You can modify or disable your request for a particular name by going back to that name and again selecting '[:show_name_email_tracking]' and clicking the '[:DISABLE]' button on the page that comes up."
+  how_describing_species:  "*Describing Species* - Click any \"Name\":#name link you see throughout the site.  For example, click on 'Names' under 'Indexes' on the left side of the page then click on any of the results, or search for a name in the search bar, or click the 'About &lt;&#110;ame&gt;...' link at the top of any \"Observation\":#observation page.  These all take you to a page summarizing everything we know about this taxon.  If you are familiar with this species and there is something you would like to add, click '[:show_name_edit_name]' and add your notes.  You are encouraged to cite references including field guides and scientific papers.  Short quotes from references are fine, but please don't make extensive quotes without obtaining permission from the original author."
+  how_projects:  "*Projects* - Projects are a way for a group of \"Users\":#user to work together to create a set of work that they want to keep out of the public eye until they are ready to publish it.  The original purpose was to support university classes where there was a desire to keep a more controlled environment while the class was going.\n\nAnyone can create a new project by clicking on '\"[:app_list_projects]\":/project/list_projects' in the left-hand panel and then clicking on '[:list_projects_add_project]'.  The person who creates the project is always a member and an administrator for that project.  An administrator for a project can add new members by clicking the '[:show_project_add_members]' link at the top of a project's 'Show Project' page.  Administrators can also make other users administrators for the project by going to one of the '[:add_members_change_status]' links available on the 'Show Project' or 'Add Members' pages.  Any User can send requests to the admins for a project.  These requests are emailed to the admins and contain a link for changing that user's status.\n\nCurrently the primary focus of projects is writing \"Descriptions\":#description for various species.  Note, however, that anyone can now create new descriptions for a species (see \"Describing Species\":#describing_species) by clicking on '[:show_name_create_description]' at the top of the 'Show Name' page. Descriptions that are created for a project are visible only to members of that project until they are published, and editable only by the owner of the description and project administrators.  When a description is published it will become the official description if no official description exists yet."
+  how_maps:  "*Working with Maps* - Currently there are three types of maps available on [:app_title]: Occurrence Maps (e.g., \"Occurrence map for **__Craterellus cornucopioides__**\":/name/map/284), Location Maps (e.g., \"Salt Point State Park\":/location/show_location/4) and the \"[:map_locations_global_map]\":/location/map_locations.\n\nTo see an occurrence map for a particular \"Name\":#name, go to the page for that name (e.g., enter the name in the search bar, select '[:NAMES]'), and click '[:app_search]', then click '[:show_name_distribution_map]' at the top of the page.\n\nUsers are encouraged to add to the occurrence map for a name.  The easiest way is to create a new \"Observation\":#observation using an already defined \"Location\":#location.  Note, however, that auto-completion for the '[:WHERE]' field will list all matching locations whether they are defined or not.\n\nYou can also explicitly choose not to have an observation show up on the occurrence map.  This allows you to record observations of mushrooms in places like mushroom fairs, old photos or other places where you may not know where the mushroom was actually collected.  When creating or editing an observation there is a checkbox labeled '[:form_observations_is_collection_location]'.  By default it is checked.  If you uncheck it, that observation will not appear in any occurrence maps."
+  how_defining_locations:  "*Defining Undefined Locations* - Many \"Observations\":#observation have been reported from undefined \"Locations\":#location.  These observations will not appear in our \"occurrence maps\":#maps.  An excellent, easy way for \"Users\":#user to help out if they have a little spare time is to locate and define these undefined locations.\n\nWhen browsing through observations, defined location names will be followed by a link labeled '[:click_for_map]'.  Undefined location names will be followed by a link labeled '[:SEARCH]'.  If you click the link for an undefined location, it will show a list of observations reported for that location.  The resulting page will include two links at the top of the page: '[:list_observations_location_define]' and '[:list_observations_location_merge]'.  Clicking on '[:list_observations_location_define]' will present a form which you can use to create that location.  Clicking on 'Merge With a Defined Location' will present you with a list of similar locations which have already been defined.  Clicking on any of these locations will perform the merge.\n\nYou can also see a list of all locations in use by clicking on '\"[:app_list_locations]\":/location/list_locations' in the left-hand panel. This page lists both the defined locations (first column, sorted alphabetically) and the undefined locations (second column, sorted by the number of observations reported from that location).  In some cases the same location has been given multiple names (e.g., 'Point Reyes National Seashore' and 'Pt Reyes Park').  You can merge an undefined location with a defined location by clicking on '[:list_place_names_merge]' next to the undefined location (see above).\n\nWhen defining a new location, the first thing to do is to review its name. Mushroom Observer tries to enforce a set of \"rules\":/location/help.\n\nIn theory it is possible for the same location to be defined more than once (presumably by different users).  If this happens, you can request a merge by editing one of the two locations and changing its name to be exactly the same as the other's.  This will not have any immediate effect, but it will display a warning message, and an email will be sent to the site administrators with the details.  Merging defined locations is restricted since it can cause significant data loss."
+  how_creating_species_lists:  "*Creating Species Lists* - To create a \"Species List\":#species_list, click '\"[:app_create_list]\":/species_list/create_species_list' in the left-hand panel.  Fill out the various fields.  In the 'Write-In Species' field, you should give each species a \"Name\":#name on a line by itself.  When you go to create the list, each line is checked to see if there is a match in the database.  If there is no matching name, you will be asked if you want to add the unknown names to the database.  This gives you a chance to catch and fix typos as well as giving you a simple way to add missing names.  Each name given in the 'Write-In Species' field (or loaded from a file) will be used to create a completely new \"Observation\":#observation.  The '[:form_species_lists_list_notes]' are only shown when the entire species list is shown.  Use '[:form_species_lists_member_notes]' to indicate text you would like to add to each new observation.\n\nThere are several methods of collecting a set of existing observations into a new list.  In the simplest method, first create an empty species list, then go to each of the observations you want to add and select '[:show_observation_manage_species_lists]'.  This will give you the opportunity to add that observation to any species list you own.  (Note, you can add anyone's observations to a species list you own.)\n\nIn another method, you may select '[:app_create_list]' directly from any index of observations or names.  For example, you may use the search bar at the top of the page or the '\"[:app_advanced_search]\":/search/advanced' feature to request all observations from Michigan.  When it shows you the first page of results, click '[:app_create_list]' (in the left-hand panel), and it will give you a list of all the matching names to choose from in the new species list form.\n\nLastly, when you are viewing an existing species list, you may click '[:species_list_show_clone_list]' or '[:species_list_show_set_source]' at the top of the page.  '[:species_list_show_clone_list]' will take you directly to a new species list form, with all the information of the existing list already filled in.  '[:species_list_show_set_source]' will copy that species list's names to the clipboard.  The next time you click '[:app_create_list]', the new species list form will give you this list of names to choose from (unless you show another observation or name index in the meantime)."
+
+  # Note, glossary terms should appear in alphabetical order.
+  how_glossary_body:  "#(#comment)       [:how_comment]\n#(#image)         [:how_image]\n#(#license)       [:how_license]\n#(#location)      [:how_location]\n#(#name)          [:how_name]\n#(#observation)   [:how_observation]\n#(#proposed_name) [:how_proposed_name]\n#(#description)   [:how_description]\n#(#species_list)  [:how_species_list]\n#(#user)          [:how_user]\n#(#vote)          [:how_vote]"
+  how_comment:  "*Comment* - Comments are the standard way to discuss an \"Observation\":#observation or its associated \"Images\":#image.  Each comment is owned by a particular \"User\":#user.  A comment may only be edited or deleted by the owner or a site administrator.  You can look up all comments that have been made about your observations by clicking on '\"[:show_user_comments_for_you]\":/comment/show_comments_for_user' in the upper right of the page (the 'inbox' icon)."
+  how_contribution:  "*Contribution* - A number or score that measures the quantity and quality of contributions a \"User\":#user has made to [:app_title].  Click '[:app_your_summary]' to see a break-down of your own contribution.  You earn points for every \"Observation\":#observation, \"Image\":#image, \"Comment\":#comment, etc. you have posted.  \"Describing Species\":#describing_species and \"Defining Locations\":defining_locations are some of the most important contributions a user can make.  (See \"How To Help\":/info/how_to_help for a list of other ways to help out.) Currently, contribution is used only in weighting your \"Votes\":#vote when voting on \"Proposed Names\":#proposed_names for observations."
+  how_description:  "*Species Description* - A collection of text describing a \"Name\":#name. Every name automatically gets one official description that everyone in the community is allowed to read and modify.  Additional descriptions may be created by any \"User\":#user, including project members.  The owner of a description may choose any level of read or write permissions, and can control who is given authorship credit.  Since descriptions, especially the official one, are often collaborative efforts, modifications by a user are subject to community review, and past versions are kept to facilitate this process.  The content of a description includes a set list of sections, including things like '[:form_names_gen_desc]', '[:form_names_diag_desc]', '[:form_names_look_alikes]', '[:form_names_refs]' and other notes."
+  how_image:  "*Image* - A photograph or illustration of one or more mushroom species. Images are associated with one or more \"Observations\":#observation.  A given Image is owned by a particular \"User\":#user who may or may not be the copyright holder.  Only the owner or a site administrator can remove an image or edit the associated information.  All images in the site are required to be released under one of the \"Creative Commons licenses\":http://creativecommons.org or in the public domain.  If you dispute the given copyright or the licensing of an image you are the copyright holder of, send mail to the \"webmaster\":/emails/ask_webmaster_question."
+  how_license:  "*License* - \"Images\":#image on [:app_title] are posted with an explicit license.  The current options are the \"Creative Commons Attribution, Share Alike License\":http://creativecommons.org/licenses/by-sa/3.0/, the \"Creative Commons Attribution, Non-Commercial, Share Alike License\":http://creativecommons.org/licenses/by-nc-sa/3.0/ and \"Public Domain\":http://wiki.creativecommons.org/Public_domain/.  The primary difference is whether the image can be used in any potentially commercial setting.  One of the side effects of selecting the non-commercial license is that your image cannot be used on \"Wikipedia\":http://wikipedia.org.  The license can be set on a per image basis.  The looser, Wikipedia compatible license is the default for new \"Users\":#user.  However, you can select the non-commercial license to be your default by selecting it on your '\"[:app_preferences]\":/account/prefs' page and clicking on '[:SAVE_CHANGES]'.  Public domain is supported primarily for images that are already in the public domain or for images from certain government institutions that cannot claim ownership of works"
+  how_location:  "*Location* - A rectangular region enclosing a given location, as defined by the northern, southern, eastern and western boundaries.  In addition to the position, locations can also include a minimum and maximum elevation along with various notes.  Note that the elevations should be in meters not feet. A location is not considered to be owned by a particular \"User\":#user.  Any user may change or define any location, but all of a user's changes are subject to review by the community.  To help with this review process, copies of the previous versions are kept."
+  how_name:  "*Name* - A name for some group of mushrooms.  Most commonly this is the name of a species, but it can be any taxon (genus, family, variety, etc.).  Names can also refer to groups that are not officially recognized scientific names such as common names or functional groups like Gasteromyces.  A name is *not* considered to be owned by a particular \"User\":#user.  Any user may change any name, but all changes are subject to review by the community.  To help with this review process, copies of previous versions are kept.  Names can have an acknowledged author.  The author is normally only given for scientific names. The author should follow the standard practice of listing the person who first correctly published the name.  In the case of names at or below the species level, the author may also include the person who transfered the species to the current genus, e.g., (Singer) Jenkins."
+  how_observation:  "*Observation* - A record of a single mushroom species at a particular time and \"Location\":#location.  Typically associated with one or more \"Names\":#name (see \"Proposed Name\":#proposed_name below) and some number of \"Images\":#image.  Each observation is owned by a \"User\":#user, and can only be edited or deleted by that user or a site administrator.  However, any user may post \"Comments\":#comment about any observation.  Observations can also be included in one or more \"Species Lists\":#species_list."
+  how_proposed_name:  "*Proposed Name* - A \"Name\":#name as proposed for a given \"Observation\":#observation.  Any number of names may be proposed for a single observation by members of the community.  No special treatment is given to any member's name.  Community consensus is arrived at through the process of \"voting\":#voting.  Each proposed name for an observation is owned by a single \"User\":#user.  However, even the user who proposed the name cannot necessarily modify or delete a name once other members of the community have cast \"Votes\":#vote for or against it.  Fortunately you may always propose additional names.  There is never any sort of penalty associated with proposing incorrect names."
+  how_species_list:  "*Species List* - A list of \"Observations\":#observation (not \"Names\":#name). Includes a date, a \"Location\":#location and a title for the list.  A given species list is owned by a particular \"User\":#user.  Only the owner or a site administrator can change or delete a species list.  There are no strict rules for how species lists should be used.  This is an area that is likely to change in the future as the community comes up with clearer ideas for how they should be used."
+  how_user:  "*User* - An account on [:app_title].  You are required to provide a valid email address when you first create an account.  This allows the system to stop automated programs from creating bogus accounts.  It also provides a way for other users to get in touch with you.  However, your email address will never be revealed unless you request an email be sent to another user and then only to that user.  If you are concerned about having your email address in our database, once you have verified your account, you can go to the '\"[:app_preferences]\":/account/prefs' page and remove your address."
+  how_vote:  "*Vote* - One \"User's\":#user vote on a \"Proposed Name\":#proposed_name for a given \"Observation\":#observation.  Expresses a level of confidence or agreement with that name, with half the choices (\"[min_pos_vote]\" and up) being positive and half (\"[min_neg_vote]\" and below) being negative.  Votes are owned by that user, and can only be changed or deleted by the owner or a site administrator."
+
+  # Location help
+  location_help_title:  Locations in Mushroom Observer
+  location_help_intro:  "The Mushroom Observer provides two ways to represent the geographic location of an observation.  The simplest are latitude and longitude positions associated with the observation.  Please keep these accurate to within at least 300 meters (or about 1000 feet).  However, the more widely used method is a simple phrase describing the location.  For example, \"Beebe Woods, Falmouth, Massachusetts, USA\". The goal of these location names is to provide a consistent, reusable way of talking about where an observation was made without necessarily revealing a precise \"spot\". If you are comfortable provide more precise lat/longs for an observation, the location names are still useful for searches so you are encouraged to provide them as well.  The location names should, by default, go from the smallest contained area to the country name.  If you prefer to describe your locations as going from the largest (country) down to the smallest contained area, you can change your preference from the default, \"Postal\", to \"Scientific\" on your preference page.  There are cases such as \"Great Smoky Mountains National Park, Blount Co., Tennessee, USA\", where the area you are describing overlaps a number of counties, states or even countries.  In these cases, the country and other official political boundaries should come at the end as shown in the example.\n\nOriginally, the Mushroom Observer was very loose about these location names, hoping that the users would create a reasonably consistent set of rules and correct each other.  After about four years and thousands of location names, we found that there were rules emerging, but they were not applied at all consistently and people were not tending to directly correct each other. Consequently, we have tried to codify these rules and when reasonable to provide warnings if you attempt to create a new location that violates these rules. It is not always possible to correct identify \"bad\" locations, so if you get some warnings, but after reviewing the location decide it should be \"good\", then simply resubmitting the form will force the name into the database. However, all new location names will get reviewed regularly and may get changed to better fit the consensus rules.  Below are some examples of \"bad\" and \"good\" location names followed by a more detailed explanation of the current rules. Each example is labeled with the following section that explains the example in more detail.  These rules are by no means set it stone and we encourage the discussion and revision of them."
+  location_help_example_help:  These are cases that are not detected automatically, so no warning would be given.
+  location_help_example_title:  Some examples
+  location_help_bad:  Bad
+  location_help_good:  Good
+  location_help_explanation:  Explanation
+  location_help_rules_title:  The Current "Rules"
+  location_help_rule_reversible:  "*Consistent and Reversible Order* - You can now ask for location names to appear in the reverse order from the default. Thus, you can see a location as either:\n\nAlbion, California, USA\n\nor as\n\nUSA, California, Albion\n\nYou can change this on your Preferences page by selecting 'Postal' (the default) or 'Scientific' (the one that starts with the country).  When you input new location names it will of course also follow your preferred order.\n\nRoy Halling was the inspiration for this feature when he started putting in his locations starting with the country names and we got into a discussion about it. Apparently the standard practice in the scientific community is to start with the largest locale (typically a country) and work down to the smallest locale (a county, town or specific location).  From looking through all the locations that have been put into MO, it is clear that most people expect to put in the smallest location first and work up to the country.\n\nIn order to enable this feature, I have had to require that the place names be easily and consistently reversible.  This means you must separate each section of the location with a ', ' (no period, no missing spaces, no double spaces). It also means that you should always enter the names in order of increasing size when you can.  There are some specific exceptions to this rule that are discussed below."
+  location_help_rule_countries:  "*Use Country Names* - As a further check when you enter an unfamiliar location, it will check to see that the largest locale has been previously entered for some other location.  This list currently consists of only countries, continents and the special location 'Unknown'. Since it does not include all possible countries, it is still possible to override the check by resubmitting the same name twice.  Such entries will be reviewed carefully to ensure that this list remains clean.  For now you should only enter country names as they are written in English.  For example, please use 'Germany' rather than 'Deutschland'.  The goal for the moment is simply consistency.  However, the long term goal is to actually allow these names to be consistently translated based on the user's language selection.  Continents should only be used if the country is not known or there is no country."
+  location_help_rule_states:  "*Use State Names* - In the case of countries where I know the states, I also check for those as the next smallest area within a country.  At the moment I am checking this for Canada, Australia and USA.  The primary goal of this in the US at least is to ensure the uniqueness of the next element in the list.  In the US it is not unusual to have the same city or county name in more than one state. If there are other countries where this check would be useful, please let me know and include an exhaustive list of all states, provinces, territories etc. To increase the understandability to people from other parts of the world, state abbreviations (even extremely standard ones) are discouraged and will create a warning.  The one current exception is 'Washington DC'.  Many people are not aware of what the 'DC' stands for and would be unlikely to enter 'Washington, District of Columbia'.  Note that in this case I have also removed the ', ' since that would cause 'USA, DC, Washington' when in 'Scientific' mode."
+  location_help_rule_counties:  "*Counties OR Cities* - In the past, MO has encouraged the use of county names whenever they are known.  The new policy is that the county should only be included when it is the smallest political area the location is contained in or when the city or town name is ambiguous.  For example, what used to be described as \"Berkeley, Alameda Co., California, USA\" should now be given as just \"Berkeley, California, USA\".  This change is in part due to seeing what people actually do.  Generally people have been good about using county names in the case of public lands like parks and national forests where the county is the most obvious political boundary.  However, with cities and towns people often don't know what county a city or town is in.  In addition, the information is typically redundant for towns and cities in the US where they are almost always completely contained in county or they are independent of the counties and there are almost never two towns with same names in a state (there are exceptions though such as Goshen, Vermont). I've also found that many of the map services such as maps.google.com and maps.yahoo.com get confused if you include both the city and the county in the search string.\n\nThat being said, there are also often areas that have a local name, but are not actually an incorporated city or town.  In these cases the county name is encouraged since the names cannot be assumed to be unique.  For example, \"North Lakeport, Lake Co., California, USA\".  Wikipedia has been the most helpful resource I've found for determining if a town is actually incorporated."
+  location_help_rule_near:  "*Use 'near'* - If there is a landmark or town near to the collection location, but the smallest political boundary is a county or country, then it is helpful to mention this using the word \"near\".  When used this way it should always be all lowercase.  For example, \"Albis Mountain Range, near Zurich, Switzerland\".  Looking through the old data, I found users used both \"near\" and \"area\" for this with \"near\" being more common.  This is also better because \"area\" sometimes gets used for place names such as \"Day-Use Area\" or \"Rest Area\"."
+  location_help_rule_southern:  "*Use of 'Southern', 'Northern' etc.* - If there isn't a known a clear landmark or town near the collection location, it is fine to use compass directions such as 'Southern', 'Northern', 'Southwestern' etc.  In these cases always use the '-ern' ending to indicate that it's descriptive.  However, these terms should be avoided if it creates ambiguity.  For example, \"Western Australia\" is the name of an official state in Australia, so it should only be used as such and should be followed by the country name."
+  location_help_rule_abbr:  "*Avoid Abbreviations (and Periods in General)* - Most abbreviations should be avoided since people apply them somewhat arbitrarily and inconsistently.  The following are examples of abbreviations that should definitely be avoided: Hwy, Mt, Mtn, CA, BC.  However, there are some specific examples, that should be used in preference to there spelled out versions.  These are:\n\nCo. for County\nRd. for Road\nSt. for Street\nAve. for Avenue\nBlvd. for Boulevard\nUSA for United States of America\nWashington DC for Washington, District of Columbia\n\n\nPeriods in general should be avoided except for the above abbreviations. They should not be used at the end of country names or as separators.\nFinally, 'and' should be used rather than '&'."
+  location_help_rule_other:  "*Other Things to Avoid* - All lowercase - In general at least the leading letter of each area should be capitalized and when in doubt capitalize every leading letter.\nNo lat/longs - There is now direct support for this for each observation. Do not include it in the name of a location.\nNo habitat info - Habitat info should go in the notes for the observation.\nParentheses and Braces - If you're tempted to use parentheses or braces, stop yourself and ask if this information should be in the notes for the observation or if there is a better way to describe the location.\nAvoid diacritics (eg é, ü etc.) - As mentioned when discussing country names, you should try to use the English version of a location name when possible and English does not include diacritics.  This is intended to encourage consistency and we are planning on providing proper support for other languages which will benefit from this consistency.  There are certainly cases where the a city or region is only know by a name that includes diacritics.  In these cases they should be used. A few simple web-searches should give you a good idea if there is a common English variation of a name (e.g., Montreal, Quebec for Montréal, Québec)."
+  location_help_rule_good_habits:  "*Stuff You Are Encouraged to Do* - If you are creating a new name, take some time to figure out a good name. Searching within Mushroom Observer can be helpful.  If you don't find anything there, then look things up in Google Maps (http://maps.google.com) and Wikipedia (http://wikipedia.org). Also feel free to use the notes section of either an observation or a location to be more specific."
+
+  # Search bar help
+  pattern_search_terms_help:  "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.  Recognized variables include:"
+
+  observation_term_date: "Фінікавы грыб назіраўся;\nYYYY-MM-DD, YYYY or MM; дыяпазоны ў парадку."
+  observation_term_created:  Date observation was first posted.
+  observation_term_modified: Дата апошняга змянення назірання.
+  observation_term_name:  Consensus name is one of these names.
+  observation_term_exclude_consensus:  Exclude Observations whose consensus is a name listed in "name:value". (When using exclude_consensus you must also use "include_all_name_proposals:yes".)
+  observation_term_include_all_name_proposals:  Include all name proposals, not just the consensus.
+  observation_term_include_subtaxa:  Include observations of subtaxa of the given names.
+  observation_term_include_synonyms:  Include observations of synonyms of the given names.
+  observation_term_herbarium:  Specimen at a fungarium.
+  observation_term_location: "Размяшчэнне (\"[:WHERE]\") назіраўся грыб. Павінен цалкам адпавядаць\n[:WHERE] поле. Звярніце ўвагу, што коскі павінны быць абаронены зваротнай касой рысай: \"Albion\\, California\\, USA\"."
+  observation_term_region:  Location mushroom was observed. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a back-slash as shown.
+  observation_term_project:  Observation belongs to one of these projects.
+  observation_term_project_lists:  Observation belongs to list in one of these projects.
+  observation_term_list:  Observation belongs to one of these species lists.
+  observation_term_user: Назіранне створана адным з гэтых карыстальнікаў.
+  observation_term_notes: Notes змяшчае зададзены радок.
+  observation_term_comments:  Comments contain the given string.
+  observation_term_confidence:  Confidence is in this range.
+  observation_term_east:  Longitude of eastern edge of search region.
+  observation_term_west:  Longitude of western edge of search region.
+  observation_term_north:  Latitude of northern edge of search region.
+  observation_term_south:  Latitude of southern edge of search region.
+  observation_term_images:  Has images? ("yes" or "no")
+  observation_term_sequence: Мае паслядоўнасць?
+  observation_term_specimen: Ёсць узор?
+  observation_term_lichen:  "\"no\" = exclude lichens, \"yes\" = include only lichens."
+  observation_term_has_name:  Has a name? (other than "Fungi sp.")
+  observation_term_has_notes:  Has Notes?
+  observation_term_has_location:  Are the [:OBSERVATION]'s [:LATITUDE] and [:LONGITUDE] fields filled in?
+  observation_term_has_field:  Has a given notes template field filled in.
+  observation_term_has_comments:  Has any comments?
+  observation_term_is_collection_location:  Mushroom was growing at the location. ("[:form_observations_is_collection_location]" is checked.)
+
+  name_term_created:  Date name was first used.
+  name_term_modified: Дата апошняга змянення назвы.
+  name_term_rank:  Rank or range of ranks, e.g., "genus" or "species-form".
+  name_term_include_synonyms:  Include synonyms of the given names.
+  name_term_include_subtaxa:  Include subtaxa of the given names.
+  name_term_has_observations:  Only names for which we have observations?
+  name_term_has_synonyms:  Has any synonyms?
+  name_term_deprecated:  "\"no\" = only accepted names, \"yes\" = only deprecated names."
+  name_term_include_misspellings:  "\"no\" = ignore misspelled names (default), \"yes\" = only misspelled names, \"either\" = ignore whether names are misspelled or not."
+  name_term_lichen:  "\"no\" = exclude lichens, \"yes\" = include only lichens."
+  name_term_has_author:  Has Author filled in?
+  name_term_has_citation:  Has Citation filled in?
+  name_term_has_classification:  Has Classification filled in?
+  name_term_has_notes:  "[:form_names_taxonomic_notes] filled in?"
+  name_term_has_comments:  Has any Comments?
+  name_term_has_description:  Has a public description?
+  name_term_author:  Author contains this string.
+  name_term_citation:  Citation contains this string.
+  name_term_classification:  Classification contains this string.
+  name_term_notes:  "[:form_names_taxonomic_notes] contains this string."
+  name_term_comments:  At least one Comment contains this string.
+
+  # link to search bar help
+  search_bar_help: Даведка па пошуку
+
+  # Search bar help page
+  search_bar_help_title: Даведка па пошуку
+
+  # Privacy policy
+  privacy_title: Палітыка прыватнасці Mushroom Observer
+
+  privacy_last_modified:  _Last Modified on November 30, 2019_
+
+  privacy_intro_header: "*Уводзіны*"
+  privacy_intro_content:  "This Privacy Policy explains how Mushroom Observer, Inc., the non-profit organization that hosts the Mushroom Observer website, collects, uses, and shares information we receive from you through your use of the website. It is essential to understand that, by using the Mushroom Observer website, you consent to the collection, transfer, processing, storage, disclosure, and use of your information as described in this Privacy Policy.\n\nWe believe that you shouldn't have to provide nonpublic personal information to participate in the free knowledge movement, citizen science, or mycology in general. You do not have to provide things like your real name, address, or date of birth to sign up for an account or contribute content to the Mushroom Observer.\n\nThis privacy policy is in large part derived from the current (July 2019) \"privacy policy of the Wikimedia Foundation\":https://foundation.wikimedia.org/wiki/Privacy_policy and is used in accordance with \"the Creative Commons Attribution-ShareAlike License\":https://creativecommons.org/licenses/by-sa/3.0/ and the Wikimedia Foundation \"Terms of Use\":https://foundation.wikimedia.org/wiki/Terms_of_Use/en."
+
+  privacy_definitions_header:  "*Definitions*"
+  privacy_definitions_content:  "Because everyone (not just lawyers) should be able to easily understand how and why their information is collected and used, we use common language instead of more formal terms throughout this Policy. To help ensure your understanding of some particular key terms, here is a table of translations:"
+
+  privacy_when_we_say:  When we say...
+  privacy_we_mean:  "... we mean"
+  privacy_mo_inc_say:  “Mushroom Observer, Inc”, “we”, “us”, “our”
+  privacy_mo_inc_mean:  The non-profit organization that operates the Mushroom Observer website.
+  privacy_mo_website_say:  “Mushroom Observer”, “MO”, “the website”
+  privacy_mo_website_mean:  The Mushroom Observer website, https://mushroomobserver.org and subdomains that provide text, images and APIs.
+  privacy_you_say:  “you”, “your”
+  privacy_you_mean:  You, regardless of whether you are an individual, group, or organization, and regardless of whether you are using the Mushroom Observer or our services on behalf of yourself or someone else.
+  privacy_this_policy_say:  “this Policy”, “this Privacy Policy”
+  privacy_this_policy_mean:  This document, entitled “The Mushroom Observer Privacy Policy”.
+  privacy_contributions_say:  “contributions”
+  privacy_contributions_mean:  Content you add or changes you make to the Mushroom Observer.
+  privacy_personal_info_say:  “personal information”
+  privacy_personal_info_mean:  "Information you provide us or information we collect from you that could be used to personally identify you. To be clear, while we do not necessarily collect all of the following types of information, we consider at least the following to be “personal information” if it is otherwise nonpublic and can be used to identify you:\na) your real name, address, phone number, email address, password, identification number on government-issued ID, IP address, user-agent information, credit card number;\nb) when associated with one of the items in subsection a), any sensitive data such as date of birth, gender, sexual orientation, racial or ethnic origins, marital or familial status, medical conditions or disabilities, political affiliation, and religion; and\nc) any of the items in subsections a) or b) when associated with your user account."
+  privacy_third_party_say:  “third party”, “third parties”
+  privacy_third_party_mean:  Individuals, entities, websites, services, products, and applications that are not controlled, managed, or operated by Mushroom Observer, Inc. This includes other Mushroom Observer users and independent organizations or groups who use the Mushroom Observer.
+
+  privacy_covers_header:  "*What This Privacy Policy Does & Doesn't Cover*"
+  privacy_covers_content:  Except as explained below, this Privacy Policy applies to our collection and handling of information about you that we receive as a result of your use of the Mushroom Observer. This Policy also applies to information that we receive from any third parties.
+
+  privacy_types_of_information_header:  "*Types of Information We Receive From You & How We Get It*"
+  privacy_public_contributions:  "Your Public Contributions\n\nOther than the email, password, and settings managed on your preferences page, whatever you post on the Mushroom Observer can be seen and used by everyone.\n\nWhen you make a contribution to the Mushroom Observer you are creating a potentially permanent, public record of every piece of content added, removed, or altered by you. The page history will show when your contribution or deletion was made, as well as your username. We may use your public contributions, either aggregated with the public contributions of others or individually, to create new features or data-related products for you or to learn more about how the Mushroom Observer is used.\n\nAnything in your public contributions is by definition not personal information.  We can take no responsibility if you happen to include what could be interpreted as personal information to your public contributions."
+
+  privacy_account_info:  "Account Information & Registration\n\nYou do not need to create an account to read the public information managed by the Mushroom Observer.\n\nIf you do create an account, you must provide an email address to activate the account.  After your account is activated you may change or delete this address through your preferences page."
+
+  privacy_location_info:  "Location Information\n\nMetadata\nSometimes, we automatically receive location data from your device. For example, if you upload a photo to the website, we may receive metadata, such as the place and time you took the photo, automatically from your device. Please be aware that the default setting on most mobile devices typically includes the metadata in your photo or video that you upload. If you do not want metadata sent to us and made public at the time of your upload, please change your settings on your device or remove this data using available third party image processing tools.\n\nIP Addresses\nFinally, when you visit the Mushroom Observer, we automatically receive the IP address of the device (or your proxy server) you are using to access the Internet, which could be used to infer your geographical location."
+
+  privacy_usage_info:  "Information Related to Your Use of the Mushroom Observer\n\nWe use certain technologies to collect information about how you use the Mushroom Observer.  Like other websites, we receive some information about you automatically when you visit the Mushroom Observer.\n\nWe also use a variety of commonly-used technologies, like cookies, to collect information regarding how you use the Mushroom Observer, make our services safer and easier to use, and to help create a better and more customizable experience for you.\n\nInformation We Receive Automatically\nBecause of how browsers work, we receive some information automatically when you visit the Mushroom Observer. This information includes the type of device you are using, the type and version of your browser, your browser's language preference, the type and version of your device's operating system, in some cases the name of your internet service provider or mobile carrier, the website that referred you to the Mushroom Observer, which pages you request and visit, and the date and time of each request you make to the Mushroom Observer.\n\nPut simply, we use this information to enhance your experience with the Mushroom Observer. For example, we use this information to administer the sites, provide greater security, and fight vandalism; optimize our applications, customize content and set language preferences, test features to see what works, and improve performance; understand how users interact with the Mushroom Observer, track and study use of various features, and analyze trends.\n\nInformation We Collect\nWe use a variety of commonly-used technologies, like cookies, to improve your experience on the Mushroom Observer. We realize that some websites use cookies for less-than-noble purposes. So we want to be as clear as we can about why we use them.\n\nWe simply use them to recognize who you are from page request to page request so we can look up the user information you have provided in your preferences (like your username, configuration options, email, or theme).\n\nWe use this information to make your experience with the Mushroom Observer better and to generally improve our services. We do not use third-party cookies. If you ever come across a third-party data collection tool that has not been authorized by you (such as one that may have been mistakenly placed by another user or administrator), please report it to us at webmaster@mushroomobserver.org."
+
+  privacy_when_we_share_info_header:  "*When May We Share Your Information?*"
+  privacy_when_we_share_info_content:  "With Your Permission\nWe may share your information when you give us specific permission to do so, for legal reasons, and in the other circumstances described below.  For example, when you request that we send an email to another user, we will share your email with the recipient so they can respond to you.  We do not manage or track any resulting email dialog between you and the other user you have asked us to send an email to.  We do not send your email to other users who request that we send an email to you.\n\nFor Legal Reasons\nWe will access, use, preserve, and/or disclose your Personal Information if we reasonably believe it necessary to satisfy a valid and legally enforceable warrant, subpoena, court order, law or regulation, or other judicial or administrative order. However, if we believe that a particular request for disclosure of a user's information is legally invalid or an abuse of the legal system and the affected user does not intend to oppose the disclosure themselves, we will try our best to fight it. We are committed to notifying you via email at least ten (10) calendar days, when possible, before we disclose your Personal Information in response to a legal demand. However, we may only provide notice if we are not legally restrained from contacting you, there is no credible threat to life or limb that is created or increased by disclosing the request, and you have provided us with a currently valid email address.\n\nNothing in this Privacy Policy is intended to limit any legal objections or defenses you may have to a third party's request (whether it be civil, criminal, or governmental) to disclose your information. We recommend seeking the advice of legal counsel immediately if such a request is made involving you.\n\nIf the Organization is Transferred (Really Unlikely!)\nIn the unlikely event that the ownership of Mushroom Observer, Inc. changes, we will provide you 30 days’ notice before any personal information is transferred to the new owners or becomes subject to a different privacy policy.\n\nIn the extremely unlikely event that ownership of all or substantially all of Mushroom Observer changes, or we go through a reorganization (such as a merger, consolidation, or acquisition), we will continue to keep your Personal Information confidential, except as provided in this Policy, and provide notice to you via the Mushroom Observer website and a notification on any appropriate Mushroom Observer mailing or online forum at least thirty (30) calendar days before any Personal Information is transferred or becomes subject to a different privacy policy.\n\nTo Protect You, Ourselves & Others\nWe, or users with certain administrative rights, may disclose information that is reasonably necessary to enforce or investigate potential violations of the Mushroom Observer policies; protect our organization, infrastructure, employees, contractors, or the public; or prevent imminent or serious bodily harm or death to a person.\n\nWe, or particular users with certain administrative rights as described below, may need to share your Personal Information if it is reasonably believed to be necessary to enforce or investigate potential violations of our Terms of Use, this Privacy Policy, or any other Mushroom Observer policies. We may also need to access and share information to investigate and defend ourselves against legal threats or actions.\n\nThe Mushroom Observer is a collaborative effort, with volunteer users like you writing most of the policies and selecting from among themselves people to hold certain administrative rights. These rights may include access to limited amounts of otherwise nonpublic information about recent contributions and activity by other users. They use this access to help protect against vandalism and abuse, fight harassment of other users, and generally try to minimize disruptive behavior on the Mushroom Observer. All such individual agree to enforce this Privacy Policy.\n\nWe hope that this never comes up, but we may disclose your Personal Information if we believe that it's reasonably necessary to prevent imminent and serious bodily harm or death to a person, or to protect our organization, employees, contractors, users, or the public. We may also disclose your Personal Information if we reasonably believe it necessary to detect, prevent, or otherwise assess and address potential spam, malware, fraud, abuse, unlawful activity, and security or technical concerns.\n\nBecause You Made It Public\nInformation that you post is public and can been seen and used by everyone.\n\nAny information you post publicly on the Mushroom Observer is just that – public. For example, if you put your mailing address in one of your comments, that is public, and not protected by this Policy. Please think carefully about your desired level of anonymity before you disclose Personal Information on your user page or elsewhere."
+
+  privacy_how_we_protect_header:  "*How Do We Protect Your Data?*"
+  privacy_how_we_protect_content:  "We strive to protect your information from unauthorized access, use, or disclosure. We use a variety of physical and technical measures, policies, and procedures (such as access control procedures, network firewalls, and physical security) designed to protect our systems and your Personal Information. Unfortunately, there's no such thing as completely secure data transmission or storage, so we can't guarantee that our security will not be breached (by technical measures or through violation of our policies and procedures).\n\nWe will never ask for your password by email. If you ever receive an email that requests your password, please let us know by sending it to webmaster@mushroomobserver.org, so we can investigate the source of the email."
+
+  privacy_how_long_do_we_keep_data_header:  "*How Long Do We Keep Your Data?*"
+  privacy_how_long_do_we_keep_data_content:  "We store your Personal Information for an indefinite amount of time.  You are free to edit most of this information through your preference page.\n\nPlease remember that certain information, such as your IP address, username, and any public contributions to the Mushroom Observer, is archived and displayed indefinitely by design; the transparency of the projects’ contribution and revision histories is critical to their efficacy and trustworthiness.\n\nFor the protection of the Mushroom Observer and other users, if you do not agree with this Privacy Policy, you may not use the Mushroom Observer."
+
+  privacy_where_is_mo_header:  "*Where is Mushroom Observer, Inc. & What Does That Mean for Me?*"
+  privacy_where_is_mo_content:  Mushroom Observer, Inc. is a non-profit organization incorporated in Massachusetts, with servers and data centers located in the U.S. If you decide to use the Mushroom Observer, whether from inside or outside of the U.S., you understand that your Personal Information will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this Privacy Policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you.
+
+  privacy_do_not_track_header:  "*Our Response to Do Not Track (DNT) signals*"
+  privacy_do_not_track_content:  "We do not allow tracking by third-party websites you have not visited.\n\nWe do not share your data with third parties for marketing purposes.\n\nWe are strongly committed to not sharing nonpublic information and Personal Information with third parties. In particular, we do not allow tracking by third-party websites you have not visited (including analytics services, advertising networks, and social platforms), nor do we share your Personal Information with any third parties for marketing purposes. Under this Policy, we may share your information only under particular situations, which you can learn more about in the “When May We Share Your Information” section of this Privacy Policy.\n\nBecause we protect all users in this manner, we do not change our behavior in response to a web browser's \"do not track\" signal."
+
+  privacy_changes_header:  "*Changes to This Privacy Policy*"
+  privacy_changes_content:  Because things naturally change over time and we want to ensure our Privacy Policy accurately reflects our practices and the law, it may be necessary to modify this Privacy Policy from time to time. We will announce any such changes in the website banner and through any appropriate mailing list or online forum.  When possible we will announce these change 30 days ahead of them taking effect and will welcome comments and proposed changes during this time.
+
+  privacy_contact_us_header:  "*Contact Us*"
+  privacy_contact_us_content:  "If you have questions or suggestions about this Privacy Policy, or the information collected under this Privacy Policy, please email us at webmaster@mushroomobserver.org.\n\nDepending on your jurisdiction, you also may have the right to lodge a complaint with a supervisory authority competent for your country or region."
+
+  privacy_thank_you_header:  "*Thank You!*"
+  privacy_thank_you_content:  Thank you for reading our Privacy Policy. We hope you enjoy using the Mushroom Observer and appreciate your participation in creating, maintaining, and constantly working to improve the largest repository of fungal observations in the world.
+
+  ##############################################################################
+
+  # ERROR MESSAGES
+
+  unsuccessful_contributor_warning:  Thanks for wanting to contribute to the Mushroom Observer. This type of contribution can only be made by users who have provided at least one observation to the system.
+
+  # ActiveRecord validation error messages.
+  validate_confirmation_mismatch:  "[Field] doesn't match confirmation."
+  validate_invalid:  Invalid [field].
+  validate_invalid_url:  Invalid URL.
+  validate_missing:  Missing [field].
+  validate_not_a_number:  "[Field] is not a number."
+  validate_not_in_range:  "[Field] is out of range."
+  validate_this_more_than_that:  "[That] should be greater than [this]."
+  validate_too_large:  "[Field] should be at most [max]."
+  validate_too_long:  "[Field] must be less than [max] characters long."
+  validate_too_long_or_short:  "[Field] must be [min] to [max] characters long."
+  validate_too_many_characters:  "[Field] has too many characters."
+  validate_too_short:  "[Field] must be at least [min] characters long."
+  validate_too_small:  "[Field] should be at least [min]."
+  validate_too_small_or_large:  "[Field] should be between [min] and [max]."
+  validate_user_selection:  You selected
+  validate_today:  today is
+
+  # One-time-use error messages.
+  validate_image_content_type_images_only:  You can only upload [:images].
+  validate_image_file_missing:  Had problems uploading [:image].
+  validate_image_file_too_big:  We can't handle [:images] that big.  Please reduce it to less than [max] before uploading.
+  validate_image_md5_mismatch:  The MD5 sum did not come out right.  Please try uploading your image again.
+  validate_invalid_year:  Year is invalid.  Should be between 1500 and present.
+  validate_future_time:  Time travel is not allowed; use a past date or the current date.
+  validate_observation_thumb_image_id_invalid:  Unable to find a corresponding [:image] for thumbnail.
+  validate_observation_where_missing: Раскажыце, калі ласка, дзе гэта было заўважана або сабрана.
+  validate_user_email_missing: Калі ласка, дайце нам сапраўдны адрас электроннай пошты, каб мы маглі праверыць ваш [:account].
+  validate_user_email_mismatch: Вашы адрасы электроннай пошты не супадаюць. Калі ласка, праверце памылку друку.
+  validate_user_login_taken: На жаль, гэта імя для ўваходу ўжо занята.
+  validate_image_wrong_type:  The file "[file]" is not a valid image; it is comes through as '[type]'.
+  validate_invalid_lifeform:  "Invalid lifeform word(s): [words].  We are strictly enforcing which types are allowed.  If you would like us to add support to additional lifeforms, please contact the admins and make your case."
+
+  # These shouldn't need translating, but you are free to override if you need to.
+  validate_comment_object_type_too_long:  "[:validate_too_long(field=''object_type'',max=30)]"
+  validate_comment_summary_missing:  "[:validate_missing(field=:summary)]"
+  validate_comment_summary_too_long:  "[:validate_too_long(field=:summary,max=100)]"
+  validate_comment_user_missing:  "[:validate_missing(field=:user)]"
+  validate_image_content_type_too_long:  "[:validate_too_long(field=''content_type'',max=100)]"
+  validate_image_copyright_holder_too_long:  "[:validate_too_long(field=:copyright_holder,max=100)]"
+  validate_image_title_too_long:  "[:validate_too_long(field=:title,max=100)]"
+  validate_image_user_missing:  "[:validate_missing(field=:user)]"
+  validate_image_when_missing:  "[:validate_missing(field=:date)]"
+  validate_interest_object_type_too_long:  "[:validate_too_long(field=''object_type'',max=30)]"
+  validate_interest_user_missing:  "[:validate_missing(field=:user)]"
+  validate_location_name_too_long:  "[:validate_too_long(field=''name'',max=1024)]"
+  validate_location_east_out_of_bounds:  "[:validate_too_small_or_large(field=:longitude,min=-180,max=180)]"
+  validate_location_high_less_than_low:  "[:validate_this_more_than_that(this=:low,that=:high)]"
+  validate_location_north_less_than_south:  "[:validate_this_more_than_that(this=:south,that=:north)]"
+  validate_location_north_too_high:  "[:validate_too_large(field=:latitude,max=90)]"
+  validate_location_search_name_too_long:  "[:validate_too_long(field=''search_name'',max=200)]"
+  validate_location_south_too_low:  "[:validate_too_small(field=:latitude,min=-90)]"
+  validate_location_user_missing:  "[:validate_missing(field=:user)]"
+  validate_location_west_out_of_bounds:  "[:validate_too_small_or_large(field=:longitude,min=-180,max=180)]"
+  validate_name_author_too_long:  "[:validate_too_many_characters(field=:authority)]"
+  validate_name_shorten:  Shorten [:form_names_text_name] and/or [:AUTHORITY].
+  validate_name_text_name_too_long:  "[:validate_too_many_characters(field=:form_names_text_name)]"
+  validate_name_use_first_author:  Use the first author followed by “et al.” per <a href="http://www.iapt-taxon.org/nomen/main.php?page=art46" target="_new">ICN Recommendation 46C.2</a>
+  validate_name_user_missing:  "[:validate_missing(field=:user)]"
+  validate_naming_name_missing:  "[:validate_missing(field=:name)]"
+  validate_naming_observation_missing:  "[:validate_missing(field=:observation)]"
+  validate_naming_reason_naming_missing:  "[:validate_missing(field=:naming)]"
+  validate_naming_reason_reason_invalid:  "[:validate_invalid(field=''reason_code'')]"
+  validate_naming_user_missing:  "[:validate_missing(field=:user)]"
+  validate_notification_user_missing:  "[:validate_missing(field=:user)]"
+  validate_observation_user_missing:  "[:validate_missing(field=:user)]"
+  validate_observation_when_missing:  "[:validate_missing(field=:date)]"
+  validate_observation_where_too_long:  "[:validate_too_long(field=:location,max=1024)]"
+  validate_project_admin_group_missing:  "[:validate_missing(field=:admin_group)]"
+  validate_project_title_missing:  "[:validate_missing(field=:title)]"
+  validate_project_title_too_long:  "[:validate_too_long(field=:title,max=100)]"
+  validate_project_user_group_missing:  "[:validate_missing(field=:user_group)]"
+  validate_project_user_missing:  "[:validate_missing(field=:user)]"
+  validate_publication_ref_missing:  "[:validate_missing(field=:publication_full)]"
+  validate_species_list_title_missing:  "[:validate_missing(field=:title)]"
+  validate_sequence_accession_unique:  "[:ACCESSIONS] for an [:OBSERVATION] must be unique"
+  validate_sequence_bases_or_archive:  Must have [:BASES] or [:DEPOSIT]
+  validate_sequence_bases_blank_lines:  "[:BASES] cannot contain blank lines in middle"
+  validate_sequence_bases_bad_codes:  "[:BASES] contain invalid code(s)"
+  validate_sequence_bases_unique:  "[:BASES] for an [:OBSERVATION] must be unique"
+  validate_sequence_deposit_complete:  "[:DEPOSIT] must have both [:ARCHIVE] and [:ACCESSION], or neither [:ARCHIVE] nor [:ACCESSION]."
+  validate_species_list_title_too_long:  "[:validate_too_long(field=:title,max=100)]"
+  validate_species_list_user_missing:  "[:validate_missing(field=:user)]"
+  validate_species_list_where_missing:  "[:validate_missing(field=:location)]"
+  validate_species_list_where_too_long:  "[:validate_too_long(field=:location,max=100)]"
+  validate_user_email_too_long:  "[:validate_too_long(field=:email_address,max=80)]"
+  validate_user_email_confirmation_missing:  "[:validate_missing(field=:email_confirmation)]"
+  validate_user_login_missing:  "[:validate_missing(field=:login_name)]"
+  validate_user_login_too_long:  "[:validate_too_long_or_short(field=:login_name,min=3,max=40)]"
+  validate_user_name_too_long:  "[:validate_too_long(field=:full_name,max=80)]"
+  validate_user_password_confirmation_missing:  "[:validate_missing(field=:password_confirmation)]"
+  validate_user_password_missing:  "[:validate_missing(field=:password)]"
+  validate_user_password_no_match:  "[:validate_confirmation_mismatch(field=:password)]"
+  validate_user_password_too_long:  "[:validate_too_long_or_short(field=:password,min=5,max=40)]"
+  validate_user_theme_too_long:  "[:validate_too_long(field=''theme_name'',max=40)]"
+  validate_vote_naming_missing:  "[:validate_missing(field=:naming)]"
+  validate_vote_user_missing:  "[:validate_missing(field=:user)]"
+  validate_vote_value_missing:  "[:validate_missing(field=:confidence_level)]"
+  validate_vote_value_not_integer:  "[:validate_not_a_number(field=:vote)]"
+  validate_vote_value_out_of_bounds:  "[:validate_not_in_range(field=:vote)]"
+
+  # Runtime error and success messages.
+  runtime_added:  Successfully added [type].
+  runtime_added_id:  "Successfully added [type] #[value]."
+  runtime_added_id_to:  "Successfully added [type] #[value] to [name]."
+  runtime_added_name:  Successfully added [type] '[value]'.
+  runtime_added_name_to:  Successfully added [type] '[value]' to [name].
+  runtime_added_to:  Successfully added [type] to [name].
+  runtime_admin_only:  That operation is restricted to site admins.
+  runtime_already_exists:  "[Type] already exists: '[value]'"
+  runtime_already_used:  "[Type] is already in use: '[value]'"
+  runtime_created_at:  Successfully created [type].
+  runtime_created_id:  "Successfully created [type] #[value]."
+  runtime_created_name:  Successfully created [type] '[value]'.
+  runtime_date_invalid:  Invalid date.
+  runtime_date_should_be_yyyymmdd:  Date should be in year-month-day format.
+  runtime_delivered_message:  Successfully delivered message.
+  runtime_delivered_question:  Successfully delivered question.
+  runtime_delivered_request:  Successfully delivered request.
+  runtime_destroyed:  Successfully destroyed [type].
+  runtime_destroyed_id:  "Successfully destroyed [type] #[value]."
+  runtime_destroyed_name:  Successfully destroyed [type] '[value]'.
+  runtime_failed_to_strip_gps:  "Failed to strip GPS data from full-size image's EXIF header: [msg]"
+  runtime_invalid:  "[Type] is invalid: '[value]'"
+  runtime_lat_long_error:  "Latitude and longitude must be real numbers between -90 and 90, and -180 and 180 respectively. Use decimal notation or degrees/minutes/seconds. Examples:\n-123.4567\n123.4567 N\n123 27.402 N\n123 24 24.12 N\n123° 24’ 24.12” N\n123deg 24min 24.12sec N"
+  runtime_altitude_error:  "Elevation must be real number in feet or meters.  Feet will be converted to meters (default).  Examples:\n1234\n1234m\n4049'\n4049 ft."
+  runtime_merge_success:  Successfully merged [type] [src] into [dest].
+  runtime_missing:  Missing [field].
+  runtime_no_changes:  No changes made.
+  runtime_no_create:  Unable to create [type].
+  runtime_no_create_id:  "Unable to create [type] #[value]."
+  runtime_no_create_name:  Unable to create [type] '[value]'.
+  runtime_no_destroy:  Unable to destroy [type].
+  runtime_no_destroy_id:  "Unable to destroy [type] #[value]."
+  runtime_no_destroy_name:  Unable to destroy [type] '[value]'.
+  runtime_no_match:  Can't find [type].
+  runtime_no_match_id:  "Can't find [type] #[value]."
+  runtime_no_match_name:  Can't find [type] matching '[value]'.
+  runtime_no_matches:  No matching [types] found.
+  runtime_no_matches_pattern:  No [types] matching '[value]' found.
+  runtime_no_matches_regexp:  No [types] matching '[value]' found.
+  runtime_no_more:  There are no more [types].
+  runtime_no_objects:  There are no [types].
+  runtime_no_parse:  "Unable to parse: '[value]'"
+  runtime_no_save:  Unable to save [type].
+  runtime_no_update:  Unable to update [type].
+  runtime_no_update_id:  "Unable to update [type] #[value]."
+  runtime_no_update_name:  Unable to update [type] '[value]'.
+  runtime_not_owner:  You are not the owner of [type] '[value]'.
+  runtime_not_owner_id:  "You are not the owner of [type] #[value]."
+  runtime_removed:  Successfully removed [type].
+  runtime_removed_from:  Successfully removed [type] from [name].
+  runtime_removed_id:  "Successfully removed [type] #[value]."
+  runtime_removed_id_from:  "Successfully removed [type] #[value] from [name]."
+  runtime_removed_name:  Successfully removed [type] '[value]'.
+  runtime_removed_name_from:  Successfully removed [type] '[value]' from [name].
+  runtime_updated_at:  Successfully updated [type].
+  runtime_updated_id:  "Successfully updated [type] #[value]."
+  runtime_updated_name:  Successfully updated [type] '[value]'.
+  runtime_uploaded:  Successfully uploaded [type].
+  runtime_uploaded_id:  "Successfully uploaded [type] #[value]."
+  runtime_uploaded_name:  Successfully uploaded [type] '[value]'.
+  runtime_user_hasnt_authored:  "[user] hasn't written any [types]."
+  runtime_user_hasnt_created:  "[user] hasn't created any [types]."
+  runtime_user_hasnt_edited:  "[user] hasn't edited any [types]."
+
+  # One-time-use messages.
+  runtime_api_key_notes_cannot_be_blank:  Notes field cannot be blank.
+  runtime_bad_use_of_imageless:  The special name _Imageless_ was not intended for observations that were created as part of species lists or which have good documentation.  Please read the discussion under "_Imageless_":/name/show_name/31080.
+  runtime_dates_must_be_same_format:  If you give two dates, they must be the same format.
+  runtime_description_added_admin:  Gave admin permission to [name].
+  runtime_description_added_reader:  Gave view permission to [name].
+  runtime_description_added_writer:  Gave edit permission to [name].
+  runtime_description_copy_success:  Successfully copied the description.
+  runtime_description_merge_delete_denied:  You don't have permission to delete the old description.
+  runtime_description_merge_deleted:  "The old description was deleted: [old]"
+  runtime_description_merge_success:  Successfully merged the descriptions.
+  runtime_description_move_success:  Successfully moved the description.
+  runtime_description_private:  That description is private!
+  runtime_description_removed_admin:  Revoked admin permission for [name].
+  runtime_description_removed_reader:  Revoked view permission for [name].
+  runtime_description_removed_writer:  Revoked edit permission for [name].
+  runtime_destroy_description_not_admin:  Only a description's admins can delete that description.
+  runtime_duplicate_rank:  "Rank appears twice: '[rank]'"
+  runtime_herbarium_record_already_exists:  Fungarium record [number] at [herbarium] already used by someone else.
+  runtime_image_updated_notes:  "Updated notes on image #[id]."
+  runtime_image_uploaded:  Uploaded image '[name]'.
+  runtime_index_no_at_location:  No [types] at [location].
+  runtime_index_no_by_rss_log:  No [types] have had any recent activity.
+  runtime_index_no_for_object:  No [types] for this object.
+  runtime_index_no_for_user:  No [types] for [user].
+  runtime_index_no_in_species_list:  No [types] in [name].
+  runtime_index_no_inside_observation:  "Observation #[id] has no [types]."
+  runtime_index_no_of_children:  There are no [types] for children of [name].
+  runtime_index_no_of_name:  There are no [types] of [name].
+  runtime_index_no_of_parents:  There are no [types] for parents of [name].
+  runtime_index_no_with:  There are no [types] with [attachments].
+  runtime_invalid_for_rank:  "Name is invalid for the rank [rank]: '[name]'"
+  runtime_invalid_rank:  "Ranks are out of order: '[line_rank]' is the same as or below '[rank]'"
+  runtime_location_merge_failed:  Failed to merge observation [name].
+  runtime_login_failed:  Login unsuccessful.
+  runtime_login_success:  Login successful.
+  runtime_map_nothing_to_map:  Nothing to map.
+  runtime_name_in_use_with_notes:  The name '[name]' is already in use and [other] has notes.
+  runtime_no_conditions:  You didn't specify any conditions!
+  runtime_no_upload_image:  Had problems uploading image '[name]'.
+  runtime_object_deleted:  This object has been deleted.
+  runtime_object_not_in_index:  "Can't find [type] #[id] in the results of the current search or index."
+  runtime_object_multiple_matches:  Multiple [types] match "[match]".
+  runtime_pivotal_getting_token:  Couldn't get access token from Pivotal.
+  runtime_pivotal_getting_stories:  Couldn't get stories from Pivotal.
+  runtime_pivotal_parsing_story:  Error parsing one or more stories from Pivotal.  Ignored them.
+  runtime_prefs_password_no_match:  Password and confirmation did not match.
+  runtime_search_has_expired:  Your query has expired, please try again.
+  runtime_show_observation_success:  Successfully changed vote.
+  runtime_species_list_clear_success:  Successfully removed all observations from list.
+  runtime_suggest_one_alternate:  No [types] match "[match]", maybe you meant this?
+  runtime_suggest_multiple_alternates:  No [types] match "[match]", maybe you meant one of these?
+  runtime_unable_to_transfer_name:  Unable to transfer [name] to another synonym.
+  runtime_wrong_rank:  Wrong rank for [name]; expected [expect], but got [actual].
+
+  # These shouldn't need translating, but you are free to override if you need to.
+  runtime_edit_article_success:  "[:runtime_updated_id(type=:article,value=id)]"
+  runtime_ask_observation_question_success:  "[:runtime_delivered_question]"
+  runtime_ask_user_question_success:  "[:runtime_delivered_question]"
+  runtime_ask_webmaster_need_address:  "[:runtime_missing(field=:email_address)]"
+  runtime_ask_webmaster_need_content:  "[:runtime_missing(field=:comment)]"
+  runtime_ask_webmaster_success:  "[:runtime_delivered_message]"
+  runtime_commercial_inquiry_success:  "[:runtime_delivered_message]"
+  runtime_create_name_success:  "[:runtime_created_name(type=:name,value=name)]"
+  runtime_description_adjust_permissions_denied:  "[:runtime_description_must_be_admin]"
+  runtime_description_adjust_permissions_no_changes:  "[:runtime_no_changes]"
+  runtime_description_publish_denied:  "[:runtime_description_must_be_admin]"
+  runtime_destroy_description_success:  "[:runtime_destroyed(type=:description)]"
+  runtime_destroy_naming_denied:  "[:runtime_not_owner_id(type=:naming,value=id)]"
+  runtime_destroy_naming_failed:  "[:runtime_no_destroy_id(type=:naming,value=id)]"
+  runtime_destroy_naming_success:  "[:runtime_destroyed_id(type=:naming,value=id)]"
+  runtime_destroy_observation_denied:  "[:runtime_not_owner_id(type=:observation,value=id)]"
+  runtime_destroy_observation_failed:  "[:runtime_no_destroy_id(type=:observation,value=id)]"
+  runtime_destroy_observation_success:  "[:runtime_destroyed_id(type=:observation,value=id)]"
+  runtime_edit_location_description_no_change:  "[:runtime_no_changes]"
+  runtime_edit_location_description_success:  "[:runtime_updated_id(type=:location_description,value=id)]"
+  runtime_edit_location_no_change:  "[:runtime_no_changes]"
+  runtime_edit_location_success:  "[:runtime_updated_id(type=:location,value=id)]"
+  runtime_edit_name_description_no_change:  "[:runtime_no_changes]"
+  runtime_edit_name_description_success:  "[:runtime_updated_id(type=:name_description,value=id)]"
+  runtime_edit_name_merge_success:  "[:runtime_merge_success(type=:name,src=this,dest=that)]"
+  runtime_edit_name_no_change:  "[:runtime_no_changes]"
+  runtime_edit_name_success:  "[:runtime_updated_name(type=:name,value=name)]"
+  runtime_edit_observation_success:  "[:runtime_updated_id(type=:observation,value=id)]"
+  runtime_edit_project_success:  "[:runtime_updated_id(type=:project,value=id)]"
+  runtime_email_new_password_failed:  "[:runtime_no_match_name(type=:user,value=user)]"
+  runtime_form_comments_create_success:  "[:runtime_created_id(type=:comment,value=id)]"
+  runtime_form_comments_destroy_failed:  "[:runtime_no_destroy_id(type=:comment,value=id)]"
+  runtime_form_comments_destroy_success:  "[:runtime_destroyed_id(type=:comment,value=id)]"
+  runtime_form_comments_edit_success:  "[:runtime_updated_id(type=:comment,value=id)]"
+  runtime_image_destroy_failed:  "[:runtime_no_destroy_id(type=:image,value=id)]"
+  runtime_image_destroy_success:  "[:runtime_destroyed_id(type=:image,value=id)]"
+  runtime_image_edit_success:  "[:runtime_updated_id(type=:image,value=id)]"
+  runtime_image_invalid_image:  "[:runtime_invalid(type=:image,value=name)]"
+  runtime_image_remove_success:  "[:runtime_removed_id(type=:image,value=id)]"
+  runtime_image_resize_denied:  "[:runtime_admin_only]"
+  runtime_image_reuse_invalid_id:  "[:runtime_no_match_id(type=:image,value=id)]"
+  runtime_image_reuse_success:  "[:runtime_added_id(type=:image,value=id)]"
+  runtime_image_uploaded_image:  "[:runtime_uploaded_name(type=:image,value=name)]"
+  runtime_invalid_classification:  "[:runtime_no_parse(value=text)]"
+  runtime_invalid_name:  "[:runtime_invalid(type=:name,value=name)]"
+  runtime_invalid_source_type:  "[:runtime_invalid(type=:source)]"
+  runtime_list_location_no_matches:  "[:runtime_no_matches(type=:location)]"
+  runtime_location_already_exists:  "[:runtime_already_exists(type=:location,value=name)]"
+  runtime_location_description_index_no_matches:  "[:runtime_no_matches(type=:location_description)]"
+  runtime_location_description_success:  "[:runtime_created_id(type=:location_description,value=id)]"
+  runtime_location_descriptions_by_author_error:  "[:runtime_user_hasnt_authored(type=:location_description)]"
+  runtime_location_descriptions_by_editor_error:  "[:runtime_user_hasnt_edited(type=:location_description)]"
+  runtime_location_merge_success:  "[:runtime_merge_success(type=:location,src=this,dest=that)]"
+  runtime_location_success:  "[:runtime_created_id(type=:location,value=id)]"
+  runtime_merge_locations_warning:  "[:runtime_merge_warning(type=:location)]"
+  runtime_merge_names_warning:  "[:runtime_merge_warning(type=:name)]"
+  runtime_name_already_used:  "[:runtime_already_used(type=:name,value=name)]"
+  runtime_name_create_already_exists:  "[:runtime_already_exists(type=:name,value=name)]"
+  runtime_name_deprecate_must_choose:  "[:runtime_missing(field=:preferred_name)]"
+  runtime_name_description_index_no_matches:  "[:runtime_no_matches(type=:name_description)]"
+  runtime_name_description_success:  "[:runtime_created_id(type=:name_description,value=id)]"
+  runtime_name_descriptions_by_author_error:  "[:runtime_user_hasnt_authored(type=:name_description)]"
+  runtime_name_descriptions_by_editor_error:  "[:runtime_user_hasnt_edited(type=:name_description)]"
+  runtime_name_index_no_matches:  "[:runtime_no_matches(type=:name)]"
+  runtime_names_by_editor_error:  "[:runtime_user_hasnt_edited(type=:name)]"
+  runtime_names_by_user_error:  "[:runtime_user_hasnt_created(type=:name)]"
+  runtime_naming_created_at:  "[:runtime_created_at(type=:naming)]"
+  runtime_naming_updated_at:  "[:runtime_updated_at(type=:naming)]"
+  runtime_no_more_search_objects:  "[:runtime_no_more]"
+  runtime_no_save_naming:  "[:runtime_no_save(type=:naming)]"
+  runtime_no_save_observation:  "[:runtime_no_save(type=:observation)]"
+  runtime_object_no_match:  "[:runtime_no_match_name(value=match)]"
+  runtime_observation_success:  "[:runtime_created_id(type=:observation,value=id)]"
+  runtime_prefs_success:  "[:runtime_updated_at(type=:preferences)]"
+  runtime_profile_invalid_image:  "[:runtime_invalid(type=:image,value=name)]"
+  runtime_profile_removed_image:  "[:runtime_removed_from(type=:image,name=:profile)]"
+  runtime_profile_success:  "[:runtime_updated_at(type=:profile)]"
+  runtime_profile_uploaded_image:  "[:runtime_uploaded_name(type=:image,value=name)]"
+  runtime_sequence_success:  "[:runtime_created_id(type=:SEQUENCE,value=id)]"
+  runtime_sequence_update_success:  "[:runtime_updated_id(type=:sequence,value=id)]"
+  runtime_species_list_add_observation_success:  "[:runtime_added_id_to(type=:observation,value=id)]"
+  runtime_species_list_create_success:  "[:runtime_created_id(type=:species_list,value=id)]"
+  runtime_species_list_destroy_success:  "[:runtime_destroyed_id(type=:species_list,value=id)]"
+  runtime_species_list_edit_success:  "[:runtime_updated_id(type=:species_list,value=id)]"
+  runtime_species_list_remove_observation_success:  "[:runtime_removed_id_from(type=:observation,value=id)]"
+  runtime_unable_to_create_name:  "[:runtime_no_create_name(type=:name,value=name)]"
+  runtime_unable_to_save_changes:  "[:runtime_no_save(type=:changes)]"
+  runtime_unrecognized_rank:  "[:runtime_invalid(type=rank,value=rank)]"
+  runtime_user_bad_rank:  "Invalid rank: '[rank]'"
+
+  # Longer messages.
+  runtime_ask_webmaster_antispam:  To cut down on robot spam, questions from unregistered users cannot contain 'http:' or HTML markup.
+  runtime_create_draft_create_denied:  You do not have permission to create a draft for the project [title].
+  runtime_create_naming_already_proposed:  Someone has already proposed that name.  If you would like to comment on it, try posting a comment instead.
+  runtime_description_already_default:  This description is already the default description!
+  runtime_description_foreign_read_wrong:  Descriptions from other servers must be readable by the general public.
+  runtime_description_foreign_write_wrong:  Descriptions from other servers must be read-only.
+  runtime_description_make_default_only_public:  You are only allowed to make public descriptions the default. All users must be allowed at least to read it.
+  runtime_description_merge_conflict:  There is a conflict.  Please merge the two descriptions by hand.  (Look at the text fields below.  Where there is a conflict both descriptions have been entered one on top of the other separated by a line.)  You may cancel the operation at any time without making any changes.  When you are finished, be sure to destroy the old description.
+  runtime_description_move_invalid_classification:  The classification has incorrect syntax.  We can't save a new description with it like this, so we've temporarily blanked out the classification field until you correct it.
+  runtime_description_must_be_admin:  You must be an admin for a description to use this feature.
+  runtime_description_permissions_fixed:  This type of description has fixed permissions.
+  runtime_description_public_read_wrong:  Public descriptions must be readable by the general public.
+  runtime_description_public_write_wrong:  Public descriptions must be writable by the general public.
+  runtime_description_user_not_found:  User or Group "[name]" not found!
+  runtime_destroy_naming_someone_else:  Sorry, someone else has given this their strongest positive vote.  You are free to propose alternate names, but we can no longer let you delete this name.
+  runtime_edit_description_denied:  You have not been given permission to edit this description.
+  runtime_edit_naming_someone_else:  Sorry, someone else has given this a positive vote, so we had to create a new name proposal to accomodate your changes.
+  runtime_email_new_password_success:  Password successfully changed.  New password has been sent to your email account.
+  runtime_form_names_misspelling_bad:  The alternate spelling you entered is not recognized.
+  runtime_form_names_misspelling_same:  Correct spelling and incorrect spelling are the same!
+  runtime_image_changed_your_image: "Выява профілю зменена на выяву\n#[id]."
+  runtime_image_move_failed:  "Something went wrong on the server and we failed to save image #[id].  Please try again."
+  runtime_image_process_failed:  "Something went wrong on the server and we failed to process image #[id]. Please try again."
+  runtime_image_remove_denied:  You do not have permission to remove images from this observation.
+  runtime_image_remove_missing:  This observation doesn't have that image!
+  runtime_merge_warning:  Because it can be destructive, only the admin can merge existing [types]. An email requesting the proposed merge has been sent to the admins.
+  runtime_name_for_description_not_found:  Sorry, the name this description belongs to no longer exists.
+  runtime_object_not_found:  "Sorry, the [type] you tried to display (id #[id]) does not exist.  Someone may have deleted it or merged it into another."
+  runtime_profile_must_define:  You must define this location before we can make it your primary location. Any other changes to your profile have been saved.
+  runtime_reverify_already_verified:  Your account is already verified!  Please log in.
+  runtime_reverify_sent:  Another verification email was sent.
+  runtime_show_description_denied:  You have not been given permission to see this description.
+  runtime_show_draft_denied:  "Permission denied: only project members can view drafts in progress."
+  runtime_signup_success:  Signup successful.  Verification email sent.
+  runtime_species_list_need_to_use_bulk:  Synonyms can only be created from the [:name_bulk_title] page.
+
+  # Pattern search error messages.
+  pattern_search_syntax_error:  Syntax error in pattern at [string].
+  pattern_search_pattern_must_be_first_error:  Filter terms come after the bare search pattern, [str].  Maybe you forgot to enclose the value for [var] in double quotes?
+  pattern_search_bad_term_error:  "Unexpected term in [type] search: [term]. [help]"
+  pattern_search_missing_value_error:  Missing value for the term [var].
+  pattern_search_too_many_values_error:  Search term [term] occurs more than once.
+  pattern_search_bad_boolean_error:  Invalid value for [term], [value], expected "yes" or "no".
+  pattern_search_bad_yes_error:  Invalid value for [term], [value], only valid value is "yes".
+  pattern_search_bad_yes_no_both_error:  Invalid value for [term], [value], expected "yes", "no" or "either".
+  pattern_search_bad_float_error:  Invalid value for [term], [value], expected a number between [min] and [max].
+  pattern_search_bad_confidence_error:  Invalid value for [term], [value], expected a number or range of numbers between -100 and 100, e.g. "0-100".
+  pattern_search_bad_name_error:  Invalid or unrecognized value for [term], [value], expected name id or string; nothing matched.
+  pattern_search_bad_herbarium_error:  Invalid or unrecognized value for [term], [value], expected fungarium id, code or name; nothing matched.
+  pattern_search_bad_location_error:  Invalid or unrecognized value for [term], [value], expected location id or name; nothing matched.
+  pattern_search_bad_project_error:  Invalid or unrecognized value for [term], [value], expected project id or title; nothing matched.
+  pattern_search_bad_species_list_error:  Invalid or unrecognized value for [term], [value], expected species list id or title; nothing matched.
+  pattern_search_bad_user_error:  Invalid or unrecognized value for [term], [value], expected user id, login or name; nothing matched.
+  pattern_search_bad_date_range_error:  Invalid value for [term], [value], expected date or date range of form YYYY, YYYY-YYYY, YYYY-MM, YYYY-MM-YYYY-MM, YYYY-MM-DD, YYYY-MM-DD-YYYY-MM-DD, MM, MM-MM or MM-DD-MM-DD.
+  pattern_search_bad_rank_range_error:  Invalid value for [term], [value], expected rank or range of ranks, e.g., "genus" or "species-form".
+  pattern_search_user_me_not_logged_in_error:  The term '[:search_term_user]:[:search_value_me]' doesn't make sense unless you are logged in!
+
+  # Advanced search error messages
+  advanced_search_bad_q_error:  Search expired or cannot be found. Please re-enter search criteria.
+
+  # content for html header title tag,
+  # used when there are no hits for a list or search
+  title_for_comment_search:  Comment Search
+  title_for_herbarium_search:  Fungarium Search
+  title_for_herbarium_record_search:  Fungarium Record Search
+  title_for_image_search:  Image Search
+  title_for_location_search:  Location Search
+  title_for_name_search:  Name Search
+  title_for_observation_search:  Observation Search
+  title_for_project_search:  Project Search
+  title_for_species_list_search:  Species List Search
+  title_for_user_search:  User Search
+
+  ##############################################################################
+
+  # LESS IMPORTANT ENUMERATED SETS OF VALUES
+
+  # Api error messages
+  api_abort_due_to_errors:  Aborted operation due to errors.
+  api_ambiguous_name:  Name "[name]" is ambiguous, matches [others].
+  api_another_users_profile_location:  You can't edit this [:location] because someone has made it their profile location.
+  api_api_key_not_verified:  API key for "[notes]" has not been activated yet. (key = "[key]")
+  api_bad_action:  Invalid request type "[action]".
+  api_bad_altitude_parameter_value:  "Invalid elevation, \"[val]\", examples: \"1234\", \"1234m\", \"4048'\", \"4048ft\"."
+  api_bad_api_key:  Bad key "[key]".
+  api_bad_boolean_parameter_value:  Invalid boolean, "[val]", expect "1", "yes", "true", "0", "no", or "false".
+  api_bad_classification:  Invalid classification string.
+  api_bad_date_parameter_value:  Invalid date, "[val]", expect "YYYYMMDD".
+  api_bad_date_range_parameter_value:  Invalid date range, "[val]", expect "YYYYMMDD-YYYYMMDD", "YYYYMM-YYYYMM", "YYYY-YYYY", "MM-MM", "YYYYMMDD", "YYYYMM", "YYYY", "MM".
+  api_bad_email_parameter_value:  Invalid email address, "[val]".
+  api_bad_external_site_parameter_value:  Invalid external site, "[val]".
+  api_bad_float_parameter_value:  Invalid float, "[val]".
+  api_bad_herbarium_parameter_value:  Invalid or unknown fungarium, "[val]", accept numerical id, code or name.
+  api_bad_image_parameter_value:  Invalid or unknown image, "[val]", accept only numerical id.
+  api_bad_integer_parameter_value:  Invalid integer, "[val]".
+  api_bad_latitude_parameter_value:  "Invalid latitude, \"[val]\", examples: \"-45.6789\", \"45.6789°S\", \"45°40.73'S\", \"45°40'44\"S\"."
+  api_bad_license_parameter_value:  Invalid or unknown license, "[val]", accept only numerical id.
+  api_bad_limited_parameter_value:  Expected "[val]" to be in [limit].
+  api_bad_location_parameter_value:  Invalid or unknown location, "[val]", accept numerical id or location name.
+  api_bad_longitude_parameter_value:  "Invalid longitude, \"[val]\", examples: \"-45.6789\", \"45.6789°W\", \"45°40.73'W\", \"45°40'44\"W\"."
+  api_bad_method:  Invalid request method "[method]".
+  api_bad_name_parameter_value:  Invalid or unknown name, "[val]", accept numerical id or scientific name (author not required).
+  api_bad_notes_field_parameter:  Invalid notes template field.  Pretty much anything but commas are allowed.
+  api_bad_object_parameter_value:  "Invalid or unknown object, \"[val]\", examples: \"name #1234\", \"observation #54321\", \"species_list #42\"."
+  api_bad_observation_parameter_value:  Invalid or unknown observation, "[val]", accept only numerical id.
+  api_bad_project_parameter_value:  Invalid or unknown project, "[val]", accept numerical id or project name.
+  api_bad_species_list_parameter_value:  Invalid or unknown species list, "[val]", accept numerical id or species list title.
+  api_bad_time_parameter_value:  Invalid time, "[val]", expect "YYYYMMDDHHMMSS".
+  api_bad_time_range_parameter_value:  Invalid time range, "[val]", expect "YYYYMMDDHHMMSS-YYYYMMDDHHMMSS", "YYYYMMDDHHMM-YYYYMMDDHHMM", "YYYYMMDDHH-YYYYMMDDHH", "YYYYMMDD-YYYYMMDD", "YYYYMM-YYYYMM", "YYYY-YYYY", "MM-MM", "YYYYMMHHMMSS", "YYYYMMDDHHMM", "YYYYMMDDHH", "YYYYMMDD", "YYYYMM", "YYYY", "MM".
+  api_bad_user_parameter_value:  Invalid or unknown user, "[val]", accept numerical id, login or name.
+  api_bad_version:  Invalid version number "[version]".
+  api_can_only_delete_your_own_account:  Only the account owner can delete their account.
+  api_can_only_synonymize_unsynonymized_names:  Presently, we're only allowing API clients to synonymize unsynonymized names with other names.  If one of the names has no synonyms, synonymize that name with the others.  But there's no way to merge two sets os synonyms via the API right now.
+  api_can_only_use_one_of_these_fields:  "Please only use one of these parameters: [fields]."
+  api_can_only_use_this_field_if_has_specimen:  The parameter, "[field]", can only be used if the observation has a specimen.
+  api_cant_add_herbarium_record: Толькі ўладальнік назірання і куратары фунгарыума могуць дадаваць запісы фунгарыюма ў назіранне.
+  api_couldnt_download_url:  "Failed to download the resource at the URL, \"[url]\": [error]"
+  api_create_failed:  "Failed to create [type] \"[name]\": [error]"
+  api_destroy_failed:  Failed to destroy [type] "[name]".
+  api_dubious_location_name:  "Location name is invalid: [reasons]"
+  api_external_link_permission_denied:  In order to create an external link, you must either have edit permissions for the observation, or you must be a member of the external site's project.
+  api_file_missing:  File "[file]" is missing.
+  api_help_message:  "Usage: [help]"
+  api_herbarium_record_already_exists:  There is already a record for [number] at [herbarium].
+  api_image_upload_failed:  "Failed to upload image: [error]"
+  api_incorrect_password:  Incorrect password.
+  api_lat_long_must_both_be_set:  Must supply both latitude and longitude, or neither.
+  api_location_already_exists:  The location "[location]" already exists.
+  api_missing_method:  Missing "method" parameter.
+  api_missing_parameter:  Missing "[arg]" parameter.
+  api_missing_set_parameters:  You didn't supply any "set" parameters.
+  api_missing_upload:  Expected an upload file.  You may send the file in the data of the HTTP request, or you may specify a URL using the "upload_url" parameter.
+  api_must_authenticate:  Must authenticate with API key to perform this operation.
+  api_must_be_admin:  You are not an admin for [project].
+  api_must_be_creator:  You can only edit [types] that you have created.
+  api_must_be_member:  You are not a member of [type] "[name]".
+  api_must_be_only_editor:  You can only edit [types] if you are the only editor.
+  api_must_be_owner:  You must be the owner of the [type] "[name]" to do this.
+  api_must_have_edit_permission:  You do not have permission to edit [type] "[name]".
+  api_must_have_view_permission:  You do not have permission to view [type] "[name]".
+  api_must_not_have_any_herbaria:  You can't edit this [:location] because there is an [:herbarium] there.
+  api_must_own_all_descriptions:  You can only edit [types] if you own all the [:descriptions].
+  api_must_own_all_namings:  You can only edit [types] if no one else has proposed that [type].
+  api_must_own_all_observations:  You can only edit [types] if you own all its [:observations].
+  api_must_own_all_species_lists:  You can only edit [types] if you own all its [:species_lists].
+  api_name_already_exists:  The name "[new]" already exists.
+  api_name_doesnt_parse:  The name, "[name]", doesn't parse as a valid scientific name.
+  api_name_wrong_for_rank:  The name, "[name]", isn't valid for [rank].
+  api_need_all_four_edges:  "Need to supply all four edges of bounding box: north, south, east and west."
+  api_no_method_for_action:  Invalid request method "[method]" for "[action]".
+  api_object_not_found_by_id:  "[Type] #[id] does not exist, or someone has deleted it."
+  api_object_not_found_by_string:  "[Type] \"[str]\" does not exist, or someone has deleted it."
+  api_one_or_the_other:  Can only use one of the parameters [args].
+  api_parameter_cant_be_blank:  It is okay to leave the [arg] parameter off, but if you include it in your PATCH request, it cannot be blank.  Leaving a set parameter off means it will leave that property alone and do nothing; setting it to a blank tells MO to delete or clear the property.  And some properties cannot be deleted or cleared.
+  api_password_incorrect:  Password incorrect.
+  api_project_taken:  The project, "[project]", already exists.
+  api_query_error:  "There was an internal problem with Query: [error]"
+  api_render_failed:  There was a problem while rendering the results. [error]
+  api_species_list_already_exists:  The [:species_list] "[title]" already exists.
+  api_string_too_long:  The string, "[val]", has more than [limit] characters.
+  api_too_many_uploads:  Only one upload allowed per request.  You may send the file in the data of the HTTP request, or you may specify a URL using the "upload_url" parameter.  But do not use both methods at the same time.
+  api_trying_to_set_multiple_locations_to_same_name:  You are attempting to update multiple locations to the same name.
+  api_trying_to_set_multiple_names_at_once:  You can only change the name, author and rank of one name at a time.
+  api_unexpected_upload:  Unexpected file attached.
+  api_unused_parameters:  "Unexpected parameters: [params]"
+  api_user_already_exists:  The user "[login]" already exists or is taken.
+  api_user_group_taken:  The user group "[title]" already exists.
+  api_user_not_verified:  The user "[login]" is not verified yet; you can request another verification email on the website.
+
+  api_help_accession_has:  search within accession number
+  api_help_accession_number:  unique fungarium id
+  api_help_accession_number_has:  search within accession number
+  api_help_any_date:  this date can mean anything you want
+  api_help_api_key_password:  password of the user you are creating an API key for
+  api_help_api_key_user:  user you are creating api key for
+  api_help_app:  identifier used to help user distinguish which api key belongs to which app
+  api_help_author_has:  search within author
+  api_help_citation_has:  search within citation
+  api_help_classification_has:  search within classification
+  api_help_clear_synonyms:  make it so this name is not synonymized with anything but leave everything it used to be synonymized with synonyms of each other
+  api_help_collector:  collector's name
+  api_help_collector_has:  search within collector's name
+  api_help_comments_has:  search within comments summary and body
+  api_help_content_has:  search within body
+  api_help_copyright_holder_has:  search within copyright holder
+  api_help_create_key:  if you pass in your app name here it will create an api key for the user for your app to use
+  api_help_creator:  creator
+  api_help_east:  max longitude
+  api_help_first_user:  creator / first to use
+  api_help_has_notes_field:  is given observation notes template field filled in?
+  api_help_has_obs_notes:  observation has notes?
+  api_help_has_observation:  is attached to an observation?
+  api_help_initial_det:  initial determination
+  api_help_initial_det_has:  search within initial determination
+  api_help_is_collection_location:  is this location where mushroom was found?
+  api_help_gps_hidden:  hide exact coordinates?
+  api_help_locus_has:  search within locus
+  api_help_log:  log this action on main page activity log and RSS feed?
+  api_help_mailing_address:  postal address
+  api_help_min_rank:  group or genus or better
+  api_help_min_size:  width or height at least 160 for thumbnail, 320 for small, 640 for medium, 960 for large, 1280 for huge
+  api_help_misspellings:  include misspellings? "either" means do not care and "only" means only show misspelt names
+  api_help_north:  max latitude
+  api_help_notes_field:  set value of the custom notes template field, substitute field name for "$field"
+  api_help_notes_has:  search within notes
+  api_help_number:  collector's number
+  api_help_number_has:  search within collector's number
+  api_help_obs_date:  observation date
+  api_help_obs_notes_has:  search within observation notes
+  api_help_observer:  observer
+  api_help_original_name:  original file name or other private identifier
+  api_help_postal:  in postal format with country last regardless of user preference
+  api_help_region:  matches locations which end in this, e.g. "California, USA"
+  api_help_set_correct_spelling:  mark this as misspelt and deprecated and synonymize with the correct spelling
+  api_help_set_is_collection_location:  is this location where mushroom was found?
+  api_help_set_gps_hidden:  hide exact coordinates?
+  api_help_south:  min latitude
+  api_help_summary_has:  search within summary
+  api_help_target:  "e.g. \"observation #1234\" or \"name #5678\""
+  api_help_text_name_has:  search within name
+  api_help_title_has:  search within title
+  api_help_uploader:  who uploaded the photo
+  api_help_west:  min longitude
+  api_help_when_seen:  when seen
+  api_help_when_taken:  when photo taken
+
+  # Query titles.
+  query_title_advanced_search:  "[:app_advanced_search]"
+  query_title_all:  "[TYPE] Index"
+  query_title_all_by:  "[TYPES] by [ORDER]"
+  query_title_at_location:  "[TYPES] from [LOCATION]"
+  query_title_at_where:  "[TYPES] from '[USER_WHERE]'"
+  query_title_by_author:  "[TYPES] Authored by [USER]"
+  query_title_by_editor:  "[TYPES] Edited by [USER]"
+  query_title_by_rss_log:  "[TYPES] in Activity Log"
+  query_title_by_user: "[TYPES] створаны [USER]"
+  query_title_for_observation:  "[TYPES] attached to [OBSERVATION]"
+  query_title_for_project:  "[TYPES] attached to [PROJECT]"
+  query_title_for_target:  "[TYPES] on [TARGET]"
+  query_title_for_user:  "[TYPES] for [USER]"
+  query_title_in_herbarium:  "[TYPES] in [HERBARIUM]"
+  query_title_in_set:  Selected [TYPES]
+  query_title_in_species_list:  "[TYPES] in [SPECIES_LIST]"
+  query_title_inside_observation:  "[TYPES] of [OBSERVATION]"
+  query_title_nonpersonal:  List of Institutional Fungaria
+  query_title_of_children:  Lower Taxa under [NAME]
+  query_title_of_name:  "[TYPES] of [NAME]"
+  query_title_of_name_synonym:  "[TYPES] of Synonyms of [NAME]"
+  query_title_of_name_nonconsensus:  "[TYPES] That Might Be [NAME]"
+  query_title_of_parents:  Higher Taxa Containing [NAME]
+  query_title_pattern_search:  "[TYPES] Matching '[pattern]'"
+  query_title_regexp_search:  "[TYPES] Matching '[regexp]'"
+  query_title_with_descriptions:  "[TYPES] with [:DESCRIPTIONS]"
+  query_title_with_descriptions_by_author:  "[TYPES] with [:query_title_by_author(type=:description)]"
+  query_title_with_descriptions_by_editor:  "[TYPES] with [:query_title_by_editor(type=:description)]"
+  query_title_with_descriptions_by_user:  "[TYPES] with [:query_title_by_user(type=:description)]"
+  query_title_with_descriptions_in_set:  "[TYPES] with [descriptions]"
+  query_title_with_observations:  "[TYPES] with [:OBSERVATIONS]"
+  query_title_with_observations_at_location:  "[TYPES] with [:query_title_at_location(type=:observation)]"
+  query_title_with_observations_at_where:  "[TYPES] with [:query_title_at_where(type=:observation)]"
+  query_title_with_observations_by_user:  "[TYPES] with [:query_title_by_user(type=:observation)]"
+  query_title_with_observations_for_project:  "[TYPES] with [:query_title_for_project(type=:observation)]"
+  query_title_with_observations_in_set:  "[TYPES] for [observations]"
+  query_title_with_observations_in_species_list:  "[TYPES] with [:query_title_in_species_list(type=:observation)]"
+  query_title_with_observations_of_children:  "[TYPES] with [:query_title_of_children(type=:observation)]"
+  query_title_with_observations_of_name:  "[TYPES] with [:query_title_of_name(type=:observation)]"
+  query_title_with_observations_of_name_synonym:  "[TYPES] with [:query_title_of_name_synonym(type=:observation)]"
+  query_title_with_observations_of_name_nonconsensus:  "[TYPES] with [:query_title_of_name_nonconsensus(type=:observation)]"
+
+  # Brief description of each query flavor.
+  query_help_comment_all:  all comments
+  query_help_comment_by_user:  comments created by a given user
+  query_help_comment_in_set:  comments in a given set
+  query_help_comment_for_object:  comments about a given object
+  query_help_comment_for_user:  comments sent to a given user
+  query_help_comment_pattern_search:  comments matching a search string
+  query_help_herbarium_record_in_herbarium:  records in a given fungarium
+  query_help_herbarium_record_for_observation:  records attached to a given observation
+  query_help_image_advanced_search:  images of observations matching advanced search criteria
+  query_help_image_all:  all images
+  query_help_image_by_user:  images created by a given user
+  query_help_image_in_set:  images in a given set
+  query_help_image_inside_observation:  images belonging to an outer observation query
+  query_help_image_pattern_search:  images matching a search_string
+  query_help_image_with_observations:  images of observations
+  query_help_image_with_observations_at_location:  images of observations at a defined location
+  query_help_image_with_observations_at_where:  images of observations at an undefined location
+  query_help_image_with_observations_by_user:  images of observations by a given user
+  query_help_image_with_observations_in_set:  images of observations in a given set
+  query_help_image_with_observations_in_species_list:  images of observations in a given species list
+  query_help_image_with_observations_of_children:  images of observations of children a given name
+  query_help_image_with_observations_of_name:  images of observations of a given name
+  query_help_location_advanced_search:  locations of observations matching advanced search criteria
+  query_help_location_all:  all locations
+  query_help_location_by_user:  locations created by a given user
+  query_help_location_by_editor:  locations modified by a given user
+  query_help_location_by_rss_log:  locations with recent activity
+  query_help_location_in_set:  locations in a given set
+  query_help_location_pattern_search:  locations matching a search string
+  query_help_location_with_descriptions:  locations with descriptions
+  query_help_location_with_descriptions_by_author: месцы з апісаннямі, створанымі дадзеным карыстальнікам
+  query_help_location_with_descriptions_by_editor:  locations with descriptions edited by a given user
+  query_help_location_with_descriptions_by_user:  locations with descriptions created by a given user
+  query_help_location_with_descriptions_in_set:  locations with descriptions in a given set
+  query_help_location_with_observations:  locations of observations
+  query_help_location_with_observations_by_user:  locations of observations by a given user
+  query_help_location_with_observations_in_set:  locations of observations in a given set
+  query_help_location_with_observations_in_species_list:  locations of observations in a given species list
+  query_help_location_with_observations_of_children:  locations of observations of children of a given name
+  query_help_location_with_observations_of_name:  locations of observations of a given name
+  query_help_location_description_all:  all location descriptions
+  query_help_location_description_by_author:  location descriptions that list given user as an author
+  query_help_location_description_by_editor:  location descriptions that list given user as an editor
+  query_help_location_description_by_user:  location descriptions created by a given user
+  query_help_location_description_in_set:  location descriptions in a given set
+  query_help_name_advanced_search:  names of observations matching advanced search criteria
+  query_help_name_all:  all names
+  query_help_name_by_user:  names created by a given user
+  query_help_name_by_editor:  names modified by a given user
+  query_help_name_by_rss_log:  names with recent activity
+  query_help_name_in_set:  names in a given set
+  query_help_name_of_children:  names of children of a name
+  query_help_name_of_parents:  names of parents of a name
+  query_help_name_pattern_search:  names matching a search string
+  query_help_name_with_descriptions:  names with descriptions
+  query_help_name_with_descriptions_by_author:  names with descriptions authored by a given user
+  query_help_name_with_descriptions_by_editor:  names with descriptions edited by a given user
+  query_help_name_with_descriptions_by_user:  names with descriptions created by a given user
+  query_help_name_with_descriptions_in_set:  names with descriptions in a given set
+  query_help_name_with_observations:  names of observations, alphabetically
+  query_help_name_with_observations_at_location:  names of observations at a defined location
+  query_help_name_with_observations_at_where:  names of observations at an undefined location
+  query_help_name_with_observations_by_user:  names of observations by a given user
+  query_help_name_with_observations_in_set:  names of observations in a given set
+  query_help_name_with_observations_in_species_list:  names of observations in a given species list
+  query_help_name_description_all:  all name descriptions
+  query_help_name_description_by_author: апісанні імёнаў, якія паказваюць дадзенага карыстальніка ў якасці аўтара
+  query_help_name_description_by_editor: апісанні імёнаў, якія паказваюць дадзенага карыстальніка ў якасці рэдактара
+  query_help_name_description_by_user: апісанні імёнаў, створаныя дадзеным карыстальнікам
+  query_help_name_description_in_set: апісання назвы ў дадзеным наборы
+  query_help_observation_advanced_search:  observations matching advanced search criteria
+  query_help_observation_all:  all observations
+  query_help_observation_at_location:  observations at a defined location
+  query_help_observation_at_where:  observations at an undefined location
+  query_help_observation_by_rss_log:  observations with recent activity
+  query_help_observation_by_user:  observations created by a given user
+  query_help_observation_in_set:  observations in a given set
+  query_help_observation_in_species_list:  observations in a given species list
+  query_help_observation_of_children:  observations of children of a given name
+  query_help_observation_of_name:  observations of a given name
+  query_help_observation_pattern_search:  observations matching a search string
+  query_help_project_all:  all projects
+  query_help_project_by_rss_log:  projects with recent activity
+  query_help_project_in_set:  projects in a given set
+  query_help_project_pattern_search:  projects matching a search string
+  query_help_rss_log_all:  all recent activity logs
+  query_help_rss_log_in_set:  activity logs in a given set
+  query_help_species_list_all:  all species lists
+  query_help_species_list_at_location:  species lists at a defined location
+  query_help_species_list_at_where:  species lists at an undefined location
+  query_help_species_list_by_rss_log:  species lists with recent activity
+  query_help_species_list_by_user:  species lists created by a given user
+  query_help_species_list_in_set:  species lists in a given set
+  query_help_species_list_pattern_search:  species lists matching a search string
+  query_help_user_all:  all users
+  query_help_user_in_set:  users in a given set
+  query_help_user_pattern_search:  users matching a search string
+
+  # Sorting criteria.
+  sort_by_code:  Code
+  sort_by_code_then_name:  Code and Name
+  sort_by_confidence:  "[:CONFIDENCE_LEVEL]"
+  sort_by_contribution:  Contribution
+  sort_by_copyright_holder:  "[:COPYRIGHT_HOLDER]"
+  sort_by_created_at: Дата стварэння
+  sort_by_date:  "[:DATE]"
+  sort_by_filename:  File Name
+  sort_by_header: "Сартаваць па:"
+  sort_by_herbarium_label:  Label
+  sort_by_herbarium_name:  Fungarium
+  sort_by_id:  ID
+  sort_by_image_quality: Якасць выявы
+  sort_by_last_login:  Last Login
+  sort_by_location:  "[:LOCATION]"
+  sort_by_login:  "[:LOGIN_NAME]"
+  sort_by_name:  "[:NAME]"
+  sort_by_num_views:  Popularity
+  sort_by_number:  Number
+  sort_by_observation:  "[:OBSERVATION]"
+  sort_by_posted:  Date Posted
+  sort_by_records:  "#Records"
+  sort_by_reverse:  Reverse Order
+  sort_by_rss_log:  "[:sort_by_updated_at]"
+  sort_by_summary:  "[:SUMMARY]"
+  sort_by_thumbnail_quality: Якасць эскізаў
+  sort_by_title:  "[:TITLE]"
+  sort_by_updated_at: Час апошняга змянення
+  sort_by_user:  "[:USER]"
+  sort_by_where:  "[:LOCATION]"
+
+  ##############################################################################
+
+  # DEBUGGING STUFF -- this doesn't need translating
+
+  # observations/recalc
+  observer_recalc_old_name:  "old_name: [name]"
+  observer_recalc_new_name:  "new_name: [name]"
+  observer_recalc_caught_error:  "Caught exception: [error]"
+
+  # observer/status
+  system_status_browser_status_size:  Browser status cache size
+  system_status_clear_caches:  Clear Caches
+  system_status_gc:  GC
+  system_status_textile_name_size:  Textile name cache size
+  system_status_title:  Server Status

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1893,6 +1893,7 @@
   prefs_email_names_reviewer: someone changes a name I've reviewed.
   prefs_email_prefs: Email preferences
   prefs_email_html: It's okay to use HTML in my emails.
+  prefs_email_no_emails: Opt out of _all_ email from MO.
   prefs_email_digest_daily: Send me summary at the end of the day.
   prefs_email_digest_immediate: Notify me of events as they happen.
   prefs_email_digest_weekly: Send me summary at the end of the week.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1893,7 +1893,7 @@
   prefs_email_names_reviewer: someone changes a name I've reviewed.
   prefs_email_prefs: Email preferences
   prefs_email_html: It's okay to use HTML in my emails.
-  prefs_email_no_emails: Opt out of _all_ email from MO.
+  prefs_no_emails: Opt out of _all_ email from MO.
   prefs_email_digest_daily: Send me summary at the end of the day.
   prefs_email_digest_immediate: Notify me of events as they happen.
   prefs_email_digest_weekly: Send me summary at the end of the week.

--- a/config/locales/fa.txt
+++ b/config/locales/fa.txt
@@ -1,0 +1,4221 @@
+#
+#  Be sure to rake lang:update and restart your server if you modify this file.
+#
+################################################################################
+#
+#  Rails Comments
+#
+#  Files in the config/locales directory are used for internationalization
+#  and are automatically loaded by Rails. If you want to use locales other
+#  than English, add the necessary files in this directory.
+#
+#  To use the locales, use `I18n.t`:
+#
+#      I18n.t 'hello'
+#
+#  In views, this is aliased to just `t`:
+#
+#      <%= t('hello') %>
+#
+#  To use a different locale, set it with `I18n.locale`:
+#
+#      I18n.locale = :es
+#
+#  This would use the information in config/locales/es.yml.
+#
+#  To learn more, please read the Rails Internationalization guide
+#  available at http://guides.rubyonrails.org/i18n.html.
+#
+################################################################################
+#
+#  MO Differences
+#
+#  In MO, locales files are created and modified differently.  One should never
+#  change the locale.yml files by hand.  And further, how to change the
+#  translations is different for English (the "official" language) than the
+#  other languages.
+#
+#  English:  ""
+#
+#  Change and check in en.txt (not en.yml!), and run "rake lang:update"
+#  both locally and on the production server to pick up the changes.
+#  This should be the *only* way we make changes to the English "translations".
+#  Any other method will get clobbered next time someone runs "rake lang:update".
+#
+#  Other languages:
+#
+#  Option one: "Export" a .txt file, e.g., es.txt ("rake lang:export:es"),
+#  change the exported file, then import that on the server into the live
+#  database ("rake lang:import:es").
+#
+#  Option two: Change the translations on the live, running site via the "Edit
+#  Translations on This Page" link at the bottom of the page while viewing the
+#  page in the desired language.  Any changes made here will be stored in the
+#  live database, and will propagate automatically to all other currently
+#  running instances immediately.
+#
+#  rake lang:update:
+#
+#  This command clobbers es.txt and es.yml, and recreates them fresh from the
+#  strings stored in the database.  It does NOT clobber en.txt, making an
+#  exception for that one case.  This is critical because we need to be able to
+#  check this in to git.  The foreign translations are not checked into git,
+#  they are considered "data" at present.  Instead, MO "imports" en.txt each
+#  time "rake lang:update" is run, and syncs the English translations in the
+#  database with the current data in en.txt.  Furthermore, en.txt is special in
+#  one additional way: it is used as the template for the other "export" files,
+#  es.txt, fr.txt, etc.  It preserves comments, order, etc. exactly like it
+#  appears in en.txt.)
+#
+################################################################################
+#
+#  How to Create and Import a New Language:
+#
+#  First create the language in the database:
+#
+#    INSERT INTO languages (`locale`, `name`, `order`, `beta`)
+#      VALUES (
+#        "jp",          # locale, e.g. "pt" for Portuguese
+#        "日本語",      # name of the language *in that language*
+#        "Nihongo",     # transliteration of the above (so it sorts right)
+#        1              # beta=1 means it won't appear in site's language menu
+#      );
+#
+#  Create stub language files:
+#
+#    mo$ rake lang:update
+#    mo$ rake lang:export:jp
+#
+#  You should now have an import/export file called config/locales/jp.txt.
+#  Once you're done editing this file -- remembering to remove the extra space
+#  between "tag:" and "value"!! -- test if it's valid:
+#
+#    mo$ ruby -e "require 'yaml'; YAML.load_file('config/locales/jp.txt')"
+#
+#  Sorry, it doesn't always tell you where the syntax errors are. Look for
+#  things like "tag: [..." or "tag: blah: ..."  That should be the cause of
+#  most of the grief.  Just protect those strings in quotes, remembering to
+#  backslash-protect embedded quotes when you do so.
+#
+#  Now you should be ready to import the file.  Note that this can be redone
+#  as many times as necessary if you see problems when you test it.  This is
+#  why it's good to keep new languages beta!!
+#
+#    mo$ cp config/locales/jp.txt config/locales/jp.txt.bak
+#    mo$ rake user_id=1234 lang:import:jp
+#    mo$ rake lang:update
+#    mo$ uni reload
+#
+#  You need to supply user_id to lang:import because it needs to know who
+#  created each translation_string.  You can give "user_name=xxx" instead.
+#  If that works, then you should be able to test it on the server.  Note
+#  that the new language is still "beta" so it doesn't show up as a publically
+#  available option.  Instead add "?user_locale=jp" to the end of any URL:
+#
+#    http:  ""
+#
+#  It should stay in Japanese now until you tell it to switch to another.
+#  If you need to re-import, it's safest to purge the old strings first:
+#
+#    DELETE FROM translation_strings WHERE language_id = xxx;
+#
+#  Note that it's important to backup the original import file, because
+#  rake lang:update will clobber it.  Looking at the new jp.txt can help
+#  identify problems with the import file, too.  You may even be able to
+#  diff the two, depending how the translator does their work.
+#
+#  Once you're satisfied, repeat all this on the live server, and clear the
+#  beta flag in the languages table.
+#
+#    UPDATE languages SET beta=0 WHERE language_id=xxx;
+#
+#  -Jason 20180320
+#
+################################################################################
+#
+#  Hints about the entries.
+#
+#  Each entry is a *one-line* string. It must not contain a carriage return or
+#  line feed. To display a new line, use: \n, <br>, or <\br>.
+#  Example:  ""
+#    entry:  ""
+#  will display as
+#    1st line
+#    2nd line
+#
+#  The string can include html (without newline characters).
+#  Examples:  ""
+#    entry:  ""
+#    entry:  ""
+#
+#  The string can incorporate other entries by including those entries' labels.
+#  An entry which includes other labels must be dumbquoted.
+#  Example:  ""
+#    quoted_entry:  ""
+#    quoting_entry:  ""
+#
+#  Then in the code,
+#    quoting_entry.t
+#  will display as:
+#    Hello there.
+#
+#  Within a dumbquoted entry, dumbquotes must be escaped: \"
+#  (Smartquotes must *not* be escaped.)
+#  Example
+#    entry:  ""
+#  will display as
+#    "dumbquoted" “smartquoted”.
+#
+#  - Joe Cohen 20170312
+#
+################################################################################
+
+  all_months: ژانویه مارس آوریل آوریل ماه ژوئن جولای اوت سپتامبر اکتبر دسامبر
+  all_month_abbrs:  Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+
+  # Important examples:
+  hello:  Hello world
+  they_flew_by:  The [they] flew by
+  they_fly:  "[THEY] fly"
+  quote_test:  This has "quotes"
+  quote_them:  This has "[THEM]"
+  one:  one
+
+  # Yes and No are apparently broken
+  YEP:  "Yes"
+  yep:  "yes"
+  NOPE: نه
+  nope: نه
+
+  # Test with new lines
+  with_newlines:  "This\nhas\nnewlines"
+
+  # Test with a link
+  with_a_link:  "\"See this link\":https://mushroomobserver.org"
+
+  ##############################################################################
+  #
+  #  Overview of File
+  #
+  #  Translations are presented roughly in order of decreasing importance,
+  #  starting with things that are seen on every page, progressing through
+  #  commonly-used to rarely-used pages, to emails, error messages, and finally
+  #  administrative and debugging messages. Sections:
+  #
+  #    COMMON WORDS AND PHRASES
+  #    ENUMERATED SETS OF VALUES
+  #    APPLICATION LAYOUT
+  #    MOST POPULAR PAGES
+  #    LESS POPULAR PAGES
+  #    ADMIN-TYPE PAGES
+  #    EMAIL MESSAGES
+  #    INTRO PAGE
+  #    HOW TO HELP PAGE
+  #    HOW TO USE PAGE (COMMON TASKS)
+  #    HOW TO USE PAGE (GLOSSARY)
+  #    LOCATION HELP PAGE
+  #    ERROR MESSAGES
+  #    LESS IMPORTANT ENUMERATED SETS OF VALUES
+  #    DEBUGGING STUFF
+  #
+  ##############################################################################
+
+  # COMMON WORDS AND PHRASES
+
+  # Object titles, all nouns.
+  API_KEY:  API Key
+  api_key:  API key
+  API_KEYS:  API Keys
+  api_keys:  API keys
+  ARTICLE: مقاله
+  article: مقاله
+  ARTICLES: مقالات
+  articles: مقالات
+  COLLECTION_NUMBER: شماره جمع آوری
+  collection_number: شماره جمع آوری
+  COLLECTION_NUMBERS: جمع آوری اعداد
+  collection_numbers: جمع آوری اعداد
+  COMMENT: نظر
+  comment: نظر
+  COMMENTS: نظرات
+  comments: نظرات
+  DESCRIPTION: توصیف:__________
+  description: توصیف:__________
+  DESCRIPTIONS: شرح
+  descriptions: شرح
+  DRAFT:  Draft
+  draft:  draft
+  DRAFTS:  Drafts
+  drafts:  drafts
+  EXTERNAL_LINK:  External Link
+  external_link:  external link
+  EXTERNAL_LINKS:  External Links
+  external_links:  external links
+  EXTERNAL_SITE:  External Site
+  external_site:  external site
+  EXTERNAL_SITES:  External Sites
+  external_sites:  external sites
+  IMAGE: تصویر
+  image: تصویر
+  IMAGES: تصاویر
+  images: تصاویر
+  ignore: نادیده گرفتن
+  IGNORE: نادیده گرفتن
+  GEOLOCATION:  Geolocation
+  geolocation:  geolocation
+  GLOSSARY: واژه نامه
+  glossary: واژه نامه
+  GLOSSARY_TERM: اصطلاح واژه‌نامه
+  glossary_term: اصطلاح واژه‌نامه
+  GLOSSARY_TERMS: اصطلاحات واژه نامه ای
+  glossary_terms: اصطلاحات واژه نامه ای
+  HERBARIUM_RECORD: قارچ رکورد
+  herbarium_record: قارچ رکورد
+  HERBARIUM_RECORDS: قارچ سوابق
+  herbarium_records: قارچ سوابق
+  HERBARIA: فونگاریا
+  herbaria: فونگاریا
+  HERBARIUM:  Fungarium
+  herbarium:  fungarium
+  HERBARIUMS:  Fungaria
+  herbariums:  fungaria
+  LICENSE:  License
+  license:  license
+  LICENSES:  Licenses
+  licenses:  licenses
+  LOCATION: محل
+  location: محل
+  LOCATIONS: مکان‌ها
+  locations: مکان‌ها
+  LOCATION_DESCRIPTION:  Location Description
+  location_description:  location description
+  LOCATION_DESCRIPTIONS:  Location Descriptions
+  location_descriptions:  location descriptions
+  LOG: ورود به سیستم
+  log: ورود به سیستم
+  LOGS: Logs
+  logs: logs
+  MAP:  Map
+  map:  map
+  MAPS:  Maps
+  maps:  maps
+  NAME: نام
+  name: نام
+  NAMES: نام
+  names: نام
+  NAME_DESCRIPTION:  Name Description
+  name_description:  name description
+  NAME_DESCRIPTIONS:  Name Descriptions
+  name_descriptions:  name descriptions
+  NAMING: نام پیشنهادی
+  naming: نام پیشنهادی
+  NAMINGS: نام های پیشنهادی
+  namings: نام های پیشنهادی
+  NEWS: اخبار
+  news: اخبار
+  NOTIFICATION:  Notification
+  notification:  notification
+  NOTIFICATIONS:  Notifications
+  notifications:  notifications
+  # generic object
+  OBJECT:  Object
+  object:  object
+  OBJECTS:  Objects
+  objects:  objects
+  OBSERVATION: مشاهده
+  observation: مشاهده
+  OBSERVATIONS: مشاهدات
+  observations: مشاهدات
+  PAST_LOCATION: تغییر مکان
+  past_location: تغییر مکان
+  PAST_LOCATIONS: تغییرات مکان
+  past_locations: تغییرات مکان
+  PAST_NAME: تغییر نام
+  past_name: تغییر نام
+  PAST_NAMES: تغییرات نام
+  past_names: تغییرات نام
+  PROJECT: پروژه
+  project: پروژه
+  PROJECTS: پروژه
+  projects: پروژه
+  PUBLICATION: انتشار
+  publication: انتشار
+  PUBLICATIONS: انتشارات
+  publications: انتشارات
+  RSS_LOG: ورود به سیستم فعالیت
+  rss_log: ورود به سیستم فعالیت
+  RSS_LOGS: سیاهههای مربوط به فعالیت
+  rss_logs: سیاهههای مربوط به فعالیت
+  SEQUENCE: دنباله
+  sequence: دنباله
+  SEQUENCES: توالی
+  sequences: توالی
+  SOURCE:  Source
+  source:  source
+  SOURCES:  Sources
+  sources:  sources
+  SPECIES_LIST: فهرست گونه ها
+  species_list: فهرست گونه ها
+  SPECIES_LISTS: فهرست گونه ها
+  species_lists: فهرست گونه ها
+  SPECIMEN: نمونه
+  specimen: نمونه
+  SPECIMENS: نمونه
+  specimens: نمونه
+  USER: کاربر
+  user: کاربر
+  USERS: کاربران
+  users: کاربران
+  USER_GROUP:  User Group
+  user_group:  user group
+  USER_GROUPS:  User Groups
+  user_groups:  user groups
+  VOTE: رای
+  vote: رای
+  VOTES: رای
+  votes: رای
+
+  # Other common nouns.
+  ACCESSION: الحاق
+  ACCESSIONS: اتسس
+  accession: الحاق
+  accessions: اتسس
+  ACCOUNT: حساب
+  account: حساب
+  ACCOUNTS: حساب
+  accounts: حساب
+  ADMIN:  Admin
+  admin:  admin
+  ADMINS:  Admins
+  admins:  admins
+  ADMIN_GROUP:  Admin Group
+  admin_group:  admin group
+  ADMIN_GROUPS:  Admin Groups
+  admin_groups:  admin groups
+  # ("Author" is person(s) who wrote a book, description, or news Article.)
+  AUTHOR: نویسنده
+  author: نویسنده
+  AUTHORS: نویسنده
+  authors: نویسنده
+  # ("Authority" is authority on a scientific name.)
+  ALTITUDE: ارتفاع
+  altitude: ارتفاع
+  # online database with nucleotide Sequence data
+  ARCHIVE:  Archive
+  archive:  archive
+  AUTHORITY: نویسنده
+  authority: نویسنده
+  AUTHORITYS: نویسنده
+  authoritys: نویسنده
+  # nucleotide bases of Sequences
+  BASES:  Bases
+  bases:  bases
+  CHANGE:  Change
+  change:  change
+  CHANGES:  Changes
+  changes:  changes
+  CITATION: استناد
+  citation: استناد
+  CITATIONS: استناد
+  citations: استناد
+  CONFIDENCE_LEVEL: سطح اعتماد به نفس
+  confidence_level: سطح اعتماد به نفس
+  CONFIDENCE_LEVELS: سطح اعتماد به نفس
+  confidence_levels: سطح اعتماد به نفس
+  COPYRIGHT_HOLDER: دارنده کپی رایت
+  copyright_holder: دارنده کپی رایت
+  COPYRIGHT_HOLDERS: دارندگان کپی رایت
+  copyright_holders: دارندگان کپی رایت
+  CORRECT_SPELLING: املای صحیح
+  correct_spelling: املای صحیح
+  CORRECT_SPELLINGS: املای صحیح
+  correct_spellings: املای صحیح
+  CONSENSUS: اجماع
+  DATE: تاریخ
+  date: تاریخ
+  DATES: تاریخ
+  dates: تاریخ
+  # deposit of Sequence Bases in an Archive
+  DEPOSIT: سپرده
+  deposit: سپرده
+  EDITOR:  Editor
+  editor:  editor
+  EDITORS:  Editors
+  editors:  editors
+  EMAIL: ایمیل
+  email: ایمیل
+  EMAILS: ایمیل
+  emails: ایمیل
+  EMAIL_ADDRESS: آدرس ایمیل
+  email_address: آدرس ایمیل
+  EMAIL_ADDRESSS: آدرس های ایمیل
+  email_addresss: آدرس های ایمیل
+  FULL_NAME: نام کامل
+  full_name: نام کامل
+  FULL_NAMES: نام کامل
+  full_names: نام کامل
+  ICN_ID: ICN شناسه
+  icn_id: ICN شناسه
+  ID:  ID
+  id:  ID
+  IDS:  IDs
+  ids:  IDs
+  IDENTIFIER: شناسه
+  identifier: شناسه
+  IDENTIFIERS: شناسه
+  identifiers: شناسه
+  INDEX: شاخص
+  index: شاخص
+  INDEXES: شاخص
+  indexes: شاخص
+  LATITUDE:  Latitude
+  latitude:  latitude
+  LATITUDES:  Latitudes
+  latitudes:  latitudes
+  LOCUS:  Locus
+  locus:  locus
+  LOGIN_NAME: نام ورود
+  login_name: نام ورود
+  LOGIN_NAMES: نام ورود
+  login_names: نام ورود
+  LONGITUDE:  Longitude
+  longitude:  longitude
+  LONGITUDES:  Longitudes
+  longitudes:  longitudes
+  MEMBER: عضو
+  member: عضو
+  MEMBERS: اعضای
+  members: اعضای
+  MESSAGE: پیام
+  message: پیام
+  MESSAGES: پیام
+  messages: پیام
+  NOTE: توجه داشته باشید
+  note: توجه داشته باشید
+  NOTES: یادداشت
+  notes: یادداشت
+  OBSERVER: ناظر
+  observer: ناظر
+  OBSERVERS: ناظران
+  observers: ناظران
+  OWNER:  Owner
+  owner:  owner
+  OWNERS:  Owners
+  owners:  owners
+  PASSWORD: رمز عبور
+  password: رمز عبور
+  PASSWORDS: کلمه عبور
+  passwords: کلمه عبور
+  PREFERENCES: تنظیمات
+  preferences: تنظیمات
+  PREFERRED_NAME: نام ترجیحی
+  preferred_name: نام ترجیحی
+  PREFERRED_NAMES: نام های ترجیحی
+  preferred_names: نام های ترجیحی
+  PROFILE: مشخصات
+  profile: مشخصات
+  PROFILES: پروفایل
+  profiles: پروفایل
+  QUALITY: کیفیت
+  quality: کیفیت
+  RANK: رتبه
+  rank: رتبه
+  RANKS: رتبه
+  ranks: رتبه
+  REVIEWER:  Reviewer
+  reviewer:  reviewer
+  REVIEWERS:  Reviewers
+  reviewers:  reviewers
+  SIZE:  Size
+  size:  size
+  STATUS: وضعیت
+  status: وضعیت
+  STATUSS: وضعیت
+  statuss: وضعیت
+  SUBJECT:  Subject
+  subject:  subject
+  SUBJECTS:  Subjects
+  subjects:  subjects
+  SUMMARY: خلاصه
+  summary: خلاصه
+  SUMMARYS: خلاصه
+  summarys: خلاصه
+  # ("Tag" refers to a keyword, will be used to tag names and images.)
+  TAG:  Tag
+  tag:  tag
+  TAGS:  Tags
+  tags:  tags
+  TIME: زمان
+  time: زمان
+  TIMES: بار
+  times: بار
+  TITLE: عنوان
+  title: عنوان
+  TITLES: عنوان
+  titles: عنوان
+  VERSION: نسخهٔ
+  version: نسخهٔ
+  VERSIONS: نسخه
+  versions: نسخه
+
+  # (Only used by validation errors, I think.)
+  email_confirmation: تایید ایمیل
+  password_confirmation: تایید رمز عبور
+
+  # Common nouns/adjectives used as labels, never pluralized.
+  ALL:  All
+  all:  all
+  NONE:  None
+  none:  none
+  HIGH:  High
+  high:  high
+  LOW:  Low
+  low:  low
+  LESS:  Less
+  less:  less
+  MORE: بیشتر
+  more: بیشتر
+  PREV: قبلی
+  prev: قبلی
+  NEXT: بعدی
+  next: بعدی
+  BACK: قبلی
+  back: قبلی
+  FORWARD: بعدی
+  forward: بعدی
+  EAST:  East
+  east:  east
+  NORTH:  North
+  north:  north
+  SOUTH:  South
+  south:  south
+  WEST:  West
+  west:  west
+
+  # Labels for fields answering: "What did you observe?", "When did you observe
+  # it?", "Where did you observe it?", and "Who observed it?".
+  WHAT: نام علمی
+  what: نام علمی
+  WHEN: وقتی
+  when: وقتی
+  WHERE: محل
+  where: محل
+  WHO: چه کسی
+  who: چه کسی
+
+  # Common verbs/actions used as button labels.
+  ADD: اضافه کردن
+  add: اضافه کردن
+  # activate an API key
+  ACTIVATE:  Activate
+  activate:  activate
+  # approve a name
+  APPROVE:  Approve
+  approve:  approve
+  # attach an observation to a project
+  ATTACH:  Attach
+  attach:  attach
+  CANCEL: لغو
+  cancel: لغو
+  # close a popup window
+  CLOSE:  Close
+  close:  close
+  CREATE: ایجاد
+  create: ایجاد
+  DELETE: حذف
+  delete: حذف
+  # deprecate a name
+  DEPRECATE:  Deprecate
+  deprecate:  deprecate
+  # destroy an observation or other object
+  DESTROY: نابود
+  destroy: نابود
+  DISABLE:  Disable
+  disable:  disable
+  download:  download
+  DOWNLOAD:  Download
+  EDIT: ویرایش
+  edit: ویرایش
+  ENABLE:  Enable
+  enable:  enable
+  # merge one object into another
+  MERGE:  Merge
+  merge:  merge
+  OKAY:  Okay
+  okay:  okay
+  # reload a form
+  RELOAD: بارگذاری
+  reload: بارگذاری
+  # remove an image from an observation, or an observation from a project
+  REMOVE:  Remove
+  remove:  remove
+  SAVE: ذخیره
+  save: ذخیره
+  SAVE_CHANGES:  Save Changes
+  save_changes:  save changes
+  SAVE_EDITS:  Save Edits
+  save_edits:  save edits
+  SEARCH: جستجو
+  search: جستجو
+  SEARCHES:  Searches
+  SEND: ارسال
+  send: ارسال
+  SHOW: نمایش
+  show: نمایش
+  # submit a form
+  SUBMIT: ارسال
+  submit: ارسال
+  UPDATE: روز رسانی
+  update: روز رسانی
+  # upload an image or checklist
+  UPLOAD: آپلود
+  upload: آپلود
+
+  # Common adjectives.
+  ANONYMOUS: ناشناس
+  anonymous: ناشناس
+  BY: توسط
+  by: توسط
+  CREATED: ایجاد
+  created: ایجاد
+  CREATED_AT: ایجاد شده در
+  created_at: ایجاد شده در
+  DESTROYED: نابود
+  destroyed: نابود
+  FILTERED: فیلتر
+  filtered: فیلتر
+  MODIFIED: تغییر
+  modified: تغییر
+  OPTIONAL: اختیاری
+  optional: اختیاری
+  REQUIRED: مورد نیاز
+  required: مورد نیاز
+  WATCHING: تماشای
+  watching: تماشای
+  IGNORING: نادیده گرفتن
+  ignoring: نادیده گرفتن
+  TRACKING: ردیابی
+  tracking: ردیابی
+  UPDATED: بروز رسانی
+  updated: بروز رسانی
+  UPDATED_AT: به روز شده در
+  updated_at: به روز شده در
+  VIEWED: مشاهده
+  viewed: مشاهده
+
+  # Common adjectives describing species names. (Note: "approved" seems to be
+  # interchangeable with "accepted" in our site -- both indicate that the
+  # scientific community accepts this name as correct.  "Reviewed" on the
+  # other hand indicates that a user in the "reviewers" group has looked at
+  # an object and didn't see any obvious mistakes.)
+  APPROVED:  Approved
+  approved:  approved
+  ACCEPTED: پذیرفته شده
+  accepted: پذیرفته شده
+  DEPRECATED: مذموم
+  deprecated: مذموم
+  MISSPELLED:  Misspelt
+  misspelled:  misspelt
+  NOT_MISSPELLED:  Spelled Correctly
+  not_misspelled:  spelled correctly
+  REVIEWED:  Reviewed
+  reviewed:  reviewed
+  UNKNOWN:  Unknown
+  unknown:  unknown
+
+  # Permission states: restricted means access is restricted but the current user
+  # has access; private means the current user does not have access; default means
+  # this is the default description that shows up on the show_name/location page
+  # (synonyms that might work better are "principle" or "main" or "official").
+  PRIVATE:  Private
+  private:  private
+  PUBLIC:  Public
+  public:  public
+  RESTRICTED:  Restricted
+  restricted:  restricted
+  DEFAULT: پیش فرض
+  default: پیش فرض
+
+  # Common verbs/actions with objects.
+  add_object: اضافه کردن [TYPE]
+  add_objects: اضافه کردن [TYPES]
+  all_objects:  All [TYPES]
+  cancel_and_show: لغو (نمایش [TYPE])
+  create_object: ایجاد [TYPE]
+  destroy_object:  Destroy [TYPE]
+  edit_object: ویرایش [TYPE]
+  list_objects:  List [TYPES]
+  remove_object: حذف [TYPE]
+  remove_objects: حذف [TYPES]
+  show_all:  Show All
+  map_all:  Map All
+  show_location: نمایش [LOCATION]
+  show_location_description: نمایش [DESCRIPTION]
+  show_name: مورد [NAME]
+  show_name_description: نمایش [DESCRIPTION]
+  show_object: نمایش [TYPE]
+  show_objects: نمایش [TYPES]
+  sort_by_object: مرتب سازی بر اساس [TYPE]
+
+  # Other generic phrases.
+  added_to_list:  Added observation to "[list]".
+  attached_to_project:  Attached [object] to "[project]".
+  and_num_more:  And [num] more...
+  are_you_sure: مطمئنی?
+  click_for_map: برای نقشه کلیک کنید
+  CREATED_BY: ایجاد شده توسط
+  EDITING:  Editing
+  google_images: گوگل تصاویر
+  MAXIMUM:  Maximum
+  show_on_map: نمایش بر روی نقشه
+  many_times: "[num] بار"
+  one_time:  once
+  permission_denied:  Permission denied.
+  removed_from_list:  Removed observation from "[list]".
+  removed_from_project:  Removed [object] from "[project]".
+  select_file: انتخاب پرونده...
+  no_file_selected: هیچ پرونده ای انتخاب نشده است.
+  "YES":  "Yes"
+  "NO":  "No"
+  "yes":  "yes"
+  "no":  "no"
+
+  ##############################################################################
+
+  # ENUMERATED SETS OF VALUES
+
+  # Units.
+  units_meters:  meters
+
+  # Names we recognize for the "unknown" location: comma-separated list.
+  unknown_locations:  Unknown, Earth, World, Worldwide, Anywhere, Everywhere
+
+  # Quality values.
+  image_vote_long_0: بدون نظر .
+  image_vote_long_1: خوبه ولی نه چندان مفید.
+  image_vote_long_2: مفید برای شناسایی.
+  image_vote_long_3: خوب به اندازه کافی برای یک راهنمای میدان.
+  image_vote_long_4: بزرگ! فراتر از کار فانی ها.
+  image_vote_help_0: بدون نظر .
+  image_vote_help_1: خيلي خب ولي خيلي مفيد نيست
+  image_vote_help_2: مفید برای شناسایی.
+  image_vote_help_3: به اندازه کافي براي يه راهنماي ميداني خوبه
+  image_vote_help_4: عالی! فراتر از کار فاني ها .
+  image_vote_short_0: بدون امتیاز
+  image_vote_short_1: باشه
+  image_vote_short_2: مفید
+  image_vote_short_3: خوب
+  image_vote_short_4: عالی
+
+  # Review statuses. (Note: "unvetted" means it's been looked at but the reviewer
+  # doesn't feel comfortable declaring it "accurate"; thus "unvetted" means
+  # "reviewed" and "vetted" means "approved".  Sorry, we inherited these odd
+  # terms from EOL; they weren't my choice!)
+  review_unreviewed:  Unreviewed
+  review_unvetted:  Reviewed
+  review_vetted:  Approved
+  review_inaccurate:  Inaccurate/Incomplete
+  review_no_export:  Not for Export
+  review_ok_for_export:  Okay for Export
+  review_no_ml:  Not for Machine Learning
+  review_ok_for_ml:  Okay for Machine Learning
+
+  # Naming reasons.
+  naming_reason_label_1: به رسمیت شناخته شده توسط دید
+  naming_reason_label_2: منابع مورد استفاده
+  naming_reason_label_3: بر اساس ویژگی های میکروسکوپی
+  naming_reason_label_4: بر اساس ویژگی های شیمیایی
+
+  # Name/location description types.  These are used as page title and in index
+  # results -- must include both the type of description and the title of the
+  # object ([object]) they're describing.
+  description_full_title_public:  Public [:DESCRIPTION] of [object]
+  description_full_title_foreign:  "[:DESCRIPTION] of [object] from [text]"
+  description_full_title_project:  Draft of [object] for [text] by [user]
+  description_full_title_source:  "[:DESCRIPTION] of [object] from [text]"
+  description_full_title_user:  "[USER]'s [:DESCRIPTION] of [object]"
+
+  # Name/location description types.  These are used when listing the available
+  # descriptions in the show_name page.
+  description_part_title_public: عمومی [:DESCRIPTION]
+  description_part_title_user:  "[USER]'s [:DESCRIPTION]"
+
+  # Name/location description types.  These are used when listing the available
+  # descriptions in the show_name page, but this time the optional text field was
+  # filled in.  Note that the text field is not optional for half of the source
+  # types.
+  description_part_title_public_with_text:  "[TEXT]"
+  description_part_title_foreign_with_text:  "[:DESCRIPTION] From [TEXT]"
+  description_part_title_project_with_text:  Draft for [TEXT] by [USER]
+  description_part_title_source_with_text:  "[:DESCRIPTION] From [TEXT]"
+  description_part_title_user_with_text:  "[TEXT] by [USER]"
+
+  # Footers -- "Created: [date]", "By: [user]", "Obs Created: 2008-11-03", etc.
+  footer_created_at:  "*[:Created]:* [date]"
+  footer_created_by: "*[:Created]:* [date] *توسط* [user]"
+  footer_updated_at:  "*[:Modified]:* [date]"
+  footer_updated_by: "*[:Modified]:* [date] *توسط* [user]"
+  footer_last_updated_at: "*آخرین [:modified]:* [date]"
+  footer_last_updated_by: "*آخرین [:modified]:* [date] *توسط* [user]"
+  footer_viewed: "*[:Viewed]:* [times], *آخرین [:viewed]:* [date]"
+  footer_last_you_viewed: "*آخرین مشاهده شده توسط شما:* [date]"
+  footer_never: هرگز
+  footer_version_out_of:  "*[:Version]:* [num] *of* [total]"
+
+  # Taxonomic ranks.
+  RANK_DOMAIN: دامنه
+  rank_domain: دامنه
+  RANK_PLURAL_DOMAIN: دامنه
+  rank_plural_domain: دامنه
+  RANK_KINGDOM: پادشاهی
+  rank_kingdom: پادشاهی
+  RANK_PLURAL_KINGDOM:  Kingdoms
+  rank_plural_kingdom:  kingdoms
+  RANK_PHYLUM: فیلوم
+  rank_phylum: فیلوم
+  RANK_PLURAL_PHYLUM:  Phyla
+  rank_plural_phylum:  phyla
+  RANK_CLASS: کلاس
+  rank_class: کلاس
+  RANK_PLURAL_CLASS:  Classes
+  rank_plural_class:  classes
+  RANK_ORDER: سفارش
+  rank_order: سفارش
+  RANK_PLURAL_ORDER:  Orders
+  rank_plural_order:  orders
+  RANK_FAMILY: خانواده
+  rank_family: خانواده
+  RANK_PLURAL_FAMILY:  Families
+  rank_plural_family:  families
+  RANK_GENUS: جنس
+  rank_genus: جنس
+  RANK_PLURAL_GENUS:  Genera
+  rank_plural_genus:  genera
+  RANK_SUBGENUS: زیرژنوس
+  rank_subgenus: زیرژنوس
+  RANK_PLURAL_SUBGENUS:  Subgenera
+  rank_plural_subgenus:  subgenera
+  RANK_SECTION: بخش
+  rank_section: بخش
+  RANK_PLURAL_SECTION:  Sections
+  rank_plural_section:  sections
+  RANK_SUBSECTION:  Subsection
+  rank_subsection:  subsection
+  RANK_PLURAL_SUBSECTION:  Subsections
+  rank_plural_subsection:  subsections
+  RANK_STIRPS:  Stirps
+  rank_stirps:  stirps
+  RANK_PLURAL_STIRPS:  Stirpes
+  rank_plural_stirps:  stirpes
+  RANK_SPECIES: گونه
+  rank_species: گونه
+  RANK_PLURAL_SPECIES: گونه
+  rank_plural_species: گونه
+  RANK_SUBSPECIES:  Subspecies
+  rank_subspecies:  subspecies
+  RANK_PLURAL_SUBSPECIES:  Subspecies
+  rank_plural_subspecies:  subspecies
+  RANK_VARIETY:  Variety
+  rank_variety:  variety
+  RANK_PLURAL_VARIETY:  Varieties
+  rank_plural_variety:  varieties
+  RANK_FORM:  Form
+  rank_form:  form
+  RANK_PLURAL_FORM:  Forms
+  rank_plural_form:  forms
+  RANK_GROUP:  Group or Clade
+  rank_group:  group or clade
+  RANK_PLURAL_GROUP:  Groups or Clades
+  rank_plural_group:  groups or clades
+
+  # These two are used when parsing rank, e.g., in name pattern search.
+  rank_alt_phylum:  phylum, division
+  rank_alt_group:  group, clade, complex
+
+  # User statistics field names.
+  user_stats_comments:  "[:COMMENTS]"
+  user_stats_contributing_users:  ""
+  user_stats_images:  "[:IMAGES]"
+  user_stats_location_description_authors:  "[:LOCATION_DESCRIPTIONS] Authored"
+  user_stats_location_description_editors:  "[:LOCATION_DESCRIPTIONS] Edited"
+  user_stats_locations:  "[:LOCATIONS] Created"
+  user_stats_locations_versions:  "[:LOCATIONS] Edited"
+  user_stats_name_description_authors:  "[:NAME_DESCRIPTIONS] Authored"
+  user_stats_name_description_editors:  "[:NAME_DESCRIPTIONS] Edited"
+  user_stats_names:  "[:NAMES] Created"
+  user_stats_names_versions:  "[:NAMES] Edited"
+  user_stats_namings:  Proposed IDs
+  user_stats_observations:  "[:OBSERVATIONS]"
+  user_stats_observations_with_voucher:  Observations with Specimen, Notes and Images
+  user_stats_observations_without_voucher:  All Other Observations
+  user_stats_sequences:  ""
+  user_stats_sequenced_observations:  ""
+  user_stats_species_list_entries:  "[:SPECIES_LIST] Entries"
+  user_stats_species_lists:  "[:SPECIES_LISTS]"
+  user_stats_users:  ""
+  user_stats_votes:  "[:VOTES]"
+
+  # Site statistics field names.
+  site_stats_comments:  "[:COMMENTS]"
+  site_stats_contributing_users:  Contributing Users
+  site_stats_images:  "[:IMAGES]"
+  site_stats_listed_taxa:  Listed Taxa
+  site_stats_location_description_authors:  Authored [:LOCATION_DESCRIPTIONS]
+  site_stats_location_description_editors:  ""
+  site_stats_locations:  Defined [:LOCATIONS]
+  site_stats_locations_versions:  ""
+  site_stats_name_description_authors:  Authored [:NAME_DESCRIPTIONS]
+  site_stats_name_description_editors:  ""
+  site_stats_names:  ""
+  site_stats_names_versions:  ""
+  site_stats_namings:  Proposed IDs
+  site_stats_observations:  "[:OBSERVATIONS]"
+  site_stats_observations_with_voucher:  Observations with Full Data
+  site_stats_observations_without_voucher:  Other Observations
+  site_stats_observed_taxa:  Observed Taxa
+  site_stats_sequences:  "[:SEQUENCES]"
+  site_stats_sequenced_observations:  Sequenced Observations
+  site_stats_species_list_entries:  "[:SPECIES_LIST] Entries"
+  site_stats_species_lists:  "[:SPECIES_LISTS]"
+  site_stats_users:  Members
+  site_stats_votes:  "[:VOTES]"
+
+  # Vote descriptions.
+  vote_no_opinion: بدون نظر
+  vote_confidence_100: من اسمش رو ميذارم که
+  vote_confidence_80: امیدوار
+  vote_confidence_60: ميتونه باشه
+  vote_confidence_40: شک
+  vote_confidence_20: نه به احتمال زیاد
+  vote_confidence_0: انگار!
+  vote_agreement_100: من اسمش رو ميذارم که
+  vote_agreement_80: امیدوار
+  vote_agreement_60: ميتونه باشه
+  vote_agreement_40: شک
+  vote_agreement_20: نه به احتمال زیاد
+  vote_agreement_0: انگار!
+
+  # Time quantities.
+  time_just_seconds_ago: چند ثانيه پيش
+  time_one_minute_ago: يه دقيقه پيش
+  time_minutes_ago: "[n] دقایقی پیش"
+  time_one_hour_ago: یک ساعت پیش
+  time_hours_ago: "[n] ساعاتی پیش"
+  time_one_day_ago: دیروز
+  time_days_ago: "[n] چند روز پیش، [date]"
+  time_one_week_ago: هفته ی قبل [date]
+  time_weeks_ago: "[n] چند هفته پيش [date]"
+  time_one_month_ago: ماه گذشته، [date]
+  time_months_ago: "[n] ماه ها پیش، [date]"
+  time_one_year_ago: پارسال [date]
+  time_years_ago: "[n] سال ها پیش، [date]"
+
+  # Lifeform "tags".
+  lifeform_basidiolichen:  Basidiolichen
+  lifeform_lichen:  Lichen
+  lifeform_lichen_ally:  Lichen Ally
+  lifeform_lichenicolous:  Lichenicolous
+  lifeform_help_basidiolichen:  Lichen-forming fungus with a mushroom fruiting body.
+  lifeform_help_lichen:  Lichen-forming fungus which grows a specialized thallus when in symbiosis with one or more green algae or cyanobacteria.
+  lifeform_help_lichen_ally:  Fungus related to lichens and often studied by lichenologists despite being nonlichenized.
+  lifeform_help_lichenicolous:  Fungus which often or exclusively grows on or within a lichen.
+
+  # These are the search terms we look for, e.g. "date" in "date:today".
+  search_term_author:  author
+  search_term_citation:  citation
+  search_term_classification:  classification
+  search_term_comments: نظرات
+  search_term_confidence:  confidence
+  search_term_created:  created
+  search_term_date:  date
+  search_term_deprecated:  deprecated
+  search_term_east:  east
+  search_term_exclude_consensus:  exclude_consensus
+  search_term_has_author:  has_author
+  search_term_has_citation:  has_citation
+  search_term_has_classification:  has_classification
+  search_term_has_comments:  has_comments
+  search_term_has_description:  has_description
+  search_term_has_field:  has_field
+  search_term_has_location:  has_location
+  search_term_has_name:  has_name
+  search_term_has_notes:  has_notes
+  search_term_has_observations:  has_observations
+  search_term_has_synonyms:  has_synonyms
+  search_term_herbarium:  herbarium
+  search_term_images: تصاویر
+  search_term_include_all_name_proposals:  include_all_name_proposals
+  search_term_include_misspellings:  include_misspellings
+  search_term_include_subtaxa:  include_subtaxa
+  search_term_include_synonyms:  include_synonyms
+  search_term_is_collection_location:  is_collection_location
+  search_term_lichen:  lichen
+  search_term_list:  list
+  search_term_location: محل
+  search_term_modified:  modified
+  search_term_name:  name
+  search_term_north:  north
+  search_term_notes:  notes
+  search_term_project:  project
+  search_term_project_lists:  project_lists
+  search_term_rank:  rank
+  search_term_region:  region
+  search_term_sequence:  sequence
+  search_term_south:  south
+  search_term_specimen:  specimen
+  search_term_user:  user
+  search_term_west:  west
+
+  # Words recognized in search bar.
+  # e.g. "user:me"
+  search_value_me:  me
+  # e.g. "has_images:yes"
+  search_value_true:  yes|true
+  # e.g. "has_specimen:no"
+  search_value_false:  no|false
+  # e.g. "include_misspellings:either" meaning include both correctly and incorrectly spelled names
+  search_value_both:  both|either
+  # e.g. "date:last month-today"
+  search_value_today:  today
+  search_value_yesterday:  yesterday
+  search_value_days_ago:  N days ago
+  search_value_this_week:  this week
+  search_value_last_week:  last week
+  search_value_weeks_ago:  N weeks ago
+  search_value_this_month:  this month
+  search_value_last_month:  last month
+  search_value_months_ago:  N months ago
+  search_value_this_year:  this year
+  search_value_last_year:  last year
+  search_value_years_ago:  N years ago
+
+  # Rss log messages.
+  log_ancient:  "[String]"
+  log_approved_by:  Approved by [user].
+  log_approved_by_with_comment:  "[:log_approved_by] [comment]"
+  log_consensus_changed: "اجماع از: [old]."
+  log_consensus_created:  Initial name [name].
+  log_consensus_created_at:  "[:log_consensus_created]"
+  log_consensus_reached:  "Consensus established: [name]"
+  log_deprecated_by:  Deprecated by [user].
+  log_deprecated_by_with_comment:  "[:log_deprecated_by] [comment]"
+  log_changed_default_description:  Default description changed to [name] by [user].
+  log_changed_permissions:  "Permissions modified by [user]: [name]"
+  log_name_approved:  Approved by [user] over [other].
+  log_name_approved_with_comment:  "[:log_name_approved] [comment]"
+  log_name_deprecated: "محروم شده توسط\n[user] به نفع\n[other]."
+  log_name_deprecated_with_comment:  "[:log_name_deprecated] [comment]"
+  log_object_accessioned: "[name] به هم می آيند [user]"
+  log_object_added_by_user: "[Type] اضافه شده توسط [user]."
+  log_object_added_by_user_with_name: "[Type] اضافه شده توسط [user]: [name]"
+  log_object_created_by_user: "[Type] ایجاد شده توسط [user]."
+  log_object_created_by_user_with_name: "[Type] ایجاد شده توسط [user]: [name]"
+  log_object_destroyed_by_user: "[Type] نابود شده توسط [user]."
+  log_object_destroyed_by_user_with_name: "[Type] نابود شده توسط [user]: [name]"
+  log_object_merged_by_user: "[Type] ادغام شده در [that] توسط [user]."
+  log_object_moved_by_user:  "[Type] moved to [to] by [user]."
+  log_object_removed_by_user: "[Type] حذف شده توسط [user]."
+  log_object_removed_by_user_with_name:  "[Type] removed by [user]: [name]"
+  log_object_removed_no_user: "[Type] حذف."
+  log_object_updated_by_user: "[Type] به روز شده توسط [user]."
+  log_object_updated_by_user_with_name: "[Type] به روز شده توسط [user]: [name]"
+  log_orphan:  "[Title]"
+  log_published_description: "توضیحات منتشر شده توسط [user]: [name]"
+  log_updated_by: به روز شده توسط [user].
+
+  # These should not need any translation.
+  log_article_created:  "[:log_object_created_by_user(type=:article)]"
+  log_article_created_at:  "[:log_object_created_by_user(type=:article)]"
+  log_article_destroyed:  "[:log_object_destroyed_by_user(type=:article)]"
+  log_article_updated:  "[:log_object_updated_by_user(type=:article)]"
+  log_article_updated_at:  "[:log_object_updated_by_user(type=:article)]"
+  log_collection_number_added:  "[:log_object_added_by_user_with_name(type=:collection_number)]"
+  log_collection_number_updated:  "[:log_object_updated_by_user_with_name(type=:collection_number)]"
+  log_collection_number_updated_at:  "[:log_object_updated_by_user_with_name(type=:collection_number)]"
+  log_collection_number_removed:  "[:log_object_removed_by_user_with_name(type=:collection_number)]"
+  log_comment_added:  "[:log_object_added_by_user_with_name(type=:comment,name=summary)]"
+  log_comment_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:comment,name=summary)]"
+  log_comment_updated:  "[:log_object_updated_by_user_with_name(type=:comment,name=summary)]"
+  log_comment_updated_at:  "[:log_object_updated_by_user_with_name(type=:comment,name=summary)]"
+  log_description_created:  "[:log_object_created_by_user_with_name(type=:description)]"
+  log_description_created_at:  "[:log_object_created_by_user_with_name(type=:description)]"
+  log_description_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:description)]"
+  log_description_updated:  "[:log_object_updated_by_user_with_name(type=:description)]"
+  log_description_updated_at:  "[:log_object_updated_by_user_with_name(type=:description)]"
+  log_glossary_term_created:  "[:log_object_created_by_user(type=:glossary_term)]"
+  log_glossary_term_created_at:  "[:log_object_created_by_user(type=:glossary_term)]"
+  log_glossary_term_updated:  "[:log_object_updated_by_user(type=:glossary_term)]"
+  log_glossary_term_updated_at:  "[:log_object_updated_by_user(type=:glossary_term)]"
+  log_herbarium_record_added:  "[:log_object_added_by_user_with_name(type=:herbarium_record)]"
+  log_herbarium_record_moved:  "[:log_object_moved_by_user(type=:specimen)]"
+  log_herbarium_record_updated:  "[:log_object_updated_by_user_with_name(type=:herbarium_record)]"
+  log_herbarium_record_updated_at:  "[:log_object_updated_by_user_with_name(type=:herbarium_record)]"
+  log_herbarium_record_removed:  "[:log_object_removed_by_user_with_name(type=:herbarium_record)]"
+  log_image_created:  "[:log_object_added_by_user_with_name(type=:image)]"
+  log_image_created_at:  "[:log_object_added_by_user_with_name(type=:image)]"
+  log_image_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:image)]"
+  log_image_removed:  "[:log_object_removed_by_user_with_name(type=:image)]"
+  log_image_reused:  "[:log_object_added_by_user_with_name(type=:image)]"
+  log_image_updated:  "[:log_object_updated_by_user_with_name(type=:image)]"
+  log_image_updated_at:  "[:log_object_updated_by_user_with_name(type=:image)]"
+  log_location_created:  "[:log_object_created_by_user(type=:location)]"
+  log_location_created_at:  "[:log_object_created_by_user(type=:location)]"
+  log_location_destroyed:  "[:log_object_destroyed_by_user(type=:location)]"
+  log_location_merged:  "[:log_object_merged_by_user(type=:location)]"
+  log_location_updated:  "[:log_object_updated_by_user(type=:location)]"
+  log_location_updated_at:  "[:log_object_updated_by_user(type=:location)]"
+  log_name_created:  "[:log_object_created_by_user(type=:name)]"
+  log_name_created_at:  "[:log_object_created_by_user(type=:name)]"
+  log_name_destroyed:  "[:log_object_destroyed_by_user(type=:name)]"
+  log_name_merged:  "[:log_object_merged_by_user(type=:name)]"
+  log_name_updated:  "[:log_object_updated_by_user(type=:name)]"
+  log_name_updated_at:  "[:log_object_updated_by_user(type=:name)]"
+  log_naming_created:  "[:log_object_created_by_user_with_name(type=:naming)]"
+  log_naming_created_at:  "[:log_object_created_by_user_with_name(type=:naming)]"
+  log_naming_destroyed:  "[:log_object_destroyed_by_user_with_name(type=:naming)]"
+  log_naming_updated:  "[:log_object_updated_by_user_with_name(type=:naming)]"
+  log_naming_updated_at:  "[:log_object_updated_by_user_with_name(type=:naming)]"
+  log_observation_created:  "[:log_object_created_by_user(type=:observation)]"
+  log_observation_created_at:  "[:log_object_created_by_user(type=:observation)]"
+  log_observation_destroyed2:  "[:log_object_destroyed_by_user_with_name(type=:observation)]"
+  log_observation_destroyed:  "[:log_object_destroyed_by_user(type=:observation)]"
+  log_observation_updated:  "[:log_object_updated_by_user(type=:observation)]"
+  log_observation_updated_at:  "[:log_object_updated_by_user(type=:observation)]"
+  log_project_added_admin:  "[:log_object_added_by_user_with_name(type=:admin)]"
+  log_project_added_member:  "[:log_object_added_by_user_with_name(type=:member)]"
+  log_project_created:  "[:log_object_created_by_user(type=:project)]"
+  log_project_created_at:  "[:log_object_created_by_user(type=:project)]"
+  log_project_destroyed:  "[:log_object_destroyed_by_user(type=:project)]"
+  log_project_removed_admin:  "[:log_object_removed_by_user_with_name(type=:admin)]"
+  log_project_removed_member:  "[:log_object_removed_by_user_with_name(type=:member)]"
+  log_project_updated:  "[:log_object_updated_by_user(type=:project)]"
+  log_project_updated_at:  "[:log_object_updated_by_user(type=:project)]"
+  log_species_list_created:  "[:log_object_created_by_user(type=:species_list)]"
+  log_species_list_created_at:  "[:log_object_created_by_user(type=:species_list)]"
+  log_species_list_destroyed:  "[:log_object_destroyed_by_user(type=:species_list)]"
+  log_species_list_updated:  "[:log_object_updated_by_user(type=:species_list)]"
+  log_species_list_updated_at:  "[:log_object_updated_by_user(type=:species_list)]"
+  log_sequence_added:  "[:log_object_added_by_user(type=name)]"
+  log_sequence_accessioned:  "[:log_object_accessioned(type=:sequence)]"
+  log_sequence_destroyed:  "[:log_object_destroyed_by_user(type=:sequence)]"
+  log_specimen_added:  "[:log_object_added_by_user_with_name(type=:herbarium_record)]"
+  log_object_added:  "[:log_object_added_by_user]"
+  log_object_created:  "[:log_object_created_by_user]"
+  log_object_created_at:  "[:log_object_created_by_user]"
+  log_object_destroyed:  "[:log_object_destroyed_by_user]"
+  log_object_removed:  "[:log_object_removed_by_user]"
+  log_object_updated:  "[:log_object_updated_by_user]"
+  log_object_updated_at:  "[:log_object_updated_by_user]"
+
+  ##############################################################################
+
+  # APPLICATION LAYOUT -- this stuff appears on every single page
+
+  # This goes in the title bar of the browser.  You don't need to translate this,
+  # it's up to you.
+  app_title:  Mushroom Observer
+
+  # This goes in a box at the top of the page.
+  app_banner_box: "**MO Merch!!!  اتمام آن را از \"MO فروشگاه در Etsy\":https://www.etsy.com/shop/MushroomObsMerch!**<br>\nبا تشکر از هانا و آن برای ساخت این اتفاق می افتد!"
+
+  # These are the controls/links in the left-hand panel.
+  app_intro: مقدمه
+  app_how_to_use: چگونه استفاده کنیم
+  app_how_to_help: چگونه برای کمک به
+  app_privacy_policy: سیاست حفظ حریم خصوصی
+  app_donate: اهدا
+  app_send_a_comment: ارسال نظر
+  app_index_a_z:  "[:INDEXES]: [:NAMES]"
+  app_list_locations:  "[:list_objects(type=:location)]"
+  app_list_projects:  "[:list_objects(type=:project)]"
+  app_latest: آخرین
+  app_latest_changes: تغییرات توسط کاربران
+  app_newest_images:  "[:IMAGES]"
+  app_comments:  "[:COMMENTS]"
+  app_observations_left:  "[:OBSERVATIONS]"
+  app_create_observation:  "[:create_object(type=:observation)]"
+  app_sort_by_date_obs:  "[:sort_by_object(type=:date)]"
+  app_sort_by:  "[:sort_by_object(type=order)]"
+  app_species_list:  "[:SPECIES_LISTS]"
+  app_create_list: ایجاد لیست
+  app_sort_by_date_spl:  "[:sort_by_object(type=:date)]"
+  app_sort_by_title:  "[:sort_by_object(type=:title)]"
+  app_account: حساب
+  app_login: ورود
+  app_create_account: ایجاد حساب
+  app_current_user: کاربر فعلی
+  app_comments_for_you: نظرات برای شما
+  app_your_observations: مشاهدات شما
+  app_your_lists: لیست های شما
+  app_your_interests: منافع شما
+  app_your_summary: خلاصه شما
+  app_preferences: تنظیمات
+  app_life_list: لیست زندگی
+  app_checklist: فهرست
+  app_join_mailing_list: عضویت در لیست پستی
+  app_logout: خروج
+  app_admin:  Admin
+  app_blocked_ips:  Blocked IPs
+  app_switch_users:  Switch Users
+  app_users:  "[:list_objects(type=:user)]"
+  app_email_all_users:  Email All Users
+  app_add_to_group:  Add to Group
+  app_turn_admin_on:  Turn on Admin Mode
+  app_turn_admin_off:  Turn off Admin Mode
+  app_languages: زبان
+  app_contributors: همکاران
+  app_site_stats: آمار سایت
+  app_colors_from: رنگ ها از [theme]
+  app_powered_by:  Powered by
+  app_preferred_browser:  Preferred browser
+  app_feature_tracker: ردیاب ویژگی
+  app_publications: انتشارات
+  app_more: بیشتر
+  app_other:  Other
+
+  # This is for the search bar at the top of every page.
+  app_find: پیدا کردن
+  app_search: جستجو
+  app_search_google: سایت (از طریق گوگل)
+  app_advanced_search: جستجوی پیشرفته
+  app_timer: "زمان: [seconds] ثانیه"
+  app_index_timer: "[num] نتایج در [seconds] ثانیه"
+
+  # This shows up at the bottom of every page.  We recommend something like: \n
+  # "Translated into <Language> by _user your-login_"
+  app_translators_credit: ترجمه شده به فارسی توسط
+  app_translators_credit_and_others: و دیگران
+  app_edit_translations: ویرایش همه ترجمه ها
+  app_edit_translations_on_page: ویرایش ترجمه ها در این صفحه
+
+  # These are general alerts that appear near the top of the page.
+  app_no_ajax:  Your Browser Is Out of Date
+  app_no_browser:  We Don't Recognize Your Browser
+  app_no_javascript:  Javascript Is Disabled
+  app_no_session:  You Have Cookies Disabled
+
+  # Title of the RSS auto-discovery link in the HTML header section.
+  app_rss:  "[:app_title] RSS"
+
+  ##############################################################################
+
+  # MOST POPULAR PAGES
+
+  # emails/ask_observation_question
+  ask_observation_question_title:  Question about [name]
+  ask_observation_question_label:  Enter your question below.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this observation as well as your email address.
+
+  # emails/ask_user_question
+  ask_user_question_title:  Email Message for [user]
+  ask_user_question_label:  Enter your question below.  When you hit "[:SEND]" it will be emailed to [user].  The email will include your email address as the 'Reply To' address.
+  ask_user_question_message:  "[:Message]"
+  ask_user_question_subject:  "[:Subject]"
+
+  # emails/ask_webmaster_question
+  ask_webmaster_title:  Email Question or Comment
+  ask_webmaster_your_email:  Your email address
+  ask_webmaster_question:  Question or Comment
+  ask_webmaster_note:  "Thanks for your interest in the Mushroom Observer website.  This website was first launched in mid-2006.  The site is owned by the non-profit \"Mushroom Observer, Inc.\":/support/governance and administered by a group of volunteer developers and maintainers.  We welcome any questions you might have about using the site or comments on how the site might be improved.  Please have a look at our \"feature tracker\":/pivotal/index or our \"account on Pivotal Tracker\":https://www.pivotaltracker.com/projects/224629 to see what we have planned.  You can vote and comment on all the various suggestions for future development there.  However, they are only rough guides, subject to bugs or others issues that may come up and, of course, the availability of our own time to work on the site.\n\nThe Mushroom Observer Team"
+
+  # comment/add_comment
+  comment_add_title: اضافه کردن نظر به [name]
+  comment_add_create:  "[:CREATE]"
+
+  # comment/edit_comment
+  comment_edit_title:  Edit Comment on [name]
+
+  # comment/list_comments (This is used to describe the object the comment is
+  # about if the object has been deleted, orphaning the comment.)
+  comment_list_deleted:  object deleted
+
+  # comment/show_comment
+  comment_show_title: نظر در [Name]
+  comment_show_created_at:  "[:Created]"
+  comment_show_by:  "[:By]"
+  comment_show_summary:  "[:Summary]"
+  comment_show_comment:  "[:Comment]"
+  comment_show_show:  "[:show_object]"
+  comment_show_edit:  "[:EDIT]"
+  comment_show_destroy:  "[:DESTROY]"
+
+  # emails/commercial_inquiry
+  commercial_inquiry_title:  Commercial Inquiry About [name]
+  commercial_inquiry_header:  Enter your commercial inquiry about this image.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this image as well as your email address.
+
+  # location/create_location_description
+  create_location_description_title:  "[:create_name_description_title]"
+
+  # location/create_location
+  create_location_title:  "[:create_object(type=:location)]"
+
+  # name/create_name_description
+  create_name_description_title: ایجاد توضیحات برای [name]
+
+  # name/create_name
+  create_name_title:  "[:create_object(type=:name)]"
+  create_name_multiple_names_match:  There are already multiple names matching "[str]".
+  create_name_duplicate_identifier:  is used by another Name
+
+  # naming/create
+  create_naming_title: "پیشنهاد نام برای مشاهده #[id]"
+  create_new_naming_warn:  Sorry, someone else has given this a positive vote, so we had to create a new Naming to accomodate your changes."
+
+  # observer/create_observation
+  create_observation_title:  "[:create_object(type=:observation)]"
+
+  # observation/download_observations
+  download_observations_title: دانلود مشاهدات
+  download_observations_back:  Cancel (Back to Index)
+  download_observations_format:  Choose format
+  download_observations_raw:  CSV spreadsheet
+  download_observations_adolf:  The Adolf Special™
+  download_observations_darwin:  Darwin Core
+  download_observations_symbiota:  Symbiota
+  download_observations_fundis:  FunDiS
+  download_observations_what_is_this:  what is this?
+  download_observations_encoding:  Choose character encoding
+  download_observations_ascii:  ASCII (no accents)
+  download_observations_windows:  WINDOWS-1252 (best for Excel)
+  download_observations_utf8:  UTF-8 (most universal)
+  download_observations_utf16:  UTF-16 (best for Windows 7 and up)
+  download_observations_print_labels_header:  Or you can print labels for the selected observations
+  download_observations_print_labels:  Print Labels
+
+  # location/edit_location
+  edit_location_title:  "[:edit_object(type=:location)]"
+
+  # location/edit_location_description
+  edit_location_description_title:  Edit [name]
+
+  # name/edit_name_description
+  edit_name_description_title:  Edit [name]
+
+  # name/edit_name
+  edit_name_title:  Edit Name [name]
+  edit_name_multiple_names_match:  "Multiple names match \"[str]\".  If you want to get rid of this name, please choose one of the following names to merge it with: [matches]"
+  edit_name_fill_in_classification_for_genus_first:  You need to fill in a classification for the genus first.
+  edit_lifeform_title:  Edit Lifeform of [name]
+  edit_lifeform_help:  Check boxes of all categories which apply to this taxon.
+  edit_lifeform_save:  "[:SAVE]"
+  propagate_lifeform_title:  Propagate Lifeform to Subtaxa of [name]
+  propagate_lifeform_add:  Check boxes of categories to add to all subtaxa.
+  propagate_lifeform_remove:  Check boxes of categories to remove from all subtaxa.
+  propagate_lifeform_apply:  Apply
+
+  # observer/edit_naming
+  edit_naming_title:  "Edit [:NAMING] for Observation #[id]"
+
+  # observations/edit
+  edit_observation_title:  "[:edit_object(type=:observation)]: [name]"
+  edit_observation_turn_off_specimen_with_records_present:  You just told us there is no longer a specimen available.  Don't forget to remove the corresponding collection numbers, fungarium records and/or sequences below, too, if you need to.
+
+  # account/email_new_password
+  email_new_password_title: ایمیل رمز عبور جدید
+  email_new_password_login: ورود
+
+  # observer/email_merge_request
+  email_merge_request_title:  Send [TYPE] Merge Request
+  email_merge_request_help:  By changing the name of a [type] to be the same as the name of another [type] you are effectively requesting that we merge two [types].  If this is really what you want to do, please take a minute to explain why you think this is the right thing to do.  This will send a request to the admins, and if we agree with you, we will perform the merge.  Note that merging two [types] cannot be undone. It will implicitly affect all [:observations] or other objects attached to the two [types].
+  email_merge_request_success:  Your request has been sent.  Thank you!
+
+  # emails/name_change_request
+  email_name_change_request_title:  Send Name Change Request
+  email_name_change_request_help:  "Changing this Name will indirectly affect other Names that depend on this Name. For instance, another Name may: include this Name as part of its Classification; or have this Name as an approved synonym. If you really want to change this Name, please explain why. This will send a request to the admins, and if we agree with you, we will make the change."
+  new_name:  New Name
+  email_change_name_request_success:  Your request has been sent. Thank you!
+
+  # observer/_form_comments
+  form_comments_comment:  "[:Comment]"
+  form_comments_summary:  "[:Summary]"
+
+  # shared/_form_description
+  form_description_source:  "[:SOURCE]"
+  form_description_source_public:  Public [:app_title] Description
+  form_description_source_foreign:  From Another [:app_title] Server
+  form_description_source_project:  "[:PROJECT]"
+  form_description_source_source:  Independent Source
+  form_description_source_user:  "[:USER]"
+  form_description_permissions:  Permissions
+  form_description_public_writable:  Modifiable by the general public.
+  form_description_public_readable:  Visible to the general public.
+  form_description_source_help:  "There are three kinds of descriptions you can create:\n1. *Public:* These are wikipedia-style documents that are editable by everyone on the site.  The default title is \"[:description_part_title_public]\". Use the text field above to customize this.\n2. *Source:* These descriptions come from a third-party source, and typically are not meant to be modifiable.  Enter the name of the source in the text field above.  Note, if you are posting a description that derives from copyrighted material, please be sure to rewrite it in your own words.\n3. *User:* Use this to create your own personalized description.  The default title will be \"[:description_part_title_user(user=:name)]\".  Use the text field above to customize this.  In both this and the 'Source' type above, you will have exclusive rights to choose who can view and modify this description (see the check-boxes below)."
+  form_description_permissions_help:  Is the general public is allowed to view or make modifications to this description?  If you wish to have more control over read, write and admin permissions, please use the '[:show_description_adjust_permissions]' link above.
+  form_description_license_help:  Please select "license":/info/how_to_use#license you want to use for this description.
+
+  # observations/_form_images
+  form_images_when_taken:  When Was It Taken
+  form_images_when_help:  Date the photograph or drawing was created.
+  form_images_notes_help:  Enter notes that are specific to this particular image.
+  form_images_copyright_holder:  "[:COPYRIGHT_HOLDER]"
+  form_images_original_name:  Original File Name
+  form_images_select_license:  Select a "License":/info/how_to_use#license
+  form_images_license_help:  Select "license":/info/how_to_use#license you want to give for this image.
+  form_images_project_help:  Check any projects you wish to attach this image to.
+  form_images_camera_date:  Camera Date
+
+  # observer/_form_list_feedback
+  form_list_feedback_missing_names:  The following names could not be found.
+  form_list_feedback_missing_names_help:  Click 'Save'/'Update' to create these names.  If you want to correct any you entered by hand, do so in the area below and click 'Save' to re-evaluate the list.  If the names came from an uploaded species list, create a correct file and select it for upload.
+
+  # location/_form_location
+  form_locations_locked:  Lock this location so users cannot change the name or coordinates?
+  form_locations_gen_desc:  General Description
+  form_locations_ecology:  Habitat Description
+  form_locations_species:  Interesting Species
+  form_locations_notes:  "[:Notes]"
+  form_locations_refs:  "[:form_names_refs]"
+  form_locations_refs_help:  "[:form_names_refs_help]"
+  form_locations_help:  "<a href=\"/location/help\" target=\"_new\">Help</a>"
+  form_locations_find_on_map: پیدا کردن در نقشه =>
+  form_locations_lat_long_help:  All values should be in decimal degrees.
+  form_locations_license_help:  Select "license":/info/how_to_use#license you want to give for the above text.
+  form_locations_gen_desc_help:  Describe the geographical location of this location.
+  form_locations_ecology_help:  Summarize the climate, geology, ecology, plant communities, etc.
+  form_locations_species_help:  List the common, rare, or otherwise interesting species found here.
+  form_locations_notes_help:  Enter notes that are specific to this particular location.  For example, whether it is private or public, whether permits are required, driving directions, etc.
+  form_locations_dubious_help:  Submit again to use this location name or edit the text below to correct any typo.
+
+  # observer/_form_name
+  form_names_locked:  Lock this name so users cannot change name, author or rank?
+  form_names_text_name:  Scientific Name
+  form_names_icn_id:  "ICN Identifier #"
+  form_names_identifier_help:  Index Fungorum or MycoBank registration number, if known.
+  form_names_misspelling:  This name is misspelt.
+  form_names_misspelling_it_should_be:  It should be
+  form_names_taxonomic_notes: یادداشت‌هایی در مورد  تاکسی
+  form_names_taxonomic_notes_warning:  Please avoid duplicating information from <a href=\"http://www.indexfungorum.org/\">Index Fungorum</a> (IF) or  <a href=\"https://www.mycobank.org/\">MycoBank</a> (MB) in the [:form_names_taxonomic_notes]. Instead, enter the Index Fungorum Registration Identifier or the MycoBank number in the [:form_names_icn_id] field above. This will automatically create links to both IF and MB.
+  form_names_classification:  Taxonomic Classification
+  form_names_gen_desc:  General Description
+  form_names_diag_desc:  Diagnostic Description
+  form_names_look_alikes:  Look Alikes
+  form_names_habitat:  Habitat
+  form_names_distribution:  Distribution
+  form_names_uses:  Uses
+  form_names_notes:  Notes
+  form_names_refs:  References
+  form_names_text_name_help:  "Unformatted taxon name <i>without</i> author info or status info. E.g.: <br>&nbsp;&nbsp; Amanita muscaria var. flavivolvata <br>For a <b>group or clade</b>, select <b>[:RANK]</b> “[:RANK_GROUP]” above, and add either “group” or “clade” at the end of <b>[:form_names_text_name]</b>. E.g.: <br>&nbsp;&nbsp; Amanita muscaria group <br>&nbsp;&nbsp; Morchella elata clade"
+  form_names_author_help:  "Include the author using <a href=\"http://www.iapt-taxon.org/nomen/main.php?page=art46\" target=\"_new\">ICN</a> format. <b>[:Authority]</b> may also include “sensu” and/or status information. E.g.: <br>&nbsp;&nbsp; (Singer) Jenkins <br>&nbsp;&nbsp; sensu Ginns <br>&nbsp;&nbsp; N. Siegel & C.F. Schwarz nom. prov."
+  form_names_citation_help:  Citation for the publication of this name.
+  form_names_citation_textilize_note:  Citations can be formatted using the <a href="/info/textile_sandbox" target="_new">Textile markup system</a>.
+  form_names_misspelling_note:  If this name is misspelt, please check the box and enter the correct spelling. *NOTE:* Please do not use this to deprecate correctly-spelled synonyms.
+  form_names_classification_help:  "List the higher taxa containing this [rank], one name per rank. Do not include genus or lower ranks. Example:<br/> Domain: _Eukarya_<br/> Kingdom: _Fungi_<br/> Phylum: _Basidiomycota_<br/> Class: _Agaricomycetes_<br/> Order: _Agaricales_<br/> Family: _Agaricaceae_<br/>"
+  form_names_gen_desc_help:  Describe the general appearance of this taxon.
+  form_names_diag_desc_help:  Describe what distinguishes this taxon from closely related taxa.
+  form_names_look_alikes_help:  What other taxa look similar to this one?
+  form_names_habitat_help:  What habitats has taxon has been found in?
+  form_names_distribution_help:  Where geographically has this taxon been found and where is it expected to occur?
+  form_names_uses_help:  How has this taxon been used by people?
+  form_names_notes_help:  Please include notes about the validity of this name, common misuses of the name, and more appropriate names to be used when applicable.
+  form_names_refs_help:  Each line is considered a separate reference, but no other formatting is enforced.
+  name_error_unregistrable:  The [rank] '[name]' is not eligible for an ICN identifier.
+  name_error_icn_id_in_use:  An ICN identifier number may be used by only one Name. '[number]' is already used by '[name]'.
+  name_error_field_start:  "[field] must not start with '[start]'."
+  name_error_field_end:  "[field] must not end with '[end]'."
+
+  # observer/_form_naming
+  form_naming_confidence:  Confidence
+  form_naming_valid_synonyms:  Valid synonyms are
+  form_naming_deprecated:  The name '[name]' is deprecated.
+  form_naming_not_recognized:  MO does not recognize the name '[name]'.
+  form_naming_parent_deprecated:  The [rank] [parent] is deprecated.
+  form_naming_name_help:  The **scientific name** (without author) that identifies this Observation. **Leave this field blank if you don't know the scientific name.**
+  form_naming_deprecated_help:  Select a valid name or click '[button]' to use '[name]'.
+  form_naming_correct_help:  Did you mean one of the following names? [:form_naming_deprecated_help]
+  form_naming_not_recognized_help:  "To proceed: Edit the name to be a valid, correctly spelled, scientific name\n(or -- if you are creating an Observation -- erase the name).\nThen click '[button]'."
+  form_naming_multiple_names:  Multiple names match '[name]'.  Select the one you intended.
+  form_naming_multiple_names_help:  The number after each name is how many observations are currently using that name.
+  form_naming_confidence_help:  How confident are you of this identification?  Please justify how you arrived at your decision in the boxes below, as well.
+
+  # observer/_form_observations
+  form_observations_specimen_available:  Specimen Available
+  form_observations_is_collection_location:  Is this location where it was collected?
+  form_observations_gps_hidden:  Hide exact coordinates?
+  form_observations_original_name:  Original File Name
+  form_observations_upload_images:  Upload Images
+  form_observations_uploading_images:  Uploading Images
+  form_observations_upload_another:  Upload Another...
+  form_observations_creating_observation:  Creating Observation
+  form_observations_edit_image:  Edit Image
+  form_observations_remove_image:  Remove Image
+  form_observations_lat_long_help:  "Optional GPS location within **[:WHERE]**. Latitude must be -90.0 to 90.0;  longitude must be -180.0 to 180.0. Elevation will be converted to meters. If you choose to provide this data please make it as accurate as possible. Examples: \"34.1164\" = \"34°6&apos;59&quot;N\", \"-118.1459\" = \"118 8.754 W\", \"239 m\" = \"784 ft.\""
+  form_observations_log_change:  Log Change
+  form_observations_is_collection_location_help:  Check when the location is where the mushroom was growing.  Uncheck when it is only where the mushroom was seen (e.g., mushroom fairs, grocery, foray id table where collection location is unknown etc.).
+  form_observations_open_map:  Open Interactive Map
+  form_observations_clear_map:  Clear Map
+  form_observations_notes_help:  Please include any additional information you can think of about this observation that isn't clear from the photographs, e.g., habitat, substrate or nearby trees; distinctive texture, scent, taste, staining or bruising; results of chemical or microscopic analyses, etc.
+  form_observations_remove_image_confirm:  Are you sure you want to remove this image?  This will only remove this image from this observation.  If it is attached to other observations, it will remain attached to them.
+  form_observations_specimen_available_help:  Check when there is a preserved specimen available for further study.
+  form_observations_upload_help:  Use the checkboxes on the left to select the image you would like to use as the thumbnail for this observation.
+  form_observations_upload_help_multi_select:  Use the checkboxes on the left to select the image you would like to use as the thumbnail for this observation. In the file select dialog you can select multiple images at a time.  You can also continue to add additional images by clicking the button below.
+  form_observations_where_help:  "Place where the Observation was made. **In the US this should be at least as precise as the county.**\nInclude administrative divisons ordered from smallest to largest, ending with the full name of the country, except use 'USA' for the United States of America.\nExamples:\n&nbsp;&nbsp; [loc1]\n&nbsp;&nbsp; [loc2]"
+  form_observations_locate_on_map_help:  Use the Locate on Map Button to bring this location up on the map. Then click to add a marker and drag it to the specific Latitude & Longitude.
+  form_observations_dubious_help:  Click '[button]' to use this location name or edit the text below to correct any typo.
+  form_observations_project_help:  Check any projects you wish to attach this observation to.  All images you upload will also automatically be attached to these projects, too.
+  form_observations_list_help:  Check any species lists you would like to add this observation to.
+  form_observations_edit_specimens_help:  Please add, edit and remove specimen data from the main observation page.
+  form_observations_use_date:  Use this date
+  form_observations_date_warning:  "Note: The camera date on some of your photos doesn't match the observation date you have entered."
+  form_observations_gps_info:  We were able to detect GPS coordinates in the image(s) you attached. Select one of the coordinates then click 'update' to apply the coordinates to your observation.
+  form_observations_set_observation_date_to:  Set observation date to
+  form_observations_set_image_dates_to:  Set image dates to
+  form_observations_image_too_big:  This image is too large. Images must be less than [max]Mb in file size.
+  form_observations_upload_error:  Something went wrong while uploading image. Skipping it for now. You can try uploading it again later after we've created the observation.
+  form_observations_collection_number_help:  Enter the collector's full name and their record identifier.  The identifier can be anything.  It's whatever you use to keep track of your specimens, and it is typically written on the specimen label.  This is most commonly a sequential number starting at 1 for your first specimen, and working up over your life time.  Another common format is a year or date along with a collection number for that date, e.g., "17-034".  But it can be anything you like, including letters and punctuation.
+  form_observations_herbarium_record_help:  If you've sent a specimen to a fungarium, you can enter that here, along with their accession number if you know it.  Otherwise let it default to your personal fungarium and leave the accession number blank.
+  form_observations_there_is_a_problem_with_location:  There is a problem with the location. "+See message below.+":#location_messages
+  form_observations_there_is_a_problem_with_name:  There is a problem with the name. "+See message below.+":#name_messages
+
+  # observer/_form_species_list
+  form_species_lists_title:  Title
+  form_species_lists_species_to_add:  Select Species to Add
+  form_species_lists_write_in_species:  "Write-In Species: (enter a name on each line)"
+  form_species_lists_list_notes:  Species List Notes
+  form_species_lists_member_notes:  Notes for each new member
+  form_species_lists_confidence:  Confidence in identifications
+  form_species_lists_deprecated:  The following names are deprecated
+  form_species_lists_deprecated_help:  Select any names you would prefer to use.  If you prefer a name you entered then don't select one of the suggested synonyms.
+  form_species_lists_multiple_names:  Multiple names match each of the following entries
+  form_species_lists_multiple_names_help:  In each case, select the intended name.  The number after each name is how many observations are currently using that name.
+  form_species_lists_project_help:  Check any projects you wish to attach this species list to.  Any observations you create for this species list will also automatically be attached to these projects, too.  (But not pre-existing observations.)
+
+  # observer/_form_synonyms
+  form_synonyms_names:  Names
+  form_synonyms_names_help:  List the names you want to be synonymized with [name].
+  form_synonyms_current_synonyms:  Current Synonyms
+  form_synonyms_current_synonyms_help:  Unchecked items will no longer be synonymized with this name, but will remain synonymized with each other.
+  form_synonyms_proposed_synonyms:  Proposed Synonyms
+  form_synonyms_proposed_synonyms_help:  Unchecked items will no longer be synonymized with this name, but will retain their relationships with each other.
+  form_synonyms_deprecate_synonyms:  Deprecate Synonyms
+  form_synonyms_deprecate_synonyms_help:  If checked all listed synonyms become deprecated names.  Otherwise, they are left as they are with new names created as not deprecated.
+  form_synonyms_missing_names:  The following names could not be found.
+  form_synonyms_missing_names_help:  Click [:name_change_synonyms_submit] to create these names.  If you want to correct any names, do so in the area below and click [:name_change_synonyms_submit] to re-evaluate the list.
+
+  # image/add_image
+  image_set_default: تنظیم به عنوان تصویر بندانگشتی پیش فرض
+  image_add_title:  Add an Image for [name]
+  image_add_edit:  "[:edit_object(type=:observation)]"
+  image_add_default: تصویر بندانگشتی پیش فرض
+  image_add_image:  "[:Image]"
+  image_add_optional:  "[:optional]"
+  image_add_upload:  "[:UPLOAD]"
+  image_add_warning:  Please only upload images that you created or which you own the copyright of. By uploading images you are giving us permission to distribute this image to other users ("legalese":http://creativecommons.org/licenses/by-nc-sa/2.5/). You are also giving us permission to display this image along side advertisements or other fund-raising tools that may be used to support this site.
+
+  # image/reuse_image_for_user
+  image_reuse_all_users:  Include other users' images.
+  image_reuse_just_yours:  Only show your images.
+
+  # image/edit_image
+  image_edit_title:  "Editing Image: [name]"
+
+  # image/remove_images
+  image_remove_edit:  "[:edit_object(type=:observation)]"
+  image_remove_remove:  Remove
+  image_remove_title:  Remove Images from [name]
+
+  # image/reuse_images
+  image_reuse_title:  Reuse Image for [name]
+  image_reuse_edit:  "[:edit_object(type=:observation)]"
+  image_reuse_id:  Image ID
+  image_reuse_reuse:  Reuse
+  image_reuse_id_help:  Either click one of the images below, or if you know the image ID, just enter it here and click '[:image_reuse_reuse]'.
+
+  # image/show_image
+  image_show_title:  "[:IMAGE]: [name]"
+  image_show_inquiry: ارسال پرس و جو تجاری
+  image_show_rotate_left:  Rotate Left
+  image_show_rotate_right:  Rotate Right
+  image_show_mirror:  Mirror
+  image_show_edit:  "[:EDIT]"
+  image_show_destroy:  "[:DESTROY]"
+  image_show_when:  "[:WHEN]"
+  image_show_notes:  "[:NOTES]"
+  image_show_copyright: حق تکثیر
+  image_show_public_domain: دامنه عمومی توسط
+  image_show_quality: کیفیت
+  image_show_your_vote: رای شما
+  image_show_vote_and_next: رای دادن و [:NEXT]
+  image_show_comments:  "[num] comment(s)"
+  image_show_observations:  "[:OBSERVATIONS]"
+  image_show_thumbnail: بندانگشتی
+  image_show_small:  Small
+  image_show_medium:  Medium
+  image_show_large:  Large
+  image_show_huge:  Huge
+  image_show_full_size:  Full Size
+  image_show_original: نمایش تصویر اصلی
+  image_show_exif: نمایش هدر EXIF
+  image_show_original_name: نام پرونده اصلی
+  image_show_make_default: این را به اندازه پیش فرض
+  image_show_transform_note:  Image is being processed. This may take several seconds.
+
+  # observation/list_observations
+  list_observations_location_all: همه مکان ها
+  list_observations_location_define:  Define This Location
+  list_observations_location_merge:  Merge With A Defined Location
+  list_observations_alternate_spellings:  Maybe you meant one of the following names?
+  list_observations_suggestions:  Other Links
+  list_observation_name:  "[:NAME]"
+  list_observation_observations:  Observations of
+  list_observations_add_to_list: اضافه کردن به / حذف از لیست گونه ها
+  list_observations_download_as_csv: دانلود مشاهدات
+
+  # location/list_place_names (list_locations)
+  list_place_names_known:  Known Locations
+  list_place_names_known_order:  "(by name)"
+  list_place_names_map:  Map Locations
+  list_place_names_merge:  Merge
+  list_place_names_parenthetical:  Number in parentheses shows Observation count.
+  list_place_names_popularity:  "\"[:sort_by_num_views]\" means how many times the page was visited."
+  list_place_names_undef:  Undefined Locations
+  list_place_names_undef_order:  "(by frequency)"
+
+  # location/list_countries
+  list_countries: فهرست کشور
+  list_countries_known:  Countries With Observations
+  list_countries_title:  Countries and Other Localities
+  list_countries_unknown:  Other Localities With Observations
+  list_countries_missing:  Countries Without Observations
+
+  # _location (RSS log display)
+  location_change:  Change to Location
+
+  # model/location
+  location_dubious_ambiguous_country:  Ambiguous country or state, '[country]'
+  location_dubious_bad_char:  Contains unexpected character '[char]'
+  location_dubious_bad_term:  For consistency, we prefer '[good]' instead of '[bad]'.
+  location_dubious_commas:  All commas should be followed by a space and another word
+  location_dubious_empty: مکان خالی داده شده
+  location_dubious_redundant_county:  County may not be required in this name; for greatest consistency we prefer that you not include the county for towns and cities.
+  location_dubious_redundant_state:  Both '[state]' and '[country]' are on the list of countries and continents.  A common mistake is to include the continent in addition to the country; this is unnecessary.
+  location_dubious_unknown_country: کشور ناشناخته '[country]'
+  location_dubious_unknown_state:  Unrecognized state or province '[state]' for '[country]'.
+
+  # account/login
+  login_please_login: لطفا وارد شوید
+  login_login: ورود
+  login_user: نام کاربر یا آدرس ایمیل
+  login_password: رمز عبور
+  login_remember_me: منو توي اين کامپيوتر يادت باشه .
+  login_forgot_password: رمز عبورم را فراموش کردم.  "يه ايميل جديد برام بذار":/account/email_new_password
+  login_no_account: من حسابي ندارم .  "يه حساب جديد درست کن":/account/signup
+  login_having_problems: اگر شما با مشکل ورود به حساب کاربری خود ، ارسال "ایمیل به مدیر سایت":/emails/ask_webmaster_question.
+  email_new_password_help: هنگامی که این صفحه را تکمیل می کنید و روی "ارسال" کلیک می کنید، ما یک ایمیل با اطلاعات تأیید برای شما ارسال می کنیم.
+  email_spam_notice: اگر ایمیل را در صندوق پستی خود نمی بینید، پوشه اسپم خود را بررسی کنید. اگر آن را در پوشه اسپم خود را، لطفا (1) به ارائه دهنده ایمیل خود اطلاع دهید که آن را هرزنامه نیست و (2) whitelist "mushroomobserver.org". این ممکن است از پایان دادن ایمیل های MO آینده به پوشه های شما -- یا دیگر کاربران -- هرزنامه ها جلوگیری کند.
+  login_layout_description: یک وب سایت برای ثبت مشاهدات در مورد قارچ، کمک به مردم برای شناسایی قارچ های ناآشنا، و گسترش جامعه در اطراف اکتشاف علمی قارچ (قارچ شناسی).
+  login_create_account_caption: ایجاد یک حساب رایگان
+  login_explain_login_requirement: برای جلوگیری از مصرف بیش از حد منابع برنامه های خودکار، استفاده از وب سایت را به کاربران ثبت نام شده محدود می کنیم.
+  login_data_without_login_caption: دریافت اطلاعات MO بدون ورود به سیستم
+  login_images_without_login: دریافت "MO تصاویر برای یادگیری ماشین":/articles/20.
+  login_data_without_login:  Get "MO Data":https://github.com/MushroomObserver/mushroom-observer/blob/master/README_API.md#csv-files.
+
+  # account/logout
+  logout_title: خروج
+  logout_note: تو الان از اينجا خارج شدي [:app_title] وب سایت.  توابع ویرایش غیر فعال هستند.
+
+  # location/map_locations
+  map_locations_title:  Map of [locations]
+  map_locations_global_map:  Global Map
+
+  # name/approve_name
+  name_approve_title:  Approve [name]
+  name_approve_comment_summary:  "[:Approved]"
+  name_approve_comments:  "[:Comments]"
+  name_approve_comments_help:  "Please include any notes about why this name has been approved.\nThis will be added to the notes for [name]."
+  name_approve_deprecate:  Deprecate the following synonyms
+  name_approve_deprecate_help:  If you want to split up a set of synonyms, click 'Approve' or 'Cancel' and then click the 'Change Synonyms' link.
+
+  # name/change_synonyms
+  name_change_synonyms_title:  Synonyms for [name]
+  name_change_synonyms_submit:  Submit Changes
+  name_change_synonyms_confirm:  Please confirm that this is what you intended.
+
+  # name/deprecate_name
+  name_deprecate_title:  Deprecate [name]
+  name_deprecate_preferred: نام ترجیحی
+  name_deprecate_comment_summary:  "[:Deprecated]"
+  name_deprecate_comments:  "[:Comments]"
+  name_deprecate_submit:  "[:SUBMIT]"
+  name_deprecate_preferred_help:  Enter the preferred name. Author citation is recommended but not required.
+  name_deprecate_comments_help:  "Please say why this Name has been deprecated (e.g, a link to Index Fungorum).\nThis will be added to the Comments for [name]."
+
+  # name/name_index (and other actions using same view)
+  name_index_add_name:  Add Name
+  name_index_bulk_edit:  "[:name_bulk_title]"
+
+  # name/map
+  name_map_title: نقشه وقوع برای [name]
+  name_map_about:  "[:show_name]"
+  name_map_no_maps:  No observations of [name] have mappable location information.
+
+  # info/news
+  news_title:  "Latest Release: April 17, 2017"
+  news_header:  This page provides notes on the latest releases and changes to [:app_title].
+  news_content:  "[:news_content_pr_306]\n\n[:news_content_pr_301]\n\n[:news_content_pr_294]\n\n[:news_content_pr_291]\n\n[:news_content_pr_293]\n\n[:news_content_pr_276]\n\n[:news_content_pr_261]\n\n[:news_content_pr_258]\n\n[:news_content_pr_256]\n\n[:news_content_pr_249]\n\n[:news_content_pr_248]\n\n[:news_content_pr_247]\n\n[:news_content_pr_246]\n\n[:news_content_commit_efa11ea]\n\n[:news_content_pr_241]\n\n[:news_content_pr_240]\n\n[:news_content_pr_238]\n\n[:news_content_commit_22deee6]\n\n[:news_content_commit_33639d5]\n\n[:news_content_commit_96e27e9]\n\n[:news_content_pr_236]\n\n[:news_content_pr_235]\n\n[:news_content_pr_233]\n\n[:news_content_pr_232]\n\n[:news_content_pr_231]\n\n[:news_content_pr_230]\n\n[:news_content_pr_226]\n\n[:news_content_pr_224]\n\n[:news_content_pr_223]\n\n[:news_content_pr_221]\n\n[:news_content_pr_220]\n\n[:news_content_pr_219]\n\n[:news_content_pr_217]\n\n[:news_content_pr_216]\n\n[:news_content_pr_215]\n\n[:news_content_pr_213]\n\n[:news_content_pr_212]\n\n[:news_content_pr_208]"
+
+  # info/news individual updates
+  news_content_pr_306:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/306\" target=\"_new\">PR #306</a> (April 17, 2017) Allow removal of author from Name; allow Group or Clade authored/unauthored Name pairs."
+  news_content_pr_301:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/301\" target=\"_new\">PR #301</a> (April 1, 2017) Add google map inset to observation form to help users enter good lat/long and elevation for observatons."
+  news_content_pr_294:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/294\" target=\"_new\">PR #294</a> (March 19, 2017) Add support for clade names. These are just like group names, but use “clade” instead of “group”. Clarify and expand instructions on the Create Name and Edit Name pages."
+  news_content_pr_291:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/291\" target=\"_new\">PR #291</a> (March 18, 2017) Improve group names: allow “group” to be appended to any ICN valid Scientific Name, requiring “group” to be in the Scientific Name field."
+  news_content_pr_293:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/293\">PR #293</a> (March 16, 2017) Fixed bug which caused loss of “Big Eyes” next to a Proposed Name and caused incorrect calculation of Observer Preference."
+  news_content_pr_276:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/276\">PR #276</a> (January 24, 2017) Revived pages explaining color themes. See https://mushroomobserver.org/theme/color_themes. Moved theme actions to a new controller."
+  news_content_pr_261:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/261\">PR #261</a> (January 7, 2017) Added prototype ability to create \"external links\" between observations and corresponding records on external websites, such as MycoPortal and GenBank."
+  news_content_pr_258:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/258\">PR #258</a> (December 27, 2016) Add - via user preferences - persistent filters giving user the option to exclude imageless observations and/or observations without specimens from Activity Feed and other displays of observations."
+  news_content_pr_256:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/256\">PR #256</a> (December 25, 2016) Made it so users who have only proposed a name for an observation will get comment response notifications, instead of requiring users to comment in order to get comment response notifications."
+  news_content_pr_249:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/249\">PR #249</a> (December 24, 2016) Re-enabled donations through paypal  MO, Inc. can now officially accept tax-free donations!"
+  news_content_pr_248:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/248\">PR #248</a> (December 22, 2016) You can now notify users by mentioning them in comments with the usual notations: \"_user john_\" or \"@john\".  If a user's login contains non-alphanumeric characters (like dashes, periods, spaces), then use this format: \"@John Doe@\"."
+  news_content_pr_247:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/247\">PR #247</a> (December 22, 2016) The vote pull-down menus on observation pages now automatically save without requiring an additional page load."
+  news_content_pr_246:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/246\">PR #246</a> (December 22, 2016) Added ability to add (or remove) results of an observation query to (from) an existing species list.  Look for link in upper right corner of any observation index page."
+  news_content_commit_efa11ea:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/efa11ea\">Commit #efa11ea</a> (December 20, 2016) Added support for already-existing query capabilities via the search bar.  Search for observations matching \"help:me\" to see full list of new capabilites."
+  news_content_pr_241:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/241\">PR #241</a> (September 15, 2016) Extensive refactor of Query model in preparation for user filters."
+  news_content_pr_240:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/240\">PR #240</a> (September 11, 2016) Allows 'comb.' e.g., comb. nov., in author field.  Standardize 'comb.' and similar status indicators in future Name edits and creates."
+  news_content_pr_238:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/238\">PR #238</a> (September 9, 2016) Fixes bug in email tracking which caused uploader's mailing address to be used in place of the person who wants the notifications."
+  news_content_commit_22deee6:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/22deee6\">Commit #22deee6</a> (Aug 16, 2016) Fix errors cause by corrupted RSS log. Make failures more graceful if log gets corrupted in the future."
+  news_content_commit_33639d5:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/33639d5\">Commit #33639d5</a> (Aug 10, 2016) Letter to MO Community stating policy on abuse, community openness.  Block user account."
+  news_content_commit_96e27e9:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/commit/96e27e9\">Commit #96e27e9</a> (Aug 7, 2016) Add basic documentation of API to GitHub."
+  news_content_pr_236:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/236\">PR #236</a> (July 28, 2016) Prevent use of the Name \"Imageless\"."
+  news_content_pr_235:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/235\">PR #235</a> (July 28, 2016) Improve link to MycoBank for taxa at the Group rank."
+  news_content_pr_233:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/233\">PR #233</a> (July 28, 2016) Restore padding of tables created with Textile. Reduce size of Textile quoted paragraphs."
+  news_content_pr_232:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/232\">PR #232</a> (July 28, 2016) Wrap long words (to prevent them from extending into other windows)."
+  news_content_pr_231:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/230\">PR #231</a> (July 28, 2016) Improve test coverage of extensions."
+  news_content_pr_230:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/230\">PR #230</a> (July 28, 2016) Refactor fixtures and tests to use Advanced Fixtures."
+  news_content_pr_226:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/226\">PR #226</a> (May 30, 2016) Fix intermittent testing bug (in export_round_trip)."
+  news_content_pr_224:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/224\">PR #224</a> (May 7, 2016) Prevent changes to the \"Unknown\" Location."
+  news_content_pr_223:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/221\">PR #223</a> (April 24, 2016) Expand Show RSS Log page so it is easier to read."
+  news_content_pr_221:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/221\">PR #221</a> (April 24, 2016) Fix bug where weakened confidence level vote sometimes caused mistaken calculation of Observer's favorite."
+  news_content_pr_220:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/220\">PR #220</a> (February 1, 2016) Allow creation of Observations with observation date more than 20 years old."
+  news_content_pr_219:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/219\">PR #219</a> (January 16, 2016) Create Vote Controller."
+  news_content_pr_217:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/217\">PR #217</a> (January 15, 2016) Make \"Textile markup system\" a link everywhere on edit_name form."
+  news_content_pr_216:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/216\">PR #216</a> (January 15, 2016) Remove IP address blocking from Rails code."
+  news_content_pr_215:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/215\">PR #215</a> (January 15, 2016) Always show Observer Preference line in Observations if user checks \"View Observer’s Preferred ID?\"."
+  news_content_pr_213:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/213\">PR #213</a> (January 14, 2016) Add Capybara gem and counterparts of 2 older integration tests."
+  news_content_pr_212:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/212\">PR #212</a> (January 14, 2016) Enable web console in development mode on the VM."
+  news_content_pr_208:  "<a href=\"https://github.com/MushroomObserver/mushroom-observer/pull/208\">PR #208</a> (December 13, 2015) <u>Rails 4.2.5</u>\n\nAt long last the Mushroom Observer website is up to date with the latest stable version of Ruby on Rails (4.2.5). This has not been true since at least March of 2009.  The upgrade process started last August when we were still using the 2.1.1 version of Ruby on Rails.\n\nThis has been a huge team effort by all the volunteer developers on the project. Thanks to every one of you for helping to make this happen.\n\nFor those who are interested in the technical low-down of this specific release, we got to 4.1 last month and the biggest change between 4.1 and 4.2 was a new HTML parsing library that required many minor code changes throughout out code base. There have also been some changes to how email is handled and a variety of other small changes to the code base.  You should see no new changes in the site due to this latest upgrade, but of course <a href=\"/emails/ask_webmaster_question\">send us a note</a> if you see anything wrong."
+
+  # shared/_observation_list
+  observation_made_confidence:  Community confidence
+
+  # account/prefs
+  prefs_title:  Change Preferences
+  prefs_link:  Edit Preferences
+  prefs_login:  Login
+  prefs_email:  Email address
+  prefs_password_new:  New password
+  prefs_password_confirm:  Confirm new password
+
+  prefs_appearance:  Appearance Settings
+  prefs_theme:  Preferred theme
+  prefs_themes_about:  About Themes
+  prefs_locale:  Language
+  prefs_location_format:  Location Format
+  prefs_location_format_postal:  Postal (New York, USA)
+  prefs_location_format_scientific:  Scientific (USA, New York)
+  prefs_hide_authors:  "[:AUTHORITYS]"
+  prefs_hide_authors_none:  show author for all ranks (default)
+  prefs_hide_authors_above_species:  hide author for genus and higher ranks
+  prefs_thumbnail_size:  Thumbnail size
+  prefs_thumbnail_small:  "[:image_show_small]"
+  prefs_thumbnail_large:  "[:image_show_large]"
+  prefs_thumbnail_maps:  View thumbnail map on Observation page?
+  prefs_image_size:  Image size
+  prefs_image_size_help:  Size shown when you click on an image.
+  prefs_image_small:  "[:image_show_small] (320 x 320)"
+  prefs_image_medium:  "[:image_show_medium] (640 x 640)"
+  prefs_image_large:  "[:image_show_large] (960 x 960)"
+  prefs_image_huge:  "[:image_show_huge] Huge (1280 x 1280)"
+  prefs_image_full_size:  "[:image_show_full_size]"
+  prefs_layout_count:  List page items
+  prefs_layout_title:  List page layout
+  prefs_rows_by:  rows ×
+  prefs_columns:  columns
+  prefs_alt_col_colors:  Alternate column colors.
+  prefs_alt_row_colors:  Alternate row colors.
+  prefs_text_below_images:  Put text below images.
+  prefs_view_owner_id:  View Observer's Preferred ID?
+  prefs_view_owner_id_help:  View Observer's preferred ID for Observation (in addition to consensus ID)
+
+  prefs_content_filters:  Content Filters
+  prefs_content_filters_explanation:  Control content visibility site-wide.
+  prefs_filters_has_images:  Hide observations with no images
+  prefs_filters_has_specimen:  Hide observations with no specimens
+  prefs_filters_lichen:  Filter observations of lichens
+  prefs_filters_lichen_yes:  Show only lichens
+  prefs_filters_lichen_no:  Hide lichens
+  prefs_filters_region:  Show only observations and locations within this region
+  prefs_filters_region_help:  Must match the end of the location name, e.g., "Thailand" and "California, USA".
+  prefs_filters_clade:  Show only observations within this taxonomic clade
+  prefs_filters_clade_help:  Any taxonomic level is okay, e.g., "Agaricales", "Amanitaceae" and "Cortinarius".
+  prefs_filter_off:  filter off
+
+  prefs_notes_template:  Observation Notes Template
+  notes_template:  "[:prefs_notes_template]"
+  prefs_notes_template_explanation:  Comma-separated list of Notes sub-headings for the Create Observation page.
+  prefs_notes_template_no_other:  must not include a heading named “[part]”
+  prefs_notes_template_no_dups:  contains duplicate heading “[part]”
+  prefs_privacy:  Privacy Settings
+  prefs_votes_anonymous:  Votes on proposed names and images
+  prefs_votes_anonymous_no:  Always public
+  prefs_votes_anonymous_yes:  Always anonymous
+  prefs_votes_anonymous_old:  Public after [cutoff]
+  prefs_keep_image_filenames:  Keep original file name of uploaded images?
+  prefs_keep_image_filenames_toss:  remove from database completely
+  prefs_keep_image_filenames_keep_but_hide:  save but keep them private
+  prefs_keep_image_filenames_keep_and_show:  save and make them public
+  prefs_bulk_filename_purge:  Purge All Filenames from Database
+  prefs_bulk_filename_purge_confirm:  Are you sure you want to purge all image filenames from our database? This action cannot be undone.  Please note that no one but you is able to see these filenames, anyway.
+  prefs_bulk_filename_purge_success:  Successfully purged all image filenames from our database.
+  prefs_change_image_vote_anonymity:  Change Image Vote Anonymity
+  prefs_license_note:  Default "license":/info/how_to_use#license you want for new images.
+
+  prefs_email_please_notify:  Please notify me when...
+  prefs_email_general:  General Email
+  prefs_email_general_commercial:  someone is interested in using an image of mine for commercial purposes.
+  prefs_email_general_features:  new features come out.
+  prefs_email_general_questions:  someone wants to send me a question about my observations, etc.
+  prefs_email_comments: "[:Comment] ایمیل"
+  prefs_email_comments_all: هر کسی نظر در مورد هر چیزی.
+  prefs_email_comments_owner: کسی نظر در مشاهدات من ، نام ، و غیره.
+  prefs_email_comments_response: کسی پاسخ به نظرات من.
+  prefs_email_locations: "[:Location] ایمیل"
+  prefs_email_locations_all: هر کسی هر مکان را تغییر می دهد.
+  prefs_email_locations_admin: کسی تغییر مکان من مدیریت.
+  prefs_email_locations_author: کسی تغییر مکان من نویسنده در.
+  prefs_email_locations_editor: کسی مکانی را که ویرایش کرده ام تغییر می دهد.
+  prefs_email_observations: "[:Observation] ایمیل"
+  prefs_email_observations_all: هر اتفاقی برای هر مشاهده ای می افتد.
+  prefs_email_observations_consensus: تغییرات نام اجماع برای یکی از مشاهدات من.
+  prefs_email_observations_naming: کسی نامی را برای یکی از مشاهدات من پیشنهاد می کند.
+  prefs_email_names: "[:Name] ایمیل"
+  prefs_email_names_all: هر کسی هر نامی را تغییر می دهد.
+  prefs_email_names_admin: کسی تغییر نام من مدیریت.
+  prefs_email_names_author: کسی تغییر نام من نویسنده در.
+  prefs_email_names_editor: کسی نامی را که ویرایش کرده ام تغییر می دهد.
+  prefs_email_names_reviewer: کسی تغییر نام من بررسی شده است.
+  prefs_email_prefs: ترجیحات ایمیل
+  prefs_email_html: اشکالی ندارد که از HTML در ایمیل هایم استفاده کنم.
+  prefs_email_digest_daily: خلاصه آخر روز را برایم بفرستید.
+  prefs_email_digest_immediate: همونطور که اتفاق ميافته منو از اتفاقات آگاه کن
+  prefs_email_digest_weekly: خلاصه آخر هفته برام بفرست.
+  prefs_email_note: توجه داشته باشید که هیچ یک از این ویژگی های ایمیل باعث نمی شود که آدرس ایمیل شما در یک صفحه وب نمایش داده شود یا به فردی که می خواهد با شما تماس گیرد اجازه دهد تا آدرس ایمیل شما را به دست آورد.  شما یک ایمیل از اخبار در mushroomobserver.org که حاوی اطلاعات تماس برای کسی که می خواهد با شما تماس بگیرید ارسال خواهد شد.  این کاملا به شما خواهد بود اگر شما می خواهید به آنها پاسخ دهد.
+
+  # account/profile
+  profile_title:  "[:edit_object(type=:profile)]"
+  profile_link:  "[:edit_object(type=:profile)]"
+  profile_button:  "[:SAVE_CHANGES]"
+  profile_name:  "[:Name]"
+  profile_notes: درباره خودت
+  profile_location: محل اولیه
+  profile_mailing_address: آدرس پستی برای مجموعه ها
+  profile_image_create: آپلود عکس
+  profile_image_change: آپلود عکس جدید
+  profile_image_remove: "(حذف عکس.)"
+  profile_image_reuse:  "(Reuse another photo.)"
+  profile_copyright_holder:  Copyright holder and license for this image
+  profile_copyright_warning:  Please only upload an image that you created or which you own the copyright of.
+
+  # account/reverify
+  reverify_welcome: حساب احترام
+  reverify_link: احترام
+  reverify_note: "حساب شما، [user], هنوز تایید نشده است.\n\nایمیل خود را برای آدرس تایید خود را بررسی کنید و یا با کلیک بر روی لینک زیر را به ایمیل تایید کیه."
+
+  # rss_logs/rss
+  rss_description: فهرست تغییرات در [:app_title] همونطور که اتفاق ميافته .
+  rss_log_of_deleted_item: مورد حذف شده
+  rss_log_title: ورود به فعالیت
+  rss_by: توسط [user]
+  rss_title:  "[:app_title]"
+  rss_filtered_mouseover: "[:app_title] فیلتر (ها) را بر اساس ترجیحات شما اعمال کرده است."
+  rss_show: "نمایش:"
+  rss_hide: "مخفی کردن:"
+  rss_all: همه چیز
+  rss_all_help: همه انواع شی را نشان می دهد.
+  rss_one_observation:  "[:OBSERVATIONS]"
+  rss_one_name:  "[:NAMES]"
+  rss_one_location:  "[:LOCATIONS]"
+  rss_one_species_list:  "[:SPECIES_LISTS]"
+  rss_one_project:  "[:PROJECTS]"
+  rss_one_glossary_term:  "[:GLOSSARY]"
+  rss_one_article:  "[:NEWS]"
+  rss_one_help: فقط نشون بده [types].
+  rss_make_default: این را پیش فرض من
+  rss_this_is_default: این پیش فرض شماست
+  rss_created_at: "[TYPE] ایجاد"
+  rss_changed: "[TYPE] تغییر"
+  rss_destroyed: "[TYPE] نابود"
+  rss_consensus_reached: اجماع برقرار شد
+
+  # shared/_textile_help
+  general_textile_link:  Can be formatted with <a href="/info/textile_sandbox" target="_new">Textile</a>.
+  shared_textile_link:  More details here.
+  shared_textile_help: یادداشت ها را می توان با استفاده از فرمت <a href="/info/textile_sandbox" target="_new">Textile markup system</a>.<br/> _Amanita ocreata_, _A. ocreata_ ---> <u><b><i>Amanita ocreata</i></b></u> (مرتبط با توضیحات نام)<br/> __italic__, **bold** ---> <i>italic</i>, <b>bold</b><br/>
+
+  field_textile_link:  This field can be formatted with <a href="/info/textile_sandbox" target="_new">Textile</a>.
+
+  # comment/_show_comments
+  show_comments_add_comment:  "[:add_object(type=:comment)]"
+  show_comments_no_comments_yet: هنوز کسی اظهار نظر نکرده است.
+  show_comments_and_more:  And [num] more...
+
+  # observation/_show_consensus
+  show_consensus_species:  Species in [name]
+
+  # name/show_name_description or location/show_location_description
+  show_description_empty:  Nothing has been written for this description yet.
+  show_description_destroy:  "[:DESTROY]"
+  show_description_edit:  "[:EDIT]"
+  show_description_clone:  Clone
+  show_description_merge:  Merge With Another
+  show_description_publish:  Publish
+  show_description_make_default:  Make Default
+  show_description_adjust_permissions:  Adjust Permissions
+  show_description_read_permissions:  View
+  show_description_write_permissions:  Edit
+  show_description_clone_help:  Create your own description based on this description.
+  show_description_merge_help:  Merge this description into another, then remove this one.
+  show_description_publish_help:  Publish this draft and make it the default public description.
+  show_description_make_default_help:  Make this the default description that is shown on the main '[:show_name(name=:name)]' page.
+  show_description_adjust_permissions_help:  Change the set of users who are allowed to view, modify or administrate this description.
+
+  # observer/_show_images
+  show_images_small_thumbs:  "(small thumbnails)"
+  show_images_large_thumbs:  "(large thumbnails)"
+
+  # observer/_show_lists
+  show_lists_header:  "[:SPECIES_LISTS]"
+
+  # location/show_location
+  show_location_title:  "[:LOCATION]: [name]"
+  show_location_create:  "[:create_object(type=:location)]"
+  show_location_edit:  "[:edit_object(type=:location)]"
+  show_location_destroy:  "[:destroy_object(type=:location)]"
+  show_location_observations: مشاهدات در این مکان
+  show_location_highest:  Highest Elevation
+  show_location_lowest:  Lowest Elevation
+  show_location_no_descriptions:  There are no descriptions for this location yet.
+  show_location_create_description:  "[:CREATE]"
+  show_location_creator: کاربری که این مکان را تعریف کرده است
+  show_location_editor:  "[:Editors]"
+  show_location_editors:  "[:Editors]"
+  show_location_reverse:  Reverse Location
+  show_location_locked: این مکان قفل شده است. اگر می خواهید محل مشاهده خود را تغییر دهید، لطفا ً به جای آن مشاهده را ویرایش کنید.  تغییر نام مکان یا مختصات به طور ضمنی تمام مشاهدات در آن مکان را نیز تغییر می دهد.
+
+  # name/show_name
+  show_name_title:  "[:NAME]: [name]"
+  show_name_add_name:  "[:add_object(type=:name)]"
+  show_name_edit_name:  "[:edit_object(type=:name)]"
+  show_name_bulk_name_edit:  "[:name_bulk_title]"
+  show_name_distribution_map: نقشه وقوع
+  show_name_change_synonyms: تغییر مترادف
+  show_name_email_tracking: ردیابی ایمیل
+  show_name_create_description:  "[:CREATE]"
+  show_name_synonyms:  Synonym(s)
+  show_name_preferred_synonyms: مترادف های ترجیحی
+  show_name_deprecated_synonyms: مترادف های مذموم
+  show_name_misspelled_synonyms: بدفروشی ها
+  show_name_misspelling: این نام را به بدی می نامند.
+  show_name_misspelling_correct:  "[:CORRECT_SPELLING]"
+  show_name_refresh_classification:  Refresh from Genus
+  show_name_propagate_classification:  Propagate to Subtaxa
+  show_name_lifeform: شکل زندگی
+  show_name_propagate_lifeform:  Propagate to Subtaxa
+  show_name_notes:  "[:form_names_taxonomic_notes]"
+  show_name_descriptions: "[:DESCRIPTIONS]"
+  show_name_create_draft: ایجاد پیش نویس جدید برای
+  show_name_no_descriptions:  There are no descriptions for this name yet.
+  show_name_description_author:  "[:Description] author"
+  show_name_description_authors:  "[:Description] authors"
+  show_name_description_editor:  "[:Description] editor"
+  show_name_description_editors:  "[:Description] editors"
+  show_name_author_request:  Request Authorship Credit
+  show_name_content_status:  Description status
+  show_name_latest_review:  "Latest review: [date] by [user]"
+  show_name_most_confident: مطمئن ترین مشاهدات
+  show_name_previous_version: نسخه قبلی
+  show_name_other_versions:  Other Versions
+  show_name_creator: اولین کسی که از این نام در MO استفاده کرد
+  show_name_editor:  "[:Editors]"
+  show_name_editors:  "[:Editors]"
+  show_name_other_observations_notes:  "(Someone proposed [name] for these observations, but consensus hasn't accepted it.  Confidence value is for __this__ name, not the consensus name.)"
+  show_name_nomenclature:  Nomenclature
+  show_name_classification: طبقه بندی
+  show_name_brief_description: شرح مختصر
+  show_name_see_more: بیشتر ببینید
+  show_name_icn_id_missing: گم شده
+  index_fungorum:  Index Fungorum
+  index_fungorum_search:  Index Fungorum search
+  mycobank:  MycoBank
+  mycobank_search:  MycoBank search
+  gsd_species_synonymy:  GSD Species Synonymy
+  sf_species_synonymy:  SF Species Synonymy
+
+  # name/show_name - links to observations
+  show_name_observations:  More [:OBSERVATIONS]
+  show_name_observations_of:  More [:OBSERVATIONS] of [name]
+  show_name_all_observations:  More [:OBSERVATIONS] (all synonyms)
+  show_name_synonym_observations:  Synonym [:OBSERVATIONS]
+  show_name_other_observations:  Similar [:OBSERVATIONS]
+  show_observations_of:  "[:OBSERVATIONS] of:"
+  obss_of_this_name: این نام
+  obss_of_taxon: اين تاکسون، هر اسمي
+  taxon_obss_other_names:  this taxon, other names
+  obss_name_proposed: هر تاکسون، اين اسم پيشنهاد شده
+  obss_taxon_proposed: تاکسی دیگر، این تاکسی پیشنهاد شده است
+  show_subtaxa_obss: زیر تاکسی
+  show_name_locked:  This name is locked. If you want to change the name of your observation, please propose a new name for your observation and vote on it, instead.  If you change a name record on MO, it implicitly changes all the observations of that name.
+  show_name_inherit_classification:  Copy from parent.
+  edit_classification_title:  Edit Classification of [name]
+  inherit_classification_title:  Copy Classification from Parent of [name]
+  inherit_classification_parent_name:  Name of Parent
+  inherit_classification_parent_blank:  Parent has no classification, either!
+  inherit_classification_no_matches:  No names match.
+  inherit_classification_alt_spellings:  No names match.  Maybe you meant one of these?
+  inherit_classification_multiple_matches:  Multiple names match.  Which did you mean?
+  inherit_classification_parent_lower_rank:  Parent must be higher rank than [rank].
+  show_name_num_notifications: "*تعداد کاربران علاقه مند به این نام:* [num]"
+
+  # observer/_show_namings
+  show_namings_proposed_name:  "[:NAMING]"
+  show_namings_proposed_names:  "[:NAMINGS]"
+  show_namings_no_names_yet: هنوز نامی پیشنهاد نشده است.
+  show_namings_propose_new_name: پیشنهاد نام دیگر
+  show_namings_eye_help: انتخاب ناظر
+  show_namings_eyes_help: اجماع فعلی
+  show_namings_community_favorite:  This is the community favorite.
+  show_namings_consensus: رای جامعه
+  show_namings_no_votes:  no votes
+  show_namings_your_vote: رای شما
+  show_namings_update_votes:  Update Votes
+  show_namings_suggest_names:  Name Suggestions
+  show_namings_cast:  Cast Vote
+  show_namings_user:  "[:User]"
+  show_namings_consensus_help: برای هر نام ذکر شده در بالا نظر خود را انتخاب کنید که چگونه به خوبی که نام در این مشاهده اعمال می شود.  انتخاب '[:show_namings_propose_new_name]' اگر می خواهید گزینه دیگری را پیشنهاد کنید.  مشاهده "چگونه استفاده کنیم":/info/how_to_use#voting صفحه برای جزئیات بیشتر در مورد چگونگی رای tallied.
+  show_namings_lose_changes:  You must click '[:show_namings_update_votes]' to save any changes you've made to your votes.
+  show_namings_please_login:  Please login to propose your own names and vote on existing names.
+  show_namings_saving:  Saving
+
+  # observer/show_observation
+  show_observation_title:  "[:OBSERVATION]: [name]"
+  show_observation_header:  "[:OBSERVATION]"
+  show_observation_site_id: شناسه سایت
+  show_observation_owner_id: ترجیح ناظر
+  show_observation_no_clear_preference:  no clear preference
+  show_observation_edit_observation:  "[:edit_object(type=:observation)]"
+  show_observation_propose_new_name:  "[:show_namings_propose_new_name]"
+  show_observation_debug_consensus:  Debug Consensus
+  show_observation_alternative_names:  Alternative Name(s)
+  show_observation_preferred_names:  Preferred Name(s)
+  show_observation_observation_created_at:  Observation created
+  # This is used if this is the location where the thing was growing.
+  show_observation_collection_location: محل جمع آوری
+  # This is used if this is NOT the location where the thing was growing.
+  show_observation_seen_at: دیده می شود در
+  show_observation_gps_hidden: مختصات پنهان از عموم
+  show_observation_specimen_available:  Specimen available
+  show_observation_specimen_not_available: هیچ نمونه ای در دسترس نیست
+  show_observation_remove_images:  "[:remove_objects(type=:image)]"
+  show_observation_reuse_image:  Reuse Image
+  show_observation_add_images:  "[:add_objects(type=:image)]"
+  show_observation_species_lists:  "[:SPECIES_LISTS]"
+  show_observation_manage_species_lists: مدیریت لیست گونه ها
+  show_observation_send_question: ارسال ناظر یک سوال
+  show_observation_view_notifications:  View Notifications
+  show_observation_hide_map:  Hide thumbnail map.
+  show_observation_thumbnail_map_hidden:  Thumbnail map hidden.  To re-enable this feature, go to your "[:app_preferences]":/account/prefs page.
+  show_observation_add_link_dialog:  "Enter full URL, including \"http://\":"
+  show_observation_edit_link_dialog:  "[:show_observation_add_link_dialog]"
+  show_observation_remove_link_dialog:  Are you sure you want to remove this link?
+  show_observation_no_collection_numbers:  No [:collection_numbers]
+  show_observation_no_herbarium_records:  No [:herbarium_records]
+  show_observation_add_sequence: اضافه کردن [:SEQUENCE]
+  show_observation_no_sequences:  No [:sequences]
+  show_observation_archive_link:  Show Archive Record
+  show_observation_blast_link: اجرا BLAST®
+  show_observation_more_like_this: بیشتر شبیه به این
+  show_observation_look_alikes: شبیه به هم هستند
+  show_observation_related_taxa: تاکسا مرتبط
+  map_observation_title: "نقشه مشاهده #[ID]"
+
+  # observer/suggestions
+  suggestions_title:  Confident Suggestions
+  suggestions_title_others:  Wild Guesses
+  suggestions_already_proposed:  already proposed
+  suggestions_propose_name: پیشنهاد این نام
+  suggestions_confidence: اعتماد
+  suggestions_max:  Max
+  suggestions_avg:  Avg
+  suggestions_excellent:  excellent
+  suggestions_good:  good
+  suggestions_fair:  fair
+  suggestions_poor:  poor
+  suggestions_processing_images: بارگذاری تصاویر
+  suggestions_processing_image:  Analyzing image
+  suggestions_processing_results:  Processing results
+  suggestions_error: يه مشکلي پيش اومده، ببخشيد!
+
+  # location/show_past_location
+  show_past_location_title:  "[:VERSION] [num]: [name]"
+  show_past_location_other_versions:  Other Versions
+  show_past_location_no_version:  No version specified
+
+  # location/show_past_location_description
+  show_past_location_description_title:  "[:VERSION] [num]: [name]"
+
+  # name/show_past_name
+  show_past_name_title:  "[:VERSION] [num]: [name]"
+
+  # name/show_past_name_description
+  show_past_name_description_title:  "[:VERSION] [num]: [name]"
+
+  # object/show_past_versions
+  show_past_version_merged_with:  "(merged with #[id])"
+
+  # observer/show_rss_log
+  show_rss_log_title:  Log for [title]
+
+  # info/site_stats
+  show_site_stats_title:  Site Statistics
+
+  # observer/_show_votes
+  show_votes_title:  Show Votes for [name]
+  show_votes_users:  "[:Users]"
+  show_votes_vote:  "[:Vote]"
+  show_votes_weight:  Weight
+  show_votes_average:  Average
+  show_votes_score:  Score
+  show_votes_go_public:  Make all of my votes public.
+  show_votes_go_private:  Make all of my votes anonymous.
+  show_votes_total:  "Overall Score\nsum(score * weight) /\n(total weight + 1)"
+  show_votes_descript:  User's votes are weighted by their contribution to the site (log<small>10</small> contribution). In addition, the user who created the observation gets an extra vote.
+  show_votes_go_public_confirm:  This will make all your votes for all observations public, not just your vote for this name.  Is this what you want to do?
+  show_votes_go_private_confirm:  This will make all your votes for all observations anonymous, not just your vote for this name.  Is this what you want to do?
+  show_votes_gone_public:  Thank you!  Your preferences have been updated.  Other users can now see your votes.
+  show_votes_gone_private:  Your preferences have been updated.  Other users can no longer see your votes.
+
+  # users/show
+  show_user_title:  Contribution Summary for [user]
+  show_user_contributors:  "[:app_contributors]"
+  show_user_observations_by:  Observations by [name]
+  show_user_your_observations:  Your Observations
+  show_user_comments_for:  Comments for [name]
+  show_user_comments_for_you:  Comments for You
+  show_user_your_notifications:  Your Email Alerts
+  show_user_edit_profile:  Edit Profile
+  show_user_email_to:  Email [name]
+  show_user_joined:  Joined
+  show_user_mailing_address:  Mailing Address for Collections
+  show_user_primary_location:  Primary Location
+  show_user_personal_herbarium:  Personal Fungarium
+  show_user_total:  Total
+  show_user_language_contribution:  "Translations: [name]"
+  show_user_life_list:  "\"Life List\":[url]: [species] species in [genera] genera"
+
+  # sequence
+  sequence_edit_title:  Editing [name]
+
+  # account/signup
+  signup_title:  Account signup
+  signup_name:  Name (optional)
+  signup_login:  Desired login
+  signup_email_address:  Email address
+  signup_email_confirmation:  Confirm email
+  signup_choose_password:  Choose password
+  signup_confirm_password:  Confirm password
+  signup_preferred_theme:  Preferred Theme (optional)
+  signup_random:  Random
+  signup_button:  Signup
+  signup_email_help:  "A working email address is required to verify your account.  This helps us keep the spammers out.\n\nOnce you verify your account, you can change your email on your account Preferences page. We are very careful to never show your email address on a webpage that others can access.  We will never sell your email address.  We will only share your email address if you ask us to (e.g., when you send an email to another member, they will see your email).  By default your email address will be used to send you information about changes to the site as well as notifications relevant to your contributions to the site.  You can opt out of these uses by changing your Preferences.\n\nWhen you complete this page and click \"Signup\", we will send you an email with account verification information."
+
+  # species_list/create_species_list
+  species_list_create_title:  "[:create_object(type=:species_list)]"
+
+  # species_list/edit_species_list
+  species_list_edit_title:  "[:edit_object(type=:species_list)]: [name]"
+
+  # species_list/add_remove_observations
+  species_list_add_remove_title:  Add or Remove Observations from Species List
+  species_list_add_remove_cancel:  Cancel (back to observation index)
+  species_list_add_remove_body:  Adding or removing [num] observation(s) to/from species list. Enter title or id of target species list. Don't worry, it will ignore observations already added or removed from the list.
+  species_list_add_remove_label:  Target species list
+  species_list_add_remove_add_success:  Successfully added [num] observation(s) to species list.
+  species_list_add_remove_remove_success:  Successfully removed [num] observation(s) from species list.
+  species_list_add_remove_no_query:  Missing observation query results, or query has expired.
+  species_list_add_remove_bad_name:  "Unrecognized species list id or title: [name]"
+
+  # species_list/manage_species_lists
+  species_list_manage_title:  Manage Species Lists for [name]
+  species_list_manage_belongs_to:  This observation belongs to
+  species_list_manage_doesnt_contain:  Lists you own that do not contain this observation
+
+  # species_list/manage_projects
+  species_list_projects_title:  Manage Projects for [List]
+  species_list_projects_which_objects:  Which objects?
+  species_list_projects_which_projects:  Which projects?
+  species_list_projects_this_list:  this species list
+  species_list_projects_observations:  observations in this list
+  species_list_projects_images:  images in this list
+  species_list_projects_no_add_to_project:  You do not have permission to attach objects to the project "[proj]".
+  species_list_projects_help:  "This form allows you to either attach this list or its observations or images to one or more projects, or remove them from one or more projects.  Choose which objects you wish to attach or remove, then choose the project or projects you wish to attach them to or remove them from, then click on \"Attach\" or \"Remove\" to perform the operation.  Note: It will only allow you to attach or remove objects which you have permission to edit."
+
+  # species_list/show_species_list
+  species_list_show_title:  "[:SPECIES_LIST]: [name]"
+  species_list_show_download:  Downloads, Reports, Print Labels
+  species_list_show_save_as_txt:  Save as Plain Text
+  species_list_show_save_as_rtf:  Save as Rich Text
+  species_list_show_save_as_csv:  Save as Spreadsheet
+  species_list_show_print_labels:  Print Labels
+  species_list_show_set_source:  Save This List for Later
+  species_list_show_set_source_help:  Save this list for the next time you create or edit a species list. It will display a list of the species in this list for you to choose from.
+  species_list_show_clone_list:  Make a Copy of This List
+  species_list_show_add_remove_from_another_list:  Add To / Remove From Another List
+  species_list_show_manage_projects:  Manage Projects
+  species_list_show_manage_projects_help:  Change which projects this list and its observations and images are attached to.
+  species_list_show_manage_observations_too:  If you would like to attach/remove observations or images, too, please use the "[:species_list_show_manage_projects]" link.
+  species_list_show_edit:  Edit This List
+  species_list_show_clear_list:  Clear This List
+  species_list_show_destroy:  Destroy This List
+  species_list_show_members:  Members
+  species_list_show_no_members:  This list contains no observations.
+  species_list_show_regular_index:  Regular Index
+  species_list_show_regular_index_help:  Show observations in the "regular" index as a table of thumbnails.
+
+  # species_list/species_lists_by_title
+  species_list_by_title_title:  "[:SPECIES_LISTS] by Title"
+  species_list_by_title_created_at:  "[:Created]"
+  species_list_by_title_list_name:  List Name
+  species_list_by_title_owner:  Owner
+  species_list_by_title_size:  Size
+
+  # species_list/upload_species_list
+  species_list_upload_title:  "[:UPLOAD] [:SPECIES_LIST]"
+  species_list_upload_label:  "[:UPLOAD] [:SPECIES_LIST]"
+  species_list_upload_help:  A species list can either be a simple text file with each name on its own line, or the 'list' format generated by the Name species listing program.
+
+  # species_list/download
+  species_list_download_title:  Species List Reports and Downloads
+  species_list_download_back:  Back to Species List
+  species_list_labels_header:  Print Labels for Observation
+  species_list_labels_button:  Print Labels
+  species_list_report_header:  Save a Checklist of Names
+  species_list_report_button:  Save Names
+  species_list_download_header:  Download Observation Data
+
+  # sequence/add_sequence
+  sequence_add_title:  Add [:SEQUENCE]
+  sequence_add_edit:  "[:image_add_edit]"
+  sequence_add_owner_id:  "[:show_observation_owner_id]"
+
+  # sequence/form_sequence
+  form_sequence_locus_help:  "Start with a short abbreviation (because the [:OBSERVATION] displays only the first [locus_width] characters). Examples:\n&nbsp;&nbsp;ITS\n&nbsp;&nbsp;multi-locus\n&nbsp;&nbsp;LSU large subunit ribosomal RNA gene, partial sequence"
+  form_sequence_both_required:  "[:BASES] and/or both [:ARCHIVE]/[:ACCESSION] required"
+  form_sequence_bases_format:  "<a href=[help_url]>FASTA or Bare Sequence format</a>"
+  form_sequence_archive_help:  On-line, public database with [:sequence] data for this [:OBSERVATION].
+  form_sequence_accession:  "[:ACCESSION] number/code"
+  form_sequence_accession_help:  "Examples:\n&nbsp;&nbsp;KT968655\n&nbsp;&nbsp;UDB024324"
+  form_sequence_valid_deposit:  "[:deposit] requires both [:archive] and [:accession]"
+  form_sequence_bases_or_deposit_required:  bases and/or deposit required
+
+  # users/by_contribution
+  users_by_contribution_title:  List of Contributors
+  users_by_contribution_2a:  "[:images]"
+  users_by_contribution_2b:  "[:name]"
+  users_by_contribution_2c:  "[:observation]"
+  users_by_contribution_2d:  "[:naming]"
+  users_by_contribution_2e:  "[:vote]"
+  users_by_contribution_2f:  points
+  users_by_contribution_1:  "The order is currently based on an automated estimation of what each person has contributed to the site.  The purpose of creating this order is to recognize the individual contributions of the members of the [:app_title] community.\n\nThe current formula is a weighted sum of each contribution.  The current weighting is:"
+  users_by_contribution_2:  "Thus an observation of a species not previously in the site with three images would count as:"
+  users_by_contribution_3:  These weights or the overall method of ranking is likely to change over time based on feedback from the members of the community.
+
+  # account/verify
+  verify_note: "حساب شما تایید شده است...\n\nشما اکنون باید قادر به ارسال مشاهدات، آپلود تصاویر، ویرایش توضیحات نام، تعریف مکان های جدید، اضافه کردن نظرات، و پیشنهاد و رای دادن در شناسایی در \"[:app_title]\":[domain].\n\nبا تشکر برای پیوستن به!"
+
+  # account/choose_password
+  account_choose_password_title: تأیید حساب شما
+  account_choose_password_warning: شما باید یک رمز عبور را انتخاب کنید قبل از اینکه ما می توانیم حساب کاربری خود را تایید کنید.
+
+  # account/welcome
+  welcome_no_user_title:  User not set in session
+  welcome_logout_link: خروج
+  welcome_no_user_note:  If you are not a spammer, please report this as an error.
+  welcome_note: تو الان وارد سيستم شدي...
+
+  # semantic_vernacular/delete
+  delete_svd_not_allowed:  Only admins can delete components of Semantic Vernacular Descriptions
+  semantic_vernacular_index:  Go to all Semantic Vernacular Descriptions
+  semantic_vernacular_proposed: پیشنهاد شده توسط [name] در [date_time]
+  semantic_vernacular_delete:  Delete
+  semantic_vernacular_title:  "SVD Detail: [name]"
+
+  # glossary term fields
+  glossary_term_created_at:  Created At
+  glossary_term_updated_at:  Updated At
+  glossary_term_name:  Name
+  glossary_term_description:  Description
+  glossary_term_copyright_holder:  Copyright holder and license for this image
+  glossary_term_copyright_warning:  Please upload only an image that you created or which you own the copyright of.
+
+  # glossary_term#show
+  show_glossary_term:  Show Glossary Term
+  show_glossary_term_title:  "Glossary Term: [name]"
+  show_glossary_term_reuse_image:  Add Example
+  show_glossary_term_remove_image:  Remove Examples
+
+  # glossary_term#show_past_glossary_term
+  show_past_glossary_term_title:  "[:VERSION] [num]: [name]"
+  show_past_glossary_term_no_version:  No version specified
+
+  # glossary_term#create_glossary_term
+  create_glossary_term:  Create New Glossary Term
+  create_glossary_term_add:  Add Glossary Term
+  create_glossary_term_title:  Create New Glossary Term
+
+  # glossary_term#index
+  glossary_term_index: واژه نامه
+  glossary_term_index_title: واژه نامه اصطلاحات میکولوژی
+  glossary_term_index_intro:  "In collaboration with the Rhode Island School of Design, students from Jean Blackburn's Scientific Illustration class to create high-quality Creative Commons licensed scientific illustrations of fungal anatomy terms. To share these works, this new glossary feature for Mushroom Observer was created.\nThis release provides the bare minimum of functionality to be able to discover and view these illustrations. New glossary terms can also be created by anyone in the community. Currently these terms are illustrated by single images, but my intent is to add support for multiple images including both scientific illustrations and example photographs. There will also be a search feature, the ability to add links to terms as part of any Mushroom Observer markup. A particular feature that needs discussion is how best to handle translations of these terms and their definitions. Discussion of these features including additional desired terms are welcome on either the Mushroom Observer mailing list (<a href=\"https://groups.google.com/forum/?fromgroups=#!forum/mo-general\">mo-general@googlegroups.com</a>) or the <a href=\"https://www.facebook.com/groups/105230049528087/\">unofficial Mushroom Observer Facebook page</a>."
+
+  # glossary_term#edit
+  edit_glossary_term:  "[:edit_object(type=:glossary_term)]"
+  edit_glossary_term_title:  "Editing Glossary Term: [name]"
+  edit_glossary_term_save:  Save
+  edit_glossary_term_not_allowed:  Only admins can edit glossary terms
+
+  # glossary_term errors
+  glossary_error_name_blank:  Name cannot be blank.
+  glossary_error_duplicate_name:  Name must be unique.
+  glossary_error_description_or_image:  Glossary term must have a description or image.
+
+  # news article fields
+  article_title:  Title
+  article_body:  Body
+
+  # article/create_article
+  create_article_title:  "[:create_object(type=:article)]"
+  article_body_required:  "[:article_body] [:REQUIRED]"
+  article_title_required:  "[:article_title] [:REQUIRED]"
+  form_article_title_help:  This field will appear in the Activity Feed.
+
+  # article/show_article
+  show_article:  "[:show_object(type=:article)]"
+
+  # article/index_article
+  index_article:  "[:ARTICLE] Index"
+
+  # publication fields
+  publication_full:  Full Reference
+  publication_link:  Link
+  publication_peer_reviewed:  Publication was peer reviewed
+  publication_how_helped:  How did Mushroom Observer help with this publication?
+  publication_mo_mentioned:  Mushroom Observer is mentioned or referenced in the publication
+
+  # publication/index
+  publication_index:  Publication List
+  publication_index_title:  List of All Publications
+  publication_index_intro:  This is a list of all known publications that benefitted in some way by the existence of the Mushroom Observer. If you are aware of an article that should be added to this list please "add it":/publications/new. If you find an error, please add the correct citation and "send us a note":/emails/ask_webmaster_question.
+  publication_full_help:  When possible please use the other citations as a model for how to format new ones and specifically start the citation with the family name of the lead author.
+  publication_legend:  "*P* indicates that it is a scientific, peer-reviewed article.\n*M* indicates that the article explicitly mentions or references the Mushroom Observer."
+  publication_citation:  "We encourage you to cite Mushroom Observer this way:\n\nWilson, N., Hollinger, J., et al. 2006-present. Mushroom Observer. https://mushroomobserver.org\n\nHowever, your publisher may restrict how or whether websites can be cited. If you need a published reference the best current citation we are aware of is:"
+
+  # publication/edit
+  edit_publication:  Edit
+  edit_publication_title:  Editing Publication
+
+  # publication/create_event
+  create_publication:  Add Publication
+  create_publication_title:  Create New Publication
+
+  # publication/show
+  show_publication_title: انتشار
+  show_publication_added_by:  Added by
+
+
+
+  # herbarium fields
+  herbarium_curator:  Curator
+  herbarium_curators:  Curators
+  herbarium_mailing_address: آدرس پستی
+  herbarium_code:  Code
+  user_personal_herbarium: "[name]: فونگاریوم شخصی"
+
+  # herbaria/show
+  show_herbarium_herbarium_record_count:  This fungarium contains [count] fungarium record(s).
+  show_herbarium_add_curator:  Add Curator
+  show_herbarium_no_user:  Unable to find the user '[login]'.
+  show_herbarium_curator_request:  Request to be a Curator
+  show_herbarium_curator_help:  When you press send below, you will send a note to the admins requesting to be made an admin of this fungarium.  When we add curators to an MO fungarium, those curators are given exclusive rights to edit the fungarium's addresses and notes.  Curators are also allowed to create fungarium records for other users' observations.  For example, when a fungarium accessions a contributor's specimen, the fungarium can create a record attached to the contributor's observation on MO noting that the specimen resides at your fungarium and what its accession number is.  Please ask how MO can help your fungarium IT people automate this process via our API.
+  show_herbarium_request_sent:  Request has been sent to admins.  We'll get back to you as soon as possible.
+
+  # herbaria/create
+  create_herbarium:  Create New Fungarium
+  create_herbarium_title:  Create New Fungarium
+  create_herbarium_personal:  Check this box if this is your personal fungarium
+  create_herbarium_personal_help:  Each user can have one personal fungarium that they have curator privileges for. By default it is called "[name]", but you can change that name to anything you like.
+  create_herbarium_code:  Standard Abbreviation
+  create_herbarium_code_help:  Look up the standard abbreviation for a fungarium at "Index Herbariorum":http://sweetgum.nybg.org/science/ih/.
+  create_herbarium_email:  Email Address
+  create_herbarium_mailing_address:  Mailing Address
+  create_herbarium_duplicate_name:  Fungarium called '[name]' already exists.
+  create_herbarium_personal_already_exists:  You've already created a personal fungarium called '[name]'.
+  create_herbarium_must_define_location:  You must define this location before we can use it for this fungarium. Any other information you provided has been saved.
+  create_herbarium_name_blank:  Herbarium name must not be blank.
+
+  # herbaria/edit
+  edit_herbarium:  Edit Fungarium
+  edit_herbarium_title:  Editing Fungarium
+  edit_herbarium_this_is_personal_herbarium:  This is your personal fungarium. You are only allowed one personal fungarium. If you would like to change which fungarium is your personal fungarium, please contact the admins and explain the situation.
+  edit_herbarium_cant_make_personal:  You can't make this your personal fungarium because you don't own all the fungarium records. You will need to have an admin do this for you. Please send us a message explaining what's going on.
+  edit_herbarium_admin_make_personal:  Make this the personal fungarium for
+  edit_herbarium_user_records:  User "[name]" has [num] records in this fungarium.
+  edit_herbarium_no_herbarium_records:  No fungarium records for this fungarium.
+  edit_herbarium_user_already_has_personal_herbarium:  User "[user]" already has a personal fungarium called "[herbarium]".
+  edit_herbarium_successfully_made_personal:  Successfully made this the personal fungarium of "[user]".
+  edit_herbarium_successfully_made_nonpersonal:  Successfully made this nobody's personal fungarium.
+
+  # herbaria/index
+  herbarium_index:  Fungarium Index
+  herbarium_index_list_all_herbaria:  List All Fungaria
+  herbarium_index_nonpersonal_herbaria:  List Institutional Fungaria
+  herbarium_index_records:  Records
+  herbarium_index_merge_help:  Click on the fungarium below that you would like to merge "[name]" into.  This will cause "[name]" to be deleted and all of its records and curators to be transferred into the new fungarium.  If you do not have permission to perform the merge, it will send a request to the admins.  ("+Cancel merge.+":[url])
+
+  # herbaria/filtered
+  list_herbaria_title:  "[:list_objects(type=:herbarium)]"
+
+
+  # herbarium record fields
+  herbarium_record_herbarium_name:  Fungarium Name
+  herbarium_record_initial_det:  Initial Determination
+  herbarium_record_accession_number:  Accession Number
+  herbarium_record_user:  Record Creator
+  herbarium_record_notes:  Fungarium Record Notes
+
+  # herbarium_record/create_herbarium_record
+  create_herbarium_record: افزودن رکورد قارچ
+  create_herbarium_record_title: افزودن رکورد قارچ
+  create_herbarium_record_accession_number_help:  "Must be a unique identifier for this fungarium.  If you do not know the accession number, or there isn't one yet, use the observation number or your own collection number.  Examples:\n&nbsp;&nbsp;12419\n&nbsp;&nbsp;BRY-L-0025845\n&nbsp;&nbsp;MO 174623\n&nbsp;&nbsp;Joe Smith 17-013"
+  create_herbarium_separately:  The fungarium you entered doesn't exist. Please create it separately and then add the fungarium record to your observation.
+  create_herbarium_record_missing_herbarium_name:  Missing fungarium name.
+  create_herbarium_record_already_used:  This fungarium record already exists. We've added this observation to it. If that isn't correct, remove it from your observation, then add the correct fungarium record.
+  create_herbarium_record_already_used_by_someone_else:  This accession number has already been recorded by someone else for [herbarium_name]. Try adding your initials to the accession number to distinguish labels.
+  create_herbarium_record_only_curator_or_owner:  Only curators can add fungarium records to other users' observations.
+
+  # herbarium_record/edit_herbarium_record
+  edit_herbarium_record:  Edit Fungarium Record
+  edit_herbarium_record_title:  Edit Fungarium Record [herbarium_label]
+  edit_herbarium_record_back_to_index:  Back to Fungarium Record Index
+  edit_herbarium_record_cant_add_or_remove:  Only curators or the observer can add or remove an observation to or from a fungarium record.
+  edit_herbarium_record_already_used:  This fungarium record already exists. If you want to merge records, move the observations from this record to the other, then delete this record.
+  edit_affects_multiple_observations:  The changes you make here will affect all of the observations shown.  If you wish to change a single observation, go to that observation, remove the incorrect [type] from it, then add the correct one.  That will leave the [type] unchanged for any other observations associated with it.
+
+  # herbarium_record/destroy_herbarium_record
+  delete_herbarium_record:  Destroy Fungarium Record
+
+  # herbarium_record/herbarium_record_index (not a real page)
+  herbarium_record_index_title:  "[subject] Fungarium Record Index"
+
+  # herbarium_record/list_herbarium_records
+  list_herbarium_records_title:  "[:list_objects(type=:herbarium_record)]"
+
+
+
+  # collection number fields
+  collection_number_name:  Collector's Name
+  collection_number_number:  Collector's Number
+  collection_number_user:  Record Creator
+
+  # collection_number/create_collection_number
+  create_collection_number:  Add Collection Number
+  create_collection_number_title:  Add Collection Number
+  create_collection_number_missing_name:  Missing collector's name.
+  create_collection_number_missing_number:  Missing collector's number.
+
+  # collection_number/edit_collection_number
+  edit_collection_number:  Edit Collection Number
+  edit_collection_number_title:  Edit Collection Number [name]
+  edit_collection_number_back_to_index:  Back to Collection Number Index
+  edit_collection_number_cant_add_or_remove:  Only the observer can add or remove a collection number to or from an observation.
+  edit_collection_number_already_used:  This collection number is shared with another observation. If you need to fix it, remove it from your observation, then add the correct one.
+  edit_collection_numbers_merged:  Merged [this] into [that]. If this was not what you meant to do, remove the collection number from one of the observations, then add the correct one.
+
+  # collection_number/destroy_collection_number
+  delete_collection_number:  Destroy Collection Number
+
+  # collection_number/collection_number_index (not a real page)
+  collection_number_index_title:  "[subject] Collection Number Index"
+
+  # collection_number/list_collection_numbers
+  list_collection_numbers_title:  "[:list_objects(type=:collection_number)]"
+
+
+
+  # support/donate
+  donate_title:  Donate to Mushroom Observer, Inc.
+  donate_tab:  Donate
+  donate_other:  Other Amount
+  donate_anonymous:  Anonymous donation
+  donate_recurring:  Monthly recurring donation
+  donate_who:  Name for Donors Page
+  donate_email:  Email (to ensure uniqueness)
+  donate_confirm:  Confirm
+  donors_order:  The donors names are ordered based first on the total amount donated and then by who has donated the most recently.
+  donate_snail_mail:  "Donors who wish to donate by check should make the check payable to \"Mushroom Observer, Inc.\" and mail it to our registered corporate address:\nMushroom Observer, Inc.\n68 Bay Rd.\nNorth Falmouth, MA 02556-2404"
+  donors_title:  The Mushroom Observer Community Thanks Our Donors
+  donors_tab:  Show Donors
+  donate_thanks:  Thank you for your interest in donating to Mushroom Observer!
+  donate_explanation:  "A donation can be made in any amount. There are two ways: via PayPal or by check. We encourage you to send a check for donations of $200 or more.\n\nPayPal donations can be made with most credit cards (no PayPal account needed) or via a PayPal account by clicking on the \"Confirm\" button below.\n\nFor donations by check see below.\n\nDonors are normally acknowledged by name on the \"Mushroom Observer Donors Page\":/support/donors. If you would like special arrangements for your acknowledgement please \"send us a comment\":/emails/ask_webmaster_question."
+
+  donate_fine_print:  "\"https://www.mushroomobserver.org\":/ is operated by \"Mushroom Observer, Inc.\":/support/governance for educational purposes. Mushroom Observer, Inc. is a public charity described under section ==501(c)(3)== of the Internal Revenue Code (see \"IRS Determination Letter\":/doc/mo-determination.pdf). Donations to Mushroom Observer, Inc. are eligible to be deducted for federal income tax purposes.  To substantiate the amount of your deductible donation, you will receive an email acknowledgement from Mushroom Observer, Inc. of the amount and date of your donation."
+
+  # support/confirm
+  confirm_title:  Donation Confirmation
+  confirm_amount:  Amount
+  confirm_text:  Thank you for offering to make the following donation.  To complete this transaction using PayPal, click the button below.
+  confirm_positive_number_error:  Other Amount must be a number greater than zero
+  confirm_recurring:  Recurring monthly
+
+  # support/governance
+  governance_title:  Governance of the Mushroom Observer
+  governance:  "The \"Mushroom Observer website\":/ is owned and operated by the Massachusetts based non-profit, Mushroom Observer, Inc. - specifically the domain, mushroomobserver.org, as well as all relevant source code copyrights are owned by Mushroom Observer, Inc. The images and user entered text on the site are owned by their respective authors and are licensed for use under Creative Commons licenses as described on the \"Introduction\":/info/intro page.\n\nMushroom Observer, Inc. was organized based on its \"articles of organization\":/doc/mo-articles.pdf and operates under its \"bylaws\":/doc/mo-bylaws.pdf which may be revised from time to by its Board of Directors. Mushroom Observer, Inc. has been \"recognized as a section ==501(c)(3)== public charity\":/doc/mo-determination.pdf serving educational purposes. If you have questions about the governance of the site or need to get in touch with members of the Board of Directors please \"send us a comment\":/emails/ask_webmaster_question."
+
+  # support/thanks
+  thanks_title:  Thanks for Your Support!
+  thanks_note:  "Thank you for helping to support the Mushroom Observer.  Your support is greatly appreciated and will help Mushroom Observer continue its mission.\n\nYour donation will be acknowledged by name on the \"Mushroom Observer Donors Page\":/support/donors once the funds are received unless you have requested special arrangements for your acknowledgement.  Examples of special arrangements might be to make the donation anonymously or to leave it in someone else's name.  If you would like special arrangements for your acknowledgement please \"send us a comment\":/emails/ask_webmaster_question."
+
+  # support/letter
+  letter_title:  Open Letter to the Community
+  letter_body:  "To the Mushroom Observer Community,\n\nIt has been an amazing year for us.  This year we hit some major milestones: 100,000 images, 50,000 observations and 2,000 registered users.  This means we have essentially been doubling every year.  While Jason has achieved some minor miracles in his volunteer efforts to keep things going with the bare bones server configuration we are using, it is becoming clear that we will soon need more memory and more processors to support our continued growth.\n\nUnfortunately, this means our server expenses will be going up.  So far I have been happy to support the Mushroom Observer server needs out of my own pocket, but those expenses have also been essentially doubling every year and I will soon not be able to afford it.  As a result, I would like to start asking for donations from the community.  Those of you who have gotten a lot out of the site and want to see it continue to grow and expand, now is your chance to give a little back and help with the financial support of the site.\n\nTo that end, we have setup a \"donation page\":/support/donate that can securely accept money from a PayPal account or a regular credit card.\n\nI would like to raise at least $2000 to cover basic server costs.  The more we get, the more we can expand our capacity for traffic and growth.  And the fewer times you will encounter server down time and failed uploads.\n\nWhen you make a donation, your name by default will be added to our \"donors page\":/support/donors as soon as we confirm the donation.  If you would prefer to donate anonymously or make other special arrangements for your acknowledgement, \"send a comment\":/emails/ask_webmaster_question after you make your donation.\n\nPlease help support this active internet community of people who enjoy sharing and learning more about the mushrooms around us.\n\nThanks,\n-Nathan"
+
+  # support/wrapup_2011
+  wrapup_2011_title:  2011 Wrapup to the Mushroom Observer Community
+  wrapup_2011_body:  "To the Mushroom Observer Community,\n\n2011 has been a relatively quiet year for Mushroom Observer at least from the perspective of new development.  I have personally been working overtime on a new version of the Encyclopedia of Life and Jason has been working hard on a new lichen related website and book.\n\nEven so the site has continued to grow.  We now have over 180,000 images, 80,000 observations and we are very close to 3,000 registered users.  This continues our trend of nearly doubling every year.  Fortunately, due to generous donations from all of you, Jason was able to substantially upgrade our server configuration and to the best of our knowledge the system has been working very well despite the ever growing demand.  While we still have some money in the bank, we will continue to need \"additional donations\":/support/donate to keep the system going.\n\nAs was true last year, the donations are made through a not-for-profit corporation called The Consortium for Digital Mycology Resources (CDMR).  The CDMR is recognized as a non-profit by the state of California, but is still not an official federal ==501(c)(3)== non-profit.  However, the application process has moved forward and for now we continue to act as a non-profit and donations are tax deductible.  For anyone interested in the details of that process please visit the \"CDMR website\":http://digitalmycology.org.\n\nThere have been a few notable new features added to Mushroom Observer over the last year.  Jason did a great job developing the \"MO Feature Tracker\":/pivotal/index interface that interacts with our new freely accessible \"Pivotal Tracker account\":https://www.pivotaltracker.com/projects/224629 for tracking bugs and feature requests.  In addition, I have been working quite a bit behind the scenes to prepare for a roughly 10 fold increase in the number of Mushroom Observer images that will be sharable with the broader biodiversity community and EOL in particular.\n\nAlong with this note, we are also releasing the newly developed \"Black on White\":/observer/BlackOnWhite color theme.  With this theme I am trying to provide a more current and professional look for the site. \"Feedback on the theme or suggestions for improvements\":/emails/ask_webmaster_question are very welcome.\n\nWhile there have not been a lot of new features released this year, there have been a number of important discussions going on about potential future development. These have included discussions of better ways of managing naming and voting so they align better with standard herbarium practices, improving the expressiveness of the voting system, rearranging the interface to be more workflow driven, and expanding the role of projects to encourage more focused collaboration within MO.\n\nWhich brings us to the biggest news.  I have begun doing some of my own research with the data from the Mushroom Observer and I have received several inquiries from other scientists interested in either using Mushroom Observer as it is to support their own research or to support additional development of the Mushroom Observer to expand the connections between Mushroom Observer and the scientific community.\n\nMy own research has included some preliminary analysis of the data in the Mushroom Observer database.  The most interesting finding has been that \"users who collect in the Western US on average find more species there than users who collect in the Eastern US\":/images/fungal_biogeography.png. I am currently in the process of developing funding and collaborators to more fully pursue this and other interesting questions that can be answered using our data.  Another area of research development has been with some of the computer scientists at Rensselaer Polytechnic Institute.  The group I am working with are focused on the emerging \"semantic web\":http://en.wikipedia.org/wiki/Semantic_web. We are developing a system for creating a new naming system for amateur/citizen mycologists. It will include a global, web-based registration system for names that are then associated with rigorous definitions that computers can reason about.  We have plans to support a summer internship through the EOL to help develop this idea.\n\nIn addition, as many of you are aware Tom Bruns at UC Berkeley has already been using Mushroom Observer to catalog the collections his collaborators (including many of you) have been finding in Yosemite National Park.  He and I have also begun discussions of what features would be valuable to add Mushroom Observer to support his call for developing a \"North American Mycoflora\":http://msafungi.org/wp-content/uploads/Inoculum/62(4).pdf. Another promising development was being asked to write a letter of support for a proposal that Barabara Thiers and Roy Haling have submitted to digitize the fungal herbaria throughout the US.  If that gets funded, they are interested in making their data available through the Mushroom Observer.\n\nFinally, through connections at the EOL, I was able to participate in a workshop focused on citizen science biodiversity observation systems.  The workshop was held in October outside of London and included representatives from \"iSpot\":http://www.ispot.org.uk/ and \"iNaturalist\":http://inaturalist.org along with several other significant global projects.  I went to the workshop not only to represent the technical side of the EOL, but also the Mushroom Observer.  As a result the group of projects involved in the workshop, including Mushroom Observer, are participating in a competition called \"Badges for Lifelong Learning\":http://www.dmlcompetition.net/Competition/4/badges-competition-cfp.php. We have already successfully passed the first stage of the competition and are working on our application for the second stage.\n\nWhile many of these projects promise exciting developments for MO over the next year and some may even include financial support for the development of new Mushroom Observer features, the on-going support for the site relies on \"donations\":/support/donate from you our users. Please help support this active internet community of people who enjoy sharing and learning more about the mushrooms around us.\n\nThanks for all your contributions to the Mushroom Observer,\n-Nathan"
+
+  # support/wrapup_2012
+  wrapup_2012_title:  2012 Wrapup for the Mushroom Observer Community
+  wrapup_2012_body:  "2012 was a busy year for Mushroom Observer.  Many notable new features were added.  Highlights include:\n\n* Substantial revisions to the <a href=\"/name/show_name/383\">Show Name</a> and <a href=\"/image/show_image/267480?size=medium\">Show Image</a> pages\n* Data downloads from observation searches\n* Support for <a href=\"/herbarium\">Herbarium</a> and Specimen pages\n* Interactive support for translators\n* <a href=\"/users/checklist?user_id=1093\">Life Lists</a> from user summary pages\n* Substantial increase in data shared with EOL\n* Reciprocal links with <a href=\"http://mycoportal.org/\">MyCoPortal</a>\n\nMore details available on the <a href=\"/info/news\">Features and Fixes</a> page.\n\nOne of the goals of this work has been to increase the scientific value of the site for research. The support for Herbarium and Specimen pages as well as the reciprocal links with MyCoPortal are recent steps towards this goal. This work is directly related to a new effort to digitize fungal herbaria throughout the US led by Barbara Thiers. I continue to work with Tom Bruns at UC Berkeley and Deborah McGuinness at Rensselaer Polytechnic Institute (RPI) to find funding to directly support improvements to the Mushroom Observer.  These projects continue to promise exciting developments for MO in the future.\n\nIn addition, the site has continued to grow.  We now have over 300,000 images, 100,000 observations, and over 3800 registered users.  This not only indicates the greatest number of images we've received in a year (106,000), but is a greater growth rate than the previous year (56% vs. 49%).\n\nFortunately, due to generous donations from all of you, we have continued to be able to improve the site configuration.  While we do have a few more tricks up our sleeves that we expect to implement soon, it is increasingly clear that more substantial improvements are needed.  Historically, we have run the site off a single server.  To achieve the next level of performance we would like to separate the database from the application server, and add an additional application server along with a small load balancer.  We expect this to roughly triple the monthly costs of running the site to around $200/month.\n\nI am also excited by a recent surge in the number of folks interested in contributing their time to the Mushroom Observer development effort.  We had a summer intern, Han Wang, from RPI create a prototype system for describing Fungi using semantic web technology (references at the end of the letter).  I presented on this work at the 2012 Mycological Society of America annual meeting.  Another RPI student, Katie Chastain, has recently joined the team and is interested in working on data provenance and developing a workflow for species discovery.  Alan Rockefeller has begun looking into improving site performance and Joe Cohen has started exploring upgrading our software stack.  If you want to join the party, sign up for the new <a href=\"https://groups.google.com/forum/?fromgroups=#!forum/mo-developers\">mo-developers@googlegroups.com</a> mailing list.  One of the significant enabling pieces for this is a new simpler system for setting up a development environment.  You can find out more at the <a href=\"https://github.com/MushroomObserver/developer-startup\">developer-startup GitHub Project</a>.\n\nHowever, this year has not been entirely good news. The Consortium for Digital Mycology Resources (CDMR), was organized in 2009 to support online digital mycology resources such as Mushroom Observer, and it applied for federal tax exempt status under section ==501(c)(3)== so that it could receive deductible donations from interested users.  This ruling is still pending in the IRS.  Beginning in 2012, Mushroom Observer member John Harper, a tax lawyer with Morrison & Foerster, noticed that CDMR’s exemption application had been pending with the IRS for an unusually long time, and volunteered to help CDMR on a pro-bono basis in its attempt to attempt to obtain recognition of a section ==501(c)(3)== status for CDMR.  Since then he has briefed the IRS on the issues that the IRS has raised, and had a conference with the IRS to discuss the ruling request.  CDMR’s case is currently under review in the National Office of the IRS.\n\nIn light of CDMR’s unsettled tax status, CDMR’s board decided not to solicit donations at the end of last year.  However, the CDMR board of directors is committed to creating or joining a recognized tax-exempt non-profit that can receive deductible donations to support online mycological resources such as the Mushroom Observer.  Exactly what form this will take and how soon it will happen is still up in the air.\n\nWithout financial support from CDMR, I have been personally paying to support Mushroom Observer largely out of my own pocket over the last few months. I would very much appreciate any <a href=\"https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2TGUG7TNXYF7Q\">personal gifts</a> that you all would be willing to send to contribute to the cost of keeping Mushroom Observer online during this interim period. This will be especially important before we can attempt to improve the level of performance by adding more servers. Any gifts I receive will be used to cover costs directly associated with running the Mushroom Observer and such donations will continue to be recognized on the Mushroom Observer donors page. Unfortunately, you will not be able to count them as tax deductible donations.  You can make your gifts with a credit card through <a href=\"https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2TGUG7TNXYF7Q\">PayPal</a>\n\n\nThanks for all your contributions to the Mushroom Observer,\n-Nathan"
+
+  ##############################################################################
+
+  # LESS POPULAR PAGES
+
+  # account/api_keys
+  account_api_keys_link:  API Key Manager
+  account_api_keys_title:  API Key Manager
+  account_api_keys_last_used_column_label:  Last Used
+  account_api_keys_num_uses_column_label:  Uses
+  account_api_keys_notes_label:  "Enter the name or a brief description of the application that will use this key:"
+  account_api_keys_remove_button:  Remove the Selected Keys
+  account_api_keys_create_button:  Create a New Key
+  account_api_keys_help:  "API Keys are used by third-party applications to access the Mushroom Observer database directly.  You may request as many API Keys as you like, and no restrictions are placed on these keys.\n\nEach key is attached to a single user.  When posting observations or images, for example, your application will send this API Key in lieu of logging in. Therefore you should take some care to prevent other people or malicious agents from using your API Keys.\n\nNote that no key is required if you are only interested in _reading_ data; keys are only required if you wish to post or modify data."
+  account_api_keys_create_success:  Sucessfully created a new API Key.
+  account_api_keys_create_failed:  "Failed to create a new API Key:"
+  account_api_keys_removed_some:  Successfully removed [num] selected API Key(s).
+  account_api_keys_removed_none:  No API Keys were selected.
+  account_api_keys_updated:  Successfully updated API Key notes.
+  account_api_keys_activated:  Successfully activated key for [notes].
+  account_api_keys_no_notes:  You left name/description field empty.
+
+  # description/adjust_permissions
+  adjust_permissions_user_header:  User or Group
+  adjust_permissions_reader_header:  View
+  adjust_permissions_writer_header:  "[:EDIT]"
+  adjust_permissions_admin_header:  "[:ADMIN]"
+  adjust_permissions_all_users:  All Users
+  adjust_permissions_site_admin:  site admin
+
+  # search/advanced
+  advanced_search_at_least_one:  Please provide at least one search parameter
+  advanced_search_caveat:  "Advanced search has somewhat limited options because of performance issues that result in timeouts.  Please \"email the webmaster\":/emails/ask_webmaster_question if you experience timeouts or if there are particular types of searches you would like to have added.\n\nHints : It's okay to leave some of the fields blank, e.g., if you leave 'Observer' blank, it will return results by all [:users]. It matches the exact string given.  Use \"OR\" (all caps) to tell it to match one of several possible strings, e.g. \"Xanthoria OR Xanthomendoza\".  Use a star as a wildcard, e.g. \"Wells Gray*Canada\" will match \"Wells Gray, Canada\", \"Wells Gray Park, Canada\", and \"Wells Gray Provincial Park, Canada\".  (See notes under 'Content', too.)"
+  advanced_search_content:  Content
+  advanced_search_content_help:  Text contained in [:observation] notes or [:comments]
+  advanced_search_content_notes:  "Content search supports full Google syntax, including \"OR\", double quotes, and negation:\naaa bbb -> contains \"aaa\" and \"bbb\" in any order\n\"aaa bbb\" -> contains \"aaa\" followed immediately by \"bbb\"\naaa OR bbb -> contains either \"aaa\" or \"bbb\"\n-aaa -bbb -> reject anything that contains \"aaa\" or \"bbb\""
+  advanced_search_location_help:  Where was the mushroom found
+  advanced_search_name_help:  Name of the mushroom
+  advanced_search_none_found:  No matches found
+  advanced_search_observer_help:  Who observed the mushroom
+  advanced_search_result_type:  Result Type
+  # Image search UI temporarily disabled for performance. 2021-09-12 JDC
+  # advanced_search_result_type_help:  Do you want [:observations], [:locations] or [:names]/[:descriptions]?
+  advanced_search_result_type_help:  Do you want [:observations], [:locations] or [:names]/[:descriptions]?
+
+  advanced_search_filters:  Search Filters
+  advanced_search_filters_explain:  Apply to this search only, overrides your normal preferred content filters
+  advanced_search_filter_has_images:  Filter observations based on whether they have images
+  advanced_search_filter_has_images_off:  Include both imaged and imageless observations
+  advanced_search_filter_has_images_yes:  Exclude imageless observations
+  advanced_search_filter_has_images_no:  Exclude imaged observations
+  advanced_search_filter_has_specimen:  Filter observations based on whether they have specimens
+  advanced_search_filter_has_specimen_off:  Include both observations with and without specimens
+  advanced_search_filter_has_specimen_yes:  Exclude observations without specimens
+  advanced_search_filter_has_specimen_no:  Exclude observations with specimens
+  advanced_search_filter_lichen:  Filter observations based on whether they are lichens
+  advanced_search_filter_lichen_off:  Include both lichens and nonlichens
+  advanced_search_filter_lichen_yes:  Include only lichen-forming, lichenicolous and allied fungi
+  advanced_search_filter_lichen_no:  Exclude lichen-forming fungi
+  advanced_search_filter_region:  Restrict observations and locations to a region, e.g., "California, USA" or "Europe"
+  advanced_search_filter_clade:  Restrict observations to a taxonomic clade, e.g., "Ascomycota" or "Agaricales"
+  advanced_search_submit:  Submit Advanced Search
+
+  # observer/license_updater
+  bulk_license_link:  Bulk License Updater
+
+  # checklists
+  checklist_for_site_title:  Checklist for Mushroom Observer
+  checklist_for_user_title:  Checklist for [user]
+  checklist_for_project_title:  Checklist for [project]
+  checklist_for_species_list_title:  Checklist for [list]
+  checklist_summary:  "Summary: [species] species in [genera] genera"
+
+  # theme/color_themes
+  color_themes_text:  "**General Concept:** The [:app_title] website provides a number of color themes, some based on different groups of mushrooms.  By default the simple clean \"Black on White\" theme is used.  However, a [:user] can choose to use a particular theme throughout the site by selecting the theme on the [:user] preference page.\n\nThe idea of using mushrooms for color follows in the tradition of using mushrooms to dye fabrics.  Each color in a mushroom theme was pulled from a photograph included in the site from the given group.  The colors attempt to express the characteristic colors of the group.  In a few cases, the [:images] were adjusted using an automatic color balance operation in order to get a more characteristic color.\n\nThe following links describe each of the available themes including links to the [:images] the colors were extracted from:"
+  color_themes_title:  Color Themes
+
+  # name/email_tracking
+  email_tracking_enabled_only_for:  Enabled only for [name] -- contained taxa not yet supported for [rank].
+  email_tracking_help:  If you enable tracking then a note will be sent to the email address you have provided whenever this name is applied to an [:observation].  A link to this page will be given in each tracking email.  You can save your mailing address for collections in "your profile":/account/profile.
+  email_tracking_no_longer_tracking:  No longer tracking [name].
+  email_tracking_note:  Template for notifying an observer
+  email_tracking_note_help:  Provide a note template that will be sent as an email or shown to the observer when this name is applied to an [:observation].  If you leave it blank, then the observer will not be notified.
+  email_tracking_note_template:  "Dear :observer,\n\nI am currently doing research related to [species_name].\n\nIf possible, please make a dried specimen of any of the mushrooms described in :observation and send them to:\n\n[mailing_address]\n\nThanks,\n\n[users_name]"
+  email_tracking_now_tracking:  Now tracking [name].
+  email_tracking_title:  Email Tracking for [name]
+  email_tracking_updated_messages:  Updated tracking messages.
+
+  # name/eol_expanded_review
+  eol_expanded_review_title:  EOL Name List
+  eol_expanded_review_count:  "[count] names"
+  eol_expanded_review_total_image_count:  "[count] images"
+  eol_expanded_review_total_description_count:  "[count] descriptions"
+  eol_expanded_review_image_count:  "Images: [count]"
+  eol_expanded_review_description_count:  "Descriptions: [count]"
+
+  # name/eol_preview
+  eol_preview_name_count:  "[count] description(s)"
+  eol_preview_image_count:  "[count] image(s)"
+  eol_preview_title:  EOL Preview
+  eol_preview_explanation:  "This page provides links to or shows the content that is currently scheduled for delivery to the \"Encyclopedia of Life\":http://eol.org (EOL).  The features related to this effort are still very new and far from polished since it has been implemented quickly to meet the immediate needs to develop the fungus related content on the EOL.  The content delivered from [:app_title] to the EOL will be credited both as coming from the [:app_title] website and the individual content providers.\n\nOn this page each section represents one taxon.  The descriptive paragraphs for each listed taxon will be sent with the exception of any paragraphs marked 'Notes'.  Both the taxa and the images that are being sent have been at least quickly reviewed by expert members of the [:app_title] community.\n\nThe review status of a specific taxon is given on the page for that taxon and can only be set by a designated expert.  Images are selected based on the voting history of specific observations and their quality.  Currently only designated experts can set the quality level of an image, but this is expected to become a open voting process for the entire [:app_title] community in the near future.\n\nCurrently the designated experts are either mycology professors that are teaching classes that are planning to provide data to EOL through the [:app_title] or individuals in the [:app_title] community who have shown dedication to the site and are recognized experts in mushroom or fungal identification.  All aspect of the process of providing data to EOL are under discussion and open to change so please send any questions or comments you have to the [:app_title] webmaster.\n\nThe best way to participate in this amazing opportunity is to find a taxon you care about and work to expand the descriptive paragraphs for this taxon."
+
+  # image/license_updater
+  image_updater_count:  Count
+  image_updater_license:  "[:LICENSE]"
+  image_updater_holder:  "[:COPYRIGHT_HOLDER]"
+  image_updater_title:  Updating Licenses for [user]
+  image_updater_update:  "[:UPDATE]"
+  image_updater_help:  Listed below are all the different licenses you've posted images under, along with the number of your images which use that license.  Make any changes you want to the license or the name listed as the copyright holder, then click "[:UPDATE]" to submit changes.
+
+  # image/vote_anonymity
+  image_vote_anonymity_title:  Change Anonymity of Your Image Votes
+  image_vote_anonymity_num_anonymous:  Number of anonymous votes
+  image_vote_anonymity_num_public:  Number of public votes
+  image_vote_anonymity_make_anonymous:  Make all votes anonymous
+  image_vote_anonymity_make_public:  Make all votes public
+  image_vote_anonymity_made_anonymous:  Made all of your image votes anonymous.  Please also check your vote preference below to ensure that future votes are also anonymous.
+  image_vote_anonymity_made_public:  Made all of your image votes public.  Please also check your vote preference below to ensure that future votes are also public.
+  image_vote_anonymity_invalid_submit_button:  Invalid submit button "[label]", please "contact us":/emails/ask_webmaster_question for help.
+
+  # interest-related controls in name/show_name, observation/show_observation, etc.
+  interest_watch: پخش
+  interest_ignore: چشم پوشی
+  interest_watch_help: اینجا را کلیک کنید اگر شما می خواهید ما را به شما ایمیل ارسال هر زمان که تغییر در این وجود دارد [object].
+  interest_ignore_help:  Click here if you want to stop getting any emails about this [object].
+  interest_default_help:  Click here if you want to go back to the default -- having your account preferences determine whether you get email about this [object].
+  interest_watching:  You have told us to email you about changes in this [object].  Click one of the small icons below to change.
+  interest_ignoring:  You have told us never to email you about changes in this [object].  Click one of the small icons below to change.
+
+  # interest/list_interests
+  list_interests_title:  Your Notification Requests
+  list_interests_turn_on:  Change to Watch
+  list_interests_turn_off:  Change to Ignore
+
+  # location/list_merge_options
+  list_merge_are_you_sure:  Do merge?  This cannot be undone.
+  list_merge_options_near_matches:  Near Matches
+  list_merge_options_others:  Other Available [:locations]
+  list_merge_options_title:  Merge Options for [where]
+
+  # observer/list_notifications
+  list_notifications_title:  Email Alerts for [user]
+
+  # observer/list_users
+  list_users_joined:  Joined
+  list_users_contribution:  Contribution
+
+  # species_list/make_report
+  make_report_not_supported:  We don't support report filetype *.[type].
+
+  # description/merge_descriptions
+  merge_descriptions_title:  Merge [object]
+  merge_descriptions_merge_header:  Merge with another description
+  merge_descriptions_move_header:  Move / copy to a synonym
+  merge_descriptions_merge:  "[:MERGE]"
+  merge_descriptions_move:  Move / Copy
+  merge_descriptions_merge_or_move:  Merge / Move / Copy
+  merge_descriptions_no_others:  "(there are no other descriptions)"
+  merge_descriptions_delete_after:  Delete old description after merge?
+  merge_descriptions_merge_help:  This will copy any non-blank sections from the source description into the description you select below.  If the target description already has text in any of those fields, you will be given an editing form with the text from both descriptions.  This will allow you to reconcile any conflicts by hand before saving the form and making the merger official.
+  merge_descriptions_move_help:  This will move the source description into a synonym.  It will just copy it if you elect not to delete the old description.  If you wish to merge with an existing description in the other name, you must first move your description into that name, then select [:show_description_merge] again from there.
+
+  # name/bulk_name_edit
+  name_bulk_help:  "Each line indicates a set of changes.\n\np(bulk_text). To ensure a name is in the database, just list the name.  E.g.,\n\np(bulk_pre). Agaricus bisporus\n\np(bulk_text). To ensure a name exists with a particular author, give the name followed by the author.  E.g.,\n\np(bulk_pre). Agaricus bisporus (J.E. Lange) Pilát\n\np(bulk_text). To add a taxon above the species level, give the rank followed by the name.  E.g.,\n\np(bulk_pre). Order Agaricales\n\np(bulk_text). To make a name a deprecated synonym of another name, follow the valid name with the deprecated synonym.  E.g.,\n\np(bulk_pre). Agaricus bisporus (J.E. Lange) Pilát = Agaricus hortensis (Cke.) Imai\n\nThe changes are cumulative, so the last example by itself would ensure that the names **__@Agaricus bisporus@__** @(J.E. Lange) Pilát@ and __@Agaricus hortensis@__ @(Cke.) Imai@ exist, as well as making __@A. hortensis@__ a deprecated synononym of **__@A. bisporus@__**.  If a name exists with no author and you provide an author, then the existing name is updated. Otherwise, if the author is given and it does not match the current author, a new name is created.\n\np(bulk_text). You may include an optional one-line comment by inserting it after either the accepted or deprecated name, enclosed in square brackets. This will be saved in the notes when the name is created.\n\np(bulk_pre). Herpothallon Tobler [[citation:Aptroot, A, G Thor, ...]]"
+  name_bulk_label:  Name Edits
+  name_bulk_success:  All names are now in the database.
+  name_bulk_title: ویرایش نام فله
+
+  # species_list/name_lister
+  name_lister_bad_browser:  This page will not work on your browser, sorry!
+  name_lister_bad_submit:  Invalid commit button '[button]'.
+  name_lister_charset:  Character Encoding
+  name_lister_charset_help:  "(Try changing this if authors get garbled.)"
+  name_lister_classic:  Classic [:SPECIES_LIST] Generator
+  name_lister_genera:  Genera
+  name_lister_help:  "*Create List:* Click a genus in the first column to pull up a list of species in that genus.  Select any of these taxa and press return or double-click to add species to your list.  Accepted names are in boldface; deprecated names are followed by one or more accepted alternatives.  You may choose any.  To remove a name, select it in the third column, and press delete or double-click.  (You may also use arrows to navigate, or type partial names to search within a column.)\n\n*Save List:* When you are finished, click any of the buttons at the bottom of the page.  \"Create [:species_list]\" takes you back to the old creation form, where you will be able to enter date, location, notes, etc. before saving the list.\n\n*Reports :* The plain text report gives you a simple list of taxa with no formatting.  Rich text can be used to import the list into Microsoft Word complete with authors and all the formatting intact.  Spreadsheet produces a CSV file, with name, author, citation, and accepted columns.  Common names are not available yet.  Reports should automatically download in a separate tab or window; if not, go to your browser's File menu and click 'Save As'."
+  name_lister_names:  Selected
+  name_lister_no_js:  This page will not work if javascript is disabled.
+  name_lister_species:  Species
+  name_lister_submit_csv:  Save as Spreadsheet
+  name_lister_submit_rtf:  Save as Rich Text
+  name_lister_submit_spl:  Create [:species_list]
+  name_lister_submit_txt:  Save as Plain Text
+  name_lister_title:  Name List Generator
+
+  # name/needed_descriptions
+  needed_descriptions_help:  The following species names are the ones that have the most [:observations], but do not have a general description in the [:app_title].  Adding a general description to these common species would be a big help.
+  needed_descriptions_title:  Top 100 Needed Species [:descriptions]
+
+  # observer/no_ajax
+  no_ajax_body:  It looks like your browser is out of date.  You still have access to all of the capabilities of this site, however unless you upgrade your browser we will not be able to make use of some very useful javascript features that modern browsers support.  This includes dynamic forms, auto-completion of scientific names and locations, the new version of the [:species_list] creator, and more.
+  no_ajax_browsers:  "Browsers that we recommend (and test the site on regularly) are:\n\n* Firefox / Iceweasel 1.0 or higher\n\n* Internet Explorer 5.5 or higher\n\n* Netscape 7.0 or higher\n\n* Safari 1.2 or higher\n\n* Opera (we know 8.0 works)\n\n* Chrome\n\nIf you know that your browser supports AJAX but it's not listed here, please \"send us an e-mail\":/emails/ask_webmaster_question."
+  no_ajax_dont_care:  If you don't care and you're tired of seeing the "Your Browser is Out of Date" tab at the top of every page, "please click here":/javascript/turn_javascript_off.  (Login and go to preferences to re-enable auto-detection.)
+  no_ajax_title:  Your Browser is Out of Date
+
+  # observer/no_browser
+  no_browser_body:  "We have not seen your browser before.  This means we don't know if it supports the full capabilities of this site.  Since there are pages that won't work if we guess wrong (like voting on [:observation] names), we have to assume the worst.  However this means that a number of useful features are not available, like dynamic forms, auto-completion of scientific names and locations, the new version of the [:species_list] creator, and more.\n\nIf you would like to override this decision, \"click here to turn javascript on\":/javascript/turn_javascript_on.  If you are tired of seeing the \"We Don't Recognize Your Browser\" tab at the top of every page, please \"click here to turn javascript off\":/javascript/turn_javascript_off.  (Login and go to preferences to re-enable auto-detection.)"
+  no_browser_title:  We Don't Recognize Your Browser
+
+  # account/no_email
+  no_email_how_to_reenable:  Go to your "Preferences":/account/prefs page to re-enable this feature.
+  no_email_some_maybe_queued:  "Note: For the next few minutes you may continue to receive emails that have already been queued."
+  no_email_comments_owner_note:  You will no longer receive email notifications when other [:users] of the [:app_title] website post [:comments] about your [:observations], names, etc.
+  no_email_comments_response_note:  You will no longer receive email notifications when other [:users] of the [:app_title] website post responses to your [:comments].
+  no_email_comments_all_note:  You will no longer receive email notifications of all [:comments].
+  no_email_observations_consensus_note:  You will no longer receive email notifications when the names of your [:observations] change.
+  no_email_observations_naming_note:  You will no longer receive email notifications when other [:users] of the [:app_title] website propose names for your [:observations].
+  no_email_observations_all_note:  You will no longer receive email notifications whenenver [:observations] change.
+  no_email_names_admin_note:  You will no longer receive email notifications when other [:users] make changes to name descriptions you administrate.
+  no_email_names_author_note:  You will no longer receive email notifications when other [:users] make changes to descriptions you have written.
+  no_email_names_editor_note:  You will no longer receive email notifications when other [:users] make changes to descriptions you have edited.
+  no_email_names_reviewer_note:  You will no longer receive email notifications when other [:users] make changes to descriptions you have reviewed.
+  no_email_names_all_note:  You will no longer receive email notifications about all name changes.
+  no_email_locations_admin_note:  You will no longer receive email notifications when other [:users] make changes to location descriptions you administrate.
+  no_email_locations_author_note:  You will no longer receive email notifications when other [:users] make changes to [:locations] you have created.
+  no_email_locations_editor_note:  You will no longer receive email notifications when other [:users] make changes to [:locations] you have edited.
+  no_email_locations_all_note:  You will no longer receive email notifications about all location changes.
+  no_email_general_feature_note:  Automated email about new features has been disabled for your account.
+  no_email_general_commercial_note:  Other [:users] of the [:app_title] website can no longer send you commercial inquiries about your [:images].
+  no_email_general_question_note:  Other [:users] of the [:app_title] website can no longer send you questions about your [:observations].
+  no_email_comments_owner_success:  "[:comment] notifications disabled for [name]."
+  no_email_comments_response_success:  "[:comment] response notifications disabled for [name]."
+  no_email_comments_all_success:  "[:comment] notifications disabled for [name]."
+  no_email_observations_consensus_success:  Consensus change notifications disabled for [name].
+  no_email_observations_naming_success:  Name proposal notifications disabled for [name].
+  no_email_observations_all_success:  "[:observation] notifications disabled for [name]."
+  no_email_names_admin_success:  Admin name change notifications disabled for [name].
+  no_email_names_author_success:  Author name change notifications disabled for [name].
+  no_email_names_editor_success:  Editor name change notifications disabled for [name].
+  no_email_names_reviewer_success:  Reviewer name change notifications disabled for [name].
+  no_email_names_all_success:  All name change notifications disabled for [name].
+  no_email_locations_admin_success:  Admin location change notifications disabled for [name].
+  no_email_locations_author_success:  Author location change notifications disabled for [name].
+  no_email_locations_editor_success:  Editor location change notifications disabled for [name].
+  no_email_locations_all_success:  All location change notifications disabled for [name].
+  no_email_general_feature_success:  Automated feature email disabled for [name].
+  no_email_general_commercial_success:  Commercial inquiries disabled for [name].
+  no_email_general_question_success:  Question email disabled for [name].
+
+  # observer/no_javascript
+  no_javascript_body:  "It looks like you have javascript disabled on your browser.  You will still have access to all of the capabilities of this site, however unless you enable javascript we will not be able to make use of some very useful features that modern browsers support.  This includes dynamic forms, auto-completion of scientific names and locations, the new version of the [:species_list] creator, and more.\n\nIf you would like to turn Javascript on, but aren't sure how, try looking it up on google with this search: \"How do I enable JavaScript in my browser?\":http://www.google.com/search?hl=en&q=How+do+I+enable+Javascript+in+my+browser%3F&btnG=Google+Search"
+  no_javascript_dont_care:  If you *do* have javascript enabled, but our auto-detection algorithm is failing to detect it correctly, "please click here":/javascript/turn_javascript_on.  If you don't care and you're tired of seeing the "Javascript Disabled" tab at the top of every page, "please click here":/javascript/turn_javascript_off. (Login and go to preferences to re-enable auto-detection.)
+  no_javascript_title:  You Have Javascript Disabled
+
+  # observer/no_session
+  no_session_body:  "It looks like your browser is refusing cookies.  Without cookies, our site has no way of remembering who you are from one page to the next.  This means that you will not be able to create an account and login, and therefore you will not be able to create [:observations], upload [:images], make [:comments], and much more.  You will still be able to view everything that the general public has access to, but you will just be an observer, you will not be able to participate actively.\n\nAll we will do is store a big long number on your computer.  Next time you go to our site, we will look up that number and use it to keep track of who you are.  (We get multiple requests every second from around the world -- without this ID we wouldn't stand a chance of keeping everyone straight!)  This ID is encrypted and keeps no sensitive information in it.\n\nIf you would like to turn cookies on, but aren't sure how, try looking it up on google with this search: \"How do I enable cookies in my browser?\":http://www.google.com/search?hl=en&q=How+do+I+enable+cookies+on+my+browser%3F&btnG=Google+Search Note that most browsers will let you enable cookies for individual sites, allowing you to protect your privacy everywhere else.  For example, in Firefox, go into Edit -> Preferences -> Privacy Tab -> Exceptions."
+  no_session_title:  You Have Cookies Disabled
+
+  # pivotal/index
+  pivotal_index_title:  Directions for Future Development
+  pivotal_post_comment:  Post Comment
+  pivotal_index_header:  Use this page to browse through the many features requested by users and developers.  Some are very specific bug fixes or requests for new capabilities.  Others are just general areas people are interested in seeing Mushroom Observer grow.  Features are organized by use of the following set of labels.  Click on a label to see a list of features with that label. Click on a feature to see more detail and discussion.  If you are logged in, you will be able to vote features up or down, and you can add your own comments to the discussion.  If you would like to request a new feature, for now we request that you "send us an email":/emails/ask_webmaster_question describing what it is you'd like to do.  Please try to be as detailed as possible; concrete examples are generally the best.
+  pivotal_vote_failed:  "We were unable to process your vote.\nIf the problem persists please notify to admins.\nSorry for the inconvenience!"
+  pivotal_story_failed:  "We were unable to get the story you requested.\nIf the problem persists please notify to admins.\nSorry for the inconvenience!"
+  pivotal_comment_failed:  "We were unable to post your comment.\nIf the problem persists please notify to admins.\nSorry for the inconvenience!"
+  pivotal_story_loading:  Loading story details...
+  pivotal_posting_comment:  Posting comment...
+  pivotal_posted_by:  Posted by
+  pivotal_state_unscheduled:  unscheduled
+  pivotal_state_unstarted:  in the queue
+  pivotal_state_started:  in progress
+  pivotal_head_critical:  serious bugs or mission-critical work
+  pivotal_head_bottleneck:  stuff required by lots of other things
+  pivotal_head_open:  areas we are actively soliciting feedback
+  pivotal_head_started:  areas developers are actively working
+  pivotal_head_unstarted:  scheduled for work soon
+  pivotal_head_unscheduled:  for the indefinite future
+  pivotal_head_day:  has comments within last day
+  pivotal_head_week:  has comments within last week
+  pivotal_head_month:  has comments within last month
+  pivotal_head_none:  has no recent comments
+  pivotal_head_all:  show everything
+  pivotal_head_other:  uncategorized
+  pivotal_label_critical:  critical
+  pivotal_label_bottleneck:  bottleneck
+  pivotal_label_open:  open
+  pivotal_label_day:  day
+  pivotal_label_week:  week
+  pivotal_label_month:  month
+  pivotal_label_none:  none
+  pivotal_label_unscheduled:  "[:pivotal_state_unscheduled]"
+  pivotal_label_unstarted:  "[:pivotal_state_unstarted]"
+  pivotal_label_started:  "[:pivotal_state_started]"
+  pivotal_label_all:  "[:all]"
+  pivotal_label_other:  other
+
+  pivotal_head_api:  programmatic interface
+  pivotal_head_comments:  commenting on observations, names, etc.
+  pivotal_head_descriptions:  species descriptions and drafts
+  pivotal_head_email:  email notifications
+  pivotal_head_i18n:  translating site into other languages
+  pivotal_head_images:  image information, manipulation
+  pivotal_head_lists:  species lists, checklists
+  pivotal_head_locations:  location names, geocoding
+  pivotal_head_maps:  how observations are mapped
+  pivotal_head_names:  taxonomy, synonymy, etc.
+  pivotal_head_observations:  observation fields and interface
+  pivotal_head_performance:  site performance
+  pivotal_head_projects:  working on group projects
+  pivotal_head_search:  search capabilities and data mining
+  pivotal_head_specimen:  how fungarium specimens are documented
+  pivotal_head_voting:  voting on observation names and images
+
+  pivotal_label_api:  API
+  pivotal_label_comments:  "[:comments]"
+  pivotal_label_descriptions:  "[:descriptions]"
+  pivotal_label_email:  email
+  pivotal_label_i18n:  translations
+  pivotal_label_images:  "[:images]"
+  pivotal_label_lists:  lists
+  pivotal_label_locations:  "[:locations]"
+  pivotal_label_maps:  "[:maps]"
+  pivotal_label_names:  "[:names]"
+  pivotal_label_observations:  "[:observations]"
+  pivotal_label_performance:  performance
+  pivotal_label_projects:  "[:projects]"
+  pivotal_label_search:  search
+  pivotal_label_specimen:  "[:specimens]"
+  pivotal_label_voting:  voting
+
+  # info/textile
+  sandbox_enter:  Enter Textile you wish to test here
+  sandbox_header:  This page let's you play with the textile markup language.  Click 'Test' to see what your markup looks like.  You will need to copy the results from this page to where ever you want to use it.
+  sandbox_link4:  The RedCloth manual
+  sandbox_link5:  The old hobix.com tutorial
+  sandbox_link6:  Cheatsheet courtesy warpedivisions.org
+  sandbox_look_like:  This is what it will look like
+  sandbox_more_help:  Gotchas, more examples
+  sandbox_quick_ref:  Quick Reference
+  sandbox_sample:  "??italics??        trademark(tm)\n**boldface**       copyright(c)\n+underline+        registered(r)\n^superscript^      1.6 &amp;&#109;icro;m  ->  1.6 &micro;m\n~subscript~        34&amp;&#100;eg;17' N  ->  34&deg;17' N\n\n\"External Link\":http://google.com or !http://random.com/image.jpg!\n\nInternal links:\n_name 371_, _Amanita ocreata_, or _A. ocreata_\n_location 382_, _location Mt. Wilson_\n_user 252_, _user jason_\n_observation 12345_\n_image 12345_, !image 12345!, or !image 640/12345!\n\nInclude footnote[[1]] references after any word[[2]].\n\nfn1. And then define the footnote at the bottom.\n\nfn2. Be sure to leave blank lines around these \"xx.\" directives.\n\nh1. Header\n\nbq. Block quote\n\n* bullet list item 1\n* bullet list item 2\n\n# numbered list item 1\n# numbered list item 2\n\nTables are useful for comparing species:\n| Species 1 | value 1.1 | value 1.2 |\n| Species 2 | value 2.1 | value 2.2 |\n| Species 3 | value 3.1 | value 3.2 |"
+  sandbox_test:  Test
+  sandbox_test_codes:  Show HTML
+  sandbox_title:  Textile Sandbox
+  sandbox_web_refs:  Web References
+
+  # interest/set_interest
+  set_interest_already_deleted:  You have expressed no interest in [name].
+  set_interest_already_off:  You have already told us to ignore [name].
+  set_interest_already_on:  You have already told us to watch [name].
+  set_interest_bad_object:  "Object [type] #[id] doesn't exist."
+  set_interest_failure:  Could not save changes.  Please try again or report this to the webmaster.
+  set_interest_success_was_off:  Cancelled your ban on emails about [name].
+  set_interest_success_was_on:  Cancelled your request for emails about [name].
+  set_interest_success_off:  We will now ignore any changes in [name].
+  set_interest_success_on:  You will now be notified of any changes in [name].
+  set_interest_user_mismatch:  Another [:user] is logged on at this machine.  Please log them off, log back in as you, and try again.
+
+  # observer/show_notifications
+  show_notifications_title:  New Notifications for [user]
+
+  # species_list/bulk_editor
+  species_list_bulk_editor_title:  Species List Bulk Editor
+  species_list_bulk_editor_another:  Another
+  species_list_bulk_editor_reuse:  Reuse
+  species_list_bulk_editor_success:  Successfully updated [n] observation(s).
+  species_list_bulk_editor_you_own_no_observations:  You don't own any observations in this species list.
+  species_list_bulk_editor_ambiguous_namings:  "The proposed names are confusing for observation [id]: [name]. Please \"go to that observation\":/[id] and make your changes there."
+  species_list_bulk_editor_help:  "Hold your mouse over any of the fields in the table below to see what the field is supposed to be.  The text fields are, in order: notes (top right), date, location, latitude, longitude, elevation (second row).  Check boxes indicate, respectively, if location is where collected, and specimen.  All links open in new tabs."
+
+  # observer/<Theme>
+  theme_agaricus:  _Agaricus_ Theme
+  theme_agaricus_augustus:  "[link] is used for the left-hand panel's background color."
+  theme_agaricus_campestris:  "[link] is used for the primary background and the default link hover background color."
+  theme_agaricus_cupreobrunneus:  "[link] is used for the default text color and the visited link color."
+  theme_agaricus_lilaceps:  "[link] is used for the background color for the some rows on the list pages and the unvisited link color for the other rows."
+  theme_agaricus_semotus:  "[link] is used for the banner background color."
+  theme_agaricus_subrufescens:  "[link] is used for most unvisited links."
+  theme_agaricus_xanthodermus:  "[link] is used for the background color for some rows on the list pages and the unvisited link color for the other rows."
+  theme_amanita:  _Amanita_ Theme
+  theme_amanita_calyptroderma:  "[link] is used for all the colors of half the rows on the list pages."
+  theme_amanita_muscaria:  "[link] is used for the banner background and text, the default visited link and link hover colors as well as the text for the left-hand panel."
+  theme_amanita_pachycolea:  "[link] is used for the primary background, the default text and default unvisited links."
+  theme_amanita_phalloides:  "[link] is used for all the colors of the other half of the rows on the list pages."
+  theme_amanita_velosa:  "[link] is used for the left-hand panel's background color and the left-hand panel's visited and unvisited link colors."
+  theme_cantharellaceae:  _Cantharellaceae_ Theme
+  theme_cantharellaceae_californicus:  "[link] is used for the primary, banner and left-hand panel backgrounds."
+  theme_cantharellaceae_cinnabarinus:  "[link] is used for the default link and visited link colors."
+  theme_cantharellaceae_cornucopioides:  "[link] is used for the default text and all the colors of half the rows on the list pages."
+  theme_cantharellaceae_tubaeformis:  "[link] is used for all the colors of the other half of the rows on the list pages."
+  theme_hygrocybe:  _Hygrocybe_ Theme
+  theme_hygrocybe_conica:  "[link] is used for the default text and all the colors of half the rows on the list pages."
+  theme_hygrocybe_miniata:  "[link] is used for the left-hand panel background and link text colors."
+  theme_hygrocybe_pittacina:  "[link] is used for the default link text colors."
+  theme_hygrocybe_punicea:  "[link] is used for the default background color, the banner background color, and all the colors of the other half of the rows on the list pages."
+  theme_random:  Random
+  theme_list:  List of Themes
+  theme_black_on_white:  Black on White Theme
+  theme_black_on_white_description:  This is a simple Black on White theme that attempts to be as readable and clean as possible. The logo colors come from the [link] theme.
+  theme_switch:  To select this as your theme, go to your "preferences":/account/prefs and select [theme] as your Preferred Theme
+
+  # Theme names.
+  Agaricus:  Agaricus
+  Amanita:  Amanita
+  Cantharellaceae:  Cantharellaceae
+  Hygrocybe:  Hygrocybe
+  BlackOnWhite:  Black on White
+
+  # info/translators_note
+  translators_note: "لطفا به ما کمک کنید تا این وب سایت در سراسر جهان در دسترس!  آسونه .\n\nدر حال حاضر حدود 3000 خط با 25000 کلمه متن در این سایت وجود دارد، اما اجازه ندهید که شما را بترساند.  ما آن را سازماندهی کرده ایم تا کسی با زمان محدود بتواند روی مهم ترین متن تمرکز کند.  سپس به عنوان زمان و مجوز انرژی، آنها یا شخص دیگری می توانند به کار کردن لیست ادامه دهند تا یک روز همه چیز به پایان برسد.\n\nراه های متعددی برای شروع وجود دارد.  شما می توانید یک کپی از کل \"فایل ترجمه\" را انتخاب کنید:[repo] و شروع به ترجمه آن به هر زبانی که می خواهید.  \"برای ما ایمیل بفرستید\":/emails/ask_webmaster_question برای کسب اطلاعات بیشتر در مورد این رویکرد.\n\nحتی کار بر روی ترجمه های موجود هم آسان تر است.  فقط دنبالش ببين \"[:app_edit_translations]\" در پایین هر صفحه.  شما می توانید بلافاصله ببینید که چگونه تغییرات خود را در زمینه صفحه نگاه کنید.  اگر زبان شما در دسترس نباشد، \"send us an email\":/emails/ask_webmaster_question و ما می توانیم یک نسخه \"بتا\" برای شما ایجاد کنیم تا روی آن کار کنید.\n\nالبته برای هر خطی که ترجمه می کنید، علاوه بر قدردانی از کاربران بی شماری، پاداش اعتباری و مشارکتی دریافت خواهید کرد."
+  translators_note_title: یادداشت مترجم
+
+  # translation/edit_translations
+  edit_translations_title: ویرایش ترجمه ها
+  edit_translations_bad_locale:  "Invalid locale code: [locale]"
+  edit_translations_login_required: برای ویرایش ترجمه ها باید وارد سیستم شوید.
+  edit_translations_reviewer_required:  Only reviewers have permission to edit the English translations.
+  edit_translations_created_at:  Created translation for [tag].
+  edit_translations_changed:  Changed translation for [tag].
+  edit_translations_no_changes:  Nothing changed.
+  edit_translations_saving:  Saving...
+  edit_translations_loading:  Loading...
+  edit_translations_will_lose_changes:  There are unsaved changes. Would you like to continue anyway?
+  edit_translations_switch_language:  Switch Language
+  edit_translations_original_text:  Original Text
+  edit_translations_old_versions:  Old Versions
+  edit_translations_full_text:  full text
+  edit_translations_no_versions:  No old versions.
+  edit_translations_singular: فرم مفرد
+  edit_translations_plural: فرم جمع
+  edit_translations_lowercase: همه کوچک به عنوان برای پایان جمله
+  edit_translations_uppercase: همه بزرگ به عنوان برای عنوان
+  edit_translations_page_expired:  The page you were working on has expired.  Please go back and reload it, then click on "[:app_edit_translations_on_page]" again.
+  edit_translations_help: در سمت چپ فهرستی از رشته های ترجمه است که به صورت موضوعی با توجه به نحوه ظاهر شدن آن ها در فایل ترجمه اصلی مرتب شده اند.  اگر بر روی یکی از برچسب های زیر خط کلیک کنید، به شما این امکان را می دهد که رشته مربوطه را در پنل سمت راست ویرایش کنید.  کلیک کنید "[:SAVE]" تا تغییرات خود را ذخیره کنید.
+
+  # observer/turn_javascript_nil
+  turn_javascript_nil_body:  We will resume auto-detection of the state of javascript.
+  turn_javascript_nil_title:  Auto-Detect Javascript
+
+  # observer/turn_javascript_off
+  turn_javascript_off_body:  We will now ignore javascript.
+  turn_javascript_off_title:  Turn Javascript Off
+
+  # observer/turn_javascript_on
+  turn_javascript_on_body:  We will now assume javascript is on.
+  turn_javascript_on_title:  Turn Javascript On
+
+  ##############################################################################
+
+  # ADMIN-TYPE PAGES
+
+  # project/add_members
+  add_members_change_status:  Change Status
+  add_members_denied:  "Permission denied: only admins for a project can add new members."
+  add_members_title:  Add [:users] to [title]
+  add_members_not_found:  User "<str>" not found.
+  add_members_added_admin:  Successfully added [user] to admins.
+  add_members_added_member:  Successfully added [user] to members.
+  add_members_removed_admin:  Successfully removed [user] from admins.
+  add_members_removed_member:  Successfully removed [user] from members.
+  add_members_already_added_admin:  Already added [user] to admins.
+  add_members_already_added_member:  Already added [user] to members.
+  add_members_already_removed_admin:  Already removed [user] from admins.
+  add_members_already_removed_member:  Already removed [user] from members.
+
+  # project/add_project
+  add_project_already_exists:  A project named '[title]' already exists.
+  add_project_group_exists:  Unable to create project because a [:user_group] named '[group]' already exists.
+  add_project_need_title:  Projects must have a title.
+  add_project_success:  Project was successfully created.
+  add_project_title: ایجاد پروژه جدید
+
+  # account/add_user_to_group
+  add_user_to_group_already:  "[user] is already a member of [group]."
+  add_user_to_group_group:  Group name
+  add_user_to_group_no_group:  Unable to find the group, '[group]'.
+  add_user_to_group_no_user:  Unable to find the [:user], '[user]'.
+  add_user_to_group_success:  "[user] added to [group]."
+  add_user_to_group_title:  Add [:user] to Group
+  add_user_to_group_user:  "[:user] name"
+
+  # admin_request/author_request emails
+  admin_request_change_member_status:  Change [:user]'s status
+  admin_request_success:  Successfully sent admin request for [title]
+  admin_request_title:  Admin Request for [title]
+  admin_request_note:  Enter your request below.  When you hit "[:SEND]" it will be emailed to to project admins.  The email will include your email address so that they can respond to your request.
+  author_request_add_author:  Make sender an author
+  author_request_title:  Authorship Request for [title]
+  author_request_note:  "[:admin_request_note]"
+  request_message:  Message
+  request_show_user:  Show details on sender
+  request_subject:  Subject
+  request_success:  Delivered email.
+
+  # info/change_banner
+  change_banner_title:  Change Site Banner
+
+  # project/change_member_status
+  change_member_status_admins:  Current Project Admins
+  change_member_status_change_status:  Change Status
+  change_member_status_edit:  Edit Project
+  change_member_status_make_admin:  Make Admin
+  change_member_status_make_admin_help:  Make Admin - Allows [:user] to perform admin functions.  They will be able to add or remove members, change the ability for other members to perform admin functions, and edit any draft names for this project.  [:user] is also made a member of the project if they are not already.
+  change_member_status_make_member:  Make Regular Member
+  change_member_status_make_member_help:  Make Regular Member - Ensures that [:user] is a member of the project, but not in the admin group. Afterwords the [:user] will be able to view and create draft names for this project.  They will be the only non-admin members able to edit their drafts.
+  change_member_status_members:  Current Project Members
+  change_member_status_remove_member:  Remove Member
+  change_member_status_remove_member_help:  Remove Member - Removes all member and admin privileges for a project.  [:user] will no longer be able view or create draft names for this project.  They will not be able to perform any admin functions.
+  change_member_status_denied:  Only the admins for a project can change member permissions.
+  change_member_status_title:  Changing [:user] Status of [name] for [title]
+
+  # users/bonuses
+  change_user_bonuses_title:  Contribution Bonuses for [user]
+  change_user_bonuses:  Award Bonus
+  change_user_bonuses_help:  "List one bonus per line, each specifying a number of points and reason, like this:\n\n10000 German translations\n50000 Expert in hypogeous fungi\n\n\nThese will appear on the show_user page below the usual contribution scores. Keep the reasons short or it might mess up the formatting of the table on that page."
+
+  # project/destroy_project
+  destroy_project_failed:  Failed to destroy project.
+  destroy_project_success:  Project destroyed.
+
+  # project/edit_project
+  edit_project_destroy:  "[:destroy_object(type=:project)]"
+  edit_project_title:  "[:edit_object(type=:project)]: [title]"
+
+  # project/_form_projects
+  form_projects_title:  "[:Title]"
+
+  # project/list_projects
+  list_projects_title:  "[:list_objects(type=:project)]"
+  list_projects_add_project:  "[:add_object(type=:project)]"
+
+  # draft/publish_draft
+  publish_draft_denied:  "Permission denied: Only the creator of a draft or a project admin can publish a draft."
+
+  # observer/refresh_vote_cache
+  refresh_vote_cache:  Refreshed vote caches.
+
+  # project/review_authors
+  review_authors_add_author:  Add
+  review_authors_authors:  Current [:description] Authors
+  review_authors_denied:  Only existing authors and reviewers can change the description authors.
+  review_authors_note:  This page changes the recorded author(s) of a taxon description on the [:app_title] website.  This is in no direct way related to the original publishing author of the taxon.
+  review_authors_review_authors:  Review Authors
+  review_authors_other_users:  Other [:users]
+  review_authors_remove_author:  Remove
+  review_authors_title:  Reviewing Author(s) for [name]
+
+  # observer/send_feature_email
+  send_feature_email_success:  Delivered feature mail.
+  send_feature_email_denied:  Only the admin can send feature mail.
+
+  # project/show_project
+  show_project_add_members:  Add Members
+  show_project_admin_group:  Admin Group
+  show_project_admin_request:  Admin Request
+  show_project_by:  Owned By
+  show_project_created_at:  Created
+  show_project_destroy:  Destroy Project
+  show_project_drafts:  Drafts
+  show_project_edit:  Edit Project
+  show_project_published:  Reviewed Published Names
+  show_project_summary:  Summary
+  show_project_title:  "Project: [title]"
+  show_project_user_group:  User Group
+
+  # users/by_name
+  users_by_name_title:  Users by Name
+  users_by_name_created_at:  Created
+  users_by_name_groups:  Groups
+  users_by_name_id:  ID
+  users_by_name_last_login:  Last login
+  users_by_name_login:  Login
+  users_by_name_name:  Name
+  users_by_name_theme:  Theme
+  users_by_name_verified:  Verified
+
+  # support/create_donation
+  create_donation_title:  Record Mushroom Observer Donation
+  create_donation_not_allowed:  Only admins can record donations
+  create_donation_add:  Add
+  create_donation_tab:  Record Donation
+
+  # support/review_donations
+  review_donations_title:  Review All Donations
+  review_donations_not_allowed:  Only admins can review donations
+  review_donations_update:  Update
+  review_donations_tab:  Review Donations
+  review_reviewed:  Reviewed
+  review_id:  Id
+  review_who:  Who
+  review_anon:  Anon
+  review_amount:  Amount
+  review_email:  Email
+
+  ##############################################################################
+
+  # EMAIL MESSAGES
+
+  # Subject lines.
+  email_subject_add_herbarium_record_not_curator:  Fungarium Record Added to [herbarium_name]
+  email_subject_comment:  "[:COMMENT] About [name]"
+  email_subject_commercial_inquiry:  Commercial Inquiry About [Name]
+  email_subject_consensus_change:  Consensus Changed from [old] to [new]
+  email_subject_denied:  "[:USER] Creation Blocked"
+  email_subject_features:  New [:app_title] Features
+  email_subject_location_change:  "[name] Has Been Changed"
+  email_subject_naming_for_observer:  Research Request
+  email_subject_naming_for_tracker:  Naming Notification - [name]
+  email_subject_name_change:  "[name] Has Been Changed"
+  email_subject_name_proposal:  "[:OBSERVATION] #[id] May Be [name]"
+  email_subject_new_password:  New Password
+  email_subject_observation_change:  "[:OBSERVATION] Changed, [name]"
+  email_subject_observation_destroy:  "[:OBSERVATION] Destroyed, [name]"
+  email_subject_observation_question:  Question About [name]
+  email_subject_publish_name:  Name Published
+  email_subject_registration:  "[name] Registration Verification"
+  email_subject_update_registration:  "[name] Registration Update"
+  email_subject_verify:  Email Verification
+  email_subject_verify_api_key:  Activate API Key
+  email_subject_webmaster_question:  Question From [user]
+
+  # Field labels in the "object_change" emails.
+  email_field_added_images:  Added image(s)
+  email_field_changed_thumbnail:  Changed thumbnail
+  email_field_collection_location:  Specimen _was_ collected at this location
+  email_field_collection_not_location:  Specimen _was not_ collected at this location
+  email_field_east:  "[:East] edge"
+  email_field_image_count:  "[:Image] count"
+  email_field_new_name:  New [:name]
+  email_field_no_specimen_available:  Specimen is no longer available
+  email_field_north:  "[:North] edge"
+  email_field_old_name:  Old [:name]
+  email_field_published:  Published by
+  email_field_removed_images:  Removed image(s)
+  email_field_south:  "[:South] edge"
+  email_field_specimen_available:  Specimen is now available
+  email_field_west:  "[:West] edge"
+
+  # This is used like this: "<Label>: <old_value> changed to <new_value>"
+  email_field_is_now:  changed to
+
+  # "Helpful" links at the bottom of the email.
+  email_links_change_prefs:  Change your preferences
+  email_links_disable_tracking:  Disable tracking for this [type]
+  email_links_email_publisher:  Send email to the publisher
+  email_links_latest_changes:  Latest changes at [:app_title]
+  email_links_not_interested:  I'm not interested in this [type]
+  email_links_post_comment:  Post a [:comment]
+  email_links_show_object:  Show this [type]
+  email_links_show_user:  Show [:user]'s profile
+  email_links_show_observer:  Show [:observer]'s profile
+  email_links_show_identifier:  Show [:identifier]'s profile
+  email_links_stop_sending:  Stop sending me email like this
+  email_links_your_interests:  Review your [:notifications]
+
+  # Some other common phrases and sections.
+  email_can_respond:  It is entirely up to you whether you want to reply to [name] ([email]) by replying directly to this email.
+  email_handy_links:  "Here are some handy links:"
+  email_no_respond:  Please do not reply to this email!
+  email_naming_for_observation_warning:  "WARNING: We've heard that some people have mis-used this notification feature in the past, claiming it's for research but not using specimens for that purpose. You may want to take a moment to look at their user profile on MO and perhaps google them to verify that they are actually active mycologists before going to the effort of packaging and sending them any specimens."
+  email_report_abuse:  "If you feel this user is abusing this service please forward this entire email message to: [email]"
+  email_respond_via_comment:  Use the link below to respond via your own public comment.
+  email_welcome:  Welcome, [user]
+
+  # Main message contents.
+  email_admin_request_intro:  "h2. *Admin Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following request to you regarding [project]:"
+  email_author_request_intro:  "h2. *Author Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following request to you regarding [object]:"
+  email_comment_intro_other:  "h2. *Comment on [Type]*\n\nThe following comment was posted on the [:app_title] website regarding the [type] <u>[name]</u>:"
+  email_comment_intro_response:  "h2. *Comment Response*\n\nThe following comment was posted on the [:app_title] website in response to your comment regarding the [type] <u>[name]</u>:"
+  email_comment_intro_to_owner:  "h2. *Comment on Your [Type]*\n\nThe following comment was posted on the [:app_title] website regarding your [type] <u>[name]</u>:"
+  email_commercial_intro:  "h2. *Commercial Inquiry*\n\n[user] ([email]) asked the [:app_title] website to forward the following commercial inquiry to you about your image [image]:"
+  email_consensus_change_intro:  "h2. *Consensus Change*\n\nConsensus has changed for observation #[id]:"
+  email_add_herbarium_record_not_curator_intro:  "h2. *Fungarium Record Added By Non-Curator*\n\nThe user, [login], added the fungarium record, [herbarium_label], to the fungarium, [herbarium_name], which you curate."
+  email_features_intro:  "h2. *New Features*\n\nThe following new features have been released at the [:app_title] website:"
+  email_name_change:  "User made nontrivial change to a name:\n\nuser : [user]\nold identifier : [old_identifier]\nnew identifier : [new_identifier]\nold name : [old]\nnew name : [new]\nobservations : [observations]\nnamings : [namings]\nshow name : [show_url]\nedit name : [edit_url]"
+  email_location_change:  "User made nontrivial change to a location:\n\nuser : [user]\nold name : [old]\nnew name : [new]\nobservations : [observations]\nshow location : [show_url]\nedit location : [edit_url]"
+  email_merger_icn_id_conflict:  "User merged names; one icn_id discarded:\n\nname : [name]\nsurviving icn_id : [surviving_icn_id]\ndeleted icn_id : [deleted_icn_id]\nuser : [user]\nshow url : [show_url]\nedit url : [edit_url]"
+  email_merge_objects:  "User wants to merge two [types]:\n\nuser : [user]\nthis : [this]\ninto : [that]\nshow this : [show_this_url]\nedit this : [edit_this_url]\nshow that : [show_that_url]\nedit that : [edit_that_url]\nnotes : [notes]"
+  email_name_change_request:  "User wants to change Name having dependents:\n\nuser : [user]\nold name : [old_name]\nnew name : [new_name]\nshow url : [show_url]\nedit url : [edit_url]\nnotes : [notes]"
+  email_name_proposal_intro:  "h2. *Name Proposal*\n\nA name was proposed for observation #[id]:"
+  email_naming_for_observer_intro:  "h2. *Research Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following message to you about your [type] <u>[name]</u>:"
+  email_naming_for_tracker_intro:  "h2. *Tracking Alert*\n\nAn [obs] on the [:app_title] website has been given the name [name], which you are currently tracking.  You can contact either the [:observer] or the [:identifier] by going to the appropriate link below and clicking the email link near the top of the page."
+  email_new_password_intro:  "h2. *New Password*\n\nYour new [:app_title] password is:"
+  email_new_password_what_now:  Once you have logged in, you should change your password to something easier to remember by going to the '[:app_preferences]' page.
+  email_object_change_intro:  "h2. *[Type] was Changed*\n\nThere were change(s) made to the [type] <u>[name]</u>:"
+  email_object_new_intro:  "h2. *[Type] was Created*\n\nThe [type] <u>[name]</u> was created."
+  email_object_change_reason_all:  You received this email because you have requested to be notified when any [type] changes.
+  email_object_change_reason_admin:  You received this email because you are an admin for a description of the changed [type].
+  email_object_change_reason_editor:  You received this email because you have edited a description of the changed [type].
+  email_object_change_reason_author:  You received this email because you are an author of a description of the changed [type].
+  email_object_change_reason_reviewer:  You received this email because you reviewed a description of this [type].
+  email_object_change_reason_interest:  You received this email because you expressed interest in this [type].
+  email_observation_destroyed_intro:  h2. *Observation Destroyed*
+  email_observation_question_intro:  "h2. *Question from Another User*\n\n[user] ([email]) asked the [:app_title] website to forward the following question to you about your observation <u>[name]</u>:"
+  email_publish_name_intro:  "h2. *Draft of Name Has Been Published*\n\nA description of a name has been published on the [:app_title] website. You are receiving this email since you are listed as either an author for this taxon or as a reviewer on the site."
+  email_registration_intro:  "h2. *Hello [user]*\n\nPlease click the following link to verify that you received this email and intended to register [how_many] attendee(s) for the [name]:\n\n[link]"
+  email_update_registration_intro:  "h2. *Hello [user]*\n\nYour registration for the [name] has been updated from\n\n[before]\n\n\nto\n\n\n[after]"
+  email_user_question_intro:  "h2. *Question from Another User*\n\n[user] ([email]) asked the [:app_title] website to forward the following email to you:"
+  email_verify_intro:  "h2. *Hello [user]*\n\nPlease click the following link to verify that you received this email and activate your [:app_title] account:\n\n[link]"
+  email_verify_api_key_intro:  "h2. *Hello [user]*\n\nThe application \"[app]\" (associated with user \"[other_user]\") has requested access to your [:app_title] account.  If you recognize this application and wish to give them permission to post observations, etc. in your name, all you have to do is click on the activation link below to activate the API key they just created.  Note that you can review your list of API keys at any time by visiting the [:account_api_keys_title] from your \"[:app_preferences]\" page.\n\nActivate Key: [activate_link]\n[:account_api_keys_link]: [manager_link]\n\nTo report a suspicious access request, just respond to this email."
+
+  ##############################################################################
+
+  # HELP PAGES
+
+  # info/intro
+  intro_title:  Introduction
+  intro_purpose:  "*Purpose&#58;* The purpose of this site is to record observations about mushrooms, help people identify mushrooms they aren't familiar with, and expand the community around the scientific exploration of mushrooms (mycology).  Some have asked what counts as a mushroom.  This site takes a very broad view.  While the emphasis is on the large fleshy fungi, other fungi such as lichens, rust and molds as well as fungus-like organisms such as slime-molds are all welcome.  Ultimately, I hope this site will become a valuable resource for both amateur and professional mycologists.  I like to think of it as a living field guide for mushrooms or a collaborative mushroom field journal.\n\nFor those new to mycology, there is a huge amount of basic research that still needs to be done.  By some estimates less than 5% of the world's species of fungi are known to science.  While things are slightly better for the large fleshy fungi known as mushrooms, it is still a common experience to come across a mushroom that cannot be easily identified in the available books or which doesn't really fit the definition of any recognized species. This site is intended to address that gap by creating a place for us to talk about and record what we've found, as well as connect to the existing literature about mushrooms.  Please do not feel intimidated by the scientific bent of the site.  Everyone is welcome to dive in and add their own mushroom observations, upload mushroom photos and make [:comments] on other people's observations."
+  intro_image_sharing:  "*Image Sharing:* This site follows the principles of cooperative sharing pioneered by the \"Free Software Foundation\":http://fsf.org, further expressed by the \"Open Source software movement\":http://opensource.org, and expanded to other creative efforts by the \"Creative Commons\":http://creativecommons.org. Consequently all images are made available under one of the Creative Commons licenses or are in the public domain.  In short this means that when anyone uploads one of their images to the site, they are giving others explicit permission to use those images under certain \"conditions\":/info/how_to_use#license in perpetuity.  This type of permission is very important for basic research.  It allows future researchers to freely use these data to expand our understanding of mushrooms.  It also significantly increases the likelihood that the data will continue to be available into the distant future.\n\nIf you upload your own images, this license does not mean you are giving up your copyright or your ability to make money off your images.  Depending on which license you choose, you can still require that anyone who wishes to use any of these images for commercial purposes get in touch with the copyright holder and work out the conditions for that use.  The site includes special links on the image pages to help create those relationships."
+  intro_source_code:  "*Source Code:* Source code for the site is available at: \"[repo]\":[repo] and is licensed under the \"Open Source MIT License\":http://www.opensource.org/licenses/mit-license.php.  Source code contributions are welcome (\"README\":[readme]). Here's a list of \"planned features\":[todo_list]. All suggestions and comments are welcome.  If you would like to contribute, please send mail to *webmaster @ mushroomobserver.org* so we can coordinate our efforts."
+  intro_governance:  "*Governance:* This site is owned and operated by \"Mushroom Observer, Inc.\":/support/governance."
+  intro_note:  "*Note:* The administrators of this site reserve the right to remove any material they deem inappropriate or not in keeping with the purpose of this site."
+
+  # info/how_to_help
+  how_help_title:  How to Help Make [:app_title] Better
+  how_help_intro:  This page provides a list of skills that we could really use some help with. If you're interested in helping out just "send an email":/emails/ask_webmaster_question and let us know what you want to do.
+  how_help_contributors:  "h4. 1. Contributors\n\np(normal).  Beyond adding pictures and descriptions of mushrooms that you've seen, you can make a big difference to the site by \"describing species\":/info/how_to_use#describing_species or \"defining locations\":/info/how_to_use#defining_locations."
+  how_help_scientists:  "h4. 2. Scientists\n\np(normal).  Mention Mushroom Observer in your publications and \"add references to your publications\":/publications."
+  how_help_developers:  "h4. 3. Developers\n\np(normal).  We have \"lots of ideas\":[todo_list] about how to improve the site.  The framework, Ruby on Rails, is really easy to pick up and we are more than happy to mentor anyone who wants to dive in."
+  how_help_translators:  "h4. 4. Translators\n\np(normal). The site is set up to support foreign languages.  All we need is someone to do the translations."
+  how_help_donors:  "h4. 5. Donors\n\np(normal). Help support our server costs by \"donating\":/support/donate to the Mushroom Observer."
+  how_help_business_planning:  "h4. 6. Business Planning\n\np(normal).  So far [:app_title] has been an entirely volunteer effort, after some time consuming false starts, we are now in the process of creating a new non-profit focused solely on Mushroom Observer. This is just getting going so let us know if you want to get involved or have any business related advice."
+
+  # info/how_to_use
+  how_title:  How to Use [:app_title]
+  how_common_tasks:  Common Tasks
+  how_glossary:  Concepts Glossary
+  how_intro:  This page provides some short descriptions of common uses of this website followed by an overview of the basic concepts used.
+  how_keeping_up:  "*Keeping Up with Changes* - The default page for [:app_title] is the '[:rss_log_title]', it is also accessible through the '\"Latest Changes\":/' link in the left-hand panel.  This page shows you the most recent changes on the site.  It lists new \"Observations\":#observation and \"Species Lists\":#species_list as well as significant changes to any already existing ones.  Additions of \"Images\":#image and \"Comments\":#comment are considered significant changes to the relevant observations.  Changes to \"Names\":#name are also listed.  Click the page numbers at the top and bottom of the page to browse through older changes.  Observations and names created as a side effect of other changes are not listed separately.\n\nNote : The latest changes can be tracked using our \"RSS feed\":/activity_logs/rss. See this \"wikipedia article\":http://en.wikipedia.org/wiki/Rss for more information about RSS feeds."
+  how_searching:  "*Searching* - There are several interesting ways to search for information on the site.  The simplest is to type a search string into the search box near the top of each page and click one of the buttons next to it.  This will give you a list of all the \"Observations\":#observation, \"Images\":#image, \"Names\":#name or \"Locations\":#location that contain fields matching the given string.  If you need a little more control over the search, try clicking '[:app_advanced_search]'.\n\nYou may also browse the site using the links in the left-hand panel.  For example, clicking on 'Names' under 'Indexes' on the left of the page shows all the species that have observations, listed alphabetically.  You can page through this list, or skip directly to the letter of a name you are interested in by clicking the appropriate page number or letter along the top or bottom of the list.  Click a name from this list to see a description of the species and a list of observations of that species.  If you click a genus like 'Agaricus', it will also show a list of species in that genus.  Note, however, that in this case it will only show observations that have been identified to the genus level, not ones that have been identified as a species in that genus.  On the other hand, if two names are considered synonyms, you will see observations for either name on this page.  (*NOTE*: If you do a search on 'Agaricus', it _will_ show all the observations whose name contains that string, so you get all the observations that belong to that genus.)\n\nWhenever you click an observation or other result on an index page, it will take you to a page showing that result.  At the top of the page you will see '[:PREV]', '[:NEXT]', and '[:INDEX]' links.  These let you browse forward or backward through the results or return to the index.  At the top of the index page you will often see links allowing you to sort the results by different criteria, such as by date, name or user.  In the same place you will sometimes find links that let you turn an index of observations into an index of names or images of those same observations.  For example, if you click '[:app_your_observations]', it will show you a list of observations you have posted.  Click '[:show_objects(types=:names)]' at the top of the page to see a list of the species you have seen, or click '[:show_objects(types=:locations)]' to see a list of all the locations you've gone mushrooming in.\n\nPower users may also be interested in our new API providing direct access to our database back-end.  This can be used to mine our database for images or species descriptions for inclusion in wikipedia or other public websites. You can also use it to upload observations and images and much more.  Please contact the webmaster for more information."
+  how_unknown_help:  "*Getting Help with an Unknown* - In order to get help with an unknown, you need to have a user account.  These can be created easily by selecting '[:app_create_account]' from the left-hand panel.  See the discussion of \"Users\":#user below for more details.\n\nOnce you are logged in, create a new \"Observation\":#observation by selecting '[:app_create_observation]' in the left-hand panel.  Enter all the details you can into the resulting form.  You can leave the '[:WHAT]' field blank call it '[:unknown]', or if you think you know the genus or family or other group, give that \"Name\":#name followed by 'sp.', e.g., 'Russula sp.'. In the '[:NOTES]' field provide information about habitat, odor, smell and anything else not clear from the photos.  Once the form is as complete as you can make it, click '[:CREATE]'.\n\nYou should now be looking at a page showing you the information you just entered.  However, if you used a name that is not currently in the database, you will be asked if you want to add the name.  This also gives you a chance to catch and fix typos.  In addition, if you use a name that is considered deprecated, you will be given the option of using a preferred synonym.\n\nOnce you have created the new observation, you can upload any \"Images\":#image you have by selecting the '[:show_observation_add_images]' link on the right-side of the page.  It is very important either that it be an image you took or that you have the explicit permission of the person who created the image to upload it to the site.  If you did not take the image, please update the '[:form_images_copyright_holder]' field to reflect the actual owner.  This page also allows you to select the \"License\":#license you want to release the image under.\n\nWhen you add unknowns, the community will generally \"propose one or more names\":#proposing_names for it within 24-hours.  If you find any of the suggested names compelling, you should not hesitate to revisit your observation and \"Vote\":#vote on them.  Please see the discussion below on \"voting\":#voting, as well.  Members of the community may also post feedback via \"Comments\":#comment.  By default your account is set up to deliver comments posted about your observations to you by email.  If you are asked to provide more details on the collection, we prefer that you select '[:show_observation_edit_observation]' (at the top of the observation page) and add them to the '[:NOTES]' field than to just post another comment."
+  how_adding_observations:  "*Adding Observations You Have Identified* - Use the same process as \"Getting Help with an Unknown\":#unknown_help, except this time provide your identification in the '[:WHAT]' field.  You are strongly encouraged to say something about how you arrived at the identification.  We've provided a small set of checkboxes to make this easy ('[:naming_reason_label_1]', '[:naming_reason_label_3]', etc.), but you are encouraged to elaborate on them in the provided text fields (e.g., list the references you used, or enter 'sequenced the DNA and compared it against the data in GenBank'!). Community members will often post \"Comments\":#comment if there is some question about the collection or if they would like clarification as to why you ruled out other \"Names\":#name.  Roy Halling has provided beautifully illustrated presentations describing <a href=\"https://mushroomobserver.org/pdf/macro-features.pdf\">macroscopic</a> and <a href=\"https://mushroomobserver.org/pdf/micro-features.pdf\">microscopic</a> features. More documentation on creating scientifically valuable collections is available from the <a href=\"http://mycoportal.org/portal/misc/links.php\">MycoPortal Links Page</a>."
+  how_proposing_names:  "*Proposing Names* - Any member of the community can propose \"Names\":#name for any \"Observations\":#observation.  Click an observation (e.g., from the '[:rss_log_title]' page) and scroll down below the observation notes.  There should be a list of \"Proposed Names\":#proposed_name enclosed in a thin outlined box.  Most observations will already have at least one proposed name (by the owner).  From here you may either click '[:show_namings_propose_new_name]' or \"Vote\":#voting on existing names.  In either case you will have to log in before you are allowed to do so.\n\nWhen you click '[:show_namings_propose_new_name]' you will be presented with a form much like the one used to create an observation.  In addition to the name, you are required to choose a confidence level.  This is your \"Vote\":#vote, and you may change it on the '[:show_object(type=:observation)]' page at any time you like.  As with creating an observation, you are strongly encouraged to give some explanation as to why you think your Name applies to this Observation (and why other names don't).  When you are finished, click '[:CREATE]'.  You will be given a chance to correct typos or to choose an accepted name if you entered a deprecated one.\n\nUsers are not allowed to propose a name if someone else has already done so. The only reason to do so would be to describe alternative reasons for reaching the same conclusion.  Instead use the discussion forum provided by comments to do this."
+  how_voting:  "*Voting on Proposed Names* - Click an \"Observation\":#observation, e.g., from the '[:rss_log_title]' page, and scroll down to the '[:show_namings_proposed_names]' box.  Note that you must login before you can see or change any of your \"Votes\":#vote.  Once you have logged in, you should see pulldown menus next to each \"Proposed Name\":#proposed_name.  Your vote expresses the degree of confidence or agreement you have with placing that name on that observation.  Everything above '[min_neg_vote]' is considered a positive vote, everything below '[min_pos_vote]' negative. Choose '[no_opinion]' to tell it to delete your vote.  When you've changed all the votes you want to, be sure to click '[:show_namings_update_votes]' to record your votes.  Don't worry, if you forget and try to navigate away without casting your votes it will complain (unless you have Javascript disabled).\n\nRoughly speaking, votes for a name are weighted, summed and then divided by the number of votes for that name.  The name with the highest score wins, and that name will be applied to that observation throughout the site.  In the case where multiple synonyms are proposed for an observation it lumps the votes together, choosing each user's strongest vote within that group of synonyms.  In the end, assuming that group of synonyms wins, the currently accepted name is used as the community consensus.  If there is still debate in the scientific community about which name is appropriate for a given taxon, then it will use votes the best it can to decide between multiple accepted names.  Note that the owner's vote automatically carries a little more weight, as do the votes of users who have made a large \"Contribution\":#contribution to [:app_title] or who are considered experts.  Click '[:app_contributors]' or click a user's name to see the contribution and expert status.  (We use the log base 10 of users' contributions.)"
+  how_adding_comments:  "*Adding Comments* - When you are looking at an \"Observation\":#observation, if you would like to post or respond to a \"Comment\":#comment, select the '[:show_comments_add_comment]' link near the top of the page.  If you are not currently logged in to a \"User\":#user account, you will be asked to log in.  Once you are logged in, you will be given a form asking for a summary and your comment.  Note that you can do some simple formatting in the comment section.  This is briefly documented below the text field with a link to detailed documentation.  You can also add links within a comment using standard HTML formatting.  The HTML gets automatically cleaned to avoid security problems like script injection, so try not to get too fancy."
+  how_tracking_species:  "*Tracking a Particular Species or Genus Through Email* - [:app_title] allows you to request an email any time a particular \"Name\":#name is given to an \"Observation\":#observation.  If that name is a genus or species it will also send you an email whenever a species or subspecies is observed.  To turn this feature on, go to the page for a Name you are interested in (see \"Searching\":#searching) and click '[:show_name_email_tracking]'.  You can configure it so that the person who made the observation that was given that name will be sent a customized email to let them know you are interested in their observation.  If you don't provide any instructions, they will not be sent an email.  If the observer gives the name at the time the observation is created, they will be shown your message immediately through the website. You can modify or disable your request for a particular name by going back to that name and again selecting '[:show_name_email_tracking]' and clicking the '[:DISABLE]' button on the page that comes up."
+  how_describing_species:  "*Describing Species* - Click any \"Name\":#name link you see throughout the site.  For example, click on 'Names' under 'Indexes' on the left side of the page then click on any of the results, or search for a name in the search bar, or click the 'About &lt;&#110;ame&gt;...' link at the top of any \"Observation\":#observation page.  These all take you to a page summarizing everything we know about this taxon.  If you are familiar with this species and there is something you would like to add, click '[:show_name_edit_name]' and add your notes.  You are encouraged to cite references including field guides and scientific papers.  Short quotes from references are fine, but please don't make extensive quotes without obtaining permission from the original author."
+  how_projects:  "*Projects* - Projects are a way for a group of \"Users\":#user to work together to create a set of work that they want to keep out of the public eye until they are ready to publish it.  The original purpose was to support university classes where there was a desire to keep a more controlled environment while the class was going.\n\nAnyone can create a new project by clicking on '\"[:app_list_projects]\":/project/list_projects' in the left-hand panel and then clicking on '[:list_projects_add_project]'.  The person who creates the project is always a member and an administrator for that project.  An administrator for a project can add new members by clicking the '[:show_project_add_members]' link at the top of a project's 'Show Project' page.  Administrators can also make other users administrators for the project by going to one of the '[:add_members_change_status]' links available on the 'Show Project' or 'Add Members' pages.  Any User can send requests to the admins for a project.  These requests are emailed to the admins and contain a link for changing that user's status.\n\nCurrently the primary focus of projects is writing \"Descriptions\":#description for various species.  Note, however, that anyone can now create new descriptions for a species (see \"Describing Species\":#describing_species) by clicking on '[:show_name_create_description]' at the top of the 'Show Name' page. Descriptions that are created for a project are visible only to members of that project until they are published, and editable only by the owner of the description and project administrators.  When a description is published it will become the official description if no official description exists yet."
+  how_maps:  "*Working with Maps* - Currently there are three types of maps available on [:app_title]: Occurrence Maps (e.g., \"Occurrence map for **__Craterellus cornucopioides__**\":/name/map/284), Location Maps (e.g., \"Salt Point State Park\":/location/show_location/4) and the \"[:map_locations_global_map]\":/location/map_locations.\n\nTo see an occurrence map for a particular \"Name\":#name, go to the page for that name (e.g., enter the name in the search bar, select '[:NAMES]'), and click '[:app_search]', then click '[:show_name_distribution_map]' at the top of the page.\n\nUsers are encouraged to add to the occurrence map for a name.  The easiest way is to create a new \"Observation\":#observation using an already defined \"Location\":#location.  Note, however, that auto-completion for the '[:WHERE]' field will list all matching locations whether they are defined or not.\n\nYou can also explicitly choose not to have an observation show up on the occurrence map.  This allows you to record observations of mushrooms in places like mushroom fairs, old photos or other places where you may not know where the mushroom was actually collected.  When creating or editing an observation there is a checkbox labeled '[:form_observations_is_collection_location]'.  By default it is checked.  If you uncheck it, that observation will not appear in any occurrence maps."
+  how_defining_locations:  "*Defining Undefined Locations* - Many \"Observations\":#observation have been reported from undefined \"Locations\":#location.  These observations will not appear in our \"occurrence maps\":#maps.  An excellent, easy way for \"Users\":#user to help out if they have a little spare time is to locate and define these undefined locations.\n\nWhen browsing through observations, defined location names will be followed by a link labeled '[:click_for_map]'.  Undefined location names will be followed by a link labeled '[:SEARCH]'.  If you click the link for an undefined location, it will show a list of observations reported for that location.  The resulting page will include two links at the top of the page: '[:list_observations_location_define]' and '[:list_observations_location_merge]'.  Clicking on '[:list_observations_location_define]' will present a form which you can use to create that location.  Clicking on 'Merge With a Defined Location' will present you with a list of similar locations which have already been defined.  Clicking on any of these locations will perform the merge.\n\nYou can also see a list of all locations in use by clicking on '\"[:app_list_locations]\":/location/list_locations' in the left-hand panel. This page lists both the defined locations (first column, sorted alphabetically) and the undefined locations (second column, sorted by the number of observations reported from that location).  In some cases the same location has been given multiple names (e.g., 'Point Reyes National Seashore' and 'Pt Reyes Park').  You can merge an undefined location with a defined location by clicking on '[:list_place_names_merge]' next to the undefined location (see above).\n\nWhen defining a new location, the first thing to do is to review its name. Mushroom Observer tries to enforce a set of \"rules\":/location/help.\n\nIn theory it is possible for the same location to be defined more than once (presumably by different users).  If this happens, you can request a merge by editing one of the two locations and changing its name to be exactly the same as the other's.  This will not have any immediate effect, but it will display a warning message, and an email will be sent to the site administrators with the details.  Merging defined locations is restricted since it can cause significant data loss."
+  how_creating_species_lists:  "*Creating Species Lists* - To create a \"Species List\":#species_list, click '\"[:app_create_list]\":/species_list/create_species_list' in the left-hand panel.  Fill out the various fields.  In the 'Write-In Species' field, you should give each species a \"Name\":#name on a line by itself.  When you go to create the list, each line is checked to see if there is a match in the database.  If there is no matching name, you will be asked if you want to add the unknown names to the database.  This gives you a chance to catch and fix typos as well as giving you a simple way to add missing names.  Each name given in the 'Write-In Species' field (or loaded from a file) will be used to create a completely new \"Observation\":#observation.  The '[:form_species_lists_list_notes]' are only shown when the entire species list is shown.  Use '[:form_species_lists_member_notes]' to indicate text you would like to add to each new observation.\n\nThere are several methods of collecting a set of existing observations into a new list.  In the simplest method, first create an empty species list, then go to each of the observations you want to add and select '[:show_observation_manage_species_lists]'.  This will give you the opportunity to add that observation to any species list you own.  (Note, you can add anyone's observations to a species list you own.)\n\nIn another method, you may select '[:app_create_list]' directly from any index of observations or names.  For example, you may use the search bar at the top of the page or the '\"[:app_advanced_search]\":/search/advanced' feature to request all observations from Michigan.  When it shows you the first page of results, click '[:app_create_list]' (in the left-hand panel), and it will give you a list of all the matching names to choose from in the new species list form.\n\nLastly, when you are viewing an existing species list, you may click '[:species_list_show_clone_list]' or '[:species_list_show_set_source]' at the top of the page.  '[:species_list_show_clone_list]' will take you directly to a new species list form, with all the information of the existing list already filled in.  '[:species_list_show_set_source]' will copy that species list's names to the clipboard.  The next time you click '[:app_create_list]', the new species list form will give you this list of names to choose from (unless you show another observation or name index in the meantime)."
+
+  # Note, glossary terms should appear in alphabetical order.
+  how_glossary_body:  "#(#comment)       [:how_comment]\n#(#image)         [:how_image]\n#(#license)       [:how_license]\n#(#location)      [:how_location]\n#(#name)          [:how_name]\n#(#observation)   [:how_observation]\n#(#proposed_name) [:how_proposed_name]\n#(#description)   [:how_description]\n#(#species_list)  [:how_species_list]\n#(#user)          [:how_user]\n#(#vote)          [:how_vote]"
+  how_comment:  "*Comment* - Comments are the standard way to discuss an \"Observation\":#observation or its associated \"Images\":#image.  Each comment is owned by a particular \"User\":#user.  A comment may only be edited or deleted by the owner or a site administrator.  You can look up all comments that have been made about your observations by clicking on '\"[:show_user_comments_for_you]\":/comment/show_comments_for_user' in the upper right of the page (the 'inbox' icon)."
+  how_contribution:  "*Contribution* - A number or score that measures the quantity and quality of contributions a \"User\":#user has made to [:app_title].  Click '[:app_your_summary]' to see a break-down of your own contribution.  You earn points for every \"Observation\":#observation, \"Image\":#image, \"Comment\":#comment, etc. you have posted.  \"Describing Species\":#describing_species and \"Defining Locations\":defining_locations are some of the most important contributions a user can make.  (See \"How To Help\":/info/how_to_help for a list of other ways to help out.) Currently, contribution is used only in weighting your \"Votes\":#vote when voting on \"Proposed Names\":#proposed_names for observations."
+  how_description:  "*Species Description* - A collection of text describing a \"Name\":#name. Every name automatically gets one official description that everyone in the community is allowed to read and modify.  Additional descriptions may be created by any \"User\":#user, including project members.  The owner of a description may choose any level of read or write permissions, and can control who is given authorship credit.  Since descriptions, especially the official one, are often collaborative efforts, modifications by a user are subject to community review, and past versions are kept to facilitate this process.  The content of a description includes a set list of sections, including things like '[:form_names_gen_desc]', '[:form_names_diag_desc]', '[:form_names_look_alikes]', '[:form_names_refs]' and other notes."
+  how_image:  "*Image* - A photograph or illustration of one or more mushroom species. Images are associated with one or more \"Observations\":#observation.  A given Image is owned by a particular \"User\":#user who may or may not be the copyright holder.  Only the owner or a site administrator can remove an image or edit the associated information.  All images in the site are required to be released under one of the \"Creative Commons licenses\":http://creativecommons.org or in the public domain.  If you dispute the given copyright or the licensing of an image you are the copyright holder of, send mail to the \"webmaster\":/emails/ask_webmaster_question."
+  how_license:  "*License* - \"Images\":#image on [:app_title] are posted with an explicit license.  The current options are the \"Creative Commons Attribution, Share Alike License\":http://creativecommons.org/licenses/by-sa/3.0/, the \"Creative Commons Attribution, Non-Commercial, Share Alike License\":http://creativecommons.org/licenses/by-nc-sa/3.0/ and \"Public Domain\":http://wiki.creativecommons.org/Public_domain/.  The primary difference is whether the image can be used in any potentially commercial setting.  One of the side effects of selecting the non-commercial license is that your image cannot be used on \"Wikipedia\":http://wikipedia.org.  The license can be set on a per image basis.  The looser, Wikipedia compatible license is the default for new \"Users\":#user.  However, you can select the non-commercial license to be your default by selecting it on your '\"[:app_preferences]\":/account/prefs' page and clicking on '[:SAVE_CHANGES]'.  Public domain is supported primarily for images that are already in the public domain or for images from certain government institutions that cannot claim ownership of works"
+  how_location:  "*Location* - A rectangular region enclosing a given location, as defined by the northern, southern, eastern and western boundaries.  In addition to the position, locations can also include a minimum and maximum elevation along with various notes.  Note that the elevations should be in meters not feet. A location is not considered to be owned by a particular \"User\":#user.  Any user may change or define any location, but all of a user's changes are subject to review by the community.  To help with this review process, copies of the previous versions are kept."
+  how_name:  "*Name* - A name for some group of mushrooms.  Most commonly this is the name of a species, but it can be any taxon (genus, family, variety, etc.).  Names can also refer to groups that are not officially recognized scientific names such as common names or functional groups like Gasteromyces.  A name is *not* considered to be owned by a particular \"User\":#user.  Any user may change any name, but all changes are subject to review by the community.  To help with this review process, copies of previous versions are kept.  Names can have an acknowledged author.  The author is normally only given for scientific names. The author should follow the standard practice of listing the person who first correctly published the name.  In the case of names at or below the species level, the author may also include the person who transfered the species to the current genus, e.g., (Singer) Jenkins."
+  how_observation:  "*Observation* - A record of a single mushroom species at a particular time and \"Location\":#location.  Typically associated with one or more \"Names\":#name (see \"Proposed Name\":#proposed_name below) and some number of \"Images\":#image.  Each observation is owned by a \"User\":#user, and can only be edited or deleted by that user or a site administrator.  However, any user may post \"Comments\":#comment about any observation.  Observations can also be included in one or more \"Species Lists\":#species_list."
+  how_proposed_name:  "*Proposed Name* - A \"Name\":#name as proposed for a given \"Observation\":#observation.  Any number of names may be proposed for a single observation by members of the community.  No special treatment is given to any member's name.  Community consensus is arrived at through the process of \"voting\":#voting.  Each proposed name for an observation is owned by a single \"User\":#user.  However, even the user who proposed the name cannot necessarily modify or delete a name once other members of the community have cast \"Votes\":#vote for or against it.  Fortunately you may always propose additional names.  There is never any sort of penalty associated with proposing incorrect names."
+  how_species_list:  "*Species List* - A list of \"Observations\":#observation (not \"Names\":#name). Includes a date, a \"Location\":#location and a title for the list.  A given species list is owned by a particular \"User\":#user.  Only the owner or a site administrator can change or delete a species list.  There are no strict rules for how species lists should be used.  This is an area that is likely to change in the future as the community comes up with clearer ideas for how they should be used."
+  how_user:  "*User* - An account on [:app_title].  You are required to provide a valid email address when you first create an account.  This allows the system to stop automated programs from creating bogus accounts.  It also provides a way for other users to get in touch with you.  However, your email address will never be revealed unless you request an email be sent to another user and then only to that user.  If you are concerned about having your email address in our database, once you have verified your account, you can go to the '\"[:app_preferences]\":/account/prefs' page and remove your address."
+  how_vote:  "*Vote* - One \"User's\":#user vote on a \"Proposed Name\":#proposed_name for a given \"Observation\":#observation.  Expresses a level of confidence or agreement with that name, with half the choices (\"[min_pos_vote]\" and up) being positive and half (\"[min_neg_vote]\" and below) being negative.  Votes are owned by that user, and can only be changed or deleted by the owner or a site administrator."
+
+  # Location help
+  location_help_title:  Locations in Mushroom Observer
+  location_help_intro:  "The Mushroom Observer provides two ways to represent the geographic location of an observation.  The simplest are latitude and longitude positions associated with the observation.  Please keep these accurate to within at least 300 meters (or about 1000 feet).  However, the more widely used method is a simple phrase describing the location.  For example, \"Beebe Woods, Falmouth, Massachusetts, USA\". The goal of these location names is to provide a consistent, reusable way of talking about where an observation was made without necessarily revealing a precise \"spot\". If you are comfortable provide more precise lat/longs for an observation, the location names are still useful for searches so you are encouraged to provide them as well.  The location names should, by default, go from the smallest contained area to the country name.  If you prefer to describe your locations as going from the largest (country) down to the smallest contained area, you can change your preference from the default, \"Postal\", to \"Scientific\" on your preference page.  There are cases such as \"Great Smoky Mountains National Park, Blount Co., Tennessee, USA\", where the area you are describing overlaps a number of counties, states or even countries.  In these cases, the country and other official political boundaries should come at the end as shown in the example.\n\nOriginally, the Mushroom Observer was very loose about these location names, hoping that the users would create a reasonably consistent set of rules and correct each other.  After about four years and thousands of location names, we found that there were rules emerging, but they were not applied at all consistently and people were not tending to directly correct each other. Consequently, we have tried to codify these rules and when reasonable to provide warnings if you attempt to create a new location that violates these rules. It is not always possible to correct identify \"bad\" locations, so if you get some warnings, but after reviewing the location decide it should be \"good\", then simply resubmitting the form will force the name into the database. However, all new location names will get reviewed regularly and may get changed to better fit the consensus rules.  Below are some examples of \"bad\" and \"good\" location names followed by a more detailed explanation of the current rules. Each example is labeled with the following section that explains the example in more detail.  These rules are by no means set it stone and we encourage the discussion and revision of them."
+  location_help_example_help:  These are cases that are not detected automatically, so no warning would be given.
+  location_help_example_title:  Some examples
+  location_help_bad:  Bad
+  location_help_good:  Good
+  location_help_explanation:  Explanation
+  location_help_rules_title:  The Current "Rules"
+  location_help_rule_reversible:  "*Consistent and Reversible Order* - You can now ask for location names to appear in the reverse order from the default. Thus, you can see a location as either:\n\nAlbion, California, USA\n\nor as\n\nUSA, California, Albion\n\nYou can change this on your Preferences page by selecting 'Postal' (the default) or 'Scientific' (the one that starts with the country).  When you input new location names it will of course also follow your preferred order.\n\nRoy Halling was the inspiration for this feature when he started putting in his locations starting with the country names and we got into a discussion about it. Apparently the standard practice in the scientific community is to start with the largest locale (typically a country) and work down to the smallest locale (a county, town or specific location).  From looking through all the locations that have been put into MO, it is clear that most people expect to put in the smallest location first and work up to the country.\n\nIn order to enable this feature, I have had to require that the place names be easily and consistently reversible.  This means you must separate each section of the location with a ', ' (no period, no missing spaces, no double spaces). It also means that you should always enter the names in order of increasing size when you can.  There are some specific exceptions to this rule that are discussed below."
+  location_help_rule_countries:  "*Use Country Names* - As a further check when you enter an unfamiliar location, it will check to see that the largest locale has been previously entered for some other location.  This list currently consists of only countries, continents and the special location 'Unknown'. Since it does not include all possible countries, it is still possible to override the check by resubmitting the same name twice.  Such entries will be reviewed carefully to ensure that this list remains clean.  For now you should only enter country names as they are written in English.  For example, please use 'Germany' rather than 'Deutschland'.  The goal for the moment is simply consistency.  However, the long term goal is to actually allow these names to be consistently translated based on the user's language selection.  Continents should only be used if the country is not known or there is no country."
+  location_help_rule_states:  "*Use State Names* - In the case of countries where I know the states, I also check for those as the next smallest area within a country.  At the moment I am checking this for Canada, Australia and USA.  The primary goal of this in the US at least is to ensure the uniqueness of the next element in the list.  In the US it is not unusual to have the same city or county name in more than one state. If there are other countries where this check would be useful, please let me know and include an exhaustive list of all states, provinces, territories etc. To increase the understandability to people from other parts of the world, state abbreviations (even extremely standard ones) are discouraged and will create a warning.  The one current exception is 'Washington DC'.  Many people are not aware of what the 'DC' stands for and would be unlikely to enter 'Washington, District of Columbia'.  Note that in this case I have also removed the ', ' since that would cause 'USA, DC, Washington' when in 'Scientific' mode."
+  location_help_rule_counties:  "*Counties OR Cities* - In the past, MO has encouraged the use of county names whenever they are known.  The new policy is that the county should only be included when it is the smallest political area the location is contained in or when the city or town name is ambiguous.  For example, what used to be described as \"Berkeley, Alameda Co., California, USA\" should now be given as just \"Berkeley, California, USA\".  This change is in part due to seeing what people actually do.  Generally people have been good about using county names in the case of public lands like parks and national forests where the county is the most obvious political boundary.  However, with cities and towns people often don't know what county a city or town is in.  In addition, the information is typically redundant for towns and cities in the US where they are almost always completely contained in county or they are independent of the counties and there are almost never two towns with same names in a state (there are exceptions though such as Goshen, Vermont). I've also found that many of the map services such as maps.google.com and maps.yahoo.com get confused if you include both the city and the county in the search string.\n\nThat being said, there are also often areas that have a local name, but are not actually an incorporated city or town.  In these cases the county name is encouraged since the names cannot be assumed to be unique.  For example, \"North Lakeport, Lake Co., California, USA\".  Wikipedia has been the most helpful resource I've found for determining if a town is actually incorporated."
+  location_help_rule_near:  "*Use 'near'* - If there is a landmark or town near to the collection location, but the smallest political boundary is a county or country, then it is helpful to mention this using the word \"near\".  When used this way it should always be all lowercase.  For example, \"Albis Mountain Range, near Zurich, Switzerland\".  Looking through the old data, I found users used both \"near\" and \"area\" for this with \"near\" being more common.  This is also better because \"area\" sometimes gets used for place names such as \"Day-Use Area\" or \"Rest Area\"."
+  location_help_rule_southern:  "*Use of 'Southern', 'Northern' etc.* - If there isn't a known a clear landmark or town near the collection location, it is fine to use compass directions such as 'Southern', 'Northern', 'Southwestern' etc.  In these cases always use the '-ern' ending to indicate that it's descriptive.  However, these terms should be avoided if it creates ambiguity.  For example, \"Western Australia\" is the name of an official state in Australia, so it should only be used as such and should be followed by the country name."
+  location_help_rule_abbr:  "*Avoid Abbreviations (and Periods in General)* - Most abbreviations should be avoided since people apply them somewhat arbitrarily and inconsistently.  The following are examples of abbreviations that should definitely be avoided: Hwy, Mt, Mtn, CA, BC.  However, there are some specific examples, that should be used in preference to there spelled out versions.  These are:\n\nCo. for County\nRd. for Road\nSt. for Street\nAve. for Avenue\nBlvd. for Boulevard\nUSA for United States of America\nWashington DC for Washington, District of Columbia\n\n\nPeriods in general should be avoided except for the above abbreviations. They should not be used at the end of country names or as separators.\nFinally, 'and' should be used rather than '&'."
+  location_help_rule_other:  "*Other Things to Avoid* - All lowercase - In general at least the leading letter of each area should be capitalized and when in doubt capitalize every leading letter.\nNo lat/longs - There is now direct support for this for each observation. Do not include it in the name of a location.\nNo habitat info - Habitat info should go in the notes for the observation.\nParentheses and Braces - If you're tempted to use parentheses or braces, stop yourself and ask if this information should be in the notes for the observation or if there is a better way to describe the location.\nAvoid diacritics (eg é, ü etc.) - As mentioned when discussing country names, you should try to use the English version of a location name when possible and English does not include diacritics.  This is intended to encourage consistency and we are planning on providing proper support for other languages which will benefit from this consistency.  There are certainly cases where the a city or region is only know by a name that includes diacritics.  In these cases they should be used. A few simple web-searches should give you a good idea if there is a common English variation of a name (e.g., Montreal, Quebec for Montréal, Québec)."
+  location_help_rule_good_habits:  "*Stuff You Are Encouraged to Do* - If you are creating a new name, take some time to figure out a good name. Searching within Mushroom Observer can be helpful.  If you don't find anything there, then look things up in Google Maps (http://maps.google.com) and Wikipedia (http://wikipedia.org). Also feel free to use the notes section of either an observation or a location to be more specific."
+
+  # Search bar help
+  pattern_search_terms_help:  "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.  Recognized variables include:"
+
+  observation_term_date:  Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
+  observation_term_created:  Date observation was first posted.
+  observation_term_modified:  Date observation was last modified.
+  observation_term_name:  Consensus name is one of these names.
+  observation_term_exclude_consensus:  Exclude Observations whose consensus is a name listed in "name:value". (When using exclude_consensus you must also use "include_all_name_proposals:yes".)
+  observation_term_include_all_name_proposals:  Include all name proposals, not just the consensus.
+  observation_term_include_subtaxa:  Include observations of subtaxa of the given names.
+  observation_term_include_synonyms:  Include observations of synonyms of the given names.
+  observation_term_herbarium:  Specimen at a fungarium.
+  observation_term_location:  "Location (\"[:WHERE]\") mushroom was observed. Must exactly match the entire [:WHERE] field. Note that commas must be protected with a back-slash: \"Albion\\, California\\, USA\"."
+  observation_term_region:  Location mushroom was observed. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a back-slash as shown.
+  observation_term_project:  Observation belongs to one of these projects.
+  observation_term_project_lists:  Observation belongs to list in one of these projects.
+  observation_term_list:  Observation belongs to one of these species lists.
+  observation_term_user:  Observation created by one of these users.
+  observation_term_notes:  Notes contains the given string.
+  observation_term_comments:  Comments contain the given string.
+  observation_term_confidence:  Confidence is in this range.
+  observation_term_east:  Longitude of eastern edge of search region.
+  observation_term_west:  Longitude of western edge of search region.
+  observation_term_north:  Latitude of northern edge of search region.
+  observation_term_south:  Latitude of southern edge of search region.
+  observation_term_images:  Has images? ("yes" or "no")
+  observation_term_sequence:  Has a sequence?
+  observation_term_specimen:  Has a specimen?
+  observation_term_lichen:  "\"no\" = exclude lichens, \"yes\" = include only lichens."
+  observation_term_has_name:  Has a name? (other than "Fungi sp.")
+  observation_term_has_notes:  Has Notes?
+  observation_term_has_location:  Are the [:OBSERVATION]'s [:LATITUDE] and [:LONGITUDE] fields filled in?
+  observation_term_has_field:  Has a given notes template field filled in.
+  observation_term_has_comments:  Has any comments?
+  observation_term_is_collection_location:  Mushroom was growing at the location. ("[:form_observations_is_collection_location]" is checked.)
+
+  name_term_created:  Date name was first used.
+  name_term_modified:  Date name was last modified.
+  name_term_rank:  Rank or range of ranks, e.g., "genus" or "species-form".
+  name_term_include_synonyms:  Include synonyms of the given names.
+  name_term_include_subtaxa:  Include subtaxa of the given names.
+  name_term_has_observations:  Only names for which we have observations?
+  name_term_has_synonyms:  Has any synonyms?
+  name_term_deprecated:  "\"no\" = only accepted names, \"yes\" = only deprecated names."
+  name_term_include_misspellings:  "\"no\" = ignore misspelled names (default), \"yes\" = only misspelled names, \"either\" = ignore whether names are misspelled or not."
+  name_term_lichen:  "\"no\" = exclude lichens, \"yes\" = include only lichens."
+  name_term_has_author:  Has Author filled in?
+  name_term_has_citation:  Has Citation filled in?
+  name_term_has_classification:  Has Classification filled in?
+  name_term_has_notes:  "[:form_names_taxonomic_notes] filled in?"
+  name_term_has_comments:  Has any Comments?
+  name_term_has_description:  Has a public description?
+  name_term_author:  Author contains this string.
+  name_term_citation:  Citation contains this string.
+  name_term_classification:  Classification contains this string.
+  name_term_notes:  "[:form_names_taxonomic_notes] contains this string."
+  name_term_comments:  At least one Comment contains this string.
+
+  # link to search bar help
+  search_bar_help: جستجو راهنما
+
+  # Search bar help page
+  search_bar_help_title: راهنما نوار جستجو
+
+  # Privacy policy
+  privacy_title: سیاست حفظ حریم خصوصی ناظر قارچ
+
+  privacy_last_modified:  _Last Modified on November 30, 2019_
+
+  privacy_intro_header:  "*Introduction*"
+  privacy_intro_content:  "This Privacy Policy explains how Mushroom Observer, Inc., the non-profit organization that hosts the Mushroom Observer website, collects, uses, and shares information we receive from you through your use of the website. It is essential to understand that, by using the Mushroom Observer website, you consent to the collection, transfer, processing, storage, disclosure, and use of your information as described in this Privacy Policy.\n\nWe believe that you shouldn't have to provide nonpublic personal information to participate in the free knowledge movement, citizen science, or mycology in general. You do not have to provide things like your real name, address, or date of birth to sign up for an account or contribute content to the Mushroom Observer.\n\nThis privacy policy is in large part derived from the current (July 2019) \"privacy policy of the Wikimedia Foundation\":https://foundation.wikimedia.org/wiki/Privacy_policy and is used in accordance with \"the Creative Commons Attribution-ShareAlike License\":https://creativecommons.org/licenses/by-sa/3.0/ and the Wikimedia Foundation \"Terms of Use\":https://foundation.wikimedia.org/wiki/Terms_of_Use/en."
+
+  privacy_definitions_header:  "*Definitions*"
+  privacy_definitions_content:  "Because everyone (not just lawyers) should be able to easily understand how and why their information is collected and used, we use common language instead of more formal terms throughout this Policy. To help ensure your understanding of some particular key terms, here is a table of translations:"
+
+  privacy_when_we_say:  When we say...
+  privacy_we_mean:  "... we mean"
+  privacy_mo_inc_say:  “Mushroom Observer, Inc”, “we”, “us”, “our”
+  privacy_mo_inc_mean:  The non-profit organization that operates the Mushroom Observer website.
+  privacy_mo_website_say:  “Mushroom Observer”, “MO”, “the website”
+  privacy_mo_website_mean:  The Mushroom Observer website, https://mushroomobserver.org and subdomains that provide text, images and APIs.
+  privacy_you_say:  “you”, “your”
+  privacy_you_mean:  You, regardless of whether you are an individual, group, or organization, and regardless of whether you are using the Mushroom Observer or our services on behalf of yourself or someone else.
+  privacy_this_policy_say:  “this Policy”, “this Privacy Policy”
+  privacy_this_policy_mean:  This document, entitled “The Mushroom Observer Privacy Policy”.
+  privacy_contributions_say:  “contributions”
+  privacy_contributions_mean:  Content you add or changes you make to the Mushroom Observer.
+  privacy_personal_info_say:  “personal information”
+  privacy_personal_info_mean:  "Information you provide us or information we collect from you that could be used to personally identify you. To be clear, while we do not necessarily collect all of the following types of information, we consider at least the following to be “personal information” if it is otherwise nonpublic and can be used to identify you:\na) your real name, address, phone number, email address, password, identification number on government-issued ID, IP address, user-agent information, credit card number;\nb) when associated with one of the items in subsection a), any sensitive data such as date of birth, gender, sexual orientation, racial or ethnic origins, marital or familial status, medical conditions or disabilities, political affiliation, and religion; and\nc) any of the items in subsections a) or b) when associated with your user account."
+  privacy_third_party_say:  “third party”, “third parties”
+  privacy_third_party_mean:  Individuals, entities, websites, services, products, and applications that are not controlled, managed, or operated by Mushroom Observer, Inc. This includes other Mushroom Observer users and independent organizations or groups who use the Mushroom Observer.
+
+  privacy_covers_header:  "*What This Privacy Policy Does & Doesn't Cover*"
+  privacy_covers_content:  Except as explained below, this Privacy Policy applies to our collection and handling of information about you that we receive as a result of your use of the Mushroom Observer. This Policy also applies to information that we receive from any third parties.
+
+  privacy_types_of_information_header:  "*Types of Information We Receive From You & How We Get It*"
+  privacy_public_contributions:  "Your Public Contributions\n\nOther than the email, password, and settings managed on your preferences page, whatever you post on the Mushroom Observer can be seen and used by everyone.\n\nWhen you make a contribution to the Mushroom Observer you are creating a potentially permanent, public record of every piece of content added, removed, or altered by you. The page history will show when your contribution or deletion was made, as well as your username. We may use your public contributions, either aggregated with the public contributions of others or individually, to create new features or data-related products for you or to learn more about how the Mushroom Observer is used.\n\nAnything in your public contributions is by definition not personal information.  We can take no responsibility if you happen to include what could be interpreted as personal information to your public contributions."
+
+  privacy_account_info:  "Account Information & Registration\n\nYou do not need to create an account to read the public information managed by the Mushroom Observer.\n\nIf you do create an account, you must provide an email address to activate the account.  After your account is activated you may change or delete this address through your preferences page."
+
+  privacy_location_info:  "Location Information\n\nMetadata\nSometimes, we automatically receive location data from your device. For example, if you upload a photo to the website, we may receive metadata, such as the place and time you took the photo, automatically from your device. Please be aware that the default setting on most mobile devices typically includes the metadata in your photo or video that you upload. If you do not want metadata sent to us and made public at the time of your upload, please change your settings on your device or remove this data using available third party image processing tools.\n\nIP Addresses\nFinally, when you visit the Mushroom Observer, we automatically receive the IP address of the device (or your proxy server) you are using to access the Internet, which could be used to infer your geographical location."
+
+  privacy_usage_info:  "Information Related to Your Use of the Mushroom Observer\n\nWe use certain technologies to collect information about how you use the Mushroom Observer.  Like other websites, we receive some information about you automatically when you visit the Mushroom Observer.\n\nWe also use a variety of commonly-used technologies, like cookies, to collect information regarding how you use the Mushroom Observer, make our services safer and easier to use, and to help create a better and more customizable experience for you.\n\nInformation We Receive Automatically\nBecause of how browsers work, we receive some information automatically when you visit the Mushroom Observer. This information includes the type of device you are using, the type and version of your browser, your browser's language preference, the type and version of your device's operating system, in some cases the name of your internet service provider or mobile carrier, the website that referred you to the Mushroom Observer, which pages you request and visit, and the date and time of each request you make to the Mushroom Observer.\n\nPut simply, we use this information to enhance your experience with the Mushroom Observer. For example, we use this information to administer the sites, provide greater security, and fight vandalism; optimize our applications, customize content and set language preferences, test features to see what works, and improve performance; understand how users interact with the Mushroom Observer, track and study use of various features, and analyze trends.\n\nInformation We Collect\nWe use a variety of commonly-used technologies, like cookies, to improve your experience on the Mushroom Observer. We realize that some websites use cookies for less-than-noble purposes. So we want to be as clear as we can about why we use them.\n\nWe simply use them to recognize who you are from page request to page request so we can look up the user information you have provided in your preferences (like your username, configuration options, email, or theme).\n\nWe use this information to make your experience with the Mushroom Observer better and to generally improve our services. We do not use third-party cookies. If you ever come across a third-party data collection tool that has not been authorized by you (such as one that may have been mistakenly placed by another user or administrator), please report it to us at webmaster@mushroomobserver.org."
+
+  privacy_when_we_share_info_header:  "*When May We Share Your Information?*"
+  privacy_when_we_share_info_content:  "With Your Permission\nWe may share your information when you give us specific permission to do so, for legal reasons, and in the other circumstances described below.  For example, when you request that we send an email to another user, we will share your email with the recipient so they can respond to you.  We do not manage or track any resulting email dialog between you and the other user you have asked us to send an email to.  We do not send your email to other users who request that we send an email to you.\n\nFor Legal Reasons\nWe will access, use, preserve, and/or disclose your Personal Information if we reasonably believe it necessary to satisfy a valid and legally enforceable warrant, subpoena, court order, law or regulation, or other judicial or administrative order. However, if we believe that a particular request for disclosure of a user's information is legally invalid or an abuse of the legal system and the affected user does not intend to oppose the disclosure themselves, we will try our best to fight it. We are committed to notifying you via email at least ten (10) calendar days, when possible, before we disclose your Personal Information in response to a legal demand. However, we may only provide notice if we are not legally restrained from contacting you, there is no credible threat to life or limb that is created or increased by disclosing the request, and you have provided us with a currently valid email address.\n\nNothing in this Privacy Policy is intended to limit any legal objections or defenses you may have to a third party's request (whether it be civil, criminal, or governmental) to disclose your information. We recommend seeking the advice of legal counsel immediately if such a request is made involving you.\n\nIf the Organization is Transferred (Really Unlikely!)\nIn the unlikely event that the ownership of Mushroom Observer, Inc. changes, we will provide you 30 days’ notice before any personal information is transferred to the new owners or becomes subject to a different privacy policy.\n\nIn the extremely unlikely event that ownership of all or substantially all of Mushroom Observer changes, or we go through a reorganization (such as a merger, consolidation, or acquisition), we will continue to keep your Personal Information confidential, except as provided in this Policy, and provide notice to you via the Mushroom Observer website and a notification on any appropriate Mushroom Observer mailing or online forum at least thirty (30) calendar days before any Personal Information is transferred or becomes subject to a different privacy policy.\n\nTo Protect You, Ourselves & Others\nWe, or users with certain administrative rights, may disclose information that is reasonably necessary to enforce or investigate potential violations of the Mushroom Observer policies; protect our organization, infrastructure, employees, contractors, or the public; or prevent imminent or serious bodily harm or death to a person.\n\nWe, or particular users with certain administrative rights as described below, may need to share your Personal Information if it is reasonably believed to be necessary to enforce or investigate potential violations of our Terms of Use, this Privacy Policy, or any other Mushroom Observer policies. We may also need to access and share information to investigate and defend ourselves against legal threats or actions.\n\nThe Mushroom Observer is a collaborative effort, with volunteer users like you writing most of the policies and selecting from among themselves people to hold certain administrative rights. These rights may include access to limited amounts of otherwise nonpublic information about recent contributions and activity by other users. They use this access to help protect against vandalism and abuse, fight harassment of other users, and generally try to minimize disruptive behavior on the Mushroom Observer. All such individual agree to enforce this Privacy Policy.\n\nWe hope that this never comes up, but we may disclose your Personal Information if we believe that it's reasonably necessary to prevent imminent and serious bodily harm or death to a person, or to protect our organization, employees, contractors, users, or the public. We may also disclose your Personal Information if we reasonably believe it necessary to detect, prevent, or otherwise assess and address potential spam, malware, fraud, abuse, unlawful activity, and security or technical concerns.\n\nBecause You Made It Public\nInformation that you post is public and can been seen and used by everyone.\n\nAny information you post publicly on the Mushroom Observer is just that – public. For example, if you put your mailing address in one of your comments, that is public, and not protected by this Policy. Please think carefully about your desired level of anonymity before you disclose Personal Information on your user page or elsewhere."
+
+  privacy_how_we_protect_header:  "*How Do We Protect Your Data?*"
+  privacy_how_we_protect_content:  "We strive to protect your information from unauthorized access, use, or disclosure. We use a variety of physical and technical measures, policies, and procedures (such as access control procedures, network firewalls, and physical security) designed to protect our systems and your Personal Information. Unfortunately, there's no such thing as completely secure data transmission or storage, so we can't guarantee that our security will not be breached (by technical measures or through violation of our policies and procedures).\n\nWe will never ask for your password by email. If you ever receive an email that requests your password, please let us know by sending it to webmaster@mushroomobserver.org, so we can investigate the source of the email."
+
+  privacy_how_long_do_we_keep_data_header:  "*How Long Do We Keep Your Data?*"
+  privacy_how_long_do_we_keep_data_content:  "We store your Personal Information for an indefinite amount of time.  You are free to edit most of this information through your preference page.\n\nPlease remember that certain information, such as your IP address, username, and any public contributions to the Mushroom Observer, is archived and displayed indefinitely by design; the transparency of the projects’ contribution and revision histories is critical to their efficacy and trustworthiness.\n\nFor the protection of the Mushroom Observer and other users, if you do not agree with this Privacy Policy, you may not use the Mushroom Observer."
+
+  privacy_where_is_mo_header:  "*Where is Mushroom Observer, Inc. & What Does That Mean for Me?*"
+  privacy_where_is_mo_content:  Mushroom Observer, Inc. is a non-profit organization incorporated in Massachusetts, with servers and data centers located in the U.S. If you decide to use the Mushroom Observer, whether from inside or outside of the U.S., you understand that your Personal Information will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this Privacy Policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you.
+
+  privacy_do_not_track_header:  "*Our Response to Do Not Track (DNT) signals*"
+  privacy_do_not_track_content:  "We do not allow tracking by third-party websites you have not visited.\n\nWe do not share your data with third parties for marketing purposes.\n\nWe are strongly committed to not sharing nonpublic information and Personal Information with third parties. In particular, we do not allow tracking by third-party websites you have not visited (including analytics services, advertising networks, and social platforms), nor do we share your Personal Information with any third parties for marketing purposes. Under this Policy, we may share your information only under particular situations, which you can learn more about in the “When May We Share Your Information” section of this Privacy Policy.\n\nBecause we protect all users in this manner, we do not change our behavior in response to a web browser's \"do not track\" signal."
+
+  privacy_changes_header:  "*Changes to This Privacy Policy*"
+  privacy_changes_content:  Because things naturally change over time and we want to ensure our Privacy Policy accurately reflects our practices and the law, it may be necessary to modify this Privacy Policy from time to time. We will announce any such changes in the website banner and through any appropriate mailing list or online forum.  When possible we will announce these change 30 days ahead of them taking effect and will welcome comments and proposed changes during this time.
+
+  privacy_contact_us_header:  "*Contact Us*"
+  privacy_contact_us_content:  "If you have questions or suggestions about this Privacy Policy, or the information collected under this Privacy Policy, please email us at webmaster@mushroomobserver.org.\n\nDepending on your jurisdiction, you also may have the right to lodge a complaint with a supervisory authority competent for your country or region."
+
+  privacy_thank_you_header:  "*Thank You!*"
+  privacy_thank_you_content:  Thank you for reading our Privacy Policy. We hope you enjoy using the Mushroom Observer and appreciate your participation in creating, maintaining, and constantly working to improve the largest repository of fungal observations in the world.
+
+  ##############################################################################
+
+  # ERROR MESSAGES
+
+  unsuccessful_contributor_warning:  Thanks for wanting to contribute to the Mushroom Observer. This type of contribution can only be made by users who have provided at least one observation to the system.
+
+  # ActiveRecord validation error messages.
+  validate_confirmation_mismatch:  "[Field] doesn't match confirmation."
+  validate_invalid:  Invalid [field].
+  validate_invalid_url:  Invalid URL.
+  validate_missing:  Missing [field].
+  validate_not_a_number:  "[Field] is not a number."
+  validate_not_in_range:  "[Field] is out of range."
+  validate_this_more_than_that:  "[That] should be greater than [this]."
+  validate_too_large:  "[Field] should be at most [max]."
+  validate_too_long:  "[Field] must be less than [max] characters long."
+  validate_too_long_or_short:  "[Field] must be [min] to [max] characters long."
+  validate_too_many_characters:  "[Field] has too many characters."
+  validate_too_short:  "[Field] must be at least [min] characters long."
+  validate_too_small:  "[Field] should be at least [min]."
+  validate_too_small_or_large:  "[Field] should be between [min] and [max]."
+  validate_user_selection:  You selected
+  validate_today:  today is
+
+  # One-time-use error messages.
+  validate_image_content_type_images_only:  You can only upload [:images].
+  validate_image_file_missing:  Had problems uploading [:image].
+  validate_image_file_too_big:  We can't handle [:images] that big.  Please reduce it to less than [max] before uploading.
+  validate_image_md5_mismatch:  The MD5 sum did not come out right.  Please try uploading your image again.
+  validate_invalid_year:  Year is invalid.  Should be between 1500 and present.
+  validate_future_time:  Time travel is not allowed; use a past date or the current date.
+  validate_observation_thumb_image_id_invalid:  Unable to find a corresponding [:image] for thumbnail.
+  validate_observation_where_missing:  Please tell us where it was seen or collected.
+  validate_user_email_missing:  Please give us a valid email address so we can verify your [:account].
+  validate_user_email_mismatch:  Your email addresses don't match.  Please check for a typo.
+  validate_user_login_taken:  Sorry, that login name is already taken.
+  validate_image_wrong_type:  The file "[file]" is not a valid image; it is comes through as '[type]'.
+  validate_invalid_lifeform:  "Invalid lifeform word(s): [words].  We are strictly enforcing which types are allowed.  If you would like us to add support to additional lifeforms, please contact the admins and make your case."
+
+  # These shouldn't need translating, but you are free to override if you need to.
+  validate_comment_object_type_too_long:  "[:validate_too_long(field=''object_type'',max=30)]"
+  validate_comment_summary_missing:  "[:validate_missing(field=:summary)]"
+  validate_comment_summary_too_long:  "[:validate_too_long(field=:summary,max=100)]"
+  validate_comment_user_missing:  "[:validate_missing(field=:user)]"
+  validate_image_content_type_too_long:  "[:validate_too_long(field=''content_type'',max=100)]"
+  validate_image_copyright_holder_too_long:  "[:validate_too_long(field=:copyright_holder,max=100)]"
+  validate_image_title_too_long:  "[:validate_too_long(field=:title,max=100)]"
+  validate_image_user_missing:  "[:validate_missing(field=:user)]"
+  validate_image_when_missing:  "[:validate_missing(field=:date)]"
+  validate_interest_object_type_too_long:  "[:validate_too_long(field=''object_type'',max=30)]"
+  validate_interest_user_missing:  "[:validate_missing(field=:user)]"
+  validate_location_name_too_long:  "[:validate_too_long(field=''name'',max=1024)]"
+  validate_location_east_out_of_bounds:  "[:validate_too_small_or_large(field=:longitude,min=-180,max=180)]"
+  validate_location_high_less_than_low:  "[:validate_this_more_than_that(this=:low,that=:high)]"
+  validate_location_north_less_than_south:  "[:validate_this_more_than_that(this=:south,that=:north)]"
+  validate_location_north_too_high:  "[:validate_too_large(field=:latitude,max=90)]"
+  validate_location_search_name_too_long:  "[:validate_too_long(field=''search_name'',max=200)]"
+  validate_location_south_too_low:  "[:validate_too_small(field=:latitude,min=-90)]"
+  validate_location_user_missing:  "[:validate_missing(field=:user)]"
+  validate_location_west_out_of_bounds:  "[:validate_too_small_or_large(field=:longitude,min=-180,max=180)]"
+  validate_name_author_too_long:  "[:validate_too_many_characters(field=:authority)]"
+  validate_name_shorten:  Shorten [:form_names_text_name] and/or [:AUTHORITY].
+  validate_name_text_name_too_long:  "[:validate_too_many_characters(field=:form_names_text_name)]"
+  validate_name_use_first_author:  Use the first author followed by “et al.” per <a href="http://www.iapt-taxon.org/nomen/main.php?page=art46" target="_new">ICN Recommendation 46C.2</a>
+  validate_name_user_missing:  "[:validate_missing(field=:user)]"
+  validate_naming_name_missing:  "[:validate_missing(field=:name)]"
+  validate_naming_observation_missing:  "[:validate_missing(field=:observation)]"
+  validate_naming_reason_naming_missing:  "[:validate_missing(field=:naming)]"
+  validate_naming_reason_reason_invalid:  "[:validate_invalid(field=''reason_code'')]"
+  validate_naming_user_missing:  "[:validate_missing(field=:user)]"
+  validate_notification_user_missing:  "[:validate_missing(field=:user)]"
+  validate_observation_user_missing:  "[:validate_missing(field=:user)]"
+  validate_observation_when_missing:  "[:validate_missing(field=:date)]"
+  validate_observation_where_too_long:  "[:validate_too_long(field=:location,max=1024)]"
+  validate_project_admin_group_missing:  "[:validate_missing(field=:admin_group)]"
+  validate_project_title_missing:  "[:validate_missing(field=:title)]"
+  validate_project_title_too_long:  "[:validate_too_long(field=:title,max=100)]"
+  validate_project_user_group_missing:  "[:validate_missing(field=:user_group)]"
+  validate_project_user_missing:  "[:validate_missing(field=:user)]"
+  validate_publication_ref_missing:  "[:validate_missing(field=:publication_full)]"
+  validate_species_list_title_missing:  "[:validate_missing(field=:title)]"
+  validate_sequence_accession_unique:  "[:ACCESSIONS] for an [:OBSERVATION] must be unique"
+  validate_sequence_bases_or_archive:  Must have [:BASES] or [:DEPOSIT]
+  validate_sequence_bases_blank_lines:  "[:BASES] cannot contain blank lines in middle"
+  validate_sequence_bases_bad_codes:  "[:BASES] contain invalid code(s)"
+  validate_sequence_bases_unique:  "[:BASES] for an [:OBSERVATION] must be unique"
+  validate_sequence_deposit_complete:  "[:DEPOSIT] must have both [:ARCHIVE] and [:ACCESSION], or neither [:ARCHIVE] nor [:ACCESSION]."
+  validate_species_list_title_too_long:  "[:validate_too_long(field=:title,max=100)]"
+  validate_species_list_user_missing:  "[:validate_missing(field=:user)]"
+  validate_species_list_where_missing:  "[:validate_missing(field=:location)]"
+  validate_species_list_where_too_long:  "[:validate_too_long(field=:location,max=100)]"
+  validate_user_email_too_long:  "[:validate_too_long(field=:email_address,max=80)]"
+  validate_user_email_confirmation_missing:  "[:validate_missing(field=:email_confirmation)]"
+  validate_user_login_missing:  "[:validate_missing(field=:login_name)]"
+  validate_user_login_too_long:  "[:validate_too_long_or_short(field=:login_name,min=3,max=40)]"
+  validate_user_name_too_long:  "[:validate_too_long(field=:full_name,max=80)]"
+  validate_user_password_confirmation_missing:  "[:validate_missing(field=:password_confirmation)]"
+  validate_user_password_missing:  "[:validate_missing(field=:password)]"
+  validate_user_password_no_match:  "[:validate_confirmation_mismatch(field=:password)]"
+  validate_user_password_too_long:  "[:validate_too_long_or_short(field=:password,min=5,max=40)]"
+  validate_user_theme_too_long:  "[:validate_too_long(field=''theme_name'',max=40)]"
+  validate_vote_naming_missing:  "[:validate_missing(field=:naming)]"
+  validate_vote_user_missing:  "[:validate_missing(field=:user)]"
+  validate_vote_value_missing:  "[:validate_missing(field=:confidence_level)]"
+  validate_vote_value_not_integer:  "[:validate_not_a_number(field=:vote)]"
+  validate_vote_value_out_of_bounds:  "[:validate_not_in_range(field=:vote)]"
+
+  # Runtime error and success messages.
+  runtime_added:  Successfully added [type].
+  runtime_added_id:  "Successfully added [type] #[value]."
+  runtime_added_id_to:  "Successfully added [type] #[value] to [name]."
+  runtime_added_name:  Successfully added [type] '[value]'.
+  runtime_added_name_to:  Successfully added [type] '[value]' to [name].
+  runtime_added_to:  Successfully added [type] to [name].
+  runtime_admin_only:  That operation is restricted to site admins.
+  runtime_already_exists:  "[Type] already exists: '[value]'"
+  runtime_already_used:  "[Type] is already in use: '[value]'"
+  runtime_created_at:  Successfully created [type].
+  runtime_created_id:  "Successfully created [type] #[value]."
+  runtime_created_name:  Successfully created [type] '[value]'.
+  runtime_date_invalid:  Invalid date.
+  runtime_date_should_be_yyyymmdd:  Date should be in year-month-day format.
+  runtime_delivered_message:  Successfully delivered message.
+  runtime_delivered_question:  Successfully delivered question.
+  runtime_delivered_request:  Successfully delivered request.
+  runtime_destroyed:  Successfully destroyed [type].
+  runtime_destroyed_id:  "Successfully destroyed [type] #[value]."
+  runtime_destroyed_name:  Successfully destroyed [type] '[value]'.
+  runtime_failed_to_strip_gps:  "Failed to strip GPS data from full-size image's EXIF header: [msg]"
+  runtime_invalid:  "[Type] is invalid: '[value]'"
+  runtime_lat_long_error:  "Latitude and longitude must be real numbers between -90 and 90, and -180 and 180 respectively. Use decimal notation or degrees/minutes/seconds. Examples:\n-123.4567\n123.4567 N\n123 27.402 N\n123 24 24.12 N\n123° 24’ 24.12” N\n123deg 24min 24.12sec N"
+  runtime_altitude_error:  "Elevation must be real number in feet or meters.  Feet will be converted to meters (default).  Examples:\n1234\n1234m\n4049'\n4049 ft."
+  runtime_merge_success:  Successfully merged [type] [src] into [dest].
+  runtime_missing:  Missing [field].
+  runtime_no_changes:  No changes made.
+  runtime_no_create:  Unable to create [type].
+  runtime_no_create_id:  "Unable to create [type] #[value]."
+  runtime_no_create_name:  Unable to create [type] '[value]'.
+  runtime_no_destroy:  Unable to destroy [type].
+  runtime_no_destroy_id:  "Unable to destroy [type] #[value]."
+  runtime_no_destroy_name:  Unable to destroy [type] '[value]'.
+  runtime_no_match:  Can't find [type].
+  runtime_no_match_id:  "Can't find [type] #[value]."
+  runtime_no_match_name:  Can't find [type] matching '[value]'.
+  runtime_no_matches:  No matching [types] found.
+  runtime_no_matches_pattern:  No [types] matching '[value]' found.
+  runtime_no_matches_regexp:  No [types] matching '[value]' found.
+  runtime_no_more:  There are no more [types].
+  runtime_no_objects:  There are no [types].
+  runtime_no_parse:  "Unable to parse: '[value]'"
+  runtime_no_save:  Unable to save [type].
+  runtime_no_update:  Unable to update [type].
+  runtime_no_update_id:  "Unable to update [type] #[value]."
+  runtime_no_update_name:  Unable to update [type] '[value]'.
+  runtime_not_owner:  You are not the owner of [type] '[value]'.
+  runtime_not_owner_id:  "You are not the owner of [type] #[value]."
+  runtime_removed:  Successfully removed [type].
+  runtime_removed_from:  Successfully removed [type] from [name].
+  runtime_removed_id:  "Successfully removed [type] #[value]."
+  runtime_removed_id_from:  "Successfully removed [type] #[value] from [name]."
+  runtime_removed_name:  Successfully removed [type] '[value]'.
+  runtime_removed_name_from:  Successfully removed [type] '[value]' from [name].
+  runtime_updated_at:  Successfully updated [type].
+  runtime_updated_id:  "Successfully updated [type] #[value]."
+  runtime_updated_name:  Successfully updated [type] '[value]'.
+  runtime_uploaded:  Successfully uploaded [type].
+  runtime_uploaded_id:  "Successfully uploaded [type] #[value]."
+  runtime_uploaded_name:  Successfully uploaded [type] '[value]'.
+  runtime_user_hasnt_authored:  "[user] hasn't written any [types]."
+  runtime_user_hasnt_created:  "[user] hasn't created any [types]."
+  runtime_user_hasnt_edited:  "[user] hasn't edited any [types]."
+
+  # One-time-use messages.
+  runtime_api_key_notes_cannot_be_blank:  Notes field cannot be blank.
+  runtime_bad_use_of_imageless:  The special name _Imageless_ was not intended for observations that were created as part of species lists or which have good documentation.  Please read the discussion under "_Imageless_":/name/show_name/31080.
+  runtime_dates_must_be_same_format:  If you give two dates, they must be the same format.
+  runtime_description_added_admin:  Gave admin permission to [name].
+  runtime_description_added_reader:  Gave view permission to [name].
+  runtime_description_added_writer:  Gave edit permission to [name].
+  runtime_description_copy_success:  Successfully copied the description.
+  runtime_description_merge_delete_denied:  You don't have permission to delete the old description.
+  runtime_description_merge_deleted:  "The old description was deleted: [old]"
+  runtime_description_merge_success:  Successfully merged the descriptions.
+  runtime_description_move_success:  Successfully moved the description.
+  runtime_description_private:  That description is private!
+  runtime_description_removed_admin:  Revoked admin permission for [name].
+  runtime_description_removed_reader:  Revoked view permission for [name].
+  runtime_description_removed_writer:  Revoked edit permission for [name].
+  runtime_destroy_description_not_admin:  Only a description's admins can delete that description.
+  runtime_duplicate_rank:  "Rank appears twice: '[rank]'"
+  runtime_herbarium_record_already_exists:  Fungarium record [number] at [herbarium] already used by someone else.
+  runtime_image_updated_notes:  "Updated notes on image #[id]."
+  runtime_image_uploaded:  Uploaded image '[name]'.
+  runtime_index_no_at_location:  No [types] at [location].
+  runtime_index_no_by_rss_log:  No [types] have had any recent activity.
+  runtime_index_no_for_object:  No [types] for this object.
+  runtime_index_no_for_user:  No [types] for [user].
+  runtime_index_no_in_species_list:  No [types] in [name].
+  runtime_index_no_inside_observation:  "Observation #[id] has no [types]."
+  runtime_index_no_of_children:  There are no [types] for children of [name].
+  runtime_index_no_of_name:  There are no [types] of [name].
+  runtime_index_no_of_parents:  There are no [types] for parents of [name].
+  runtime_index_no_with:  There are no [types] with [attachments].
+  runtime_invalid_for_rank:  "Name is invalid for the rank [rank]: '[name]'"
+  runtime_invalid_rank:  "Ranks are out of order: '[line_rank]' is the same as or below '[rank]'"
+  runtime_location_merge_failed:  Failed to merge observation [name].
+  runtime_login_failed:  Login unsuccessful.
+  runtime_login_success:  Login successful.
+  runtime_map_nothing_to_map:  Nothing to map.
+  runtime_name_in_use_with_notes:  The name '[name]' is already in use and [other] has notes.
+  runtime_no_conditions:  You didn't specify any conditions!
+  runtime_no_upload_image:  Had problems uploading image '[name]'.
+  runtime_object_deleted:  This object has been deleted.
+  runtime_object_not_in_index:  "Can't find [type] #[id] in the results of the current search or index."
+  runtime_object_multiple_matches:  Multiple [types] match "[match]".
+  runtime_pivotal_getting_token:  Couldn't get access token from Pivotal.
+  runtime_pivotal_getting_stories:  Couldn't get stories from Pivotal.
+  runtime_pivotal_parsing_story:  Error parsing one or more stories from Pivotal.  Ignored them.
+  runtime_prefs_password_no_match:  Password and confirmation did not match.
+  runtime_search_has_expired:  Your query has expired, please try again.
+  runtime_show_observation_success:  Successfully changed vote.
+  runtime_species_list_clear_success:  Successfully removed all observations from list.
+  runtime_suggest_one_alternate:  No [types] match "[match]", maybe you meant this?
+  runtime_suggest_multiple_alternates:  No [types] match "[match]", maybe you meant one of these?
+  runtime_unable_to_transfer_name:  Unable to transfer [name] to another synonym.
+  runtime_wrong_rank:  Wrong rank for [name]; expected [expect], but got [actual].
+
+  # These shouldn't need translating, but you are free to override if you need to.
+  runtime_edit_article_success:  "[:runtime_updated_id(type=:article,value=id)]"
+  runtime_ask_observation_question_success:  "[:runtime_delivered_question]"
+  runtime_ask_user_question_success:  "[:runtime_delivered_question]"
+  runtime_ask_webmaster_need_address:  "[:runtime_missing(field=:email_address)]"
+  runtime_ask_webmaster_need_content:  "[:runtime_missing(field=:comment)]"
+  runtime_ask_webmaster_success:  "[:runtime_delivered_message]"
+  runtime_commercial_inquiry_success:  "[:runtime_delivered_message]"
+  runtime_create_name_success:  "[:runtime_created_name(type=:name,value=name)]"
+  runtime_description_adjust_permissions_denied:  "[:runtime_description_must_be_admin]"
+  runtime_description_adjust_permissions_no_changes:  "[:runtime_no_changes]"
+  runtime_description_publish_denied:  "[:runtime_description_must_be_admin]"
+  runtime_destroy_description_success:  "[:runtime_destroyed(type=:description)]"
+  runtime_destroy_naming_denied:  "[:runtime_not_owner_id(type=:naming,value=id)]"
+  runtime_destroy_naming_failed:  "[:runtime_no_destroy_id(type=:naming,value=id)]"
+  runtime_destroy_naming_success:  "[:runtime_destroyed_id(type=:naming,value=id)]"
+  runtime_destroy_observation_denied:  "[:runtime_not_owner_id(type=:observation,value=id)]"
+  runtime_destroy_observation_failed:  "[:runtime_no_destroy_id(type=:observation,value=id)]"
+  runtime_destroy_observation_success:  "[:runtime_destroyed_id(type=:observation,value=id)]"
+  runtime_edit_location_description_no_change:  "[:runtime_no_changes]"
+  runtime_edit_location_description_success:  "[:runtime_updated_id(type=:location_description,value=id)]"
+  runtime_edit_location_no_change:  "[:runtime_no_changes]"
+  runtime_edit_location_success:  "[:runtime_updated_id(type=:location,value=id)]"
+  runtime_edit_name_description_no_change:  "[:runtime_no_changes]"
+  runtime_edit_name_description_success:  "[:runtime_updated_id(type=:name_description,value=id)]"
+  runtime_edit_name_merge_success:  "[:runtime_merge_success(type=:name,src=this,dest=that)]"
+  runtime_edit_name_no_change:  "[:runtime_no_changes]"
+  runtime_edit_name_success:  "[:runtime_updated_name(type=:name,value=name)]"
+  runtime_edit_observation_success:  "[:runtime_updated_id(type=:observation,value=id)]"
+  runtime_edit_project_success:  "[:runtime_updated_id(type=:project,value=id)]"
+  runtime_email_new_password_failed:  "[:runtime_no_match_name(type=:user,value=user)]"
+  runtime_form_comments_create_success:  "[:runtime_created_id(type=:comment,value=id)]"
+  runtime_form_comments_destroy_failed:  "[:runtime_no_destroy_id(type=:comment,value=id)]"
+  runtime_form_comments_destroy_success:  "[:runtime_destroyed_id(type=:comment,value=id)]"
+  runtime_form_comments_edit_success:  "[:runtime_updated_id(type=:comment,value=id)]"
+  runtime_image_destroy_failed:  "[:runtime_no_destroy_id(type=:image,value=id)]"
+  runtime_image_destroy_success:  "[:runtime_destroyed_id(type=:image,value=id)]"
+  runtime_image_edit_success:  "[:runtime_updated_id(type=:image,value=id)]"
+  runtime_image_invalid_image:  "[:runtime_invalid(type=:image,value=name)]"
+  runtime_image_remove_success:  "[:runtime_removed_id(type=:image,value=id)]"
+  runtime_image_resize_denied:  "[:runtime_admin_only]"
+  runtime_image_reuse_invalid_id:  "[:runtime_no_match_id(type=:image,value=id)]"
+  runtime_image_reuse_success:  "[:runtime_added_id(type=:image,value=id)]"
+  runtime_image_uploaded_image:  "[:runtime_uploaded_name(type=:image,value=name)]"
+  runtime_invalid_classification:  "[:runtime_no_parse(value=text)]"
+  runtime_invalid_name:  "[:runtime_invalid(type=:name,value=name)]"
+  runtime_invalid_source_type:  "[:runtime_invalid(type=:source)]"
+  runtime_list_location_no_matches:  "[:runtime_no_matches(type=:location)]"
+  runtime_location_already_exists:  "[:runtime_already_exists(type=:location,value=name)]"
+  runtime_location_description_index_no_matches:  "[:runtime_no_matches(type=:location_description)]"
+  runtime_location_description_success:  "[:runtime_created_id(type=:location_description,value=id)]"
+  runtime_location_descriptions_by_author_error:  "[:runtime_user_hasnt_authored(type=:location_description)]"
+  runtime_location_descriptions_by_editor_error:  "[:runtime_user_hasnt_edited(type=:location_description)]"
+  runtime_location_merge_success:  "[:runtime_merge_success(type=:location,src=this,dest=that)]"
+  runtime_location_success:  "[:runtime_created_id(type=:location,value=id)]"
+  runtime_merge_locations_warning:  "[:runtime_merge_warning(type=:location)]"
+  runtime_merge_names_warning:  "[:runtime_merge_warning(type=:name)]"
+  runtime_name_already_used:  "[:runtime_already_used(type=:name,value=name)]"
+  runtime_name_create_already_exists:  "[:runtime_already_exists(type=:name,value=name)]"
+  runtime_name_deprecate_must_choose:  "[:runtime_missing(field=:preferred_name)]"
+  runtime_name_description_index_no_matches:  "[:runtime_no_matches(type=:name_description)]"
+  runtime_name_description_success:  "[:runtime_created_id(type=:name_description,value=id)]"
+  runtime_name_descriptions_by_author_error:  "[:runtime_user_hasnt_authored(type=:name_description)]"
+  runtime_name_descriptions_by_editor_error:  "[:runtime_user_hasnt_edited(type=:name_description)]"
+  runtime_name_index_no_matches:  "[:runtime_no_matches(type=:name)]"
+  runtime_names_by_editor_error:  "[:runtime_user_hasnt_edited(type=:name)]"
+  runtime_names_by_user_error:  "[:runtime_user_hasnt_created(type=:name)]"
+  runtime_naming_created_at:  "[:runtime_created_at(type=:naming)]"
+  runtime_naming_updated_at:  "[:runtime_updated_at(type=:naming)]"
+  runtime_no_more_search_objects:  "[:runtime_no_more]"
+  runtime_no_save_naming:  "[:runtime_no_save(type=:naming)]"
+  runtime_no_save_observation:  "[:runtime_no_save(type=:observation)]"
+  runtime_object_no_match:  "[:runtime_no_match_name(value=match)]"
+  runtime_observation_success:  "[:runtime_created_id(type=:observation,value=id)]"
+  runtime_prefs_success:  "[:runtime_updated_at(type=:preferences)]"
+  runtime_profile_invalid_image:  "[:runtime_invalid(type=:image,value=name)]"
+  runtime_profile_removed_image:  "[:runtime_removed_from(type=:image,name=:profile)]"
+  runtime_profile_success:  "[:runtime_updated_at(type=:profile)]"
+  runtime_profile_uploaded_image:  "[:runtime_uploaded_name(type=:image,value=name)]"
+  runtime_sequence_success:  "[:runtime_created_id(type=:SEQUENCE,value=id)]"
+  runtime_sequence_update_success:  "[:runtime_updated_id(type=:sequence,value=id)]"
+  runtime_species_list_add_observation_success:  "[:runtime_added_id_to(type=:observation,value=id)]"
+  runtime_species_list_create_success:  "[:runtime_created_id(type=:species_list,value=id)]"
+  runtime_species_list_destroy_success:  "[:runtime_destroyed_id(type=:species_list,value=id)]"
+  runtime_species_list_edit_success:  "[:runtime_updated_id(type=:species_list,value=id)]"
+  runtime_species_list_remove_observation_success:  "[:runtime_removed_id_from(type=:observation,value=id)]"
+  runtime_unable_to_create_name:  "[:runtime_no_create_name(type=:name,value=name)]"
+  runtime_unable_to_save_changes:  "[:runtime_no_save(type=:changes)]"
+  runtime_unrecognized_rank:  "[:runtime_invalid(type=rank,value=rank)]"
+  runtime_user_bad_rank:  "Invalid rank: '[rank]'"
+
+  # Longer messages.
+  runtime_ask_webmaster_antispam:  To cut down on robot spam, questions from unregistered users cannot contain 'http:' or HTML markup.
+  runtime_create_draft_create_denied:  You do not have permission to create a draft for the project [title].
+  runtime_create_naming_already_proposed:  Someone has already proposed that name.  If you would like to comment on it, try posting a comment instead.
+  runtime_description_already_default:  This description is already the default description!
+  runtime_description_foreign_read_wrong:  Descriptions from other servers must be readable by the general public.
+  runtime_description_foreign_write_wrong:  Descriptions from other servers must be read-only.
+  runtime_description_make_default_only_public:  You are only allowed to make public descriptions the default. All users must be allowed at least to read it.
+  runtime_description_merge_conflict:  There is a conflict.  Please merge the two descriptions by hand.  (Look at the text fields below.  Where there is a conflict both descriptions have been entered one on top of the other separated by a line.)  You may cancel the operation at any time without making any changes.  When you are finished, be sure to destroy the old description.
+  runtime_description_move_invalid_classification:  The classification has incorrect syntax.  We can't save a new description with it like this, so we've temporarily blanked out the classification field until you correct it.
+  runtime_description_must_be_admin:  You must be an admin for a description to use this feature.
+  runtime_description_permissions_fixed:  This type of description has fixed permissions.
+  runtime_description_public_read_wrong:  Public descriptions must be readable by the general public.
+  runtime_description_public_write_wrong:  Public descriptions must be writable by the general public.
+  runtime_description_user_not_found:  User or Group "[name]" not found!
+  runtime_destroy_naming_someone_else:  Sorry, someone else has given this their strongest positive vote.  You are free to propose alternate names, but we can no longer let you delete this name.
+  runtime_edit_description_denied:  You have not been given permission to edit this description.
+  runtime_edit_naming_someone_else:  Sorry, someone else has given this a positive vote, so we had to create a new name proposal to accomodate your changes.
+  runtime_email_new_password_success:  Password successfully changed.  New password has been sent to your email account.
+  runtime_form_names_misspelling_bad:  The alternate spelling you entered is not recognized.
+  runtime_form_names_misspelling_same:  Correct spelling and incorrect spelling are the same!
+  runtime_image_changed_your_image:  "Changed your profile image to image #[id]."
+  runtime_image_move_failed:  "Something went wrong on the server and we failed to save image #[id].  Please try again."
+  runtime_image_process_failed:  "Something went wrong on the server and we failed to process image #[id]. Please try again."
+  runtime_image_remove_denied:  You do not have permission to remove images from this observation.
+  runtime_image_remove_missing:  This observation doesn't have that image!
+  runtime_merge_warning:  Because it can be destructive, only the admin can merge existing [types]. An email requesting the proposed merge has been sent to the admins.
+  runtime_name_for_description_not_found:  Sorry, the name this description belongs to no longer exists.
+  runtime_object_not_found:  "Sorry, the [type] you tried to display (id #[id]) does not exist.  Someone may have deleted it or merged it into another."
+  runtime_profile_must_define:  You must define this location before we can make it your primary location. Any other changes to your profile have been saved.
+  runtime_reverify_already_verified:  Your account is already verified!  Please log in.
+  runtime_reverify_sent:  Another verification email was sent.
+  runtime_show_description_denied:  You have not been given permission to see this description.
+  runtime_show_draft_denied:  "Permission denied: only project members can view drafts in progress."
+  runtime_signup_success:  Signup successful.  Verification email sent.
+  runtime_species_list_need_to_use_bulk:  Synonyms can only be created from the [:name_bulk_title] page.
+
+  # Pattern search error messages.
+  pattern_search_syntax_error:  Syntax error in pattern at [string].
+  pattern_search_pattern_must_be_first_error:  Filter terms come after the bare search pattern, [str].  Maybe you forgot to enclose the value for [var] in double quotes?
+  pattern_search_bad_term_error:  "Unexpected term in [type] search: [term]. [help]"
+  pattern_search_missing_value_error:  Missing value for the term [var].
+  pattern_search_too_many_values_error:  Search term [term] occurs more than once.
+  pattern_search_bad_boolean_error:  Invalid value for [term], [value], expected "yes" or "no".
+  pattern_search_bad_yes_error:  Invalid value for [term], [value], only valid value is "yes".
+  pattern_search_bad_yes_no_both_error:  Invalid value for [term], [value], expected "yes", "no" or "either".
+  pattern_search_bad_float_error:  Invalid value for [term], [value], expected a number between [min] and [max].
+  pattern_search_bad_confidence_error:  Invalid value for [term], [value], expected a number or range of numbers between -100 and 100, e.g. "0-100".
+  pattern_search_bad_name_error:  Invalid or unrecognized value for [term], [value], expected name id or string; nothing matched.
+  pattern_search_bad_herbarium_error:  Invalid or unrecognized value for [term], [value], expected fungarium id, code or name; nothing matched.
+  pattern_search_bad_location_error:  Invalid or unrecognized value for [term], [value], expected location id or name; nothing matched.
+  pattern_search_bad_project_error:  Invalid or unrecognized value for [term], [value], expected project id or title; nothing matched.
+  pattern_search_bad_species_list_error:  Invalid or unrecognized value for [term], [value], expected species list id or title; nothing matched.
+  pattern_search_bad_user_error:  Invalid or unrecognized value for [term], [value], expected user id, login or name; nothing matched.
+  pattern_search_bad_date_range_error:  Invalid value for [term], [value], expected date or date range of form YYYY, YYYY-YYYY, YYYY-MM, YYYY-MM-YYYY-MM, YYYY-MM-DD, YYYY-MM-DD-YYYY-MM-DD, MM, MM-MM or MM-DD-MM-DD.
+  pattern_search_bad_rank_range_error:  Invalid value for [term], [value], expected rank or range of ranks, e.g., "genus" or "species-form".
+  pattern_search_user_me_not_logged_in_error:  The term '[:search_term_user]:[:search_value_me]' doesn't make sense unless you are logged in!
+
+  # Advanced search error messages
+  advanced_search_bad_q_error:  Search expired or cannot be found. Please re-enter search criteria.
+
+  # content for html header title tag,
+  # used when there are no hits for a list or search
+  title_for_comment_search:  Comment Search
+  title_for_herbarium_search:  Fungarium Search
+  title_for_herbarium_record_search:  Fungarium Record Search
+  title_for_image_search:  Image Search
+  title_for_location_search:  Location Search
+  title_for_name_search:  Name Search
+  title_for_observation_search:  Observation Search
+  title_for_project_search:  Project Search
+  title_for_species_list_search:  Species List Search
+  title_for_user_search:  User Search
+
+  ##############################################################################
+
+  # LESS IMPORTANT ENUMERATED SETS OF VALUES
+
+  # Api error messages
+  api_abort_due_to_errors:  Aborted operation due to errors.
+  api_ambiguous_name:  Name "[name]" is ambiguous, matches [others].
+  api_another_users_profile_location:  You can't edit this [:location] because someone has made it their profile location.
+  api_api_key_not_verified:  API key for "[notes]" has not been activated yet. (key = "[key]")
+  api_bad_action:  Invalid request type "[action]".
+  api_bad_altitude_parameter_value:  "Invalid elevation, \"[val]\", examples: \"1234\", \"1234m\", \"4048'\", \"4048ft\"."
+  api_bad_api_key:  Bad key "[key]".
+  api_bad_boolean_parameter_value:  Invalid boolean, "[val]", expect "1", "yes", "true", "0", "no", or "false".
+  api_bad_classification:  Invalid classification string.
+  api_bad_date_parameter_value:  Invalid date, "[val]", expect "YYYYMMDD".
+  api_bad_date_range_parameter_value:  Invalid date range, "[val]", expect "YYYYMMDD-YYYYMMDD", "YYYYMM-YYYYMM", "YYYY-YYYY", "MM-MM", "YYYYMMDD", "YYYYMM", "YYYY", "MM".
+  api_bad_email_parameter_value:  Invalid email address, "[val]".
+  api_bad_external_site_parameter_value:  Invalid external site, "[val]".
+  api_bad_float_parameter_value:  Invalid float, "[val]".
+  api_bad_herbarium_parameter_value:  Invalid or unknown fungarium, "[val]", accept numerical id, code or name.
+  api_bad_image_parameter_value:  Invalid or unknown image, "[val]", accept only numerical id.
+  api_bad_integer_parameter_value:  Invalid integer, "[val]".
+  api_bad_latitude_parameter_value:  "Invalid latitude, \"[val]\", examples: \"-45.6789\", \"45.6789°S\", \"45°40.73'S\", \"45°40'44\"S\"."
+  api_bad_license_parameter_value:  Invalid or unknown license, "[val]", accept only numerical id.
+  api_bad_limited_parameter_value:  Expected "[val]" to be in [limit].
+  api_bad_location_parameter_value:  Invalid or unknown location, "[val]", accept numerical id or location name.
+  api_bad_longitude_parameter_value:  "Invalid longitude, \"[val]\", examples: \"-45.6789\", \"45.6789°W\", \"45°40.73'W\", \"45°40'44\"W\"."
+  api_bad_method:  Invalid request method "[method]".
+  api_bad_name_parameter_value:  Invalid or unknown name, "[val]", accept numerical id or scientific name (author not required).
+  api_bad_notes_field_parameter:  Invalid notes template field.  Pretty much anything but commas are allowed.
+  api_bad_object_parameter_value:  "Invalid or unknown object, \"[val]\", examples: \"name #1234\", \"observation #54321\", \"species_list #42\"."
+  api_bad_observation_parameter_value:  Invalid or unknown observation, "[val]", accept only numerical id.
+  api_bad_project_parameter_value:  Invalid or unknown project, "[val]", accept numerical id or project name.
+  api_bad_species_list_parameter_value:  Invalid or unknown species list, "[val]", accept numerical id or species list title.
+  api_bad_time_parameter_value:  Invalid time, "[val]", expect "YYYYMMDDHHMMSS".
+  api_bad_time_range_parameter_value:  Invalid time range, "[val]", expect "YYYYMMDDHHMMSS-YYYYMMDDHHMMSS", "YYYYMMDDHHMM-YYYYMMDDHHMM", "YYYYMMDDHH-YYYYMMDDHH", "YYYYMMDD-YYYYMMDD", "YYYYMM-YYYYMM", "YYYY-YYYY", "MM-MM", "YYYYMMHHMMSS", "YYYYMMDDHHMM", "YYYYMMDDHH", "YYYYMMDD", "YYYYMM", "YYYY", "MM".
+  api_bad_user_parameter_value:  Invalid or unknown user, "[val]", accept numerical id, login or name.
+  api_bad_version:  Invalid version number "[version]".
+  api_can_only_delete_your_own_account:  Only the account owner can delete their account.
+  api_can_only_synonymize_unsynonymized_names:  Presently, we're only allowing API clients to synonymize unsynonymized names with other names.  If one of the names has no synonyms, synonymize that name with the others.  But there's no way to merge two sets os synonyms via the API right now.
+  api_can_only_use_one_of_these_fields:  "Please only use one of these parameters: [fields]."
+  api_can_only_use_this_field_if_has_specimen:  The parameter, "[field]", can only be used if the observation has a specimen.
+  api_cant_add_herbarium_record:  Only owner of observation and curators of fungarium can add fungarium records to an observation.
+  api_couldnt_download_url:  "Failed to download the resource at the URL, \"[url]\": [error]"
+  api_create_failed:  "Failed to create [type] \"[name]\": [error]"
+  api_destroy_failed:  Failed to destroy [type] "[name]".
+  api_dubious_location_name:  "Location name is invalid: [reasons]"
+  api_external_link_permission_denied:  In order to create an external link, you must either have edit permissions for the observation, or you must be a member of the external site's project.
+  api_file_missing:  File "[file]" is missing.
+  api_help_message:  "Usage: [help]"
+  api_herbarium_record_already_exists:  There is already a record for [number] at [herbarium].
+  api_image_upload_failed:  "Failed to upload image: [error]"
+  api_incorrect_password:  Incorrect password.
+  api_lat_long_must_both_be_set:  Must supply both latitude and longitude, or neither.
+  api_location_already_exists:  The location "[location]" already exists.
+  api_missing_method:  Missing "method" parameter.
+  api_missing_parameter:  Missing "[arg]" parameter.
+  api_missing_set_parameters:  You didn't supply any "set" parameters.
+  api_missing_upload:  Expected an upload file.  You may send the file in the data of the HTTP request, or you may specify a URL using the "upload_url" parameter.
+  api_must_authenticate:  Must authenticate with API key to perform this operation.
+  api_must_be_admin:  You are not an admin for [project].
+  api_must_be_creator:  You can only edit [types] that you have created.
+  api_must_be_member:  You are not a member of [type] "[name]".
+  api_must_be_only_editor:  You can only edit [types] if you are the only editor.
+  api_must_be_owner:  You must be the owner of the [type] "[name]" to do this.
+  api_must_have_edit_permission:  You do not have permission to edit [type] "[name]".
+  api_must_have_view_permission:  You do not have permission to view [type] "[name]".
+  api_must_not_have_any_herbaria:  You can't edit this [:location] because there is an [:herbarium] there.
+  api_must_own_all_descriptions:  You can only edit [types] if you own all the [:descriptions].
+  api_must_own_all_namings:  You can only edit [types] if no one else has proposed that [type].
+  api_must_own_all_observations:  You can only edit [types] if you own all its [:observations].
+  api_must_own_all_species_lists:  You can only edit [types] if you own all its [:species_lists].
+  api_name_already_exists:  The name "[new]" already exists.
+  api_name_doesnt_parse:  The name, "[name]", doesn't parse as a valid scientific name.
+  api_name_wrong_for_rank:  The name, "[name]", isn't valid for [rank].
+  api_need_all_four_edges:  "Need to supply all four edges of bounding box: north, south, east and west."
+  api_no_method_for_action:  Invalid request method "[method]" for "[action]".
+  api_object_not_found_by_id:  "[Type] #[id] does not exist, or someone has deleted it."
+  api_object_not_found_by_string:  "[Type] \"[str]\" does not exist, or someone has deleted it."
+  api_one_or_the_other:  Can only use one of the parameters [args].
+  api_parameter_cant_be_blank:  It is okay to leave the [arg] parameter off, but if you include it in your PATCH request, it cannot be blank.  Leaving a set parameter off means it will leave that property alone and do nothing; setting it to a blank tells MO to delete or clear the property.  And some properties cannot be deleted or cleared.
+  api_password_incorrect:  Password incorrect.
+  api_project_taken:  The project, "[project]", already exists.
+  api_query_error:  "There was an internal problem with Query: [error]"
+  api_render_failed:  There was a problem while rendering the results. [error]
+  api_species_list_already_exists:  The [:species_list] "[title]" already exists.
+  api_string_too_long:  The string, "[val]", has more than [limit] characters.
+  api_too_many_uploads:  Only one upload allowed per request.  You may send the file in the data of the HTTP request, or you may specify a URL using the "upload_url" parameter.  But do not use both methods at the same time.
+  api_trying_to_set_multiple_locations_to_same_name:  You are attempting to update multiple locations to the same name.
+  api_trying_to_set_multiple_names_at_once:  You can only change the name, author and rank of one name at a time.
+  api_unexpected_upload:  Unexpected file attached.
+  api_unused_parameters:  "Unexpected parameters: [params]"
+  api_user_already_exists:  The user "[login]" already exists or is taken.
+  api_user_group_taken:  The user group "[title]" already exists.
+  api_user_not_verified:  The user "[login]" is not verified yet; you can request another verification email on the website.
+
+  api_help_accession_has:  search within accession number
+  api_help_accession_number:  unique fungarium id
+  api_help_accession_number_has:  search within accession number
+  api_help_any_date:  this date can mean anything you want
+  api_help_api_key_password:  password of the user you are creating an API key for
+  api_help_api_key_user:  user you are creating api key for
+  api_help_app:  identifier used to help user distinguish which api key belongs to which app
+  api_help_author_has:  search within author
+  api_help_citation_has:  search within citation
+  api_help_classification_has:  search within classification
+  api_help_clear_synonyms:  make it so this name is not synonymized with anything but leave everything it used to be synonymized with synonyms of each other
+  api_help_collector:  collector's name
+  api_help_collector_has:  search within collector's name
+  api_help_comments_has:  search within comments summary and body
+  api_help_content_has:  search within body
+  api_help_copyright_holder_has:  search within copyright holder
+  api_help_create_key:  if you pass in your app name here it will create an api key for the user for your app to use
+  api_help_creator:  creator
+  api_help_east:  max longitude
+  api_help_first_user:  creator / first to use
+  api_help_has_notes_field:  is given observation notes template field filled in?
+  api_help_has_obs_notes:  observation has notes?
+  api_help_has_observation:  is attached to an observation?
+  api_help_initial_det:  initial determination
+  api_help_initial_det_has:  search within initial determination
+  api_help_is_collection_location:  is this location where mushroom was found?
+  api_help_gps_hidden:  hide exact coordinates?
+  api_help_locus_has:  search within locus
+  api_help_log:  log this action on main page activity log and RSS feed?
+  api_help_mailing_address:  postal address
+  api_help_min_rank:  group or genus or better
+  api_help_min_size:  width or height at least 160 for thumbnail, 320 for small, 640 for medium, 960 for large, 1280 for huge
+  api_help_misspellings:  include misspellings? "either" means do not care and "only" means only show misspelt names
+  api_help_north:  max latitude
+  api_help_notes_field:  set value of the custom notes template field, substitute field name for "$field"
+  api_help_notes_has:  search within notes
+  api_help_number:  collector's number
+  api_help_number_has:  search within collector's number
+  api_help_obs_date:  observation date
+  api_help_obs_notes_has:  search within observation notes
+  api_help_observer:  observer
+  api_help_original_name:  original file name or other private identifier
+  api_help_postal:  in postal format with country last regardless of user preference
+  api_help_region:  matches locations which end in this, e.g. "California, USA"
+  api_help_set_correct_spelling:  mark this as misspelt and deprecated and synonymize with the correct spelling
+  api_help_set_is_collection_location:  is this location where mushroom was found?
+  api_help_set_gps_hidden:  hide exact coordinates?
+  api_help_south:  min latitude
+  api_help_summary_has:  search within summary
+  api_help_target:  "e.g. \"observation #1234\" or \"name #5678\""
+  api_help_text_name_has:  search within name
+  api_help_title_has:  search within title
+  api_help_uploader:  who uploaded the photo
+  api_help_west:  min longitude
+  api_help_when_seen:  when seen
+  api_help_when_taken:  when photo taken
+
+  # Query titles.
+  query_title_advanced_search:  "[:app_advanced_search]"
+  query_title_all:  "[TYPE] Index"
+  query_title_all_by:  "[TYPES] by [ORDER]"
+  query_title_at_location:  "[TYPES] from [LOCATION]"
+  query_title_at_where:  "[TYPES] from '[USER_WHERE]'"
+  query_title_by_author:  "[TYPES] Authored by [USER]"
+  query_title_by_editor:  "[TYPES] Edited by [USER]"
+  query_title_by_rss_log:  "[TYPES] in Activity Log"
+  query_title_by_user:  "[TYPES] created by [USER]"
+  query_title_for_observation:  "[TYPES] attached to [OBSERVATION]"
+  query_title_for_project:  "[TYPES] attached to [PROJECT]"
+  query_title_for_target:  "[TYPES] on [TARGET]"
+  query_title_for_user:  "[TYPES] for [USER]"
+  query_title_in_herbarium:  "[TYPES] in [HERBARIUM]"
+  query_title_in_set:  Selected [TYPES]
+  query_title_in_species_list:  "[TYPES] in [SPECIES_LIST]"
+  query_title_inside_observation:  "[TYPES] of [OBSERVATION]"
+  query_title_nonpersonal:  List of Institutional Fungaria
+  query_title_of_children:  Lower Taxa under [NAME]
+  query_title_of_name:  "[TYPES] of [NAME]"
+  query_title_of_name_synonym:  "[TYPES] of Synonyms of [NAME]"
+  query_title_of_name_nonconsensus:  "[TYPES] That Might Be [NAME]"
+  query_title_of_parents:  Higher Taxa Containing [NAME]
+  query_title_pattern_search:  "[TYPES] Matching '[pattern]'"
+  query_title_regexp_search:  "[TYPES] Matching '[regexp]'"
+  query_title_with_descriptions:  "[TYPES] with [:DESCRIPTIONS]"
+  query_title_with_descriptions_by_author:  "[TYPES] with [:query_title_by_author(type=:description)]"
+  query_title_with_descriptions_by_editor:  "[TYPES] with [:query_title_by_editor(type=:description)]"
+  query_title_with_descriptions_by_user:  "[TYPES] with [:query_title_by_user(type=:description)]"
+  query_title_with_descriptions_in_set:  "[TYPES] with [descriptions]"
+  query_title_with_observations:  "[TYPES] with [:OBSERVATIONS]"
+  query_title_with_observations_at_location:  "[TYPES] with [:query_title_at_location(type=:observation)]"
+  query_title_with_observations_at_where:  "[TYPES] with [:query_title_at_where(type=:observation)]"
+  query_title_with_observations_by_user:  "[TYPES] with [:query_title_by_user(type=:observation)]"
+  query_title_with_observations_for_project:  "[TYPES] with [:query_title_for_project(type=:observation)]"
+  query_title_with_observations_in_set:  "[TYPES] for [observations]"
+  query_title_with_observations_in_species_list:  "[TYPES] with [:query_title_in_species_list(type=:observation)]"
+  query_title_with_observations_of_children:  "[TYPES] with [:query_title_of_children(type=:observation)]"
+  query_title_with_observations_of_name:  "[TYPES] with [:query_title_of_name(type=:observation)]"
+  query_title_with_observations_of_name_synonym:  "[TYPES] with [:query_title_of_name_synonym(type=:observation)]"
+  query_title_with_observations_of_name_nonconsensus:  "[TYPES] with [:query_title_of_name_nonconsensus(type=:observation)]"
+
+  # Brief description of each query flavor.
+  query_help_comment_all:  all comments
+  query_help_comment_by_user:  comments created by a given user
+  query_help_comment_in_set:  comments in a given set
+  query_help_comment_for_object:  comments about a given object
+  query_help_comment_for_user:  comments sent to a given user
+  query_help_comment_pattern_search:  comments matching a search string
+  query_help_herbarium_record_in_herbarium:  records in a given fungarium
+  query_help_herbarium_record_for_observation:  records attached to a given observation
+  query_help_image_advanced_search:  images of observations matching advanced search criteria
+  query_help_image_all:  all images
+  query_help_image_by_user:  images created by a given user
+  query_help_image_in_set:  images in a given set
+  query_help_image_inside_observation:  images belonging to an outer observation query
+  query_help_image_pattern_search:  images matching a search_string
+  query_help_image_with_observations:  images of observations
+  query_help_image_with_observations_at_location:  images of observations at a defined location
+  query_help_image_with_observations_at_where:  images of observations at an undefined location
+  query_help_image_with_observations_by_user:  images of observations by a given user
+  query_help_image_with_observations_in_set:  images of observations in a given set
+  query_help_image_with_observations_in_species_list:  images of observations in a given species list
+  query_help_image_with_observations_of_children:  images of observations of children a given name
+  query_help_image_with_observations_of_name:  images of observations of a given name
+  query_help_location_advanced_search:  locations of observations matching advanced search criteria
+  query_help_location_all:  all locations
+  query_help_location_by_user:  locations created by a given user
+  query_help_location_by_editor:  locations modified by a given user
+  query_help_location_by_rss_log:  locations with recent activity
+  query_help_location_in_set:  locations in a given set
+  query_help_location_pattern_search:  locations matching a search string
+  query_help_location_with_descriptions:  locations with descriptions
+  query_help_location_with_descriptions_by_author:  locations with descriptions authored by a given user
+  query_help_location_with_descriptions_by_editor:  locations with descriptions edited by a given user
+  query_help_location_with_descriptions_by_user:  locations with descriptions created by a given user
+  query_help_location_with_descriptions_in_set:  locations with descriptions in a given set
+  query_help_location_with_observations:  locations of observations
+  query_help_location_with_observations_by_user:  locations of observations by a given user
+  query_help_location_with_observations_in_set:  locations of observations in a given set
+  query_help_location_with_observations_in_species_list:  locations of observations in a given species list
+  query_help_location_with_observations_of_children:  locations of observations of children of a given name
+  query_help_location_with_observations_of_name:  locations of observations of a given name
+  query_help_location_description_all:  all location descriptions
+  query_help_location_description_by_author:  location descriptions that list given user as an author
+  query_help_location_description_by_editor:  location descriptions that list given user as an editor
+  query_help_location_description_by_user:  location descriptions created by a given user
+  query_help_location_description_in_set:  location descriptions in a given set
+  query_help_name_advanced_search:  names of observations matching advanced search criteria
+  query_help_name_all:  all names
+  query_help_name_by_user:  names created by a given user
+  query_help_name_by_editor:  names modified by a given user
+  query_help_name_by_rss_log:  names with recent activity
+  query_help_name_in_set:  names in a given set
+  query_help_name_of_children:  names of children of a name
+  query_help_name_of_parents:  names of parents of a name
+  query_help_name_pattern_search:  names matching a search string
+  query_help_name_with_descriptions:  names with descriptions
+  query_help_name_with_descriptions_by_author:  names with descriptions authored by a given user
+  query_help_name_with_descriptions_by_editor:  names with descriptions edited by a given user
+  query_help_name_with_descriptions_by_user:  names with descriptions created by a given user
+  query_help_name_with_descriptions_in_set:  names with descriptions in a given set
+  query_help_name_with_observations:  names of observations, alphabetically
+  query_help_name_with_observations_at_location:  names of observations at a defined location
+  query_help_name_with_observations_at_where:  names of observations at an undefined location
+  query_help_name_with_observations_by_user:  names of observations by a given user
+  query_help_name_with_observations_in_set:  names of observations in a given set
+  query_help_name_with_observations_in_species_list:  names of observations in a given species list
+  query_help_name_description_all:  all name descriptions
+  query_help_name_description_by_author:  name descriptions that list a given user as an author
+  query_help_name_description_by_editor:  name descriptions that list a given user as an editor
+  query_help_name_description_by_user:  name descriptions created by a given user
+  query_help_name_description_in_set:  name descriptions in a given set
+  query_help_observation_advanced_search:  observations matching advanced search criteria
+  query_help_observation_all:  all observations
+  query_help_observation_at_location:  observations at a defined location
+  query_help_observation_at_where:  observations at an undefined location
+  query_help_observation_by_rss_log:  observations with recent activity
+  query_help_observation_by_user:  observations created by a given user
+  query_help_observation_in_set:  observations in a given set
+  query_help_observation_in_species_list:  observations in a given species list
+  query_help_observation_of_children:  observations of children of a given name
+  query_help_observation_of_name:  observations of a given name
+  query_help_observation_pattern_search:  observations matching a search string
+  query_help_project_all:  all projects
+  query_help_project_by_rss_log:  projects with recent activity
+  query_help_project_in_set:  projects in a given set
+  query_help_project_pattern_search:  projects matching a search string
+  query_help_rss_log_all:  all recent activity logs
+  query_help_rss_log_in_set:  activity logs in a given set
+  query_help_species_list_all:  all species lists
+  query_help_species_list_at_location:  species lists at a defined location
+  query_help_species_list_at_where:  species lists at an undefined location
+  query_help_species_list_by_rss_log:  species lists with recent activity
+  query_help_species_list_by_user:  species lists created by a given user
+  query_help_species_list_in_set:  species lists in a given set
+  query_help_species_list_pattern_search:  species lists matching a search string
+  query_help_user_all:  all users
+  query_help_user_in_set:  users in a given set
+  query_help_user_pattern_search:  users matching a search string
+
+  # Sorting criteria.
+  sort_by_code:  Code
+  sort_by_code_then_name:  Code and Name
+  sort_by_confidence:  "[:CONFIDENCE_LEVEL]"
+  sort_by_contribution:  Contribution
+  sort_by_copyright_holder:  "[:COPYRIGHT_HOLDER]"
+  sort_by_created_at:  Date Created
+  sort_by_date:  "[:DATE]"
+  sort_by_filename:  File Name
+  sort_by_header:  "Sort by:"
+  sort_by_herbarium_label:  Label
+  sort_by_herbarium_name:  Fungarium
+  sort_by_id:  ID
+  sort_by_image_quality:  Image Quality
+  sort_by_last_login:  Last Login
+  sort_by_location:  "[:LOCATION]"
+  sort_by_login:  "[:LOGIN_NAME]"
+  sort_by_name:  "[:NAME]"
+  sort_by_num_views:  Popularity
+  sort_by_number:  Number
+  sort_by_observation:  "[:OBSERVATION]"
+  sort_by_posted:  Date Posted
+  sort_by_records:  "#Records"
+  sort_by_reverse:  Reverse Order
+  sort_by_rss_log:  "[:sort_by_updated_at]"
+  sort_by_summary:  "[:SUMMARY]"
+  sort_by_thumbnail_quality:  Thumbnail Quality
+  sort_by_title:  "[:TITLE]"
+  sort_by_updated_at:  Time Last Modified
+  sort_by_user:  "[:USER]"
+  sort_by_where:  "[:LOCATION]"
+
+  ##############################################################################
+
+  # DEBUGGING STUFF -- this doesn't need translating
+
+  # observations/recalc
+  observer_recalc_old_name:  "old_name: [name]"
+  observer_recalc_new_name:  "new_name: [name]"
+  observer_recalc_caught_error:  "Caught exception: [error]"
+
+  # observer/status
+  system_status_browser_status_size:  Browser status cache size
+  system_status_clear_caches:  Clear Caches
+  system_status_gc:  GC
+  system_status_textile_name_size:  Textile name cache size
+  system_status_title:  Server Status

--- a/db/migrate/20221125111600_add_no_emails_to_users.rb
+++ b/db/migrate/20221125111600_add_no_emails_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNoEmailsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column(:users, :no_emails, :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_28_163200) do
+ActiveRecord::Schema.define(version: 2022_11_25_111600) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -684,6 +684,7 @@ ActiveRecord::Schema.define(version: 2022_09_28_163200) do
     t.string "content_filter"
     t.text "notes_template"
     t.boolean "blocked", default: false, null: false
+    t.boolean "no_emails", default: false, null: false
   end
 
   create_table "votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/controllers/emails_controller_test.rb
+++ b/test/controllers/emails_controller_test.rb
@@ -45,8 +45,12 @@ class EmailsControllerTest < FunctionalTestCase
     # Prove that trying to ask question of user who refuses questions
     # redirects to that user's page (instead of an email form).
     user = users(:no_general_questions_user)
-    login(user.name)
-    get(:ask_user_question, params: { id: user.id })
+    requires_login(:ask_user_question, id: user.id)
+    assert_flash_text(:permission_denied.t)
+
+    # Prove that it won't email someone who has opted out of all emails.
+    mary.update(no_emails: true)
+    requires_login(:ask_user_question, id: mary.id)
     assert_flash_text(:permission_denied.t)
   end
 

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1463,6 +1463,8 @@ class ObservationsControllerTest < FunctionalTestCase
     notifications = Notification.where(flavor: flavor, obj_id: name.id)
     assert_equal(2, notifications.length,
                  "Should be 2 name notifications for name ##{name.id}")
+    assert(notifications.map(&:user).include?(mary))
+    mary.update(no_emails: true)
 
     where = "Simple, Massachusetts, USA"
     generic_construct_observation({
@@ -1475,7 +1477,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_equal(where, obs.where) # Make sure it's the right observation
     assert_equal(name.id, nam.name_id) # Make sure it's the right name
     assert_not_nil(obs.rss_log)
-    assert_equal(count_before + 2, QueuedEmail.count)
+    assert_equal(count_before + 1, QueuedEmail.count)
     QueuedEmail.queue_emails(false)
   end
 

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -295,4 +295,11 @@ class ApplicationMailerTest < UnitTestCase
     assert_nil(ActionMailer::Base.deliveries.last,
                "Should not have delivered an email to 'bogus.address'.")
   end
+
+  def test_opt_out
+    mary.update(no_emails: true)
+    UserMailer.build(rolf, mary, "subject", "body").deliver_now
+    assert_nil(ActionMailer::Base.deliveries.last,
+               "Should not deliver email if recipient has opted out.")
+  end
 end


### PR DESCRIPTION
The purpose of this is to let admins essentially disable emails to users who have invalid email addresses.  One of the requirements for "responsible" emailers is that they not repeatedly try to send mail to nonexistent accounts.  But out users will occasionally deliberately change their address to a bogus address in order to prevent us from sending them emails.  (Even though they could simply uncheck all the email boxes on the preference form.)  And in some cases email accounts simply get closed out and no longer work.  In both cases I would like, as an admin, to be able to sudo over to that user and check the "opt out of all emails" preference to stop MO from trying to send mail to bogus addresses.