### PR TITLE
Require login for observations/maps

### DIFF
--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -2,6 +2,8 @@
 
 module Observations
   class MapsController < ApplicationController
+    before_action :login_required
+
     # Map results of a search or index.
     def index
       show and return if params[:id].present?


### PR DESCRIPTION
- Restricts use of `observations/maps` to logged-in users.
- This avoids some anonymous requests that visibly affect website performance. 
This kind of request can be expensive. For instance:
>I, [2023-03-09T20:40:02.553167 #2516968]  INFO -- : Started GET "/observer/map_observations?q=1hN7q" for 174.250.192.4 
I, [2023-03-09T20:40:03.550769 #2516968]  INFO -- : Started GET "/observations/map" for 174.250.192.4 
W, [2023-03-09T20:40:03.582535 #2516968]  WARN -- : user=0 robot=N ip=174.250.192.4
W, [2023-03-09T20:40:33.290790 #2516968]  WARN -- : **TIME: 29.736066374** 200 observations/maps index user 174.250.192.4	https://mushroomobserver.org/observations/map	Mozilla/5.0 (Linux; Android 5.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.127 Safari/537.36

- Delivers [Pivotal 184667327](https://www.pivotaltracker.com/story/show/184667327)