### PR TITLE
Pull `@sorts` index ivar out of `ApplicationController`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1413,14 +1413,10 @@ class ApplicationController < ActionController::Base
   # letter_arg::    Param used to store letter for pagination.
   # number_arg::    Param used to store page number for pagination.
   # num_per_page::  Number of results per page.
-  # sorting_links:: Array of pairs: ["by" String, label String]
   # always_index::  Always show index, even if only one result.
-  # link_all_sorts:: Don't gray-out the current sort criteria.
   #
   # Side-effects: (sets/uses the following instance variables for the view)
   # @title::        Provides default title.
-  # @links:         Extra links to add to right hand tab set.
-  # @sorts::
   # @layout::
   # @pages::        Paginator instance.
   # @objects::      Array of objects to be shown.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1488,7 +1488,7 @@ class ApplicationController < ActionController::Base
 
   ###########################################################################
   #
-  # INDEX VIEW METHODS - MOVE TO HELPERS?
+  # INDEX VIEW METHODS - MOVE SORTING LINKS TO HELPERS
 
   # These useful methods set a bunch of ivars used in all indexes.
   # Converting it to a helper seems desirable re: separation of concerns,
@@ -1500,15 +1500,12 @@ class ApplicationController < ActionController::Base
   def set_index_view_ivars(query, args)
     @error ||= :runtime_no_matches.t(type: query.model.type_tag)
     @layout = calc_layout_params if args[:matrix]
-    @timer_start = Time.current
     @num_results = query.num_results
-    @timer_end = Time.current
     if @num_results.zero?
       @title = args[:no_hits_title]
     else
       @title ||= index_default_title(query)
     end
-    @sorts = (@num_results > 1 ? sorting_links(query, args) : nil)
   end
 
   # Special title for new obs default home page query
@@ -1519,53 +1516,6 @@ class ApplicationController < ActionController::Base
     end
 
     query.title
-  end
-
-  def sorting_links(query, args)
-    return nil unless (sorts = args[:sorting_links]) &&
-                      (sorts.length > 1) &&
-                      !browser.bot?
-
-    add_sorting_links(query, sorts, args[:link_all_sorts])
-  end
-
-  public ##########
-
-  # Create sorting links for index pages, "graying-out" the current order.
-  def add_sorting_links(query, links, link_all = false)
-    results = []
-    this_by = (query.params[:by] || query.default_order).sub(/^reverse_/, "")
-
-    links.each do |by, label|
-      results << link_or_grayed_text(link_all, this_by, label, query, by)
-    end
-
-    # Add a "reverse" button.
-    results << sort_link(:sort_by_reverse.t, query, reverse_by(query, this_by))
-  end
-
-  private ##########
-
-  def link_or_grayed_text(link_all, this_by, label, query, by)
-    if !link_all && (by.to_s == this_by)
-      [label.t, nil]
-    else
-      sort_link(label.t, query, by)
-    end
-  end
-
-  def sort_link(text, query, by)
-    [text, { controller: query.model.show_controller,
-             action: query.model.index_action,
-             by: by }.merge(query_params)]
-  end
-
-  def reverse_by(query, this_by)
-    if query.params[:by].to_s.start_with?("reverse_")
-      this_by
-    else
-      "reverse_#{this_by}"
-    end
   end
 
   ###########################################################################

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1494,6 +1494,7 @@ class ApplicationController < ActionController::Base
   # I believe we'd have to add a helper manually to each index. - AN 2023
   #
   def set_index_view_ivars(query, args)
+    @query = query
     @error ||= :runtime_no_matches.t(type: query.model.type_tag)
     @layout = calc_layout_params if args[:matrix]
     @num_results = query.num_results

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1484,14 +1484,10 @@ class ApplicationController < ActionController::Base
 
   ###########################################################################
   #
-  # INDEX VIEW METHODS - MOVE SORTING LINKS TO HELPERS
+  # INDEX VIEW METHODS - MOVE VIEW CODE TO HELPERS
 
-  # These useful methods set a bunch of ivars used in all indexes.
-  # Converting it to a helper seems desirable re: separation of concerns,
-  # but we'd need access to the args passed to show_index_of_objects
-  # by the controller index action in the hypothetical helper.
-  # Also, these ivars are magically available to any index by default.
-  # I believe we'd have to add a helper manually to each index. - AN 2023
+  # Set some ivars used in all index views.
+  # Makes @query available to the :index template for query-dependent tabs
   #
   def set_index_view_ivars(query, args)
     @query = query

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1491,12 +1491,15 @@ class ApplicationController < ActionController::Base
 
   ###########################################################################
   #
-  #  INDEX VIEW METHODS - MOVE TO HELPERS
+  # INDEX VIEW METHODS - MOVE TO HELPERS?
 
-  # This useful method sets a bunch of ivars used in all indexes.
+  # These useful methods set a bunch of ivars used in all indexes.
   # Converting it to a helper seems desirable re: separation of concerns,
-  # but how to attach to any index by default?
-  # I believe we have to add helper manually to each index. - AN 2023
+  # but we'd need access to the args passed to show_index_of_objects
+  # by the controller index action in the hypothetical helper.
+  # Also, these ivars are magically available to any index by default.
+  # I believe we'd have to add a helper manually to each index. - AN 2023
+  #
   def set_index_view_ivars(query, args)
     @error ||= :runtime_no_matches.t(type: query.model.type_tag)
     @layout = calc_layout_params if args[:matrix]

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -121,11 +121,7 @@ class ArticlesController < ApplicationController
       action: :index,
       letters: "articles.title",
       num_per_page: 50,
-      include: :user,
-      sorting_links: [["created_at",  :sort_by_created_at.t],
-                      ["updated_at",  :sort_by_updated_at.t],
-                      ["user",        :sort_by_user.t],
-                      ["title",       :sort_by_title.t]].freeze
+      include: :user
     }.merge(args)
 
     show_index_of_objects(query, args)

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -167,14 +167,6 @@ class CollectionNumbersController < ApplicationController
       num_per_page: 100
     }.merge(args)
 
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      ["name",       :sort_by_name.t],
-      ["number",     :sort_by_number.t],
-      ["created_at", :sort_by_created_at.t],
-      ["updated_at", :sort_by_updated_at.t]
-    ]
-
     show_index_of_objects(query, args)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -121,14 +121,6 @@ class CommentsController < ApplicationController
       include: [:target, :user]
     }.merge(args)
 
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      # ["summary",  :sort_by_summary.t],
-      ["user", :sort_by_user.t],
-      ["created_at", :sort_by_posted.t],
-      ["updated_at", :sort_by_updated_at.t]
-    ]
-
     # Paginate by letter if sorting by user.
     if (query.params[:by] == "user") ||
        (query.params[:by] == "reverse_user")

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -111,7 +111,6 @@ class GlossaryTermsController < ApplicationController
       num_per_page: 50,
       include: includes
     }.merge(args)
-    @links ||= []
 
     show_index_of_objects(query, args)
   end

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -171,12 +171,6 @@ class HerbariaController < ApplicationController
   def show_selected_herbaria(query, args = {})
     args = show_index_args(args)
 
-    # Clean up display by removing user-related stuff from nonpersonal index.
-    if query.flavor == :nonpersonal
-      args[:sorting_links].reject! { |x| x[0] == "user" }
-      @no_user_column = true
-    end
-
     # If user clicks "merge" on an herbarium, it reloads the page and asks
     # them to click on the destination herbarium to merge it with.
     @merge = Herbarium.safe_find(params[:merge])

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -189,15 +189,7 @@ class HerbariaController < ApplicationController
       letters: "herbaria.name",
       num_per_page: 100,
       include: [:curators, :herbarium_records, :personal_user]
-    }.merge(args,
-            template: "/herbaria/index", # render with this template
-            # Add some alternate sorting criteria.
-            sorting_links: [["records",     :sort_by_records.t],
-                            ["user",        :sort_by_user.t],
-                            ["code",        :sort_by_code.t],
-                            ["name",        :sort_by_name.t],
-                            ["created_at",  :sort_by_created_at.t],
-                            ["updated_at",  :sort_by_updated_at.t]])
+    }.merge(args)
   end
 
   def make_sure_can_edit!

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -197,14 +197,6 @@ class HerbariumRecordsController < ApplicationController
       include: [{ herbarium: :curators }, { observations: :name }, :user]
     }.merge(args)
 
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      ["herbarium_name",  :sort_by_herbarium_name.t],
-      ["herbarium_label", :sort_by_herbarium_label.t],
-      ["created_at",      :sort_by_created_at.t],
-      ["updated_at",      :sort_by_updated_at.t]
-    ]
-
     show_index_of_objects(query, args)
   end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -146,9 +146,6 @@ class ImagesController < ApplicationController
                 :thumb_glossary_terms, :glossary_terms, :image_votes]
     }.merge(args)
 
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = SORTING_LINKS
-
     # Paginate by letter if sorting by user.
     case query.params[:by]
     when "user", "reverse_user"
@@ -163,19 +160,6 @@ class ImagesController < ApplicationController
 
     show_index_of_objects(query, args)
   end
-
-  SORTING_LINKS = [
-    ["name",          :sort_by_name.t],
-    ["original_name", :sort_by_filename.t],
-    ["date",          :sort_by_date.t],
-    ["user",          :sort_by_user.t],
-    # ["copyright_holder", :sort_by_copyright_holder.t],
-    ["created_at",    :sort_by_posted.t],
-    ["updated_at",    :sort_by_updated_at.t],
-    ["confidence",    :sort_by_confidence.t],
-    ["image_quality", :sort_by_image_quality.t],
-    ["num_views",     :sort_by_num_views.t]
-  ].freeze
 
   public
 

--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -91,14 +91,6 @@ module Locations
         num_per_page: 50
       }.merge(args)
 
-      # Add some alternate sorting criteria.
-      args[:sorting_links] = [
-        ["name",        :sort_by_name.t],
-        ["created_at",  :sort_by_created_at.t],
-        ["updated_at",  :sort_by_updated_at.t],
-        ["num_views",   :sort_by_num_views.t]
-      ]
-
       show_index_of_objects(query, args)
     end
 

--- a/app/controllers/locations/maps_controller.rb
+++ b/app/controllers/locations/maps_controller.rb
@@ -17,14 +17,11 @@ module Locations
                  :map_locations_title.t(locations: @query.title)
                end
       @query = restrict_query_to_box(@query)
-      @timer_start = Time.current
       columns = %w[name north south east west].map { |x| "locations.#{x}" }
       args = { select: "DISTINCT(locations.id), #{columns.join(", ")}" }
       @locations = @query.select_rows(args).map do |id, *the_rest|
         MinimalMapLocation.new(id, *the_rest)
       end
-      @num_results = @locations.count
-      @timer_end = Time.current
     end
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -131,15 +131,6 @@ class LocationsController < ApplicationController
 
   # Show selected search results as a list with 'list_locations' template.
   def show_selected_locations(query, args = {})
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      ["name",        :sort_by_name.t],
-      ["created_at",  :sort_by_created_at.t],
-      [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
-       :sort_by_updated_at.t],
-      ["num_views", :sort_by_num_views.t]
-    ]
-
     # Restrict to subset within a geographical region (used by map
     # if it needed to stuff multiple locations into a single marker).
     query = restrict_query_to_box(query)

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -106,14 +106,6 @@ module Names
         num_per_page: 50
       }.merge(args)
 
-      # Add some alternate sorting criteria.
-      args[:sorting_links] = [
-        ["name",        :sort_by_name.t],
-        ["created_at",  :sort_by_created_at.t],
-        ["updated_at",  :sort_by_updated_at.t],
-        ["num_views",   :sort_by_num_views.t]
-      ]
-
       show_index_of_objects(query, args)
     end
 

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -158,24 +158,13 @@ class NamesController < ApplicationController
     end
   end
 
-  def add_default_index_args(query, args)
-    args = {
+  def add_default_index_args(_query, args)
+    {
       controller: "/names",
       action: "index",
       letters: "names.sort_name",
       num_per_page: (/^[a-z]/i.match?(params[:letter].to_s) ? 500 : 50)
     }.merge(args)
-
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      ["name", :sort_by_name.t],
-      ["created_at", :sort_by_created_at.t],
-      [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
-       :sort_by_updated_at.t],
-      ["num_views", :sort_by_num_views.t]
-    ]
-
-    args
   end
 
   ###################################

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -65,12 +65,13 @@ module Observations
     # or better yet `respond_to do |format|` and write index.js.erb templates
     # to just render the #results div.
     def show_selected_results(query)
-      show_index_of_objects(query,
-                            { matrix: true,
-                              include: [:location, :user, :rss_log,
-                                        { name: :synonym },
-                                        { namings: :name },
-                                        { thumb_image: :image_votes }] })
+      args = { matrix: true,
+               include: [:location, :user, :rss_log,
+                         { name: :synonym },
+                         { namings: :name },
+                         { thumb_image: :image_votes }] }
+
+      show_index_of_objects(query, args)
     end
   end
 end

--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -12,12 +12,9 @@ module Observations
       apply_content_filters(@query)
       @title = :map_locations_title.t(locations: @query.title)
       @query = restrict_query_to_box(@query)
-      @timer_start = Time.current
 
       find_locations_matching_observations
 
-      @num_results = @observations.count
-      @timer_end = Time.current
       render(template: "observations/maps/index")
     end
 

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -201,21 +201,6 @@ class ObservationsController
                include: [:name, :location, :user, :rss_log,
                          { thumb_image: :image_votes }] }.merge(args)
 
-      # Add some alternate sorting criteria.
-      links = [
-        ["rss_log", :sort_by_activity.t],
-        ["date", :sort_by_date.t],
-        ["created_at", :sort_by_posted.t],
-        # kind of redundant to sort by rss_logs, though not strictly ===
-        # ["updated_at", :sort_by_updated_at.t],
-        ["name", :sort_by_name.t],
-        ["user", :sort_by_user.t],
-        ["confidence", :sort_by_confidence.t],
-        ["thumbnail_quality", :sort_by_thumbnail_quality.t],
-        ["num_views", :sort_by_num_views.t]
-      ]
-      args[:sorting_links] = links
-
       # Paginate by letter if sorting by user.
       case query.params[:by]
       when "user", "reverse_user"

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -188,9 +188,6 @@ class ObservationsController
       # if it needed to stuff multiple locations into a single marker).
       query = restrict_query_to_box(query)
 
-      # make @query available to the :index template for query-dependent tabs
-      @query = query
-
       show_index_of_objects(query, args)
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -194,15 +194,6 @@ class ProjectsController < ApplicationController
       include: :user
     }.merge(args)
 
-    @links ||= []
-
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      ["name",        :sort_by_title.t],
-      ["created_at",  :sort_by_created_at.t],
-      ["updated_at",  :sort_by_updated_at.t]
-    ]
-
     show_index_of_objects(query, args)
   end
 

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -171,17 +171,7 @@ class SequencesController < ApplicationController
     args = { include: [{ observation: :name }, :user],
              letters: "sequences.locus",
              num_per_page: 50 }.merge(args)
-    args[:sorting_links] = sequence_index_sorts
     show_index_of_objects(query, args)
-  end
-
-  def sequence_index_sorts
-    [
-      ["created_at",  :sort_by_created_at.t],
-      ["updated_at",  :sort_by_updated_at.t],
-      ["user",        :USER.t],
-      ["observation", :OBSERVATION.t]
-    ].freeze
   end
 
   # ---------- Create, Edit ----------------------------------------------------

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -193,16 +193,6 @@ class SpeciesListsController < ApplicationController
       letters: "species_lists.title"
     }.merge(args)
 
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = [
-      ["title",       :sort_by_title.t],
-      ["date",        :sort_by_date.t],
-      ["user",        :sort_by_user.t],
-      ["created_at",  :sort_by_created_at.t],
-      [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
-       :sort_by_updated_at.t]
-    ]
-
     # Paginate by letter if sorting by user.
     args[:letters] =
       if [query.params[:by]].intersect?(%w[user reverse_user])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -73,9 +73,6 @@ class UsersController < ApplicationController
       matrix: !in_admin_mode?
     }.merge(args)
 
-    # Add some alternate sorting criteria.
-    args[:sorting_links] = args_sorting_links
-
     # Paginate by "correct" letter.
     args[:letters] = if (query.params[:by] == "login") ||
                         (query.params[:by] == "reverse_login")
@@ -85,27 +82,6 @@ class UsersController < ApplicationController
                      end
 
     show_index_of_objects(query, args)
-  end
-
-  def args_sorting_links
-    if in_admin_mode?
-      [
-        ["id",          :sort_by_id.t],
-        ["login",       :sort_by_login.t],
-        ["name",        :sort_by_name.t],
-        ["created_at",  :sort_by_created_at.t],
-        ["updated_at",  :sort_by_updated_at.t],
-        ["last_login",  :sort_by_last_login.t]
-      ]
-    else
-      [
-        ["login",         :sort_by_login.t],
-        ["name",          :sort_by_name.t],
-        ["created_at",    :sort_by_created_at.t],
-        ["location",      :sort_by_location.t],
-        ["contribution",  :sort_by_contribution.t]
-      ]
-    end
   end
 
   # set @observations whose thumbnails will display in user summary

--- a/app/helpers/tabs/articles_helper.rb
+++ b/app/helpers/tabs/articles_helper.rb
@@ -14,6 +14,15 @@ module Tabs
       [new_article_link]
     end
 
+    def articles_index_sorts
+      [
+        ["created_at",  :sort_by_created_at.t],
+        ["updated_at",  :sort_by_updated_at.t],
+        ["user",        :sort_by_user.t],
+        ["title",       :sort_by_title.t]
+      ].freeze
+    end
+
     def article_show_links(article:, user:)
       links = [articles_index_link]
       # Can user modify all articles

--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -17,6 +17,15 @@ module Tabs
       ]
     end
 
+    def collection_numbers_index_sorts
+      [
+        ["name",       :sort_by_name.t],
+        ["number",     :sort_by_number.t],
+        ["created_at", :sort_by_created_at.t],
+        ["updated_at", :sort_by_updated_at.t]
+      ].freeze
+    end
+
     def collection_number_form_new_links(obs:)
       [object_return_link(obs)]
     end

--- a/app/helpers/tabs/comments_helper.rb
+++ b/app/helpers/tabs/comments_helper.rb
@@ -39,5 +39,14 @@ module Tabs
     def destroy_comment_link(comment)
       [:comment_show_destroy.t, comment, { button: :destroy }]
     end
+
+    def comments_index_sorts
+      [
+        # ["summary",  :sort_by_summary.t],
+        ["user", :sort_by_user.t],
+        ["created_at", :sort_by_posted.t],
+        ["updated_at", :sort_by_updated_at.t]
+      ].freeze
+    end
   end
 end

--- a/app/helpers/tabs/descriptions_helper.rb
+++ b/app/helpers/tabs/descriptions_helper.rb
@@ -128,5 +128,14 @@ module Tabs
          project: project.id, source: "project" },
        { class: __method__.to_s }]
     end
+
+    def descriptions_index_sorts
+      [
+        ["name",        :sort_by_name.t],
+        ["created_at",  :sort_by_created_at.t],
+        ["updated_at",  :sort_by_updated_at.t],
+        ["num_views",   :sort_by_num_views.t]
+      ].freeze
+    end
   end
 end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -13,7 +13,13 @@ module Tabs
       links << new_herbarium_link
     end
 
-    def herbaria_index_sorts
+    def herbaria_index_sorts(query:)
+      return nonpersonal_herbaria_index_sorts if query.flavor == :nonpersonal
+
+      full_herbaria_index_sorts
+    end
+
+    def full_herbaria_index_sorts
       [
         ["records",     :sort_by_records.t],
         ["user",        :sort_by_user.t],
@@ -22,6 +28,11 @@ module Tabs
         ["created_at",  :sort_by_created_at.t],
         ["updated_at",  :sort_by_updated_at.t]
       ].freeze
+    end
+
+    def nonpersonal_herbaria_index_sorts
+      sorts = full_herbaria_index_sorts
+      sorts.reject! { |x| x[0] == "user" }
     end
 
     def herbarium_show_links(herbarium:, user:)

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -31,7 +31,8 @@ module Tabs
     end
 
     def nonpersonal_herbaria_index_sorts
-      sorts = full_herbaria_index_sorts
+      # must dup a frozen array, this is new ruby 3 policy
+      sorts = full_herbaria_index_sorts.map(&:clone)
       sorts.reject! { |x| x[0] == "user" }
     end
 

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -14,7 +14,7 @@ module Tabs
     end
 
     def herbaria_index_sorts(query:)
-      return nonpersonal_herbaria_index_sorts if query.flavor == :nonpersonal
+      return nonpersonal_herbaria_index_sorts if query&.flavor == :nonpersonal
 
       full_herbaria_index_sorts
     end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -13,6 +13,17 @@ module Tabs
       links << new_herbarium_link
     end
 
+    def herbaria_index_sorts
+      [
+        ["records",     :sort_by_records.t],
+        ["user",        :sort_by_user.t],
+        ["code",        :sort_by_code.t],
+        ["name",        :sort_by_name.t],
+        ["created_at",  :sort_by_created_at.t],
+        ["updated_at",  :sort_by_updated_at.t]
+      ].freeze
+    end
+
     def herbarium_show_links(herbarium:, user:)
       tabs = []
       if herbarium.curators.empty? ||

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -5,7 +5,7 @@
 module Tabs
   module HerbariumRecordsHelper
     include HerbariaHelper
-    def herbarium_record_index_links(obs:)
+    def herbarium_records_index_links(obs:)
       links = []
       if obs.present?
         links = [
@@ -15,6 +15,15 @@ module Tabs
       end
       links << new_herbarium_link
       links << nonpersonal_herbaria_index_link
+    end
+
+    def herbarium_records_index_sorts
+      [
+        ["herbarium_name",  :sort_by_herbarium_name.t],
+        ["herbarium_label", :sort_by_herbarium_label.t],
+        ["created_at",      :sort_by_created_at.t],
+        ["updated_at",      :sort_by_updated_at.t]
+      ].freeze
     end
 
     def herbarium_record_show_links(h_r:)

--- a/app/helpers/tabs/images_helper.rb
+++ b/app/helpers/tabs/images_helper.rb
@@ -22,7 +22,7 @@ module Tabs
       [object_return_link(image)]
     end
 
-    def images_sorting_links
+    def images_index_sorts
       [
         ["name",          :sort_by_name.t],
         ["original_name", :sort_by_filename.t],

--- a/app/helpers/tabs/images_helper.rb
+++ b/app/helpers/tabs/images_helper.rb
@@ -22,6 +22,21 @@ module Tabs
       [object_return_link(image)]
     end
 
+    def images_sorting_links
+      [
+        ["name",          :sort_by_name.t],
+        ["original_name", :sort_by_filename.t],
+        ["date",          :sort_by_date.t],
+        ["user",          :sort_by_user.t],
+        # ["copyright_holder", :sort_by_copyright_holder.t],
+        ["created_at",    :sort_by_posted.t],
+        ["updated_at",    :sort_by_updated_at.t],
+        ["confidence",    :sort_by_confidence.t],
+        ["image_quality", :sort_by_image_quality.t],
+        ["num_views",     :sort_by_num_views.t]
+      ].freeze
+    end
+
     private
 
     def show_image_obs_links(image)

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -99,7 +99,7 @@ module Tabs
       [
         ["name", :sort_by_name.t],
         ["created_at", :sort_by_created_at.t],
-        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
+        [(query&.flavor == :by_rss_log ? "rss_log" : "updated_at"),
          :sort_by_updated_at.t],
         ["num_views", :sort_by_num_views.t]
       ]

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -94,6 +94,17 @@ module Tabs
       [locations_index_link]
     end
 
+    # Add some alternate sorting criteria.
+    def location_index_sorts(query:)
+      [
+        ["name", :sort_by_name.t],
+        ["created_at", :sort_by_created_at.t],
+        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
+         :sort_by_updated_at.t],
+        ["num_views", :sort_by_num_views.t]
+      ]
+    end
+
     # link attribute arrays
     def location_form_new_links(location:)
       tabs = [locations_index_link]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -117,6 +117,16 @@ module Tabs
        { class: __method__.to_s }]
     end
 
+    def names_index_sorts(query:)
+      [
+        ["name", :sort_by_name.t],
+        ["created_at", :sort_by_created_at.t],
+        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
+         :sort_by_updated_at.t],
+        ["num_views", :sort_by_num_views.t]
+      ]
+    end
+
     ### Forms
     def name_form_new_links
       [names_index_link]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -121,7 +121,7 @@ module Tabs
       [
         ["name", :sort_by_name.t],
         ["created_at", :sort_by_created_at.t],
-        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
+        [(query&.flavor == :by_rss_log ? "rss_log" : "updated_at"),
          :sort_by_updated_at.t],
         ["num_views", :sort_by_num_views.t]
       ]

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -82,7 +82,7 @@ module Tabs
     ############################################
     # INDEX
 
-    def index_observation_links(query:)
+    def observations_index_links(query:)
       links = [
         *observations_at_where_links(query), # maybe multiple links
         map_observations_link(query),
@@ -103,6 +103,21 @@ module Tabs
         merge_locations_link(query),
         locations_index_link
       ]
+    end
+
+    def observations_index_sorts
+      [
+        ["rss_log", :sort_by_activity.t],
+        ["date", :sort_by_date.t],
+        ["created_at", :sort_by_posted.t],
+        # kind of redundant to sort by rss_logs, though not strictly ===
+        # ["updated_at", :sort_by_updated_at.t],
+        ["name", :sort_by_name.t],
+        ["user", :sort_by_user.t],
+        ["confidence", :sort_by_confidence.t],
+        ["thumbnail_quality", :sort_by_thumbnail_quality.t],
+        ["num_views", :sort_by_num_views.t]
+      ].freeze
     end
 
     def map_observations_link(query)

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -89,5 +89,14 @@ module Tabs
     def destroy_project_link(project)
       [nil, project, { button: :destroy }]
     end
+
+    # Add some alternate sorting criteria.
+    def projects_index_sorts
+      [
+        ["name", :sort_by_title.t],
+        ["created_at",  :sort_by_created_at.t],
+        ["updated_at",  :sort_by_updated_at.t]
+      ].freeze
+    end
   end
 end

--- a/app/helpers/tabs/sequences_helper.rb
+++ b/app/helpers/tabs/sequences_helper.rb
@@ -32,5 +32,14 @@ module Tabs
       [:destroy_object.t(type: :sequence), seq,
        { button: :destroy, back: url_after_delete(seq) }]
     end
+
+    def sequences_index_sorts
+      [
+        ["created_at",  :sort_by_created_at.t],
+        ["updated_at",  :sort_by_updated_at.t],
+        ["user",        :USER.t],
+        ["observation", :OBSERVATION.t]
+      ].freeze
+    end
   end
 end

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -135,7 +135,7 @@ module Tabs
         ["date",        :sort_by_date.t],
         ["user",        :sort_by_user.t],
         ["created_at",  :sort_by_created_at.t],
-        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
+        [(query&.flavor == :by_rss_log ? "rss_log" : "updated_at"),
          :sort_by_updated_at.t]
       ]
     end

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -128,5 +128,16 @@ module Tabs
     def species_list_download_links(list:)
       [object_return_link(list)]
     end
+
+    def species_lists_index_sorts(query:)
+      [
+        ["title",       :sort_by_title.t],
+        ["date",        :sort_by_date.t],
+        ["user",        :sort_by_user.t],
+        ["created_at",  :sort_by_created_at.t],
+        [(query.flavor == :by_rss_log ? "rss_log" : "updated_at"),
+         :sort_by_updated_at.t]
+      ]
+    end
   end
 end

--- a/app/helpers/tabs/users_helper.rb
+++ b/app/helpers/tabs/users_helper.rb
@@ -82,5 +82,28 @@ module Tabs
     def admin_destroy_user_link(user)
       [nil, admin_users_path(id: user.id), { button: :destroy }]
     end
+
+    def users_index_sorts
+      return admin_users_index_sorts if in_admin_mode?
+
+      [
+        ["login",         :sort_by_login.t],
+        ["name",          :sort_by_name.t],
+        ["created_at",    :sort_by_created_at.t],
+        ["location",      :sort_by_location.t],
+        ["contribution",  :sort_by_contribution.t]
+      ].freeze
+    end
+
+    def admin_users_index_sorts
+      [
+        ["id",          :sort_by_id.t],
+        ["login",       :sort_by_login.t],
+        ["name",        :sort_by_name.t],
+        ["created_at",  :sort_by_created_at.t],
+        ["updated_at",  :sort_by_updated_at.t],
+        ["last_login",  :sort_by_last_login.t]
+      ].freeze
+    end
   end
 end

--- a/app/helpers/tabs/users_helper.rb
+++ b/app/helpers/tabs/users_helper.rb
@@ -83,9 +83,13 @@ module Tabs
       [nil, admin_users_path(id: user.id), { button: :destroy }]
     end
 
-    def users_index_sorts
-      return admin_users_index_sorts if in_admin_mode?
+    def users_index_sorts(admin)
+      return admin_users_index_sorts if admin
 
+      regular_user_index_sorts
+    end
+
+    def regular_user_index_sorts
       [
         ["login",         :sort_by_login.t],
         ["name",          :sort_by_name.t],

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -128,7 +128,7 @@ module TitleAndTabsetHelper
     types == [type] ? label : link_with_query(label, link, **help)
   end
 
-  # @sorts is set by ApplicationController#show_index_count_results
+  # @sorts is set by ApplicationController#set_index_view_ivars
   def index_sorter(sorts)
     return "" unless sorts
 

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -128,6 +128,7 @@ module TitleAndTabsetHelper
     types == [type] ? label : link_with_query(label, link, **help)
   end
 
+  # Sort links, for indexes
   def add_sorter(query, links)
     content_for(:sorter) do
       return "" unless links && query && query.num_results > 1
@@ -138,7 +139,7 @@ module TitleAndTabsetHelper
     end
   end
 
-  # Create sorting links for index pages, "graying-out" the current order.
+  # Create sorting links, "graying-out" the current order.
   # Need query to know which is current order
   def create_sorting_links(query, links, link_all = false)
     results = []

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -131,11 +131,13 @@ module TitleAndTabsetHelper
   # Sort links, for indexes
   def add_sorter(query, links, link_all: false)
     content_for(:sorter) do
-      return "" unless links && query && (query.num_results > 1)
+      if links && (query.num_results > 1)
+        sorts = create_sorting_links(query, links, link_all)
 
-      sorts = create_sorting_links(query, links, link_all)
-
-      render(partial: "application/content/sorter", locals: { sorts: sorts })
+        render(partial: "application/content/sorter", locals: { sorts: sorts })
+      else
+        ""
+      end
     end
   end
 

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -129,11 +129,11 @@ module TitleAndTabsetHelper
   end
 
   # Sort links, for indexes
-  def add_sorter(query, links)
+  def add_sorter(query, links, link_all: false)
     content_for(:sorter) do
       return "" unless links && query && query.num_results > 1
 
-      sorts = create_sorting_links(query, links, false)
+      sorts = create_sorting_links(query, links, link_all)
 
       render(partial: "application/content/sorter", locals: { sorts: sorts })
     end
@@ -141,7 +141,7 @@ module TitleAndTabsetHelper
 
   # Create sorting links, "graying-out" the current order.
   # Need query to know which is current order
-  def create_sorting_links(query, links, link_all = false)
+  def create_sorting_links(query, links, link_all)
     results = []
     this_by = (query.params[:by] || query.default_order).sub(/^reverse_/, "")
 

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -131,7 +131,7 @@ module TitleAndTabsetHelper
   # Sort links, for indexes
   def add_sorter(query, links, link_all: false)
     content_for(:sorter) do
-      if links && (query.num_results > 1)
+      if links && (query&.num_results&.> 1)
         sorts = create_sorting_links(query, links, link_all)
 
         render(partial: "application/content/sorter", locals: { sorts: sorts })

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -131,7 +131,7 @@ module TitleAndTabsetHelper
   # Sort links, for indexes
   def add_sorter(query, links, link_all: false)
     content_for(:sorter) do
-      return "" unless links && query && query.num_results > 1
+      return "" unless links && query && (query.num_results > 1)
 
       sorts = create_sorting_links(query, links, link_all)
 

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -130,7 +130,7 @@ module TitleAndTabsetHelper
 
   def add_sorter(query, links)
     content_for(:sorter) do
-      return "" unless links && query&.num_results&. > 1
+      return "" unless links && query && query.num_results > 1
 
       sorts = create_sorting_links(query, links, false)
 

--- a/app/views/application/content/_title_and_tab_sets.html.erb
+++ b/app/views/application/content/_title_and_tab_sets.html.erb
@@ -47,5 +47,6 @@ sorts
       end %>
 
   <!-- Sorter. conditionally renders the partial -->
-  <%= index_sorter(@sorts) %>
+  <%= yield(:sorter) %>
+
 </div>

--- a/app/views/application/top_nav/_search_form.html.erb
+++ b/app/views/application/top_nav/_search_form.html.erb
@@ -15,10 +15,6 @@ options = [
   [:app_search_google.l, :google],
 ].sort
 
-@timer_end ||= Time.zone.now
-secs = "%.2f" % (@timer_end.to_f - @timer_start.to_f)
-timer = "(#{ :app_index_timer.t(seconds: secs,
-                                num: @num_results.to_i) })"
 adv_search = link_to(
   content_tag(:span, :app_advanced_search.l, class: "text-nowrap"),
   search_advanced_path
@@ -64,19 +60,10 @@ identify_page = controller.controller_name == "identify"
   <span class=""> |</span>
 </p>
 
-<% if @timer_start %>
-  <div class="navbar-text my-1 mx-2 hidden-xs smaller">
-    <span id="timer"><%= timer %></span><br/>
-    <%= adv_search %>
-  </div>
-<% else %>
-  <p class="navbar-text mx-2 hidden-xs">
-    <%= adv_search %>
-  </p>
-<% end %>
+<p class="navbar-text mx-2 hidden-xs">
+  <%= adv_search %>
+</p>
 
 <div class="visible-xs">
-  <%= content_tag(:span, timer, id: "timer",
-                  class: "text-nowrap") if @timer_start %>
   <%= adv_search %>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,7 +1,8 @@
 <%
+@container = :wide
 @title ||= :ARTICLES.t
 add_tab_set(articles_index_links(user: @user))
-@container = :wide
+add_sorter(@query, articles_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,5 +1,6 @@
 <%
 @container = :wide
+# the no_hits_title.
 @title ||= :ARTICLES.t
 add_tab_set(articles_index_links(user: @user))
 add_sorter(@query, articles_index_sorts)

--- a/app/views/collection_numbers/index.html.erb
+++ b/app/views/collection_numbers/index.html.erb
@@ -1,10 +1,11 @@
 <%
+@container = :wide
 @title ||= :list_collection_numbers_title.t
 
 add_tab_set(collection_numbers_index_links(obs: @observation))
+add_sorter(@query, collection_numbers_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
-@container = :wide
 %>
 
 <%= paginate_block(@pages) do %>

--- a/app/views/collection_numbers/index.html.erb
+++ b/app/views/collection_numbers/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
+# the no_hits_title.
 @title ||= :list_collection_numbers_title.t
-
 add_tab_set(collection_numbers_index_links(obs: @observation))
 add_sorter(@query, collection_numbers_index_sorts)
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -2,6 +2,7 @@
 # NOTE: this is the searchable comments index for the whole site. The list of
 # comments for a particular object is in the partial "comments_for_object"
 @container = :text_image
+add_sorter(@query, comments_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -3,9 +3,10 @@
 @title ||= :list_herbaria_title.t
 
 add_tab_set(herbaria_index_links(query: @query))
-add_sorter(@query, herbaria_index_sorts)
+add_sorter(@query, herbaria_index_sorts(query: @query))
 
 flash_error(@error) if @error && @objects.empty?
+nonpersonal = (@query.flavor == :nonpersonal)
 %>
 
 <% if @merge %>
@@ -21,7 +22,7 @@ flash_error(@error) if @error && @objects.empty?
       <thead>
         <tr>
           <th><%= :herbarium_index_records.t %></th>
-          <th><%= :USER.t unless @no_user_column %></th>
+          <th><%= :USER.t unless nonpersonal %></th>
           <th><%= :herbarium_code.t %></th>
           <th><%= :NAME.t %></th>
         </tr>
@@ -33,7 +34,7 @@ flash_error(@error) if @error && @objects.empty?
               <%= herbarium.herbarium_records.length %>
             </td>
             <td>
-              <%= if !@no_user_column && herbarium.personal_user.present?
+              <%= if !nonpersonal && herbarium.personal_user.present?
                     tag.span(user_link(herbarium.personal_user),
                             title: herbarium.personal_user.unique_text_name)
               end %>

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -6,7 +6,7 @@ add_tab_set(herbaria_index_links(query: @query))
 add_sorter(@query, herbaria_index_sorts(query: @query))
 
 flash_error(@error) if @error && @objects.empty?
-nonpersonal = (@query.flavor == :nonpersonal)
+nonpersonal = (@query&.flavor == :nonpersonal)
 %>
 
 <% if @merge %>

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -1,8 +1,9 @@
 <%
+@container = :wide
 @title ||= :list_herbaria_title.t
 
 add_tab_set(herbaria_index_links(query: @query))
-@container = :wide
+add_sorter(@query, herbaria_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/herbarium_records/index.html.erb
+++ b/app/views/herbarium_records/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
+# the no_hits_title.
 @title ||= :list_herbarium_records_title.t
-
 add_tab_set(herbarium_records_index_links(obs: @observation))
 add_sorter(@query, herbarium_records_index_sorts)
 

--- a/app/views/herbarium_records/index.html.erb
+++ b/app/views/herbarium_records/index.html.erb
@@ -1,8 +1,9 @@
 <%
+@container = :wide
 @title ||= :list_herbarium_records_title.t
 
-add_tab_set(herbarium_record_index_links(obs: @observation))
-@container = :wide
+add_tab_set(herbarium_records_index_links(obs: @observation))
+add_sorter(@query, herbarium_records_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,7 +1,8 @@
 <%
-add_tab_set(images_index_links(query: @query))
-
 @container = :full
+add_tab_set(images_index_links(query: @query))
+add_sorter(@query, images_sorting_links)
+
 flash_error(@error) if @error && @objects.empty?
 %>
 

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_tab_set(images_index_links(query: @query))
-add_sorter(@query, images_sorting_links)
+add_sorter(@query, images_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/locations/descriptions/index.html.erb
+++ b/app/views/locations/descriptions/index.html.erb
@@ -1,5 +1,6 @@
 <%
 add_tab_set(location_description_index_links(query: @query))
+add_sorter(@query, descriptions_index_sorts)
 @container = :wide
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,7 +1,14 @@
 <%
 @container = :wide
 add_tab_set(locations_index_links(query: @query))
-add_sorter(@query, location_index_sorts(query: @query))
+all_links = if (params[:id].present? ||
+                params[:by].present? ||
+                params[:by_user].present?)
+              false
+            else
+              true
+            end
+add_sorter(@query, location_index_sorts(query: @query), link_all: all_links)
 @known_pages = @pages
 @known_data  = @objects
 

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,7 +1,7 @@
 <%
-add_tab_set(locations_index_links(query: @query))
 @container = :wide
-
+add_tab_set(locations_index_links(query: @query))
+add_sorter(@query, location_index_sorts(query: @query))
 @known_pages = @pages
 @known_data  = @objects
 

--- a/app/views/names/descriptions/index.html.erb
+++ b/app/views/names/descriptions/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_tab_set(name_description_index_links(query: @query))
-
+add_sorter(@query, descriptions_index_sorts)
 flash_error(@error) if @error && @objects.empty?
 %>
 

--- a/app/views/names/index.html.erb
+++ b/app/views/names/index.html.erb
@@ -1,6 +1,7 @@
 <%
-add_tab_set(names_index_links(query: @query))
 @container = :full
+add_tab_set(names_index_links(query: @query))
+add_sorter(@query, names_index_sorts(query: @query))
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,6 +1,6 @@
 <%
-add_tab_set(index_observation_links(query: @query)) if @objects.any?
-
+add_tab_set(observations_index_links(query: @query)) if @objects.any?
+add_sorter(@query, observations_index_sorts)
 @container = :full
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,6 +1,6 @@
 <%
+# the no_hits_title.
 @title ||= :list_projects_title.t
-
 add_tab_set(projects_index_links)
 add_sorter(@query, projects_index_sorts)
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -2,6 +2,7 @@
 @title ||= :list_projects_title.t
 
 add_tab_set(projects_index_links)
+add_sorter(@query, projects_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/sequences/index.html.erb
+++ b/app/views/sequences/index.html.erb
@@ -1,6 +1,6 @@
 <%
+# the no_hits_title.
 @title ||= :SEQUENCES.t
-
 add_sorter(@query, sequences_index_sorts)
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/sequences/index.html.erb
+++ b/app/views/sequences/index.html.erb
@@ -1,6 +1,7 @@
 <%
 @title ||= :SEQUENCES.t
 
+add_sorter(@query, sequences_index_sorts)
 flash_error(@error) if @error && @objects.empty?
 %>
 

--- a/app/views/species_lists/index.html.erb
+++ b/app/views/species_lists/index.html.erb
@@ -1,5 +1,6 @@
 <%
-  flash_error(@error) if @error && @objects.empty?
+add_sorter(@query, species_lists_index_sorts(query: @query))
+flash_error(@error) if @error && @objects.empty?
 %>
 
 <%= paginate_block(@pages) do %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,5 @@
 <%
+@container = :full
 @title ||= :users_by_name_title.t
 add_sorter(@query, users_index_sorts(in_admin_mode?))
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,8 @@
 <%
-   @title ||= :users_by_name_title.t
+@title ||= :users_by_name_title.t
+add_sorter(@query, users_index_sorts)
 
-   flash_error(@error) if @error && @objects.empty?
+flash_error(@error) if @error && @objects.empty?
 %>
 
 <%

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,6 @@
 <%
 @title ||= :users_by_name_title.t
-add_sorter(@query, users_index_sorts)
+add_sorter(@query, users_index_sorts(in_admin_mode?))
 
 flash_error(@error) if @error && @objects.empty?
 %>


### PR DESCRIPTION
Build the result sorter for index views in the `title_and_tabsets_helper`, removing it from the `ApplicationController`. 

Move the sorts arrays out of the controller, where they were passed to `show_index_of_objects` as `args[:sorting_links]`, to the helper.

Also removes the timer ivars and the timer from the `ApplicationController` and the searchbar view.