### PR TITLE
Bump gem versions for three recent Dependabot security updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,12 +35,15 @@ group :rails do
   gem("sprockets-rails")
 end
 
-# security fix for CVE-2021-41817 regex denial of service vulnerability
+# Security fix updates via Dependabot
+# CVE-2021-41817 regex denial of service vulnerability
 gem("date", ">= 3.2.1")
-
-# security fix for CVE-2022-23476 unchecked return value from
-# xmlTextReaderExpand
+# CVE-2022-23476
 gem("nokogiri", ">= 1.13.10")
+# CVE-2022-23515
+gem("loofah", ">= 2.19.1")
+# CVE-2022-23518
+gem("rails-html-sanitizer", ">= 1.4.4")
 
 # Use mysql2 as db connector
 # See https://github.com/brianmario/mysql2

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,10 @@ end
 # security fix for CVE-2021-41817 regex denial of service vulnerability
 gem("date", ">= 3.2.1")
 
+# security fix for CVE-2022-23476 unchecked return value from
+# xmlTextReaderExpand
+gem("nokogiri", ">= 1.13.10")
+
 # Use mysql2 as db connector
 # See https://github.com/brianmario/mysql2
 gem("mysql2")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     kgio (2.11.4)
     libv8-node (16.10.0.0-arm64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
-    loofah (2.18.0)
+    loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -181,8 +181,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
     railties (6.1.6.1)
       actionpack (= 6.1.6.1)
       activesupport (= 6.1.6.1)
@@ -309,6 +309,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-slick-rails
+  loofah (>= 2.19.1)
   mail
   mimemagic
   mini_racer
@@ -323,6 +324,7 @@ DEPENDENCIES
   nokogiri (>= 1.13.10)
   rack-cors
   rails-controller-testing
+  rails-html-sanitizer (>= 1.4.4)
   railties (~> 6.1)
   rtf
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,16 +159,16 @@ GEM
       timeout
     net-smtp (0.3.2)
       net-protocol
-    nokogiri (1.13.9-arm64-darwin)
+    nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.9-x86_64-linux)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
     promise.rb (0.7.4)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.1)
     rack (2.2.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -320,6 +320,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  nokogiri (>= 1.13.10)
   rack-cors
   rails-controller-testing
   railties (~> 6.1)


### PR DESCRIPTION
For some reason the dependabot PRs don't pass tests, they lack the Rails credentials. 
This PR does the same updates "manually": #1216 #1234 & #1235.

Gems updated: `nokogiri 1.13.10`, `loofah 2.19.1`, `rails-html-sanitizer 1.4.4`