### PR TITLE
Get rid of visited link colors

### DIFF
--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -2,16 +2,16 @@
 // link, button, alert themed styles
 // --------------------------------------------------
 
-a:not(.btn):not(.list-group-item):not(.theater-btn):visited {
-  color: $LINK_VISITED_FG_COLOR;
-}
+// a:not(.btn):not(.list-group-item):not(.theater-btn):visited {
+//   color: $LINK_VISITED_FG_COLOR;
+// }
 
-.navbar {
-  a,
-  a:visited {
-    color: $LINK_FG_COLOR !important;
-  }
-}
+// .navbar-default {
+//   a,
+//   a:visited {
+//     color: $LINK_FG_COLOR !important;
+//   }
+// }
 
 .btn-link {
   font-weight: normal !important;

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@
 
 require("open3")
 require("mimemagic")
-require("fastimage")
+# require("fastimage")
 #
 #  = Image Model
 #

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@
 
 require("open3")
 require("mimemagic")
-# require("fastimage")
+require("fastimage")
 #
 #  = Image Model
 #


### PR DESCRIPTION
So far we've had visited links a different color (purple instead of blue, on the black and white theme).  If Bootstrap is an indicator, they've totally retired visited link styling 10 years ago.  I personally don't feel having two colors to indicate links is helpful, but i'm open to hear about situations where it IS helpful, and figure out how visited links can be indicated in a more useful way.

I do think it's useful for example to indicate on a matrix box that you've already viewed that observation. I'd like to do it a different way, though.

This fixes an issue where left bar links are incorrectly styled on the Amanita theme.