### PR TITLE
Consistent-ify modal ids

### DIFF
--- a/app/views/observations/namings/_modal.html.erb
+++ b/app/views/observations/namings/_modal.html.erb
@@ -13,7 +13,7 @@
                         class:"modal-title",
                         id: "modal_header_naming") %>
       </div>
-      <div class="modal-body" id="modal_naming_body">
+      <div class="modal-body" id="modal_body_naming">
         <div id="modal_flash"></div>
         <%= render(partial: 'observations/namings/form',
                    locals: { action: action, show_reasons: true,

--- a/app/views/observations/namings/form_reload.js.erb
+++ b/app/views/observations/namings/form_reload.js.erb
@@ -1,6 +1,6 @@
 // What to do if create or update doesn't save
 
-var modal_body = $("#modal_naming_body");
+var modal_body = $("#modal_body_naming");
 
 // replace the flash notices in the modal
 $("#modal_flash").remove();


### PR DESCRIPTION
Quick fix. I was using inconsistent id structure, which will make trouble in the future if i DRY up the modal templates.