### PR TITLE
Cache `rss_logs.updated_at` on `observations` table to eliminate join on home page

### DIFF
--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -193,8 +193,14 @@ module Query
       def sort_by_rss_log(model)
         return unless model.column_names.include?("rss_log_id")
 
-        add_join(:rss_logs)
-        "rss_logs.updated_at DESC"
+        # use cached column if exists, and don't join
+        # calling index method should include rss_logs
+        if model.column_names.include?("log_updated_at")
+          "#{model.table_name}.log_updated_at DESC"
+        else
+          add_join(:rss_logs)
+          "rss_logs.updated_at DESC"
+        end
       end
 
       def sort_by_summary(model)

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -659,9 +659,16 @@ class AbstractModel < ApplicationRecord
   #
   def log(tag, args = {})
     init_rss_log unless rss_log
-    touch unless new_record? ||
-                 args[:touch] == false
+    touch_when_logging unless new_record? ||
+                              args[:touch] == false
     rss_log.add_with_date(tag, args)
+  end
+
+  # This allows a model to override touch in this context only, e.g.,
+  # Observation caches a log_updated_at value so the activity index doesn't
+  # have to do a join to rss_logs
+  def touch_when_logging
+    touch
   end
 
   # Add message to RssLog if you're about to destroy this object, creating new

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -53,6 +53,7 @@
 #  notes::                  Arbitrary text supplied by User and serialized.
 #  num_views::              Number of times it has been viewed.
 #  last_view::              Last time it was viewed.
+#  log_updated_at::         Cache of RssLogs.updated_at, for speedier index
 #
 #  ==== "Fake" attributes
 #  place_name::             Wrapper on top of +where+ and +location+.
@@ -62,6 +63,7 @@
 #
 #  refresh_vote_cache::     Refresh cache for all Observation's.
 #  define_a_location::      Update any observations using the old "where" name.
+#  touch_when_logging::     Override of AbstractModel's hook when updating log
 #  ---
 #  no_notes::               value of observation.notes if there are no notes
 #  no_notes_persisted::     no_notes persisted in the db
@@ -579,6 +581,13 @@ class Observation < AbstractModel
 
   def old_last_viewed_by(user)
     @old_last_viewed_by && @old_last_viewed_by[user&.id]
+  end
+
+  # This allows Observation to override AR `touch` in this context only,
+  # to cache a log_updated_at value
+  def touch_when_logging
+    self.log_updated_at = Time.zone.now
+    touch
   end
 
   ##############################################################################

--- a/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
+++ b/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
@@ -3,9 +3,9 @@ class AddColumnToObservationsLogUpdatedAt < ActiveRecord::Migration[6.1]
     add_column(:observations, :log_updated_at, :datetime)
     Observation.joins(:rss_log).update_all(log_updated_at: RssLog[:updated_at])
     # cleanup the 24113 observations with no rss_log
-    Observation.where(log_updated_at: nil).
-                update_all(log_updated_at: Observation[:updated_at])
-    change_column(:observations, :log_updated_at, :datetime, null: false)
+    # Observation.where(log_updated_at: nil).
+    #             update_all(log_updated_at: Observation[:updated_at])
+    # change_column(:observations, :log_updated_at, :datetime, null: false)
   end
   def down
     remove_column(:observations, :log_updated_at)

--- a/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
+++ b/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
@@ -1,0 +1,9 @@
+class AddColumnToObservationsLogUpdatedAt < ActiveRecord::Migration[6.1]
+  def up
+    add_column(:observations, :log_updated_at, :datetime, null: false)
+    Observation.joins(:rss_log).update_all(log_updated_at: RssLog[:updated_at])
+  end
+  def down
+    remove_column(:observations, :log_updated_at)
+  end
+end

--- a/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
+++ b/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
@@ -2,10 +2,6 @@ class AddColumnToObservationsLogUpdatedAt < ActiveRecord::Migration[6.1]
   def up
     add_column(:observations, :log_updated_at, :datetime)
     Observation.joins(:rss_log).update_all(log_updated_at: RssLog[:updated_at])
-    # cleanup the 24113 observations with no rss_log
-    # Observation.where(log_updated_at: nil).
-    #             update_all(log_updated_at: Observation[:updated_at])
-    # change_column(:observations, :log_updated_at, :datetime, null: false)
   end
   def down
     remove_column(:observations, :log_updated_at)

--- a/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
+++ b/db/migrate/20230430044838_add_column_to_observations_log_updated_at.rb
@@ -1,7 +1,11 @@
 class AddColumnToObservationsLogUpdatedAt < ActiveRecord::Migration[6.1]
   def up
-    add_column(:observations, :log_updated_at, :datetime, null: false)
+    add_column(:observations, :log_updated_at, :datetime)
     Observation.joins(:rss_log).update_all(log_updated_at: RssLog[:updated_at])
+    # cleanup the 24113 observations with no rss_log
+    Observation.where(log_updated_at: nil).
+                update_all(log_updated_at: Observation[:updated_at])
+    change_column(:observations, :log_updated_at, :datetime, null: false)
   end
   def down
     remove_column(:observations, :log_updated_at)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_30_044207) do
+ActiveRecord::Schema.define(version: 2023_04_30_044838) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -482,6 +482,7 @@ ActiveRecord::Schema.define(version: 2023_04_30_044207) do
     t.text "classification"
     t.boolean "gps_hidden", default: false, null: false
     t.integer "source"
+    t.datetime "log_updated_at"
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_30_044207) do
+ActiveRecord::Schema.define(version: 2023_04_30_044838) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -482,6 +482,7 @@ ActiveRecord::Schema.define(version: 2023_04_30_044207) do
     t.text "classification"
     t.boolean "gps_hidden", default: false, null: false
     t.integer "source"
+    t.datetime "log_updated_at", null: false
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_30_044838) do
+ActiveRecord::Schema.define(version: 2023_04_30_044207) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -482,7 +482,6 @@ ActiveRecord::Schema.define(version: 2023_04_30_044838) do
     t.text "classification"
     t.boolean "gps_hidden", default: false, null: false
     t.integer "source"
-    t.datetime "log_updated_at", null: false
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
Adds new column `observations.log_updated_at`, to cache the value of the obs's corresponding `rss_log.updated_at`. Migration populates it with correct value, or if `rss_log` is missing, it leaves the column `null`. 

(An earlier idea of populating missing values with the obs' own `updated_at`, and making the column non-nullable, tabled for now. Many obs with missing logs are draft obs from the name_lister; others are very early days of MO. We may want to treat these differently.)

Changes the new home page, obs by rss log index, to order by the cached column, so it doesn't have to join to `rss_logs` just to find out the correct order.

#### Code note: ####
Alters `AbstractModel#log`, to call an MO method `touch_when_logging` instead of AR `touch`, which can then be defined at the model (default is `touch`). Allows any model in the future to piggyback on `touch` in this way and cache a value, or do anything else, on a log event. 


