### PR TITLE
Fix truncated Symbiota notes

### DIFF
--- a/app/classes/report/symbiota.rb
+++ b/app/classes/report/symbiota.rb
@@ -92,7 +92,10 @@ module Report
     end
 
     def clean_notes(str)
-      str.strip.t.html_to_ascii.gsub(/\s+/, " ")
+      str.strip.
+        # Compress conssecutive newlines because they confuse Textile
+        gsub(/(\r|\n)+/, "\n").
+        t.html_to_ascii.gsub(/\s+/, " ")
     end
 
     def image_urls(row)

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -345,6 +345,52 @@ class ReportTest < UnitTestCase
     do_tsv_test(Report::Symbiota, obs, expect, &:id)
   end
 
+  def test_symbiota_compress_consecutive_newlines
+    obs = observations(:detailed_unknown_obs)
+    obs.notes = {
+      Substrate: "wood\tchips",
+      Habitat: "lawn",
+      Host: "_Agaricus_",
+      Other: "First line.\r\n\r\nSecond line."
+    }
+    obs.save!
+
+    img1 = images(:in_situ_image)
+    img2 = images(:turned_over_image)
+    expect = [
+      "Fungi",
+      "",
+      "Kingdom",
+      "Fungi",
+      "",
+      "",
+      "Mary Newbie",
+      "174",
+      "NY",
+      "2006-05-11",
+      "2006",
+      "5",
+      "11",
+      "USA",
+      "California",
+      "",
+      "Burbank",
+      "34.185",
+      "-118.33",
+      "148",
+      "294",
+      "#{obs.updated_at.api_time} UTC",
+      "wood chips",
+      "Agaricus",
+      "Habitat: lawn Other: First line. Second line.",
+      obs.id.to_s,
+      "https://mushroomobserver.org/#{obs.id}",
+      "https://mushroomobserver.org/images/orig/#{img1.id}.jpg " \
+        "https://mushroomobserver.org/images/orig/#{img2.id}.jpg"
+    ]
+    do_tsv_test(Report::Symbiota, obs, expect, &:id)
+  end
+
   def test_rounding_of_latitudes_etc
     row = Report::Row.new(vals = [])
     vals[2] = 1.20456


### PR DESCRIPTION
- Deletes consecutive newlines before textilizing.
- Includes test.
- Delivers  [Pivotal #185214534](https://www.pivotaltracker.com/story/show/185214534).

### Manual Test
- https://mushroomobserver.org/observations?pattern=user%3A2873+notes%3AUBC+date%3A2007-11-10
- click Download Observations
- select Symbiota
- click Dowload
- save the resulting tsv file
- open that file
Result: the fieldNotes field for row 2 should be 
>Original Herbarium Label: Lepiota pseudofelina J.E. Lange as in Moser & Breitenbach et al. Herbarium Specimen: UBC F29500 

(In the main branch, the fieldNotes field (= MO Notes) of row 2 (= https://mushroomobserver.org/65468) is truncated.
See [Pivotal #185214534](https://www.pivotaltracker.com/story/show/185214534) for details.