### PR TITLE
Create new panel helper

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -15,9 +15,9 @@ module FormsHelper
     end
   end
 
-  def panel_with_header(**args, &block)
+  def panel_with_heading(**args, &block)
     html = []
-    html << content_tag(:h4, args[:header]) if args[:header]
+    html << content_tag(:h4, args[:heading]) if args[:heading]
     html << panel_block(**args, &block)
     safe_join(html)
   end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -14,4 +14,16 @@ module FormsHelper
       end
     end
   end
+
+  def panel_block(**args, &block)
+    content_tag(
+      :div,
+      class: "panel panel-default #{args[:class]}",
+      id: args[:id]
+    ) do
+      content_tag(:div, class: "panel-body") do
+        concat(capture(&block).to_s)
+      end
+    end
+  end
 end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -15,13 +15,20 @@ module FormsHelper
     end
   end
 
+  def panel_with_header(**args, &block)
+    html = []
+    html << content_tag(:h4, args[:header]) if args[:header]
+    html << panel_block(**args, &block)
+    safe_join(html)
+  end
+
   def panel_block(**args, &block)
     content_tag(
       :div,
       class: "panel panel-default #{args[:class]}",
       id: args[:id]
     ) do
-      content_tag(:div, class: "panel-body") do
+      content_tag(:div, class: "panel-body #{args[:inner_class]}") do
         concat(capture(&block).to_s)
       end
     end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -17,7 +17,7 @@ module FormsHelper
 
   def panel_with_outer_heading(**args, &block)
     html = []
-    h_tag = args[:h_tag].present? ? args[:h_tag] : :h4
+    h_tag = (args[:h_tag].presence || :h4)
     html << content_tag(h_tag, args[:heading]) if args[:heading]
     html << panel_block(**args, &block)
     safe_join(html)

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -15,9 +15,10 @@ module FormsHelper
     end
   end
 
-  def panel_with_heading(**args, &block)
+  def panel_with_outer_heading(**args, &block)
     html = []
-    html << content_tag(:h4, args[:heading]) if args[:heading]
+    h_tag = args[:h_tag].present? ? args[:h_tag] : :h4
+    html << content_tag(h_tag, args[:heading]) if args[:heading]
     html << panel_block(**args, &block)
     safe_join(html)
   end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -9,10 +9,6 @@
   <%= content_tag(:small, @article.created_at.fancy_time) %>
 </div>
 
-<div class="mt-3 panel panel-default">
-  <div class="panel-body">
-    <%= @article.body.tpl %>
-  </div>
-</div>
+<%= panel_block(class: "mt-3") do @article.body.tpl end %>
 
 <%= show_object_footer(@article) %>

--- a/app/views/checklists/show.html.erb
+++ b/app/views/checklists/show.html.erb
@@ -52,12 +52,10 @@
                            genera: @data.num_genera) %>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-body checklist">
-    <ul class="list-unstyled">
-      <% names.each do |name| %>
-        <li><i><%= link_to(name[0], name_path(name[1])) %></i></li>
-      <% end %>
-    </ul>
-  </div>
-</div>
+<%= panel_block(inner_class: "checklist") do %>
+  <ul class="list-unstyled">
+    <% names.each do |name| %>
+      <li><i><%= link_to(name[0], name_path(name[1])) %></i></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -40,11 +40,7 @@
 <div class="row">
   <% @other_images.each do |image|  %>
     <div class="col-sm-4">
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <%= thumbnail(image, votes: true) %>
-        </div>
-      </div>
+      <%= panel_block do thumbnail(image, votes: true) end %>
     </div>
   <% end %>
 </div><!--.row-->

--- a/app/views/images/show/_license_history_panel.html.erb
+++ b/app/views/images/show/_license_history_panel.html.erb
@@ -1,46 +1,44 @@
 <!-- LICENSE_HISTORY -->
 <% chgs = @image.copyright_changes.sort_by(&:id)
 if chgs.any? %>
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <table class="table table-responsive table-striped small">
-        <thead>
-          <tr>
-            <th><%= :DATES.t %></th>
-            <th><%= :LICENSE.t %></th>
-            <th><%= :COPYRIGHT_HOLDER.t %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% (0..chgs.length-1).each do |i| %>
-            <tr>
-              <td>
-                <%= i > 0 ? chgs[i-1].updated_at.web_date : @image.created_at.web_date %> &rarr;
-                <%= chgs[i].updated_at.web_date %>
-              </td>
-              <td>
-                <%= link_to(chgs[i].license.display_name.t, chgs[i].license.url) %>
-              </td>
-              <td>
-                <%= chgs[i].license.copyright_text(chgs[i].year, chgs[i].name) %>
-              </td>
-            </tr>
-          <% end %>
+  <%= panel_block do %>
+    <table class="table table-responsive table-striped small">
+      <thead>
+        <tr>
+          <th><%= :DATES.t %></th>
+          <th><%= :LICENSE.t %></th>
+          <th><%= :COPYRIGHT_HOLDER.t %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% (0..chgs.length-1).each do |i| %>
           <tr>
             <td>
-              <%= chgs[-1].updated_at.web_date %> &rarr;
-              <%= Time.zone.now.web_date %>
+              <%= i > 0 ? chgs[i-1].updated_at.web_date : @image.created_at.web_date %> &rarr;
+              <%= chgs[i].updated_at.web_date %>
             </td>
             <td>
-              <%= link_to(@image.license.display_name.t, @image.license.url) %>
+              <%= link_to(chgs[i].license.display_name.t, chgs[i].license.url) %>
             </td>
             <td>
-              <%= image_copyright(@image) %>
+              <%= chgs[i].license.copyright_text(chgs[i].year, chgs[i].name) %>
             </td>
           </tr>
-        </tbody>
-      </table>
-    </div><!--.panel-body-->
-  </div><!--.panel-->
+        <% end %>
+        <tr>
+          <td>
+            <%= chgs[-1].updated_at.web_date %> &rarr;
+            <%= Time.zone.now.web_date %>
+          </td>
+          <td>
+            <%= link_to(@image.license.display_name.t, @image.license.url) %>
+          </td>
+          <td>
+            <%= image_copyright(@image) %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  <% end %>
 <% end %>
 <!-- /LICENSE_HISTORY -->

--- a/app/views/images/show/_vote_panel.html.erb
+++ b/app/views/images/show/_vote_panel.html.erb
@@ -12,7 +12,7 @@
     </div>
     <!-- /CURRENT_VOTE -->
 
-    <div class="panel-body py-5pxding">
+    <div class="panel-body py-5px">
 
       <!-- YOUR_VOTE -->
       <% if @user

--- a/app/views/images/show/_vote_panel.html.erb
+++ b/app/views/images/show/_vote_panel.html.erb
@@ -12,7 +12,7 @@
     </div>
     <!-- /CURRENT_VOTE -->
 
-    <div class="panel-body py-5px">
+    <div class="panel-body py-2">
 
       <!-- YOUR_VOTE -->
       <% if @user

--- a/app/views/names/descriptions/show.html.erb
+++ b/app/views/names/descriptions/show.html.erb
@@ -4,22 +4,20 @@
   @container = :wide
 %>
 
-<div class="panel panel-default">
-  <div class="panel-body">
-    <div class="row">
+<%= panel_block do %>
+  <div class="row">
 
-      <div class="col-xs-12 col-md-6">
-        <%= render( partial: "shared/show_description",
-                    locals: { description: @description }) %>
-      </div><!-- .col -->
+    <div class="col-xs-12 col-md-6">
+      <%= render( partial: "shared/show_description",
+                  locals: { description: @description }) %>
+    </div><!-- .col -->
 
-      <div class="col-xs-12 col-md-6">
-        <%= show_alt_descriptions(object: @name, projects: @projects) %>
-      </div><!-- .col -->
+    <div class="col-xs-12 col-md-6">
+      <%= show_alt_descriptions(object: @name, projects: @projects) %>
+    </div><!-- .col -->
 
-    </div><!-- .row -->
-  </div><!-- .panel-body -->
-</div><!-- .panel -->
+  </div><!-- .row -->
+<% end %>
 
 <%= render(partial: "names/descriptions/show/name_description",
            object: @description, locals: { review: true }) %>

--- a/app/views/names/show.html.erb
+++ b/app/views/names/show.html.erb
@@ -20,11 +20,9 @@
     </div>
 
     <div id="name_authors_editors">
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <%= show_authors_and_editors(@name) %>
-        </div>
-      </div>
+      <%= panel_block do %>
+        <%= show_authors_and_editors(@name) %>
+      <% end %>
     </div>
 
   </div><!--LEFT COLUMN-->

--- a/app/views/names/show/_best_description_panel.html.erb
+++ b/app/views/names/show/_best_description_panel.html.erb
@@ -4,9 +4,7 @@
           name_description_path(@name.description.id)) %> |
       <%= link_with_query(:EDIT.t,
           edit_name_description_path(@name.description.id)) %>]
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <%= @best_description.tpl %>
-    </div>
-  </div>
+  <%= panel_block do %>
+    <%= @best_description.tpl %>
+  <% end %>
 </div><!--#name_best_description-->

--- a/app/views/names/show/_classification_panel.html.erb
+++ b/app/views/names/show/_classification_panel.html.erb
@@ -1,14 +1,13 @@
 <div class="col-sm-6">
   <div id="name_classification">
     <strong><%= :show_name_classification.t %>:</strong>
-      <% if @user %>
-        [<%= link_with_query(:EDIT.t,
-                              edit_name_classification_path(@name.id)) %>]
-      <% end %>
-    <div class="panel panel-default">
-      <div class="panel-body name-section" id="classification_section">
-        <%= render(partial: "names/show/classification") %>
-      </div>
-    </div>
+    <% if @user %>
+      [<%= link_with_query(:EDIT.t,
+                            edit_name_classification_path(@name.id)) %>]
+    <% end %>
+    <%= panel_block(inner_class: "name-section",
+                    id: "classification_section") do
+      render(partial: "names/show/classification")
+    end %>
   </div><!--#name_classification-->
 </div>

--- a/app/views/names/show/_confident_observations_panel.html.erb
+++ b/app/views/names/show/_confident_observations_panel.html.erb
@@ -1,12 +1,13 @@
-<div id="name_confident_observations">
-  <% if @first_four&.length&.positive? %>
-    <strong><%= :show_name_most_confident.t %>:</strong>
-    <div class="panel panel-default">
-      <% @first_four.each do |obs| %>
-        <div class="panel-body">
-          <%= show_best_image(obs) %>
-        </div>
-      <% end %>
-    </div>
+<% if @first_four&.length&.positive? %>
+  <%= panel_with_outer_heading(
+    heading: "#{:show_name_most_confident.t}:",
+    h_tag: :strong,
+    id: "name_confident_observations"
+  ) do %>
+    <% @first_four.each do |obs| %>
+      <%= content_tag(:div, class: "my-4") do
+        show_best_image(obs)
+      end %>
+    <% end %>
   <% end %>
-</div><!--#name_confident_observations-->
+<% end %>

--- a/app/views/names/show/_descriptions_panel.html.erb
+++ b/app/views/names/show/_descriptions_panel.html.erb
@@ -6,12 +6,10 @@ description_links = list_descriptions(object: @name) || []
   <strong><%= :show_name_descriptions.t %>:</strong>
     [<%= link_with_query(:show_name_create_description.t,
                           new_name_description_path(@name.id)) %>]
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <% description_links.each do |desc| %>
-      <div><%= desc %></div>
-      <% end %>
-      <%= :show_name_no_descriptions.t if description_links.empty? %>
-    </div>
-  </div>
+  <%= panel_block do %>
+    <% description_links.each do |desc| %>
+    <div><%= desc %></div>
+    <% end %>
+    <%= :show_name_no_descriptions.t if description_links.empty? %>
+  <% end %>
 </div><!--#name_descriptions-->

--- a/app/views/names/show/_lifeform_panel.html.erb
+++ b/app/views/names/show/_lifeform_panel.html.erb
@@ -1,14 +1,13 @@
 <div class="col-sm-6">
   <div id="name_lifeform">
     <strong><%= :show_name_lifeform.t %>:</strong>
-      <% if @user %>
-        [<%= link_with_query(:EDIT.t,
-                              edit_name_lifeform_path(@name.id)) %>]
-      <% end %>
-    <div class="panel panel-default">
-      <div class="panel-body name-section" id="lifeform_section">
-        <%= render(partial: "names/show/lifeform") %>
-      </div>
-    </div>
+    <% if @user %>
+      [<%= link_with_query(:EDIT.t,
+                            edit_name_lifeform_path(@name.id)) %>]
+    <% end %>
+    <%= panel_block(inner_class: "name-section",
+                    id: "lifeform_section") do
+      render(partial: "names/show/lifeform")
+    end %>
   </div>
 </div><!--#name_lifeform-->

--- a/app/views/names/show/_nomenclature.html.erb
+++ b/app/views/names/show/_nomenclature.html.erb
@@ -1,103 +1,102 @@
 <%# Nomenclature partial; used by:
     show_name, show_past_name, and add_comment (via _object) %>
 <strong><%= :show_name_nomenclature.t %>:</strong>
-<div class="panel panel-default" id="nomenclature">
-  <div class="panel-body name-section">
+<%= panel_block(inner_class: "name-section",
+                id: "nomenclature") do %>
 
-    <div class="row">
+  <div class="row">
 
-      <div class="col-sm-7 name-section">
-        <p><%= :RANK.t %>:
-           <%= name.rank ? rank_as_string(name.rank) : :unknown.t %></p>
-        <p><%= :STATUS.t %>: <%= name.status %>
-          <% if name.is_misspelling? %>
-            (<%= :MISSPELLED.t %>)
-          <% end %></p>
-        <p><%= :NAME.t %>: <%= h(name.real_text_name) %></p>
-      </div><!--.col-->
+    <div class="col-sm-7 name-section">
+      <p><%= :RANK.t %>:
+          <%= name.rank ? rank_as_string(name.rank) : :unknown.t %></p>
+      <p><%= :STATUS.t %>: <%= name.status %>
+        <% if name.is_misspelling? %>
+          (<%= :MISSPELLED.t %>)
+        <% end %></p>
+      <p><%= :NAME.t %>: <%= h(name.real_text_name) %></p>
+    </div><!--.col-->
 
-      <div class="col-sm-5 name-section">
-        <% if name.icn_id? %>
-          <p><%= link_to("[##{name.icn_id}]",
-                         index_fungorum_record_url(name.icn_id)) %>
-             Index Fungorum</p>
-          <p><%= link_to("[##{name.icn_id}]",
-                         mycobank_record_url(name.icn_id)) %>
-             MycoBank</p>
-          <p>
-            <% if name.at_or_below_species? %>
-              <%= link_to(:gsd_species_synonymy.t,
-                          species_fungorum_gsd_synonymy(name.icn_id)) %>
-            <% elsif ["Genus", "Family"].include?(name.rank) %>
-              <%= link_to(:sf_species_synonymy.t,
-                          species_fungorum_sf_synonymy(name.icn_id)) %>
-            <% end %>
-          </p>
-       <% elsif name.registrable? %>
-          <p><%= :ICN_ID.t %>: <em><%= :show_name_icn_id_missing.t %></em></p>
-          <p><%= link_to(:index_fungorum_search.t,
-                         index_fungorum_basic_search_url) %></p>
-          <p><%= link_to(:mycobank_search.t,
-                         mycobank_name_search_url(name)) %></p>
-        <% elsif name.searchable_in_registry? %>
-          <p><%= link_to(:index_fungorum_search.t,
-                         index_fungorum_basic_search_url) %></p>
-          <p><%= link_to(:mycobank_search.t, mycobank_basic_search_url) %></p>
-        <% end %>
-      </div><!--.col-->
+    <div class="col-sm-5 name-section">
+      <% if name.icn_id? %>
+        <p><%= link_to("[##{name.icn_id}]",
+                        index_fungorum_record_url(name.icn_id)) %>
+            Index Fungorum</p>
+        <p><%= link_to("[##{name.icn_id}]",
+                        mycobank_record_url(name.icn_id)) %>
+            MycoBank</p>
+        <p>
+          <% if name.at_or_below_species? %>
+            <%= link_to(:gsd_species_synonymy.t,
+                        species_fungorum_gsd_synonymy(name.icn_id)) %>
+          <% elsif ["Genus", "Family"].include?(name.rank) %>
+            <%= link_to(:sf_species_synonymy.t,
+                        species_fungorum_sf_synonymy(name.icn_id)) %>
+          <% end %>
+        </p>
+      <% elsif name.registrable? %>
+        <p><%= :ICN_ID.t %>: <em><%= :show_name_icn_id_missing.t %></em></p>
+        <p><%= link_to(:index_fungorum_search.t,
+                        index_fungorum_basic_search_url) %></p>
+        <p><%= link_to(:mycobank_search.t,
+                        mycobank_name_search_url(name)) %></p>
+      <% elsif name.searchable_in_registry? %>
+        <p><%= link_to(:index_fungorum_search.t,
+                        index_fungorum_basic_search_url) %></p>
+        <p><%= link_to(:mycobank_search.t, mycobank_basic_search_url) %></p>
+      <% end %>
+    </div><!--.col-->
 
-    </div><!--.row-->
+  </div><!--.row-->
 
-    <p><%= :AUTHORITY.t %>: <%= name.author.to_s.t %></p>
-    <p><%= :CITATION.t %>: <%= name.citation.to_s.tl %></p>
-    <%
-    if name.is_misspelling? %>
-      <p><%= :show_name_misspelling_correct.t %>:
-      <%=
-      if name.correct_spelling
-        link_with_query(name.correct_spelling.display_name.t,
-                        name_path(name.correct_spelling_id))
-      else
-        # This can apparently happen for past_names.
-        name.correct_spelling_id
+  <p><%= :AUTHORITY.t %>: <%= name.author.to_s.t %></p>
+  <p><%= :CITATION.t %>: <%= name.citation.to_s.tl %></p>
+  <%
+  if name.is_misspelling? %>
+    <p><%= :show_name_misspelling_correct.t %>:
+    <%=
+    if name.correct_spelling
+      link_with_query(name.correct_spelling.display_name.t,
+                      name_path(name.correct_spelling_id))
+    else
+      # This can apparently happen for past_names.
+      name.correct_spelling_id
+    end %>
+    </p>
+  <%
+  end %>
+
+  <%
+  if synonyms
+    approved_synonyms, deprecated_synonyms = name.sort_synonyms
+    misspellings = deprecated_synonyms.select(&:correct_spelling_id)
+    deprecated_synonyms.reject!(&:correct_spelling_id)
+    if approved_synonyms.try(&:any?)
+      links = approved_synonyms.map do |n|
+        link_with_query(n.display_name.t, name_path(n.id))
       end %>
-      </p>
+      <p><%=
+      name.deprecated ? :show_name_preferred_synonyms.t : :show_name_synonyms.t
+      %>: <%=
+      links.safe_join(", ")
+      %></p>
     <%
-    end %>
-
+    end
+    if deprecated_synonyms.try(&:any?)
+      links = deprecated_synonyms.map do |n|
+        link_with_query(n.display_name.t, name_path(n.id))
+      end %>
+      <p><%= :show_name_deprecated_synonyms.t %>:
+        <%= links.safe_join(", ") %></p>
     <%
-    if synonyms
-      approved_synonyms, deprecated_synonyms = name.sort_synonyms
-      misspellings = deprecated_synonyms.select(&:correct_spelling_id)
-      deprecated_synonyms.reject!(&:correct_spelling_id)
-      if approved_synonyms.try(&:any?)
-        links = approved_synonyms.map do |n|
-          link_with_query(n.display_name.t, name_path(n.id))
-        end %>
-        <p><%=
-        name.deprecated ? :show_name_preferred_synonyms.t : :show_name_synonyms.t
-        %>: <%=
-        links.safe_join(", ")
-        %></p>
-      <%
-      end
-      if deprecated_synonyms.try(&:any?)
-        links = deprecated_synonyms.map do |n|
-          link_with_query(n.display_name.t, name_path(n.id))
-        end %>
-        <p><%= :show_name_deprecated_synonyms.t %>:
-          <%= links.safe_join(", ") %></p>
-      <%
-      end
-      if misspellings.try(&:any?)
-        links = misspellings.map do |n|
-          link_with_query(n.display_name.t, name_path(n.id))
-        end %>
-        <p><%= :show_name_misspelled_synonyms.t %>:
-          <%= links.safe_join(", ") %></p>
-      <%
-      end
-    end %>
+    end
+    if misspellings.try(&:any?)
+      links = misspellings.map do |n|
+        link_with_query(n.display_name.t, name_path(n.id))
+      end %>
+      <p><%= :show_name_misspelled_synonyms.t %>:
+        <%= links.safe_join(", ") %></p>
+    <%
+    end
+  end %>
 
-  </div><!--.panel-body-->
-</div><!--.panel-->
+<% end %>

--- a/app/views/names/show/_notes_panel.html.erb
+++ b/app/views/names/show/_notes_panel.html.erb
@@ -1,9 +1,5 @@
 <div id="name_notes">
   <strong><%= :show_name_notes.t %>:</strong>
     [<%= link_with_query(:EDIT.t, edit_name_path(@name.id)) %>]
-  <div class="panel panel-default">
-    <div class="panel-body">
-        <%= @name.notes.tpl %>
-    </div>
-  </div>
+  <%= panel_block do @name.notes.tpl end %>
 </div><!--#name_notes-->

--- a/app/views/names/show/_observations_menu.html.erb
+++ b/app/views/names/show/_observations_menu.html.erb
@@ -2,48 +2,44 @@
 #  This is just a two-column panel
 %>
 
-<div id="name_observations_menu">
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <div class="row">
-        <div class="col-sm-7 name-section">
-          <%= tag.p(:show_observations_of.t) %>
-          <div class="pl-3">
-            <%= # Observations of this name
-              tag.p(obss_of_name(@name) || "#{:obss_of_this_name.t} (0)")  %>
-            <%= # Observations of taxon under other names
-              tag.p(taxon_obss_other_names(@name) ||
-                    "#{:taxon_obss_other_names.t} (0)") %>
-            <%= # Observations of taxon under any name
-              tag.p(taxon_observations(@name) || "#{:obss_of_taxon.t} (0)") %>
-            <%= # Observations of other taxa where this taxon was proposed
-              tag.p(taxon_proposed(@name) || "#{:obss_taxon_proposed.t} (0)") %>
-            <%= # Observations where this Nae was proposed
-              tag.p(name_proposed(@name) ||
-                    "#{:obss_name_proposed.t} (0)") %>
-            <%= name_section_link(:show_subtaxa_obss.t,
-                                  @has_subtaxa, @subtaxa_query) %>
-          </div>
-        </div>
-        <div class="col-sm-5 name-section">
-          <% if @name.searchable_in_registry? %>
-            <%= tag.p(link_to(
-                  "MyCoPortal", mycoportal_url(@name), target: :_blank
-                )) %>
-          <% end %>
-          <%= tag.p(link_to(
-                "EOL", @name.eol_url, target: :_blank
-              )) if @name.eol_url %>
-          <%= tag.p(link_to(
-                :google_images.t,
-                "https://images.google.com/images?q=#{@name.real_text_name}",
-                target: :_blank
-              )) %>
-          <%= tag.p(link_with_query(
-                :show_name_distribution_map.t, map_name_path(@name.id)
-              )) %>
-        </div>
+<%= panel_block(id: "name_observations_menu") do %>
+  <div class="row">
+    <div class="col-sm-7 name-section">
+      <%= tag.p(:show_observations_of.t) %>
+      <div class="pl-3">
+        <%= # Observations of this name
+          tag.p(obss_of_name(@name) || "#{:obss_of_this_name.t} (0)")  %>
+        <%= # Observations of taxon under other names
+          tag.p(taxon_obss_other_names(@name) ||
+                "#{:taxon_obss_other_names.t} (0)") %>
+        <%= # Observations of taxon under any name
+          tag.p(taxon_observations(@name) || "#{:obss_of_taxon.t} (0)") %>
+        <%= # Observations of other taxa where this taxon was proposed
+          tag.p(taxon_proposed(@name) || "#{:obss_taxon_proposed.t} (0)") %>
+        <%= # Observations where this Nae was proposed
+          tag.p(name_proposed(@name) ||
+                "#{:obss_name_proposed.t} (0)") %>
+        <%= name_section_link(:show_subtaxa_obss.t,
+                              @has_subtaxa, @subtaxa_query) %>
       </div>
     </div>
+    <div class="col-sm-5 name-section">
+      <% if @name.searchable_in_registry? %>
+        <%= tag.p(link_to(
+              "MyCoPortal", mycoportal_url(@name), target: :_blank
+            )) %>
+      <% end %>
+      <%= tag.p(link_to(
+            "EOL", @name.eol_url, target: :_blank
+          )) if @name.eol_url %>
+      <%= tag.p(link_to(
+            :google_images.t,
+            "https://images.google.com/images?q=#{@name.real_text_name}",
+            target: :_blank
+          )) %>
+      <%= tag.p(link_with_query(
+            :show_name_distribution_map.t, map_name_path(@name.id)
+          )) %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/names/show/_projects_panel.html.erb
+++ b/app/views/names/show/_projects_panel.html.erb
@@ -2,16 +2,14 @@
   <div>
     <strong><%= :show_name_create_draft.t %>:</strong>
   </div>
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <% @projects.each do |project| %>
-        <%= link_with_query(project.title,
-                            new_name_description_path(
-                              @name.id,
-                              project: project.id,
-                              source: :project
-                            )) %><br>
-      <% end %>
-    </div>
-  </div>
+  <%= panel_block do %>
+    <% @projects.each do |project| %>
+      <%= link_with_query(project.title,
+                          new_name_description_path(
+                            @name.id,
+                            project: project.id,
+                            source: :project
+                          )) %><br>
+    <% end %>
+  <% end %>
 </div><!--#name_projects-->

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -8,44 +8,51 @@
   show_map   = @user ? @user.thumbnail_maps : !session[:hide_thumbnail_maps]
   show_lists = @user && @observation.species_lists.any?
   show_links = @user && (@observation.external_links.any? || @new_sites.any?)
+
+  obs_locals = { observation: @observation }
 %>
 
 <div class="row">
   <div class="col-md-8 float-sm-left">
     <%= panel_block(id: "observation_details", class: "name-section") do
-      render(partial: "observations/show/observation",
-             locals: { observation: @observation })
+      render(partial: "observations/show/observation", locals: obs_locals)
     end %>
   </div>
   <div class="col-md-4 float-sm-right">
     <% if @user %>
-      <%= render(partial: "observations/show/name_info",
-                 locals: { observation: @observation }) %>
+      <%= panel_block(id: "observation_name_info",
+                      class: "name-section small") do
+        render(partial: "observations/show/name_info", locals: obs_locals)
+      end %>
 
       <% if show_lists %>
-        <%= render(partial: "observations/show/species_lists",
-                   locals: {observation: @observation}) %>
+        <%= panel_with_header(header: :show_lists_header.t,
+                              id: "observation_species_lists",
+                              inner_class: "p-0") do
+          render(partial: "observations/show/species_lists", locals: obs_locals)
+        end %>
       <% end %>
 
       <% if show_links %>
-        <%= render(partial: "observations/show/links",
-                   locals: {observation: @observation}) %>
+        <%= panel_with_header(header: :EXTERNAL_LINKS.t,
+                              id: "observation_links",
+                              inner_class: "p-0") do
+          render(partial: "observations/show/links", locals: obs_locals)
+        end %>
       <% end %>
     <% end %>
 
     <% if show_map %>
       <%= render(partial: "observations/show/thumbnail_map",
-                 locals: { observation: @observation }) %>
+                 locals: obs_locals) %>
     <% end %>
 
-    <%= render(partial: "observations/show/images",
-               locals: { observation: @observation }) %>
+    <%= render(partial: "observations/show/images", locals: obs_locals) %>
   </div>
 
   <div class="col-md-8 float-sm-left">
     <% if @user %>
-      <%= render(partial: "observations/show/namings",
-                 locals: { observation: @observation }) %>
+      <%= render(partial: "observations/show/namings", locals: obs_locals) %>
     <% end %>
 
     <%= render(partial: "comments/comments_for_object",

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -26,17 +26,17 @@
       end %>
 
       <% if show_lists %>
-        <%= panel_with_heading(heading: :show_lists_header.t,
-                               id: "observation_species_lists",
-                               inner_class: "p-0") do
+        <%= panel_with_outer_heading(heading: :show_lists_header.t,
+                                     id: "observation_species_lists",
+                                     inner_class: "p-0") do
           render(partial: "observations/show/species_lists", locals: obs_locals)
         end %>
       <% end %>
 
       <% if show_links %>
-        <%= panel_with_heading(heading: :EXTERNAL_LINKS.t,
-                               id: "observation_links",
-                               inner_class: "p-0") do
+        <%= panel_with_outer_heading(heading: :EXTERNAL_LINKS.t,
+                                     id: "observation_links",
+                                     inner_class: "p-0") do
           render(partial: "observations/show/links", locals: obs_locals)
         end %>
       <% end %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -26,17 +26,17 @@
       end %>
 
       <% if show_lists %>
-        <%= panel_with_header(header: :show_lists_header.t,
-                              id: "observation_species_lists",
-                              inner_class: "p-0") do
+        <%= panel_with_heading(heading: :show_lists_header.t,
+                               id: "observation_species_lists",
+                               inner_class: "p-0") do
           render(partial: "observations/show/species_lists", locals: obs_locals)
         end %>
       <% end %>
 
       <% if show_links %>
-        <%= panel_with_header(header: :EXTERNAL_LINKS.t,
-                              id: "observation_links",
-                              inner_class: "p-0") do
+        <%= panel_with_heading(heading: :EXTERNAL_LINKS.t,
+                               id: "observation_links",
+                               inner_class: "p-0") do
           render(partial: "observations/show/links", locals: obs_locals)
         end %>
       <% end %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -12,8 +12,10 @@
 
 <div class="row">
   <div class="col-md-8 float-sm-left">
-    <%= render(partial: "observations/show/observation",
-               locals: { observation: @observation }) %>
+    <%= panel_block(id: "observation_details", class: "name-section") do
+      render(partial: "observations/show/observation",
+             locals: { observation: @observation })
+    end %>
   </div>
   <div class="col-md-4 float-sm-right">
     <% if @user %>

--- a/app/views/observations/show/_links.html.erb
+++ b/app/views/observations/show/_links.html.erb
@@ -1,43 +1,36 @@
-<h4>
-  <%= :EXTERNAL_LINKS.t %>
-</h4>
-<div class="list-group">
-  <div class="list-group-item p-0">
-    <table class="table table-responsive mx-0 mb-0">
-      <% observation.external_links.
-                     sort_by(&:site_name).each do |link| %>
-        <tr>
-          <td style="border-top:0">
-            <%= content_tag(:a, link.external_site.name, href: link.url,
-                data: { role: "link", url: link.url, link: link.id,
-                        site: link.external_site.id, obs: observation.id }) %>
-            <% if link.can_edit?(@user) || in_admin_mode? %>
-              <span data-role="link-controls" class="hidden-links">[<%=
-                content_tag(:a, :EDIT.t, href: "#",
-                                 data: { role: "edit-link" })
-              %>|<%=
-                content_tag(:a, :REMOVE.t, href: "#",
-                                data: { role: "remove-link" })
-              %>]</span>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-      <% @new_sites.sort_by(&:name).each do |site| %>
-        <tr class="hidden-links">
-          <td style="border-top:0">
-            <%= content_tag(:span, site.name,
-                data: { role: "link", obs: observation.id, site: site.id }) %>
-            <span data-role="link-controls">[<%=
-              content_tag(:a, :ADD.t, href: "#",
-                          data: { role: "add-link" })
-            %>]</span>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  </div>
-</div>
+<table class="table table-responsive mx-0 mb-0">
+  <% observation.external_links.
+                  sort_by(&:site_name).each do |link| %>
+    <tr>
+      <td style="border-top:0">
+        <%= content_tag(:a, link.external_site.name, href: link.url,
+            data: { role: "link", url: link.url, link: link.id,
+                    site: link.external_site.id, obs: observation.id }) %>
+        <% if link.can_edit?(@user) || in_admin_mode? %>
+          <span data-role="link-controls" class="hidden-links">[<%=
+            content_tag(:a, :EDIT.t, href: "#",
+                              data: { role: "edit-link" })
+          %>|<%=
+            content_tag(:a, :REMOVE.t, href: "#",
+                            data: { role: "remove-link" })
+          %>]</span>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  <% @new_sites.sort_by(&:name).each do |site| %>
+    <tr class="hidden-links">
+      <td style="border-top:0">
+        <%= content_tag(:span, site.name,
+            data: { role: "link", obs: observation.id, site: site.id }) %>
+        <span data-role="link-controls">[<%=
+          content_tag(:a, :ADD.t, href: "#",
+                      data: { role: "add-link" })
+        %>]</span>
+      </td>
+    </tr>
+  <% end %>
+</table>
 <%= javascript_tag %(
   var ADD_LINK_DIALOG    = "#{j :show_observation_add_link_dialog.l}";
   var EDIT_LINK_DIALOG   = "#{j :show_observation_edit_link_dialog.l}";

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -3,26 +3,20 @@
   name = observation.name
 %>
 
-<div class="panel panel-default">
-  <div class="panel-body name-section small">
-
-    <%= content_tag(:p,
-                    link_to(:show_name.t(name: name.display_name_brief_authors),
-                            name_path(name.id))) %>
-    <%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),
-                                target: :_blank)) %>
-    <%= content_tag(:p, link_to("Mycobank", mycobank_name_search_url(name),
-                                target: :_blank)) %>
-    <%= content_tag(:p, link_to(:show_observation_more_like_this.t,
-                                observations_path(name: name.id))) %>
-    <%= content_tag(:p, link_to(:show_observation_look_alikes.t,
-                                observations_path(name: name.id,
-                                                  look_alikes: "1"))) %>
-    <%= content_tag(:p, link_to(:show_observation_related_taxa.t,
-                                observations_path(name: name.id,
-                                                  related_taxa: "1"))) %>
-    <%= list_descriptions(object: name)&.map { |link|
-          content_tag(:div, link) }.safe_join %>
-
-  </div><!--.panel-body-->
-</div><!--.panel-->
+<%= content_tag(:p,
+                link_to(:show_name.t(name: name.display_name_brief_authors),
+                        name_path(name.id))) %>
+<%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),
+                            target: :_blank)) %>
+<%= content_tag(:p, link_to("Mycobank", mycobank_name_search_url(name),
+                            target: :_blank)) %>
+<%= content_tag(:p, link_to(:show_observation_more_like_this.t,
+                            observations_path(name: name.id))) %>
+<%= content_tag(:p, link_to(:show_observation_look_alikes.t,
+                            observations_path(name: name.id,
+                                              look_alikes: "1"))) %>
+<%= content_tag(:p, link_to(:show_observation_related_taxa.t,
+                            observations_path(name: name.id,
+                                              related_taxa: "1"))) %>
+<%= list_descriptions(object: name)&.map { |link|
+      content_tag(:div, link) }.safe_join %>

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -1,7 +1,3 @@
-<div class="panel panel-default name-section"
-     id="observation_details">
-  <div class="panel-body">
-
     <p id="observation_when">
       <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
     </p>
@@ -82,7 +78,4 @@
         )
       end %>
     </div><!--.obs-notes-->
-
-  </div><!--.panel-body-->
-</div><!--.panel#observation_details-->
 

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -1,81 +1,81 @@
-    <p id="observation_when">
-      <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
-    </p>
+<p id="observation_when">
+  <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
+</p>
 
-    <p id="observation_where">
-      <%= observation.is_collection_location ?
-            :show_observation_collection_location.t :
-            :show_observation_seen_at.t %>:
-      <span class="font-weight-bold">
-        <%= location_link(observation.place_name,
-                          observation.location, nil, true) %>
-      </span>
-    </p>
+<p id="observation_where">
+  <%= observation.is_collection_location ?
+        :show_observation_collection_location.t :
+        :show_observation_seen_at.t %>:
+  <span class="font-weight-bold">
+    <%= location_link(observation.place_name,
+                      observation.location, nil, true) %>
+  </span>
+</p>
 
-    <p id="observation_lat_lng">
-      <%=
-        hidden = "<i>(#{:show_observation_gps_hidden.t})</i>".html_safe
-        if observation.lat &&
-            (!observation.gps_hidden || observation.can_edit?)
-          link_to("#{observation.display_lat_long.t} " \
-                  "#{observation.display_alt.t} " \
-                  "[#{:click_for_map.t}]".html_safe,
-                  map_observation_path(id: observation.id))
-        elsif observation.lat
-          hidden + " ".html_safe + observation.display_alt.t
-        else
-          observation.display_alt.t
-        end
-      %>
-      <%=
-        if observation.lat && observation.gps_hidden && observation.can_edit?
-          hidden
-        end
-      %>
-    </p>
+<p id="observation_lat_lng">
+  <%=
+    hidden = "<i>(#{:show_observation_gps_hidden.t})</i>".html_safe
+    if observation.lat &&
+        (!observation.gps_hidden || observation.can_edit?)
+      link_to("#{observation.display_lat_long.t} " \
+              "#{observation.display_alt.t} " \
+              "[#{:click_for_map.t}]".html_safe,
+              map_observation_path(id: observation.id))
+    elsif observation.lat
+      hidden + " ".html_safe + observation.display_alt.t
+    else
+      observation.display_alt.t
+    end
+  %>
+  <%=
+    if observation.lat && observation.gps_hidden && observation.can_edit?
+      hidden
+    end
+  %>
+</p>
 
-    <p id="observation_who">
-      <%= :WHO.t %>: <span class="font-weight-bold"><%= user_link(observation.user) %></span>
-    </p>
+<p id="observation_who">
+  <%= :WHO.t %>: <span class="font-weight-bold"><%= user_link(observation.user) %></span>
+</p>
 
-    <% if @user %>
-      <div id="observation_projects">
-        <% observation.projects.each do |project| %>
-              <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
-        <% end %>
-      </div>
+<% if @user %>
+  <div id="observation_projects">
+    <% observation.projects.each do |project| %>
+          <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
     <% end %>
+  </div>
+<% end %>
 
-    <div id="observation_specimen_available">
-      <%= observation.specimen ? :show_observation_specimen_available.t :
-                                 :show_observation_specimen_not_available.t %>
-    </div>
+<div id="observation_specimen_available">
+  <%= observation.specimen ? :show_observation_specimen_available.t :
+                              :show_observation_specimen_not_available.t %>
+</div>
 
-    <% if @user %>
-      <div id="observation_collection_numbers">
-        <%= render(partial: "observations/show/collection_numbers",
-                    locals: { observation: observation }) %>
-      </div>
+<% if @user %>
+  <div id="observation_collection_numbers">
+    <%= render(partial: "observations/show/collection_numbers",
+                locals: { observation: observation }) %>
+  </div>
 
-      <div id="observation_herbarium_records">
-        <%= render(partial: "observations/show/herbarium_records",
-                    locals: { observation: observation }) %>
-      </div>
+  <div id="observation_herbarium_records">
+    <%= render(partial: "observations/show/herbarium_records",
+                locals: { observation: observation }) %>
+  </div>
 
-      <div id="observation_sequences">
-        <%= render(partial: "observations/show/sequences",
-                    locals: { observation: observation }) %>
-      </div>
-    <% end %>
+  <div id="observation_sequences">
+    <%= render(partial: "observations/show/sequences",
+                locals: { observation: observation }) %>
+  </div>
+<% end %>
 
-    <div class="obs-notes" id="observation_notes">
-      <%= if observation.notes?
-        Textile.clear_textile_cache
-        Textile.register_name(*observation.namings.map(&:name))
-        Textile.register_name(observation.name)
-        content_tag(
-          :div, observation.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
-        )
-      end %>
-    </div><!--.obs-notes-->
+<div class="obs-notes" id="observation_notes">
+  <%= if observation.notes?
+    Textile.clear_textile_cache
+    Textile.register_name(*observation.namings.map(&:name))
+    Textile.register_name(observation.name)
+    content_tag(
+      :div, observation.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
+    )
+  end %>
+</div><!--.obs-notes-->
 

--- a/app/views/observations/show/_species_lists.html.erb
+++ b/app/views/observations/show/_species_lists.html.erb
@@ -1,24 +1,17 @@
-<h4>
-  <%= :show_lists_header.t %>
-</h4>
-<div class="list-group">
-  <div class="list-group-item p-0">
-    <table class="table table-responsive mx-0 mb-0">
-      <% observation.species_lists.each do |spl| %>
-        <tr>
-          <td style="border-top:0">
-            <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
-            <%= if check_permission(spl)
-              put_button(name: :REMOVE.t,
-                        path: observation_species_list_path(
-                          id: @observation.id, species_list_id: spl.id,
-                          commit: "remove"
-                        ),
-                        data: { confirm: :are_you_sure.l })
-            end %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  </div>
-</div>
+<table class="table table-responsive mx-0 mb-0">
+  <% observation.species_lists.each do |spl| %>
+    <tr>
+      <td style="border-top:0">
+        <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
+        <%= if check_permission(spl)
+          put_button(name: :REMOVE.t,
+                    path: observation_species_list_path(
+                      id: @observation.id, species_list_id: spl.id,
+                      commit: "remove"
+                    ),
+                    data: { confirm: :are_you_sure.l })
+        end %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -27,68 +27,65 @@
 
 <div class="row">
   <div class="col-md-6">
-    <div class="list-group">
-      <div class="list-group-item">
-        <p><b><%= :show_project_created_at.t %>:</b> <%= @project.created_at.web_date %></p>
-        <% if false %>
-          <p><b><%= :show_project_published.t %>:</b> <%= @name_count %></p>
-        <% end %>
-        <p><b><%= :show_project_by.t %>:</b> <%= user_link(@project.user) %></p>
-        <p><b><%= :show_project_user_group.t %>:</b> <%= @project.user_group.name.t %></p>
-        <p><b><%= :show_project_admin_group.t %>:</b> <%= @project.admin_group.name.t %></p>
-        <%= ("*" + :show_project_summary.l + ":* " + @project.summary.to_s.html_safe).tpl %>
-        <%= if @user && @project.user_group.users.member?(@user)
-          render(partial: "groups", locals: { project: @project })
-        end %>
-      </div>
-    </div>
+    <%= panel_block do %>
+      <p><b><%= :show_project_created_at.t %>:</b> <%= @project.created_at.web_date %></p>
+      <% if false %>
+        <p><b><%= :show_project_published.t %>:</b> <%= @name_count %></p>
+      <% end %>
+      <p><b><%= :show_project_by.t %>:</b> <%= user_link(@project.user) %></p>
+      <p><b><%= :show_project_user_group.t %>:</b> <%= @project.user_group.name.t %></p>
+      <p><b><%= :show_project_admin_group.t %>:</b> <%= @project.admin_group.name.t %></p>
+      <%= ("*" + :show_project_summary.l + ":* " + @project.summary.to_s.html_safe).tpl %>
+      <%= if @user && @project.user_group.users.member?(@user)
+        render(partial: "groups", locals: { project: @project })
+      end %>
+    <% end %>
   </div>
 
   <div class="col-md-6">
-    <div class="list-group">
-      <div class="list-group-item">
+    <%= panel_block do %>
 
-        <b><%= :OBSERVATIONS.t %>:</b>
-        <% if @project.observations.any? %>
-          <%= @project.observations.length %>
-          (<%= link_to(:SHOW.t, observations_path(project: @project.id)) %> |
-          <%= link_to(:app_checklist.t,
-                      checklist_path(project_id: @project.id)) %>)
-        <% else %>
-          <%= :NONE.t %>
+      <b><%= :OBSERVATIONS.t %>:</b>
+      <% if @project.observations.any? %>
+        <%= @project.observations.length %>
+        (<%= link_to(:SHOW.t, observations_path(project: @project.id)) %> |
+        <%= link_to(:app_checklist.t,
+                    checklist_path(project_id: @project.id)) %>)
+      <% else %>
+        <%= :NONE.t %>
+      <% end %>
+      <br/>
+
+      <b><%= :IMAGES.t %>:</b>
+      <% if @project.images.any? %>
+        <%= @project.images.length %>
+        (<%= link_to(:SHOW.t, images_path(for_project: @project.id)) %>)
+      <% else %>
+        <%= :NONE.t %>
+      <% end %>
+      <br/>
+
+      <b><%= :SPECIES_LISTS.t %>:</b>
+      <% if @project.species_lists.any? %>
+        <%= @project.species_lists.length %>
+        (<%= link_to(:SHOW.t,
+                      species_lists_path(for_project: @project.id)) %>)
+      <% else %>
+        <%= :NONE.t %>
+      <% end %>
+      <br/>
+
+      <b><%= :show_project_drafts.t %>:</b>
+      <%= @drafts.any? ? @drafts.length : :NONE.t %><br/>
+      <div class="ml-3">
+        <% @drafts.each do |draft| %>
+          <%= link_with_query(draft.name&.display_name&.t,
+                              name_description_path(draft.id)) %>
+          (<%= user_link(draft.user) %>)<br/>
         <% end %>
-        <br/>
-
-        <b><%= :IMAGES.t %>:</b>
-        <% if @project.images.any? %>
-          <%= @project.images.length %>
-          (<%= link_to(:SHOW.t, images_path(for_project: @project.id)) %>)
-        <% else %>
-          <%= :NONE.t %>
-        <% end %>
-        <br/>
-
-        <b><%= :SPECIES_LISTS.t %>:</b>
-        <% if @project.species_lists.any? %>
-          <%= @project.species_lists.length %>
-          (<%= link_to(:SHOW.t,
-                       species_lists_path(for_project: @project.id)) %>)
-        <% else %>
-          <%= :NONE.t %>
-        <% end %>
-        <br/>
-
-        <b><%= :show_project_drafts.t %>:</b>
-        <%= @drafts.any? ? @drafts.length : :NONE.t %><br/>
-        <div class="ml-3">
-          <% @drafts.each do |draft| %>
-            <%= link_with_query(draft.name&.display_name&.t,
-                                name_description_path(draft.id)) %>
-            (<%= user_link(draft.user) %>)<br/>
-          <% end %>
-        </div>
       </div>
-    </div>
+
+    <% end %>
   </div>
 </div><!--.row-->
 

--- a/app/views/shared/_images_to_reuse.html.erb
+++ b/app/views/shared/_images_to_reuse.html.erb
@@ -40,16 +40,14 @@ query = query_images_to_reuse(@all_users, @user)
     <%= render(layout: "shared/matrix_table",
                locals: { objects: @objects }) do |image| %>
       <li class="matrix-box col-xs-12 col-sm-6 col-md-4">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <%= thumbnail(image,
-                          link: form_action.merge(img_id: image.id),
-                          link_method: :post,
-                          votes: false,
-                          extra_classes: "image-to-reuse",
-                          original: true) %>
-          </div>
-        </div>
+        <%= panel_block do %>
+          <%= thumbnail(image,
+                        link: form_action.merge(img_id: image.id),
+                        link_method: :post,
+                        votes: false,
+                        extra_classes: "image-to-reuse",
+                        original: true) %>
+        <% end %>
       </li>
     <% end %>
 

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -7,31 +7,29 @@ columns ||= "col-xs-12 col-sm-6 col-md-4"
 
 <% if presenter %>
   <li class="matrix-box <%= columns %>">
-    <div class="panel panel-default">
-      <div class="panel-body rss-box-details">
-        <div class="thumbnail-container">
-          <%= presenter.thumbnail %>
-        </div><!-- .thumbnail-container -->
-        <div class="rss-what">
-          <h5><%= presenter.what %></h5>
-        </div><!-- .rss-what -->
-        <div class="rss-where">
-          <small><strong><%= presenter.where %></strong></small>
-        </div><!-- .rss-where -->
-        <div class="rss-what">
-          <small class="nowrap-ellipsis">
-            <% unless presenter.when.blank? %>
-              <%= presenter.when %>: <%= presenter.who %>
-            <% end %>
-          </small>
-        </div><!-- .rss-when -->
-        <div class="rss-detail">
-          <%= presenter.detail %>
-        </div><!-- .rss-detail -->
-        <div class="rss-what">
-          <small><%= presenter.fancy_time %></small>
-        </div><!-- .rss-fancy-time -->
-      </div>
-    </div>
+    <%= panel_block(inner_class: "rss-box-details") do %>
+      <div class="thumbnail-container">
+        <%= presenter.thumbnail %>
+      </div><!-- .thumbnail-container -->
+      <div class="rss-what">
+        <h5><%= presenter.what %></h5>
+      </div><!-- .rss-what -->
+      <div class="rss-where">
+        <small><strong><%= presenter.where %></strong></small>
+      </div><!-- .rss-where -->
+      <div class="rss-what">
+        <small class="nowrap-ellipsis">
+          <% unless presenter.when.blank? %>
+            <%= presenter.when %>: <%= presenter.who %>
+          <% end %>
+        </small>
+      </div><!-- .rss-when -->
+      <div class="rss-detail">
+        <%= presenter.detail %>
+      </div><!-- .rss-detail -->
+      <div class="rss-what">
+        <small><%= presenter.fancy_time %></small>
+      </div><!-- .rss-fancy-time -->
+    <% end %>
   </li><!-- .matrix-box -->
 <% end %>

--- a/app/views/species_lists/show.html.erb
+++ b/app/views/species_lists/show.html.erb
@@ -40,24 +40,22 @@
 %>
 
 <div class="container-text">
-  <div class="list-group">
-    <div class="list-group-item">
-      <div><b><%= :WHEN.t %>:</b> <%= @species_list.when.web_date %></div>
-      <div><b><%= :OBSERVATIONS.t %>:</b> <%= @query.num_results %></div>
-      <div><b><%= :WHERE.t %>:</b>
-        <%= location_link(@species_list.place_name, @species_list.location, nil, true) rescue :UNKNOWN.t %>
-      </div>
-      <div><b><%= :WHO.t %>:</b> <%= user_link(@species_list.user) %></div>
-      <% if @species_list.projects.any? %>
-        <div><b><%= :PROJECTS.t %>:</b>
-          <%= @species_list.projects.map {|p| link_to_object(p)}.safe_join(" | ") %>
-        </div>
-      <% end %>
-      <% if @species_list.notes.present? %>
-        <div><%= ("*" + :NOTES.t + ":* " + @species_list.notes.to_s).tpl %></div>
-      <% end %>
+  <%= panel_block do %>
+    <div><b><%= :WHEN.t %>:</b> <%= @species_list.when.web_date %></div>
+    <div><b><%= :OBSERVATIONS.t %>:</b> <%= @query.num_results %></div>
+    <div><b><%= :WHERE.t %>:</b>
+      <%= location_link(@species_list.place_name, @species_list.location, nil, true) rescue :UNKNOWN.t %>
     </div>
-  </div>
+    <div><b><%= :WHO.t %>:</b> <%= user_link(@species_list.user) %></div>
+    <% if @species_list.projects.any? %>
+      <div><b><%= :PROJECTS.t %>:</b>
+        <%= @species_list.projects.map {|p| link_to_object(p)}.safe_join(" | ") %>
+      </div>
+    <% end %>
+    <% if @species_list.notes.present? %>
+      <div><%= ("*" + :NOTES.t + ":* " + @species_list.notes.to_s).tpl %></div>
+    <% end %>
+  <% end %>
 </div>
 
 <% if @pages.any?

--- a/app/views/visual_groups/_image_matrix.html.erb
+++ b/app/views/visual_groups/_image_matrix.html.erb
@@ -4,15 +4,13 @@
       <%= render(layout: "shared/matrix_table",
                  locals: {objects: @vals}) do |row| %>
         <li class="matrix-box col-xs-12 col-sm-6 col-md-4">
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <%= thumbnail(row[0], votes: false, original: true) %>
-              <%= render(partial: "visual_group_status_links",
-                         locals: { visual_group: visual_group,
-                         image_id: row[0],
-                         status: row[1] }) %>
-            </div>
-          </div>
+          <%= panel_block do %>
+            <%= thumbnail(row[0], votes: false, original: true) %>
+            <%= render(partial: "visual_group_status_links",
+                        locals: { visual_group: visual_group,
+                        image_id: row[0],
+                        status: row[1] }) %>
+          <% end %>
         </li><!-- .matrix-box -->
       <% end %>
     </ul>


### PR DESCRIPTION
This consolidates a repetitive pattern of nested Bootstrap divs (most often used on show_name and show_obs) into a single helper, and implements it. 

Desirable because it 
- helps eliminate typos and ensures consistency of the pattern
- the css classes are about to change for Bootstrap 4
- still allows rendering partials inside the block
- allows separating the partial content from the panel wrap (needed for example in the identify-obs UX).

Before:
```ruby
# layout.html.erb

render(partial: "partial") 

# _partial.html.erb

<div class="panel panel-default unexpected" id="special_id">
  <div class="panel-body modifiers">
    <%= complicated_stuff_in_ruby %>
  </div>
</div>
```

After:
```ruby
# layout.html.erb

<%= panel_block(id: "special_id", class: "unexpected",
                inner_class: "modifiers") do
  render(partial: "partial") 
end %>

# _partial.html.erb

<%= complicated_stuff_in_ruby %>
```
