### PR TITLE
Fix edit Classification

### DIFF
--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -16,7 +16,7 @@
   <%= text_area_with_label(
         form: f, field: :classification, rows: 10, value: @name.classification,
         between: help_block(p, :form_names_classification_help.l(rank: rank)),
-        label: :"form_names_classification".t + ":",
+        label: "#{:form_names_classification.t}:",
         data: { autofocus: true }
       ) %>
 

--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -11,7 +11,7 @@
   @container = :text
 %>
 
-<%= form_with(url: action) do |f| %>
+<%= form_with(url: action, method: :put) do |f| %>
 
   <%= text_area_with_label(
         form: f, field: :classification, rows: 10, value: @name.classification,

--- a/test/controllers/names/classification_controller_test.rb
+++ b/test/controllers/names/classification_controller_test.rb
@@ -25,6 +25,10 @@ module Names
       assert_response(:success)
       assert_template("names/classification/edit")
       assert_textarea_value(:classification, "")
+      assert_select("form[action = '#{name_classification_path(name)}']") do
+        assert_select("input[value = 'put']", { count: 1 },
+                      "Form should submit via PUT")
+      end
 
       name = names(:agaricus_campestris)
       get(:edit, params: { id: name.id })


### PR DESCRIPTION
- Fixes a bug that throws an error when the Edit Classification form is submitted.
- Adds a test assertion to expose the bug:
```ruby
Routing Error
No route matches [POST] "/names/883/classification"
```
- Submits with PUT rather than POST. 
- Delivers [Pivotal #184899433](https://www.pivotaltracker.com/story/show/184899433)

### Manual Test
- Edit a Classification. Ex: http://localhost:3000/names/883/classification/edit
- erase or modify the Classification string
- Save
**Expected Result**: It should display the Name with the changed Classification.