### PR TITLE
Fix thumbnail links on obs index

### DIFF
--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -1,9 +1,9 @@
 <%
 # Requires local variable object: RssLog, Observation, Image, etc. instance.
-link_type ||= nil
-link_method ||= nil
-identify ||= nil
-presenter = MatrixBoxPresenter.new(object, @view, link_type, link_method)
+link_type ||= :target
+link_method ||= :get
+identify ||= false
+presenter = MatrixBoxPresenter.new(object, @view, link_type, link_method, identify)
 columns ||= "col-xs-12 col-sm-6 col-md-4"
 object_id = object&.id.present? ? object.id : "no_ID"
 %>


### PR DESCRIPTION
Sets local defaults at `matrix_box.html.erb` for link_type, link_method and identify, called in presenter and thumbnail. 

Please test before deploying if possible. Works for me locally.