### PR TITLE
Added max-width and max-height to images inside textile divs.

### DIFF
--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -82,3 +82,8 @@ ul.tight-list {
   margin-bottom: 0.5em;
   padding-left: 1em;
 }
+
+div.textile img {
+  max-width: 100%;
+  max-height: auto;
+}


### PR DESCRIPTION
Oh my god, it's so fast!  I just want to fix everything on MO now.  I need a better internet connection!!!! ;)

The problem this PR solves is that user content sometimes is _way_ too big for the container.  A common example is including images in-line in comments.  If they are too large they overflow and cover other parts of the page.  This PR puts a max-width:100% max-height:auto on all images inside textile divs.

It may be worth expanding this to other images later, but for now, I'm trying to be careful to limit any unintended side-effects to images inside user content.

Thanks to Nimmo for supplying the magic CSS that solevs the problem.