### PR TITLE
Config: Try to fix request auth header issue

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,6 +10,10 @@ MushroomObserver::Application.configure do
   config.domain      = "mushroomobserver.org"
   config.http_domain = "https://mushroomobserver.org"
 
+  # ActionDispatch::HostAuthorization
+  # Accept requests from mo and any subdomain.
+  config.hosts << ".mushroomobserver.org"
+
   # List of alternate server domains.
   # We redirect from each of these to the real one.
   config.bad_domains = ["www.#{config.domain}"]


### PR DESCRIPTION
Two new refactored routes: 
- Image voting (a Rails `post method: :put` request) 
- Image EXIF data (a `get` request)

work locally on main, but not on production. They're giving a 405 error to every request, which indicates `Method not allowed` and usually has to do with CORS headers.

The `AjaxController` subclasses that formerly handled these requests disabled filters, which does `skip_before_action :verify_authenticity_token`

However, the Propose a name form AJAX does not skip that action, and works as before, and it’s making the same kind of request. So this is a mystery, but i'm going to try this before adding the `skip_before_action` to those two new controllers.
