### PR TITLE
Add test_helper to RssLogsControllerTest

### DIFF
--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require("test_helper")
+
 class RssLogsControllerTest < FunctionalTestCase
   def test_page_loads
     login


### PR DESCRIPTION
Fixes at least:
```ruby
$ rails t test/controllers/rss_logs_controller_test.rb
/vagrant/mushroom-observer/test/controllers/rss_logs_controller_test.rb:3:in `<top (required)>': uninitialized constant FunctionalTestCase (NameError)

class RssLogsControllerTest < FunctionalTestCase
....
```