### PR TITLE
Added backwards compatibility for the old /observer/observation_search.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -993,6 +993,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
 
   # ----- Search: legacy action redirects ---------------------------------
   get("/observer/pattern_search", to: redirect("/search/pattern"))
+  get("/observer/observation_search", to: redirect("/observations"))
   get("/observer/advanced_search_form", to: redirect("/search/advanced"))
 
   ###


### PR DESCRIPTION
This URL is being used by FunDiS.  Costs nothing to make a simple alias for it in the router.