### PR TITLE
Set default val for `goodImageVals` in multi_image_upload.js

### DIFF
--- a/app/assets/javascripts/multi_image_upload.js
+++ b/app/assets/javascripts/multi_image_upload.js
@@ -537,7 +537,7 @@ function MultiImageUploader(localized_text) {
       if (xhrReq.readyState == 4) {
         if (xhrReq.status == 200) {
           var image = JSON.parse(xhrReq.response);
-          goodImageVals = $goodImages.val();
+          goodImageVals = $goodImages.val() ? $goodImages.val() : "";
           $goodImages.val(goodImageVals.length == 0 ? image.id : goodImageVals + ' ' + image.id); //add id to the good images form field.
           if (_this.dom_element.find('input[name="observation[thumb_image_id]"]')[0].checked) {
             //set the thumbnail if it is selected


### PR DESCRIPTION
Fixes a js error discovered by @pellaea today.

Unlikely to cause trouble. It just sets a backup default value for a var that might not get assigned.

```
Uncaught TypeError: goodImageVals is undefined
onreadystatechange https://mushroomobserver.org/assets/application-a3015424f037a08d1bce306ea77c078eef407c0180ed92424e216cc89981a2e3.js:1
```

**Background**: `goodImageVals` is jQuery's assessment of the value of a hidden form field in the Obs form, whose name and id are both `good_images`. It's printed in the form erb by Ruby mapping the ids of the `@good_images` ivar.  If there are no already uploaded images, this value will be nil.