### PR TITLE
Reduce tallest proportion of tall images in matrix box

### DIFF
--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -94,7 +94,7 @@ class ThumbnailPresenter < BasePresenter
     img_height = image&.height ? BigDecimal(image&.height) : 100
     img_proportion = BigDecimal(img_height / img_width)
     # Limit proportion 2:1 h/w for thumbnail
-    img_proportion = "200" if img_proportion.to_i > 200 # default for tall
+    img_proportion = "150" if img_proportion.to_i > 150 # default for tall
     self.proportion = (img_proportion * 100).to_f.truncate(1)
 
     if args[:context] == :matrix_box


### PR DESCRIPTION
To 150%, from 200%.

Extra tall (eg, 9x16 == 177.6%) images will crop from center in the thumbnail view. 
Full image will show in theater mode.