### PR TITLE
Change home page to Observations#index by RssLog

### DIFF
--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -171,7 +171,7 @@ module Query
     end
 
     def self.default_order
-      "updated_at"
+      "rss_log"
     end
   end
 end

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -171,7 +171,7 @@ module Query
     end
 
     def self.default_order
-      "rss_log"
+      "date"
     end
   end
 end

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -171,7 +171,7 @@ module Query
     end
 
     def self.default_order
-      "date"
+      "updated_at"
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1494,8 +1494,22 @@ class ApplicationController < ActionController::Base
     @timer_start = Time.current
     @num_results = query.num_results
     @timer_end = Time.current
-    @num_results.zero? ? @title = args[:no_hits_title] : @title ||= query.title
+    if @num_results.zero?
+      @title = args[:no_hits_title]
+    else
+      @title ||= index_default_title(query)
+    end
     @sorts = (@num_results > 1 ? sorting_links(query, args) : nil)
+  end
+
+  # Special title for new obs by updated at default home page query
+  def index_default_title(query)
+    if query.title_args[:type] == :observation &&
+       query.title_args[:order] == :sort_by_updated_at
+      return :query_title_observations_by_updated_at.l
+    end
+
+    query.title
   end
 
   def show_action_redirect(query)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1502,11 +1502,11 @@ class ApplicationController < ActionController::Base
     @sorts = (@num_results > 1 ? sorting_links(query, args) : nil)
   end
 
-  # Special title for new obs by updated at default home page query
+  # Special title for new obs default home page query
   def index_default_title(query)
     if query.title_args[:type] == :observation &&
        query.title_args[:order] == :sort_by_rss_log
-      return :query_title_observations_by_activity.l
+      return :query_title_observations_by_activity_log.l
     end
 
     query.title

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1505,8 +1505,8 @@ class ApplicationController < ActionController::Base
   # Special title for new obs by updated at default home page query
   def index_default_title(query)
     if query.title_args[:type] == :observation &&
-       query.title_args[:order] == :sort_by_updated_at
-      return :query_title_observations_by_updated_at.l
+       query.title_args[:order] == :sort_by_rss_log
+      return :query_title_observations_by_activity.l
     end
 
     query.title

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -197,7 +197,7 @@ class ImagesController < ApplicationController
   # Outputs: @image
   def show
     store_location
-    return false unless (@image = find_image!)
+    return false unless find_image!
 
     case params[:flow]
     when "next"
@@ -221,7 +221,14 @@ class ImagesController < ApplicationController
   private
 
   def find_image!
-    find_or_goto_index(Image, params[:id].to_s)
+    @image = Image.includes(show_image_includes).find_by(id: params[:id]) ||
+             flash_error_and_goto_index(Image, params[:id])
+  end
+
+  def show_image_includes
+    [
+      { image_votes: :user }
+    ]
   end
 
   def set_default_size

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -206,12 +206,13 @@ class ObservationsController
 
       # Add some alternate sorting criteria.
       links = [
-        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
-         :sort_by_updated_at.t],
+        ["rss_log", :sort_by_activity.t],
         ["date", :sort_by_date.t],
+        ["created_at", :sort_by_posted.t],
+        # kind of redundant to sort by rss_logs, though not strictly ===
+        # ["updated_at", :sort_by_updated_at.t],
         ["name", :sort_by_name.t],
         ["user", :sort_by_user.t],
-        ["created_at", :sort_by_posted.t],
         ["confidence", :sort_by_confidence.t],
         ["thumbnail_quality", :sort_by_thumbnail_quality.t],
         ["num_views", :sort_by_num_views.t]

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -21,10 +21,6 @@ class ObservationsController
       show_selected_observations(query)
     end
 
-    def default_sort_order
-      ::Query::ObservationBase.default_order
-    end
-
     # Displays matrix of selected Observations (based on current Query).
     # NOTE: Why are all the :id params converted .to_s below?
     def index_query_results

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -206,12 +206,12 @@ class ObservationsController
 
       # Add some alternate sorting criteria.
       links = [
-        ["name", :sort_by_name.t],
-        ["date", :sort_by_date.t],
-        ["user", :sort_by_user.t],
-        ["created_at", :sort_by_posted.t],
         [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
          :sort_by_updated_at.t],
+        ["date", :sort_by_date.t],
+        ["name", :sort_by_name.t],
+        ["user", :sort_by_user.t],
+        ["created_at", :sort_by_posted.t],
         ["confidence", :sort_by_confidence.t],
         ["thumbnail_quality", :sort_by_thumbnail_quality.t],
         ["num_views", :sort_by_num_views.t]

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -14,9 +14,10 @@ class ObservationsController
       list_all
     end
 
-    # Displays matrix of all Observation's, sorted by date.
+    # Displays home matrix of all Observation's, sorted by :rss_log
+    # Note all other filters of the obs index are sorted by date.
     def list_all
-      query = create_query(:Observation, :all, by: default_sort_order)
+      query = create_query(:Observation, :all, by: :rss_log)
       show_selected_observations(query)
     end
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -223,6 +223,8 @@
   # COMMON WORDS AND PHRASES
 
   # Object titles, all nouns.
+  ACTIVITY: Activity
+  activity: activity
   API_KEY: API Key
   api_key: API key
   API_KEYS: API Keys
@@ -4132,6 +4134,7 @@
   query_title_advanced_search: "[:app_advanced_search]"
   query_title_all: "[TYPE] Index"
   query_title_all_by: "[TYPES] by [ORDER]"
+  query_title_observations_by_updated_at: "Observation Activity"
   query_title_at_location: "[TYPES] from [LOCATION]"
   query_title_at_where: "[TYPES] from '[USER_WHERE]'"
   query_title_by_author: "[TYPES] Authored by [USER]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4134,7 +4134,7 @@
   query_title_advanced_search: "[:app_advanced_search]"
   query_title_all: "[TYPE] Index"
   query_title_all_by: "[TYPES] by [ORDER]"
-  query_title_observations_by_activity: "Observation Activity"
+  query_title_observations_by_activity_log: "Observation Activity"
   query_title_at_location: "[TYPES] from [LOCATION]"
   query_title_at_where: "[TYPES] from '[USER_WHERE]'"
   query_title_by_author: "[TYPES] Authored by [USER]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4134,7 +4134,7 @@
   query_title_advanced_search: "[:app_advanced_search]"
   query_title_all: "[TYPE] Index"
   query_title_all_by: "[TYPES] by [ORDER]"
-  query_title_observations_by_updated_at: "Observation Activity"
+  query_title_observations_by_activity: "Observation Activity"
   query_title_at_location: "[TYPES] from [LOCATION]"
   query_title_at_where: "[TYPES] from '[USER_WHERE]'"
   query_title_by_author: "[TYPES] Authored by [USER]"
@@ -4275,6 +4275,7 @@
   query_help_user_pattern_search: users matching a search string
 
   # Sorting criteria.
+  sort_by_activity: "[:ACTIVITY]"
   sort_by_code: Code
   sort_by_code_then_name: Code and Name
   sort_by_confidence: "[:CONFIDENCE_LEVEL]"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,7 +294,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   #     resources :products
   #   end
 
-  # Default page is /rss_logs
+  # Default page "/" is /observations ordered by: :rss_log
   root "observations#index"
 
   # Route /123 to /observations/123.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,7 +295,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   #   end
 
   # Default page is /rss_logs
-  root "rss_logs#index"
+  root "observations#index"
 
   # Route /123 to /observations/123.
   get ":id" => "observations#show", id: /\d+/, as: "permanent_observation"

--- a/test/controllers/observations/images_controller_test.rb
+++ b/test/controllers/observations/images_controller_test.rb
@@ -138,7 +138,7 @@ module Observations
       image = images(:agaricus_campestris_image)
       obs = image.observations.first
       assert(obs)
-      assert(obs.rss_log.nil?)
+      assert_not_nil(obs.rss_log)
       new_name = "new nāme.jpg"
 
       params = {

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -175,7 +175,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:index)
 
     assert_template("shared/_matrix_box")
-    assert_displayed_title("Observation Activity")
+    assert_displayed_title(:query_title_observations_by_activity_log.l)
   end
 
   def test_index_sorted_by_name
@@ -222,7 +222,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title("Observation Activity")
+    assert_displayed_title(:query_title_observations_by_activity_log.l)
   end
 
   def test_index_useless_param_page2
@@ -231,7 +231,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title("Observation Activity")
+    assert_displayed_title(:query_title_observations_by_activity_log.l)
     assert_select("#results a", { text: "« Prev" },
                   "Wrong page or display is missing a link to Prev page")
   end

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -175,7 +175,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:index)
 
     assert_template("shared/_matrix_box")
-    assert_displayed_title("Observations by Date")
+    assert_displayed_title("Observation Activity")
   end
 
   def test_index_sorted_by_name
@@ -222,7 +222,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title("Observations by Date")
+    assert_displayed_title("Observation Activity")
   end
 
   def test_index_useless_param_page2
@@ -231,7 +231,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title("Observations by Date")
+    assert_displayed_title("Observation Activity")
     assert_select("#results a", { text: "« Prev" },
                   "Wrong page or display is missing a link to Prev page")
   end

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1230,7 +1230,7 @@ class ObservationsControllerTest < FunctionalTestCase
     o_chron = Observation.order(created_at: :desc, id: :desc)
     login
     # need to save a query here to get :next in a non-standard order
-    query = Query.lookup_and_save(:Observation, :all, by: :created_at)
+    Query.lookup_and_save(:Observation, :all, by: :created_at)
     qr = QueryRecord.last.id.alphabetize
 
     get(:show, params: { id: o_chron.fourth.id, flow: :next, q: qr })

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1225,17 +1225,19 @@ class ObservationsControllerTest < FunctionalTestCase
     end
   end
 
-  def test_prev_and_next_observation
-    # Uses default observation query
-    o_chron = Observation.order(:created_at)
+  def test_prev_and_next_observation_simple
+    # Uses non-default observation query. :when is the default order
+    o_chron = Observation.order(created_at: :desc, id: :desc)
     login
-    get(:show, params: { id: o_chron.fourth.id, flow: "next" })
-    assert_redirected_to(action: :show, id: o_chron.third.id,
-                         params: @controller.query_params(QueryRecord.last))
+    # need to save a query here to get :next in a non-standard order
+    query = Query.lookup_and_save(:Observation, :all, by: :created_at)
+    qr = QueryRecord.last.id.alphabetize
 
-    get(:show, params: { id: o_chron.fourth.id, flow: "prev" })
-    assert_redirected_to(action: :show, id: o_chron.fifth.id,
-                         params: @controller.query_params(QueryRecord.last))
+    get(:show, params: { id: o_chron.fourth.id, flow: :next, q: qr })
+    assert_redirected_to(action: :show, id: o_chron.fifth.id, q: qr)
+
+    get(:show, params: { id: o_chron.fourth.id, flow: :prev, q: qr })
+    assert_redirected_to(action: :show, id: o_chron.third.id, q: qr)
   end
 
   def test_prev_and_next_observation_with_fancy_query

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -590,7 +590,7 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_index_user_by_known_user
     # Make sure fixtures are still okay
     obs = observations(:coprinus_comatus_obs)
-    assert_nil(obs.rss_log_id)
+    assert_not_nil(obs.rss_log_id)
     assert_not_nil(obs.thumb_image_id)
     user = rolf
     assert(

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -61,7 +61,8 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_match(/#{expect.glossary_term.name}/, css_select(".rss-what").text)
     assert_match(
       /#{rss_logs(:detailed_unknown_obs_rss_log).observation.name.text_name}/,
-      css_select(".rss-what").text)
+      css_select(".rss-what").text
+    )
 
     comments_for_path = comments_path(for_user: User.current_id)
     assert_select(
@@ -95,7 +96,6 @@ class RssLogsControllerTest < FunctionalTestCase
   def test_next_and_prev_rss_log
     # First 2 log entries
     logs = RssLog.order(updated_at: :desc).limit(2)
-
     login
     get(:show, params: { flow: "next", id: logs.first })
     # assert_redirected_to does not work here because #next redirects to a url

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -15,7 +15,7 @@ class RssLogsControllerTest < FunctionalTestCase
     get(:rss)
     assert_template(:rss)
 
-    get(:show, params: { id: rss_logs(:observation_rss_log).id })
+    get(:show, params: { id: rss_logs(:detailed_unknown_obs_rss_log).id })
     assert_template(:show)
   end
 
@@ -51,14 +51,17 @@ class RssLogsControllerTest < FunctionalTestCase
     login
     get(:index, params: { type: :glossary_term })
     assert_match(/#{expect.glossary_term.name}/, css_select(".rss-what").text)
-    assert_no_match(/#{rss_logs(:observation_rss_log).observation.name}/,
-                    css_select(".rss-what").text)
+    assert_no_match(
+      /#{rss_logs(:detailed_unknown_obs_rss_log).observation.name}/,
+      css_select(".rss-what").text
+    )
 
     # Without params[:type], it should display all logs
     get(:index)
     assert_match(/#{expect.glossary_term.name}/, css_select(".rss-what").text)
-    assert_match(/#{rss_logs(:observation_rss_log).observation.name.text_name}/,
-                 css_select(".rss-what").text)
+    assert_match(
+      /#{rss_logs(:detailed_unknown_obs_rss_log).observation.name.text_name}/,
+      css_select(".rss-what").text)
 
     comments_for_path = comments_path(for_user: User.current_id)
     assert_select(
@@ -86,7 +89,7 @@ class RssLogsControllerTest < FunctionalTestCase
     results = @controller.instance_variable_get(:@objects)
 
     assert(results.exclude?(rss_logs(:imged_unvouchered_obs_rss_log)))
-    assert(results.include?(rss_logs(:observation_rss_log)))
+    assert(results.include?(rss_logs(:detailed_unknown_obs_rss_log)))
   end
 
   def test_next_and_prev_rss_log

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -21,15 +21,17 @@ class SearchControllerTest < FunctionalTestCase
         }
       )
       assert_response(:redirect)
-      if model.controller_normalized?
-        assert_match(
-          "http://test.host/#{model.to_s.downcase.pluralize}?advanced_search=1",
-          redirect_to_url
-        )
-      else
-        assert_match(%r{#{model.show_controller}/advanced_search},
-                     redirect_to_url)
-      end
+      # Account for Observations being the home page
+      route = model == Observation ? "" : model.to_s.downcase.pluralize
+      # if model.controller_normalized?
+      assert_match(
+        "http://test.host/#{route}?advanced_search=1",
+        redirect_to_url
+      )
+      # else
+      #   assert_match(%r{#{model.show_controller}/advanced_search},
+      #                redirect_to_url)
+      # end
     end
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -23,15 +23,10 @@ class SearchControllerTest < FunctionalTestCase
       assert_response(:redirect)
       # Account for Observations being the home page
       route = model == Observation ? "" : model.to_s.downcase.pluralize
-      # if model.controller_normalized?
       assert_match(
         "http://test.host/#{route}?advanced_search=1",
         redirect_to_url
       )
-      # else
-      #   assert_match(%r{#{model.show_controller}/advanced_search},
-      #                redirect_to_url)
-      # end
     end
   end
 

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -28,9 +28,9 @@ DEFAULTS: &DEFAULTS
 
 minimal_unknown_obs:
   <<: *DEFAULTS
-  created_at: 2005-05-12 17:20:00
-  updated_at: 2005-05-12 17:21:00
-  when: 2005-05-11
+  created_at: 2006-05-12 17:20:00
+  updated_at: 2006-05-12 17:21:00
+  when: 2006-05-11
   user: mary
   location: burbank
   is_collection_location: 1

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -10,6 +10,12 @@
 #   where: somewhere
 #   location:
 
+# IMPORTANT: When creating a new observation fixture, you need to also create a
+# corresponding rss_log, since the observation index now sorts by rss_log.
+
+# Instead of writing simple one-off fixtures for new tests, consider creating
+# records on the fly within the test. This will generate both obs and rss_log.
+
 DEFAULTS: &DEFAULTS
   name: boletus_edulis
   notes: <%= Observation.no_notes %>
@@ -22,14 +28,12 @@ DEFAULTS: &DEFAULTS
   lifeform: " "
   text_name: Boletus edulis
   classification: ""
-  created_at: 2005-05-12 17:20:00
-  updated_at: 2005-05-12 17:21:00
   rss_log: $LABEL_rss_log
 
 minimal_unknown_obs:
   <<: *DEFAULTS
-  created_at: 2006-05-12 17:20:00
-  updated_at: 2006-05-12 17:21:00
+  created_at: 2006-05-12 14:20:00
+  updated_at: 2006-05-12 14:21:00
   when: 2006-05-11
   user: mary
   location: burbank
@@ -118,8 +122,8 @@ agaricus_campestrus_obs:
 
 agaricus_campestras_obs:
   <<: *DEFAULTS
-  created_at: 2007-06-24 12:00:00
-  updated_at: 2007-06-24 12:00:00
+  created_at: 2007-06-24 09:00:00
+  updated_at: 2007-06-24 09:00:01
   when: 2007-06-24
   location: burbank
   where: Burbank, California, USA
@@ -133,7 +137,7 @@ agaricus_campestras_obs:
 agaricus_campestros_obs:
   <<: *DEFAULTS
   created_at: 2007-06-24 12:00:00
-  updated_at: 2007-06-24 12:00:00
+  updated_at: 2007-06-24 12:00:01
   when: 2007-06-24
   location: burbank
   where: Burbank, California, USA
@@ -159,7 +163,9 @@ strobilurus_diminutivus_obs:
 
 stereum_hirsutum_1:
   <<: *DEFAULTS
-  when: 2017-06-23
+  created_at: 2017-06-22 17:20:00
+  updated_at: 2017-06-22 17:21:00
+  when: 2017-06-22
   location: burbank
   where: Burbank, California, USA
   user: rolf
@@ -168,7 +174,9 @@ stereum_hirsutum_1:
 
 stereum_hirsutum_2:
   <<: *DEFAULTS
-  when: 2017-06-24
+  created_at: 2017-06-23 17:20:00
+  updated_at: 2017-06-23 17:21:00
+  when: 2017-06-23
   location: burbank
   where: Burbank, California, USA
   user: rolf
@@ -177,7 +185,9 @@ stereum_hirsutum_2:
 
 tubaria_furfuracea_1:
   <<: *DEFAULTS
-  when: 2017-06-23
+  created_at: 2017-06-24 17:20:00
+  updated_at: 2017-06-24 17:21:00
+  when: 2017-06-24
   location: burbank
   where: Burbank, California, USA
   user: rolf
@@ -186,6 +196,8 @@ tubaria_furfuracea_1:
 
 tubaria_furfuracea_2:
   <<: *DEFAULTS
+  created_at: 2017-06-24 20:20:00
+  updated_at: 2017-06-24 20:21:00
   when: 2017-06-24
   location: burbank
   where: Burbank, California, USA
@@ -195,6 +207,8 @@ tubaria_furfuracea_2:
 
 unknown_with_no_naming:
   <<: *DEFAULTS
+  created_at: 2008-09-23 17:20:00
+  updated_at: 2008-09-23 17:21:00
   when: 2008-09-23
   user: mary
   location:
@@ -237,6 +251,8 @@ amateur_obs:
 
 peltigera_obs:
   <<: *DEFAULTS
+  created_at: 2014-04-04 04:04:03
+  updated_at: 2014-04-04 04:04:03
   when: 2012-06-07
   user: rolf
   location:
@@ -252,12 +268,12 @@ peltigera_obs:
   images: peltigera_image
   species_lists: one_genus_three_species_list
   lifeform: " lichen "
-  created_at: 2014-04-04 04:04:03
-  updated_at: 2014-04-04 04:04:03
   herbarium_records: field_museum_record
 
 peltigera_rolf_obs:
   <<: *DEFAULTS
+  created_at: 2014-04-04 04:04:04
+  updated_at: 2014-04-04 04:04:04
   when: 2013-09-08
   user: mary
   location:
@@ -272,11 +288,11 @@ peltigera_rolf_obs:
   thumb_image: rolf_profile_image
   images: rolf_profile_image
   lifeform: " lichen "
-  created_at: 2014-04-04 04:04:04
-  updated_at: 2014-04-04 04:04:04
 
 fungi_obs:
   <<: *DEFAULTS
+  created_at: 2013-09-15 04:04:04
+  updated_at: 2013-09-15 04:04:07
   when: 2013-09-15
   user: rolf
   location:
@@ -292,6 +308,8 @@ fungi_obs:
 
 boletus_edulis_obs:
   <<: *DEFAULTS
+  created_at: 2014-04-21 04:04:04
+  updated_at: 2014-04-21 04:04:07
   when: 2014-04-21
   location:
   where: 'New York, New York, USA'
@@ -305,43 +323,63 @@ boletus_edulis_obs:
 
 owner_only_favorite_eq_fungi:
   <<: *DEFAULTS
+  created_at: 2018-04-21 04:04:04
+  when: 2018-04-21
 
 owner_only_favorite_eq_consensus:
   <<: *DEFAULTS
+  created_at: 2018-04-21 04:06:04
+  when: 2018-04-21
 
 owner_only_favorite_ne_consensus:
   <<: *DEFAULTS
+  created_at: 2020-02-03 04:06:04
+  when: 2020-02-03
   name: tremella
   text_name: Tremella
   lifeform: " lichenicolous "
 
 owner_multiple_favorites:
   <<: *DEFAULTS
+  created_at: 2020-04-05 04:06:04
+  when: 2020-04-05
 
 owner_uncertain_favorite:
   <<: *DEFAULTS
+  created_at: 2020-06-07 04:06:04
+  when: 2020-06-07
 
 owner_accepts_general_questions:
   <<: *DEFAULTS
+  created_at: 2020-07-08 04:06:04
+  when: 2020-07-08
   user: roy                      # roy has email_general_questions == true
 
 owner_refuses_general_questions:
   <<: *DEFAULTS
+  created_at: 2020-05-05 04:06:04
+  when: 2020-05-05
   user: dick                     # dick has email_general_questions == false
 
 collected_at_obs:
   <<: *DEFAULTS
+  created_at: 2020-05-06 04:06:04
+  when: 2020-05-06
   location: collection_location
   where: Collection Location
 
 displayed_at_obs:
   <<: *DEFAULTS
+  created_at: 2020-05-07 04:06:04
+  when: 2020-05-07
   location: display_location
   where: Display Location
   is_collection_location: false
 
 two_img_obs:
   <<: *DEFAULTS
+  created_at: 2020-05-08 04:06:04
+  when: 2020-05-08
   location: display_location
   where: Display Location
   is_collection_location: false
@@ -350,28 +388,37 @@ two_img_obs:
 
 imageless_unvouchered_obs:
   <<: *DEFAULTS
+  created_at: 2020-11-11 04:06:04
+  when: 2020-11-11
   user: ignore_imageless_user
 
 # need >=2 imaged B edulis Obs's for filter tests
 imged_unvouchered_obs:
   <<: *DEFAULTS
+  created_at: 2020-11-12 04:06:04
+  when: 2020-11-12
   images: query_first_image
   thumb_image: query_first_image
 
 vouchered_obs:
   <<: *DEFAULTS
+  created_at: 2020-11-20 04:06:04
+  when: 2020-11-20
   specimen: 1
 
 vouchered_imged_obs:
   <<: *DEFAULTS
+  created_at: 2020-11-21 04:06:04
+  when: 2020-11-21
   specimen: 1
   images: query_first_image
   thumb_image: query_first_image
 
 updated_2013_obs:
   <<: *DEFAULTS
-  when: 2013-09-08
+  created_at: 2013-09-08 04:06:04
   updated_at: 2013-09-08 17:21:00
+  when: 2013-09-08
 
 # Two Observations sortable by Name, Date, Date Posted, Time Last Modified
 sortable_obs_users_first_obs:
@@ -400,6 +447,8 @@ sortable_obs_users_second_obs:
 
 unlisted_rolf_obs:
   <<: *DEFAULTS
+  created_at: 2010-07-10 04:06:04
+  when: 2010-07-10
   location: point_reyes
   where: Point Reyes National Seashore, Marin Co., California, USA
   user: rolf
@@ -408,10 +457,14 @@ unlisted_rolf_obs:
 # used for testing change vote
 unequal_positive_namings_obs:
   <<: *DEFAULTS
+  created_at: 2010-07-11 04:06:04
+  when: 2010-07-11
 
 # used for testing calc_consensus
 all_namings_deprecated_obs:
   <<: *DEFAULTS
+  created_at: 2010-07-12 04:06:04
+  when: 2010-07-12
   name: namings_deprecated
   text_name: Namings deprecated
 
@@ -419,12 +472,16 @@ all_namings_deprecated_obs:
 # Has two namings, which (under current rules) makes the Names unmergeable
 authored_with_naming_obs:
   <<: *DEFAULTS
+  created_at: 2010-08-12 04:06:04
+  when: 2010-08-12
   name: authored_with_naming
   text_name: Psalliota naming
 
 # dick owns the Name and Observation, but mary owns a Naming
 other_user_owns_naming_obs:
   <<: *DEFAULTS
+  created_at: 2010-08-13 04:06:04
+  when: 2010-08-13
   name: other_user_owns_naming_name
   text_name: Otheruserownsnaming
   user: dick
@@ -432,6 +489,8 @@ other_user_owns_naming_obs:
 # dick owns the Name and Naming, but mary owns an Observation
 other_user_owns_obs:
   <<: *DEFAULTS
+  created_at: 2010-08-14 04:06:04
+  when: 2010-08-14
   name: other_user_owns_observation
   text_name: Otheruserownsobs
   user: mary
@@ -439,6 +498,8 @@ other_user_owns_obs:
 # dick owns the Name and the only Observation and Naming
 same_user_owns_name_and_naming_obs:
   <<: *DEFAULTS
+  created_at: 2015-06-01 14:26:07
+  when: 2015-06-01
   name: same_user_owns_naming_and_observation
   text_name: Sameuserownsnamingandobservation
   user: dick
@@ -446,48 +507,66 @@ same_user_owns_name_and_naming_obs:
 # has Sequence which has not been deposited in an Archive
 locally_sequenced_obs:
   <<: *DEFAULTS
+  created_at: 2015-06-01 14:36:04
+  when: 2015-06-01
   images: locally_sequenced_obs_image
   thumb_image: locally_sequenced_obs_image
 
 # has Sequence which is in GenBank
 genbanked_obs:
   <<: *DEFAULTS
+  created_at: 2015-06-02 14:26:05
+  when: 2015-06-02
 
 substrate_notes_obs:
   <<: *DEFAULTS
+  created_at: 2015-06-02 04:07:05
+  when: 2015-06-02
   notes:
     :substrate: soil
 
 substrate_and_other_notes_obs:
   <<: *DEFAULTS
+  created_at: 2015-06-02 04:08:05
+  when: 2015-06-02
   notes:
     :substrate: soil
     :Other: slimy
 
 templater_noteless_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 03:08:03
+  when: 2015-05-05
   user: notes_templater
 
 templater_other_notes_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 03:09:03
+  when: 2015-05-05
   notes:
     :Other: some notes
   user: notes_templater
 
 templater_orphaned_notes_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 08:06:03
+  when: 2015-05-05
   notes:
     :orphaned_caption: orphaned notes
   user: notes_templater
 
 template_only_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 09:03:03
+  when: 2015-05-05
   notes:
     :Cap: red
   user: notes_templater
 
 template_and_other_notes_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 12:06:03
+  when: 2015-05-05
   notes:
     :Cap: red
     :Other: some notes
@@ -495,6 +574,8 @@ template_and_other_notes_obs:
 
 template_and_orphaned_notes_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 14:06:03
+  when: 2015-05-05
   notes:
     :Cap: red
     :orphaned_caption: orphaned notes
@@ -502,6 +583,8 @@ template_and_orphaned_notes_obs:
 
 template_and_orphaned_notes_scrambled_obs:
   <<: *DEFAULTS
+  created_at: 2015-05-05 14:06:04
+  when: 2015-05-05
   notes:
     :Nearby_trees: pine
     :orphaned_caption_1: orphaned notes 1
@@ -512,11 +595,15 @@ template_and_orphaned_notes_scrambled_obs:
 
 california_obs:
   <<: *DEFAULTS
+  created_at: 2022-04-05 04:06:04
+  when: 2022-04-05
   location: california
   where: California, USA
 
 # has alternative preferred name
 chlorophyllum_rachodes_obs:
   <<: *DEFAULTS
+  created_at: 2023-02-04 04:06:04
+  when: 2023-02-04
   name: chlorophyllum_rachodes
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -22,6 +22,7 @@ DEFAULTS: &DEFAULTS
   lifeform: " "
   text_name: Boletus edulis
   classification: ""
+  rss_log: $LABEL_rss_log
 
 minimal_unknown_obs:
   <<: *DEFAULTS
@@ -52,7 +53,6 @@ detailed_unknown_obs:
   specimen: 1
   notes:
     :Other: Found in a strange place... & with śtrangè characters™
-  rss_log: observation_rss_log
   thumb_image: in_situ_image
   images: in_situ_image, turned_over_image
   species_lists: unknown_species_list
@@ -355,7 +355,6 @@ imged_unvouchered_obs:
   <<: *DEFAULTS
   images: query_first_image
   thumb_image: query_first_image
-  rss_log: imged_unvouchered_obs_rss_log
 
 vouchered_obs:
   <<: *DEFAULTS
@@ -445,7 +444,6 @@ same_user_owns_name_and_naming_obs:
 # has Sequence which has not been deposited in an Archive
 locally_sequenced_obs:
   <<: *DEFAULTS
-  rss_log: $LABEL_rss_log
   images: locally_sequenced_obs_image
   thumb_image: locally_sequenced_obs_image
 

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -22,13 +22,15 @@ DEFAULTS: &DEFAULTS
   lifeform: " "
   text_name: Boletus edulis
   classification: ""
+  created_at: 2005-05-12 17:20:00
+  updated_at: 2005-05-12 17:21:00
   rss_log: $LABEL_rss_log
 
 minimal_unknown_obs:
   <<: *DEFAULTS
   created_at: 2005-05-12 17:20:00
   updated_at: 2005-05-12 17:21:00
-  when: 2006-05-11
+  when: 2005-05-11
   user: mary
   location: burbank
   is_collection_location: 1

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -30,119 +30,119 @@ coprinus_comatus_obs_rss_log:
   observation: coprinus_comatus_obs
   updated_at: 2007-02-27 20:21:04
   created_at: 2007-02-27 20:20:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20070227202104 log_observation_created user rolf\n"
 
 agaricus_campestris_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestris_obs
   updated_at: 2007-03-19 20:21:02
   created_at: 2007-03-19 20:20:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20070319202102 log_observation_created user rolf\n"
 
 agaricus_campestrus_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestrus_obs
   updated_at: 2007-06-23 20:00:01
   created_at: 2007-06-23 20:00:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20070623200001 log_observation_created user rolf\n"
 
 agaricus_campestras_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestras_obs
   updated_at: 2007-06-24 12:00:01
   created_at: 2007-06-24 12:00:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20070624120001 log_observation_created user rolf\n"
 
 agaricus_campestros_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestros_obs
   updated_at: 2007-06-24 12:00:01
   created_at: 2007-06-24 12:00:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20070624120001 log_observation_created user rolf\n"
 
 strobilurus_diminutivus_obs_rss_log:
   <<: *DEFAULTS
   observation: strobilurus_diminutivus_obs
   updated_at: 2007-07-20 20:54:46
   created_at: 2007-07-20 20:54:45
-  notes: " log_observation_created user rolf\n"
+  notes: "20070720205446 log_observation_created user rolf\n"
 
 stereum_hirsutum_1_rss_log:
   <<: *DEFAULTS
   observation: stereum_hirsutum_1
   updated_at: 2017-06-23 09:02:00
   created_at: 2017-06-23 09:01:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20170623090200 log_observation_created user rolf\n"
 
 stereum_hirsutum_2_rss_log:
   <<: *DEFAULTS
   observation: stereum_hirsutum_2
   updated_at: 2017-06-24 09:02:00
   created_at: 2017-06-24 09:01:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20170624090200 log_observation_created user rolf\n"
 
 tubaria_furfuracea_1_rss_log:
   <<: *DEFAULTS
   observation: tubaria_furfuracea_1
   updated_at: 2017-06-23 09:22:00
   created_at: 2017-06-23 09:21:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20170623092200 log_observation_created user rolf\n"
 
 tubaria_furfuracea_2_rss_log:
   <<: *DEFAULTS
   observation: tubaria_furfuracea_2
   updated_at: 2017-06-24 09:03:00
   created_at: 2017-06-24 09:02:00
-  notes: " log_observation_created user rolf\n"
+  notes: "20170624090300 log_observation_created user rolf\n"
 
 unknown_with_no_naming_rss_log:
   <<: *DEFAULTS
   observation: unknown_with_no_naming
   updated_at: 2008-09-23 09:03:00
   created_at: 2008-09-23 09:00:00
-  notes: " log_observation_created user mary\n"
+  notes: "20080923090300 log_observation_created user mary\n"
 
 unknown_with_lat_long_rss_log:
   <<: *DEFAULTS
   observation: unknown_with_lat_long
   updated_at: 2010-07-22 09:21:00
   created_at: 2010-07-22 09:20:00
-  notes: " log_observation_created user mary\n"
+  notes: "20100722092100 log_observation_created user mary\n"
 
 amateur_obs_rss_log:
   <<: *DEFAULTS
   observation: amateur_obs
   updated_at: 2010-12-31 06:47:00
   created_at: 2010-12-31 06:46:00
-  notes: " log_observation_created user katrina\n"
+  notes: "20101231064700 log_observation_created user katrina\n"
 
 peltigera_obs_rss_log:
   <<: *DEFAULTS
   observation: peltigera_obs
-  updated_at: 2014-04-04 04:04:03
+  updated_at: 2014-04-04 04:04:06
   created_at: 2014-04-04 04:04:03
-  notes: " log_observation_created user rolf\n"
+  notes: "20140404040406 log_observation_created user rolf\n"
 
 peltigera_rolf_obs_rss_log:
   <<: *DEFAULTS
   observation: peltigera_rolf_obs
-  updated_at: 2014-04-04 04:04:04
+  updated_at: 2014-04-04 04:04:05
   created_at: 2014-04-04 04:04:04
-  notes: " log_observation_created user mary\n"
+  notes: "20140404040405 log_observation_created user mary\n"
 
 fungi_obs_rss_log:
   <<: *DEFAULTS
   observation: fungi_obs
-  updated_at: 2013-09-15
-  created_at: 2013-09-15
-  notes: " log_observation_created user rolf\n"
+  updated_at: 2013-09-15 04:04:05
+  created_at: 2013-09-15 04:04:04
+  notes: "20130915040405 log_observation_created user rolf\n"
 
 boletus_edulis_obs_rss_log:
   <<: *DEFAULTS
   observation: boletus_edulis_obs
-  updated_at: 2014-04-21
-  created_at: 2014-04-21
-  notes: " log_observation_created user dick\n"
+  updated_at: 2014-04-21 04:04:08
+  created_at: 2014-04-21 04:04:06
+  notes: "20140421040408 log_observation_created user dick\n"
 
 owner_only_favorite_eq_fungi_rss_log:
   <<: *DEFAULTS
@@ -247,28 +247,28 @@ updated_2013_obs_rss_log:
   observation: updated_2013_obs
   updated_at: 2013-09-08 17:21:00
   created_at: 2013-09-08 17:20:00
-  notes: " log_observation_created user \n"
+  notes: "20130908172100 log_observation_created user \n"
 
 sortable_obs_users_first_obs_rss_log:
   <<: *DEFAULTS
   observation: sortable_obs_users_first_obs
   created_at: 2016-01-10 17:20:00
   updated_at: 2016-01-11 17:20:00
-  notes: " log_observation_created user sortable_obs_user\n"
+  notes: "20160110172000 log_observation_created user sortable_obs_user\n"
 
 sortable_obs_users_second_obs_rss_log:
   <<: *DEFAULTS
   observation: sortable_obs_users_second_obs
   updated_at: 2017-01-11 17:20:00
   created_at: 2017-01-10 17:20:00
-  notes: " log_observation_created user sortable_obs_user\n"
+  notes: "20170111172000 log_observation_created user sortable_obs_user\n"
 
 unlisted_rolf_obs_rss_log:
   <<: *DEFAULTS
   observation: unlisted_rolf_obs
   updated_at: 2005-03-02 21:14:00
   created_at: 2005-03-01 15:25:02
-  notes: " log_observation_created user rolf\n"
+  notes: "20050302211400 log_observation_created user rolf\n"
 
 unequal_positive_namings_obs_rss_log:
   <<: *DEFAULTS
@@ -394,7 +394,7 @@ california_obs_rss_log:
   observation: california_obs
   updated_at: 2005-03-02 21:14:00
   created_at: 2005-03-01 15:25:02
-  notes: " log_observation_created user dick\n"
+  notes: "20050302211400 log_observation_created user dick\n"
 
 chlorophyllum_rachodes_obs_rss_log:
   <<: *DEFAULTS

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -6,25 +6,404 @@
 # All logged Observations should have at least one Image in case an integration
 # test clicks on the image.
 
-# Some integration tests expect this to be at the top of the RSS Log.
-# Therefore insure that other Observation entries have earlier updated_at's.
-observation_rss_log:
+DEFAULTS: &DEFAULTS
+  updated_at: 2005-05-12 17:21:00
+  created_at: 2005-05-12 17:20:00
+  notes: "20050512172000 log_observation_created user dick\n"
+
+minimal_unknown_obs_rss_log:
+  <<: *DEFAULTS
+  observation: minimal_unknown_obs
+  updated_at: 2005-05-12 17:21:00
+  created_at: 2005-05-12 17:20:00
+  notes: "20050512172000 log_observation_created user mary\n"
+
+detailed_unknown_obs_rss_log:
+  <<: *DEFAULTS
   observation: detailed_unknown_obs
   updated_at: 2006-03-02 21:14:00
   created_at: 2006-03-02 21:13:05
   notes: "20060302211400 log_image_created user mary\n20060302211305 log_observation_created user mary"
 
+coprinus_comatus_obs_rss_log:
+  <<: *DEFAULTS
+  observation: coprinus_comatus_obs
+  updated_at: 2007-02-27 20:21:00
+  created_at: 2007-02-27 20:20:00
+  notes: " log_observation_created user rolf\n"
+
+agaricus_campestris_obs_rss_log:
+  <<: *DEFAULTS
+  observation: agaricus_campestris_obs
+  updated_at: 2007-03-19 20:21:00
+  created_at: 2007-03-19 20:20:00
+  notes: " log_observation_created user rolf\n"
+
+agaricus_campestrus_obs_rss_log:
+  <<: *DEFAULTS
+  observation: agaricus_campestrus_obs
+  updated_at: 2007-06-23 20:00:00
+  created_at: 2007-06-23 20:00:00
+  notes: " log_observation_created user rolf\n"
+
+agaricus_campestras_obs_rss_log:
+  <<: *DEFAULTS
+  observation: agaricus_campestras_obs
+  updated_at: 2007-06-24 12:00:00
+  created_at: 2007-06-24 12:00:00
+  notes: " log_observation_created user rolf\n"
+
+agaricus_campestros_obs_rss_log:
+  <<: *DEFAULTS
+  observation: agaricus_campestros_obs
+  updated_at: 2007-06-24 12:00:00
+  created_at: 2007-06-24 12:00:00
+  notes: " log_observation_created user rolf\n"
+
+strobilurus_diminutivus_obs_rss_log:
+  <<: *DEFAULTS
+  observation: strobilurus_diminutivus_obs
+  updated_at: 2007-07-20 20:54:45
+  created_at: 2007-07-20 20:54:45
+  notes: " log_observation_created user rolf\n"
+
+stereum_hirsutum_1_rss_log:
+  <<: *DEFAULTS
+  observation: stereum_hirsutum_1
+  updated_at: 2017-06-23
+  created_at: 2017-06-23
+  notes: " log_observation_created user rolf\n"
+
+stereum_hirsutum_2_rss_log:
+  <<: *DEFAULTS
+  observation: stereum_hirsutum_2
+  updated_at: 2017-06-24
+  created_at: 2017-06-24
+  notes: " log_observation_created user rolf\n"
+
+tubaria_furfuracea_1_rss_log:
+  <<: *DEFAULTS
+  observation: tubaria_furfuracea_1
+  updated_at: 2017-06-23
+  created_at: 2017-06-23
+  notes: " log_observation_created user rolf\n"
+
+tubaria_furfuracea_2_rss_log:
+  <<: *DEFAULTS
+  observation: tubaria_furfuracea_2
+  updated_at: 2017-06-24
+  created_at: 2017-06-24
+  notes: " log_observation_created user rolf\n"
+
+unknown_with_no_naming_rss_log:
+  <<: *DEFAULTS
+  observation: unknown_with_no_naming
+  updated_at: 2008-09-23
+  created_at: 2008-09-23
+  notes: " log_observation_created user mary\n"
+
+unknown_with_lat_long_rss_log:
+  <<: *DEFAULTS
+  observation: unknown_with_lat_long
+  updated_at: 2010-07-22 09:21:00
+  created_at: 2010-07-22 09:20:00
+  notes: " log_observation_created user mary\n"
+
+amateur_obs_rss_log:
+  <<: *DEFAULTS
+  observation: amateur_obs
+  updated_at: 2010-12-31 06:47:00
+  created_at: 2010-12-31 06:46:00
+  notes: " log_observation_created user katrina\n"
+
+peltigera_obs_rss_log:
+  <<: *DEFAULTS
+  observation: peltigera_obs
+  updated_at: 2014-04-04 04:04:03
+  created_at: 2014-04-04 04:04:03
+  notes: " log_observation_created user rolf\n"
+
+peltigera_rolf_obs_rss_log:
+  <<: *DEFAULTS
+  observation: peltigera_rolf_obs
+  updated_at: 2014-04-04 04:04:04
+  created_at: 2014-04-04 04:04:04
+  notes: " log_observation_created user mary\n"
+
+fungi_obs_rss_log:
+  <<: *DEFAULTS
+  observation: fungi_obs
+  updated_at: 2013-09-15
+  created_at: 2013-09-15
+  notes: " log_observation_created user rolf\n"
+
+boletus_edulis_obs_rss_log:
+  <<: *DEFAULTS
+  observation: boletus_edulis_obs
+  updated_at: 2014-04-21
+  created_at: 2014-04-21
+  notes: " log_observation_created user dick\n"
+
+owner_only_favorite_eq_fungi_rss_log:
+  <<: *DEFAULTS
+  observation: owner_only_favorite_eq_fungi
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+owner_only_favorite_eq_consensus_rss_log:
+  <<: *DEFAULTS
+  observation: owner_only_favorite_eq_consensus
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+owner_only_favorite_ne_consensus_rss_log:
+  <<: *DEFAULTS
+  observation: owner_only_favorite_ne_consensus
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+owner_multiple_favorites_rss_log:
+  <<: *DEFAULTS
+  observation: owner_multiple_favorites
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+owner_uncertain_favorite_rss_log:
+  <<: *DEFAULTS
+  observation: owner_uncertain_favorite
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+owner_accepts_general_questions_rss_log:
+  <<: *DEFAULTS
+  observation: owner_accepts_general_questions
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+owner_refuses_general_questions_rss_log:
+  <<: *DEFAULTS
+  observation: owner_refuses_general_questions
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+collected_at_obs_rss_log:
+  <<: *DEFAULTS
+  observation: collected_at_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+displayed_at_obs_rss_log:
+  <<: *DEFAULTS
+  observation: displayed_at_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+two_img_obs_rss_log:
+  <<: *DEFAULTS
+  observation: two_img_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+imageless_unvouchered_obs_rss_log:
+  <<: *DEFAULTS
+  observation: imageless_unvouchered_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
 imged_unvouchered_obs_rss_log:
+  <<: *DEFAULTS
   observation: imged_unvouchered_obs
   updated_at: 2005-03-02 21:14:00
   created_at: 2005-03-01 15:25:02
   notes: "20050301152502 log_observation_created user dick\n"
 
+vouchered_obs_rss_log:
+  <<: *DEFAULTS
+  observation: vouchered_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+vouchered_imged_obs_rss_log:
+  <<: *DEFAULTS
+  observation: vouchered_imged_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+updated_2013_obs_rss_log:
+  <<: *DEFAULTS
+  observation: updated_2013_obs
+  updated_at: 2013-09-08 17:21:00
+  created_at: 2013-09-08 17:20:00
+  notes: " log_observation_created user \n"
+
+sortable_obs_users_first_obs_rss_log:
+  <<: *DEFAULTS
+  observation: sortable_obs_users_first_obs
+  created_at: 2016-01-10 17:20:00
+  updated_at: 2016-01-11 17:20:00
+  notes: " log_observation_created user sortable_obs_user\n"
+
+sortable_obs_users_second_obs_rss_log:
+  <<: *DEFAULTS
+  observation: sortable_obs_users_second_obs
+  updated_at: 2017-01-11 17:20:00
+  created_at: 2017-01-10 17:20:00
+  notes: " log_observation_created user sortable_obs_user\n"
+
+unlisted_rolf_obs_rss_log:
+  <<: *DEFAULTS
+  observation: unlisted_rolf_obs
+  updated_at: 2005-03-02 21:14:00
+  created_at: 2005-03-01 15:25:02
+  notes: " log_observation_created user rolf\n"
+
+unequal_positive_namings_obs_rss_log:
+  <<: *DEFAULTS
+  observation: unequal_positive_namings_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+all_namings_deprecated_obs_rss_log:
+  <<: *DEFAULTS
+  observation: all_namings_deprecated_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+authored_with_naming_obs_rss_log:
+  <<: *DEFAULTS
+  observation: authored_with_naming_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+other_user_owns_naming_obs_rss_log:
+  <<: *DEFAULTS
+  observation: other_user_owns_naming_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+other_user_owns_obs_rss_log:
+  <<: *DEFAULTS
+  observation: other_user_owns_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+same_user_owns_name_and_naming_obs_rss_log:
+  <<: *DEFAULTS
+  observation: same_user_owns_name_and_naming_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
 locally_sequenced_obs_rss_log:
+  <<: *DEFAULTS
   observation: locally_sequenced_obs
   updated_at: 2004-03-02 20:14:02
   created_at: 2004-03-02 20:13:05
   notes: "20040302201305 log_observation_created user dick\n"
+
+genbanked_obs_rss_log:
+  <<: *DEFAULTS
+  observation: genbanked_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+substrate_notes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: substrate_notes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+substrate_and_other_notes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: substrate_and_other_notes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+templater_noteless_obs_rss_log:
+  <<: *DEFAULTS
+  observation: templater_noteless_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+templater_other_notes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: templater_other_notes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+templater_orphaned_notes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: templater_orphaned_notes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+template_only_obs_rss_log:
+  <<: *DEFAULTS
+  observation: template_only_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+template_and_other_notes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: template_and_other_notes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+template_and_orphaned_notes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: template_and_orphaned_notes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+template_and_orphaned_notes_scrambled_obs_rss_log:
+  <<: *DEFAULTS
+  observation: template_and_orphaned_notes_scrambled_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+california_obs_rss_log:
+  <<: *DEFAULTS
+  observation: california_obs
+  updated_at: 2005-03-02 21:14:00
+  created_at: 2005-03-01 15:25:02
+  notes: " log_observation_created user dick\n"
+
+chlorophyllum_rachodes_obs_rss_log:
+  <<: *DEFAULTS
+  observation: chlorophyllum_rachodes_obs
+  # updated_at:
+  # created_at:
+  # notes: " log_observation_created user \n"
+
+
 
 species_list_rss_log:
   species_list: first_species_list

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -28,78 +28,78 @@ detailed_unknown_obs_rss_log:
 coprinus_comatus_obs_rss_log:
   <<: *DEFAULTS
   observation: coprinus_comatus_obs
-  updated_at: 2007-02-27 20:21:00
+  updated_at: 2007-02-27 20:21:04
   created_at: 2007-02-27 20:20:00
   notes: " log_observation_created user rolf\n"
 
 agaricus_campestris_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestris_obs
-  updated_at: 2007-03-19 20:21:00
+  updated_at: 2007-03-19 20:21:02
   created_at: 2007-03-19 20:20:00
   notes: " log_observation_created user rolf\n"
 
 agaricus_campestrus_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestrus_obs
-  updated_at: 2007-06-23 20:00:00
+  updated_at: 2007-06-23 20:00:01
   created_at: 2007-06-23 20:00:00
   notes: " log_observation_created user rolf\n"
 
 agaricus_campestras_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestras_obs
-  updated_at: 2007-06-24 12:00:00
+  updated_at: 2007-06-24 12:00:01
   created_at: 2007-06-24 12:00:00
   notes: " log_observation_created user rolf\n"
 
 agaricus_campestros_obs_rss_log:
   <<: *DEFAULTS
   observation: agaricus_campestros_obs
-  updated_at: 2007-06-24 12:00:00
+  updated_at: 2007-06-24 12:00:01
   created_at: 2007-06-24 12:00:00
   notes: " log_observation_created user rolf\n"
 
 strobilurus_diminutivus_obs_rss_log:
   <<: *DEFAULTS
   observation: strobilurus_diminutivus_obs
-  updated_at: 2007-07-20 20:54:45
+  updated_at: 2007-07-20 20:54:46
   created_at: 2007-07-20 20:54:45
   notes: " log_observation_created user rolf\n"
 
 stereum_hirsutum_1_rss_log:
   <<: *DEFAULTS
   observation: stereum_hirsutum_1
-  updated_at: 2017-06-23
-  created_at: 2017-06-23
+  updated_at: 2017-06-23 09:02:00
+  created_at: 2017-06-23 09:01:00
   notes: " log_observation_created user rolf\n"
 
 stereum_hirsutum_2_rss_log:
   <<: *DEFAULTS
   observation: stereum_hirsutum_2
-  updated_at: 2017-06-24
-  created_at: 2017-06-24
+  updated_at: 2017-06-24 09:02:00
+  created_at: 2017-06-24 09:01:00
   notes: " log_observation_created user rolf\n"
 
 tubaria_furfuracea_1_rss_log:
   <<: *DEFAULTS
   observation: tubaria_furfuracea_1
-  updated_at: 2017-06-23
-  created_at: 2017-06-23
+  updated_at: 2017-06-23 09:22:00
+  created_at: 2017-06-23 09:21:00
   notes: " log_observation_created user rolf\n"
 
 tubaria_furfuracea_2_rss_log:
   <<: *DEFAULTS
   observation: tubaria_furfuracea_2
-  updated_at: 2017-06-24
-  created_at: 2017-06-24
+  updated_at: 2017-06-24 09:03:00
+  created_at: 2017-06-24 09:02:00
   notes: " log_observation_created user rolf\n"
 
 unknown_with_no_naming_rss_log:
   <<: *DEFAULTS
   observation: unknown_with_no_naming
-  updated_at: 2008-09-23
-  created_at: 2008-09-23
+  updated_at: 2008-09-23 09:03:00
+  created_at: 2008-09-23 09:00:00
   notes: " log_observation_created user mary\n"
 
 unknown_with_lat_long_rss_log:

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -14,8 +14,8 @@ class LurkerTest < CapybaraIntegrationTestCase
     assert_selector("#box_#{rss_log.id} .rss-id",
                     text: rss_log.observation_id)
 
-    # Click on first obs immediately after one that has images. NOTE: must
-    # be a "created" log. Hopefully future rss_logs will not break this!
+    # Click on first obs immediately after one that has images.
+    # NOTE: BS4 matrix-box will make it easier to find siblings
     first(".image-link").ancestor(".matrix-box+.matrix-box").
       first(".rss-detail", text: "Observation Created").
       ancestor(".panel").first(".rss-box-details").first("a").click

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -307,7 +307,7 @@ class LurkerTest < CapybaraIntegrationTestCase
     assert_equal(save_path, current_fullpath,
                  "Went next then prev, should be back where we started.")
     within("#title_bar") do
-      click_link(text: "Index", href: /#{observations_path}/)
+      click_link(text: "Index") # href: /#{observations_path}/
     end
     results = results_observation_links
     assert_equal(query_params, parse_query_params(results.first[:href]))
@@ -332,7 +332,11 @@ class LurkerTest < CapybaraIntegrationTestCase
 
     # Following gives more informative error message than
     # assert(page.has_title?("#{:app_title.l }: Activity Log"), "Wrong page")
-    assert_equal("#{:app_title.l}: Activity Log", page.title, "Login failed")
+    # assert_equal("#{:app_title.l}: Activity Log", page.title, "Login failed")
+    assert_equal(
+      "#{:app_title.l}: #{:query_title_observations_by_updated_at.l}",
+      page.title, "Login failed"
+    )
   end
 
   # This returns results so you can reset a `results` variable within test scope

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -9,21 +9,22 @@ class LurkerTest < CapybaraIntegrationTestCase
     reset_session!
     login
 
-    # Click on first observation in feed results
-    first(".rss-detail", text: "Observation Created").
+    # Click on first obs immediately after one that has images. NOTE: must
+    # be a "created" log. Hopefully future rss_logs will not break this!
+    first(".image-link").ancestor(".matrix-box+.matrix-box").
+      first(".rss-detail", text: "Observation Created").
       ancestor(".panel").first(".rss-box-details").first("a").click
     assert_match(/#{:app_title.l}: Observation/, page.title, "Wrong page")
 
     # Click on next (catches a bug seen in the wild).
     # Above comment about "next" does not match "Prev" in code
-    # push_page is a stop-gap until a js-enabled driver is installed and working
     go_back_after do
       click_link("« Prev")
     end
     # back at Observation
     assert_match(/#{:app_title.l}: Observation/, page.title, "Wrong page")
 
-    # Click on the first image.
+    # Click on the first image. (That's why we picked the one after this.)
     go_back_after do
       first("#content .show_images .image-link").click
       assert_match(/#{:app_title.l}: Image/, page.title, "Wrong page")

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -9,14 +9,17 @@ class LurkerTest < CapybaraIntegrationTestCase
     reset_session!
     login
 
-    # visit("/activity_logs")
-    rss_log = RssLog.where.not(observation_id: nil).last
+    visit("/activity_logs")
+    rss_log = RssLog.where.not(observation_id: nil).order(:updated_at).last
     assert_selector("#box_#{rss_log.id} .rss-id",
                     text: rss_log.observation_id)
 
     # Click on first obs immediately after one that has images.
-    # NOTE: BS4 matrix-box will make it easier to find siblings
-    first(".image-link").ancestor(".matrix-box+.matrix-box").
+    # NOTE: BS3 matrix-box are a bit harder to find siblings
+    # because the layout clearfix boxes interrupt the matrix boxes.
+    # This selects next matching peer, but you can do adjacent in bs4
+    # (do + instead of ~)
+    first(".image-link").ancestor(".matrix-box~.matrix-box").
       first(".rss-detail", text: "Observation Created").
       ancestor(".panel").first(".rss-box-details").first("a").click
     assert_match(/#{:app_title.l}: Observation/, page.title, "Wrong page")

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -334,7 +334,7 @@ class LurkerTest < CapybaraIntegrationTestCase
     # assert(page.has_title?("#{:app_title.l }: Activity Log"), "Wrong page")
     # assert_equal("#{:app_title.l}: Activity Log", page.title, "Login failed")
     assert_equal(
-      "#{:app_title.l}: #{:query_title_observations_by_updated_at.l}",
+      "#{:app_title.l}: #{:query_title_observations_by_activity.l}",
       page.title, "Login failed"
     )
   end

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -343,7 +343,7 @@ class LurkerTest < CapybaraIntegrationTestCase
     # assert(page.has_title?("#{:app_title.l }: Activity Log"), "Wrong page")
     # assert_equal("#{:app_title.l}: Activity Log", page.title, "Login failed")
     assert_equal(
-      "#{:app_title.l}: #{:query_title_observations_by_activity.l}",
+      "#{:app_title.l}: #{:query_title_observations_by_activity_log.l}",
       page.title, "Login failed"
     )
   end

--- a/test/integration/rails-dom-testing/amateur_test.rb
+++ b/test/integration/rails-dom-testing/amateur_test.rb
@@ -48,7 +48,7 @@ class AmateurTest < IntegrationTestCase
       form.change("password", "testpassword")
       form.submit("Login")
     end
-    assert_template("rss_logs/index")
+    assert_template("observations/index")
     assert_flash_text(/success/i)
 
     # This should only be accessible if logged in.

--- a/test/integration/rails-dom-testing/post_observation_test.rb
+++ b/test/integration/rails-dom-testing/post_observation_test.rb
@@ -28,10 +28,10 @@ class PostObservationTest < IntegrationTestCase
     open_edit_observation_form
     submit_observation_form_with_changes
     path = @request.fullpath
-    make_sure_observation_is_in_main_index(obs = Observation.last)
+    make_sure_observation_is_in_log_index(obs = Observation.last)
     get(path)
     destroy_observation
-    make_sure_observation_is_not_in_main_index(obs)
+    make_sure_observation_is_not_in_log_index(obs)
   end
 
   def open_create_observation_form
@@ -125,16 +125,16 @@ class PostObservationTest < IntegrationTestCase
     assert_template(OBSERVATION_INDEX_TEMPLATE)
   end
 
-  def make_sure_observation_is_in_main_index(obs)
+  def make_sure_observation_is_in_log_index(obs)
     open_session do
-      get("/")
+      get(activity_logs_path)
       assert_link_exists_beginning_with("/#{obs.id}?")
     end
   end
 
-  def make_sure_observation_is_not_in_main_index(obs)
+  def make_sure_observation_is_not_in_log_index(obs)
     open_session do
-      get("/")
+      get(activity_logs_path)
       assert_no_link_exists_beginning_with("/#{obs.id}?")
       assert_exists_deleted_item_log
     end

--- a/test/integration/rails-dom-testing/random_test.rb
+++ b/test/integration/rails-dom-testing/random_test.rb
@@ -23,7 +23,7 @@ class RandomTest < IntegrationTestCase
   test "the homepage" do
     login(users(:zero_user))
     get("/")
-    assert_template("rss_logs/index")
+    assert_template("observations/index")
     assert(/account/i, response.body)
   end
 

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2953,6 +2953,11 @@ class QueryTest < UnitTestCase
     assert_query(ids, :RssLog, :all)
   end
 
+  def test_rss_log_type
+    ids = [rss_logs(:species_list_rss_log).id]
+    assert_query(ids, :RssLog, :all, type: :species_list)
+  end
+
   def test_rss_log_in_set
     rsslog_set_ids = [rss_logs(:species_list_rss_log).id,
                       rss_logs(:name_rss_log).id]

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -31,7 +31,7 @@ class RssLogTest < UnitTestCase
   def test_detail_for_complexly_created_observation
     # Observation is created then an image is immediately uploaded.
     # We want it to return "observation created" not "image added".
-    log = rss_logs(:observation_rss_log)
+    log = rss_logs(:detailed_unknown_obs_rss_log)
     detail = log.detail
     assert_equal(:rss_created_at.t(type: :observation), detail)
   end


### PR DESCRIPTION
Changes the default home page from RssLogs to the Observations index, ordered by rss_log activity.

>~and adds a new preference to restore the RssLogs as homepage for power-users who want that~.  (Actually, no. Adding a preference like that is a lot of work. If people want the activity log there is a link in the main nav for it.)

There seems to be consensus as of the last meeting that this is a good idea. It will make the home page query slightly less expensive, and quicken the many default redirects on the site. And in my opinion, getting the housekeeping out of the homepage is better UX, especially for beginners.

**Revised - see comment below**. The query used for this page is "Observations by: :rss_log", and it adds an "Activity" button to the sort tabs.

>So... for this Obs home index, I’d like to hear peoples' ideas of which query to use. We discussed Obs by RssLog. Obs by date is currently the default query for the obs index, but i prefer the idea of obs by updated_at, which is in the spirit of the the activity log but less expensive. 
>
>Question:
>- I notice that the query class `ObservationByRssLog` is different from `ObservationAll by: :rss_log`
>
>Both of these involve a join to RssLogs, so they are slower than `ObservationAll by: :updated_at`, and i believe the main difference is that the join to `:rss_logs` returns deleted observations. In my opinion, deleted observations don't need to be in the homepage feed. If somebody wants to check the log, they’ll be there.

