### PR TITLE
Fix links to Decriptions Authored

### DIFF
--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -16,6 +16,10 @@ module UserStatsHelper
     links
   end
 
+  #########################################################
+
+  private
+
   # NOTE: Second arg is controller name
   # Last arg is a hash of index params.
   def user_stats_links_table(user)

--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -1,39 +1,43 @@
 # frozen_string_literal: true
 
-# View Helpers for GlossaryTerms
+# Helpers for user view
 module UserStatsHelper
-  def user_stats_links(show_user)
-    # NOTE: Second arg is controller name - plural for normalized.
-    # Normalized controller links last arg must be hash of index params.
+  def user_stats_links(user)
     links = {}
-    [
-      [:comments, "/comments", :index, { by_user: show_user.id }],
-      [:comments_for, "/comments", :index, { for_user: show_user.id }],
-      [:images, "/images", :index, { by_user: show_user.id }],
-      [:location_description_authors, "/locations/descriptions",
-       :index, { by_author: show_user.id }],
-      [:location_description_editors, "/locations/descriptions",
-       :index, { by_editor: show_user.id }],
-      [:locations, "/locations", :index, { by_user: show_user.id }],
-      [:locations_versions, "/locations", :index, { by_editor: show_user.id }],
-      [:name_description_authors, "/names/descriptions",
-       :index, { by_author: show_user.id }],
-      [:name_description_editors, "/names/descriptions",
-       :index, { by_editor: show_user.id }],
-      [:names, "/names", :index, { by_user: show_user.id }],
-      [:names_versions, "/names", :index, { by_editor: show_user.id }],
-      [:observations, "/observations", :index, { user: show_user.id }],
-      [:species_lists, "/species_lists", :index, { by_user: show_user.id }],
-      [:life_list, "/checklists", :show, {}]
-    ].each do |key, controller, action, params|
+    user_stats_links_table(user).each do |key, controller, action, params|
       unless [key].intersect?([:location_description_authors,
                                :name_description_authors])
-        params[:id] = show_user.id
+        params[:id] = user.id
       end
 
       links[key] = url_for(controller: controller, action: action,
                            params: params)
     end
     links
+  end
+
+  # NOTE: Second arg is controller name
+  # Last arg is a hash of index params.
+  def user_stats_links_table(user)
+    [
+      [:comments, "/comments", :index, { by_user: user.id }],
+      [:comments_for, "/comments", :index, { for_user: user.id }],
+      [:images, "/images", :index, { by_user: user.id }],
+      [:location_description_authors, "/locations/descriptions",
+       :index, { by_author: user.id }],
+      [:location_description_editors, "/locations/descriptions",
+       :index, { by_editor: user.id }],
+      [:locations, "/locations", :index, { by_user: user.id }],
+      [:locations_versions, "/locations", :index, { by_editor: user.id }],
+      [:name_description_authors, "/names/descriptions",
+       :index, { by_author: user.id }],
+      [:name_description_editors, "/names/descriptions",
+       :index, { by_editor: user.id }],
+      [:names, "/names", :index, { by_user: user.id }],
+      [:names_versions, "/names", :index, { by_editor: user.id }],
+      [:observations, "/observations", :index, { user: user.id }],
+      [:species_lists, "/species_lists", :index, { by_user: user.id }],
+      [:life_list, "/checklists", :show, {}]
+    ]
   end
 end

--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -2,10 +2,9 @@
 
 # View Helpers for GlossaryTerms
 module UserStatsHelper
-  def links(show_user)
+  def user_stats_links(show_user)
     # NOTE: Second arg is controller name - plural for normalized.
-    # Normalized controller links need hash of index params
-    # as the last argument.
+    # Normalized controller links last arg must be hash of index params.
     links = {}
     [
       [:comments, "/comments", :index, { by_user: show_user.id }],
@@ -27,14 +26,14 @@ module UserStatsHelper
       [:species_lists, "/species_lists", :index, { by_user: show_user.id }],
       [:life_list, "/checklists", :show, {}]
     ].each do |key, controller, action, params|
-      if [key].intersect?([:location_description_authors,
-                           :name_description_authors])
-        links[key] = url_for(controller: controller, action: action,
-                             params: params)
-      else
-        links[key] = url_for(controller: controller, action: action,
-                             params: params.merge({ id: show_user.id }))
+      unless [key].intersect?([:location_description_authors,
+                               :name_description_authors])
+        params[:id] = show_user.id
       end
+
+      links[key] = url_for(controller: controller, action: action,
+                           params: params)
     end
+    links
   end
 end

--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# View Helpers for GlossaryTerms
+module UserStatsHelper
+  def links(show_user)
+    # NOTE: Second arg is controller name - plural for normalized.
+    # Normalized controller links need hash of index params
+    # as the last argument.
+    links = {}
+    [
+      [:comments, "/comments", :index, { by_user: show_user.id }],
+      [:comments_for, "/comments", :index, { for_user: show_user.id }],
+      [:images, "/images", :index, { by_user: show_user.id }],
+      [:location_description_authors, "/locations/descriptions",
+       :index, { by_author: show_user.id }],
+      [:location_description_editors, "/locations/descriptions",
+       :index, { by_editor: show_user.id }],
+      [:locations, "/locations", :index, { by_user: show_user.id }],
+      [:locations_versions, "/locations", :index, { by_editor: show_user.id }],
+      [:name_description_authors, "/names/descriptions",
+       :index, { by_author: show_user.id }],
+      [:name_description_editors, "/names/descriptions",
+       :index, { by_editor: show_user.id }],
+      [:names, "/names", :index, { by_user: show_user.id }],
+      [:names_versions, "/names", :index, { by_editor: show_user.id }],
+      [:observations, "/observations", :index, { user: show_user.id }],
+      [:species_lists, "/species_lists", :index, { by_user: show_user.id }],
+      [:life_list, "/checklists", :show, {}]
+    ].each do |key, controller, action, params|
+      if [key].intersect?([:location_description_authors,
+                           :name_description_authors])
+        links[key] = url_for(controller: controller, action: action,
+                             params: params)
+      else
+        links[key] = url_for(controller: controller, action: action,
+                             params: params.merge({ id: show_user.id }))
+      end
+    end
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,8 +27,13 @@
     [ :species_lists, "/species_lists", :index, { by_user: @show_user.id } ],
     [ :life_list, "/checklists", :show, {} ]
   ].each do |key, controller, action, params|
-    links[key] = url_for(controller: controller, action: action,
-                         params: params.merge({ id: id }))
+    if key == :location_description_authors
+      links[key] = url_for(controller: controller, action: action,
+                           params: params)
+    else
+      links[key] = url_for(controller: controller, action: action,
+                           params: params.merge({ id: id }))
+    end
   end
 
   tabs = [

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,7 @@
     [ :comments_for, "/comments", :index, { for_user: @show_user.id } ],
     [ :images, "/images", :index, { by_user: @show_user.id } ],
     [ :location_description_authors, "/locations/descriptions",
-      :index, { by_user: @show_user.id } ],
+      :index, { by_author: @show_user.id } ],
     [ :location_description_editors, "/locations/descriptions",
       :index, { by_editor: @show_user.id } ],
     [ :locations, "/locations", :index, { by_user: @show_user.id } ],

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,7 +18,7 @@
     [ :locations, "/locations", :index, { by_user: @show_user.id } ],
     [ :locations_versions, "/locations", :index, { by_editor: @show_user.id } ],
     [ :name_description_authors, "/names/descriptions",
-      :index, { by_user: @show_user.id } ],
+      :index, { by_author: @show_user.id } ],
     [ :name_description_editors, "/names/descriptions",
       :index, { by_editor: @show_user.id } ],
     [ :names, "/names", :index, { by_user: @show_user.id } ],
@@ -27,7 +27,8 @@
     [ :species_lists, "/species_lists", :index, { by_user: @show_user.id } ],
     [ :life_list, "/checklists", :show, {} ]
   ].each do |key, controller, action, params|
-    if key == :location_description_authors
+    if [key].intersect?([:location_description_authors,
+                         :name_description_authors])
       links[key] = url_for(controller: controller, action: action,
                            params: params)
     else

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,40 +3,7 @@
   name = @show_user.unique_text_name
   @title = :show_user_title.t(user: name)
   @container = :full
-
-  # NOTE: Second arg is controller name - plural for normalized.
-  # Normalized controller links need hash of index params as the last argument.
-  links = {}
-  [
-    [ :comments, "/comments", :index, { by_user: @show_user.id } ],
-    [ :comments_for, "/comments", :index, { for_user: @show_user.id } ],
-    [ :images, "/images", :index, { by_user: @show_user.id } ],
-    [ :location_description_authors, "/locations/descriptions",
-      :index, { by_author: @show_user.id } ],
-    [ :location_description_editors, "/locations/descriptions",
-      :index, { by_editor: @show_user.id } ],
-    [ :locations, "/locations", :index, { by_user: @show_user.id } ],
-    [ :locations_versions, "/locations", :index, { by_editor: @show_user.id } ],
-    [ :name_description_authors, "/names/descriptions",
-      :index, { by_author: @show_user.id } ],
-    [ :name_description_editors, "/names/descriptions",
-      :index, { by_editor: @show_user.id } ],
-    [ :names, "/names", :index, { by_user: @show_user.id } ],
-    [ :names_versions, "/names", :index, { by_editor: @show_user.id } ],
-    [ :observations, "/observations", :index, { user: @show_user.id } ],
-    [ :species_lists, "/species_lists", :index, { by_user: @show_user.id } ],
-    [ :life_list, "/checklists", :show, {} ]
-  ].each do |key, controller, action, params|
-    if [key].intersect?([:location_description_authors,
-                         :name_description_authors])
-      links[key] = url_for(controller: controller, action: action,
-                           params: params)
-    else
-      links[key] = url_for(controller: controller, action: action,
-                           params: params.merge({ id: id }))
-    end
-  end
-
+  links = user_stats_links(@show_user)
   tabs = [
     link_to(:show_user_contributors.t, contributors_path)
   ]

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -87,6 +87,9 @@ class UsersControllerTest < FunctionalTestCase
     assert_select(
       "a[href = '#{location_descriptions_path}?by_author=#{user.id}']"
     )
+    assert_select(
+      "a[href = '#{name_descriptions_path}?by_author=#{user.id}']"
+    )
   end
 
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -85,7 +85,7 @@ class UsersControllerTest < FunctionalTestCase
 
     assert_template(:show)
     assert_select(
-      "a[href ^= '#{location_descriptions_path}?by_author=#{user.id}']"
+      "a[href = '#{location_descriptions_path}?by_author=#{user.id}']"
     )
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -74,6 +74,23 @@ class UsersControllerTest < FunctionalTestCase
   end
 
   #   ---------------
+  #    show
+  #   ---------------
+
+  def test_show
+    user = users(:rolf)
+
+    login
+    get(:show, params: { id: user.id })
+
+    assert_template(:show)
+    assert_select(
+      "a[href ^= '#{location_descriptions_path}?by_author=#{user.id}']"
+    )
+  end
+
+
+  #   ---------------
   #    admin actions
   #   ---------------
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -92,7 +92,6 @@ class UsersControllerTest < FunctionalTestCase
     )
   end
 
-
   #   ---------------
   #    admin actions
   #   ---------------


### PR DESCRIPTION
- Fixes 2 bugs in the links to Names Descriptions Authored and Locations Descriptions Authored on the `/user` page.
- Extracts a long variable definition from a view to a helper.
The bugs are:
  - The link href is to Descriptions Created, not Descriptions Authored
  - The href incorrectly includes the `:id` parameter. 
- Delivers [Pivotal #184478428](https://www.pivotaltracker.com/story/show/184478428).
- Makes it much easier for me to move forward on #1329 ( Njw dispatch refactor).

### Manual Test
- On the production server goto https://mushroomobserver.org/users/4468
- Click [Name Descriptions Authored](https://mushroomobserver.org/names/descriptions?by_user=4468&id=4468) and [Location Descriptions Authored](https://mushroomobserver.org/locations/descriptions?by_user=4468&id=4468)
- Do the same in this branch http://localhost:3000/users/4468, and compare the results of clicking the same links
[Name Descriptions Authored](http://localhost:3000/names/descriptions?by_author=4468), [Location Descriptions Authored](http://localhost:3000/locations/descriptions?by_author=4468)
