### PR TITLE
Fix Remove Collection Number

### DIFF
--- a/app/views/observations/show/_collection_numbers.html.erb
+++ b/app/views/observations/show/_collection_numbers.html.erb
@@ -27,12 +27,14 @@
                                  id: number.id,
                                  params: { back: observation.id }
                                )) %> |
-           <%= link_with_query(:REMOVE.t,
-                               collection_number_remove_observation_path(
-                                 collection_number_id: number.id,
-                                 params: { observation_id: observation.id }
-                               ),
-                               { data: { confirm: :are_you_sure.t } }) %>]
+           <%= patch_button(name: :REMOVE.t,
+                            path: collection_number_remove_observation_path(
+                              collection_number_id: number.id,
+                              observation_id: observation.id,
+                              q: get_query_param,
+                            ),
+                            data: { confirm: :are_you_sure.t }) %>]
+
         </li>
       <% end %>
     </ul>

--- a/test/integration/capybara/observations_controller_supplemental_test.rb
+++ b/test/integration/capybara/observations_controller_supplemental_test.rb
@@ -92,13 +92,15 @@ class ObservationsControllerSupplementalTest < CapybaraIntegrationTestCase
 
   def test_observation_remove_collection_number
     obs = observations(:minimal_unknown_obs)
+    assert_not_empty(obs.collection_numbers,
+                     "Test needs a fixture with a collection number(s)")
     user = obs.user
 
     login(user)
     visit(observation_path(obs.id))
-    page.find("#observation_collection_numbers").click_on("Remove")
-
-    assert_empty(obs.collection_numbers)
+    assert_difference("obs.collection_numbers.count", -1) do
+      page.find("#observation_collection_numbers").click_on("Remove")
+    end
   end
 
   def test_locales_when_sending_email_question

--- a/test/integration/capybara/observations_controller_supplemental_test.rb
+++ b/test/integration/capybara/observations_controller_supplemental_test.rb
@@ -90,6 +90,17 @@ class ObservationsControllerSupplementalTest < CapybaraIntegrationTestCase
     assert_not_includes(species_list.observations, observation)
   end
 
+  def test_observation_remove_collection_number
+    obs = observations(:minimal_unknown_obs)
+    user = obs.user
+
+    login(user)
+    visit(observation_path(obs.id))
+    page.find("#observation_collection_numbers").click_on("Remove")
+
+    assert_empty(obs.collection_numbers)
+  end
+
   def test_locales_when_sending_email_question
     sender = users(:rolf)
     receiver = users(:mary)


### PR DESCRIPTION
Removing a Collection Number from an Observation currently throws an error. (And one user has complained.)
```ruby
Started GET "/collection_numbers/11072/remove_observation?observation_id=512701&q=1oAhh" for 127.0.0.1 at 2023-01-11 23:55:58 +0000
ActionController::RoutingError (No route matches [GET] "/collection_numbers/11072/remove_observation")
```
This PR:
- Adds a test that provokes the bug;
- Fixes the bug by replacing the Collection Numbers `Remove` link with a PATCH button.
- Delivers [Pivotal #184210741](https://www.pivotaltracker.com/story/show/184210741)

### Manual Test

- Create an Observation, checking the Specimen Available box, and adding a Collector's Number
- Remove the Collection Number