### PR TITLE
Add method `rubric` to `ApplicationController`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,13 @@
 #  ==== Other stuff
 #  disable_link_prefetching::    (filter: prevents prefetching of destroy
 #                                 methods)
+#  default_thumbnail_size::      Default thumbnail size: :thumbnail or :small.
+#  default_thumbnail_size_set::  Change default thumbnail size for current user.
+#  rubric::                      Label for what the controller deals with
 #  update_view_stats::           Called after each show_object request.
 #  calc_layout_params::          Gather User's list layout preferences.
 #  catch_errors_and_log_request_stats::
 #                                (filter: catches errors for integration tests)
-#  default_thumbnail_size::      Default thumbnail size: :thumbnail or :small.
-#  default_thumbnail_size_set::  Change default thumbnail size for current user.
 #
 class ApplicationController < ActionController::Base
   require "extensions"
@@ -1823,6 +1824,35 @@ class ApplicationController < ActionController::Base
       session[:thumbnail_size] = val
     end
   end
+
+  # "rubric"
+  # The name of the "application domain" of the present controller. In human
+  # terms, it's a label for "what we're dealing with on this page, generally."
+  # Usually that would be the same as the controller_name, like
+  # "Observations" or "Account". But in a nested controller like
+  # "Locations::Descriptions::DefaultsController" though, what we want is just
+  # the "Locations" part, so we need to parse the class.module_parent.
+  #   gotcha - `Object` is the module_parent of a top-level controller!
+  #
+  # NOTE: The rubric can of course be overridden in each controller.
+  #
+  # Returns a translation string.
+  #
+  def rubric
+    # Levels of nesting. parent_module is one level.
+    if (parent_module = self.class.module_parent).present? &&
+       parent_module != Object
+
+      if (grandma_module = parent_module.to_s.rpartition("::").first).present?
+        return grandma_module.underscore.upcase.to_sym.t
+      end
+
+      return parent_module.to_s.underscore.upcase.to_sym.t
+    end
+
+    controller_name.upcase.to_sym.t
+  end
+  helper_method :rubric
 
   def calc_layout_params
     count = @user&.layout_count || MO.default_layout_count

--- a/app/views/application/_top_nav.html.erb
+++ b/app/views/application/_top_nav.html.erb
@@ -2,6 +2,7 @@
 <nav id="top_nav" class="navbar navbar-default hidden-xs hidden-print">
 
   <div class="container-fluid px-0">
+    <%= tag.span(rubric, class: "hidden") %>
     <% if controller.controller_name == "identify" %>
       <%= render(partial: "observations/identify/form_identify_filter") %>
     <% else ##user is logged in %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -233,6 +233,7 @@
   article: article
   ARTICLES: Articles
   articles: articles
+  CHECKLISTS: Checklists
   CLADE: Clade
   clade: clade
   COLLECTION_NUMBER: Collection Number
@@ -243,10 +244,12 @@
   comment: comment
   COMMENTS: Comments
   comments: comments
+  CONTRIBUTORS: Contributors
   DESCRIPTION: Description
   description: description
   DESCRIPTIONS: Descriptions
   descriptions: descriptions
+  DONATIONS: Donations
   DRAFT: Draft
   draft: draft
   DRAFTS: Drafts
@@ -263,8 +266,11 @@
   image: image
   IMAGES: Images
   images: images
-  ignore: ignore
   IGNORE: Ignore
+  ignore: ignore
+  INFO: Info
+  INFORMATION: Information
+  INTERESTS: Interests
   GEOLOCATION: Geolocation
   geolocation: geolocation
   GLOSSARY: Glossary
@@ -344,6 +350,8 @@
   past_name: name change
   PAST_NAMES: Name Changes
   past_names: name changes
+  PIVOTAL: Pivotal
+  POLICY: Policy
   PROJECT: Project
   project: project
   PROJECTS: Projects
@@ -374,6 +382,13 @@
   specimen: specimen
   SPECIMENS: Specimens
   specimens: specimens
+  SUPPORT: Support
+  support: support
+  THEME: Theme
+  TRANSLATION: Translation
+  translation: translation
+  TRANSLATIONS: Translations
+  translations: translations
   USER: User
   user: user
   USERS: Users


### PR DESCRIPTION
In the BS5 branch, in the top nav, I'd like to be able to call a translated "rubric" in views that describes the context the user is currently operating in.

For example, if they're writing a Location Description, it would say "Luoghi" or "Locations"; if they're checking out observations it would say "Observations".  Deriving this string from the controller name seems simple, but the new nested controllers make it actually kind of tricky to derive the name of the top level module. A lot of experimentation was necessary.

This PR adds a method in `ApplicationController` to provide a default `rubric` to views in the present controller. It can be overridden at the controller level.

It also adds a hidden span in the search bar that prints the current rubric, for test coverage. This exposed some missing translation strings, which are also added here.