### PR TITLE
Fix `observations/show/_name_info.html.erb` layout

### DIFF
--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -22,7 +22,7 @@
                                 observations_path(name: name.id,
                                                   related_taxa: "1"))) %>
     <%= list_descriptions(object: name)&.map { |link|
-          content_tag(:p, link) }.safe_join %>
+          content_tag(:div, link) }.safe_join %>
 
   </div><!--.panel-body-->
 </div><!--.panel-->


### PR DESCRIPTION
The name info panel is a list of links about the proposed name for an Observation, on the Show Observation page. 

If the user happens to be the author of the public description for that name, the last line shows [ Edit | Destroy ] links.
Because of CRUD, the destroy link is now a `destroy_link`, so it will not display inside a `<p>`.
<img width="491" alt="Screen Shot 2023-01-27 at 7 45 55 PM" src="https://user-images.githubusercontent.com/1948095/215240730-5d40ab23-dd97-4b56-ba84-223f6359dc5e.png">

This PR changes that to a `<div>`. Result:
<img width="496" alt="Screen Shot 2023-01-27 at 7 46 04 PM" src="https://user-images.githubusercontent.com/1948095/215240783-125809d4-eb5c-4f06-979d-0047c98f8dba.png">
