### PR TITLE
Form submit button helper, more form consolidation

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -102,7 +102,7 @@ class SearchController < ApplicationController
 
   def add_applicable_filter_parameters(query_params, model)
     ContentFilter.by_model(model).each do |fltr|
-      query_params[fltr.sym] = params[:"content_filter_#{fltr.sym}"]
+      query_params[fltr.sym] = params.dig(:content_filter, :"#{fltr.sym}")
     end
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -38,11 +38,12 @@ module FormsHelper
     end
   end
 
-  def center_form_submit(**args)
+  # <%= centered_submit(form: f, button: button.t) %>
+  def centered_submit(**args)
     opts = args.except(:form, :button, :class)
     opts[:class] = "btn btn-default center-block my-3 #{args[:class]}"
 
-    form.submit(button.t, opts)
+    form.submit(button, opts)
   end
 
   # Bootstrap checkbox: form, field, (label) text, class,

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -40,6 +40,10 @@ module FormsHelper
 
   # <%= submit_button(form: f, button: button.t, center: true) %>
   def submit_button(**args)
+    unless args[:form].is_a?(ActionView::Helpers::FormBuilder)
+      return args[:button]
+    end
+
     opts = args.except(:form, :button, :class, :center)
     opts[:class] = "btn btn-default"
     opts[:class] += " center-block my-3" if args[:center] == true
@@ -74,7 +78,7 @@ module FormsHelper
     opts = args.except(:form, :field, :value, :text, :class)
 
     content_tag(:div, class: "radio #{args[:class]}") do
-      args[:form].label(args[:field]) do
+      args[:form].label("#{args[:field]}_#{args[:value]}") do
         concat(args[:form].radio_button(args[:field], args[:value], opts))
         concat(args[:text])
       end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -45,7 +45,7 @@ module FormsHelper
     opts[:class] += " center-block my-3" if args[:center] == true
     opts[:class] += " #{args[:class]}" if args[:class].present?
 
-    form.submit(button, opts)
+    args[:form].submit(args[:button], opts)
   end
 
   # Bootstrap checkbox: form, field, (label) text, class,

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -52,57 +52,61 @@ module FormsHelper
     args[:form].submit(args[:button], opts)
   end
 
-  # Bootstrap checkbox: form, field, (label) text, class,
+  # Bootstrap checkbox: form, field, label, class,
   # checkbox options: checked, value, disabled, data, etc.
   # NOTE: Only need to set `checked` if state not inferrable from db field name
   # (i.e. a model attribute of the form_with(@model))
   def check_box_with_label(**args)
-    opts = args.except(:form, :field, :text, :class)
+    opts = args.except(:form, :field, :label, :class)
 
     content_tag(:div, class: "checkbox #{args[:class]}") do
       args[:form].label(args[:field]) do
         concat(args[:form].check_box(args[:field], opts))
-        concat(args[:text])
+        concat(args[:label])
       end
     end
   end
 
   # convenience for account prefs: auto-populates label text arg
   def prefs_check_box_with_label(args)
-    args = args.merge({ text: :"prefs_#{args[:field]}".t })
+    args = args.merge({ label: :"prefs_#{args[:field]}".t })
     check_box_with_label(**args)
   end
 
-  # Bootstrap radio: form, field, value, (label) text, class, checked
+  # Bootstrap radio: form, field, value, label, class, checked
   def radio_with_label(**args)
-    opts = args.except(:form, :field, :value, :text, :class)
+    opts = args.except(:form, :field, :value, :label, :class)
 
     content_tag(:div, class: "radio #{args[:class]}") do
       args[:form].label("#{args[:field]}_#{args[:value]}") do
         concat(args[:form].radio_button(args[:field], args[:value], opts))
-        concat(args[:text])
+        concat(args[:label])
       end
     end
   end
 
-  # Bootstrap inline text_field: form, field, (label) text, class, checked
-  def inline_label_text_field(**args)
-    opts = args.except(:form, :field, :text, :class)
+  # Bootstrap inline text_field: form, field, label, class, checked
+  def text_field_with_label(**args)
+    opts = args.except(:form, :field, :label, :class, :inline)
     opts[:class] = "form-control"
 
-    content_tag(:div, class: "form-group form-inline #{args[:class]}") do
-      concat(args[:form].label(args[:field], args[:text], class: "mr-3"))
+    args[:class] += " form-inline" if args[:inline] == true
+
+    content_tag(:div, class: "form-group #{args[:class]}") do
+      concat(args[:form].label(args[:field], args[:label], class: "mr-3"))
       concat(args[:form].text_field(args[:field], opts))
     end
   end
 
-  # Bootstrap inline text_area: form, field, (label) text, class, checked
-  def inline_label_text_area(**args)
-    opts = args.except(:form, :field, :text, :class)
+  # Bootstrap inline text_area: form, field, label, class, checked
+  def text_area_with_label(**args)
+    opts = args.except(:form, :field, :label, :class, :inline)
     opts[:class] = "form-control"
 
-    content_tag(:div, class: "form-group form-inline #{args[:class]}") do
-      concat(args[:form].label(args[:field], args[:text], class: "mr-3"))
+    args[:class] += " form-inline" if args[:inline] == true
+
+    content_tag(:div, class: "form-group #{args[:class]}") do
+      concat(args[:form].label(args[:field], args[:label], class: "mr-3"))
       concat(args[:form].text_area(args[:field], opts))
     end
   end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -38,10 +38,12 @@ module FormsHelper
     end
   end
 
-  # <%= centered_submit(form: f, button: button.t) %>
-  def centered_submit(**args)
-    opts = args.except(:form, :button, :class)
-    opts[:class] = "btn btn-default center-block my-3 #{args[:class]}"
+  # <%= submit_button(form: f, button: button.t, center: true) %>
+  def submit_button(**args)
+    opts = args.except(:form, :button, :class, :center)
+    opts[:class] = "btn btn-default"
+    opts[:class] += " center-block my-3" if args[:center] == true
+    opts[:class] += " #{args[:class]}" if args[:class].present?
 
     form.submit(button, opts)
   end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -90,6 +90,7 @@ module FormsHelper
     opts = args.except(:form, :field, :label, :class, :inline)
     opts[:class] = "form-control"
 
+    args[:class] ||= ""
     args[:class] += " form-inline" if args[:inline] == true
 
     content_tag(:div, class: "form-group #{args[:class]}") do
@@ -103,6 +104,7 @@ module FormsHelper
     opts = args.except(:form, :field, :label, :class, :inline)
     opts[:class] = "form-control"
 
+    args[:class] ||= ""
     args[:class] += " form-inline" if args[:inline] == true
 
     content_tag(:div, class: "form-group #{args[:class]}") do

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -38,6 +38,13 @@ module FormsHelper
     end
   end
 
+  def center_form_submit(**args)
+    opts = args.except(:form, :button, :class)
+    opts[:class] = "btn btn-default center-block my-3 #{args[:class]}"
+
+    form.submit(button.t, opts)
+  end
+
   # Bootstrap checkbox: form, field, (label) text, class,
   # checkbox options: checked, value, disabled, data, etc.
   # NOTE: Only need to set `checked` if state not inferrable from db field name

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -16,7 +16,7 @@ module ObjectLinkHelper
   def where_string(where, count = nil)
     result = where.t
     result += " (#{count})" if count
-    content_tag(:span, result, class: "Data")
+    content_tag(:span, result)
   end
 
   # Wrap location name in link to show_location / observations/index.

--- a/app/views/account/api_keys/_existing_keys_form.html.erb
+++ b/app/views/account/api_keys/_existing_keys_form.html.erb
@@ -51,8 +51,7 @@
 
   </table>
 
-  <%= f.submit(:account_api_keys_remove_button.l,
-               id: "remove_button",
-               class: "btn btn-default center-block") %>
+  <%= centered_submit(form: f, button: :account_api_keys_remove_button.l,
+                      id: "remove_button") %>
 
 <% end %>

--- a/app/views/account/api_keys/_existing_keys_form.html.erb
+++ b/app/views/account/api_keys/_existing_keys_form.html.erb
@@ -51,7 +51,7 @@
 
   </table>
 
-  <%= centered_submit(form: f, button: :account_api_keys_remove_button.l,
-                      id: "remove_button") %>
+  <%= submit_button(form: f, button: :account_api_keys_remove_button.l,
+                    center: true, id: "remove_button") %>
 
 <% end %>

--- a/app/views/account/api_keys/_new_key_form.html.erb
+++ b/app/views/account/api_keys/_new_key_form.html.erb
@@ -6,7 +6,7 @@
     <%= f.text_field(:notes, class: "form-control") %>
   </div>
 
-  <%= f.submit(:account_api_keys_create_button.l, id: "create_button",
-                class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :account_api_keys_create_button.l,
+                      id: "create_button") %>
 
 <% end %>

--- a/app/views/account/api_keys/_new_key_form.html.erb
+++ b/app/views/account/api_keys/_new_key_form.html.erb
@@ -6,7 +6,7 @@
     <%= f.text_field(:notes, class: "form-control") %>
   </div>
 
-  <%= centered_submit(form: f, button: :account_api_keys_create_button.l,
-                      id: "create_button") %>
+  <%= submit_button(form: f, button: :account_api_keys_create_button.l,
+                    center: true, id: "create_button") %>
 
 <% end %>

--- a/app/views/account/api_keys/edit.html.erb
+++ b/app/views/account/api_keys/edit.html.erb
@@ -41,6 +41,6 @@
   <div class="text-center mt-3">
     <%= submit_button(form: f, button: :UPDATE.l) %>
     <span style="margin-left:5em"></span>
-    <%= submit_button(form: r, button: :CANCEL.l) %>
+    <%= submit_button(form: f, button: :CANCEL.l) %>
   </div><!-- .text-center -->
 <% end %>

--- a/app/views/account/api_keys/edit.html.erb
+++ b/app/views/account/api_keys/edit.html.erb
@@ -39,8 +39,8 @@
   </div>
 
   <div class="text-center mt-3">
-    <%= f.submit(:UPDATE.l, class: "btn btn-default") %>
+    <%= submit_button(form: f, button: :UPDATE.l) %>
     <span style="margin-left:5em"></span>
-    <%= f.submit(:CANCEL.l, class: "btn btn-default") %>
+    <%= submit_button(form: r, button: :CANCEL.l) %>
   </div><!-- .text-center -->
 <% end %>

--- a/app/views/account/login/email_new_password.html.erb
+++ b/app/views/account/login/email_new_password.html.erb
@@ -8,10 +8,12 @@
 
 <%= form_with(scope: :new_user, url: account_new_password_request_path,
               id: "account_email_new_password_form") do |f| %>
+
   <div class="form-group">
     <%= f.label(:login, :login_user.t + ":") %>
     <%= f.text_field(:login, data: { autofocus: true }) %>
   </div>
 
-  <%= f.submit(:SEND.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SEND.l) %>
+
 <% end %>

--- a/app/views/account/login/email_new_password.html.erb
+++ b/app/views/account/login/email_new_password.html.erb
@@ -14,6 +14,6 @@
     <%= f.text_field(:login, data: { autofocus: true }) %>
   </div>
 
-  <%= centered_submit(form: f, button: :SEND.l) %>
+  <%= submit_button(form: f, button: :SEND.l, center: true) %>
 
 <% end %>

--- a/app/views/account/login/new.html.erb
+++ b/app/views/account/login/new.html.erb
@@ -22,7 +22,7 @@
   <%= check_box_with_label(form: f, field: :remember_me, checked: @remember,
                            class: "mt-3", text: :login_remember_me.t) %>
 
-  <%= centered_submit(form: f, button: :login_login.l) %>
+  <%= submit_button(form: f, button: :login_login.l, center: true) %>
 
   <div class="form-group mt-3">
     <%= :login_forgot_password.tp %>

--- a/app/views/account/login/new.html.erb
+++ b/app/views/account/login/new.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <%= check_box_with_label(form: f, field: :remember_me, checked: @remember,
-                           class: "mt-3", text: :login_remember_me.t) %>
+                           class: "mt-3", label: :login_remember_me.t) %>
 
   <%= submit_button(form: f, button: :login_login.l, center: true) %>
 

--- a/app/views/account/login/new.html.erb
+++ b/app/views/account/login/new.html.erb
@@ -22,7 +22,7 @@
   <%= check_box_with_label(form: f, field: :remember_me, checked: @remember,
                            class: "mt-3", text: :login_remember_me.t) %>
 
-  <%= f.submit(:login_login.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :login_login.l) %>
 
   <div class="form-group mt-3">
     <%= :login_forgot_password.tp %>

--- a/app/views/account/new.html.erb
+++ b/app/views/account/new.html.erb
@@ -46,7 +46,6 @@
                   class: "form-control") %>
   </div>
 
-  <%= f.submit(:signup_button.l,
-               class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :signup_button.l) %>
 
 <% end %>

--- a/app/views/account/new.html.erb
+++ b/app/views/account/new.html.erb
@@ -46,6 +46,6 @@
                   class: "form-control") %>
   </div>
 
-  <%= centered_submit(form: f, button: :signup_button.l) %>
+  <%= submit_button(form: f, button: :signup_button.l, center: true) %>
 
 <% end %>

--- a/app/views/account/preferences/_appearance.html.erb
+++ b/app/views/account/preferences/_appearance.html.erb
@@ -64,4 +64,4 @@ image_sizes = options_for_select(
   <%= f.select(:image_size, image_sizes, {}, { class: "form-control" }) %>
 </div>
 
-<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+<%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>

--- a/app/views/account/preferences/_appearance.html.erb
+++ b/app/views/account/preferences/_appearance.html.erb
@@ -64,4 +64,4 @@ image_sizes = options_for_select(
   <%= f.select(:image_size, image_sizes, {}, { class: "form-control" }) %>
 </div>
 
-<%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>

--- a/app/views/account/preferences/_email.html.erb
+++ b/app/views/account/preferences/_email.html.erb
@@ -59,4 +59,4 @@
   <%= :prefs_email_note.tp %>
 </div>
 
-<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+<%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>

--- a/app/views/account/preferences/_email.html.erb
+++ b/app/views/account/preferences/_email.html.erb
@@ -59,4 +59,4 @@
   <%= :prefs_email_note.tp %>
 </div>
 
-<%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>

--- a/app/views/account/preferences/_filters.html.erb
+++ b/app/views/account/preferences/_filters.html.erb
@@ -21,4 +21,4 @@
 
 <% end %>
 
-<%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>

--- a/app/views/account/preferences/_filters.html.erb
+++ b/app/views/account/preferences/_filters.html.erb
@@ -21,4 +21,4 @@
 
 <% end %>
 
-<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+<%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>

--- a/app/views/account/preferences/_login.html.erb
+++ b/app/views/account/preferences/_login.html.erb
@@ -21,4 +21,4 @@
                           class: "form-control") %>
 </div>
 
-<%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>

--- a/app/views/account/preferences/_login.html.erb
+++ b/app/views/account/preferences/_login.html.erb
@@ -21,4 +21,4 @@
                           class: "form-control") %>
 </div>
 
-<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+<%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>

--- a/app/views/account/preferences/_notes.html.erb
+++ b/app/views/account/preferences/_notes.html.erb
@@ -7,4 +7,4 @@
   <%= f.text_area(:notes_template, rows: 1, class: "form-control") %>
 </div>
 
-<%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>

--- a/app/views/account/preferences/_notes.html.erb
+++ b/app/views/account/preferences/_notes.html.erb
@@ -7,4 +7,4 @@
   <%= f.text_area(:notes_template, rows: 1, class: "form-control") %>
 </div>
 
-<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+<%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>

--- a/app/views/account/preferences/_privacy.html.erb
+++ b/app/views/account/preferences/_privacy.html.erb
@@ -43,4 +43,4 @@ filename_values = [
                 { class: "form-control d-inline-block w-auto mr-3" }) %>
 </div>
 
-<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+<%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>

--- a/app/views/account/preferences/_privacy.html.erb
+++ b/app/views/account/preferences/_privacy.html.erb
@@ -37,7 +37,8 @@ filename_values = [
 
 <div class="form-group mt-3">
   <%= f.label(:license_id, :License.t + ":") %>
-  <%= content_tag(:span, "(#{:prefs_license_note.t})", class: "help-note") %>
+  <%= content_tag(:span, ["(", :prefs_license_note.t, ")"].safe_join,
+                  class: "help-note") %>
   <br/>
   <%= f.select(:license_id, @licenses, {},
                 { class: "form-control d-inline-block w-auto mr-3" }) %>

--- a/app/views/account/preferences/_privacy.html.erb
+++ b/app/views/account/preferences/_privacy.html.erb
@@ -12,7 +12,7 @@ end
 filename_values = [
   [:prefs_keep_image_filenames_toss.l, "toss"],
   [:prefs_keep_image_filenames_keep_but_hide.l, "keep_but_hide"],
-  [:prefs_keep_image_filenames_keep_and_show.l, "keep_and_show"]
+  [:prefs_keep_image_filenames_keep_and_show.l, "keep_and_show"],
 ]
 %>
 
@@ -37,7 +37,7 @@ filename_values = [
 
 <div class="form-group mt-3">
   <%= f.label(:license_id, :License.t + ":") %>
-  <%= content_tag(:span, "(#{:prefs_license_note.t} %>)", class: "help-note") %>
+  <%= content_tag(:span, "(#{:prefs_license_note.t})", class: "help-note") %>
   <br/>
   <%= f.select(:license_id, @licenses, {},
                 { class: "form-control d-inline-block w-auto mr-3" }) %>

--- a/app/views/account/preferences/_privacy.html.erb
+++ b/app/views/account/preferences/_privacy.html.erb
@@ -37,9 +37,10 @@ filename_values = [
 
 <div class="form-group mt-3">
   <%= f.label(:license_id, :License.t + ":") %>
-  <span class="help-note">(<%= :prefs_license_note.t %>)</span><br/>
+  <%= content_tag(:span, "(#{:prefs_license_note.t} %>)", class: "help-note") %>
+  <br/>
   <%= f.select(:license_id, @licenses, {},
                 { class: "form-control d-inline-block w-auto mr-3" }) %>
 </div>
 
-<%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+<%= centered_submit(form: f, button: :SAVE_EDITS.l) %>

--- a/app/views/account/preferences/filters/_checkbox.html.erb
+++ b/app/views/account/preferences/filters/_checkbox.html.erb
@@ -8,4 +8,4 @@ checked = if @user.content_filter[filter.sym] == filter.prefs_vals.first
 %>
 
 <%= check_box_with_label(form: form, field: :"#{filter.sym}", checked: checked,
-                         text: :"prefs_filters_#{filter.sym}".t) %>
+                         label: :"prefs_filters_#{filter.sym}".t) %>

--- a/app/views/account/profile/_form.html.erb
+++ b/app/views/account/profile/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: @user, url: account_profile_path,
               html: { multipart: true }, id: "account_profile_form") do |f| %>
 
-  <%= f.submit(:profile_button.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :profile_button.l) %>
 
   <div class="form-group mt-3">
     <%= f.label(:name, :profile_name.t + ":") %>
@@ -62,6 +62,6 @@
     <%= f.text_area(:mailing_address, rows: 5, class: "form-control") %>
   </div>
 
-  <%= f.button(:profile_button.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :profile_button.l) %>
 
 <% end %>

--- a/app/views/account/profile/_form.html.erb
+++ b/app/views/account/profile/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: @user, url: account_profile_path,
               html: { multipart: true }, id: "account_profile_form") do |f| %>
 
-  <%= centered_submit(form: f, button: :profile_button.l) %>
+  <%= submit_button(form: f, button: :profile_button.l, center: true) %>
 
   <div class="form-group mt-3">
     <%= f.label(:name, :profile_name.t + ":") %>
@@ -62,6 +62,6 @@
     <%= f.text_area(:mailing_address, rows: 5, class: "form-control") %>
   </div>
 
-  <%= centered_submit(form: f, button: :profile_button.l) %>
+  <%= submit_button(form: f, button: :profile_button.l, center: true) %>
 
 <% end %>

--- a/app/views/admin/add_user_to_group/new.html.erb
+++ b/app/views/admin/add_user_to_group/new.html.erb
@@ -15,6 +15,6 @@
     <%= f.text_field(:group_name, { value: "", class: "form-control" }) %>
   </div>
 
-  <%= f.submit(:ADD.t, class: "btn btn-default mt-3 center-block") %>
+  <%= centered_submit(form: f, button: :ADD.t) %>
 
 <% end %>

--- a/app/views/admin/add_user_to_group/new.html.erb
+++ b/app/views/admin/add_user_to_group/new.html.erb
@@ -15,6 +15,6 @@
     <%= f.text_field(:group_name, { value: "", class: "form-control" }) %>
   </div>
 
-  <%= centered_submit(form: f, button: :ADD.t) %>
+  <%= submit_button(form: f, button: :ADD.t, center: true) %>
 
 <% end %>

--- a/app/views/admin/banner/edit.html.erb
+++ b/app/views/admin/banner/edit.html.erb
@@ -6,6 +6,6 @@
   <%= f.text_area(:val, value: @val, rows: 5, id: "val",
                   class: "form-control") %>
 
-  <%= centered_submit(form: f, button: :SUBMIT.l) %>
+  <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
 
 <% end %>

--- a/app/views/admin/banner/edit.html.erb
+++ b/app/views/admin/banner/edit.html.erb
@@ -6,6 +6,6 @@
   <%= f.text_area(:val, value: @val, rows: 5, id: "val",
                   class: "form-control") %>
 
-  <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SUBMIT.l) %>
 
 <% end %>

--- a/app/views/admin/blocked_ips/edit.html.erb
+++ b/app/views/admin/blocked_ips/edit.html.erb
@@ -18,7 +18,7 @@
                            { value: "", size: 20,
                              data: { autofocus: true },
                              class: "form-control" }) %>
-          <%= f.submit(:ADD.l, class: "btn btn-default ml-3") %>
+          <%= submit_button(form: f, button: :ADD.l, class: "ml-3") %>
         </div>
       <% end %>
 
@@ -50,7 +50,7 @@
                            { value: "", size: 20,
                              data: { autofocus: true },
                              class: "form-control" }) %>
-          <%= f.submit(:ADD.l, class: "btn btn-default ml-3") %>
+          <%= submit_button(form: f, button: :ADD.l, class: "ml-3") %>
         </div>
       <% end %>
 

--- a/app/views/admin/donations/edit.html.erb
+++ b/app/views/admin/donations/edit.html.erb
@@ -13,7 +13,7 @@
 <%= form_with(url: admin_donations_path,
               id: "admin_review_donations_form", method: :patch) do |f| %>
 
-  <%= centered_submit(form: f, button: :review_donations_update.l) %>
+  <%= submit_button(form: f, button: :review_donations_update.l, center: true) %>
 
   <div class="text-center">
     <table class="table-striped table-review-donations mb-3 mt-3">
@@ -40,5 +40,5 @@
     </table>
   </div><!-- .text-center -->
 
-  <%= centered_submit(form: f, button: :review_donations_update.l) %>
+  <%= submit_button(form: f, button: :review_donations_update.l, center: true) %>
 <% end %>

--- a/app/views/admin/donations/edit.html.erb
+++ b/app/views/admin/donations/edit.html.erb
@@ -13,8 +13,7 @@
 <%= form_with(url: admin_donations_path,
               id: "admin_review_donations_form", method: :patch) do |f| %>
 
-  <%= f.submit(:review_donations_update.l,
-               class: "btn btn-default center-block") %>
+  <%= centered_submit(form: f, button: :review_donations_update.l) %>
 
   <div class="text-center">
     <table class="table-striped table-review-donations mb-3 mt-3">
@@ -41,6 +40,5 @@
     </table>
   </div><!-- .text-center -->
 
-  <%= f.submit(:review_donations_update.l,
-               class: "btn btn-default center-block") %>
+  <%= centered_submit(form: f, button: :review_donations_update.l) %>
 <% end %>

--- a/app/views/admin/donations/new.html.erb
+++ b/app/views/admin/donations/new.html.erb
@@ -24,7 +24,6 @@
   <%= inline_label_text_field(form: f, field: :email, size: 50,
                               text: "#{:EMAIL.t}:") %>
 
-  <%= f.submit(:create_donation_add.l,
-                  class: "btn btn-default center-block") %>
+  <%= centered_submit(form: f, button: :create_donation_add.l) %>
 
 <% end %>

--- a/app/views/admin/donations/new.html.erb
+++ b/app/views/admin/donations/new.html.erb
@@ -12,17 +12,17 @@
 <%= form_with(model: @donation, url: admin_donations_path,
               id: "admin_new_donations_form") do |f| %>
 
-  <%= inline_label_text_field(form: f, field: :amount, size: 7,
-                              text: "#{:confirm_amount.t}:") %>
+  <%= text_field_with_label(form: f, field: :amount, size: 7,
+                            label: "#{:confirm_amount.t}:", inline: true) %>
 
-  <%= inline_label_text_field(form: f, field: :who, size: 50,
-                              text: "#{:WHO.t}:") %>
+  <%= text_field_with_label(form: f, field: :who, size: 50,
+                            label: "#{:WHO.t}:", inline: true) %>
 
   <%= check_box_with_label(form: f, field: :anonymous,
-                            text: :donate_anonymous.t) %>
+                           label: :donate_anonymous.t) %>
 
-  <%= inline_label_text_field(form: f, field: :email, size: 50,
-                              text: "#{:EMAIL.t}:") %>
+  <%= text_field_with_label(form: f, field: :email, size: 50,
+                            label: "#{:EMAIL.t}:", inline: true) %>
 
   <%= submit_button(form: f, button: :create_donation_add.l, center: true) %>
 

--- a/app/views/admin/donations/new.html.erb
+++ b/app/views/admin/donations/new.html.erb
@@ -24,6 +24,6 @@
   <%= inline_label_text_field(form: f, field: :email, size: 50,
                               text: "#{:EMAIL.t}:") %>
 
-  <%= centered_submit(form: f, button: :create_donation_add.l) %>
+  <%= submit_button(form: f, button: :create_donation_add.l, center: true) %>
 
 <% end %>

--- a/app/views/admin/email/features/new.html.erb
+++ b/app/views/admin/email/features/new.html.erb
@@ -7,8 +7,10 @@
     <%= f.label(:content, "Feature Email:") %>
     <%= f.text_area(:content, rows: 20, class: "form-control") %>
 
-    <%= f.submit(:SEND.l, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SEND.l) %>
   <% end %>
 
-  <p>Users: <%= (@users.map { |u| u.login }).safe_join(", ") %></p>
+  <div class="form-group">
+    <%= "#{:USERS.l}:" + (@users.map { |u| u.login }).safe_join(", ") %>
+  </div>
 <% end %>

--- a/app/views/admin/email/features/new.html.erb
+++ b/app/views/admin/email/features/new.html.erb
@@ -7,7 +7,7 @@
     <%= f.label(:content, "Feature Email:") %>
     <%= f.text_area(:content, rows: 20, class: "form-control") %>
 
-    <%= centered_submit(form: f, button: :SEND.l) %>
+    <%= submit_button(form: f, button: :SEND.l, center: true) %>
   <% end %>
 
   <div class="form-group">

--- a/app/views/admin/session/edit.html.erb
+++ b/app/views/admin/session/edit.html.erb
@@ -15,6 +15,6 @@
                         class: "form-control" ) %><br/>
   <% turn_into_user_auto_completer(:id) %>
 
-  <%= centered_submit(form: f, button: :SUBMIT.t) %>
+  <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
 
 <% end %>

--- a/app/views/admin/session/edit.html.erb
+++ b/app/views/admin/session/edit.html.erb
@@ -8,13 +8,13 @@
 <%= form_with(url: admin_mode_path, class: "mt-3 pb-2", method: :put,
               id: "admin_switch_users_form") do |f| %>
 
-  <span class="text-larger"><%= :LOGIN_NAME.t %>:</span><!-- .text-larger --><br/>
+  <%= content_tag(:span, "#{:LOGIN_NAME.t}:", class: "text-larger") %><br/>
 
   <%= f.text_field(:id, value: @id, size: 40, id: "id",
                         data: { autofocus: true },
                         class: "form-control" ) %><br/>
   <% turn_into_user_auto_completer(:id) %>
 
-  <%= f.submit(:SUBMIT.t, class: "btn btn-default ml-3") %>
+  <%= centered_submit(form: f, button: :SUBMIT.t) %>
 
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -9,5 +9,5 @@
   <%= f.text_area(:val, value: h(@val), rows: 5,
                   class: "form-control mt-3") %>
 
-  <%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -9,5 +9,5 @@
   <%= f.text_area(:val, value: h(@val), rows: 5,
                   class: "form-control mt-3") %>
 
-  <%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+  <%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>
 <% end %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -15,6 +15,6 @@
     <p class="help-block"><%= :field_textile_link.t %></p>
   </div>
 
-  <%= f.submit(:SUBMIT.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SUBMIT.t) %>
 
 <% end %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -15,6 +15,6 @@
     <p class="help-block"><%= :field_textile_link.t %></p>
   </div>
 
-  <%= centered_submit(form: f, button: :SUBMIT.t) %>
+  <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
 
 <% end %>

--- a/app/views/authors/email_requests/new.html.erb
+++ b/app/views/authors/email_requests/new.html.erb
@@ -2,25 +2,25 @@
 
 <%= form_with(url: authors_email_requests_path(id: @object.id,
       type: @object.type_tag, q: get_query_param),
-      id: "authors_email_requests_form") do |form| %>
+      id: "authors_email_requests_form") do |f| %>
 
   <%= :author_request_note.tp %>
 
-  <%= fields_for(:email) do |f| %>
+  <%= fields_for(:email) do |f_e| %>
 
     <div class="form-group mt-3">
-      <%= f.label(:subject, :request_subject.t + ":") %>
-      <%= f.text_field(:subject, data: { autofocus: true },
+      <%= f_e.label(:subject, :request_subject.t + ":") %>
+      <%= f_e.text_field(:subject, data: { autofocus: true },
                       class: "form-control") %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.label(:content, :request_message.t + ":") %>
-      <%= f.text_area(:content, rows: 10, class: "form-control") %>
+      <%= f_e.label(:content, :request_message.t + ":") %>
+      <%= f_e.text_area(:content, rows: 10, class: "form-control") %>
     </div>
 
   <% end %>
 
-  <%= form.submit(:SEND.l, class: "btn btn-default") %>
+  <%= centered_submit(form: f, button: :SEND.l) %>
 
 <% end %>

--- a/app/views/authors/email_requests/new.html.erb
+++ b/app/views/authors/email_requests/new.html.erb
@@ -21,6 +21,6 @@
 
   <% end %>
 
-  <%= centered_submit(form: f, button: :SEND.l) %>
+  <%= submit_button(form: f, button: :SEND.l, center: true) %>
 
 <% end %>

--- a/app/views/collection_numbers/_form.html.erb
+++ b/app/views/collection_numbers/_form.html.erb
@@ -7,7 +7,7 @@ url_params = url_params.merge({ back: back }) if action == :update
 
 <%= form_with(model: @collection_number, url: url_params) do |f| %>
 
-  <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name.t) %>
 
   <% if @collection_number.observations.count > 1 %>
     <div class="alert alert-warning mt-3">
@@ -17,16 +17,16 @@ url_params = url_params.merge({ back: back }) if action == :update
 
   <div class="form-group mt-3">
     <%= f.label(:name, "#{:collection_number_name.t}:".html_safe) %>
-    <span class="help-note">(<%= :required.t %>)</span>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note") %>
     <%= f.text_field(:name, class: "form-control") %>
   </div>
 
   <div class="form-group mt-3">
     <%= f.label(:number, "#{:collection_number_number.t}:".html_safe) %>
-    <span class="help-note">(<%= :required.t %>)</span>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note") %>
     <%= f.text_field(:number, class:"form-control") %>
   </div>
 
-  <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name.t) %>
 
 <% end %>

--- a/app/views/collection_numbers/_form.html.erb
+++ b/app/views/collection_numbers/_form.html.erb
@@ -7,7 +7,7 @@ url_params = url_params.merge({ back: back }) if action == :update
 
 <%= form_with(model: @collection_number, url: url_params) do |f| %>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
   <% if @collection_number.observations.count > 1 %>
     <div class="alert alert-warning mt-3">
@@ -27,6 +27,6 @@ url_params = url_params.merge({ back: back }) if action == :update
     <%= f.text_field(:number, class:"form-control") %>
   </div>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -12,6 +12,7 @@ end
 <!--[form:comment]-->
 <%= form_with(model: @comment, url: url, id: "comment_form",
               local: local) do |f| %>
+
   <div class="form-group mt-3">
     <%= f.label(:summary, :form_comments_summary.t + ":") %>
     <%= f.text_field(:summary, size: 80, data: { autofocus: true },
@@ -24,6 +25,7 @@ end
     <%= render(partial: "shared/textilize_help") %>
   </div>
 
-  <%= f.submit(button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button) %>
+
 <% end %>
 <!--[eoform:comment]-->

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -25,7 +25,7 @@ end
     <%= render(partial: "shared/textilize_help") %>
   </div>
 
-  <%= centered_submit(form: f, button: button) %>
+  <%= submit_button(form: f, button: button, center: true) %>
 
 <% end %>
 <!--[eoform:comment]-->

--- a/app/views/descriptions/_form_merge.html.erb
+++ b/app/views/descriptions/_form_merge.html.erb
@@ -11,9 +11,10 @@ moves.reject!(&:is_misspelling?)
 
   <ul type="none">
     <% merges.each do |desc| %>
-      <li><%= radio_button_tag(:target, desc.id,
-                                merges.length == 1 && moves.length == 0) %>
-          <%= description_title(desc) %></li>
+      <li><%= radio_with_label(form: f, field: :target, value: desc.id,
+                               label: description_title(desc),
+                               checked: merges.length == 1 &&
+                                        moves.length == 0) %></li>
     <% end
     if merges.empty? %>
       <li><%= :merge_descriptions_no_others.t %></li>
@@ -23,7 +24,7 @@ moves.reject!(&:is_misspelling?)
   <% if merges.any? %>
     <%= check_box_with_label(form: f, field: :delete, value: "1",
                              checked: description.is_admin?(@user),
-                             text: :merge_descriptions_delete_after.t) %>
+                             label: :merge_descriptions_delete_after.t) %>
   <% end %>
 
   <% button = merges.any? ? :merge_descriptions_merge.l : nil

--- a/app/views/descriptions/_form_merge.html.erb
+++ b/app/views/descriptions/_form_merge.html.erb
@@ -28,7 +28,7 @@ moves.reject!(&:is_misspelling?)
 
   <% button = merges.any? ? :merge_descriptions_merge.l : nil
   if button %>
-    <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SUBMIT.l) %>
   <% end %>
 
 <% end %>

--- a/app/views/descriptions/_form_merge.html.erb
+++ b/app/views/descriptions/_form_merge.html.erb
@@ -9,17 +9,17 @@ moves.reject!(&:is_misspelling?)
   <%= content_tag(:h4, "#{:merge_descriptions_merge_header.t}:") %>
   <%= content_tag(:p, :merge_descriptions_merge_help.t, class: "help-note") %>
 
-  <ul type="none">
+  <div class="form-group">
     <% merges.each do |desc| %>
-      <li><%= radio_with_label(form: f, field: :target, value: desc.id,
+      <%= radio_with_label(form: f, field: :target, value: desc.id,
                                label: description_title(desc),
                                checked: merges.length == 1 &&
-                                        moves.length == 0) %></li>
+                                        moves.length == 0) %>
     <% end
     if merges.empty? %>
-      <li><%= :merge_descriptions_no_others.t %></li>
+      <%= content_tag(:p, :merge_descriptions_no_others.t) %>
     <% end %>
-  </ul>
+  </div>
 
   <% if merges.any? %>
     <%= check_box_with_label(form: f, field: :delete, value: "1",

--- a/app/views/descriptions/_form_merge.html.erb
+++ b/app/views/descriptions/_form_merge.html.erb
@@ -28,7 +28,7 @@ moves.reject!(&:is_misspelling?)
 
   <% button = merges.any? ? :merge_descriptions_merge.l : nil
   if button %>
-    <%= centered_submit(form: f, button: :SUBMIT.l) %>
+    <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
   <% end %>
 
 <% end %>

--- a/app/views/descriptions/_form_move.html.erb
+++ b/app/views/descriptions/_form_move.html.erb
@@ -26,7 +26,7 @@ moves.reject!(&:is_misspelling?)
 
   <% button = moves.any? ? :merge_descriptions_move.l : nil
   if button %>
-    <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SUBMIT.l) %>
   <% end %>
 
 <% end %>

--- a/app/views/descriptions/_form_move.html.erb
+++ b/app/views/descriptions/_form_move.html.erb
@@ -26,7 +26,7 @@ moves.reject!(&:is_misspelling?)
 
   <% button = moves.any? ? :merge_descriptions_move.l : nil
   if button %>
-    <%= centered_submit(form: f, button: :SUBMIT.l) %>
+    <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
   <% end %>
 
 <% end %>

--- a/app/views/descriptions/_form_move.html.erb
+++ b/app/views/descriptions/_form_move.html.erb
@@ -13,15 +13,16 @@ moves.reject!(&:is_misspelling?)
     <ul type="none">
       <% moves.sort_by.each do |name|
         [ (a.deprecated ? 1 : 0), a.sort_name, a.id ] %>
-        <li><%= radio_button_tag(:target, name.id,
-                  merges.length == 0 && moves.length == 1) %>
-            <%= name.display_name.t %></li>
+        <li><%= radio_with_label(form: f, field: :target, value: name.id,
+                                 label: name.display_name.t,
+                                 checked: merges.length == 0 &&
+                                          moves.length == 1) %></li>
       <% end %>
     </ul>
 
     <%= check_box_with_label(form: f, field: :delete, value: "1",
                              checked: description.is_admin?(@user),
-                             text: :merge_descriptions_delete_after.t) %>
+                             label: :merge_descriptions_delete_after.t) %>
   <% end %>
 
   <% button = moves.any? ? :merge_descriptions_move.l : nil

--- a/app/views/descriptions/_form_move.html.erb
+++ b/app/views/descriptions/_form_move.html.erb
@@ -10,15 +10,15 @@ moves.reject!(&:is_misspelling?)
   <%= content_tag(:p, :merge_descriptions_move_help.t, class: "help-note") %>
 
   <% if moves.any? %>
-    <ul type="none">
+    <div class="form-group">
       <% moves.sort_by.each do |name|
         [ (a.deprecated ? 1 : 0), a.sort_name, a.id ] %>
-        <li><%= radio_with_label(form: f, field: :target, value: name.id,
-                                 label: name.display_name.t,
-                                 checked: merges.length == 0 &&
-                                          moves.length == 1) %></li>
+        <%= radio_with_label(form: f, field: :target, value: name.id,
+                              label: name.display_name.t,
+                              checked: merges.length == 0 &&
+                                      moves.length == 1) %>
       <% end %>
-    </ul>
+    </div>
 
     <%= check_box_with_label(form: f, field: :delete, value: "1",
                              checked: description.is_admin?(@user),

--- a/app/views/descriptions/_form_permissions.html.erb
+++ b/app/views/descriptions/_form_permissions.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(url: action, method: :put,
               id: "description_permissions_form") do |f| %>
 
-  <%= centered_submit(form: f, button: :SUBMIT.l) %>
+  <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
 
   <table class="w-100 table-striped table-description-permissions">
     <thead>
@@ -109,6 +109,6 @@
     </tbody>
   </table>
 
-  <%= centered_submit(form: f, button: :SUBMIT.l) %>
+  <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
 
 <% end %>

--- a/app/views/descriptions/_form_permissions.html.erb
+++ b/app/views/descriptions/_form_permissions.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(url: action, method: :put,
               id: "description_permissions_form") do |f| %>
 
-  <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block my-3") %>
+  <%= centered_submit(form: f, button: :SUBMIT.l) %>
 
   <table class="w-100 table-striped table-description-permissions">
     <thead>
@@ -109,6 +109,6 @@
     </tbody>
   </table>
 
-  <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SUBMIT.l) %>
 
 <% end %>

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -13,6 +13,6 @@
 
   <%= yield f %>
 
-  <%= f.submit(:SAVE.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SAVE.t) %>
 
 <% end %>

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -13,6 +13,6 @@
 
   <%= yield f %>
 
-  <%= centered_submit(form: f, button: :SAVE.t) %>
+  <%= submit_button(form: f, button: :SAVE.t, center: true) %>
 
 <% end %>

--- a/app/views/herbaria/_form.html.erb
+++ b/app/views/herbaria/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: @herbarium, id: "herbarium_form") do |f| %>
 
-  <%= f.submit(button_name.t, class: %w[btn btn-default center-block mt-3]) %>
+  <%= centered_submit(form: f, button: button_name.t) %>
 
   <%= f.hidden_field :back, value: @back %>
   <%= f.hidden_field :q, value: get_query_param %>
@@ -89,6 +89,6 @@
     <%= f.text_area(:description, rows: 10, class: "form-control") %>
   </div>
 
-  <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name.t) %>
 
 <% end %>

--- a/app/views/herbaria/_form.html.erb
+++ b/app/views/herbaria/_form.html.erb
@@ -12,8 +12,8 @@
   </div>
 
   <% if in_admin_mode? %>
-    <%= inline_label_text_field(form: f, field: :personal_user_name,
-                                text: :edit_herbarium_admin_make_personal.t) %>
+    <%= text_field_with_label(form: f, field: :personal_user_name, inline: true,
+                              label: :edit_herbarium_admin_make_personal.t) %>
     <% turn_into_user_auto_completer(:herbarium_personal_user_name) %>
 
     <% if button_name != :CREATE %>
@@ -39,7 +39,7 @@
     <% if button_name == :CREATE || @herbarium.can_make_personal?(@user) %>
       <div class="form-group">
         <%= check_box_with_label(form: f, field: :personal,
-                                 text: :create_herbarium_personal.t) %>
+                                 label: :create_herbarium_personal.t) %>
         <%= help_block_with_arrow("up") do %>
           <%= :create_herbarium_personal_help.t(
                 name: @user.personal_herbarium_name
@@ -52,8 +52,8 @@
   <% if !@herbarium.personal_user_id %>
     <div class="form-group">
       <div class="form-inline">
-        <%= inline_label_text_field(form: f, field: :code, size: 8,
-                                    text: "#{:create_herbarium_code.t}:") %>
+        <%= text_field_with_label(form: f, field: :code, size: 8, inline: true,
+                                  label: "#{:create_herbarium_code.t}:") %>
         <%= content_tag(:span, "(#{:optional.t})", class: "help-note") %>
       </div>
       <%= help_block_with_arrow("up") do %>

--- a/app/views/herbaria/_form.html.erb
+++ b/app/views/herbaria/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: @herbarium, id: "herbarium_form") do |f| %>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
   <%= f.hidden_field :back, value: @back %>
   <%= f.hidden_field :q, value: get_query_param %>
@@ -89,6 +89,6 @@
     <%= f.text_area(:description, rows: 10, class: "form-control") %>
   </div>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
 <% end %>

--- a/app/views/herbaria/curator_requests/new.html.erb
+++ b/app/views/herbaria/curator_requests/new.html.erb
@@ -26,6 +26,6 @@
                     data: { autofocus: true }) %>
   </div>
 
-  <%= f.submit(:SEND.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SEND.l) %>
 
 <% end %>

--- a/app/views/herbaria/curator_requests/new.html.erb
+++ b/app/views/herbaria/curator_requests/new.html.erb
@@ -26,6 +26,6 @@
                     data: { autofocus: true }) %>
   </div>
 
-  <%= centered_submit(form: f, button: :SEND.l) %>
+  <%= submit_button(form: f, button: :SEND.l, center: true) %>
 
 <% end %>

--- a/app/views/herbaria/show.html.erb
+++ b/app/views/herbaria/show.html.erb
@@ -51,8 +51,8 @@
             <%= f.text_field(:add_curator, class: "form-control") %>
             <% turn_into_user_auto_completer(:add_curator) %>
             <label for="add_curator">
-              <%= f.submit(:show_herbarium_add_curator.t,
-                           class: "btn btn-default") %>
+              <%= submit_button(form: f,
+                                button: :show_herbarium_add_curator.t) %>
             </label>
           </div>
         <% end %>

--- a/app/views/herbarium_records/_form.html.erb
+++ b/app/views/herbarium_records/_form.html.erb
@@ -10,7 +10,7 @@ end
 <%= form_with(model: @herbarium_record, url: url_params,
               id: "herbarium_record_form") do |f| %>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
   <% if @herbarium_record.observations.count > 1 %>
     <div class="alert alert-warning">
@@ -49,6 +49,6 @@ end
     <%= f.text_area(:notes, class: "form-control", rows: 6) %>
   </div>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
 <% end %>

--- a/app/views/herbarium_records/_form.html.erb
+++ b/app/views/herbarium_records/_form.html.erb
@@ -10,7 +10,7 @@ end
 <%= form_with(model: @herbarium_record, url: url_params,
               id: "herbarium_record_form") do |f| %>
 
-  <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name.t) %>
 
   <% if @herbarium_record.observations.count > 1 %>
     <div class="alert alert-warning">
@@ -20,7 +20,7 @@ end
 
   <div class="form-group">
     <%= f.label(:herbarium_name, :NAME.t + ":") %>
-    <span class="help-note">(<%= :required.t %>)</span>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note ml-3") %>
     <%= f.text_field(:herbarium_name, class: "form-control") %>
     <% turn_into_herbarium_auto_completer(:herbarium_record_herbarium_name) %>
   </div>
@@ -28,7 +28,7 @@ end
   <div class="form-group">
     <%= f.label(:initial_det,
                 "#{:herbarium_record_initial_det.t}:".html_safe) %>
-    <span class="help-note">(<%= :optional.t %>)</span>
+    <%= content_tag(:span, "(#{:optional.t})", class: "help-note ml-3") %>
     <%= f.text_field(:initial_det, class:"form-control") %>
   </div>
 
@@ -36,7 +36,7 @@ end
     <%= f.label(:accession_number,
                 "#{:herbarium_record_accession_number.t}:".html_safe) %>
     <%= f.text_field(:accession_number, class:"form-control") %>
-    <span class="help-note">(<%= :required.t %>)</span>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note") %>
   </div>
 
   <%= help_block_with_arrow("up") do %>
@@ -45,10 +45,10 @@ end
 
   <div class="form-group">
     <%= f.label(:notes, :NOTES.t + ":") %>
-    <span class="help-note">(<%= :optional.t %>)</span>
+    <%= content_tag(:span, "(#{:optional.t})", class: "help-note ml-3") %>
     <%= f.text_area(:notes, class: "form-control", rows: 6) %>
   </div>
 
-  <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name.t) %>
 
 <% end %>

--- a/app/views/images/licenses/edit.html.erb
+++ b/app/views/images/licenses/edit.html.erb
@@ -52,7 +52,7 @@
               </td>
             </tr>
           <% end %>
-            
+
         <% end %>
       </tbody>
 
@@ -60,6 +60,5 @@
 
   </table>
 
-  <%= f.submit(:image_updater_update.l,
-               class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :image_updater_update.l) %>
 <% end %>

--- a/app/views/images/licenses/edit.html.erb
+++ b/app/views/images/licenses/edit.html.erb
@@ -60,5 +60,5 @@
 
   </table>
 
-  <%= centered_submit(form: f, button: :image_updater_update.l) %>
+  <%= submit_button(form: f, button: :image_updater_update.l, center: true) %>
 <% end %>

--- a/app/views/images/votes/anonymity/edit.html.erb
+++ b/app/views/images/votes/anonymity/edit.html.erb
@@ -13,9 +13,9 @@ form_action = {
   </div>
 
   <div class="mt-3">
-    <%= f.submit(:image_vote_anonymity_make_anonymous.l,
-                 class: "btn btn-default") %><br/>
-    <%= f.submit(:image_vote_anonymity_make_public.l,
-                 class: "btn btn-default") %><br/>
+    <%= submit_button(form: f,
+                      button: :image_vote_anonymity_make_anonymous.l) %><br/>
+    <%= submit_button(form: f,
+                      button: :image_vote_anonymity_make_public.l) %><br/>
   </div>
 <% end %>

--- a/app/views/layouts/search_bar/_search_form.html.erb
+++ b/app/views/layouts/search_bar/_search_form.html.erb
@@ -52,7 +52,7 @@ identify_page = controller.controller_name == "identify"
   <%= hidden_field_tag(:needs_id, true) if identify_page %>
 
   <div class="form-group text-nowrap">
-    <%= f.submit(:app_search.l, class: "btn btn-default mr-2") %>
+    <%= submit_button(form: f, button: :app_search.l, class: "mr-2") %>
   </div><!--.form-group-->
 
 <% end %>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -9,7 +9,7 @@
     <div class="row">
       <div class="col-md-8 col-lg-6">
 
-        <%= centered_submit(form: f, button: button.l) %>
+        <%= submit_button(form: f, button: button.l, center: true) %>
 
         <%= render(partial: "locations/form/admin_locked_field",
                    locals: { f: f }) %>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -9,7 +9,7 @@
     <div class="row">
       <div class="col-md-8 col-lg-6">
 
-        <%= f.submit(button.l, class: "btn btn-default center-block mt-3") %>
+        <%= centered_submit(form: f, button: button.l) %>
 
         <%= render(partial: "locations/form/admin_locked_field",
                    locals: { f: f }) %>

--- a/app/views/locations/descriptions/_form.html.erb
+++ b/app/views/locations/descriptions/_form.html.erb
@@ -5,7 +5,7 @@ presenter = LocationDescriptionFormPresenter.new(@description, @view, action)
 <%= form_with(scope: :description, url: presenter.url, method: presenter.method,
               id: "location_description_form") do |f| %>
 
-  <%= centered_submit(form: f, button: presenter.button) %>
+  <%= submit_button(form: f, button: presenter.button, center: true) %>
 
   <%= render(partial: "shared/fields_for_description", locals: { f: f }) %>
 
@@ -22,7 +22,7 @@ presenter = LocationDescriptionFormPresenter.new(@description, @view, action)
 
   <%= render(partial: "shared/textilize_help") %>
 
-  <%= centered_submit(form: f, button: presenter.button) %>
+  <%= submit_button(form: f, button: presenter.button, center: true) %>
 
   <% if (action == :update) && @merge %>
     <%= hidden_field_tag(:old_desc_id, @old_desc_id) %>

--- a/app/views/locations/descriptions/_form.html.erb
+++ b/app/views/locations/descriptions/_form.html.erb
@@ -5,7 +5,7 @@ presenter = LocationDescriptionFormPresenter.new(@description, @view, action)
 <%= form_with(scope: :description, url: presenter.url, method: presenter.method,
               id: "location_description_form") do |f| %>
 
-  <%= f.submit(presenter.button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: presenter.button) %>
 
   <%= render(partial: "shared/fields_for_description", locals: { f: f }) %>
 
@@ -22,7 +22,7 @@ presenter = LocationDescriptionFormPresenter.new(@description, @view, action)
 
   <%= render(partial: "shared/textilize_help") %>
 
-  <%= f.submit(presenter.button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: presenter.button) %>
 
   <% if (action == :update) && @merge %>
     <%= hidden_field_tag(:old_desc_id, @old_desc_id) %>

--- a/app/views/locations/form/_admin_locked_field.html.erb
+++ b/app/views/locations/form/_admin_locked_field.html.erb
@@ -1,4 +1,4 @@
 <% if in_admin_mode? %>
   <%= check_box_with_label(form: f, field: :locked, class: "mt-3",
-                           text: :form_locations_locked.t) %>
+                           label: :form_locations_locked.t) %>
 <% end %>

--- a/app/views/names/_form.html.erb
+++ b/app/views/names/_form.html.erb
@@ -11,14 +11,14 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
 
   <% if in_admin_mode? %>
     <%= check_box_with_label(form: f, field: :locked, class: "mt-3",
-                             text: :form_names_locked.t) %>
+                             label: :form_names_locked.t) %>
   <% end %>
 
   <% if !@name.locked || in_admin_mode? %>
     <div class="form-group mt-3">
-      <%= inline_label_text_field(form: f, field: :icn_id,
-                                  text: "#{:form_names_icn_id.t}:",
-                                  size: 8) %>
+      <%= text_field_with_label(form: f, field: :icn_id,
+                                label: "#{:form_names_icn_id.t}:",
+                                size: 8, inline: true) %>
       <%= content_tag(:p, :form_names_identifier_help.t, class: "help-block") %>
     </div>
 
@@ -35,16 +35,16 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
     </div>
 
     <div class="form-group pt-3">
-      <%= inline_label_text_field(form: f, field: :text_name,
-                                  text: "#{:form_names_text_name.t}:",
-                                  value: @name_string,
-                                  data: { autofocus: true }) %>
+      <%= text_field_with_label(form: f, field: :text_name,
+                                label: "#{:form_names_text_name.t}:",
+                                value: @name_string, inline: true,
+                                data: { autofocus: true }) %>
       <%= content_tag(:p, :form_names_text_name_help.t, class: "help-block") %>
     </div>
 
     <div class="form-group mt-3">
-      <%= inline_label_text_field(form: f, field: :author,
-                                  text: "#{:Authority.t}:") %>
+      <%= text_field_with_label(form: f, field: :author,
+                                label: "#{:Authority.t}:", inline: true) %>
       <%= content_tag(:p, :form_names_author_help.t, class: "help-block") %>
     </div>
 
@@ -65,8 +65,8 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
   <% end %>
 
   <div class="form-group mt-3">
-    <%= inline_label_text_field(form: f, field: :citation,
-                                text: "#{:Citation.t}:") %>
+    <%= text_field_with_label(form: f, field: :citation,
+                              label: "#{:Citation.t}:", inline: true) %>
     <%= content_tag(:p, class: "help-block") do
       concat(:form_names_citation_help.t)
       concat(:form_names_citation_textilize_note.t)
@@ -77,10 +77,11 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
     <div class="my-4 mx-0">
       <%= check_box_with_label(form: f, field: :misspelling,
                                checked: @misspelling,
-                               text: :form_names_misspelling.t) %>
-      <%= inline_label_text_field(form: f,
-            field: :correct_spelling, value: @correct_spelling,
-            text: "#{:form_names_misspelling_it_should_be.t}:") %>
+                               label: :form_names_misspelling.t) %>
+      <%= text_field_with_label(
+            form: f, field: :correct_spelling, value: @correct_spelling,
+            label: "#{:form_names_misspelling_it_should_be.t}:", inline: true
+          ) %>
       <%= content_tag(:p, :form_names_misspelling_note.t,
                       class: "help-block") %>
       <% turn_into_name_auto_completer(:name_correct_spelling,

--- a/app/views/names/_form.html.erb
+++ b/app/views/names/_form.html.erb
@@ -7,7 +7,7 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
 <!--[form:name]-->
 <%= form_with(model: @name, url: add_query_param(action)) do |f| %>
 
-  <%= f.submit(button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button) %>
 
   <% if in_admin_mode? %>
     <%= check_box_with_label(form: f, field: :locked, class: "mt-3",
@@ -94,7 +94,7 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
   <%= f.text_area(:notes, rows: 6, class: "form-control") %>
   <%= render(partial: "shared/textilize_help") %>
 
-  <%= f.submit(button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button) %>
 
 <% end %>
 <!--[eoform:name]-->

--- a/app/views/names/_form.html.erb
+++ b/app/views/names/_form.html.erb
@@ -7,7 +7,7 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
 <!--[form:name]-->
 <%= form_with(model: @name, url: add_query_param(action)) do |f| %>
 
-  <%= centered_submit(form: f, button: button) %>
+  <%= submit_button(form: f, button: button, center: true) %>
 
   <% if in_admin_mode? %>
     <%= check_box_with_label(form: f, field: :locked, class: "mt-3",
@@ -94,7 +94,7 @@ statuses = [[:ACCEPTED.t, false], [:DEPRECATED.t, true]]
   <%= f.text_area(:notes, rows: 6, class: "form-control") %>
   <%= render(partial: "shared/textilize_help") %>
 
-  <%= centered_submit(form: f, button: button) %>
+  <%= submit_button(form: f, button: button, center: true) %>
 
 <% end %>
 <!--[eoform:name]-->

--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -22,7 +22,7 @@
                       rows: 10, class: "form-control",
                       data: { autofocus: true }) %>
 
-    <%= f.submit(:SAVE.t, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SAVE.t) %>
 
   <% end %>
 

--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -22,7 +22,7 @@
                       rows: 10, class: "form-control",
                       data: { autofocus: true }) %>
 
-    <%= centered_submit(form: f, button: :SAVE.t) %>
+    <%= submit_button(form: f, button: :SAVE.t, center: true) %>
 
   <% end %>
 

--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -8,22 +8,19 @@
   rank = rank_as_lower_string(@name.rank)
   action = { controller: "/names/classification", action: :update,
              id: @name.id, q: get_query_param }
+  @container = :text
 %>
 
-<div class="mt-3 container-text">
+<%= form_with(url: action) do |f| %>
 
-  <%= form_with(url: action) do |f| %>
+  <%= label_tag(:classification, :"form_names_classification".t + ":") %>
+  <p class="help-block mt-0">
+    <%= :form_names_classification_help.l(rank: rank) %>
+  </p>
+  <%= text_area_tag(:classification, @name.classification,
+                    rows: 10, class: "form-control",
+                    data: { autofocus: true }) %>
 
-    <%= label_tag(:classification, :"form_names_classification".t + ":") %>
-    <p class="help-block mt-0">
-      <%= :form_names_classification_help.l(rank: rank) %>
-    </p>
-    <%= text_area_tag(:classification, @name.classification,
-                      rows: 10, class: "form-control",
-                      data: { autofocus: true }) %>
+  <%= submit_button(form: f, button: :SAVE.t, center: true) %>
 
-    <%= submit_button(form: f, button: :SAVE.t, center: true) %>
-
-  <% end %>
-
-</div><!--.container-text-->
+<% end %>

--- a/app/views/names/classification/inherit/new.html.erb
+++ b/app/views/names/classification/inherit/new.html.erb
@@ -27,7 +27,7 @@
     <%= text_field_tag(:parent, @parent_text_name,
                        class: "form-control", data: { autofocus: true }) %>
 
-    <%= f.submit(:SUBMIT.t, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SUBMIT.t) %>
 
   <% end %>
 

--- a/app/views/names/classification/inherit/new.html.erb
+++ b/app/views/names/classification/inherit/new.html.erb
@@ -7,30 +7,27 @@
   @tabsets = { right: draw_tab_set(tabs) }
   action = { controller: "/names/classification/inherit", action: :create,
              id: @name.id, q: get_query_param }
+  @container = :text
 %>
 
-<div class="mt-3 container-text">
+<%= form_with(url: action) do |f| %>
 
-  <%= form_with(url: action) do |f| %>
-
-    <% if @options %>
-      <div class="alert alert-warning">
-        <%= @message.tp %>
-        <% @options.each do |name| %>
-          <%= radio_with_label(form: f, field: :options, value: name.id,
-                               label: name.display_name.t) %>
-        <% end %>
-      </div>
-    <% end %>
-
-    <%= text_field_with_label(
-          form: f, field: :parent, value: @parent_text_name,
-          label: "#{:inherit_classification_parent_name.t}:",
-          data: { autofocus: true }, inline: true
-        ) %>
-
-    <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
-
+  <% if @options %>
+    <div class="alert alert-warning">
+      <%= @message.tp %>
+      <% @options.each do |name| %>
+        <%= radio_with_label(form: f, field: :options, value: name.id,
+                              label: name.display_name.t) %>
+      <% end %>
+    </div>
   <% end %>
 
-</div><!--.container-text-->
+  <%= text_field_with_label(
+        form: f, field: :parent, value: @parent_text_name,
+        label: "#{:inherit_classification_parent_name.t}:",
+        data: { autofocus: true }, inline: true
+      ) %>
+
+  <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
+
+<% end %>

--- a/app/views/names/classification/inherit/new.html.erb
+++ b/app/views/names/classification/inherit/new.html.erb
@@ -27,7 +27,7 @@
     <%= text_field_tag(:parent, @parent_text_name,
                        class: "form-control", data: { autofocus: true }) %>
 
-    <%= centered_submit(form: f, button: :SUBMIT.t) %>
+    <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
 
   <% end %>
 

--- a/app/views/names/classification/inherit/new.html.erb
+++ b/app/views/names/classification/inherit/new.html.erb
@@ -17,15 +17,17 @@
       <div class="alert alert-warning">
         <%= @message.tp %>
         <% @options.each do |name| %>
-          <%= radio_button_tag(:options, name.id) %>
-          <%= content_tag(:span, name.display_name.t) %><br/>
+          <%= radio_with_label(form: f, field: :options, value: name.id,
+                               label: name.display_name.t) %>
         <% end %>
       </div>
     <% end %>
 
-    <%= label_tag(:parent, :inherit_classification_parent_name.t + ":") %>
-    <%= text_field_tag(:parent, @parent_text_name,
-                       class: "form-control", data: { autofocus: true }) %>
+    <%= text_field_with_label(
+          form: f, field: :parent, value: @parent_text_name,
+          label: "#{:inherit_classification_parent_name.t}:",
+          data: { autofocus: true }, inline: true
+        ) %>
 
     <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
 

--- a/app/views/names/descriptions/_form.html.erb
+++ b/app/views/names/descriptions/_form.html.erb
@@ -3,7 +3,7 @@
               id: "name_description_form") do |f| %>
 
   <div class="container-text">
-    <%= f.submit(button.l, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: button.l) %>
 
     <%= render(partial: "shared/fields_for_description", locals: {f: f}) %>
 
@@ -20,7 +20,7 @@
       </div>
     <% end %>
 
-    <%= f.submit(button.l, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: button.l) %>
   </div><!--.container-text-->
 
   <% if (button == :SAVE_EDITS) && @merge %>

--- a/app/views/names/descriptions/_form.html.erb
+++ b/app/views/names/descriptions/_form.html.erb
@@ -3,7 +3,7 @@
               id: "name_description_form") do |f| %>
 
   <div class="container-text">
-    <%= centered_submit(form: f, button: button.l) %>
+    <%= submit_button(form: f, button: button.l, center: true) %>
 
     <%= render(partial: "shared/fields_for_description", locals: {f: f}) %>
 
@@ -20,7 +20,7 @@
       </div>
     <% end %>
 
-    <%= centered_submit(form: f, button: button.l) %>
+    <%= submit_button(form: f, button: button.l, center: true) %>
   </div><!--.container-text-->
 
   <% if (button == :SAVE_EDITS) && @merge %>

--- a/app/views/names/lifeforms/edit.html.erb
+++ b/app/views/names/lifeforms/edit.html.erb
@@ -22,7 +22,7 @@
           <%= checked = @name.lifeform.include?(" #{word} ")
           check_box_with_label(form: f, field: word, value: "1",
                                checked: checked, class: "mt-2",
-                               text: :"lifeform_#{word}".t) %>
+                               label: :"lifeform_#{word}".t) %>
         </td>
         <td class="container-text">
           <%= :"lifeform_help_#{word}".t %>

--- a/app/views/names/lifeforms/edit.html.erb
+++ b/app/views/names/lifeforms/edit.html.erb
@@ -31,6 +31,6 @@
     <% end %>
   </table>
 
-  <%= centered_submit(form: f, button: :SAVE.t) %>
+  <%= submit_button(form: f, button: :SAVE.t, center: true) %>
 
 <% end %>

--- a/app/views/names/lifeforms/edit.html.erb
+++ b/app/views/names/lifeforms/edit.html.erb
@@ -31,6 +31,6 @@
     <% end %>
   </table>
 
-  <%= f.submit(:SAVE.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SAVE.t) %>
 
 <% end %>

--- a/app/views/names/lifeforms/propagate/edit.html.erb
+++ b/app/views/names/lifeforms/propagate/edit.html.erb
@@ -49,6 +49,6 @@
     <% end %>
   </table>
 
-  <%= f.submit(:APPLY.t, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :APPLY.t) %>
 
 <% end %>

--- a/app/views/names/lifeforms/propagate/edit.html.erb
+++ b/app/views/names/lifeforms/propagate/edit.html.erb
@@ -49,6 +49,6 @@
     <% end %>
   </table>
 
-  <%= centered_submit(form: f, button: :APPLY.t) %>
+  <%= submit_button(form: f, button: :APPLY.t, center: true) %>
 
 <% end %>

--- a/app/views/names/lifeforms/propagate/edit.html.erb
+++ b/app/views/names/lifeforms/propagate/edit.html.erb
@@ -21,7 +21,7 @@
         <td>
           <%= check_box_with_label(form: f, field: :"add_#{word}",
                                    value: "1", checked: false,
-                                   text: :"lifeform_#{word}".t) %>
+                                   label: :"lifeform_#{word}".t) %>
         </td>
         <td class="container-text">
           <%= :"lifeform_help_#{word}".t %>
@@ -40,7 +40,7 @@
         <td>
           <%= check_box_with_label(form: f, field: :"remove_#{word}",
                                    value: "1", checked: false,
-                                   text: :"lifeform_#{word}".t) %>
+                                   label: :"lifeform_#{word}".t) %>
         </td>
         <td class="container-text">
           <%= :"lifeform_help_#{word}".t %>

--- a/app/views/names/synonyms/_fields_existing.html.erb
+++ b/app/views/names/synonyms/_fields_existing.html.erb
@@ -11,7 +11,7 @@
         <% if n != @name %>
           <%= check_box_with_label(form: fes, field: n.id,
                                    value: "1", checked: "0",
-                                   text: link_to(n.display_name.t,
+                                   label: link_to(n.display_name.t,
                                                  name_path(n.id))) %>
         <% end %>
       <% end %>

--- a/app/views/names/synonyms/_fields_members.html.erb
+++ b/app/views/names/synonyms/_fields_members.html.erb
@@ -16,7 +16,7 @@
 <div class="form-group">
   <%= check_box_with_label(form: f, field: :deprecate_all, value: "1",
                            checked: @deprecate_all && "checked",
-                           text: :form_synonyms_deprecate_synonyms.t) %>
+                           label: :form_synonyms_deprecate_synonyms.t) %>
   <%= content_tag(:p, :form_synonyms_deprecate_synonyms_help.t,
                   class: "help-block") %>
 </div>

--- a/app/views/names/synonyms/_fields_proposed.html.erb
+++ b/app/views/names/synonyms/_fields_proposed.html.erb
@@ -11,7 +11,7 @@
         <% unless current_synonyms.member?(n) %>
           <%= check_box_with_label(form: fps, field: n.id,
                                    value: "1", checked: "0",
-                                   text: link_to(n.display_name.t,
+                                   label: link_to(n.display_name.t,
                                                  name_path(n.id))) %>
         <% end %>
       <% end %>

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_with(url: action, id: "name_approve_synonym_form") do |f| %>
 
-  <%= centered_submit(form: f, button: :APPROVE.l) %>
+  <%= submit_button(form: f, button: :APPROVE.l, center: true) %>
 
   <% if @approved_names %>
     <%= check_box_with_label(form: f, field: :deprecate_others,

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_with(url: action, id: "name_approve_synonym_form") do |f| %>
 
-  <%= f.submit(:APPROVE.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :APPROVE.l) %>
 
   <% if @approved_names %>
     <%= check_box_with_label(form: f, field: :deprecate_others,

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -17,16 +17,16 @@
   <% if @approved_names %>
     <%= check_box_with_label(form: f, field: :deprecate_others,
                              checked: "checked",
-                             text: :name_approve_deprecate.t) %>
+                             label: :name_approve_deprecate.t) %>
     <% @approved_names.each do |n| %>
       <%= n.display_name.t %><br/>
     <% end %></p>
   <% end %>
   <%= content_tag(:div, :name_approve_deprecate_help.tp, class: "help-note") %>
 
-  <%= inline_label_text_area(form: f, field: :comment,
-                             text: "#{:name_approve_comments.t}:",
-                             cols: 80, rows: 5, data: { autofocus: true }) %>
+  <%= text_area_with_label(form: f, field: :comment, inline: true,
+                           label: "#{:name_approve_comments.t}:",
+                           cols: 80, rows: 5, data: { autofocus: true }) %>
   <%= content_tag(:div,
                   :name_approve_comments_help.tp(name: @name.display_name),
                   class: "help-note") %>

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -8,6 +8,15 @@
 
   action = { controller: "/names/synonyms/deprecate", action: :create,
              id: @name.id, approved_name: @what }
+
+  feedback_locals = {
+    button_name: :SUBMIT.l,
+    what: @what,
+    valid_names: @valid_names,
+    suggest_corrections: @suggest_corrections,
+    parent_deprecated: @parent_deprecated,
+    names: @names
+  }
 %>
 
 <%= form_with(url: action, id: "name_deprecate_synonym_form") do |f| %>
@@ -15,12 +24,7 @@
   <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
 
   <%= render(partial: "shared/form_name_feedback",
-             locals: { button_name: :SUBMIT.l,
-                       what: @what,
-                       valid_names: @valid_names,
-                       suggest_corrections: @suggest_corrections,
-                       parent_deprecated: @parent_deprecated,
-                       names: @names }) if @what.present? %>
+             locals: feedback_locals.merge({ f: f })) if @what.present? %>
 
   <%= text_field_with_label(form: f, field: :proposed_name, inline: true,
                             label: "#{:name_deprecate_preferred.t}:",

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_with(url: action, id: "name_deprecate_synonym_form") do |f| %>
 
-  <%= centered_submit(form: f, button: :SUBMIT.l) %>
+  <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
 
   <%= render(partial: "shared/form_name_feedback",
              locals: { button_name: :SUBMIT.l,

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_with(url: action, id: "name_deprecate_synonym_form") do |f| %>
 
-  <%= f.submit(:SUBMIT.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SUBMIT.l) %>
 
   <%= render(partial: "shared/form_name_feedback",
              locals: { button_name: :SUBMIT.l,

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -22,20 +22,20 @@
                        parent_deprecated: @parent_deprecated,
                        names: @names }) if @what.present? %>
 
-  <%= inline_label_text_field(form: f, field: :proposed_name,
-                              text: "#{:name_deprecate_preferred.t}:",
-                              value: @what, data: { autofocus: true }) %>
+  <%= text_field_with_label(form: f, field: :proposed_name, inline: true,
+                            label: "#{:name_deprecate_preferred.t}:",
+                            value: @what, data: { autofocus: true }) %>
   <%= content_tag(:div, :name_deprecate_preferred_help.tp,
                   class: "help-note") %>
   <% turn_into_name_auto_completer(:proposed_name, primer: Name.primer) %>
 
   <%= check_box_with_label(form: f, field: :is_misspelling,
                            checked: @misspelling,
-                           text: :form_names_misspelling.t) %>
+                           label: :form_names_misspelling.t) %>
 
-  <%= inline_label_text_area(form: f, field: :comment,
-                             text: "#{:name_deprecate_comments.t}:",
-                             value: @comment, cols: 80, rows: 5) %>
+  <%= text_area_with_label(form: f, field: :comment, inline: true,
+                           label: "#{:name_deprecate_comments.t}:",
+                           value: @comment, cols: 80, rows: 5) %>
   <%= content_tag(:div, class: "help-note") do
     concat(:name_deprecate_comments_help.tp(
              name: @name.display_name.chomp(".")

--- a/app/views/names/synonyms/edit.html.erb
+++ b/app/views/names/synonyms/edit.html.erb
@@ -30,7 +30,6 @@
     </div><!--.col-->
   </div><!--.row-->
 
-  <%= f.submit(:name_change_synonyms_submit.l,
-               class: "btn btn-default center-block") %>
+  <%= centered_submit(form: f, button: :name_change_synonyms_submit.l) %>
 
 <% end %>

--- a/app/views/names/synonyms/edit.html.erb
+++ b/app/views/names/synonyms/edit.html.erb
@@ -30,6 +30,6 @@
     </div><!--.col-->
   </div><!--.row-->
 
-  <%= centered_submit(form: f, button: :name_change_synonyms_submit.l) %>
+  <%= submit_button(form: f, button: :name_change_synonyms_submit.l, center: true) %>
 
 <% end %>

--- a/app/views/names/trackers/_form.html.erb
+++ b/app/views/names/trackers/_form.html.erb
@@ -7,10 +7,10 @@
 
   <div class="text-center my-3">
     <%= if @name_tracker
-      f.submit(:UPDATE.t, class: "btn btn-default") + " " +
-        f.submit(:DISABLE.t, class: "btn btn-default")
+      submit_button(form: f, button: :UPDATE.t) + " " +
+        submit_button(form: f, button: :DISABLE.t)
     else
-      f.submit(:ENABLE.t, class: "btn btn-default")
+      submit_button(form: f, button: :ENABLE.t)
     end %>
   </div><!-- .text-center -->
 

--- a/app/views/names/trackers/_form.html.erb
+++ b/app/views/names/trackers/_form.html.erb
@@ -16,7 +16,7 @@
 
   <%= fields_for(:name_tracker) do |fnt| %>
     <%= check_box_with_label(form: fnt, field: :note_template_enabled,
-                             class: "mt-5", text: :email_tracking_note.t) %>
+                             class: "mt-5", label: :email_tracking_note.t) %>
 
     <%= content_tag(:div, :email_tracking_note_help.t,
                     class: "help-note mt-2 mb-5") %>

--- a/app/views/observations/_form.html.erb
+++ b/app/views/observations/_form.html.erb
@@ -16,6 +16,7 @@
   <% if include_naming
     # note this is not a separate form! just fields
     naming_locals = {
+      f:            f,
       action:       action,
       button_name:  button_name,
       show_reasons: false,

--- a/app/views/observations/_form.html.erb
+++ b/app/views/observations/_form.html.erb
@@ -7,7 +7,7 @@
               multipart: true,
               id: "observation_form") do |f| %>
 
-  <%= centered_submit(form: f, button: button_name) %>
+  <%= submit_button(form: f, button: button_name, center: true) %>
 
   <%= render(partial: "observations/form/when", locals: { f: f }) %>
   <%= render(partial: "observations/form/where",
@@ -42,7 +42,7 @@
   <% ##########################################################################     %>
 
   <% if @projects.any? || @lists.any? %>
-    <%= centered_submit(form: f, button: button_name) %>
+    <%= submit_button(form: f, button: button_name, center: true) %>
   <% end %>
 
   <% if @projects.any? %>
@@ -53,7 +53,7 @@
     <%= render(partial: "observations/form/species_lists", locals: { f: f }) %>
   <% end %>
 
-  <%= centered_submit(form: f, button: button_name) %>
+  <%= submit_button(form: f, button: button_name, center: true) %>
 
   <% if logging_optional %>
     <%= check_box_with_label(form: f, field: :log_change, checked: "checked",

--- a/app/views/observations/_form.html.erb
+++ b/app/views/observations/_form.html.erb
@@ -7,7 +7,7 @@
               multipart: true,
               id: "observation_form") do |f| %>
 
-  <%= f.submit(button_name, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name) %>
 
   <%= render(partial: "observations/form/when", locals: { f: f }) %>
   <%= render(partial: "observations/form/where",
@@ -42,7 +42,7 @@
   <% ##########################################################################     %>
 
   <% if @projects.any? || @lists.any? %>
-    <%= f.submit(button_name, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: button_name) %>
   <% end %>
 
   <% if @projects.any? %>
@@ -53,7 +53,7 @@
     <%= render(partial: "observations/form/species_lists", locals: { f: f }) %>
   <% end %>
 
-  <%= f.submit(button_name, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button_name) %>
 
   <% if logging_optional %>
     <%= check_box_with_label(form: f, field: :log_change, checked: "checked",

--- a/app/views/observations/_form.html.erb
+++ b/app/views/observations/_form.html.erb
@@ -57,7 +57,7 @@
 
   <% if logging_optional %>
     <%= check_box_with_label(form: f, field: :log_change, checked: "checked",
-                             text: :form_observations_log_change.t) %>
+                             label: :form_observations_log_change.t) %>
   <% end %>
 
 <% end %><!--[/form:observation]-->

--- a/app/views/observations/downloads/_form.html.erb
+++ b/app/views/observations/downloads/_form.html.erb
@@ -9,56 +9,64 @@
   <p><%= :download_observations_format.t %>:</p>
   <ul type="none">
     <li>
-      <%= radio_button_tag(:format, :raw, @format == "raw") %>
-      <%= :download_observations_raw.t %>
+      <%= radio_with_label(form: f, field: :format, value: :raw,
+                           checked: (@format == "raw") && "checked",
+                           text: :download_observations_raw.t) %>
     </li>
     <li>
-      <%= radio_button_tag(:format, :adolf, @format == "adolf") %>
-      <%= :download_observations_adolf.t %>
+      <%= radio_with_label(form: f, field: :format, value: :adolf,
+                           checked: (@format == "adolf") && "checked",
+                           text: :download_observations_adolf.t) %>
     </li>
     <li>
-      <%= radio_button_tag(:format, :darwin, @format == "darwin") %>
-      <%= :download_observations_darwin.t %>
+      <%= radio_with_label(form: f, field: :format, value: :darwin,
+                           checked: (@format == "darwin") && "checked",
+                           text: :download_observations_darwin.t) %>
       (<%= link_to(:download_observations_what_is_this.t,
                    "http://rs.tdwg.org/dwc/index.htm",
                    target: "_new") %>)
     </li>
     <li>
-      <%= radio_button_tag(:format, :symbiota, @format == "symbiota") %>
-      <%= :download_observations_symbiota.t %>
+      <%= radio_with_label(form: f, field: :format, value: :symbiota,
+                           checked: (@format == "symbiota") && "checked",
+                           text: :download_observations_symbiota.t) %>
     </li>
     <li>
-      <%= radio_button_tag(:format, :fundis, @format == "fundis") %>
-      <%= :download_observations_fundis.t %>
+      <%= radio_with_label(form: f, field: :format, value: :fundis,
+                           checked: (@format == "fundis") && "checked",
+                           text: :download_observations_fundis.t) %>
     </li>
   </ul>
 
   <p><%= :download_observations_encoding.t %>:</p>
   <ul type="none">
     <li>
-      <%= radio_button_tag(:encoding, "ASCII", @encoding == "ASCII") %>
-      <%= :download_observations_ascii.t %>
+      <%= radio_with_label(form: f, field: :encoding, value: "ASCII",
+                           checked: (@encoding == "ASCII") && "checked",
+                           text: :download_observations_ascii.t) %>
     </li>
     <li>
-      <%= radio_button_tag(:encoding, "WINDOWS-1252",
-                           @encoding == "WINDOWS-1252") %>
-      <%= :download_observations_windows.t %>
+      <%= radio_with_label(form: f, field: :encoding, value: "WINDOWS-1252",
+                           checked: (@encoding == "WINDOWS-1252") && "checked",
+                           text: :download_observations_windows.t) %>
     </li>
     <li>
-      <%= radio_button_tag(:encoding, "UTF-8", @encoding == "UTF-8") %>
-      <%= :download_observations_utf8.t %>
+      <%= radio_with_label(form: f, field: :encoding, value: "UTF-8",
+                           checked: (@encoding == "UTF-8") && "checked",
+                           text: :download_observations_utf8.t) %>
     </li>
     <li>
-      <%= radio_button_tag(:encoding, "UTF-16", @encoding == "UTF-16") %>
-      <%= :download_observations_utf16.t %>
+      <%= radio_with_label(form: f, field: :encoding, value: "UTF-16",
+                           checked: (@encoding == "UTF-16") && "checked",
+                           text: :download_observations_utf16.t) %>
     </li>
   </ul>
 
-  <%= f.submit(:DOWNLOAD.l, class: "btn btn-default") %>
-  <%= f.submit(:CANCEL.l, class: "btn btn-default") %>
+  <%= submit_button(form: f, button: :DOWNLOAD.l) %>
+  <%= submit_button(form: f, button: :CANCEL.l) %>
 
-  <p class="mt-5"><%= :download_observations_print_labels_header.t %>:</p>
-  <%= f.submit(:download_observations_print_labels.l,
-               class: "btn btn-default") %>
+  <%= content_tag(:p, "#{:download_observations_print_labels_header.t}:"
+                  class: "mt-5") %>
+  <%= submit_button(form: f, button: :download_observations_print_labels.l) %>
 
 <% end %>

--- a/app/views/observations/downloads/_form.html.erb
+++ b/app/views/observations/downloads/_form.html.erb
@@ -7,65 +7,47 @@
   <h3 class="mt-5"><%= :species_list_download_header.t %>:</h3>
 
   <p><%= :download_observations_format.t %>:</p>
-  <ul type="none">
-    <li>
-      <%= radio_with_label(form: f, field: :format, value: :raw,
-                           checked: (@format == "raw") && "checked",
-                           label: :download_observations_raw.t) %>
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :format, value: :adolf,
-                           checked: (@format == "adolf") && "checked",
-                           label: :download_observations_adolf.t) %>
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :format, value: :darwin,
-                           checked: (@format == "darwin") && "checked",
-                           label: :download_observations_darwin.t) %>
-      (<%= link_to(:download_observations_what_is_this.t,
-                   "http://rs.tdwg.org/dwc/index.htm",
-                   target: "_new") %>)
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :format, value: :symbiota,
-                           checked: (@format == "symbiota") && "checked",
-                           label: :download_observations_symbiota.t) %>
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :format, value: :fundis,
-                           checked: (@format == "fundis") && "checked",
-                           label: :download_observations_fundis.t) %>
-    </li>
-  </ul>
+  <div class="form-group">
+    <%= radio_with_label(form: f, field: :format, value: :raw,
+                          checked: (@format == "raw") && "checked",
+                          label: :download_observations_raw.t) %>
+    <%= radio_with_label(form: f, field: :format, value: :adolf,
+                          checked: (@format == "adolf") && "checked",
+                          label: :download_observations_adolf.t) %>
+    <%= radio_with_label(form: f, field: :format, value: :darwin,
+                          checked: (@format == "darwin") && "checked",
+                          label: :download_observations_darwin.t) %>
+    (<%= link_to(:download_observations_what_is_this.t,
+                  "http://rs.tdwg.org/dwc/index.htm",
+                  target: "_new") %>)
+    <%= radio_with_label(form: f, field: :format, value: :symbiota,
+                          checked: (@format == "symbiota") && "checked",
+                          label: :download_observations_symbiota.t) %>
+    <%= radio_with_label(form: f, field: :format, value: :fundis,
+                          checked: (@format == "fundis") && "checked",
+                          label: :download_observations_fundis.t) %>
+  </div>
 
   <p><%= :download_observations_encoding.t %>:</p>
-  <ul type="none">
-    <li>
-      <%= radio_with_label(form: f, field: :encoding, value: "ASCII",
-                           checked: (@encoding == "ASCII") && "checked",
-                           label: :download_observations_ascii.t) %>
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :encoding, value: "WINDOWS-1252",
-                           checked: (@encoding == "WINDOWS-1252") && "checked",
-                           label: :download_observations_windows.t) %>
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :encoding, value: "UTF-8",
-                           checked: (@encoding == "UTF-8") && "checked",
-                           label: :download_observations_utf8.t) %>
-    </li>
-    <li>
-      <%= radio_with_label(form: f, field: :encoding, value: "UTF-16",
-                           checked: (@encoding == "UTF-16") && "checked",
-                           label: :download_observations_utf16.t) %>
-    </li>
-  </ul>
+  <div class="form-group">
+    <%= radio_with_label(form: f, field: :encoding, value: "ASCII",
+                          checked: (@encoding == "ASCII") && "checked",
+                          label: :download_observations_ascii.t) %>
+    <%= radio_with_label(form: f, field: :encoding, value: "WINDOWS-1252",
+                          checked: (@encoding == "WINDOWS-1252") && "checked",
+                          label: :download_observations_windows.t) %>
+    <%= radio_with_label(form: f, field: :encoding, value: "UTF-8",
+                          checked: (@encoding == "UTF-8") && "checked",
+                          label: :download_observations_utf8.t) %>
+    <%= radio_with_label(form: f, field: :encoding, value: "UTF-16",
+                          checked: (@encoding == "UTF-16") && "checked",
+                          label: :download_observations_utf16.t) %>
+  </div>
 
   <%= submit_button(form: f, button: :DOWNLOAD.l) %>
   <%= submit_button(form: f, button: :CANCEL.l) %>
 
-  <%= content_tag(:p, "#{:download_observations_print_labels_header.t}:"
+  <%= content_tag(:p, "#{:download_observations_print_labels_header.t}:",
                   class: "mt-5") %>
   <%= submit_button(form: f, button: :download_observations_print_labels.l) %>
 

--- a/app/views/observations/downloads/_form.html.erb
+++ b/app/views/observations/downloads/_form.html.erb
@@ -11,17 +11,17 @@
     <li>
       <%= radio_with_label(form: f, field: :format, value: :raw,
                            checked: (@format == "raw") && "checked",
-                           text: :download_observations_raw.t) %>
+                           label: :download_observations_raw.t) %>
     </li>
     <li>
       <%= radio_with_label(form: f, field: :format, value: :adolf,
                            checked: (@format == "adolf") && "checked",
-                           text: :download_observations_adolf.t) %>
+                           label: :download_observations_adolf.t) %>
     </li>
     <li>
       <%= radio_with_label(form: f, field: :format, value: :darwin,
                            checked: (@format == "darwin") && "checked",
-                           text: :download_observations_darwin.t) %>
+                           label: :download_observations_darwin.t) %>
       (<%= link_to(:download_observations_what_is_this.t,
                    "http://rs.tdwg.org/dwc/index.htm",
                    target: "_new") %>)
@@ -29,12 +29,12 @@
     <li>
       <%= radio_with_label(form: f, field: :format, value: :symbiota,
                            checked: (@format == "symbiota") && "checked",
-                           text: :download_observations_symbiota.t) %>
+                           label: :download_observations_symbiota.t) %>
     </li>
     <li>
       <%= radio_with_label(form: f, field: :format, value: :fundis,
                            checked: (@format == "fundis") && "checked",
-                           text: :download_observations_fundis.t) %>
+                           label: :download_observations_fundis.t) %>
     </li>
   </ul>
 
@@ -43,22 +43,22 @@
     <li>
       <%= radio_with_label(form: f, field: :encoding, value: "ASCII",
                            checked: (@encoding == "ASCII") && "checked",
-                           text: :download_observations_ascii.t) %>
+                           label: :download_observations_ascii.t) %>
     </li>
     <li>
       <%= radio_with_label(form: f, field: :encoding, value: "WINDOWS-1252",
                            checked: (@encoding == "WINDOWS-1252") && "checked",
-                           text: :download_observations_windows.t) %>
+                           label: :download_observations_windows.t) %>
     </li>
     <li>
       <%= radio_with_label(form: f, field: :encoding, value: "UTF-8",
                            checked: (@encoding == "UTF-8") && "checked",
-                           text: :download_observations_utf8.t) %>
+                           label: :download_observations_utf8.t) %>
     </li>
     <li>
       <%= radio_with_label(form: f, field: :encoding, value: "UTF-16",
                            checked: (@encoding == "UTF-16") && "checked",
-                           text: :download_observations_utf16.t) %>
+                           label: :download_observations_utf16.t) %>
     </li>
   </ul>
 

--- a/app/views/observations/form/_projects.html.erb
+++ b/app/views/observations/form/_projects.html.erb
@@ -15,7 +15,7 @@
                                  checked: @project_checks[project.id],
                                  disabled: @observation.user != @user &&
                                    !project.is_member?(@user),
-                                 text: link_to_object(project)) %>
+                                 label: link_to_object(project)) %>
       <% end %>
     <% end %>
 

--- a/app/views/observations/form/_species_lists.html.erb
+++ b/app/views/observations/form/_species_lists.html.erb
@@ -14,7 +14,7 @@
         <%= check_box_with_label(form: f_l, field: :"id_#{list.id}",
                                  checked: @list_checks[list.id],
                                  disabled: !check_permission(list),
-                                 text: link_to_object(list)) %>
+                                 label: link_to_object(list)) %>
       <% end %>
     <% end %>
 

--- a/app/views/observations/form/_specimen_info.html.erb
+++ b/app/views/observations/form/_specimen_info.html.erb
@@ -7,7 +7,7 @@
 <div class="mt-3 row">
   <div class="col-xs-12 col-sm-6">
     <%= check_box_with_label(form: f, field: :specimen,
-                             text: :form_observations_specimen_available.t) %>
+                             label: :form_observations_specimen_available.t) %>
     <%= help_block_with_arrow("up") do %>
       <%= :form_observations_specimen_available_help.t %>
     <% end  # help_block_with_arrow do %>

--- a/app/views/observations/form/_where.html.erb
+++ b/app/views/observations/form/_where.html.erb
@@ -45,8 +45,10 @@
 <!-- IS_COLLECTION_LOCATION -->
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <%= check_box_with_label(form: f, field: :is_collection_location,
-                             text: :form_observations_is_collection_location.t) %>
+    <%= check_box_with_label(
+          form: f, field: :is_collection_location,
+          label: :form_observations_is_collection_location.t
+        ) %>
     <%= help_block_with_arrow("up", id: "is_collection_location_help") do %>
       <%= :form_observations_is_collection_location_help.t %>
     <% end  # help_block_with_arrow do %>
@@ -96,7 +98,7 @@
       </div>
       <div class="col-xs-12 col-sm-12">
         <%= check_box_with_label(form: f, field: :gps_hidden,
-                                 text: :form_observations_gps_hidden.t) %>
+                                 label: :form_observations_gps_hidden.t) %>
       </div>
     </div><!--.row-->
   </div>

--- a/app/views/observations/images/edit.html.erb
+++ b/app/views/observations/images/edit.html.erb
@@ -16,7 +16,7 @@
   <div class="col-xs-12 col-sm-8 col-md-6 col-lg-4">
     <%= form_with(model: @image, url: form_action, method: :put) do |f| %>
 
-      <%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
+      <%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>
 
       <%= render(partial: "observations/images/form/fields_for_images",
                 locals: { f: f, leave_out_original_file_name: false }) %>

--- a/app/views/observations/images/edit.html.erb
+++ b/app/views/observations/images/edit.html.erb
@@ -16,7 +16,7 @@
   <div class="col-xs-12 col-sm-8 col-md-6 col-lg-4">
     <%= form_with(model: @image, url: form_action, method: :put) do |f| %>
 
-      <%= f.submit(:SAVE_EDITS.l, class: "btn btn-default center-block mt-3") %>
+      <%= centered_submit(form: f, button: :SAVE_EDITS.l) %>
 
       <%= render(partial: "observations/images/form/fields_for_images",
                 locals: { f: f, leave_out_original_file_name: false }) %>

--- a/app/views/observations/images/edit.html.erb
+++ b/app/views/observations/images/edit.html.erb
@@ -31,7 +31,7 @@
       <% end %>
 
       <div class="text-center mt-3 mb-5">
-        <%= f.submit(:SAVE_EDITS.l, class: "btn btn-default") %>
+        <%= submit_button(form: f, button: :SAVE_EDITS.l) %>
         <%= link_with_query(:cancel_and_show.t(type: :image),
                             image_path(@image.id),
                             { class: "btn btn-default" }) %>

--- a/app/views/observations/images/form/_project.html.erb
+++ b/app/views/observations/images/form/_project.html.erb
@@ -4,6 +4,6 @@
                              checked: @project_checks[project.id],
                              disabled: @image.user != @user &&
                                !project.is_member?(@user),
-                             text: link_to_object(project)) %>
+                             label: link_to_object(project)) %>
   </div>
 <% end %>

--- a/app/views/observations/images/new.html.erb
+++ b/app/views/observations/images/new.html.erb
@@ -19,7 +19,7 @@
 
   <div id="license-notice mt-3"><%= :image_add_warning.tp %></div>
 
-  <%= centered_submit(form: f, button: :image_add_upload.l) %>
+  <%= submit_button(form: f, button: :image_add_upload.l, center: true) %>
 
   <%= render(partial: "observations/images/form/fields_for_upload") %>
 
@@ -31,6 +31,6 @@
                collection: @projects) %>
   <% end %>
 
-  <%= centered_submit(form: f, button: :image_add_upload.l) %>
+  <%= submit_button(form: f, button: :image_add_upload.l, center: true) %>
 
 <% end %>

--- a/app/views/observations/images/new.html.erb
+++ b/app/views/observations/images/new.html.erb
@@ -19,8 +19,7 @@
 
   <div id="license-notice mt-3"><%= :image_add_warning.tp %></div>
 
-  <%= f.submit(:image_add_upload.l,
-               class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :image_add_upload.l) %>
 
   <%= render(partial: "observations/images/form/fields_for_upload") %>
 
@@ -28,10 +27,10 @@
              locals: { f: f, leave_out_original_file_name: true }) %>
 
   <% if @projects.any? %>
-    <%= render(partial: "observations/images/form/project", 
+    <%= render(partial: "observations/images/form/project",
                collection: @projects) %>
   <% end %>
 
-  <%= f.submit(:image_add_upload.l,
-               class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :image_add_upload.l) %>
+
 <% end %>

--- a/app/views/observations/namings/_fields.html.erb
+++ b/app/views/observations/namings/_fields.html.erb
@@ -14,7 +14,8 @@ unfocused ||= false
 focus_on_name = !unfocused && (button_name != :CREATE.l || what.empty?)
 focus_on_vote = !unfocused && (button_name == :CREATE.l && what.present?)
 
-locals = {
+feedback_locals = {
+  f: f,
   button_name: button_name,
   what: what,
   valid_names: valid_names,
@@ -27,7 +28,7 @@ locals = {
 <div class="row">
   <div class="col-xs-12 col-sm-6">
     <%= render(partial: "shared/form_name_feedback",
-               locals: locals) if what.present? %>
+               locals: feedback_locals) if what.present? %>
   </div>
 </div><!--.row-->
 

--- a/app/views/observations/namings/_form.html.erb
+++ b/app/views/observations/namings/_form.html.erb
@@ -20,7 +20,7 @@ end
 <%= form_with(model: @naming, url: url, method: method, local: local,
               id: "naming_form") do |f| %>
 
-  <%= f.submit(button_name, class: "btn btn-default center-block mt-5") %>
+  <%= centered_submit(form: f, button: button_name) %>
 
   <%= render(partial: "observations/namings/fields",
              locals: { action: action, button_name: button_name,

--- a/app/views/observations/namings/_form.html.erb
+++ b/app/views/observations/namings/_form.html.erb
@@ -23,7 +23,7 @@ end
   <%= submit_button(form: f, button: button_name, center: true) %>
 
   <%= render(partial: "observations/namings/fields",
-             locals: { action: action, button_name: button_name,
+             locals: { f: f, action: action, button_name: button_name,
                        show_reasons: true }) %>
 
 <% end # form %>

--- a/app/views/observations/namings/_form.html.erb
+++ b/app/views/observations/namings/_form.html.erb
@@ -20,7 +20,7 @@ end
 <%= form_with(model: @naming, url: url, method: method, local: local,
               id: "naming_form") do |f| %>
 
-  <%= centered_submit(form: f, button: button_name) %>
+  <%= submit_button(form: f, button: button_name, center: true) %>
 
   <%= render(partial: "observations/namings/fields",
              locals: { action: action, button_name: button_name,

--- a/app/views/observations/namings/votes/_form.html.erb
+++ b/app/views/observations/namings/votes/_form.html.erb
@@ -23,7 +23,7 @@ end
                     data: { role: "change_vote", id: naming.id } }) %>
   <% end %>
 
-  <%= f.submit(:show_namings_cast.l, class: "btn btn-default w-100",
-               data: { role: "save_vote" }) %>
+  <%= submit_button(form: f, button: :show_namings_cast.l, class: "w-100",
+                    data: { role: "save_vote" }) %>
 
 <% end %>

--- a/app/views/observations/namings/votes/_form.html.erb
+++ b/app/views/observations/namings/votes/_form.html.erb
@@ -14,12 +14,16 @@ end
 <%= form_with(url: naming_vote_path(naming_id: naming.id), method: :patch,
               local: false, id: "naming_vote_#{naming.id}",
               class: "naming-vote-form") do |f| %>
+
   <%= fields_for(:vote) do |fv| %>
+
     <%= fv.select(:value, menu, {},
                   { class: "form-control w-100",
                     onchange: "Rails.fire(this.closest('form'), 'submit')",
                     data: { role: "change_vote", id: naming.id } }) %>
   <% end %>
+
   <%= f.submit(:show_namings_cast.l, class: "btn btn-default w-100",
                data: { role: "save_vote" }) %>
+
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: @project, id: "project_form") do |f| %>
 
-  <%= f.submit(button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button) %>
 
   <div class="form-group mt-3">
     <%= f.label(:title, :form_projects_title.t + ":") %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: @project, id: "project_form") do |f| %>
 
-  <%= centered_submit(form: f, button: button) %>
+  <%= submit_button(form: f, button: button, center: true) %>
 
   <div class="form-group mt-3">
     <%= f.label(:title, :form_projects_title.t + ":") %>

--- a/app/views/projects/admin_requests/new.html.erb
+++ b/app/views/projects/admin_requests/new.html.erb
@@ -20,6 +20,6 @@
     <%= f.text_area(:content, rows: 5, class: "form-control") %>
   </div>
 
-  <%= centered_submit(form: f, button: :SEND.l) %>
+  <%= submit_button(form: f, button: :SEND.l, center: true) %>
 
 <% end %>

--- a/app/views/projects/admin_requests/new.html.erb
+++ b/app/views/projects/admin_requests/new.html.erb
@@ -20,6 +20,6 @@
     <%= f.text_area(:content, rows: 5, class: "form-control") %>
   </div>
 
-  <%= f.submit(:SEND.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :SEND.l) %>
 
 <% end %>

--- a/app/views/projects/members/edit.html.erb
+++ b/app/views/projects/members/edit.html.erb
@@ -28,7 +28,7 @@
   </div>
 
   <div class="form-group mt-3">
-    <%= submit_button(form: f, button: :change_member_status_remove_member.l
+    <%= submit_button(form: f, button: :change_member_status_remove_member.l,
                       center: true) %>
     <%= :change_member_status_remove_member_help.t %>
   </div>

--- a/app/views/projects/members/edit.html.erb
+++ b/app/views/projects/members/edit.html.erb
@@ -22,7 +22,7 @@
 
 <%= form_with(url: action, method: :patch, id: "project_member_form") do |f| %>
   <div class="form-group mt-3">
-    <%= centered_submit(form: f, button: :change_member_status_make_member.l) %>
+    <%= submit_button(form: f, button: :change_member_status_make_member.l, center: true) %>
     <%= :change_member_status_make_member_help.t %>
   </div>
 
@@ -33,7 +33,7 @@
   </div>
 
   <div class="form-group mt-3">
-    <%= centered_submit(form: f, button: :change_member_status_make_admin.l) %>
+    <%= submit_button(form: f, button: :change_member_status_make_admin.l, center: true) %>
     <%= :change_member_status_make_admin_help.t %>
   </div>
 <% end %>

--- a/app/views/projects/members/edit.html.erb
+++ b/app/views/projects/members/edit.html.erb
@@ -22,18 +22,20 @@
 
 <%= form_with(url: action, method: :patch, id: "project_member_form") do |f| %>
   <div class="form-group mt-3">
-    <%= submit_button(form: f, button: :change_member_status_make_member.l, center: true) %>
+    <%= submit_button(form: f, button: :change_member_status_make_member.l,
+                      center: true) %>
     <%= :change_member_status_make_member_help.t %>
   </div>
 
   <div class="form-group mt-3">
-    <%= centered_submit(form: f,
-                        button: :change_member_status_remove_member.l) %>
+    <%= submit_button(form: f, button: :change_member_status_remove_member.l
+                      center: true) %>
     <%= :change_member_status_remove_member_help.t %>
   </div>
 
   <div class="form-group mt-3">
-    <%= submit_button(form: f, button: :change_member_status_make_admin.l, center: true) %>
+    <%= submit_button(form: f, button: :change_member_status_make_admin.l,
+                      center: true) %>
     <%= :change_member_status_make_admin_help.t %>
   </div>
 <% end %>

--- a/app/views/projects/members/edit.html.erb
+++ b/app/views/projects/members/edit.html.erb
@@ -22,20 +22,18 @@
 
 <%= form_with(url: action, method: :patch, id: "project_member_form") do |f| %>
   <div class="form-group mt-3">
-    <%= f.submit(:change_member_status_make_member.l,
-                 class: "btn btn-default center-block mb-3") %>
+    <%= centered_submit(form: f, button: :change_member_status_make_member.l) %>
     <%= :change_member_status_make_member_help.t %>
   </div>
 
   <div class="form-group mt-3">
-    <%= f.submit(:change_member_status_remove_member.l,
-                 class: "btn btn-default center-block mb-3") %>
+    <%= centered_submit(form: f,
+                        button: :change_member_status_remove_member.l) %>
     <%= :change_member_status_remove_member_help.t %>
   </div>
 
   <div class="form-group mt-3">
-    <%= f.submit(:change_member_status_make_admin.l,
-                 class: "btn btn-default center-block mb-3") %>
+    <%= centered_submit(form: f, button: :change_member_status_make_admin.l) %>
     <%= :change_member_status_make_admin_help.t %>
   </div>
 <% end %>

--- a/app/views/projects/members/new.html.erb
+++ b/app/views/projects/members/new.html.erb
@@ -23,7 +23,7 @@
                                                class: "form-control") %><br/>
     <% turn_into_user_auto_completer(:candidate) %>
 
-    <%= f.submit(:ADD.t, class: "btn btn-default ml-3") %>
+    <%= submit_button(form: f, button: :ADD.t, class: "ml-3") %>
 
   <% end %>
 

--- a/app/views/publications/_form.html.erb
+++ b/app/views/publications/_form.html.erb
@@ -27,6 +27,6 @@ button = (action == :create) ? :CREATE.t : :SAVE.t
   <%= check_box_with_label(form: f, field: :mo_mentioned,
                           text: :publication_mo_mentioned.t) %>
 
-  <%= centered_submit(form: f, button: button) %>
+  <%= submit_button(form: f, button: button, center: true) %>
 
 <% end %>

--- a/app/views/publications/_form.html.erb
+++ b/app/views/publications/_form.html.erb
@@ -17,7 +17,7 @@ button = (action == :create) ? :CREATE.t : :SAVE.t
   </div>
 
   <%= check_box_with_label(form: f, field: :peer_reviewed,
-                          text: :publication_peer_reviewed.t) %>
+                           label: :publication_peer_reviewed.t) %>
 
   <div class="form-group mt-3">
     <%= f.label(:how_helped, :publication_how_helped.t) %>
@@ -25,7 +25,7 @@ button = (action == :create) ? :CREATE.t : :SAVE.t
   </div>
 
   <%= check_box_with_label(form: f, field: :mo_mentioned,
-                          text: :publication_mo_mentioned.t) %>
+                           label: :publication_mo_mentioned.t) %>
 
   <%= submit_button(form: f, button: button, center: true) %>
 

--- a/app/views/publications/_form.html.erb
+++ b/app/views/publications/_form.html.erb
@@ -27,6 +27,6 @@ button = (action == :create) ? :CREATE.t : :SAVE.t
   <%= check_box_with_label(form: f, field: :mo_mentioned,
                           text: :publication_mo_mentioned.t) %>
 
-  <%= f.submit(button, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button) %>
 
 <% end %>

--- a/app/views/search/_advanced_search_filter_radio_buttons.html.erb
+++ b/app/views/search/_advanced_search_filter_radio_buttons.html.erb
@@ -10,6 +10,6 @@
 
 <% checked = @filter_defaults[filter.sym].to_s == filter.off_val.to_s %>
 <%= radio_with_label(
-      form: f, field: :"#{filter.sym}", value: "off", checked: checked,
+      form: f, field: :"#{filter.sym}", value: "", checked: checked,
       label: :"advanced_search_filter_#{filter.sym}_off".l
     ) %>

--- a/app/views/search/_advanced_search_filter_radio_buttons.html.erb
+++ b/app/views/search/_advanced_search_filter_radio_buttons.html.erb
@@ -1,10 +1,15 @@
 <%= :"advanced_search_filter_#{filter.sym}".t %>.<br/>
+
 <% filter.on_vals.each do |val| %>
-  <%= checked = @filter_defaults[filter.sym].to_s == val.to_s
-      radio_button_tag(:"content_filter_#{filter.sym}", val, checked) %>
-  <%= :"advanced_search_filter_#{filter.sym}_#{val}".l %>.<br/>
+  <% checked = @filter_defaults[filter.sym].to_s == val.to_s %>
+  <%= radio_with_label(
+        form: f, field: :"#{filter.sym}", value: val, checked: checked,
+        label: :"advanced_search_filter_#{filter.sym}_#{val}".l
+      ) %>
 <% end %>
-<%= checked = @filter_defaults[filter.sym].to_s == filter.off_val.to_s
-    radio_button_tag(:"content_filter_#{filter.sym}", "", checked) %>
-<%= :"advanced_search_filter_#{filter.sym}_off".l %>.<br/>
-<br/>
+
+<% checked = @filter_defaults[filter.sym].to_s == filter.off_val.to_s %>
+<%= radio_with_label(
+      form: f, field: :"#{filter.sym}", value: "off", checked: checked,
+      label: :"advanced_search_filter_#{filter.sym}_off".l
+    ) %>

--- a/app/views/search/_advanced_search_filter_text_field.html.erb
+++ b/app/views/search/_advanced_search_filter_text_field.html.erb
@@ -1,4 +1,5 @@
 <%= :"advanced_search_filter_#{filter.sym}".t %>.<br/>
-<%= text_field_tag(:"content_filter_#{filter.sym}",
-                   @filter_defaults[filter.sym]) %><br/>
+<%= f.text_field(:"#{filter.sym}",
+                 value: @filter_defaults[filter.sym],
+                 class: "form-control") %><br/>
 <br/>

--- a/app/views/search/_advanced_search_filters.html.erb
+++ b/app/views/search/_advanced_search_filters.html.erb
@@ -2,7 +2,7 @@
 <% javascript_include "advanced_search" %>
 
 <%= fields_for(:content_filter) do |fcf| %>
-  <div class="" id="advanced_search_filters">
+  <div id="advanced_search_filters">
 
     <div class="mt-3">
       <span class="font-weight-bold"><%= :advanced_search_filters.t %></span>

--- a/app/views/search/_advanced_search_filters.html.erb
+++ b/app/views/search/_advanced_search_filters.html.erb
@@ -1,24 +1,33 @@
 <!-- Filters Settings of Advanced Search Form -->
 <% javascript_include "advanced_search" %>
-<div id="advanced_search_filters">
-  <div class="form-group">
+
+<%= fields_for(:content_filter) do |fcf| %>
+  <div class="" id="advanced_search_filters">
+
     <div class="mt-3">
       <span class="font-weight-bold"><%= :advanced_search_filters.t %></span>
       <p><%= :advanced_search_filters_explain.t %>.<p>
     </div>
+
     <% ContentFilter.all.each do |filter| %>
       <% models = filter.models.map {|m| m.name.underscore}.join(" ") %>
-      <div class="form-inline" data-role="filter" data-models="<%= j models %>">
+
+      <div class="form-group"
+            data-role="filter" data-models="<%= j models %>">
+
         <% if filter.type == :boolean %>
           <%= render partial: "advanced_search_filter_radio_buttons",
-                     locals: { filter: filter } %>
+                    locals: { f: fcf, filter: filter } %>
         <% elsif filter.type == [:string] %>
           <%= render partial: "advanced_search_filter_text_field",
-                     locals: { filter: filter } %>
+                    locals: { f: fcf, filter: filter } %>
         <% else %>
           <% raise "Unexpected filter type #{filter.type.inspect}" %>
         <% end %>
+
       </div>
+
     <% end %>
+
   </div>
-</div>
+<% end # fields_for %>

--- a/app/views/search/advanced.html.erb
+++ b/app/views/search/advanced.html.erb
@@ -1,62 +1,67 @@
 <%
   @title = :app_advanced_search.t
+  models = [
+    [:OBSERVATIONS.l, :observation],
+    # temporarily disabled for performance
+    # 2021-09-12 JDC
+    # [:IMAGES.l, :image],
+    [:LOCATIONS.l, :location],
+    [:NAMES.l, :name],
+  ]
 %>
 
 <p class="help-block"><%= :advanced_search_caveat.t %></p>
 
-<%= form_tag(action: :advanced, method: :get) do %>
-  <p>
-    <%= submit_tag(:advanced_search_submit.l,
-                    class: "btn btn-default center-block") %>
-  </p>
+<%= form_with(scope: :search, url: { action: :advanced },
+              method: :get) do |f| %>
+
+  <%= submit_button(form: f, button: :advanced_search_submit.l, center: true) %>
 
   <div class="form-group">
-    <%= label_tag(:search_model, :advanced_search_result_type.t + ":") %>
-    <span class="help"><%= :advanced_search_result_type_help.t %></span><br/>
-    <%= select(:search, :model, [
-                                  [:OBSERVATIONS.l, :observation],
-                                  # temporarily disabled for performance
-                                  # 2021-09-12 JDC
-                                  # [:IMAGES.l, :image],
-                                  [:LOCATIONS.l, :location],
-                                  [:NAMES.l, :name],
-                                ]) %>
+    <%= f.label(:model, :advanced_search_result_type.t + ":") %>
+    <%= content_tag(:span, :advanced_search_result_type_help.t,
+                    class: "help") %><br/>
+    <%= f.select(:model, models, class: "form-control") %>
   </div>
 
   <div class="form-group">
-    <%= label_tag(:search_name, :NAME.t + ":") %>
-    <span class="help"><%= :advanced_search_name_help.t %></span>
-    <%= text_field(:search, :name, class: "form-control") %>
+    <%= f.label(:name, :NAME.t + ":") %>
+    <%= content_tag(:span, :advanced_search_name_help.t, class: "help") %>
+    <%= f.text_field(:name, class: "form-control") %>
     <% turn_into_name_auto_completer(:search_name, primer: Name.primer,
                                       token: " OR ") %>
   </div>
 
   <div class="form-group">
-    <%= label_tag(:search_user, :OBSERVER.t + ":") %>
-    <span class="help"><%= :advanced_search_observer_help.t %></span>
-    <%= text_field(:search, :user, class: "form-control") %>
+    <%= f.label(:user, :OBSERVER.t + ":") %>
+    <%= content_tag(:span, :advanced_search_observer_help.t,
+                    class: "help") %>
+    <%= f.text_field(:user, class: "form-control") %>
     <% turn_into_user_auto_completer(:search_user, primer: User.primer,
                                       token: " OR ") %>
   </div>
 
   <div class="form-group">
-    <%= label_tag(:search_location, :LOCATION.t + ":") %>
-    <span class="help"><%= :advanced_search_location_help.t %></span>
-    <%= text_field(:search, :location, class: "form-control") %>
+    <%= f.label(:location, :LOCATION.t + ":") %>
+    <%= content_tag(:span, :advanced_search_location_help.t,
+                    class: "help") %>
+    <%= f.text_field(:location, class: "form-control") %>
     <% turn_into_location_auto_completer(:search_location,
                                           primer: Location.primer,
                                           token: " OR ") %>
   </div>
 
   <div class="form-group">
-    <%= label_tag(:search_content, :advanced_search_content.t + ":") %>
-    <span class="help"><%= :advanced_search_content_help.t %></span>
-    <%= text_field(:search, :content, class: "form-control") %>
-    <p class="help-block"><%= :advanced_search_content_notes.t %></p>
+    <%= f.label(:content, :advanced_search_content.t + ":") %>
+    <%= content_tag(:span, :advanced_search_content_help.t,
+                    class: "help") %>
+    <%= f.text_field(:content, class: "form-control") %>
+    <%= content_tag(:p, :advanced_search_content_notes.t,
+                    class: "help-block") %>
   </div>
 
-  <%= render partial: "advanced_search_filters" %>
+  <%= render(partial: "advanced_search_filters", locals: { f: f }) %>
 
-  <%= submit_tag(:advanced_search_submit.l,
-                 class: "btn btn-default center-block") %>
+  <%= submit_button(form: f, button: :advanced_search_submit.l, center: true) %>
+
 <% end %>

--- a/app/views/sequences/_form.html.erb
+++ b/app/views/sequences/_form.html.erb
@@ -9,6 +9,7 @@ end
 
 <%= form_with(model: @sequence, url: url_params,
               id: "sequence_form") do |f| %>
+
   <%# locus %>
   <div class="form-group mt-3">
     <%= f.label(:locus, "#{:LOCUS.t}:") %>
@@ -57,14 +58,13 @@ end
   <%# notes %>
   <div class="form-group mt-3">
     <%= f.label(:notes, "#{:NOTES.t}:") %>
-    <span class="help-note">(<%= :optional.t %>)</span>
+    <%= content_tag(:span, "(#{:optional.t})", class: "help-note ml-3") %>
     <%= f.text_area(:notes, rows: 3, class: "form-control") %>
     <%= help_block_with_arrow("up", id: "textile_help", class: "mt-3") do %>
       <%= :field_textile_link.t %>
     <% end %>
   </div>
 
-  <div class="form-group">
-    <%= f.submit(button_name.t, class: "btn btn-default center-block mt-3") %>
-  </div><!--.row-->
+  <%= centered_submit(form: f, button: button_name.t) %>
+
 <% end %>

--- a/app/views/sequences/_form.html.erb
+++ b/app/views/sequences/_form.html.erb
@@ -65,6 +65,6 @@ end
     <% end %>
   </div>
 
-  <%= centered_submit(form: f, button: button_name.t) %>
+  <%= submit_button(form: f, button: button_name.t, center: true) %>
 
 <% end %>

--- a/app/views/shared/_fields_for_description.html.erb
+++ b/app/views/shared/_fields_for_description.html.erb
@@ -57,9 +57,9 @@ source_types = [
   <div class="form-group">
     <%= content_tag(:b, "#{:form_description_permissions.t}:") %>
     <%= check_box_with_label(form: f, field: :public_write, disabled: disabled,
-                             text: :form_description_public_writable.t) %>
+                             label: :form_description_public_writable.t) %>
     <%= check_box_with_label(form: f, field: :public, disabled: disabled,
-                             text: :form_description_public_readable.t) %>
+                             label: :form_description_public_readable.t) %>
     <%= content_tag(:p, :form_description_permissions_help.t,
                     class: "help-block") %>
   </div>

--- a/app/views/shared/_form_list_feedback.html.erb
+++ b/app/views/shared/_form_list_feedback.html.erb
@@ -27,10 +27,13 @@
         approved_names = name.approved_synonyms %>
         <%= name.display_name.t %><br/>
         <% if approved_names != [] %>
-          <% approved_names.each do |other_name| %>
-            <%= indent + radio_button("chosen_approved_names", name.id,
-                                      other_name.id) %>
-            <%= other_name.display_name.t %><br/>
+          <%= fields_for(:chosen) do |f_c| %>
+            <% approved_names.each do |other_name| %>
+              <%= radio_with_label(form: f_c, field: :approved_names,
+                                  value: name.id, checked: other_name.id,
+                                  label: other_name.display_name.t,
+                                  class: "ml-4") %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
@@ -42,18 +45,20 @@
   <div class="Errors" id="ambiguous_names">
     <p>
       <b><%= :form_species_lists_multiple_names.t %>:</b><br/>
-      <span class="help-note">
-        <%= :form_species_lists_multiple_names_help.t %>
-      </span>
+      <%= content_tag(:span, :form_species_lists_multiple_names_help.t,
+                      class: "help-note") %>
     </p>
     <p class="Data">
       <% @multiple_names.each do |name| %>
         <%= name.display_name.t %><br/>
-        <% name.other_authors.each do |other_name| %>
-          <%= indent + radio_button("chosen_multiple_names", name.id,
-                                    other_name.id) %>
-          <%= other_name.display_name.t %>
+        <%= fields_for(:chosen) do |f_c| %>
+          <% name.other_authors.each do |other_name| %>
+            <%= radio_with_label(form: f_c, field: :multiple_names,
+                                value: name.id, checked: other_name.id,
+                                label: other_name.display_name.t,
+                                class: "ml-4") %>
             (<%= other_name.observations.count %>)<br/>
+          <% end %>
         <% end %>
       <% end %>
     </p>

--- a/app/views/shared/_form_list_feedback.html.erb
+++ b/app/views/shared/_form_list_feedback.html.erb
@@ -6,7 +6,7 @@
         <%= :form_list_feedback_missing_names_help.t %>
       </span>
     </p>
-    <p class="Data">
+    <p>
       <% @new_names.each do |n| %>
       <br/><%= indent + h(n) %>
       <% end %>
@@ -22,7 +22,7 @@
         <%= :form_species_lists_deprecated_help.t %>
       </span>
     </p>
-    <p class="Data">
+    <p>
       <% @deprecated_names.each do |name|
         approved_names = name.approved_synonyms %>
         <%= name.display_name.t %><br/>
@@ -48,7 +48,7 @@
       <%= content_tag(:span, :form_species_lists_multiple_names_help.t,
                       class: "help-note") %>
     </p>
-    <p class="Data">
+    <p>
       <% @multiple_names.each do |name| %>
         <%= name.display_name.t %><br/>
         <%= fields_for(:chosen_multiple_names) do |f_c| %>

--- a/app/views/shared/_form_list_feedback.html.erb
+++ b/app/views/shared/_form_list_feedback.html.erb
@@ -27,10 +27,10 @@
         approved_names = name.approved_synonyms %>
         <%= name.display_name.t %><br/>
         <% if approved_names != [] %>
-          <%= fields_for(:chosen) do |f_c| %>
+          <%= fields_for(:chosen_approved_names) do |f_c| %>
             <% approved_names.each do |other_name| %>
-              <%= radio_with_label(form: f_c, field: :approved_names,
-                                  value: name.id, checked: other_name.id,
+              <%= radio_with_label(form: f_c, field: name.id,
+                                  value: other_name.id,
                                   label: other_name.display_name.t,
                                   class: "ml-4") %>
             <% end %>
@@ -51,10 +51,10 @@
     <p class="Data">
       <% @multiple_names.each do |name| %>
         <%= name.display_name.t %><br/>
-        <%= fields_for(:chosen) do |f_c| %>
+        <%= fields_for(:chosen_multiple_names) do |f_c| %>
           <% name.other_authors.each do |other_name| %>
-            <%= radio_with_label(form: f_c, field: :multiple_names,
-                                value: name.id, checked: other_name.id,
+            <%= radio_with_label(form: f_c, field: name.id,
+                                value: other_name.id,
                                 label: other_name.display_name.t,
                                 class: "ml-4") %>
             (<%= other_name.observations.count %>)<br/>

--- a/app/views/shared/_form_name_feedback.html.erb
+++ b/app/views/shared/_form_name_feedback.html.erb
@@ -19,7 +19,7 @@ if valid_names
   flash_warning(:form_observations_there_is_a_problem_with_name.t) %>
 
   <div class="alert alert-warning" id="name_messages">
-    <span class="Data"><%=
+    <span><%=
     if suggest_corrections || names.blank?
       :form_naming_not_recognized.t(name: what)
     elsif parent_deprecated
@@ -43,7 +43,7 @@ if valid_names
                                              name: what) %>
         </span><br/><%
       end %>
-      <span class="Data"><%
+      <span><%
       if !suggest_corrections && !parent_deprecated %>
         <%= :form_naming_valid_synonyms.t %>:<br/><%
       end %>
@@ -69,7 +69,7 @@ elsif names&.length == 0
   flash_error(:form_observations_there_is_a_problem_with_name.t) %>
 
   <div class="alert alert-danger" id="name_messages">
-    <span class="Data">
+    <span>
       <%= :form_naming_not_recognized.t(name: what) %>
     </span><br/>
     <span class="help-note">
@@ -82,18 +82,16 @@ elsif names&.length &.> 1
   flash_error(:form_observations_there_is_a_problem_with_name.t) %>
 
   <div class="alert alert-danger" id="name_messages">
-    <span class="Data">
-      <%= :form_naming_multiple_names.t(name: what) %>:<br/>
-      <%= fields_for(:chosen_name) do |f_c| %>
-        <% names.each do |n| %>
-          <%= radio_with_label(form: f, field: :name_id,
-                                value: n.id,
-                                label: n.display_name.t,
-                                class: "ml-4") %>
-          (<%= n.observations.size %>)<br/>
-        <% end %>
+    <%= :form_naming_multiple_names.t(name: what) %>:<br/>
+    <%= fields_for(:chosen_name) do |f_c| %>
+      <% names.each do |n| %>
+        <%= radio_with_label(form: f, field: :name_id,
+                              value: n.id,
+                              label: n.display_name.t,
+                              class: "ml-4") %>
+        (<%= n.observations.size %>)<br/>
       <% end %>
-    </span>
+    <% end %>
     <%= content_tag(:div, :form_naming_multiple_names_help.t,
                     class: "help-note") %>
   </div><!--.alert--><%

--- a/app/views/shared/_form_name_feedback.html.erb
+++ b/app/views/shared/_form_name_feedback.html.erb
@@ -48,7 +48,7 @@ if valid_names
         <%= :form_naming_valid_synonyms.t %>:<br/><%
       end %><%
       valid_names.each do |n| %>
-          <%= indent + radio_button(:chosen_name, :name_id, n.id) %>
+          <%= radio_button(:chosen_name, :name_id, n.id, class: "ml-4") %>
           <%= n.display_name.t %><br/><%
       end %>
       </span><%
@@ -79,15 +79,17 @@ elsif names&.length &.> 1
 
   <div class="alert alert-danger" id="name_messages">
     <span class="Data">
-      <%= :form_naming_multiple_names.t(name: what) %>:<br/><%
-      names.each do |n| %>
-        <%= indent + radio_button(:chosen_name, :name_id, n.id) %>
-        <%= n.display_name.t %> (<%= n.observations.size %>)<br/><%
-      end %>
+      <%= :form_naming_multiple_names.t(name: what) %>:<br/>
+      <% names.each do |n| %>
+        <%= radio_with_label(form: f, field: :chosen_name,
+                              value: :name_id, checked: n.id,
+                              label: n.display_name.t,
+                              class: "ml-4") %>
+        (<%= n.observations.size %>)<br/>
+      <% end %>
     </span>
-    <span class="help-note">
-      <%= :form_naming_multiple_names_help.t %>
-    </span><br/>
+    <%= content_tag(:div, :form_naming_multiple_names_help.t,
+                    class: "help-note") %>
   </div><!--.alert--><%
 
 end %>

--- a/app/views/shared/_form_name_feedback.html.erb
+++ b/app/views/shared/_form_name_feedback.html.erb
@@ -46,11 +46,15 @@ if valid_names
       <span class="Data"><%
       if !suggest_corrections && !parent_deprecated %>
         <%= :form_naming_valid_synonyms.t %>:<br/><%
-      end %><%
-      valid_names.each do |n| %>
-          <%= radio_button(:chosen_name, :name_id, n.id, class: "ml-4") %>
-          <%= n.display_name.t %><br/><%
       end %>
+      <%= fields_for(:chosen_name) do |f_c| %>
+        <% valid_names.each do |n| %>
+          <%= radio_with_label(form: f, field: :name_id,
+                                value: n.id,
+                                label: n.display_name.t,
+                                class: "ml-4") %>
+        <% end %>
+      <% end %>
       </span><%
     else %>
       <span class="help-note">
@@ -80,12 +84,14 @@ elsif names&.length &.> 1
   <div class="alert alert-danger" id="name_messages">
     <span class="Data">
       <%= :form_naming_multiple_names.t(name: what) %>:<br/>
-      <% names.each do |n| %>
-        <%= radio_with_label(form: f, field: :chosen_name,
-                              value: :name_id, checked: n.id,
-                              label: n.display_name.t,
-                              class: "ml-4") %>
-        (<%= n.observations.size %>)<br/>
+      <%= fields_for(:chosen_name) do |f_c| %>
+        <% names.each do |n| %>
+          <%= radio_with_label(form: f, field: :name_id,
+                                value: n.id,
+                                label: n.display_name.t,
+                                class: "ml-4") %>
+          (<%= n.observations.size %>)<br/>
+        <% end %>
       <% end %>
     </span>
     <%= content_tag(:div, :form_naming_multiple_names_help.t,

--- a/app/views/shared/_images_to_remove.html.erb
+++ b/app/views/shared/_images_to_remove.html.erb
@@ -2,10 +2,9 @@
 # Note this uses a specialized matrix box here, not using the general partial.
 %>
 
-<%= form_with(url: form_action, method: :put) do |form| %>
+<%= form_with(url: form_action, method: :put) do |f| %>
 
-  <%= form.submit(:image_remove_remove.l,
-                  class: "btn btn-default d-block mx-auto my-3") %>
+  <%= centered_submit(form: f, button: :image_remove_remove.l) %>
 
   <ul class="row list-unstyled mt-3">
 
@@ -32,8 +31,7 @@
 
   </ul>
 
-  <%= form.submit(:image_remove_remove.l,
-                  class: "btn btn-default d-block mx-auto my-3") %>
+  <%= centered_submit(form: f, button: :image_remove_remove.l) %>
 
 <% end %>
 

--- a/app/views/shared/_images_to_remove.html.erb
+++ b/app/views/shared/_images_to_remove.html.erb
@@ -4,7 +4,7 @@
 
 <%= form_with(url: form_action, method: :put) do |f| %>
 
-  <%= centered_submit(form: f, button: :image_remove_remove.l) %>
+  <%= submit_button(form: f, button: :image_remove_remove.l, center: true) %>
 
   <ul class="row list-unstyled mt-3">
 
@@ -31,7 +31,7 @@
 
   </ul>
 
-  <%= centered_submit(form: f, button: :image_remove_remove.l) %>
+  <%= submit_button(form: f, button: :image_remove_remove.l, center: true) %>
 
 <% end %>
 

--- a/app/views/shared/_images_to_reuse.html.erb
+++ b/app/views/shared/_images_to_reuse.html.erb
@@ -18,8 +18,7 @@ query = query_images_to_reuse(@all_users, @user)
       <%= f.text_field(:img_id,
                           { size: 8, data: { autofocus: true },
                             class: "form-control" }) %>
-      <%= f.submit(:image_reuse_reuse.l,
-                      { class: "btn btn-default ml-3" }) %>
+      <%= submit_button(form: f, button: :image_reuse_reuse.l, class: "ml-3") %>
     </div>
 
     <%= content_tag(:div, :image_reuse_id_help.tp,

--- a/app/views/shared/_images_to_reuse.html.erb
+++ b/app/views/shared/_images_to_reuse.html.erb
@@ -10,18 +10,20 @@ query = query_images_to_reuse(@all_users, @user)
 @objects = query.paginate(@pages, include: [:user, { observations: :name }])
 
 %>
-<%= form_with(url: form_action, method: :post) do |form|%>
+<%= form_with(url: form_action, method: :post) do |f| %>
+
   <div class="container-text">
     <div class="form-group form-inline">
-      <%= form.label(:img_id, "#{:image_reuse_id.t}:") %>
-      <%= form.text_field(:img_id,
+      <%= f.label(:img_id, "#{:image_reuse_id.t}:") %>
+      <%= f.text_field(:img_id,
                           { size: 8, data: { autofocus: true },
                             class: "form-control" }) %>
-      <%= form.submit(:image_reuse_reuse.l,
+      <%= f.submit(:image_reuse_reuse.l,
                       { class: "btn btn-default ml-3" }) %>
     </div>
 
-    <p class="help-block"><%= :image_reuse_id_help.tp %></p>
+    <%= content_tag(:div, :image_reuse_id_help.tp,
+                    class: "help-block form-group") %>
 
     <div class="form-group mt-3">
       <%= link_with_query((@all_users ? :image_reuse_just_yours.t :

--- a/app/views/species_lists/_form.html.erb
+++ b/app/views/species_lists/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: @species_list, url: action,
               id: "species_list_form") do |f| %>
 
-  <%= centered_submit(form: f, button: button.l) %>
+  <%= submit_button(form: f, button: button.l, center: true) %>
 
   <%= if !(partial = render(partial: "shared/form_list_feedback")).blank?
     content_tag(:div, partial)
@@ -69,6 +69,6 @@
                locals: { f: f }) %>
   <% end %>
 
-  <%= centered_submit(form: f, button: button.l) %>
+  <%= submit_button(form: f, button: button.l, center: true) %>
 
 <% end %>

--- a/app/views/species_lists/_form.html.erb
+++ b/app/views/species_lists/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: @species_list, url: action,
               id: "species_list_form") do |f| %>
 
-  <%= f.submit(button.l, class: "btn btn-default center-block mt-3 mb-3") %>
+  <%= centered_submit(form: f, button: button.l) %>
 
   <%= if !(partial = render(partial: "shared/form_list_feedback")).blank?
     content_tag(:div, partial)
@@ -32,7 +32,8 @@
 
   <div class="form-group mt-3">
     <%= f.label(:title,
-                :form_species_lists_title.t + ":") %> (<%= :required.t %>)
+                :form_species_lists_title.t + ":") %>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note") %>
     <%= f.text_field(:title, class: "form-control") %>
   </div>
 
@@ -54,7 +55,8 @@
              locals: { button: button } ) %>
 
   <div class="form-group mt-3">
-    <%= f.label(:place_name, :WHERE.t + ":") %> (<%= :required.t %>)
+    <%= f.label(:place_name, :WHERE.t + ":") %>
+    <%= content_tag(:span, "(#{:required.t})", class: "help-note ml-3") %>
     <%= f.text_field(:place_name, class: "form-control") %>
   </div>
   <% turn_into_location_auto_completer(:species_list_place_name) %>
@@ -67,6 +69,6 @@
                locals: { f: f }) %>
   <% end %>
 
-  <%= f.submit(button.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: button.l) %>
 
 <% end %>

--- a/app/views/species_lists/_form.html.erb
+++ b/app/views/species_lists/_form.html.erb
@@ -3,7 +3,8 @@
 
   <%= submit_button(form: f, button: button.l, center: true) %>
 
-  <%= if !(partial = render(partial: "shared/form_list_feedback")).blank?
+  <%= if !(partial = render(partial: "shared/form_list_feedback",
+                            locals: { f: f })).blank?
     content_tag(:div, partial)
   end %>
 

--- a/app/views/species_lists/_species_list.html.erb
+++ b/app/views/species_lists/_species_list.html.erb
@@ -1,10 +1,10 @@
 <div class="mt-3">
-  <%= :WHEN.t %>: <span class="Data"><%= species_list.when.web_date %></span>
+  <%= :WHEN.t %>: <span><%= species_list.when.web_date %></span>
   </br/>
   <%= :WHERE.t %>: <%= location_link(species_list.place_name,
                                      species_list.location, nil, true) %>
   <br/>
-  <%= :WHO.t %>: <span class="Data"><%= user_link(species_list.user) %></span>
+  <%= :WHO.t %>: <span><%= user_link(species_list.user) %></span>
   <br/>
   <% if species_list.notes.present? %>
     <div class="mt-3 mb-n3">

--- a/app/views/species_lists/downloads/_form_print_labels.html.erb
+++ b/app/views/species_lists/downloads/_form_print_labels.html.erb
@@ -3,6 +3,6 @@
 
   <%= content_tag(:h3, "#{:species_list_labels_header.t}:", class: "mt-5") %>
 
-  <%= centered_submit(form: f, button: :species_list_labels_button.l) %>
+  <%= submit_button(form: f, button: :species_list_labels_button.l, center: true) %>
 
 <% end %>

--- a/app/views/species_lists/downloads/_form_print_labels.html.erb
+++ b/app/views/species_lists/downloads/_form_print_labels.html.erb
@@ -1,5 +1,8 @@
 <%= form_with(url: print_labels_for_observations_path(q: query_param),
               id: "species_list_download_print_labels") do |f| %>
-  <h3 class="mt-5"><%= :species_list_labels_header.t %>:</h3>
-  <%= f.submit(:species_list_labels_button.l, class: "btn btn-default") %>
+
+  <%= content_tag(:h3, "#{:species_list_labels_header.t}:", class: "mt-5") %>
+
+  <%= centered_submit(form: f, button: :species_list_labels_button.l) %>
+
 <% end %>

--- a/app/views/species_lists/downloads/_form_species_list_report.html.erb
+++ b/app/views/species_lists/downloads/_form_species_list_report.html.erb
@@ -20,6 +20,6 @@
     </li>
   </ul>
 
-  <%= centered_submit(form: f, button: :species_list_report_button.l) %>
+  <%= submit_button(form: f, button: :species_list_report_button.l, center: true) %>
 
 <% end %>

--- a/app/views/species_lists/downloads/_form_species_list_report.html.erb
+++ b/app/views/species_lists/downloads/_form_species_list_report.html.erb
@@ -20,6 +20,6 @@
     </li>
   </ul>
 
-  <%= f.submit(:species_list_report_button.l, class: "btn btn-default") %>
+  <%= centered_submit(form: f, button: :species_list_report_button.l) %>
 
 <% end %>

--- a/app/views/species_lists/downloads/_form_species_list_report.html.erb
+++ b/app/views/species_lists/downloads/_form_species_list_report.html.erb
@@ -5,21 +5,19 @@
 
   <p><%= :download_observations_format.t %>:</p>
 
-  <ul type="none">
-    <li>
-      <%= radio_button_tag(:type, :txt, @type == "txt") %>
-      <%= :species_list_show_save_as_txt.t %>
-    </li>
-    <li>
-      <%= radio_button_tag(:type, :rtf, @type == "rtf") %>
-      <%= :species_list_show_save_as_rtf.t %>
-    </li>
-    <li>
-      <%= radio_button_tag(:type, :csv, @type == "csv") %>
-      <%= :species_list_show_save_as_csv.t %>
-    </li>
-  </ul>
+  <div class="form-group">
+    <%= radio_with_label(form: f, field: :type, value: :txt,
+                          checked: @type == "txt",
+                          label: :species_list_show_save_as_txt.t) %>
+    <%= radio_with_label(form: f, field: :type, value: :rtf,
+                          checked: @type == "rtf",
+                          label: :species_list_show_save_as_rtf.t) %>
+    <%= radio_with_label(form: f, field: :type, value: :csv,
+                          checked: @type == "csv",
+                          label: :species_list_show_save_as_csv.t) %>
+  </div>
 
-  <%= submit_button(form: f, button: :species_list_report_button.l, center: true) %>
+  <%= submit_button(form: f, button: :species_list_report_button.l,
+                    center: true) %>
 
 <% end %>

--- a/app/views/species_lists/form/_fields_for_checklist.erb
+++ b/app/views/species_lists/form/_fields_for_checklist.erb
@@ -6,7 +6,7 @@
       <% @checklist.sort_by(&:first).each do |name, id| %>
         <%= check_box_with_label(form: fcd, field: id,
                                  checked: @checklist_names[id],
-                                 text: name.t) %>
+                                 label: name.t) %>
       <% end %>
     </div>
   </div>

--- a/app/views/species_lists/form/_fields_for_member.erb
+++ b/app/views/species_lists/form/_fields_for_member.erb
@@ -36,14 +36,15 @@
 
   <%= check_box_with_label(form: f_m, field: :is_collection_location,
                            checked: @member_is_collection_location,
-                           text: :form_observations_is_collection_location.t) %>
+                           label: :form_observations_is_collection_location.t)
+                           %>
   <%= content_tag(:span,
                   :form_observations_is_collection_location_help.t,
                   class: "help-note") %>
 
   <%= check_box_with_label(form: f_m, field: :specimen,
                            checked: @member_specimen,
-                           text: :form_observations_specimen_available.t) %>
+                           label: :form_observations_specimen_available.t) %>
   <%= content_tag(:span,
                   :form_observations_specimen_available_help.t,
                   class: "help-note") %>

--- a/app/views/species_lists/form/_fields_for_project.erb
+++ b/app/views/species_lists/form/_fields_for_project.erb
@@ -9,7 +9,7 @@
                                  checked: @project_checks[project.id],
                                  disabled: @species_list.user_id != @user.id &&
                                    !project.is_member?(@user),
-                                 text: link_to_object(project)) %>
+                                 label: link_to_object(project)) %>
       <% end %>
     </div>
   </div>

--- a/app/views/species_lists/name_lists/_form.html.erb
+++ b/app/views/species_lists/name_lists/_form.html.erb
@@ -1,16 +1,19 @@
+<%
+charsets = ["ISO-8859-1", "WINDOWS-1252", "UTF-8"]
+%>
+
 <%= form_with(url: { action: :create },
               id: "name_lister_form") do |f| %>
 
   <div class="text-center">
-    <%= f.submit(:name_lister_submit_spl.l,
-                 class: "btn btn-default mx-3",
-                 disabled: !@user) %>
-    <%= f.submit(:name_lister_submit_txt.l,
-                 class: "btn btn-default mx-3") %>
-    <%= f.submit(:name_lister_submit_rtf.l,
-                 class: "btn btn-default mx-3") %>
-    <%= f.submit(:name_lister_submit_csv.l,
-                 class: "btn btn-default mx-3") %>
+    <%= submit_button(form: f, button: :name_lister_submit_spl.l,
+                      class: "mx-3", disabled: !@user) %>
+    <%= submit_button(form: f, button: :name_lister_submit_txt.l,
+                      class: "mx-3") %>
+    <%= submit_button(form: f, button: :name_lister_submit_rtf.l,
+                      class: "mx-3") %>
+    <%= submit_button(form: f, button: :name_lister_submit_csv.l,
+                      class: "mx-3") %>
   </div><!-- .text-center -->
 
   <%= hidden_field_tag(:results, @name_strings.join("\n")) %>
@@ -18,9 +21,8 @@
   <% if false %>
     <br/>
     <%= f.label(:charset, :name_lister_charset.t + ":") %>
-    <%= f.select(:charset, options_for_select(["ISO-8859-1",
-                  "WINDOWS-1252", "UTF-8"], @charset)) %>
-    <span class="help-note"><%= :name_lister_charset_help.t %></span>
+    <%= f.select(:charset, options_for_select(charsets, @charset)) %>
+    <%= content_tag(:span, :name_lister_charset_help.t, class: "help-note") %>
   <% end %>
 
 <% end %>

--- a/app/views/species_lists/observations/_form.html.erb
+++ b/app/views/species_lists/observations/_form.html.erb
@@ -15,8 +15,8 @@ action = { controller: "/species_lists/observations", action: :update,
   </div>
 
   <div class="form-group center-block">
-    <%= f.submit(:ADD.l, class: "btn btn-default") %>
-    <%= f.submit(:REMOVE.l, class: "btn btn-default") %>
+    <%= submit_button(form: f, button: :ADD.l) %>
+    <%= submit_button(form: f, button: :REMOVE.l) %>
   </div>
 
 <% end %>

--- a/app/views/species_lists/projects/edit.html.erb
+++ b/app/views/species_lists/projects/edit.html.erb
@@ -21,13 +21,13 @@
     <%= f.label(:objects, :species_list_projects_which_objects.t) %>
     <%= check_box_with_label(form: f, field: :objects_list,
                              value: 1, checked: @object_states[:list],
-                             text: :species_list_projects_this_list.t) %>
+                             label: :species_list_projects_this_list.t) %>
     <%= check_box_with_label(form: f, field: :objects_obs,
                              value: 1, checked: @object_states[:obs],
-                             text: :species_list_projects_observations.t) %>
+                             label: :species_list_projects_observations.t) %>
     <%= check_box_with_label(form: f, field: :objects_img,
                              value: 1, checked: @object_states[:img],
-                             text: :species_list_projects_images.t) %>
+                             label: :species_list_projects_images.t) %>
   </div>
 
   <div class="form-group form-inline mt-3">
@@ -35,7 +35,7 @@
     <% @projects.sort_by(&:text_name).each do |proj| %>
       <%= check_box_with_label(form: f, field: :"projects_#{proj.id}",
                                value: 1, checked: @project_states[proj.id],
-                               text: proj.title.t) %>
+                               label: proj.title.t) %>
     <% end %>
   </div>
 

--- a/app/views/species_lists/projects/edit.html.erb
+++ b/app/views/species_lists/projects/edit.html.erb
@@ -40,9 +40,9 @@
   </div>
 
   <div class="text-center mt-3">
-    <%= f.submit(:ATTACH.l, class: "btn btn-default") %>
+    <%= submit_button(form: f, button: :ATTACH.l) %>
     &nbsp;
-    <%= f.submit(:REMOVE.l, class: "btn btn-default") %>
+    <%= submit_button(form: f, button: :REMOVE.l) %>
   </div><!-- .text-center -->
 
 <% end %>

--- a/app/views/species_lists/uploads/new.html.erb
+++ b/app/views/species_lists/uploads/new.html.erb
@@ -15,6 +15,6 @@
     </div>
   </div>
 
-  <%= centered_submit(form: f, button: :UPLOAD.l) %>
+  <%= submit_button(form: f, button: :UPLOAD.l, center: true) %>
 
 <% end %>

--- a/app/views/species_lists/uploads/new.html.erb
+++ b/app/views/species_lists/uploads/new.html.erb
@@ -15,6 +15,6 @@
     </div>
   </div>
 
-  <%= f.submit(:UPLOAD.l, class: "btn btn-default center-block mt-3") %>
+  <%= centered_submit(form: f, button: :UPLOAD.l) %>
 
 <% end %>

--- a/app/views/support/donate.html.erb
+++ b/app/views/support/donate.html.erb
@@ -28,28 +28,29 @@ javascript_include "donate"
     <% amounts.each do |a| %>
       <div class="col-xs-3">
         <%= radio_with_label(form: f, field: :amount, value: a,
-                             text: "$#{a.to_i}") %>
+                             label: "$#{a.to_i}") %>
       </div>
     <% end %>
   </div>
 
   <%= radio_with_label(form: f, field: :amount, value: "other",
-                       text: "#{:donate_other.t}: ",
+                       label: "#{:donate_other.t}: ",
                        class: "d-inline-block") %>
-  <%= inline_label_text_field(form: f, field: :other_amount, size: 7,
-                              text: "$ ", class: "d-inline-block ml-4") %>
+  <%= text_field_with_label(form: f, field: :other_amount, size: 7,
+                            label: "$ ", class: "d-inline-block ml-4",
+                            inline: true) %>
 
   <%= check_box_with_label(form: f, field: :recurring,
-                           text: :donate_recurring.t) %>
+                           label: :donate_recurring.t) %>
 
-  <%= inline_label_text_field(form: f, field: :who, size: 30,
-                              text: :donate_who.t) %>
+  <%= text_field_with_label(form: f, field: :who, size: 30,
+                            label: :donate_who.t, inline: true) %>
 
   <%= check_box_with_label(form: f, field: :anonymous,
-                           text: :donate_anonymous.t) %>
+                           label: :donate_anonymous.t) %>
 
-  <%= inline_label_text_field(form: f, field: :email, size: 30,
-                              text: :donate_email.t) %>
+  <%= text_field_with_label(form: f, field: :email, size: 30,
+                            label: :donate_email.t, inline: true) %>
 
   <%= submit_button(form: f, button: :donate_confirm.t, center: true) %>
 

--- a/app/views/support/donate.html.erb
+++ b/app/views/support/donate.html.erb
@@ -51,7 +51,7 @@ javascript_include "donate"
   <%= inline_label_text_field(form: f, field: :email, size: 30,
                               text: :donate_email.t) %>
 
-  <%= f.submit(:donate_confirm.t, class: "btn btn-default center-block my-3") %>
+  <%= submit_button(form: f, button: :donate_confirm.t, center: true) %>
 
 <% end %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,7 +17,7 @@
     <%= paginate_block(@pages) do %>
       <table align="center" class="table table-striped permissions" cellspacing="2">
         <thead>
-          <tr class="Data">
+          <tr>
             <th><%= :users_by_name_verified.t %></th>
             <th><%= :users_by_name_groups.t %></th>
             <th><%= :users_by_name_last_login.t %></th>

--- a/app/views/visual_groups/_form.html.erb
+++ b/app/views/visual_groups/_form.html.erb
@@ -35,6 +35,6 @@
   </div>
 
   <div class="actions">
-    <%= centered_submit(form: f, button: :SUBMIT.t) %>
+    <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
   </div>
 <% end %>

--- a/app/views/visual_groups/_form.html.erb
+++ b/app/views/visual_groups/_form.html.erb
@@ -31,7 +31,7 @@
                          class: "form-control") %>
     </div>
 
-    <%= check_box_with_label(form: f, field: :approved, text: :APPROVED.t) %>
+    <%= check_box_with_label(form: f, field: :approved, label: :APPROVED.t) %>
   </div>
 
   <div class="actions">

--- a/app/views/visual_groups/_form.html.erb
+++ b/app/views/visual_groups/_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_with(model: [@visual_model, @visual_group], local: true,
-              id: "visual_group_form") do |form| %>
+              id: "visual_group_form") do |f| %>
+
   <% if visual_group.errors.any? %>
     <div id="error_explanation">
       <h2>
@@ -17,23 +18,23 @@
 
   <div>
     <div class="form-group">
-      <%= form.label(:name) %>
+      <%= f.label(:name) %>
       <div class="form-inline">
-        <%= form.text_field(:name, size: 40, class: "form-control") %>
+        <%= f.text_field(:name, size: 40, class: "form-control") %>
         <%= content_tag(:span, :VISUAL_GROUP.t, class: "ml-3") %>
       </div>
     </div>
 
     <div class="form-group">
-      <%= form.label(:description) %><br>
-      <%= form.text_area(:description, cols: 60, rows: 10,
+      <%= f.label(:description) %><br>
+      <%= f.text_area(:description, cols: 60, rows: 10,
                          class: "form-control") %>
     </div>
 
-    <%= check_box_with_label(form: form, field: :approved, text: :APPROVED.t) %>
+    <%= check_box_with_label(form: f, field: :approved, text: :APPROVED.t) %>
   </div>
 
   <div class="actions">
-    <%= form.submit(:SUBMIT.t, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SUBMIT.t) %>
   </div>
 <% end %>

--- a/app/views/visual_groups/edit.html.erb
+++ b/app/views/visual_groups/edit.html.erb
@@ -36,8 +36,7 @@
     <div class="form-group form-inline">
       <%= f.text_field(:filter, value: @filter, size: 60,
                        class: "form-control", id: "filter") %>
-      <%= f.submit(:edit_visual_group_update_filter.t,
-                   class: "btn btn-default") %>
+      <%= submit_button(form: f, button: :edit_visual_group_update_filter.t) %>
     </div>
 
   <% end %>

--- a/app/views/visual_groups/edit.html.erb
+++ b/app/views/visual_groups/edit.html.erb
@@ -30,14 +30,14 @@
   <hr>
 
   <%= form_with(url: edit_visual_group_path(@visual_group), method: :get,
-                id: "visual_group_filters_form") do |form| %>
+                id: "visual_group_filters_form") do |f| %>
 
-    <%= form.label(:filter, :edit_visual_group_filter_options.t) %>
+    <%= f.label(:filter, :edit_visual_group_filter_options.t) %>
     <div class="form-group form-inline">
-      <%= form.text_field(:filter, value: @filter, size: 60,
-                          class: "form-control", id: "filter") %>
-      <%= form.submit(:edit_visual_group_update_filter.t,
-                      class: "btn btn-default") %>
+      <%= f.text_field(:filter, value: @filter, size: 60,
+                       class: "form-control", id: "filter") %>
+      <%= f.submit(:edit_visual_group_update_filter.t,
+                   class: "btn btn-default") %>
     </div>
 
   <% end %>

--- a/app/views/visual_models/_form.html.erb
+++ b/app/views/visual_models/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: visual_model) do |form| %>
+<%= form_with(model: visual_model) do |f| %>
   <% if visual_model.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(visual_model.errors.count, "error") %> prohibited this visual_model from being saved:</h2>
@@ -12,12 +12,12 @@
   <% end %>
 
   <div class="form-group field">
-    <%= form.label(:name) %>
-    <%= form.text_field(:name, class: "form-control") %>
+    <%= f.label(:name) %>
+    <%= f.text_field(:name, class: "form-control") %>
     <%= :VISUAL_MODEL.t %>
   </div>
 
   <div class="actions">
-    <%= form.submit(:SUBMIT.t, class: "btn btn-default center-block mt-3") %>
+    <%= centered_submit(form: f, button: :SUBMIT.t) %>
   </div>
 <% end %>

--- a/app/views/visual_models/_form.html.erb
+++ b/app/views/visual_models/_form.html.erb
@@ -18,6 +18,6 @@
   </div>
 
   <div class="actions">
-    <%= centered_submit(form: f, button: :SUBMIT.t) %>
+    <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
   </div>
 <% end %>

--- a/test/controllers/names/classification/inherit_controller_test.rb
+++ b/test/controllers/names/classification/inherit_controller_test.rb
@@ -77,7 +77,7 @@ module Names::Classification
       assert_template("names/classification/inherit/new")
       assert_not_blank(assigns(:message))
       assert_not_empty(assigns(:options))
-      assert_select("span", text: "Agaricales")
+      assert_select("label", text: "Agaricales")
       assert_input_value("parent", "Agariclaes")
 
       # Test ambiguity: three names all accepted and with classifications.

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -54,11 +54,13 @@ class SearchControllerTest < FunctionalTestCase
         model: "observation",
         user: "rolf"
       },
-      content_filter_has_images: "",
-      content_filter_has_specimen: "yes",
-      content_filter_lichen: "no",
-      content_filter_region: "California",
-      content_filter_clade: ""
+      content_filter: {
+        has_images: "",
+        has_specimen: "yes",
+        lichen: "no",
+        region: "California",
+        clade: ""
+      }
     }
     get(:advanced, params: params)
     query = QueryRecord.last.query


### PR DESCRIPTION
DRY up the form submit buttons. There are more than 100 submit buttons in /views! 

Part of the process of writing helpers to make it easier to code consistent forms, and apply repetitive Bootstrap classes in one place (the helper rather than in every view). This PR continues to evolve other existing helpers to be versatile enough to use on almost all inputs. More helpers on the way.

Before: 
```ruby
f.submit(button.t, class: "btn btn-default center-block my-3")
```

After:
```ruby
submit_button(form: f, button: button, center: true)
```

Also refactors the few remaining form inputs that didn't use form helpers yet.