### PR TITLE
Redirect legacy name_search

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -922,6 +922,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
 
   # ----- Names: legacy action redirects -----------------------------------
   get("name/eol", to: redirect("names/eol_data#show"))
+  get("name/name_search", to: redirect(path: "names"))
 
   # ----- Lookups: legacy action redirects ---------------------------
   # The only legacy lookup that was ok'd for use by external sites

--- a/test/integration/rails-dom-testing/redirects_test.rb
+++ b/test/integration/rails-dom-testing/redirects_test.rb
@@ -156,6 +156,17 @@ class RedirectsTest < IntegrationTestCase
     )
   end
 
+  # Name ---------------------------------
+
+  def test_name_search_get
+    name = names(:tremella_mesenterica)
+
+    login
+    get("/name/name_search?pattern=#{name.text_name}")
+
+    assert_equal(name_path(name.id), @response.request.path)
+  end
+
   # SpecisList/show  ---------------------------------
   def test_show_species_list
     spl = species_lists(:first_species_list)


### PR DESCRIPTION
- Redirects legacy `/name/name_search` actions to `/names`
iNat is using the old  url in order to link to MO Name pages from INat name pages.
As with #1499, it costs epsilon to make the old url work. 
- Delivers https://www.pivotaltracker.com/story/show/185114318

=== Manual test
- http://localhost:3000/name/name_search?pattern=Tremella%20mesenterica
Result: http://localhost:3000/names?pattern=Tremella+mesenterica
Names Matching ‘Tremella mesenterica’  (in any field)