### PR TITLE
Improve scope division between `helpers` and `presenters`

### DIFF
--- a/app/helpers/identify_helper.rb
+++ b/app/helpers/identify_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# buttons (forms) for observation identify UI
+module IdentifyHelper
+  def propose_naming_link(id, btn_class = "btn-primary my-3")
+    render(partial: "observations/namings/propose_button",
+           locals: { obs_id: id, text: :create_naming.t,
+                     btn_class: "#{btn_class} d-inline-block" },
+           layout: false)
+  end
+
+  # NOTE: There are potentially two of these toggles for the same obs, on
+  # the obs_needing_ids index. Ideally, they'd be in sync. In reality, only
+  # the matrix_box (page) checkbox will update if the (lightbox) caption
+  # checkbox changes. Updating the lightbox checkbox to stay sync with the page
+  # is harder because the caption is not created. Updating it would only work
+  # with some additions to the lightbox JS, to keep track of the checked
+  # state on show, and cost an extra db lookup. Not worth it, IMO.
+  # - Nimmo 20230215
+  def mark_as_reviewed_toggle(id, selector = "caption_reviewed",
+                              label_class = "")
+    render(partial: "observation_views/mark_as_reviewed",
+           locals: { id: id, selector: selector, label_class: label_class },
+           layout: false)
+  end
+end

--- a/app/helpers/image_votes_helper.rb
+++ b/app/helpers/image_votes_helper.rb
@@ -16,7 +16,7 @@ module ImageVotesHelper
   # JS is listening to any element with [data-role="image_vote"],
   # Even though this is not an <a> tag, but an <input>, it's ok.
   def image_vote_link(image, vote)
-    current_vote = image.users_vote(@user)
+    current_vote = image.users_vote(User.current)
     vote_text = vote.zero? ? "(x)" : image_vote_as_short_string(vote)
 
     if current_vote == vote

--- a/app/helpers/image_votes_helper.rb
+++ b/app/helpers/image_votes_helper.rb
@@ -1,8 +1,35 @@
 # frozen_string_literal: true
 
-# image vote lookup used in show_image
 module ImageVotesHelper
-  # moved from the ImagesController
+  # used in shared/image_thumbnail
+  def vote_section_html(votes, image)
+    return "" unless votes && image && User.current
+
+    content_tag(:div, "", class: "vote-section") do
+      render(partial: "shared/image_vote_links",
+             locals: { image: image })
+    end
+  end
+
+  # Create an image link vote, where vote param is vote number ie: 3
+  # Returns a form input button if the user has NOT voted this way
+  # JS is listening to any element with [data-role="image_vote"],
+  # Even though this is not an <a> tag, but an <input>, it's ok.
+  def image_vote_link(image, vote)
+    current_vote = image.users_vote(@user)
+    vote_text = vote.zero? ? "(x)" : image_vote_as_short_string(vote)
+
+    if current_vote == vote
+      return content_tag(:span, image_vote_as_short_string(vote))
+    end
+
+    put_button(name: vote_text, remote: true,
+               path: image_vote_path(image_id: image.id, value: vote),
+               title: image_vote_as_help_string(vote),
+               data: { role: "image_vote", image_id: image.id, value: vote })
+  end
+
+  # image vote lookup used in show_image
   def find_list_of_votes(image)
     image.image_votes.sort_by do |v|
       (v.anonymous ? :anonymous.l : v.user.unique_text_name).downcase

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# special markup for the lightbox
+module LightboxHelper
+  # this link needs to contain all the data for the lightbox image
+  def lightbox_link(lightbox_data)
+    icon = content_tag(:i, "", class: "glyphicon glyphicon-fullscreen")
+    caption = lightbox_caption_html(lightbox_data)
+
+    link_to(icon, lightbox_data[:url],
+            class: "theater-btn",
+            data: { lightbox: lightbox_data[:id], title: caption })
+  end
+
+  # everything in the caption
+  def lightbox_caption_html(lightbox_data)
+    obs_data = lightbox_data[:obs_data]
+    html = []
+    if obs_data[:id].present?
+      html = lightbox_obs_caption(html, obs_data, lightbox_data[:identify])
+    end
+    html << caption_image_links(lightbox_data[:image_id])
+    safe_join(html)
+  end
+
+  # observation part of the caption. returns an array of html strings (to join)
+  # template local assign "caption" skips the obs relations (projects, etc)
+  def lightbox_obs_caption(html, obs_data, identify)
+    if identify ||
+       (obs_data[:obs].vote_cache.present? && obs_data[:obs].vote_cache <= 0)
+      html << propose_naming_link(obs_data[:id])
+      html << content_tag(:span, "&nbsp;".html_safe, class: "mx-2")
+      html << mark_as_reviewed_toggle(obs_data[:id])
+    end
+    html << caption_obs_title(obs_data)
+    html << render(partial: "observations/show/observation",
+                   locals: { observation: obs_data[:obs], caption: true })
+  end
+
+  def caption_obs_title(obs_data)
+    content_tag(:h4, show_obs_title(obs: obs_data[:obs]),
+                class: "obs-what", id: "observation_what_#{obs_data[:id]}")
+  end
+
+  # links relating to the image object, pre-joined as a div
+  def caption_image_links(image_id)
+    links = []
+    links << original_image_link(image_id, "lightbox_link")
+    links << " | "
+    links << image_exif_link(image_id, "lightbox_link")
+    content_tag(:div, class: "caption-image-links my-3") do
+      safe_join(links)
+    end
+  end
+end

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module MatrixBoxHelper
+  # Obs with uncertain name: vote on naming, or propose (if it's "Fungi")
+  # used if matrix_box local_assigns identify == true
+  def vote_or_propose_ui(identify, object)
+    return unless identify
+
+    if (object.name_id != 1) && (nam = object.consensus_naming)
+      content_tag(:div, class: "vote-select-container mb-3") do
+        render(partial: "observations/namings/votes/form",
+               locals: { naming: nam })
+      end
+    else
+      propose_naming_link(object.id, "btn-default mb-3")
+    end
+  end
+
+  # Obs with uncertain name: mark as reviewed (to skip in future)
+  # used if matrix_box local_assigns identify == true
+  def identify_footer(identify, object_id)
+    return unless identify
+
+    content_tag(
+      :div,
+      class: "panel-footer panel-active text-center position-relative"
+    ) do
+      mark_as_reviewed_toggle(object_id, "box_reviewed", "stretched-link")
+    end
+  end
+end

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -87,9 +87,8 @@ module ThumbnailHelper
       return content_tag(:span, image_vote_as_short_string(vote))
     end
 
-    # must use full URL here because of lazyload?
     put_button(name: vote_text, remote: true,
-               path: image_vote_url(image_id: image.id, value: vote),
+               path: image_vote_path(image_id: image.id, value: vote),
                title: image_vote_as_help_string(vote),
                data: { role: "image_vote", image_id: image.id, value: vote })
   end
@@ -99,9 +98,8 @@ module ThumbnailHelper
     state_text = visual_group_status_text(state)
     return content_tag(:b, link_text) if link_text == state_text
 
-    # must use full URL here because of lazyload?
     put_button(name: link_text,
-               path: image_vote_url(image_id: image_id, vote: 1),
+               path: image_vote_path(image_id: image_id, vote: 1),
                title: link_text,
                data: { role: "visual_group_status",
                        imgid: image_id,

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -128,7 +128,7 @@ module ThumbnailHelper
     end
     html << caption_obs_title(obs_data)
     html << render(partial: "observations/show/observation",
-                   locals: { observation: obs_data[:obs] })
+                   locals: { observation: obs_data[:obs], caption: true })
   end
 
   def caption_obs_title(obs_data)

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -6,7 +6,7 @@ class ThumbnailPresenter < BasePresenter
     :image,            # image instance or id
     :proportion,       # sizer proportion, to size img correctly pre-lazyload
     :width,            # image container width (to be removed soon)
-    :img_lazy_tag,     # thumbnail image tag with placeholder (src lazy-loaded)
+    :img_tag_lazy,     # thumbnail image tag with placeholder (src lazy-loaded)
     :img_tag,          # thumbnail image tag with real src (when no lazy-load)
     :stretched_link,   # image overlay stretched-link (may be link/button/form)
     :lightbox_link,    # contains data passed to lightbox (incl. caption)

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -6,8 +6,8 @@ class ThumbnailPresenter < BasePresenter
     :image,            # image instance or id
     :proportion,       # sizer proportion, to size img correctly pre-lazyload
     :width,            # image container width (to be removed soon)
-    :img_tag,          # thumbnail image tag with placeholder (src lazy-loaded)
-    :noscript_img_tag, # thumbnail image tag with real src (when no lazy-load)
+    :img_lazy_tag,     # thumbnail image tag with placeholder (src lazy-loaded)
+    :img_tag,          # thumbnail image tag with real src (when no lazy-load)
     :stretched_link,   # image overlay stretched-link (may be link/button/form)
     :lightbox_link,    # contains data passed to lightbox (incl. caption)
     :vote_section,     # show votes? boolean
@@ -50,7 +50,7 @@ class ThumbnailPresenter < BasePresenter
     # img_srcset = thumbnail_srcset(img_urls[:small], img_urls[:medium],
     #                               img_urls[:large], img_urls[:huge])
     # img_sizes = args[:data_sizes] || thumbnail_srcset_sizes
-    img_class = "img-fluid lazy ab-fab object-fit-cover"
+    img_class = "img-fluid ab-fab object-fit-cover"
     img_class += " #{args[:extra_classes]}" if args[:extra_classes]
 
     # <img> data attributes. Account for possible data-confirm, etc
@@ -63,7 +63,7 @@ class ThumbnailPresenter < BasePresenter
     # <img> attributes
     html_options = {
       alt: args[:notes],
-      class: img_class,
+      class: "#{img_class} lazy",
       data: img_data
     }
 
@@ -71,8 +71,8 @@ class ThumbnailPresenter < BasePresenter
     noscript_html_options[:class] = "#{img_class} img-noscript"
 
     self.image = image || nil
-    self.img_tag = h.image_tag("placeholder.svg", html_options)
-    self.noscript_img_tag = noscript_img(img_src, noscript_html_options)
+    self.img_lazy_tag = h.image_tag("placeholder.svg", html_options)
+    self.img_tag = h.image_tag(img_src, noscript_html_options)
     self.stretched_link = image_link_html(args[:image_link], args[:link_method])
     self.vote_section = vote_section_html(args, image)
     self.image_filename = image_orig_name(args, image)
@@ -124,12 +124,6 @@ class ThumbnailPresenter < BasePresenter
   #     "(min-width: 992px) 30vw"
   #   ].join(",")
   # end
-
-  def noscript_img(img_src, html_options)
-    h.content_tag(:noscript) do
-      h.image_tag(img_src, html_options)
-    end
-  end
 
   # NOTE: `stretched_link` might be a link to #show_obs or #show_image,
   # but it may also be a button/input (with params[:img_id]) sending to

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -31,7 +31,7 @@ class ThumbnailPresenter < BasePresenter
       extra_classes: false,
       obs_data: {}, # used in lightbox caption
       identify: false,
-      image_link: h.image_path(image_id),
+      image_link: h.image_path(image_id), # to ImagesController#show
       link_method: :get,
       votes: true,
       is_set: true

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -3,15 +3,17 @@
 # Gather details for items in matrix-style ndex pages.
 class ThumbnailPresenter < BasePresenter
   attr_accessor \
-    :image,            # image instance or id
-    :proportion,       # sizer proportion, to size img correctly pre-lazyload
-    :width,            # image container width (to be removed soon)
-    :img_tag_lazy,     # thumbnail image tag with placeholder (src lazy-loaded)
-    :img_tag,          # thumbnail image tag with real src (when no lazy-load)
-    :stretched_link,   # image overlay stretched-link (may be link/button/form)
-    :lightbox_link,    # contains data passed to lightbox (incl. caption)
-    :vote_section,     # show votes? boolean
-    :image_filename    # original image filename (maybe none)
+    :image,             # image instance or id
+    :img_src,           # img src for noscript image
+    :proportion,        # sizer proportion, to size img correctly pre-lazyload
+    :width,             # image container width (to be removed soon)
+    :options_lazy,      # html_options for placeholder (src lazy-loaded)
+    :options_noscript,  # html_options for noscript (when no lazy-load)
+    :image_link,        # image stretched-link url (may be link/button/form)
+    :image_link_method, # needed for helper
+    :lightbox_data,     # contains data passed to lightbox (incl. caption)
+    :votes,             # show votes? boolean
+    :original           # show original image filename? (boolean)
 
   def initialize(image, view, args = {})
     super
@@ -34,6 +36,7 @@ class ThumbnailPresenter < BasePresenter
       image_link: h.image_path(image_id), # to ImagesController#show
       link_method: :get,
       votes: true,
+      original: false,
       is_set: true
     }
     args = default_args.merge(args)
@@ -75,11 +78,13 @@ class ThumbnailPresenter < BasePresenter
     }
 
     self.image = image || nil
-    self.img_tag_lazy = h.image_tag("placeholder.svg", html_options_lazy)
-    self.img_tag = h.image_tag(img_src, html_options_noscript)
-    self.stretched_link = image_link_html(args[:image_link], args[:link_method])
-    self.vote_section = vote_section_html(args, image)
-    self.image_filename = image_orig_name(args, image)
+    self.img_src = img_src
+    self.options_lazy = html_options_lazy
+    self.options_noscript = html_options_noscript
+    self.image_link = args[:image_link]
+    self.image_link_method = args[:link_method]
+    self.votes = args[:votes]
+    self.original = args[:original]
   end
 
   def sizing_info_to_presenter(image, args)
@@ -104,12 +109,14 @@ class ThumbnailPresenter < BasePresenter
   def lightbox_args_to_presenter(image_id, img_urls, args)
     # The src size appearing in the lightbox is a user pref
     lb_size = User.current&.image_size&.to_sym || :huge
-    lb_url = img_urls[lb_size]
-    lb_id = args[:is_set] ? "observation-set" : SecureRandom.uuid
-    lb_caption = lightbox_caption_html(image_id,
-                                       args[:obs_data], args[:identify])
 
-    self.lightbox_link = lb_link(lb_url, lb_id, lb_caption)
+    self.lightbox_data = {
+      url: img_urls[lb_size],
+      id: args[:is_set] ? "observation-set" : SecureRandom.uuid,
+      image_id: image_id,
+      obs_data: args[:obs_data],
+      identify: args[:identify]
+    }
   end
 
   # def thumbnail_srcset(small_url, medium_url, large_url, huge_url)
@@ -128,95 +135,4 @@ class ThumbnailPresenter < BasePresenter
   #     "(min-width: 992px) 30vw"
   #   ].join(",")
   # end
-
-  # NOTE: `stretched_link` might be a link to #show_obs or #show_image,
-  # but it may also be a button/input (with params[:img_id]) sending to
-  # #reuse_image or #remove_image ...or any other clickable element. Elements
-  # use .ab-fab instead of .stretched-link to keep .theater-btn clickable
-  def image_link_html(path, link_method)
-    case link_method
-    when :get
-      h.link_with_query("", path, class: image_link_classes)
-    when :post
-      h.post_button(name: "", path: path, class: image_link_classes)
-    when :put
-      h.put_button(name: "", path: path, class: image_link_classes)
-    when :patch
-      h.patch_button(name: "", path: path, class: image_link_classes)
-    when :delete
-      h.destroy_button(name: "", target: path, class: image_link_classes)
-    when :remote
-      h.link_with_query("", path, class: image_link_classes, remote: true)
-    end
-  end
-
-  def image_link_classes
-    "image-link stretched-link"
-  end
-
-  def lightbox_caption_html(image_id, obs_data, identify)
-    html = []
-    if obs_data[:id].present?
-      html = image_observation_caption(html, obs_data, identify)
-    end
-    html << caption_image_links(image_id)
-    h.safe_join(html)
-  end
-
-  def image_observation_caption(html, obs_data, identify)
-    if identify ||
-       (obs_data[:obs].vote_cache.present? && obs_data[:obs].vote_cache <= 0)
-      html << h.propose_naming_link(obs_data[:id])
-      html << h.content_tag(:span, "&nbsp;".html_safe, class: "mx-2")
-      html << h.mark_as_reviewed_toggle(obs_data[:id])
-    end
-    html << caption_obs_title(obs_data)
-    html << h.render(partial: "observations/show/observation",
-                     locals: { observation: obs_data[:obs] })
-  end
-
-  def caption_obs_title(obs_data)
-    h.content_tag(:h4, h.show_obs_title(obs: obs_data[:obs]),
-                  class: "obs-what", id: "observation_what_#{obs_data[:id]}")
-  end
-
-  def caption_image_links(image_id)
-    links = []
-    links << h.original_image_link(image_id, "lightbox_link")
-    links << " | "
-    links << h.image_exif_link(image_id, "lightbox_link")
-    h.content_tag(:div, class: "caption-image-links my-3") do
-      h.safe_join(links)
-    end
-  end
-
-  def lb_link(lb_url, lb_id, lb_caption)
-    icon = h.content_tag(:i, "", class: "glyphicon glyphicon-fullscreen")
-    h.link_to(icon, lb_url,
-              class: "theater-btn",
-              data: { lightbox: lb_id, title: lb_caption })
-  end
-
-  def vote_section_html(args, image)
-    return "" unless args[:votes] && image && User.current
-
-    h.content_tag(:div, "", class: "vote-section") do
-      h.render(partial: "shared/image_vote_links",
-               locals: { image: image })
-    end
-  end
-
-  def image_orig_name(args, image)
-    return "" unless image && show_original_name(args, image)
-
-    h.content_tag(:div, image.original_name, class: "mt-3")
-  end
-
-  def show_original_name(args, image)
-    args[:original] && image &&
-      image.original_name.present? &&
-      (h.check_permission(image) ||
-       image.user &&
-       image.user.keep_filenames == "keep_and_show")
-  end
 end

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -61,18 +61,18 @@ class ThumbnailPresenter < BasePresenter
     }.merge(args[:data])
 
     # <img> attributes
-    html_options = {
+    html_options_lazy = {
       alt: args[:notes],
       class: "#{img_class} lazy",
       data: img_data
     }
 
-    noscript_html_options = html_options.dup
-    noscript_html_options[:class] = "#{img_class} img-noscript"
+    html_options_noscript = html_options_lazy.dup
+    html_options_noscript[:class] = "#{img_class} img-noscript"
 
     self.image = image || nil
-    self.img_lazy_tag = h.image_tag("placeholder.svg", html_options)
-    self.img_tag = h.image_tag(img_src, noscript_html_options)
+    self.img_tag_lazy = h.image_tag("placeholder.svg", html_options_lazy)
+    self.img_tag = h.image_tag(img_src, html_options_noscript)
     self.stretched_link = image_link_html(args[:image_link], args[:link_method])
     self.vote_section = vote_section_html(args, image)
     self.image_filename = image_orig_name(args, image)

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -67,8 +67,12 @@ class ThumbnailPresenter < BasePresenter
       data: img_data
     }
 
-    html_options_noscript = html_options_lazy.dup
-    html_options_noscript[:class] = "#{img_class} img-noscript"
+    html_options_noscript = {
+      alt: args[:notes],
+      class: "#{img_class} img-noscript"
+      #   srcset: img_srcset,
+      #   sizes: img_sizes
+    }
 
     self.image = image || nil
     self.img_tag_lazy = h.image_tag("placeholder.svg", html_options_lazy)

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -1,6 +1,7 @@
 <%
 # The basic info box for the observation
 obs_id = observation.id
+caption ||= false
 %>
 <p class="obs-when" id="observation_when_<%= obs_id %>">
   <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
@@ -40,34 +41,37 @@ obs_id = observation.id
   <%= :WHO.t %>: <span><%= user_link(observation.user) %></span>
 </p>
 
-<% if @user %>
-  <div class="obs-projects" id="observation_projects_<%= obs_id %>">
-    <% observation.projects.each do |project| %>
-      <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
-    <% end %>
-  </div>
-<% end %>
+<% if !caption %>
+  <% if @user %>
+    <div class="obs-projects" id="observation_projects_<%= obs_id %>">
+      <% observation.projects.each do |project| %>
+        <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
+      <% end %>
+    </div>
+  <% end %>
 
-<div class="obs-specimen" id="observation_specimen_available_<%= obs_id %>">
-  <%= observation.specimen ? :show_observation_specimen_available.t :
-                              :show_observation_specimen_not_available.t %>
-</div>
-
-<% if @user %>
-  <div class="obs-collection" id="observation_collection_numbers_<%= obs_id %>">
-    <%= render(partial: "observations/show/collection_numbers",
-               locals: { observation: observation }) %>
+  <div class="obs-specimen" id="observation_specimen_available_<%= obs_id %>">
+    <%= observation.specimen ? :show_observation_specimen_available.t :
+                                :show_observation_specimen_not_available.t %>
   </div>
 
-  <div class="obs-herbarium" id="observation_herbarium_records_<%= obs_id %>">
-    <%= render(partial: "observations/show/herbarium_records",
-               locals: { observation: observation }) %>
-  </div>
+  <% if @user %>
+    <div class="obs-collection"
+         id="observation_collection_numbers_<%= obs_id %>">
+      <%= render(partial: "observations/show/collection_numbers",
+                locals: { observation: observation }) %>
+    </div>
 
-  <div class="obs-sequence" id="observation_sequences_<%= obs_id %>">
-    <%= render(partial: "observations/show/sequences",
-               locals: { observation: observation }) %>
-  </div>
+    <div class="obs-herbarium" id="observation_herbarium_records_<%= obs_id %>">
+      <%= render(partial: "observations/show/herbarium_records",
+                locals: { observation: observation }) %>
+    </div>
+
+    <div class="obs-sequence" id="observation_sequences_<%= obs_id %>">
+      <%= render(partial: "observations/show/sequences",
+                locals: { observation: observation }) %>
+    </div>
+  <% end %>
 <% end %>
 
 <div class="obs-notes" id="observation_notes_<%= obs_id %>">

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -6,8 +6,10 @@ presenter = ThumbnailPresenter.new(image, @view, local_assigns.except(:image))
      style="width: <%= presenter.width %>px;">
   <div class="image-lazy-sizer overflow-hidden"
        style="padding-bottom: <%= presenter.proportion %>%;">
-    <%= presenter.img_tag %>
-    <%= presenter.noscript_img_tag %>
+    <%= presenter.img_lazy_tag %>
+    <noscript>
+      <%= presenter.img_tag %>
+    </noscript>
   </div>
   <%= presenter.stretched_link %>
   <%= presenter.lightbox_link %>

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -6,7 +6,7 @@ presenter = ThumbnailPresenter.new(image, @view, local_assigns.except(:image))
      style="width: <%= presenter.width %>px;">
   <div class="image-lazy-sizer overflow-hidden"
        style="padding-bottom: <%= presenter.proportion %>%;">
-    <%= presenter.img_lazy_tag %>
+    <%= presenter.img_tag_lazy %>
     <noscript>
       <%= presenter.img_tag %>
     </noscript>

--- a/app/views/shared/_image_thumbnail.html.erb
+++ b/app/views/shared/_image_thumbnail.html.erb
@@ -6,13 +6,13 @@ presenter = ThumbnailPresenter.new(image, @view, local_assigns.except(:image))
      style="width: <%= presenter.width %>px;">
   <div class="image-lazy-sizer overflow-hidden"
        style="padding-bottom: <%= presenter.proportion %>%;">
-    <%= presenter.img_tag_lazy %>
+    <%= image_tag("placeholder.svg", presenter.options_lazy) %>
     <noscript>
-      <%= presenter.img_tag %>
+      <%= image_tag(presenter.img_src, presenter.options_noscript) %>
     </noscript>
   </div>
-  <%= presenter.stretched_link %>
-  <%= presenter.lightbox_link %>
-  <%= presenter.vote_section %>
+  <%= image_stretched_link(presenter.image_link, presenter.image_link_method) %>
+  <%= lightbox_link(presenter.lightbox_data) %>
+  <%= vote_section_html(presenter.votes, presenter.image) %>
 </div>
-<%= presenter.image_filename %>
+<%= image_original_name(presenter.original, presenter.image) %>

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -19,25 +19,18 @@ if presenter
           end %>
         </div><!-- .thumbnail-container -->
         <div class="rss-what pt-2">
-          <h5><%= presenter.what %></h5>
-          <%= if identify
-            if (object.name_id != 1) && (nam = object.consensus_naming)
-              content_tag(:div, class: "vote-select-container mb-3") do
-                render(partial: "observations/namings/votes/form",
-                       locals: { naming: nam })
-              end
-            else
-              propose_naming_link(object_id, "btn-default mb-3")
-            end
-          end %>
+          <h5><%= link_with_query(presenter.name,
+                                  presenter.what.show_link_args) %></h5>
+          <%= vote_or_propose_ui(identify, object) %>
         </div><!-- .rss-what -->
         <div class="rss-where">
-          <small><%= presenter.where %></small>
+          <small><%= location_link(presenter.place_name,
+                                   presenter.where) %></small>
         </div><!-- .rss-where -->
         <div class="rss-what">
           <small class="nowrap-ellipsis">
             <% unless presenter.when.blank? %>
-              <%= presenter.when %>: <%= presenter.who %>
+              <%= presenter.when %>: <%= user_link(presenter.who) %>
             <% end %>
           </small>
         </div><!-- .rss-when -->
@@ -48,14 +41,7 @@ if presenter
           <small><%= presenter.fancy_time %></small>
         </div><!-- .rss-fancy-time -->
       </div><!-- .panel-body -->
-      <% if identify %>
-        <%= content_tag(
-              :div,
-              class: "panel-footer panel-active text-center position-relative"
-            ) do
-          mark_as_reviewed_toggle(object_id, "box_reviewed", "stretched-link")
-        end %>
-      <% end %>
+      <%= identify_footer(identify, object_id) %>
     </div><!-- .panel -->
   </li><!-- .matrix-box -->
 <% end %>

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -16,7 +16,7 @@ if presenter
         <%= if presenter.image_data
           content_tag(:div, class: "thumbnail-container") do
             render(partial: "shared/image_thumbnail",
-                  locals: locals.merge(presenter.image_data))
+                   locals: locals.merge(presenter.image_data))
           end
         end %>
 
@@ -38,7 +38,9 @@ if presenter
         <% unless presenter.when.blank? %>
           <div class="rss-what">
             <%= content_tag(:small, class: "nowrap-ellipsis") do
-              "#{presenter.when}: #{user_link(presenter.who)}"
+              concat(presenter.when)
+              concat(": ")
+              concat(user_link(presenter.who))
             end %>
           </div><!-- .rss-when -->
         <% end %>

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -12,36 +12,51 @@ if presenter
   <li class="matrix-box <%= columns %>" id="box_<%= object_id %>">
     <div class="panel panel-default">
       <div class="panel-body rss-box-details">
-        <div class="thumbnail-container">
-          <%= if presenter.image_data
+
+        <%= if presenter.image_data
+          content_tag(:div, class: "thumbnail-container") do
             render(partial: "shared/image_thumbnail",
-                   locals: locals.merge(presenter.image_data))
-          end %>
-        </div><!-- .thumbnail-container -->
+                  locals: locals.merge(presenter.image_data))
+          end
+        end %>
+
         <div class="rss-what pt-2">
-          <h5><%= link_with_query(presenter.name,
-                                  presenter.what.show_link_args) %></h5>
+          <%= content_tag(:h5) do
+                link_with_query(presenter.name, presenter.what.show_link_args)
+              end %>
           <%= vote_or_propose_ui(identify, object) %>
         </div><!-- .rss-what -->
-        <div class="rss-where">
-          <small><%= location_link(presenter.place_name,
-                                   presenter.where) %></small>
-        </div><!-- .rss-where -->
-        <div class="rss-what">
-          <small class="nowrap-ellipsis">
-            <% unless presenter.when.blank? %>
-              <%= presenter.when %>: <%= user_link(presenter.who) %>
-            <% end %>
-          </small>
-        </div><!-- .rss-when -->
-        <div class="rss-detail">
-          <%= presenter.detail %>
-        </div><!-- .rss-detail -->
+
+        <% if presenter.where %>
+          <div class="rss-where">
+            <%= content_tag(:small) do
+              location_link(presenter.place_name, presenter.where)
+            end %>
+          </div><!-- .rss-where -->
+        <% end %>
+
+        <% unless presenter.when.blank? %>
+          <div class="rss-what">
+            <%= content_tag(:small, class: "nowrap-ellipsis") do
+              "#{presenter.when}: #{user_link(presenter.who)}"
+            end %>
+          </div><!-- .rss-when -->
+        <% end %>
+
+        <% unless presenter.detail.blank? %>
+          <div class="rss-detail">
+            <%= presenter.detail %>
+          </div><!-- .rss-detail -->
+        <% end %>
+
         <div class="rss-what">
           <small><%= presenter.fancy_time %></small>
         </div><!-- .rss-fancy-time -->
+
       </div><!-- .panel-body -->
+
       <%= identify_footer(identify, object_id) %>
+
     </div><!-- .panel -->
   </li><!-- .matrix-box -->
 <% end %>


### PR DESCRIPTION
Nowwwww  I understand the intended pattern...
- Presenters were conceived primarily for preparing data for a view, that is, data that isn't coming straight off the db. They can keep controllers simpler and logic out of the view. They're basically a service object.
- Helpers are for rendering html, like `content_tag`

This PR sorts these things back to where i believe they will be easier to remember, for thumbnails and matrix_boxes. It moves helpers back to the helper, and gets rid of the "need" to call helpers in the presenter. It also moves some helpers into their own files, hopefully easier to find.

We now have two presenters that just present data! 🥳