### PR TITLE
Observation form minor refactor

### DIFF
--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -13,7 +13,7 @@ module ObservationsController::EditAndUpdate
   #   params[:id]                       observation id
   #   params[:observation][...]         observation args
   #   params[:image][n][...]            image args
-  #   params[:log_change][:checked]     log change in RSS feed?
+  #   params[:log_change]               log change in RSS feed?
   #
   # Outputs:
   #   @observation                      populated object
@@ -137,7 +137,7 @@ module ObservationsController::EditAndUpdate
     if save_observation(@observation)
       id = @observation.id
       flash_notice(:runtime_edit_observation_success.t(id: id))
-      touch = (param_lookup([:log_change, :checked]) == "1")
+      touch = params[:log_change] == "1"
       @observation.log(:log_observation_updated, touch: touch)
     else
       @any_errors = true

--- a/app/views/observations/_form.html.erb
+++ b/app/views/observations/_form.html.erb
@@ -56,11 +56,8 @@
   <%= f.submit(button_name, class: "btn btn-default center-block mt-3") %>
 
   <% if logging_optional %>
-    <div class="form-inline">
-      <%= check_box(:log_change, :checked, checked: "1",
-                    class: "form-control-xxx") %>
-      <%= label_tag(:log_change_checked, :form_observations_log_change.t) %>
-    </div>
+    <%= check_box_with_label(form: f, field: :log_change, checked: "checked",
+                             text: :form_observations_log_change.t) %>
   <% end %>
 
 <% end %><!--[/form:observation]-->

--- a/app/views/observations/form/_collection_number.html.erb
+++ b/app/views/observations/form/_collection_number.html.erb
@@ -1,3 +1,5 @@
+<%# collection_number section of create_observation form %>
+
 <div class="row mb-3">
 
   <div class="col-sm-6">

--- a/app/views/observations/form/_good_image.html.erb
+++ b/app/views/observations/form/_good_image.html.erb
@@ -1,3 +1,5 @@
+<%# good image section of create_observation form %>
+
 <div class="row my-4 form_image">
 
   <!-- GOOD_IMAGE -->

--- a/app/views/observations/form/_good_image_fields.html.erb
+++ b/app/views/observations/form/_good_image_fields.html.erb
@@ -1,3 +1,5 @@
+<%# good image fields partial section of create_observation form %>
+
 <table class="table-observation-images">
   <tr>
     <td>

--- a/app/views/observations/form/_herbarium_record.html.erb
+++ b/app/views/observations/form/_herbarium_record.html.erb
@@ -1,3 +1,5 @@
+<%# herbarium_record section of create_observation form %>
+
 <div class="row mb-3">
 
   <div class="col-sm-6">

--- a/app/views/observations/form/_images.html.erb
+++ b/app/views/observations/form/_images.html.erb
@@ -1,11 +1,11 @@
+<%# Images (already attached) section of create_observation form %>
 <%
-# Images (already attached) section of create_observation form
 good_image_ids_str = @good_images.map { |img| img.id }.join(" ")
 %>
 
 <div class="" id="observation_images">
 
-  <p class="font-weight-bold">Images:</p>
+  <%= content_tag(:p, "#{:IMAGES.t}:", class: "font-weight-bold") %>
 
   <% @good_images.each do |image| %>
 

--- a/app/views/observations/form/_images_upload.html.erb
+++ b/app/views/observations/form/_images_upload.html.erb
@@ -1,4 +1,4 @@
-<% # Images upload section of create_observation form %>
+<%# Images upload section of create_observation form %>
 
 <div class="mt-3" id="observation_images_upload">
 

--- a/app/views/observations/form/_notes.html.erb
+++ b/app/views/observations/form/_notes.html.erb
@@ -4,52 +4,54 @@
 <!-- NOTES -->
 <div class="mt-3" id="observation_notes">
 
-  <%= content_tag(:span, "#{:NOTES.t} ", class: "font-weight-bold") %>
-  <% if @observation.form_notes_parts(@user) == [Observation.other_notes_part]
-       part = Observation.other_notes_part %>
+  <%= content_tag(:p, "#{:NOTES.t} ", class: "font-weight-bold") %>
 
-    <div class="row">
-      <div class="col-xs-12 col-sm-6">
-        <div>
-          <textarea
-            class="form-control"
-            rows="10"
-            id=<%= @observation.notes_part_id(part) %>
-            name=<%= @observation.notes_part_name(part) %>
-          ><%= @observation.notes_part_value(part) %></textarea>
+  <% if @observation.form_notes_parts(@user) == [Observation.other_notes_part]
+      part = Observation.other_notes_part %>
+
+    <%= f.fields_for(:notes) do |f_n| %>
+
+      <div class="row">
+        <div class="col-xs-12 col-sm-6">
+          <%= f_n.text_area(@observation.notes_normalized_key(part),
+                            value: @observation.notes_part_value(part),
+                            rows: 10, class: "form-control mb-3") %>
         </div>
-      </div>
-      <div class="col-xs-12 col-sm-6">
-        <%= help_block_with_arrow("left", id: "notes_help") do %>
-          <%= content_tag(:p, :form_observations_notes_help.t,
-                          class: "pt-0 mt-0") %>
-          <%= render(partial: "shared/textilize_help") %>
-        <% end # help_block_with_arrow %>
-      </div>
-    </div><!--.row-->
+        <div class="col-xs-12 col-sm-6">
+          <%= help_block_with_arrow("left", id: "notes_help") do %>
+            <%= content_tag(:p, :form_observations_notes_help.t,
+                            class: "pt-0 mt-0") %>
+            <%= render(partial: "shared/textilize_help") %>
+          <% end # help_block_with_arrow %>
+        </div>
+      </div><!--.row-->
+
+    <% end # f.fields_for(:notes) %>
 
   <% else %>
 
     (<%= :general_textile_link.t %>)
     <% @observation.form_notes_parts(@user).each do |part| %>
 
-      <div class="row">
-        <div class="col-xs-12 col-sm-6">
-          <div><%= "#{strip_tags(part.tl)}: "%></div>
-          <div>
-            <textarea
-              class="form-control"
-              rows="1"
-              id=<%= @observation.notes_part_id(part) %>
-              name=<%= @observation.notes_part_name(part) %>
-            ><%= @observation.notes_part_value(part) %></textarea>
+      <%= f.fields_for(:notes) do |f_n| %>
+
+        <div class="row">
+          <div class="col-xs-12 col-sm-6">
+            <%= f_n.label(@observation.notes_normalized_key(part),
+                          "#{strip_tags(part.tl)}: ") %>
+            <%= f_n.text_area(@observation.notes_normalized_key(part),
+                              value: @observation.notes_part_value(part),
+                              rows: 1, class: "form-control mb-3") %>
           </div>
-        </div>
-      </div><!--.row-->
+        </div><!--.row-->
+
+      <% end # f.fields_for(:notes) %>
 
     <% end # each do part %>
 
   <% end # if user_notes_part %>
+
+
 
 </div><!--#observation_notes-->
 <!-- /NOTES -->

--- a/app/views/observations/form/_notes.html.erb
+++ b/app/views/observations/form/_notes.html.erb
@@ -1,10 +1,9 @@
-<%
-# Notes section of create_observation form
-%>
+<%# Notes section of create_observation form %>
+
 <!-- NOTES -->
 <div class="mt-3" id="observation_notes">
 
-  <%= content_tag(:p, "#{:NOTES.t} ", class: "font-weight-bold") %>
+  <%= content_tag(:p, "#{:NOTES.t}:", class: "font-weight-bold") %>
 
   <% if @observation.form_notes_parts(@user) == [Observation.other_notes_part]
       part = Observation.other_notes_part %>

--- a/app/views/observations/form/_projects.html.erb
+++ b/app/views/observations/form/_projects.html.erb
@@ -10,14 +10,11 @@
 
     <%= fields_for(:project) do |f_p| %>
       <% @projects.each do |project| %>
-        <div class="form-inline">
-          <%= f_p.check_box("id_#{project.id}",
-                            checked: @project_checks[project.id],
-                            disabled: @observation.user != @user &&
-                              !project.is_member?(@user),
-                            class: "form-control-xxx") %>
-          <%= link_to_object(project) %>
-        </div>
+        <%= check_box_with_label(form: f_p, field: :"id_#{project.id}",
+                                 checked: @project_checks[project.id],
+                                 disabled: @observation.user != @user &&
+                                   !project.is_member?(@user),
+                                 text: link_to_object(project)) %>
       <% end %>
     <% end %>
 

--- a/app/views/observations/form/_projects.html.erb
+++ b/app/views/observations/form/_projects.html.erb
@@ -1,4 +1,5 @@
-<% # Projects section of create_observation form %>
+<%# Projects section of create_observation form %>
+
 <div class="mt-3 row" id="observation_projects">
   <div class="col-xs-12 col-sm-6 col-sm-push-6">
     <%= help_block_with_arrow("left", id: "project_help") do %>

--- a/app/views/observations/form/_species_lists.html.erb
+++ b/app/views/observations/form/_species_lists.html.erb
@@ -1,4 +1,5 @@
-<% # Species Lists section of create_observation form %>
+<%# species_list section of create_observation form %>
+
 <div class="row mt-3" id="observation_species_lists">
   <div class="col-xs-12 col-sm-6 col-sm-push-6">
     <%= help_block_with_arrow("left", id: "species_lists_help") do %>

--- a/app/views/observations/form/_species_lists.html.erb
+++ b/app/views/observations/form/_species_lists.html.erb
@@ -10,13 +10,10 @@
 
     <%= fields_for(:list) do |f_l| %>
       <% @lists.each do |list| %>
-        <div class="form-inline">
-          <%= f_l.check_box("id_#{list.id}",
-                            checked: @list_checks[list.id],
-                            disabled: !check_permission(list),
-                            class: "form-control-xxx") %>
-          <%= link_to_object(list) %>
-        </div>
+        <%= check_box_with_label(form: f_l, field: :"id_#{list.id}",
+                                 checked: @list_checks[list.id],
+                                 disabled: !check_permission(list),
+                                 text: link_to_object(list)) %>
       <% end %>
     <% end %>
 

--- a/app/views/observations/form/_specimen_info.html.erb
+++ b/app/views/observations/form/_specimen_info.html.erb
@@ -6,11 +6,8 @@
 
 <div class="mt-3 row">
   <div class="col-xs-12 col-sm-6">
-    <div class="form-inline mb-3">
-      <%= f.check_box(:specimen, class: "form-control-xxx") %>
-      <%= f.label(:specimen,
-                  :form_observations_specimen_available.t) %>
-    </div>
+    <%= check_box_with_label(form: f, field: :specimen,
+                             text: :form_observations_specimen_available.t) %>
     <%= help_block_with_arrow("up") do %>
       <%= :form_observations_specimen_available_help.t %>
     <% end  # help_block_with_arrow do %>

--- a/app/views/observations/form/_when.html.erb
+++ b/app/views/observations/form/_when.html.erb
@@ -1,6 +1,5 @@
-<%
-# When section of create_observation form
-%>
+<%# When section of create_observation form %>
+
 <!-- WHEN -->
 <div class="container-text">
   <%= f.label(:when_li, :WHEN.t + ":") %>

--- a/app/views/observations/form/_where.html.erb
+++ b/app/views/observations/form/_where.html.erb
@@ -1,7 +1,5 @@
-<%
-# Where (location) section of create_observation form
-# including location autocomplete, map, lat/long/alt
-%>
+<%# Where (location) section of create_observation form
+    including location autocomplete, map, lat/long/alt %>
 
 <!-- WHERE_REASONS -->
 <% if @dubious_where_reasons.any? %>

--- a/app/views/observations/form/_where.html.erb
+++ b/app/views/observations/form/_where.html.erb
@@ -54,12 +54,8 @@
 <!-- IS_COLLECTION_LOCATION -->
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <div class="form-inline mb-3">
-      <%= f.check_box(:is_collection_location,
-                      class: "form-control-xxx") %>
-      <%= f.label(:is_collection_location,
-                  :form_observations_is_collection_location.t) %>
-    </div>
+    <%= check_box_with_label(form: f, field: :is_collection_location,
+                             text: :form_observations_is_collection_location.t) %>
     <%= help_block_with_arrow("up", id: "is_collection_location_help") do %>
       <%= :form_observations_is_collection_location_help.t %>
     <% end  # help_block_with_arrow do %>
@@ -108,11 +104,8 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-12">
-        <div class="form-inline">
-          <%= f.check_box(:gps_hidden, class: "form-control-xxx") %>
-          <%= f.label(:gps_hidden,
-                      :form_observations_gps_hidden.t) %>
-        </div>
+        <%= check_box_with_label(form: f, field: :gps_hidden,
+                                 text: :form_observations_gps_hidden.t) %>
       </div>
     </div><!--.row-->
   </div>

--- a/app/views/observations/images/form/_project.html.erb
+++ b/app/views/observations/images/form/_project.html.erb
@@ -1,7 +1,7 @@
 <%= fields_for(:project) do |f_p| %>
   <div class="text-nowrap">
     <%= check_box_with_label(form: f_p, field: :"id_#{project.id}",
-                             checked: @project_checks[list.id],
+                             checked: @project_checks[project.id],
                              disabled: @image.user != @user &&
                                !project.is_member?(@user),
                              text: link_to_object(project)) %>

--- a/app/views/observations/images/form/_project.html.erb
+++ b/app/views/observations/images/form/_project.html.erb
@@ -1,9 +1,9 @@
 <%= fields_for(:project) do |f_p| %>
   <div class="text-nowrap">
-    <%= f_p.check_box("id_#{project.id}",
-                      checked: @project_checks[project.id],
-                      disabled: @image.user != @user && !project.is_member?(@user),
-                      class: "form-control") %>
-    <%= f_p.label("id_#{project.id}", link_to_object(project)) %>
+    <%= check_box_with_label(form: f_p, field: :"id_#{project.id}",
+                             checked: @project_checks[list.id],
+                             disabled: @image.user != @user &&
+                               !project.is_member?(@user),
+                             text: link_to_object(project)) %>
   </div>
 <% end %>

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -10,7 +10,7 @@
   names = Name.suggest_alternate_spellings(@suggest_alternate_spellings)
   if names.any? %>
     <div class="alert-warning">
-      <div><%= :list_observations_suggestions.t %>:</div>
+      <%= content_tag(:p, "#{:list_observations_suggestions.t}:") %>
       <% names.sort_by(&:sort_name).each do |name| %>
         <div class="pl-3"><%=
           search = PatternSearch::Observation.new(name.text_name)

--- a/app/views/observations/namings/_fields.html.erb
+++ b/app/views/observations/namings/_fields.html.erb
@@ -66,7 +66,7 @@ locals = {
 
       <%= f_n.fields_for(:reasons) do |f_r| %>
         <% reasons.values.sort_by(&:order).each do |r| %>
-          <div class="form-group form-inline m-0">
+          <div class="checkbox">
             <%= f_r.label("#{r.num}_check",
                           { data: {
                               toggle: "collapse",

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -2110,7 +2110,7 @@ class ObservationsControllerTest < FunctionalTestCase
           license_id: licenses(:ccwiki30).id
         }
       },
-      log_change: { checked: "1" }
+      log_change: "1"
     }
     put_requires_user(
       :update,
@@ -2147,7 +2147,7 @@ class ObservationsControllerTest < FunctionalTestCase
         notes: obs.notes,
         specimen: obs.specimen
       },
-      log_change: { checked: "0" }
+      log_change: "0"
     }
     put_requires_user(
       :update,
@@ -2178,7 +2178,7 @@ class ObservationsControllerTest < FunctionalTestCase
         specimen: new_specimen,
         thumb_image_id: "0"
       },
-      log_change: { checked: "1" }
+      log_change: "1"
     }
     put_requires_user(
       :update,


### PR DESCRIPTION
This PR 
- implements the new form helpers
- switches to tag helpers where possible
- switches to a couple of unimplemented translation strings where text was untranslated
- straightens out some tangled field param nesting in Observation Notes
- adds comments