### PR TITLE
Remove `flavor` from `Notification`

### DIFF
--- a/app/controllers/name_controller.rb
+++ b/app/controllers/name_controller.rb
@@ -1062,9 +1062,8 @@ class NameController < ApplicationController
     @name = find_or_goto_index(Name, name_id)
     return unless @name
 
-    flavor = Notification.flavors[:name]
     @notification = Notification.
-                    find_by(flavor: flavor, obj_id: name_id, user_id: @user.id)
+                    find_by(obj_id: name_id, user_id: @user.id)
     if request.method == "POST"
       submit_tracking_form(name_id)
     else
@@ -1094,8 +1093,7 @@ class NameController < ApplicationController
       note_template = params[:notification][:note_template]
       note_template = nil if note_template.blank?
       if @notification.nil?
-        @notification = Notification.new(flavor: "name",
-                                         user: @user,
+        @notification = Notification.new(user: @user,
                                          obj_id: name_id,
                                          note_template: note_template)
         flash_notice(:email_tracking_now_tracking.t(name: @name.display_name))

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -105,8 +105,7 @@ module Name::Format
   end
 
   def interests_plus_notifications
-    interests.count +
-      Notification.where(flavor: Notification.flavors[:name], obj_id: id).count
+    interests.count + Notification.where(obj_id: id).count
   end
 
   #############################################################################

--- a/app/models/name/merge.rb
+++ b/app/models/name/merge.rb
@@ -49,8 +49,7 @@ module Name::Merge
     end
 
     # Move over any notifications on the old name.
-    Notification.where(flavor: Notification.flavors[:name],
-                       obj_id: old_name.id).find_each do |note|
+    Notification.where(obj_id: old_name.id).find_each do |note|
       note.obj_id = id
       note.save
     end

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -166,9 +166,8 @@ class Naming < AbstractModel
     taxa.push(name)
     taxa.push(Name.find_by(text_name: "Lichen")) if name.is_lichen?
     done_user = {}
-    flavor = Notification.flavors[:name]
     taxa.each do |taxon|
-      Notification.where(flavor: flavor, obj_id: taxon.id).includes(:user).
+      Notification.where(obj_id: taxon.id).includes(:user).
         find_each do |n|
         next unless (n.user_id != user.id) && !done_user[n.user_id] &&
                     (!n.require_specimen || observation.specimen)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,14 +8,9 @@
 #  id::               Locally unique numerical id, starting at 1
 #  updated_at::       Date/time it was last updated
 #  user::             User who created it
-#  flavor::           Type of Notification
 #  obj_id::           Id of principal object
 #  note_template::   Template for an email, context depends on Notification type
 #  require_specimen:: Require observation to have a specimen?
-#
-#  == Class methods
-#
-#  all_flavors::       List of Notifcation types available.
 #
 #  == Instance methods
 #
@@ -34,18 +29,6 @@ class Notification < AbstractModel
 
   scope :for_user,
         ->(user) { where(user: user) }
-
-  # Do not change the integer associated with a value
-  enum flavor:
-       {
-         name: 1
-       },
-       _suffix: :flavor
-
-  # List of all available flavors (strings).
-  def self.all_flavors
-    flavors.keys
-  end
 
   # Create body of the email we're about to send.  Each flavor requires a
   # different set of arguments:

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -54,14 +54,14 @@ class Notification < AbstractModel
   #   user::      Owner of Observation.
   #   naming::    Naming that triggered this email.
   #
-  def calc_note(args) # rubocop:disable Metrics/AbcSize
-    return nil unless (template = note_template) && flavor == "name"
+  def calc_note(args)
+    return nil unless (template = note_template)
 
     tracker  = user
     observer = args[:user]
     naming   = args[:naming]
-    raise("Missing 'user' argument for #{flavor} notification.") unless observer
-    raise("Missing 'naming' argument for #{flavor} notification.") unless naming
+    raise("Missing 'user' argument for name notification.") unless observer
+    raise("Missing 'naming' argument for name notification.") unless naming
 
     template.
       gsub(":observer", observer.login).
@@ -77,16 +77,12 @@ class Notification < AbstractModel
   # name::   Name that User is tracking.
   #
   def target
-    @target ||= flavor == "name" ? Name.find(obj_id) : nil
+    @target ||= Name.find(obj_id)
   end
 
   # Return a string summarizing what this Notification is about.
   def summary
-    if flavor == "name"
-      "#{:TRACKING.l} #{:name.l}: #{target ? target.display_name : "?"}"
-    else
-      "Unrecognized notification flavor"
-    end
+    "#{:TRACKING.l} #{:name.l}: #{target ? target.display_name : "?"}"
   end
   alias text_name summary
 
@@ -96,11 +92,9 @@ class Notification < AbstractModel
   #
   def link_params
     result = {}
-    if flavor == "name"
-      result[:controller] = :name
-      result[:action] = :email_tracking
-      result[:id] = obj_id
-    end
+    result[:controller] = :name
+    result[:action] = :email_tracking
+    result[:id] = obj_id
     result
   end
 

--- a/app/views/naming_observer_mailer/build.html.erb
+++ b/app/views/naming_observer_mailer/build.html.erb
@@ -1,12 +1,12 @@
 <%
-  case @notification.flavor.to_s
-  when "name"
+  # case @notification.flavor.to_s
+  # when "name"
     obj  = @naming.observation
     type = :observation
-  else
-    obj  = @notification.object
-    type = obj.type_tag
-  end
+  # else
+  #   obj  = @notification.object
+  #   type = obj.type_tag
+  # end
 
   intro = :email_naming_for_observer_intro.l(
     user:  @notification.user.legal_name,
@@ -27,13 +27,13 @@
   handy_links.sub!(/\n*\Z/, "\n" + :email_handy_links.l)
 
   links = []
-  if obj.class.controller_normalized?
+  # if obj.class.controller_normalized?
     links.push([:email_links_show_object.t(type: type),
-      "#{MO.http_domain}#{obj.show_controller}/#{obj.id}"])
-  else
-    links.push([:email_links_show_object.t(type: type),
-      "#{MO.http_domain}#{obj.show_controller}/#{obj.show_action}/#{obj.id}"])
-  end
+      "#{MO.http_domain}/#{obj.id}"])
+  # else
+  #   links.push([:email_links_show_object.t(type: type),
+  #     "#{MO.http_domain}#{obj.show_controller}/#{obj.show_action}/#{obj.id}"])
+  # end
 
   links.push([:email_links_latest_changes.t,
     MO.http_domain])

--- a/db/migrate/20221215065834_remove_flavor_from_notifications.rb
+++ b/db/migrate/20221215065834_remove_flavor_from_notifications.rb
@@ -1,0 +1,5 @@
+class RemoveFlavorFromNotifications < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :notifications, :flavor, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_25_111600) do
+ActiveRecord::Schema.define(version: 2022_12_15_065834) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -426,7 +426,6 @@ ActiveRecord::Schema.define(version: 2022_11_25_111600) do
 
   create_table "notifications", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
-    t.integer "flavor"
     t.integer "obj_id"
     t.text "note_template"
     t.datetime "updated_at"

--- a/test/application_mailer/naming_for_observer.html
+++ b/test/application_mailer/naming_for_observer.html
@@ -15,7 +15,7 @@ Subject: [MO] Research Request
 <div class="textile"><p>It is entirely up to you whether you want to reply to Mary Newbie (mary&#64;collectivesource.com) by replying directly to this email.<br />
 Here are some handy links:</p></div>
 <ul type=none>
-<li>Show this observation: <a href="https://mushroomobserver.org/observations/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %>">https://mushroomobserver.org/observations/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %></a></li>
+<li>Show this observation: <a href="https://mushroomobserver.org/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %>">https://mushroomobserver.org/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %></a></li>
 <li>Latest changes at Mushroom Observer: <a href="https://mushroomobserver.org">https://mushroomobserver.org</a></li>
 </ul>
 <div class="textile"><p>WARNING: We&#8217;ve heard that some people have mis-used this notification feature in the past, claiming it&#8217;s for research but not using specimens for that purpose. You may want to take a moment to look at their user profile on MO and perhaps google them to verify that they are actually active mycologists before going to the effort of packaging and sending them any specimens.</p></div>

--- a/test/application_mailer/naming_for_observer.text
+++ b/test/application_mailer/naming_for_observer.text
@@ -14,7 +14,7 @@ A note about https://mushroomobserver.org/<%= ActiveRecord::FixtureSet.identify(
 It is entirely up to you whether you want to reply to Mary Newbie (mary@collectivesource.com) by replying directly to this email.
 Here are some handy links:
 
-Show this observation: https://mushroomobserver.org/observations/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %>
+Show this observation: https://mushroomobserver.org/<%= ActiveRecord::FixtureSet.identify(:agaricus_campestris_obs) %>
 Latest changes at Mushroom Observer: https://mushroomobserver.org
 
 WARNING: We've heard that some people have mis-used this notification feature in the past, claiming it's for research but not using specimens for that purpose. You may want to take a moment to look at their user profile on MO and perhaps google them to verify that they are actually active mycologists before going to the effort of packaging and sending them any specimens.

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -4237,9 +4237,7 @@ class NameControllerTest < FunctionalTestCase
   def test_email_tracking_enable_no_note
     name = names(:conocybe_filaris)
     count_before = Notification.count
-    flavor = Notification.flavors[:name]
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert_nil(notification)
     params = {
       id: name.id,
@@ -4252,8 +4250,7 @@ class NameControllerTest < FunctionalTestCase
     # This is needed before the next find for some reason
     count_after = Notification.count
     assert_equal(count_before + 1, count_after)
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert(notification)
     assert_nil(notification.note_template)
     assert_nil(
@@ -4265,9 +4262,7 @@ class NameControllerTest < FunctionalTestCase
   def test_email_tracking_enable_with_note
     name = names(:conocybe_filaris)
     count_before = Notification.count
-    flavor = Notification.flavors[:name]
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert_nil(notification)
     params = {
       id: name.id,
@@ -4282,8 +4277,7 @@ class NameControllerTest < FunctionalTestCase
     # This is needed before the next find for some reason
     count_after = Notification.count
     assert_equal(count_before + 1, count_after)
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert(notification)
     assert(notification.note_template)
     assert(notification.calc_note(user: mary,
@@ -4293,9 +4287,7 @@ class NameControllerTest < FunctionalTestCase
   def test_email_tracking_update_add_note
     name = names(:coprinus_comatus)
     count_before = Notification.count
-    flavor = Notification.flavors[:name]
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert(notification)
     assert_nil(notification.note_template)
     params = {
@@ -4311,8 +4303,7 @@ class NameControllerTest < FunctionalTestCase
     # This is needed before the next find for some reason
     count_after = Notification.count
     assert_equal(count_before, count_after)
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert(notification)
     assert(notification.note_template)
     assert(notification.calc_note(user: rolf,
@@ -4321,9 +4312,7 @@ class NameControllerTest < FunctionalTestCase
 
   def test_email_tracking_disable
     name = names(:coprinus_comatus)
-    flavor = Notification.flavors[:name]
-    notification = Notification.
-                   find_by(flavor: flavor, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert(notification)
     params = {
       id: name.id,
@@ -4335,8 +4324,7 @@ class NameControllerTest < FunctionalTestCase
     login("rolf")
     post(:email_tracking, params: params)
     assert_redirected_to(action: :show_name, id: name.id)
-    notification = Notification.
-                   find_by(flavor: :name, obj_id: name.id, user_id: rolf.id)
+    notification = Notification.find_by(obj_id: name.id, user_id: rolf.id)
     assert_nil(notification)
   end
 

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1462,8 +1462,7 @@ class ObservationsControllerTest < FunctionalTestCase
     QueuedEmail.queue_emails(true)
     count_before = QueuedEmail.count
     name = names(:agaricus_campestris)
-    flavor = Notification.flavors[:name]
-    notifications = Notification.where(flavor: flavor, obj_id: name.id)
+    notifications = Notification.where(obj_id: name.id)
     assert_equal(2, notifications.length,
                  "Should be 2 name notifications for name ##{name.id}")
     assert(notifications.map(&:user).include?(mary))

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -5,7 +5,6 @@
 # Specify obj association with id, not label.
 
 DEFAULTS: &DEFAULTS
-  flavor: <%= Notification.flavors[:name] %>
   obj_id: <%= ActiveRecord::FixtureSet.identify(:agaricus_campestris) %>
 
 coprinus_comatus_notification:
@@ -26,8 +25,3 @@ no_observation_notification:
   <<: *DEFAULTS
   user: dick
   obj_id: <%= ActiveRecord::FixtureSet.identify(:notification_but_no_observation) %>
-
-bad_flavor_notification:
-  <<: *DEFAULTS
-  user: mary
-  flavor: -1  # non-existent flavor

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -9,8 +9,8 @@ class NotificationTest < UnitTestCase
     obj = Name.find(notification.obj_id)
     assert_match(obj.display_name, notification.summary)
 
-    notification = notifications(:bad_flavor_notification)
-    assert_equal("Unrecognized notification flavor", notification.summary)
+    # notification = notifications(:bad_flavor_notification)
+    # assert_equal("Unrecognized notification flavor", notification.summary)
   end
 
   def test_no_user


### PR DESCRIPTION
This is in preparation for renaming `Notification` > `NameTracker` and making it one of the possible targets of an `Interest`.
Discussion here: #1237

**Note**: This drops the column `notifications.flavor` from the DB. Please review!

Background: Notifications are only used to track names (namings). Possible other projected "flavors" of notifications, which have not yet been built, could now be achieved by making other models like this, trackers that target objects, and hold mail templates and other data. 

Interests could then target any of these tracker classes.

The goal is to clear up the functional overlap between Interests and Notifications.