### PR TITLE
`herbaria_helper.rb` SQL -> AR/Arel

### DIFF
--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -4,8 +4,8 @@
 module HerbariaHelper
   def herbarium_top_users(herbarium_id)
     User.joins(:herbarium_records).
-      where(HerbariumRecord[:herbarium_id].eq(herbarium_id)).
-      select(User[:name], User[:login], User[:id].count).
-      group(User[:id]).order(User[:id].count.desc).take(5)
+      where(herbarium_records: { herbarium_id: herbarium_id }).
+      select(:name, :login, User[:id].count).
+      group(:id).order(User[:id].count.desc).take(5)
   end
 end

--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -6,6 +6,6 @@ module HerbariaHelper
     User.joins(:herbarium_records).
       where(HerbariumRecord[:id].eq(herbarium.id)).
       select(User[:name], User[:login], User[:id].count).
-      group(User[:id]).order("COUNT(`users`.`id`) DESC").take(5)
+      group(User[:id]).order(User[:id].count.desc).take(5)
   end
 end

--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -4,7 +4,6 @@
 module HerbariaHelper
   def herbarium_top_users(herbarium)
     User.joins(:herbarium_records).
-      where(User[:id].eq(HerbariumRecord[:user_id])).
       where(HerbariumRecord[:id].eq(herbarium.id)).
       select(User[:name], User[:login], User[:id].count).
       group(User[:id]).order(User[:id].count(:desc)).take(5)

--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -3,11 +3,10 @@
 # helper methods for Herbaria views
 module HerbariaHelper
   def herbarium_top_users(herbarium)
-    Herbarium.connection.select_rows(%(
-      SELECT u.name, u.login, COUNT(u.id)
-      FROM herbarium_records hr JOIN users u ON u.id = hr.user_id
-      WHERE hr.herbarium_id = #{herbarium.id}
-      GROUP BY u.id ORDER BY COUNT(u.id) DESC LIMIT 5
-    ))
+    User.joins(:herbarium_records).
+      where(User[:id].eq(HerbariumRecord[:user_id])).
+      where(HerbariumRecord[:id].eq(herbarium.id)).
+      select(User[:name], User[:login], User[:id].count).
+      group(User[:id]).order(User[:id].count(:desc)).take(5)
   end
 end

--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -2,9 +2,9 @@
 
 # helper methods for Herbaria views
 module HerbariaHelper
-  def herbarium_top_users(herbarium)
+  def herbarium_top_users(herbarium_id)
     User.joins(:herbarium_records).
-      where(HerbariumRecord[:herbarium_id].eq(herbarium.id)).
+      where(HerbariumRecord[:herbarium_id].eq(herbarium_id)).
       select(User[:name], User[:login], User[:id].count).
       group(User[:id]).order(User[:id].count.desc).take(5)
   end

--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -6,6 +6,6 @@ module HerbariaHelper
     User.joins(:herbarium_records).
       where(HerbariumRecord[:id].eq(herbarium.id)).
       select(User[:name], User[:login], User[:id].count).
-      group(User[:id]).order(User[:id].count(:desc)).take(5)
+      group(User[:id]).order("COUNT(`users`.`id`) DESC").take(5)
   end
 end

--- a/app/helpers/herbaria_helper.rb
+++ b/app/helpers/herbaria_helper.rb
@@ -4,7 +4,7 @@
 module HerbariaHelper
   def herbarium_top_users(herbarium)
     User.joins(:herbarium_records).
-      where(HerbariumRecord[:id].eq(herbarium.id)).
+      where(HerbariumRecord[:herbarium_id].eq(herbarium.id)).
       select(User[:name], User[:login], User[:id].count).
       group(User[:id]).order(User[:id].count.desc).take(5)
   end

--- a/app/views/herbaria/_form.html.erb
+++ b/app/views/herbaria/_form.html.erb
@@ -25,7 +25,7 @@
         </div>
         <% if button_name != :CREATE %>
           <%= help_block_with_arrow("up") do %>
-            <% top_users = herbarium_top_users(@herbarium)
+            <% top_users = herbarium_top_users(@herbarium.id)
                top_users.each do |name, login, count| %>
               <%= :edit_herbarium_user_records.t(
                     name: "#{name} (#{login})", num: count

--- a/test/helpers/herbaria_helper_test.rb
+++ b/test/helpers/herbaria_helper_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# test the helpers for HerbariaController
+class HerbariaHelperTest < ActionView::TestCase
+  def test_herbarium_top_users
+    # This herbarium has two curators: rolf and roy
+    # But only rolf has used it
+    nybg_h_top_users = herbarium_top_users(herbaria(:nybg_herbarium).id)
+    assert_equal(1, nybg_h_top_users.count)
+    assert_equal("rolf", nybg_h_top_users[0].login)
+
+    # Dick has not used his herbarium
+    dick_h_top_users = herbarium_top_users(herbaria(:dick_herbarium).id)
+    assert_equal(0, dick_h_top_users.count)
+
+    # Mary's the top user of fundis herbarium
+    fundis_h_top_users = herbarium_top_users(herbaria(:fundis_herbarium).id)
+    assert_equal(1, fundis_h_top_users.count)
+    assert_equal("mary", fundis_h_top_users[0].login)
+
+    # Thorsten's the top user of fundis herbarium
+    field_h_top_users = herbarium_top_users(herbaria(:field_museum).id)
+    assert_equal(1, field_h_top_users.count)
+    assert_equal("thorsten", field_h_top_users[0].login)
+    # Now change the attribution of thorsten's herbarium record
+    HerbariumRecord.find(herbarium_records(:field_museum_record).id).
+      update(user_id: users(:katrina).id)
+    field_h_top_users = herbarium_top_users(herbaria(:field_museum).id)
+    assert_equal(1, field_h_top_users.count)
+    assert_equal("katrina", field_h_top_users[0].login)
+  end
+end

--- a/test/helpers/herbaria_helper_test.rb
+++ b/test/helpers/herbaria_helper_test.rb
@@ -19,6 +19,13 @@ class HerbariaHelperTest < ActionView::TestCase
     fundis_h_top_users = herbarium_top_users(herbaria(:fundis_herbarium).id)
     assert_equal(1, fundis_h_top_users.count)
     assert_equal("mary", fundis_h_top_users[0].login)
+    # Now move all rolf's records to this herbarium
+    HerbariumRecord.where(user_id: users(:rolf).id).
+      update_all(herbarium_id: herbaria(:fundis_herbarium).id)
+    fundis_h_top_users = herbarium_top_users(herbaria(:fundis_herbarium).id)
+    assert_equal(2, fundis_h_top_users.count)
+    assert_equal("rolf", fundis_h_top_users[0].login)
+    assert_equal("mary", fundis_h_top_users[1].login)
 
     # Thorsten's the top user of fundis herbarium
     field_h_top_users = herbarium_top_users(herbaria(:field_museum).id)


### PR DESCRIPTION
Existing method:
```sql
SELECT u.name, u.login, COUNT(u.id)
FROM herbarium_records hr JOIN users u ON u.id = hr.user_id
WHERE hr.herbarium_id = #{herbarium.id}
GROUP BY u.id ORDER BY COUNT(u.id) DESC LIMIT 5
```

This rewrite produces the SQL:

```sql
SELECT `users`.`name`, `users`.`login`, COUNT(`users`.`id`) 
FROM `users` INNER JOIN `herbarium_records` ON `herbarium_records`.`user_id` = `users`.`id` 
WHERE `herbarium_records`.`herbarium_id` = #{herbarium.id} 
GROUP BY `users`.`id` ORDER BY COUNT(`users`.`id`) DESC LIMIT 5
```

Does this seem correct?