### PR TITLE
Fix LocationDescriptions by_author

### DIFF
--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -77,7 +77,11 @@ module Locations
 
     # Display list of location_descriptions that a given user is author on.
     def location_descriptions_by_author
-      user = params[:id] ? find_or_goto_index(User, params[:id].to_s) : @user
+      user = if params[:by_author]
+               find_or_goto_index(User, params[:by_author].to_s)
+             else
+               @user
+             end
       return unless user
 
       query = create_query(:LocationDescription, :by_author, user: user)

--- a/test/controllers/locations/descriptions_controller_test.rb
+++ b/test/controllers/locations/descriptions_controller_test.rb
@@ -66,10 +66,21 @@ module Locations
       assert_template("index")
     end
 
-    def test_location_descriptions_by_author
+    def test_by_author_of_one_description
       desc = location_descriptions(:albion_desc)
       login
       get(:index, params: { by_author: rolf.id })
+      assert_redirected_to(
+        %r{/locations/descriptions/#{desc.id}}
+      )
+    end
+
+    def test_by_author_of_one_description_different_user_logged_in
+      desc = location_descriptions(:albion_desc)
+
+      login("dick")
+      get(:index, params: { by_author: rolf.id })
+
       assert_redirected_to(
         %r{/locations/descriptions/#{desc.id}}
       )


### PR DESCRIPTION
Fix a bug exposed by #1357 
`LocationsDescriptions#index?by_author` gets the user from the wrong param.
It gets the user from `id`, but should get it from `by_author`