### PR TITLE
Update Account Verifications

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -74,7 +74,10 @@ class AccountController < ApplicationController
     UserGroup.create_user(@new_user)
     flash_notice(:runtime_signup_success.tp + :email_spam_notice.tp)
     VerifyMailer.build(@new_user).deliver_now
-    notify_root_of_blocked_verification_email(@new_user)
+    if verification_emails_blocked_as_spam?(user) ||
+       bogus_login?(user)
+      notify_root_of_blocked_verification_email(@new_user)
+    end
     redirect_back_or_default(account_welcome_path)
   end
 
@@ -174,9 +177,6 @@ class AccountController < ApplicationController
   BOGUS_LOGINS = /houghgype|vemslons/
 
   def notify_root_of_blocked_verification_email(user)
-    return if verification_emails_blocked_as_spam?(user) ||
-              bogus_login?(user)
-
     Account::VerificationsController.notify_root_of_verification_email(user)
   end
 

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -107,7 +107,9 @@ class AccountController < ApplicationController
     # Too Many Requests == 429. Any 4xx status (Client Error) would also work.
     render(status: :too_many_requests,
            content_type: "text/plain",
-           plain: "We grow weary of this. Please go away.")
+           plain: "We blocked your signup because your chosen login name or " \
+                  "email address matches one used by a spammer. " \
+                  "Please contact us if you have been blocked in error.")
   end
 
   # Some recurring patterns we've noticed

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -57,12 +57,7 @@ class AccountController < ApplicationController
 
     initialize_new_user
 
-    if block_evil_signups!
-      # Too Many Requests == 429. Any 4xx status (Client Error) would also work.
-      render(status: :too_many_requests,
-             content_type: "text/plain",
-             plain: "We grow weary of this. Please go away.") and return
-    end
+    return block_evil_signups! if evil_signup_credentials?
 
     unless make_sure_theme_is_valid!
       redirect_back_or_default(action: :welcome)
@@ -111,9 +106,10 @@ class AccountController < ApplicationController
   # the Verification email will cause Undelivered Mail Returned to Send; and/or
   # it's a known spammer.
   def block_evil_signups!
-    return false unless evil_signup_credentials?
-
-    true
+    # Too Many Requests == 429. Any 4xx status (Client Error) would also work.
+    render(status: :too_many_requests,
+           content_type: "text/plain",
+           plain: "We grow weary of this. Please go away.")
   end
 
   # Some recurring patterns we've noticed

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -116,15 +116,31 @@ class AccountController < ApplicationController
     true
   end
 
+  # Some recurring patterns we've noticed
+  BOGUS_EMAILS = / namnerbca\.com |
+                   0mg0mg0mg |
+                   yourmail@gmail\.com |
+                   @mnawl.sibicomail\.com
+                   /ix
+
+  # Some recurring patterns we've noticed
   BOGUS_LOGINS = / houghgype |
-                   Uplilla |
+                   uplilla |
                    vemslons /ix
 
   def evil_signup_credentials?
-    BOGUS_LOGINS.match?(@new_user.login) ||
-      /namnerbca.com$/ =~ @new_user.email ||
+    bogus_email? || bogus_login?
+  end
+
+  def bogus_email?
+    BOGUS_EMAILS.match?(@new_user.email) ||
       # Spammer using variations of "b.l.izk.o.ya.n201.7@gmail.com\r\n"
-      @new_user.email.remove(".").include?("blizkoyan2017")
+      @new_user.email.remove(".").include?("blizkoyan") ||
+      @new_user.email.count(".") > 5
+  end
+
+  def bogus_login?
+    BOGUS_LOGINS.match?(@new_user.login)
   end
 
   def make_sure_theme_is_valid!

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -169,10 +169,7 @@ class AccountController < ApplicationController
     end
   end
 
-  SPAM_BLOCKERS = %w[
-    hotmail.com
-    live.com
-  ].freeze
+  SPAM_BLOCKERS = %w[].freeze
 
   BOGUS_LOGINS = /houghgype|vemslons/
 

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -81,7 +81,7 @@ class AccountController < ApplicationController
   # This is the welcome page for new users who just created an account.
   def welcome; end
 
-  private
+  private #################################################
 
   def initialize_new_user
     now = Time.zone.now
@@ -174,10 +174,18 @@ class AccountController < ApplicationController
   BOGUS_LOGINS = /houghgype|vemslons/
 
   def notify_root_of_blocked_verification_email(user)
-    domain = user.email.to_s.sub(/^.*@/, "")
-    return unless SPAM_BLOCKERS.any?(domain)
-    return if user.login.to_s.match(BOGUS_LOGINS)
+    return if verification_emails_blocked_as_spam?(user) ||
+              bogus_login?(user)
 
     Account::VerificationsController.notify_root_of_verification_email(user)
+  end
+
+  def verification_emails_blocked_as_spam?(user)
+    domain = user.email.to_s.sub(/^.*@/, "")
+    SPAM_BLOCKERS.any?(domain)
+  end
+
+  def bogus_login?(user)
+    user.login.to_s.match?(BOGUS_LOGINS)
   end
 end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -74,7 +74,6 @@ class AccountController < ApplicationController
     UserGroup.create_user(@new_user)
     flash_notice(:runtime_signup_success.tp + :email_spam_notice.tp)
     VerifyMailer.build(@new_user).deliver_now
-    notify_root_of_blocked_verification_email(@new_user)
     redirect_back_or_default(account_welcome_path)
   end
 
@@ -171,20 +170,5 @@ class AccountController < ApplicationController
     elsif @new_user.email != @new_user.email_confirmation
       @new_user.errors.add(:email, :validate_user_email_mismatch.t)
     end
-  end
-
-  SPAM_BLOCKERS = %w[].freeze
-
-  def notify_root_if_blocked_verification_email(user)
-    Account::VerificationsController.notify_root_of_verification_email(user)
-  end
-
-  def verification_emails_blocked_as_spam?(user)
-    domain = user.email.to_s.sub(/^.*@/, "")
-    SPAM_BLOCKERS.any?(domain)
-  end
-
-  def bogus_login?(user)
-    user.login.to_s.match?(BOGUS_LOGINS)
   end
 end

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -102,16 +102,3 @@ class RssLogsController < ApplicationController
     show_index_of_objects(query, args)
   end
 end
-
-  def update_user_default_rss_type
-    return unless @user
-
-    if params[:make_default] == "1"
-      @user.default_rss_type = @types.join(" ")
-      @user.save_without_our_callbacks
-    elsif @user.default_rss_type.to_s.split.sort != @types
-      @links << [:rss_make_default.t,
-                 add_query_param(action: :index, make_default: 1)]
-    end
-  end
-end

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Activity feed / Website default page
 class RssLogsController < ApplicationController
   # Uncertain these are necessary, can delete if not.
   require "find"
@@ -13,19 +12,29 @@ class RssLogsController < ApplicationController
   ]
   before_action :disable_link_prefetching
 
-  # Default page. Just displays latest happenings. The actual action is
+  # Default page.  Just displays latest happenings.  The actual action is
   # buried way down toward the end of this file.
   # Displays matrix of selected RssLog's (based on current Query, if exists).
   def index
     # POST requests with param `type` potentially show an array of types
     # of objects. The array comes from the checkboxes in tabset
-    query = if params[:type].present?
-              type_query
-            elsif params[:q].present?
-              saved_or_new_query
-            else
-              new_query
-            end
+    if params[:type].present?
+      types = Array(params[:type])
+      types = RssLog.all_types.intersection(types)
+      types = "all" if types.length == RssLog.all_types.length
+      types = "none" if types.empty?
+      types = types.map(&:to_s).join(" ") if types.is_a?(Array)
+      query = find_or_create_query(:RssLog, type: types)
+    # Previously saved query, incorporating type and other params
+    elsif params[:q].present?
+      query = find_query(:RssLog)
+      query ||= create_query(:RssLog, :all,
+                             type: @user ? @user.default_rss_type : "all")
+    # Fresh version of the index, no existing query
+    else
+      query = create_query(:RssLog, :all,
+                           type: @user ? @user.default_rss_type : "all")
+    end
     show_selected_rss_logs(query, id: params[:id].to_s, always_index: true)
   end
 
@@ -52,27 +61,7 @@ class RssLogsController < ApplicationController
     render_xml(layout: false)
   end
 
-  #########################################################
-
   private
-
-  def type_query
-    types = Array(params[:type])
-    types = RssLog.all_types.intersection(types)
-    types = "all" if types.length == RssLog.all_types.length
-    types = "none" if types.empty?
-    types = types.map(&:to_s).join(" ") if types.is_a?(Array)
-    find_or_create_query(:RssLog, type: types)
-  end
-
-  def saved_or_new_query
-    find_query(:RssLog) || new_query
-  end
-
-  def new_query
-    create_query(:RssLog, :all,
-                 type: @user ? @user.default_rss_type : "all")
-  end
 
   # Show selected search results as a matrix with "index" template.
   def show_selected_rss_logs(query, args = {})
@@ -99,9 +88,20 @@ class RssLogsController < ApplicationController
     @types = query.params[:type].to_s.split.sort
     @links = []
 
-    update_user_default_rss_type
+    # Let the user make this their default and fine tune.
+    if @user
+      if params[:make_default] == "1"
+        @user.default_rss_type = @types.join(" ")
+        @user.save_without_our_callbacks
+      elsif @user.default_rss_type.to_s.split.sort != @types
+        @links << [:rss_make_default.t,
+                   add_query_param(action: :index, make_default: 1)]
+      end
+    end
+
     show_index_of_objects(query, args)
   end
+end
 
   def update_user_default_rss_type
     return unless @user


### PR DESCRIPTION
- Cease emailing webmaster every time a verification email is send to a hotmail or live.com address.
(Those emails to webmaster were used to debug hotmail's rejecting us as spam, which has since been fixed.)
- Refactors terminating new user signups when user is malicious.
