### PR TITLE
Observation log_updated_at

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -587,7 +587,7 @@ class Observation < AbstractModel
   # to cache a log_updated_at value
   def touch_when_logging
     self.log_updated_at = Time.zone.now
-    touch
+    save
   end
 
   ##############################################################################

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -155,6 +155,8 @@ class API2ControllerTest < FunctionalTestCase
     assert_equal(false, obs.specimen)
     assert_equal(true, obs.is_collection_location)
     assert_equal(Observation.no_notes, obs.notes)
+    assert(obs.log_updated_at.is_a?(ActiveSupport::TimeWithZone),
+           "Observation should have log_updated_at time")
     assert_obj_arrays_equal([], obs.images)
     assert_nil(obs.thumb_image)
     assert_obj_arrays_equal([], obs.projects)

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -155,7 +155,7 @@ class API2ControllerTest < FunctionalTestCase
     assert_equal(false, obs.specimen)
     assert_equal(true, obs.is_collection_location)
     assert_equal(Observation.no_notes, obs.notes)
-    assert(obs.log_updated_at.is_a?(ActiveSupport::TimeWithZone),
+    assert(obs.log_updated_at.is_a?(Time),
            "Observation should have log_updated_at time")
     assert_obj_arrays_equal([], obs.images)
     assert_nil(obs.thumb_image)

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1407,6 +1407,20 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_true(@response.body.include?("California, Mendocino Co., Albion"))
   end
 
+  def test_create_log_updated_at
+    params = {
+      naming: { name: "", vote: { value: "" } },
+      user: rolf,
+      where: locations.first.name
+    }
+
+    users(:rolf).login
+    post_requires_login(:create, params)
+
+    assert(Observation.last.log_updated_at.is_a?(Time),
+           "Observation should have log_updated_at time")
+  end
+
   def test_create_observation_with_unrecognized_name
     text_name = "Elfin saddle"
     params = { naming: { name: text_name },


### PR DESCRIPTION
- Insures that `observation.log_updated_at` is saved
- Fixes #1518, https://www.pivotaltracker.com/story/show/185297843

### Manual Test

- Create an Observation with a valid Location but no Scientific Name
- Goto the home page, http://localhost:3000/
Result: the Observation you just created should be the first one displayed in the Observation Activity feed
