### PR TITLE
Country links

### DIFF
--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -5,7 +5,7 @@
 module LocationsHelper
   def country_link(country, count = nil)
     str = country + (count ? ": #{count}" : "")
-    link_to(str, location_countries_path(country: country))
+    link_to(str, locations_path(country: country))
   end
 
   # title of a link to Observations at a location, with observation count

--- a/test/controllers/locations/countries_controller_test.rb
+++ b/test/controllers/locations/countries_controller_test.rb
@@ -5,12 +5,23 @@ require("set")
 
 module Locations
   class CountriesControllerTest < FunctionalTestCase
-    include ObjectLinkHelper
+    # include ObjectLinkHelper
 
     def test_list_countries
+      cc = CountryCounter.new
+      links_to_countries_with_obss = cc.known_by_count.length
+      links_to_other_localities_with_obss = cc.unknown_by_count.length
+
       login
       get(:index)
-      assert_template("index")
+
+      assert_select("#title", text: :list_countries_title.l)
+      assert_select(
+        "a:match('href', ?)", %r{^/locations\?country=\S+},
+        { count: links_to_countries_with_obss +
+                 links_to_other_localities_with_obss },
+        "Wrong number of links to countries and other localities"
+      )
     end
   end
 end


### PR DESCRIPTION
 This PR fixes the broken country links on the [Country List](https://mushroomobserver.org/locations/countries). 
(Currently, clicking on any country under Countries With Observations simply reloads the Country list.)
- Includes revised test to prevent reversion.
- Delivers [Pivotal #184558424](https://www.pivotaltracker.com/story/show/184558424)

### Manual test
- Go to Country List. http://localhost:3000/locations/countries
- Click any country under Countries With Observations
Result: "Locations Matching ‘<country>$’"
(The trailing $ is an old issue that's [another story](https://www.pivotaltracker.com/story/show/184554008).)
