### PR TITLE
Fix for behavior of `section_update.js.erb`

### DIFF
--- a/app/views/observations/show/_collection_numbers.html.erb
+++ b/app/views/observations/show/_collection_numbers.html.erb
@@ -7,6 +7,7 @@
   cn_query = Query.lookup(:CollectionNumber, :all, observations: observation.id)
 %>
 
+<div class="obs-collection" id="observation_collection_numbers">
 <% unless @user.try(&:hide_specimen_stuff?) ||
           observation.user.try(&:hide_specimen_stuff?) %>
   <% if numbers.any? && can_edit %>
@@ -68,3 +69,4 @@
     %>]
   <% end %>
 <% end %>
+</div>

--- a/app/views/observations/show/_herbarium_records.html.erb
+++ b/app/views/observations/show/_herbarium_records.html.erb
@@ -8,6 +8,7 @@
   query = Query.lookup(:HerbariumRecord, :all, observations: observation.id)
 %>
 
+<div class="obs-herbarium" id="observation_herbarium_records">
 <% unless @user.try(&:hide_specimen_stuff?) ||
           observation.user.try(&:hide_specimen_stuff?) %>
   <% if records.any? && can_add %>
@@ -74,3 +75,4 @@
     %>]
   <% end %>
 <% end %>
+</div>

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -56,21 +56,14 @@ caption ||= false
   </div>
 
   <% if @user %>
-    <div class="obs-collection"
-         id="observation_collection_numbers">
-      <%= render(partial: "observations/show/collection_numbers",
-                 locals: { observation: observation }) %>
-    </div>
+    <%= render(partial: "observations/show/collection_numbers",
+               locals: { observation: observation }) %>
 
-    <div class="obs-herbarium" id="observation_herbarium_records">
-      <%= render(partial: "observations/show/herbarium_records",
-                 locals: { observation: observation }) %>
-    </div>
+    <%= render(partial: "observations/show/herbarium_records",
+               locals: { observation: observation }) %>
 
-    <div class="obs-sequence" id="observation_sequences">
-      <%= render(partial: "observations/show/sequences",
-                 locals: { observation: observation }) %>
-    </div>
+    <%= render(partial: "observations/show/sequences",
+               locals: { observation: observation }) %>
   <% end %>
 <% end %>
 

--- a/app/views/observations/show/_section_update.js.erb
+++ b/app/views/observations/show/_section_update.js.erb
@@ -14,7 +14,7 @@ else
 end
 %>
 
-$("#<%= id %>").html('<%= j render(
+$("#<%= id %>").replaceWith('<%= j render(
   partial: partial,
   locals: { observation: @observation.reload },
   layout: false

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -7,6 +7,7 @@
   query = Query.lookup(:Sequence, :all, observations: observation.id)
 %>
 
+<div class="obs-sequence" id="observation_sequences">
 <% unless @user.try(&:hide_specimen_stuff?) ||
           observation.user.try(&:hide_specimen_stuff?) %>
   <% if @user || sequences.any? %>
@@ -70,3 +71,4 @@
     </ul>
   <% end %>
 <% end %>
+</div>


### PR DESCRIPTION
AJAX update or create on the obs page should replace the section with the given ID entirely, not the *contents* of the section.

Fixes a hard-to-detect bug where the naming table gets nested under the naming table div after a naming/vote update.