### PR TITLE
Update `.gitignore` to ignore `.vscode` config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ production-logs
 rubocop.out
 coverage
 
+# Ignore VS Code config
+.vscode
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 


### PR DESCRIPTION
That's all this does. 

(My) personal workspace configuration of the text editor doesn't need to be in the repo.

Merging immediately.