### PR TITLE
Add integration test for unverified user trying to login

### DIFF
--- a/app/controllers/account/verifications_controller.rb
+++ b/app/controllers/account/verifications_controller.rb
@@ -68,7 +68,7 @@ module Account
       raise("This action should never occur!")
     end
 
-    # This is used by the "reverify" page to re-send the verification email.
+    # Route linked from the "reverify" template. Re-sends verification email.
     def resend_email
       return unless (user = find_or_goto_index(User, params[:id]))
 
@@ -82,7 +82,6 @@ module Account
     def self.notify_root_of_verification_email(user)
       url = "#{MO.http_domain}/account/verify/#{user.id}?" \
             "auth_code=#{user.auth_code}"
-      # url = account_verify_url(id: user.id, auth_code: user.auth_code)
       subject = :email_subject_verify.l
       content = :email_verify_intro.tp(user: user.login, link: url)
       content = "email: #{user.email}\n\n" + content.html_to_ascii

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -517,10 +517,14 @@ class String
       html_safe # rubocop:disable Rails/OutputSafety
   end
 
-  # For integration test comparisons:
-  # Render special encoded characters as they appear in HTML
-  def render_html
+  # Render special encoded characters as regular characters in HTML
+  def unescape_html
     CGI.unescapeHTML(self)
+  end
+
+  # For integration test comparisons: the whole string as rendered in browser
+  def as_displayed
+    unescape_html.strip_squeeze
   end
 
   # Insert a line break between the scientific name and the author

--- a/app/views/account/verifications/reverify.html.erb
+++ b/app/views/account/verifications/reverify.html.erb
@@ -6,4 +6,4 @@
 <%= post_button(name: :reverify_link.t,
                 path: account_resend_verification_email_path(
                         id: @unverified_user.id),
-                id: "account_reverify_link") %>
+                class: "btn btn-primary", id: "account_reverify_link") %>

--- a/app/views/account/verifications/reverify.html.erb
+++ b/app/views/account/verifications/reverify.html.erb
@@ -5,4 +5,5 @@
 <%= :reverify_note.tp(user: @unverified_user.login) + :email_spam_notice.tp %>
 <%= post_button(name: :reverify_link.t,
                 path: account_resend_verification_email_path(
-                        id: @unverified_user.id)) %>
+                        id: @unverified_user.id),
+                id: "account_reverify_link") %>

--- a/test/capybara_session_extensions.rb
+++ b/test/capybara_session_extensions.rb
@@ -61,6 +61,25 @@ module CapybaraSessionExtensions
     params["q"]
   end
 
+  # Mail parsing methods. Pass `pos` to get nth-from-last mail delivered
+  def delivered_mail(pos = 1)
+    ActionMailer::Base.deliveries.last(pos).first
+  end
+
+  # Just the HTML
+  def delivered_mail_html(pos = 1)
+    delivered_mail(pos).body.raw_source
+  end
+
+  def delivered_mail_data(pos = 1)
+    Nokogiri::HTML(delivered_mail_html(pos))
+  end
+
+  def first_link_in_mail(pos = 1)
+    href_value = delivered_mail_data(pos).at_css("a")[:href]
+    URI.parse(href_value).request_uri
+  end
+
   def assert_flash_text(text = "")
     assert_selector("#flash_notices")
     assert_selector("#flash_notices", text: text)

--- a/test/integration/capybara/account_test.rb
+++ b/test/integration/capybara/account_test.rb
@@ -79,7 +79,7 @@ class AccountTest < CapybaraIntegrationTestCase
       fill_in("user_password", with: "Hagrid_24!")
       click_commit
     end
-    # Should render reverify action where he can get another email link
+    # Should render reverify action where they can get another email link
     assert_button("account_reverify_link")
 
     # He receives an email with this link. A GET to this path should verify 'm

--- a/test/integration/capybara/account_test.rb
+++ b/test/integration/capybara/account_test.rb
@@ -70,6 +70,18 @@ class AccountTest < CapybaraIntegrationTestCase
     wizard = User.find_by(email: "webmaster@hogwarts.org")
     assert_false(wizard.verified)
 
+    # Actually happens: User tries to sign in immediately, without verifying
+    click_link(id: "nav_login_link")
+    assert_selector("body.login__new")
+
+    within("#account_login_form") do
+      fill_in("user_login", with: "Dumbledore")
+      fill_in("user_password", with: "Hagrid_24!")
+      click_commit
+    end
+    # Should render reverify action where he can get another email link
+    assert_button("account_reverify_link")
+
     # He receives an email with this link. A GET to this path should verify 'm
     visit(account_verify_email_path(id: wizard.id, auth_code: wizard.auth_code))
     assert_true(wizard.reload.verified)


### PR DESCRIPTION
This was the actual issue encountered in the wild. 

Logging in an unverified user tried to render a route, but it should have called `render` on the path to the template. This tests that scenario, that they actually get to a `reverify` link.