### PR TITLE
Really fix Comment email test error

### DIFF
--- a/app/models/queued_email.rb
+++ b/app/models/queued_email.rb
@@ -210,7 +210,6 @@ class QueuedEmail < AbstractModel
          queued_email_integers.map { |x| "#{x.key}=#{x.value}" }.join(" ") +
          queued_email_strings.map { |x| "#{x.key}=\"#{x.value}\"" }.join(" "))
     current_locale = I18n.locale
-    # unless MO.queue_email || @@queue
     unless MO.queue_email || QueuedEmail.queue
       deliver_email if RunLevel.is_normal?
       destroy

--- a/app/models/queued_email.rb
+++ b/app/models/queued_email.rb
@@ -151,17 +151,14 @@ class QueuedEmail < AbstractModel
     @@all_flavors
   end
 
-  @@queue = false
   # This lets me turn queuing on in unit tests.
   #
   #   # Turn on queuing.
-  #   QueuedEmail.queue_emails(true)
+  #   QueuedEmail.queue = true
   #
   #   # Turn off queuing.
-  #   QueuedEmail.queue_emails(false)
-  def self.queue_emails(state)
-    @@queue = state
-  end
+  #   QueuedEmail.queue = false
+  cattr_accessor(:queue, default: false)
 
   # Create new email and save it.
   #
@@ -213,7 +210,8 @@ class QueuedEmail < AbstractModel
          queued_email_integers.map { |x| "#{x.key}=#{x.value}" }.join(" ") +
          queued_email_strings.map { |x| "#{x.key}=\"#{x.value}\"" }.join(" "))
     current_locale = I18n.locale
-    unless MO.queue_email || @@queue
+    # unless MO.queue_email || @@queue
+    unless MO.queue_email || QueuedEmail.queue
       deliver_email if RunLevel.is_normal?
       destroy
     end

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -4354,7 +4354,7 @@ class NameControllerTest < FunctionalTestCase
   end
 
   def test_approve_tracker_with_template
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
     assert_equal(0, QueuedEmail.count)
 
     tracker = name_trackers(:agaricus_campestris_name_tracker_with_note)
@@ -4383,7 +4383,7 @@ class NameControllerTest < FunctionalTestCase
     assert_flash_warning
     assert(tracker.reload.approved)
     assert_equal(1, QueuedEmail.count)
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   # ----------------------------

--- a/test/controllers/name_controller_test.rb
+++ b/test/controllers/name_controller_test.rb
@@ -4383,6 +4383,7 @@ class NameControllerTest < FunctionalTestCase
     assert_flash_warning
     assert(tracker.reload.approved)
     assert_equal(1, QueuedEmail.count)
+    QueuedEmail.queue_emails(false)
   end
 
   # ----------------------------

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1440,7 +1440,7 @@ class ObservationsControllerTest < FunctionalTestCase
   end
 
   def test_create_observation_that_generates_email
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
     count_before = QueuedEmail.count
     name = names(:agaricus_campestris)
     name_trackers = NameTracker.where(name: name)
@@ -1461,7 +1461,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_equal(name.id, nam.name_id) # Make sure it's the right name
     assert_not_nil(obs.rss_log)
     assert_equal(count_before + 1, QueuedEmail.count)
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_create_observation_with_decimal_geolocation_and_unknown_name

--- a/test/mailers/queued_email_test.rb
+++ b/test/mailers/queued_email_test.rb
@@ -4,12 +4,12 @@ require("test_helper")
 
 class QueuedEmailTest < UnitTestCase
   def setup
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
     super
   end
 
   def teardown
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
     super
   end
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -116,7 +116,7 @@ class LocationTest < UnitTestCase
     loc  = locations(:albion)
     desc = location_descriptions(:albion_desc)
 
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
     QueuedEmail.all.map(&:destroy)
     location_version = loc.version
     description_version = desc.version
@@ -319,7 +319,7 @@ class LocationTest < UnitTestCase
                  old_description_version: desc.version,
                  new_description_version: desc.version)
     assert_equal(4, QueuedEmail.count)
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_parse_latitude

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1953,7 +1953,7 @@ class NameTest < UnitTestCase
     desc.reload
     name_version = name.version
     description_version = desc.version
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
     QueuedEmail.all.map(&:destroy)
 
     assert_equal(0, desc.authors.length)
@@ -2170,7 +2170,7 @@ class NameTest < UnitTestCase
                  old_description_version: 0,
                  new_description_version: 0,
                  review_status: "no_change")
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_misspelling

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -193,7 +193,7 @@ class ObservationTest < UnitTestCase
   # --------------------------------------
   def test_email_notification_1
     NameTracker.all.map(&:destroy)
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
 
     obs = observations(:coprinus_comatus_obs)
 
@@ -266,12 +266,12 @@ class ObservationTest < UnitTestCase
     obs.change_vote(new_naming, 3)
     assert_equal(names(:peltigera), obs.reload.name)
     assert_equal(2, QueuedEmail.count)
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_email_notification_2
     NameTracker.all.map(&:destroy)
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
 
     obs = observations(:coprinus_comatus_obs)
 
@@ -351,12 +351,12 @@ class ObservationTest < UnitTestCase
                  from: rolf,
                  to: mary,
                  comment: new_comment.id)
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_email_notification_3
     NameTracker.all.map(&:destroy)
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
 
     obs = observations(:coprinus_comatus_obs)
 
@@ -461,12 +461,12 @@ class ObservationTest < UnitTestCase
                  to: dick,
                  observation: observations(:coprinus_comatus_obs).id,
                  note: "notes,location,added_image,removed_image")
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_email_notification_4
     NameTracker.all.map(&:destroy)
-    QueuedEmail.queue_emails(true)
+    QueuedEmail.queue = true
 
     obs = observations(:coprinus_comatus_obs)
     marys_interest = Interest.create(
@@ -534,7 +534,7 @@ class ObservationTest < UnitTestCase
                  observation: 0,
                  note: "**__Coprinus comatus__** (O.F. Müll.) Pers. " \
                        "(#{observations(:coprinus_comatus_obs).id})")
-    QueuedEmail.queue_emails(false)
+    QueuedEmail.queue = false
   end
 
   def test_vote_favorite


### PR DESCRIPTION
The new test for name tracker emails turns `queue_emails(true)` on, but forgets to set it back to `false`.

It seems that this only causes an issue if the `CommentTest` runs after `NameControllerTest`. 