### PR TITLE
SpeciesLists#show backward compatibility

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -976,6 +976,11 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # ----- Sequences: nonstandard legacy action redirects
   get("/sequence/list_sequences", to: redirect("/sequences?flavor=all"))
 
+  # ----- SpeciesLists: legacy action redirects
+  redirect_legacy_actions(
+    old_controller: "species_list", new_controller: "species_lists",
+    actions: [:show]
+  )
   # ----- Users: legacy action redirects  ----------------------------------
   get("/observer/user_search", to: redirect(path: "/users"))
   get("/observer/index_user/:id", to: redirect(path: "/users?id=%{id}"))

--- a/test/integration/rails-dom-testing/redirects_test.rb
+++ b/test/integration/rails-dom-testing/redirects_test.rb
@@ -155,4 +155,13 @@ class RedirectsTest < IntegrationTestCase
       :get, "/observer/lookup_name/#{name.id}", name_path(name.id)
     )
   end
+
+  # SpecisList/show  ---------------------------------
+  def test_show_species_list
+    spl = species_lists(:first_species_list)
+    login
+    assert_old_url_redirects_to_new_path(
+      :get, "/species_list/show_species_list//#{spl.id}", species_list_path(spl)
+    )
+  end
 end


### PR DESCRIPTION
- Redirects pre-CRUD show SpeciesList request to the current CRUDified url.
- Responds to a user complaint. See email from intersolar to webmaster:
>Bug Report: When I tried to open my species list for the genus Galerina (https://mushroomobserver.org/species_list/show_species_list/2026), the following error appeared:
The page you were looking for doesn't exist.
- Delivers [Pivotal 184671459](https://www.pivotaltracker.com/story/show/184671459)

### Manual Test
- Follow this link: https://mushroomobserver.org/species_list/show_species_list/2026
