### PR TITLE
Allow city + county

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -531,7 +531,6 @@ class Location < AbstractModel
     unless check_db && location_exists(name)
       reasons += check_for_empty_name(name)
       reasons += check_for_dubious_commas(name)
-      reasons += check_for_dubious_county(name)
       reasons += check_for_bad_country_or_state(name)
       reasons += check_for_bad_terms(name)
       reasons += check_for_bad_chars(name)
@@ -549,14 +548,6 @@ class Location < AbstractModel
     return [] unless comma_test(name)
 
     [:location_dubious_commas.l]
-  end
-
-  def self.check_for_dubious_county(name)
-    return [] if name.blank?
-    return [] if /Forest,|Park,|near /.match?(name)
-    return [] unless has_dubious_county?(name)
-
-    [:location_dubious_redundant_county.l]
   end
 
   def self.check_for_bad_country_or_state(name)
@@ -648,16 +639,6 @@ class Location < AbstractModel
 
   def self.dubious_country?(name)
     !understood_country?(country(name))
-  end
-
-  def self.has_dubious_county?(name)
-    tokens = name.split(", ")
-    return if tokens.length < 2
-
-    alt = [tokens[0]]
-    tokens[1..].each { |t| alt.push(t) if t[-4..] != " Co." }
-    result = alt.join(", ")
-    result == name ? nil : result
   end
 
   def self.fix_country(name)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1715,7 +1715,6 @@
   location_dubious_bad_term: For consistency, we prefer '[good]' instead of '[bad]'.
   location_dubious_commas: All commas should be followed by a space and another word
   location_dubious_empty: Empty location given
-  location_dubious_redundant_county: County may not be required in this name; for greatest consistency we prefer that you not include the county for towns and cities.
   location_dubious_redundant_state: Both '[state]' and '[country]' are on the list of countries and continents.  A common mistake is to include the continent in addition to the country; this is unnecessary.
   location_dubious_unknown_country: Unknown country '[country]'
   location_dubious_unknown_state: Unrecognized state or province '[state]' for '[country]'.

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1743,24 +1743,24 @@ class ObservationsControllerTest < FunctionalTestCase
     generic_construct_observation({
                                     observation: { place_name: where },
                                     naming: { name: "Unknown" }
-                                  }, 0, 0, 0)
+                                  }, 1, 0, 0)
     where = "USA, California, Los Angeles Co., Burbank"
     generic_construct_observation({
                                     observation: { place_name: where },
                                     naming: { name: "Unknown" }
-                                  }, 0, 0, 0, roy)
+                                  }, 1, 0, 0, roy)
 
     # Test mix of city and county
     where = "Falmouth, Barnstable Co., Massachusetts, USA"
     generic_construct_observation({
                                     observation: { place_name: where },
                                     naming: { name: "Unknown" }
-                                  }, 0, 0, 0)
+                                  }, 1, 0, 0)
     where = "USA, Massachusetts, Barnstable Co., Falmouth"
     generic_construct_observation({
                                     observation: { place_name: where },
                                     naming: { name: "Unknown" }
-                                  }, 0, 0, 0, roy)
+                                  }, 1, 0, 0, roy)
 
     # Test some bad terms
     where = "Some County, Ohio, USA"

--- a/test/integration/rails-dom-testing/post_observation_test.rb
+++ b/test/integration/rails-dom-testing/post_observation_test.rb
@@ -67,7 +67,7 @@ class PostObservationTest < IntegrationTestCase
     submit_form_with_changes(create_location_form_first_changes,
                              /create/i, "#location_form")
     assert_template(CREATE_LOCATION_TEMPLATE)
-    assert_has_location_warning(/County may not be required/)
+    assert_has_location_warning(/Contains unexpected character/)
     assert_form_has_correct_values(
       create_location_form_values_after_first_changes
     )
@@ -341,7 +341,10 @@ class PostObservationTest < IntegrationTestCase
 
   def create_location_form_first_changes
     {
-      "location_display_name" => "Pasadena, Some Co., California, USA",
+
+      # "location_display_name" => "({[;:|]}), California, USA",
+      "location_display_name" =>
+        "Pasadena: Disneyland, Some Co., California, USA",
       "location_high" => 8765,
       "location_low" => 4321,
       "location_notes" => "oops"
@@ -350,6 +353,7 @@ class PostObservationTest < IntegrationTestCase
 
   def create_location_form_second_changes
     {
+      "location_display_name" => "Pasadena, Some Co., California, USA",
       "location_high" => 5678,
       "location_low" => 1234,
       "location_notes" => "Notes for location"

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -17,7 +17,6 @@ class LocationTest < UnitTestCase
     bad_location("USA, North America")
     bad_location("San Francisco, USA")
     bad_location("San Francisco, CA, USA")
-    bad_location("San Francisco, San Francisco Co., California, USA")
     # bad_location("Tilden Park, California, USA") - can't detect
     # bad_location("Tilden Park, Kensington, California, USA") - can't detect
     bad_location("Albis Mountain Range, Zurich area, Switzerland")
@@ -38,6 +37,7 @@ class LocationTest < UnitTestCase
     good_location("Earth")
     good_location("North America")
     good_location("San Francisco, California, USA")
+    good_location("San Francisco, San Francisco Co., California, USA")
     good_location("Tilden Park, Contra Costa Co., California, USA")
     good_location("Albis Mountain Range, near Zurich, Switzerland")
     good_location("Southern California, USA")


### PR DESCRIPTION
- Lets users include both city and county in Location name.
We used to tell users that we prefer to omit county in order to have consistent Location names.
But county is now included in so many Locations that this no longer makes sense.
See e.g.:
>Jason Hollinger  Sun, Jan 15, 2023 at 4:47 PM
To: Joseph Cohen 
Cc: "webmaster mushroomobserver.org" 
And while we're at it, can we finally remove the bit about "county may not be necessary"?  The community has clearly
voted to ignore that rule!

- Delivers [Pivotal 184449491](https://www.pivotaltracker.com/story/show/184449491)