### PR TITLE
Remove unused method from `ObservationTabsHelper`

### DIFF
--- a/app/helpers/observation_tabs_helper.rb
+++ b/app/helpers/observation_tabs_helper.rb
@@ -67,17 +67,4 @@ module ObservationTabsHelper
       destroy_button(target: obs)
     ]
   end
-
-  def prefs_tabset
-    tabs = [
-      link_to(:bulk_license_link.t,
-              controller: :image, action: :license_updater),
-      link_to(:prefs_change_image_vote_anonymity.t,
-              controller: :image, action: :bulk_vote_anonymity_updater),
-      link_to(:profile_link.t, action: :profile),
-      link_to(:show_user_your_notifications.t, interests_path),
-      link_to(:account_api_keys_link.t, action: :api_keys)
-    ]
-    { right: draw_tab_set(tabs) }
-  end
 end


### PR DESCRIPTION
The `prefs_tabset` has since a few months been moved to the account preferences view. 

This just deletes the method that used to define the tabset, back when `AccountController` was part of `ObserverController`.