### PR TITLE
Implement User pref `image_size` for lightbox

### DIFF
--- a/app/views/account/preferences/_appearance.html.erb
+++ b/app/views/account/preferences/_appearance.html.erb
@@ -60,7 +60,9 @@
   <%= f.select(:image_size,
                options_for_select(
                  User.image_sizes.filter_map { |key, value|
-                   [key.titleize, User.image_sizes.key(value)] if (value >= 3)
+                   if value > User.image_sizes[:small]
+                     ["image_show_#{key}".to_sym.l, key]
+                   end
                  }, @user.image_size
                ),
                {}, { class: "form-control" }) %>

--- a/app/views/account/preferences/_appearance.html.erb
+++ b/app/views/account/preferences/_appearance.html.erb
@@ -55,4 +55,15 @@
   <%= f.number_field(:layout_count, class: "form-control", min: 1) %>
 </div>
 
+<div class="form-group mt-3 form-inline">
+  <%= f.label(:image_size, :prefs_image_size.t) %>
+  <%= f.select(:image_size,
+               options_for_select(
+                 User.image_sizes.filter_map { |key, value|
+                   [key.titleize, User.image_sizes.key(value)] if (value >= 3)
+                 }, @user.image_size
+               ),
+               {}, { class: "form-control" }) %>
+</div>
+
 <%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -14,6 +14,7 @@
   # Lightbox stuff. obs_data comes from the matrix_box presenter,
   # link_type from view (for naming links)
   lightbox_id = is_set ? "observation-set" : SecureRandom.uuid
+  lightbox_url = (User.image_size == "full_size") ? full_url : huge_url
   caption = image_caption_html(image_id, obs_data, link_type)
 
   # Show original name?
@@ -33,7 +34,7 @@
                       data: { toggle: "tooltip", placement: "bottom" }) %>
         <%= image_link %>
       </div>
-      <%= link_to("", huge_url,
+      <%= link_to("", lightbox_url,
                   class: "glyphicon glyphicon-fullscreen theater-btn",
                   data: { lightbox: lightbox_id, title: caption }) %>
       <div class="mt-3">

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -14,7 +14,7 @@
   # Lightbox stuff. obs_data comes from the matrix_box presenter,
   # link_type from view (for naming links)
   lightbox_id = is_set ? "observation-set" : SecureRandom.uuid
-  lightbox_url = (User.image_size == "full_size") ? full_url : huge_url
+  lightbox_url = (User.current&.image_size == "full_size") ? full_url : huge_url
   caption = image_caption_html(image_id, obs_data, link_type)
 
   # Show original name?

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -14,7 +14,13 @@
   # Lightbox stuff. obs_data comes from the matrix_box presenter,
   # link_type from view (for naming links)
   lightbox_id = is_set ? "observation-set" : SecureRandom.uuid
-  lightbox_url = (User.current&.image_size == "full_size") ? full_url : huge_url
+  p_map = {
+    "medium" => medium_url,
+    "large" => large_url,
+    "huge" => huge_url,
+    "full_size" => full_url
+  }
+  lightbox_url = (usize = User.current&.image_size) ? p_map[usize] : huge_url
   caption = image_caption_html(image_id, obs_data, link_type)
 
   # Show original name?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1836,7 +1836,7 @@
   prefs_thumbnail_small: "[:image_show_small]"
   prefs_thumbnail_large: "[:image_show_large]"
   prefs_thumbnail_maps: View thumbnail map on Observation page?
-  prefs_image_size: Image size
+  prefs_image_size: Image size for "lightbox"
   prefs_image_size_help: Size shown when you click on an image.
   prefs_image_small: "[:image_show_small] (320 x 320)"
   prefs_image_medium: "[:image_show_medium] (640 x 640)"

--- a/db/migrate/20230217081246_reset_user_image_size_values.rb
+++ b/db/migrate/20230217081246_reset_user_image_size_values.rb
@@ -1,0 +1,5 @@
+class ResetUserImageSizeValues < ActiveRecord::Migration[6.1]
+  def change
+    User.update_all(image_size: "huge")
+  end
+end

--- a/db/migrate/20230217081246_reset_user_image_size_values.rb
+++ b/db/migrate/20230217081246_reset_user_image_size_values.rb
@@ -1,5 +1,6 @@
 class ResetUserImageSizeValues < ActiveRecord::Migration[6.1]
   def change
+    change_column_default :users, :image_size, 5
     User.update_all(image_size: "huge")
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_15_221813) do
+ActiveRecord::Schema.define(version: 2023_02_17_081246) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -455,6 +455,7 @@ ActiveRecord::Schema.define(version: 2023_02_15_221813) do
     t.integer "observation_id"
     t.integer "user_id"
     t.datetime "last_view"
+    t.boolean "reviewed"
   end
 
   create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -671,7 +671,7 @@ ActiveRecord::Schema.define(version: 2023_02_17_081246) do
     t.boolean "email_locations_admin", default: false
     t.boolean "email_names_admin", default: false
     t.integer "thumbnail_size", default: 1
-    t.integer "image_size", default: 3
+    t.integer "image_size", default: 5
     t.string "default_rss_type", limit: 40, default: "all"
     t.integer "votes_anonymous", default: 1
     t.integer "location_format", default: 1

--- a/test/controllers/account/preferences_controller_test.rb
+++ b/test/controllers/account/preferences_controller_test.rb
@@ -30,6 +30,7 @@ module Account
       email_observations_consensus: "1",
       email_observations_naming: "1",
       hide_authors: "above_species",
+      image_size: "full_size",
       keep_filenames: "keep_but_hide",
       # license_id: licenses(:publicdomain).id.to_s,
       layout_count: "100",
@@ -65,6 +66,7 @@ module Account
       assert_input_value(:user_password_confirmation, "")
       assert_input_value(:user_thumbnail_maps, "1")
       assert_input_value(:user_view_owner_id, "1")
+      assert_input_value(:user_image_size, "medium")
       assert_input_value(:user_has_images, "")
       assert_input_value(:user_has_specimen, "")
       assert_input_value(:user_lichen, nil)
@@ -109,6 +111,7 @@ module Account
       assert_input_value(:user_email_observations_consensus, "1")
       assert_input_value(:user_email_observations_naming, "1")
       assert_input_value(:user_hide_authors, "above_species")
+      assert_input_value(:user_image_size, "full_size")
       assert_input_value(:user_keep_filenames, "keep_but_hide")
       assert_input_value(:user_license_id, licenses(:publicdomain).id.to_s)
       assert_input_value(:user_layout_count, "100")
@@ -162,6 +165,7 @@ module Account
       assert_equal("above_species", user.hide_authors)
       assert_equal("keep_but_hide", user.keep_filenames)
       assert_equal(100, user.layout_count)
+      assert_equal("full_size", user.image_size)
       assert_equal(licenses(:publicdomain), user.license)
       assert_equal("el", user.locale)
       assert_equal("scientific", user.location_format)

--- a/test/integration/capybara/account_test.rb
+++ b/test/integration/capybara/account_test.rb
@@ -236,6 +236,7 @@ class AccountTest < CapybaraIntegrationTestCase
              from: "user_hide_authors")
       select("Postal (New York, USA)", from: "user_location_format")
       select("Agaricus", from: "user_theme")
+      select("Full Size", from: "user_image_size")
       assert_select("user_locale",
                     with_options: %w[Ελληνικά English Français Español])
       select("Ελληνικά", from: "user_locale")


### PR DESCRIPTION
Uses the old user `image_size` pref to choose which resolution of image pops up in the lightbox. (Changes the English translation string to make the "lightbox" part clear.)  Also does a migration to set everybody's pref at `huge` which is the size image served by the lightbox the last few years. 

Choices are:
```
Medium
Large
Huge
Full Size
```

If certain lichenologists 👀 select `full_size` for example, they'll get all the pixels and won't have to wait for the large image to load, then click through to the `Show original image` link.

Adds tests for the new pref: controller and integration.


