### PR TITLE
Add index to `namings` table on `observation_id`

### DIFF
--- a/db/migrate/20230215221813_add_index_to_namings_observation_id.rb
+++ b/db/migrate/20230215221813_add_index_to_namings_observation_id.rb
@@ -1,5 +1,5 @@
 class AddIndexToNamingsObservationId < ActiveRecord::Migration[6.1]
   def change
-    add_index :namings, :observation_id, unique: true
+    add_index :namings, :observation_id
   end
 end

--- a/db/migrate/20230215221813_add_index_to_namings_observation_id.rb
+++ b/db/migrate/20230215221813_add_index_to_namings_observation_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToNamingsObservationId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :namings, :observation_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_26_160800) do
+ActiveRecord::Schema.define(version: 2023_02_15_221813) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -431,6 +431,7 @@ ActiveRecord::Schema.define(version: 2022_12_26_160800) do
     t.integer "user_id"
     t.float "vote_cache", default: 0.0
     t.text "reasons"
+    t.index ["observation_id"], name: "index_namings_on_observation_id"
   end
 
   create_table "observation_collection_numbers", charset: "utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
Adds an index to the namings table to speed up observation namings queries, which are so slow.

Interestingly, this index key `observation_id` cannot be unique ~yet, although it seems like it should be, because we have duplicates in the db presently. (At least one, `140296`, was raised by my first migration attempt).~

I don't know if we have duplicates by design, ~but they seem like they could have been caused by namings proposed on an obs at the same time.~   EDIT: Apparently we do. 

~I found [an article about it](https://dev.to/nodefiend/rails-migration-adding-a-unique-index-and-deleting-duplicates-5cde), with suggestions for cleanup. If this is the situation, it seems like we should maybe merge, rather than delete, the duplicate data though.~