### PR TITLE
Add api endpoints for descriptions

### DIFF
--- a/app/classes/api2/location_description_api.rb
+++ b/app/classes/api2/location_description_api.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class API2
+  # API for Location Description
+  class LocationDescriptionAPI < ModelAPI
+    self.model = LocationDescription
+
+    self.high_detail_page_length = 100
+    self.low_detail_page_length  = 100
+    self.put_page_length         = 100
+    self.delete_page_length      = 100
+
+    self.low_detail_includes = [
+      :license
+    ]
+
+    self.high_detail_includes = []
+
+    def query_params
+      {
+        where: sql_id_condition,
+        created_at: parse_range(:time, :created_at),
+        updated_at: parse_range(:time, :updated_at),
+        users: parse_array(:user, :user, help: :first_user),
+        locations: parse_array(:location, :location),
+        public: true
+      }
+    end
+
+    def post
+      raise(NoMethodForAction.new("POST", action))
+    end
+
+    def patch
+      raise(NoMethodForAction.new("PATCH", action))
+    end
+
+    def delete
+      raise(NoMethodForAction.new("DELETE", action))
+    end
+  end
+end

--- a/app/classes/api2/name_description_api.rb
+++ b/app/classes/api2/name_description_api.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class API2
+  # API for Name Description
+  class NameDescriptionAPI < ModelAPI
+    self.model = NameDescription
+
+    self.high_detail_page_length = 100
+    self.low_detail_page_length  = 100
+    self.put_page_length         = 100
+    self.delete_page_length      = 100
+
+    self.low_detail_includes = [
+      :license
+    ]
+
+    self.high_detail_includes = []
+
+    def query_params
+      {
+        where: sql_id_condition,
+        created_at: parse_range(:time, :created_at),
+        updated_at: parse_range(:time, :updated_at),
+        users: parse_array(:user, :user, help: :first_user),
+        names: parse_array(:name, :name),
+        public: true
+      }
+    end
+
+    def post
+      raise(NoMethodForAction.new("POST", action))
+    end
+
+    def patch
+      raise(NoMethodForAction.new("PATCH", action))
+    end
+
+    def delete
+      raise(NoMethodForAction.new("DELETE", action))
+    end
+  end
+end

--- a/app/classes/query/location_description_base.rb
+++ b/app/classes/query/location_description_base.rb
@@ -9,12 +9,21 @@ class Query::LocationDescriptionBase < Query::Base
     super.merge(
       created_at?: [:time],
       updated_at?: [:time],
-      users?: [User]
+      users?: [User],
+      locations?: [Location],
+      public?: :boolean
     )
   end
 
   def initialize_flavor
     add_owner_and_time_stamp_conditions("location_descriptions")
+    locations = lookup_locations_by_name(params[:locations])
+    add_id_condition("location_descriptions.location_id", locations)
+    add_boolean_condition(
+      "location_descriptions.public IS TRUE",
+      "location_descriptions.public IS FALSE",
+      params[:public]
+    )
     super
   end
 

--- a/app/classes/query/name_description_base.rb
+++ b/app/classes/query/name_description_base.rb
@@ -9,12 +9,21 @@ class Query::NameDescriptionBase < Query::Base
     super.merge(
       created_at?: [:time],
       updated_at?: [:time],
-      users?: [User]
+      users?: [User],
+      names?: [Name],
+      public?: :boolean
     )
   end
 
   def initialize_flavor
     add_owner_and_time_stamp_conditions("name_descriptions")
+    names = lookup_names_by_name(names: params[:names])
+    add_id_condition("name_descriptions.name_id", names)
+    add_boolean_condition(
+      "name_descriptions.public IS TRUE",
+      "name_descriptions.public IS FALSE",
+      params[:public]
+    )
     super
   end
 

--- a/app/views/api2/_location_description.json.jbuilder
+++ b/app/views/api2/_location_description.json.jbuilder
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+json.id(object.id)
+json.type("location_description")
+json.location_id(object.location_id)
+json.created_at(object.created_at.try(&:utc))
+json.updated_at(object.updated_at.try(&:utc))
+json.number_of_views(object.num_views)
+json.last_viewed(object.last_view.try(&:utc))
+json.ok_for_export(object.ok_for_export ? true : false)
+json.source_type(object.source_type.to_s)
+json.source_name(object.source_name.to_s) if objecct.source_name.present?
+json.license(object.license.try(&:display_name).to_s)
+json.public(object.public ? true : false)
+json.locale(object.locale.to_s)
+json.gen_desc(object.gen_desc.to_s.tpl_nodiv) if object.gen_desc.present?
+json.ecology(object.ecology.to_s.tpl_nodiv) if object.ecology.present?
+json.species(object.species.to_s.tpl_nodiv) if object.species.present?
+json.notes(object.notes.to_s.tpl_nodiv) if object.notes.present?
+json.refs(object.refs.to_s.tpl_nodiv) if object.refs.present?

--- a/app/views/api2/_location_description.xml.builder
+++ b/app/views/api2/_location_description.xml.builder
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+xml.tag!(
+  tag,
+  id: object.id,
+  url: object.show_url,
+  type: "location_description"
+) do
+  xml_integer(xml, :location_id, object.location_id)
+  xml_datetime(xml, :created_at, object.created_at)
+  xml_datetime(xml, :updated_at, object.updated_at)
+  xml_integer(xml, :number_of_views, object.num_views)
+  xml_datetime(xml, :last_viewed, object.last_view)
+  xml_boolean(xml, :ok_for_export, true) if object.ok_for_export
+  xml_string(xml, :source_type, object.source_type)
+  xml_string(xml, :source_name, object.source_name)
+  xml_string(xml, :license, object.license.try(&:display_name))
+  xml_boolean(xml, :public, true) if object.public
+  xml_string(xml, :locale, object.locale)
+  xml_string(xml, :gen_desc, object.gen_desc)
+  xml_string(xml, :ecology, object.ecology)
+  xml_string(xml, :species, object.species)
+  xml_string(xml, :notes, object.notes)
+  xml_string(xml, :refs, object.refs)
+end

--- a/app/views/api2/_name.json.jbuilder
+++ b/app/views/api2/_name.json.jbuilder
@@ -14,15 +14,15 @@ json.updated_at(object.updated_at.try(&:utc))
 json.number_of_views(object.num_views)
 json.last_viewed(object.last_view.try(&:utc))
 json.ok_for_export(object.ok_for_export ? true : false)
+if object.classification.present?
+  parse = Name.parse_classification(object.classification)
+  json.parents(parse.map do |rank, name|
+    { name: name, rank: rank.to_s.downcase }
+  end)
+end
 if detail
   if object.synonym_id
     json.synonyms((object.synonyms - [object]).map { |x| json_name(x) })
-  end
-  if object.classification.present?
-    parse = Name.parse_classification(object.classification)
-    json.parents(parse.map do |rank, name|
-      { name: name, rank: rank.to_s.downcase }
-    end)
   end
   if object.comments.any?
     json.comments(object.comments.map { |x| json_comment(x) })

--- a/app/views/api2/_name.xml.builder
+++ b/app/views/api2/_name.xml.builder
@@ -18,22 +18,22 @@ xml.tag!(
   xml_integer(xml, :number_of_views, object.num_views)
   xml_datetime(xml, :last_viewed, object.last_view)
   xml_boolean(xml, :ok_for_export, true) if object.ok_for_export
+  if object.classification.present?
+    parse = Name.parse_classification(object.classification)
+    xml.parents(number: parse.length) do
+      parse.each do |rank, name|
+        xml.parent do
+          xml_string(xml, :name, name)
+          xml_string(xml, :rank, rank.to_s.downcase)
+        end
+      end
+    end
+  end
   if detail
     if object.synonym_id
       xml.synonyms(number: object.synonyms.length - 1) do
         (object.synonyms - [object]).each do |synonym|
           xml_detailed_object(xml, :synonym, synonym)
-        end
-      end
-    end
-    if object.classification.present?
-      parse = Name.parse_classification(object.classification)
-      xml.parents(number: parse.length) do
-        parse.each do |rank, name|
-          xml.parent do
-            xml_string(xml, :name, name)
-            xml_string(xml, :rank, rank.to_s.downcase)
-          end
         end
       end
     end

--- a/app/views/api2/_name_description.json.jbuilder
+++ b/app/views/api2/_name_description.json.jbuilder
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+json.id(object.id)
+json.type("name_description")
+json.name_id(object.name_id)
+json.created_at(object.created_at.try(&:utc))
+json.updated_at(object.updated_at.try(&:utc))
+json.number_of_views(object.num_views)
+json.last_viewed(object.last_view.try(&:utc))
+json.ok_for_export(object.ok_for_export ? true : false)
+json.source_type(object.source_type.to_s)
+json.source_name(object.source_name.to_s) if objecct.source_name.present?
+json.license(object.license.try(&:display_name).to_s)
+json.public(object.public ? true : false)
+json.locale(object.locale.to_s)
+json.gen_desc(object.gen_desc.to_s.tpl_nodiv) if object.gen_desc.present?
+json.diag_desc(object.diag_desc.to_s.tpl_nodiv) if object.diag_desc.present?
+json.distribution(object.distribution.to_s.tpl_nodiv) \
+  if object.distribution.present?
+json.habitat(object.habitat.to_s.tpl_nodiv) if object.habitat.present?
+json.look_alikes(object.look_alikes.to_s.tpl_nodiv) \
+  if object.look_alikes.present?
+json.uses(object.uses.to_s.tpl_nodiv) if object.uses.present?
+json.notes(object.notes.to_s.tpl_nodiv) if object.notes.present?
+json.refs(object.refs.to_s.tpl_nodiv) if object.refs.present?
+json.classification(object.classification.to_s.tpl_nodiv) \
+  if object.classification.present?

--- a/app/views/api2/_name_description.xml.builder
+++ b/app/views/api2/_name_description.xml.builder
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+xml.tag!(
+  tag,
+  id: object.id,
+  url: object.show_url,
+  type: "name_description"
+) do
+  xml_integer(xml, :name_id, object.name_id)
+  xml_datetime(xml, :created_at, object.created_at)
+  xml_datetime(xml, :updated_at, object.updated_at)
+  xml_integer(xml, :number_of_views, object.num_views)
+  xml_datetime(xml, :last_viewed, object.last_view)
+  xml_boolean(xml, :ok_for_export, true) if object.ok_for_export
+  xml_string(xml, :source_type, object.source_type)
+  xml_string(xml, :source_name, object.source_name)
+  xml_string(xml, :license, object.license.try(&:display_name))
+  xml_boolean(xml, :public, true) if object.public
+  xml_string(xml, :locale, object.locale)
+  xml_string(xml, :gen_desc, object.gen_desc)
+  xml_string(xml, :diag_desc, object.diag_desc)
+  xml_string(xml, :distribution, object.distribution)
+  xml_string(xml, :habitat, object.habitat)
+  xml_string(xml, :look_alikes, object.look_alikes)
+  xml_string(xml, :uses, object.uses)
+  xml_string(xml, :notes, object.notes)
+  xml_string(xml, :refs, object.refs)
+  xml_string(xml, :classification, object.classification)
+end

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -384,8 +384,16 @@ class API2Test < UnitTestCase
     do_basic_get_test(Location)
   end
 
+  def test_basic_location_description_get
+    do_basic_get_test(LocationDescription, public: true)
+  end
+
   def test_basic_name_get
     do_basic_get_test(Name)
+  end
+
+  def test_basic_name_description_get
+    do_basic_get_test(NameDescription, public: true)
   end
 
   def test_basic_observation_get
@@ -408,8 +416,8 @@ class API2Test < UnitTestCase
     do_basic_get_test(User)
   end
 
-  def do_basic_get_test(model)
-    expected_object = model.first
+  def do_basic_get_test(model, *args)
+    expected_object = args.empty? ? model.first : model.where(*args).first
     api = API2.execute(
       method: :get,
       action: model.type_tag,

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2199,8 +2199,19 @@ class QueryTest < UnitTestCase
   end
 
   def test_location_description_all
-    all = LocationDescription.all.to_a
-    assert_query(all, :LocationDescription, :all, by: :id)
+    gualala = locations(:gualala)
+    all_descs = LocationDescription.all.to_a
+    all_gualala_descs = LocationDescription.where(location: gualala).to_a
+    public_gualala_descs = LocationDescription.where(location: gualala,
+                                                     public: true).to_a
+    assert(all_gualala_descs.length < all_descs.length)
+    assert(public_gualala_descs.length < all_gualala_descs.length)
+
+    assert_query(all_descs, :LocationDescription, :all, by: :id)
+    assert_query(all_gualala_descs, :LocationDescription, :all,
+                 by: :id, locations: gualala)
+    assert_query(public_gualala_descs, :LocationDescription, :all,
+                 by: :id, locations: gualala, public: "yes")
   end
 
   def test_location_description_by_user
@@ -2607,8 +2618,17 @@ class QueryTest < UnitTestCase
   end
 
   def test_name_description_all
-    all = NameDescription.all.to_a
-    assert_query(all, :NameDescription, :all, by: :id)
+    pelt = names(:peltigera)
+    all_descs = NameDescription.all.to_a
+    all_pelt_descs = NameDescription.where(name: pelt).to_a
+    public_pelt_descs = NameDescription.where(name: pelt, public: true).to_a
+    assert(all_pelt_descs.length < all_descs.length)
+    assert(public_pelt_descs.length < all_pelt_descs.length)
+
+    assert_query(all_descs, :NameDescription, :all, by: :id)
+    assert_query(all_pelt_descs, :NameDescription, :all, by: :id, names: pelt)
+    assert_query(public_pelt_descs, :NameDescription, :all,
+                 by: :id, names: pelt, public: "yes")
   end
 
   def test_name_description_by_user


### PR DESCRIPTION
Another thing requested by a group of users:

This adds basic GET-only API2 endpoints for name and location descriptions.  It only returns public descriptions, so that we can avoid the whole permissions quagmire.

Also, it moves classification info for names from the high-detail to the low-detail response.  (There are no includes required, so it really belongs there anyway, but I had put it in high-detail because significant parsing is required.)

Basic tests are added for both the tweaks required by Query as well as the new API2 endpoints.

Everything passes tests and rubocop locally.