### PR TITLE
Make visited links in the navbar the same color as other links

### DIFF
--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -2,12 +2,15 @@
 // link, button, alert themed styles
 // --------------------------------------------------
 
-a:not(.btn):visited {
+a:not(.btn):not(.list-group-item):visited {
   color: $LINK_VISITED_FG_COLOR;
 }
 
-.navbar a:visited {
-  color: inherit;
+.navbar {
+  a,
+  a:visited {
+    color: $LINK_FG_COLOR !important;
+  }
 }
 
 //

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -6,6 +6,10 @@ a:not(.btn):visited {
   color: $LINK_VISITED_FG_COLOR;
 }
 
+.navbar a:visited {
+  color: inherit;
+}
+
 //
 // alerts
 // --------------------------------------------------


### PR DESCRIPTION
It's kind of unclear and distracting to have **visited navigation links** potentially differently colored (depending on theme).
We need nav colors available to signal more important things.

Current:
<img width="162" alt="Screen Shot 2023-02-21 at 1 53 35 PM" src="https://user-images.githubusercontent.com/1948095/220467189-314da4ea-b279-4545-ab4a-9e84ceaaea25.png">

This PR:
<img width="155" alt="Screen Shot 2023-02-21 at 1 54 14 PM" src="https://user-images.githubusercontent.com/1948095/220467278-b69608d8-99e2-49a9-9d76-8e850658daac.png">
