### PR TITLE
Continue refactoring tabset helpers - `Observations`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,14 +8,6 @@
 #  css_theme
 #  container_class
 #
-#  --- links and buttons ----
-#
-#  title_tag_contents           # text to put in html header <title>
-#  link_next                    # link to next object
-#  link_prev                    # link to prev object
-#  create_links                 # convert links into list of tabs
-#  draw_tab_set
-#
 #  --------------------------
 #
 #  indent                       # in-lined white-space element of n pixels
@@ -62,88 +54,6 @@ module ApplicationHelper
     else
       "container-full"
     end
-  end
-
-  # --------- template nav ------------------------------------------------
-
-  # contents of the <title> in html header
-  def title_tag_contents(action_name)
-    if @title.present?
-      @title.strip_html.html_safe
-    elsif TranslationString.where(tag: "title_for_#{action_name}").present?
-      :"title_for_#{action_name}".t
-    else
-      action_name.tr("_", " ").titleize
-    end
-  end
-
-  # link to next object in query results
-  def link_next(object)
-    path = if object.class.controller_normalized?
-             if object.type_tag == :rss_log
-               send(:activity_log_path, object.id, flow: "next")
-             else
-               send("#{object.type_tag}_path", object.id, flow: "next")
-             end
-           else
-             { controller: object.show_controller,
-               action: :show, id: object.id }
-           end
-    link_with_query("#{:FORWARD.t} »", path)
-  end
-
-  # link to previous object in query results
-  def link_prev(object)
-    path = if object.class.controller_normalized?
-             if object.type_tag == :rss_log
-               send(:activity_log_path, object.id, flow: "prev")
-             else
-               send("#{object.type_tag}_path", object.id, flow: "prev")
-             end
-           else
-             { controller: object.show_controller,
-               action: :show, id: object.id }
-           end
-    link_with_query("« #{:BACK.t}", path)
-  end
-
-  # Convert @links in index views into a list of HTML links for RHS tab set.
-  def create_links(links)
-    return [] unless links
-
-    links.compact.map { |str, url, args| link_to(str, url, args) }
-  end
-
-  # Convert an array (of arrays) of link attributes into an array of HTML tabs
-  # that may be either links or CRUD button_to's, for RHS tab set
-  def create_tabs(links)
-    return [] unless links
-
-    links.compact.map do |str, url, args|
-      case args[:button]
-      when :destroy
-        destroy_button(name: str, target: url, **args)
-      when :post
-        post_button(name: str, path: url, **args)
-      when :put
-        put_button(name: str, path: url, **args)
-      when :patch
-        patch_button(name: str, path: url, **args)
-      else
-        link_to(str, url, args)
-      end
-    end
-  end
-
-  # Short-hand to render shared tab_set partial for a given set of links.
-  def draw_tab_set(links)
-    render(partial: "layouts/content/tab_set", locals: { links: links })
-  end
-
-  def index_sorter(sorts)
-    return "" unless sorts
-
-    render(partial: "layouts/content/sorter", locals: { sorts: sorts })
   end
 
   # ----------------------------------------------------------------------------

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,11 +107,32 @@ module ApplicationHelper
     link_with_query("« #{:BACK.t}", path)
   end
 
-  # Convert @links in index views into a list of tabs for RHS tab set.
+  # Convert @links in index views into a list of HTML links for RHS tab set.
   def create_links(links)
     return [] unless links
 
     links.compact.map { |str, url, args| link_to(str, url, args) }
+  end
+
+  # Convert an array (of arrays) of link attributes into an array of HTML tabs
+  # that may be either links or CRUD button_to's, for RHS tab set
+  def create_tabs(links)
+    return [] unless links
+
+    links.compact.each do |str, url, args|
+      case args[:button]
+      when :destroy
+        destroy_button(name: str, target: url, **args)
+      when :post
+        post_button(name: str, path: url, **args)
+      when :put
+        put_button(name: str, path: url, **args)
+      when :patch
+        patch_button(name: str, path: url, **args)
+      else
+        link_to(str, url, args)
+      end
+    end
   end
 
   # Short-hand to render shared tab_set partial for a given set of links.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,7 +119,7 @@ module ApplicationHelper
   def create_tabs(links)
     return [] unless links
 
-    links.compact.each do |str, url, args|
+    links.compact.map do |str, url, args|
       case args[:button]
       when :destroy
         destroy_button(name: str, target: url, **args)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -60,7 +60,8 @@ module LinkHelper
   #     name: :destroy_object.t(type: :herbarium),
   #     target: herbarium_path(@herbarium, back: url_after_delete(@herbarium))
   #   )
-  def destroy_button(name: :DESTROY.t, target:, **args)
+  def destroy_button(target:, name: :DESTROY.t, **args)
+    name = :DESTROY.t if name.blank? # necessary if nil/empty string passed
     path = if target.is_a?(String)
              target
            else

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -60,7 +60,7 @@ module LinkHelper
   #     name: :destroy_object.t(type: :herbarium),
   #     target: herbarium_path(@herbarium, back: url_after_delete(@herbarium))
   #   )
-  def destroy_button(target:, name: :DESTROY.t, **args)
+  def destroy_button(name: :DESTROY.t, target:, **args)
     path = if target.is_a?(String)
              target
            else

--- a/app/helpers/tabs/articles_helper.rb
+++ b/app/helpers/tabs/articles_helper.rb
@@ -8,25 +8,23 @@
 #
 module Tabs
   module ArticlesHelper
-    def index_links_for_user(user:)
+    def articles_index_links(user:)
       return [] unless permitted?(user)
 
-      [
-        [:create_article_title.t, new_article_path,
-         { class: "new_article_link" }]
-      ]
+      [[:create_article_title.t, new_article_path,
+        { class: "new_article_link" }]]
     end
 
-    def show_tabs_for_user(article:, user:)
-      tabs = [link_to(:index_article.t, articles_path,
-                      { class: "articles_link" })]
-      return tabs unless permitted?(user)
+    def article_show_links(article:, user:)
+      links = [[:index_article.t, articles_path,
+                { class: "articles_index_link" }]]
+      return links unless permitted?(user)
 
-      tabs.push(link_to(:create_article_title.t, new_article_path,
-                        { class: "new_article_link" }),
-                link_to(:EDIT.t, edit_article_path(article.id),
-                        { class: "edit_article_link" }),
-                destroy_button(target: article))
+      links.push([:create_article_title.t, new_article_path,
+                  { class: "new_article_link" }],
+                 [:EDIT.t, edit_article_path(article.id),
+                  { class: "edit_article_link" }],
+                 [nil, article, { button: :destroy }])
     end
 
     # Can user modify all articles
@@ -35,16 +33,14 @@ module Tabs
     end
 
     def article_form_new_links
-      [
-        [:index_article.t, articles_path, { class: "articles_link" }]
-      ]
+      [[:index_article.t, articles_path, { class: "articles_index_link" }]]
     end
 
     def article_form_edit_links(article:)
       [
         [:cancel_and_show.t(type: :article),
          article_path(article.id), { class: "article_link" }],
-        [:index_article.t, articles_path, { class: "articles_link" }]
+        [:index_article.t, articles_path, { class: "articles_index_link" }]
       ]
     end
 

--- a/app/helpers/tabs/descriptions_helper.rb
+++ b/app/helpers/tabs/descriptions_helper.rb
@@ -4,11 +4,11 @@
 module Tabs
   module DescriptionsHelper
     # The whole tabset, made of composed links.
-    def show_description_tabset(description:, pager: false)
+    def show_description_links(description:)
       type = description.parent.type_tag
       admin = is_admin?(description)
       # assemble HTML for "tabset" for show_{type}_description
-      tabs = [
+      [
         show_parent_link(description, type),
         edit_description_link(description),
         destroy_description_link(description, admin),
@@ -18,127 +18,106 @@ module Tabs
         make_default_link(description),
         project_link(description),
         publish_draft_link(description, type, admin)
-      ].flatten.reject(&:empty?)
-      tabset = { right: draw_tab_set(tabs) }
-      tabset = tabset.merge(pager_for: description) if pager
-      tabset
+      ].reject(&:empty?)
     end
 
     def show_parent_link(description, type)
-      link_to(:show_object.t(type: type),
-              add_query_param(description.parent.show_link_args),
-              { class: "description_parent_link_#{description.id}" })
+      [:show_object.t(type: type),
+       add_query_param(description.parent.show_link_args),
+       { class: "description_parent_link_#{description.id}" }]
     end
 
     def create_description_link(object)
-      link_to(
-        :show_name_create_description.t,
-        { controller: "#{object.show_controller}/descriptions",
-          action: :new, id: object.id, q: get_query_param },
-        class: "create_description_link_#{object.id}"
-      )
+      [:show_name_create_description.t,
+       { controller: "#{object.show_controller}/descriptions",
+         action: :new, id: object.id, q: get_query_param },
+       { class: "create_description_link_#{object.id}" }]
     end
 
     def edit_description_link(description)
       return unless writer?(description)
 
-      link_to(:show_description_edit.t,
-              add_query_param(description.edit_link_args),
-              class: "description_edit_link_#{description.id}")
+      [:show_description_edit.t,
+       add_query_param(description.edit_link_args),
+       { class: "description_edit_link_#{description.id}" }]
     end
 
     def destroy_description_link(description, admin)
       return unless admin
 
-      destroy_button(name: :show_description_destroy.t,
-                     target: description, q: get_query_param)
+      [:show_description_destroy.t, description, { button: :destroy }]
     end
 
     def clone_description_link(description)
-      link_to(
-        :show_description_clone.t,
-        { controller: description.show_controller,
-          action: :new, id: description.parent_id,
-          clone: description.id, q: get_query_param },
-        help: :show_description_clone_help.l,
-        class: "description_clone_link_#{description.id}"
-      )
+      [:show_description_clone.t,
+       { controller: description.show_controller,
+         action: :new, id: description.parent_id,
+         clone: description.id, q: get_query_param },
+       { help: :show_description_clone_help.l,
+         class: "description_clone_link_#{description.id}" }]
     end
 
     def merge_description_link(description, admin)
       return unless admin
 
-      link_to(
-        :show_description_merge.t,
-        { controller: "#{description.show_controller}/merges",
-          action: :new, id: description.id, q: get_query_param },
-        help: :show_description_merge_help.l,
-        class: "description_merge_link_#{description.id}"
-      )
+      [:show_description_merge.t,
+       { controller: "#{description.show_controller}/merges",
+         action: :new, id: description.id, q: get_query_param },
+       { help: :show_description_merge_help.l,
+         class: "description_merge_link_#{description.id}" }]
     end
 
     def move_description_link(description, admin)
       return unless admin
 
       parent_type = description.parent.type_tag.to_s
-      link_to(
-        :show_description_move.t,
-        { controller: "#{description.show_controller}/moves",
-          action: :new, id: description.id, q: get_query_param },
-        help: :show_description_move_help.l(parent: parent_type),
-        class: "description_move_link_#{description.id}"
-      )
+      [:show_description_move.t,
+       { controller: "#{description.show_controller}/moves",
+         action: :new, id: description.id, q: get_query_param },
+       { help: :show_description_move_help.l(parent: parent_type),
+         class: "description_move_link_#{description.id}" }]
     end
 
     def adjust_permissions_link(description, type, admin)
       return unless admin && type == :name
 
-      link_to(
-        :show_description_adjust_permissions.t,
-        { controller: "#{description.show_controller}/permissions",
-          action: :edit, id: description.id, q: get_query_param },
-        help: :show_description_adjust_permissions_help.l,
-        class: "description_permissions_link_#{description.id}"
-      )
+      [:show_description_adjust_permissions.t,
+       { controller: "#{description.show_controller}/permissions",
+         action: :edit, id: description.id, q: get_query_param },
+       { help: :show_description_adjust_permissions_help.l,
+         class: "description_permissions_link_#{description.id}" }]
     end
 
     def make_default_link(description)
       return unless description.public && User.current &&
                     (description.parent.description_id != description.id)
 
-      put_button(
-        name: :show_description_make_default.t,
-        path: { controller: "#{description.show_controller}/defaults",
-                action: :update, id: description.id,
-                q: get_query_param },
-        help: :show_description_make_default_help.l,
-        class: "description_make_default_link_#{description.id}"
-      )
+      [:show_description_make_default.t,
+       { controller: "#{description.show_controller}/defaults",
+         action: :update, id: description.id,
+         q: get_query_param },
+       { button: :put, help: :show_description_make_default_help.l,
+         class: "description_make_default_link_#{description.id}" }]
     end
 
     def project_link(description)
       return unless (description.source_type == :project) &&
                     (project = description.source_object)
 
-      link_to(
-        :show_object.t(type: :project),
-        add_query_param(project.show_link_args),
-        class: "description_project_link"
-      )
+      [:show_object.t(type: :project), add_query_param(project.show_link_args),
+       { class: "description_project_link" }]
     end
 
     def publish_draft_link(description, type, admin)
       return unless admin && (type == :name) &&
                     (description.source_type != :public)
 
-      put_button(
-        name: :show_description_publish.t,
-        path: { controller: "#{description.show_controller}/publish",
-                action: :update, id: description.id,
-                q: get_query_param },
-        help: :show_description_publish_help.l,
-        class: "description_publish_draft_link"
-      )
+      [:show_description_publish.t,
+       { controller: "#{description.show_controller}/publish",
+         action: :update, id: description.id,
+         q: get_query_param },
+       { button: :put, help: :show_description_publish_help.l,
+         class: "description_publish_draft_link" }]
     end
   end
 end

--- a/app/helpers/tabs/descriptions_helper.rb
+++ b/app/helpers/tabs/descriptions_helper.rb
@@ -25,8 +25,9 @@ module Tabs
     end
 
     def show_parent_link(description, type)
-      link_with_query(:show_object.t(type: type),
-                      description.parent.show_link_args)
+      link_to(:show_object.t(type: type),
+              add_query_param(description.parent.show_link_args),
+              { class: "description_parent_link_#{description.id}" })
     end
 
     def create_description_link(object)
@@ -41,9 +42,9 @@ module Tabs
     def edit_description_link(description)
       return unless writer?(description)
 
-      link_with_query(
-        :show_description_edit.t, description.edit_link_args
-      )
+      link_to(:show_description_edit.t,
+              add_query_param(description.edit_link_args),
+              class: "description_edit_link_#{description.id}")
     end
 
     def destroy_description_link(description, admin)
@@ -54,23 +55,25 @@ module Tabs
     end
 
     def clone_description_link(description)
-      link_with_query(
+      link_to(
         :show_description_clone.t,
         { controller: description.show_controller,
           action: :new, id: description.parent_id,
-          clone: description.id },
-        help: :show_description_clone_help.l
+          clone: description.id, q: get_query_param },
+        help: :show_description_clone_help.l,
+        class: "description_clone_link_#{description.id}"
       )
     end
 
     def merge_description_link(description, admin)
       return unless admin
 
-      link_with_query(
+      link_to(
         :show_description_merge.t,
         { controller: "#{description.show_controller}/merges",
-          action: :new, id: description.id },
-        help: :show_description_merge_help.l
+          action: :new, id: description.id, q: get_query_param },
+        help: :show_description_merge_help.l,
+        class: "description_merge_link_#{description.id}"
       )
     end
 
@@ -78,22 +81,24 @@ module Tabs
       return unless admin
 
       parent_type = description.parent.type_tag.to_s
-      link_with_query(
+      link_to(
         :show_description_move.t,
         { controller: "#{description.show_controller}/moves",
-          action: :new, id: description.id },
-        help: :show_description_move_help.l(parent: parent_type)
+          action: :new, id: description.id, q: get_query_param },
+        help: :show_description_move_help.l(parent: parent_type),
+        class: "description_move_link_#{description.id}"
       )
     end
 
     def adjust_permissions_link(description, type, admin)
       return unless admin && type == :name
 
-      link_with_query(
+      link_to(
         :show_description_adjust_permissions.t,
         { controller: "#{description.show_controller}/permissions",
-          action: :edit, id: description.id },
-        help: :show_description_adjust_permissions_help.l
+          action: :edit, id: description.id, q: get_query_param },
+        help: :show_description_adjust_permissions_help.l,
+        class: "description_permissions_link_#{description.id}"
       )
     end
 
@@ -106,7 +111,8 @@ module Tabs
         path: { controller: "#{description.show_controller}/defaults",
                 action: :update, id: description.id,
                 q: get_query_param },
-        help: :show_description_make_default_help.l
+        help: :show_description_make_default_help.l,
+        class: "description_make_default_link_#{description.id}"
       )
     end
 
@@ -114,8 +120,10 @@ module Tabs
       return unless (description.source_type == :project) &&
                     (project = description.source_object)
 
-      link_with_query(
-        :show_object.t(type: :project), project.show_link_args
+      link_to(
+        :show_object.t(type: :project),
+        add_query_param(project.show_link_args),
+        class: "description_project_link"
       )
     end
 
@@ -128,7 +136,8 @@ module Tabs
         path: { controller: "#{description.show_controller}/publish",
                 action: :update, id: description.id,
                 q: get_query_param },
-        help: :show_description_publish_help.l
+        help: :show_description_publish_help.l,
+        class: "description_publish_draft_link"
       )
     end
   end

--- a/app/helpers/tabs/descriptions_helper.rb
+++ b/app/helpers/tabs/descriptions_helper.rb
@@ -3,25 +3,26 @@
 # html used in tabsets
 module Tabs
   module DescriptionsHelper
-    # The whole tabset, made of composed links.
+    # Links for the tabset
     def show_description_links(description:)
       type = description.parent.type_tag
       admin = is_admin?(description)
       # assemble HTML for "tabset" for show_{type}_description
       [
-        show_parent_link(description, type),
+        description_show_parent_link(description, type),
         edit_description_link(description),
         destroy_description_link(description, admin),
         clone_description_link(description),
         merge_description_link(description, admin),
-        adjust_permissions_link(description, type, admin),
-        make_default_link(description),
-        project_link(description),
-        publish_draft_link(description, type, admin)
+        description_adjust_permissions_link(description, type, admin),
+        description_make_default_link(description),
+        description_show_project_link(description),
+        description_publish_draft_link(description, type, admin)
       ].reject(&:empty?)
     end
 
-    def show_parent_link(description, type)
+    # Components of the above AND similar links for helpers/descriptions_helper
+    def description_show_parent_link(description, type)
       [:show_object.t(type: type),
        add_query_param(description.parent.show_link_args),
        { class: "description_parent_link_#{description.id}" }]
@@ -78,7 +79,7 @@ module Tabs
          class: "description_move_link_#{description.id}" }]
     end
 
-    def adjust_permissions_link(description, type, admin)
+    def description_adjust_permissions_link(description, type, admin)
       return unless admin && type == :name
 
       [:show_description_adjust_permissions.t,
@@ -88,7 +89,7 @@ module Tabs
          class: "description_permissions_link_#{description.id}" }]
     end
 
-    def make_default_link(description)
+    def description_make_default_link(description)
       return unless description.public && User.current &&
                     (description.parent.description_id != description.id)
 
@@ -100,7 +101,7 @@ module Tabs
          class: "description_make_default_link_#{description.id}" }]
     end
 
-    def project_link(description)
+    def description_show_project_link(description)
       return unless (description.source_type == :project) &&
                     (project = description.source_object)
 
@@ -108,7 +109,7 @@ module Tabs
        { class: "description_project_link" }]
     end
 
-    def publish_draft_link(description, type, admin)
+    def description_publish_draft_link(description, type, admin)
       return unless admin && (type == :name) &&
                     (description.source_type != :public)
 
@@ -118,6 +119,14 @@ module Tabs
          q: get_query_param },
        { button: :put, help: :show_description_publish_help.l,
          class: "description_publish_draft_link" }]
+    end
+
+    def new_description_for_project_link(object, project)
+      [project.title,
+       { controller: "#{object.show_controller}/descriptions",
+         action: :new, id: object.id,
+         project: project.id, source: "project" },
+       { class: "new_description_for_project_link" }]
     end
   end
 end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -26,8 +26,8 @@ module Tabs
       if herbarium.curators.empty? ||
          herbarium.curator?(user) || in_admin_mode?
         tabs += [
-          link_with_query(:edit_herbarium.t,
-                          edit_herbarium_path(herbarium.id)),
+          link_to(:edit_herbarium.t,
+                  add_query_param(edit_herbarium_path(herbarium.id))),
           destroy_button(
             name: :destroy_object.t(type: :herbarium),
             target: herbarium_path(herbarium,
@@ -37,10 +37,12 @@ module Tabs
         ]
       end
       tabs += [
-        link_with_query(:create_herbarium.t, new_herbarium_path,
-                        id: "new_herbarium_link"),
-        link_with_query(:herbarium_index.t, herbaria_path(flavor: :nonpersonal),
-                        id: "herbarium_index_link")
+        link_to(:create_herbarium.t,
+                add_query_param(new_herbarium_path),
+                id: "new_herbarium_link"),
+        link_to(:herbarium_index.t,
+                add_query_param(herbaria_path(flavor: :nonpersonal)),
+                id: "herbarium_index_link")
       ]
       tabs
     end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -4,7 +4,6 @@
 # NOTE: this uses ids not classes for identifiers, change this
 module Tabs
   module HerbariaHelper
-    # link attribute arrays
     def herbaria_index_links(query:)
       links ||= []
       unless query&.flavor == :all
@@ -21,51 +20,55 @@ module Tabs
                 { class: "new_herbarium_link" }]
     end
 
-    # Composed links because there's a destroy_button
-    def herbarium_show_tabs(herbarium:, user:)
+    def herbarium_show_links(herbarium:, user:)
       tabs = []
       if herbarium.curators.empty? ||
          herbarium.curator?(user) || in_admin_mode?
         tabs += [
-          link_to(:edit_herbarium.t,
-                  add_query_param(edit_herbarium_path(herbarium.id)),
-                  class: "edit_herbarium_link"),
-          destroy_button(
-            name: :destroy_object.t(type: :herbarium),
-            target: herbarium_path(herbarium,
-                                   back: url_after_delete(herbarium)),
-            class: "delete_herbarium_link"
-          )
+          [:edit_herbarium.t,
+           add_query_param(edit_herbarium_path(herbarium.id)),
+           { class: "edit_herbarium_link" }],
+          [:destroy_object.t(type: :herbarium),
+           herbarium_path(herbarium, back: url_after_delete(herbarium)),
+           { button: :destroy, class: "delete_herbarium_link" }]
         ]
       end
       tabs += [
-        link_to(:create_herbarium.t,
-                add_query_param(new_herbarium_path),
-                class: "new_herbarium_link"),
-        link_to(:herbarium_index.t,
-                add_query_param(herbaria_path(flavor: :nonpersonal)),
-                class: "herbaria_index_link")
+        [:create_herbarium.t, add_query_param(new_herbarium_path),
+         { class: "new_herbarium_link" }],
+        nonpersonal_herbaria_index_link_unlabeled
       ]
       tabs
     end
 
-    # link attribute arrays
     def herbarium_form_new_links
-      [[:herbarium_index.t,
-        add_query_param(herbaria_path(flavor: :nonpersonal)),
-        { class: "herbaria_index_link" }]]
+      nonpersonal_herbaria_index_link_unlabeled
     end
 
-    # link attribute arrays
     def herbarium_form_edit_links(herbarium:)
       [
-        [:cancel_and_show.t(type: :herbarium),
-         add_query_param(herbarium_path(herbarium)),
-         { class: "herbarium_link" }],
-        [:herbarium_index.t,
-         add_query_param(herbaria_path(flavor: :nonpersonal)),
-         { class: "herbaria_index_link" }]
+        herbarium_return_link(herbarium),
+        nonpersonal_herbaria_index_link_unlabeled
       ]
+    end
+
+    def herbaria_curator_request_links(herbarium:)
+      [
+        herbarium_return_link(herbarium),
+        nonpersonal_herbaria_index_link_unlabeled
+      ]
+    end
+
+    def herbarium_return_link(herbarium)
+      [:cancel_and_show.t(type: :herbarium),
+       add_query_param(herbarium_path(herbarium)),
+       { class: "herbarium_link" }]
+    end
+
+    def nonpersonal_herbaria_index_link_unlabeled
+      [:herbarium_index.t,
+       add_query_param(herbaria_path(flavor: :nonpersonal)),
+       { class: "nonpersonal_herbaria_index_link" }]
     end
   end
 end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -9,15 +9,16 @@ module Tabs
       links ||= []
       unless query&.flavor == :all
         links << [:herbarium_index_list_all_herbaria.l,
-                  herbaria_path(flavor: :all), { id: "all_herbaria_link" }]
+                  herbaria_path(flavor: :all),
+                  { class: "herbaria_index_link" }]
       end
       unless query&.flavor == :nonpersonal
         links << [:herbarium_index_nonpersonal_herbaria.l,
                   herbaria_path(flavor: :nonpersonal),
-                  { id: "all_nonpersonal_herbaria_link" }]
+                  { class: "nonpersonal_herbaria_index_link" }]
       end
       links << [:create_herbarium.l, new_herbarium_path,
-                { id: "new_herbarium_link" }]
+                { class: "new_herbarium_link" }]
     end
 
     # Composed links because there's a destroy_button
@@ -27,22 +28,23 @@ module Tabs
          herbarium.curator?(user) || in_admin_mode?
         tabs += [
           link_to(:edit_herbarium.t,
-                  add_query_param(edit_herbarium_path(herbarium.id))),
+                  add_query_param(edit_herbarium_path(herbarium.id)),
+                  class: "edit_herbarium_link"),
           destroy_button(
             name: :destroy_object.t(type: :herbarium),
             target: herbarium_path(herbarium,
                                    back: url_after_delete(herbarium)),
-            id: "delete_herbarium_link"
+            class: "delete_herbarium_link"
           )
         ]
       end
       tabs += [
         link_to(:create_herbarium.t,
                 add_query_param(new_herbarium_path),
-                id: "new_herbarium_link"),
+                class: "new_herbarium_link"),
         link_to(:herbarium_index.t,
                 add_query_param(herbaria_path(flavor: :nonpersonal)),
-                id: "herbarium_index_link")
+                class: "herbaria_index_link")
       ]
       tabs
     end
@@ -51,7 +53,7 @@ module Tabs
     def herbarium_form_new_links
       [[:herbarium_index.t,
         add_query_param(herbaria_path(flavor: :nonpersonal)),
-        { id: "herbarium_index_link" }]]
+        { class: "herbaria_index_link" }]]
     end
 
     # link attribute arrays
@@ -59,10 +61,10 @@ module Tabs
       [
         [:cancel_and_show.t(type: :herbarium),
          add_query_param(herbarium_path(herbarium)),
-         { id: "herbarium_link" }],
+         { class: "herbarium_link" }],
         [:herbarium_index.t,
          add_query_param(herbaria_path(flavor: :nonpersonal)),
-         { id: "herbarium_index_link" }]
+         { class: "herbaria_index_link" }]
       ]
     end
   end

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -39,7 +39,8 @@ module Tabs
           id: "destroy_herbarium_record_link"
         )
       end
-      tabs << link_to(:herbarium_index.t, herbaria_path(flavor: :nonpersonal),
+      tabs << link_to(:herbarium_index.t,
+                      add_query_param(herbaria_path(flavor: :nonpersonal)),
                       id: "herbarium_index_link")
       tabs
     end

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -4,14 +4,14 @@
 #
 module Tabs
   module HerbariumRecordsHelper
-    # link attribute arrays
+    include HerbariaHelper
     def herbarium_record_index_links
       links = []
       if params[:observation_id].present?
         links = [
           [:show_object.l(type: :observation),
            observation_path(params[:observation_id]),
-           { class: "herbarium_observation_link" }],
+           { class: "observation_link" }],
           [:create_herbarium_record.l,
            new_herbarium_record_path(id: params[:id]),
            { class: "new_herbarium_record_link" }]
@@ -23,55 +23,45 @@ module Tabs
                 { class: "nonpersonal_herbaria_index_link" }]
     end
 
-    # HTML links because there's a destroy_button
-    def herbarium_record_show_tabs(herbarium_record:)
-      tabs = []
+    def herbarium_record_show_links(herbarium_record:)
+      links = []
       if in_admin_mode? || herbarium_record.can_edit?
-        tabs << link_to(
-          :edit_herbarium_record.t,
-          edit_herbarium_record_path(id: herbarium_record.id,
-                                     back: :show, q: get_query_param),
-          class: "edit_herbarium_record_link"
-        )
-        tabs << destroy_button(
-          name: :destroy_object.t(type: :herbarium_record),
-          target: herbarium_record_path(herbarium_record.id),
-          class: "destroy_herbarium_record_link"
+        links.push(
+          [:edit_herbarium_record.t,
+           edit_herbarium_record_path(id: herbarium_record.id,
+                                      back: :show, q: get_query_param),
+           { class: "edit_herbarium_record_link" }],
+          [:destroy_object.t(type: :herbarium_record),
+           herbarium_record, { button: :destroy }]
         )
       end
-      tabs << link_to(:herbarium_index.t,
-                      add_query_param(herbaria_path(flavor: :nonpersonal)),
-                      class: "herbaria_index_link")
-      tabs
+      links << nonpersonal_herbaria_index_link_unlabeled
+      links
     end
 
-    # link attribute arrays
     def herbarium_record_form_new_links(observation:)
       [
         [:cancel_and_show.t(type: :observation),
          add_query_param(observation_path(observation.id)),
-         { class: "show_observation_link" }],
+         { class: "observation_link" }],
         [:create_herbarium.t,
          add_query_param(new_herbarium_path),
          { class: "new_herbarium_link" }],
-        [:herbarium_index.t,
-         add_query_param(herbaria_path(flavor: :nonpersonal)),
-         { class: "nonpersonal_herbaria_index_link" }]
+        nonpersonal_herbaria_index_link_unlabeled
       ]
     end
 
-    # link attribute arrays
     def herbarium_record_form_edit_links(back:, back_object:)
       links = []
       if back == "index"
         links << [:edit_herbarium_record_back_to_index.t,
                   herbarium_records_path(q: get_query_param),
-                  { class: "herbarium_records_link" }]
+                  { class: "herbarium_records_index_link" }]
       elsif back_object&.type_tag == :observation
         links << [:cancel_and_show.t(type: back_object.type_tag),
                   observation_path(id: back_object.id,
                                    q: get_query_param),
-                  { class: "herbarium_record_observation_link" }]
+                  { class: "observation_link" }]
       elsif back_object&.type_tag == :herbarium_record
         links << [:cancel_and_show.t(type: back_object.type_tag),
                   herbarium_record_path(id: back_object.id,
@@ -81,9 +71,7 @@ module Tabs
       links << [:create_herbarium.t,
                 new_herbarium_path(q: get_query_param),
                 { class: "new_herbarium_link" }]
-      links << [:herbarium_index.t,
-                herbaria_path(flavor: :nonpersonal),
-                { class: "nonpersonal_herbaria_index_link" }]
+      links << nonpersonal_herbaria_index_link_unlabeled
     end
   end
 end

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -11,16 +11,16 @@ module Tabs
         links = [
           [:show_object.l(type: :observation),
            observation_path(params[:observation_id]),
-           { id: "herbarium_observation_link" }],
+           { class: "herbarium_observation_link" }],
           [:create_herbarium_record.l,
            new_herbarium_record_path(id: params[:id]),
-           { id: "new_herbarium_record_link" }]
+           { class: "new_herbarium_record_link" }]
         ]
       end
       links << [:create_herbarium.l, new_herbarium_path,
-                { id: "new_herbarium_link" }]
+                { class: "new_herbarium_link" }]
       links << [:herbarium_index.t, herbaria_path(flavor: :nonpersonal),
-                { id: "all_nonpersonal_herbaria_link" }]
+                { class: "nonpersonal_herbaria_index_link" }]
     end
 
     # HTML links because there's a destroy_button
@@ -31,17 +31,17 @@ module Tabs
           :edit_herbarium_record.t,
           edit_herbarium_record_path(id: herbarium_record.id,
                                      back: :show, q: get_query_param),
-          id: "edit_herbarium_record_link"
+          class: "edit_herbarium_record_link"
         )
         tabs << destroy_button(
           name: :destroy_object.t(type: :herbarium_record),
           target: herbarium_record_path(herbarium_record.id),
-          id: "destroy_herbarium_record_link"
+          class: "destroy_herbarium_record_link"
         )
       end
       tabs << link_to(:herbarium_index.t,
                       add_query_param(herbaria_path(flavor: :nonpersonal)),
-                      id: "herbarium_index_link")
+                      class: "herbaria_index_link")
       tabs
     end
 
@@ -50,13 +50,13 @@ module Tabs
       [
         [:cancel_and_show.t(type: :observation),
          add_query_param(observation_path(observation.id)),
-         { id: "show_observation_link" }],
+         { class: "show_observation_link" }],
         [:create_herbarium.t,
          add_query_param(new_herbarium_path),
-         { id: "new_herbarium_link" }],
+         { class: "new_herbarium_link" }],
         [:herbarium_index.t,
          add_query_param(herbaria_path(flavor: :nonpersonal)),
-         { id: "all_nonpersonal_herbaria_link" }]
+         { class: "nonpersonal_herbaria_index_link" }]
       ]
     end
 
@@ -66,24 +66,24 @@ module Tabs
       if back == "index"
         links << [:edit_herbarium_record_back_to_index.t,
                   herbarium_records_path(q: get_query_param),
-                  { id: "herbarium_records_link" }]
+                  { class: "herbarium_records_link" }]
       elsif back_object&.type_tag == :observation
         links << [:cancel_and_show.t(type: back_object.type_tag),
                   observation_path(id: back_object.id,
                                    q: get_query_param),
-                  { id: "herbarium_record_observation_link" }]
+                  { class: "herbarium_record_observation_link" }]
       elsif back_object&.type_tag == :herbarium_record
         links << [:cancel_and_show.t(type: back_object.type_tag),
                   herbarium_record_path(id: back_object.id,
                                         q: get_query_param),
-                  { id: "herbarium_record_link" }]
+                  { class: "herbarium_record_link" }]
       end
       links << [:create_herbarium.t,
                 new_herbarium_path(q: get_query_param),
-                { id: "new_herbarium_link" }]
+                { class: "new_herbarium_link" }]
       links << [:herbarium_index.t,
                 herbaria_path(flavor: :nonpersonal),
-                { id: "all_nonpersonal_herbaria_link" }]
+                { class: "nonpersonal_herbaria_index_link" }]
     end
   end
 end

--- a/app/helpers/tabs/images_helper.rb
+++ b/app/helpers/tabs/images_helper.rb
@@ -39,28 +39,32 @@ module Tabs
 
       obs = image.observations.first
       [
-        link_with_query(:show_object.t(type: :observation),
-                        permanent_observation_path(obs.id)),
-        link_with_query(:show_object.t(type: :name),
-                        name_path(obs.name.id)),
+        link_to(:show_object.t(type: :observation),
+                add_query_param(permanent_observation_path(obs.id)),
+                class: "image_observation_link"),
+        link_to(:show_object.t(type: :name),
+                add_query_param(name_path(obs.name.id)),
+                class: "image_name_link"),
         link_to(:google_images.t,
                 "http://images.google.com/images?q=#{obs.name.search_name}",
-                target: "_blank", rel: "noopener")
+                target: "_blank", rel: "noopener", class: "image_google_link")
       ]
     end
 
     def eol_link(image)
       return unless (eol_url = image.eol_url)
 
-      link_to("EOL", eol_url, target: "_blank", rel: "noopener")
+      link_to("EOL", eol_url, target: "_blank", rel: "noopener",
+                              class: "image_eol_link")
     end
 
     def edit_and_destroy_links(image)
       return unless check_permission(image)
 
       [
-        link_with_query(:edit_object.t(type: :image),
-                        edit_image_path(image.id)),
+        link_to(:edit_object.t(type: :image),
+                add_query_param(edit_image_path(image.id)),
+                class: "image_edit_link"),
         destroy_button(name: :destroy_object.t(type: :image),
                        target: image)
       ]
@@ -69,8 +73,9 @@ module Tabs
     def email_commercial_inquiry_link(image)
       return unless image.user.email_general_commercial && !image.user.no_emails
 
-      link_with_query(:image_show_inquiry.t,
-                      emails_commercial_inquiry_path(image.id))
+      link_to(:image_show_inquiry.t,
+              add_query_param(emails_commercial_inquiry_path(image.id)),
+              class: "image_commercial_inquiry_link")
     end
   end
 end

--- a/app/helpers/tabs/images_helper.rb
+++ b/app/helpers/tabs/images_helper.rb
@@ -13,15 +13,14 @@ module Tabs
       ]
     end
 
-    # assemble HTML for "tabset" for show_image
-    # actually a list of links and the interest icons
-    def show_image_tabset(image:)
+    # assemble links for show_image
+    def show_image_links(image:)
       [
-        show_image_obs_links(image),
+        *show_image_obs_links(image),
         eol_link(image),
-        edit_and_destroy_links(image),
+        *edit_and_destroy_links(image),
         email_commercial_inquiry_link(image)
-      ].flatten.reject(&:empty?)
+      ].reject(&:empty?)
     end
 
     def images_exif_show_links(image:)
@@ -39,43 +38,42 @@ module Tabs
 
       obs = image.observations.first
       [
-        link_to(:show_object.t(type: :observation),
-                add_query_param(permanent_observation_path(obs.id)),
-                class: "image_observation_link"),
-        link_to(:show_object.t(type: :name),
-                add_query_param(name_path(obs.name.id)),
-                class: "image_name_link"),
-        link_to(:google_images.t,
-                "http://images.google.com/images?q=#{obs.name.search_name}",
-                target: "_blank", rel: "noopener", class: "image_google_link")
+        [:show_object.t(type: :observation),
+         add_query_param(permanent_observation_path(obs.id)),
+         { class: "image_observation_link" }],
+        [:show_object.t(type: :name),
+         add_query_param(name_path(obs.name.id)),
+         { class: "image_name_link" }],
+        [:google_images.t,
+         "http://images.google.com/images?q=#{obs.name.search_name}",
+         { target: "_blank", rel: "noopener", class: "image_google_link" }]
       ]
     end
 
     def eol_link(image)
       return unless (eol_url = image.eol_url)
 
-      link_to("EOL", eol_url, target: "_blank", rel: "noopener",
-                              class: "image_eol_link")
+      ["EOL", eol_url, { target: "_blank", rel: "noopener",
+                         class: "image_eol_link" }]
     end
 
     def edit_and_destroy_links(image)
       return unless check_permission(image)
 
       [
-        link_to(:edit_object.t(type: :image),
-                add_query_param(edit_image_path(image.id)),
-                class: "image_edit_link"),
-        destroy_button(name: :destroy_object.t(type: :image),
-                       target: image)
+        [:edit_object.t(type: :image),
+         add_query_param(edit_image_path(image.id)),
+         { class: "image_edit_link" }],
+        [:destroy_object.t(type: :image), image, { button: :destroy }]
       ]
     end
 
     def email_commercial_inquiry_link(image)
       return unless image.user.email_general_commercial && !image.user.no_emails
 
-      link_to(:image_show_inquiry.t,
-              add_query_param(emails_commercial_inquiry_path(image.id)),
-              class: "image_commercial_inquiry_link")
+      [:image_show_inquiry.t,
+       add_query_param(emails_commercial_inquiry_path(image.id)),
+       { class: "commercial_inquiry_link" }]
     end
   end
 end

--- a/app/helpers/tabs/locations/descriptions_helper.rb
+++ b/app/helpers/tabs/locations/descriptions_helper.rb
@@ -16,18 +16,12 @@ module Tabs
       end
 
       def location_description_form_new_links(description:)
-        [
-          [:cancel_and_show.t(type: :location),
-           add_query_param(description.location.show_link_args),
-           { class: "location_return_link" }]
-        ]
+        [location_return_link(description)]
       end
 
       def location_description_form_edit_links(description:)
         [
-          [:show_object.t(type: :location),
-           add_query_param(description.location.show_link_args),
-           { class: "location_return_link" }],
+          location_return_link(description),
           [:cancel_and_show.t(type: :location_description),
            add_query_param(description.show_link_args),
            { class: "location_description_return_link" }]
@@ -36,9 +30,7 @@ module Tabs
 
       def location_description_form_permissions_links(description:)
         [
-          [:show_object.t(type: :location),
-           add_query_param(location_path(description.location_id)),
-           { class: "location_return_link" }],
+          location_return_link(description),
           [:show_object.t(type: :location_description),
            add_query_param(location_description_path(description.id)),
            { class: "location_description_return_link" }]
@@ -51,6 +43,12 @@ module Tabs
            add_query_param(location_description_path(description.id)),
            { class: "location_description_return_link" }]
         ]
+      end
+
+      def location_return_link(description)
+        [:cancel_and_show.t(type: :location),
+         add_query_param(location_path(description.location_id)),
+         { class: "location_return_link" }]
       end
     end
   end

--- a/app/helpers/tabs/locations/descriptions_helper.rb
+++ b/app/helpers/tabs/locations/descriptions_helper.rb
@@ -16,12 +16,12 @@ module Tabs
       end
 
       def location_description_form_new_links(description:)
-        [location_return_link(description)]
+        [description_location_return_link(description)]
       end
 
       def location_description_form_edit_links(description:)
         [
-          location_return_link(description),
+          description_location_return_link(description),
           [:cancel_and_show.t(type: :location_description),
            add_query_param(description.show_link_args),
            { class: "location_description_return_link" }]
@@ -30,7 +30,7 @@ module Tabs
 
       def location_description_form_permissions_links(description:)
         [
-          location_return_link(description),
+          description_location_return_link(description),
           [:show_object.t(type: :location_description),
            add_query_param(location_description_path(description.id)),
            { class: "location_description_return_link" }]
@@ -45,7 +45,7 @@ module Tabs
         ]
       end
 
-      def location_return_link(description)
+      def description_location_return_link(description)
         [:cancel_and_show.t(type: :location),
          add_query_param(location_path(description.location_id)),
          { class: "location_return_link" }]

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -20,30 +20,28 @@ module Tabs
     end
 
     # Composed links because there's interest_icons
-    def location_show_tabs(location:)
-      tabs = [
-        link_to(show_obs_link_title_with_count(location),
-                add_query_param(observations_path(location: location.id)),
-                class: "location_observations_link"),
-        link_to(:all_objects.t(type: :location), locations_path,
-                class: "locations_index_link"),
-        link_to(:show_location_create.t, add_query_param(new_location_path),
-                class: "new_location_link"),
-        link_to(:show_location_edit.t,
-                add_query_param(edit_location_path(location.id)),
-                class: "edit_location_link")
+    def location_show_links(location:)
+      links = [
+        [show_obs_link_title_with_count(location),
+         add_query_param(observations_path(location: location.id)),
+         { class: "location_observations_link" }],
+        [:all_objects.t(type: :location), locations_path,
+         { class: "locations_index_link" }],
+        [:show_location_create.t, add_query_param(new_location_path),
+         { class: "new_location_link" }],
+        [:show_location_edit.t,
+         add_query_param(edit_location_path(location.id)),
+         { class: "edit_location_link" }]
       ]
       if in_admin_mode?
-        tabs += [
-          destroy_button(name: :show_location_destroy.t, target: location),
-          link_to(
-            :show_location_reverse.t,
-            add_query_param(location_reverse_name_order_path(location.id)),
-            class: "location_reverse_order_link"
-          )
+        links += [
+          [:show_location_destroy.t, location, { button: :destroy }],
+          [:show_location_reverse.t,
+           add_query_param(location_reverse_name_order_path(location.id)),
+           { class: "location_reverse_order_link" }]
         ]
       end
-      tabs
+      links
     end
 
     def location_version_links(location:)

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -7,11 +7,11 @@ module Tabs
     def locations_index_links(query:)
       [
         [:show_location_create.t, add_query_param(new_location_path),
-         { id: "new_location_link" }],
+         { class: "new_location_link" }],
         [:list_place_names_map.t, add_query_param(map_locations_path),
-         { id: "map_locations_link" }],
+         { class: "map_locations_link" }],
         [:list_countries.t, location_countries_path,
-         { id: "location_countries_link" }],
+         { class: "location_countries_link" }],
         # Add "show observations" link if this query can be coerced into an
         # observation query. (coerced_query_link returns array)
         [*coerced_query_link(query, Observation),
@@ -22,18 +22,25 @@ module Tabs
     # Composed links because there's interest_icons
     def location_show_tabs(location:)
       tabs = [
-        link_with_query(show_obs_link_title_with_count(location),
-                        observations_path(location: location.id)),
-        link_to(:all_objects.t(type: :location), locations_path),
-        link_with_query(:show_location_create.t, new_location_path),
-        link_with_query(:show_location_edit.t,
-                        edit_location_path(location.id))
+        link_to(show_obs_link_title_with_count(location),
+                add_query_param(observations_path(location: location.id)),
+                class: "location_observations_link"),
+        link_to(:all_objects.t(type: :location), locations_path,
+                class: "locations_index_link"),
+        link_to(:show_location_create.t, add_query_param(new_location_path),
+                class: "new_location_link"),
+        link_to(:show_location_edit.t,
+                add_query_param(edit_location_path(location.id)),
+                class: "edit_location_link")
       ]
       if in_admin_mode?
         tabs += [
           destroy_button(name: :show_location_destroy.t, target: location),
-          link_with_query(:show_location_reverse.t,
-                          location_reverse_name_order_path(location.id))
+          link_to(
+            :show_location_reverse.t,
+            add_query_param(location_reverse_name_order_path(location.id)),
+            class: "location_reverse_order_link"
+          )
         ]
       end
       tabs
@@ -77,7 +84,7 @@ module Tabs
         locations_index_link,
         [:cancel_and_show.t(type: :location),
          add_query_param(location.show_link_args),
-         { id: "location_link" }]
+         { class: "location_link" }]
       ]
       tabs += location_search_links(location.name)
       tabs
@@ -85,7 +92,7 @@ module Tabs
 
     def locations_index_link
       [:all_objects.t(type: :location), locations_path,
-       { id: "locations_index_link" }]
+       { class: "locations_index_link" }]
     end
 
     # Dictionary of urls for searches on external sites

--- a/app/helpers/tabs/names/descriptions_helper.rb
+++ b/app/helpers/tabs/names/descriptions_helper.rb
@@ -9,7 +9,7 @@ module Tabs
       end
 
       def name_description_form_new_links(description:)
-        [name_return_link(description)]
+        [description_name_return_link(description)]
       end
 
       def name_description_form_edit_links(description:, user:)
@@ -31,7 +31,7 @@ module Tabs
 
       def name_description_form_permissions_links(description:)
         [
-          name_return_link(description),
+          description_name_return_link(description),
           [:show_object.t(type: :name_description),
            add_query_param(name_description_path(description.id)),
            { class: "name_description_return_link" }]
@@ -44,7 +44,7 @@ module Tabs
           { class: "name_description_return_link" }]]
       end
 
-      def name_return_link(description)
+      def description_name_return_link(description)
         [:cancel_and_show.t(type: :name),
          add_query_param(name_path(description.name_id)),
          { class: "name_return_link" }]

--- a/app/helpers/tabs/names/descriptions_helper.rb
+++ b/app/helpers/tabs/names/descriptions_helper.rb
@@ -5,17 +5,11 @@ module Tabs
   module Names
     module DescriptionsHelper
       def name_description_index_links(query:)
-        [
-          [*coerced_query_link(query, Name), { class: "name_query_link" }]
-        ]
+        [[*coerced_query_link(query, Name), { class: "name_query_link" }]]
       end
 
       def name_description_form_new_links(description:)
-        [
-          [:cancel_and_show.t(type: :name),
-           add_query_param(name_path(description.name_id)),
-           { class: "name_return_link" }]
-        ]
+        [name_return_link(description)]
       end
 
       def name_description_form_edit_links(description:, user:)
@@ -37,9 +31,7 @@ module Tabs
 
       def name_description_form_permissions_links(description:)
         [
-          [:show_object.t(type: :name),
-           add_query_param(name_path(description.name_id)),
-           { class: "name_return_link" }],
+          name_return_link(description),
           [:show_object.t(type: :name_description),
            add_query_param(name_description_path(description.id)),
            { class: "name_description_return_link" }]
@@ -47,11 +39,15 @@ module Tabs
       end
 
       def name_description_version_links(description:, desc_title:)
-        [
-          [:show_name_description.t(description: desc_title),
-           add_query_param(name_description_path(description.id)),
-           { class: "name_description_return_link" }]
-        ]
+        [[:show_name_description.t(description: desc_title),
+          add_query_param(name_description_path(description.id)),
+          { class: "name_description_return_link" }]]
+      end
+
+      def name_return_link(description)
+        [:cancel_and_show.t(type: :name),
+         add_query_param(name_path(description.name_id)),
+         { class: "name_return_link" }]
       end
     end
   end

--- a/app/helpers/tabs/observations/images_helper.rb
+++ b/app/helpers/tabs/observations/images_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# html used in tabsets
-module Tabs
-  module Observations
-    module ImagesHelper
-    end
-  end
-end

--- a/app/helpers/tabs/observations/images_helper.rb
+++ b/app/helpers/tabs/observations/images_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# html used in tabsets
+module Tabs
+  module Observations
+    module ImagesHelper
+    end
+  end
+end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -76,12 +76,13 @@ module Tabs
     # INDEX
 
     def index_observation_links(query:)
-      links = []
-      links += at_where_links(query) # maybe multiple links
-      links << index_map_link(query)
-      links += coerced_query_links(query) # multiple links
-      links << add_to_list_link(query)
-      links << download_as_csv_link(query)
+      links = [
+        *at_where_links(query), # maybe multiple links
+        index_map_link(query),
+        *coerced_query_links(query), # multiple links
+        add_to_list_link(query),
+        download_as_csv_link(query)
+      ]
       links.reject(&:empty?)
     end
 
@@ -141,20 +142,12 @@ module Tabs
     # FORMS
 
     def new_observation_links
-      [
-        [:create_herbarium.t, add_query_param(new_herbarium_path),
-         { class: "new_herbarium_link" }]
-      ]
+      [[:create_herbarium.t, add_query_param(new_herbarium_path),
+        { class: "new_herbarium_link" }]]
     end
 
     def edit_observation_links(observation:)
       [observation_return_link(observation)]
-    end
-
-    def observation_return_link(observation)
-      [:cancel_and_show.t(type: :observation),
-       add_query_param(observation.show_link_args),
-       { class: "observation_return_link" }]
     end
 
     def observation_maps_links(query:)
@@ -180,6 +173,45 @@ module Tabs
 
     def observation_list_links(observation:)
       [observation_return_link(observation)]
+    end
+
+    def observation_images_edit_links(image:)
+      [[:cancel_and_show.t(type: :image),
+        add_query_param(image.show_link_args),
+        { class: "image_return_link" }]]
+    end
+
+    def observation_images_new_links(obs:)
+      [
+        observation_return_link(obs),
+        edit_observation_link(obs)
+      ]
+    end
+
+    def observation_images_remove_links(obj:)
+      [
+        observation_return_link(obs),
+        edit_observation_link(obs)
+      ]
+    end
+
+    def observation_images_reuse_links(obs:)
+      [
+        observation_return_link(obs),
+        edit_observation_link(obs)
+      ]
+    end
+
+    def observation_return_link(obs)
+      [:cancel_and_show.t(type: :observation),
+       add_query_param(obs.show_link_args),
+       { class: "observation_return_link" }]
+    end
+
+    def edit_observation_link(obs)
+      [:edit_object.t(type: Observation),
+       add_query_param(edit_observation_path(obs.id)),
+       { class: "edit_observation_link" }]
     end
   end
 end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -146,8 +146,8 @@ module Tabs
         { class: "new_herbarium_link" }]]
     end
 
-    def edit_observation_links(observation:)
-      [observation_return_link(observation)]
+    def edit_observation_links(obs:)
+      [observation_return_link(obs)]
     end
 
     def observation_maps_links(query:)
@@ -159,20 +159,20 @@ module Tabs
       ]
     end
 
-    def new_naming_links(observation:)
-      [observation_return_link(observation)]
+    def new_naming_links(obs:)
+      [observation_return_link(obs)]
     end
 
-    def edit_naming_links(observation:)
-      [observation_return_link(observation)]
+    def edit_naming_links(obs:)
+      [observation_return_link(obs)]
     end
 
-    def naming_suggestion_links(observation:)
-      [observation_return_link(observation)]
+    def naming_suggestion_links(obs:)
+      [observation_return_link(obs)]
     end
 
-    def observation_list_links(observation:)
-      [observation_return_link(observation)]
+    def observation_list_links(obs:)
+      [observation_return_link(obs)]
     end
 
     def observation_images_edit_links(image:)
@@ -188,10 +188,11 @@ module Tabs
       ]
     end
 
+    # Note this takes `obj:` not `obs:`
     def observation_images_remove_links(obj:)
       [
-        observation_return_link(obs),
-        edit_observation_link(obs)
+        observation_return_link(obj),
+        edit_observation_link(obj)
       ]
     end
 

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -3,18 +3,16 @@
 # html used in tabsets
 module Tabs
   module ObservationsHelper
-    # assemble HTML for "tabset" for show_observation
+    # assemble links for "tabset" for show_observation
     # actually a list of links and the interest icons
-    def show_observation_tabset(obs:, user:, mappable:)
-      tabs = [
-        show_obs_google_links_for(obs.name),
+    def show_observation_links(obs:, user:, mappable:)
+      [
+        *show_obs_google_links_for(obs.name),
         general_questions_link(obs, user),
         manage_lists_link(obs, user),
         map_link(mappable),
-        obs_change_links(obs),
-        draw_interest_icons(obs)
-      ].flatten.reject(&:empty?)
-      { pager_for: obs, right: draw_tab_set(tabs) }
+        *obs_change_links(obs)
+      ].reject(&:empty?)
     end
 
     def show_obs_google_links_for(obs_name)
@@ -24,8 +22,8 @@ module Tabs
     end
 
     def google_images_for(obs_name)
-      link_to(:google_images.t, google_images_link(obs_name),
-              class: "google_images_link")
+      [:google_images.t, google_images_link(obs_name),
+       { class: "google_images_link" }]
     end
 
     def google_images_link(obs_name)
@@ -33,44 +31,44 @@ module Tabs
     end
 
     def google_distribution_map_for(obs_name)
-      link_to(:show_name_distribution_map.t,
-              add_query_param(map_name_path(id: obs_name.id)),
-              class: "google_name_distribution_map_link")
+      [:show_name_distribution_map.t,
+       add_query_param(map_name_path(id: obs_name.id)),
+       { class: "google_name_distribution_map_link" }]
     end
 
     def general_questions_link(obs, user)
       return if obs.user.no_emails
       return unless obs.user.email_general_question && obs.user != user
 
-      link_to(:show_observation_send_question.t,
-              add_query_param(new_question_for_observation_path(obs.id)),
-              remote: true, onclick: "MOEvents.whirly();",
-              class: "send_observer_question_link")
+      [:show_observation_send_question.t,
+       add_query_param(new_question_for_observation_path(obs.id)),
+       { remote: true, onclick: "MOEvents.whirly();",
+         class: "send_observer_question_link" }]
     end
 
     def manage_lists_link(obs, user)
       return unless user
 
-      link_to(:show_observation_manage_species_lists.t,
-              add_query_param(edit_observation_species_lists_path(obs.id)),
-              class: "manage_lists_link")
+      [:show_observation_manage_species_lists.t,
+       add_query_param(edit_observation_species_lists_path(obs.id)),
+       { class: "manage_lists_link" }]
     end
 
     def map_link(mappable)
       return unless mappable
 
-      link_to(:MAP.t, add_query_param(map_locations_path),
-              class: "map_locations_link")
+      [:MAP.t, add_query_param(map_locations_path),
+       { class: "map_locations_link" }]
     end
 
     def obs_change_links(obs)
       return unless check_permission(obs)
 
       [
-        link_to(:show_observation_edit_observation.t,
-                add_query_param(edit_observation_path(obs.id)),
-                class: "edit_observation_link_#{obs.id}"),
-        destroy_button(target: obs)
+        [:show_observation_edit_observation.t,
+         add_query_param(edit_observation_path(obs.id)),
+         { class: "edit_observation_link_#{obs.id}" }],
+        [nil, obs, { button: :destroy }]
       ]
     end
 

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -78,19 +78,19 @@ module Tabs
     # INDEX
 
     def index_observation_links(query:)
-      [
-        at_where_links(query),
-        index_map_link(query),
-        coerced_query_links(query),
-        add_to_list_link(query),
-        download_as_csv_link(query)
-      ].flatten.reject(&:empty?)
+      links = []
+      links += at_where_links(query) # maybe multiple links
+      links << index_map_link(query)
+      links += coerced_query_links(query) # multiple links
+      links << add_to_list_link(query)
+      links << download_as_csv_link(query)
+      links.reject(&:empty?)
     end
 
     def at_where_links(query)
       # Add some extra links to the index user is sent to if they click on an
       # undefined location.
-      return unless query.flavor == :at_where
+      return [] unless query.flavor == :at_where
 
       [
         [:list_observations_location_define.l,

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -84,7 +84,7 @@ module Tabs
         coerced_query_links(query),
         add_to_list_link(query),
         download_as_csv_link(query)
-      ].reject(&:empty?)
+      ].flatten.reject(&:empty?)
     end
 
     def at_where_links(query)
@@ -183,6 +183,5 @@ module Tabs
     def observation_list_links(observation:)
       [observation_return_link(observation)]
     end
-
   end
 end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -24,7 +24,8 @@ module Tabs
     end
 
     def google_images_for(obs_name)
-      link_to(:google_images.t, google_images_link(obs_name))
+      link_to(:google_images.t, google_images_link(obs_name),
+              class: "google_images_link")
     end
 
     def google_images_link(obs_name)
@@ -32,95 +33,156 @@ module Tabs
     end
 
     def google_distribution_map_for(obs_name)
-      link_with_query(:show_name_distribution_map.t,
-                      map_name_path(id: obs_name.id))
+      link_to(:show_name_distribution_map.t,
+              add_query_param(map_name_path(id: obs_name.id)),
+              class: "google_name_distribution_map_link")
     end
 
     def general_questions_link(obs, user)
       return if obs.user.no_emails
       return unless obs.user.email_general_question && obs.user != user
 
-      link_with_query(:show_observation_send_question.t,
-                      new_question_for_observation_path(obs.id),
-                      remote: true, onclick: "MOEvents.whirly();")
+      link_to(:show_observation_send_question.t,
+              add_query_param(new_question_for_observation_path(obs.id)),
+              remote: true, onclick: "MOEvents.whirly();",
+              class: "send_observer_question_link")
     end
 
     def manage_lists_link(obs, user)
       return unless user
 
-      link_with_query(:show_observation_manage_species_lists.t,
-                      edit_observation_species_lists_path(obs.id))
+      link_to(:show_observation_manage_species_lists.t,
+              add_query_param(edit_observation_species_lists_path(obs.id)),
+              class: "manage_lists_link")
     end
 
     def map_link(mappable)
       return unless mappable
 
-      link_with_query(:MAP.t, map_locations_path)
+      link_to(:MAP.t, add_query_param(map_locations_path),
+              class: "map_locations_link")
     end
 
     def obs_change_links(obs)
       return unless check_permission(obs)
 
       [
-        link_with_query(:show_observation_edit_observation.t,
-                        edit_observation_path(obs.id),
-                        class: "edit_observation_link_#{obs.id}"),
+        link_to(:show_observation_edit_observation.t,
+                add_query_param(edit_observation_path(obs.id)),
+                class: "edit_observation_link_#{obs.id}"),
         destroy_button(target: obs)
       ]
     end
 
-    def index_observation_tabset(query:)
-      tabs = [
-        tabs_at_where(query),
-        index_map_tab(query),
-        coerced_query_tabs(query),
-        add_to_list_tab(query),
-        download_as_csv_tab(query)
-      ].flatten.reject(&:empty?)
-      { right: draw_tab_set(tabs) }
+    ############################################
+    # INDEX
+
+    def index_observation_links(query:)
+      [
+        at_where_links(query),
+        index_map_link(query),
+        coerced_query_links(query),
+        add_to_list_link(query),
+        download_as_csv_link(query)
+      ].reject(&:empty?)
     end
 
-    def tabs_at_where(query)
+    def at_where_links(query)
       # Add some extra links to the index user is sent to if they click on an
       # undefined location.
       return unless query.flavor == :at_where
 
       [
-        link_with_query(:list_observations_location_define.l,
-                        new_location_path(
-                          where: query.params[:user_where]
-                        )),
-        link_with_query(:list_observations_location_merge.l,
-                        location_merges_form_path(
-                          where: query.params[:user_where]
-                        )),
-        link_with_query(:list_observations_location_all.l,
-                        locations_path)
+        [:list_observations_location_define.l,
+         add_query_param(new_location_path(
+                           where: query.params[:user_where]
+                         )),
+         { class: "new_location_link" }],
+        [:list_observations_location_merge.l,
+         add_query_param(location_merges_form_path(
+                           where: query.params[:user_where]
+                         )),
+         { class: "merge_locations_link" }],
+        [:list_observations_location_all.l,
+         add_query_param(locations_path),
+         { class: "locations_index_link" }]
       ]
     end
 
-    def index_map_tab(query)
-      link_to(:show_object.t(type: :map),
-              map_observations_path(q: get_query_param(query)))
+    def index_map_link(query)
+      [:show_object.t(type: :map),
+       map_observations_path(q: get_query_param(query)),
+       { class: "map_observations_link" }]
     end
 
     # NOTE: coerced_query_link returns an array
-    def coerced_query_tabs(query)
+    def coerced_query_links(query)
       [
-        link_to(*coerced_query_link(query, Location)),
-        link_to(*coerced_query_link(query, Name)),
-        link_to(*coerced_query_link(query, Image))
+        [*coerced_query_link(query, Location),
+         { class: "location_query_link" }],
+        [*coerced_query_link(query, Name),
+         { class: "name_query_link" }],
+        [*coerced_query_link(query, Image),
+         { class: "image_query_link" }]
       ]
     end
 
-    def add_to_list_tab(query)
-      link_to(:list_observations_add_to_list.t,
-              add_query_param(edit_species_list_observations_path, query))
+    def add_to_list_link(query)
+      [:list_observations_add_to_list.t,
+       add_query_param(edit_species_list_observations_path, query),
+       { class: "add_to_list_link" }]
     end
 
-    def download_as_csv_tab(query)
-      link_to(:list_observations_download_as_csv.t,
-              add_query_param(new_observations_download_path, query))
+    def download_as_csv_link(query)
+      [:list_observations_download_as_csv.t,
+       add_query_param(new_observations_download_path, query),
+       { class: "download_as_csv_link" }]
     end
+
+    ############################################
+    # FORMS
+
+    def new_observation_links
+      [
+        [:create_herbarium.t, add_query_param(new_herbarium_path),
+         { class: "new_herbarium_link" }]
+      ]
+    end
+
+    def edit_observation_links(observation:)
+      [observation_return_link(observation)]
+    end
+
+    def observation_return_link(observation)
+      [:cancel_and_show.t(type: :observation),
+       add_query_param(observation.show_link_args),
+       { class: "observation_return_link" }]
+    end
+
+    def observation_maps_links(query:)
+      [
+        [*coerced_query_link(query, Observation),
+         { class: "observation_query_link" }],
+        [*coerced_query_link(query, Location),
+         { class: "location_query_link" }]
+      ]
+    end
+
+    def new_naming_links(observation:)
+      [observation_return_link(observation)]
+    end
+
+    def edit_naming_links(observation:)
+      [observation_return_link(observation)]
+    end
+
+    def naming_suggestion_links(observation:)
+      [observation_return_link(observation)]
+    end
+
+    def observation_list_links(observation:)
+      [observation_return_link(observation)]
+    end
+
   end
 end

--- a/app/helpers/tabs/rss_logs_helper.rb
+++ b/app/helpers/tabs/rss_logs_helper.rb
@@ -5,13 +5,13 @@
 module Tabs
   module RssLogsHelper
     # TABSET
-    def rss_logs_index_tabset(user, types)
+    def rss_logs_index_links(user:, types:)
       [
-        default_rss_types_for_user_tab(user, types)
+        default_rss_types_for_user_link(user, types)
       ]
     end
 
-    def default_rss_types_for_user_tab(user, types)
+    def default_rss_types_for_user_link(user, types)
       return unless params[:make_default] != "1"
 
       return unless user&.default_rss_type.to_s.split.sort != types

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -14,7 +14,7 @@ module TitleAndTabsetHelper
   # contents of the <title> in html header
   def title_tag_contents(title:, action_name:)
     if title.present?
-      title.strip_html
+      title.strip_html.unescape_html # removes tags and special chars
     elsif TranslationString.where(tag: "title_for_#{action_name}").present?
       :"title_for_#{action_name}".t
     else

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -66,17 +66,18 @@ module TitleAndTabsetHelper
     return [] unless links
 
     links.compact.map do |str, url, args|
+      kwargs = args.except(:button, :target)
       case args[:button]
       when :destroy
-        destroy_button(name: str, target: url, **args)
+        destroy_button(name: str, target: args[:target] || url, **kwargs)
       when :post
-        post_button(name: str, path: url, **args)
+        post_button(name: str, path: url, **kwargs)
       when :put
-        put_button(name: str, path: url, **args)
+        put_button(name: str, path: url, **kwargs)
       when :patch
-        patch_button(name: str, path: url, **args)
+        patch_button(name: str, path: url, **kwargs)
       else
-        link_to(str, url, args)
+        link_to(str, url, kwargs)
       end
     end
   end

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -52,16 +52,17 @@ module TitleAndTabsetHelper
     link_with_query("« #{:BACK.t}", path)
   end
 
-  # Convert @links in index views into a list of HTML links for RHS tab set.
-  # Obsolete - does not handle CRUD button_to. Switch to create_tabs
-  def create_links(links)
-    return [] unless links
-
-    links.compact.map { |str, url, args| link_to(str, url, args) }
-  end
-
   # Convert an array (of arrays) of link attributes into an array of HTML tabs
   # that may be either links or CRUD button_to's, for RHS tab set
+  # Example
+  # links = [
+  #   ["text", "url", { class: "edit_form_link" }],
+  #   [nil, article, { button: :destroy }]
+  # ]
+  # create_tabs(links) will make an array of the following HTML
+  #   "<a href="url" class="edit_form_link">text</a>",
+  #   "(an HTML form)" via destroy_button, gives default button text and class
+  #
   def create_tabs(links)
     return [] unless links
 

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -12,9 +12,9 @@
 
 module TitleAndTabsetHelper
   # contents of the <title> in html header
-  def title_tag_contents(action_name)
-    if @title.present?
-      @title.strip_html.html_safe
+  def title_tag_contents(title:, action_name:)
+    if title.present?
+      title.strip_html
     elsif TranslationString.where(tag: "title_for_#{action_name}").present?
       :"title_for_#{action_name}".t
     else

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -24,30 +24,20 @@ module TitleAndTabsetHelper
 
   # link to next object in query results
   def link_next(object)
-    path = if object.class.controller_normalized?
-             if object.type_tag == :rss_log
-               send(:activity_log_path, object.id, flow: "next")
-             else
-               send("#{object.type_tag}_path", object.id, flow: "next")
-             end
+    path = if object.type_tag == :rss_log
+             send(:activity_log_path, object.id, flow: "next")
            else
-             { controller: object.show_controller,
-               action: :show, id: object.id }
+             send("#{object.type_tag}_path", object.id, flow: "next")
            end
     link_with_query("#{:FORWARD.t} »", path)
   end
 
   # link to previous object in query results
   def link_prev(object)
-    path = if object.class.controller_normalized?
-             if object.type_tag == :rss_log
-               send(:activity_log_path, object.id, flow: "prev")
-             else
-               send("#{object.type_tag}_path", object.id, flow: "prev")
-             end
+    path = if object.type_tag == :rss_log
+             send(:activity_log_path, object.id, flow: "prev")
            else
-             { controller: object.show_controller,
-               action: :show, id: object.id }
+             send("#{object.type_tag}_path", object.id, flow: "prev")
            end
     link_with_query("« #{:BACK.t}", path)
   end

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -67,7 +67,7 @@ module TitleAndTabsetHelper
     return [] unless links
 
     links.compact.map do |str, url, args|
-      kwargs = args.except(:button, :target)
+      kwargs = args&.except(:button, :target)
       case args[:button]
       when :destroy
         destroy_button(name: str, target: args[:target] || url, **kwargs)

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -67,6 +67,7 @@ module TitleAndTabsetHelper
     return [] unless links
 
     links.compact.map do |str, url, args|
+      args ||= {}
       kwargs = args&.except(:button, :target)
       case args[:button]
       when :destroy

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# --------- contextual nav ------------------------------------------------
+#  --- links and buttons ----
+#
+#  title_tag_contents           # text to put in html header <title>
+#  link_next                    # link to next object
+#  link_prev                    # link to prev object
+#  create_links                 # convert links into list of tabs
+#  draw_tab_set
+#
+
+module TitleAndTabsetHelper
+  # contents of the <title> in html header
+  def title_tag_contents(action_name)
+    if @title.present?
+      @title.strip_html.html_safe
+    elsif TranslationString.where(tag: "title_for_#{action_name}").present?
+      :"title_for_#{action_name}".t
+    else
+      action_name.tr("_", " ").titleize
+    end
+  end
+
+  # link to next object in query results
+  def link_next(object)
+    path = if object.class.controller_normalized?
+             if object.type_tag == :rss_log
+               send(:activity_log_path, object.id, flow: "next")
+             else
+               send("#{object.type_tag}_path", object.id, flow: "next")
+             end
+           else
+             { controller: object.show_controller,
+               action: :show, id: object.id }
+           end
+    link_with_query("#{:FORWARD.t} »", path)
+  end
+
+  # link to previous object in query results
+  def link_prev(object)
+    path = if object.class.controller_normalized?
+             if object.type_tag == :rss_log
+               send(:activity_log_path, object.id, flow: "prev")
+             else
+               send("#{object.type_tag}_path", object.id, flow: "prev")
+             end
+           else
+             { controller: object.show_controller,
+               action: :show, id: object.id }
+           end
+    link_with_query("« #{:BACK.t}", path)
+  end
+
+  # Convert @links in index views into a list of HTML links for RHS tab set.
+  # Obsolete - does not handle CRUD button_to. Switch to create_tabs
+  def create_links(links)
+    return [] unless links
+
+    links.compact.map { |str, url, args| link_to(str, url, args) }
+  end
+
+  # Convert an array (of arrays) of link attributes into an array of HTML tabs
+  # that may be either links or CRUD button_to's, for RHS tab set
+  def create_tabs(links)
+    return [] unless links
+
+    links.compact.map do |str, url, args|
+      case args[:button]
+      when :destroy
+        destroy_button(name: str, target: url, **args)
+      when :post
+        post_button(name: str, path: url, **args)
+      when :put
+        put_button(name: str, path: url, **args)
+      when :patch
+        patch_button(name: str, path: url, **args)
+      else
+        link_to(str, url, args)
+      end
+    end
+  end
+
+  # Short-hand to render shared tab_set partial for a given set of links.
+  def draw_tab_set(links)
+    render(partial: "layouts/content/tab_set", locals: { links: links })
+  end
+
+  def index_sorter(sorts)
+    return "" unless sorts
+
+    render(partial: "layouts/content/sorter", locals: { sorts: sorts })
+  end
+end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 @title = edit_title(@article)
-tabs = create_links(article_form_edit_links(article: @article))
+tabs = create_tabs(article_form_edit_links(article: @article))
 @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,6 +1,6 @@
 <%
   @title ||= :ARTICLES.t
-  tabs = create_links(index_links_for_user(user: @user))
+  tabs = create_tabs(articles_index_links(user: @user))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,6 +1,6 @@
 <%
 @title = :create_article_title.l
-tabs = create_links(article_form_new_links)
+tabs = create_tabs(article_form_new_links)
 @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,6 +1,6 @@
 <%
   @title = show_title(@article)
-  tabs = show_tabs_for_user(article: @article, user: @user)
+  tabs = create_tabs(article_show_links(article: @article, user: @user))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 %>

--- a/app/views/collection_numbers/index.html.erb
+++ b/app/views/collection_numbers/index.html.erb
@@ -1,7 +1,7 @@
 <%
   @title ||= :list_collection_numbers_title.t
 
-  tabs = create_links(@links)
+  tabs = create_tabs(@links)
   @tabsets = { right: draw_tab_set(tabs) }
 
   flash_error(@error) if @error && @objects.empty?

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -3,7 +3,7 @@
 # comments for a particular object is in the partial "comments_for_object"
 
 if @links.any?
-  tabs = create_links(@links)
+  tabs = create_tabs(@links)
   @tabsets = { right: draw_tab_set(tabs) }
 end
 @container = :text_image

--- a/app/views/herbaria/curator_requests/new.html.erb
+++ b/app/views/herbaria/curator_requests/new.html.erb
@@ -2,12 +2,7 @@
 <%
   @title = :show_herbarium_curator_request.t
 
-  tabs = [
-    link_with_query(
-      :cancel_and_show.t(type: :herbarium), herbarium_path(@herbarium)
-    ),
-    link_with_query(:herbarium_index.t, herbaria_path(flavor: :nonpersonal))
-  ]
+  tabs = create_tabs(herbaria_curator_request_links(herbarium: @herbarium))
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/herbaria/edit.html.erb
+++ b/app/views/herbaria/edit.html.erb
@@ -1,7 +1,7 @@
 <%
   @title = :edit_herbarium_title.l
 
-  tabs = create_links(herbarium_form_edit_links(herbarium: @herbarium))
+  tabs = create_tabs(herbarium_form_edit_links(herbarium: @herbarium))
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -1,7 +1,7 @@
 <%
   @title ||= :list_herbaria_title.t
 
-  links = create_links(herbaria_index_links(query: @query))
+  links = create_tabs(herbaria_index_links(query: @query))
   @tabsets = { right: draw_tab_set(links) }
   @container = :wide
 

--- a/app/views/herbaria/new.html.erb
+++ b/app/views/herbaria/new.html.erb
@@ -2,7 +2,7 @@
 <%
   @title = :create_herbarium_title.l
 
-  tabs = create_links(herbarium_form_new_links)
+  tabs = create_tabs(herbarium_form_new_links)
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/herbaria/show.html.erb
+++ b/app/views/herbaria/show.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = @herbarium.format_name.t
 
-tabs = herbarium_show_tabs(herbarium: @herbarium, user: @user)
+tabs = create_tabs(herbarium_show_links(herbarium: @herbarium, user: @user))
 @tabsets = { pager_for: @herbarium, right: draw_tab_set(tabs) }
 
 map = @herbarium.location ? true : false

--- a/app/views/herbarium_records/edit.html.erb
+++ b/app/views/herbarium_records/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 links = herbarium_record_form_edit_links(back: @back, back_object: @back_object)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :wide
 %>

--- a/app/views/herbarium_records/index.html.erb
+++ b/app/views/herbarium_records/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @title ||= :list_herbarium_records_title.t
 
-tabs = create_links(herbarium_record_index_links)
+tabs = create_tabs(herbarium_record_index_links)
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :wide
 

--- a/app/views/herbarium_records/new.html.erb
+++ b/app/views/herbarium_records/new.html.erb
@@ -1,5 +1,5 @@
 <%
-tabs = create_links(herbarium_record_form_new_links(observation: @observation))
+tabs = create_tabs(herbarium_record_form_new_links(observation: @observation))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :full
 %>

--- a/app/views/herbarium_records/show.html.erb
+++ b/app/views/herbarium_records/show.html.erb
@@ -2,7 +2,8 @@
 @title = :HERBARIUM_RECORD.t + " '".html_safe +
          @herbarium_record.format_name.t + "'".html_safe
 
-tabs = herbarium_record_show_tabs(herbarium_record: @herbarium_record)
+links = herbarium_record_show_links(herbarium_record: @herbarium_record)
+tabs = create_tabs(links)
 @tabsets = { pager_for: @herbarium_record, right: draw_tab_set(tabs) }
 
 herbarium = @herbarium_record.herbarium

--- a/app/views/images/exif/show.html.erb
+++ b/app/views/images/exif/show.html.erb
@@ -1,6 +1,6 @@
 <%
 @title = :exif_data_for_image.t(image: @image.id)
-tabs = create_links(images_exif_show_links(image: @image))
+tabs = create_tabs(images_exif_show_links(image: @image))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text
 %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,5 +1,5 @@
 <%
-tabs = create_links(images_index_links(query: @query))
+tabs = create_tabs(images_index_links(query: @query))
 if tabs.any?
   @tabsets = { right: draw_tab_set(tabs) }
 end

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,6 +1,6 @@
 <%
 @title = :image_show_title.t(name: @image.unique_format_name)
-tabs = show_image_tabset(image: @image)
+tabs = create_tabs(show_image_links(image: @image))
 @tabsets = { pager_for: @image, right: draw_tab_set(tabs) }
 @container = :wide
 %>

--- a/app/views/layouts/app/_head.html.erb
+++ b/app/views/layouts/app/_head.html.erb
@@ -14,7 +14,7 @@
 <%= auto_discovery_link_tag(
   :rss, activity_logs_rss_path, { title: :app_rss.l }
 ) %>
-<title><%= :app_title.l%>: <%= title_tag_contents(controller.action_name)%></title>
+<title><%= :app_title.l%>: <%= title_tag_contents(title: @title, action_name: controller.action_name)%></title>
 <link rel="SHORTCUT ICON" href="/favicon.ico?20220116"/>
 <% if @canonical_url %>
 <link href="<%= escape_once(@canonical_url) %>" rel="canonical"/>

--- a/app/views/locations/countries/index.html.erb
+++ b/app/views/locations/countries/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :list_countries_title.t
 
-tabs = create_links(location_countries_links)
+tabs = create_tabs(location_countries_links)
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :wide
 %>

--- a/app/views/locations/descriptions/edit.html.erb
+++ b/app/views/locations/descriptions/edit.html.erb
@@ -2,7 +2,7 @@
 @title ||= :edit_location_description_title.t(name: @description.format_name)
 
 links = location_description_form_edit_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/locations/descriptions/index.html.erb
+++ b/app/views/locations/descriptions/index.html.erb
@@ -1,5 +1,5 @@
 <%
-tabs = create_links(location_description_index_links(query: @query))
+tabs = create_tabs(location_description_index_links(query: @query))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :wide
 

--- a/app/views/locations/descriptions/merges/new.html.erb
+++ b/app/views/locations/descriptions/merges/new.html.erb
@@ -2,7 +2,7 @@
 @title ||= :merge_descriptions_title.t(object: @description.format_name)
 
 links = location_description_form_permissions_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names/descriptions/merges", action: :create,
             id: @description.id, q: get_query_param }

--- a/app/views/locations/descriptions/moves/new.html.erb
+++ b/app/views/locations/descriptions/moves/new.html.erb
@@ -2,7 +2,7 @@
 @title ||= :merge_descriptions_title.t(object: @description.format_name)
 
 links = location_description_form_permissions_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names/descriptions/moves", action: :create,
             id: @description.id, q: get_query_param }

--- a/app/views/locations/descriptions/new.html.erb
+++ b/app/views/locations/descriptions/new.html.erb
@@ -2,7 +2,7 @@
 @title ||= :create_location_description_title.t(name: @location.display_name)
 
 links = location_description_form_new_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/locations/descriptions/permissions/edit.html.erb
+++ b/app/views/locations/descriptions/permissions/edit.html.erb
@@ -2,7 +2,7 @@
 @title ||= @description.format_name.t
 
 links = location_description_form_permissions_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/locations/descriptions/permissions", action: :update,
             id: @description.id, q: get_query_param }

--- a/app/views/locations/descriptions/show.html.erb
+++ b/app/views/locations/descriptions/show.html.erb
@@ -1,7 +1,8 @@
 <%
 @title ||= @description.format_name.t
 
-@tabsets = show_description_tabset(description: @description, pager: true)
+tabs = create_tabs(show_description_links(description: @description))
+tabsets = { right: draw_tab_set(tabs), pager_for: @description }
 @container = :wide
 %>
 

--- a/app/views/locations/descriptions/versions/show.html.erb
+++ b/app/views/locations/descriptions/versions/show.html.erb
@@ -8,7 +8,7 @@ desc_title = description_title(@description)
 
 links = location_description_version_links(description: @description,
                                            desc_title: desc_title)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -1,7 +1,7 @@
 <%
   @title ||= :edit_location_title.t(name: @location.display_name)
 
-  tabs = create_links(location_form_edit_links(location: @location))
+  tabs = create_tabs(location_form_edit_links(location: @location))
   @tabsets = {
     pager_for: @image,
     right: draw_tab_set(tabs),

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,5 +1,5 @@
 <%
-  links = create_links(locations_index_links(query: @query))
+  links = create_tabs(locations_index_links(query: @query))
   @tabsets = { right: draw_tab_set(links) }
   @container = :wide
 

--- a/app/views/locations/maps/show.html.erb
+++ b/app/views/locations/maps/show.html.erb
@@ -1,6 +1,6 @@
 <%
 links = location_map_links(query: @query)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text_image
 %>

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -1,7 +1,7 @@
 <%
   @title ||= :create_location_title.t
 
-  tabs = create_links(location_form_new_links(location: @location))
+  tabs = create_tabs(location_form_new_links(location: @location))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :full
 

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :show_location_title.t(name: @location.display_name)
 
-tabs = location_show_tabs(location: @location)
+tabs = create_tabs(location_show_links(location: @location))
 tabs << draw_interest_icons(@location)
 @tabsets = { pager_for: @location, right: draw_tab_set(tabs) }
 @container = :wide

--- a/app/views/locations/versions/show.html.erb
+++ b/app/views/locations/versions/show.html.erb
@@ -5,7 +5,7 @@
 )
 
 links = location_version_links(location: @location)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :edit_classification_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 rank = rank_as_lower_string(@name.rank)
 action = { controller: "/names/classification", action: :update,

--- a/app/views/names/classification/inherit/new.html.erb
+++ b/app/views/names/classification/inherit/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :inherit_classification_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names/classification/inherit", action: :create,
             id: @name.id, q: get_query_param }

--- a/app/views/names/descriptions/edit.html.erb
+++ b/app/views/names/descriptions/edit.html.erb
@@ -2,7 +2,7 @@
 @title ||= :edit_name_description_title.t(name: @description.format_name)
 
 links = name_description_form_edit_links(description: @description, user: @user)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 
 action = { controller: "/names/descriptions", action: :update,

--- a/app/views/names/descriptions/index.html.erb
+++ b/app/views/names/descriptions/index.html.erb
@@ -1,5 +1,5 @@
 <%
-tabs = create_links(name_description_index_links(query: @query))
+tabs = create_tabs(name_description_index_links(query: @query))
 @tabsets = { right: draw_tab_set(tabs) }
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/names/descriptions/merges/new.html.erb
+++ b/app/views/names/descriptions/merges/new.html.erb
@@ -2,7 +2,7 @@
 @title ||= :merge_descriptions_title.t(object: @description.format_name)
 
 links = name_description_form_permissions_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names/descriptions/merges", action: :create,
             id: @description.id }

--- a/app/views/names/descriptions/moves/new.html.erb
+++ b/app/views/names/descriptions/moves/new.html.erb
@@ -2,7 +2,7 @@
 @title ||= :merge_descriptions_title.t(object: @description.format_name)
 
 links = name_description_form_permissions_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names/descriptions/moves", action: :create,
             id: @description.id }

--- a/app/views/names/descriptions/new.html.erb
+++ b/app/views/names/descriptions/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @title ||= :create_name_description_title.t(name: @name.display_name)
 
-tabs = create_links(name_description_form_new_links(description: @description))
+tabs = create_tabs(name_description_form_new_links(description: @description))
 @tabsets = { right: draw_tab_set(tabs) }
 
 action = { controller: "/names/descriptions", action: :create,

--- a/app/views/names/descriptions/permissions/edit.html.erb
+++ b/app/views/names/descriptions/permissions/edit.html.erb
@@ -2,7 +2,7 @@
 @title ||= @description.format_name.t
 
 links = name_description_form_permissions_links(description: @description)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names/descriptions/permissions", action: :update,
             id: @description.id, q: get_query_param }

--- a/app/views/names/descriptions/show.html.erb
+++ b/app/views/names/descriptions/show.html.erb
@@ -1,6 +1,7 @@
 <%
 @title ||= @description.format_name.t
-@tabsets = show_description_tabset(description: @description, pager: false)
+tabs = create_tabs(show_description_links(description: @description))
+tabsets = { right: draw_tab_set(tabs) }
 @container = :wide
 %>
 

--- a/app/views/names/descriptions/versions/show.html.erb
+++ b/app/views/names/descriptions/versions/show.html.erb
@@ -8,7 +8,7 @@ desc_title = description_title(@description)
 
 links = name_description_version_links(description: @description,
                                        desc_title: desc_title)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 
 Textile.register_name(@name)

--- a/app/views/names/edit.html.erb
+++ b/app/views/names/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @title ||= :edit_name_title.t(name: @name.display_name)
 
-tabs = create_links(name_form_edit_links(name: @name))
+tabs = create_tabs(name_form_edit_links(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 action = { controller: "/names", action: :update, id: @name.id }
 %>

--- a/app/views/names/index.html.erb
+++ b/app/views/names/index.html.erb
@@ -1,6 +1,6 @@
 <%
 links = names_index_links(query: @query)
-tabs = create_links(links)
+tabs = create_tabs(links)
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :full
 

--- a/app/views/names/lifeforms/edit.html.erb
+++ b/app/views/names/lifeforms/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :edit_lifeform_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text_image
 

--- a/app/views/names/lifeforms/propagate/edit.html.erb
+++ b/app/views/names/lifeforms/propagate/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :propagate_lifeform_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text_image
 action = { controller: "/names/lifeforms/propagate", action: :update,

--- a/app/views/names/new.html.erb
+++ b/app/views/names/new.html.erb
@@ -1,6 +1,6 @@
 <%
 @title ||= :create_name_title.t
-tabs = create_links(name_form_new_links)
+tabs = create_tabs(name_form_new_links)
 @tabsets = { right: draw_tab_set(tabs) }
 action = add_query_param({ controller: "/names", action: :create })
 %>

--- a/app/views/names/show.html.erb
+++ b/app/views/names/show.html.erb
@@ -3,7 +3,7 @@
 
 Textile.register_name(@name)
 
-tabs = create_links(name_show_links(name: @name, user: @user))
+tabs = create_tabs(name_show_links(name: @name, user: @user))
 tabs << draw_interest_icons(@name)
 @tabsets = { pager_for: @name, right: draw_tab_set(tabs) }
 

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :name_approve_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 
 action = { controller: "/names/synonyms/approve", action: :create,

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :name_deprecate_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 
 action = { controller: "/names/synonyms/deprecate", action: :create,

--- a/app/views/names/synonyms/edit.html.erb
+++ b/app/views/names/synonyms/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @title = :name_change_synonyms_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text_image
 

--- a/app/views/names/trackers/edit.html.erb
+++ b/app/views/names/trackers/edit.html.erb
@@ -3,7 +3,7 @@
 
 @title = :email_tracking_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 
 action = { controller: "/names/trackers", action: :update, id: @name.id,

--- a/app/views/names/trackers/new.html.erb
+++ b/app/views/names/trackers/new.html.erb
@@ -3,7 +3,7 @@
 
 @title = :email_tracking_title.t(name: @name.display_name)
 
-tabs = create_links(name_return_link(name: @name))
+tabs = create_tabs(name_return_link(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 
 action = { controller: "/names/trackers", action: :create, id: @name.id,

--- a/app/views/names/versions/show.html.erb
+++ b/app/views/names/versions/show.html.erb
@@ -4,7 +4,7 @@
   name: @name.display_name
 )
 
-tabs = create_links(name_versions_links(name: @name))
+tabs = create_tabs(name_versions_links(name: @name))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :text
 %>

--- a/app/views/observations/edit.html.erb
+++ b/app/views/observations/edit.html.erb
@@ -1,10 +1,7 @@
 <%
   @title = :edit_observation_title.t(name: @observation.unique_format_name)
 
-  tabs = [
-    link_with_query(:cancel_and_show.t(type: :observation),
-                    @observation.show_link_args)
-  ]
+  tabs = create_links(edit_observation_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 %>

--- a/app/views/observations/edit.html.erb
+++ b/app/views/observations/edit.html.erb
@@ -1,7 +1,7 @@
 <%
   @title = :edit_observation_title.t(name: @observation.unique_format_name)
 
-  tabs = create_links(edit_observation_links(observation: @observation))
+  tabs = create_tabs(edit_observation_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 %>

--- a/app/views/observations/edit.html.erb
+++ b/app/views/observations/edit.html.erb
@@ -1,7 +1,7 @@
 <%
   @title = :edit_observation_title.t(name: @observation.unique_format_name)
 
-  tabs = create_tabs(edit_observation_links(observation: @observation))
+  tabs = create_tabs(edit_observation_links(obs: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 %>

--- a/app/views/observations/images/edit.html.erb
+++ b/app/views/observations/images/edit.html.erb
@@ -1,9 +1,7 @@
 <%
   @title = :image_edit_title.t(name: @image.unique_format_name)
 
-  tabs = [
-    link_with_query(:cancel_and_show.t(type: :image), @image.show_link_args)
-  ]
+  tabs = create_tabs(observation_images_edit_links(image: @image))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
   form_action = { controller: "/observations/images",

--- a/app/views/observations/images/new.html.erb
+++ b/app/views/observations/images/new.html.erb
@@ -1,11 +1,7 @@
 <%
   @title = :image_add_title.t(name: @observation.unique_format_name)
 
-  tabs = [
-    link_with_query(:cancel_and_show.t(type: :observation),
-                    observation_path(@observation.id)),
-    link_with_query(:image_add_edit.t, edit_observation_path(@observation.id))
-  ]
+  tabs = create_tabs(observation_images_new_links(obs: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/observations/images/remove.html.erb
+++ b/app/views/observations/images/remove.html.erb
@@ -6,10 +6,7 @@
 # Note totally general title and tabs based on @object target_class
 @title = :image_remove_title.t(name: @object.unique_format_name)
 
-tabs = [
-  link_with_query(:show_object.t(type: Observation), @object.show_link_args),
-  link_with_query(:edit_object.t(type: Observation), @object.edit_link_args)
-]
+tabs = create_tabs(observation_images_remove_links(obj: @object))
 @tabsets = { right: draw_tab_set(tabs) }
 
 @container = :full

--- a/app/views/observations/images/reuse.html.erb
+++ b/app/views/observations/images/reuse.html.erb
@@ -3,19 +3,14 @@
 #       Observations::ImagesController#reuse
 # Partial should be in shared
 @title = :image_reuse_title.t(name: @observation.unique_format_name)
-obs_id = @observation.id
-tabs = [
-  link_with_query(:show_object.t(type: :observation),
-                  permanent_observation_path(obs_id)),
-  link_with_query(:image_reuse_edit.t,
-                  edit_observation_path(obs_id))
-]
+
+tabs = create_tabs(observation_images_reuse_links(obs: @observation))
 @tabsets = { right: draw_tab_set(tabs) }
 @container = :full
 # Use a path here:
 form_action = { controller: "/observations/images",
                 action: :attach,
-                id: obs_id,
+                id: @observation.id,
                 q: get_query_param }
 %>
 

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,7 +1,7 @@
 <%
 if @objects.any?
   links = index_observation_links(query: @query)
-  tabs = create_links(links)
+  tabs = create_tabs(links)
   @tabsets = { right: draw_tab_set(tabs) }
 end
 

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,9 +1,13 @@
 <%
-  @tabsets = index_observation_tabset(query: @query) if @objects.any?
+if @objects.any?
+  links = index_observation_links(query: @query)
+  tabs = create_links(links)
+  @tabsets = { right: draw_tab_set(tabs) }
+end
 
-  @container = :full
+@container = :full
 
-  flash_error(@error) if @error && @objects.empty?
+flash_error(@error) if @error && @objects.empty?
 %>
 
 <% if @suggest_alternate_spellings && @objects.empty?

--- a/app/views/observations/maps/index.html.erb
+++ b/app/views/observations/maps/index.html.erb
@@ -1,5 +1,5 @@
 <%
-  tabs = create_links(observation_maps_links(query: @query))
+  tabs = create_tabs(observation_maps_links(query: @query))
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/observations/maps/index.html.erb
+++ b/app/views/observations/maps/index.html.erb
@@ -1,8 +1,5 @@
 <%
-  tabs = [
-    link_to_coerced_query(@query, Observation),
-    link_to_coerced_query(@query, Location)
-  ]
+  tabs = create_link(observation_maps_links(query: @query))
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/observations/maps/index.html.erb
+++ b/app/views/observations/maps/index.html.erb
@@ -1,5 +1,5 @@
 <%
-  tabs = create_link(observation_maps_links(query: @query))
+  tabs = create_links(observation_maps_links(query: @query))
   @tabsets = { right: draw_tab_set(tabs) }
 %>
 

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -1,5 +1,5 @@
 <%
-  tabs = create_tabs(edit_naming_links(observation: @observation))
+  tabs = create_tabs(edit_naming_links(obs: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -1,5 +1,5 @@
 <%
-  tabs = create_links(edit_naming_links(observation: @observation))
+  tabs = create_tabs(edit_naming_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -1,8 +1,5 @@
 <%
-  tabs = [
-    link_with_query(:cancel_and_show.t(type: :observation),
-                    @observation.show_link_args)
-  ]
+  tabs = create_links(edit_naming_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -1,5 +1,5 @@
 <%
-  tabs = create_tabs(new_naming_links(observation: @observation))
+  tabs = create_tabs(new_naming_links(obs: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -1,8 +1,5 @@
 <%
-  tabs = [
-    link_with_query(:cancel_and_show.t(type: :observation),
-                    @observation.show_link_args)
-  ]
+  tabs = create_links(new_naming_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -1,5 +1,5 @@
 <%
-  tabs = create_links(new_naming_links(observation: @observation))
+  tabs = create_tabs(new_naming_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -3,10 +3,7 @@
   @title = show_obs_title(obs: @observation, owner_naming: @owner_naming)
   num_images = @observation.images.length
 
-  tabs = [
-    link_with_query(:show_object.t(type: :observation),
-                    observation_path(id: @observation.id))
-  ]
+  tabs = create_links(naming_suggestion_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -3,7 +3,7 @@
   @title = show_obs_title(obs: @observation, owner_naming: @owner_naming)
   num_images = @observation.images.length
 
-  tabs = create_tabs(naming_suggestion_links(observation: @observation))
+  tabs = create_tabs(naming_suggestion_links(obs: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -3,7 +3,7 @@
   @title = show_obs_title(obs: @observation, owner_naming: @owner_naming)
   num_images = @observation.images.length
 
-  tabs = create_links(naming_suggestion_links(observation: @observation))
+  tabs = create_tabs(naming_suggestion_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :double
 %>

--- a/app/views/observations/new.html.erb
+++ b/app/views/observations/new.html.erb
@@ -1,9 +1,7 @@
 <%
   @title = :create_observation_title.t
 
-  tabs = [
-    link_with_query(:create_herbarium.t, new_herbarium_path)
-  ]
+  tabs = create_links(new_observation_links)
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 %>

--- a/app/views/observations/new.html.erb
+++ b/app/views/observations/new.html.erb
@@ -1,7 +1,7 @@
 <%
   @title = :create_observation_title.t
 
-  tabs = create_links(new_observation_links)
+  tabs = create_tabs(new_observation_links)
   @tabsets = { right: draw_tab_set(tabs) }
   @container = :wide
 %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -1,8 +1,12 @@
 <%
   @owner_naming = owner_naming_line(@observation) # must before show_obs_title
   @title = show_obs_title(obs: @observation, owner_naming: @owner_naming)
-  @tabsets = show_observation_tabset(obs: @observation, user: @user,
-                                     mappable: @mappable)
+
+  tabs = create_tabs(show_observation_links(obs: @observation, user: @user,
+                                            mappable: @mappable))
+  tabs << draw_interest_icons(@observation)
+  @tabsets = { pager_for: @observation, right: draw_tab_set(tabs) }
+
   @container = :double
 
   show_map   = @user ? @user.thumbnail_maps : !session[:hide_thumbnail_maps]

--- a/app/views/observations/species_lists/edit.html.erb
+++ b/app/views/observations/species_lists/edit.html.erb
@@ -2,7 +2,7 @@
 # :manage_species_lists
   @title = :species_list_manage_title.t(name: @observation.unique_format_name)
 
-  tabs = create_tabs(observation_list_links(observation: @observation))
+  tabs = create_tabs(observation_list_links(obs: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
 
   obs_lists = []

--- a/app/views/observations/species_lists/edit.html.erb
+++ b/app/views/observations/species_lists/edit.html.erb
@@ -2,9 +2,7 @@
 # :manage_species_lists
   @title = :species_list_manage_title.t(name: @observation.unique_format_name)
 
-  tabs = [
-    link_to(:cancel_and_show.t(type: :observation), @observation.show_link_args)
-  ]
+  tabs = create_links(observation_list_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
 
   obs_lists = []

--- a/app/views/observations/species_lists/edit.html.erb
+++ b/app/views/observations/species_lists/edit.html.erb
@@ -2,7 +2,7 @@
 # :manage_species_lists
   @title = :species_list_manage_title.t(name: @observation.unique_format_name)
 
-  tabs = create_links(observation_list_links(observation: @observation))
+  tabs = create_tabs(observation_list_links(observation: @observation))
   @tabsets = { right: draw_tab_set(tabs) }
 
   obs_lists = []

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -4,7 +4,7 @@
   tabs = [
     link_with_query(:list_projects_add_project.t, new_project_path)
   ]
-  tabs += create_links(@links)
+  tabs += create_tabs(@links)
   @tabsets = { right: draw_tab_set(tabs) }
 
   flash_error(@error) if @error && @objects.empty?

--- a/app/views/rss_logs/index.html.erb
+++ b/app/views/rss_logs/index.html.erb
@@ -1,6 +1,6 @@
 <%
   @title = content_tag(:span, :rss_log_title.t, class: "text-nowrap")
-  links = rss_logs_index_tabset(@user, @types)
+  links = rss_logs_index_links(user: @user, types: @types)
   @tabsets = { right: draw_tab_set(create_links(links)) }
   @full_width_tab_set = render(partial: "type_filters")
 

--- a/app/views/rss_logs/index.html.erb
+++ b/app/views/rss_logs/index.html.erb
@@ -1,7 +1,7 @@
 <%
   @title = content_tag(:span, :rss_log_title.t, class: "text-nowrap")
-  links = rss_logs_index_links(user: @user, types: @types)
-  @tabsets = { right: draw_tab_set(create_links(links)) }
+  tabs = create_tabs(rss_logs_index_links(user: @user, types: @types))
+  @tabsets = { right: draw_tab_set(tabs) }
   @full_width_tab_set = render(partial: "type_filters")
 
   @container = :full

--- a/app/views/sequences/index.html.erb
+++ b/app/views/sequences/index.html.erb
@@ -1,7 +1,7 @@
 <%
   @title ||= :SEQUENCES.t
 
-  tabs = create_links(@links)
+  tabs = create_tabs(@links)
   @tabsets = { right: draw_tab_set(tabs) }
 
   flash_error(@error) if @error && @objects.empty?

--- a/app/views/species_lists/index.html.erb
+++ b/app/views/species_lists/index.html.erb
@@ -1,6 +1,6 @@
 <%
   if @links.any?
-    tabs = create_links(@links)
+    tabs = create_tabs(@links)
     @tabsets = { right: draw_tab_set(tabs) }
   end
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1636,7 +1636,6 @@
   # images/new
   image_set_default: Set as default thumbnail
   image_add_title: Add an Image for [name]
-  image_add_edit: "[:edit_object(type=:observation)]"
   image_add_default: Default thumbnail
   image_add_image: "[:Image]"
   image_add_optional: "[:optional]"
@@ -1651,13 +1650,11 @@
   image_edit_title: "Editing Image: [name]"
 
   # observations/images/remove
-  image_remove_edit: "[:edit_object(type=:observation)]"
   image_remove_remove: Remove
   image_remove_title: Remove Images from [name]
 
   # observations/images/reuse
   image_reuse_title: Reuse Image for [name]
-  image_reuse_edit: "[:edit_object(type=:observation)]"
   image_reuse_id: Image ID
   image_reuse_reuse: Reuse
   image_reuse_id_help: Either click one of the images below, or if you know the image ID, just enter it here and click '[:image_reuse_reuse]'.
@@ -2350,7 +2347,7 @@
 
   # sequence/add_sequence
   sequence_add_title: Add [:SEQUENCE]
-  sequence_add_edit: "[:image_add_edit]"
+  sequence_add_edit: "[:edit_object(type=:observation)]"
   sequence_add_owner_id: "[:show_observation_owner_id]"
 
   # sequence/form_sequence

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -62,6 +62,32 @@ class ArticlesControllerTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  # Partly duplicates the title_and_tabset_helper_test `test_create_tabs`.
+  # But we want to test a `destroy_button` tab too.
+  # That method calls `add_query_param` and others unavailable to helper tests
+  def test_create_tabs_helper
+    article = Article.last
+    links = [[:create_article_title.t, new_article_path,
+              { class: "new_article_link" }],
+             [:EDIT.t, edit_article_path(article.id),
+              { class: "edit_article_link" }],
+             [nil, article, { button: :destroy }]]
+
+    tabs = @controller.helpers.create_tabs(links)
+
+    tab1 = @controller.helpers.link_to(
+      :create_article_title.t, new_article_path, { class: "new_article_link" }
+    )
+    tab2 = @controller.helpers.link_to(
+      :EDIT.t, edit_article_path(article.id), { class: "edit_article_link" }
+    )
+    tab3 = @controller.helpers.destroy_button(target: article)
+
+    assert_includes(tabs, tab1)
+    assert_includes(tabs, tab2)
+    assert_includes(tabs, tab3)
+  end
+
   ############ test Actions that Display forms -- (new, edit, etc.)
 
   def test_new

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -4,30 +4,6 @@ require("test_helper")
 
 # test the application-wide helpers
 class ApplicationHelperTest < ActionView::TestCase
-  def test_title_tag_contents
-    # Prove that if @title is present, <title> contents are @title
-    @title = "@title present"
-    action_name = "something_else"
-    assert_equal(@title,
-                 title_tag_contents(action_name))
-
-    # Prove that if @title is absent,
-    # and there's an en.txt label for :title_for_action_name,
-    # then <title> contents are the translation for that label
-    @title = ""
-    action_name = "user_search"
-    assert_equal("User Search",
-                 title_tag_contents(action_name))
-
-    # Prove that if @title is absent,
-    # and no en.txt label for :title_for_action_name,
-    # then <title> contents are action name humanized
-    @title = ""
-    action_name = "blah_blah"
-    assert_equal("Blah Blah",
-                 title_tag_contents(action_name))
-  end
-
   def test_add_args_to_url_two_args
     assert_equal("/abcdef?foo=bar&this=that",
                  add_args_to_url("/abcdef", foo: "bar", this: "that"))

--- a/test/helpers/title_and_tabset_helper_test.rb
+++ b/test/helpers/title_and_tabset_helper_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# test the application-wide helpers
+class TitleAndTabsetHelperTest < ActionView::TestCase
+  def test_title_tag_contents
+    # Prove that if @title is present, <title> contents are @title
+    @title = "@title present"
+    action_name = "something_else"
+    assert_equal(@title,
+                 title_tag_contents(action_name))
+
+    # Prove that if @title is absent,
+    # and there's an en.txt label for :title_for_action_name,
+    # then <title> contents are the translation for that label
+    @title = ""
+    action_name = "user_search"
+    assert_equal("User Search",
+                 title_tag_contents(action_name))
+
+    # Prove that if @title is absent,
+    # and no en.txt label for :title_for_action_name,
+    # then <title> contents are action name humanized
+    @title = ""
+    action_name = "blah_blah"
+    assert_equal("Blah Blah",
+                 title_tag_contents(action_name))
+  end
+end

--- a/test/helpers/title_and_tabset_helper_test.rb
+++ b/test/helpers/title_and_tabset_helper_test.rb
@@ -39,7 +39,9 @@ class TitleAndTabsetHelperTest < ActionView::TestCase
               { class: "new_article_link" }],
              [:EDIT.t, edit_article_path(article.id),
               { class: "edit_article_link" }],
-             ["merge", article_path(article.id), { button: :put }]]
+             ["merge", article_path(article.id), { button: :put }],
+             ["move", article_path(article.id), { button: :patch }],
+             ["celebrate", article_path(article.id), { button: :post }]]
 
     tabs = create_tabs(links)
 
@@ -50,9 +52,13 @@ class TitleAndTabsetHelperTest < ActionView::TestCase
       :EDIT.t, edit_article_path(article.id), { class: "edit_article_link" }
     )
     tab3 = put_button(name: "merge", path: article_path(article.id))
+    tab4 = patch_button(name: "move", path: article_path(article.id))
+    tab5 = post_button(name: "celebrate", path: article_path(article.id))
 
     assert_includes(tabs, tab1)
     assert_includes(tabs, tab2)
     assert_includes(tabs, tab3)
+    assert_includes(tabs, tab4)
+    assert_includes(tabs, tab5)
   end
 end

--- a/test/helpers/title_and_tabset_helper_test.rb
+++ b/test/helpers/title_and_tabset_helper_test.rb
@@ -8,26 +8,26 @@ class TitleAndTabsetHelperTest < ActionView::TestCase
 
   def test_title_tag_contents
     # Prove that if @title is present, <title> contents are @title
-    @title = "@title present"
+    title = "@title present"
     action_name = "something_else"
-    assert_equal(@title,
-                 title_tag_contents(action_name))
+    assert_equal(title,
+                 title_tag_contents(title: title, action_name: action_name))
 
     # Prove that if @title is absent,
     # and there's an en.txt label for :title_for_action_name,
     # then <title> contents are the translation for that label
-    @title = ""
+    title = ""
     action_name = "user_search"
     assert_equal("User Search",
-                 title_tag_contents(action_name))
+                 title_tag_contents(title: title, action_name: action_name))
 
     # Prove that if @title is absent,
     # and no en.txt label for :title_for_action_name,
     # then <title> contents are action name humanized
-    @title = ""
+    title = ""
     action_name = "blah_blah"
     assert_equal("Blah Blah",
-                 title_tag_contents(action_name))
+                 title_tag_contents(title: title, action_name: action_name))
   end
 
   # destroy_button tab tested in articles_controller_test

--- a/test/helpers/title_and_tabset_helper_test.rb
+++ b/test/helpers/title_and_tabset_helper_test.rb
@@ -4,6 +4,8 @@ require("test_helper")
 
 # test the application-wide helpers
 class TitleAndTabsetHelperTest < ActionView::TestCase
+  include LinkHelper
+
   def test_title_tag_contents
     # Prove that if @title is present, <title> contents are @title
     @title = "@title present"
@@ -26,5 +28,31 @@ class TitleAndTabsetHelperTest < ActionView::TestCase
     action_name = "blah_blah"
     assert_equal("Blah Blah",
                  title_tag_contents(action_name))
+  end
+
+  # destroy_button tab tested in articles_controller_test
+  # That method calls `add_query_param` and others unavailable to helper tests
+  # put_button is not used for articles, but we're just testing HTML output
+  def test_create_tabs
+    article = Article.last
+    links = [[:create_article_title.t, new_article_path,
+              { class: "new_article_link" }],
+             [:EDIT.t, edit_article_path(article.id),
+              { class: "edit_article_link" }],
+             ["merge", article_path(article.id), { button: :put }]]
+
+    tabs = create_tabs(links)
+
+    tab1 = link_to(
+      :create_article_title.t, new_article_path, { class: "new_article_link" }
+    )
+    tab2 = link_to(
+      :EDIT.t, edit_article_path(article.id), { class: "edit_article_link" }
+    )
+    tab3 = put_button(name: "merge", path: article_path(article.id))
+
+    assert_includes(tabs, tab1)
+    assert_includes(tabs, tab2)
+    assert_includes(tabs, tab3)
   end
 end

--- a/test/integration/capybara/herbarium_curator_test.rb
+++ b/test/integration/capybara/herbarium_curator_test.rb
@@ -92,7 +92,7 @@ class HerbariumCuratorTest < CapybaraIntegrationTestCase
     end
 
     assert_selector("body.herbarium_records__show")
-    click_on(id: "destroy_herbarium_record_link")
+    click_on(class: "destroy_herbarium_record_link")
 
     assert_selector("body.herbarium_records__index")
     assert_not(obs.reload.herbarium_records.include?(rec))
@@ -167,7 +167,7 @@ class HerbariumCuratorTest < CapybaraIntegrationTestCase
     obs = observations(:minimal_unknown_obs)
     login!("mary")
     visit(new_herbarium_record_path(observation_id: obs.id))
-    click_link(id: "all_nonpersonal_herbaria_link")
+    click_link(class: "nonpersonal_herbaria_index_link")
 
     assert_selector("#title", text: :query_title_nonpersonal.l)
   end
@@ -231,7 +231,7 @@ class HerbariumCuratorTest < CapybaraIntegrationTestCase
     assert_equal([], user.curated_herbaria)
     login!(user.login)
     visit(herbaria_path(flavor: :all))
-    click_link(id: "new_herbarium_link")
+    click_link(class: "new_herbarium_link")
 
     within("#herbarium_form") do
       assert_field("herbarium_name")
@@ -253,7 +253,7 @@ class HerbariumCuratorTest < CapybaraIntegrationTestCase
       "#title", text: "Mary’s Herbarium" # smart apostrophe
     )
     # Seems like these destroy links don't work with `click_button`
-    first("#delete_herbarium_link").click
+    first(".delete_herbarium_link").click
     assert_selector("#title", text: :herbarium_index.l)
   end
 

--- a/test/integration/capybara/herbarium_curator_test.rb
+++ b/test/integration/capybara/herbarium_curator_test.rb
@@ -92,7 +92,7 @@ class HerbariumCuratorTest < CapybaraIntegrationTestCase
     end
 
     assert_selector("body.herbarium_records__show")
-    click_on(class: "destroy_herbarium_record_link")
+    click_on(class: "destroy_herbarium_record_link_#{rec.id}")
 
     assert_selector("body.herbarium_records__index")
     assert_not(obs.reload.herbarium_records.include?(rec))


### PR DESCRIPTION
Refining reusable patterns for the tab helpers.

- use `class` instead of `id` for link identifiers (adjust integration tests accordingly)
- new method: `create_tabs` to replace `create_links`, handles a `button` arg 
- change as many templates as possible, to make this PR unreviewable
- increase test coverage