### PR TITLE
Dispatch index action to subactions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1399,22 +1399,6 @@ class ApplicationController < ActionController::Base
   # query_params_set::        Tells +query_params+ to pass this query on
   #                           in links on this page.
   #
-  class << self
-    attr :dispatch_table_for_index_subactions
-  end
-
-  def index
-    dispatch_index_to_subaction
-  end
-
-  def dispatch_index_to_subaction
-    self.class.
-      dispatch_table_for_index_subactions.each do |subaction_key, subaction|
-      return send(subaction || subaction_key) if params[subaction_key].present?
-    end
-    default_index_action
-  end
-
   def show_index_of_objects(query, args = {})
     letter_arg   = args[:letter_arg] || :letter
     number_arg   = args[:number_arg] || :page
@@ -1556,6 +1540,18 @@ class ApplicationController < ActionController::Base
   end
 
   private ##########
+
+  class << self
+    attr :dispatch_table_for_index_subactions
+  end
+
+  def dispatch_index_to_subaction
+    self.class.
+      dispatch_table_for_index_subactions.each do |subaction_key, subaction|
+      return send(subaction || subaction_key) if params[subaction_key].present?
+    end
+    default_index_action
+  end
 
   def apply_content_filters(query)
     filters = users_content_filters || {}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1545,7 +1545,7 @@ class ApplicationController < ActionController::Base
     attr :dispatch_table_for_index_subactions
   end
 
-  def dispatch_index_to_subaction
+  def dispatch_to_index_subaction
     self.class.
       dispatch_table_for_index_subactions.each do |subaction_key, subaction|
       return send(subaction || subaction_key) if params[subaction_key].present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1399,6 +1399,22 @@ class ApplicationController < ActionController::Base
   # query_params_set::        Tells +query_params+ to pass this query on
   #                           in links on this page.
   #
+  class << self
+    attr :dispatch_table_for_index_subactions
+  end
+
+  def index
+    dispatch_index_to_subaction
+  end
+
+  def dispatch_index_to_subaction
+    self.class.
+      dispatch_table_for_index_subactions.each do |subaction_key, subaction|
+      return send(subaction || subaction_key) if params[subaction_key].present?
+    end
+    default_index_action
+  end
+
   def show_index_of_objects(query, args = {})
     letter_arg   = args[:letter_arg] || :letter
     number_arg   = args[:number_arg] || :page

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -23,7 +23,7 @@ class CollectionNumbersController < ApplicationController
   }.freeze
 
   def index
-    dispatch_index_to_subaction
+    dispatch_to_index_subaction
   end
 
   def show

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -14,16 +14,16 @@ class CollectionNumbersController < ApplicationController
   before_action :pass_query_params, except: :index
   before_action :store_location, except: [:index, :destroy]
 
-  def index # rubocop:disable Metrics/AbcSize
-    if params[:pattern].present? # rubocop:disable Style/GuardClause
-      collection_number_search and return
-    elsif params[:observation_id].present?
-      observation_index and return
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_collection_number and return
-    else
-      list_collection_numbers and return
-    end
+  @dispatch_table_for_index_subactions = {
+    pattern: :collection_number_search,
+    observation_id: :observation_index,
+    by: :index_collection_number,
+    q: :index_collection_number,
+    id: :index_collection_number
+  }.freeze
+
+  def index
+    dispatch_index_to_subaction
   end
 
   def show
@@ -88,6 +88,10 @@ class CollectionNumbersController < ApplicationController
   ##############################################################################
 
   private
+
+  def default_index_action
+    list_collection_numbers
+  end
 
   # Displays matrix of selected CollectionNumber's (based on current Query).
   def index_collection_number

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -43,25 +43,6 @@ class CommentsController < ApplicationController
   #  :section: Searches and Indexes
   #
   ##############################################################################
-=begin
-  # rubocop:disable Metrics/AbcSize
-  def index
-    if params[:target].present?
-      show_comments_for_target
-    elsif params[:pattern].present?
-      comment_search
-    elsif params[:by_user].present?
-      show_comments_by_user
-    elsif params[:for_user].present?
-      show_comments_for_user
-    elsif params[:by].present?
-      index_comment
-    else
-      list_comments
-    end
-  end
-  # rubocop:enable Metrics/AbcSize
-=end
 
   @dispatch_table_for_index_subactions = {
     target: :show_comments_for_target,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -43,7 +43,7 @@ class CommentsController < ApplicationController
   #  :section: Searches and Indexes
   #
   ##############################################################################
-
+=begin
   # rubocop:disable Metrics/AbcSize
   def index
     if params[:target].present?
@@ -61,10 +61,29 @@ class CommentsController < ApplicationController
     end
   end
   # rubocop:enable Metrics/AbcSize
+=end
 
-  private
+  @dispatch_table_for_index_subactions = {
+    target: :show_comments_for_target,
+    pattern: :comment_search,
+    by_user: :show_comments_by_user,
+    for_user: :show_comments_for_user,
+    by: :index_comment
+  }.freeze
 
-  # Show selected list of comments, based on current Query.  (Linked from
+  def index
+    dispatch_to_index_subaction
+  end
+
+##############################################################################
+
+private
+
+def default_index_action
+  list_comments
+end
+
+# Show selected list of comments, based on current Query.  (Linked from
   # show_comment, next to "prev" and "next"... or will be.)
   def index_comment
     query = find_or_create_query(:Comment, by: params[:by])

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -75,15 +75,15 @@ class CommentsController < ApplicationController
     dispatch_to_index_subaction
   end
 
-##############################################################################
+  ############################################################################
 
-private
+  private
 
-def default_index_action
-  list_comments
-end
+  def default_index_action
+    list_comments
+  end
 
-# Show selected list of comments, based on current Query.  (Linked from
+  # Show selected list of comments, based on current Query.  (Linked from
   # show_comment, next to "prev" and "next"... or will be.)
   def index_comment
     query = find_or_create_query(:Comment, by: params[:by])

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -27,7 +27,7 @@ class HerbariumRecordsController < ApplicationController
   }.freeze
 
   def index
-    dispatch_index_to_subaction
+    dispatch_to_index_subaction
   end
 
   def show

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -17,15 +17,6 @@ class HerbariumRecordsController < ApplicationController
   before_action :pass_query_params, except: :index
   before_action :store_location, except: [:index, :destroy]
 
-  INDEX_SUBACTION_KEYS = [
-    :pattern,
-    :herbarium_id,
-    :observation_id,
-    :by,
-    :q,
-    :id
-  ].freeze
-
   KEY_TO_SUBACTION = {
     pattern: :herbarium_record_search,
     herbarium_id: :herbarium_index,
@@ -36,10 +27,8 @@ class HerbariumRecordsController < ApplicationController
   }.freeze
 
   def index
-    INDEX_SUBACTION_KEYS.each do |subaction|
-      if params[subaction].present?
-        return send(KEY_TO_SUBACTION[subaction] || subaction)
-      end
+    KEY_TO_SUBACTION.each do |index_key, subaction|
+      return send(subaction || index_key) if params[index_key].present?
     end
     list_herbarium_records
   end

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -17,7 +17,7 @@ class HerbariumRecordsController < ApplicationController
   before_action :pass_query_params, except: :index
   before_action :store_location, except: [:index, :destroy]
 
-  KEY_TO_SUBACTION = {
+  @dispatch_table_for_index_subactions = {
     pattern: :herbarium_record_search,
     herbarium_id: :herbarium_index,
     observation_id: :observation_index,
@@ -25,13 +25,6 @@ class HerbariumRecordsController < ApplicationController
     q: :index_herbarium_record,
     id: :index_herbarium_record
   }.freeze
-
-  def index
-    KEY_TO_SUBACTION.each do |subaction_key, subaction|
-      return send(subaction || subaction_key) if params[subaction_key].present?
-    end
-    default_index_action
-  end
 
   def show
     case params[:flow]

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -17,21 +17,32 @@ class HerbariumRecordsController < ApplicationController
   before_action :pass_query_params, except: :index
   before_action :store_location, except: [:index, :destroy]
 
-  # rubocop:disable Metrics/AbcSize
+  INDEX_SUBACTION_KEYS = [
+    :pattern,
+    :herbarium_id,
+    :observation_id,
+    :by,
+    :q,
+    :id
+  ].freeze
+
+  KEY_TO_SUBACTION = {
+    pattern: :herbarium_record_search,
+    herbarium_id: :herbarium_index,
+    observation_id: :observation_index,
+    by: :index_herbarium_record,
+    q: :index_herbarium_record,
+    id: :index_herbarium_record
+  }.freeze
+
   def index
-    if params[:pattern].present? # rubocop:disable Style/GuardClause
-      herbarium_record_search and return
-    elsif params[:herbarium_id].present?
-      herbarium_index and return
-    elsif params[:observation_id].present?
-      observation_index and return
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_herbarium_record and return
-    else
-      list_herbarium_records and return
+    INDEX_SUBACTION_KEYS.each do |subaction|
+      if params[subaction].present?
+        return send(KEY_TO_SUBACTION[subaction] || subaction)
+      end
     end
+    list_herbarium_records
   end
-  # rubocop:enable Metrics/AbcSize
 
   def show
     case params[:flow]

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -26,6 +26,10 @@ class HerbariumRecordsController < ApplicationController
     id: :index_herbarium_record
   }.freeze
 
+  def index
+    dispatch_index_to_subaction
+  end
+
   def show
     case params[:flow]
     when "next"

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -30,7 +30,7 @@ class HerbariumRecordsController < ApplicationController
     KEY_TO_SUBACTION.each do |index_key, subaction|
       return send(subaction || index_key) if params[index_key].present?
     end
-    list_herbarium_records
+    default_index_action
   end
 
   def show
@@ -95,6 +95,10 @@ class HerbariumRecordsController < ApplicationController
   ##############################################################################
 
   private
+
+  def default_index_action
+    list_herbarium_records
+  end
 
   def set_ivars_for_new
     @layout = calc_layout_params

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -27,8 +27,8 @@ class HerbariumRecordsController < ApplicationController
   }.freeze
 
   def index
-    KEY_TO_SUBACTION.each do |index_key, subaction|
-      return send(subaction || index_key) if params[index_key].present?
+    KEY_TO_SUBACTION.each do |subaction_key, subaction|
+      return send(subaction || subaction_key) if params[subaction_key].present?
     end
     default_index_action
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -43,7 +43,7 @@ class ImagesController < ApplicationController
     pattern: :image_search,
     by_user: :images_by_user,
     for_project: :images_for_project,
-    by: :index_image,
+    by: :index_image
   }.freeze
 
   def index

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -38,23 +38,25 @@ class ImagesController < ApplicationController
   #
   ##############################################################################
 
-  def index # rubocop:disable Metrics/AbcSize
-    if params[:advanced_search].present?
-      advanced_search
-    elsif params[:pattern].present?
-      image_search
-    elsif params[:by_user].present?
-      images_by_user
-    elsif params[:for_project].present?
-      images_for_project
-    elsif params[:by].present?
-      index_image
-    else
-      list_images
-    end
+  @dispatch_table_for_index_subactions = {
+    advanced_search: :advanced_search,
+    pattern: :image_search,
+    by_user: :images_by_user,
+    for_project: :images_for_project,
+    by: :index_image,
+  }.freeze
+
+  def index
+    dispatch_to_index_subaction
   end
 
+  ########################
+
   private
+
+  def default_index_action
+    list_images
+  end
 
   # Display matrix of selected images, based on current Query.
   def index_image

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -29,4 +29,21 @@ class ObservationsController < ApplicationController
     # an observation from a species_list, but I can't figure out how.
     :edit
   ]
+
+  # Defined here, rather than in a module,
+  # because the superclass needs a class instance variable
+  @dispatch_table_for_index_subactions = {
+    advanced_search: :advanced_search,
+    pattern: :observation_search,
+    look_alikes: :observations_of_look_alikes,
+    related_taxa: :observations_of_related_taxa,
+    name: :observations_of_name,
+    user: :observations_by_user,
+    location: :observations_at_location,
+    where: :observations_at_where,
+    project: :observations_for_project,
+    by: :index_observation,
+    q: :index_observation,
+    id: :index_observation
+  }.freeze
 end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -4,6 +4,7 @@
 module ObservationsController::Index
   # Displays matrix of all Observations, sorted by date.
   # Searches come first because they may have the other params
+=begin
   # cop disabled per https://github.com/MushroomObserver/mushroom-observer/pull/1060#issuecomment-1179410808
   # NOTE: ABC offense could be fixed with the technique described in
   # https://github.com/MushroomObserver/mushroom-observer/pull/1060#issuecomment-1179469322
@@ -34,8 +35,21 @@ module ObservationsController::Index
       list_observations and return
     end
   end
+=end
 
-  # Displays matrix of selected Observations (based on current Query).
+@dispatch_table_for_index_subactions = {
+  advanced_search: :advanced_search,
+  pattern: :image_search,
+  by_user: :images_by_user,
+  for_project: :images_for_project,
+  by: :index_image,
+}.freeze
+
+def index
+  dispatch_to_index_subaction
+end
+
+ # Displays matrix of selected Observations (based on current Query).
   # NOTE: Why are all the :id params converted .to_s below?
   def index_observation
     query = find_or_create_query(:Observation, by: params[:by])

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -4,52 +4,11 @@
 module ObservationsController::Index
   # Displays matrix of all Observations, sorted by date.
   # Searches come first because they may have the other params
-=begin
-  # cop disabled per https://github.com/MushroomObserver/mushroom-observer/pull/1060#issuecomment-1179410808
-  # NOTE: ABC offense could be fixed with the technique described in
-  # https://github.com/MushroomObserver/mushroom-observer/pull/1060#issuecomment-1179469322
-  def index # rubocop:disable Metrics/AbcSize
-    # cop disabled because immediate fix is ugly and the offense is avoidable
-    # by fixing the ABC offense. See above
-    if params[:advanced_search].present? # rubocop:disable Style/GuardClause
-      advanced_search and return
-    elsif params[:pattern].present?
-      observation_search and return
-    elsif params[:look_alikes].present? && params[:name].present?
-      observations_of_look_alikes and return
-    elsif params[:related_taxa].present? && params[:name].present?
-      observations_of_related_taxa and return
-    elsif params[:name].present?
-      observations_of_name and return
-    elsif params[:user].present?
-      observations_by_user and return
-    elsif params[:location].present?
-      observations_at_location and return
-    elsif params[:where].present?
-      observations_at_where and return
-    elsif params[:project].present?
-      observations_for_project and return
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_observation and return
-    else
-      list_observations and return
-    end
+  def index
+    dispatch_to_index_subaction
   end
-=end
 
-@dispatch_table_for_index_subactions = {
-  advanced_search: :advanced_search,
-  pattern: :image_search,
-  by_user: :images_by_user,
-  for_project: :images_for_project,
-  by: :index_image,
-}.freeze
-
-def index
-  dispatch_to_index_subaction
-end
-
- # Displays matrix of selected Observations (based on current Query).
+  # Displays matrix of selected Observations (based on current Query).
   # NOTE: Why are all the :id params converted .to_s below?
   def index_observation
     query = find_or_create_query(:Observation, by: params[:by])
@@ -195,7 +154,13 @@ end
     show_index_of_objects(query, args)
   end
 
+  #########################################################################
+
   private
+
+  def default_index_action
+    list_observations
+  end
 
   def create_advanced_search_query(params) # rubocop:disable Metrics/AbcSize
     search = {}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,14 +32,13 @@ class ProjectsController < ApplicationController
   before_action :pass_query_params, except: [:index]
   before_action :disable_link_prefetching, except: [:edit, :show]
 
+  @dispatch_table_for_index_subactions = {
+    pattern: :project_search,
+    by: :index_project
+  }.freeze
+
   def index
-    if params[:pattern].present?
-      project_search
-    elsif params[:by].present?
-      index_project
-    else
-      list_projects
-    end
+    dispatch_to_index_subaction
   end
 
   # Display project by itself.
@@ -183,6 +182,10 @@ class ProjectsController < ApplicationController
   #  :section: Index private methods
   #
   ##############################################################################
+
+  def default_index_action
+    list_projects
+  end
 
   # Show list of selected projects, based on current Query.
   def index_project


### PR DESCRIPTION
- Dispatches certain `index` actions to subactions through a dispatch table instead of switches
(`case` statements of `if elsif else`).
- Improves ABC metric of those actions, fixing some Rubocop ABC offenses.
- See [@mo-nathan's email](https://groups.google.com/g/mo-developers/c/asJ1AbwHQXQ/m/wdN3tL3eAAAJ) and related discussion.

There is no manual test.