### PR TITLE
Hot fix for naming suggestions template

### DIFF
--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -8,6 +8,7 @@
                     observation_path(id: @observation.id))
   ]
   @tabsets = { right: draw_tab_set(tabs) }
+  @container = :double
 %>
 
 <div class="row">
@@ -59,7 +60,7 @@
           </td>
           <td>
             <%= thumbnail(sugg.image_obs.thumb_image,
-                          link: show_image_path(id: sugg.image_obs.id)) \
+                          link: image_path(id: sugg.image_obs.id)) \
                           if sugg.image_obs.present? %>
         </td>
       </tr>


### PR DESCRIPTION
This template is only available to image model beta testers, but has been broken for a few weeks apparently.

This doesn't fully update the layout, but it does make it render without errors and be legible.