### PR TITLE
Move sorter in to a partial with helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,6 +119,12 @@ module ApplicationHelper
     render(partial: "layouts/content/tab_set", locals: { links: links })
   end
 
+  def index_sorter(sorts)
+    return "" unless sorts
+
+    render(partial: "layouts/content/sorter", locals: { sorts: sorts })
+  end
+
   # ----------------------------------------------------------------------------
 
   # Add something to the header from within view.  This can be called as many

--- a/app/views/layouts/content/_sorter.html.erb
+++ b/app/views/layouts/content/_sorter.html.erb
@@ -1,0 +1,16 @@
+
+<div class="hidden-print col-xs-12">
+  <div class="pt-3">
+    <%= content_tag(:span, :sort_by_header.t) %>
+    <div id="sorts" class="btn-group btn-group-xs" role="group">
+      <% sorts.each do |title, action| %>
+        <%= if action.nil?
+              link_with_query(title, {}, class: "btn btn-default active",
+                                          disabled: true)
+            else
+              link_with_query(title, action, class: "btn btn-default")
+            end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/content/_title_and_tab_sets.html.erb
+++ b/app/views/layouts/content/_title_and_tab_sets.html.erb
@@ -40,21 +40,5 @@
                     class: "hidden-print col-xs-12") %>
 
   <!-- Sorter -->
-  <% if @sorts %>
-    <div class="hidden-print col-xs-12">
-      <div class="pt-3">
-        <%= content_tag(:span, :sort_by_header.t) %>
-        <div id="sorts" class="btn-group btn-group-xs" role="group">
-          <% @sorts.each do |title, action| %>
-            <%= if action.nil?
-                  link_with_query(title, {}, class: "btn btn-default active",
-                                              disabled: true)
-                else
-                  link_with_query(title, action, class: "btn btn-default")
-                end %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  <% end %>
+  <%= index_sorter(@sorts) %>
 </div>


### PR DESCRIPTION
The sorter is currently built in `layout/content/title_and_tab_sets`. This breaks it out into a partial, with a helper that calls the partial with `@sorts`.