### PR TITLE
Simplify HTML/CSS of naming form's collapsible reasons

### DIFF
--- a/app/views/observations/namings/_fields.html.erb
+++ b/app/views/observations/namings/_fields.html.erb
@@ -57,7 +57,7 @@ locals = {
           <%= f_v.label(:value, :form_naming_confidence.t + ":") %><br>
           <%= f_v.select(:value,
                          options_for_select(Vote.confidence_menu, vote&.value),
-                         { include_blank: (action == :create) } ,
+                         { include_blank: (action == :create) },
                          class: "form-control",
                          data: { autofocus: focus_on_vote }) %>
         </div>
@@ -66,21 +66,26 @@ locals = {
       <%= f_n.fields_for(:reasons) do |f_r| %>
         <% reasons.values.sort_by(&:order).each do |r| %>
           <div class="form-group form-inline m-0">
-            <label>
+            <%= f_r.label("#{r.num}_check",
+                          { data: {
+                              toggle: "collapse",
+                              target: "#reasons_#{r.num}_notes"
+                            },
+                            aria: {
+                              expanded: "false",
+                              controls: "reasons_#{r.num}_notes"
+                            } }) do %>
               <%= f_r.check_box(
                         :check,
                         { index: r.num,
                           checked: r.used?,
-                          data: {
-                            role: "collapser",
-                            target: "#naming_reasons_#{r.num}_notes"
-                          },
                           class: "" },
                         "1") %>
               <%= r.label.t %>
-            </label>
+            <% end  # label %>
           </div>
-          <div class="form-group mb-3 <%= "collapse" if !r.used? %>">
+          <div class="form-group mb-3 <%= "collapse" if !r.used? %>"
+               id="reasons_<%= r.num %>_notes">
             <%= f_r.text_area(:notes,
                               index: r.num, rows: 3, value: r.notes,
                               class: "form-control") %>
@@ -95,21 +100,8 @@ locals = {
 <%= hidden_field_tag(:was_js_on, "yes") if can_do_ajax? %>
 <% inject_javascript_at_end %(
   jQuery(document).ready(function() {
-    function collapse_reason() {
-      var this2 = jQuery(this);
-      var target = jQuery(this2.attr("data-target")).parent();
-      var old_state = target.hasClass("collapse");
-      var new_state = !this2.is(':checked');
-      if (old_state && !new_state) {
-        target.removeClass("collapse");
-      } else if (!old_state && new_state) {
-        target.addClass("collapse");
-      }
-    }
-    jQuery('[data-role="collapser"]').each(collapse_reason)
-                                     .change(collapse_reason);
-    jQuery('.collapse').on('shown.bs.collapse', function () {
-      $(this).focus();
+    jQuery(document).on('shown.bs.collapse', '.collapse', function () {
+      $(this).first('textarea').focus();
     });
   });
 ) %>

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -8,7 +8,7 @@
                     @observation.show_link_args)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
-  @container = :wide
+  @container = :double
 %>
 
 <div class="row">

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -8,7 +8,7 @@
                     @observation.show_link_args)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
-  @container = :wide
+  @container = :double
 %>
 
 <div class="row">


### PR DESCRIPTION
This switches the naming from from using customized JS (relying on Bootstrap), to do the same thing using default Bootstrap JS. 

<img width="456" alt="Screen Shot 2023-02-10 at 5 06 22 PM" src="https://user-images.githubusercontent.com/1948095/218228981-df2624ac-84e5-45e2-8d68-02ecfbeeeb1c.png">

- As before, clicking on a "reason" `checkbox` or `label` "opens" the `textarea` below, where you can type in notes about the reason.
- Because it uses basic Bootstrap JS, there's less JS to maintain. The only thing our JS does now is `focus` the `textarea`.
- We get the Bootstrap JS for free just by adjusting the `<label>` tag attributes.
- Needed for #1346, when this form will appear in a popup. (Bootstrap is able to find `collapse` elements that are dynamically generated, but our JS was not able to find them, when generated after page load.)

This PR also widens the layout a bit on the naming form pages (new and edit).

<img width="931" alt="Screen Shot 2023-02-10 at 5 07 35 PM" src="https://user-images.githubusercontent.com/1948095/218229067-91c40435-ce60-482f-8ccc-8b20c530ddfa.png">

