### PR TITLE
Bump Brakeman

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (5.3.1)
+    brakeman (5.4.0)
     browser (5.3.1)
     builder (3.2.4)
     bullet (7.0.2)


### PR DESCRIPTION
Upgrade Brakeman from 5.3.1 to 5.4.0
See https://brakemanscanner.org/blog/2022/11/17/brakeman-5-dot-4-dot-0-released