### PR TITLE
Glossary blame

### DIFF
--- a/app/views/glossary_terms/_form.html.erb
+++ b/app/views/glossary_terms/_form.html.erb
@@ -1,5 +1,10 @@
 <%= form_with(model: @glossary_term, html: { multipart: true }) do |f| %>
 
+  <% if in_admin_mode? %>
+  <%= check_box_with_label(form: f, field: :locked, class: "mt-3",
+                            label: :edit_glossary_term_locked.t) %>
+  <% end %>
+
   <%= text_field_with_label(form: f, field: :name,
                             label: :glossary_term_name.t + ":",
                             data: { autofocus: true }) %>

--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -51,4 +51,10 @@
     <%= :footer_created_at.t(date: @glossary_term.created_at.web_time) %><br/>
     <%= :footer_last_updated_at.t(date: @glossary_term.updated_at.web_time) %>
   </p>
+
+  <div id="glossary_term_authors_editors">
+    <%= panel_block do %>
+      <%= show_authors_and_editors(obj: @glossary_term, user: @user) %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2404,6 +2404,10 @@
   show_glossary_term_title: "Glossary Term: [name]"
   show_glossary_term_reuse_image: Add Example
   show_glossary_term_remove_image: Remove Examples
+  show_glossary_term_creator: Creator of this Glossary Term
+  show_glossary_term_editor: "[:Editors]"
+  show_glossary_term_editors: "[:Editors]"
+
 
   # glossary_term#show_past_glossary_term
   show_past_glossary_term_title: "[:VERSION] [num]: [name]"

--- a/test/controllers/glossary_terms/versions_controller_test.rb
+++ b/test/controllers/glossary_terms/versions_controller_test.rb
@@ -10,6 +10,7 @@ module GlossaryTerms
     def test_show_past
       term = glossary_terms(:square_glossary_term)
       version = term.versions.first # oldest version
+
       login
       get(:show, params: { id: term.id, version: version.version })
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -85,7 +85,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     end
     assert_select("a[href='#{prior_version_path}']", true,
                   "Page should have link to prior version")
-    assert_select("name_authors_editors", { count: 1 },
+    assert_select("#glossary_term_authors_editors", { count: 1 },
                   "GlossaryTerm page should show creator and editors")
   end
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -55,15 +55,24 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   end
 
   # ***** show *****
-  def test_show
+  def test_show_public
     term = glossary_terms(:square_glossary_term)
-    # make sure public can access
+
     get(:show, params: { id: term.id })
 
-    assert_response(:success)
-    prior_version_path = glossary_term_versions_path(
-      term.id, version: term.version - 1
+    assert_response(
+      :success,
+      "Public should be able to view Glossary Terms without logging in"
     )
+  end
+
+  def test_show_logged_in
+    term = glossary_terms(:square_glossary_term)
+    assert_operator(term.version, :>, 1,
+                    "Test needs a GlossaryTerm fixture with multiple versions")
+    prior_version_path =
+      glossary_term_versions_path(term.id, version: term.version - 1)
+
     login
     get(:show, params: { id: term.id })
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -85,6 +85,8 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     end
     assert_select("a[href='#{prior_version_path}']", true,
                   "Page should have link to prior version")
+    assert_select("name_authors_editors", { count: 1 },
+                  "GlossaryTerm page should show creator and editors")
   end
 
   def test_show_admin_delete

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -85,8 +85,11 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     end
     assert_select("a[href='#{prior_version_path}']", true,
                   "Page should have link to prior version")
-    assert_select("#glossary_term_authors_editors", { count: 1 },
-                  "GlossaryTerm page should show creator and editors")
+    assert_select(
+      "#glossary_term_authors_editors",
+      { count: 1,
+        text: /Creator.*: #{rolf.name}Editors: #{mary.name}, #{katrina.name}/ }
+    )
   end
 
   def test_show_admin_delete

--- a/test/fixtures/glossary_terms_versions.yml
+++ b/test/fixtures/glossary_terms_versions.yml
@@ -1,11 +1,10 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 # glossary term association must be referenced by id
 
-
 DEFAULTS: &DEFAULTS
-  updated_at: <%= Time.current %>
   version: 1
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
+  updated_at: <%= Time.current %>
   name: $LABEL
   description: Description of Term $LABEL
 
@@ -31,6 +30,7 @@ conic_glossary_term_v1:
 square_glossary_term_v1:
   <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
+  user_id: <%= ActiveRecord::FixtureSet.identify(:mary) %>
   name: Square
   description: shape
 
@@ -38,6 +38,7 @@ square_glossary_term_v2:
   <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
   version: 2
+  user_id: <%= ActiveRecord::FixtureSet.identify(:katrina) %>
   name: Square
   description: quadrilateral
 

--- a/test/fixtures/glossary_terms_versions.yml
+++ b/test/fixtures/glossary_terms_versions.yml
@@ -1,45 +1,49 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 # glossary term association must be referenced by id
 
-plane_glossary_term_v1:
-  glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:plane_glossary_term) %>
+
+DEFAULTS: &DEFAULTS
+  updated_at: <%= Time.current %>
   version: 1
-  updated_at: 2013-08-17 06:33:50
+  user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
+  name: $LABEL
+  description: Description of Term $LABEL
+
+plane_glossary_term_v1:
+  <<: *DEFAULTS
+  glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:plane_glossary_term) %>
   name: Plane
-  description:
+  description: Three points define a plane & be sure to test unsafe html
 
 plane_glossary_term_v2:
+  <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:plane_glossary_term) %>
   version: 2
-  updated_at: 2013-08-17 06:35:20
   name: Plane
   description: Three points define a plane
 
 conic_glossary_term_v1:
+  <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:conic_glossary_term) %>
-  version: 1
-  updated_at: 2013-08-04 07:49:12
   name: Conic
   description: Cute little cone head
 
 square_glossary_term_v1:
+  <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
-  version: 1
-  updated_at: 2013-08-04 07:49:12
   name: Square
-  description:
+  description: shape
 
 square_glossary_term_v2:
+  <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
   version: 2
-  updated_at: 2013-08-04 07:49:12
   name: Square
   description: quadrilateral
 
 square_glossary_term_v3:
+  <<: *DEFAULTS
   glossary_term_id: <%= ActiveRecord::FixtureSet.identify(:square_glossary_term) %>
   version: 3
-  updated_at: 2013-08-04 07:49:12
   name: Square
   description: equilateral
-


### PR DESCRIPTION
Displays the Creator and Editor on the GlossaryTerm page.
As discussed in the 2023-07-01 Tech Meeting. https://groups.google.com/g/mo-developers/c/qJxCqu3J-u0

### Manual Test
- Run the script found at this link: https://github.com/MushroomObserver/mushroom-observer/blob/e322883554e23c7bcddd7d6f9740c72fcf72cc87/script/db_fix_term_user.rb
(It fixes some errors in the db snapshot, which errors have already been fixed in the live db.)
- View a Glossary Term that you did not create
- Edit it
Expected result: It should list the Creator and Editor(s).
