### PR TITLE
Enable direct filtering of obs needing ids index

### DIFF
--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -114,12 +114,22 @@ module ObservationsController::Index
       search.errors.each do |error|
         flash_error(error.to_s)
       end
-      render("index", location: observations_path)
+      if params[:needs_id]
+        redirect_to({ controller: "/observations/identify", action: :index,
+                      q: get_query_param })
+      else
+        render("index", location: observations_path)
+      end
     else
       @suggest_alternate_spellings = search.query.params[:pattern]
-      show_selected_observations(
-        search.query, no_hits_title: :title_for_observation_search.t
-      )
+      if params[:needs_id]
+        redirect_to({ controller: "/observations/identify", action: :index,
+                      q: search.query })
+      else
+        show_selected_observations(
+          search.query, no_hits_title: :title_for_observation_search.t
+        )
+      end
     end
   end
 

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -124,7 +124,7 @@ module ObservationsController::Index
       @suggest_alternate_spellings = search.query.params[:pattern]
       if params[:needs_id]
         redirect_to({ controller: "/observations/identify", action: :index,
-                      q: search.query })
+                      q: get_query_param })
       else
         show_selected_observations(
           search.query, no_hits_title: :title_for_observation_search.t

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -124,7 +124,7 @@ module ObservationsController::Index
       @suggest_alternate_spellings = search.query.params[:pattern]
       if params[:needs_id]
         redirect_to({ controller: "/observations/identify", action: :index,
-                      q: get_query_param })
+                      q: get_query_param(search.query) })
       else
         show_selected_observations(
           search.query, no_hits_title: :title_for_observation_search.t

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -24,7 +24,13 @@ class SearchController < ApplicationController
     session[:pattern] = pattern
     session[:search_type] = type
 
-    special_params = type == :herbarium ? { flavor: :all } : {}
+    special_params = if type == :herbarium
+                       { flavor: :all }
+                     elsif params[:needs_id] == "true"
+                       { needs_id: true }
+                     else
+                       {}
+                     end
 
     forward_pattern_search(type, pattern, special_params)
   end
@@ -63,6 +69,7 @@ class SearchController < ApplicationController
     end
   end
 
+  # In the case of "needs_id", this is added to the search path params
   def forward_pattern_search(type, pattern, special_params)
     case type
     when :google
@@ -71,7 +78,8 @@ class SearchController < ApplicationController
          :observation, :project, :species_list, :user
       redirect_to_search_or_index(
         pattern: pattern,
-        search_path: send("#{type.to_s.pluralize}_path", pattern: pattern),
+        search_path: send("#{type.to_s.pluralize}_path",
+                          params: { pattern: pattern }.merge(special_params)),
         index_path: send("#{type.to_s.pluralize}_path", special_params)
       )
     else

--- a/app/views/layouts/search_bar/_search_form.html.erb
+++ b/app/views/layouts/search_bar/_search_form.html.erb
@@ -27,27 +27,31 @@ identify_page = controller.controller_name == "identify"
 # Fields have attributes nested under search via fields_for, eg search[:type]
 %>
 
-<%= form_with(scope: :search, url: search_pattern_path, method: :get,
+<%= form_with(url: search_pattern_path, method: :get,
               class: "navbar-form navbar-left px-0",
               id: "pattern_search_form") do |f| %>
 
-  <div class="form-group has-feedback has-search">
-    <span class="glyphicon glyphicon-search form-control-feedback"></span>
-      <%= f.text_field(:pattern, { value: session[:pattern],
-                                   class: "form-control",
-                                   placeholder: :app_find.t }) %>
-  </div><!--.form-group-->
+  <%= fields_for(:search) do |f_s| %>
+    <div class="form-group has-feedback has-search">
+      <span class="glyphicon glyphicon-search form-control-feedback"></span>
+        <%= f_s.text_field(:pattern, { value: session[:pattern],
+                                    class: "form-control",
+                                    placeholder: :app_find.t }) %>
+    </div><!--.form-group-->
 
-  <div class="form-group text-nowrap">
-      <%= f.select(
+    <div class="form-group text-nowrap">
+      <%= f_s.select(
             :type,
             options_for_select(options, session[:search_type] || :observation),
             { }, { class: "form-control w-auto" }
           ) %>
-  </div><!--.form-group-->
+    </div><!--.form-group-->
+  <% end %>
+
+  <%= hidden_field_tag(:needs_id, true) if identify_page %>
 
   <div class="form-group text-nowrap">
-      <%= f.submit(:app_search.l, class: "btn btn-default mr-2") %>
+    <%= f.submit(:app_search.l, class: "btn btn-default mr-2") %>
   </div><!--.form-group-->
 
 <% end %>


### PR DESCRIPTION
Adds a hidden field `params[:needs_id]` to the site search form if the form is rendered on the Obs Needing Ids index, only.

Passes `params[:needs_id]` thru to the `ObservationsController#index`, which will save the search as the new query param, and then render the results via `Observations::IdentifyController#index` if the param is present.

The alternative to this is to make a whole 'nother `type` of `PatternSearch`, and i don't believe that's necessary.