### PR TITLE
Refactor Lookups Controller

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -635,7 +635,6 @@ Style/OptionalBooleanParameter:
     - 'app/classes/query/modules/sql.rb'
     - 'app/classes/textile.rb'
     - 'app/controllers/application_controller.rb'
-    - 'app/controllers/lookups_controller.rb'
     - 'app/extensions/string_extensions.rb'
     - 'app/extensions/symbol_extensions.rb'
     - 'app/helpers/content_helper.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -113,7 +113,6 @@ Metrics/BlockNesting:
   Exclude:
     - 'app/classes/map_set.rb'
     - 'app/classes/tree.rb'
-    - 'app/controllers/lookups_controller.rb'
     - 'app/controllers/observations_controller/form_helpers.rb'
     - 'lib/tasks/email.rake'
     - 'test/controller_extensions.rb'

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -97,7 +97,7 @@ class LookupsController < ApplicationController
       flash_error(e.to_s) unless Rails.env.production?
     end
 
-    return unless obj
+    return nil unless obj
 
     [[obj], nil]
   end

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -50,6 +50,10 @@ class LookupsController < ApplicationController
     lookup_general(User)
   end
 
+  ##############################################################################
+
+  private
+
   # Alternative to controller/show_object/id.  These were included for the
   # benefit of the textile wrapper: We don't want to be looking up all these
   # names and objects every time we display comments, etc.  Instead we make
@@ -57,7 +61,7 @@ class LookupsController < ApplicationController
   # user actually clicks on one.  These redirect to the appropriate
   # controller/action after looking up the object.
   # inputs: model Class, true/false
-  def lookup_general (model, accepted = false)
+  def lookup_general(model, accepted = false)
     # type = model.type_tag
     id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
 

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -203,7 +203,10 @@ class LookupsController < ApplicationController
         model: model, id: id, matches: matches, suggestions: suggestions
       )
     else
-      handle_multiple_matches_or_suggestions(matches, suggestions, id, model)
+      handle_multiple_matches_or_suggestions(
+        model: model, id: id, matches: matches, suggestions: suggestions
+      )
+
     end
   end
 
@@ -228,7 +231,9 @@ class LookupsController < ApplicationController
                 id: obj.id)
   end
 
-  def handle_multiple_matches_or_suggestions(matches, suggestions, id, model)
+  def handle_multiple_matches_or_suggestions(
+    model:, id:, matches:, suggestions:
+  )
     obj = matches.first || suggestions.first
     query = Query.lookup(model, :in_set, ids: matches + suggestions)
     if suggestions.any?

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -61,20 +61,6 @@ class LookupsController < ApplicationController
     type = model.type_tag
     id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
 
-=begin
-    begin
-      if /^\d+$/.match?(id)
-        obj = find_or_goto_index(model, id)
-        return unless obj
-
-        matches = [obj]
-      else
-        matches, suggestions = find_matches_and_suggestions(model, id, accepted)
-      end
-    rescue StandardError => e
-      flash_error(e.to_s) unless Rails.env.production?
-    end
-=end
     matches, suggestions = find_matches_and_suggestions(model, id, accepted)
     return if /^\d+$/.match?(id) && !matches
 

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -62,7 +62,6 @@ class LookupsController < ApplicationController
   # controller/action after looking up the object.
   # inputs: model Class, true/false
   def lookup_general(model, accepted: false)
-    # type = model.type_tag
     id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
 
     matches, suggestions = find_matches_and_suggestions(model, id, accepted)

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -124,6 +124,16 @@ class LookupsController < ApplicationController
     matches
   end
 
+  def fix_name_matches(matches, accepted)
+    matches.filter_map do |name|
+      if accepted && name.deprecated
+        name.approved_synonyms.first
+      else
+        name.correct_spelling || name
+      end
+    end
+  end
+
   def find_location_matches(id)
     pattern = "%#{id}%"
 
@@ -215,15 +225,5 @@ class LookupsController < ApplicationController
     redirect_to(add_query_param({ controller: obj.show_controller,
                                   action: obj.index_action },
                                 query))
-  end
-
-  def fix_name_matches(matches, accepted)
-    matches.filter_map do |name|
-      if accepted && name.deprecated
-        name.approved_synonyms.first
-      else
-        name.correct_spelling || name
-      end
-    end
   end
 end

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -61,6 +61,7 @@ class LookupsController < ApplicationController
     type = model.type_tag
     id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
 
+=begin
     begin
       if /^\d+$/.match?(id)
         obj = find_or_goto_index(model, id)
@@ -73,11 +74,16 @@ class LookupsController < ApplicationController
     rescue StandardError => e
       flash_error(e.to_s) unless Rails.env.production?
     end
+=end
+    matches, suggestions = find_matches_and_suggestions(model, id, accepted)
+    return if /^\d+$/.match?(id) && !matches
 
     handle_matches_and_suggestions(id, type, model, matches, suggestions)
   end
 
   def find_matches_and_suggestions(model, id, accepted)
+    return find_integer_matches(model, id) if /^\d+$/.match?(id)
+
     case model.to_s
     when "Name"
       find_name_matches_and_suggestions(id, accepted)
@@ -90,6 +96,18 @@ class LookupsController < ApplicationController
     when "User"
       find_user_matches(id)
     end
+  end
+
+  def find_integer_matches(model, id)
+    begin
+      obj = find_or_goto_index(model, id)
+    rescue StandardError => e
+      flash_error(e.to_s) unless Rails.env.production?
+    end
+
+    return unless obj
+
+    [[obj], nil]
   end
 
   def find_name_matches_and_suggestions(id, accepted)

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -199,7 +199,9 @@ class LookupsController < ApplicationController
     if matches.empty? && suggestions.empty?
       handle_no_match_error(id, model)
     elsif matches.length == 1 || suggestions&.length == 1
-      handle_single_match_or_suggestion(matches, suggestions, id, model)
+      handle_single_match_or_suggestion(
+        model: model, id: id, matches: matches, suggestions: suggestions
+      )
     else
       handle_multiple_matches_or_suggestions(matches, suggestions, id, model)
     end
@@ -214,7 +216,7 @@ class LookupsController < ApplicationController
     end
   end
 
-  def handle_single_match_or_suggestion(matches, suggestions, id, model)
+  def handle_single_match_or_suggestion(model:, id:, matches:, suggestions:)
     obj = matches.first || suggestions.first
     if suggestions.any?
       flash_warning(

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -31,7 +31,7 @@ class LookupsController < ApplicationController
   # it a name ID.  This is, of course, bizarre behavior, but we're ignoring it
   # because it should never be called that way in the first place. -JPH 1/2017
   def lookup_accepted_name
-    lookup_general(Name, true)
+    lookup_general(Name, accepted: true)
   end
 
   def lookup_observation
@@ -61,7 +61,7 @@ class LookupsController < ApplicationController
   # user actually clicks on one.  These redirect to the appropriate
   # controller/action after looking up the object.
   # inputs: model Class, true/false
-  def lookup_general(model, accepted = false)
+  def lookup_general(model, accepted: false)
     # type = model.type_tag
     id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
 

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -68,7 +68,9 @@ class LookupsController < ApplicationController
     matches, suggestions = find_matches_and_suggestions(model, id, accepted)
     return if /^\d+$/.match?(id) && !matches
 
-    handle_matches_and_suggestions(id, model, matches, suggestions)
+    handle_matches_and_suggestions(
+      model: model, id: id, matches: matches, suggestions: suggestions
+    )
   end
 
   def find_matches_and_suggestions(model, id, accepted)
@@ -193,7 +195,7 @@ class LookupsController < ApplicationController
     [matches, []]
   end
 
-  def handle_matches_and_suggestions(id, model, matches, suggestions)
+  def handle_matches_and_suggestions(model:, id:, matches:, suggestions:)
     if matches.empty? && suggestions.empty?
       handle_no_match_error(id, model)
     elsif matches.length == 1 || suggestions&.length == 1

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -74,13 +74,7 @@ class LookupsController < ApplicationController
       flash_error(e.to_s) unless Rails.env.production?
     end
 
-    if matches.empty? && suggestions.empty?
-      handle_no_match_error(id, type, model)
-    elsif matches.length == 1 || suggestions&.length == 1
-      handle_single_match_or_suggestion(matches, suggestions, id, type)
-    else
-      handle_multiple_matches_or_suggestions(matches, suggestions, id, type, model)
-    end
+    handle_matches_and_suggestions(id, type, model, matches, suggestions)
   end
 
   def find_matches_and_suggestions(model, id, accepted)
@@ -170,6 +164,16 @@ class LookupsController < ApplicationController
     end
 
     [matches, []]
+  end
+
+  def handle_matches_and_suggestions(id, type, model, matches, suggestions)
+    if matches.empty? && suggestions.empty?
+      handle_no_match_error(id, type, model)
+    elsif matches.length == 1 || suggestions&.length == 1
+      handle_single_match_or_suggestion(matches, suggestions, id, type)
+    else
+      handle_multiple_matches_or_suggestions(matches, suggestions, id, type, model)
+    end
   end
 
   def handle_no_match_error(id, type, model)

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -197,7 +197,7 @@ class LookupsController < ApplicationController
 
   def handle_matches_and_suggestions(model:, id:, matches:, suggestions:)
     if matches.empty? && suggestions.empty?
-      handle_no_match_error(id, model)
+      handle_no_match(model, id)
     elsif matches.length == 1 || suggestions&.length == 1
       handle_single_match_or_suggestion(
         model: model, id: id, matches: matches, suggestions: suggestions
@@ -210,7 +210,7 @@ class LookupsController < ApplicationController
     end
   end
 
-  def handle_no_match_error(id, model)
+  def handle_no_match(model, id)
     flash_error(:runtime_object_no_match.t(match: id, type: model.type_tag))
     if model == User
       redirect_to("/")

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -57,11 +57,10 @@ class LookupsController < ApplicationController
   # user actually clicks on one.  These redirect to the appropriate
   # controller/action after looking up the object.
   # inputs: model Class, true/false
-  def lookup_general(model, accepted = false)
-    matches = []
-    suggestions = []
+  def lookup_general (model, accepted = false)
     type = model.type_tag
     id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
+
     begin
       if /^\d+$/.match?(id)
         obj = find_or_goto_index(model, id)
@@ -69,70 +68,140 @@ class LookupsController < ApplicationController
 
         matches = [obj]
       else
-        case model.to_s
-        when "Name"
-          if (parse = Name.parse_name(id))
-            matches = Name.where(search_name: parse.search_name)
-            matches = Name.where(text_name: parse.text_name) if matches.empty?
-            matches = fix_name_matches(matches, accepted)
-          end
-          if matches.empty?
-            suggestions = Name.suggest_alternate_spellings(id)
-            suggestions = fix_name_matches(suggestions, accepted)
-          end
-        when "Location"
-          pattern = "%#{id}%"
-          matches = Location.limit(100).
-                    where(Location[:name].matches(pattern).
-                      or(Location[:scientific_name].matches(pattern)))
-        when "Project"
-          pattern = "%#{id}%"
-          matches = Project.limit(100).
-                    where(Project[:title].matches(pattern))
-
-        when "SpeciesList"
-          pattern = "%#{id}%"
-          matches = SpeciesList.limit(100).
-                    where(SpeciesList[:title].matches(pattern))
-        when "User"
-          matches = User.where(login: id)
-          matches = User.where(name: id) if matches.empty?
-        end
+        matches, suggestions = find_matches_and_suggestions(model, id, accepted)
       end
     rescue StandardError => e
       flash_error(e.to_s) unless Rails.env.production?
     end
 
     if matches.empty? && suggestions.empty?
-      flash_error(:runtime_object_no_match.t(match: id, type: type))
-      if model == User
-        redirect_to("/") # (no public index for users)
-      else
-        redirect_to(controller: model.show_controller,
-                    action: model.index_action)
-      end
-    elsif matches.length == 1 || suggestions.length == 1
-      obj = matches.first || suggestions.first
-      if suggestions.any?
-        flash_warning(:runtime_suggest_one_alternate.t(match: id, type: type))
-      end
-      redirect_to(controller: obj.show_controller,
-                  action: obj.show_action,
-                  id: obj.id)
+      handle_no_match_error(id, type, model)
+    elsif matches.length == 1 || suggestions&.length == 1
+      handle_single_match_or_suggestion(matches, suggestions, id, type)
     else
-      obj = matches.first || suggestions.first
-      query = Query.lookup(model, :in_set, ids: matches + suggestions)
-      if suggestions.any?
-        flash_warning(:runtime_suggest_multiple_alternates.t(match: id,
-                                                             type: type))
-      else
-        flash_warning(:runtime_object_multiple_matches.t(match: id,
-                                                         type: type))
-      end
-      redirect_to(add_query_param({ controller: obj.show_controller,
-                                    action: obj.index_action },
-                                  query))
+      handle_multiple_matches_or_suggestions(matches, suggestions, id, type, model)
     end
+  end
+
+  def find_matches_and_suggestions(model, id, accepted)
+    case model.to_s
+    when "Name"
+      find_name_matches_and_suggestions(id, accepted)
+    when "Location"
+      find_location_matches(id)
+    when "Project"
+      find_project_matches(id)
+    when "SpeciesList"
+      find_species_list_matches(id)
+    when "User"
+      find_user_matches(id)
+    end
+  end
+
+  def find_name_matches_and_suggestions(id, accepted)
+    matches = []
+    suggestions = []
+
+    begin
+      parse = Name.parse_name(id)
+      if parse
+        matches = Name.where(search_name: parse.search_name)
+        matches = Name.where(text_name: parse.text_name) if matches.empty?
+        matches = fix_name_matches(matches, accepted)
+      end
+      return [matches, []] unless matches.empty?
+
+      suggestions = Name.suggest_alternate_spellings(id)
+      suggestions = fix_name_matches(suggestions, accepted) if suggestions.any?
+      [[], suggestions]
+    rescue StandardError => e
+      flash_error(e.to_s) unless Rails.env.production?
+    end
+
+    [matches, suggestions]
+  end
+
+  def find_location_matches(id)
+    pattern = "%#{id}%"
+
+    begin
+      matches = Location.limit(100).
+                where(Location[:name].matches(pattern).
+                or(Location[:scientific_name].matches(pattern)))
+    rescue StandardError => e
+      flash_error(e.to_s) unless Rails.env.production?
+    end
+
+    [matches, []]
+  end
+
+  def find_project_matches(id)
+    pattern = "%#{id}%"
+
+    begin
+      matches = Project.limit(100).
+                where(Project[:title].matches(pattern))
+    rescue StandardError => e
+      flash_error(e.to_s) unless Rails.env.production?
+    end
+
+    [matches, []]
+  end
+
+  def find_species_list_matches(id)
+    pattern = "%#{id}%"
+
+    begin
+      matches = SpeciesList.limit(100).
+                where(SpeciesList[:title].matches(pattern))
+    rescue StandardError => e
+      flash_error(e.to_s) unless Rails.env.production?
+    end
+
+    [matches, []]
+  end
+
+  def find_user_matches(id)
+    begin
+      matches = User.where(login: id)
+      matches = User.where(name: id) if matches.empty?
+    rescue StandardError => e
+      flash_error(e.to_s) unless Rails.env.production?
+    end
+
+    [matches, []]
+  end
+
+  def handle_no_match_error(id, type, model)
+    flash_error(:runtime_object_no_match.t(match: id, type: type))
+    if model == User
+      redirect_to("/")
+    else
+      redirect_to(controller: model.show_controller, action: model.index_action)
+    end
+  end
+
+  def handle_single_match_or_suggestion(matches, suggestions, id, type)
+    obj = matches.first || suggestions.first
+    if suggestions.any?
+      flash_warning(:runtime_suggest_one_alternate.t(match: id, type: type))
+    end
+    redirect_to(controller: obj.show_controller,
+                action: obj.show_action,
+                id: obj.id)
+  end
+
+  def handle_multiple_matches_or_suggestions(matches, suggestions, id, type, model)
+    obj = matches.first || suggestions.first
+    query = Query.lookup(model, :in_set, ids: matches + suggestions)
+    if suggestions.any?
+      flash_warning(:runtime_suggest_multiple_alternates.t(match: id, type: type))
+    else
+      flash_warning(:runtime_object_multiple_matches.t(match: id, type: type))
+    end
+    redirect_to(add_query_param({ controller: obj.show_controller,
+                                  action: obj.index_action },
+                                query))
   end
 
   def fix_name_matches(matches, accepted)

--- a/test/controllers/lookups_controller_test.rb
+++ b/test/controllers/lookups_controller_test.rb
@@ -101,13 +101,23 @@ class LookupsControllerTest < FunctionalTestCase
                                                              match: "Verpab"))
     # Must test against regex because passed query param borks path match
     assert_redirected_to(%r{/names})
+  end
 
-    # Prove that lookup_name adds flash message when it hits an error,
-    # stubbing a method called by lookup_name in order to provoke an error.
+  def test_lookup_name_with_error
+    # Stub a private method called by lookup_name in order to provoke an error.
     LookupsController.any_instance.stubs(:fix_name_matches).
       raises(RuntimeError)
+    login
+
+    get(:lookup_name, params: { id: names(:fungi).id })
+    assert_no_flash("Errors should be ignored if looking up by integer")
+    assert_response(nil, "Errors should be ignored if looking up by integer")
+
     get(:lookup_name, params: { id: names(:fungi).text_name })
-    assert_flash_text("RuntimeError")
+    assert_flash_text(
+      "RuntimeError",
+      "Error should provoke a flash if looking up by non-integer"
+    )
   end
 
   def test_lookup_observation

--- a/test/controllers/lookups_controller_test.rb
+++ b/test/controllers/lookups_controller_test.rb
@@ -62,6 +62,14 @@ class LookupsControllerTest < FunctionalTestCase
     get(:lookup_name, params: { id: n_id })
     assert_redirected_to(name_path(n_id))
 
+    get(:lookup_name, params: { id: images(:in_situ_image).id.to_s })
+    assert_redirected_to(
+      names_path,
+      "Should redirect to index if looking up by integer " \
+      "and object doesn't exist"
+    )
+    assert_flash_error
+
     get(:lookup_name, params: { id: names(:coprinus_comatus).id })
     # Must test against regex because passed query param borks path match
     assert_redirected_to(%r{/names/#{names(:coprinus_comatus).id}})
@@ -108,10 +116,6 @@ class LookupsControllerTest < FunctionalTestCase
     LookupsController.any_instance.stubs(:fix_name_matches).
       raises(RuntimeError)
     login
-
-    get(:lookup_name, params: { id: names(:fungi).id })
-    assert_no_flash("Errors should be ignored if looking up by integer")
-    assert_response(nil, "Errors should be ignored if looking up by integer")
 
     get(:lookup_name, params: { id: names(:fungi).text_name })
     assert_flash_text(

--- a/test/controllers/lookups_controller_test.rb
+++ b/test/controllers/lookups_controller_test.rb
@@ -104,7 +104,7 @@ class LookupsControllerTest < FunctionalTestCase
   end
 
   def test_lookup_name_with_error
-    # Stub a private method called by lookup_name in order to provoke an error.
+    # Stub a method called by lookup_name in order to provoke an error.
     LookupsController.any_instance.stubs(:fix_name_matches).
       raises(RuntimeError)
     login


### PR DESCRIPTION
- Reduces AbcSize of `LookupsController#lookups_general` from 82.13 to <= 17 (the current default).
- Fixes other RuboCop offenses in the controller.

