### PR TITLE
Repair observation form map

### DIFF
--- a/app/assets/javascripts/observation_form_map.js
+++ b/app/assets/javascripts/observation_form_map.js
@@ -9,17 +9,15 @@ var GMAPS_API_SCRIPT = "https://maps.googleapis.com/maps/api/js?key=" +
 // ./observations/new
 $(document).ready(function () {
   var opened = false;
-  var map_div = $('#observationFormMap');
+  // NOTE: for gmap, map_div can't be a jQuery object. only use vanilla JS w/ it
+  var map_div = document.getElementById('observation_form_map');
 
   var open_map = function (focus_immediately) {
     opened = true;
-    var indicator_url = map_div.data("indicator-url");
+    var indicator_url = map_div.dataset.indicatorUrl //("indicator-url");
 
-    map_div.removeClass("hidden").css({
-      "background-position": "center center",
-      "background-image": "url(" + indicator_url + ")",
-      "background-repeat": "no-repeat"
-    });
+    map_div.classList.remove("hidden");
+    map_div.style.backgroundImage = "url(" + indicator_url + ")";
     $('.map-clear').removeClass("hidden");
     $('.map-open').hide();
 

--- a/app/assets/stylesheets/mo/_thumbnail_map.scss
+++ b/app/assets/stylesheets/mo/_thumbnail_map.scss
@@ -2,9 +2,11 @@
 // thumbnail map styles
 //
 
-.form-observation-map {
+.observation-form-map {
   height: 400px;
   width: 100%;
+  background-position: center center;
+  background-repeat: none;
 }
 
 .thumbnail-map-container {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@
 #
 #  1. Anonymous User pokes around until they try to post a Comment, say.  This
 #     page requires a login (via +login_required+ filter in controller, see
-#     below).  This causes the User to be redirected to <tt>/account/login</tt>.
+#     below).  This causes the User to be redirected to /account/login/new.
 #
 #  2. If the User already has an account, they login here, and wind up
 #     redirected back to the form that triggered the login.
@@ -52,7 +52,7 @@
 #
 #  3. +set_timezone+: Set timezone from cookie set by client's browser.
 #
-#  4. +login_required+: (optional) Redirects to <tt>/account/login</tt> if not
+#  4. +login_required+: (optional) Redirects to /account/login/new if not
 #     logged in.
 #
 #  == Contribution Score

--- a/app/views/observations/form/_where.html.erb
+++ b/app/views/observations/form/_where.html.erb
@@ -71,7 +71,7 @@
 <div class="row mt-3" id="observation_geolocation">
   <div class="col-sm-6">
     <%= tag.label("#{:GEOLOCATION.t}: (#{:optional.t})") %>
-    <div id="observationFormMap" class="form-observation-map hidden"
+    <div id="observation_form_map" class="observation-form-map hidden"
          data-indicator-url="<%= asset_path('indicator.gif') %>"></div>
     <div>
       <button type="button" class="map-open btn btn-default"><%= :form_observations_open_map.t %></span>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1707,7 +1707,7 @@
   location_dubious_unknown_country: Unknown country '[country]'
   location_dubious_unknown_state: Unrecognized state or province '[state]' for '[country]'.
 
-  # account/login
+  # account/login/new
   login_please_login: Please login
   login_login: Login
   login_user: User name or Email address

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -445,7 +445,7 @@ module ControllerExtensions
   #
   #   # Short-hand for common redirects:
   #   assert_response(:index)   => /rss_logs
-  #   assert_response(:login)   => /account/login
+  #   assert_response(:login)   => /account/login/new
   #   assert_response(:welcome) => /account/welcome
   #
   #   # Lastly, expect redirect to full explicit URL.
@@ -510,7 +510,7 @@ module ControllerExtensions
         msg += "Expected redirect to <root>#{got}"
         assert_redirected_to("/", msg)
       elsif arg == :login
-        msg += "Expected redirect to <account/login>#{got}"
+        msg += "Expected redirect to <account/login/new>#{got}"
         assert_redirected_to(new_account_login_path, msg)
       elsif arg == :welcome
         msg += "Expected redirect to <account/welcome>#{got}"

--- a/test/integration/rails-dom-testing/name_description_integration_test.rb
+++ b/test/integration/rails-dom-testing/name_description_integration_test.rb
@@ -357,7 +357,7 @@ class NameDescriptionIntegrationTest < IntegrationTestCase
     def check_edit_description_link_behavior
       click_mo_link(href: edit_name_description_uri)
       if edit_description_requires_login?
-        assert_match(%r{account/login}, response.body)
+        assert_match(%r{account/login/new}, response.body)
       else
         check_name_description_fields
       end


### PR DESCRIPTION
**Please test drive.** Works for me locally.

I was trying to pass a jQuery object to Google Maps.  Gmaps can only deal with a vanilla JS object, not a jQuery object.

This also renames the div, and fixes a bunch of leftover references to the incorrect login page url.