### PR TITLE
Fix bulk license update

### DIFF
--- a/app/views/images/licenses/edit.html.erb
+++ b/app/views/images/licenses/edit.html.erb
@@ -36,7 +36,7 @@
           license_id = datum["license_id"].to_i
           copyright_holder = datum["copyright_holder"].to_s %>
 
-          <%= fields_for("#{row}") do |f_r| %>
+          <%= f.fields_for("#{row}") do |f_r| %>
             <tr>
               <td>
                 <%= datum["license_count"].to_s %>

--- a/test/controllers/images/licenses_controller_test.rb
+++ b/test/controllers/images/licenses_controller_test.rb
@@ -7,7 +7,12 @@ module Images
   class LicensesControllerTest < FunctionalTestCase
     def test_edit_license_page_access
       requires_login(:edit)
+
       assert_form_action(action: :update)
+      assert_select(
+        "select[name='updates[1][new_id]']", count = 1,
+        "Form should have numerical selectors nested under `updates`"
+      )
     end
 
     def test_update_licenses

--- a/test/controllers/images/licenses_controller_test.rb
+++ b/test/controllers/images/licenses_controller_test.rb
@@ -10,7 +10,7 @@ module Images
 
       assert_form_action(action: :update)
       assert_select(
-        "select[name='updates[1][new_id]']", count = 1,
+        "select[name='updates[1][new_id]']", { count: 1 },
         "Form should have numerical selectors nested under `updates`"
       )
     end


### PR DESCRIPTION
- Nests returned params under `updates`
- Fixes form bug that threw error when updating licenses. (Issue #1520, https://www.pivotaltracker.com/story/show/185313081)

### Manual Test
- http://localhost:3000/images/licenses
- Make >1 change
- Update
Result: No Error, changes should be made