### PR TITLE
Contributors login

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -2,6 +2,7 @@
 
 # display information about user contributions to the site
 class ContributorsController < ApplicationController
+  before_action :login_required
   before_action :disable_link_prefetching
 
   # Contributors index


### PR DESCRIPTION
This PR is a one-line change to require login to view the Contributors index.

I  just noticed that anonymous users can view the Contributors page.
It's an expensive page (see), and I think that the intention was to require login. 
(Note that the test logs in before doing a `get`.) 
```ruby
I, [2023-04-23T23:26:41.186964 #360686]  INFO -- : Started GET "/contributors" for 50.45.244.151 at 2023-04-23 23:26:41 +0000
W, [2023-04-23T23:26:54.928883 #360686]  WARN -- : TIME: 13.739002582 200 contributors index user 50.45.244.151	https://mushroomobserver.org/contributors	
```

### Manual Test
- Login, goto `/contributors`. Result: List of Contributors
- Logout, goto `/contributors`. Result: Please login