### PR TITLE
Fix versions table

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -99,9 +99,9 @@ module VersionsHelper
   end
 
   def initial_version_link_text(ver)
-    link = "#{:VERSION.t} #{ver.version}"
-    return link unless ver.respond_to?(:format_name)
+    text = "#{:VERSION.t} #{ver.version}"
+    return text unless ver.respond_to?(:format_name)
 
-    link + " #{ver.format_name.t}"
+    text + " #{ver.format_name.t}"
   end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -43,7 +43,7 @@ module VersionsHelper
 
   def previous_version_link(previous_version, obj)
     str = :show_name_previous_version.t + " " + previous_version.version.to_i
-    initial_html(obj) +
+    initial_version_html(obj) +
       link_with_query(str,
                       controller: "#{obj.show_controller}/versions",
                       action: :show, id: obj.id,
@@ -51,20 +51,20 @@ module VersionsHelper
       safe_br
   end
 
-  def initial_html(obj)
+  def initial_version_html(obj)
     :VERSION.t + ": " + obj.version.to_s + safe_br
   end
 
   def build_version_table(obj, args)
     obj.versions.reverse.map do |ver|
-      [find_ver_date(ver), indent,
-       find_ver_user(ver), indent,
-       calc_link(obj, ver, args), indent]
+      [find_version_date(ver), indent,
+       find_version_user(ver), indent,
+       style_version_link(obj, ver, args), indent]
     end
   end
 
-  def calc_link(obj, ver, args)
-    link = query_link(obj, ver, initial_link(ver))
+  def style_version_link(obj, ver, args)
+    link = link_to_version(initial_version_link_text(ver), ver, obj)
     if args[:bold]&.call(ver)
       content_tag(:b, link)
     else
@@ -72,51 +72,36 @@ module VersionsHelper
     end
   end
 
-  def find_ver_date(ver)
+  def find_version_date(ver)
     ver.updated_at.web_date
   rescue StandardError
     :unknown.t
   end
 
-  def find_ver_user(ver)
+  def find_version_user(ver)
     user = User.safe_find(ver.user_id)
     return :unknown.t unless user
 
     user_link(user, user.login)
   end
 
-  def link_to_ver(link, ver, obj)
+  def link_to_version(text, ver, obj)
     if ver == obj.versions.last
-      link_with_query(link, controller: obj.show_controller,
+      link_with_query(text, controller: obj.show_controller,
                             action: obj.show_action,
                             id: obj.id)
     else
-      link_with_query(link,
+      link_with_query(text,
                       controller: "#{obj.show_controller}/versions",
                       action: :show, id: obj.id,
                       version: ver.version)
     end
   end
 
-  def initial_link(ver)
+  def initial_version_link_text(ver)
     link = "#{:VERSION.t} #{ver.version}"
     return link unless ver.respond_to?(:format_name)
 
     link + " #{ver.format_name.t}"
-  end
-
-  def query_link(obj, ver, link)
-    return link if ver.version != obj.version
-
-    if ver == obj.versions.last
-      link_with_query(link, controller: obj.show_controller,
-                            action: obj.show_action,
-                            id: obj.id)
-    else
-      link_with_query(link,
-                      controller: "#{obj.show_controller}/versions",
-                      action: :show, id: obj.id,
-                      version: ver.version)
-    end
   end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -33,7 +33,8 @@ module VersionsHelper
   #   </p>
   #
   def show_past_versions(obj, args = {})
-    table = make_table(build_version_table(obj, args), class: "w-100")
+    table = make_table(build_version_table(obj, args),
+                       class: "table table-condensed")
     panel = content_tag(:div, table, class: "panel-body")
     tag.strong("#{:VERSIONS.t}:") +
       content_tag(:div, panel, class: "panel panel-default")
@@ -59,16 +60,7 @@ module VersionsHelper
     obj.versions.reverse.map do |ver|
       [find_version_date(ver), indent,
        find_version_user(ver), indent,
-       style_version_link(obj, ver, args), indent]
-    end
-  end
-
-  def style_version_link(obj, ver, args)
-    link = link_to_version(initial_version_link_text(ver), ver, obj)
-    if args[:bold]&.call(ver)
-      content_tag(:b, link)
-    else
-      link
+       link_to_version(initial_version_link_text(ver, args), ver, obj), indent]
     end
   end
 
@@ -87,9 +79,10 @@ module VersionsHelper
 
   def link_to_version(text, ver, obj)
     if ver == obj.versions.last
-      link_with_query(text, controller: obj.show_controller,
-                            action: obj.show_action,
-                            id: obj.id)
+      link_with_query(text,
+                      controller: obj.show_controller,
+                      action: obj.show_action,
+                      id: obj.id)
     else
       link_with_query(text,
                       controller: "#{obj.show_controller}/versions",
@@ -98,10 +91,12 @@ module VersionsHelper
     end
   end
 
-  def initial_version_link_text(ver)
+  def initial_version_link_text(ver, args)
     text = "#{:VERSION.t} #{ver.version}"
-    return text unless ver.respond_to?(:format_name)
+    text = content_tag(:strong, text) if args[:bold]&.call(ver)
+    return text unless ver.respond_to?(:display_name)
 
-    text + " #{ver.format_name.t}"
+    # keep this out of the above `strong` tag, because it has its own tags
+    text + "<br/> #{ver.display_name.t}".html_safe
   end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -15,7 +15,7 @@ module VersionsHelper
     if previous_version
       previous_version_link(previous_version, obj)
     else
-      initial_html(obj)
+      initial_version_html(obj)
     end
   end
 

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -97,6 +97,6 @@ module VersionsHelper
     return text unless ver.respond_to?(:display_name)
 
     # keep this out of the above `strong` tag, because it has its own tags
-    text + "<br/> #{ver.display_name.t}".html_safe
+    [text, safe_br, ver.display_name.t].safe_join
   end
 end


### PR DESCRIPTION
Fixes #1456. The table helper was just returning the link *text* if it wasn't the current version of the object.

- In some places, we've been passing the argument name `link` for the `text` of the link. This is likely to cause confusion when methods are broken down for abc, because we may assume we're dealing with a link when we're only dealing with a string. Recently I've been trying to replace that arg name wherever I encounter it.
- Helper methods are all in the global namespace, even potentially "private" methods. So i'm renaming some of these methods to be more specific.