### PR TITLE
Fix ID on matrix boxes!

### DIFF
--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -47,14 +47,14 @@ module MatrixBoxHelper
 
   # Obs with uncertain name: mark as reviewed (to skip in future)
   # used if matrix_box local_assigns identify == true
-  def matrix_box_identify_footer(identify, object_id)
+  def matrix_box_identify_footer(identify, obs_id)
     return unless identify
 
     content_tag(
       :div,
       class: "panel-footer panel-active text-center position-relative"
     ) do
-      mark_as_reviewed_toggle(object_id, "box_reviewed", "stretched-link")
+      mark_as_reviewed_toggle(obs_id, "box_reviewed", "stretched-link")
     end
   end
 end

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -3,6 +3,7 @@
 # Gather details for items in matrix-style ndex pages.
 class MatrixBoxPresenter < BasePresenter
   attr_accessor \
+    :id,         # id of the target or log object
     :type,       # what kind of box is this
     :image_data, # data passed to thumbnail_presenter
     :when,       # when object or target was created
@@ -32,6 +33,7 @@ class MatrixBoxPresenter < BasePresenter
   # Grabs all the information needed for view from RssLog instance.
   def rss_log_to_presenter(rss_log)
     target = rss_log.target
+    self.id = target.id || rss_log.id
     self.type = rss_log.target_type || :rss_log
     self.when = target.when&.web_date if target.respond_to?(:when)
     self.who  = target.user if target&.user
@@ -68,6 +70,7 @@ class MatrixBoxPresenter < BasePresenter
 
   # Grabs all the information needed for view from Image instance.
   def image_to_presenter(image)
+    self.id = image.id
     self.type = :image
     self.when = begin
                   image.when.web_date
@@ -86,6 +89,7 @@ class MatrixBoxPresenter < BasePresenter
 
   # Grabs all the information needed for view from Observation instance.
   def observation_to_presenter(observation)
+    self.id         = observation.id
     self.type       = :observation
     self.when       = observation.when.web_date
     self.who        = observation.user if observation.user
@@ -109,6 +113,7 @@ class MatrixBoxPresenter < BasePresenter
 
   # Grabs all the information needed for view from User instance.
   def user_to_presenter(user)
+    self.id = user.id
     self.type = :user
     # rubocop:disable Rails/OutputSafety
     # The results of .t and web_date are guaranteed to be safe, and both

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -33,7 +33,7 @@ class MatrixBoxPresenter < BasePresenter
   # Grabs all the information needed for view from RssLog instance.
   def rss_log_to_presenter(rss_log)
     target = rss_log.target
-    self.id = target.id || rss_log.id
+    self.id = target&.id || rss_log.id
     self.type = rss_log.target_type || :rss_log
     self.when = target.when&.web_date if target.respond_to?(:when)
     self.who  = target.user if target&.user

--- a/app/views/shared/_matrix_box.html.erb
+++ b/app/views/shared/_matrix_box.html.erb
@@ -14,7 +14,7 @@ if presenter
                   except(:columns, :object, :object_counter, :object_iteration).
                   merge(presenter.image_data || {})
   h_element = presenter.image_data ? :h5 : :h3 # bigger heading if no image
-  link_heading = content_tag(:small, "(#{object_id})",
+  link_heading = content_tag(:small, "(#{presenter.id})",
                               class: "rss-id float-right") +
                 content_tag(:span, presenter.name, class: "rss-name")
   %>
@@ -63,7 +63,7 @@ if presenter
 
       <%= matrix_box_log_footer(presenter) %>
 
-      <%= matrix_box_identify_footer(identify, object_id) %>
+      <%= matrix_box_identify_footer(identify, presenter.id) %>
 
     </div><!-- .panel -->
   <% end %><!-- .matrix-box -->

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -9,6 +9,11 @@ class LurkerTest < CapybaraIntegrationTestCase
     reset_session!
     login
 
+    # visit("/activity_logs")
+    rss_log = RssLog.where.not(observation_id: nil).last
+    assert_selector("#box_#{rss_log.id} .rss-id",
+                    text: rss_log.observation_id)
+
     # Click on first observation in feed results
     first(".rss-detail", text: "Observation Created").
       ancestor(".panel").first(".rss-box-details").first("a").click


### PR DESCRIPTION
On the RssLogs index, the `object` for the purposes of the partial is the RssLog, not the `rss_log.target`. I was pulling the `object.id` for the id printed in the obs title, so it was printing the `rss_log.id`. Not very helpful!

This PR adds the correct target ID to the data returned by the matrix box presenter, for easy access. If no target, it defaults to the RssLog id. For the purposes of testing, the RssLogs index `.matrix-box` element still has an HTML id of `"box_#{rss_log.id}"`, but on an obs index that id would be `"box_#{obs.id}"`, because it's an index of observations.

Now there's a test lurking in LurkerTest to keep it fixed.