### PR TITLE
Fix "previous version" links in `versions_helper.rb`

### DIFF
--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -20,6 +20,11 @@
 #  strip_html::         Remove HTML tags (not entities) from string.
 #  truncate_html::      Truncate an HTML string to N display characters.
 #  html_to_ascii::      Convert HTML into plain text.
+#  gsub_html_special_chars:: auxiliary to html_to_ascii
+#  unescape_html::
+#  as_displayed::
+#  break_name::
+#  small_author::
 #  nowrap::             Surround HTML string inside '<nowrap>' span.
 #  strip_squeeze::      Strip and squeeze spaces.
 #  rand_char::          Pick a single random character from the string.
@@ -525,9 +530,10 @@ class String
     CGI.unescapeHTML(self)
   end
 
-  # For integration test comparisons: the whole string as rendered in browser
+  # For integration test comparisons: no tags and no special char encodings
+  # i.e., the whole string as a human would encounter it in the browser
   def as_displayed
-    unescape_html.strip_squeeze
+    strip_html.unescape_html.strip_squeeze
   end
 
   # Insert a line break between the scientific name and the author

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -79,15 +79,12 @@ module VersionsHelper
 
   def link_to_version(text, ver, obj)
     if ver == obj.versions.last
-      link_with_query(text,
-                      controller: obj.show_controller,
-                      action: obj.show_action,
-                      id: obj.id)
+      link_with_query(text, obj.show_link_args)
     else
       link_with_query(text,
-                      controller: "#{obj.show_controller}/versions",
-                      action: :show, id: obj.id,
-                      version: ver.version)
+                      { controller: "#{obj.show_controller}/versions",
+                        action: :show, id: obj.id,
+                        version: ver.version })
     end
   end
 

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -43,12 +43,13 @@ module VersionsHelper
   private
 
   def previous_version_link(previous_version, obj)
-    str = :show_name_previous_version.t + " " + previous_version.version.to_i
+    str = "#{:show_name_previous_version.t} #{previous_version.version}"
     initial_version_html(obj) +
       link_with_query(str,
                       { controller: "#{obj.show_controller}/versions",
                         action: :show, id: obj.id,
-                        version: previous_version.version }) +
+                        version: previous_version.version },
+                      class: "previous_version_link") +
       safe_br
   end
 
@@ -79,12 +80,13 @@ module VersionsHelper
 
   def link_to_version(text, ver, obj)
     if ver == obj.versions.last
-      link_with_query(text, obj.show_link_args)
+      link_with_query(text, obj.show_link_args, class: "latest_version_link")
     else
       link_with_query(text,
                       { controller: "#{obj.show_controller}/versions",
                         action: :show, id: obj.id,
-                        version: ver.version })
+                        version: ver.version },
+                      class: "initial_version_link")
     end
   end
 

--- a/test/integration/capybara/names_integration_test.rb
+++ b/test/integration/capybara/names_integration_test.rb
@@ -4,6 +4,26 @@ require("test_helper")
 
 # Tests which supplement controller/name_controller_test.rb
 class NamesIntegrationTest < CapybaraIntegrationTestCase
+  def test_name_show_previous_version
+    # a name with versions
+    name = names(:coprinellus_micaceus)
+    # current_version_number = name.version
+    previous_version = name.versions.reverse[1]
+    login
+    visit("/names/#{name.id}")
+    click_on(class: "previous_version_link")
+    assert_selector("body.versions__show")
+    title = :show_past_name_title.t(
+      num: previous_version.version,
+      name: previous_version.display_name
+    )
+    assert_selector("#title", text: title.as_displayed)
+    # go back to the name page
+    click_on(class: "latest_version_link")
+    title = :show_name_title.t(name: name.display_name)
+    assert_selector("#title", text: title.as_displayed)
+  end
+
   # Email tracking template should not contain ":mailing_address"
   # because, when email is sent, that will be interpreted as
   # recipient's mailing_address


### PR DESCRIPTION
I refactored `link_with_query` a couple weeks ago to take the same args as `link_to(text, path, **html_options, &block)`, and it now requires something like one of the following for the path arg:
 - `name_path(obj.id)`
 - `obj.show_link_args`
 - `{ controller: :obj.show_controller, action: obj.show_action, id: obj.id }`

In other words, you can't pass `controller` and `action` as separate `kwargs` anymore, just have to enclose them in a hash. These helpers seem to be the last that I missed converting, of the 201 uses of `link_with_query`.