### PR TITLE
Change name of ajax progress whirly modal to `mo_ajax_progress`

### DIFF
--- a/app/assets/javascripts/mo_events.js
+++ b/app/assets/javascripts/mo_events.js
@@ -7,14 +7,14 @@ MOEvents.alert = function (element) {
 }
 
 MOEvents.whirly = function () {
-  $("#naming_ajax_progress").modal('show');
+  $("#mo_ajax_progress").modal('show');
 }
 
 MOEvents.savingWhirly = function () {
-  // $('#naming_ajax_progress_caption').empty().append(
+  // $('#mo_ajax_progress_caption').empty().append(
   //   $("<span>").text(translations.show_namings_saving + "... "),
   //   $("<span class='spinner-right mx-2'></span>")
   // );
 
-  $("#naming_ajax_progress").modal('show');
+  $("#mo_ajax_progress").modal('show');
 }

--- a/app/assets/javascripts/naming_vote_ajax.js
+++ b/app/assets/javascripts/naming_vote_ajax.js
@@ -18,11 +18,11 @@ function VoteByAjaxModule(translations) {
     var attach_bindings = function () {
       change_vote_selects().on("change", function (event) {
         // bootstrap modal printed in layout already, just activate it
-        $('#naming_ajax_progress_caption').empty().append(
+        $('#mo_ajax_progress_caption').empty().append(
           $("<span>").text(translations.show_namings_saving + "... "),
           $("<span class='spinner-right mx-2'></span>")
         );
-        $("#naming_ajax_progress").modal({ backdrop: 'static', keyboard: false });
+        $("#mo_ajax_progress").modal({ backdrop: 'static', keyboard: false });
       });
     };
 

--- a/app/assets/javascripts/suggestions.js
+++ b/app/assets/javascripts/suggestions.js
@@ -7,9 +7,9 @@ function SuggestionModule(ids, url, text) {
 
     button.on('click', function (event) {
       button.attr("disabled", "disabled");
-      var progress = $("#naming_ajax_progress_caption")
+      var progress = $("#mo_ajax_progress_caption")
         .html(text.suggestions_processing_images + "..." + whirly);
-      var progressModal = $("#naming_ajax_progress").modal("show");
+      var progressModal = $("#mo_ajax_progress").modal("show");
       var resetModal = function () {
         progress.empty();
         progressModal.modal("hide");

--- a/app/views/observations/namings/_form_bindings.js.erb
+++ b/app/views/observations/namings/_form_bindings.js.erb
@@ -1,5 +1,5 @@
 // Bindings for both new.js.erb and edit.js.erb
-$("#naming_ajax_progress").modal('hide');
+$("#mo_ajax_progress").modal('hide');
 
 $('#modal_naming').on('hidden.bs.modal', function () {
   $(this).remove();

--- a/app/views/observations/namings/_update_page.js.erb
+++ b/app/views/observations/namings/_update_page.js.erb
@@ -1,6 +1,6 @@
 // Update page with results of update or create naming or vote
-$('#naming_ajax_progress_caption').html('<%= j safe_spinner %>');
-$('#naming_ajax_progress').modal('hide');
+$('#mo_ajax_progress_caption').html('<%= j safe_spinner %>');
+$('#mo_ajax_progress').modal('hide');
 $("#namings_table").remove();
 
 // reset title of obs if necessary

--- a/app/views/observations/namings/votes/show.js.erb
+++ b/app/views/observations/namings/votes/show.js.erb
@@ -1,6 +1,6 @@
 $('body').append('<%= j render(partial: "observations/namings/votes/modal_community_votes", locals: { naming: @naming }) %>');
 
-$("#naming_ajax_progress").modal('hide');
+$("#mo_ajax_progress").modal('hide');
 
 // Show the modal
 $('#show_votes_<%= j @naming.id %>').modal('show');

--- a/app/views/shared/_modal_ajax_progress.html.erb
+++ b/app/views/shared/_modal_ajax_progress.html.erb
@@ -4,11 +4,11 @@
 message ||= ""
 %>
 
-<div class="modal" id="naming_ajax_progress" role="dialog"
-     aria-labelledby="naming_ajax_progress_caption">
+<div class="modal" id="mo_ajax_progress" role="dialog"
+     aria-labelledby="mo_ajax_progress_caption">
   <div class="modal-dialog modal-sm" role="document">
     <div class="modal-content">
-      <div class="modal-body text-center" id="naming_ajax_progress_caption">
+      <div class="modal-body text-center" id="mo_ajax_progress_caption">
         <%= safe_spinner(message) %>
       </div>
     </div>


### PR DESCRIPTION
So it doesn't seem like it's only for the use of Naming ajax stuff.

This is the modal called by the `MOEvents.whirly`