### PR TITLE
Move obs map link to pager where expected

### DIFF
--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -5,7 +5,7 @@ module Tabs
   module ObservationsHelper
     # assemble links for "tabset" for show_observation
     # actually a list of links and the interest icons
-    def show_observation_links(obs:, user:, mappable:)
+    def show_observation_links(obs:, user:)
       [
         google_images_for_name_link(obs.name),
         occurrence_map_for_name_link(obs.name),

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -7,19 +7,12 @@ module Tabs
     # actually a list of links and the interest icons
     def show_observation_links(obs:, user:, mappable:)
       [
-        *show_obs_google_links_for(obs.name),
+        google_images_for_name_link(obs_name),
+        occurrence_map_for_name_link(obs_name),
         send_observer_question_link(obs, user),
         observation_manage_lists_link(obs, user),
-        observation_map_link(mappable),
         *obs_change_links(obs)
       ].reject(&:empty?)
-    end
-
-    def show_obs_google_links_for(obs_name)
-      return unless obs_name.known?
-
-      [google_images_for_name_link(obs_name),
-       google_distribution_map_for_name_link(obs_name)]
     end
 
     def google_images_for_name_link(obs_name)
@@ -29,7 +22,7 @@ module Tabs
        { class: __method__.to_s }]
     end
 
-    def google_distribution_map_for_name_link(obs_name)
+    def occurrence_map_for_name_link(obs_name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: obs_name.id)),
        { class: __method__.to_s }]

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -7,8 +7,8 @@ module Tabs
     # actually a list of links and the interest icons
     def show_observation_links(obs:, user:, mappable:)
       [
-        google_images_for_name_link(obs_name),
-        occurrence_map_for_name_link(obs_name),
+        google_images_for_name_link(obs.name),
+        occurrence_map_for_name_link(obs.name),
         send_observer_question_link(obs, user),
         observation_manage_lists_link(obs, user),
         *obs_change_links(obs)

--- a/app/views/application/content/_prev_next_pager.html.erb
+++ b/app/views/application/content/_prev_next_pager.html.erb
@@ -4,9 +4,7 @@
   <div>
     <%= link_prev(object) %> |
     <%= link_with_query(:INDEX.t, object.index_link_args) %> |
-    <% if @mappable %>
-      <%= link_with_query(:MAP.t, map_locations_path) %> |
-    <% end %>
+    <%= link_to(*observation_map_link(@mappable)) if @mappable %> |
     <%= link_next(object) %>
   </div>
 <% end %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -4,8 +4,7 @@
 
 add_pager_for(@observation)
 add_interest_icons(@user, @observation)
-add_tab_set(show_observation_links(obs: @observation, user: @user,
-                                          mappable: @mappable))
+add_tab_set(show_observation_links(obs: @observation, user: @user))
 
 @container = :double
 


### PR DESCRIPTION
Removes the obs "Map" link from the tabset, and updates the "Map" link in the Show Obs pager to point to the map of the obs.