### PR TITLE
Symbiota notes v2

### DIFF
--- a/app/classes/report/symbiota.rb
+++ b/app/classes/report/symbiota.rb
@@ -93,8 +93,9 @@ module Report
 
     def clean_notes(str)
       str.strip.
-        # Compress conssecutive whitespaces before (not after) Textilizing
+        # Compress consecutive whitespaces before (not after) Textilizing
         # because some whitespace combinations can confuse Textile
+        # Example: `\r\n \r\n`
         gsub(/\s+/, " ").
         t.html_to_ascii
     end

--- a/app/classes/report/symbiota.rb
+++ b/app/classes/report/symbiota.rb
@@ -93,9 +93,10 @@ module Report
 
     def clean_notes(str)
       str.strip.
-        # Compress conssecutive newlines because they confuse Textile
-        gsub(/(\r|\n)+/, "\n").
-        t.html_to_ascii.gsub(/\s+/, " ")
+        # Compress conssecutive whitespaces before (not after) Textilizing
+        # because some whitespace combinations can confuse Textile
+        gsub(/\s+/, " ").
+        t.html_to_ascii
     end
 
     def image_urls(row)

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -345,13 +345,13 @@ class ReportTest < UnitTestCase
     do_tsv_test(Report::Symbiota, obs, expect, &:id)
   end
 
-  def test_symbiota_compress_consecutive_newlines
+  def test_symbiota_compress_consecutive_whitespace
     obs = observations(:detailed_unknown_obs)
     obs.notes = {
       Substrate: "wood\tchips",
       Habitat: "lawn",
       Host: "_Agaricus_",
-      Other: "First line.\r\n\r\nSecond line."
+      Other: "1st line.\r\n\r\n2nd line.\r\n \r\n3rd line."
     }
     obs.save!
 
@@ -382,7 +382,7 @@ class ReportTest < UnitTestCase
       "#{obs.updated_at.api_time} UTC",
       "wood chips",
       "Agaricus",
-      "Habitat: lawn Other: First line. Second line.",
+      "Habitat: lawn Other: 1st line. 2nd line. 3rd line.",
       obs.id.to_s,
       "https://mushroomobserver.org/#{obs.id}",
       "https://mushroomobserver.org/images/orig/#{img1.id}.jpg " \


### PR DESCRIPTION
Fixes a bug in #1511 which failed to deal with an edge case.

### Manual Test
- Export, in Symbiota format, all Ceska Observations with a UBC accession. 
I.e., https://mushroomobserver.org/observations?pattern=user%3A2873+notes%3AUBC
Expected result: The fieldNotes for each record have a UBC accession number.

