### PR TITLE
Revert stabby syntax to make Uglifier happy.

### DIFF
--- a/app/assets/javascripts/suggestions.js
+++ b/app/assets/javascripts/suggestions.js
@@ -45,7 +45,7 @@ function SuggestionModule(ids, url, text) {
                 window.location.href = url;
             } else {
               progress.html(text.suggestions_error);
-              window.setTimeout(() => {
+              window.setTimeout(function () {
                 resetModal();
               }, 1000);
             }


### PR DESCRIPTION
Maybe unnecessary after merging @nathan's fix to Uglifier configuration, but I'm gonna do it anyway to keep things consistent.  (The same file already had an old-style `function ()` syntax!  Can we at least agree to use the same syntax throughout a single file?! :)