### PR TITLE
Refactor `thumbnail_helper` to use a new `thumbnail_presenter`, disentangle from `matrix_box_presenter`

### DIFF
--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -2,7 +2,7 @@
 // link, button, alert themed styles
 // --------------------------------------------------
 
-a:not(.btn):not(.list-group-item):visited {
+a:not(.btn):not(.list-group-item):not(.theater-btn):visited {
   color: $LINK_VISITED_FG_COLOR;
 }
 

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -11,24 +11,16 @@ module ThumbnailHelper
   #   html_options::     Additional HTML attributes to add to <img> tag.
   #   notes::            Show image notes??
   #
-  def thumbnail(image, args = {})
-    image_id = image.is_a?(Integer) ? image : image.id
-    locals = {
-      image: image,
-      link: image_path(image_id),
-      link_type: :target, # or :remote
-      link_method: :get,
-      size: :small,
-      votes: true,
-      original: false,
-      theater_on_click: false,
-      html_options: {}, # we don't want to always pass class: "img-fluid"
-      extra_classes: "",
-      notes: "",
-      identify: false,
-      obs_data: {}
-    }.merge(args)
-    render(partial: "shared/image_thumbnail", locals: locals)
+  # def thumbnail(
+  #   image,
+  #   args = {
+  #     notes: "",
+  #     extra_classes: ""
+  #   }
+  # )
+  def thumbnail(image, args)
+    render(partial: "shared/image_thumbnail",
+           locals: args.merge({ image: image }))
   end
 
   def show_best_image(obs)
@@ -38,57 +30,6 @@ module ThumbnailHelper
               link: observation_path(id: obs.id),
               size: :thumbnail,
               votes: true) + image_copyright(obs.thumb_image)
-  end
-
-  # NOTE: The local var `link` might be to #show_image as you'd expect,
-  # or it may be a GET with params[:img_id] to the actions for #reuse_image
-  # or #remove_image ...or any other link.
-  # These use .ab-fab instead of .stretched-link so .theater-btn is clickable
-  def image_link_html(link = "", link_method = :get)
-    case link_method
-    when :get
-      link_with_query("", link, class: "image-link ab-fab")
-    when :post
-      post_button(name: "", path: link, class: "image-link ab-fab")
-    when :put
-      put_button(name: "", path: link, class: "image-link ab-fab")
-    when :patch
-      patch_button(name: "", path: link, class: "image-link ab-fab")
-    when :delete
-      destroy_button(name: "", target: link, class: "image-link ab-fab")
-    when :remote
-      link_with_query("", link, class: "image-link ab-fab", remote: true)
-    end
-  end
-
-  def image_caption_html(image_id, obs_data, identify)
-    html = []
-    if obs_data[:id].present?
-      html = image_observation_data(html, obs_data, identify)
-    end
-    html << caption_image_links(image_id)
-    safe_join(html)
-  end
-
-  def image_observation_data(html, obs_data, identify)
-    if identify ||
-       (obs_data[:obs].vote_cache.present? && obs_data[:obs].vote_cache <= 0)
-      html << propose_naming_link(obs_data[:id])
-      html << content_tag(:span, "&nbsp;".html_safe, class: "mx-2")
-      html << mark_as_reviewed_toggle(obs_data[:id])
-    end
-    html << caption_obs_title(obs_data)
-    html << render(partial: "observations/show/observation",
-                   locals: { observation: obs_data[:obs] })
-  end
-
-  def caption_image_links(image_id)
-    orig_url = Image.url(:original, image_id)
-    links = []
-    links << original_image_link(orig_url)
-    links << " | "
-    links << image_exif_link(image_id)
-    safe_join(links)
   end
 
   def propose_naming_link(id, btn_class = "btn-primary my-3")
@@ -113,26 +54,6 @@ module ThumbnailHelper
            layout: false)
   end
 
-  def caption_obs_title(obs_data)
-    content_tag(:h4, show_obs_title(obs: obs_data[:obs]),
-                class: "obs-what", id: "observation_what_#{obs_data[:id]}")
-  end
-
-  def original_image_link(orig_url)
-    link_to(:image_show_original.t, orig_url,
-            { class: "lightbox_link", target: "_blank", rel: "noopener" })
-  end
-
-  def image_exif_link(image_id)
-    content_tag(:button, :image_show_exif.t,
-                { class: "btn btn-link px-0 lightbox_link",
-                  data: {
-                    toggle: "modal",
-                    target: "#image_exif_modal",
-                    image: image_id
-                  } })
-  end
-
   # Grab the copyright_text for an Image.
   def image_copyright(image)
     link = if image.copyright_holder == image.user.legal_name
@@ -144,6 +65,9 @@ module ThumbnailHelper
   end
 
   # Create an image link vote, where vote param is vote number ie: 3
+  # Returns a form input button if the user has NOT voted this way
+  # JS is listening to any element with [data-role="image_vote"],
+  # Even though this is not an <a> tag, but an <input>, it's ok.
   def image_vote_link(image, vote)
     current_vote = image.users_vote(@user)
     vote_text = vote.zero? ? "(x)" : image_vote_as_short_string(vote)
@@ -151,9 +75,6 @@ module ThumbnailHelper
       return content_tag(:span, image_vote_as_short_string(vote))
     end
 
-    # return a form input button if the user has NOT voted this way
-    # NOTE: JS is checking any element with [data-role="image_vote"],
-    # Even though this is not an <a> tag, it's an <input>, it's ok.
     put_button(name: vote_text,
                path: image_vote_path(id: image.id, vote: vote),
                title: image_vote_as_help_string(vote),

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# https://nithinbekal.com/posts/rails-presenters/
+# By inheriting from Ruby’s builtin SimpleDelegator class and calling super
+# in the initialize method, we make sure that if we call any method that is
+# not defined in the presenter, it passes it on to the model object.
+class BasePresenter < SimpleDelegator
+  def initialize(model, view)
+    @view = view
+    super(model)
+  end
+
+  # h is a convention for the view context, to access helpers
+  def h
+    @view
+  end
+end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -5,7 +5,7 @@
 # in the initialize method, we make sure that if we call any method that is
 # not defined in the presenter, it passes it on to the model object.
 class BasePresenter < SimpleDelegator
-  def initialize(model, view)
+  def initialize(model, view, _args = {})
     @view = view
     super(model)
   end

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -1,52 +1,54 @@
 # frozen_string_literal: true
 
 # Gather details for items in matrix-style ndex pages.
-class MatrixBoxPresenter
+class MatrixBoxPresenter < BasePresenter
   attr_accessor \
-    :thumbnail, # thumbnail image tag
-    :detail,    # string with extra details
-    :when,      # when object or target was created
-    :who,       # owner of object or target
-    :what,      # link to object or target
-    :where,     # location of object or target
-    :time       # when object or target was last modified
+    :image_data, # thumbnail image tag
+    :detail,     # string with extra details
+    :when,       # when object or target was created
+    :who,        # owner of object or target
+    :what,       # link to object or target
+    :where,      # location of object or target
+    :time        # when object or target was last modified
 
-  def initialize(object, view,
-                 link_type: :target, link_method: :get, identify: nil)
+  def initialize(object, view)
+    @view = view
+
     case object
     when Image
-      image_to_presenter(object, view)
+      image_to_presenter(object)
     when Observation
-      observation_to_presenter(object, view, link_type, link_method, identify)
+      observation_to_presenter(object)
     when RssLog
-      rss_log_to_presenter(object, view)
+      rss_log_to_presenter(object)
     when User
-      user_to_presenter(object, view)
+      user_to_presenter(object)
     end
   end
 
   # Grabs all the information needed for view from RssLog instance.
-  def rss_log_to_presenter(rss_log, view)
+  def rss_log_to_presenter(rss_log)
     target = rss_log.target
     name = target ? target.unique_format_name.t : rss_log.unique_format_name.t
     self.when = target.when&.web_date if target.respond_to?(:when)
-    self.who  = view.user_link(target.user) if target&.user
+    self.who  = h.user_link(target.user) if target&.user
     self.what =
       if target
-        view.link_with_query(name, target.show_link_args)
+        h.link_with_query(name, target.show_link_args)
       else
-        view.link_with_query(name, rss_log.show_link_args)
+        h.link_with_query(name, rss_log.show_link_args)
       end
-    self.where = view.location_link(target.place_name, target.location) \
+    self.where = h.location_link(target.place_name, target.location) \
                  if target&.respond_to?(:location)
     self.time = rss_log.updated_at
 
-    self.thumbnail =
-      if target&.respond_to?(:thumb_image) && target&.thumb_image
-        view.thumbnail(target.thumb_image,
-                       link: target.show_link_args,
-                       obs_data: obs_data_hash(target))
-      end
+    if target&.respond_to?(:thumb_image) && target&.thumb_image
+      self.image_data = {
+        image: target.thumb_image,
+        image_link: target.show_link_args,
+        obs_data: obs_data_hash(target)
+      }
+    end
     return unless (temp = rss_log.detail)
 
     temp = target.source_credit.tpl if target.respond_to?(:source_credit) &&
@@ -57,27 +59,29 @@ class MatrixBoxPresenter
   end
 
   # Grabs all the information needed for view from Image instance.
-  def image_to_presenter(image, view)
+  def image_to_presenter(image)
     name = image.unique_format_name.t
     self.when = begin
                   image.when.web_date
                 rescue StandardError
                   nil
                 end
-    self.who  = view.user_link(image.user)
-    self.what = view.link_with_query(name, image.show_link_args)
-    self.thumbnail = view.thumbnail(image, link: image.show_link_args)
+    self.who  = h.user_link(image.user)
+    self.what = h.link_with_query(name, image.show_link_args)
+    self.image_data = {
+      image: image,
+      image_link: image.show_link_args
+    }
   end
 
   # Grabs all the information needed for view from Observation instance.
-  def observation_to_presenter(observation, view, link_type, link_method,
-                               identify)
+  def observation_to_presenter(observation)
     name = observation.unique_format_name.t
     self.when  = observation.when.web_date
-    self.who   = view.user_link(observation.user) if observation.user
-    self.what  = view.link_with_query(name, observation.show_link_args)
-    self.where = view.location_link(observation.place_name,
-                                    observation.location)
+    self.who   = h.user_link(observation.user) if observation.user
+    self.what  = h.link_with_query(name, observation.show_link_args)
+    self.where = h.location_link(observation.place_name,
+                                 observation.location)
     if observation.rss_log
       self.detail = observation.rss_log.detail
       self.time = observation.rss_log.updated_at
@@ -86,15 +90,15 @@ class MatrixBoxPresenter
 
     # link_type allows an obs box to link to show_obs, or something else
     # thumbnail_helper uses identify to maybe add a "propose a name" link
-    self.thumbnail =
-      view.thumbnail(observation.thumb_image,
-                     link: obs_or_other_link(observation),
-                     link_type: link_type, link_method: link_method,
-                     identify: identify, obs_data: obs_data_hash(observation))
+    self.image_data = {
+      image: observation.thumb_image,
+      image_link: obs_or_other_link(observation),
+      obs_data: obs_data_hash(observation)
+    }
   end
 
   # Grabs all the information needed for view from User instance.
-  def user_to_presenter(user, view)
+  def user_to_presenter(user)
     name = user.unique_text_name
     # rubocop:disable Rails/OutputSafety
     # The results of .t and web_date are guaranteed to be safe, and both
@@ -103,12 +107,15 @@ class MatrixBoxPresenter
                    #{:list_users_contribution.t}: #{user.contribution}<br/>
                    #{:Observations.t}: #{user.observations.count}".html_safe
     # rubocop:enable Rails/OutputSafety
-    self.what  = view.link_with_query(name, user.show_link_args)
-    self.where = view.location_link(nil, user.location) if user.location
+    self.what  = h.link_with_query(name, user.show_link_args)
+    self.where = h.location_link(nil, user.location) if user.location
     return unless user.image_id
 
-    self.thumbnail =
-      view.thumbnail(user.image_id, link: user.show_link_args, votes: false)
+    self.image_data = {
+      image: user.image_id,
+      image_link: user.show_link_args,
+      votes: false
+    }
   end
 
   def fancy_time

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -12,7 +12,7 @@ class MatrixBoxPresenter < BasePresenter
     :time        # when object or target was last modified
 
   def initialize(object, view)
-    @view = view
+    super
 
     case object
     when Image

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -59,8 +59,8 @@ class ThumbnailPresenter < BasePresenter
       # data: img_data
     }
 
-    # The size src appearing in the lightbox is a user pref
-    lb_size = User.current&.image_size || "huge"
+    # The src size appearing in the lightbox is a user pref
+    lb_size = User.current&.image_size&.to_sym || :huge
     lb_url = img_urls[lb_size]
     lb_id = args[:is_set] ? "observation-set" : SecureRandom.uuid
     lb_caption = image_caption_html(image_id, args[:obs_data], args[:identify])

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -28,7 +28,8 @@ class ThumbnailPresenter < BasePresenter
       identify: false,
       link: h.image_path(image_id),
       link_method: :get,
-      votes: true
+      votes: true,
+      is_set: true
     }
     args = default_args.merge(args)
 
@@ -100,10 +101,10 @@ class ThumbnailPresenter < BasePresenter
   #   ].join(",")
   # end
 
-  # NOTE: The local var `link` might be to #show_image as you'd expect,
-  # or it may be a GET with params[:img_id] to the actions for #reuse_image
-  # or #remove_image ...or any other link.
-  # These use .ab-fab instead of .stretched-link so .theater-btn is clickable
+  # NOTE: The local `img_link_html` might be a link to #show_obs or #show_image,
+  # but it may also be a button/input (with params[:img_id]) sending to
+  # #reuse_image or #remove_image ...or any other clickable element. Elements
+  # use .ab-fab instead of .stretched-link to keep .theater-btn clickable
   def image_link_html(link, link_method)
     case link_method
     when :get

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+# Gather details for items in matrix-style ndex pages.
+class ThumbnailPresenter < BasePresenter
+  attr_accessor \
+    :image,         # image instance or id
+    :img_tag,       # thumbnail image tag
+    :img_link_html, # stretched-link (link/button/form)
+    :lightbox_link, # what the lightbox link passes to lightbox (incl. caption)
+    :votes,         # show votes? boolean
+    :img_filename   # original image filename (maybe none)
+
+  def initialize(image, view, args = {})
+    # Sometimes it's prohibitive to do the extra join to images table,
+    # so we only have image_id. It's still possible to render the image with
+    # nothing but the image_id. (But not votes, original name, etc.)
+    image, image_id = image.is_a?(Image) ? [image, image.id] : [nil, image]
+
+    # make view methods available to presenter methods
+    @view = view
+
+    default_args = {
+      size: :small,
+      notes: "",
+      data: {},
+      data_sizes: {},
+      extra_classes: "",
+      obs_data: {}, # used in lightbox caption
+      identify: false,
+      link: h.image_path(image_id),
+      link_method: :get,
+      votes: true
+    }
+    args = default_args.merge(args)
+
+    args_to_presenter(image, image_id, args)
+  end
+
+  def args_to_presenter(image, image_id, args)
+    # Store these urls once
+    img_urls = thumbnail_urls(image_id)
+    img_src = img_urls[args[:size]]
+    img_srcset = thumbnail_srcset(img_urls[:small], img_urls[:medium],
+                                  img_urls[:large], img_urls[:huge])
+    img_sizes = args[:data_sizes] || thumbnail_srcset_sizes
+    img_class = "img-fluid lazy #{args[:extra_classes]}"
+
+    # <img> data attributes. Account for possible data-confirm, etc
+    img_data = {
+      src: img_urls[:small],
+      srcset: img_srcset,
+      sizes: img_sizes
+    }.merge(args[:data])
+
+    # <img> attributes
+    html_options = {
+      alt: args[:notes],
+      class: img_class,
+      data: img_data
+    }
+
+    # The size src appearing in the lightbox is a user pref
+    lb_size = User.current&.image_size || "huge"
+    lb_url = img_urls[lb_size]
+    lb_id = args[:is_set] ? "observation-set" : SecureRandom.uuid
+    lb_caption = image_caption_html(image_id, args[:obs_data], args[:identify])
+
+    self.image = image || nil
+    self.img_tag = h.image_tag(img_src, html_options)
+    self.img_link_html = image_link_html(args[:link], args[:link_method])
+    self.lightbox_link = lb_link(lb_url, lb_id, lb_caption)
+    self.votes = args[:votes]
+    self.img_filename = img_orig_name(args, image)
+  end
+
+  # get these once, since it's computed
+  def thumbnail_urls(image_id)
+    {
+      small: Image.url(:small, image_id),
+      medium: Image.url(:medium, image_id),
+      large: Image.url(:large, image_id),
+      huge: Image.url(:huge, image_id),
+      full_size: Image.url(:full_size, image_id)
+    }
+  end
+
+  def thumbnail_srcset(small_url, medium_url, large_url, huge_url)
+    [
+      "#{small_url} 320w",
+      "#{medium_url} 640w",
+      "#{large_url} 960w",
+      "#{huge_url} 1280w"
+    ].join(",")
+  end
+
+  def thumbnail_srcset_sizes
+    [
+      "(max-width: 575px) 100vw",
+      "(max-width: 991px) 50vw",
+      "(min-width: 992px) 30vw"
+    ].join(",")
+  end
+
+  # NOTE: The local var `link` might be to #show_image as you'd expect,
+  # or it may be a GET with params[:img_id] to the actions for #reuse_image
+  # or #remove_image ...or any other link.
+  # These use .ab-fab instead of .stretched-link so .theater-btn is clickable
+  def image_link_html(link, link_method)
+    case link_method
+    when :get
+      h.link_with_query("", link, class: "image-link ab-fab")
+    when :post
+      h.post_button(name: "", path: link, class: "image-link ab-fab")
+    when :put
+      h.put_button(name: "", path: link, class: "image-link ab-fab")
+    when :patch
+      h.patch_button(name: "", path: link, class: "image-link ab-fab")
+    when :delete
+      h.destroy_button(name: "", target: link, class: "image-link ab-fab")
+    when :remote
+      h.link_with_query("", link, class: "image-link ab-fab", remote: true)
+    end
+  end
+
+  def image_caption_html(image_id, obs_data, identify)
+    html = []
+    if obs_data[:id].present?
+      html = image_observation_caption(html, obs_data, identify)
+    end
+    html << caption_image_links(image_id)
+    h.safe_join(html)
+  end
+
+  def image_observation_caption(html, obs_data, identify)
+    if identify ||
+       (obs_data[:obs].vote_cache.present? && obs_data[:obs].vote_cache <= 0)
+      html << h.propose_naming_link(obs_data[:id])
+      html << h.content_tag(:span, "&nbsp;".html_safe, class: "mx-2")
+      html << h.mark_as_reviewed_toggle(obs_data[:id])
+    end
+    html << caption_obs_title(obs_data)
+    html << h.render(partial: "observations/show/observation",
+                     locals: { observation: obs_data[:obs] })
+  end
+
+  def caption_image_links(image_id)
+    orig_url = Image.url(:original, image_id)
+    links = []
+    links << original_image_link(orig_url)
+    links << " | "
+    links << image_exif_link(image_id)
+    h.safe_join(links)
+  end
+
+  def caption_obs_title(obs_data)
+    h.content_tag(:h4, h.show_obs_title(obs: obs_data[:obs]),
+                  class: "obs-what", id: "observation_what_#{obs_data[:id]}")
+  end
+
+  def original_image_link(orig_url)
+    h.link_to(:image_show_original.t, orig_url,
+              { class: "lightbox_link", target: "_blank", rel: "noopener" })
+  end
+
+  def image_exif_link(image_id)
+    h.content_tag(:button, :image_show_exif.t,
+                  { class: "btn btn-link px-0 lightbox_link",
+                    data: {
+                      toggle: "modal",
+                      target: "#image_exif_modal",
+                      image: image_id
+                    } })
+  end
+
+  def lb_link(lb_url, lb_id, lb_caption)
+    h.link_to("", lb_url,
+              class: "glyphicon glyphicon-fullscreen theater-btn",
+              data: { lightbox: lb_id, title: lb_caption })
+  end
+
+  def img_orig_name(args, image)
+    if show_original_name(args, image)
+      h.content_tag(:div, image.original_name)
+    else
+      ""
+    end
+  end
+
+  def show_original_name(args, image)
+    args[:original] && image &&
+      image.original_name.present? &&
+      (h.check_permission(image) ||
+       image.user &&
+       image.user.keep_filenames == "keep_and_show")
+  end
+end

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -11,13 +11,12 @@ class ThumbnailPresenter < BasePresenter
     :img_filename   # original image filename (maybe none)
 
   def initialize(image, view, args = {})
+    super
+
     # Sometimes it's prohibitive to do the extra join to images table,
     # so we only have image_id. It's still possible to render the image with
     # nothing but the image_id. (But not votes, original name, etc.)
     image, image_id = image.is_a?(Image) ? [image, image.id] : [nil, image]
-
-    # make view methods available to presenter methods
-    @view = view
 
     default_args = {
       size: :small,
@@ -40,23 +39,23 @@ class ThumbnailPresenter < BasePresenter
     # Store these urls once
     img_urls = thumbnail_urls(image_id)
     img_src = img_urls[args[:size]]
-    img_srcset = thumbnail_srcset(img_urls[:small], img_urls[:medium],
-                                  img_urls[:large], img_urls[:huge])
-    img_sizes = args[:data_sizes] || thumbnail_srcset_sizes
+    # img_srcset = thumbnail_srcset(img_urls[:small], img_urls[:medium],
+    #                               img_urls[:large], img_urls[:huge])
+    # img_sizes = args[:data_sizes] || thumbnail_srcset_sizes
     img_class = "img-fluid lazy #{args[:extra_classes]}"
 
     # <img> data attributes. Account for possible data-confirm, etc
-    img_data = {
-      src: img_urls[:small],
-      srcset: img_srcset,
-      sizes: img_sizes
-    }.merge(args[:data])
+    # img_data = {
+    #   src: img_urls[:small],
+    #   srcset: img_srcset,
+    #   sizes: img_sizes
+    # }.merge(args[:data])
 
     # <img> attributes
     html_options = {
       alt: args[:notes],
-      class: img_class,
-      data: img_data
+      class: img_class
+      # data: img_data
     }
 
     # The size src appearing in the lightbox is a user pref
@@ -84,22 +83,22 @@ class ThumbnailPresenter < BasePresenter
     }
   end
 
-  def thumbnail_srcset(small_url, medium_url, large_url, huge_url)
-    [
-      "#{small_url} 320w",
-      "#{medium_url} 640w",
-      "#{large_url} 960w",
-      "#{huge_url} 1280w"
-    ].join(",")
-  end
+  # def thumbnail_srcset(small_url, medium_url, large_url, huge_url)
+  #   [
+  #     "#{small_url} 320w",
+  #     "#{medium_url} 640w",
+  #     "#{large_url} 960w",
+  #     "#{huge_url} 1280w"
+  #   ].join(",")
+  # end
 
-  def thumbnail_srcset_sizes
-    [
-      "(max-width: 575px) 100vw",
-      "(max-width: 991px) 50vw",
-      "(min-width: 992px) 30vw"
-    ].join(",")
-  end
+  # def thumbnail_srcset_sizes
+  #   [
+  #     "(max-width: 575px) 100vw",
+  #     "(max-width: 991px) 50vw",
+  #     "(min-width: 992px) 30vw"
+  #   ].join(",")
+  # end
 
   # NOTE: The local var `link` might be to #show_image as you'd expect,
   # or it may be a GET with params[:img_id] to the actions for #reuse_image

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -1,56 +1,21 @@
 <%
-  # IMPORTANT: Sometimes it's prohibitive to do the extra join to images table,
-  # so we only have image_id.  It's still possible to render the image with
-  # nothing but the image_id.  (But not votes, original name, etc.)
-  image, image_id = image.is_a?(Image) ? [image, image.id] : [nil, image]
-  size_url   = Image.url(size, image_id)
-  medium_url = Image.url(:medium, image_id)
-  large_url  = Image.url(:large, image_id)
-  huge_url   = Image.url(:huge, image_id)
-  full_url   = Image.url(:full_size, image_id)
-  # If the image is part of an image set.
-  is_set = is_set || true
-
-  # Lightbox stuff. obs_data comes from the matrix_box presenter,
-  # link_type from view (for naming links)
-  lightbox_id = is_set ? "observation-set" : SecureRandom.uuid
-  p_map = {
-    "medium" => medium_url,
-    "large" => large_url,
-    "huge" => huge_url,
-    "full_size" => full_url
-  }
-  lightbox_url = (usize = User.current&.image_size) ? p_map[usize] : huge_url
-  caption = image_caption_html(image_id, obs_data, identify)
-
-  # Show original name?
-  show_original_name = original && image && !image.original_name.blank? &&
-    (check_permission(image) ||
-     image.user && image.user.keep_filenames == "keep_and_show")
+presenter = ThumbnailPresenter.new(image, @view, local_assigns.except(:image))
 %>
 
 <div class="position-relative">
   <div class="d-inline">
     <div data-toggle="expand-icon" class="text-center">
       <div class="click-container position-relative">
-        <%= image_tag(size_url, title: notes,
-                      class: "img-fluid #{extra_classes}",
-                      data: { toggle: "tooltip", placement: "bottom" }) %>
-        <%= image_link_html(link, link_method) %>
+        <%= presenter.img_tag %>
+        <%= presenter.img_link_html %>
       </div>
-      <%= link_to("", lightbox_url,
-                  class: "glyphicon glyphicon-fullscreen theater-btn",
-                  data: { lightbox: lightbox_id, title: caption }) %>
+      <%= presenter.lightbox_link %>
       <div class="mt-3">
-        <% if User.current and votes and image %>
+        <% if User.current and presenter.votes and presenter.image %>
           <%= render(partial: "shared/image_vote_links",
                      locals: { image: image }) %>
         <% end %>
-        <% if show_original_name %>
-          <div class="text-center">
-            <span><%= image.original_name %></span>
-          </div><!-- .text-center -->
-        <% end %>
+        <%= presenter.img_filename %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -1,22 +1,22 @@
 <%
 # Requires local variable object: RssLog, Observation, Image, etc. instance.
-link_type ||= :target
 link_method ||= :get
 identify ||= false
-presenter = MatrixBoxPresenter.new(object, @view,
-                                   link_type: link_type,
-                                   link_method: link_method,
-                                   identify: identify)
+presenter = MatrixBoxPresenter.new(object, @view)
 columns ||= "col-xs-12 col-sm-6 col-md-4"
 object_id = object&.id.present? ? object.id : "no_ID"
+locals = local_assigns.except(:columns, :object, :object_counter,
+                              :object_iteration)
+if presenter
 %>
-
-<% if presenter %>
   <li class="matrix-box <%= columns %>" id="box_<%= object_id %>">
     <div class="panel panel-default">
       <div class="panel-body rss-box-details">
         <div class="thumbnail-container">
-          <%= presenter.thumbnail %>
+          <%= if presenter.image_data
+            render(partial: "shared/image_thumbnail",
+                   locals: locals.merge(presenter.image_data))
+          end %>
         </div><!-- .thumbnail-container -->
         <div class="rss-what">
           <h5><%= presenter.what %></h5>


### PR DESCRIPTION
MO's existing presenter is not the easiest part of our code to understand, but it's kinda indispensable because of our multifarious `RssLog` template partials. `MatrixBoxPresenter` is essentially a service object that determines what data to pull for the matrix_box, (e.g. the title, and other attributes). It also figures out what image relates to the object at hand, and thanks to me, cooks up an increasingly complex set of nested elements for the thumbnail, depending on context. 

With more planned changes to `thumbnail`, it's gotten too confusing because the thumbnail args are passed around so many times. This PR attempts to simplify the situation by separating the concerns of **matrix box** data and **thumbnail** data.

### Details ###
In the current state of MO, there are a lot of local args being passed through the `matrix_box` template that are destined for the increasingly complex `image_thumbnail` template. Basic confusion arises from the routing of these passed arguments. 

Usually, these image presentation args are passed something like this:
```
rss_logs/index >  
    # An index or show template calls the matrix box partial, with locals. 
    # About half of the locals are for the matrix_box, and half are for the thumbnail.
shared/matrix_box.html.erb >  
    # instantiates the presenter with an object, and contextual args
MatrixBoxPresenter >  
    # object determines what image to show, and what kind of caption
ThumbnailHelper#thumbnail >  
    # creates some complex nested HTML, which it passes as locals to the 
    # thumbnail template
shared/image_thumbnail.html.erb  
    # draws the thumbnail, its links, lightbox caption, data...
```
It's too many layers, especially when we need to add new args to the image template. How to pass them; where to change them contextually?

This PR
- removes the handling of thumbnail args from `MatrixBoxPresenter`
- creates a new `ThumbnailPresenter`, to prepare the data for the image template separately. It removes the image args being passed to the `MatrixBoxPresenter`, and passes them directly on to the `ThumbnailPresenter` as a subset of the `local_assigns`. It moves all of the helper methods that don't need to be globally accessible from `ThumbnailHelper` into the `ThumbnailPresenter`.
- creates a new base class for presenters, to facilitate calling helper methods

I think everyone will find it's more comprehensible via reading through the code itself.