### PR TITLE
Added script to automatically backup the database.

### DIFF
--- a/script/backup_database.sh
+++ b/script/backup_database.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+#  USAGE::
+#
+#    script/backup_database.sh
+#
+#  DESCRIPTION::
+#
+#  Makes a new snapshot of the database in:
+#
+#    db/backups/
+#
+################################################################################
+set -e
+
+app_root="$( cd "$(dirname "$0")"; pwd -P | sed 's/\/script*//' )"
+config_file=$app_root/config/mysql-$RAILS_ENV.cnf
+backup_dir=$app_root/db/backups
+backup_name=snapshot-`date +%Y%m%d`.gz
+temp_file=/tmp/backup_database.$$
+db=mo_$RAILS_ENV
+
+[ -d $backup_dir ] || mkdir $backup_dir
+cd $backup_dir
+
+# Create a new snapshot.
+mysqldump --defaults-extra-file=$config_file $db | gzip -c - > $backup_name
+chmod 640 $backup_name
+
+# Decide which snapshots we want to keep.
+(
+  ls snapshot-????????.gz 2>&1 | tail -7;            # keep 7 daily backups
+  ls snapshot-??????{01,09,16,23}.gz 2>&1 | tail -9; # keep 8 weekly backups
+  ls snapshot-??????01.gz 2>&1 | tail -14;           # keep 12 monthly backups
+  ls snapshot-????0101.gz 2>&1                       # keep all yearly backups
+) | sort -u > $temp_file
+
+# Delete everything in this directory that's not one of the kept backups.
+ls | comm -23 - $temp_file | xargs rm -f
+
+rm $temp_file
+exit 0

--- a/script/backup_database.sh
+++ b/script/backup_database.sh
@@ -27,7 +27,7 @@ mysqldump --defaults-extra-file=$config_file $db | gzip -c - > $snapshot_file
 chmod 640 $snapshot_file
 scp $snapshot_file $remote_host:$backup_dir/$backup_file
 
-ssh $remote_host 'ls $backup_dir/*' > $temp_file.1
+ssh $remote_host "ls $backup_dir/*" > $temp_file.1
 
 # Decide which snapshots we want to keep.
 (


### PR DESCRIPTION
I changed it to store the snapshots on the image server, so there is no manual test now, sorry.

It keeps 7 daily backups, 8 weekly backups, 12 monthly backups, all yearly backups, and it removes anything else from the backup directory.  This will soon take up ca. 10 GB of disk space, but that's a drop in the bucket on the image server, so I don't anticipate any problems.