### PR TITLE
Fix show obs tabset map link

### DIFF
--- a/app/helpers/tabs/general_helper.rb
+++ b/app/helpers/tabs/general_helper.rb
@@ -3,31 +3,27 @@
 module Tabs
   module GeneralHelper
     def coerced_observation_query_link(query)
-      return unless query
+      return unless query && (link = coerced_query_link(query, Observation))
 
-      [*coerced_query_link(query, Observation),
-       { class: __method__.to_s }]
+      [*link, { class: __method__.to_s }]
     end
 
     def coerced_location_query_link(query)
-      return unless query
+      return unless query && (link = coerced_query_link(query, Location))
 
-      [*coerced_query_link(query, Location),
-       { class: __method__.to_s }]
+      [*link, { class: __method__.to_s }]
     end
 
     def coerced_image_query_link(query)
-      return unless query
+      return unless query && (link = coerced_query_link(query, Image))
 
-      [*coerced_query_link(query, Image),
-       { class: __method__.to_s }]
+      [*link, { class: __method__.to_s }]
     end
 
     def coerced_name_query_link(query)
-      return unless query
+      return unless query && (link = coerced_query_link(query, Name))
 
-      [*coerced_query_link(query, Name),
-       { class: __method__.to_s }]
+      [*link, { class: __method__.to_s }]
     end
 
     def object_return_link(obj, text = nil)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -10,7 +10,7 @@ module Tabs
         *show_obs_google_links_for(obs.name),
         send_observer_question_link(obs, user),
         observation_manage_lists_link(obs, user),
-        observation_map_locations_link(mappable),
+        observation_map_link(mappable),
         *obs_change_links(obs)
       ].reject(&:empty?)
     end
@@ -53,10 +53,10 @@ module Tabs
        { class: __method__.to_s }]
     end
 
-    def observation_map_locations_link(mappable)
+    def observation_map_link(mappable)
       return unless mappable
 
-      [:MAP.t, add_query_param(map_locations_path),
+      [:MAP.t, add_query_param(map_observation_path),
        { class: __method__.to_s }]
     end
 


### PR DESCRIPTION
I believe we discovered and discussed this issue at a meeting a few weeks ago, and then I forgot to fix it. The issue is that it seems the show Observation "Map" link should be a link to "show the current observation’s location on a map". 

It presently links to a "Map of Locations with Observations of {obs.name}”, which is more or less exactly the same as the “Occurrence Map for {obs.name}” linked in the same tabset above.

![obs_map](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/a6409420-9237-4ce7-8290-fea62bd5573c)
