### PR TITLE
Fix for image reuse form

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -50,7 +50,8 @@ form.button_to {
     display: inline;
   }
 
-  input[type=submit]:not(.btn) {
+  input[type=submit]:not(.btn),
+  button[type=submit]:not(.btn) {
     margin: 0;
     padding: 0;
     -webkit-appearance: caret;

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -79,7 +79,7 @@ module LinkHelper
       data: { confirm: :are_you_sure.t }
     }.merge(args)
 
-    button_to(name, path, html_options)
+    button_to(path, html_options) { name }
   end
 
   # POST to a path; used instead of a link because POST link requires js
@@ -92,7 +92,7 @@ module LinkHelper
       class: ""
     }.merge(args)
 
-    button_to(name, path, html_options)
+    button_to(path, html_options) { name }
   end
 
   # PUT to a path; used instead of a link because PUT link requires js
@@ -105,7 +105,7 @@ module LinkHelper
       class: ""
     }.merge(args)
 
-    button_to(name, path, html_options)
+    button_to(path, html_options) { name }
   end
 
   # PATCH to a path; used instead of a link because PATCH link requires js
@@ -118,6 +118,6 @@ module LinkHelper
       class: ""
     }.merge(args)
 
-    button_to(name, path, html_options)
+    button_to(path, html_options) { name }
   end
 end

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -75,7 +75,7 @@ module ThumbnailHelper
   end
 
   def stretched_link_classes
-    "image-link stretched-link"
+    "image-link ab-fab stretched-link"
   end
 
   def image_original_name(original, image)

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -53,7 +53,7 @@ class ArticlesControllerTest < FunctionalTestCase
     get(:show, params: { id: article.id })
     assert_select("a", text: :create_article_title.l)
     assert_select("a", text: :EDIT.l)
-    assert_select("form input[value='Destroy']", true,
+    assert_select(".destroy_article_link_#{article.id}", true,
                   "Page is missing Destroy button")
 
     # Prove that trying to show non-existent article provokes error & redirect

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -927,7 +927,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login("rolf")
     get(:show, params: { id: obs.id })
     assert_select("a:match('href',?)", edit_observation_path(obs.id), count: 0)
-    assert_select("form[action=?]", observation_path(obs.id), count: 0)
+    assert_select(".destroy_observation_link_#{obs.id}", count: 0)
     assert_select("a:match('href',?)",
                   new_image_for_observation_path(obs.id), count: 0)
     assert_select("a:match('href',?)",
@@ -943,8 +943,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:show, params: { id: obs.id })
     assert_select("a[href=?]", edit_observation_path(obs.id), minimum: 1)
     # Destroy button is in a form, not a link_to
-    assert_select("form[action=?]", observation_path(obs.id), minimum: 1)
-    assert_select("input[value='#{:DESTROY.t}']", minimum: 1)
+    assert_select(".destroy_observation_link_#{obs.id}", minimum: 1)
     assert_select("a[href=?]",
                   new_image_for_observation_path(obs.id), minimum: 1)
     assert_select("a[href=?]",
@@ -958,8 +957,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:show, params: { id: obs.id })
     assert_select("a[href=?]", edit_observation_path(obs.id), minimum: 1)
     # Destroy button is in a form, not a link_to
-    assert_select("form[action=?]", observation_path(obs.id), minimum: 1)
-    assert_select("input[value='#{:DESTROY.t}']", minimum: 1)
+    assert_select(".destroy_observation_link_#{obs.id}", minimum: 1)
     assert_select("a[href=?]",
                   new_image_for_observation_path(obs.id), minimum: 1)
     assert_select("a[href=?]",

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -90,7 +90,7 @@ class ObservationsControllerTest < FunctionalTestCase
   # ----------------------------
 
   def test_show_observation_noteless_image
-    obs = observations(:peltigera_rolf_obs)
+    obs = observations(:peltigera_mary_obs)
     img = images(:rolf_profile_image)
     assert_nil(img.notes)
     assert(obs.images.member?(img))

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -270,10 +270,10 @@ peltigera_obs:
   lifeform: " lichen "
   herbarium_records: field_museum_record
 
-peltigera_rolf_obs:
+peltigera_mary_obs:
   <<: *DEFAULTS
-  created_at: 2014-04-04 04:04:04
-  updated_at: 2014-04-04 04:04:04
+  created_at: 2014-05-04 05:05:05
+  updated_at: 2014-05-04 05:05:05
   when: 2013-09-08
   user: mary
   location:

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -123,12 +123,12 @@ peltigera_obs_rss_log:
   created_at: 2014-04-04 04:04:03
   notes: "20140404040406 log_observation_created user rolf\n"
 
-peltigera_rolf_obs_rss_log:
+peltigera_mary_obs_rss_log:
   <<: *DEFAULTS
-  observation: peltigera_rolf_obs
-  updated_at: 2014-04-04 04:04:05
-  created_at: 2014-04-04 04:04:04
-  notes: "20140404040405 log_observation_created user mary\n"
+  observation: peltigera_mary_obs
+  updated_at: 2014-05-04 05:05:05
+  created_at: 2014-05-04 05:05:05
+  notes: "20140504050505 log_observation_created user mary\n"
 
 fungi_obs_rss_log:
   <<: *DEFAULTS


### PR DESCRIPTION
Involves fixing CSS for image "stretched links", and makes destroy/put/patch/post `button_to` helpers behave more consistently.

The change is this: when you use `button_to`, in Rails < 7, you have to pass a `block` to be sure it prints a form with a `button[type='submit']`. If you pass a text arg, it prints a form with an `input[type='submit']` element. It's a known inconsistency in Rails and is fixed in Rails 7, so forcing this here will make the app future friendly as much as possible.

Also fixes an intermittent bug arising from the too-close times for `created_at` of the two `Peltigera` obs fixtures. Changes the name of `peltigera_rolf_obs` to `peltigera_mary_obs` to reflect fixture.