### PR TITLE
Delete stray slash in path

### DIFF
--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -24,7 +24,7 @@ namespace :email do
         # This shouldn't happen, but just in case, better safe...)
         if e.to_user
           result = nil
-          Rails.root.join("/log/email-low-level.log").open("a") do |fh|
+          Rails.root.join("log/email-low-level.log").open("a") do |fh|
             fh.puts("sending #{e.id.inspect}...")
             result = e.send_email
             fh.puts(


### PR DESCRIPTION
Hopefully fixes
>rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - /log/email-low-level.log /var/web/mo/lib/tasks/email.rake:27:in `initialize' /var/web/mo/lib/tasks/email.rake:27:in `open'
/var/web/mo/lib/tasks/email.rake:27:in `open'
/var/web/mo/lib/tasks/email.rake:27:in `block (3 levels) in <top (required)>' /usr/local/rvm/gems/ruby-3.1.2/gems/activerecord-6.1.6.1/lib/active_record/relation/delegation.rb:88:in `each' /usr/local/rvm/gems/ruby-3.1.2/gems/activerecord-6.1.6.1/lib/active_record/relation/delegation.rb:88:in `each' /var/web/mo/lib/tasks/email.rake:18:in `block (2 levels) in <top (required)>' Tasks: TOP => email:send
(See full trace by running task with --trace)