### PR TITLE
checkout@v3

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -17,7 +17,7 @@ jobs:
     # check-out repo under $GITHUB_WORKSPACE, so that workflow can access it.
     # https://github.com/actions/checkout
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # https://github.com/ruby/setup-ruby
     - name: Set up Ruby


### PR DESCRIPTION
Updates github actions code checkout from v2 to v3.
(v3 is now suggested by GitHub Docs. https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#using-the-ruby-starter-workflow) 