### PR TITLE
Move `gather_users_votes` to helper, and call from partial, for AJAX access

### DIFF
--- a/app/controllers/ajax_controller/vote.rb
+++ b/app/controllers/ajax_controller/vote.rb
@@ -28,7 +28,7 @@ module AjaxController::Vote
 
     @naming.change_vote(value, @user)
     @observation = @naming.observation
-    @votes = gather_users_votes(@observation, @user)
+    # FIXME: delete @votes = gather_users_votes(@observation, @user)
     render(partial: "observations/namings/votes/ajax_response")
   end
 

--- a/app/controllers/ajax_controller/vote.rb
+++ b/app/controllers/ajax_controller/vote.rb
@@ -28,7 +28,6 @@ module AjaxController::Vote
 
     @naming.change_vote(value, @user)
     @observation = @naming.observation
-    # FIXME: delete @votes = gather_users_votes(@observation, @user)
     render(partial: "observations/namings/votes/ajax_response")
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1868,15 +1868,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Bad place for this, but need proper refactor to have a good place.
-  def gather_users_votes(obs, user)
-    obs.namings.each_with_object({}) do |naming, votes|
-      votes[naming.id] =
-        naming.votes.find { |vote| vote.user_id == user.id } ||
-        Vote.new(value: 0)
-    end
-  end
-
   def load_for_show_observation_or_goto_index(id)
     Observation.includes(
       :collection_numbers,

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -37,7 +37,7 @@ module ObservationsController::Show
     @canonical_url = canonical_url(@observation)
     @mappable      = check_if_query_is_mappable
     @new_sites     = external_sites_user_can_add_links_to(@observation)
-    @votes         = @user ? gather_users_votes(@observation, @user) : []
+    # FIXME: @votes = @user ? gather_users_votes(@observation, @user) : []
   end
 
   def load_observation_for_show_observation_page

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -37,7 +37,6 @@ module ObservationsController::Show
     @canonical_url = canonical_url(@observation)
     @mappable      = check_if_query_is_mappable
     @new_sites     = external_sites_user_can_add_links_to(@observation)
-    # FIXME: @votes = @user ? gather_users_votes(@observation, @user) : []
   end
 
   def load_observation_for_show_observation_page

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -33,6 +33,17 @@ module ObservationsHelper
     end
   end
 
+  # gathers the user's @votes indexed by naming
+  def gather_users_votes(obs, user = nil)
+    return [] unless user
+
+    obs.namings.each_with_object({}) do |naming, votes|
+      votes[naming.id] =
+        naming.votes.find { |vote| vote.user_id == user.id } ||
+        Vote.new(value: 0)
+    end
+  end
+
   private
 
   # name portion of Observation title

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -189,7 +189,7 @@ module ObservationsHelper
 
     if can_do_ajax?
       content_tag(:button, h(percent),
-                  class: "vote-percent btn btn-link",
+                  class: "vote-percent btn btn-link px-0",
                   data: { toggle: "modal",
                           id: naming.id.to_s,
                           target: "#show_votes_#{naming.id}" })

--- a/app/views/observations/namings/_row.html.erb
+++ b/app/views/observations/namings/_row.html.erb
@@ -2,8 +2,8 @@
 # Naming Row (widescreen):
 # Shows a proposed naming for this observation, with a tiny vote form.
 # Also naming edit and delete buttons if the current user owns the naming.
-
-@vote = @votes[naming.id]
+# @vote is used by observations/namings/votes/form
+@vote = votes[naming.id]
 row = observation_naming_row(observation, naming, logged_in)
 %>
 

--- a/app/views/observations/namings/_table.html.erb
+++ b/app/views/observations/namings/_table.html.erb
@@ -4,6 +4,7 @@
 logged_in = @user&.verified
 namings = observation.namings.sort_by(&:created_at)
 header = observation_naming_header_row(observation, logged_in)
+votes = gather_users_votes(observation, @user)
 %>
 
 <div class="namings-table">
@@ -21,7 +22,7 @@ header = observation_naming_header_row(observation, logged_in)
     <% namings.each do |naming| %>
       <%= render(partial: "observations/namings/row",
                   locals: { naming: naming, observation: observation,
-                            logged_in: logged_in }) %>
+                            votes: votes, logged_in: logged_in }) %>
     <% end # each naming %>
   </div>
 </div>


### PR DESCRIPTION
Moves the method for gathering all of a user's votes (on all `naming`s of an `observation`) into the `observations_helper`, so it can be called from the template rather than the controller (and thus available to an AJAX call from another controller).

The votes are currently used to build the voting-select AJAX "form" in the naming table.