### PR TITLE
Fix destroy thumbnail

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -139,8 +139,8 @@ class ImagesController < ApplicationController
     args = {
       action: "index",
       matrix: true,
-      include: [:user, { observations: :name }, :subjects, :best_glossary_terms,
-                :glossary_terms, :image_votes]
+      include: [:user, { observations: :name }, :subjects,
+                :glossary_term_thumbnails, :glossary_terms, :image_votes]
     }.merge(args)
 
     # Add some alternate sorting criteria.

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -140,7 +140,7 @@ class ImagesController < ApplicationController
       action: "index",
       matrix: true,
       include: [:user, { observations: :name }, :subjects,
-                :glossary_term_thumbnails, :glossary_terms, :image_votes]
+                :thumbnail_glossary_terms, :glossary_terms, :image_votes]
     }.merge(args)
 
     # Add some alternate sorting criteria.

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -139,8 +139,8 @@ class ImagesController < ApplicationController
     args = {
       action: "index",
       matrix: true,
-      include: [:user, { observations: :name }, :subjects,
-                :thumbnail_glossary_terms, :glossary_terms, :image_votes]
+      include: [:user, { observations: :name }, :profile_users,
+                :thumb_glossary_terms, :glossary_terms, :image_votes]
     }.merge(args)
 
     # Add some alternate sorting criteria.

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -9,7 +9,7 @@ class GlossaryTerm < AbstractModel
 
   belongs_to(:thumb_image,
              class_name: "Image",
-             inverse_of: :best_glossary_terms)
+             inverse_of: :thumbnail_glossary_terms)
   belongs_to :user
   belongs_to :rss_log
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -9,7 +9,7 @@ class GlossaryTerm < AbstractModel
 
   belongs_to(:thumb_image,
              class_name: "Image",
-             inverse_of: :thumbnail_glossary_terms)
+             inverse_of: :thumb_glossary_terms)
   belongs_to :user
   belongs_to :rss_log
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -229,14 +229,14 @@ class Image < AbstractModel
   has_many :glossary_term_images, dependent: :destroy
   has_many :glossary_terms, through: :glossary_term_images
   has_many :thumb_glossary_terms, class_name: "GlossaryTerm",
-                                      foreign_key: "thumb_image_id",
-                                      inverse_of: :thumb_image
+                                  foreign_key: "thumb_image_id",
+                                  inverse_of: :thumb_image
 
   has_many :observation_images, dependent: :destroy
   has_many :observations, through: :observation_images
   has_many :thumb_observations, class_name: "Observation",
-                                    foreign_key: "thumb_image_id",
-                                    inverse_of: :thumb_image
+                                foreign_key: "thumb_image_id",
+                                inverse_of: :thumb_image
 
   has_many :project_images, dependent: :destroy
   has_many :projects, through: :project_images

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -183,9 +183,9 @@ require("mimemagic")
 #  unique_format_name:: Marked-up title.
 #  unique_text_name::   Plain-text title.
 #  observations::       Observations that use this image.
-#  thumbnail_observations:: Observations that use this as their "thumbnail".
+#  thumb_observations:: Observations that use this as their "thumbnail".
 #  glossary_terms::     GlossaryTerms that use this image.
-#  thumbnail_glossary_terms:: GlossaryTerms that use this as their "thumbnail".
+#  thumb_glossary_terms:: GlossaryTerms that use this as their "thumbnail".
 #  has_size?::          Does image have this size?
 #  size::               Calculate size of image of given type.
 #
@@ -228,13 +228,13 @@ class Image < AbstractModel
 
   has_many :glossary_term_images, dependent: :destroy
   has_many :glossary_terms, through: :glossary_term_images
-  has_many :thumbnail_glossary_terms, class_name: "GlossaryTerm",
+  has_many :thumb_glossary_terms, class_name: "GlossaryTerm",
                                       foreign_key: "thumb_image_id",
                                       inverse_of: :thumb_image
 
   has_many :observation_images, dependent: :destroy
   has_many :observations, through: :observation_images
-  has_many :thumbnail_observations, class_name: "Observation",
+  has_many :thumb_observations, class_name: "Observation",
                                     foreign_key: "thumb_image_id",
                                     inverse_of: :thumb_image
 
@@ -246,7 +246,7 @@ class Image < AbstractModel
 
   has_many :image_votes, dependent: :destroy
 
-  has_many :subjects, class_name: "User"
+  has_many :profile_users, class_name: "User"
 
   belongs_to :user
   belongs_to :license
@@ -261,7 +261,7 @@ class Image < AbstractModel
 
   # Array of all observations, users and glossary terms using this image.
   def all_subjects
-    observations + subjects + glossary_terms
+    observations + profile_users + glossary_terms
   end
 
   # Is image used by an object other than obj
@@ -900,7 +900,7 @@ class Image < AbstractModel
 
   # Callback that changes objects referencing an image that is being destroyed.
   def update_thumbnails
-    (thumbnail_glossary_terms + thumbnail_observations + subjects).each do |obj|
+    (thumb_glossary_terms + thumb_observations + profile_users).each do |obj|
       obj.remove_image(self)
     end
   end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -183,7 +183,8 @@
 #  announce_consensus_change::  After consensus changes: send email.
 #
 class Observation < AbstractModel
-  belongs_to :thumb_image, class_name: "Image"
+  belongs_to :thumb_image, class_name: "Image",
+                           inverse_of: :thumbnail_glossary_terms
   belongs_to :name # (used to cache consensus name)
   belongs_to :location
   belongs_to :rss_log
@@ -1176,12 +1177,10 @@ class Observation < AbstractModel
   # thumbnail to next available Image.  Saves change to thumbnail, might save
   # change to Image.  Returns Image.
   def remove_image(img)
-    if images.include?(img)
-      images.delete(img)
-      if thumb_image_id == img.id
-        self.thumb_image = images.empty? ? nil : images.first
-        save
-      end
+    if image_ids.include?(img.id) || thumb_image_id == img.id
+      image_ids.delete(img.id)
+      update(thumb_image_id: image_ids.empty? ? nil : image_ids.first) \
+        if thumb_image_id == img.id
       notify_users(:removed_image)
     end
     img

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -184,7 +184,7 @@
 #
 class Observation < AbstractModel
   belongs_to :thumb_image, class_name: "Image",
-                           inverse_of: :thumbnail_glossary_terms
+                           inverse_of: :thumb_glossary_terms
   belongs_to :name # (used to cache consensus name)
   belongs_to :location
   belongs_to :rss_log

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1177,9 +1177,9 @@ class Observation < AbstractModel
   # thumbnail to next available Image.  Saves change to thumbnail, might save
   # change to Image.  Returns Image.
   def remove_image(img)
-    if image_ids.include?(img.id) || thumb_image_id == img.id
-      image_ids.delete(img.id)
-      update(thumb_image_id: image_ids.empty? ? nil : image_ids.first) \
+    if images.include?(img) || thumb_image_id == img.id
+      images.delete(img)
+      update(thumb_image: images.empty? ? nil : images.first) \
         if thumb_image_id == img.id
       notify_users(:removed_image)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,7 +312,7 @@ class User < AbstractModel
   has_many :edited_locations, through: :location_description_editors,
                               source: :location_description
 
-  belongs_to :image         # mug shot
+  belongs_to :image, inverse_of: :profile_users # mug shot
   belongs_to :license       # user's default license
   belongs_to :location      # primary location
 
@@ -1081,7 +1081,7 @@ class User < AbstractModel
             images.joins(:glossary_term_images) -
             images.joins(:observation_images) -
             images.joins(:project_images) -
-            images.joins(:subjects)).
+            images.joins(:profile_users)).
           map(&:id)
     Image.where(id: ids).delete_all
   end

--- a/app/views/images/show/_info_panel.html.erb
+++ b/app/views/images/show/_info_panel.html.erb
@@ -15,7 +15,7 @@
             <%= link_with_query(obs.unique_format_name.t, obs.show_link_args) %>
           </div>
         <% end %>
-        <% @image.subjects.each do |user| %>
+        <% @image.profile_users.each do |user| %>
           <div>
             <%= :USER.t %>:
             <%= link_with_query(user.format_name.t, user.show_link_args) %>

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -158,9 +158,9 @@ class ImageTest < UnitTestCase
     term2 = glossary_terms(:unused_thumb_and_used_image_glossary_term)
     assert_obj_arrays_equal([term1, term2].sort_by(&:id),
                             img1.glossary_terms.sort_by(&:id))
-    assert_obj_arrays_equal([term1], img1.best_glossary_terms)
+    assert_obj_arrays_equal([term1], img1.thumbnail_glossary_terms)
     assert_obj_arrays_equal([term2], img2.glossary_terms)
-    assert_obj_arrays_equal([term2], img2.best_glossary_terms)
+    assert_obj_arrays_equal([term2], img2.thumbnail_glossary_terms)
   end
 
   def test_delete_thmubnail_of_glossary_term_with_no_other_images
@@ -184,6 +184,8 @@ class ImageTest < UnitTestCase
     other_images = term.images - [thumb]
     assert_not_nil(thumb)
     assert_not_empty(other_images)
+    assert_includes(thumb.glossary_terms, term)
+    assert_includes(thumb.thumbnail_glossary_terms, term)
     thumb_id = thumb.id
     other_image_ids = other_images.map(&:id)
 
@@ -217,6 +219,8 @@ class ImageTest < UnitTestCase
     other_images = obs.images - [thumb]
     assert_not_nil(thumb)
     assert_not_empty(other_images)
+    assert_includes(thumb.observations, obs)
+    assert_includes(thumb.thumbnail_observations, obs)
     thumb_id = thumb.id
     other_image_ids = other_images.map(&:id)
 

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -158,9 +158,9 @@ class ImageTest < UnitTestCase
     term2 = glossary_terms(:unused_thumb_and_used_image_glossary_term)
     assert_obj_arrays_equal([term1, term2].sort_by(&:id),
                             img1.glossary_terms.sort_by(&:id))
-    assert_obj_arrays_equal([term1], img1.thumbnail_glossary_terms)
+    assert_obj_arrays_equal([term1], img1.thumb_glossary_terms)
     assert_obj_arrays_equal([term2], img2.glossary_terms)
-    assert_obj_arrays_equal([term2], img2.thumbnail_glossary_terms)
+    assert_obj_arrays_equal([term2], img2.thumb_glossary_terms)
   end
 
   def test_delete_thmubnail_of_glossary_term_with_no_other_images
@@ -185,7 +185,7 @@ class ImageTest < UnitTestCase
     assert_not_nil(thumb)
     assert_not_empty(other_images)
     assert_includes(thumb.glossary_terms, term)
-    assert_includes(thumb.thumbnail_glossary_terms, term)
+    assert_includes(thumb.thumb_glossary_terms, term)
     thumb_id = thumb.id
     other_image_ids = other_images.map(&:id)
 
@@ -220,7 +220,7 @@ class ImageTest < UnitTestCase
     assert_not_nil(thumb)
     assert_not_empty(other_images)
     assert_includes(thumb.observations, obs)
-    assert_includes(thumb.thumbnail_observations, obs)
+    assert_includes(thumb.thumb_observations, obs)
     thumb_id = thumb.id
     other_image_ids = other_images.map(&:id)
 

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -162,4 +162,118 @@ class ImageTest < UnitTestCase
     assert_obj_arrays_equal([term2], img2.glossary_terms)
     assert_obj_arrays_equal([term2], img2.best_glossary_terms)
   end
+
+  def test_delete_thmubnail_of_glossary_term_with_no_other_images
+    term = glossary_terms(:conic_glossary_term)
+    thumb = term.thumb_image
+    other_images = term.images - [thumb]
+    assert_not_nil(thumb)
+    assert_empty(other_images)
+
+    User.current = thumb.user
+    thumb.destroy!
+
+    assert_nil(term.reload.thumb_image,
+               "Glossary term has destroyed image as thumbnail!")
+    assert_empty(term.images, "Glossary term should have no images left!")
+  end
+
+  def test_delete_thmubnail_of_glossary_term_with_multiple_images
+    term = glossary_terms(:plane_glossary_term)
+    thumb = term.thumb_image
+    other_images = term.images - [thumb]
+    assert_not_nil(thumb)
+    assert_not_empty(other_images)
+    thumb_id = thumb.id
+    other_image_ids = other_images.map(&:id)
+
+    User.current = thumb.user
+    thumb.destroy!
+
+    assert_false(term.reload.image_ids.include?(thumb_id),
+                 "Glossary term is attached to destroyed image!")
+    assert_true(other_image_ids.include?(term.thumb_image_id),
+                "Should have chosen another thumbnail for glossary term.")
+  end
+
+  def test_delete_thumbnail_of_observation_with_no_other_images
+    obs = observations(:coprinus_comatus_obs)
+    thumb = obs.thumb_image
+    other_images = obs.images - [thumb]
+    assert_not_nil(thumb)
+    assert_empty(other_images)
+
+    User.current = thumb.user
+    thumb.destroy!
+
+    assert_nil(obs.reload.thumb_image,
+               "Observation has destroyed image as thumbnail!")
+    assert_empty(obs.images, "Observation should have no images left!")
+  end
+
+  def test_delete_thumbnail_of_observation_with_multiple_images
+    obs = observations(:detailed_unknown_obs)
+    thumb = obs.thumb_image
+    other_images = obs.images - [thumb]
+    assert_not_nil(thumb)
+    assert_not_empty(other_images)
+    thumb_id = thumb.id
+    other_image_ids = other_images.map(&:id)
+
+    User.current = thumb.user
+    thumb.destroy!
+
+    assert_false(obs.reload.image_ids.include?(thumb_id),
+                 "Observation is attached to destroyed image!")
+    assert_true(other_image_ids.include?(obs.thumb_image_id),
+                "Should have chosen another thumbnail for observation.")
+  end
+
+  def test_delete_user_profile_image
+    assert_not_nil(rolf.image)
+
+    User.current = rolf.image.user
+    rolf.image.destroy!
+
+    assert_nil(rolf.reload.image_id,
+               "Rolf's is using a destroyed image for profile image!")
+  end
+
+  def test_delete_project_image
+    project = projects(:bolete_project)
+    image = project.images.first
+    assert_not_nil(image)
+    image_id = image.id
+
+    User.current = image.user
+    image.destroy!
+
+    assert_false(project.reload.image_ids.include?(image_id),
+                 "Project is still attached to a destroyed image!")
+  end
+
+  def test_delete_visual_group_image
+    group = visual_groups(:visual_group_one)
+    image = group.images.first
+    assert_not_nil(image)
+    image_id = image.id
+
+    User.current = image.user
+    image.destroy!
+
+    assert_false(group.reload.image_ids.include?(image_id),
+                 "VisualGroup still references a destroyed image!")
+  end
+
+  def test_delete_image_with_votes
+    image = images(:peltigera_image)
+    image_id = image.id
+    assert_not_empty(ImageVote.where(image_id: image_id))
+
+    User.current = image.user
+    image.destroy!
+
+    assert_empty(ImageVote.where(image_id: image_id),
+                 "Failed to delete ImageVotes attached to destroyed image!")
+  end
 end


### PR DESCRIPTION
This was a subtle bug.  As it turns out some associations have already been updated before the before_destroy callback is called, therefore image.observations, for example, is already empty at that point.  This is why unit testing is so important! 