### PR TITLE
Prevent reversion of bug fixed in PR #1479

### DIFF
--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -204,7 +204,6 @@ module ControllerExtensions
   #
   def either_requires_either(method, page, altpage, params = {},
                              username = "rolf", password = "testpassword")
-    # binding.break
     assert_request(
       method: method,
       action: page,

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -197,7 +197,6 @@ module Observations
           commit: "Print Labels"
         }
       )
-      # binding.break
       assert_flash_error
     end
   end

--- a/test/integration/capybara/observations_controller_supplemental_test.rb
+++ b/test/integration/capybara/observations_controller_supplemental_test.rb
@@ -51,6 +51,22 @@ class ObservationsControllerSupplementalTest < CapybaraIntegrationTestCase
                  "Wrong page")
   end
 
+  # Prevent reversion of the bug that was fixed in PR #1479
+  # https://github.com/MushroomObserver/mushroom-observer/pull/1479
+  def test_edit_observation_with_query
+    user = users(:dick)
+    obs = observations(:collected_at_obs)
+    assert_equal(user, obs.user,
+                 "Test needs an Observation fixture owned by user")
+    q_id = "123abc" # Can be anything, but is need to expose the bug
+
+    login(user)
+    # Throws an error pre-PR #1479
+    visit(edit_observation_path(obs.id, params: { q: q_id }))
+
+    assert_current_path(edit_observation_path(obs.id, params: { q: q_id }))
+  end
+
   # Prove that unchecking a Project as part of editing an Observation
   # removes the Observation from the Project.
   def test_observation_edit_uncheck_project


### PR DESCRIPTION
Adds an integration test to prevent reversion of the bug fixed by  #1479.
The test
-  Passes in this branch; and
-  Fails in # e39d5fa45 (just before #1479), with the same error as thrown in production (and development):
```ruby
ERROR ObservationsControllerSupplementalTest#test_edit_observation_with_query (6.37s)
Minitest::UnexpectedError:         ActionView::Template::Error: undefined method `[]=' for nil:NilClass
        
              params[:q] = query_param if query_param
                    ^^^^^^
            app/controllers/application_controller.rb:1034:in `add_query_param'
            app/controllers/application_controller.rb:1039:in `add_query_param'
            app/helpers/link_helper.rb:23:in `link_with_query'
            app/views/observations/edit.html.erb:5
            app/controllers/application_controller.rb:146:in `skip_bullet'
            app/controllers/application_controller.rb:241:in `catch_errors_and_log_request_stats'
            test/integration/capybara/observations_controller_supplemental_test.rb:65:in `test_edit_observation_with_query'
```