### PR TITLE
Dispatch index to subactions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1541,6 +1541,22 @@ class ApplicationController < ActionController::Base
 
   private ##########
 
+  class << self
+    attr :index_subaction_dispatch_table, :index_subaction_param_keys
+  end
+
+  def dispatch_to_index_subaction
+    self.class.index_subaction_param_keys.each do |subaction|
+      if params[subaction].present?
+        return send(
+          self.class.index_subaction_dispatch_table[subaction] ||
+          subaction
+        )
+      end
+    end
+    default_index_action
+  end
+
   def apply_content_filters(query)
     filters = users_content_filters || {}
     @any_content_filters_applied = false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1366,7 +1366,24 @@ class ApplicationController < ActionController::Base
   #
   ##############################################################################
 
-  # Render an index or set of search results as a list or matrix. Arguments:
+  class << self
+    attr :index_subaction_dispatch_table, :index_subaction_param_keys
+  end
+
+  # Dispatch to a subaction
+  def index
+    self.class.index_subaction_param_keys.each do |subaction|
+      if params[subaction].present?
+        return send(
+          self.class.index_subaction_dispatch_table[subaction] ||
+          subaction
+        )
+      end
+    end
+    default_index_subaction
+  end
+
+# Render an index or set of search results as a list or matrix. Arguments:
   # query::     Query instance describing search/index.
   # args::      Hash of options.
   #
@@ -1540,22 +1557,6 @@ class ApplicationController < ActionController::Base
   end
 
   private ##########
-
-  class << self
-    attr :index_subaction_dispatch_table, :index_subaction_param_keys
-  end
-
-  def dispatch_to_index_subaction
-    self.class.index_subaction_param_keys.each do |subaction|
-      if params[subaction].present?
-        return send(
-          self.class.index_subaction_dispatch_table[subaction] ||
-          subaction
-        )
-      end
-    end
-    default_index_subaction
-  end
 
   def apply_content_filters(query)
     filters = users_content_filters || {}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1554,7 +1554,7 @@ class ApplicationController < ActionController::Base
         )
       end
     end
-    default_index_action
+    default_index_subaction
   end
 
   def apply_content_filters(query)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1383,7 +1383,7 @@ class ApplicationController < ActionController::Base
     default_index_subaction
   end
 
-# Render an index or set of search results as a list or matrix. Arguments:
+  # Render an index or set of search results as a list or matrix. Arguments:
   # query::     Query instance describing search/index.
   # args::      Hash of options.
   #

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -14,7 +14,7 @@ class CollectionNumbersController < ApplicationController
   before_action :pass_query_params, except: :index
   before_action :store_location, except: [:index, :destroy]
 
-  INDEX_SUBACTION_PARAM_KEYS = [
+  @index_subaction_param_keys = [
     :pattern,
     :observation_id,
     :by,
@@ -22,7 +22,7 @@ class CollectionNumbersController < ApplicationController
     :id
   ].freeze
 
-  INDEX_SUBACTION_DISPATCH_TABLE = {
+  @index_subaction_dispatch_table = {
     pattern: :collection_number_search,
     observation_id: :observation_index,
     by: :index_collection_number,
@@ -96,18 +96,6 @@ class CollectionNumbersController < ApplicationController
   ##############################################################################
 
   private
-
-  def dispatch_to_index_subaction
-    INDEX_SUBACTION_PARAM_KEYS.each do |subaction|
-      if params[subaction].present?
-        return send(
-          INDEX_SUBACTION_DISPATCH_TABLE[subaction] ||
-          subaction
-        )
-      end
-    end
-    default_index_action
-  end
 
   def default_index_action
     list_collection_numbers

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -30,7 +30,10 @@ class CollectionNumbersController < ApplicationController
     id: :index_collection_number
   }.freeze
 
-  def index
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
     super
   end
 

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -97,7 +97,7 @@ class CollectionNumbersController < ApplicationController
 
   private
 
-  def default_index_action
+  def default_index_subaction
     list_collection_numbers
   end
 

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -31,7 +31,7 @@ class CollectionNumbersController < ApplicationController
   }.freeze
 
   def index
-    dispatch_to_index_subaction
+    super
   end
 
   def show

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -44,25 +44,34 @@ class CommentsController < ApplicationController
   #
   ##############################################################################
 
-  # rubocop:disable Metrics/AbcSize
-  def index
-    if params[:target].present?
-      show_comments_for_target
-    elsif params[:pattern].present?
-      comment_search
-    elsif params[:by_user].present?
-      show_comments_by_user
-    elsif params[:for_user].present?
-      show_comments_for_user
-    elsif params[:by].present?
-      index_comment
-    else
-      list_comments
-    end
+  @index_subaction_param_keys = [
+    :target,
+    :pattern,
+    :by_user,
+    :for_user,
+    :by
+  ].freeze
+
+  @index_subaction_dispatch_table = {
+    target: :show_comments_for_target,
+    pattern: :comment_search,
+    by_user: :show_comments_by_user,
+    for_user: :show_comments_for_user,
+    by: :index_comment
+  }.freeze
+
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
   end
-  # rubocop:enable Metrics/AbcSize
 
   private
+
+  def default_index_subaction
+    list_comments
+  end
 
   # Show selected list of comments, based on current Query.  (Linked from
   # show_comment, next to "prev" and "next"... or will be.)

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -17,21 +17,30 @@ class HerbariumRecordsController < ApplicationController
   before_action :pass_query_params, except: :index
   before_action :store_location, except: [:index, :destroy]
 
-  # rubocop:disable Metrics/AbcSize
-  def index
-    if params[:pattern].present? # rubocop:disable Style/GuardClause
-      herbarium_record_search and return
-    elsif params[:herbarium_id].present?
-      herbarium_index and return
-    elsif params[:observation_id].present?
-      observation_index and return
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_herbarium_record and return
-    else
-      list_herbarium_records and return
-    end
+  @index_subaction_param_keys = [
+    :pattern,
+    :herbarium_id,
+    :observation_id,
+    :by,
+    :q,
+    :id
+  ].freeze
+
+  @index_subaction_dispatch_table = {
+    pattern: :herbarium_record_search,
+    herbarium_id: :herbarium_index,
+    observation_id: :observation_index,
+    by: :index_herbarium_record,
+    q: :index_herbarium_record,
+    id: :index_herbarium_record
+  }.freeze
+
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
   end
-  # rubocop:enable Metrics/AbcSize
 
   def show
     case params[:flow]
@@ -95,6 +104,10 @@ class HerbariumRecordsController < ApplicationController
   ##############################################################################
 
   private
+
+  def default_index_subaction
+    list_herbarium_records
+  end
 
   def set_ivars_for_new
     @layout = calc_layout_params

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -38,23 +38,33 @@ class ImagesController < ApplicationController
   #
   ##############################################################################
 
-  def index # rubocop:disable Metrics/AbcSize
-    if params[:advanced_search].present?
-      advanced_search
-    elsif params[:pattern].present?
-      image_search
-    elsif params[:by_user].present?
-      images_by_user
-    elsif params[:for_project].present?
-      images_for_project
-    elsif params[:by].present?
-      index_image
-    else
-      list_images
-    end
+  @index_subaction_param_keys = [
+    :advanced_search,
+    :pattern,
+    :by_user,
+    :for_project,
+    :by
+  ].freeze
+
+  @index_subaction_dispatch_table = {
+    pattern: :image_search,
+    by_user: :images_by_user,
+    for_project: :images_for_project,
+    by: :index_image
+  }.freeze
+
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
   end
 
   private
+
+  def default_index_subaction
+    list_images
+  end
 
   # Display matrix of selected images, based on current Query.
   def index_image

--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -33,19 +33,34 @@ module Locations
     #
     ############################################################################
 
-    def index
-      if params[:by_author].present?
-        location_descriptions_by_author
-      elsif params[:by_editor].present?
-        location_descriptions_by_editor
-      elsif params[:by].present? || params[:q].present? || params[:id].present?
-        index_location_description
-      else
-        list_location_descriptions
-      end
+    @index_subaction_param_keys = [
+      :by_author,
+      :by_editor,
+      :by,
+      :q,
+      :id
+    ].freeze
+
+    @index_subaction_dispatch_table = {
+      by_author: :location_descriptions_by_author,
+      by_editor: :location_descriptions_by_editor,
+      by: :index_location_description,
+      q: :index_location_description,
+      id: :index_location_description
+    }.freeze
+
+    # Disable cop because method definition prevents a
+    # Rails/LexicallyScopedActionFilter offense
+    # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+    def index # rubocop:disable Lint/UselessMethodDefinition
+      super
     end
 
     private
+
+    def default_index_subaction
+      list_location_descriptions
+    end
 
     # Displays a list of selected locations, based on current Query.
     def index_location_description

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -54,7 +54,7 @@ class LocationsController < ApplicationController
     by_editor: :locations_by_editor,
     by: :index_location,
     q: :index_location,
-    id: :index_location,
+    id: :index_location
   }.freeze
 
   # Disable cop because method definition prevents a

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -36,25 +36,39 @@ class LocationsController < ApplicationController
   #
   ##############################################################################
 
-  def index # rubocop:disable Metrics/AbcSize
-    if params[:advanced_search].present?
-      advanced_search
-    elsif params[:pattern].present?
-      location_search
-    elsif params[:country].present?
-      list_by_country
-    elsif params[:by_user].present?
-      locations_by_user
-    elsif params[:by_editor].present?
-      locations_by_editor
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_location
-    else
-      list_locations
-    end
+  @index_subaction_param_keys = [
+    :advanced_search,
+    :pattern,
+    :country,
+    :by_user,
+    :by_editor,
+    :by,
+    :q,
+    :id
+  ].freeze
+
+  @index_subaction_dispatch_table = {
+    pattern: :location_search,
+    country: :list_by_country,
+    by_user: :locations_by_user,
+    by_editor: :locations_by_editor,
+    by: :index_location,
+    q: :index_location,
+    id: :index_location,
+  }.freeze
+
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
   end
 
   private
+
+  def default_index_subaction
+    list_locations
+  end
 
   # Displays a list of selected locations, based on current Query.
   def index_location

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -33,19 +33,36 @@ module Names
     #
     ############################################################################
 
-    def index
-      if params[:by_author].present?
-        name_descriptions_by_author
-      elsif params[:by_editor].present?
-        name_descriptions_by_editor
-      elsif params[:by].present? || params[:q].present? || params[:id].present?
-        index_name_description
-      else
-        list_name_descriptions
-      end
+    @index_subaction_param_keys = [
+      :by_author,
+      :by_editor,
+      :by,
+      :q,
+      :id
+    ].freeze
+
+    @index_subaction_dispatch_table = {
+      by_author: :name_descriptions_by_author,
+      by_editor: :name_descriptions_by_editor,
+      by: :index_name_description,
+      q: :index_name_description,
+      id: :index_name_description
+    }.freeze
+
+    # Disable cop because method definition prevents a
+    # Rails/LexicallyScopedActionFilter offense
+    # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+    def index # rubocop:disable Lint/UselessMethodDefinition
+      super
     end
 
+    #############################################
+
     private
+
+    def default_index_subaction
+      list_name_descriptions
+    end
 
     # Display list of names in last index/search query.
     def index_name_description

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -54,30 +54,46 @@ class NamesController < ApplicationController
   #  :section: Indexes and Searches
   #
   ##############################################################################
+  @index_subaction_param_keys = [
+    :advanced_search,
+    :pattern,
+    :with_observations,
+    :with_descriptions,
+    :need_descriptions,
+    :by_user,
+    :by_editor,
+    :by,
+    :q,
+    :id
+  ].freeze
 
-  def index # rubocop:disable Metrics/AbcSize
-    if params[:advanced_search].present?
-      advanced_search
-    elsif params[:pattern].present?
-      name_search
-    elsif params[:with_observations].present?
-      observation_index
-    elsif params[:with_descriptions].present?
-      names_with_descriptions
-    elsif params[:need_descriptions].present?
-      names_needing_descriptions
-    elsif params[:by_user].present?
-      names_by_user
-    elsif params[:by_editor].present?
-      names_by_editor
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_name
-    else
-      list_names
-    end
+  @index_subaction_dispatch_table = {
+    pattern: :name_search,
+    with_observations: :observation_index,
+    with_descriptions: :names_with_descriptions,
+    need_descriptions: :names_needing_descriptions,
+    by_user: :names_by_user,
+    by_editor: :names_by_editor,
+    by: :index_name,
+    q: :index_name,
+    id: :index_name
+  }.freeze
+
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
   end
 
+  ###################################
+  #  private index methods
+
   private
+
+  def default_index_subaction
+    list_names
+  end
 
   # Display list of names in last index/search query.
   def index_name

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -29,4 +29,35 @@ class ObservationsController < ApplicationController
     # an observation from a species_list, but I can't figure out how.
     :edit
   ]
+
+  # NOTE: These ivars need to be ivars of ObservationController
+  # Defining them in index.rb does not work
+  @index_subaction_param_keys = [
+    :advanced_search, # Searches come 1st because they may have the other params
+    :pattern,
+    :look_alikes,
+    :related_taxa,
+    :name,
+    :user,
+    :location,
+    :where,
+    :project,
+    :by,
+    :q,
+    :id
+  ].freeze
+
+  @index_subaction_dispatch_table = {
+    pattern: :observation_search,
+    look_alikes: :observations_of_look_alikes,
+    related_taxa: :observations_of_related_taxa,
+    name: :observations_of_name,
+    user: :observations_by_user,
+    location: :observations_at_location,
+    where: :observations_at_where,
+    project: :observations_for_project,
+    by: :index_observation,
+    q: :index_observation,
+    id: :index_observation
+  }.freeze
 end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -2,12 +2,10 @@
 
 # see observations_controller.rb
 module ObservationsController::Index
-  # Displays matrix of all Observations, sorted by date.
-  # NOTE: dipatch tables are in ObservationController
-  def index
-    # NOTE: dispatch table is in ObservationsController
-    dispatch_to_index_subaction
-  end
+
+  ###########################################################################
+  # Section: Observation#index subactions
+  # Methods called by #index via a dispatch table in ObservationController
 
   # Displays matrix of selected Observations (based on current Query).
   # NOTE: Why are all the :id params converted .to_s below?
@@ -139,6 +137,8 @@ module ObservationsController::Index
     flash_error(e.to_s) if e.present?
     redirect_to(search_advanced_path)
   end
+
+  ###########################################################################
 
   # Show selected search results as a matrix with "index" template.
   def show_selected_observations(query, args = {})

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -3,36 +3,10 @@
 # see observations_controller.rb
 module ObservationsController::Index
   # Displays matrix of all Observations, sorted by date.
-  # Searches come first because they may have the other params
-  # cop disabled per https://github.com/MushroomObserver/mushroom-observer/pull/1060#issuecomment-1179410808
-  # NOTE: ABC offense could be fixed with the technique described in
-  # https://github.com/MushroomObserver/mushroom-observer/pull/1060#issuecomment-1179469322
-  def index # rubocop:disable Metrics/AbcSize
-    # cop disabled because immediate fix is ugly and the offense is avoidable
-    # by fixing the ABC offense. See above
-    if params[:advanced_search].present? # rubocop:disable Style/GuardClause
-      advanced_search and return
-    elsif params[:pattern].present?
-      observation_search and return
-    elsif params[:look_alikes].present? && params[:name].present?
-      observations_of_look_alikes and return
-    elsif params[:related_taxa].present? && params[:name].present?
-      observations_of_related_taxa and return
-    elsif params[:name].present?
-      observations_of_name and return
-    elsif params[:user].present?
-      observations_by_user and return
-    elsif params[:location].present?
-      observations_at_location and return
-    elsif params[:where].present?
-      observations_at_where and return
-    elsif params[:project].present?
-      observations_for_project and return
-    elsif params[:by].present? || params[:q].present? || params[:id].present?
-      index_observation and return
-    else
-      list_observations and return
-    end
+  # NOTE: dipatch tables are in ObservationController
+  def index
+    # NOTE: dispatch table is in ObservationsController
+    dispatch_to_index_subaction
   end
 
   # Displays matrix of selected Observations (based on current Query).
@@ -183,6 +157,10 @@ module ObservationsController::Index
   end
 
   private
+
+  def default_index_subaction
+    list_observations
+  end
 
   def create_advanced_search_query(params) # rubocop:disable Metrics/AbcSize
     search = {}

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -2,10 +2,16 @@
 
 # see observations_controller.rb
 module ObservationsController::Index
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
+  end
 
   ###########################################################################
-  # Section: Observation#index subactions
-  # Methods called by #index via a dispatch table in ObservationController
+  # index subactions:
+  # methods called by #index via a dispatch table in ObservationController
 
   # Displays matrix of selected Observations (based on current Query).
   # NOTE: Why are all the :id params converted .to_s below?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,14 +32,21 @@ class ProjectsController < ApplicationController
   before_action :pass_query_params, except: [:index]
   before_action :disable_link_prefetching, except: [:edit, :show]
 
-  def index
-    if params[:pattern].present?
-      project_search
-    elsif params[:by].present?
-      index_project
-    else
-      list_projects
-    end
+  @index_subaction_param_keys = [
+    :pattern,
+    :by
+  ].freeze
+
+  @index_subaction_dispatch_table = {
+    pattern: :project_search,
+    by: :index_project
+  }.freeze
+
+  # Disable cop because method definition prevents a
+  # Rails/LexicallyScopedActionFilter offense
+  # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+  def index # rubocop:disable Lint/UselessMethodDefinition
+    super
   end
 
   # Display project by itself.
@@ -183,6 +190,10 @@ class ProjectsController < ApplicationController
   #  :section: Index private methods
   #
   ##############################################################################
+
+  def default_index_subaction
+    list_projects
+  end
 
   # Show list of selected projects, based on current Query.
   def index_project


### PR DESCRIPTION
- Dispatches certain `index` actions to subactions using a dispatch table instead of switches.
- Improves ABC metric of those actions, fixing some Rubocop ABC offenses.
- See [@mo-nathan's email](https://groups.google.com/g/mo-developers/c/asJ1AbwHQXQ/m/wdN3tL3eAAAJ) and related discussion.
(This is v2 of now-closed #1304)

There is no manual test.