### PR TITLE
Try using full vote/exif URLs?

### DIFF
--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -87,8 +87,9 @@ module ThumbnailHelper
       return content_tag(:span, image_vote_as_short_string(vote))
     end
 
+    # must use full URL here because of lazyload?
     put_button(name: vote_text, remote: true,
-               path: image_vote_path(image_id: image.id, value: vote),
+               path: image_vote_url(image_id: image.id, value: vote),
                title: image_vote_as_help_string(vote),
                data: { role: "image_vote", image_id: image.id, value: vote })
   end
@@ -98,8 +99,9 @@ module ThumbnailHelper
     state_text = visual_group_status_text(state)
     return content_tag(:b, link_text) if link_text == state_text
 
+    # must use full URL here because of lazyload?
     put_button(name: link_text,
-               path: image_vote_path(image_id: image_id, vote: 1),
+               path: image_vote_url(image_id: image_id, vote: 1),
                title: link_text,
                data: { role: "visual_group_status",
                        imgid: image_id,


### PR DESCRIPTION
I'm noticing that the error is actually coming from the form submitting to the wrong URL, and I have no idea how it's getting that URL.

`[Error] XMLHttpRequest cannot load https://images.mushroomobserver.org/1551468/vote due to access control checks.`

The image vote form has the right path, though.
```
<form class="button_to" method="post" action="/images/1551468/vote?value=2" data-remote="true">
  <input type="hidden" name="_method" value="put" autocomplete="off">
  <input class="" title="Useful for identification." data-role="image_vote" data-image-id="1551468" data-value="2" type="submit" value="Useful">
  <input type="hidden" name="authenticity_token" value="blJm84iawZtxjRMOSiNmdMwqqsDhg/NVyNj6dnveZ8WX3YDSraW8VX+6INjJGq4PzF7BY+IBncU3oak1eQCswQ==" autocomplete="off">
</form>
```
I'm going to try giving it a full URL, instead of a path.