### PR TITLE
Change find_query boolean positional arg to kwarg

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1098,7 +1098,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Lookup the given kind of Query, returning nil if it no longer exists.
-  def find_query(model = nil, update = !browser.bot?)
+  def find_query(model = nil, update: !browser.bot?)
     model = model.to_s if model
     q = dealphabetize_q_param
 
@@ -1136,7 +1136,7 @@ class ApplicationController < ActionController::Base
   # a new query based on the existing one but with modified arguments.
   # If it does not exist, resturn default query.
   def existing_updated_or_default_query(model, args)
-    result = find_query(model, false)
+    result = find_query(model, update: false)
     if result
       # If existing query needs updates, we need to create a new query,
       # otherwise the modifications won't persist.


### PR DESCRIPTION
A two-line change to call `find_query` like this:
```ruby
find_query(:LocationDescription, update: false)
```
instead of the puzzling
```ruby
find_query(:LocationDescription, false)
```
