### PR TITLE
Confirm Clear List

### DIFF
--- a/app/views/admin/blocked_ips/edit.html.erb
+++ b/app/views/admin/blocked_ips/edit.html.erb
@@ -26,7 +26,9 @@
                       path: admin_blocked_ips_path(clear_okay: 1),
                       class: "btn btn-default",
                       form_class: "d-inline-block float-right",
-                      id: "clear_okay_ips_list") %>
+                      id: "clear_okay_ips_list",
+                      data: { confirm: :are_you_sure.t }
+) %>
 
       <table id="okay_ips" class="ips my-3 table table-striped">
         <% @okay_ips.each do |ip| %>
@@ -58,7 +60,9 @@
                         path: admin_blocked_ips_path(clear_bad: 1),
                         class: "btn btn-default",
                         form_class: "d-inline-block float-right",
-                        id: "clear_blocked_ips_list") %>
+                        id: "clear_blocked_ips_list",
+                        data: { confirm: :are_you_sure.t }
+                      ) %>
 
       <table id="blocked_ips" class="ips my-3 table table-striped">
         <% @blocked_ips.each do |ip| %>

--- a/app/views/admin/blocked_ips/edit.html.erb
+++ b/app/views/admin/blocked_ips/edit.html.erb
@@ -23,12 +23,12 @@
       <% end %>
 
       <%= patch_button(name: "Clear List",
-                      path: admin_blocked_ips_path(clear_okay: 1),
-                      class: "btn btn-default",
-                      form_class: "d-inline-block float-right",
-                      id: "clear_okay_ips_list",
-                      data: { confirm: :are_you_sure.t }
-) %>
+                       path: admin_blocked_ips_path(clear_okay: 1),
+                       class: "btn btn-default",
+                       form_class: "d-inline-block float-right",
+                       id: "clear_okay_ips_list",
+                       data: { confirm: :are_you_sure.t }
+                      ) %>
 
       <table id="okay_ips" class="ips my-3 table table-striped">
         <% @okay_ips.each do |ip| %>
@@ -57,11 +57,11 @@
       <% end %>
 
       <%= patch_button(name: "Clear List",
-                        path: admin_blocked_ips_path(clear_bad: 1),
-                        class: "btn btn-default",
-                        form_class: "d-inline-block float-right",
-                        id: "clear_blocked_ips_list",
-                        data: { confirm: :are_you_sure.t }
+                       path: admin_blocked_ips_path(clear_bad: 1),
+                       class: "btn btn-default",
+                       form_class: "d-inline-block float-right",
+                       id: "clear_blocked_ips_list",
+                       data: { confirm: :are_you_sure.t }
                       ) %>
 
       <table id="blocked_ips" class="ips my-3 table table-striped">
@@ -69,8 +69,8 @@
           <tr>
             <td><%= ip.t %></td>
             <td>[<%= patch_button(name: :REMOVE.l,
-                       path: admin_blocked_ips_path(remove_bad: ip),
-                       id: "remove_blocked_ip_#{ip}") %>]</td>
+                     path: admin_blocked_ips_path(remove_bad: ip),
+                     id: "remove_blocked_ip_#{ip}") %>]</td>
       <% end %>
       </table>
     </section><!--#blocked_ips-->

--- a/app/views/admin/blocked_ips/edit.html.erb
+++ b/app/views/admin/blocked_ips/edit.html.erb
@@ -71,6 +71,7 @@
             <td>[<%= patch_button(name: :REMOVE.l,
                      path: admin_blocked_ips_path(remove_bad: ip),
                      id: "remove_blocked_ip_#{ip}") %>]</td>
+          </tr>
       <% end %>
       </table>
     </section><!--#blocked_ips-->


### PR DESCRIPTION
- Adds an "Are you sure?" confirmation to the Clear List buttons on the admin/blocked_ips page.
This makes it harder to accidentally toast  the OK ips or Blocked ips lists. 
(The lists are backed up, so that isn't absolutely fatal. But it it's a bit of trouble to restore them. 
I've been meaning to do this for a while.)