### PR TITLE
JS-ify observation sequence forms

### DIFF
--- a/app/controllers/collection_numbers/remove_observations_controller.rb
+++ b/app/controllers/collection_numbers/remove_observations_controller.rb
@@ -21,6 +21,8 @@ module CollectionNumbers
       return unless make_sure_can_delete!(@collection_number)
 
       @collection_number.remove_observation(@observation)
+      flash_notice(:runtime_removed.t(type: :collection_number))
+
       respond_to do |format|
         format.html do
           redirect_with_query(observation_path(@observation.id))

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -225,6 +225,9 @@ class CollectionNumbersController < ApplicationController
   def save_collection_number_and_update_associations
     @collection_number.save
     @collection_number.add_observation(@observation)
+    flash_notice(
+      :runtime_added_to.t(type: :collection_number, name: :observation)
+    )
     respond_to do |format|
       format.html do
         redirect_to_back_object_or_object(@back_object, @collection_number)
@@ -257,6 +260,7 @@ class CollectionNumbersController < ApplicationController
   def update_collection_number_and_associations(old_format_name)
     @collection_number.save
     @collection_number.change_corresponding_herbarium_records(old_format_name)
+    flash_notice(:runtime_updated_at.t(type: :collection_number))
 
     respond_to do |format|
       format.html do

--- a/app/controllers/herbarium_records/remove_observations_controller.rb
+++ b/app/controllers/herbarium_records/remove_observations_controller.rb
@@ -21,6 +21,8 @@ module HerbariumRecords
       return unless make_sure_can_delete!(@herbarium_record)
 
       @herbarium_record.remove_observation(@observation)
+      flash_notice(:runtime_removed.t(type: :herbarium_record))
+
       respond_to do |format|
         format.html do
           redirect_with_query(observation_path(@observation.id))

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -221,7 +221,8 @@ class HerbariumRecordsController < ApplicationController
     return if flash_error_and_reload_if_form_has_errors
 
     if herbarium_label_free?
-      save_herbarium_record_and_update_associations and return
+      save_herbarium_record_and_update_associations
+      return
     end
 
     if @other_record.can_edit?

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -235,6 +235,10 @@ class HerbariumRecordsController < ApplicationController
   def save_herbarium_record_and_update_associations
     @herbarium_record.save
     @herbarium_record.add_observation(@observation)
+    flash_notice(
+      :runtime_added_to.t(type: :herbarium_record, name: :observation)
+    )
+
     respond_to do |format|
       format.html do
         redirect_to_back_object_or_object(@back_object, @herbarium_record)
@@ -272,6 +276,7 @@ class HerbariumRecordsController < ApplicationController
     @herbarium_record.save
     @herbarium_record.notify_curators if
       @herbarium_record.herbarium != old_herbarium
+    flash_notice(:runtime_updated_at.t(type: :herbarium_record))
 
     respond_to do |format|
       format.html do

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -189,7 +189,8 @@ class SequencesController < ApplicationController
     false
   end
 
-  def build_sequence # create
+  # create
+  def build_sequence
     @sequence = @observation.sequences.new
     @sequence.attributes = sequence_params
     @sequence.user = @user
@@ -214,7 +215,8 @@ class SequencesController < ApplicationController
     end
   end
 
-  def save_edits # update
+  # update
+  def save_edits
     @sequence.attributes = sequence_params
     if @sequence.save
       flash_notice(:runtime_sequence_update_success.t(id: @sequence.id))

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -131,6 +131,8 @@ class SequencesController < ApplicationController
     figure_out_where_to_go_back_to
     return unless make_sure_can_delete!(@sequence)
 
+    @observation = @sequence.observation # needed for js to update obs page
+
     @sequence.destroy
     flash_notice(:runtime_destroyed_id.t(type: :sequence, value: params[:id]))
     show_flash_and_send_to_back_object
@@ -220,6 +222,7 @@ class SequencesController < ApplicationController
     @sequence.attributes = sequence_params
     if @sequence.save
       flash_notice(:runtime_sequence_update_success.t(id: @sequence.id))
+      @observation = @sequence.observation # needed for js to update obs page
       respond_to do |format|
         format.html do
           redirect_with_query(@back_object.show_link_args)
@@ -262,8 +265,8 @@ class SequencesController < ApplicationController
         end
       end
       format.js do
-        # renders the flash in the modal via js
-        render(partial: "shared/update_modal_flash") and return
+        # renders the flash in the obs page via js
+        render(partial: "update_observation") and return
       end
     end
   end

--- a/app/views/collection_numbers/_update_observation.js.erb
+++ b/app/views/collection_numbers/_update_observation.js.erb
@@ -2,3 +2,7 @@
 $('#mo_ajax_progress_caption').empty();
 $('#mo_ajax_progress').modal('hide');
 $("#observation_collection_numbers").html('<%= j render(partial: "observations/show/collection_numbers", locals: { observation: @observation.reload }, layout: false) %>');
+
+$("#page_flash").html("<%= j render(partial: 'layouts/app/flash_notices', locals: { id: 'flash_notices' }) if flash_notices? %>");
+
+$(".modal").modal('hide');

--- a/app/views/collection_numbers/create.js.erb
+++ b/app/views/collection_numbers/create.js.erb
@@ -1,4 +1,3 @@
 // What to do on ajax create
 
 <%= render(partial: "collection_numbers/update_observation", format: :js) %>
-<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/app/views/collection_numbers/update.js.erb
+++ b/app/views/collection_numbers/update.js.erb
@@ -1,4 +1,3 @@
 // What to do on ajax update. Eventually needs to handle other @back_object
 
 <%= render(partial: "collection_numbers/update_observation", format: :js) %>
-<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/app/views/herbarium_records/_update_observation.js.erb
+++ b/app/views/herbarium_records/_update_observation.js.erb
@@ -2,3 +2,7 @@
 $('#mo_ajax_progress_caption').empty();
 $('#mo_ajax_progress').modal('hide');
 $("#observation_herbarium_records").html('<%= j render(partial: "observations/show/herbarium_records", locals: { observation: @observation.reload }, layout: false) %>');
+
+$("#page_flash").html("<%= j render(partial: 'layouts/app/flash_notices', locals: { id: 'flash_notices' }) if flash_notices? %>");
+
+$(".modal").modal('hide');

--- a/app/views/herbarium_records/create.js.erb
+++ b/app/views/herbarium_records/create.js.erb
@@ -1,4 +1,3 @@
 // What to do on ajax create
 
 <%= render(partial: "herbarium_records/update_observation", format: :js) %>
-<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/app/views/herbarium_records/update.js.erb
+++ b/app/views/herbarium_records/update.js.erb
@@ -1,4 +1,3 @@
 // What to do on ajax update. Eventually needs to handle other @back_object
 
 <%= render(partial: "herbarium_records/update_observation", format: :js) %>
-<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -15,8 +15,8 @@
       <%=
           add_sequence_link = link_with_query(
             :show_observation_add_sequence.t,
-            new_sequence_path(params: { observation_id: observation.id },
-            class: "create_sequence_link_#{observation.id}")
+            new_sequence_path(params: { observation_id: observation.id }),
+            class: "create_sequence_link_#{observation.id}"
           )
           "[#{add_sequence_link}]".html_safe if @user
       %>

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -15,7 +15,8 @@
       <%=
           add_sequence_link = link_with_query(
             :show_observation_add_sequence.t,
-            new_sequence_path(params: { observation_id: observation.id })
+            new_sequence_path(params: { observation_id: observation.id },
+            class: "create_sequence_link_#{observation.id}")
           )
           "[#{add_sequence_link}]".html_safe if @user
       %>
@@ -25,14 +26,16 @@
   <% if sequences.any? %>
     <ul class="tight-list">
       <% sequences.each do |sequence| %>
-        <li>
+        <li id="sequence_<%= sequence.id %>">
           <%= locus = sequence.locus.truncate(sequence.locus_width)
             if sequence.deposit?
               link_to("#{locus} - #{sequence.archive} ##{sequence.accession}".t,
-                      add_query_param(sequence.show_link_args, query))
+                      add_query_param(sequence.show_link_args, query),
+                      class: "show_sequence_link_#{number.id}")
             else
               link_to("#{locus} - MO ##{sequence.id}".t,
-                      add_query_param(sequence.show_link_args, query))
+                      add_query_param(sequence.show_link_args, query),
+                      class: "show_sequence_link_#{number.id}")
             end %>
           <%=
             links = []
@@ -42,13 +45,19 @@
             end
             if in_admin_mode? || sequence.can_edit?(@user)
               links << link_with_query(
-                :EDIT.t, edit_sequence_path(id: sequence.id,
-                                            params: { back: observation.id })
+                :EDIT.t,
+                edit_sequence_path(id: sequence.id,
+                                   params: { back: observation.id },
+                remote: true, onclick: "MOEvents.whirly();",
+                class: "edit_sequence_link_#{number.id}")
               )
               links << destroy_button(
                 name: :destroy_object.t(type: :sequence),
                 target: sequence_path(sequence,
-                                      back: url_after_delete(sequence))
+                                      back: url_after_delete(sequence),
+                remote: true,
+                onclick: "MOEvents.whirly();",
+                class: "destroy_sequence_link_#{number.id}")
               )
             end
             if sequence.blastable?

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -31,11 +31,11 @@
             if sequence.deposit?
               link_to("#{locus} - #{sequence.archive} ##{sequence.accession}".t,
                       add_query_param(sequence.show_link_args, query),
-                      class: "show_sequence_link_#{number.id}")
+                      class: "show_sequence_link_#{sequence.id}")
             else
               link_to("#{locus} - MO ##{sequence.id}".t,
                       add_query_param(sequence.show_link_args, query),
-                      class: "show_sequence_link_#{number.id}")
+                      class: "show_sequence_link_#{sequence.id}")
             end %>
           <%=
             links = []
@@ -49,7 +49,7 @@
                 edit_sequence_path(id: sequence.id,
                                    params: { back: observation.id },
                 remote: true, onclick: "MOEvents.whirly();",
-                class: "edit_sequence_link_#{number.id}")
+                class: "edit_sequence_link_#{sequence.id}")
               )
               links << destroy_button(
                 name: :destroy_object.t(type: :sequence),
@@ -57,7 +57,7 @@
                                       back: url_after_delete(sequence),
                 remote: true,
                 onclick: "MOEvents.whirly();",
-                class: "destroy_sequence_link_#{number.id}")
+                class: "destroy_sequence_link_#{sequence.id}")
               )
             end
             if sequence.blastable?

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -16,6 +16,7 @@
           add_sequence_link = link_with_query(
             :show_observation_add_sequence.t,
             new_sequence_path(params: { observation_id: observation.id }),
+            remote: true, onclick: "MOEvents.whirly();",
             class: "create_sequence_link_#{observation.id}"
           )
           "[#{add_sequence_link}]".html_safe if @user
@@ -55,8 +56,7 @@
                 name: :destroy_object.t(type: :sequence),
                 target: sequence_path(sequence,
                                       back: url_after_delete(sequence),
-                remote: true,
-                onclick: "MOEvents.whirly();",
+                remote: true, onclick: "MOEvents.whirly();",
                 class: "destroy_sequence_link_#{sequence.id}")
               )
             end

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -47,17 +47,16 @@
             if in_admin_mode? || sequence.can_edit?(@user)
               links << link_with_query(
                 :EDIT.t,
-                edit_sequence_path(id: sequence.id,
-                                   params: { back: observation.id },
+                edit_sequence_path(id: sequence.id, back: observation.id),
                 remote: true, onclick: "MOEvents.whirly();",
-                class: "edit_sequence_link_#{sequence.id}")
+                class: "edit_sequence_link_#{sequence.id}"
               )
               links << destroy_button(
                 name: :destroy_object.t(type: :sequence),
-                target: sequence_path(sequence,
-                                      back: url_after_delete(sequence),
+                target: sequence_path(id: sequence.id,
+                                      back: url_after_delete(sequence)),
                 remote: true, onclick: "MOEvents.whirly();",
-                class: "destroy_sequence_link_#{sequence.id}")
+                class: "destroy_sequence_link_#{sequence.id}"
               )
             end
             if sequence.blastable?

--- a/app/views/sequences/_form.html.erb
+++ b/app/views/sequences/_form.html.erb
@@ -1,13 +1,16 @@
 <%
 url_params = { action: action, q: get_query_param }
-url_params = url_params.merge(
-  { observation_id: @observation.id }) if action == :create
-if action == :update && @back.present?
-  url_params = url_params.merge({ back: @back })
+case action
+when :create
+  url_params = url_params.merge({ observation_id: @observation.id })
+  button = :ADD.t
+when :update
+  url_params = url_params.merge({ back: @back }) if @back.present?
+  button = :UPDATE.t
 end
 %>
 
-<%= form_with(model: @sequence, url: url_params,
+<%= form_with(model: @sequence, url: url_params, local: local,
               id: "sequence_form") do |f| %>
 
   <%# locus %>
@@ -56,6 +59,6 @@ end
     <%= :field_textile_link.t %>
   <% end %>
 
-  <%= submit_button(form: f, button: button_name.t, center: true) %>
+  <%= submit_button(form: f, button: button, center: true) %>
 
 <% end %>

--- a/app/views/sequences/_form_bindings.js.erb
+++ b/app/views/sequences/_form_bindings.js.erb
@@ -1,0 +1,8 @@
+// Bindings for both new.js.erb and edit.js.erb
+$("#mo_ajax_progress").modal('hide');
+
+$('#modal_sequence').on('hidden.bs.modal', function () {
+  $(this).remove();
+});
+
+$('#modal_sequence').modal('show');

--- a/app/views/sequences/_form_reload.js.erb
+++ b/app/views/sequences/_form_reload.js.erb
@@ -1,0 +1,9 @@
+// What to do if create or update doesn't save
+
+// var modal_body = $("#modal_body_sequence");
+
+// replace the flash notices in the modal
+$("#modal_flash").replaceWith("<%= j render(partial: 'layouts/app/flash_notices', locals: { id: 'modal_flash' }) if flash_notices? %>");
+
+// replace the form, should show
+$("#sequence_form").replaceWith('<%= j render(partial: "sequences/form", locals: { action: @action, local: false }) %>')

--- a/app/views/sequences/_update_observation.js.erb
+++ b/app/views/sequences/_update_observation.js.erb
@@ -2,3 +2,7 @@
 $('#mo_ajax_progress_caption').empty();
 $('#mo_ajax_progress').modal('hide');
 $("#observation_sequences").html('<%= j render(partial: "observations/show/sequences", locals: { observation: @observation.reload }, layout: false) %>');
+
+$("#page_flash").html("<%= j render(partial: 'layouts/app/flash_notices', locals: { id: 'flash_notices' }) if flash_notices? %>");
+
+$(".modal").modal('hide');

--- a/app/views/sequences/_update_observation.js.erb
+++ b/app/views/sequences/_update_observation.js.erb
@@ -1,0 +1,4 @@
+// Update page with results of update or create sequence
+$('#mo_ajax_progress_caption').empty();
+$('#mo_ajax_progress').modal('hide');
+$("#observation_sequences").html('<%= j render(partial: "observations/show/sequences", locals: { observation: @observation.reload }, layout: false) %>');

--- a/app/views/sequences/create.js.erb
+++ b/app/views/sequences/create.js.erb
@@ -1,0 +1,4 @@
+// What to do on ajax create
+
+<%= render(partial: "sequences/update_observation", format: :js) %>
+<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/app/views/sequences/create.js.erb
+++ b/app/views/sequences/create.js.erb
@@ -1,6 +1,3 @@
 // What to do on ajax create
 
 <%= render(partial: "sequences/update_observation", format: :js) %>
-$("#page_flash").html("<%= j render(partial: 'layouts/app/flash_notices', locals: { id: 'flash_notices' }) if flash_notices? %>");
-
-$(".modal").modal('hide');

--- a/app/views/sequences/create.js.erb
+++ b/app/views/sequences/create.js.erb
@@ -1,4 +1,6 @@
 // What to do on ajax create
 
 <%= render(partial: "sequences/update_observation", format: :js) %>
-<%= render(partial: "shared/update_modal_flash", format: :js) %>
+$("#page_flash").html("<%= j render(partial: 'layouts/app/flash_notices', locals: { id: 'flash_notices' }) if flash_notices? %>");
+
+$(".modal").modal('hide');

--- a/app/views/sequences/destroy.js.erb
+++ b/app/views/sequences/destroy.js.erb
@@ -1,0 +1,3 @@
+// What to do on ajax destroy
+
+<%= render(partial: "sequences/update_observation", format: :js) %>

--- a/app/views/sequences/edit.html.erb
+++ b/app/views/sequences/edit.html.erb
@@ -13,10 +13,8 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-7">
-    <%= render(partial: "observation_title",
-               locals: { observation: obs }) %>
-    <%= render(partial: "form",
-               locals: { action: :update, button_name: :UPDATE }) %>
+    <%= render(partial: "observation_title", locals: { observation: obs }) %>
+    <%= render(partial: "form", locals: { action: :update, local: true }) %>
 
     <div class="small">
       <span class="font-weight-bold"><%= :CREATED_BY.t %>:</span>

--- a/app/views/sequences/edit.js.erb
+++ b/app/views/sequences/edit.js.erb
@@ -1,0 +1,3 @@
+$('body').append('<%= j render(partial: "shared/modal_form", locals: { identifier: "sequence", title: :sequence_edit_title.l(name: @sequence.unique_format_name), form: "sequences/form", action: :update }) %>');
+
+<%= render(partial: "sequences/form_bindings", format: :js) %>

--- a/app/views/sequences/new.html.erb
+++ b/app/views/sequences/new.html.erb
@@ -12,8 +12,7 @@
   <div class="col-xs-12 col-sm-7">
     <%= render(partial: "observation_title",
                locals: { observation: @observation }) %>
-    <%= render(partial: "form",
-               locals: { action: :create, button_name: :ADD }) %>
+    <%= render(partial: "form", locals: { action: :create, local: true }) %>
   </div>
 
   <div class="col-xs-12 col-sm-5">

--- a/app/views/sequences/new.js.erb
+++ b/app/views/sequences/new.js.erb
@@ -1,0 +1,3 @@
+$('body').append('<%= j render(partial: "shared/modal_form", locals: { identifier: "sequence", title: :sequence_add_title.l, form: "sequences/form", action: :create }) %>');
+
+<%= render(partial: "sequences/form_bindings", format: :js) %>

--- a/app/views/sequences/update.js.erb
+++ b/app/views/sequences/update.js.erb
@@ -1,0 +1,4 @@
+// What to do on ajax update. Eventually needs to handle other @back_object
+
+<%= render(partial: "sequences/update_observation", format: :js) %>
+<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/app/views/sequences/update.js.erb
+++ b/app/views/sequences/update.js.erb
@@ -1,4 +1,3 @@
 // What to do on ajax update. Eventually needs to handle other @back_object
 
 <%= render(partial: "sequences/update_observation", format: :js) %>
-<%= render(partial: "shared/update_modal_flash", format: :js) %>

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -206,7 +206,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     post(:create,
          params: { observation_id: obs.id, collection_number: params })
     assert_equal(collection_number_count + 1, CollectionNumber.count)
-    assert_no_flash
+    assert_flash_success
     assert_response(:redirect)
 
     number = CollectionNumber.last
@@ -232,7 +232,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     post(:create,
          params: { observation_id: obs.id, collection_number: params })
     assert_equal(collection_number_count + 1, CollectionNumber.count)
-    assert_no_flash
+    assert_flash_success
     number = CollectionNumber.last
     assert_obj_arrays_equal([number], obs.reload.collection_numbers)
 
@@ -358,7 +358,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
 
     patch(:update,
           params: { id: number.id, collection_number: params })
-    assert_no_flash
+    assert_flash_success
     assert_response(:redirect)
     assert_equal("New Name", number.reload.name)
     assert_equal("69-abc", number.number)
@@ -370,7 +370,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     make_admin("mary")
     patch(:update,
           params: { id: number.id, collection_number: params })
-    assert_no_flash
+    assert_flash_success
   end
 
   def test_update_collection_number_merge

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -247,7 +247,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     post(:create, params: params)
     assert_equal(herbarium_record_count + 1, HerbariumRecord.count)
     assert_response(:redirect)
-    assert_no_flash
+    assert_flash_success
   end
 
   def test_create_herbarium_record_redirect


### PR DESCRIPTION
Allows forms to be created/submitted va JS on the show obs page for Observation Sequences. 

Also continues evolving the js templates for reusability.

Improves flash messaging in Collection Numbers and Herbarium Records, when creating or updating one of these. Before, there was no message. Now, these actions flash a notice when the object is successfully created or updated, as they do already on Sequences