### PR TITLE
Add validation to `VotesController#update`

### DIFF
--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -33,7 +33,11 @@ module Observations::Namings
       pass_query_params
       naming = Naming.find(params[:naming_id].to_s)
       observation = naming.observation
-      observation.change_vote(naming, param_lookup([:vote, :value]))
+      value_str = param_lookup([:vote, :value])
+      value = Vote.validate_value(value_str)
+      raise("Bad value.") unless value
+
+      observation.change_vote(naming, value)
       redirect_with_query(observation_path(id: observation.id))
     end
 


### PR DESCRIPTION
This just adds the validation that is already applied to AJAX naming vote updates to the non-AJAX version, in preparation for using the same controller for both.