### PR TITLE
Glossary term forms - use form helpers

### DIFF
--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -134,8 +134,8 @@ class GlossaryTermsController < ApplicationController
   end
 
   def assign_image_form_ivars
-    @copyright_holder = params[:copyright_holder] || @user.name
-    @copyright_year = params.dig(:date, :copyright_year)&.to_i ||
+    @copyright_holder = params.dig(:upload, :copyright_holder) || @user.name
+    @copyright_year = params.dig(:upload, :copyright_year)&.to_i ||
                       Time.now.utc.year
     @licenses = License.current_names_and_ids(@user.license)
     @upload_license_id = params.dig(:upload, :license_id) || @user.license_id
@@ -176,7 +176,7 @@ class GlossaryTermsController < ApplicationController
   end
 
   def upload_specified?
-    params[:glossary_term][:upload_image]
+    params[:upload][:image]
   end
 
   def process_upload(args)
@@ -217,11 +217,11 @@ class GlossaryTermsController < ApplicationController
 
   def strong_upload_image_param
     {
-      copyright_holder: params[:copyright_holder],
-      when: Time.local(params[:date][:copyright_year]).utc,
+      copyright_holder: params[:upload][:copyright_holder],
+      when: Time.local(params[:upload][:copyright_year]).utc,
       license: License.safe_find(params[:upload][:license_id]),
       user: @user,
-      image: params[:glossary_term][:upload_image]
+      image: params[:upload][:image]
     }
   end
 
@@ -229,7 +229,7 @@ class GlossaryTermsController < ApplicationController
   # Do this only in test environment
   def permit_upload_image_param
     args = strong_upload_image_param
-    args[:image] = params[:glossary_term][:upload_image][:image]
+    args[:image] = params[:upload][:image]
     args
   end
 end

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -1,15 +1,12 @@
 <%= form_with(model: @glossary_term, html: { multipart: true }) do |f| %>
 
-  <div class="form-group mt-3">
-    <%= f.label(:name, "#{:glossary_term_name.t}:") %>
-    <%= f.text_field(:name, class: "form-control") %>
-  </div>
+  <%= text_field_with_label(form: f, field: :name,
+                            label: :glossary_term_name.t + ":",
+                            data: { autofocus: true }) %>
 
-  <div class="form-group mt-3">
-    <%= f.label(:description, "#{:glossary_term_description.t}:") %>
-    <%= f.text_area(:description, rows: 16, class: "form-control") %>
-    <%= :field_textile_link.t %>
-  </div>
+  <%= text_area_with_label(form: f, field: :description, rows: 16,
+                           label: :glossary_term_description.t + ":",
+                           append: :field_textile_link.t) %>
 
   <%= yield f %>
 

--- a/app/views/glossary_terms/new.html.erb
+++ b/app/views/glossary_terms/new.html.erb
@@ -7,33 +7,31 @@
     link_to(:glossary_term_index.t, action: :index)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
+
+
 %>
 
 <%= render("form", button_name: :edit_glossary_term_save) do |f| %>
 
-  <div class="form-group mt-3">
-    <%= label_tag(:glossary_term_upload_image, "#{:Image.t}:") %>
-    <%= custom_file_field(:glossary_term, :upload_image) %>
-  </div>
+  <%= fields_for(:upload) do |f_u| %>
+    <%= file_field_with_label(form: f_u, field: :image,
+                              label: :Image.t + ":") %>
 
-  <div class="form-group mt-3 form-inline">
+    <%= text_field_with_label(form: f_u, field: :copyright_holder, inline: true,
+                              label: :glossary_term_copyright_holder.t + ":") %>
 
-    <%= label_tag(:copyright_holder,
-                  "#{:glossary_term_copyright_holder.t}:") %><br/>
-    <%= text_field_tag(:copyright_holder, @copyright_holder,
-                        class: "form-control") %>
+    <%= select_with_label(form: f_u, field: :copyright_year,
+                          label: :WHEN.t + ":", inline: true,
+                          start_year: 1980, end_year: Time.zone.now.year,
+                          value: @copyright_year) %>
 
-    <%= select_year(@copyright_year,
-                    { field_name: :copyright_year,
-                      start_year: 1980,
-                      end_year: Time.zone.now.year },
-                    { class: "form-control" }) %><br/>
-
-    <%= select(:upload, :license_id, @licenses,
-                selected: @upload_license_id,
-                class: "form-control") %>
-
-    <p class="help_block">(<%= :glossary_term_copyright_warning.t %>)</p>
-  </div>
+    <%= select_with_label(form: f_u, field: :license_id, inline: true,
+                          label: :License.t + ":", options: @licenses,
+                          select_opts: { selected: @upload_license_id },
+                          append: help_block(:div,
+                                  ["(",
+                                    :glossary_term_copyright_warning.t,
+                                    ")"].safe_join)) %>
+  <% end %>
 
 <% end %>

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -98,7 +98,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
       assert_select("form [name='glossary_term[#{attr}]']", { count: 1 },
                     "Form should have one field for #{attr}")
     end
-    assert_select("input#glossary_term_upload_image", { count: 1 },
+    assert_select("input#upload_image", { count: 1 },
                   "Form should include upload image field")
   end
 
@@ -131,7 +131,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
       { text: /#{term.description}/, count: 1 },
       "Form lacks Description field that defaults to glossary term description"
     )
-    assert_select("input#glossary_term_upload_image", false,
+    assert_select("input#upload_image", false,
                   "Edit GlossaryTerm form should omit upload image field")
   end
 
@@ -337,9 +337,11 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   def create_term_params
     {
       glossary_term: { name: "Xevnoc", description: "Convex spelled backward" },
-      copyright_holder: "Insil Choi",
-      date: { copyright_year: "2013" },
-      upload: { license_id: licenses(:ccnc30).id }
+      upload: {
+        copyright_holder: "Insil Choi",
+        copyright_year: "2013",
+        license_id: licenses(:ccnc30).id
+      }
     }.freeze
   end
 
@@ -347,9 +349,11 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     {
       id: glossary_terms(:conic_glossary_term).id,
       glossary_term: { name: "Xevnoc", description: "Convex spelled backward" },
-      copyright_holder: "Insil Choi",
-      date: { copyright_year: 2013 },
-      upload: { license_id: licenses(:ccnc25).id }
+      upload: {
+        copyright_holder: "Insil Choi",
+        copyright_year: 2013,
+        license_id: licenses(:ccnc25).id
+      }
     }.freeze
   end
 
@@ -361,16 +365,15 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     {
       glossary_term: {
         name: "Pancake",
-        description: "Flat",
-        upload_image: {
-          image: file,
-          copyright_holder: "zuul",
-          when: Time.current
-        }
+        description: "Flat"
       },
-      copyright_holder: "Me",
-      date: { copyright_year: 2013 },
-      upload: { license_id: licenses(:ccnc25).id }
+      upload: {
+        image: file,
+        copyright_holder: "zuul",
+        copyright_year: 2013,
+        when: Time.current,
+        license_id: licenses(:ccnc25).id
+      }
     }.freeze
   end
 end


### PR DESCRIPTION
Also reorganizes param nesting: 
```ruby
{
  glossary_term: {
    name:
    description:
  },
  upload: {
    copyright_holder:
    copyright_year:
    license_id:
    when:
    image:
  }
}
```
