### PR TITLE
Reorganize show obs tabs for name info

### DIFF
--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -34,7 +34,7 @@ module LightboxHelper
     end
     html << caption_obs_title(obs_data)
     html << render(partial: "observations/show/observation",
-                   locals: { observation: obs_data[:obs], caption: true })
+                   locals: { obs: obs_data[:obs], caption: true })
   end
 
   def caption_obs_title(obs_data)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -75,13 +75,14 @@ module LinkHelper
     unless target.is_a?(String)
       classes += " destroy_#{target.type_tag}_link_#{target.id}"
     end
+    classes = class_names(classes, args[:class])
 
     html_options = {
       method: :delete,
       class: classes,
       id: id,
       data: { confirm: :are_you_sure.t }
-    }.merge(args.except(:back))
+    }.merge(args.except(:back, :class))
 
     button_to(path, html_options) { name }
   end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -6,7 +6,7 @@ module Tabs
     # assemble links for "tabset" for show_observation
     # actually a list of links and the interest icons
     def show_observation_links(obs:)
-      obs_change_links(obs).reject(&:empty?)
+      obs_change_links(obs)&.reject(&:empty?)
     end
 
     ########################################################################

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -15,19 +15,6 @@ module Tabs
       ].reject(&:empty?)
     end
 
-    def google_images_for_name_link(obs_name)
-      [:google_images.t,
-       format("https://images.google.com/images?q=%s",
-              obs_name.real_text_name),
-       { class: __method__.to_s }]
-    end
-
-    def occurrence_map_for_name_link(obs_name)
-      [:show_name_distribution_map.t,
-       add_query_param(map_name_path(id: obs_name.id)),
-       { class: __method__.to_s }]
-    end
-
     def send_observer_question_link(obs, user)
       return if obs.user.no_emails
       return unless obs.user.email_general_question && obs.user != user
@@ -46,6 +33,54 @@ module Tabs
        { class: __method__.to_s }]
     end
 
+    ########################################################################
+    # Name section -- generates HTML
+
+    # generates HTML using create_tabs with xtrargs { class: "d-block" }
+    # the hiccup is that list_descriptions is already HTML
+    def name_links_on_mo(name:)
+      tabs = create_tabs(obs_related_name_links(name), { class: "d-block" })
+      tabs += obs_name_description_links(name)
+      tabs += create_tabs([occurrence_map_for_name_link(obs_name)],
+                          { class: "d-block" })
+      tabs.reject(&:empty?)
+    end
+
+    def obs_related_name_links(name)
+      [
+        show_object_link(name,
+                         :show_name.t(name: name.display_name_brief_authors)),
+        observations_of_name_link(name),
+        observations_of_look_alikes_link(name),
+        observations_of_related_taxa_link(name)
+      ]
+    end
+
+    def observations_of_name_link(name)
+      [:show_observation_more_like_this.t,
+       observations_path(name: name.id),
+       { class: __method__.to_s }]
+    end
+
+    def observations_of_look_alikes_link(name)
+      [:show_observation_look_alikes.t,
+       observations_path(name: name.id, look_alikes: "1"),
+       { class: __method__.to_s }]
+    end
+
+    def observations_of_related_taxa_link(name)
+      [:show_observation_related_taxa.t,
+       observations_path(name: name.id, related_taxa: "1"),
+       { class: __method__.to_s }]
+    end
+
+    # from descriptions_helper
+    def obs_name_description_links(name)
+      list_descriptions(object: name)&.map do |link|
+        tag.div(link)
+      end
+    end
+
     def observation_map_link(mappable)
       return unless mappable
 
@@ -53,23 +88,40 @@ module Tabs
        { class: __method__.to_s }]
     end
 
-    def obs_change_links(obs)
-      return unless check_permission(obs)
+    def name_links_web(name:)
+      tabs = create_tabs(observation_web_name_links(name), { class: "d-block" })
+      tabs.reject(&:empty?)
+    end
 
+    def observation_web_name_links(name)
       [
-        edit_observation_link(obs),
-        destroy_observation_link(obs)
+        mycoportal_name_link(name),
+        mycobank_name_search_link(name),
+        google_images_for_name_link(name)
       ]
     end
 
-    def edit_observation_link(obs)
-      [:edit_object.t(type: Observation),
-       add_query_param(edit_observation_path(obs.id)),
-       { class: "#{__method__}_#{obs.id}" }]
+    def mycoportal_name_link(name)
+      ["MyCoPortal", mycoportal_url(name),
+       { class: __method__.to_s, target: :_blank, rel: :noopener }]
     end
 
-    def destroy_observation_link(obs)
-      [nil, obs, { button: :destroy }]
+    def mycobank_name_search_link(name)
+      ["Mycobank", mycobank_name_search_url(name),
+       { class: __method__.to_s, target: :_blank, rel: :noopener }]
+    end
+
+    def google_images_for_name_link(obs_name)
+      [:google_images.t,
+       format("https://images.google.com/images?q=%s",
+              obs_name.real_text_name),
+       { class: __method__.to_s }]
+    end
+
+    def occurrence_map_for_name_link(obs_name)
+      [:show_name_distribution_map.t,
+       add_query_param(map_name_path(id: obs_name.id)),
+       { class: __method__.to_s }]
     end
 
     ############################################
@@ -208,6 +260,25 @@ module Tabs
       [:download_observations_back.t,
        add_query_param(observations_path),
        { class: __method__.to_s }]
+    end
+
+    def obs_change_links(obs)
+      return unless check_permission(obs)
+
+      [
+        edit_observation_link(obs),
+        destroy_observation_link(obs)
+      ]
+    end
+
+    def edit_observation_link(obs)
+      [:edit_object.t(type: Observation),
+       add_query_param(edit_observation_path(obs.id)),
+       { class: "#{__method__}_#{obs.id}" }]
+    end
+
+    def destroy_observation_link(obs)
+      [nil, obs, { button: :destroy }]
     end
   end
 end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -5,14 +5,19 @@ module Tabs
   module ObservationsHelper
     # assemble links for "tabset" for show_observation
     # actually a list of links and the interest icons
-    def show_observation_links(obs:)
-      obs_change_links(obs)&.reject(&:empty?)
+    def show_observation_links(obs:, user:)
+      [
+        send_observer_question_link(obs, user),
+        observation_manage_lists_link(obs, user),
+        *obs_change_links(obs)&.reject(&:empty?)
+      ]
     end
 
     ########################################################################
     # LINKS FOR PANELS
     #
     # Used in the observation panel
+
     def send_observer_question_link(obs, user)
       return if obs.user.no_emails
       return unless obs.user.email_general_question && obs.user != user

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -5,16 +5,14 @@ module Tabs
   module ObservationsHelper
     # assemble links for "tabset" for show_observation
     # actually a list of links and the interest icons
-    def show_observation_links(obs:, user:)
-      [
-        google_images_for_name_link(obs.name),
-        occurrence_map_for_name_link(obs.name),
-        send_observer_question_link(obs, user),
-        observation_manage_lists_link(obs, user),
-        *obs_change_links(obs)
-      ].reject(&:empty?)
+    def show_observation_links(obs:)
+      obs_change_links(obs).reject(&:empty?)
     end
 
+    ########################################################################
+    # LINKS FOR PANELS
+    #
+    # Used in the observation panel
     def send_observer_question_link(obs, user)
       return if obs.user.no_emails
       return unless obs.user.email_general_question && obs.user != user
@@ -25,6 +23,7 @@ module Tabs
          class: __method__.to_s }]
     end
 
+    # Used in the lists panel
     def observation_manage_lists_link(obs, user)
       return unless user
 
@@ -33,11 +32,10 @@ module Tabs
        { class: __method__.to_s }]
     end
 
-    ########################################################################
-    # Name section -- generates HTML
+    # Name panel -- generates HTML
 
-    # generates HTML using create_tabs with xtrargs { class: "d-block" }
-    # the hiccup is that list_descriptions is already HTML
+    # uses create_links_to with extra_args { class: "d-block" }
+    # the hiccup here is that list_descriptions is already HTML, an inline list
     def name_links_on_mo(name:)
       tabs = create_links_to(obs_related_name_links(name), { class: "d-block" })
       tabs += obs_name_description_links(name)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -39,10 +39,10 @@ module Tabs
     # generates HTML using create_tabs with xtrargs { class: "d-block" }
     # the hiccup is that list_descriptions is already HTML
     def name_links_on_mo(name:)
-      tabs = create_tabs(obs_related_name_links(name), { class: "d-block" })
+      tabs = create_links_to(obs_related_name_links(name), { class: "d-block" })
       tabs += obs_name_description_links(name)
-      tabs += create_tabs([occurrence_map_for_name_link(obs_name)],
-                          { class: "d-block" })
+      tabs += create_links_to([occurrence_map_for_name_link(obs_name)],
+                              { class: "d-block" })
       tabs.reject(&:empty?)
     end
 

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -41,7 +41,7 @@ module Tabs
     def name_links_on_mo(name:)
       tabs = create_links_to(obs_related_name_links(name), { class: "d-block" })
       tabs += obs_name_description_links(name)
-      tabs += create_links_to([occurrence_map_for_name_link(obs_name)],
+      tabs += create_links_to([occurrence_map_for_name_link(name)],
                               { class: "d-block" })
       tabs.reject(&:empty?)
     end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -89,7 +89,8 @@ module Tabs
     end
 
     def name_links_web(name:)
-      tabs = create_tabs(observation_web_name_links(name), { class: "d-block" })
+      tabs = create_links_to(observation_web_name_links(name),
+                             { class: "d-block" })
       tabs.reject(&:empty?)
     end
 

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -116,7 +116,7 @@ module Tabs
       [:google_images.t,
        format("https://images.google.com/images?q=%s",
               obs_name.real_text_name),
-       { class: __method__.to_s }]
+       { class: __method__.to_s, target: :_blank, rel: :noopener }]
     end
 
     def occurrence_map_for_name_link(obs_name)

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -146,20 +146,28 @@ module TitleAndTabsetHelper
   #   "<a href="url" class="edit_form_link">text</a>",
   #   "(an HTML form)" via destroy_button, gives default button text and class
   #
-  def create_links_to(links)
+  # Allows passing an extra args hash to be merged with each link's args
+  #
+  def create_links_to(links, extra_args = {})
     return [] unless links
 
     links.compact.map do |link|
-      create_link_to(link)
+      create_link_to(link, extra_args)
     end
   end
 
   # Unpacks the [text, url, args] array for a single link and figures out
   # which HTML to return for that type of link
-  def create_link_to(link)
+  # Pass extra args hash to
+  def create_link_to(link, extra_args = {})
     str, url, args = link
     args ||= {}
+    # kwargs that will be passed to link. remove args used in button helpers
     kwargs = args&.except(:button, :target)
+    # blend in the class names that may come from the extra_args
+    kwargs[:class] = class_names(kwargs[:class], extra_args[:class])
+    # merge in other args from extra_args (will overwrite keys!)
+    kwargs = kwargs&.merge(extra_args&.except(:class))
     case args[:button]
     when :destroy
       destroy_button(name: str, target: args[:target] || url, **kwargs)

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -146,7 +146,7 @@ module TitleAndTabsetHelper
   #   "<a href="url" class="edit_form_link">text</a>",
   #   "(an HTML form)" via destroy_button, gives default button text and class
   #
-  # Allows passing an extra args hash to be merged with each link's args
+  # Allows passing an extra_args hash to be merged with each link's args
   #
   def create_links_to(links, extra_args = {})
     return [] unless links
@@ -158,7 +158,7 @@ module TitleAndTabsetHelper
 
   # Unpacks the [text, url, args] array for a single link and figures out
   # which HTML to return for that type of link
-  # Pass extra args hash to
+  # Pass extra_args hash to modify the link/button attributes
   def create_link_to(link, extra_args = {})
     str, url, args = link
     args ||= {}

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -144,7 +144,8 @@ module TitleAndTabsetHelper
   # ]
   # create_links_to(links) will make an array of the following HTML
   #   "<a href="url" class="edit_form_link">text</a>",
-  #   "(an HTML form)" via destroy_button, gives default button text and class
+  #   "<form action='destroy'>" etc via destroy_button
+  #   (The above array gives default button text and class)
   #
   # Allows passing an extra_args hash to be merged with each link's args
   #

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -254,6 +254,7 @@ module TitleAndTabsetHelper
 
   # Create sorting links, "graying-out" the current order.
   # Need query to know which is current order
+  # Links are arrays of [text, path]
   def create_sorting_links(query, links, link_all)
     results = []
     this_by = (query.params[:by] || query.default_order).sub(/^reverse_/, "")

--- a/app/views/application/content/_title_and_tab_sets.html.erb
+++ b/app/views/application/content/_title_and_tab_sets.html.erb
@@ -12,13 +12,14 @@ sorts
 %>
 <%
 add_filter_help(@any_content_filters_applied)
+add_right_tabs = (content_for?(:tab_set) || content_for?(:interest_icons))
 %>
 
 <div class="row">
   <!-- Push down pager, title on small, xs screens so buttons do not block -->
   <%= tag.div(safe_nbsp, class: "hidden-print visible-xs visible-sm mt-4") %>
 
-  <div class="col-xs-<%= content_for?(:tab_set) ? 8 : 12 %>" id="title_bar">
+  <div class="col-xs-<%= add_right_tabs ? 8 : 12 %>" id="title_bar">
     <!-- Pager -->
     <%= content_tag_if(content_for?(:prev_next_object), :div,
                        class: "hidden-print") do
@@ -33,8 +34,7 @@ add_filter_help(@any_content_filters_applied)
   </div>
 
   <!-- Tabsets and interest icons, within "#right_tabs" -->
-  <%= content_tag_if(content_for?(:tab_set) || content_for?(:interest_icons),
-                    :div, id: "right_tabs",
+  <%= content_tag_if(add_right_tabs, :div, id: "right_tabs",
                     class: "hidden-print text-right col-sm-4 mb-3") do
         concat(yield(:interest_icons))
         concat(yield(:tab_set))

--- a/app/views/comments/_object.html.erb
+++ b/app/views/comments/_object.html.erb
@@ -19,8 +19,7 @@
     render(partial: "names/descriptions/show/name_description", object: object, locals: { review: false })
 
   when "Observation"
-    render(partial: "observations/show/observation",
-           locals: { observation: object })
+    render(partial: "observations/show/observation", locals: { obs: object })
 
   when "Project"
     render(partial: "project/project", object: object)

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -13,7 +13,7 @@ add_tab_set(comment_form_new_links(target: @target))
   <% if @target.is_a?(Observation) %>
     <div class="col-xs-12 col-sm-4">
       <%= render(partial: "observations/show/images",
-                 locals: { observation: @target, thumb_size_control: false }) %>
+                 locals: { obs: @target, thumb_size_control: false }) %>
     </div>
   <% end %>
 </div><!--.row-->

--- a/app/views/observations/namings/_row.html.erb
+++ b/app/views/observations/namings/_row.html.erb
@@ -4,7 +4,7 @@
 # Also naming edit and delete buttons if the current user owns the naming.
 # @vote is used by observations/namings/votes/form
 @vote = votes[naming.id]
-row = observation_naming_row(observation, naming, logged_in)
+row = observation_naming_row(obs, naming, logged_in)
 %>
 
 <div class="row" id="observation_naming_<%= naming.id %>">

--- a/app/views/observations/namings/_table.html.erb
+++ b/app/views/observations/namings/_table.html.erb
@@ -2,9 +2,9 @@
 # called from observations/show/namings
 # Just the "table" of current namings, with headers
 logged_in = @user&.verified
-namings = observation.namings.sort_by(&:created_at)
-header = observation_naming_header_row(observation, logged_in)
-votes = gather_users_votes(observation, @user)
+namings = obs.namings.sort_by(&:created_at)
+header = observation_naming_header_row(obs, logged_in)
+votes = gather_users_votes(obs, @user)
 %>
 
 <div class="namings-table" id="namings_table">
@@ -21,7 +21,7 @@ votes = gather_users_votes(observation, @user)
   <div class="container-fluid panel panel-default">
     <% namings.each do |naming| %>
       <%= render(partial: "observations/namings/row",
-                  locals: { naming: naming, observation: observation,
+                  locals: { naming: naming, obs: obs,
                             votes: votes, logged_in: logged_in }) %>
     <% end # each naming %>
   </div>

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -8,7 +8,7 @@ add_tab_set(edit_naming_links(obs: @observation))
   <div class="col-xs-12 col-sm-8">
     <div class="mt-3">
       <%= render(partial: "observations/show/observation",
-                 locals: { observation: @observation }) %>
+                 locals: { obs: @observation }) %>
     </div>
 
     <div class="mt-3">
@@ -20,7 +20,7 @@ add_tab_set(edit_naming_links(obs: @observation))
 
   <div class="col-xs-12 col-sm-4">
     <%= render(partial: "observations/show/images",
-               locals: { observation: @observation,
+               locals: { obs: @observation,
                          thumb_size_control: false }) %>
   </div><!--.col-->
 </div><!--.row-->

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -8,7 +8,7 @@ add_tab_set(new_naming_links(obs: @observation))
   <div class="col-xs-12 col-sm-8">
     <div class="mt-3">
       <%= render(partial: "observations/show/observation",
-                 locals: { observation: @observation }) %>
+                 locals: { obs: @observation }) %>
     </div>
 
     <div class="mt-3">
@@ -20,7 +20,7 @@ add_tab_set(new_naming_links(obs: @observation))
 
   <div class="col-xs-12 col-sm-4">
     <%= render(partial: "observations/show/images",
-              locals: { observation: @observation,
+              locals: { obs: @observation,
                         thumb_size_control: false }) %>
   </div><!--.col-->
 </div><!--.row-->

--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -66,6 +66,6 @@ add_tab_set(naming_suggestion_links(obs: @observation))
   </div>
   <div class="col-sm-4 float-sm-right">
     <%= render(partial: "observations/show/images",
-               locals: { observation: @observation }) %>
+               locals: { obs: @observation }) %>
   </div>
 </div><!--.row-->

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -4,12 +4,11 @@ add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
 add_owner_naming(@owner_naming)
 add_pager_for(@observation)
 add_interest_icons(@user, @observation)
-add_tab_set(show_observation_links(obs: @observation, user: @user))
+add_tab_set(show_observation_links(obs: @observation))
 
 @container = :double
 
 show_map   = @user ? @user.thumbnail_maps : !session[:hide_thumbnail_maps]
-show_lists = @user && @observation.species_lists.any?
 show_links = @user && (@observation.external_links.any? || @new_sites.any?)
 
 obs_locals = { observation: @observation }
@@ -23,7 +22,7 @@ obs_locals = { observation: @observation }
     <% if @user %>
       <%= render(partial: "observations/show/name_info", locals: obs_locals) %>
 
-      <% if show_lists %>
+      <% if @user %>
         <%= render(partial: "observations/show/species_lists",
                    locals: obs_locals) %>
       <% end %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -4,14 +4,15 @@ add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
 add_owner_naming(@owner_naming)
 add_pager_for(@observation)
 add_interest_icons(@user, @observation)
-add_tab_set(show_observation_links(obs: @observation))
+add_tab_set(show_observation_links(obs: @observation, user: @user))
 
 @container = :double
 
 show_map   = @user ? @user.thumbnail_maps : !session[:hide_thumbnail_maps]
+show_lists = @user && @observation.species_lists.any?
 show_links = @user && (@observation.external_links.any? || @new_sites.any?)
 
-obs_locals = { observation: @observation }
+obs_locals = { obs: @observation }
 %>
 
 <div class="row">
@@ -22,7 +23,7 @@ obs_locals = { observation: @observation }
     <% if @user %>
       <%= render(partial: "observations/show/name_info", locals: obs_locals) %>
 
-      <% if @user %>
+      <% if show_lists %>
         <%= render(partial: "observations/show/species_lists",
                    locals: obs_locals) %>
       <% end %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -17,31 +17,19 @@ obs_locals = { observation: @observation }
 
 <div class="row">
   <div class="col-sm-8 col-lg-7 float-sm-left">
-    <%= panel_block(id: "observation_details", class: "name-section") do
-      render(partial: "observations/show/observation", locals: obs_locals)
-    end %>
+    <%= render(partial: "observations/show/observation", locals: obs_locals) %>
   </div>
   <div class="col-sm-4 col-lg-5 float-sm-right">
     <% if @user %>
-      <%= panel_block(id: "observation_name_info",
-                      class: "name-section small") do
-        render(partial: "observations/show/name_info", locals: obs_locals)
-      end %>
+      <%= render(partial: "observations/show/name_info", locals: obs_locals) %>
 
       <% if show_lists %>
-        <%= panel_with_outer_heading(heading: :show_lists_header.t,
-                                     id: "observation_species_lists",
-                                     inner_class: "p-0") do
-          render(partial: "observations/show/species_lists", locals: obs_locals)
-        end %>
+        <%= render(partial: "observations/show/species_lists",
+                   locals: obs_locals) %>
       <% end %>
 
       <% if show_links %>
-        <%= panel_with_outer_heading(heading: :EXTERNAL_LINKS.t,
-                                     id: "observation_links",
-                                     inner_class: "p-0") do
-          render(partial: "observations/show/links", locals: obs_locals)
-        end %>
+        <%= render(partial: "observations/show/links", locals: obs_locals) %>
       <% end %>
     <% end %>
 

--- a/app/views/observations/show/_collection_numbers.html.erb
+++ b/app/views/observations/show/_collection_numbers.html.erb
@@ -1,15 +1,15 @@
 <%
-  numbers  = observation.collection_numbers
-  can_edit = in_admin_mode? || observation.can_edit?
-  obs_id = observation.id
-  # This is passed in to show_collection_number, allowing users to do prev,
-  # next and index from there to navigate through all the rest for this obs.
-  cn_query = Query.lookup(:CollectionNumber, :all, observations: observation.id)
+numbers  = obs.collection_numbers
+can_edit = in_admin_mode? || obs.can_edit?
+obs_id = obs.id
+# This is passed in to show_collection_number, allowing users to do prev,
+# next and index from there to navigate through all the rest for this obs.
+cn_query = Query.lookup(:CollectionNumber, :all, observations: obs.id)
 %>
 
 <div class="obs-collection" id="observation_collection_numbers">
 <% unless @user.try(&:hide_specimen_stuff?) ||
-          observation.user.try(&:hide_specimen_stuff?) %>
+          obs.user.try(&:hide_specimen_stuff?) %>
   <% if numbers.any? && can_edit %>
     <div>
       <%= :Collection_numbers.t %>: [<%=

--- a/app/views/observations/show/_herbarium_records.html.erb
+++ b/app/views/observations/show/_herbarium_records.html.erb
@@ -1,16 +1,16 @@
 <%
-  records = observation.herbarium_records
-  can_add = in_admin_mode? || observation.can_edit? ||
-            @user && @user.curated_herbaria.any?
-  obs_id = observation.id
-  # This is passed in to show_herbarium_record, allowing users to do prev,
-  # next and index from there to navigate through all the rest for this obs.
-  query = Query.lookup(:HerbariumRecord, :all, observations: observation.id)
+records = obs.herbarium_records
+can_add = in_admin_mode? || obs.can_edit? ||
+          @user && @user.curated_herbaria.any?
+obs_id = obs.id
+# This is passed in to show_herbarium_record, allowing users to do prev,
+# next and index from there to navigate through all the rest for this obs.
+query = Query.lookup(:HerbariumRecord, :all, observations: obs.id)
 %>
 
 <div class="obs-herbarium" id="observation_herbarium_records">
 <% unless @user.try(&:hide_specimen_stuff?) ||
-          observation.user.try(&:hide_specimen_stuff?) %>
+          obs.user.try(&:hide_specimen_stuff?) %>
   <% if records.any? && can_add %>
     <div>
       <%= :Herbarium_records.t %>: [<%=

--- a/app/views/observations/show/_images.html.erb
+++ b/app/views/observations/show/_images.html.erb
@@ -1,18 +1,18 @@
-<% if observation.images.any? || check_permission(observation) %>
+<% if obs.images.any? || check_permission(obs) %>
   <div class="row">
     <div class="col-sm-6 col-md-4">
       <%= content_tag(:h4, :IMAGES.t, class: "mt-0") %>
     </div>
-    <% if check_permission(observation) %>
+    <% if check_permission(obs) %>
       <div class="col-sm-6 col-md-8 float-sm-right">
         <small>
           <%= link_with_query(:show_observation_add_images.t,
-                              new_image_for_observation_path(observation.id)) %>
+                              new_image_for_observation_path(obs.id)) %>
           | <%= link_with_query(:show_observation_reuse_image.t,
-                                reuse_images_for_observation_path(observation.id)) %>
-          <% if observation.images.length > 0 %>
+                                reuse_images_for_observation_path(obs.id)) %>
+          <% if obs.images.length > 0 %>
             | <%= link_with_query(:show_observation_remove_images.t,
-                                  remove_images_from_observation_path(observation.id)) %>
+                                  remove_images_from_observation_path(obs.id)) %>
             <% end %>
         </small>
       </div>
@@ -20,24 +20,23 @@
   </div><!--.row-->
 <% end %>
 
-<% if observation.images.any? %>
+<% if obs.images.any? %>
   <div class="show_images list-group text-center">
     <%
     # This sort puts the thumbnail first.  We can't use thumb_image, because we
     # haven't eager-loaded it; we *have* eager-loaded all the other images.
-    observation.images.
-                sort_by {|x| x.id == observation.thumb_image_id ? -1 : x.id}.
-                each do |image| %>
+    obs.images.sort_by {|x| x.id == obs.thumb_image_id ? -1 : x.id}.
+               each do |image| %>
       <div class="list-group-item">
         <%= thumbnail(
               image,
-              image_link: image.show_link_args.merge({ obs: observation.id }),
+              image_link: image.show_link_args.merge({ obs: obs.id }),
               original: true,
               is_set: true,
               votes: true) %>
         <%=
           notes = []
-          if image.copyright_holder != observation.user.legal_name
+          if image.copyright_holder != obs.user.legal_name
             notes << image_copyright(image)
           end
           if !image.notes.blank?

--- a/app/views/observations/show/_links.html.erb
+++ b/app/views/observations/show/_links.html.erb
@@ -1,36 +1,43 @@
-<table class="table table-responsive mx-0 mb-0">
-  <% observation.external_links.
-                  sort_by(&:site_name).each do |link| %>
-    <tr>
-      <td style="border-top:0">
-        <%= content_tag(:a, link.external_site.name, href: link.url,
-            data: { role: "link", url: link.url, link: link.id,
-                    site: link.external_site.id, obs: observation.id }) %>
-        <% if link.can_edit?(@user) || in_admin_mode? %>
-          <span data-role="link-controls" class="hidden-links">[<%=
-            content_tag(:a, :EDIT.t, href: "#",
-                              data: { role: "edit-link" })
-          %>|<%=
-            content_tag(:a, :REMOVE.t, href: "#",
-                            data: { role: "remove-link" })
+<%= panel_with_outer_heading(heading: :EXTERNAL_LINKS.t,
+                                     id: "observation_links",
+                                     inner_class: "p-0") do %>
+
+  <table class="table table-responsive mx-0 mb-0">
+    <% observation.external_links.
+                    sort_by(&:site_name).each do |link| %>
+      <tr>
+        <td style="border-top:0">
+          <%= content_tag(:a, link.external_site.name, href: link.url,
+              data: { role: "link", url: link.url, link: link.id,
+                      site: link.external_site.id, obs: observation.id }) %>
+          <% if link.can_edit?(@user) || in_admin_mode? %>
+            <span data-role="link-controls" class="hidden-links">[<%=
+              content_tag(:a, :EDIT.t, href: "#",
+                                data: { role: "edit-link" })
+            %>|<%=
+              content_tag(:a, :REMOVE.t, href: "#",
+                              data: { role: "remove-link" })
+            %>]</span>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+    <% @new_sites.sort_by(&:name).each do |site| %>
+      <tr class="hidden-links">
+        <td style="border-top:0">
+          <%= content_tag(:span, site.name,
+              data: { role: "link", obs: observation.id, site: site.id }) %>
+          <span data-role="link-controls">[<%=
+            content_tag(:a, :ADD.t, href: "#",
+                        data: { role: "add-link" })
           %>]</span>
-        <% end %>
-      </td>
-    </tr>
-  <% end %>
-  <% @new_sites.sort_by(&:name).each do |site| %>
-    <tr class="hidden-links">
-      <td style="border-top:0">
-        <%= content_tag(:span, site.name,
-            data: { role: "link", obs: observation.id, site: site.id }) %>
-        <span data-role="link-controls">[<%=
-          content_tag(:a, :ADD.t, href: "#",
-                      data: { role: "add-link" })
-        %>]</span>
-      </td>
-    </tr>
-  <% end %>
-</table>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+
+<% end %>
+
 <%= javascript_tag %(
   var ADD_LINK_DIALOG    = "#{j :show_observation_add_link_dialog.l}";
   var EDIT_LINK_DIALOG   = "#{j :show_observation_edit_link_dialog.l}";

--- a/app/views/observations/show/_links.html.erb
+++ b/app/views/observations/show/_links.html.erb
@@ -3,13 +3,13 @@
                                      inner_class: "p-0") do %>
 
   <table class="table table-responsive mx-0 mb-0">
-    <% observation.external_links.
+    <% obs.external_links.
                     sort_by(&:site_name).each do |link| %>
       <tr>
         <td style="border-top:0">
           <%= content_tag(:a, link.external_site.name, href: link.url,
               data: { role: "link", url: link.url, link: link.id,
-                      site: link.external_site.id, obs: observation.id }) %>
+                      site: link.external_site.id, obs: obs.id }) %>
           <% if link.can_edit?(@user) || in_admin_mode? %>
             <span data-role="link-controls" class="hidden-links">[<%=
               content_tag(:a, :EDIT.t, href: "#",
@@ -26,7 +26,7 @@
       <tr class="hidden-links">
         <td style="border-top:0">
           <%= content_tag(:span, site.name,
-              data: { role: "link", obs: observation.id, site: site.id }) %>
+              data: { role: "link", obs: obs.id, site: site.id }) %>
           <span data-role="link-controls">[<%=
             content_tag(:a, :ADD.t, href: "#",
                         data: { role: "add-link" })

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -3,20 +3,25 @@
   name = observation.name
 %>
 
-<%= content_tag(:p,
-                link_to(:show_name.t(name: name.display_name_brief_authors),
-                        name_path(name.id))) %>
-<%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),
-                            target: :_blank)) %>
-<%= content_tag(:p, link_to("Mycobank", mycobank_name_search_url(name),
-                            target: :_blank)) %>
-<%= content_tag(:p, link_to(:show_observation_more_like_this.t,
-                            observations_path(name: name.id))) %>
-<%= content_tag(:p, link_to(:show_observation_look_alikes.t,
-                            observations_path(name: name.id,
-                                              look_alikes: "1"))) %>
-<%= content_tag(:p, link_to(:show_observation_related_taxa.t,
-                            observations_path(name: name.id,
-                                              related_taxa: "1"))) %>
-<%= list_descriptions(object: name)&.map { |link|
-      content_tag(:div, link) }.safe_join %>
+<%= panel_block(id: "observation_name_info",
+                      class: "name-section small") do %>
+
+  <%= content_tag(:p,
+                  link_to(:show_name.t(name: name.display_name_brief_authors),
+                          name_path(name.id))) %>
+  <%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),
+                              target: :_blank)) %>
+  <%= content_tag(:p, link_to("Mycobank", mycobank_name_search_url(name),
+                              target: :_blank)) %>
+  <%= content_tag(:p, link_to(:show_observation_more_like_this.t,
+                              observations_path(name: name.id))) %>
+  <%= content_tag(:p, link_to(:show_observation_look_alikes.t,
+                              observations_path(name: name.id,
+                                                look_alikes: "1"))) %>
+  <%= content_tag(:p, link_to(:show_observation_related_taxa.t,
+                              observations_path(name: name.id,
+                                                related_taxa: "1"))) %>
+  <%= list_descriptions(object: name)&.map { |link|
+        content_tag(:div, link) }.safe_join %>
+
+<% end %>

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -6,22 +6,15 @@
 <%= panel_block(id: "observation_name_info",
                 class: "name-section small") do %>
 
-  <%= content_tag(:p,
-                  link_to(:show_name.t(name: name.display_name_brief_authors),
-                          name_path(name.id))) %>
-  <%= content_tag(:p, link_to("MyCoPortal", mycoportal_url(name),
-                              target: :_blank)) %>
-  <%= content_tag(:p, link_to("Mycobank", mycobank_name_search_url(name),
-                              target: :_blank)) %>
-  <%= content_tag(:p, link_to(:show_observation_more_like_this.t,
-                              observations_path(name: name.id))) %>
-  <%= content_tag(:p, link_to(:show_observation_look_alikes.t,
-                              observations_path(name: name.id,
-                                                look_alikes: "1"))) %>
-  <%= content_tag(:p, link_to(:show_observation_related_taxa.t,
-                              observations_path(name: name.id,
-                                                related_taxa: "1"))) %>
-  <%= list_descriptions(object: name)&.map { |link|
-        content_tag(:div, link) }.safe_join %>
+  <%= tag.div(class: "row") do %>
+    <%= tag.div(class: "col-6") do
+      concat(tag.div("On MO:", class: "font-weight-bold"))
+      concat(name_links_on_mo(name: name).safe_join)
+    end %>
+    <%= tag.div(class: "col-6") do
+      concat(tag.div("On the web:", class: "font-weight-bold"))
+      concat(name_links_web(name: name).safe_join)
+    end %>
+  <% end %>
 
 <% end %>

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -1,6 +1,6 @@
 <% # Section showing information about consensus name in ShowObservation
-  lines = []
-  name = observation.name
+lines = []
+name = obs.name
 %>
 
 <%=
@@ -11,11 +11,11 @@ panel_with_outer_heading(
 ) do %>
 
   <%= tag.div(class: "row") do %>
-    <%= tag.div(class: "col-6") do
+    <%= tag.div(class: "col-xs-6") do
       concat(tag.div("On MO:", class: "font-weight-bold"))
       concat(name_links_on_mo(name: name).safe_join)
     end %>
-    <%= tag.div(class: "col-6") do
+    <%= tag.div(class: "col-xs-6") do
       concat(tag.div("On the web:", class: "font-weight-bold"))
       concat(name_links_web(name: name).safe_join)
     end %>

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <%= panel_block(id: "observation_name_info",
-                      class: "name-section small") do %>
+                class: "name-section small") do %>
 
   <%= content_tag(:p,
                   link_to(:show_name.t(name: name.display_name_brief_authors),

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -6,17 +6,17 @@ name = obs.name
 <%=
 panel_with_outer_heading(
   id: "observation_name_info",
-  heading: :show_name.t(name: name.display_name_brief_authors),
+  heading: :about_this_taxon.l,
   inner_class: "name-section small"
 ) do %>
 
   <%= tag.div(class: "row") do %>
     <%= tag.div(class: "col-xs-6") do
-      concat(tag.div("On MO:", class: "font-weight-bold"))
+      concat(tag.div("#{:on_mo.l}:", class: "font-weight-bold"))
       concat(name_links_on_mo(name: name).safe_join)
     end %>
     <%= tag.div(class: "col-xs-6") do
-      concat(tag.div("On the web:", class: "font-weight-bold"))
+      concat(tag.div("#{:on_the_web.l}:", class: "font-weight-bold"))
       concat(name_links_web(name: name).safe_join)
     end %>
   <% end %>

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -3,9 +3,12 @@
   name = observation.name
 %>
 
-<%= panel_with_outer_heading(id: "observation_name_info",
-                             heading: :about_taxon.t,
-                             inner_class: "name-section small") do %>
+<%=
+panel_with_outer_heading(
+  id: "observation_name_info",
+  heading: :show_name.t(name: name.display_name_brief_authors),
+  inner_class: "name-section small"
+) do %>
 
   <%= tag.div(class: "row") do %>
     <%= tag.div(class: "col-6") do

--- a/app/views/observations/show/_name_info.html.erb
+++ b/app/views/observations/show/_name_info.html.erb
@@ -3,8 +3,9 @@
   name = observation.name
 %>
 
-<%= panel_block(id: "observation_name_info",
-                class: "name-section small") do %>
+<%= panel_with_outer_heading(id: "observation_name_info",
+                             heading: :about_taxon.t,
+                             inner_class: "name-section small") do %>
 
   <%= tag.div(class: "row") do %>
     <%= tag.div(class: "col-6") do

--- a/app/views/observations/show/_namings.html.erb
+++ b/app/views/observations/show/_namings.html.erb
@@ -1,9 +1,9 @@
 <%
 logged_in = @user&.verified
-do_suggestions = logged_in && observation.thumb_image_id.present? &&
+do_suggestions = logged_in && obs.thumb_image_id.present? &&
                   (@user.admin ||
                    MO.image_model_beta_testers.include?(@user.id))
-buttons = observation_naming_buttons(observation, do_suggestions)
+buttons = observation_naming_buttons(obs, do_suggestions)
 help = logged_in ? :show_namings_consensus_help.t : :show_namings_please_login.t
 eye  = content_tag(:div,
          "#{image_tag("eye3.png")} = #{:show_namings_eye_help.t}".html_safe,
@@ -17,7 +17,7 @@ eyes = content_tag(:div,
 
   <!--TABLE OF NAMES / REFRESHED BY AJAX -->
   <%= render(partial: "observations/namings/table",
-             locals: { observation: observation }) %>
+             locals: { obs: obs }) %>
   <!--/TABLE OF NAMES -->
 
   <!--HELP TEXT AND EYES -->
@@ -46,11 +46,11 @@ inject_javascript_at_end %(
 <!--SUGGESTIONS-->
 <%
 @query ||= nil
-url = naming_suggestions_for_observation_path(id: observation.id,
+url = naming_suggestions_for_observation_path(id: obs.id,
         names: :xxx, q: get_query_param(@query))
 
 inject_javascript_at_end %(
-  SuggestionModule(#{observation.image_ids}, "#{url}", {
+  SuggestionModule(#{obs.image_ids}, "#{url}", {
     suggestions_processing_images:  "#{j :suggestions_processing_images.t}",
     suggestions_processing_image:   "#{j :suggestions_processing_image.t}",
     suggestions_processing_results: "#{j :suggestions_processing_results.t}",

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -1,84 +1,81 @@
 <%
 # The basic info box for the observation
-obs_id = observation.id
+obs_id = obs.id
 caption ||= false
 %>
 
 <%= panel_block(id: "observation_details", class: "name-section") do %>
 
   <p class="obs-when" id="observation_when">
-    <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
+    <%= :WHEN.t %>: <span class="font-weight-bold"><%= obs.when.web_date %></span>
   </p>
 
   <p class="obs-where" id="observation_where">
-    <%= observation.is_collection_location ?
+    <%= obs.is_collection_location ?
           :show_observation_collection_location.t :
           :show_observation_seen_at.t %>:
-    <%= location_link(observation.place_name,
-                      observation.location, nil, true) %>
+    <%= location_link(obs.place_name,
+                      obs.location, nil, true) %>
   </p>
 
   <p class="obs-lat-lng" id="observation_lat_lng">
     <%=
       hidden = "<i>(#{:show_observation_gps_hidden.t})</i>".html_safe
-      if observation.lat &&
-          (!observation.gps_hidden || observation.can_edit?)
-        link_to("#{observation.display_lat_long.t} " \
-                "#{observation.display_alt.t} " \
+      if obs.lat &&
+          (!obs.gps_hidden || obs.can_edit?)
+        link_to("#{obs.display_lat_long.t} " \
+                "#{obs.display_alt.t} " \
                 "[#{:click_for_map.t}]".html_safe,
                 map_observation_path(id: obs_id))
-      elsif observation.lat
-        hidden + " ".html_safe + observation.display_alt.t
+      elsif obs.lat
+        hidden + " ".html_safe + obs.display_alt.t
       else
-        observation.display_alt.t
+        obs.display_alt.t
       end
     %>
     <%=
-      if observation.lat && observation.gps_hidden && observation.can_edit?
+      if obs.lat && obs.gps_hidden && obs.can_edit?
         hidden
       end
     %>
   </p>
 
   <p class="obs-who" id="observation_who">
-    <%= :WHO.t %>: <span><%= user_link(observation.user) %></span>
-    <%= create_link_to(
-      send_observer_question_link(observation, observation.user)
-    ) %>
+    <%= :WHO.t %>: <span><%= user_link(obs.user) %></span>
   </p>
 
   <% if !caption %>
     <% if @user %>
       <div class="obs-projects" id="observation_projects">
-        <% observation.projects.each do |project| %>
+        <% obs.projects.each do |project| %>
           <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
         <% end %>
       </div>
     <% end %>
 
     <div class="obs-specimen" id="observation_specimen_available">
-      <%= observation.specimen ? :show_observation_specimen_available.t :
+      <%= obs.specimen ? :show_observation_specimen_available.t :
                                   :show_observation_specimen_not_available.t %>
     </div>
 
     <% if @user %>
       <%= render(partial: "observations/show/collection_numbers",
-                locals: { observation: observation }) %>
+                locals: { obs: obs }) %>
 
       <%= render(partial: "observations/show/herbarium_records",
-                locals: { observation: observation }) %>
+                locals: { obs: obs }) %>
 
       <%= render(partial: "observations/show/sequences",
-                locals: { observation: observation }) %>
+                locals: { obs: obs }) %>
     <% end %>
   <% end %>
 
   <div class="obs-notes" id="observation_notes">
-    <%= if observation.notes?
+    <%= if obs.notes?
       Textile.clear_textile_cache
-      Textile.register_name(observation.name)
+      Textile.register_name(obs.name)
       content_tag(
-        :div, observation.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
+        :div, obs.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
       )
     end %>
   </div><!--.obs-notes-->

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -42,6 +42,9 @@ caption ||= false
 
   <p class="obs-who" id="observation_who">
     <%= :WHO.t %>: <span><%= user_link(observation.user) %></span>
+    <%= create_link_to(
+      send_observer_question_link(observation, observation.user)
+    ) %>
   </p>
 
   <% if !caption %>

--- a/app/views/observations/show/_observation.html.erb
+++ b/app/views/observations/show/_observation.html.erb
@@ -3,77 +3,81 @@
 obs_id = observation.id
 caption ||= false
 %>
-<p class="obs-when" id="observation_when">
-  <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
-</p>
 
-<p class="obs-where" id="observation_where">
-  <%= observation.is_collection_location ?
-        :show_observation_collection_location.t :
-        :show_observation_seen_at.t %>:
-  <%= location_link(observation.place_name,
-                    observation.location, nil, true) %>
-</p>
+<%= panel_block(id: "observation_details", class: "name-section") do %>
 
-<p class="obs-lat-lng" id="observation_lat_lng">
-  <%=
-    hidden = "<i>(#{:show_observation_gps_hidden.t})</i>".html_safe
-    if observation.lat &&
-        (!observation.gps_hidden || observation.can_edit?)
-      link_to("#{observation.display_lat_long.t} " \
-              "#{observation.display_alt.t} " \
-              "[#{:click_for_map.t}]".html_safe,
-              map_observation_path(id: obs_id))
-    elsif observation.lat
-      hidden + " ".html_safe + observation.display_alt.t
-    else
-      observation.display_alt.t
-    end
-  %>
-  <%=
-    if observation.lat && observation.gps_hidden && observation.can_edit?
-      hidden
-    end
-  %>
-</p>
+  <p class="obs-when" id="observation_when">
+    <%= :WHEN.t %>: <span class="font-weight-bold"><%= observation.when.web_date %></span>
+  </p>
 
-<p class="obs-who" id="observation_who">
-  <%= :WHO.t %>: <span><%= user_link(observation.user) %></span>
-</p>
+  <p class="obs-where" id="observation_where">
+    <%= observation.is_collection_location ?
+          :show_observation_collection_location.t :
+          :show_observation_seen_at.t %>:
+    <%= location_link(observation.place_name,
+                      observation.location, nil, true) %>
+  </p>
 
-<% if !caption %>
-  <% if @user %>
-    <div class="obs-projects" id="observation_projects">
-      <% observation.projects.each do |project| %>
-        <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
-      <% end %>
+  <p class="obs-lat-lng" id="observation_lat_lng">
+    <%=
+      hidden = "<i>(#{:show_observation_gps_hidden.t})</i>".html_safe
+      if observation.lat &&
+          (!observation.gps_hidden || observation.can_edit?)
+        link_to("#{observation.display_lat_long.t} " \
+                "#{observation.display_alt.t} " \
+                "[#{:click_for_map.t}]".html_safe,
+                map_observation_path(id: obs_id))
+      elsif observation.lat
+        hidden + " ".html_safe + observation.display_alt.t
+      else
+        observation.display_alt.t
+      end
+    %>
+    <%=
+      if observation.lat && observation.gps_hidden && observation.can_edit?
+        hidden
+      end
+    %>
+  </p>
+
+  <p class="obs-who" id="observation_who">
+    <%= :WHO.t %>: <span><%= user_link(observation.user) %></span>
+  </p>
+
+  <% if !caption %>
+    <% if @user %>
+      <div class="obs-projects" id="observation_projects">
+        <% observation.projects.each do |project| %>
+          <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="obs-specimen" id="observation_specimen_available">
+      <%= observation.specimen ? :show_observation_specimen_available.t :
+                                  :show_observation_specimen_not_available.t %>
     </div>
+
+    <% if @user %>
+      <%= render(partial: "observations/show/collection_numbers",
+                locals: { observation: observation }) %>
+
+      <%= render(partial: "observations/show/herbarium_records",
+                locals: { observation: observation }) %>
+
+      <%= render(partial: "observations/show/sequences",
+                locals: { observation: observation }) %>
+    <% end %>
   <% end %>
 
-  <div class="obs-specimen" id="observation_specimen_available">
-    <%= observation.specimen ? :show_observation_specimen_available.t :
-                                :show_observation_specimen_not_available.t %>
-  </div>
+  <div class="obs-notes" id="observation_notes">
+    <%= if observation.notes?
+      Textile.clear_textile_cache
+      Textile.register_name(observation.name)
+      content_tag(
+        :div, observation.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
+      )
+    end %>
+  </div><!--.obs-notes-->
 
-  <% if @user %>
-    <%= render(partial: "observations/show/collection_numbers",
-               locals: { observation: observation }) %>
-
-    <%= render(partial: "observations/show/herbarium_records",
-               locals: { observation: observation }) %>
-
-    <%= render(partial: "observations/show/sequences",
-               locals: { observation: observation }) %>
-  <% end %>
 <% end %>
-
-<div class="obs-notes" id="observation_notes">
-  <%= if observation.notes?
-    Textile.clear_textile_cache
-    Textile.register_name(observation.name)
-    content_tag(
-      :div, observation.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
-    )
-  end %>
-</div><!--.obs-notes-->
-

--- a/app/views/observations/show/_section_update.js.erb
+++ b/app/views/observations/show/_section_update.js.erb
@@ -16,7 +16,7 @@ end
 
 $("#<%= id %>").replaceWith('<%= j render(
   partial: partial,
-  locals: { observation: @observation.reload },
+  locals: { obs: @observation.reload },
   layout: false
 ) %>');
 

--- a/app/views/observations/show/_sequences.html.erb
+++ b/app/views/observations/show/_sequences.html.erb
@@ -1,24 +1,24 @@
 <%
-  sequences = observation.sequences
-  can_edit  = in_admin_mode? || observation.can_edit?
+sequences = obs.sequences
+can_edit  = in_admin_mode? || obs.can_edit?
 
-  # This is passed in to show_sequence, allowing users to do prev,
-  # next and index from there to navigate through all the rest for this obs.
-  query = Query.lookup(:Sequence, :all, observations: observation.id)
+# This is passed in to show_sequence, allowing users to do prev,
+# next and index from there to navigate through all the rest for this obs.
+query = Query.lookup(:Sequence, :all, observations: obs.id)
 %>
 
 <div class="obs-sequence" id="observation_sequences">
 <% unless @user.try(&:hide_specimen_stuff?) ||
-          observation.user.try(&:hide_specimen_stuff?) %>
+          obs.user.try(&:hide_specimen_stuff?) %>
   <% if @user || sequences.any? %>
     <div>
       <%= sequences.any? ? :Sequences.t + ":".html_safe : :show_observation_no_sequences.t %>
       <%=
           add_sequence_link = link_with_query(
             :show_observation_add_sequence.t,
-            new_sequence_path(params: { observation_id: observation.id }),
+            new_sequence_path(params: { observation_id: obs.id }),
             remote: true, onclick: "MOEvents.whirly();",
-            class: "create_sequence_link_#{observation.id}"
+            class: "create_sequence_link_#{obs.id}"
           )
           "[#{add_sequence_link}]".html_safe if @user
       %>
@@ -48,7 +48,7 @@
             if in_admin_mode? || sequence.can_edit?(@user)
               links << link_with_query(
                 :EDIT.t,
-                edit_sequence_path(id: sequence.id, back: observation.id),
+                edit_sequence_path(id: sequence.id, back: obs.id),
                 remote: true, onclick: "MOEvents.whirly();",
                 class: "edit_sequence_link_#{sequence.id}"
               )

--- a/app/views/observations/show/_species_lists.html.erb
+++ b/app/views/observations/show/_species_lists.html.erb
@@ -2,26 +2,22 @@
                             id: "observation_species_lists",
                             inner_class: "p-0") do %>
 
-  <% if observation.species_lists.any? %>
-    <table class="table table-responsive mx-0 mb-0">
-      <% observation.species_lists.each do |spl| %>
-        <tr>
-          <td style="border-top:0">
-            <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
-            <%= if check_permission(spl)
-              put_button(name: :REMOVE.t,
-                        path: observation_species_list_path(
-                          id: observation.id, species_list_id: spl.id,
-                          commit: "remove"
-                        ),
-                        data: { confirm: :are_you_sure.l })
-            end %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  <% end %>
-
-  <%= create_link_to(observation_manage_lists_link(observation, @user)) %>
+  <table class="table table-responsive mx-0 mb-0">
+    <% obs.species_lists.each do |spl| %>
+      <tr>
+        <td style="border-top:0">
+          <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
+          <%= if check_permission(spl)
+            put_button(name: :REMOVE.t,
+                      path: observation_species_list_path(
+                        id: obs.id, species_list_id: spl.id,
+                        commit: "remove"
+                      ),
+                      data: { confirm: :are_you_sure.l })
+          end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
 
 <% end %>

--- a/app/views/observations/show/_species_lists.html.erb
+++ b/app/views/observations/show/_species_lists.html.erb
@@ -2,22 +2,26 @@
                             id: "observation_species_lists",
                             inner_class: "p-0") do %>
 
-  <table class="table table-responsive mx-0 mb-0">
-    <% observation.species_lists.each do |spl| %>
-      <tr>
-        <td style="border-top:0">
-          <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
-          <%= if check_permission(spl)
-            put_button(name: :REMOVE.t,
-                      path: observation_species_list_path(
-                        id: @observation.id, species_list_id: spl.id,
-                        commit: "remove"
-                      ),
-                      data: { confirm: :are_you_sure.l })
-          end %>
-        </td>
-      </tr>
-    <% end %>
-  </table>
+  <% if observation.species_lists.any? %>
+    <table class="table table-responsive mx-0 mb-0">
+      <% observation.species_lists.each do |spl| %>
+        <tr>
+          <td style="border-top:0">
+            <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
+            <%= if check_permission(spl)
+              put_button(name: :REMOVE.t,
+                        path: observation_species_list_path(
+                          id: observation.id, species_list_id: spl.id,
+                          commit: "remove"
+                        ),
+                        data: { confirm: :are_you_sure.l })
+            end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
+
+  <%= create_link_to(observation_manage_lists_link(observation, @user)) %>
 
 <% end %>

--- a/app/views/observations/show/_species_lists.html.erb
+++ b/app/views/observations/show/_species_lists.html.erb
@@ -1,6 +1,6 @@
 <%= panel_with_outer_heading(heading: :show_lists_header.t,
-                                     id: "observation_species_lists",
-                                     inner_class: "p-0") do %>
+                            id: "observation_species_lists",
+                            inner_class: "p-0") do %>
 
   <table class="table table-responsive mx-0 mb-0">
     <% observation.species_lists.each do |spl| %>

--- a/app/views/observations/show/_species_lists.html.erb
+++ b/app/views/observations/show/_species_lists.html.erb
@@ -1,17 +1,23 @@
-<table class="table table-responsive mx-0 mb-0">
-  <% observation.species_lists.each do |spl| %>
-    <tr>
-      <td style="border-top:0">
-        <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
-        <%= if check_permission(spl)
-          put_button(name: :REMOVE.t,
-                    path: observation_species_list_path(
-                      id: @observation.id, species_list_id: spl.id,
-                      commit: "remove"
-                    ),
-                    data: { confirm: :are_you_sure.l })
-        end %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+<%= panel_with_outer_heading(heading: :show_lists_header.t,
+                                     id: "observation_species_lists",
+                                     inner_class: "p-0") do %>
+
+  <table class="table table-responsive mx-0 mb-0">
+    <% observation.species_lists.each do |spl| %>
+      <tr>
+        <td style="border-top:0">
+          <%= link_to(spl.format_name.t, species_list_path(spl.id)) %>
+          <%= if check_permission(spl)
+            put_button(name: :REMOVE.t,
+                      path: observation_species_list_path(
+                        id: @observation.id, species_list_id: spl.id,
+                        commit: "remove"
+                      ),
+                      data: { confirm: :are_you_sure.l })
+          end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+
+<% end %>

--- a/app/views/observations/show/_thumbnail_map.html.erb
+++ b/app/views/observations/show/_thumbnail_map.html.erb
@@ -1,23 +1,23 @@
 <%
-  if observation.location
-    loc = observation.location
+  if obs.location
+    loc = obs.location
     n = ((90.0 - loc.north) / 1.80).round(6)
     s = ((90.0 - loc.south) / 1.80).round(6)
     e = ((180.0 + loc.east) / 3.60).round(6)
     w = ((180.0 + loc.west) / 3.60).round(6)
   end
 
-  lat, long = if observation.lat && observation.long
-    [observation.public_lat, observation.public_long]
-  elsif observation.location
-    observation.location.center
+  lat, long = if obs.lat && obs.long
+    [obs.public_lat, obs.public_long]
+  elsif obs.location
+    obs.location.center
   end
   if lat && long
     x = ((180.0 + long) / 3.60).round(6)
     y = ((90.0 - lat) / 1.80).round(6)
   end
 
-  map_url = map_observation_path(id: observation.id, q: get_query_param)
+  map_url = map_observation_path(id: obs.id, q: get_query_param)
 %>
 
 <div class="hidden-xs" id="observation_thumbnail_map">
@@ -26,7 +26,7 @@
   <span class="pull-right inline">
     <%= link_with_query(
           :show_observation_hide_map.t,
-          javascript_hide_thumbnail_map_path(id: @observation.id)
+          javascript_hide_thumbnail_map_path(id: obs.id)
         ) %>
   </span>
 
@@ -39,7 +39,7 @@
 
     <div class="thumbnail-map">
 
-      <%= if observation.location
+      <%= if obs.location
         if w < e && s > n
           content_tag(:div, "",
             class: "thumbnail-map-box",

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -295,6 +295,8 @@
   licenses: licenses
   LICHEN: Lichen
   lichen: lichen
+  LINKS: Links
+  links: links
   LOCATION: Location
   location: location
   LOCATIONS: Locations

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -794,6 +794,7 @@
   map_all: Map All
   show_location: Show [LOCATION]
   show_location_description: Show [DESCRIPTION]
+  about_this_taxon: About this taxon
   show_name: About [NAME]
   show_name_description: Show [DESCRIPTION]
   show_object: Show [TYPE]
@@ -810,6 +811,8 @@
   EDITING: Editing
   google_images: Google Images
   MAXIMUM: Maximum
+  on_mo: On MO
+  on_the_web: On the web
   show_on_map: Show on map
   many_times: "[num] times"
   one_time: once


### PR DESCRIPTION
Move some show obs "tabset" links to a reconfigured name panel

The name panel is now in two columns, for links "on MO" and "on the web"

<img width="464" alt="about_name" src="https://github.com/MushroomObserver/mushroom-observer/assets/1948095/c4081a9d-0b55-4cf3-9da5-22ef7d98a3b6">
