### PR TITLE
Added integration test to properly test name synonymy forms.

### DIFF
--- a/app/controllers/names/synonyms/deprecate_controller.rb
+++ b/app/controllers/names/synonyms/deprecate_controller.rb
@@ -69,15 +69,13 @@ module Names::Synonyms
 
     def init_params_for_new
       # These parameters aren't always provided.
-      params[:proposed]    ||= {}
-      params[:comment]     ||= {}
       params[:chosen_name] ||= {}
       params[:is]          ||= {}
     end
 
     def init_ivars_for_new
-      @what             = params[:proposed][:name].to_s.strip_squeeze
-      @comment          = params[:comment][:comment].to_s.strip_squeeze
+      @what             = params[:proposed_name].to_s.strip_squeeze
+      @comment          = params[:comment_comment].to_s.strip_squeeze
       @list_members     = nil
       @new_names        = []
       @synonym_name_ids = []

--- a/app/models/name/validation.rb
+++ b/app/models/name/validation.rb
@@ -80,6 +80,7 @@ module Name::Validation
   end
 
   def check_user
-    errors.add(:user, :validate_name_user_missing.t) if !user && !User.current
+    errors.add(:user, :validate_name_user_missing.t) \
+      if !user_id && !User.current
   end
 end

--- a/app/views/comments/_comments_for_object.html.erb
+++ b/app/views/comments/_comments_for_object.html.erb
@@ -1,5 +1,5 @@
 <%
-  comments = object.comments.sort_by(&:created_at).reverse
+  comments = object.comments.includes(:user).sort_by(&:created_at).reverse
   if limit
     and_more = comments.length - limit
     comments = comments[0..limit-1]

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -29,6 +29,4 @@
     <%= :name_approve_comments_help.tp(name: @name.display_name) %>
   </div>
 
-  <%= f.submit(:APPROVE.l, class: "btn btn-default center-block mt-3") %>
-
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -613,13 +613,13 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # Approve Name Synonyms: form and callback:
   get("names/:id/synonyms/approve/new", to: "names/synonyms/approve#new",
                                         as: "approve_name_synonym_form")
-  post("names/:id/synonyms", to: "names/synonyms/approve#create",
-                             as: "approve_name_synonym")
+  post("names/:id/synonyms/approve", to: "names/synonyms/approve#create",
+                                     as: "approve_name_synonym")
   # Deprecate Name Synonyms: form and callback:
   get("names/:id/synonyms/deprecate/new", to: "names/synonyms/deprecate#new",
                                           as: "deprecate_name_synonym_form")
-  post("names/:id/synonyms", to: "names/synonyms/deprecate#create",
-                             as: "deprecate_name_synonym")
+  post("names/:id/synonyms/deprecate", to: "names/synonyms/deprecate#create",
+                                       as: "deprecate_name_synonym")
   # Name Trackers: form and callback:
   get("names/:id/trackers/new", to: "names/trackers#new",
                                 as: "new_name_tracker")

--- a/test/controllers/names/synonyms/deprecate_controller_test.rb
+++ b/test/controllers/names/synonyms/deprecate_controller_test.rb
@@ -37,8 +37,8 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        proposed: { name: new_name.text_name },
-        comment: { comment: "Don't like this name" }
+        proposed_name: new_name.text_name,
+        comment_comment: "Don't like this name"
       }
       post_requires_login(:create, params)
       assert_redirected_to(name_path(old_name.id))
@@ -79,8 +79,8 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        proposed: { name: new_name.text_name },
-        comment: { comment: "" }
+        proposed_name: new_name.text_name,
+        comment_comment: ""
       }
       login("rolf")
       post(:create, params: params)
@@ -114,9 +114,9 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        proposed: { name: new_name.text_name },
+        proposed_name: new_name.text_name,
         chosen_name: { name_id: new_name.id },
-        comment: { comment: "Don't like this name" }
+        comment_comment: "Don't like this name"
       }
       login("rolf")
       post(:create, params: params)
@@ -145,8 +145,8 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        proposed: { name: new_name_str },
-        comment: { comment: "Don't like this name" }
+        proposed_name: new_name_str,
+        comment_comment: "Don't like this name"
       }
       login("rolf")
       post(:create, params: params)
@@ -171,9 +171,9 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        proposed: { name: new_name_str },
+        proposed_name: new_name_str,
         approved_name: new_name_str,
-        comment: { comment: "Don't like this name" }
+        comment_comment: "Don't like this name"
       }
       login("rolf")
       post(:create, params: params)
@@ -199,9 +199,9 @@ module Names::Synonyms
       name.save
       params = {
         id: name.id,
-        proposed: { name: name2.search_name },
+        proposed_name: name2.search_name,
         approved_name: name2.search_name,
-        comment: { comment: "" }
+        comment_comment: ""
       }
 
       login("rolf")

--- a/test/integration/capybara/name_controller_supplemental_test.rb
+++ b/test/integration/capybara/name_controller_supplemental_test.rb
@@ -14,4 +14,53 @@ class NameControllerSupplementalTest < CapybaraIntegrationTestCase
     template = find("#name_tracker_note_template")
     template.assert_no_text(":mailing_address")
   end
+
+  def test_name_deprecation
+    bad_name = names(:agaricus_campestros)
+    good_name = names(:agaricus_campestris)
+    assert_not(bad_name.deprecated)
+    assert_not(good_name.deprecated)
+    assert_nil(bad_name.synonym_id)
+    assert_nil(good_name.synonym_id)
+
+    login(rolf)
+    visit("/names/#{bad_name.id}")
+
+    # First deprecate bad_name.
+    within("#right_tabs") { click_link(text: "Deprecate") }
+    fill_in("proposed_name", with: good_name.text_name)
+    fill_in("comment_comment", with: "bad name")
+    click_on("Submit")
+
+    assert(bad_name.reload.deprecated)
+    assert_not(good_name.reload.deprecated)
+    assert_not_nil(bad_name.synonym_id)
+    assert_equal(bad_name.synonym_id, good_name.synonym_id)
+    comment = bad_name.comments.last
+    assert_not_nil(comment)
+    assert_equal("bad name", comment.comment)
+
+    # Then undo it and approve it.
+    within("#right_tabs") { click_link(text: "Approve") }
+    page.uncheck("deprecate[others]")
+    fill_in("comment[comment]", with: "my bad")
+    click_on("Approve")
+
+    assert_not(bad_name.reload.deprecated)
+    assert_not(good_name.reload.deprecated)
+    assert_not_nil(bad_name.synonym_id)
+    assert_equal(bad_name.synonym_id, good_name.synonym_id)
+    comment = bad_name.comments.last
+    assert_not_nil(comment)
+    assert_equal("my bad", comment.comment)
+
+    # But still need to undo the synonymy.
+    within("#right_tabs") { click_link(text: "Change Synonyms") }
+    click_on("Submit Changes")
+
+    assert_not(bad_name.reload.deprecated)
+    assert_not(good_name.reload.deprecated)
+    assert_nil(bad_name.synonym_id)
+    assert_nil(good_name.synonym_id)
+  end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3651,4 +3651,16 @@ class NameTest < UnitTestCase
     name.author = "(A, B & C) D, E & F, sp. nov."
     assert_equal("(A et al.) D et al.", name.send(:brief_author))
   end
+
+  def test_user_validation
+    params = {
+      text_name: "Whoosia whatsitii",
+      author: "Blah & de Blah",
+      display_name: "__Whoosia whatsitii__ Blah & de Blah",
+      deprecated: true,
+      rank: "Species",
+    }
+    assert_nil(Name.create(params).id)
+    assert_not_nil(Name.create(params.merge(user: rolf)).id)
+  end
 end


### PR DESCRIPTION
There were several problems.  Basically, just because of lack of live testing of the name CRUDification PR from a few weeks ago.

1. The form input field ids were not the same as the parameters used in the controller tests, so the controller tests were passing fine, but the forms didn't actually set those parameters.  The new integration test should catch any mismatches like that in the future.  At least in this one tiny corner of the vast ocean of code. :(

2. Also, the routes were wrong for approve and deprecate -- they were being sent to names controller (or maybe the names/synonymy controller, I forget now), when they should be getting sent to the names/synonymy/approve and names/synonymy/deprecate controllers.  Again, the integration test should help catch such things.

There were also some eager-loading problems uncovered by the integration test.  One thing is interesting.  Apparently just doing `blah.user.present?` loads the stupid user!  Instead, if all you want to do is test for the presence of the user, do `blah.user_id.present?`.

Also, and I don't know if this works universally, but a way to separate concerns when eager-loading may be to change from this:

class Controller
  def action
    @object = Model.where(blah).includes(comments: :user)
  end
end

to

app/views/comments/_comments_for_object.html.erb:
  comments = @object.comments.include(:user)

This way the action doesn't necessarily need to know that the comments partial will eventually load the user info.  The comments partial itself can do the eager-loading.  Since nowhere else in the code are the comments' users needed, this works in this case.

I guess we'll see how many things I broke by adding that eager-loading to the comments partial in a second...   For example, I know show_observation does the eager-loading for all the partials right at the top.  Does that mean it now eager-loads the comments' users twice??  Ugh.