### PR TITLE
Clean up name synonym approve/deprecate forms

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -1,9 +1,9 @@
 // form elements and inputs
 
-input[type=checkbox] {
-  // fixes alignment issue in firefox; bootstrap applies this only to IE9:
-  // margin-top: 1px \9;
-  margin-top: 1px;
+.checkbox {
+  label {
+    font-weight: $btn-font-weight;
+  }
 }
 
 input.has-error,

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -13,6 +13,10 @@ a:not(.btn):not(.list-group-item):not(.theater-btn):visited {
   }
 }
 
+.btn-link {
+  font-weight: normal !important;
+}
+
 //
 // alerts
 // --------------------------------------------------

--- a/app/assets/stylesheets/mo/_variables.scss
+++ b/app/assets/stylesheets/mo/_variables.scss
@@ -147,7 +147,7 @@ $table-border-color:            #ddd !default;
 //
 //## For each of Bootstrap's buttons, define text, background and border color.
 
-$btn-font-weight:                normal !default;
+$btn-font-weight:                bold !default;
 
 $btn-default-color:              #333 !default;
 $btn-default-bg:                 #fff !default;

--- a/app/controllers/names/synonyms/approve_controller.rb
+++ b/app/controllers/names/synonyms/approve_controller.rb
@@ -35,8 +35,7 @@ module Names::Synonyms
     end
 
     def deprecate_others
-      return false unless params[:deprecate] &&
-                          params[:deprecate][:others] == "1"
+      return false unless params[:deprecate_others] == "1"
 
       @others = []
       @name.approved_synonyms.each do |n|
@@ -59,9 +58,9 @@ module Names::Synonyms
     end
 
     def post_approval_comment
-      return unless params[:comment] && params[:comment][:comment]
+      return unless params[:comment]
 
-      comment = params[:comment][:comment].to_s.strip_squeeze
+      comment = params[:comment].to_s.strip_squeeze
       return unless comment != ""
 
       post_comment(:approve, @name, comment)

--- a/app/controllers/names/synonyms/deprecate_controller.rb
+++ b/app/controllers/names/synonyms/deprecate_controller.rb
@@ -75,7 +75,7 @@ module Names::Synonyms
 
     def init_ivars_for_new
       @what             = params[:proposed_name].to_s.strip_squeeze
-      @comment          = params[:comment_comment].to_s.strip_squeeze
+      @comment          = params[:comment].to_s.strip_squeeze
       @list_members     = nil
       @new_names        = []
       @synonym_name_ids = []

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -81,4 +81,15 @@ module FormsHelper
       concat(args[:form].text_field(args[:field], opts))
     end
   end
+
+  # Bootstrap inline text_area: form, field, (label) text, class, checked
+  def inline_label_text_area(**args)
+    opts = args.except(:form, :field, :text, :class)
+    opts[:class] = "form-control"
+
+    content_tag(:div, class: "form-group form-inline #{args[:class]}") do
+      concat(args[:form].label(args[:field], args[:text]))
+      concat(args[:form].text_area(args[:field], opts))
+    end
+  end
 end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -72,7 +72,7 @@ module FormsHelper
   end
 
   # Bootstrap inline text_field: form, field, (label) text, class, checked
-  def inline_text_field_with_label(**args)
+  def inline_label_text_field(**args)
     opts = args.except(:form, :field, :text, :class)
     opts[:class] = "form-control"
 

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -24,11 +24,9 @@
   <% end %>
   <%= content_tag(:div, :name_approve_deprecate_help.tp, class: "help-note") %>
 
-  <div class="form-group form-inline">
-    <%= f.label(:comment, "#{:name_approve_comments.t}:") %>
-    <%= f.text_area(:comment, cols: 80, rows: 5,
-                    data: { autofocus: true }) %>
-  </div>
+  <%= inline_label_text_area(form: f, field: :comment,
+                             text: "#{:name_approve_comments.t}:",
+                             cols: 80, rows: 5, data: { autofocus: true }) %>
   <%= content_tag(:div,
                   :name_approve_comments_help.tp(name: @name.display_name),
                   class: "help-note") %>

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -15,18 +15,22 @@
   <%= f.submit(:APPROVE.l, class: "btn btn-default center-block mt-3") %>
 
   <% if @approved_names %>
-    <p><%= check_box(:deprecate, :others, checked: "checked") %>
-    <label for="deprecate_others"><%= :name_approve_deprecate.t %>:</label><br/><br/>
+    <%= check_box_with_label(form: f, field: :deprecate_others,
+                             checked: "checked",
+                             text: :name_approve_deprecate.t) %>
     <% @approved_names.each do |n| %>
       <%= n.display_name.t %><br/>
     <% end %></p>
   <% end %>
-  <div class="help-note"><%= :name_approve_deprecate_help.tp %></div>
+  <%= content_tag(:div, :name_approve_deprecate_help.tp, class: "help-note") %>
 
-  <p><label for="comment_comment"><%= :name_approve_comments.t %>:</label><br/>
-  <%= text_area(:comment, :comment, cols: 80, rows: 5, data: {autofocus: true}) %></p>
-  <div class="help-note">
-    <%= :name_approve_comments_help.tp(name: @name.display_name) %>
+  <div class="form-group form-inline">
+    <%= f.label(:comment, "#{:name_approve_comments.t}:") %>
+    <%= f.text_area(:comment, cols: 80, rows: 5,
+                    data: { autofocus: true }) %>
   </div>
+  <%= content_tag(:div,
+                  :name_approve_comments_help.tp(name: @name.display_name),
+                  class: "help-note") %>
 
 <% end %>

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -12,33 +12,36 @@
 
 <%= form_with(url: action, id: "name_deprecate_synonym_form") do |f| %>
 
-  <%= f.submit(:name_deprecate_submit.l,
-               class: "btn btn-default center-block mt-3") %>
+  <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block mt-3") %>
 
   <%= render(partial: "shared/form_name_feedback",
-            locals: { button_name: :name_deprecate_submit.l,
-                      what: @what,
-                      valid_names: @valid_names,
-                      suggest_corrections: @suggest_corrections,
-                      parent_deprecated: @parent_deprecated,
-                      names: @names }) if @what.present? %>
+             locals: { button_name: :SUBMIT.l,
+                       what: @what,
+                       valid_names: @valid_names,
+                       suggest_corrections: @suggest_corrections,
+                       parent_deprecated: @parent_deprecated,
+                       names: @names }) if @what.present? %>
 
-  <p><%= f.label(:proposed_name, :name_deprecate_preferred.t) %>:
-    <%= f.text_field(:proposed_name,
-                     value: @what, data: { autofocus: true }) %></p>
-  <div class="help-note">
-    <%= :name_deprecate_preferred_help.tp %>
-  </div>
+  <%= inline_label_text_field(form: f, field: :proposed_name,
+                              text: "#{:name_deprecate_preferred.t}:",
+                              value: @what, data: { autofocus: true }) %>
+  <%= content_tag(:div, :name_deprecate_preferred_help.tp,
+                  class: "help-note") %>
   <% turn_into_name_auto_completer(:proposed_name, primer: Name.primer) %>
 
-  <p><%= f.check_box(:is_misspelling, checked: @misspelling) %>
-  <%= f.label(:is_misspelling, :form_names_misspelling.t) %></p>
+  <%= check_box_with_label(form: f, field: :is_misspelling,
+                           checked: @misspelling,
+                           text: :form_names_misspelling.t) %>
 
-  <p><%= f.label(:comment_comment, :name_deprecate_comments.t) %>:</label><br/>
-  <%= f.text_area(:comment_comment, cols: 80, rows: 5, value: @comment) %></p>
-  <div class="help-note">
-    <%= :name_deprecate_comments_help.tp(name: @name.display_name.chomp(".")) %>
-    <%= :field_textile_link.tp %>
+  <div class="form-group form-inline">
+    <%= f.label(:comment, "#{:name_deprecate_comments.t}:") %>
+    <%= f.text_area(:comment, cols: 80, rows: 5, value: @comment) %>
   </div>
+  <%= content_tag(:div, class: "help-note") do
+    concat(:name_deprecate_comments_help.tp(
+             name: @name.display_name.chomp(".")
+           ))
+    concat(:field_textile_link.tp)
+  end %>
 
 <% end %>

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -33,10 +33,9 @@
                            checked: @misspelling,
                            text: :form_names_misspelling.t) %>
 
-  <div class="form-group form-inline">
-    <%= f.label(:comment, "#{:name_deprecate_comments.t}:") %>
-    <%= f.text_area(:comment, cols: 80, rows: 5, value: @comment) %>
-  </div>
+  <%= inline_label_text_area(form: f, field: :comment,
+                             text: "#{:name_deprecate_comments.t}:",
+                             value: @comment, cols: 80, rows: 5) %>
   <%= content_tag(:div, class: "help-note") do
     concat(:name_deprecate_comments_help.tp(
              name: @name.display_name.chomp(".")

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1763,7 +1763,6 @@
   name_deprecate_preferred: Preferred name
   name_deprecate_comment_summary: "[:Deprecated]"
   name_deprecate_comments: "[:Comments]"
-  name_deprecate_submit: "[:SUBMIT]"
   name_deprecate_preferred_help: Enter the preferred name. Author citation is recommended but not required.
   name_deprecate_comments_help: "Please say why this Name has been deprecated (e.g, a link to Index Fungorum).\nThis will be added to the Comments for [name]."
 

--- a/test/controllers/names/synonyms/approve_controller_test.rb
+++ b/test/controllers/names/synonyms/approve_controller_test.rb
@@ -29,8 +29,8 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        deprecate: { others: "1" },
-        comment: { comment: "Prefer this name" }
+        deprecate_others: "1",
+        comment: "Prefer this name"
       }
       post_requires_login(:create, params)
       assert_redirected_to(name_path(old_name.id))
@@ -61,8 +61,8 @@ module Names::Synonyms
 
       params = {
         id: old_name.id,
-        deprecate: { others: "0" },
-        comment: { comment: "" }
+        deprecate_others: "0",
+        comment: ""
       }
       login("rolf")
       post(:create, params: params)
@@ -82,8 +82,8 @@ module Names::Synonyms
       name.save
       params = {
         id: name.id,
-        deprecate: { others: "0" },
-        comment: { comment: "" }
+        deprecate_others: "0",
+        comment: ""
       }
 
       login("rolf")

--- a/test/controllers/names/synonyms/deprecate_controller_test.rb
+++ b/test/controllers/names/synonyms/deprecate_controller_test.rb
@@ -38,7 +38,7 @@ module Names::Synonyms
       params = {
         id: old_name.id,
         proposed_name: new_name.text_name,
-        comment_comment: "Don't like this name"
+        comment: "Don't like this name"
       }
       post_requires_login(:create, params)
       assert_redirected_to(name_path(old_name.id))
@@ -80,7 +80,7 @@ module Names::Synonyms
       params = {
         id: old_name.id,
         proposed_name: new_name.text_name,
-        comment_comment: ""
+        comment: ""
       }
       login("rolf")
       post(:create, params: params)
@@ -116,7 +116,7 @@ module Names::Synonyms
         id: old_name.id,
         proposed_name: new_name.text_name,
         chosen_name: { name_id: new_name.id },
-        comment_comment: "Don't like this name"
+        comment: "Don't like this name"
       }
       login("rolf")
       post(:create, params: params)
@@ -146,7 +146,7 @@ module Names::Synonyms
       params = {
         id: old_name.id,
         proposed_name: new_name_str,
-        comment_comment: "Don't like this name"
+        comment: "Don't like this name"
       }
       login("rolf")
       post(:create, params: params)
@@ -173,7 +173,7 @@ module Names::Synonyms
         id: old_name.id,
         proposed_name: new_name_str,
         approved_name: new_name_str,
-        comment_comment: "Don't like this name"
+        comment: "Don't like this name"
       }
       login("rolf")
       post(:create, params: params)
@@ -201,7 +201,7 @@ module Names::Synonyms
         id: name.id,
         proposed_name: name2.search_name,
         approved_name: name2.search_name,
-        comment_comment: ""
+        comment: ""
       }
 
       login("rolf")

--- a/test/integration/capybara/name_controller_supplemental_test.rb
+++ b/test/integration/capybara/name_controller_supplemental_test.rb
@@ -29,7 +29,7 @@ class NameControllerSupplementalTest < CapybaraIntegrationTestCase
     # First deprecate bad_name.
     within("#right_tabs") { click_link(text: "Deprecate") }
     fill_in("proposed_name", with: good_name.text_name)
-    fill_in("comment_comment", with: "bad name")
+    fill_in("comment", with: "bad name")
     click_on("Submit")
 
     assert(bad_name.reload.deprecated)
@@ -42,8 +42,8 @@ class NameControllerSupplementalTest < CapybaraIntegrationTestCase
 
     # Then undo it and approve it.
     within("#right_tabs") { click_link(text: "Approve") }
-    page.uncheck("deprecate[others]")
-    fill_in("comment[comment]", with: "my bad")
+    page.uncheck("deprecate_others")
+    fill_in("comment", with: "my bad")
     click_on("Approve")
 
     assert_not(bad_name.reload.deprecated)


### PR DESCRIPTION
Flattens unnecessarily nested params (requires updating controller and tests).

Uses new form helpers to DRY up markup.