### PR TITLE
Make glossary public

### DIFF
--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -2,7 +2,7 @@
 
 # create and edit Glossary terms
 class GlossaryTermsController < ApplicationController
-  before_action :login_required
+  before_action :login_required, except: [:index, :show]
   before_action :store_location, except: [:create, :update, :destroy]
 
   # ---------- Actions to Display data (index, show, etc.) ---------------------

--- a/app/views/glossary_terms/index.html.erb
+++ b/app/views/glossary_terms/index.html.erb
@@ -1,9 +1,9 @@
 <%
 @title = :glossary_term_index_title.t
 
-tabs = [
+tabs = User.current ? [
   link_to(:create_glossary_term.t, new_glossary_term_path)
-]
+] : []
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text_image
 %>

--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -1,11 +1,11 @@
 <%
   @title = :show_glossary_term_title.t(name: @glossary_term.name)
 
-  tabs = [
+  tabs = User.current ? [
     link_to(:glossary_term_index.t, glossary_terms_path),
     link_to(:create_glossary_term.t, new_glossary_term_path),
     link_to(:edit_glossary_term.t, edit_glossary_term_path(@glossary_term.id))
-  ]
+  ] : []
   tabs << glossary_term_destroy_button(@glossary_term) if in_admin_mode?
 
   @tabsets = { right: draw_tab_set(tabs) }

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -10,7 +10,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
 
   # ***** index *****
   def test_index
-    login
+    # make sure public can access
     get(:index)
 
     assert_response(:success)
@@ -25,7 +25,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   end
 
   def test_index_by_letter
-    login
+    # make sure public can access
     term = glossary_terms(:plane_glossary_term)
     get(:index, params: { letter: "P" })
     assert_template("index")
@@ -36,7 +36,6 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   end
 
   def test_glossary_term_search
-    login
     conic = glossary_terms(:conic_glossary_term)
     convex = glossary_terms(:convex_glossary_term)
 
@@ -44,6 +43,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     qr = QueryRecord.last.id.alphabetize
     assert_redirected_to(glossary_term_path(conic.id, params: { q: qr }))
 
+    login
     get(:index, params: { pattern: "con" })
     assert_template("index")
     assert_select(
@@ -57,6 +57,10 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   # ***** show *****
   def test_show
     term = glossary_terms(:square_glossary_term)
+    # make sure public can access
+    get(:show, params: { id: term.id })
+
+    assert_response(:success)
     prior_version_path = glossary_term_versions_path(
       term.id, version: term.version - 1
     )


### PR DESCRIPTION
Now that the glossary is paged, i think @pellaea's old PR #1139 is ready to go.

This PR adds a conditional on the nav tabs - you still have to be logged in to edit or create a glossary term, so those tabs don't even display if you're not logged in.