### PR TITLE
Fix LH Navbar comments_for link

### DIFF
--- a/app/views/layouts/sidebar/_user.html.erb
+++ b/app/views/layouts/sidebar/_user.html.erb
@@ -7,7 +7,7 @@
   </span>
 </div>
 <%= link_to(:app_comments_for_you.t,
-            comments_path(by_user: @user.id),
+            comments_path(for_user: @user.id),
             { class: classes[:mobile_only],
               id: "nav_mobile_your_comments_link" }) %>
 <%= link_to(:app_your_observations.t,

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -63,7 +63,8 @@ class RssLogsControllerTest < FunctionalTestCase
     comments_for_path = comments_path(for_user: User.current_id)
     assert_select(
       "a#nav_mobile_your_comments_link[href='#{comments_for_path}']",
-      true, "LH NavBar 'Commments for` link broken")
+      true, "LH NavBar 'Commments for` link broken"
+    )
   end
 
   def test_user_default_rss_log

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -59,6 +59,11 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_match(/#{expect.glossary_term.name}/, css_select(".rss-what").text)
     assert_match(/#{rss_logs(:observation_rss_log).observation.name.text_name}/,
                  css_select(".rss-what").text)
+
+    comments_for_path = comments_path(for_user: User.current_id)
+    assert_select(
+      "a#nav_mobile_your_comments_link[href='#{comments_for_path}']",
+      true, "LH NavBar 'Commments for` link broken")
   end
 
   def test_user_default_rss_log


### PR DESCRIPTION
Fixes a bug reported by user 6698

### Manual Test

- Goto http://mushroomobserver.org/
- Login if necessary
- In browser, choose View, Developer Tools (or similar)
- In developer console choose Dimensions iPhone XR
- Click the 4-bar icon to display the LH NavBar
- In the NavBar, click Comments for You 
Result: Comments for <your name>
