### PR TITLE
Fix typo and mistake in form

### DIFF
--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -15,7 +15,7 @@
 
   <%= text_area_with_label(
         form: f, field: :classification, rows: 10, value: @name.classification,
-        between: help_block(p, :form_names_classification_help.l(rank: rank)),
+        between: help_block(:p, :form_names_classification_help.t(rank: rank)),
         label: "#{:form_names_classification.t}:",
         data: { autofocus: true }
       ) %>


### PR DESCRIPTION
Fixes #1455

The first arg for `help_block` should be a symbol: `:p` not `p`

As @JoeCohen  and @pellaea noted, the second arg should get a `.t` not a `.l`