### PR TITLE
Standardize matrix boxes in a helper

### DIFF
--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 module MatrixBoxHelper
+  # Use this helper to produce a standard li.matrix-box with an object id.
+  # Or, send your own column classes and other args
   def matrix_box(**args, &block)
     columns = args[:columns] || "col-xs-12 col-sm-6 col-md-4 col-lg-3"
     extra_classes = args[:class] || ""
     box_id = args[:id] ? "box_#{args[:id]}" : ""
-    div_class = "matrix-box #{columns} #{extra_classes}"
-    div_args = args.except(:columns, :class, :id)
+    wrap_class = "matrix-box #{columns} #{extra_classes}"
+    wrap_args = args.except(:columns, :class, :id)
 
-    content_tag(:li, class: div_class, id: box_id, **div_args) do
+    content_tag(:li, class: wrap_class, id: box_id, **wrap_args) do
       capture(&block)
     end
   end

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 module MatrixBoxHelper
+  def matrix_box(**args, &block)
+    columns = args[:columns] || "col-xs-12 col-sm-6 col-md-4 col-lg-3"
+    extra_classes = args[:class] || ""
+    box_id = args[:id] ? "box_#{args[:id]}" : ""
+    div_class = "matrix-box #{columns} #{extra_classes}"
+    div_args = args.except(:columns, :class, :id)
+
+    content_tag(:li, class: div_class, id: box_id, **div_args) do
+      capture(&block)
+    end
+  end
+
   # Obs with uncertain name: vote on naming, or propose (if it's "Fungi")
   # used if matrix_box local_assigns identify == true
   def matrix_box_vote_or_propose_ui(identify, object)

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -92,10 +92,11 @@ class ThumbnailPresenter < BasePresenter
     # NOTE: requires image, or defaults to 1:1. Be sure it works in all cases
     img_width = image&.width ? BigDecimal(image&.width) : 100
     img_height = image&.height ? BigDecimal(image&.height) : 100
-    img_proportion = (BigDecimal(img_height / img_width) * 100).to_f.truncate(1)
+    img_proportion = BigDecimal(img_height / img_width)
+    img_padding = (img_proportion * 100).to_f.truncate(1)
     # Limit proportion 2:1 h/w for thumbnail
-    img_proportion = "150" if img_proportion.to_i > 150 # default for tall
-    self.proportion = img_proportion
+    img_padding = "150" if img_padding.to_i > 150 # default for tall
+    self.proportion = img_padding
 
     if args[:context] == :matrix_box
       self.width = false

--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -92,10 +92,10 @@ class ThumbnailPresenter < BasePresenter
     # NOTE: requires image, or defaults to 1:1. Be sure it works in all cases
     img_width = image&.width ? BigDecimal(image&.width) : 100
     img_height = image&.height ? BigDecimal(image&.height) : 100
-    img_proportion = BigDecimal(img_height / img_width)
+    img_proportion = (BigDecimal(img_height / img_width) * 100).to_f.truncate(1)
     # Limit proportion 2:1 h/w for thumbnail
     img_proportion = "150" if img_proportion.to_i > 150 # default for tall
-    self.proportion = (img_proportion * 100).to_f.truncate(1)
+    self.proportion = img_proportion
 
     if args[:context] == :matrix_box
       self.width = false

--- a/app/views/shared/_images_to_remove.html.erb
+++ b/app/views/shared/_images_to_remove.html.erb
@@ -11,7 +11,7 @@
     <%= render(layout: "shared/matrix_table",
                locals: {objects: @object.images}) do |image| %>
 
-      <li class="matrix-box col-xs-12 col-sm-6 col-md-4">
+      <li class="matrix-box col-xs-12 col-sm-6 col-md-4 col-lg-3">
         <div class="py-3 text-center">
           <% # no special link-or-button param here, there's a checkbox below %>
           <%= thumbnail(image,

--- a/app/views/shared/_images_to_remove.html.erb
+++ b/app/views/shared/_images_to_remove.html.erb
@@ -11,7 +11,7 @@
     <%= render(layout: "shared/matrix_table",
                locals: {objects: @object.images}) do |image| %>
 
-      <li class="matrix-box col-xs-12 col-sm-6 col-md-4 col-lg-3">
+      <%= matrix_box(id: image.id) do %>
         <div class="py-3 text-center">
           <% # no special link-or-button param here, there's a checkbox below %>
           <%= thumbnail(image,
@@ -25,7 +25,7 @@
             <%= f_s.label(image.id, "#{:image.t} ##{image.id}") %>
           <% end %>
         </div>
-      </li><!-- .matrix-box -->
+      <% end %><!-- .matrix-box -->
 
     <% end %>
 

--- a/app/views/shared/_images_to_reuse.html.erb
+++ b/app/views/shared/_images_to_reuse.html.erb
@@ -39,7 +39,7 @@ query = query_images_to_reuse(@all_users, @user)
 
     <%= render(layout: "shared/matrix_table",
                locals: { objects: @objects }) do |image| %>
-      <li class="matrix-box col-xs-12 col-sm-6 col-md-4 text-center">
+      <li class="matrix-box col-xs-12 col-sm-6 col-md-4 col-lg-3 text-center">
         <%= panel_block do %>
           <%= thumbnail(image,
                         image_link: form_action.merge(img_id: image.id),

--- a/app/views/shared/_images_to_reuse.html.erb
+++ b/app/views/shared/_images_to_reuse.html.erb
@@ -39,7 +39,7 @@ query = query_images_to_reuse(@all_users, @user)
 
     <%= render(layout: "shared/matrix_table",
                locals: { objects: @objects }) do |image| %>
-      <li class="matrix-box col-xs-12 col-sm-6 col-md-4 col-lg-3 text-center">
+      <%= matrix_box(class: "text-center", id: image.id) do %>
         <%= panel_block do %>
           <%= thumbnail(image,
                         image_link: form_action.merge(img_id: image.id),
@@ -48,7 +48,7 @@ query = query_images_to_reuse(@all_users, @user)
                         extra_classes: "image-to-reuse",
                         original: true) %>
         <% end %>
-      </li>
+      <% end %>
     <% end %>
 
   </ul>

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -7,7 +7,7 @@ if presenter
 
   link_method ||= :get
   identify ||= false
-  columns ||= "col-xs-12 col-sm-6 col-md-4 col-lg-3"
+  columns ||= "col-xs-12 col-sm-6 col-md-4 col-lg-3" # maybe passed as a local
   object_id = object&.id.present? ? object.id : "no_ID"
   # presenter.image_data includes context: :matrix_box where appropriate
   thumb_locals = local_assigns.
@@ -19,7 +19,7 @@ if presenter
                 content_tag(:span, presenter.name, class: "rss-name")
   %>
 
-  <li class="matrix-box <%= columns %>" id="box_<%= object_id %>">
+  <%= matrix_box(columns: columns, id: object_id) do %>
     <div class="panel panel-default">
 
       <div class="panel-sizing">
@@ -66,5 +66,5 @@ if presenter
       <%= matrix_box_identify_footer(identify, object_id) %>
 
     </div><!-- .panel -->
-  </li><!-- .matrix-box -->
+  <% end %><!-- .matrix-box -->
 <% end %>

--- a/app/views/visual_groups/_image_matrix.html.erb
+++ b/app/views/visual_groups/_image_matrix.html.erb
@@ -3,7 +3,7 @@
     <ul class="row list-unstyled mt-3">
       <%= render(layout: "shared/matrix_table",
                locals: {objects: @subset}) do |row| %>
-        <li class="matrix-box col-xs-12 col-sm-6 col-md-4">
+        <li class="matrix-box col-xs-12 col-sm-6 col-md-4 col-lg-3">
           <%= panel_block do %>
             <%= thumbnail(row[0], original: true, votes: false) %>
             <%= render(partial: "visual_group_status_links",

--- a/app/views/visual_groups/_image_matrix.html.erb
+++ b/app/views/visual_groups/_image_matrix.html.erb
@@ -5,7 +5,8 @@
                locals: {objects: @subset}) do |row| %>
         <%= matrix_box(id: row[0]) do %>
           <%= panel_block do %>
-            <%= thumbnail(row[0], original: true, votes: false) %>
+            <%= thumbnail(row[0], original: true, votes: false,
+                                  context: :matrix_box) %>
             <%= render(partial: "visual_group_status_links",
                        locals: {
                          visual_group: visual_group,

--- a/app/views/visual_groups/_image_matrix.html.erb
+++ b/app/views/visual_groups/_image_matrix.html.erb
@@ -3,7 +3,7 @@
     <ul class="row list-unstyled mt-3">
       <%= render(layout: "shared/matrix_table",
                locals: {objects: @subset}) do |row| %>
-        <li class="matrix-box col-xs-12 col-sm-6 col-md-4 col-lg-3">
+        <%= matrix_box(id: row[0]) do %>
           <%= panel_block do %>
             <%= thumbnail(row[0], original: true, votes: false) %>
             <%= render(partial: "visual_group_status_links",
@@ -13,7 +13,7 @@
                          status: row[1]
                        }) %>
           <% end %>
-        </li><!-- .matrix-box -->
+        <% end %><!-- .matrix-box -->
       <% end %>
     </ul>
   <% end %>

--- a/app/views/visual_groups/_visual_group_status_links.html.erb
+++ b/app/views/visual_groups/_visual_group_status_links.html.erb
@@ -1,11 +1,19 @@
+<%
+links = [
+          visual_group_status_link(visual_group, image_id, status, nil),
+          visual_group_status_link(visual_group, image_id, status, true),
+          visual_group_status_link(visual_group, image_id, status, false)
+        ].safe_join("|")
+%>
+
 <div id="status_buttons">
-  <div class="visual_group_status_links_container mt-n2" id="visual_group_status_links_<%= image_id %>">
+  <div class="visual_group_status_links_container mt-3"
+       id="visual_group_status_links_<%= image_id %>">
     <div class="text-center">
       <small>
-        <%= [visual_group_status_link(visual_group, image_id, status, nil),
-             visual_group_status_link(visual_group, image_id, status, true),
-             visual_group_status_link(visual_group, image_id, status, false)].safe_join("|") %><br>
-        <%= :image_reuse_id.t + ": " + link_to(image_id, image_path(id: image_id)) %>
+        <%= links %><br>
+        <%= :image_reuse_id.t + ": " + link_to(image_id,
+                                               image_path(id: image_id)) %>
       </small>
     </div><!-- .text-center -->
     <span class="hidden data_container" data-id="<%= image_id %>"</span>


### PR DESCRIPTION
Moves matrix box defaults to a helper so you only have to write 
```ruby
matrix_box(id: obj.id) do
  your_thing
end
```
for a basic matrix_box. Columns and other args are modifiable but have defaults.

Also actually caps thumbnail vertical proportion. The previous PR didn't cut it.