### PR TITLE
Observation addenda form fixes

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -273,6 +273,10 @@
   margin-left: 1.5rem !important;
 }
 
+.ml-5 {
+  margin-left: 3rem !important;
+}
+
 .p-0 {
   padding: 0 !important;
 }

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -70,16 +70,16 @@ class SequencesController < ApplicationController
     # Observation.id is passed as a query param (rather than route :id param)
     # in order to give :id param a consistent meaning (the sequence id)
     # in this controller and in order to avoid an extra, non-standard route
-    return if params[:obs_id].blank?
+    return if params[:observation_id].blank?
 
-    @observation = find_or_goto_index(Observation, params[:obs_id].to_s)
+    @observation = find_or_goto_index(Observation, params[:observation_id].to_s)
     return unless @observation
 
     @sequence = Sequence.new
   end
 
   def create
-    @observation = find_or_goto_index(Observation, params[:obs_id].to_s)
+    @observation = find_or_goto_index(Observation, params[:observation_id].to_s)
     return unless @observation
 
     build_sequence

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -4,13 +4,16 @@
 module FormsHelper
   # draw a help block with an arrow
   def help_block_with_arrow(direction = nil, **args, &block)
-    content_tag(:div, class: "well well-sm help-block position-relative",
+    div_class = "well well-sm help-block position-relative"
+    div_class += " mt-3" if direction == "up"
+
+    content_tag(:div, class: div_class,
                       id: args[:id]) do
       concat(capture(&block).to_s)
       if direction
-        klass = "arrow-#{direction}"
-        klass += " hidden-xs" unless args[:mobile]
-        concat(content_tag(:div, "", class: klass))
+        arrow_class = "arrow-#{direction}"
+        arrow_class += " hidden-xs" unless args[:mobile]
+        concat(content_tag(:div, "", class: arrow_class))
       end
     end
   end

--- a/app/views/collection_numbers/edit.html.erb
+++ b/app/views/collection_numbers/edit.html.erb
@@ -24,7 +24,8 @@
     <ul class="row list-unstyled">
       <% @collection_number.observations.each do |obs| %>
         <%= render(partial: "shared/matrix_box",
-                   locals: { object: obs.rss_log, columns: "col-xs-12" }) %>
+                   locals: { object: obs.rss_log || obs,
+                             columns: "col-xs-12" }) %>
       <% end %>
     </ul>
   </div>

--- a/app/views/collection_numbers/new.html.erb
+++ b/app/views/collection_numbers/new.html.erb
@@ -7,7 +7,6 @@
   ]
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :full
-  @object = @observation.rss_log || @observation
 %>
 
 <div class="row">
@@ -19,7 +18,8 @@
   <div class="col-xs-12 col-sm-5">
     <ul class="row list-unstyled">
       <%= render(partial: "shared/matrix_box",
-                 locals: { object: @object, columns: "col-xs-12" }) %>
+                 locals: { object: @observation.rss_log || @observation,
+                           columns: "col-xs-12" }) %>
     </ul>
   </div>
 </div><!--.row-->

--- a/app/views/collection_numbers/new.html.erb
+++ b/app/views/collection_numbers/new.html.erb
@@ -7,6 +7,7 @@
   ]
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :full
+  @object = @observation.rss_log || @observation
 %>
 
 <div class="row">
@@ -18,8 +19,7 @@
   <div class="col-xs-12 col-sm-5">
     <ul class="row list-unstyled">
       <%= render(partial: "shared/matrix_box",
-                locals: { object: @observation.rss_log,
-                          columns: "col-xs-12" }) %>
+                 locals: { object: @object, columns: "col-xs-12" }) %>
     </ul>
   </div>
 </div><!--.row-->

--- a/app/views/herbarium_records/edit.html.erb
+++ b/app/views/herbarium_records/edit.html.erb
@@ -33,7 +33,8 @@
     <ul class="row list-unstyled">
       <% @herbarium_record.observations.each do |obs| %>
         <%= render(partial: "shared/matrix_box",
-                  locals: { object: obs.rss_log, columns: "col-xs-12" }) %>
+                   locals: { object: obs.rss_log || obs,
+                             columns: "col-xs-12" }) %>
       <% end %>
     </ul>
   </div>

--- a/app/views/herbarium_records/new.html.erb
+++ b/app/views/herbarium_records/new.html.erb
@@ -11,7 +11,8 @@
                     id: "all_nonpersonal_herbaria_link")
   ]
   @tabsets = { right: draw_tab_set(tabs) }
-  @container = :wide
+  @container = :full
+  @object = @observation.rss_log || @observation
 %>
 
 <div class="row">
@@ -24,8 +25,7 @@
   <div class="col-xs-12 col-sm-5">
     <ul class="row list-unstyled">
       <%= render(partial: "shared/matrix_box",
-                locals: { object: @observation.rss_log,
-                          columns: "col-xs-12" }) %>
+                 locals: { object: @object, columns: "col-xs-12" }) %>
     </ul>
   </div>
 </div><!--.row-->

--- a/app/views/herbarium_records/new.html.erb
+++ b/app/views/herbarium_records/new.html.erb
@@ -12,7 +12,6 @@
   ]
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :full
-  @object = @observation.rss_log || @observation
 %>
 
 <div class="row">
@@ -25,7 +24,8 @@
   <div class="col-xs-12 col-sm-5">
     <ul class="row list-unstyled">
       <%= render(partial: "shared/matrix_box",
-                 locals: { object: @object, columns: "col-xs-12" }) %>
+                 locals: { object: @observation.rss_log || @observation,
+                           columns: "col-xs-12" }) %>
     </ul>
   </div>
 </div><!--.row-->

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -56,17 +56,17 @@ obs_id = observation.id
 <% if @user %>
   <div class="obs-collection" id="observation_collection_numbers_<%= obs_id %>">
     <%= render(partial: "observations/show/collection_numbers",
-                locals: { observation: observation }) %>
+               locals: { observation: observation }) %>
   </div>
 
   <div class="obs-herbarium" id="observation_herbarium_records_<%= obs_id %>">
     <%= render(partial: "observations/show/herbarium_records",
-                locals: { observation: observation }) %>
+               locals: { observation: observation }) %>
   </div>
 
   <div class="obs-sequence" id="observation_sequences_<%= obs_id %>">
     <%= render(partial: "observations/show/sequences",
-                locals: { observation: observation }) %>
+               locals: { observation: observation }) %>
   </div>
 <% end %>
 

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -15,7 +15,7 @@
       <%=
           add_sequence_link = link_with_query(
             :show_observation_add_sequence.t,
-            new_sequence_path(params: { obs_id: observation.id })
+            new_sequence_path(params: { observation_id: observation.id })
           )
           "[#{add_sequence_link}]".html_safe if @user
       %>

--- a/app/views/sequences/_form.html.erb
+++ b/app/views/sequences/_form.html.erb
@@ -1,79 +1,70 @@
-<%= form_with(model: @sequence, url: url) do |form| %>
+<%
+url_params = { action: action, q: get_query_param }
+url_params = url_params.merge(
+  { observation_id: @observation.id }) if action == :create
+if action == :update && @back.present?
+  url_params = url_params.merge({ back: @back })
+end
+%>
+
+<%= form_with(model: @sequence, url: url_params,
+              id: "sequence_form") do |f| %>
   <%# locus %>
-  <div class="row mt-3">
-    <div class="form-group col-xs-12 col-md-6">
-      <%= form.label(:locus, "#{:LOCUS.t}:") %>
-      <span class="help-note">(<%= :required.t %>)</span>
-        <%# style stops area from changing size on reload %>
-        <%= form.text_area(:locus, rows: 1, class:"form-control", style:"width: 100%;" ) %>
-    </div>
-    <div class="col-xs-12 col-sm-6">
-      <%= help_block_with_arrow("left", id: "sequence_locus_help") do %>
-        <%= :form_sequence_locus_help.t(locus_width: Sequence.locus_width) %>
-      <% end %>
-    </div>
-  </div><!--.row-->
+  <div class="form-group mt-3">
+    <%= f.label(:locus, "#{:LOCUS.t}:") %>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note") %>
+    <%# w-100 stops area from changing size on reload %>
+    <%= f.text_area(:locus, rows: 1, class:"form-control w-100" ) %>
+    <%= help_block_with_arrow("up", id: "sequence_locus_help",
+                              class: "mt-3") do
+      :form_sequence_locus_help.t(locus_width: Sequence.locus_width)
+    end %>
+  </div><!--.form-group-->
 
   <%# bases %>
-  <div class="row mt-3">
-    <div class="form-group">
-      <span class="col-md-6">
-        <%= form.label(:sequence_bases, "#{:BASES.t}:") %>
-        <span class="help-note">
-        (<%= :form_sequence_bases_or_deposit_required.t %>)
-        </span>
-      </span>
-      <span class="col-md-6">
-        <%= url = WebSequenceArchive.blast_format_help
-            :form_sequence_bases_format.t(help_url: url) %>
-      </span>
-      <div class="col-md-9 text-monospace">
-        <%= form.text_area(:bases, size: "80x3", class:"form-control") %>
-      </div>
-      <div class="col-md-3">
-      </div>
-    </div>
-  </div><!--.row-->
+  <div class="form-group mt-3">
+    <%= f.label(:bases, "#{:BASES.t}:") %>
+    <%= content_tag(:span,
+          "(#{:form_sequence_bases_or_deposit_required.t})",
+          class: "help-note") %>
+    <%= link_to("(#{:form_sequence_bases_format.t})",
+                WebSequenceArchive.blast_format_help,
+                class: "d-inline-block float-right") %>
+    <%= f.text_area(:bases, size: "80x5",
+                    class:"form-control text-monospace") %>
+  </div><!--.form-group-->
 
   <%# deposit info %>
-  <div class="row mt-3 form-group">
-    <div class="col-xs-12">
-      <%= form.label(:sequence_nothing, "#{:DEPOSIT.t}:") %>
-      <span class="help-note">(<%= :form_sequence_valid_deposit.t %>)</span>
-    </div>
-    <div class="col-xs-1">
-    </div>
-    <div class="col-xs-5 col-md-2">
-      <%= form.label(:sequence_archive, :ARCHIVE.t) %>
-      <%= form.select(:archive, archive_dropdown,
-                      { include_blank: true }, { class: "form-control" }) %>
-    </div>
-    <div class="col-xs-6 col-md-3">
-      <span class="font-weight-bold"><%= :form_sequence_accession.t %></span>
-      <%= form.text_field(:accession, class: "form-control") %>
-    </div>
-    <div class="col-xs-12 col-md-6">
-      <%= help_block_with_arrow("left", id: "sequence_accession_help") do %>
-        <%= :form_sequence_accession_help.t %>
-      <% end %>
-    </div>
-  </div><!--.row-->
+  <div>
+    <%= content_tag(:strong, "#{:DEPOSIT.t}:") %>
+    <%= content_tag(:span, "(#{:form_sequence_valid_deposit.t})",
+                    class: "help-note") %>
+  </div>
+  <div class="form-group form-inline mt-3 ml-5">
+    <%= f.label(:archive, "#{:ARCHIVE.t}: ") %>
+    <%= f.select(:archive, archive_dropdown, { include_blank: true },
+                 { class: "form-control" }) %>
+  </div><!--.form-group-->
+  <div class="form-group form-inline mt-3 ml-5">
+    <%= f.label(:accession, "#{:form_sequence_accession.t}: ") %>
+    <%= f.text_field(:accession, class: "form-control") %>
+    <%= help_block_with_arrow("up", id: "sequence_accession_help",
+                              class: "mt-3") do
+      :form_sequence_accession_help.t
+    end %>
+  </div><!--.form-group-->
 
   <%# notes %>
-  <div class="row mt-3">
-    <div class="form-group col-xs-12 col-md-6">
-      <%= form.label(:sequence_notes, "#{:NOTES.t}:") %>
-      <span class="help-note">(<%= :optional.t %>)</span>
-      <%= form.text_area(:notes, rows: 3, class: "form-control") %>
-    </div>
-    <div class="col-xs-12 col-md-6">
-      <%= help_block_with_arrow("left", id: "textile_help") do %>
-        <%= :field_textile_link.t %>
-      <% end %>
-    </div>
-  </div><!--.row-->
+  <div class="form-group mt-3">
+    <%= f.label(:notes, "#{:NOTES.t}:") %>
+    <span class="help-note">(<%= :optional.t %>)</span>
+    <%= f.text_area(:notes, rows: 3, class: "form-control") %>
+    <%= help_block_with_arrow("up", id: "textile_help", class: "mt-3") do %>
+      <%= :field_textile_link.t %>
+    <% end %>
+  </div>
 
-  <div class="form-group row">
-    <%= form.submit(:SUBMIT.t, class: "btn btn-default center-block mt-3") %>
+  <div class="form-group">
+    <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
   </div><!--.row-->
 <% end %>

--- a/app/views/sequences/edit.html.erb
+++ b/app/views/sequences/edit.html.erb
@@ -8,12 +8,13 @@
 
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
+  obs = @sequence.observation
 %>
 
 <div class="row">
   <div class="col-xs-12 col-sm-7">
     <%= render(partial: "observation_title",
-               locals: { observation: @sequence.observation }) %>
+               locals: { observation: obs }) %>
     <%= render(partial: "form",
                locals: { action: :update, button_name: :UPDATE }) %>
 
@@ -28,7 +29,8 @@
   <div class="col-xs-12 col-sm-5">
     <ul class="row list-unstyled">
       <%= render(partial: "shared/matrix_box",
-                 locals: { object: @object, columns: "col-xs-12" }) %>
+                 locals: { object: obs.rss_log || obs,
+                           columns: "col-xs-12" }) %>
     </ul>
   </div>
 </div><!--.row-->

--- a/app/views/sequences/edit.html.erb
+++ b/app/views/sequences/edit.html.erb
@@ -10,16 +10,25 @@
   @container = :wide
 %>
 
-<%= render(partial: "observation_title",
-           locals: { observation: @sequence.observation }) %>
+<div class="row">
+  <div class="col-xs-12 col-sm-7">
+    <%= render(partial: "observation_title",
+               locals: { observation: @sequence.observation }) %>
+    <%= render(partial: "form",
+               locals: { action: :update, button_name: :UPDATE }) %>
 
-<%= render(partial: "form",
-           method: :patch,
-           locals: { url: add_query_param(action: :update, back: @back) } ) %>
+    <div class="small">
+      <span class="font-weight-bold"><%= :CREATED_BY.t %>:</span>
+      <%= user_link(@sequence.user) %>
+    </div>
 
-<div class="small">
-  <span class="font-weight-bold"><%= :CREATED_BY.t %>:</span>
-  <%= user_link(@sequence.user) %>
-</div>
+    <%= show_object_footer(@sequence) %>
+  </div>
 
-<%= show_object_footer(@sequence) %>
+  <div class="col-xs-12 col-sm-5">
+    <ul class="row list-unstyled">
+      <%= render(partial: "shared/matrix_box",
+                 locals: { object: @object, columns: "col-xs-12" }) %>
+    </ul>
+  </div>
+</div><!--.row-->

--- a/app/views/sequences/new.html.erb
+++ b/app/views/sequences/new.html.erb
@@ -6,7 +6,6 @@
   ]
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :full
-  @object = @observation.rss_log || @observation
 %>
 
 <div class="row">
@@ -20,7 +19,8 @@
   <div class="col-xs-12 col-sm-5">
     <ul class="row list-unstyled">
       <%= render(partial: "shared/matrix_box",
-                 locals: { object: @object, columns: "col-xs-12" }) %>
+                 locals: { object: @observation.rss_log || @observation,
+                           columns: "col-xs-12" }) %>
     </ul>
   </div>
 </div><!--.row-->

--- a/app/views/sequences/new.html.erb
+++ b/app/views/sequences/new.html.erb
@@ -5,15 +5,22 @@
                     @observation.show_link_args)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
-  @container = :wide
+  @container = :full
+  @object = @observation.rss_log || @observation
 %>
 
-<%= render(partial: "observation_title",
-           locals: { observation: @observation }) %>
+<div class="row">
+  <div class="col-xs-12 col-sm-7">
+    <%= render(partial: "observation_title",
+               locals: { observation: @observation }) %>
+    <%= render(partial: "form",
+               locals: { action: :create, button_name: :ADD }) %>
+  </div>
 
-<%= render(
-  partial: "form",
-  locals: {
-    url: add_query_param(sequences_path(params: { obs_id: @observation.id }))
-  }
-) %>
+  <div class="col-xs-12 col-sm-5">
+    <ul class="row list-unstyled">
+      <%= render(partial: "shared/matrix_box",
+                 locals: { object: @object, columns: "col-xs-12" }) %>
+    </ul>
+  </div>
+</div><!--.row-->

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2336,7 +2336,7 @@
   # sequence/form_sequence
   form_sequence_locus_help: "Start with a short abbreviation (because the [:OBSERVATION] displays only the first [locus_width] characters). Examples:\n&nbsp;&nbsp;ITS\n&nbsp;&nbsp;multi-locus\n&nbsp;&nbsp;LSU large subunit ribosomal RNA gene, partial sequence"
   form_sequence_both_required: "[:BASES] and/or both [:ARCHIVE]/[:ACCESSION] required"
-  form_sequence_bases_format: "<a href=[help_url]>FASTA or Bare Sequence format</a>"
+  form_sequence_bases_format: "FASTA or Bare Sequence format"
   form_sequence_archive_help: On-line, public database with [:sequence] data for this [:OBSERVATION].
   form_sequence_accession: "[:ACCESSION] number/code"
   form_sequence_accession_help: "Examples:\n&nbsp;&nbsp;KT968655\n&nbsp;&nbsp;UDB024324"

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -908,7 +908,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs2.id,
                     [[obs2.herbarium_records.first.id, false]],
                     false)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs2.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs2.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     get(:show, params: { id: obs3.id })
@@ -918,7 +918,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs3.id,
                     obs3.herbarium_records.map { |x| [x.id, false] },
                     false)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs3.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs3.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     # Roy is a curator at NY, so can add herbarium records, and modify existing
@@ -938,7 +938,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs2.id,
                     [[obs2.herbarium_records.first.id, true]],
                     true)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs2.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs2.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     get(:show, params: { id: obs3.id })
@@ -948,7 +948,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs3.id,
                     obs3.herbarium_records.map { |x| [x.id, x.can_edit?(roy)] },
                     true)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs3.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs3.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     # Dick owns all of the sequences, is on obs3's project, and has a personal
@@ -967,7 +967,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs2.id,
                     [[obs2.herbarium_records.first.id, false]],
                     true)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs2.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs2.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     get(:show, params: { id: obs3.id })
@@ -977,7 +977,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs3.id,
                     obs3.herbarium_records.map { |x| [x.id, false] },
                     true)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs3.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs3.id)}']",
                   { count: 1 },
                   "Observation page missing an Add Sequence link")
 
@@ -997,7 +997,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_show_obs(:herbarium_records, obs2.id,
                     [[obs2.herbarium_records.first.id, true]],
                     true)
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs2.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs2.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     get(:show, params: { id: obs3.id })
@@ -1008,7 +1008,7 @@ class ObservationsControllerTest < FunctionalTestCase
       obs3.herbarium_records.map { |x| [x.id, x.can_edit?(rolf)] },
       true
     )
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs3.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs3.id)}']",
                   { count: 1 },
                   "Observation page missing an Add Sequence link")
 
@@ -1031,7 +1031,7 @@ class ObservationsControllerTest < FunctionalTestCase
       [[obs2.herbarium_records.first.id, false]],
       true
     )
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs2.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs2.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     get(:show, params: { id: obs3.id })
@@ -1045,7 +1045,7 @@ class ObservationsControllerTest < FunctionalTestCase
       obs3.herbarium_records.map { |x| [x.id, x.can_edit?(mary)] },
       true
     )
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs3.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs3.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     # Make sure admins can do everything.
@@ -1067,7 +1067,7 @@ class ObservationsControllerTest < FunctionalTestCase
       [[obs2.herbarium_records.first.id, true]],
       true
     )
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs2.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs2.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
 
     get(:show, params: { id: obs3.id })
@@ -1081,7 +1081,7 @@ class ObservationsControllerTest < FunctionalTestCase
       obs3.herbarium_records.map { |x| [x.id, true] },
       true
     )
-    assert_select("a[href ^= '#{new_sequence_path(obs_id: obs3.id)}']",
+    assert_select("a[href ^= '#{new_sequence_path(observation_id: obs3.id)}']",
                   { count: 1 }, "Observation page missing an Add Sequence link")
   end
 

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -100,7 +100,8 @@ class SequencesControllerTest < FunctionalTestCase
                     "A user should be able to get form to add Sequence " \
                     "to someone else's Observation")
     assert_select(
-      "form[action^='#{sequences_path(params: { observation_id: obs.id })}']", true,
+      "form[action^='#{sequences_path(params: { observation_id: obs.id })}']",
+      true,
       "Sequence form has missing/incorrect `observation_id`` query param"
     )
     assert_select(

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -91,7 +91,7 @@ class SequencesControllerTest < FunctionalTestCase
     obs = observations(:minimal_unknown_obs)
     query = Query.lookup_and_save(:Sequence, :all)
     q = query.id.alphabetize
-    params = { obs_id: obs.id, q: q }
+    params = { observation_id: obs.id, q: q }
 
     login("zero") # This user has no Observations
     get(:new, params: params)
@@ -100,8 +100,8 @@ class SequencesControllerTest < FunctionalTestCase
                     "A user should be able to get form to add Sequence " \
                     "to someone else's Observation")
     assert_select(
-      "form[action^='#{sequences_path(params: { obs_id: obs.id })}']", true,
-      "Sequence form has missing/incorrect `obs_id`` query param"
+      "form[action^='#{sequences_path(params: { observation_id: obs.id })}']", true,
+      "Sequence form has missing/incorrect `observation_id`` query param"
     )
     assert_select(
       "form[action*='q=#{q}']", true,
@@ -112,7 +112,7 @@ class SequencesControllerTest < FunctionalTestCase
   def test_new_login_required
     # choose an obs not owned by Rolf (`requires_login` will login Rolf)
     obs = observations(:minimal_unknown_obs)
-    params = { obs_id: obs.id }
+    params = { observation_id: obs.id }
 
     # Prove method requires login
     get(:new, params: params)
@@ -126,7 +126,7 @@ class SequencesControllerTest < FunctionalTestCase
     locus = "ITS"
     bases = ITS_BASES
     params = {
-      obs_id: obs.id,
+      observation_id: obs.id,
       sequence: { locus: locus,
                   bases: bases }
     }
@@ -155,7 +155,7 @@ class SequencesControllerTest < FunctionalTestCase
     locus = "ITS"
     bases = "gagtatgtgc acacctgccg tctttatcta tccacctgtg cacacattgt agtcttgggg"
     params = {
-      obs_id: obs.id,
+      observation_id: obs.id,
       sequence: { locus: locus,
                   bases: bases }
     }
@@ -182,7 +182,7 @@ class SequencesControllerTest < FunctionalTestCase
     archive =   "GenBank"
     accession = "KY366491.1"
     params = {
-      obs_id: obs.id,
+      observation_id: obs.id,
       sequence: { locus: locus,
                   archive: archive,
                   accession: accession }
@@ -204,7 +204,7 @@ class SequencesControllerTest < FunctionalTestCase
     locus = "ITS"
     bases = ITS_BASES
     params = {
-      obs_id: obs.id,
+      observation_id: obs.id,
       sequence: { locus: locus,
                   bases: bases }
     }
@@ -215,7 +215,7 @@ class SequencesControllerTest < FunctionalTestCase
   def test_create_no_locus
     # Prove that locus is required.
     obs = observations(:coprinus_comatus_obs)
-    params = { obs_id: obs.id,
+    params = { observation_id: obs.id,
                sequence: { locus: "",
                            bases: "actgct" } }
     login(obs.user.login)
@@ -228,7 +228,7 @@ class SequencesControllerTest < FunctionalTestCase
   def test_create_no_bases_or_equivalent
     # Prove that bases or archive+accession required.
     obs = observations(:coprinus_comatus_obs)
-    params = { obs_id: obs.id,
+    params = { observation_id: obs.id,
                sequence: { locus: "ITS" } }
     login(obs.user.login)
 
@@ -240,7 +240,7 @@ class SequencesControllerTest < FunctionalTestCase
   def test_create_archive_without_accession
     # Prove that accession required if archive present.
     obs = observations(:coprinus_comatus_obs)
-    params = { obs_id: obs.id,
+    params = { observation_id: obs.id,
                sequence: { locus: "ITS", archive: "GenBank" } }
     login(obs.user.login)
 
@@ -251,7 +251,7 @@ class SequencesControllerTest < FunctionalTestCase
 
   def test_create_accession_without_archive
     obs = observations(:coprinus_comatus_obs)
-    params = { obs_id: obs.id,
+    params = { observation_id: obs.id,
                sequence: { locus: "ITS", accession: "KY133294.1" } }
     login(obs.user.login)
 
@@ -264,7 +264,7 @@ class SequencesControllerTest < FunctionalTestCase
     obs = observations(:genbanked_obs)
     query = Query.lookup_and_save(:Sequence, :all)
     q = query.id.alphabetize
-    params = { obs_id: obs.id,
+    params = { observation_id: obs.id,
                sequence: { locus: "ITS", bases: "atgc" },
                q: q }
 

--- a/test/integration/capybara/sequencer_test.rb
+++ b/test/integration/capybara/sequencer_test.rb
@@ -18,12 +18,12 @@ class SequencerTest < CapybaraIntegrationTestCase
     visit(observation_path(obs))
     click_on("Add Sequence")
     fill_in("sequence[locus]", with: "New locus")
-    click_on("Submit")
+    click_on("Add")
     assert_equal(sequence_original_count, Sequence.count,
                  "Sequence without Bases should not have been created")
 
     fill_in("sequence[bases]", with: "catcatcat")
-    click_on("Submit")
+    click_on("Add")
     assert_equal(sequence_original_count + 1, Sequence.count,
                  "Sequence should have been created")
 
@@ -32,7 +32,7 @@ class SequencerTest < CapybaraIntegrationTestCase
     find("#observation_sequences_#{obs.id}").click_link("Edit")
     fill_in("sequence[locus]", with: new_locus)
     fill_in("sequence[bases]", with: "gag gag gag")
-    click_on("Submit")
+    click_on("Update")
     assert_equal(new_locus, new_sequence.reload.locus,
                  "Sequence should have been updated")
 


### PR DESCRIPTION
Forms for `new` and `edit` `CollectionNumber` and `HerbariumRecord` were not correctly showing an obs matrix box, in the event the obs did not have an associated rss_log (yet). This fixes those forms to provide a fallback to show the obs, if there's no rss_log, for the matrix box.  

(I encountered this accidentally, while testing my matrix_box refactors...)

This PR also refactors the `Sequence` form to more closely resemble the other two, adding a matrix box, reformatting the HTML into one column, and DRYing up form syntax. The param `obs_id` is changed to `observation_id` to match the other two, and Rails pattern of generating nested params.