### PR TITLE
Switch to `fastimage` gem to read image dimensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,9 @@ gem("rtf")
 # Enable remote procedure calls over HTTP (used in MO API)
 gem("xmlrpc")
 
+# Get image sizes from a file
+gem("fastimage")
+
 # Simple versioning
 # Use our own fork, which stores enum attrs as integers in the db
 gem("mo_acts_as_versioned", ">= 0.6.6",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     docile (1.4.0)
     erubi (1.12.0)
     execjs (2.8.1)
+    fastimage (2.2.6)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -322,6 +323,7 @@ DEPENDENCIES
   database_cleaner-active_record
   date (>= 3.2.1)
   debug (>= 1.0.0)
+  fastimage
   graphiql-rails!
   graphql
   graphql-batch

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -759,9 +759,10 @@ class Image < AbstractModel
   # Get image size from JPEG header and set the corresponding record fields.
   # Saves the record.
   def set_image_size(file = local_file_name(:full_size))
-    script = Rails.root.join("script/jpegsize").to_s
-    output, _status = Open3.capture2(script, file)
-    w, h = output.to_s.chomp.split
+    # script = Rails.root.join("script/jpegsize").to_s
+    # output, _status = Open3.capture2(script, file)
+    # w, h = output.to_s.chomp.split
+    w, h = FastImage.size(file)
     return unless /^\d+$/.match?(w.to_s)
 
     self.width  = w.to_i

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -757,11 +757,8 @@ class Image < AbstractModel
   end
 
   # Get image size from JPEG header and set the corresponding record fields.
-  # Saves the record.
+  # Saves the record. NOTE: Requires gem("fastimage")
   def set_image_size(file = local_file_name(:full_size))
-    # script = Rails.root.join("script/jpegsize").to_s
-    # output, _status = Open3.capture2(script, file)
-    # w, h = output.to_s.chomp.split
     w, h = FastImage.size(file)
     return unless /^\d+$/.match?(w.to_s)
 

--- a/script/jpegsize
+++ b/script/jpegsize
@@ -1,40 +1,19 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require("fastimage")
+require("stringio")
 #
-#  Read width and height of JPEG image from header.  (ImageMagick loads the
-#  entire image into memory!)
+#  Uses FastImage gem to read width and height of JPEG image from header.
+#  We could use ImageMagick identify to do the same thing. This script was
+#  originally written because ImageMagick loaded the entire image into memory.
+#  That is no longer true, but gem is probably faster and used for consistency.
 #
 ################################################################################
 
 # ------------------------------------
 #  Grab dimensions from JPEG header.
 # ------------------------------------
-
-def get_size(file)
-  w = h = nil
-  File.open(file) do |fh|
-    x = fh.sysread(2).unpack1("n")
-    if x != 0xFFD8
-      warn("#{file}: not jpeg")
-      break
-    end
-    baseline_dct_or_progressive_dct = [0xFFC0, 0xFFC2].freeze
-    while (str = fh.sysread(4))
-      x, l = str.unpack("nn")
-      if baseline_dct_or_progressive_dct.include?(x)
-        h, w = fh.sysread(5).unpack("xnn")
-        break
-      # elsif x < 0xFF00
-      #   $stderr.puts('Invalid header!')
-      #   exit 1
-      else
-        fh.sysseek(l - 2, IO::SEEK_CUR)
-      end
-    end
-  end
-  [w, h]
-end
 
 # ----------------------------
 #  Main program.
@@ -52,7 +31,7 @@ when "-f", "--file"
   any = false
   File.readlines(file).each do |line|
     file2 = line.chomp
-    w, h = get_size(file2)
+    w, h = FastImage.size(file2)
     if w
       $stdout.puts("#{file2}: #{w} #{h}")
       any = true
@@ -64,7 +43,7 @@ when "-f", "--file"
 else
   if (ARGV.length == 1) && !ARGV[0].start_with?("-")
     file = ARGV[0]
-    w, h = get_size(file)
+    w, h = FastImage.size(file)
     if w
       $stdout.puts("#{w} #{h}")
       exit(0)

--- a/script/process_image
+++ b/script/process_image
@@ -75,8 +75,9 @@ fi
 # Make sure image is oriented correctly.
 log_cmd exifautotran $full_file
 
+# Changing from $app_root/script/jpegsize to identify (ImageMagick)
 if (( $set_size )); then
-  size=$( $app_root/script/jpegsize $full_file )
+  size=$( identify $full_file )
   w=$( echo $size | sed "s/ .*//" )
   h=$( echo $size | sed "s/.* //" )
   log_mysql "UPDATE images SET width=$w, height=$h WHERE id=$id" || true
@@ -121,7 +122,7 @@ if (( !$development && !$errors && $transferred_any )); then
 fi
 
 if (( !$development && $errors )); then
-  send_mail -s "[MO] process_image" $webmaster_email < $log_file 
+  send_mail -s "[MO] process_image" $webmaster_email < $log_file
 fi
 
 exit $errors

--- a/script/process_image
+++ b/script/process_image
@@ -75,9 +75,8 @@ fi
 # Make sure image is oriented correctly.
 log_cmd exifautotran $full_file
 
-# Changing from $app_root/script/jpegsize to identify (ImageMagick)
 if (( $set_size )); then
-  size=$( identify $full_file )
+  size=$( $app_root/script/jpegsize $full_file )
   w=$( echo $size | sed "s/ .*//" )
   h=$( echo $size | sed "s/.* //" )
   log_mysql "UPDATE images SET width=$w, height=$h WHERE id=$id" || true

--- a/script/rotate_image
+++ b/script/rotate_image
@@ -22,7 +22,7 @@ DESCRIPTION
   This grabs the original image from the image server if it's already
   been moved, rotates or flips the original as requested, updates the
   database, then transfers execution to script/process_image.  It aborts at
-  the first sign of trouble. 
+  the first sign of trouble.
 
 OPERATIONS
   0     No transformation, just reprocess the image.
@@ -80,7 +80,8 @@ case $op in
 esac
 
 # Update size and clear "transferred" bit in database.
-size=$( $app_root/script/jpegsize $orig_file )
+# Changing from $app_root/script/jpegsize to identify (ImageMagick)
+size=$( identify $orig_file )
 w=$( echo $size | sed "s/ .*//" )
 h=$( echo $size | sed "s/.* //" )
 run_mysql "UPDATE images SET transferred=FALSE, width=$w, height=$h WHERE id=$id" || warn "Failed to update database: $id should be $w x $h."

--- a/script/rotate_image
+++ b/script/rotate_image
@@ -80,8 +80,7 @@ case $op in
 esac
 
 # Update size and clear "transferred" bit in database.
-# Changing from $app_root/script/jpegsize to identify (ImageMagick)
-size=$( identify $orig_file )
+size=$( $app_root/script/jpegsize $orig_file )
 w=$( echo $size | sed "s/ .*//" )
 h=$( echo $size | sed "s/.* //" )
 run_mysql "UPDATE images SET transferred=FALSE, width=$w, height=$h WHERE id=$id" || warn "Failed to update database: $id should be $w x $h."

--- a/test/models/image_script_test.rb
+++ b/test/models/image_script_test.rb
@@ -114,11 +114,11 @@ class ScriptTest < UnitTestCase
       file.puts("#{local_root}/320//#{in_situ_id}.jpg")
       file.puts("#{local_root}/thumb//#{in_situ_id}.jpg")
     end
-    # output, _status = Open3.capture2(script_file("jpegsize"), "-f", tempfile)
-    # sizes = output.each_line.map do |line|
-    #   line[local_root.length + 1..-1].chomp
-    # end
-    sizes = FastImage.sizes(tempfile)
+    # Not sure how to convert this to ImageMagick `identify`
+    output, _status = Open3.capture2(script_file("jpegsize"), "-f", tempfile)
+    sizes = output.each_line.map do |line|
+      line[local_root.length + 1..-1].chomp
+    end
     assert_equal("orig//#{in_situ_id}.jpg: 2560 1920", sizes[0],
                  "full-size image is wrong size")
     assert_equal("1280//#{in_situ_id}.jpg: 1280 960", sizes[1],

--- a/test/models/image_script_test.rb
+++ b/test/models/image_script_test.rb
@@ -114,10 +114,11 @@ class ScriptTest < UnitTestCase
       file.puts("#{local_root}/320//#{in_situ_id}.jpg")
       file.puts("#{local_root}/thumb//#{in_situ_id}.jpg")
     end
-    output, _status = Open3.capture2(script_file("jpegsize"), "-f", tempfile)
-    sizes = output.each_line.map do |line|
-      line[local_root.length + 1..-1].chomp
-    end
+    # output, _status = Open3.capture2(script_file("jpegsize"), "-f", tempfile)
+    # sizes = output.each_line.map do |line|
+    #   line[local_root.length + 1..-1].chomp
+    # end
+    sizes = FastImage.sizes(tempfile)
     assert_equal("orig//#{in_situ_id}.jpg: 2560 1920", sizes[0],
                  "full-size image is wrong size")
     assert_equal("1280//#{in_situ_id}.jpg: 1280 960", sizes[1],

--- a/test/models/image_script_test.rb
+++ b/test/models/image_script_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class ScriptTest < UnitTestCase
+class ImageScriptTest < UnitTestCase
   DATABASE_CONFIG = YAML.safe_load(
     Rails.root.join("config/database.yml").read
   )["test"]
@@ -114,7 +114,6 @@ class ScriptTest < UnitTestCase
       file.puts("#{local_root}/320//#{in_situ_id}.jpg")
       file.puts("#{local_root}/thumb//#{in_situ_id}.jpg")
     end
-    # Not sure how to convert this to ImageMagick `identify`
     output, _status = Open3.capture2(script_file("jpegsize"), "-f", tempfile)
     sizes = output.each_line.map do |line|
       line[local_root.length + 1..-1].chomp

--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -34,6 +34,7 @@ class ScriptTest < UnitTestCase
     assert_equal(expect, actual)
   end
 
+  # Now uses gem, no need to test here
   # test "jpegsize" do
   #   script = script_file("jpegsize")
   #   [

--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -34,17 +34,17 @@ class ScriptTest < UnitTestCase
     assert_equal(expect, actual)
   end
 
-  test "jpegsize" do
-    script = script_file("jpegsize")
-    [
-      ["Coprinus_comatus.jpg", 2288, 2168],
-      ["perf.jpg", 4288, 2848],
-      ["sticky.jpg", 407, 500]
-    ].each do |file, width, height|
-      result = `#{script} #{::Rails.root}/test/images/#{file}`.chomp
-      assert_equal("#{width} #{height}", result)
-    end
-  end
+  # test "jpegsize" do
+  #   script = script_file("jpegsize")
+  #   [
+  #     ["Coprinus_comatus.jpg", 2288, 2168],
+  #     ["perf.jpg", 4288, 2848],
+  #     ["sticky.jpg", 407, 500]
+  #   ].each do |file, width, height|
+  #     result = `#{script} #{::Rails.root}/test/images/#{file}`.chomp
+  #     assert_equal("#{width} #{height}", result)
+  #   end
+  # end
 
   test "lookup_user" do
     script = script_file("lookup_user")


### PR DESCRIPTION
There's a persistent issue with certain devices' images getting uploaded. When they are stored in the db, the width and height are swapped, leading to layout problems that only became apparent when I added lazyloading and image dimensions.

So - This is what happens in our code during the action of uploading the image to an observation. The obs controller calls

- `ObservationsController#create_image_objects`…
- `Image.process_image`...
- `Image.set_image_size`. This is the action that actually saves the width and height to the database, using our script `jpegsize`.

```ruby
  # Get image size from JPEG header and set the corresponding record fields.
  # Saves the record.
  def set_image_size(file = local_file_name(:full_size))
    script = Rails.root.join("script/jpegsize").to_s
    output, _status = Open3.capture2(script, file)
    w, h = output.to_s.chomp.split
    return unless /^\d+$/.match?(w.to_s)

    self.width  = w.to_i
    self.height = h.to_i
    save_without_our_callbacks
  end
```

After experimenting with some user images that were getting the proportions swapped, I found that the `fastimage` gem reads the dimensions correctly, so without further ado, I propose changing the dependency from our own `jpegsize` to the gem.

Two other scripts depend on `jpegsize` though: `rotate_image` and `process_image`.