### PR TITLE
Revert recent config-fix changes and routes, fix `nginx.conf` instead

### DIFF
--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -87,9 +87,8 @@ module ThumbnailHelper
       return content_tag(:span, image_vote_as_short_string(vote))
     end
 
-    # must use full URL here because of lazyload?
     put_button(name: vote_text, remote: true,
-               path: image_vote_url(image_id: image.id, value: vote),
+               path: image_vote_path(image_id: image.id, value: vote),
                title: image_vote_as_help_string(vote),
                data: { role: "image_vote", image_id: image.id, value: vote })
   end
@@ -99,9 +98,8 @@ module ThumbnailHelper
     state_text = visual_group_status_text(state)
     return content_tag(:b, link_text) if link_text == state_text
 
-    # must use full URL here because of lazyload?
     put_button(name: link_text,
-               path: image_vote_url(image_id: image_id, vote: 1),
+               path: image_vote_path(image_id: image_id, vote: 1),
                title: link_text,
                data: { role: "visual_group_status",
                        imgid: image_id,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,10 +10,6 @@ MushroomObserver::Application.configure do
   config.domain      = "mushroomobserver.org"
   config.http_domain = "https://mushroomobserver.org"
 
-  # ActionDispatch::HostAuthorization
-  # Accept requests from mo and any subdomain.
-  config.hosts << ".mushroomobserver.org"
-
   # List of alternate server domains.
   # We redirect from each of these to the real one.
   config.bad_domains = ["www.#{config.domain}"]

--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -65,7 +65,7 @@ http {
   server {
     server_name www.mushroomobserver.org;
     return 301 $scheme://mushroomobserver.org$request_uri;
-  
+
     listen 80; # managed by Certbot
 
     # (add "http2" after "ssl" in the following line)
@@ -164,7 +164,8 @@ http {
     rewrite "^/images/orig/((\d{1,6}|1[0]\d\d\d\d\d)\.\w+)$" https://storage.googleapis.com/mo-image-archive-bucket/orig/$1?;
 
     # serve all the rest of the images from Alan's image server
-    rewrite "^/images/(.*)/(.*)$" https://images.mushroomobserver.org/$1/$2?;
+    # being careful to permit routes like `/images/21345/vote`
+    rewrite "^/images/(\w*)/(\d*)\.\w+$" https://images.mushroomobserver.org/$1/$2?;
 
     # SSL stuff.
     ssl_certificate /etc/letsencrypt/live/mushroomobserver.org/fullchain.pem; # managed by Certbot


### PR DESCRIPTION
This was the issue: nginx.conf was intercepting the request to
`https://mushroomobserver.org/images/1250918/vote`
and routing it to
`https://images.mushroomobserver.org/1250918/vote`

That’s why requests to these two routes are failing, and not requests to “Propose a name” or any other route.
These paths both start with `/images/:image_id`.

(I had suspected lazyload was replacing the form action URL, but it is not)