### PR TITLE
Fix GlossaryTerm#update

### DIFF
--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -50,7 +50,6 @@ class GlossaryTermsController < ApplicationController
 
     @glossary_term.attributes = params[:glossary_term].
                                 permit(:name, :description)
-    @glossary_term.user = @user
 
     return reload_form("edit") unless @glossary_term.save
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -247,14 +247,20 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   # ***** update *****
   def test_update
     term = glossary_terms(:conic_glossary_term)
+    creator = term.user
+    user = mary
+    assert_not_equal(user, creator,
+                     "Test needs user who didn't create the term.")
     params = changes_to_conic
-    login
 
+    login(user.login)
     assert_difference("term.versions.count") do
       post(:update, params: params)
     end
     assert_equal(params[:glossary_term][:name], term.reload.name)
     assert_equal(params[:glossary_term][:description], term.description)
+    assert_equal(creator, term.user,
+                 "Editing a Term should not change term.user")
     assert_redirected_to(glossary_term_path(term.id))
   end
 


### PR DESCRIPTION
Fixes a bug in `GlossaryTerm#update` which updated `<term>.user`. 
That caused `user` to set to the most recent editor of the Term (vs not touching `user`).

NOTE: In the live db, any incorrect `user` attributes should be fixed.