### PR TITLE
Fix glossary search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,6 +5,7 @@ class SearchController < ApplicationController
   # This is the action the search bar commits to.  It just redirects to one of
   # several "foreign" search actions:
   #   /comments/index (params[:pattern])
+  #   /glossary_terms/index (params[:pattern])
   #   /herbaria/index (params[:pattern])
   #   /herbarium_records/index (params[:pattern])
   #   /images/index (params[:pattern])
@@ -74,8 +75,8 @@ class SearchController < ApplicationController
     case type
     when :google
       site_google_search(pattern)
-    when :comment, :herbarium, :herbarium_record, :image, :location, :name,
-         :observation, :project, :species_list, :user
+    when :comment, :glossary_term, :herbarium, :herbarium_record, :image,
+         :location, :name, :observation, :project, :species_list, :user
       redirect_to_search_or_index(
         pattern: pattern,
         search_path: send("#{type.to_s.pluralize}_path",

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -105,6 +105,10 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern, params: params)
     assert_redirected_to(users_path(pattern: "34"))
 
+    params = { search: { pattern: "34", type: :glossary_term } }
+    get(:pattern, params: params)
+    assert_redirected_to(glossary_terms_path(pattern: "34"))
+
     stub_request(:any, /google.com/)
     pattern =  "hexiexiva"
     params = { search: { pattern: pattern, type: :google } }


### PR DESCRIPTION
The `glossary_terms_controller_test` for searches worked, but the UI did not! Thanks to EXD for pointing it out.

That's because the search form hits the search controller first, and when i made the glossary index a paginated query, I did not yet permit glossary searches. Now they're permitted.

Adds a search controller test. Ideally, would write some integration tests, but no time at the moment.