### PR TITLE
Fix edit obs bug, remaining link_with_query calls

### DIFF
--- a/app/views/collection_numbers/edit.html.erb
+++ b/app/views/collection_numbers/edit.html.erb
@@ -4,7 +4,7 @@
   tabs = []
   if @back == "index"
     tabs << link_with_query(:edit_collection_number_back_to_index.t,
-                            action: :index)
+                            @collection_number.index_link_args)
   else
     tabs << link_with_query(:cancel_and_show.t(type: @back_object.type_tag),
                             @back_object.show_link_args)

--- a/app/views/observations/edit.html.erb
+++ b/app/views/observations/edit.html.erb
@@ -3,7 +3,7 @@
 
   tabs = [
     link_with_query(:cancel_and_show.t(type: :observation),
-                    action: :show, id: @observation.id)
+                    @observation.show_link_args)
   ]
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide


### PR DESCRIPTION
The problem is in the edit page tabs “Cancel and show observation”, I missed one (actually two) when correcting for the new link_with_query syntax.

I changed `link_with_query` so it takes exactly the same signature as `link_to`; that means that if the **link destination** is a hash of args (rather than a path builder like `observations_path`) it needs to be sent as a hash proper, not implicit. 

So, in the case of this bug: The “return to obs” tab on edit obs was being built with 
```ruby
link_with_query(:cancel_and_show.t(type: :observation),
                action: :show, id: @observation.id)
```
Note that `action:` and `id:` are not part of a hash. We could put brackets around them, but the better fix is just to send `@observation.show_link_args`, which is a hash.

There was only one other instance of `link_with_query` still built with separate controller args, in collection numbers. Also fixed here.

In `link_with_query` now, as with `link_to`, only the **html options** are implicitly scooped up as a hash. This allows you to write 
```ruby
link_with_query(:cancel_and_show.t(type: :observation),
                @observation.show_link_args, class: "text-danger")
```

The change was done to allow us to pass a block to `link_with_query`, which is essential for using icons.
```ruby
link_with_query(:cancel_and_show.t(type: :observation),
                @observation.show_link_args, class: "text-danger") do
  [
    icon(args),
    text.l
  ].safe_join
end
```
