### PR TITLE
Fix the "everything" tab on RssLogs

### DIFF
--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -19,15 +19,8 @@ class RssLogsController < ApplicationController
     # POST requests with param `type` potentially show an array of types
     # of objects. The array comes from the checkboxes in tabset
     if params[:type].present?
-      if params[:type].is_a?(Array)
-        types = RssLog.all_types.intersection(types)
-        types = "all" if types.length == RssLog.all_types.length
-        types = "none" if types.empty?
-        types = types.map(&:to_s).join(" ") if types.is_a?(Array)
-      elsif params[:type].is_a?(String)
-        types = params[:type]
-      end
-      query = find_or_create_query(:RssLog, type: types)
+      query = find_or_create_query(:RssLog,
+                                   type: types_query_string_from_params)
     # Previously saved query, incorporating type and other params
     elsif params[:q].present?
       query = find_query(:RssLog)
@@ -40,6 +33,24 @@ class RssLogsController < ApplicationController
     end
     show_selected_rss_logs(query, id: params[:id].to_s, always_index: true)
   end
+
+  private
+
+  def types_query_string_from_params
+    types = params[:type]
+    if types.is_a?(Array)
+      if types.empty?
+        types = "none"
+      else
+        types = RssLog.all_types.intersection(types)
+        types = "all" if types.length == RssLog.all_types.length
+        types = types.map(&:to_s).join(" ") if types.is_a?(Array)
+      end
+    end
+    types
+  end
+
+  public
 
   # Show a single RssLog.
   def show
@@ -63,8 +74,6 @@ class RssLogsController < ApplicationController
 
     render_xml(layout: false)
   end
-
-  private
 
   # Show selected search results as a matrix with "index" template.
   def show_selected_rss_logs(query, args = {})

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -19,11 +19,14 @@ class RssLogsController < ApplicationController
     # POST requests with param `type` potentially show an array of types
     # of objects. The array comes from the checkboxes in tabset
     if params[:type].present?
-      types = Array(params[:type])
-      types = RssLog.all_types.intersection(types)
-      types = "all" if types.length == RssLog.all_types.length
-      types = "none" if types.empty?
-      types = types.map(&:to_s).join(" ") if types.is_a?(Array)
+      if params[:type].is_a?(Array)
+        types = RssLog.all_types.intersection(types)
+        types = "all" if types.length == RssLog.all_types.length
+        types = "none" if types.empty?
+        types = types.map(&:to_s).join(" ") if types.is_a?(Array)
+      elsif params[:type].is_a?(String)
+        types = params[:type]
+      end
       query = find_or_create_query(:RssLog, type: types)
     # Previously saved query, incorporating type and other params
     elsif params[:q].present?

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -47,6 +47,9 @@ class RssLogsControllerTest < FunctionalTestCase
     # Be sure "all" loads some rss_logs!
     get(:index, params: { type: "all" })
     assert_template("shared/_matrix_box")
+
+    get(:index, params: { type: [] })
+    assert_template(:index)
   end
 
   def test_get_index_rss_log

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -50,11 +50,6 @@ class RssLogsControllerTest < FunctionalTestCase
 
     get(:index, params: { type: [] })
     assert_template(:index)
-
-    Query.lookup_and_save(:RssLog, :all, type: "observation")
-    qr = QueryRecord.last.id.alphabetize
-    get(:index, params: { q: qr })
-    assert_template(:index)
   end
 
   def test_get_index_rss_log
@@ -93,6 +88,10 @@ class RssLogsControllerTest < FunctionalTestCase
     # Prove that user can change his default rss log type.
     get(:index, params: { type: :glossary_term, make_default: 1 })
     assert_equal("glossary_term", rolf.reload.default_rss_type)
+    # Test that this actually works
+    qr = QueryRecord.last.id.alphabetize
+    get(:index, params: { q: qr })
+    assert_template(:index)
   end
 
   # Prove that user content_filter works on rss_log

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -43,6 +43,10 @@ class RssLogsControllerTest < FunctionalTestCase
     params[:type] = RssLog.all_types
     post(:index, params: params)
     assert_template(:index)
+
+    # Be sure "all" loads some rss_logs!
+    get(:index, params: { type: "all" })
+    assert_template("shared/_matrix_box")
   end
 
   def test_get_index_rss_log

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -50,6 +50,11 @@ class RssLogsControllerTest < FunctionalTestCase
 
     get(:index, params: { type: [] })
     assert_template(:index)
+
+    Query.lookup_and_save(:RssLog, :all, type: "observation")
+    qr = QueryRecord.last.id.alphabetize
+    get(:index, params: { q: qr })
+    assert_template(:index)
   end
 
   def test_get_index_rss_log


### PR DESCRIPTION
Wasn't working (it loaded no rss_logs, instead of "all" types).

Adds tests to be sure.