### PR TITLE
`Query` class: eliminate second query for `num_results`

### DIFF
--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -32,23 +32,8 @@ module Query::Modules::HighLevelQueries
   INSTANTIATE_ARGS = [:include].freeze
 
   # Number of results the query returns.
-  def num_results(args = {})
-    @num_results ||=
-      if @result_ids
-        @result_ids.count
-      else
-        # Explicitly disable GROUP BY and ORDER clauses for the purposes of
-        # simply counting the number of results.  This is important because
-        # GROUP BY in particular will mess up the COUNT(*) spec.  Passing in
-        # empty strings for group and order will tell it to explicitly override
-        # anything in self.group and self.order.
-        rows = select_rows(args.merge(select: "COUNT(*)", group: "", order: ""))
-        begin
-          rows[0][0].to_i
-        rescue StandardError
-          0
-        end
-      end
+  def num_results(_args = {})
+    @num_results ||= result_ids&.count || 0
   end
 
   # Array of all results, just ids.


### PR DESCRIPTION
This tiny PR may shave more than 40% off the load time of the home index.

When I paid close attention to the load of the new obs by rss_log home index in the dev environment, i found something in the log that seems off. Turns out this had been bugging @pellaea also.

There are two giant queries being executed on page load:
```
(4355.3ms)  
      SELECT COUNT(*)
      FROM `observations` JOIN `rss_logs` ON observations.rss_log_id = [rss_logs.id](http://rss_logs.id/)
    
QUERY starting: "\n      SELECT DISTINCT [observations.id](http://observations.id/)\n      FROM `observations` JOIN `rss_logs` ON observations.rss_log_id = [rss_logs.id](http://rss_logs.id/)\n      ORDER BY rss_logs.updated_at DESC, [observations.id](http://observations.id/) DESC\n"
   (5806.0ms)  
      SELECT DISTINCT [observations.id](http://observations.id/)
      FROM `observations` JOIN `rss_logs` ON observations.rss_log_id = [rss_logs.id](http://rss_logs.id/)
      ORDER BY rss_logs.updated_at DESC, [observations.id](http://observations.id/) DESC
```

The first query is just whatever the current query is, minus `group` and `order` args, and it's run by `HighLevelQueries#num_results`, to get an accurate count of the results, for pagination. It covers edge cases where a `group` arg in the query can throw off the number of results.

@pellaea suggested an alteration: just accepting the number of results returned by the main query. On a large query like the home page, any discrepancy is not going to matter, and it's hard to think of the edge cases where it will matter (and especially, matter more than the effect of basically doubling the page load time for indexes).