### PR TITLE
Fix project and species list forms and redirects after commit

### DIFF
--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -42,7 +42,10 @@ module Observations
       else
         # puts("Invalid mode: #{params[:commit].inspect}")
         flash_error("Invalid mode: #{params[:commit].inspect}")
-        render("edit")
+        render("edit",
+               location: edit_observation_species_lists_path(
+                 id: @observation.id
+               ))
       end
     end
 
@@ -61,8 +64,7 @@ module Observations
       species_list.add_observation(observation)
       flash_notice(:runtime_species_list_add_observation_success.
         t(name: species_list.unique_format_name, id: observation.id))
-      render("edit",
-             location: edit_observation_species_lists_path(id: observation.id))
+      redirect_to(species_list_path(id: species_list.id))
     end
 
     # Used by manage_species_lists.
@@ -70,8 +72,7 @@ module Observations
       species_list.remove_observation(observation)
       flash_notice(:runtime_species_list_remove_observation_success.
         t(name: species_list.unique_format_name, id: observation.id))
-      render("edit",
-             location: edit_observation_species_lists_path(id: observation.id))
+      redirect_to(species_list_path(id: species_list.id))
     end
   end
 end

--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -4,8 +4,6 @@
 # Linked from observation_tabs_helper, maybe should also link from spl :show?
 # Table of links for dealing with a list of obs line by line, can add or remove
 #
-# MAYBE MOVE TO Observations::SpeciesListsController
-#
 module Observations
   class SpeciesListsController < ApplicationController
     before_action :login_required
@@ -40,7 +38,6 @@ module Observations
       when "remove"
         remove_observation_from_species_list(@species_list, @observation)
       else
-        # puts("Invalid mode: #{params[:commit].inspect}")
         flash_error("Invalid mode: #{params[:commit].inspect}")
         render("edit",
                location: edit_observation_species_lists_path(

--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -5,6 +5,7 @@
 # Table of links for dealing with a list of obs line by line, can add or remove
 #
 module Observations
+  # Add or remove one Observation from the Species List
   class SpeciesListsController < ApplicationController
     before_action :login_required
 

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -78,6 +78,7 @@ module Projects
       @candidate = find_or_goto_index(User, params[:candidate])
     end
 
+    # Redirects back to show_project.
     def add_member(str, project)
       if (user = find_member(str))
         set_status(project, :member, user, :add)
@@ -85,6 +86,7 @@ module Projects
       else
         flash_error(:add_members_not_found.t(str))
       end
+      redirect_to(project_path(project.id, q: get_query_param))
     end
 
     def find_member(str)
@@ -93,6 +95,7 @@ module Projects
       User.find_by(login: str.to_s.sub(/ <.*>$/, ""))
     end
 
+    # Redirects back to show_project.
     def update_member_status(project, candidate)
       admin = member = :remove
       case params[:commit]

--- a/app/views/observations/show/_species_lists.html.erb
+++ b/app/views/observations/show/_species_lists.html.erb
@@ -10,11 +10,11 @@
             <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
             <%= if check_permission(spl)
               put_button(name: :REMOVE.t,
-                      path: observation_species_list_path(
-                        id: @observation.id, species_list_id: spl.id,
-                        commit: "remove"
-                      ),
-                      data: { confirm: :are_you_sure.l })
+                        path: observation_species_list_path(
+                          id: @observation.id, species_list_id: spl.id,
+                          commit: "remove"
+                        ),
+                        data: { confirm: :are_you_sure.l })
             end %>
           </td>
         </tr>

--- a/app/views/projects/members/edit.html.erb
+++ b/app/views/projects/members/edit.html.erb
@@ -18,19 +18,22 @@
                                candidate: @candidate.id, q: get_query_param)
 %>
 
-<%= form_with(url: action, id: "project_member_form") do |f| %>
+<%= form_with(url: action, method: :patch, id: "project_member_form") do |f| %>
   <div class="form-group mt-3">
-    <%= submit_tag(:change_member_status_make_member.l, class: "btn btn-default center-block mb-3") %>
+    <%= f.submit(:change_member_status_make_member.l,
+                 class: "btn btn-default center-block mb-3") %>
     <%= :change_member_status_make_member_help.t %>
   </div>
 
   <div class="form-group mt-3">
-    <%= submit_tag(:change_member_status_remove_member.l, class: "btn btn-default center-block mb-3") %>
+    <%= f.submit(:change_member_status_remove_member.l,
+                 class: "btn btn-default center-block mb-3") %>
     <%= :change_member_status_remove_member_help.t %>
   </div>
 
   <div class="form-group mt-3">
-    <%= submit_tag(:change_member_status_make_admin.l, class: "btn btn-default center-block mb-3") %>
+    <%= f.submit(:change_member_status_make_admin.l,
+                 class: "btn btn-default center-block mb-3") %>
     <%= :change_member_status_make_admin_help.t %>
   </div>
 <% end %>

--- a/app/views/projects/members/new.html.erb
+++ b/app/views/projects/members/new.html.erb
@@ -11,14 +11,20 @@
 %>
 
 <div class="container-text mt-3 pb-2">
+
   <%= form_with(url: action, id: "project_member_form") do |f| %>
-    <span class="text-larger"><%= :LOGIN_NAME.t %>:</span><!-- .text-larger --><br/>
+
+    <h4><%= :LOGIN_NAME.t %>:</h4>
+
     <%= text_field_tag(:candidate, @candidate, size: 40,
                                                data: { autofocus: true },
                                                class: "form-control") %><br/>
     <% turn_into_user_auto_completer(:candidate) %>
+
     <%= f.submit(:ADD.t, class: "btn btn-default ml-3") %>
+
   <% end %>
+
 </div><!--.container-text-->
 
 <table class="table-striped table-project-members mt-3">

--- a/app/views/species_lists/observations/_form.html.erb
+++ b/app/views/species_lists/observations/_form.html.erb
@@ -1,6 +1,5 @@
 <%= form_with(url: species_list_observations_path(q: get_query_param),
-              # method: :put,
-              id: "species_list_observations_form") do |f| %>
+              method: :put, id: "species_list_observations_form") do |f| %>
 
   <p><%= :species_list_add_remove_body.tp(num: @query.num_results) %></p>
 

--- a/app/views/species_lists/observations/edit.html.erb
+++ b/app/views/species_lists/observations/edit.html.erb
@@ -1,6 +1,7 @@
 <%
 # Linked from observations :index and species_lists :show
 # :add_remove_observations
+# for adding or removing a *query* of obs (not 1 by 1)
 @title = :species_list_add_remove_title.t
 
 tabs = [

--- a/app/views/species_lists/show.html.erb
+++ b/app/views/species_lists/show.html.erb
@@ -84,25 +84,33 @@
         <% @objects.each do |observation| %>
           <div class="list-group-item">
             <div class="row">
-              <div class="col-sm-4 col-md-3 col-lg-2">
+              <div class="col-sm-4 col-md-3">
                 <%= if observation.thumb_image_id
                   thumbnail(observation.thumb_image,
                             link: observation_path(id: observation.id),
                             votes: true)
                 end %>
               </div>
-              <div class="col-sm-8 col-md-9 col-lg-10">
-                <div class="font-weight-bold">
+              <div class="col-sm-8 col-md-9">
+                <p class="font-weight-bold mb-0">
                   <%= link_to(observation.unique_format_name.t,
                               observation_path(id: observation.id,
                                                q: get_query_param(@query))) %>
-                </div>
-                <div>
+                </p>
+                <p>
                   <b><%= location_link(observation.place_name,
                                        observation.location) %></b><br/>
                   <span><%= user_link(observation.user) %></span>:
                   <span><%= observation.when.web_date %></span>
-                </div>
+                </p>
+                <%= put_button(name: :REMOVE.t,
+                              path: observation_species_list_path(
+                                id: observation.id,
+                                species_list_id: @species_list.id,
+                                commit: "remove"
+                              ),
+                              class: "btn btn-default",
+                              data: { confirm: :are_you_sure.l }) %>
               </div>
             </div>
           </div>
@@ -119,6 +127,6 @@
 <% end %>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: {object: @species_list, controls: true, limit: nil}) %>
+           locals: { object: @species_list, controls: true, limit: nil }) %>
 
 <%= show_object_footer(@species_list) %>

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -21,24 +21,24 @@ module Observations
     end
 
     def test_add_observation_to_species_list
-      sp = species_lists(:first_species_list)
+      spl = species_lists(:first_species_list)
       obs = observations(:coprinus_comatus_obs)
-      assert_not(sp.observations.member?(obs))
-      params = { id: obs.id, species_list_id: sp.id, commit: "add" }
+      assert_not(spl.observations.member?(obs))
+      params = { id: obs.id, species_list_id: spl.id, commit: "add" }
       requires_login(:update, params)
-      assert_template("edit")
-      assert(sp.reload.observations.member?(obs))
+      assert_redirected_to(species_list_path(spl.id))
+      assert(spl.reload.observations.member?(obs))
     end
 
     def test_add_observation_to_species_list_no_permission
-      sp = species_lists(:first_species_list)
+      spl = species_lists(:first_species_list)
       obs = observations(:coprinus_comatus_obs)
-      assert_not(sp.observations.member?(obs))
-      params = { id: obs.id, species_list_id: sp.id, commit: "add" }
+      assert_not(spl.observations.member?(obs))
+      params = { id: obs.id, species_list_id: spl.id, commit: "add" }
       login("dick")
       put(:update, params: params)
-      assert_redirected_to(species_list_path(sp.id))
-      assert_not(sp.reload.observations.member?(obs))
+      assert_redirected_to(species_list_path(spl.id))
+      assert_not(spl.reload.observations.member?(obs))
     end
 
     def test_remove_observation_from_species_list
@@ -57,7 +57,7 @@ module Observations
 
       login(owner)
       put(:update, params: params)
-      assert_template("edit")
+      assert_redirected_to(species_list_path(spl.id))
       assert_not(spl.reload.observations.member?(obs))
     end
 
@@ -120,7 +120,8 @@ module Observations
 
       put(:update,
           params: { id: obs2.id, species_list_id: spl1.id, commit: "add" })
-      assert_template("edit")
+      assert_redirected_to(species_list_path(spl1.id))
+      get(:edit, params: { id: obs2.id })
       assert_select("form[action=?]",
                     observation_species_list_path(id: obs2.id,
                                                   species_list_id: spl1.id,
@@ -131,7 +132,8 @@ module Observations
 
       put(:update,
           params: { id: obs2.id, species_list_id: spl1.id, commit: "remove" })
-      assert_template("edit")
+      assert_redirected_to(species_list_path(spl1.id))
+      get(:edit, params: { id: obs2.id })
       assert_select("form[action=?]",
                     observation_species_list_path(id: obs2.id,
                                                   species_list_id: spl1.id,

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -11,6 +11,7 @@ module Observations
     def assigns_exist
       !assigns(:all_lists).empty?
     rescue StandardError
+      # do nothing (This comment prevents Lint/SuppressedException offense.)
     end
 
     def test_manage_species_lists

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -49,8 +49,8 @@ module Observations
       params = { id: obs.id, species_list_id: spl.id, commit: "invalid_param" }
 
       requires_login(:update, params)
+
       assert_flash_error
-      assert_redirected_to(species_list_path(spl.id))
       assert_not(spl.reload.observations.member?(obs))
     end
 

--- a/test/controllers/projects/members_controller_test.rb
+++ b/test/controllers/projects/members_controller_test.rb
@@ -147,7 +147,7 @@ module Projects
         candidate: target_user.id
       }
       post_requires_login(:create, params, mary.login)
-      assert_response(:success)
+      assert_redirected_to(project_path(eol_project.id))
       target_user = User.find(target_user.id)
       assert_equal(false, target_user.in_group?(eol_project.admin_group.name))
       assert_equal(true, target_user.in_group?(eol_project.user_group.name))
@@ -180,7 +180,7 @@ module Projects
         candidate: "#{target_user.login} <Should Ignore This>"
       }
       post_requires_login(:create, params, mary.login)
-      assert_response(:success)
+      assert_redirected_to(project_path(eol_project.id))
       target_user.reload
       assert_not(target_user.in_group?(eol_project.admin_group.name))
       assert(target_user.in_group?(eol_project.user_group.name))
@@ -194,7 +194,7 @@ module Projects
         candidate: "freddymercury"
       }
       post_requires_login(:create, params, mary.login)
-      assert_response(:success)
+      assert_redirected_to(project_path(eol_project.id))
       assert_flash_error
       assert_equal(num_before, eol_project.reload.user_group.users.count)
     end


### PR DESCRIPTION
This changes "add member to project/change_member_status" and "add/remove observation to species list" forms to redirect to the relevant project or species list after commit.

These (to me) intuitively feel like the most constructive redirects, but i don't use these features, please let me know if this should be different. Nothing better than a test drive, probably.

It also adds a new "remove" button to each obs in the list of observations of a species list. When playing with the interface, I felt like it needed one.