### PR TITLE
Supply string instead of PathName to `require`

### DIFF
--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -11,7 +11,7 @@ namespace :email do
 
   desc "Send queued emails"
   task(send: :environment) do
-    require Rails.root.join("/app/extensions/extensions.rb")
+    require Rails.root.join("/app/extensions/extensions.rb").to_s
     count = 0
     # for e in QueuedEmail.find(:all) # Rails 3
     QueuedEmail.all.each do |e|


### PR DESCRIPTION
Fixes bug in rake Send queued emails.
Bug was introduced in PR #1241