### PR TITLE
Delete redundant id param on User page

### DIFF
--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -3,12 +3,10 @@
 # Helpers for user view
 module UserStatsHelper
   def user_stats_links(user)
-    links = {}
-    user_stats_links_table(user).each do |key, controller, action, params|
-      links[key] = url_for(controller: controller, action: action,
-                           params: params)
+    user_stats_links_table(user).each_with_object({}) do |row, links|
+      links[row[0]] = url_for(controller: row[1], action: row[2],
+                              params: row[3])
     end
-    links
   end
 
   #########################################################

--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -5,11 +5,6 @@ module UserStatsHelper
   def user_stats_links(user)
     links = {}
     user_stats_links_table(user).each do |key, controller, action, params|
-      unless [key].intersect?([:location_description_authors,
-                               :name_description_authors])
-        params[:id] = user.id
-      end
-
       links[key] = url_for(controller: controller, action: action,
                            params: params)
     end
@@ -41,7 +36,7 @@ module UserStatsHelper
       [:names_versions, "/names", :index, { by_editor: user.id }],
       [:observations, "/observations", :index, { user: user.id }],
       [:species_lists, "/species_lists", :index, { by_user: user.id }],
-      [:life_list, "/checklists", :show, {}]
+      [:life_list, "/checklists", :show, { id: user.id }]
     ]
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -91,10 +91,16 @@ class UsersControllerTest < FunctionalTestCase
       "a[href = '#{name_descriptions_path}?by_author=#{user.id}']"
     )
     assert_select(
-      "#content a:match('href', ?)",
-      /\?.*=(\d+).*&id=\1/, # some param=nnn followed by id with same value
+      "a:match('href', ?)",
+      /\?.*=(\d+).*&id=\1/, # some param=n followed by id with same value
       false,
-      "Links should not repeat one param=value as id=value"
+      "Links should not use the same value for id and another param"
+    )
+    assert_select(
+      "a:match('href', ?)",
+      /\?.*id=(\d+).*&\S+=\1/, # id=n followed by another param with same value
+      false,
+      "Links should not use the same value for id and another param"
     )
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -90,6 +90,12 @@ class UsersControllerTest < FunctionalTestCase
     assert_select(
       "a[href = '#{name_descriptions_path}?by_author=#{user.id}']"
     )
+    assert_select(
+      "#content a:match('href', ?)",
+      /\?.*=(\d+).*&id=\1/, # some param=nnn followed by id with same value
+      false,
+      "Links should not repeat one param=value as id=value"
+    )
   end
 
   #   ---------------


### PR DESCRIPTION
- Deletes, on the user page, `id:` params which repeat other param's values.
Ex:
```ruby
https://mushroomobserver.org/locations/descriptions?by_editor=4468&id=4468
```
The `id=4468` is unnecessary and can create a query which later causes an index to display starting at the wrong index page.
- Delivers [Pivotal 184539899](https://www.pivotaltracker.com/story/show/184539899)

### Suggested Manual Test
- Go to any User page (/users/nnnn)
- Make sure the links work in the RH navbar and in the contributions area.
