### PR TITLE
`VerifyAPIKey` troubleshooting

### DIFF
--- a/app/classes/api2/api_key_api.rb
+++ b/app/classes/api2/api_key_api.rb
@@ -42,7 +42,7 @@ class API2
     def after_create(api_key)
       return if api_key.verified
 
-      VerifyAPIKeyMailer.build(@for_user, @user, api_key).deliver_now
+      QueuedEmail::VerifyAPIKey.create_email(@for_user, @user, api_key)
     end
 
     def get

--- a/app/models/queued_email/verify_api_key.rb
+++ b/app/models/queued_email/verify_api_key.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# VerifyAPIKey Email
+class QueuedEmail
+  class VerifyAPIKey < QueuedEmail
+    def api_key
+      get_object(:api_key, ::APIKey)
+    end
+
+    def self.create_email(for_user = nil, user, api_key)
+      raise("Missing api_key!") unless api_key
+
+      result = create(::User.admin, user)
+
+      # for_user ||= user
+      # if other_user
+      result.add_integer(:for_user, user.id) if for_user
+      # else
+      #   result.add_integer(:other_user, recipient.id)
+      # end
+
+      result.add_integer(:api_key, api_key.id)
+      result.finish
+      result
+    end
+
+    def deliver_email
+      # Make sure it hasn't been deleted since email was queued.
+      return unless api_key
+
+      VerifyAPIKeyMailer.build(for_user, user, api_key).deliver_now
+    end
+  end
+end

--- a/test/mailers/queued_email_test.rb
+++ b/test/mailers/queued_email_test.rb
@@ -62,10 +62,10 @@ class QueuedEmailTest < UnitTestCase
     assert(email)
   end
 
-  def test_feature_email
-    QueuedEmail::Feature.create_email(mary, "blah blah blah")
+  def test_features_email
+    QueuedEmail::Features.create_email(mary, "blah blah blah")
     assert_email(0,
-                 flavor: "QueuedEmail::Feature",
+                 flavor: "QueuedEmail::Features",
                  to: mary,
                  note: "blah blah blah")
     email = QueuedEmail.first.deliver_email
@@ -216,5 +216,18 @@ class QueuedEmailTest < UnitTestCase
                  note: "Please make me the author")
     email = QueuedEmail.first.deliver_email
     assert(email)
+  end
+
+  def test_verify_api_key_email
+    key = api_keys(:marys_api_key)
+
+    QueuedEmail::VerifyAPIKey.create_email(mary, dick, key)
+    assert_email(0,
+                 flavor: "QueuedEmail::VerifyAPIKey",
+                 from: mary,
+                 to: dick,
+                 user: mary.id,
+                 for_user: dick.id,
+                 api_key: key.id)
   end
 end


### PR DESCRIPTION
@pellaea could you have a look at this and see if you notice what's amiss here? There are two related errors that boil down to the fact that `for_user` is not getting defined. It could be a test error, i guess, but i imagine it's in how i'm handling that optional arg. I've spent about 4 hours on it and i'm flummoxed.

- In the VerifyAPIKey request, who's the `for_user` and who's the `user`? Confused because these vars are inconsistently named in related methods (`user` and `other_user` respectively). I'm guessing `for_user` is marked as the sender of the APIKey when it's being sent to someone else. Otherwise it's people creating keys for themselves and there's no `for_user`.
- Disclaimer: I still don't really understand the `QueuedEmail` class, even after reading and rereading the note block in that class. What i'm writing is purely code mimicry and probably as ridiculous as anything ChatGPT would write, with extra typos indicating human origin. (Does `create_email` instantiate an object of the class?) 
- What sort of object (eg `Comment`), sent to a mailer method, needs an associated ID via`get_integer`? All of them? Why does it need that ID integer, when the mailer uses the whole object? And why don't sender/recipient `User` objects need integers, when the mailer refers to the object by ivar?

- I found that Model class names may collide with classes under `QueuedEmail`. Calls to any Model class, even in mailers, may need to specify global namespace like `::User`. Preemptively doing this all over the place cleared up a lot of errors. 