### PR TITLE
Brakeman 6.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -59,16 +59,17 @@ checks:
 
 # CodeClimate will run these plugins when CodeClimate is triggered.
 # For configuration of specific plugins, see CodeClimate documentation
-#   for that engine.
+# for that engine.
 
 plugins:
 # check Rails apps for security vulnerabilities
   brakeman:
-    # Do not use Codeclimate's version of Brakeman as of 2022-06-18
-    # It is dated and throws many false positives
-    # Instead run brakeman locally or in CI rely on Github action plugin
-    # https://github.com/devmasx/brakeman-linter-action
-    enabled: false
+    # Use highest available channel https://docs.codeclimate.com/docs/brakeman
+    # because Github actions linter is broken
+    # See .github/workflows/ci_rails.yml
+    # JDC 2023-06-04
+    channel: beta
+    enabled: true
 
 # helps find security vulnerabilities in Ruby dependencies
   bundler-audit:

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -81,7 +81,8 @@ jobs:
     # https://github.com/devmasx/brakeman-linter-action
     # Temporarily disable brakeman in CI because it causes an error
     # See https://github.com/MushroomObserver/mushroom-observer/issues/1514
-    # JDC 2023-05-27
+    # Instead use brakeman's plugin. See .codeclimate.yml
+    # JDC 2023-06-05
     # - name: brakeman report
     #   run: |
     #     bundle exec brakeman -f json > brakeman.json || exit 0

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -79,11 +79,14 @@ jobs:
         path-to-lcov: ./coverage/lcov/lcov.info
 
     # https://github.com/devmasx/brakeman-linter-action
-    - name: brakeman report
-      run: |
-        bundle exec brakeman -f json > brakeman.json || exit 0
-    - name: Brakeman
-      uses: devmasx/brakeman-linter-action@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        REPORT_PATH: brakeman.json
+    # Temporarily disable brakeman in CI because it causes an error
+    # See https://github.com/MushroomObserver/mushroom-observer/issues/1514
+    # JDC 2023-05-27
+    # - name: brakeman report
+    #   run: |
+    #     bundle exec brakeman -f json > brakeman.json || exit 0
+    # - name: Brakeman
+    #   uses: devmasx/brakeman-linter-action@v1.0.0
+    #   env:
+    #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    #     REPORT_PATH: brakeman.json

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -79,14 +79,11 @@ jobs:
         path-to-lcov: ./coverage/lcov/lcov.info
 
     # https://github.com/devmasx/brakeman-linter-action
-    # Temporarily disable brakeman in CI because it causes an error
-    # See https://github.com/MushroomObserver/mushroom-observer/issues/1514
-    # JDC 2023-05-27
-    # - name: brakeman report
-    #   run: |
-    #     bundle exec brakeman -f json > brakeman.json || exit 0
-    # - name: Brakeman
-    #   uses: devmasx/brakeman-linter-action@v1.0.0
-    #   env:
-    #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    #     REPORT_PATH: brakeman.json
+    - name: brakeman report
+      run: |
+        bundle exec brakeman -f json > brakeman.json || exit 0
+    - name: Brakeman
+      uses: devmasx/brakeman-linter-action@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        REPORT_PATH: brakeman.json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (5.4.1)
+    brakeman (6.0.0)
     browser (5.3.1)
     builder (3.2.4)
     bullet (7.0.7)


### PR DESCRIPTION
- Updates brakeman gem to  6.0
- Enables Codeclimate brakeman plugin. 
This is not ideal because the the plugin uses v 5.3.1. 
But it's better than nothing; I can't figure out how to make the Github Actions brakeman runner work with v 6.0.