### PR TITLE
Redirect lookup_name

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -841,6 +841,10 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   get("/observer/textile_sandbox", to: redirect("/info/textile_sandbox"))
   get("/observer/translators_note", to: redirect("/info/translators_note"))
 
+  # ----- Lookups: legacy action redirects ---------------------------
+  # The only legacy lookup that was ok'd for use by external sites
+  get("/observer/lookup_name(/:id)", to: "lookups#lookup_name", id: /\S.*/)
+
   # ----- Observations: legacy action redirects ----------------------------
   get("/observer/create_observation", to: redirect("/observations/new"))
   get("/observer/observation_search", to: redirect("/observations"))

--- a/test/integration/rails-dom-testing/redirects_test.rb
+++ b/test/integration/rails-dom-testing/redirects_test.rb
@@ -152,4 +152,15 @@ class RedirectsTest < IntegrationTestCase
       :get, "/herbarium/show_herbarium/#{nybg.id}", herbarium_path(nybg)
     )
   end
+
+  # Observer/lookup_... to Lookups  ---------------------------------
+
+  # The only legacy lookup that was ok'd for use by external sites
+  def test_lookup_name_get
+    name = names(:fungi)
+    login
+    assert_old_url_redirects_to_new_path(
+      :get, "/observer/lookup_name/#{name.id}", show_name_path(name.id)
+    )
+  end
 end


### PR DESCRIPTION
- Redirects the legacy lookup_name action. 
We ok'd external websites to use the old url, so we need to redirect it.
- Includes a test to prevent reversion.

#### Manual test

- Paste the old url (with a valid id) into the browser address bar.
Example: `http://localhost:3000/observer/lookup_name/5077`
Result: It should display the Name with that id. 
(For the example above, it should display the Name page for _Peltigera_.)