### PR TITLE
Add `no_emails: false` default to user fixtures

### DIFF
--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -17,6 +17,7 @@ DEFAULTS: &DEFAULTS
   verified:       <%= Time.now.strftime("%F %T")%>
   user_groups:    all_users, $LABEL_only
   votes_anonymous: <%= User.votes_anonymous[:no] %>
+  no_emails:      false
 
 # Rolf is an experienced user
 # Also the default user for Images fixtures


### PR DESCRIPTION
This repairs an intermittent test failure (discovered by @JoeCohen on a certain test seed, via `rails t -n /CommentTest/  --seed 53296`) where expected emails are not sent out in tests.