### PR TITLE
Add query tests for new `GlossaryTermsQuery`

### DIFF
--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -7,7 +7,7 @@ DEFAULTS: &DEFAULTS
   version: 1
   user: rolf
   name: $LABEL
-  description: Description of $LABEL
+  description: Description of Term $LABEL
 
 conic_glossary_term:
   <<: *DEFAULTS

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1442,6 +1442,37 @@ class QueryTest < UnitTestCase
                  :ExternalLink, :all, url: "iNaturalist")
   end
 
+  def test_glossary_term_all
+    expect = GlossaryTerm.all.sort_by(&:name)
+    assert_query(expect, :GlossaryTerm, :all)
+  end
+
+  def test_glossary_term_pattern_search
+    assert_query([], :GlossaryTerm, :pattern_search,
+                 pattern: "no glossary term has this")
+    # name
+    assert_query(
+      GlossaryTerm.
+        where(GlossaryTerm[:name].matches("%conic_glossary_term%").
+        or(GlossaryTerm[:description].matches("%conic_glossary_term%"))),
+      :GlossaryTerm, :pattern_search, pattern: "conic_glossary_term"
+    )
+    # description
+    expect =
+      GlossaryTerm.where(GlossaryTerm[:name].matches("%Description%")).
+      where(GlossaryTerm[:name].matches("%of%")).
+      where(GlossaryTerm[:name].matches("%Term%")).
+      or(
+        GlossaryTerm.where(GlossaryTerm[:description].matches("%Description%")).
+        where(GlossaryTerm[:description].matches("%of%")).
+        where(GlossaryTerm[:description].matches("%Term%"))
+      )
+    assert_query(expect,
+                 :GlossaryTerm, :pattern_search, pattern: "Description of Term")
+    assert_query(GlossaryTerm.all,
+                 :GlossaryTerm, :pattern_search, pattern: "")
+  end
+
   def test_herbarium_all
     expect = Herbarium.all.sort_by(&:name)
     assert_query(expect, :Herbarium, :all)


### PR DESCRIPTION
Conveniently reuses @JoeCohen's tests developed for the unimplemented Articles pattern search query.