### PR TITLE
Fix account preferences form

### DIFF
--- a/app/views/account/preferences/_privacy.html.erb
+++ b/app/views/account/preferences/_privacy.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
 anon_values = [
   [:prefs_votes_anonymous_no.l, :no],
   [:prefs_votes_anonymous_yes.l, :yes],
@@ -26,25 +26,13 @@ filename_values = [
               :prefs_votes_anonymous.t + ":") %><br/>
   <%= f.select(:votes_anonymous, anon_values, {},
                { class: "form-control d-inline-block w-auto mr-3" }) %>
-
-  <span class="help-note">
-    <%= put_button(name: :prefs_change_image_vote_anonymity.t,
-                   path: images_bulk_vote_anonymity_updater_path) %>
-  </span>
-
 </div>
 
 <div class="form-group mt-3">
   <%= f.label(:keep_filenames,
               :prefs_keep_image_filenames.t + ":") %><br/>
-  <%= f.select(:keep_filenames, filename_values, {}, 
+  <%= f.select(:keep_filenames, filename_values, {},
                { class: "form-control d-inline-block w-auto mr-3" }) %>
-
-  <span class="help-note">
-    <%= put_button(name: :prefs_bulk_filename_purge.t,
-                   path: images_bulk_filename_purge_path,
-                   data: { confirm: :prefs_bulk_filename_purge_confirm.l }) %>
-  </span>
 </div>
 
 <div class="form-group mt-3">
@@ -52,10 +40,6 @@ filename_values = [
   <span class="help-note">(<%= :prefs_license_note.t %>)</span><br/>
   <%= f.select(:license_id, @licenses, {},
                 { class: "form-control d-inline-block w-auto mr-3" }) %>
-  <span class="help-note">
-    <%= put_button(name: :bulk_license_link.t, 
-                   path: images_license_updater_path) %>
-  </span>
 </div>
 
 <%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>

--- a/app/views/account/preferences/_put_buttons.html.erb
+++ b/app/views/account/preferences/_put_buttons.html.erb
@@ -1,0 +1,15 @@
+<div class="form-group mt-3">
+  <span class="help-note">
+    <%= put_button(name: :prefs_change_image_vote_anonymity.t,
+                   path: images_bulk_vote_anonymity_updater_path) %>
+  </span>
+  <span class="help-note">
+    <%= put_button(name: :prefs_bulk_filename_purge.t,
+                   path: images_bulk_filename_purge_path,
+                   data: { confirm: :prefs_bulk_filename_purge_confirm.l }) %>
+  </span>
+  <span class="help-note">
+    <%= put_button(name: :bulk_license_link.t,
+                   path: images_license_updater_path) %>
+  </span>
+</div>

--- a/app/views/account/preferences/edit.html.erb
+++ b/app/views/account/preferences/edit.html.erb
@@ -21,4 +21,4 @@
   <%= render(partial: "account/preferences/email", locals: { f: form })%>
 <% end %>
 
-<%= render(partial: "account/preferences/put_buttons", locals: { f: form })%>
+<%= render(partial: "account/preferences/put_buttons")%>

--- a/app/views/account/preferences/edit.html.erb
+++ b/app/views/account/preferences/edit.html.erb
@@ -20,3 +20,5 @@
   <%= render(partial: "account/preferences/notes", locals: { f: form })%>
   <%= render(partial: "account/preferences/email", locals: { f: form })%>
 <% end %>
+
+<%= render(partial: "account/preferences/put_buttons", locals: { f: form })%>


### PR DESCRIPTION
"Put buttons" in this form (for bulk filename purge, image vote anonymity updater, and license updater) cause the browser to prematurely close out the form tag, disabling most of the form. 

Temporary fix: move these buttons to the bottom, outside of the form, and get the form and buttons working again. 
May need to re-open `get` routes for these actions so the links can be inside the form tag.

(Same issue as obs form today. Discovered while testing/adjusting my prefs on the live site.)