### PR TITLE
Paginate `GlossaryTerms` index and add `pattern_search`

### DIFF
--- a/app/classes/query/glossary_term_all.rb
+++ b/app/classes/query/glossary_term_all.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Query::GlossaryTermAll < Query::GlossaryTermBase
+  def initialize_flavor
+    add_sort_order_to_title
+    super
+  end
+end

--- a/app/classes/query/glossary_term_all.rb
+++ b/app/classes/query/glossary_term_all.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-class Query::GlossaryTermAll < Query::GlossaryTermBase
-  def initialize_flavor
-    add_sort_order_to_title
-    super
+module Query
+  class GlossaryTermAll < Query::GlossaryTermBase
+    def initialize_flavor
+      add_sort_order_to_title
+      super
+    end
   end
 end

--- a/app/classes/query/glossary_term_base.rb
+++ b/app/classes/query/glossary_term_base.rb
@@ -1,28 +1,31 @@
 # frozen_string_literal: true
 
-class Query::GlossaryTermBase < Query::Base
-  def model
-    GlossaryTerm
-  end
+module Query
+  class GlossaryTermBase < Query::Base
+    def model
+      GlossaryTerm
+    end
 
-  def parameter_declarations
-    super.merge(
-      created_at?: [:time],
-      updated_at?: [:time],
-      users?: [User],
-      name_has?: :string,
-      description_has?: :string
-    )
-  end
+    def parameter_declarations
+      super.merge(
+        created_at?: [:time],
+        updated_at?: [:time],
+        users?: [User],
+        name_has?: :string,
+        description_has?: :string
+      )
+    end
 
-  def initialize_flavor
-    add_owner_and_time_stamp_conditions("glossary_terms")
-    add_search_condition("glossary_terms.name", params[:name_has])
-    add_search_condition("glossary_terms.description", params[:description_has])
-    super
-  end
+    def initialize_flavor
+      add_owner_and_time_stamp_conditions("glossary_terms")
+      add_search_condition("glossary_terms.name", params[:name_has])
+      add_search_condition("glossary_terms.description",
+                           params[:description_has])
+      super
+    end
 
-  def self.default_order
-    "name"
+    def self.default_order
+      "name"
+    end
   end
 end

--- a/app/classes/query/glossary_term_base.rb
+++ b/app/classes/query/glossary_term_base.rb
@@ -10,19 +10,19 @@ class Query::GlossaryTermBase < Query::Base
       created_at?: [:time],
       updated_at?: [:time],
       users?: [User],
-      title_has?: :string,
-      body_has?: :string
+      name_has?: :string,
+      description_has?: :string
     )
   end
 
   def initialize_flavor
     add_owner_and_time_stamp_conditions("glossary_terms")
-    add_search_condition("glossary_terms.title", params[:title_has])
-    add_search_condition("glossary_terms.body", params[:body_has])
+    add_search_condition("glossary_terms.name", params[:name_has])
+    add_search_condition("glossary_terms.description", params[:description_has])
     super
   end
 
   def self.default_order
-    "created_at"
+    "name"
   end
 end

--- a/app/classes/query/glossary_term_base.rb
+++ b/app/classes/query/glossary_term_base.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Query::GlossaryTermBase < Query::Base
+  def model
+    GlossaryTerm
+  end
+
+  def parameter_declarations
+    super.merge(
+      created_at?: [:time],
+      updated_at?: [:time],
+      users?: [User],
+      title_has?: :string,
+      body_has?: :string
+    )
+  end
+
+  def initialize_flavor
+    add_owner_and_time_stamp_conditions("glossary_terms")
+    add_search_condition("glossary_terms.title", params[:title_has])
+    add_search_condition("glossary_terms.body", params[:body_has])
+    super
+  end
+
+  def self.default_order
+    "created_at"
+  end
+end

--- a/app/classes/query/glossary_term_pattern_search.rb
+++ b/app/classes/query/glossary_term_pattern_search.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-class Query::GlossaryTermPatternSearch < Query::GlossaryTermBase
-  def parameter_declarations
-    super.merge(
-      pattern: :string
-    )
-  end
+module Query
+  class GlossaryTermPatternSearch < Query::GlossaryTermBase
+    def parameter_declarations
+      super.merge(
+        pattern: :string
+      )
+    end
 
-  def initialize_flavor
-    add_search_condition(search_fields, params[:pattern])
-    super
-  end
+    def initialize_flavor
+      add_search_condition(search_fields, params[:pattern])
+      super
+    end
 
-  def search_fields
-    "CONCAT(" \
-      "glossary_terms.name," \
-      "COALESCE(glossary_terms.description,'')" \
-      ")"
+    def search_fields
+      "CONCAT(" \
+        "glossary_terms.name," \
+        "COALESCE(glossary_terms.description,'')" \
+        ")"
+    end
   end
 end

--- a/app/classes/query/glossary_term_pattern_search.rb
+++ b/app/classes/query/glossary_term_pattern_search.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Query::GlossaryTermPatternSearch < Query::GlossaryTermBase
+  def parameter_declarations
+    super.merge(
+      pattern: :string
+    )
+  end
+
+  def initialize_flavor
+    add_search_condition(search_fields, params[:pattern])
+    super
+  end
+
+  def search_fields
+    "CONCAT(" \
+      "glossary_terms.name," \
+      "COALESCE(glossary_terms.description,'')" \
+      ")"
+  end
+end

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -8,12 +8,6 @@ class GlossaryTermsController < ApplicationController
   # ---------- Actions to Display data (index, show, etc.) ---------------------
 
   def index
-    # Index should be paged with alpha and number tabs
-    # See https://www.pivotaltracker.com/story/show/167657202
-    # Glossary should be query-able
-    # See https://www.pivotaltracker.com/story/show/167809123
-    # includes = @user ? { thumb_image: :image_votes } : :thumb_image
-    # @glossary_terms = GlossaryTerm.includes(includes).order(:name)
     filter_index? ? index_filtered : index_full
   end
 

--- a/app/views/glossary_terms/_object.html.erb
+++ b/app/views/glossary_terms/_object.html.erb
@@ -1,0 +1,14 @@
+<div class="list-group-item">
+  <div class="row">
+    <div class="col-xs-12 col-sm-9">
+      <h4><%= link_to(object.name, glossary_term_path(object.id)) %>:</h4>
+      <%= object.description.tpl %>
+    </div><!--.col-->
+    <div class="col-xs-12 col-sm-3">
+      <%= glossary_term_destroy_button(object) if in_admin_mode? %>
+      <%= if object&.thumb_image_id&.nonzero?
+        thumbnail(object.thumb_image, votes: true)
+      end %>
+    </div><!--.col-->
+  </div><!--.row-->
+</div><!--.list-group-item-->

--- a/app/views/glossary_terms/index.html.erb
+++ b/app/views/glossary_terms/index.html.erb
@@ -10,21 +10,8 @@ tabs = [
 
 <%= content_tag(:div, :glossary_term_index_intro.tp, class: "container-text") %>
 
-<div class="list-group">
-  <% @glossary_terms.each do |term| %>
-    <div class="list-group-item">
-      <div class="row">
-        <div class="col-xs-12 col-sm-9">
-          <h4><%= link_to(term.name, glossary_term_path(term.id)) %>:</h4>
-          <%= term.description.tpl %>
-        </div><!--.col-->
-        <div class="col-xs-12 col-sm-3">
-          <%= glossary_term_destroy_button(term) if in_admin_mode? %>
-          <%= if term&.thumb_image_id&.nonzero?
-            thumbnail(term.thumb_image, votes: true)
-          end %>
-        </div><!--.col-->
-      </div><!--.row-->
-    </div><!--.list-group-item-->
-  <% end %>
-</div><!--.list-group-->
+<%= paginate_block(@pages) do %>
+  <div class="list-group">
+    <%= render(partial: "object", collection: @objects) %>
+  </div>
+<% end %>

--- a/app/views/layouts/search_bar/_search_form.html.erb
+++ b/app/views/layouts/search_bar/_search_form.html.erb
@@ -1,8 +1,8 @@
 <%
 options = [
   [:COMMENTS.l, :comment],
+  [:GLOSSARY.l, :glossary_term],
   [:HERBARIA.l, :herbarium],
-  # [:GLOSSARY_TERMS.l, :glossary_term],
   # Temporarily disabled for performance reasons. 2021-09-12 JDC
   # [:IMAGES.l, :image],
   [:LOCATIONS.l, :location],
@@ -36,8 +36,8 @@ identify_page = controller.controller_name == "identify"
     <div class="form-group has-feedback has-search">
       <span class="glyphicon glyphicon-search form-control-feedback"></span>
         <%= f_s.text_field(:pattern, { value: session[:pattern],
-                                    class: "form-control",
-                                    placeholder: :app_find.t }) %>
+                                       class: "form-control",
+                                       placeholder: :app_find.t }) %>
     </div><!--.form-group-->
 
     <div class="form-group text-nowrap">

--- a/app/views/layouts/search_bar/_search_form.html.erb
+++ b/app/views/layouts/search_bar/_search_form.html.erb
@@ -2,6 +2,7 @@
 options = [
   [:COMMENTS.l, :comment],
   [:HERBARIA.l, :herbarium],
+  # [:GLOSSARY_TERMS.l, :glossary_term],
   # Temporarily disabled for performance reasons. 2021-09-12 JDC
   # [:IMAGES.l, :image],
   [:LOCATIONS.l, :location],

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -37,11 +37,20 @@ class GlossaryTermsControllerTest < FunctionalTestCase
 
   def test_glossary_term_search
     login
+    conic = glossary_terms(:conic_glossary_term)
+    convex = glossary_terms(:convex_glossary_term)
+
     get(:index, params: { pattern: "conic" })
+    qr = QueryRecord.last.id.alphabetize
+    assert_redirected_to(glossary_term_path(conic.id, params: { q: qr }))
+
+    get(:index, params: { pattern: "con" })
     assert_template("index")
     assert_select(
-      "a[href*='glossary_terms/#{glossary_terms(:conic_glossary_term).id}']",
-      text: glossary_terms(:conic_glossary_term).name
+      "a[href*='glossary_terms/#{conic.id}']", text: conic.name
+    )
+    assert_select(
+      "a[href*='glossary_terms/#{convex.id}']", text: convex.name
     )
   end
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -24,6 +24,27 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     end
   end
 
+  def test_index_by_letter
+    login
+    term = glossary_terms(:plane_glossary_term)
+    get(:index, params: { letter: "P" })
+    assert_template("index")
+    assert_select(
+      "a[href *= '#{glossary_term_path(term.id)}']", true,
+      "Glossary Index at `P` missing link to #{term.unique_text_name})"
+    )
+  end
+
+  def test_glossary_term_search
+    login
+    get(:index, params: { pattern: "conic" })
+    assert_template("index")
+    assert_select(
+      "a[href*='glossary_terms/#{glossary_terms(:conic_glossary_term).id}']",
+      text: glossary_terms(:conic_glossary_term).name
+    )
+  end
+
   # ***** show *****
   def test_show
     term = glossary_terms(:square_glossary_term)

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -47,12 +47,6 @@ class NamesControllerTest < FunctionalTestCase
     assert_template("index")
   end
 
-  def test_name_index
-    login
-    get(:index)
-    assert_template("index")
-  end
-
   def test_index_sort_by_user
     by = "user"
 
@@ -266,7 +260,7 @@ class NamesControllerTest < FunctionalTestCase
   def test_pagination_letter
     # Now try a letter.
     query_params = pagination_query_params
-    l_names = Name.where("text_name LIKE 'L%'").
+    l_names = Name.where(Name[:text_name].matches("L%")).
               order("text_name, author").to_a
     login
     get(:test_index, params: { num_per_page: l_names.size,
@@ -291,7 +285,7 @@ class NamesControllerTest < FunctionalTestCase
 
   def test_pagination_letter_with_page
     query_params = pagination_query_params
-    l_names = Name.where("text_name LIKE 'L%'").
+    l_names = Name.where(Name[:text_name].matches("L%")).
               order("text_name, author").to_a
     # Do it again, but make page size exactly one too small.
     l_names.pop
@@ -317,7 +311,7 @@ class NamesControllerTest < FunctionalTestCase
 
   def test_pagination_letter_with_page_2
     query_params = pagination_query_params
-    l_names = Name.where("text_name LIKE 'L%'").
+    l_names = Name.where(Name[:text_name].matches("L%")).
               order("text_name, author").to_a
     last_name = l_names.pop
     # Check second page.


### PR DESCRIPTION
Adds a very simple `Query` class for `GlossaryTerm`, which allows us to paginate the glossary terms index, and the `pattern_search` subclass that allows searching. 

Modeled directly on Joe's exceptionally clear code for `ArticlesController`... that is to say, copied verbatim!

@JoeCohen i believe this satisfies these Pivotal stories:
Pagination https://www.pivotaltracker.com/story/show/167657202
Searchable https://www.pivotaltracker.com/story/show/167809123

Also - cleans up `names_controller_test` in a couple spots. Doing it while I think about it.