### PR TITLE
Fix matrix_box locations

### DIFF
--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -27,7 +27,7 @@ if presenter
           <%= vote_or_propose_ui(identify, object) %>
         </div><!-- .rss-what -->
 
-        <% if presenter.where %>
+        <% if presenter.place_name %>
           <div class="rss-where">
             <%= content_tag(:small) do
               location_link(presenter.place_name, presenter.where)


### PR DESCRIPTION
Until my recent presenter/template refactor, `matrix_box` printed a location for observations whether they had a string "location", or an actual db `Location`.

I unintentionally changed it to only print a location if there is a db `Location`.  Reported by `excited_delirium` this morning.

This reverts the change.