### PR TITLE
Fix edit location form commit, edit obs image upload 

### DIFF
--- a/app/views/location/edit_location.html.erb
+++ b/app/views/location/edit_location.html.erb
@@ -18,7 +18,7 @@
       action: :edit_location,
       id: @location.id,
       approved_where: @display_name
-    ), id: "location_form") do |form| %>
+    ), method: :post, id: "location_form") do |form| %>
   <%= render(partial: "form_location",
             locals: { form: form, button: :UPDATE }) %>
 <% end %>

--- a/app/views/observations/_form.html.erb
+++ b/app/views/observations/_form.html.erb
@@ -34,7 +34,10 @@
 
   <% if include_images %>
 
-    <%= render(partial: "observations/form/images", locals: { f: f }) %>
+    <% if @good_images.any? %>
+      <%= render(partial: "observations/form/images", locals: { f: f }) %>
+    <% end # if @good_images %>
+
     <%= render(partial: "observations/form/images_upload", locals: { f: f }) %>
 
   <% end # if include_images %>

--- a/app/views/observations/form/_collection_number.html.erb
+++ b/app/views/observations/form/_collection_number.html.erb
@@ -1,0 +1,24 @@
+<div class="row mb-3">
+
+  <div class="col-sm-6">
+    <%= fields_for(:collection_number) do |fcn| %>
+      <div class="form-group">
+        <%= fcn.label(:name, :collection_number_name.t + ":") %>
+        <%= fcn.text_field(:name, value: @collectors_name,
+                            class: "form-control") %>
+      </div>
+      <div class="form-group">
+        <%= fcn.label(:number, :collection_number_number.t + ":") %>
+        <%= fcn.text_field(:number, value: @collectors_number,
+                            class: "form-control") %>
+      </div>
+    <% end # fields_for %>
+  </div>
+
+  <div class="col-sm-6">
+    <%= help_block_with_arrow("left", id: "collection_number_help") do %>
+      <%= :form_observations_collection_number_help.t %>
+    <% end  # help_block_with_arrow do %>
+  </div>
+
+</div><!--.row-->

--- a/app/views/observations/form/_good_image.html.erb
+++ b/app/views/observations/form/_good_image.html.erb
@@ -1,0 +1,74 @@
+<table class="table-observation-images">
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_notes",
+                    :NOTES.t + ":") %>
+    </td>
+    <td>
+      <%= text_area(:good_image, :notes,
+                    value: image.notes,
+                    index: image.id,
+                    rows: 1,
+                    class: "form-control form-control-sm") %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag(
+            "image_#{image.id}_original_name",
+            :form_observations_original_name.t + ":"
+          ) %>
+    </td>
+    <td>
+      <%= text_field(:good_image, :original_name,
+                      value: image.original_name,
+                      index: image.id,
+                      size: 40,
+                      class: "form-control form-control-sm") %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_copyright_holder",
+                    "#{:form_images_copyright_holder.t}:") %>
+    </td>
+    <td>
+      <%= text_field(:good_image, :copyright_holder,
+                      value: image.copyright_holder,
+                      index: image.id,
+                      class: "form-control form-control-sm") %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_when_1i",
+                    :form_images_when_taken.t + ":") %>
+    </td>
+    <td>
+      <div class="form-inline">
+        <%= date_select(:good_image, :when,
+              date_select_opts(image).merge(object: image,
+                                            index: image.id),
+              { class: "form-control form-control-sm",
+                onchange:
+                "CHANGED_DATES[#{image.id}] = true"}) %>
+        <% turn_into_year_auto_completer(
+              "good_image_#{image.id}_when_1i"
+            ) %>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_license_id",
+            "#{:form_images_select_license.t}:".html_safe) %>
+    </td>
+    <td>
+      <%= select(:good_image, :license_id,
+                  License.current_names_and_ids(image.license),
+                  { selected: image.license_id,
+                    index: image.id },
+                  { class: "form-control form-control-sm" }) %>
+    </td>
+  </tr>
+</table>

--- a/app/views/observations/form/_good_image.html.erb
+++ b/app/views/observations/form/_good_image.html.erb
@@ -1,74 +1,21 @@
-<table class="table-observation-images">
-  <tr>
-    <td>
-      <%= label_tag("image_#{image.id}_notes",
-                    :NOTES.t + ":") %>
-    </td>
-    <td>
-      <%= text_area(:good_image, :notes,
-                    value: image.notes,
-                    index: image.id,
-                    rows: 1,
-                    class: "form-control form-control-sm") %>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <%= label_tag(
-            "image_#{image.id}_original_name",
-            :form_observations_original_name.t + ":"
-          ) %>
-    </td>
-    <td>
-      <%= text_field(:good_image, :original_name,
-                      value: image.original_name,
-                      index: image.id,
-                      size: 40,
-                      class: "form-control form-control-sm") %>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <%= label_tag("image_#{image.id}_copyright_holder",
-                    "#{:form_images_copyright_holder.t}:") %>
-    </td>
-    <td>
-      <%= text_field(:good_image, :copyright_holder,
-                      value: image.copyright_holder,
-                      index: image.id,
-                      class: "form-control form-control-sm") %>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <%= label_tag("image_#{image.id}_when_1i",
-                    :form_images_when_taken.t + ":") %>
-    </td>
-    <td>
-      <div class="form-inline">
-        <%= date_select(:good_image, :when,
-              date_select_opts(image).merge(object: image,
-                                            index: image.id),
-              { class: "form-control form-control-sm",
-                onchange:
-                "CHANGED_DATES[#{image.id}] = true"}) %>
-        <% turn_into_year_auto_completer(
-              "good_image_#{image.id}_when_1i"
-            ) %>
-      </div>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <%= label_tag("image_#{image.id}_license_id",
-            "#{:form_images_select_license.t}:".html_safe) %>
-    </td>
-    <td>
-      <%= select(:good_image, :license_id,
-                  License.current_names_and_ids(image.license),
-                  { selected: image.license_id,
-                    index: image.id },
-                  { class: "form-control form-control-sm" }) %>
-    </td>
-  </tr>
-</table>
+<div class="row my-3 form_image">
+
+  <!-- GOOD_IMAGE -->
+  <div class="col-xs-1" style="max-width:30px">
+    <%= f.radio_button(:thumb_image_id, image.id) %>
+  </div><!--.col-->
+
+  <div class="col-xs-11 col-sm-3">
+    <%= thumbnail(image, border: 0,
+                  obs: @observation.id, votes: false) %>
+  </div><!--.col-->
+
+  <div class="col-xs-12 col-sm-8">
+    <% if check_permission(image) %>
+      <%= render(partial: "observations/form/good_image_fields",
+                 locals: { f: f, image: image }) %>
+    <% end # if check_permission %>
+  </div><!--.col-->
+  <!-- GOOD_IMAGE -->
+
+</div><!--.row.form_image-->

--- a/app/views/observations/form/_good_image.html.erb
+++ b/app/views/observations/form/_good_image.html.erb
@@ -1,4 +1,4 @@
-<div class="row my-3 form_image">
+<div class="row my-4 form_image">
 
   <!-- GOOD_IMAGE -->
   <div class="col-xs-1" style="max-width:30px">

--- a/app/views/observations/form/_good_image_fields.html.erb
+++ b/app/views/observations/form/_good_image_fields.html.erb
@@ -1,0 +1,66 @@
+<table class="table-observation-images">
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_notes", :NOTES.t + ":") %>
+    </td>
+    <td>
+      <%= text_area(:good_image, :notes,
+                    value: image.notes, index: image.id,
+                    rows: 1, class: "form-control form-control-sm") %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_original_name",
+                    :form_observations_original_name.t + ":") %>
+    </td>
+    <td>
+      <%= text_field(:good_image, :original_name,
+                      value: image.original_name, index: image.id,
+                      size: 40, class: "form-control form-control-sm") %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_copyright_holder",
+                    "#{:form_images_copyright_holder.t}:") %>
+    </td>
+    <td>
+      <%= text_field(:good_image, :copyright_holder,
+                      value: image.copyright_holder, index: image.id,
+                      class: "form-control form-control-sm") %>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_when_1i",
+                    :form_images_when_taken.t + ":") %>
+    </td>
+    <td>
+      <div class="form-inline">
+        <%= date_select(:good_image, :when,
+              date_select_opts(image).merge(object: image,
+                                            index: image.id),
+              { class: "form-control form-control-sm",
+                onchange:
+                "CHANGED_DATES[#{image.id}] = true"}) %>
+        <% turn_into_year_auto_completer(
+              "good_image_#{image.id}_when_1i"
+            ) %>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <%= label_tag("image_#{image.id}_license_id",
+            "#{:form_images_select_license.t}:".html_safe) %>
+    </td>
+    <td>
+      <%= select(:good_image, :license_id,
+                  License.current_names_and_ids(image.license),
+                  { selected: image.license_id,
+                    index: image.id },
+                  { class: "form-control form-control-sm" }) %>
+    </td>
+  </tr>
+</table>

--- a/app/views/observations/form/_herbarium_record.html.erb
+++ b/app/views/observations/form/_herbarium_record.html.erb
@@ -1,0 +1,33 @@
+<div class="row mb-3">
+
+  <div class="col-sm-6">
+    <%= fields_for(:herbarium_record) do |fhr| %>
+      <div class="form-group">
+        <%= fhr.label(:herbarium_name,
+                      :herbarium_record_herbarium_name.t + ":") %>
+        <%= fhr.text_field(:herbarium_name, value: @herbarium_name,
+                          class: "form-control") %>
+        <% turn_into_herbarium_auto_completer(
+            :herbarium_record_herbarium_name
+          ) %>
+      </div>
+      <div class="form-group">
+        <%= fhr.label(:herbarium_id,
+                      :herbarium_record_accession_number.t + ":") %>
+        <%= fhr.text_field(:herbarium_id, value: @herbarium_id,
+                          class: "form-control") %>
+      </div>
+      <div class="form-group">
+        <%= fhr.label(:notes, "#{:herbarium_record_notes.t}:") %>
+        <%= fhr.text_field(:notes, value: "", class: "form-control") %>
+      </div>
+    <% end # fields_for(:herbarium_record) %>
+  </div>
+
+  <div class="col-sm-6">
+    <%= help_block_with_arrow("left", id: "herbarium_record_help") do %>
+      <%= :form_observations_herbarium_record_help.t %>
+    <% end # help_block_with_arrow do %>
+  </div>
+
+</div><!--.row-->

--- a/app/views/observations/form/_images.html.erb
+++ b/app/views/observations/form/_images.html.erb
@@ -1,42 +1,19 @@
 <%
 # Images (already attached) section of create_observation form
+good_image_ids_str = @good_images.map { |img| img.id }.join(" ")
 %>
 
 <div class="" id="observation_images">
-  <% # @observation.thumb_image_id ||= 0 %>
 
-  <% if @good_images.any? %>
+  <p class="font-weight-bold">Images:</p>
 
-    <p class="font-weight-bold"><b>Images:</b></p>
+  <% @good_images.each do |image| %>
 
-    <% @good_images.each do |image| %>
+    <%= render(partial: "observations/form/good_image",
+               locals: { f: f, image: image }) %>
 
-      <div class="row mt-3 form_image">
+  <% end # @good_images.each do image %>
 
-        <!-- GOOD_IMAGE -->
-        <div class="col-xs-1" style="max-width:30px">
-          <%= f.radio_button(:thumb_image_id, image.id) %>
-        </div><!--.col-->
-
-        <div class="col-xs-11 col-sm-3">
-          <%= thumbnail(image, border: 0,
-                        obs: @observation.id, votes: true) %>
-        </div><!--.col-->
-
-        <div class="col-xs-12 col-sm-8">
-          <% if check_permission(image) %>
-            <%= render(partial: "observations/form/good_image",
-                       locals: { f: f, image: image }) %>
-          <% end # if check_permission %>
-        </div><!--.col-->
-        <!-- GOOD_IMAGE -->
-
-      </div><!--.row.form_image-->
-
-    <% end # @good_images.each do image %>
-
-  <% end # if @good_images %>
-
-  <%= hidden_field_tag(:good_images, @good_images.map { |o| o.id }.join(" ")) %>
+  <%= hidden_field_tag(:good_images, good_image_ids_str) %>
 
 </div><!--#observation_images-->

--- a/app/views/observations/form/_images.html.erb
+++ b/app/views/observations/form/_images.html.erb
@@ -1,101 +1,42 @@
-<% # Images (already attached) section of create_observation form %>
+<%
+# Images (already attached) section of create_observation form
+%>
+
 <div class="" id="observation_images">
   <% # @observation.thumb_image_id ||= 0 %>
 
   <% if @good_images.any? %>
+
     <p class="font-weight-bold"><b>Images:</b></p>
 
     <% @good_images.each do |image| %>
+
       <div class="row mt-3 form_image">
+
         <!-- GOOD_IMAGE -->
         <div class="col-xs-1" style="max-width:30px">
           <%= f.radio_button(:thumb_image_id, image.id) %>
         </div><!--.col-->
+
         <div class="col-xs-11 col-sm-3">
           <%= thumbnail(image, border: 0,
                         obs: @observation.id, votes: true) %>
         </div><!--.col-->
+
         <div class="col-xs-12 col-sm-8">
           <% if check_permission(image) %>
-            <table class="table-observation-images">
-              <tr>
-                <td>
-                  <%= label_tag("image_#{image.id}_notes",
-                                :NOTES.t + ":") %>
-                </td>
-                <td>
-                  <%= text_area(:good_image, :notes,
-                                value: image.notes,
-                                index: image.id,
-                                rows: 1,
-                                class: "form-control form-control-sm") %>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <%= label_tag(
-                        "image_#{image.id}_original_name",
-                        :form_observations_original_name.t + ":"
-                      ) %>
-                </td>
-                <td>
-                  <%= text_field(:good_image, :original_name,
-                                  value: image.original_name,
-                                  index: image.id,
-                                  size: 40,
-                                  class: "form-control form-control-sm") %>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <%= label_tag("image_#{image.id}_copyright_holder",
-                                "#{:form_images_copyright_holder.t}:") %>
-                </td>
-                <td>
-                  <%= text_field(:good_image, :copyright_holder,
-                                  value: image.copyright_holder,
-                                  index: image.id,
-                                  class: "form-control form-control-sm") %>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <%= label_tag("image_#{image.id}_when_1i",
-                                :form_images_when_taken.t + ":") %>
-                </td>
-                <td>
-                  <div class="form-inline">
-                    <%= date_select(:good_image, :when,
-                          date_select_opts(image).merge(object: image,
-                                                        index: image.id),
-                          { class: "form-control form-control-sm",
-                            onchange:
-                            "CHANGED_DATES[#{image.id}] = true"}) %>
-                    <% turn_into_year_auto_completer(
-                          "good_image_#{image.id}_when_1i"
-                        ) %>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <%= label_tag("image_#{image.id}_license_id",
-                        "#{:form_images_select_license.t}:".html_safe) %>
-                </td>
-                <td>
-                  <%= select(:good_image, :license_id,
-                              License.current_names_and_ids(image.license),
-                              { selected: image.license_id,
-                                index: image.id },
-                              { class: "form-control form-control-sm" }) %>
-                </td>
-              </tr>
-            </table>
+            <%= render(partial: "observations/form/good_image",
+                       locals: { f: f, image: image }) %>
           <% end # if check_permission %>
         </div><!--.col-->
         <!-- GOOD_IMAGE -->
+
       </div><!--.row.form_image-->
-    <% end # for image %>
+
+    <% end # @good_images.each do image %>
+
   <% end # if @good_images %>
+
   <%= hidden_field_tag(:good_images, @good_images.map { |o| o.id }.join(" ")) %>
+
 </div><!--#observation_images-->

--- a/app/views/observations/form/_images_upload.html.erb
+++ b/app/views/observations/form/_images_upload.html.erb
@@ -55,7 +55,7 @@
       }";
     ) %>
 
-  <% end %>
+  <% end # if can_do_multifile_upload %>
   <!-- /MONOFILE_UPLOAD_FORM -->
 
 </div><!--#observation_images_upload-->

--- a/app/views/observations/form/_notes.html.erb
+++ b/app/views/observations/form/_notes.html.erb
@@ -1,6 +1,9 @@
-<% # Notes section of create_observation form %>
+<%
+# Notes section of create_observation form
+%>
 <!-- NOTES -->
 <div class="mt-3" id="observation_notes">
+
   <%= content_tag(:span, "#{:NOTES.t} ", class: "font-weight-bold") %>
   <% if @observation.form_notes_parts(@user) == [Observation.other_notes_part]
        part = Observation.other_notes_part %>
@@ -21,7 +24,7 @@
           <%= content_tag(:p, :form_observations_notes_help.t,
                           class: "pt-0 mt-0") %>
           <%= render(partial: "shared/textilize_help") %>
-        <% end %>
+        <% end # help_block_with_arrow %>
       </div>
     </div><!--.row-->
 
@@ -29,6 +32,7 @@
 
     (<%= :general_textile_link.t %>)
     <% @observation.form_notes_parts(@user).each do |part| %>
+
       <div class="row">
         <div class="col-xs-12 col-sm-6">
           <div><%= "#{strip_tags(part.tl)}: "%></div>
@@ -42,9 +46,10 @@
           </div>
         </div>
       </div><!--.row-->
-    <% end %>
 
-  <% end %>
+    <% end # each do part %>
+
+  <% end # if user_notes_part %>
 
 </div><!--#observation_notes-->
 <!-- /NOTES -->

--- a/app/views/observations/form/_specimen_info.html.erb
+++ b/app/views/observations/form/_specimen_info.html.erb
@@ -13,14 +13,14 @@
     </div>
     <%= help_block_with_arrow("up") do %>
       <%= :form_observations_specimen_available_help.t %>
-    <% end %>
+    <% end  # help_block_with_arrow do %>
 
     <!-- no_specimen_info -->
     <% if button_name == :SAVE_EDITS.l %>
       <div class="well well-sm help-block">
         <%= :form_observations_edit_specimens_help.t %>
-      </div>
-    <% end %><!--.well-->
+      </div><!--.well-->
+    <% end # if button_name %>
     <!-- /no_specimen_info -->
 
   </div><!--.col-->
@@ -29,62 +29,10 @@
 <% if button_name == :CREATE.l %>
   <!-- specimen_info -->
   <div id="specimen_info" class="<%= "hidden" if !@observation.specimen %>">
-    <div class="row mb-3">
-      <div class="col-sm-6">
 
-        <%= fields_for(:collection_number) do |fcn| %>
-          <div class="form-group">
-            <%= fcn.label(:name, :collection_number_name.t + ":") %>
-            <%= fcn.text_field(:name, value: @collectors_name,
-                               class: "form-control") %>
-          </div>
-          <div class="form-group">
-            <%= fcn.label(:number, :collection_number_number.t + ":") %>
-            <%= fcn.text_field(:number, value: @collectors_number,
-                               class: "form-control") %>
-          </div>
-        <% end %>
+    <%= render(partial: "collection_number", locals: { f: f } ) %>
+    <%= render(partial: "herbarium_record", locals: { f: f } ) %>
 
-      </div>
-      <div class="col-sm-6">
-        <%= help_block_with_arrow("left", id: "collection_number_help") do %>
-          <%= :form_observations_collection_number_help.t %>
-        <% end %>
-      </div>
-    </div><!--.row-->
-
-    <div class="row mb-3">
-      <div class="col-sm-6">
-
-        <%= fields_for(:herbarium_record) do |fhr| %>
-          <div class="form-group">
-            <%= fhr.label(:herbarium_name,
-                          :herbarium_record_herbarium_name.t + ":") %>
-            <%= fhr.text_field(:herbarium_name, value: @herbarium_name,
-                              class: "form-control") %>
-            <% turn_into_herbarium_auto_completer(
-                :herbarium_record_herbarium_name
-              ) %>
-          </div>
-          <div class="form-group">
-            <%= fhr.label(:herbarium_id,
-                          :herbarium_record_accession_number.t + ":") %>
-            <%= fhr.text_field(:herbarium_id, value: @herbarium_id,
-                              class: "form-control") %>
-          </div>
-          <div class="form-group">
-            <%= fhr.label(:notes, "#{:herbarium_record_notes.t}:") %>
-            <%= fhr.text_field(:notes, value: "", class: "form-control") %>
-          </div>
-        <% end %>
-
-      </div>
-      <div class="col-sm-6">
-        <%= help_block_with_arrow("left", id: "herbarium_record_help") do %>
-          <%= :form_observations_herbarium_record_help.t %>
-        <% end %>
-      </div>
-    </div><!--.row-->
   </div><!--#specimen_info-->
   <!-- /specimen_info -->
 

--- a/app/views/observations/form/_specimen_info.html.erb
+++ b/app/views/observations/form/_specimen_info.html.erb
@@ -30,8 +30,10 @@
   <!-- specimen_info -->
   <div id="specimen_info" class="<%= "hidden" if !@observation.specimen %>">
 
-    <%= render(partial: "collection_number", locals: { f: f } ) %>
-    <%= render(partial: "herbarium_record", locals: { f: f } ) %>
+    <%= render(partial: "observations/form/collection_number",
+               locals: { f: f } ) %>
+    <%= render(partial: "observations/form/herbarium_record",
+               locals: { f: f } ) %>
 
   </div><!--#specimen_info-->
   <!-- /specimen_info -->

--- a/app/views/observations/form/_where.html.erb
+++ b/app/views/observations/form/_where.html.erb
@@ -12,7 +12,7 @@
       <%= :form_observations_dubious_help.t(button: button_name) %>
     </p>
   </div><!--.container-text-->
-<% end %>
+<% end # if @dubious_where_reasons.any? %>
 <!-- /WHERE_REASONS -->
 
 <!-- WHERE -->
@@ -34,10 +34,10 @@
         if User.current_location_format == "scientific"
           loc1 = Location.reverse_name(loc1)
           loc2 = Location.reverse_name(loc2)
-        end
+        end # if User.current_location_format
         :form_observations_where_help.t(loc1: loc1, loc2: loc2)
       %>
-    <% end %>
+    <% end # help_block_with_arrow do %>
   </div>
 </div><!--.row-->
 
@@ -46,7 +46,7 @@
     <button type="button" class="map-locate btn btn-default my-3">Locate on Map</button>
     <%= help_block_with_arrow("up", id: "locate_on_map_help") do %>
       <%= :form_observations_locate_on_map_help.t %>
-    <% end %>
+    <% end  # help_block_with_arrow do %>
   </div>
 </div><!--.row-->
 <!-- /WHERE -->
@@ -62,7 +62,7 @@
     </div>
     <%= help_block_with_arrow("up", id: "is_collection_location_help") do %>
       <%= :form_observations_is_collection_location_help.t %>
-    <% end %>
+    <% end  # help_block_with_arrow do %>
   </div><!--.col-->
 </div><!--.row-->
 <!-- /IS_COLLECTION_LOCATION -->
@@ -81,7 +81,7 @@
   <div class="col-sm-6">
     <%= help_block_with_arrow("left", id: "geolocation_help") do %>
       <%= :form_observations_lat_long_help.t %>
-    <% end %>
+    <% end  # help_block_with_arrow do %>
   </div>
 </div><!--.row-->
 

--- a/app/views/observations/form/images_upload/_mono.html.erb
+++ b/app/views/observations/form/images_upload/_mono.html.erb
@@ -46,6 +46,6 @@
     CHANGED_DATES[#{index}] = false;
   ) %>
 
-</div><!--#form_image-->
+</div><!--.form_image-->
 
 <!--[eoform:image]-->

--- a/app/views/observations/form/images_upload/_mono.html.erb
+++ b/app/views/observations/form/images_upload/_mono.html.erb
@@ -5,19 +5,24 @@
 <div id="image_<%= index %>_box" class="form_image">
 
   <%= radio_button(:observation, :thumb_image_id, -index) %>
-  <%= custom_file_field(:image, :image, index: index, onchange: "auto_image_new(#{index})") %>
+  <%= custom_file_field(:image, :image, index: index,
+                        onchange: "auto_image_new(#{index})") %>
 
   <% if @js %>
     <span class="ml-10px">&nbsp;</span>
-    <input id="image_<%=index%>_more" onclick="image_on(<%=index%>);" type="button" class="btn btn-default" value="<%=:MORE.t%> »" />
-    <input id="image_<%=index%>_less" onclick="image_off(<%=index%>);" type="button" class="btn btn-default" value="« <%=:LESS.t%>" style="display:none" />
+    <input id="image_<%=index%>_more" onclick="image_on(<%=index%>);"
+           type="button" class="btn btn-default" value="<%=:MORE.t%> »" />
+    <input id="image_<%=index%>_less" onclick="image_off(<%=index%>);"
+           type="button" class="btn btn-default" value="« <%=:LESS.t%>"
+           style="display:none" />
   <% end %><br/>
 
   <%= fields_for(:image) do |f_i| %>
     <%= f_i.label("#{index}_notes".to_sym, "#{:NOTES.t}:") %>
     <%= f_i.text_field(:notes, index: index, size: 50, class: "form-control") %>
 
-    <div id="image_<%= index %>_div" style="line-height:100%<%= "; display:none" if @js %>">
+    <div id="image_<%= index %>_div"
+         style="line-height:100%<%= "; display:none" if @js %>">
       <%= f_i.label("#{index}_copyright_holder".to_sym,
                     "#{:form_images_copyright_holder.t}:") %>
       <%= f_i.text_field(:copyright_holder, index: index) %></p>

--- a/app/views/observations/form/images_upload/_multi.html.erb
+++ b/app/views/observations/form/images_upload/_multi.html.erb
@@ -1,6 +1,6 @@
 <!-- MULTIFILE_UPLOAD_FORM -->
-<% 
-# javascript_include("multi_image_upload") 
+<%
+# javascript_include("multi_image_upload")
 max_size = MO.image_upload_max_size
 legible_max_size = (max_size.to_f/1024/1024).round
 %>
@@ -9,14 +9,15 @@ legible_max_size = (max_size.to_f/1024/1024).round
 
 <div class="row">
   <div class="col-sm-6">
-    <input type="file" multiple id="multiple_images_button" accept="image/*" class="mt-3"/>
+    <input type="file" multiple id="multiple_images_button"
+           accept="image/*" class="mt-3"/>
   </div><!--.col-->
   <div class="col-sm-6">
     <%= help_block_with_arrow("left", id: "upload_multi_help") do %>
       <p class="">
         <%= :form_observations_upload_help_multi_select.t %>
       </p>
-    <% end %>
+    <% end # help_block_with_arrow do %>
   </div><!--.col-->
 </div><!--.row-->
 
@@ -28,9 +29,9 @@ legible_max_size = (max_size.to_f/1024/1024).round
 
       <div class="col-sm-7">
         <div class="inconsistent_date_options">
-          <p class="mb-0"><strong><%= :form_observations_set_observation_date_to.t %>:</strong></p>
+          <p class="mb-0 font-weight-bold"><%= :form_observations_set_observation_date_to.t %>:</p>
           <div id="image_date_radio_container"></div>
-          <p class="mb-0"><strong><%= :form_observations_set_image_dates_to.t %>:</strong></p>
+          <p class="mb-0 font-weight-bold"><%= :form_observations_set_image_dates_to.t %>:</p>
           <div id="observation_date_radio_container"></div>
         </div>
         <div class="mt-3">

--- a/app/views/observations/form/images_upload/_template.erb
+++ b/app/views/observations/form/images_upload/_template.erb
@@ -101,7 +101,7 @@
 
         </div><!--#added_image_additional_details_container-->
 
-      <% end %>
+      <% end # fields_for %>
 
     </div><!--#added_image_details_container.col-->
 

--- a/app/views/observations/namings/_fields.html.erb
+++ b/app/views/observations/namings/_fields.html.erb
@@ -22,7 +22,8 @@ locals = {
   parent_deprecated: parent_deprecated,
   names: names
 }
-@container = :wide %>
+@container = :wide
+%>
 
 <div class="row">
   <div class="col-xs-12 col-sm-6">
@@ -45,7 +46,7 @@ locals = {
     <div class="col-sm-6">
       <%= help_block_with_arrow("left", id: "naming_name_help") do %>
         <%= tag.p(:form_naming_name_help.t) %>
-      <% end %>
+      <% end # help_block_with_arrow do %>
     </div>
   </div><!--.row-->
 
@@ -61,7 +62,7 @@ locals = {
                          class: "form-control",
                          data: { autofocus: focus_on_vote }) %>
         </div>
-      <% end %>
+      <% end # fields_for(:vote) %>
 
       <%= f_n.fields_for(:reasons) do |f_r| %>
         <% reasons.values.sort_by(&:order).each do |r| %>
@@ -85,12 +86,12 @@ locals = {
                               index: r.num, rows: 3, value: r.notes,
                               class: "form-control") %>
           </div>
-        <% end %>
-      <% end %>
+        <% end # reasons.values.each %>
+      <% end  # fields_for(:reasons) do %>
 
     </div><!--.col-->
   </div><!--.row-->
-<% end %>
+<% end # fields_for(:naming) do %>
 
 <%= hidden_field_tag(:was_js_on, "yes") if can_do_ajax? %>
 <% inject_javascript_at_end %(


### PR DESCRIPTION
**In the edit observation form:**
The issue was the image voting interface, which is now made of `post_button`s that each create a mini `form`. (Rails does not want you to write to the db via GET, and voting originally did that. We do that still in a few other places.) Its presence induces a browser to automatically close out the enclosing form tag, and open a new one around the button.

So, any form embedding thumbnails, for now, will have to do without image votes in the form context.  I feel that is actually preferable, because it’s not a context where people should be trying to vote on images.  (Maybe someone is editing their own obs, and wants to "vote" on their own image, but those people will have to wait for another template, like the very next one, `show`.)

**In the edit location form:**
Despite locations not yet being CRUDified on master, Rails somehow figured out this was an edit form and added its automatic `method: :put` special sauce to the form. This explicitly sets `method: :post`.