### PR TITLE
Added quick script to look for broken external links in user content.

### DIFF
--- a/script/check_links.rb
+++ b/script/check_links.rb
@@ -29,10 +29,10 @@ def find_links(val)
 end
 
 def test_link!(id, link)
-  STDERR.puts "testing: #{link}"
+  warn("testing: #{link}")
   return if system("curl", "-o/dev/null", "-sfIL", link)
 
-  puts "#{id} #{link}"
+  puts("#{id} #{link}")
 end
 
 table = ARGV[0]

--- a/script/check_links.rb
+++ b/script/check_links.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require(File.expand_path("../config/boot.rb", __dir__))
+require(File.expand_path("../config/environment.rb", __dir__))
+require(File.expand_path("../app/extensions/extensions.rb", __dir__))
+
+abort(<<"HELP") if ARGV.length != 2
+
+  USAGE::
+
+    script/check_links.rb <table> <column>
+
+  DESCRIPTION::
+
+    Loads all the nonempty values in $table.$column and checks any links it
+    finds to see if any are broken.
+
+  PARAMETERS::
+
+    --help     Print this message.
+
+HELP
+
+def find_links(val)
+  Nokogiri::HTML(val.tpl).css("[href]").map do |node|
+    node.attributes["href"]
+  end
+end
+
+def test_link!(id, link)
+  STDERR.puts "testing: #{link}"
+  return if system("curl", "-o/dev/null", "-sfIL", link)
+
+  puts "#{id} #{link}"
+end
+
+table = ARGV[0]
+column = ARGV[1]
+
+model = table.classify.constantize
+model.all.pluck("id", column).each do |id, val|
+  find_links(val).each { |link| test_link!(id, link) } if val.present?
+end
+
+exit 0


### PR DESCRIPTION
For example run:

```
mo> script/check_links names citation > broken_citations.txt
44 https://www.fs.fed.us/rm/pubs_exp_for/priest_river/exp_for_priest_river_1964_smith.pdf#page=24
45 https://www.fs.fed.us/rm/pubs_exp_for/priest_river/exp_for_priest_river_1964_smith.pdf#page=22
46 https://www.fs.fed.us/rm/pubs_exp_for/priest_river/exp_for_priest_river_1964_smith.pdf#page=37
47 https://www.fs.fed.us/rm/pubs_exp_for/priest_river/exp_for_priest_river_1964_smith.pdf#page=23

```

It produces a list of broken URLs, each paired to the id of the names record which contains it.