### PR TITLE
Make print_labels a POST rather than a GET

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -642,8 +642,8 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
     end
     collection do
       get("map", to: "observations/maps#index")
-      get("print_labels", to: "observations/downloads#print_labels",
-                          as: "print_labels_for")
+      post("print_labels", to: "observations/downloads#print_labels",
+                           as: "print_labels_for")
     end
   end
   # NOTE: the intentional "backwards" param specificity here:


### PR DESCRIPTION
Seems to fix the issue reported on Facebook about print labels from a species list.