### PR TITLE
Rename `String#unescape_html` just in case

### DIFF
--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -518,13 +518,13 @@ class String
   end
 
   # Render special encoded characters as regular characters in HTML
-  def unescape_html
-    CGI.unescapeHTML(self)
+  def decode_html_entities
+    HTMLEntities.new.decode(self)
   end
 
   # For integration test comparisons: the whole string as rendered in browser
   def as_displayed
-    unescape_html.strip_squeeze
+    decode_html_entities.strip_squeeze
   end
 
   # Insert a line break between the scientific name and the author


### PR DESCRIPTION
Plus, call a different Ruby class that is [more appropriate for what this method does](https://stackoverflow.com/questions/32065012/ruby-unescape-html-string), and handles stuff like `&mdash;`.

