### PR TITLE
Should `SpeciesList#name_lister` log "draft" observations?

### DIFF
--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -355,6 +355,8 @@ class SpeciesList < AbstractModel
       is_collection_location: args[:is_collection_location],
       specimen: args[:specimen]
     )
+    obs.log(:log_observation_created)
+
     args[:projects].each do |project|
       project.add_observation(obs)
     end


### PR DESCRIPTION
`SpeciesList` has not been logging the observations it creates (via `name_lister`). This seems to account for many of the 25,000 observations in the db without a corresponding `rss_log`. (Others are from early days of MO.)

This PR should also probably
- create an `RssLog` for all the observations that didn't get logged so far, because the existence of an rss_log governs them showing up on the home page
- add a test that new obs from name_lister are getting a log. This seems tricky, because the name_lister controller test doesn't actually create any obs (yet).