### PR TITLE
Update paths for `Textile` lookups

### DIFF
--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -393,7 +393,7 @@ class Textile < String
       id.gsub!(/&#822[01];/, '"')
       id = CGI.unescapeHTML(id)
       id = CGI.escape(id)
-      url = "#{MO.http_domain}/observer/lookup_#{type.downcase}/#{id}"
+      url = "#{MO.http_domain}/lookups/lookup_#{type.downcase}/#{id}"
       "<a href=\"#{url}\">#{label}</a>"
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -846,7 +846,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
     patch("#{controller}/#{action}", controller: controller, action: action)
   end
 
-  # Accept non-numeric ids for the /observer/lookup_xxx/id actions.
+  # Accept non-numeric ids for the /lookups/lookup_xxx/id actions.
   LOOKUP_ACTIONS.each do |action|
     get("lookups/#{action}(/:id)", to: "lookups##{action}", id: /\S.*/)
     get("/observer/#{action}(/:id)", to: "lookups##{action}", id: /\S.*/)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -848,13 +848,12 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
 
   # Accept non-numeric ids for the /lookups/lookup_xxx/id actions.
   LOOKUP_ACTIONS.each do |action|
-    get("lookups/#{action}(/:id)", to: "lookups##{action}", id: /\S.*/)
-    get("/observer/#{action}(/:id)", to: "lookups##{action}", id: /\S.*/)
+    get("/lookups/#{action}(/:id)", to: "lookups##{action}", id: /\S.*/)
   end
 
   # declare routes for the actions in the ACTIONS hash
   route_actions_hash
 
   # routes for actions that Rails automatically creates from view templates
-  MO.themes.each { |scheme| get "theme/#{scheme}" }
+  MO.themes.each { |scheme| get "/theme/#{scheme}" }
 end

--- a/test/integration/rails-dom-testing/amateur_test.rb
+++ b/test/integration/rails-dom-testing/amateur_test.rb
@@ -178,7 +178,7 @@ class AmateurTest < IntegrationTestCase
     # (There should be a link in there to look up Xylaria polymorpha.)
     assert_select("a[href*=lookup_name]", 1) do |links|
       url = links.first.attributes["href"]
-      assert_equal("#{MO.http_domain}/observer/lookup_name/Xylaria+polymorpha",
+      assert_equal("#{MO.http_domain}/lookups/lookup_name/Xylaria+polymorpha",
                    url.value)
     end
 

--- a/test/models/textile_test.rb
+++ b/test/models/textile_test.rb
@@ -174,7 +174,7 @@ class TextileTest < UnitTestCase
     loc = "OSU, Corvallis, Oregon, USA"
     textile = "_location #{loc}_".tpl
     assert_match(
-      "#{MO.http_domain}/observer/lookup_location/#{CGI.escape(loc)}", # href
+      "#{MO.http_domain}/lookups/lookup_location/#{CGI.escape(loc)}", # href
       textile
     )
     assert_match("<i>#{loc}</i>", textile) # anchor text
@@ -182,7 +182,7 @@ class TextileTest < UnitTestCase
 
   def test_url_formatting
     assert_href_equal(
-      "#{MO.http_domain}/observer/lookup_name/Amanita+%22sp-O01%22",
+      "#{MO.http_domain}/lookups/lookup_name/Amanita+%22sp-O01%22",
       '_Amanita "sp-O01"_'
     )
     assert_href_equal("http://www.amanitaceae.org?Amanita+sp-O01",


### PR DESCRIPTION
Belatedly. 
From `observer/lookup_{path}` to `lookups/lookup_{path}` for actions handled by the 'LookupsController`

Deletes the redirect for the old `observer/` paths, not necessary any more since calls to these actions come from MO itself. (The redirect works though, that is why i didn't notice the old paths still in the Textile class and test.)