### PR TITLE
Make sorting links a symmetrical 2d array

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1595,7 +1595,7 @@ class ApplicationController < ActionController::Base
 
   def link_or_grayed_text(link_all, this_by, label, query, by)
     if !link_all && (by.to_s == this_by)
-      label.t
+      [label.t, nil]
     else
       sort_link(label.t, query, by)
     end


### PR DESCRIPTION
Currently in `application_controller#show_index_of_objects`, via `show_index_count_results`, `sorting_links`, `add_sorting_links`, `link_or_greyed_out_text`, we're producing this 2d array:

```ruby
["Activity",
 ["Date", {:controller=>"/observations", :action=>:index, :by=>"date", :q=>"1oN3C"}],
 ["Date Posted", {:controller=>"/observations", :action=>:index, :by=>"created_at", :q=>"1oN3C"}],
 ["Name", {:controller=>"/observations", :action=>:index, :by=>"name", :q=>"1oN3C"}],
 ["User", {:controller=>"/observations", :action=>:index, :by=>"user", :q=>"1oN3C"}],
 ["Confidence Level", {:controller=>"/observations", :action=>:index, :by=>"confidence", :q=>"1oN3C"}],
 ["Thumbnail Quality", {:controller=>"/observations", :action=>:index, :by=>"thumbnail_quality", :q=>"1oN3C"}],
 ["Popularity", {:controller=>"/observations", :action=>:index, :by=>"num_views", :q=>"1oN3C"}],
 ["Reverse Order", {:controller=>"/observations", :action=>:index, :by=>"reverse_rss_log", :q=>"1oN3C"}]]
```

In the bs4 branch, i'm refactoring the HTML that uses these links. Iterating over this array breaks because the first item (or whichever item is active) is not an array like the others. 

This tiny PR makes it a consistent 2D array whose second value for the active item, the link URL, is explicitly `nil`.

New array:
```ruby
[["Activity", nil],
 ["Date", {:controller=>"/observations", :action=>:index, :by=>"date", :q=>"1oN3C"}],
 ["Date Posted", {:controller=>"/observations", :action=>:index, :by=>"created_at", :q=>"1oN3C"}],
 ["Name", {:controller=>"/observations", :action=>:index, :by=>"name", :q=>"1oN3C"}],
 ["User", {:controller=>"/observations", :action=>:index, :by=>"user", :q=>"1oN3C"}],
 ["Confidence Level", {:controller=>"/observations", :action=>:index, :by=>"confidence", :q=>"1oN3C"}],
 ["Thumbnail Quality", {:controller=>"/observations", :action=>:index, :by=>"thumbnail_quality", :q=>"1oN3C"}],
 ["Popularity", {:controller=>"/observations", :action=>:index, :by=>"num_views", :q=>"1oN3C"}],
 ["Reverse Order", {:controller=>"/observations", :action=>:index, :by=>"reverse_rss_log", :q=>"1oN3C"}]]
```