### PR TITLE
Cinch down the tall thumbnails a bit more

### DIFF
--- a/app/presenters/thumbnail_presenter.rb
+++ b/app/presenters/thumbnail_presenter.rb
@@ -94,8 +94,8 @@ class ThumbnailPresenter < BasePresenter
     img_height = image&.height ? BigDecimal(image&.height) : 100
     img_proportion = BigDecimal(img_height / img_width)
     img_padding = (img_proportion * 100).to_f.truncate(1)
-    # Limit proportion 2:1 h/w for thumbnail
-    img_padding = "150" if img_padding.to_i > 150 # default for tall
+    # Limit proportion 1.3:1 h/w for thumbnail
+    img_padding = "133.33" if img_padding.to_i > 133 # default for tall
     self.proportion = img_padding
 
     if args[:context] == :matrix_box


### PR DESCRIPTION
This would further limit the tall images on the indexes to 4:3, from 3:2 currently. Responds to HuaFang's feedback.

The max proportion of our users' cameras is likely 16:9, so it's a significant crop from a new iPhone, but these proportions would affect matrix box thumbnails only. Lightboxes and the new Bootstrap 4 carousel on show-obs would show the uncropped image.

Here's the proportion difference. 
Yellow = newest phones
Mycena = good photographer's camera (go Alan!)
Pink = proposed proportion cap

![proportions](https://user-images.githubusercontent.com/1948095/232954296-58222d1d-16ca-42f4-9a59-ba4584fee8e5.jpg)
