### PR TITLE
Tweaked Name#brief_author to leave qualifiers at the end intact

### DIFF
--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -108,13 +108,21 @@ module Name::Format
 
   private
 
+  PROV                       = /[a-z]+\.? prov\.?|ined\.?|ad ?int\.?/
+  INVAL                      = /[a-z]+\.? (inval|illeg(it)?)\.?/
+  ANY_ENDING_AFTER_COMMA     = /^(.*)(, [a-z. ]+)$/
+  SOME_ENDINGS_WITHOUT_COMMA = /^(.*)( (#{PROV}|#{INVAL}))$/
+  ENDINGS_WORTH_KEEPING      = / (#{PROV}|#{INVAL})$/
+
   # author(s) string shortened per ICN Recommendation 46C.2
   # Relies on name.author having a comma only if there are > 2 authors
   def brief_author
     str = author
     # pull of any qualifiers at the end, like "ined.", "nom. prov.", etc.
-    if (match = author.match(/^(.*)(, [a-z. ]+)$/))
+    if (match = author.match(ANY_ENDING_AFTER_COMMA) ||
+                author.match(SOME_ENDINGS_WITHOUT_COMMA))
       str, ending = match[1, 2]
+      ending = "" unless ending.match(ENDINGS_WORTH_KEEPING)
     end
     str.sub(/,.*\)/, " et al.)"). # shorten > 2 authors in parens
       sub(/,.*/, " et al.") +     # then shorten any remaining > 2 authors

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -111,8 +111,14 @@ module Name::Format
   # author(s) string shortened per ICN Recommendation 46C.2
   # Relies on name.author having a comma only if there are > 2 authors
   def brief_author
-    author.sub(/(\(*.),.*\)/, "\\1 et al.)"). # shorten > 2 authors in parens
-      sub(/,.*/, " et al.") # then shorten any remaining > 2 authors
+    str = author
+    # pull of any qualifiers at the end, like "ined.", "nom. prov.", etc.
+    if (match = author.match(/^(.*)(, [a-z. ]+)$/))
+      str, ending = match[1, 2]
+    end
+    str.sub(/,.*\)/, " et al.)"). # shorten > 2 authors in parens
+      sub(/,.*/, " et al.") +     # then shorten any remaining > 2 authors
+      ending.to_s                 # tack qualifiers back onto end
   end
 
   module ClassMethods

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3629,13 +3629,26 @@ class NameTest < UnitTestCase
 
   def test_more_brief_authors
     name = Name.new
+
     name.author = "(A, B, C, D & E)"
     assert_equal("(A et al.)", name.send(:brief_author))
+
     name.author = "(Blah) A, B, C, D & E"
     assert_equal("(Blah) A et al.", name.send(:brief_author))
+
     name.author = "One & Two, nom. prov."
     assert_equal("One & Two, nom. prov.", name.send(:brief_author))
-    name.author = "(A, B & C) D, E & F, ined."
-    assert_equal("(A et al.) D et al., ined.", name.send(:brief_author))
+
+    name.author = "(A, B & C) D, E & F ined."
+    assert_equal("(A et al.) D et al. ined.", name.send(:brief_author))
+
+    name.author = "(A, B & C) D, E & F nom illeg"
+    assert_equal("(A et al.) D et al. nom illeg", name.send(:brief_author))
+
+    name.author = "(A, B & C) D, E & F nom cons"
+    assert_equal("(A et al.) D et al.", name.send(:brief_author))
+
+    name.author = "(A, B & C) D, E & F, sp. nov."
+    assert_equal("(A et al.) D et al.", name.send(:brief_author))
   end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3626,4 +3626,16 @@ class NameTest < UnitTestCase
     )
     assert_empty(Name.in_box(n: 0.0001, s: 0, e: 0.0001, w: 0))
   end
+
+  def test_more_brief_authors
+    name = Name.new
+    name.author = "(A, B, C, D & E)"
+    assert_equal("(A et al.)", name.send(:brief_author))
+    name.author = "(Blah) A, B, C, D & E"
+    assert_equal("(Blah) A et al.", name.send(:brief_author))
+    name.author = "One & Two, nom. prov."
+    assert_equal("One & Two, nom. prov.", name.send(:brief_author))
+    name.author = "(A, B & C) D, E & F, ined."
+    assert_equal("(A et al.) D et al., ined.", name.send(:brief_author))
+  end
 end


### PR DESCRIPTION
I think at least some qualifiers are critically important, such as "nom. prov." and "ined."  This PR currently tells Name#brief_author to preserve all such qualifiers -- defined as any number of lowercase words and dots following the final comma.

I'm working on getting a list of all currently used qualifiers so we can have an informed discussion about whether this is the right thing to do...