### PR TITLE
Catch `q` and `id` params for all refactored `index_{object}` methods

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -54,7 +54,7 @@ class CommentsController < ApplicationController
       show_comments_by_user
     elsif params[:for_user].present?
       show_comments_for_user
-    elsif params[:by].present?
+    elsif params[:by].present? || params[:q].present? || params[:id].present?
       index_comment
     else
       list_comments

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -47,7 +47,7 @@ class ImagesController < ApplicationController
       images_by_user
     elsif params[:for_project].present?
       images_for_project
-    elsif params[:by].present?
+    elsif params[:by].present? || params[:q].present? || params[:id].present?
       index_image
     else
       list_images

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -35,7 +35,7 @@ class ProjectsController < ApplicationController
   def index
     if params[:pattern].present?
       project_search
-    elsif params[:by].present?
+    elsif params[:by].present? || params[:q].present? || params[:id].present?
       index_project
     else
       list_projects

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -53,7 +53,7 @@ class SpeciesListsController < ApplicationController
       species_lists_for_project
     elsif params[:by] == "title"
       species_lists_by_title
-    elsif params[:by].present?
+    elsif params[:by].present? || params[:q].present? || params[:id].present?
       index_species_list
     else
       list_species_lists


### PR DESCRIPTION
In my controller refactors my pattern has been to route all `index_{object}` methods through `index` with params, and change all links (e.g. `{ controller: "/images", action: :index, by_user: user.id }` or `images_path(by_user: user.id)`. 

However, I did not always encounter conditionals to handle the query param, and i forgot to handle it in my `index` switch. The result of this  that a link sending a `q` param to certain controllers will not get an index of the relevant query.

No one has reported a problem so far. But it's not the right pattern: any request for an index with a param should hit one of the sub-methods built to handle params, rather than a plain `index`.

This adds a catch for the `q` and `id` params to the `index` switch in these controllers. I'm not sure the `id` is always necessary, but if someone's requesting an index with an `id` this is likely what they want.