### PR TITLE
GlossaryTerm Lock

### DIFF
--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -30,11 +30,10 @@ class GlossaryTermsController < ApplicationController
 
   def edit
     return unless find_glossary_term!
+    return unless @glossary_term.locked? && !in_admin_mode? # happy path
 
-    if @glossary_term.locked? && !in_admin_mode?
-      flash_error(:edit_glossary_term_not_allowed.t)
-      redirect_to(glossary_term_path(@glossary_term))
-    end
+    flash_error(:edit_glossary_term_not_allowed.t)
+    redirect_to(glossary_term_path(@glossary_term))
   end
 
   # ---------- Actions to Modify data: (create, update, destroy, etc.) ---------

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -30,6 +30,11 @@ class GlossaryTermsController < ApplicationController
 
   def edit
     return unless find_glossary_term!
+
+    if @glossary_term.locked? && !in_admin_mode?
+      flash_error(:edit_glossary_term_locked.t)
+      redirect_to(glossary_term_path(@glossary_term))
+    end
   end
 
   # ---------- Actions to Modify data: (create, update, destroy, etc.) ---------

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -32,7 +32,7 @@ class GlossaryTermsController < ApplicationController
     return unless find_glossary_term!
 
     if @glossary_term.locked? && !in_admin_mode?
-      flash_error(:edit_glossary_term_locked.t)
+      flash_error(:edit_glossary_term_not_allowed.t)
       redirect_to(glossary_term_path(@glossary_term))
     end
   end
@@ -55,6 +55,7 @@ class GlossaryTermsController < ApplicationController
 
     @glossary_term.attributes = params[:glossary_term].
                                 permit(:name, :description)
+    @glossary_term.locked = params[:glossary_term][:locked] if in_admin_mode?
 
     return reload_form("edit") unless @glossary_term.save
 

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -39,7 +39,8 @@ class GlossaryTerm < AbstractModel
     "thumb_image_id",
     "created_at",
     "updated_at",
-    "rss_log_id"
+    "rss_log_id",
+    "locked"
   )
   versioned_class.before_save { |x| x.user_id = User.current_id }
 

--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -1,5 +1,10 @@
 <%= form_with(model: @glossary_term, html: { multipart: true }) do |f| %>
 
+  <% if in_admin_mode? %>
+    <%= check_box_with_label(form: f, field: :locked, class: "mt-3",
+                             label: :edit_glossary_term_locked.t) %>
+  <% end %>
+
   <%= text_field_with_label(form: f, field: :name,
                             label: :glossary_term_name.t + ":",
                             data: { autofocus: true }) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2424,6 +2424,8 @@
   edit_glossary_term_title: "Editing Glossary Term: [name]"
   edit_glossary_term_save: Save
   edit_glossary_term_not_allowed: Only admins can edit glossary terms
+  edit_glossary_term_locked: This Glossary Term has been locked by the site admins.
+
 
   # glossary_term errors
   glossary_error_name_blank: Name cannot be blank.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2423,8 +2423,8 @@
   edit_glossary_term: "[:edit_object(type=:glossary_term)]"
   edit_glossary_term_title: "Editing Glossary Term: [name]"
   edit_glossary_term_save: Save
-  edit_glossary_term_not_allowed: Only admins can edit glossary terms
-  edit_glossary_term_locked: This Glossary Term has been locked by the site admins.
+  edit_glossary_term_not_allowed: This Glossary Term has been locked by the site admins
+  edit_glossary_term_locked: Lock this Glossary Term?
 
 
   # glossary_term errors

--- a/db/migrate/20230709202131_add_locked_to_glossary_terms.rb
+++ b/db/migrate/20230709202131_add_locked_to_glossary_terms.rb
@@ -1,0 +1,5 @@
+class AddLockedToGlossaryTerms < ActiveRecord::Migration[6.1]
+  def change
+    add_column :glossary_terms, :locked, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_30_044838) do
+ActiveRecord::Schema.define(version: 2023_07_09_202131) do
 
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2023_04_30_044838) do
     t.integer "rss_log_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "locked", default: false, null: false
   end
 
   create_table "glossary_terms_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -114,8 +114,9 @@ class GlossaryTermsControllerTest < FunctionalTestCase
 
   # ***** edit *****
   def test_edit
+    term = glossary_terms(:conic_glossary_term)
+
     login
-    term = GlossaryTerm.first
     assert(term.can_edit?)
 
     post(:edit, params: { id: term.id })
@@ -146,7 +147,9 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   end
 
   def test_edit_no_login
-    post(:edit, params: { id: GlossaryTerm.first.id })
+    term = glossary_terms(:conic_glossary_term)
+
+    post(:edit, params: { id: term.id })
     assert_response(:redirect,
                     "Unlogged-in user should not be able to edit term")
   end

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -116,6 +116,8 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   def test_edit
     login
     term = GlossaryTerm.first
+    assert(term.can_edit?)
+
     get(:edit, params: { id: term.id })
 
     assert_response(:success)

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -147,6 +147,16 @@ class GlossaryTermsControllerTest < FunctionalTestCase
                     "Unlogged-in user should not be able to edit term")
   end
 
+  def test_edit_locked_by_non_admin
+    term = glossary_terms(:locked_glossary_term)
+
+    login
+    post(:edit, params: { id: term.id })
+
+    assert_flash_error
+    assert_redirected_to(glossary_term_path(term))
+  end
+
   # ---------- Test actions that Modify data: (create, update, destroy, etc.) --
 
   # ***** create *****

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -141,9 +141,8 @@ class GlossaryTermsControllerTest < FunctionalTestCase
                   "Edit GlossaryTerm form should omit upload image field")
     assert_select(
       "#glossary_term_locked", false,
-      "GlossaryTerm form should not show show `Locked` input to non-admin user"
+      "GlossaryTerm form should not show `Locked` input to non-admin user"
     )
-
   end
 
   def test_edit_no_login
@@ -421,7 +420,6 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     assert_redirected_to(glossary_term_path(term.id),
                          "It should redisplay a Term it fails to destroy")
   end
-
 
   # ---------- helpers ---------------------------------------------------------
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -301,7 +301,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
 
     login
     make_admin
-    get(:destroy, params: { id: term.id })
+    delete(:destroy, params: { id: term.id })
 
     assert_flash_success
     assert_response(:redirect)
@@ -319,7 +319,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
 
     login
     make_admin
-    get(:destroy, params: { id: term.id })
+    delete(:destroy, params: { id: term.id })
 
     assert_flash_success
     assert_response(:redirect)
@@ -334,7 +334,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   def test_destroy_no_login
     term = GlossaryTerm.first
     login(users(:zero_user).login)
-    get(:destroy, params: { id: term.id })
+    delete(:destroy, params: { id: term.id })
 
     assert_flash_text(:permission_denied.l)
     assert_response(:redirect)

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -342,6 +342,19 @@ class GlossaryTermsControllerTest < FunctionalTestCase
            "Non-admin should not be able to destroy glossary term")
   end
 
+  def test_destroy_fails
+    term = glossary_terms(:no_images_glossary_term)
+    GlossaryTerm.any_instance.stubs(:destroy).returns(false)
+
+    login
+    make_admin
+    delete(:destroy, params: { id: term.id })
+
+    assert_redirected_to(glossary_term_path(term.id),
+                         "It should redisplay a Term it fails to destroy")
+  end
+
+
   # ---------- helpers ---------------------------------------------------------
 
   def create_term_params

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -52,3 +52,8 @@ multiple_word_glossary_term:
 fungi_glossary_term:
   <<: *DEFAULTS
   name: Fungi
+
+locked_glossary_term:
+  <<: *DEFAULTS
+  name: complex
+  description: A _monophyletic_ group of species that are indistinguishable from each other in the field.

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -57,3 +57,4 @@ locked_glossary_term:
   <<: *DEFAULTS
   name: complex
   description: A _monophyletic_ group of species that are indistinguishable from each other in the field.
+  locked: true

--- a/test/fixtures/glossary_terms.yml
+++ b/test/fixtures/glossary_terms.yml
@@ -8,6 +8,7 @@ DEFAULTS: &DEFAULTS
   user: rolf
   name: $LABEL
   description: Description of Term $LABEL
+  locked: false
 
 conic_glossary_term:
   <<: *DEFAULTS

--- a/test/fixtures/glossary_terms_versions.yml
+++ b/test/fixtures/glossary_terms_versions.yml
@@ -1,6 +1,13 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 # glossary term association must be referenced by id
 
+DEFAULTS: &DEFAULTS
+  updated_at: <%= Time.current %>
+  version: 1
+  user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
+  name: $LABEL
+  description: Description of Term $LABEL
+
 plane_glossary_term_v1:
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:plane_glossary_term) %>
   version: 1
@@ -43,3 +50,8 @@ square_glossary_term_v3:
   name: Square
   description: equilateral
 
+locked_glossary_term_v1:
+  <<: *DEFAULTS
+  glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:locked_glossary_term) %>
+  name: complex
+  description: A _monophyletic_ group of species that are indistinguishable from each other in the field.


### PR DESCRIPTION
Allows admins to lock or unlock a GlossaryTerm.
As discussed in the 2023-07-01 Tech Meeting. https://groups.google.com/g/mo-developers/c/qJxCqu3J-u0
Delivers [Pivotal #185556780](https://www.pivotaltracker.com/story/show/185556780)

### Manual Test
- enter admin mode 
- lock a  GlossaryTerm (edit a term, checking the "Lock this Glossary Term?" checkbox)
- leave admin mode
- click Edit Glossary Term 
Expected result: flash error and redirect to the term
- re-enter admin mode; 
- unlock the term (edit it, unchecking the  "Lock this Glossary Term?" checkbox)
- leave admin mode
- click Edit Glossary Term 
Expected result: Edit GlossaryTerm form.