### PR TITLE
Slight refactor of naming vote AJAX

### DIFF
--- a/app/assets/javascripts/naming_vote_ajax.js
+++ b/app/assets/javascripts/naming_vote_ajax.js
@@ -33,26 +33,26 @@ function VoteByAjaxModule(translations) {
         }
 
         // bootstrap modal printed in layout already, just activate it
-        $('#naming_ajax_progress_caption').append(
+        $('#naming_ajax_progress_caption').empty().append(
           $("<span>").text(translations.show_namings_saving + "... "),
           $("<span class='spinner-right mx-2'></span>")
         );
         $("#naming_ajax_progress").modal('show');
 
         $.ajax("/ajax/vote/naming/" + naming_id, {
-          data: {value: value, authenticity_token: csrf_token()},
+          data: { value: value, authenticity_token: csrf_token() },
           dataType: "text",
           async: true,
           complete: function (request) {
             _haveVotesChanged = false;
-            $('#naming_ajax_progress').modal('hide');
             $('#naming_ajax_progress_caption').empty();
+            $('#naming_ajax_progress').modal('hide');
             if (request.status == 200) {
-              var html     = $(request.responseText);
-              var title    = html.children().eq(0);
-              var div      = html.children().eq(1).html();
-              var percent  = html.children().eq(2).html();
-              var num_vot  = html.children().eq(3).html();
+              var html = $(request.responseText);
+              var title = html.children().eq(0);
+              var div = html.children().eq(1).html();
+              var percent = html.children().eq(2).html();
+              var num_vot = html.children().eq(3).html();
               // update the obs title, votes table, votes and percentage
               document.title = title.attr("title");
               $("#title").html(title.html());
@@ -65,8 +65,8 @@ function VoteByAjaxModule(translations) {
               save_vote_buttons().hide();
             } else {
               change_vote_selects().each(function () {
-               _this.val(_this.data("old_value"))
-                       .attr("disabled", null);
+                _this.val(_this.data("old_value"))
+                  .attr("disabled", null);
               });
               alert(request.responseText);
             }

--- a/app/controllers/ajax_controller/vote.rb
+++ b/app/controllers/ajax_controller/vote.rb
@@ -29,17 +29,7 @@ module AjaxController::Vote
     @naming.change_vote(value, @user)
     @observation = @naming.observation
     @votes = gather_users_votes(@observation, @user)
-    # Send four things: Recalculated show_obs_title,
-    # refreshed votes table, the new vote %, and the new num_votes
-    render(inline: %(<div>
-      <%= content_tag(:div, show_obs_title(obs: @observation),
-            title: show_obs_title(obs: @observation).strip_html.html_safe) %>
-      <%= content_tag(:div, render(partial: 'observations/namings/votes/table',
-            locals: { do_cancel: false, observation: @observation,
-                      naming: @naming })) %>
-      <%= content_tag(:span, "#{@naming.reload.vote_percent.round}%") %>
-      <%= content_tag(:span, "#{@naming.reload.votes.length}") %>
-    </div>))
+    render(partial: "observations/namings/votes/ajax_response")
   end
 
   def cast_image_vote(id, value)

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -180,7 +180,7 @@ module ObservationsHelper
       content_tag(:button, h(percent),
                   class: "vote-percent btn btn-link",
                   data: { toggle: "modal",
-                          id: "#{naming.id}",
+                          id: naming.id.to_s,
                           target: "#show_votes_#{naming.id}" })
     else
       link_with_query(h(percent),

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -180,6 +180,7 @@ module ObservationsHelper
       content_tag(:button, h(percent),
                   class: "vote-percent btn btn-link",
                   data: { toggle: "modal",
+                          id: "#{naming.id}",
                           target: "#show_votes_#{naming.id}" })
     else
       link_with_query(h(percent),

--- a/app/views/observations/namings/votes/_ajax_response.html.erb
+++ b/app/views/observations/namings/votes/_ajax_response.html.erb
@@ -1,0 +1,15 @@
+<%
+# Response for a naming vote.
+# Renders divs that are used to update page content by naming_vote.js
+# Recalculated show_obs_title, refreshed votes table,
+# the new vote %, and the new num_votes
+%>
+<div>
+  <%= content_tag(:div, show_obs_title(obs: @observation),
+        title: show_obs_title(obs: @observation).strip_html.html_safe) %>
+  <%= content_tag(:div, render(partial: 'observations/namings/votes/table',
+        locals: { do_cancel: false, observation: @observation,
+                  naming: @naming })) %>
+  <%= content_tag(:span, "#{@naming.reload.vote_percent.round}%") %>
+  <%= content_tag(:span, "#{@naming.reload.votes.length}") %>
+</div>

--- a/app/views/observations/namings/votes/_ajax_response.html.erb
+++ b/app/views/observations/namings/votes/_ajax_response.html.erb
@@ -1,8 +1,8 @@
 <%
 # Response for a naming vote.
 # Renders divs that are used to update page content by naming_vote.js
-# Recalculated show_obs_title, refreshed votes table,
-# the new vote %, and the new num_votes
+# Sends: a recalculated show_obs_title, the refreshed votes table,
+#        the new vote %, and the new num_votes
 %>
 <div>
   <%= content_tag(:div, show_obs_title(obs: @observation),

--- a/app/views/observations/namings/votes/_table.html.erb
+++ b/app/views/observations/namings/votes/_table.html.erb
@@ -36,7 +36,7 @@
               else
                 "..."
               end
-            end.safe_join(",") + ")"
+            end.safe_join(", ") + ")"
           end
         %></small></td>
       </tr>


### PR DESCRIPTION
This fixes a mistake I made in the JS that was intended to update the "community vote" percentage when you vote on a naming. (The % was updated in the db, and showed up on page refresh, but should update it "live" on the page. The prob was an errant CSS selector.)

It also moves the ajax HTML response into a partial. 
(Was `render(inline: string_of_html)` now: `render(partial: "observations/namings/votes/ajax_response")`