### PR TITLE
Fix Visuals `validates` messages

### DIFF
--- a/app/models/visual_group.rb
+++ b/app/models/visual_group.rb
@@ -8,7 +8,9 @@ class VisualGroup < AbstractModel
   validates :name, presence: {
     message: proc { :cannot_be_blank.t }
   }
-  validates :name, format: { without: /\t/, message: :cannot_include_tabs.t }
+  validates :name, format: {
+    without: /\t/, message: proc { :cannot_include_tabs.t }
+  }
 
   def image_count(status = true)
     return visual_group_images.count if status.nil? || status == "needs_review"

--- a/app/models/visual_model.rb
+++ b/app/models/visual_model.rb
@@ -6,7 +6,9 @@ class VisualModel < AbstractModel
   validates :name, presence: {
     message: proc { :cannot_be_blank.t }
   }
-  validates :name, format: { without: /\t/, message: :cannot_include_tabs.t }
+  validates :name, format: {
+    without: /\t/, message: proc { :cannot_include_tabs.t }
+  }
 
   def to_json(_)
     {

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -109,7 +109,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     patch(:update, params: {
             id: @visual_group.id,
             visual_group:
-              { name: "Tab %{\t} here",
+              { name: "Tab\there",
                 approved: @visual_group.approved }
           })
     assert_flash_text(/#{:cannot_include_tabs.t}/)

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -104,18 +104,6 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_redirected_to edit_visual_group_url(@visual_group)
   end
 
-  test "should prevent names with tabs" do
-    login
-    patch(:update, params: {
-            id: @visual_group.id,
-            visual_group:
-              { name: "Tab\there",
-                approved: @visual_group.approved }
-          })
-    assert_flash_text(/#{:cannot_include_tabs.t}/)
-    assert_redirected_to edit_visual_group_url(@visual_group)
-  end
-
   test "should destroy visual_group" do
     login
     assert_difference("VisualGroup.count", -1) do

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -98,9 +98,21 @@ class VisualGroupsControllerTest < FunctionalTestCase
     patch(:update, params: {
             id: @visual_group.id,
             visual_group:
-              { name: "",
+            { name: "",
+              approved: @visual_group.approved }
+          })
+    assert_redirected_to edit_visual_group_url(@visual_group)
+  end
+
+  test "should prevent names with tabs" do
+    login
+    patch(:update, params: {
+            id: @visual_group.id,
+            visual_group:
+              { name: "Tab %{\t} here",
                 approved: @visual_group.approved }
           })
+    assert_flash_text(/#{:cannot_include_tabs.t}/)
     assert_redirected_to edit_visual_group_url(@visual_group)
   end
 


### PR DESCRIPTION
The old messages caused this problem:
` :cannot_include_tabs.t` was called when starting
 any test (even if unrelated to VisualGroup or VisualModel).
This, in turn, threw errors when testing certain changes in `Textile`.
 To verify the problem
 - In the master/main branch, put a breakpoint in `StringExtensions#t`
 - run `rails t test/models/donation_test.rb -n test_truth`
 - when it halts at the breakpoint, `display self`.

### Manual Test
There is none; I couldn't figure out how to insert a tab into the `name` field on the forms.