### PR TITLE
Flip method naming terminology: use `tab` = link attribute array, `link` = HTML link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1070,17 +1070,6 @@ class ApplicationController < ActionController::Base
     url_for(add_query_param(args, query))
   end
 
-  def coerced_query_link(query, model)
-    return nil unless query&.coercable?(model.name.to_sym)
-
-    [
-      :show_objects.t(type: model.type_tag),
-      add_query_param({ controller: model.show_controller,
-                        action: model.index_action }, query)
-    ]
-  end
-  helper_method :coerced_query_link
-
   # Pass the in-coming query parameter(s) through to the next request.
   def pass_query_params
     @query_params = {}

--- a/app/helpers/descriptions_helper.rb
+++ b/app/helpers/descriptions_helper.rb
@@ -30,7 +30,7 @@ module DescriptionsHelper
 
   def description_mod_links(desc)
     links = []
-    links << link_to(*edit_description_link(desc)) if writer?(desc)
+    links << link_to(*edit_description_tab(desc)) if writer?(desc)
     links << destroy_button(target: desc) if is_admin?(desc)
     links
   end
@@ -79,7 +79,7 @@ module DescriptionsHelper
     # Add "fake" default public description if there aren't any public ones.
     if fake_default && obj.descriptions.none? { |d| d.source_type == :public }
       str = :description_part_title_public.t
-      link = link_to(*create_description_link(obj))
+      link = link_to(*create_description_tab(obj))
       str += indent + "[" + link + "]"
       list.unshift(str)
     end
@@ -110,7 +110,7 @@ module DescriptionsHelper
 
     # Show existing drafts, with link to create new one.
     head = tag.b(:show_name_descriptions.t) + ": "
-    head += link_to(*create_description_link(object))
+    head += link_to(*create_description_tab(object))
 
     # Add title and maybe "no descriptions", wrapping it all up in paragraph.
     list = list_descriptions(object: object).map { |link| indent + link }
@@ -130,7 +130,7 @@ module DescriptionsHelper
 
     head2 = :show_name_create_draft.t + ": "
     list = [head2] + projects.map do |project|
-      item = link_to(*new_description_for_project_link(object, project))
+      item = link_to(*new_description_for_project_tab(object, project))
       indent + item
     end
     html2 = list.safe_join(safe_br)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -44,10 +44,10 @@ module LinkHelper
   # Take a query which can be coerced into a different model, and create a link
   # to the results of that coerced query.  Return +nil+ if not coercable.
   def link_to_coerced_query(query, model)
-    link = coerced_query_link(query, model)
-    return nil unless link
+    tab = coerced_query_tab(query, model)
+    return nil unless tab
 
-    link_to(*link)
+    link_to(*tab)
   end
 
   # button to destroy object

--- a/app/helpers/tabs/account_helper.rb
+++ b/app/helpers/tabs/account_helper.rb
@@ -10,61 +10,61 @@ module Tabs
       end
     end
 
-    def account_profile_edit_links
+    def account_profile_edit_tabs
       [
-        account_bulk_license_updater_link,
-        account_show_notifications_link,
-        account_edit_preferences_link,
-        account_show_api_keys_link
+        account_bulk_license_updater_tab,
+        account_show_notifications_tab,
+        account_edit_preferences_tab,
+        account_show_api_keys_tab
       ]
     end
 
-    def account_preferences_edit_links
+    def account_preferences_edit_tabs
       [
-        account_bulk_license_updater_link,
-        account_change_image_vote_anonymity_link,
-        account_edit_profile_link,
-        account_show_notifications_link,
-        account_show_api_keys_link
+        account_bulk_license_updater_tab,
+        account_change_image_vote_anonymity_tab,
+        account_edit_profile_tab,
+        account_show_notifications_tab,
+        account_show_api_keys_tab
       ]
     end
 
-    def account_api_links
+    def account_api_tabs
       [
-        account_edit_preferences_link,
-        account_edit_profile_link
+        account_edit_preferences_tab,
+        account_edit_profile_tab
       ]
     end
 
-    def account_edit_preferences_link
+    def account_edit_preferences_tab
       [:prefs_link.t, edit_account_preferences_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def account_edit_profile_link
+    def account_edit_profile_tab
       [:profile_link.t, edit_account_profile_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def account_bulk_license_updater_link
+    def account_bulk_license_updater_tab
       [:bulk_license_link.t, images_license_updater_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def account_show_notifications_link
+    def account_show_notifications_tab
       [:show_user_your_notifications.t, interests_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def account_show_api_keys_link
+    def account_show_api_keys_tab
       [:account_api_keys_link.t, account_api_keys_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def account_change_image_vote_anonymity_link
+    def account_change_image_vote_anonymity_tab
       [:prefs_change_image_vote_anonymity.t,
        images_edit_vote_anonymity_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/admin_helper.rb
+++ b/app/helpers/tabs/admin_helper.rb
@@ -2,29 +2,29 @@
 
 module Tabs
   module AdminHelper
-    def admin_donations_form_edit_links
-      links = support_governance_links
-      links << admin_create_donation_link
+    def admin_donations_form_edit_tabs
+      links = support_governance_tabs
+      links << admin_create_donation_tab
       links
     end
 
-    def admin_donations_form_new_links
-      links = support_governance_links
-      links << admin_review_donations_link
+    def admin_donations_form_new_tabs
+      links = support_governance_tabs
+      links << admin_review_donations_tab
       links
     end
 
-    def admin_create_donation_link
+    def admin_create_donation_tab
       [:create_donation_tab.t, new_admin_donations_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def admin_review_donations_link
+    def admin_review_donations_tab
       [:review_donations_tab.t, edit_admin_donations_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def admin_test_links
+    def admin_test_tabs
       [
         ["Action One", "/"],
         ["Action Two", "/"],

--- a/app/helpers/tabs/articles_helper.rb
+++ b/app/helpers/tabs/articles_helper.rb
@@ -8,10 +8,10 @@
 #
 module Tabs
   module ArticlesHelper
-    def articles_index_links(user:)
+    def articles_index_tabs(user:)
       return [] unless Article.can_edit?(user)
 
-      [new_article_link]
+      [new_article_tab]
     end
 
     def articles_index_sorts
@@ -23,47 +23,47 @@ module Tabs
       ].freeze
     end
 
-    def article_show_links(article:, user:)
-      links = [articles_index_link]
+    def article_show_tabs(article:, user:)
+      links = [articles_index_tab]
       # Can user modify all articles
       return links unless Article.can_edit?(user)
 
-      links.push(new_article_link,
-                 edit_article_link(article),
-                 destroy_article_link(article))
+      links.push(new_article_tab,
+                 edit_article_tab(article),
+                 destroy_article_tab(article))
     end
 
-    def article_form_new_links
-      [articles_index_link]
+    def article_form_new_tabs
+      [articles_index_tab]
     end
 
-    def article_form_edit_links(article:)
+    def article_form_edit_tabs(article:)
       [
-        object_return_link(article),
-        articles_index_link
+        object_return_tab(article),
+        articles_index_tab
       ]
     end
 
-    def new_article_link
+    def new_article_tab
       [:create_article_title.t, new_article_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_article_link(article)
+    def edit_article_tab(article)
       [:EDIT.t, edit_article_path(article.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_article_link(article)
+    def destroy_article_tab(article)
       [nil, article, { button: :destroy }]
     end
 
-    def articles_index_link
-      [:index_article.t, articles_path, { class: __method__.to_s }]
+    def articles_index_tab
+      [:index_article.t, articles_path, { class: tab_id(__method__.to_s) }]
     end
 
     # "Title (#nnn)" textilized
-    def show_title(article)
+    def article_show_title(article)
       capture do
         concat(article.display_title.t)
         concat(" (##{article.id || "?"})")
@@ -71,10 +71,10 @@ module Tabs
     end
 
     # "Editing: Title (#nnn)"  textilized
-    def edit_title(article)
+    def article_edit_title(article)
       capture do
         concat("#{:EDITING.l}: ")
-        concat(show_title(article))
+        concat(article_show_title(article))
       end
     end
   end

--- a/app/helpers/tabs/authors_helper.rb
+++ b/app/helpers/tabs/authors_helper.rb
@@ -2,10 +2,10 @@
 
 module Tabs
   module AuthorsHelper
-    def author_review_links(obj:)
+    def author_review_tabs(obj:)
       [
-        show_parent_link(obj),
-        show_object_link(obj)
+        show_parent_tab(obj),
+        show_object_tab(obj)
       ]
     end
   end

--- a/app/helpers/tabs/checklists_helper.rb
+++ b/app/helpers/tabs/checklists_helper.rb
@@ -14,55 +14,55 @@ module Tabs
       end
     end
 
-    def checklist_show_links(user:, project:, list:)
+    def checklist_show_tabs(user:, project:, list:)
       if user
-        checklist_for_user_links(user)
+        checklist_for_user_tabs(user)
       elsif project
-        checklist_for_project_links(project)
+        checklist_for_project_tabs(project)
       elsif list
-        checklist_for_species_list_links(list)
+        checklist_for_species_list_tabs(list)
       else
-        checklist_for_site_links
+        checklist_for_site_tabs
       end
     end
 
-    def checklist_for_user_links(user)
+    def checklist_for_user_tabs(user)
       [
-        user_profile_link(user),
-        user_observations_link(user),
-        email_user_question_link(user)
+        user_profile_tab(user),
+        user_observations_tab(user),
+        email_user_question_tab(user)
       ]
     end
 
-    def checklist_for_project_links(project)
+    def checklist_for_project_tabs(project)
       [
-        show_object_link(project),
-        object_index_link(project)
+        show_object_tab(project),
+        object_index_tab(project)
       ]
     end
 
-    def checklist_for_species_list_links(list)
+    def checklist_for_species_list_tabs(list)
       links = [
-        show_object_link(list)
+        show_object_tab(list)
       ]
       if check_permission(list)
         links += [
-          edit_species_list_link(list)
+          edit_species_list_tab(list)
         ]
       end
       links
     end
 
-    def checklist_for_site_links
+    def checklist_for_site_tabs
       [
-        site_contributors_link,
-        info_site_stats_link
+        site_contributors_tab,
+        info_site_stats_tab
       ]
     end
 
-    def site_checklist_link
+    def site_checklist_tab
       [:site_stats_observed_taxa.t, checklist_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -2,18 +2,18 @@
 
 module Tabs
   module CollectionNumbersHelper
-    def collection_number_show_links(c_n:)
+    def collection_number_show_tabs(c_n:)
       return [] unless in_admin_mode? || c_n.can_edit?
 
-      collection_number_mod_links(c_n)
+      collection_number_mod_tabs(c_n)
     end
 
-    def collection_numbers_index_links(obs:)
+    def collection_numbers_index_tabs(obs:)
       return [] if obs.blank?
 
       [
-        object_return_link(obs),
-        new_collection_number_for_obs_link(obs)
+        object_return_tab(obs),
+        new_collection_number_for_obs_tab(obs)
       ]
     end
 
@@ -26,43 +26,43 @@ module Tabs
       ].freeze
     end
 
-    def collection_number_form_new_links(obs:)
-      [object_return_link(obs)]
+    def collection_number_form_new_tabs(obs:)
+      [object_return_tab(obs)]
     end
 
-    def collection_number_form_edit_links(c_n:, back:, obj:)
+    def collection_number_form_edit_tabs(c_n:, back:, obj:)
       links = []
       links << if back == "index"
-                 collection_numbers_index_link(c_n)
+                 collection_numbers_index_tab(c_n)
                else
-                 object_return_link(obj)
+                 object_return_tab(obj)
                end
     end
 
-    def collection_numbers_index_link(c_n)
+    def collection_numbers_index_tab(c_n)
       [:edit_collection_number_back_to_index.t,
        add_query_param(c_n.index_link_args),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def collection_number_mod_links(c_n)
-      [edit_collection_number_link(c_n),
-       destroy_collection_number_link(c_n)]
+    def collection_number_mod_tabs(c_n)
+      [edit_collection_number_tab(c_n),
+       destroy_collection_number_tab(c_n)]
     end
 
-    def new_collection_number_for_obs_link(obs)
+    def new_collection_number_for_obs_tab(obs)
       [:create_collection_number.l,
        add_query_param(new_collection_number_path(obs)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_collection_number_link(c_n)
+    def edit_collection_number_tab(c_n)
       [:edit_collection_number.t,
        add_query_param(edit_collection_number_path(id: c_n.id, back: :show)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_collection_number_link(c_n)
+    def destroy_collection_number_tab(c_n)
       [:delete_collection_number.t, c_n, { button: :destroy }]
     end
   end

--- a/app/helpers/tabs/comments_helper.rb
+++ b/app/helpers/tabs/comments_helper.rb
@@ -2,41 +2,41 @@
 
 module Tabs
   module CommentsHelper
-    def comment_show_links(comment:, target:)
+    def comment_show_tabs(comment:, target:)
       links = [
-        object_return_link(
+        object_return_tab(
           target,
           :comment_show_show.t(type: comment.target_type_localized)
         )
       ]
       return unless check_permission(comment)
 
-      links += comment_mod_links(comment)
+      links += comment_mod_tabs(comment)
       links
     end
 
-    def comment_form_new_links(target:)
-      [object_return_link(target)]
+    def comment_form_new_tabs(target:)
+      [object_return_tab(target)]
     end
 
-    def comment_form_edit_links(comment:)
-      [object_return_link(comment)]
+    def comment_form_edit_tabs(comment:)
+      [object_return_tab(comment)]
     end
 
-    def comment_mod_links(comment)
+    def comment_mod_tabs(comment)
       [
-        edit_comment_link(comment),
-        destroy_comment_link(comment)
+        edit_comment_tab(comment),
+        destroy_comment_tab(comment)
       ]
     end
 
-    def edit_comment_link(comment)
+    def edit_comment_tab(comment)
       [:comment_show_edit.t,
        add_query_param(edit_comment_path(comment.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_comment_link(comment)
+    def destroy_comment_tab(comment)
       [:comment_show_destroy.t, comment, { button: :destroy }]
     end
 

--- a/app/helpers/tabs/contributors_helper.rb
+++ b/app/helpers/tabs/contributors_helper.rb
@@ -2,18 +2,18 @@
 
 module Tabs
   module ContributorsHelper
-    def contributors_index_links
-      [info_site_stats_link]
+    def contributors_index_tabs
+      [info_site_stats_tab]
     end
 
-    def info_site_stats_link
+    def info_site_stats_tab
       [:app_site_stats.t, info_site_stats_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def site_contributors_link
+    def site_contributors_tab
       [:app_contributors.t, contributors_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/descriptions_helper.rb
+++ b/app/helpers/tabs/descriptions_helper.rb
@@ -4,38 +4,38 @@
 module Tabs
   module DescriptionsHelper
     # Links for the tabset
-    def show_description_links(description:)
+    def show_description_tabs(description:)
       type = description.parent.type_tag
       admin = is_admin?(description)
       # assemble HTML for "tabset" for show_{type}_description
       [
-        description_parent_link(description, type),
-        edit_description_link(description),
-        destroy_description_link(description, admin),
-        clone_description_link(description),
-        merge_description_link(description, admin),
-        adjust_description_permissions_link(description, type, admin),
-        make_description_default_link(description),
-        description_project_link(description),
-        publish_description_draft_link(description, type, admin)
+        description_parent_tab(description, type),
+        edit_description_tab(description),
+        destroy_description_tab(description, admin),
+        clone_description_tab(description),
+        merge_description_tab(description, admin),
+        adjust_description_permissions_tab(description, type, admin),
+        make_description_default_tab(description),
+        description_project_tab(description),
+        publish_description_draft_tab(description, type, admin)
       ].reject(&:empty?)
     end
 
     # Components of the above AND similar links for helpers/descriptions_helper
-    def description_parent_link(description, type)
+    def description_parent_tab(description, type)
       [:show_object.t(type: type),
        add_query_param(description.parent.show_link_args),
        { class: "#{__method__}_#{description.id}" }]
     end
 
-    def create_description_link(object)
+    def create_description_tab(object)
       [:show_name_create_description.t,
        { controller: "#{object.show_controller}/descriptions",
          action: :new, id: object.id, q: get_query_param },
        { class: "#{__method__}_#{object.id}" }]
     end
 
-    def edit_description_link(description)
+    def edit_description_tab(description)
       return unless writer?(description)
 
       [:show_description_edit.t,
@@ -43,32 +43,32 @@ module Tabs
        { class: "#{__method__}_#{description.id}" }]
     end
 
-    def destroy_description_link(description, admin)
+    def destroy_description_tab(description, admin)
       return unless admin
 
       [:show_description_destroy.t, description, { button: :destroy }]
     end
 
-    def clone_description_link(description)
+    def clone_description_tab(description)
       [:show_description_clone.t,
        { controller: description.show_controller,
          action: :new, id: description.parent_id,
          clone: description.id, q: get_query_param },
        { help: :show_description_clone_help.l,
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def merge_description_link(description, admin)
+    def merge_description_tab(description, admin)
       return unless admin
 
       [:show_description_merge.t,
        { controller: "#{description.show_controller}/merges",
          action: :new, id: description.id, q: get_query_param },
        { help: :show_description_merge_help.l,
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def move_description_link(description, admin)
+    def move_description_tab(description, admin)
       return unless admin
 
       parent_type = description.parent.type_tag.to_s
@@ -76,20 +76,20 @@ module Tabs
        { controller: "#{description.show_controller}/moves",
          action: :new, id: description.id, q: get_query_param },
        { help: :show_description_move_help.l(parent: parent_type),
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def adjust_description_permissions_link(description, type, admin)
+    def adjust_description_permissions_tab(description, type, admin)
       return unless admin && type == :name
 
       [:show_description_adjust_permissions.t,
        { controller: "#{description.show_controller}/permissions",
          action: :edit, id: description.id, q: get_query_param },
        { help: :show_description_adjust_permissions_help.l,
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def make_description_default_link(description)
+    def make_description_default_tab(description)
       return unless description.public && User.current &&
                     (description.parent.description_id != description.id)
 
@@ -98,18 +98,18 @@ module Tabs
          action: :update, id: description.id,
          q: get_query_param },
        { button: :put, help: :show_description_make_default_help.l,
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def description_project_link(description)
+    def description_project_tab(description)
       return unless (description.source_type == :project) &&
                     (project = description.source_object)
 
       [:show_object.t(type: :project), add_query_param(project.show_link_args),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def publish_description_draft_link(description, type, admin)
+    def publish_description_draft_tab(description, type, admin)
       return unless admin && (type == :name) &&
                     (description.source_type != :public)
 
@@ -118,15 +118,15 @@ module Tabs
          action: :update, id: description.id,
          q: get_query_param },
        { button: :put, help: :show_description_publish_help.l,
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def new_description_for_project_link(object, project)
+    def new_description_for_project_tab(object, project)
       [project.title,
        { controller: "#{object.show_controller}/descriptions",
          action: :new, id: object.id,
          project: project.id, source: "project" },
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     def descriptions_index_sorts

--- a/app/helpers/tabs/emails_helper.rb
+++ b/app/helpers/tabs/emails_helper.rb
@@ -2,12 +2,12 @@
 
 module Tabs
   module EmailsHelper
-    def email_name_change_request_links(name:)
-      [object_return_link(name)]
+    def email_name_change_request_tabs(name:)
+      [object_return_tab(name)]
     end
 
-    def email_merge_request_links(old_obj:)
-      [object_return_link(old_obj)]
+    def email_merge_request_tabs(old_obj:)
+      [object_return_tab(old_obj)]
     end
   end
 end

--- a/app/helpers/tabs/general_helper.rb
+++ b/app/helpers/tabs/general_helper.rb
@@ -2,49 +2,73 @@
 
 module Tabs
   module GeneralHelper
-    def coerced_observation_query_link(query)
-      return unless query && (link = coerced_query_link(query, Observation))
+    def coerced_query_tab(query, model)
+      return nil unless query&.coercable?(model.name.to_sym)
 
-      [*link, { class: __method__.to_s }]
+      [:show_objects.t(type: model.type_tag),
+       add_query_param({ controller: model.show_controller,
+                         action: model.index_action }, query)]
     end
 
-    def coerced_location_query_link(query)
-      return unless query && (link = coerced_query_link(query, Location))
+    def coerced_observation_query_tab(query)
+      return unless query && (tab = coerced_query_tab(query, Observation))
 
-      [*link, { class: __method__.to_s }]
+      [*tab, { class: tab_id(__method__.to_s) }]
     end
 
-    def coerced_image_query_link(query)
-      return unless query && (link = coerced_query_link(query, Image))
+    def coerced_location_query_tab(query)
+      return unless query && (tab = coerced_query_tab(query, Location))
 
-      [*link, { class: __method__.to_s }]
+      [*tab, { class: tab_id(__method__.to_s) }]
     end
 
-    def coerced_name_query_link(query)
-      return unless query && (link = coerced_query_link(query, Name))
+    def coerced_image_query_tab(query)
+      return unless query && (tab = coerced_query_tab(query, Image))
 
-      [*link, { class: __method__.to_s }]
+      [*tab, { class: tab_id(__method__.to_s) }]
     end
 
-    def object_return_link(obj, text = nil)
+    def coerced_name_query_tab(query)
+      return unless query && (tab = coerced_query_tab(query, Name))
+
+      [*tab, { class: tab_id(__method__.to_s) }]
+    end
+
+    def search_tab_for(site_symbol, search_string)
+      return unless (url = external_search_urls[site_symbol])
+
+      [site_symbol.to_s.titlecase, "#{url}#{search_string}",
+       { id: "search_link_to_#{site_symbol}_#{search_string}" }]
+    end
+
+    # Dictionary of urls for searches on external sites
+    def external_search_urls
+      {
+        Google_Maps: "https://maps.google.com/maps?q=",
+        Google_Search: "https://www.google.com/search?q=",
+        Wikipedia: "https://en.wikipedia.org/w/index.php?search="
+      }.freeze
+    end
+
+    def object_return_tab(obj, text = nil)
       text ||= :cancel_and_show.t(type: obj.type_tag)
       [text, add_query_param(obj.show_link_args),
        { class: "#{obj.type_tag}_return_link" }]
     end
 
-    def show_object_link(obj, text = nil)
+    def show_object_tab(obj, text = nil)
       text ||= :show_object.t(type: obj.type_tag)
       [text, add_query_param(obj.show_link_args),
        { class: "#{obj.type_tag}_link" }]
     end
 
-    def show_parent_link(obj, text = nil)
+    def show_parent_tab(obj, text = nil)
       text ||= :show_object.t(type: obj.parent.type_tag)
       [text, add_query_param(obj.parent.show_link_args),
        { class: "parent_#{obj.parent.type_tag}_link" }]
     end
 
-    def object_index_link(obj, text = nil)
+    def object_index_tab(obj, text = nil)
       text ||= :list_objects.t(type: obj.type_tag)
       [text, add_query_param(obj.index_link_args),
        { class: "#{obj.type_tag.to_s.pluralize}_index_link" }]

--- a/app/helpers/tabs/glossary_terms_helper.rb
+++ b/app/helpers/tabs/glossary_terms_helper.rb
@@ -2,79 +2,79 @@
 
 module Tabs
   module GlossaryTermsHelper
-    def glossary_term_show_links(term:, user:)
+    def glossary_term_show_tabs(term:, user:)
       return [] unless user
 
       links = [
-        glossary_terms_index_link,
-        new_glossary_term_link,
-        edit_glossary_term_link(term)
+        glossary_terms_index_tab,
+        new_glossary_term_tab,
+        edit_glossary_term_tab(term)
       ]
-      links << destroy_glossary_term_link(term) if in_admin_mode?
+      links << destroy_glossary_term_tab(term) if in_admin_mode?
       links
     end
 
-    def glossary_term_index_links
-      [new_glossary_term_link]
+    def glossary_term_index_tabs
+      [new_glossary_term_tab]
     end
 
-    def glossary_term_form_new_links
+    def glossary_term_form_new_tabs
       [
         # Replace this link with a "Cancel" link (back to glossary)
         # See https://www.pivotaltracker.com/story/show/174614188
-        glossary_terms_index_link
+        glossary_terms_index_tab
       ]
     end
 
-    def glossary_term_form_edit_links(term:)
+    def glossary_term_form_edit_tabs(term:)
       [
         # Replace these two links with a "Cancel" link
         # See https://www.pivotaltracker.com/story/show/174614188
-        glossary_term_return_link(term),
-        glossary_terms_index_link
+        glossary_term_return_tab(term),
+        glossary_terms_index_tab
       ]
     end
 
-    def glossary_term_image_form_links(term:)
+    def glossary_term_image_form_tabs(term:)
       [
-        glossary_term_return_link(term),
-        edit_glossary_term_link(term)
+        glossary_term_return_tab(term),
+        edit_glossary_term_tab(term)
       ]
     end
 
-    def glossary_term_version_links(term:)
-      [show_glossary_term_link(term)]
+    def glossary_term_version_tabs(term:)
+      [show_glossary_term_tab(term)]
     end
 
-    def show_glossary_term_link(term)
+    def show_glossary_term_tab(term)
       [:show_glossary_term.t(glossary_term: term.name),
        glossary_term_path(term.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def glossary_term_return_link(term)
+    def glossary_term_return_tab(term)
       [:cancel_and_show.t(type: :glossary_term),
        glossary_term_path(term.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_glossary_term_link(term)
+    def destroy_glossary_term_tab(term)
       [nil, term, { button: :destroy }]
     end
 
-    def glossary_terms_index_link
+    def glossary_terms_index_tab
       [:glossary_term_index.t, glossary_terms_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def new_glossary_term_link
+    def new_glossary_term_tab
       [:create_glossary_term.t, new_glossary_term_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_glossary_term_link(term)
+    def edit_glossary_term_tab(term)
       [:edit_glossary_term.t, edit_glossary_term_path(term.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -4,13 +4,13 @@
 # NOTE: this uses ids not classes for identifiers, change this
 module Tabs
   module HerbariaHelper
-    def herbaria_index_links(query:)
+    def herbaria_index_tabs(query:)
       links ||= []
-      links << herbaria_index_link unless query&.flavor == :all
+      links << herbaria_index_tab unless query&.flavor == :all
       unless query&.flavor == :nonpersonal
-        links << labeled_nonpersonal_herbaria_index_link
+        links << labeled_nonpersonal_herbaria_index_tab
       end
-      links << new_herbarium_link
+      links << new_herbarium_tab
     end
 
     def herbaria_index_sorts(query:)
@@ -36,76 +36,76 @@ module Tabs
       sorts.reject! { |x| x[0] == "user" }
     end
 
-    def herbarium_show_links(herbarium:, user:)
+    def herbarium_show_tabs(herbarium:, user:)
       tabs = []
       if herbarium.curators.empty? ||
          herbarium.curator?(user) || in_admin_mode?
         tabs += [
-          edit_herbarium_link(herbarium),
-          destroy_herbarium_link(herbarium)
+          edit_herbarium_tab(herbarium),
+          destroy_herbarium_tab(herbarium)
         ]
       end
       tabs += [
-        new_herbarium_link,
-        nonpersonal_herbaria_index_link
+        new_herbarium_tab,
+        nonpersonal_herbaria_index_tab
       ]
       tabs
     end
 
-    def herbarium_form_new_links
-      nonpersonal_herbaria_index_link
+    def herbarium_form_new_tabs
+      nonpersonal_herbaria_index_tab
     end
 
-    def herbarium_form_edit_links(herbarium:)
+    def herbarium_form_edit_tabs(herbarium:)
       [
-        herbarium_return_link(herbarium),
-        nonpersonal_herbaria_index_link
+        herbarium_return_tab(herbarium),
+        nonpersonal_herbaria_index_tab
       ]
     end
 
-    def herbaria_curator_request_links(herbarium:)
+    def herbaria_curator_request_tabs(herbarium:)
       [
-        herbarium_return_link(herbarium),
-        nonpersonal_herbaria_index_link
+        herbarium_return_tab(herbarium),
+        nonpersonal_herbaria_index_tab
       ]
     end
 
-    def new_herbarium_link
+    def new_herbarium_tab
       [:create_herbarium.t, add_query_param(new_herbarium_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_herbarium_link(herbarium)
+    def edit_herbarium_tab(herbarium)
       [:edit_herbarium.t,
        add_query_param(edit_herbarium_path(herbarium.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_herbarium_link(herbarium)
+    def destroy_herbarium_tab(herbarium)
       [:destroy_object.t(type: :herbarium),
        herbarium,
        { button: :destroy, back: url_after_delete(herbarium) }]
     end
 
-    def herbaria_index_link
+    def herbaria_index_tab
       [:herbarium_index_list_all_herbaria.l,
        herbaria_path(flavor: :all),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def herbarium_return_link(herbarium)
+    def herbarium_return_tab(herbarium)
       [:cancel_and_show.t(type: :herbarium),
        add_query_param(herbarium_path(herbarium)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def nonpersonal_herbaria_index_link
+    def nonpersonal_herbaria_index_tab
       [:herbarium_index.t,
        add_query_param(herbaria_path(flavor: :nonpersonal)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def labeled_nonpersonal_herbaria_index_link
+    def labeled_nonpersonal_herbaria_index_tab
       [:herbarium_index_nonpersonal_herbaria.l,
        herbaria_path(flavor: :nonpersonal),
        { class: "nonpersonal_herbaria_index_link" }]

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -5,16 +5,16 @@
 module Tabs
   module HerbariumRecordsHelper
     include HerbariaHelper
-    def herbarium_records_index_links(obs:)
+    def herbarium_records_index_tabs(obs:)
       links = []
       if obs.present?
         links = [
-          object_return_link(obs),
-          new_herbarium_record_link
+          object_return_tab(obs),
+          new_herbarium_record_tab
         ]
       end
-      links << new_herbarium_link
-      links << nonpersonal_herbaria_index_link
+      links << new_herbarium_tab
+      links << nonpersonal_herbaria_index_tab
     end
 
     def herbarium_records_index_sorts
@@ -26,57 +26,57 @@ module Tabs
       ].freeze
     end
 
-    def herbarium_record_show_links(h_r:)
+    def herbarium_record_show_tabs(h_r:)
       links = []
       if in_admin_mode? || h_r.can_edit?
         links.push(
-          edit_herbarium_record_link(h_r),
-          destroy_herbarium_record_link(h_r)
+          edit_herbarium_record_tab(h_r),
+          destroy_herbarium_record_tab(h_r)
         )
       end
-      links << nonpersonal_herbaria_index_link
+      links << nonpersonal_herbaria_index_tab
       links
     end
 
-    def herbarium_record_form_new_links(obs:)
+    def herbarium_record_form_new_tabs(obs:)
       [
-        object_return_link(obs),
-        new_herbarium_link,
-        nonpersonal_herbaria_index_link
+        object_return_tab(obs),
+        new_herbarium_tab,
+        nonpersonal_herbaria_index_tab
       ]
     end
 
-    def herbarium_record_form_edit_links(back:, back_object:)
+    def herbarium_record_form_edit_tabs(back:, back_object:)
       links = []
       if back == "index"
-        links << herbarium_records_index_return_link
+        links << herbarium_records_index_return_tab
       elsif back_object
-        links << object_return_link(back_object)
+        links << object_return_tab(back_object)
       end
-      links << new_herbarium_link
-      links << nonpersonal_herbaria_index_link
+      links << new_herbarium_tab
+      links << nonpersonal_herbaria_index_tab
     end
 
-    def new_herbarium_record_link
+    def new_herbarium_record_tab
       [:create_herbarium_record.l,
        new_herbarium_record_path(id: params[:id]),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_herbarium_record_link(h_r)
+    def edit_herbarium_record_tab(h_r)
       [:edit_herbarium_record.t,
        add_query_param(edit_herbarium_record_path(h_r.id, back: :show)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_herbarium_record_link(h_r)
+    def destroy_herbarium_record_tab(h_r)
       [:destroy_object.t(type: :herbarium_record), h_r, { button: :destroy }]
     end
 
-    def herbarium_records_index_return_link
+    def herbarium_records_index_return_tab
       [:edit_herbarium_record_back_to_index.t,
        herbarium_records_path(q: get_query_param),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/images_helper.rb
+++ b/app/helpers/tabs/images_helper.rb
@@ -4,22 +4,22 @@
 module Tabs
   module ImagesHelper
     # link attribute arrays
-    def images_index_links(query:)
-      [coerced_observation_query_link(query)]
+    def images_index_tabs(query:)
+      [coerced_observation_query_tab(query)]
     end
 
     # assemble links for show_image
-    def show_image_links(image:)
+    def show_image_tabs(image:)
       [
-        *show_image_obs_links(image),
-        image_eol_link(image),
-        *image_mod_links(image),
-        image_commercial_inquiry_link(image)
+        *show_image_obs_tabs(image),
+        image_eol_tab(image),
+        *image_mod_tabs(image),
+        image_commercial_inquiry_tab(image)
       ].reject(&:empty?)
     end
 
-    def images_exif_show_links(image:)
-      [object_return_link(image)]
+    def images_exif_show_tabs(image:)
+      [object_return_tab(image)]
     end
 
     def images_index_sorts
@@ -39,58 +39,58 @@ module Tabs
 
     private
 
-    def show_image_obs_links(image)
+    def show_image_obs_tabs(image)
       return unless image.observations.length == 1
 
       obs = image.observations.first
       [
-        show_object_link(obs),
-        show_object_link(obs.name),
-        name_google_images_link(obs.name)
+        show_object_tab(obs),
+        show_object_tab(obs.name),
+        name_google_images_tab(obs.name)
       ]
     end
 
-    def name_google_images_link(name)
+    def name_google_images_tab(name)
       [:google_images.t,
        "http://images.google.com/images?q=#{name.search_name}",
-       { target: "_blank", rel: "noopener", class: __method__.to_s }]
+       { target: "_blank", rel: "noopener", class: tab_id(__method__.to_s) }]
     end
 
-    def image_eol_link(image)
+    def image_eol_tab(image)
       return unless (eol_url = image.eol_url)
 
       ["EOL", eol_url, { target: "_blank", rel: "noopener",
-                         class: __method__.to_s }]
+                         class: tab_id(__method__.to_s) }]
     end
 
-    def image_mod_links(image)
+    def image_mod_tabs(image)
       return unless check_permission(image)
 
       [
-        edit_image_link(image),
-        destroy_image_link(image)
+        edit_image_tab(image),
+        destroy_image_tab(image)
       ]
     end
 
-    def edit_image_link(image)
+    def edit_image_tab(image)
       [:edit_object.t(type: :image),
        add_query_param(edit_image_path(image.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_image_link(image)
+    def destroy_image_tab(image)
       [:destroy_object.t(type: :image), image, { button: :destroy }]
     end
 
-    def image_commercial_inquiry_link(image)
+    def image_commercial_inquiry_tab(image)
       return unless image.user.email_general_commercial && !image.user.no_emails
 
       [:image_show_inquiry.t,
        add_query_param(emails_commercial_inquiry_path(image.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def test_add_image_report_links
+    def test_add_image_report_tabs
       [["Test Again", { action: :test_add_image },
         { class: "test_add_image_report_link" }]]
     end

--- a/app/helpers/tabs/info_helper.rb
+++ b/app/helpers/tabs/info_helper.rb
@@ -2,10 +2,10 @@
 
 module Tabs
   module InfoHelper
-    def info_site_stats_links
+    def info_site_stats_tabs
       [
-        site_contributors_link,
-        site_checklist_link
+        site_contributors_tab,
+        site_checklist_tab
       ]
     end
   end

--- a/app/helpers/tabs/locations/descriptions_helper.rb
+++ b/app/helpers/tabs/locations/descriptions_helper.rb
@@ -4,36 +4,36 @@
 module Tabs
   module Locations
     module DescriptionsHelper
-      def location_description_index_links(query:)
+      def location_description_index_tabs(query:)
         [
-          map_locations_link,
-          locations_index_link,
-          coerced_location_query_link(query)
+          map_locations_tab,
+          locations_index_tab,
+          coerced_location_query_tab(query)
         ]
       end
 
-      def location_description_form_new_links(description:)
-        [object_return_link(description.location)]
+      def location_description_form_new_tabs(description:)
+        [object_return_tab(description.location)]
       end
 
-      def location_description_form_edit_links(description:)
+      def location_description_form_edit_tabs(description:)
         [
-          object_return_link(description.location),
-          object_return_link(description)
+          object_return_tab(description.location),
+          object_return_tab(description)
         ]
       end
 
-      def location_description_form_permissions_links(description:)
+      def location_description_form_permissions_tabs(description:)
         [
-          object_return_link(description.location),
-          object_return_link(description,
-                             :show_object.t(type: :location_description))
+          object_return_tab(description.location),
+          object_return_tab(description,
+                            :show_object.t(type: :location_description))
         ]
       end
 
-      def location_description_version_links(description:, desc_title:)
+      def location_description_version_tabs(description:, desc_title:)
         [
-          object_return_link(
+          object_return_tab(
             description,
             :show_location_description.t(description: desc_title)
           )

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -3,83 +3,83 @@
 # html used in tabsets
 module Tabs
   module LocationsHelper
-    # link attribute arrays (coerced_query_link returns array)
-    def locations_index_links(query:)
+    # link attribute arrays (coerced_query_tab returns array)
+    def locations_index_tabs(query:)
       [
-        new_location_link,
-        map_locations_link,
-        location_countries_link,
-        coerced_observation_query_link(query)
+        new_location_tab,
+        map_locations_tab,
+        location_countries_tab,
+        coerced_observation_query_tab(query)
       ]
     end
 
     # Composed links because there's interest_icons
-    def location_show_links(location:)
+    def location_show_tabs(location:)
       links = [
-        observations_at_location_link(location),
-        locations_index_link,
-        new_location_link,
-        edit_location_link(location)
+        observations_at_location_tab(location),
+        locations_index_tab,
+        new_location_tab,
+        edit_location_tab(location)
       ]
       if in_admin_mode?
         links += [
-          destroy_location_link(location),
-          location_reverse_order_link(location)
+          destroy_location_tab(location),
+          location_reverse_order_tab(location)
         ]
       end
       links
     end
 
-    def new_location_link
+    def new_location_tab
       [:show_location_create.t, add_query_param(new_location_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def map_locations_link
+    def map_locations_tab
       [:list_place_names_map.t, add_query_param(map_locations_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def location_countries_link
+    def location_countries_tab
       [:list_countries.t, location_countries_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_location_link(location)
+    def edit_location_tab(location)
       [:show_location_edit.t,
        add_query_param(edit_location_path(location.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_location_link(location)
+    def destroy_location_tab(location)
       [:show_location_destroy.t, location, { button: :destroy }]
     end
 
-    def location_reverse_order_link(location)
+    def location_reverse_order_tab(location)
       [:show_location_reverse.t,
        add_query_param(location_reverse_name_order_path(location.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def location_version_links(location:)
-      [location_versions_link(location)]
+    def location_version_tabs(location:)
+      [location_versions_tab(location)]
     end
 
-    def location_versions_link(location)
+    def location_versions_tab(location)
       [:show_location.t(location: location.display_name),
        location_path(location.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def locations_index_link
+    def locations_index_tab
       [:all_objects.t(type: :location), locations_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def observations_at_location_link(location)
+    def observations_at_location_tab(location)
       [show_obs_link_title_with_count(location),
        add_query_param(observations_path(location: location.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     def location_map_title(query:)
@@ -90,16 +90,16 @@ module Tabs
       end
     end
 
-    def location_map_links(query:)
+    def location_map_tabs(query:)
       [
-        locations_index_link,
-        coerced_observation_query_link(query),
-        coerced_location_query_link(query)
+        locations_index_tab,
+        coerced_observation_query_tab(query),
+        coerced_location_query_tab(query)
       ]
     end
 
-    def location_countries_links
-      [locations_index_link]
+    def location_countries_tabs
+      [locations_index_tab]
     end
 
     # Add some alternate sorting criteria.
@@ -114,61 +114,46 @@ module Tabs
     end
 
     # link attribute arrays
-    def location_form_new_links(location:)
-      tabs = [locations_index_link]
-      tabs += location_search_links(location.name)
+    def location_form_new_tabs(location:)
+      tabs = [locations_index_tab]
+      tabs += location_search_tabs(location.name)
       tabs
     end
 
-    def location_form_edit_links(location:)
+    def location_form_edit_tabs(location:)
       tabs = [
-        locations_index_link,
-        object_return_link(location)
+        locations_index_tab,
+        object_return_tab(location)
       ]
-      tabs += location_search_links(location.name)
+      tabs += location_search_tabs(location.name)
       tabs
     end
-
-    # Dictionary of urls for searches on external sites
-    LOCATION_SEARCH_URLS = {
-      Google_Maps: "https://maps.google.com/maps?q=",
-      Google_Search: "https://www.google.com/search?q=",
-      Wikipedia: "https://en.wikipedia.org/w/index.php?search="
-    }.freeze
 
     # Array of link attribute arrays to searches on external sites;
     # Shown on create/edit location pages
-    def location_search_links(name)
+    def location_search_tabs(name)
       search_string = name.gsub(" Co.", " County").gsub(", USA", "").
                       tr(" ", "+").gsub(",", "%2C")
-      LOCATION_SEARCH_URLS.each_with_object([]) do |site, link_array|
-        link_array << search_link_to(site.first, search_string)
+      external_search_urls.each_with_object([]) do |site, link_array|
+        link_array << search_tab_for(site.first, search_string)
       end
     end
 
-    # link attribute arrays
-    def search_link_to(site_symbol, search_string)
-      return unless (url = LOCATION_SEARCH_URLS[site_symbol])
-
-      [site_symbol.to_s.titlecase, "#{url}#{search_string}",
-       { id: "search_link_to_#{site_symbol}_#{search_string}" }]
-    end
-
     # these are from the observations form
-    def define_location_link(query)
+    def define_location_tab(query)
       [:list_observations_location_define.l,
        add_query_param(new_location_path(
                          where: query.params[:user_where]
                        )),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def merge_locations_link(query)
+    def merge_locations_tab(query)
       [:list_observations_location_merge.l,
        add_query_param(location_merges_form_path(
                          where: query.params[:user_where]
                        )),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/names/descriptions_helper.rb
+++ b/app/helpers/tabs/names/descriptions_helper.rb
@@ -4,36 +4,36 @@
 module Tabs
   module Names
     module DescriptionsHelper
-      def name_description_index_links(query:)
-        [coerced_name_query_link(query)]
+      def name_description_index_tabs(query:)
+        [coerced_name_query_tab(query)]
       end
 
-      def name_description_form_new_links(description:)
-        [object_return_link(description.name)]
+      def name_description_form_new_tabs(description:)
+        [object_return_tab(description.name)]
       end
 
-      def name_description_form_edit_links(description:, user:)
+      def name_description_form_edit_tabs(description:, user:)
         links = [
-          object_return_link(description.name, :show_object.t(type: :name)),
-          object_return_link(description)
+          object_return_tab(description.name, :show_object.t(type: :name)),
+          object_return_tab(description)
         ]
         if description.is_admin?(user) || in_admin_mode?
-          links << adjust_description_permissions_link(description, :name, true)
+          links << adjust_description_permissions_tab(description, :name, true)
         end
         links
       end
 
-      def name_description_form_permissions_links(description:)
+      def name_description_form_permissions_tabs(description:)
         [
-          object_return_link(description.name),
-          object_return_link(description,
-                             :show_object.t(type: :name_description))
+          object_return_tab(description.name),
+          object_return_tab(description,
+                            :show_object.t(type: :name_description))
         ]
       end
 
-      def name_description_version_links(description:, desc_title:)
-        [object_return_link(description,
-                            :show_name_description.t(description: desc_title))]
+      def name_description_version_tabs(description:, desc_title:)
+        [object_return_tab(description,
+                           :show_name_description.t(description: desc_title))]
       end
     end
   end

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -4,117 +4,117 @@
 module Tabs
   module NamesHelper
     # assemble links for "tabset" for show_name
-    def name_show_links(name:, user:)
+    def name_show_tabs(name:, user:)
       [
-        edit_name_link(name),
-        new_name_link,
-        edit_synonym_form_link(name),
-        approve_synonym_form_link(name),
-        deprecate_synonym_form_link(name),
-        name_tracker_form_link(name, user)
+        edit_name_tab(name),
+        new_name_tab,
+        edit_synonym_form_tab(name),
+        approve_synonym_form_tab(name),
+        deprecate_synonym_form_tab(name),
+        name_tracker_form_tab(name, user)
       ].reject(&:empty?)
     end
 
-    def edit_name_link(name)
+    def edit_name_tab(name)
       [:show_name_edit_name.t, add_query_param(edit_name_path(name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def new_name_link
+    def new_name_tab
       [:show_name_add_name.t, add_query_param(new_name_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def edit_synonym_form_link(name)
+    def edit_synonym_form_tab(name)
       return unless in_admin_mode? || !name.locked
 
-      edit_name_synonym_link(name)
+      edit_name_synonym_tab(name)
     end
 
-    def approve_synonym_form_link(name)
+    def approve_synonym_form_tab(name)
       return unless name.deprecated && (in_admin_mode? || !name.locked)
 
-      approve_name_synonym_link(name)
+      approve_name_synonym_tab(name)
     end
 
-    def deprecate_synonym_form_link(name)
+    def deprecate_synonym_form_tab(name)
       return unless !name.deprecated && (in_admin_mode? || !name.locked)
 
-      deprecate_name_link(name)
+      deprecate_name_tab(name)
     end
 
-    def edit_name_synonym_link(name)
+    def edit_name_synonym_tab(name)
       [:show_name_change_synonyms.t,
        add_query_param(edit_name_synonyms_path(name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def deprecate_name_link(name)
+    def deprecate_name_tab(name)
       [:DEPRECATE.t, add_query_param(deprecate_name_synonym_form_path(name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def approve_name_synonym_link(name)
+    def approve_name_synonym_tab(name)
       [:APPROVE.t, add_query_param(approve_name_synonym_form_path(name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def name_tracker_form_link(name, user)
+    def name_tracker_form_tab(name, user)
       existing_name_tracker = NameTracker.find_by(name_id: name.id,
                                                   user_id: user.id)
       if existing_name_tracker
-        edit_name_tracker_link(name)
+        edit_name_tracker_tab(name)
       else
-        new_name_tracker_link(name)
+        new_name_tracker_tab(name)
       end
     end
 
-    def name_map_links(name:, query:)
+    def name_map_tabs(name:, query:)
       [
-        show_object_link(name, :name_map_about.t(name: name.display_name)),
-        coerced_location_query_link(query),
-        coerced_observation_query_link(query)
+        show_object_tab(name, :name_map_about.t(name: name.display_name)),
+        coerced_location_query_tab(query),
+        coerced_observation_query_tab(query)
       ]
     end
 
-    def edit_name_tracker_link(name)
+    def edit_name_tracker_tab(name)
       [:show_name_email_tracking.t,
        add_query_param(edit_name_tracker_path(name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def new_name_tracker_link(name)
+    def new_name_tracker_tab(name)
       [:show_name_email_tracking.t,
        add_query_param(new_name_tracker_path(name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     ##########################################################################
     #
     #    Index:
 
-    def names_index_links(query:)
+    def names_index_tabs(query:)
       [
-        new_name_link,
-        names_with_observations_link(query),
-        coerced_observation_query_link(query),
-        descriptions_of_these_names_link(query)
+        new_name_tab,
+        names_with_observations_tab(query),
+        coerced_observation_query_tab(query),
+        descriptions_of_these_names_tab(query)
       ].reject(&:empty?)
     end
 
-    def names_with_observations_link(query)
+    def names_with_observations_tab(query)
       return unless query&.flavor == :with_observations
 
       [:all_objects.t(type: :name), names_path(with_observations: true),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def descriptions_of_these_names_link(query)
+    def descriptions_of_these_names_tab(query)
       return unless query&.coercable?(:NameDescription)
 
       [:show_objects.t(type: :description),
        add_query_param(name_descriptions_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     def names_index_sorts(query:)
@@ -128,25 +128,26 @@ module Tabs
     end
 
     ### Forms
-    def name_form_new_links
-      [names_index_link]
+    def name_form_new_tabs
+      [names_index_tab]
     end
 
-    def names_index_link
-      [:all_objects.t(type: :name), names_path, { class: __method__.to_s }]
+    def names_index_tab
+      [:all_objects.t(type: :name), names_path,
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def name_form_edit_links(name:)
-      [object_return_link(name),
-       object_index_link(name)]
+    def name_form_edit_tabs(name:)
+      [object_return_tab(name),
+       object_index_tab(name)]
     end
 
-    def name_versions_links(name:)
-      [show_object_link(name, :show_name.t(name: name.display_name))]
+    def name_version_tabs(name:)
+      [show_object_tab(name, :show_name.t(name: name.display_name))]
     end
 
-    def name_forms_return_links(name:)
-      [object_return_link(name)]
+    def name_forms_return_tabs(name:)
+      [object_return_tab(name)]
     end
   end
 end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -278,7 +278,7 @@ module Tabs
     def edit_observation_tab(obs)
       [:edit_object.t(type: Observation),
        add_query_param(edit_observation_path(obs.id)),
-       { class: "#{__method__}_#{obs.id}" }]
+       { class: "#{tab_id(__method__.to_s)}_#{obs.id}" }]
     end
 
     def destroy_observation_tab(obs)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -5,11 +5,11 @@ module Tabs
   module ObservationsHelper
     # assemble links for "tabset" for show_observation
     # actually a list of links and the interest icons
-    def show_observation_links(obs:, user:)
+    def show_observation_tabs(obs:, user:)
       [
-        send_observer_question_link(obs, user),
-        observation_manage_lists_link(obs, user),
-        *obs_change_links(obs)&.reject(&:empty?)
+        send_observer_question_tab(obs, user),
+        observation_manage_lists_tab(obs, user),
+        *obs_change_tabs(obs)&.reject(&:empty?)
       ]
     end
 
@@ -18,23 +18,23 @@ module Tabs
     #
     # Used in the observation panel
 
-    def send_observer_question_link(obs, user)
+    def send_observer_question_tab(obs, user)
       return if obs.user.no_emails
       return unless obs.user.email_general_question && obs.user != user
 
       [:show_observation_send_question.t,
        add_query_param(new_question_for_observation_path(obs.id)),
        { remote: true, onclick: "MOEvents.whirly();",
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
     # Used in the lists panel
-    def observation_manage_lists_link(obs, user)
+    def observation_manage_lists_tab(obs, user)
       return unless user
 
       [:show_observation_manage_species_lists.t,
        add_query_param(edit_observation_species_lists_path(obs.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     # Name panel -- generates HTML
@@ -42,115 +42,115 @@ module Tabs
     # uses create_links_to with extra_args { class: "d-block" }
     # the hiccup here is that list_descriptions is already HTML, an inline list
     def name_links_on_mo(name:)
-      tabs = create_links_to(obs_related_name_links(name), { class: "d-block" })
-      tabs += obs_name_description_links(name)
-      tabs += create_links_to([occurrence_map_for_name_link(name)],
+      tabs = create_links_to(obs_related_name_tabs(name), { class: "d-block" })
+      tabs += obs_name_description_tabs(name)
+      tabs += create_links_to([occurrence_map_for_name_tab(name)],
                               { class: "d-block" })
       tabs.reject(&:empty?)
     end
 
-    def obs_related_name_links(name)
+    def obs_related_name_tabs(name)
       [
-        show_object_link(name,
-                         :show_name.t(name: name.display_name_brief_authors)),
-        observations_of_name_link(name),
-        observations_of_look_alikes_link(name),
-        observations_of_related_taxa_link(name)
+        show_object_tab(name,
+                        :show_name.t(name: name.display_name_brief_authors)),
+        observations_of_name_tab(name),
+        observations_of_look_alikes_tab(name),
+        observations_of_related_taxa_tab(name)
       ]
     end
 
-    def observations_of_name_link(name)
+    def observations_of_name_tab(name)
       [:show_observation_more_like_this.t,
        observations_path(name: name.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def observations_of_look_alikes_link(name)
+    def observations_of_look_alikes_tab(name)
       [:show_observation_look_alikes.t,
        observations_path(name: name.id, look_alikes: "1"),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def observations_of_related_taxa_link(name)
+    def observations_of_related_taxa_tab(name)
       [:show_observation_related_taxa.t,
        observations_path(name: name.id, related_taxa: "1"),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     # from descriptions_helper
-    def obs_name_description_links(name)
+    def obs_name_description_tabs(name)
       list_descriptions(object: name)&.map do |link|
         tag.div(link)
       end
     end
 
-    def observation_map_link(mappable)
+    def observation_map_tab(mappable)
       return unless mappable
 
       [:MAP.t, add_query_param(map_observation_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     def name_links_web(name:)
-      tabs = create_links_to(observation_web_name_links(name),
+      tabs = create_links_to(observation_web_name_tabs(name),
                              { class: "d-block" })
       tabs.reject(&:empty?)
     end
 
-    def observation_web_name_links(name)
+    def observation_web_name_tabs(name)
       [
-        mycoportal_name_link(name),
-        mycobank_name_search_link(name),
-        google_images_for_name_link(name)
+        mycoportal_name_tab(name),
+        mycobank_name_search_tab(name),
+        google_images_for_name_tab(name)
       ]
     end
 
-    def mycoportal_name_link(name)
+    def mycoportal_name_tab(name)
       ["MyCoPortal", mycoportal_url(name),
-       { class: __method__.to_s, target: :_blank, rel: :noopener }]
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def mycobank_name_search_link(name)
+    def mycobank_name_search_tab(name)
       ["Mycobank", mycobank_name_search_url(name),
-       { class: __method__.to_s, target: :_blank, rel: :noopener }]
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def google_images_for_name_link(obs_name)
+    def google_images_for_name_tab(obs_name)
       [:google_images.t,
        format("https://images.google.com/images?q=%s",
               obs_name.real_text_name),
-       { class: __method__.to_s, target: :_blank, rel: :noopener }]
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def occurrence_map_for_name_link(obs_name)
+    def occurrence_map_for_name_tab(obs_name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: obs_name.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     ############################################
     # INDEX
 
-    def observations_index_links(query:)
+    def observations_index_tabs(query:)
       links = [
-        *observations_at_where_links(query), # maybe multiple links
-        map_observations_link(query),
-        *observations_coerced_query_links(query), # multiple links
-        observations_add_to_list_link(query),
-        observations_download_as_csv_link(query)
+        *observations_at_where_tabs(query), # maybe multiple links
+        map_observations_tab(query),
+        *observations_coerced_query_tabs(query), # multiple links
+        observations_add_to_list_tab(query),
+        observations_download_as_csv_tab(query)
       ]
       links.reject(&:empty?)
     end
 
-    def observations_at_where_links(query)
+    def observations_at_where_tabs(query)
       # Add some extra links to the index user is sent to if they click on an
       # undefined location.
       return [] unless query.flavor == :at_where
 
       [
-        define_location_link(query),
-        merge_locations_link(query),
-        locations_index_link
+        define_location_tab(query),
+        merge_locations_tab(query),
+        locations_index_tab
       ]
     end
 
@@ -169,119 +169,119 @@ module Tabs
       ].freeze
     end
 
-    def map_observations_link(query)
+    def map_observations_tab(query)
       [:show_object.t(type: :map),
        map_observations_path(q: get_query_param(query)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    # NOTE: coerced_query_link returns an array
-    def observations_coerced_query_links(query)
+    # NOTE: coerced_query_tab returns an array
+    def observations_coerced_query_tabs(query)
       [
-        coerced_location_query_link(query),
-        coerced_name_query_link(query),
-        coerced_image_query_link(query)
+        coerced_location_query_tab(query),
+        coerced_name_query_tab(query),
+        coerced_image_query_tab(query)
       ]
     end
 
-    def observations_add_to_list_link(query)
+    def observations_add_to_list_tab(query)
       [:list_observations_add_to_list.t,
        add_query_param(edit_species_list_observations_path, query),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def observations_download_as_csv_link(query)
+    def observations_download_as_csv_tab(query)
       [:list_observations_download_as_csv.t,
        add_query_param(new_observations_download_path, query),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
     ############################################
     # FORMS
 
-    def observation_form_new_links
-      [new_herbarium_link]
+    def observation_form_new_tabs
+      [new_herbarium_tab]
     end
 
-    def observation_form_edit_links(obs:)
-      [object_return_link(obs)]
+    def observation_form_edit_tabs(obs:)
+      [object_return_tab(obs)]
     end
 
-    def observation_maps_links(query:)
+    def observation_maps_tabs(query:)
       [
-        coerced_observation_query_link(query),
-        coerced_location_query_link(query)
+        coerced_observation_query_tab(query),
+        coerced_location_query_tab(query)
       ]
     end
 
-    def new_naming_links(obs:)
-      [object_return_link(obs)]
+    def new_naming_tabs(obs:)
+      [object_return_tab(obs)]
     end
 
-    def edit_naming_links(obs:)
-      [object_return_link(obs)]
+    def edit_naming_tabs(obs:)
+      [object_return_tab(obs)]
     end
 
-    def naming_suggestion_links(obs:)
-      [object_return_link(obs)]
+    def naming_suggestion_tabs(obs:)
+      [object_return_tab(obs)]
     end
 
-    def observation_list_links(obs:)
-      [object_return_link(obs)]
+    def observation_list_tabs(obs:)
+      [object_return_tab(obs)]
     end
 
-    def observation_images_edit_links(image:)
-      [object_return_link(image)]
+    def observation_images_edit_tabs(image:)
+      [object_return_tab(image)]
     end
 
-    def observation_images_new_links(obs:)
+    def observation_images_new_tabs(obs:)
       [
-        object_return_link(obs),
-        edit_observation_link(obs)
+        object_return_tab(obs),
+        edit_observation_tab(obs)
       ]
     end
 
     # Note this takes `obj:` not `obs:`
-    def observation_images_remove_links(obj:)
+    def observation_images_remove_tabs(obj:)
       [
-        object_return_link(obj),
-        edit_observation_link(obj)
+        object_return_tab(obj),
+        edit_observation_tab(obj)
       ]
     end
 
-    def observation_images_reuse_links(obs:)
+    def observation_images_reuse_tabs(obs:)
       [
-        object_return_link(obs),
-        edit_observation_link(obs)
+        object_return_tab(obs),
+        edit_observation_tab(obs)
       ]
     end
 
-    def observation_download_links
-      [observations_index_link]
+    def observation_download_tabs
+      [observations_index_tab]
     end
 
-    def observations_index_link
+    def observations_index_tab
       [:download_observations_back.t,
        add_query_param(observations_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def obs_change_links(obs)
+    def obs_change_tabs(obs)
       return unless check_permission(obs)
 
       [
-        edit_observation_link(obs),
-        destroy_observation_link(obs)
+        edit_observation_tab(obs),
+        destroy_observation_tab(obs)
       ]
     end
 
-    def edit_observation_link(obs)
+    def edit_observation_tab(obs)
       [:edit_object.t(type: Observation),
        add_query_param(edit_observation_path(obs.id)),
        { class: "#{__method__}_#{obs.id}" }]
     end
 
-    def destroy_observation_link(obs)
+    def destroy_observation_tab(obs)
       [nil, obs, { button: :destroy }]
     end
   end

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -2,91 +2,91 @@
 
 module Tabs
   module ProjectsHelper
-    def project_show_links(project:, user:)
+    def project_show_tabs(project:, user:)
       links = [
-        projects_index_link,
-        project_admin_request_link(project)
+        projects_index_tab,
+        project_admin_request_tab(project)
       ]
-      links << project_add_members_link(project) if project.is_admin?(user)
-      links += project_mod_links(project) if check_permission(project)
+      links << project_add_members_tab(project) if project.is_admin?(user)
+      links += project_mod_tabs(project) if check_permission(project)
       links
     end
 
-    def project_form_new_links
-      [projects_index_link]
+    def project_form_new_tabs
+      [projects_index_tab]
     end
 
-    def project_form_edit_links(project:)
+    def project_form_edit_tabs(project:)
       links = [
-        projects_index_link,
-        object_return_link(project)
+        projects_index_tab,
+        object_return_tab(project)
       ]
-      links << destroy_project_link(project) if check_permission(project)
+      links << destroy_project_tab(project) if check_permission(project)
       links
     end
 
-    def projects_index_links
-      [new_project_link]
+    def projects_index_tabs
+      [new_project_tab]
     end
 
-    def project_members_form_new_links(project:)
-      [object_return_link(project)]
+    def project_members_form_new_tabs(project:)
+      [object_return_tab(project)]
     end
 
-    def project_member_form_edit_links(project:)
+    def project_member_form_edit_tabs(project:)
       links = [
-        projects_index_link,
-        object_return_link(project)
+        projects_index_tab,
+        object_return_tab(project)
       ]
       return unless check_permission(project)
 
-      # Note this is just an edit_project_link with different wording
-      links << change_member_status_link(project)
+      # Note this is just an edit_project_tab with different wording
+      links << change_member_status_tab(project)
     end
 
-    def projects_index_link
+    def projects_index_tab
       [:app_list_projects.t, projects_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def new_project_link
+    def new_project_tab
       [:list_projects_add_project.t, add_query_param(new_project_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def change_member_status_link(project)
+    def change_member_status_tab(project)
       [:change_member_status_edit.t,
        edit_project_path(project.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def project_add_members_link(project)
+    def project_add_members_tab(project)
       [:show_project_add_members.t,
        add_query_param(new_project_member_path(project_id: project.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def project_admin_request_link(project)
+    def project_admin_request_tab(project)
       [:show_project_admin_request.t,
        add_query_param(
          new_project_admin_request_path(project_id: project.id)
-       ), { class: __method__.to_s }]
+       ), { class: tab_id(__method__.to_s) }]
     end
 
-    def project_mod_links(project)
+    def project_mod_tabs(project)
       [
-        edit_project_link(project),
-        destroy_project_link(project)
+        edit_project_tab(project),
+        destroy_project_tab(project)
       ]
     end
 
-    def edit_project_link(project)
+    def edit_project_tab(project)
       [:show_project_edit.t,
        add_query_param(edit_project_path(project.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_project_link(project)
+    def destroy_project_tab(project)
       [nil, project, { button: :destroy }]
     end
 

--- a/app/helpers/tabs/publications_helper.rb
+++ b/app/helpers/tabs/publications_helper.rb
@@ -2,55 +2,55 @@
 
 module Tabs
   module PublicationsHelper
-    def publication_show_links(pub:, user:)
+    def publication_show_tabs(pub:, user:)
       links = [
-        new_publication_link,
-        publications_index_link
+        new_publication_tab,
+        publications_index_tab
       ]
       return links unless in_admin_mode? || pub.can_edit?(user)
 
-      links += publication_mod_links(pub)
+      links += publication_mod_tabs(pub)
       links
     end
 
-    def publications_index_links
-      [new_publication_link]
+    def publications_index_tabs
+      [new_publication_tab]
     end
 
-    def publication_form_new_links
-      [publications_index_link]
+    def publication_form_new_tabs
+      [publications_index_tab]
     end
 
-    def publication_form_edit_links(pub:)
+    def publication_form_edit_tabs(pub:)
       [
-        object_return_link(pub),
-        publications_index_link
+        object_return_tab(pub),
+        publications_index_tab
       ]
     end
 
-    def new_publication_link
+    def new_publication_tab
       [:create_publication.t, new_publication_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def publications_index_link
+    def publications_index_tab
       [:publication_index.t, publications_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def publication_mod_links(pub)
+    def publication_mod_tabs(pub)
       [
-        edit_publication_link(pub),
-        destroy_publication_link(pub)
+        edit_publication_tab(pub),
+        destroy_publication_tab(pub)
       ]
     end
 
-    def edit_publication_link(pub)
+    def edit_publication_tab(pub)
       [:EDIT.t, edit_publication_path(pub.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_publication_link(pub)
+    def destroy_publication_tab(pub)
       [nil, pub, { button: :destroy }]
     end
   end

--- a/app/helpers/tabs/rss_logs_helper.rb
+++ b/app/helpers/tabs/rss_logs_helper.rb
@@ -4,20 +4,20 @@
 #
 module Tabs
   module RssLogsHelper
-    def rss_logs_index_links(user:, types:)
+    def rss_logs_index_tabs(user:, types:)
       [
-        activity_log_default_types_for_user_link(user, types)
+        activity_log_default_types_for_user_tab(user, types)
       ]
     end
 
-    def activity_log_default_types_for_user_link(user, types)
+    def activity_log_default_types_for_user_tab(user, types)
       return unless params[:make_default] != "1"
 
       return unless user&.default_rss_type.to_s.split.sort != types
 
       [:rss_make_default.t,
        add_query_param(action: :index, make_default: 1),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/sequences_helper.rb
+++ b/app/helpers/tabs/sequences_helper.rb
@@ -2,33 +2,33 @@
 
 module Tabs
   module SequencesHelper
-    def sequence_show_links(seq:)
+    def sequence_show_tabs(seq:)
       links = [
         link_to(:cancel_and_show.t(type: :observation),
                 seq.observation.show_link_args)
       ]
       return unless check_permission(seq)
 
-      links += sequence_mod_links(seq)
+      links += sequence_mod_tabs(seq)
       links
     end
 
-    def sequence_form_links(obj:)
-      [object_return_link(obj)]
+    def sequence_form_tabs(obj:)
+      [object_return_tab(obj)]
     end
 
-    def sequence_mod_links(seq)
-      [edit_sequence_link(seq),
-       destroy_sequence_link(seq)]
+    def sequence_mod_tabs(seq)
+      [edit_sequence_tab(seq),
+       destroy_sequence_tab(seq)]
     end
 
-    def edit_sequence_link(seq)
+    def edit_sequence_tab(seq)
       [:edit_object.t(type: :sequence),
        seq.edit_link_args.merge(back: :show),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def destroy_sequence_link(seq)
+    def destroy_sequence_tab(seq)
       [:destroy_object.t(type: :sequence), seq,
        { button: :destroy, back: url_after_delete(seq) }]
     end

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -2,131 +2,132 @@
 
 module Tabs
   module SpeciesListsHelper
-    # Moved download link into logged_in_show_links and nixed user: kwarg
+    # Moved download link into species_list_logged_in_show_tabs and
+    # nixed user: kwarg
     # Can't access this page unless logged in as of 2023
-    def species_list_show_links(list:)
-      links = species_list_logged_in_show_links(list)
-      return links unless check_permission(list)
+    def species_list_show_tabs(list:)
+      tabs = species_list_logged_in_show_tabs(list)
+      return tabs unless check_permission(list)
 
-      links += species_list_user_show_links(list)
-      links
+      tabs += species_list_user_show_tabs(list)
+      tabs
     end
 
-    def species_list_logged_in_show_links(list)
+    def species_list_logged_in_show_tabs(list)
       [
-        species_list_download_link(list),
-        species_list_set_source_link(list),
-        clone_species_list_link(list),
-        species_list_add_remove_from_another_list_link(list)
+        species_list_download_tab(list),
+        species_list_set_source_tab(list),
+        clone_species_list_tab(list),
+        species_list_add_remove_from_another_list_tab(list)
       ]
     end
 
-    def species_list_user_show_links(list)
+    def species_list_user_show_tabs(list)
       [
-        manage_species_list_projects_link(list),
-        edit_species_list_link(list),
-        clear_species_list_link(list),
-        destroy_species_list_link(list)
+        manage_species_list_projects_tab(list),
+        edit_species_list_tab(list),
+        clear_species_list_tab(list),
+        destroy_species_list_tab(list)
       ]
     end
 
-    def manage_species_list_projects_link(list)
+    def manage_species_list_projects_tab(list)
       [:species_list_show_manage_projects.t,
        add_query_param(edit_species_list_projects_path(list.id)),
        { help: :species_list_show_manage_projects_help.l,
-         class: __method__.to_s }]
+         class: tab_id(__method__.to_s) }]
     end
 
-    def edit_species_list_link(list)
+    def edit_species_list_tab(list)
       [:species_list_show_edit.t,
        add_query_param(edit_species_list_path(list.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def species_list_download_link(list)
+    def species_list_download_tab(list)
       [:species_list_show_download.t,
        add_query_param(new_species_list_download_path(list.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def species_list_set_source_link(list)
+    def species_list_set_source_tab(list)
       [:species_list_show_set_source.t,
        add_query_param(species_list_path(list.id, set_source: 1)),
-       { class: __method__.to_s,
+       { class: tab_id(__method__.to_s),
          help: :species_list_show_set_source_help.l }]
     end
 
-    def species_list_add_remove_from_another_list_link(list)
+    def species_list_add_remove_from_another_list_tab(list)
       [:species_list_show_add_remove_from_another_list.t,
        add_query_param(
          edit_species_list_observations_path(species_list: list.id)
        ),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def clone_species_list_link(list)
+    def clone_species_list_tab(list)
       [:species_list_show_clone_list.t,
        add_query_param(new_species_list_path(clone: list.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def clear_species_list_link(list)
+    def clear_species_list_tab(list)
       [:species_list_show_clear_list.t,
        clear_species_list_path(list.id),
        { button: :put, class: "#{__method__} text-danger",
          data: { confirm: :are_you_sure.l } }]
     end
 
-    def destroy_species_list_link(list)
+    def destroy_species_list_tab(list)
       [:species_list_show_destroy.t, list, { button: :destroy }]
     end
 
-    def species_list_form_new_links
-      [name_lister_link]
+    def species_list_form_new_tabs
+      [name_lister_tab]
     end
 
-    def species_list_form_edit_links(list:)
+    def species_list_form_edit_tabs(list:)
       [
-        object_return_link(list),
-        species_list_upload_link(list)
+        object_return_tab(list),
+        species_list_upload_tab(list)
       ]
     end
 
-    def species_list_upload_link(list)
+    def species_list_upload_tab(list)
       [:species_list_upload_title.t,
        add_query_param(new_species_list_upload_path(list.id)),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def species_list_edit_project_links(list:)
-      [object_return_link(list)]
+    def species_list_edit_project_tabs(list:)
+      [object_return_tab(list)]
     end
 
-    def species_list_form_observations_links
-      [observations_index_return_link]
+    def species_list_form_observations_tabs
+      [observations_index_return_tab]
     end
 
-    def observations_index_return_link
+    def observations_index_return_tab
       [:species_list_add_remove_cancel.t, add_query_param(observations_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def species_list_form_name_list_links
-      [name_lister_classic_link]
+    def species_list_form_name_list_tabs
+      [name_lister_classic_tab]
     end
 
-    def name_lister_link
+    def name_lister_tab
       [:name_lister_title.t, new_species_list_name_lister_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def name_lister_classic_link
+    def name_lister_classic_tab
       [:name_lister_classic.t, add_query_param(new_species_list_path),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def species_list_download_links(list:)
-      [object_return_link(list)]
+    def species_list_download_tabs(list:)
+      [object_return_tab(list)]
     end
 
     def species_lists_index_sorts(query:)

--- a/app/helpers/tabs/support_helper.rb
+++ b/app/helpers/tabs/support_helper.rb
@@ -2,52 +2,52 @@
 
 module Tabs
   module SupportHelper
-    def support_donate_links
-      links = [support_donors_link]
+    def support_donate_tabs
+      links = [support_donors_tab]
       return unless in_admin_mode?
 
-      links += support_admin_links
+      links += support_admin_tabs
       links
     end
 
-    def support_donors_links
-      links = [support_donate_link]
+    def support_donors_tabs
+      links = [support_donate_tab]
       return unless in_admin_mode?
 
-      links += support_admin_links
+      links += support_admin_tabs
       links
     end
 
-    def support_governance_links
+    def support_governance_tabs
       [
-        support_donate_link,
-        support_donors_link
+        support_donate_tab,
+        support_donors_tab
       ]
     end
 
-    def support_donors_link
-      [:donors_tab.t, support_donors_path, { class: __method__.to_s }]
+    def support_donors_tab
+      [:donors_tab.t, support_donors_path, { class: tab_id(__method__.to_s) }]
     end
 
-    def support_donate_link
-      [:donate_tab.t, support_donate_path, { class: __method__.to_s }]
+    def support_donate_tab
+      [:donate_tab.t, support_donate_path, { class: tab_id(__method__.to_s) }]
     end
 
-    def support_admin_links
+    def support_admin_tabs
       [
-        admin_new_donation_link,
-        admin_review_donations_link
+        admin_new_donation_tab,
+        admin_review_donations_tab
       ]
     end
 
-    def admin_new_donation_link
+    def admin_new_donation_tab
       [:create_donation_tab.t, new_admin_donations_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def admin_review_donations_link
+    def admin_review_donations_tab
       [:review_donations_tab.t, admin_review_donations_path,
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/themes_helper.rb
+++ b/app/helpers/tabs/themes_helper.rb
@@ -2,13 +2,14 @@
 
 module Tabs
   module ThemesHelper
-    def theme_show_links
-      [theme_list_link,
-       account_edit_preferences_link]
+    def theme_show_tabs
+      [theme_list_tab,
+       account_edit_preferences_tab]
     end
 
-    def theme_list_link
-      [:theme_list.t, theme_color_themes_path, { class: __method__.to_s }]
+    def theme_list_tab
+      [:theme_list.t, theme_color_themes_path,
+       { class: tab_id(__method__.to_s) }]
     end
   end
 end

--- a/app/helpers/tabs/users_helper.rb
+++ b/app/helpers/tabs/users_helper.rb
@@ -2,8 +2,8 @@
 
 module Tabs
   module UsersHelper
-    def user_show_links(show_user:, user:)
-      links = [site_contributors_link]
+    def user_show_tabs(show_user:, user:)
+      links = [site_contributors_tab]
       links += if show_user == user
                  links_for_this_user(show_user)
                else
@@ -11,7 +11,7 @@ module Tabs
                end
       return links unless in_admin_mode?
 
-      links += user_links_for_admin(show_user)
+      links += user_tabs_for_admin(show_user)
 
       links
     end
@@ -22,64 +22,64 @@ module Tabs
 
     def links_for_this_user(user)
       [
-        user_observations_link(user, :show_user_your_observations.t),
-        comments_for_user_link(user, :show_user_comments_for_you.t),
-        account_show_notifications_link,
-        account_edit_profile_link,
-        account_edit_preferences_link,
-        user_life_list_link(user)
+        user_observations_tab(user, :show_user_your_observations.t),
+        comments_for_user_tab(user, :show_user_comments_for_you.t),
+        account_show_notifications_tab,
+        account_edit_profile_tab,
+        account_edit_preferences_tab,
+        user_life_list_tab(user)
       ]
     end
 
     def links_for_that_user(user)
       [
-        user_observations_link(user),
-        comments_for_user_link(user),
-        email_user_question_link(user)
+        user_observations_tab(user),
+        comments_for_user_tab(user),
+        email_user_question_tab(user)
       ]
     end
 
-    def user_life_list_link(user)
+    def user_life_list_tab(user)
       [:app_life_list.t, checklist_path(id: user.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def user_profile_link(user)
+    def user_profile_tab(user)
       [:show_object.t(type: :profile), user_path(user.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def user_observations_link(user, text = nil)
+    def user_observations_tab(user, text = nil)
       text ||= :show_user_observations_by.t(name: user.unique_text_name)
       [text, observations_path(user: user.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def comments_for_user_link(user, text = nil)
+    def comments_for_user_tab(user, text = nil)
       text ||= :show_user_comments_for.t(name: user.unique_text_name)
       [text, comments_path(for_user: user.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def email_user_question_link(user)
+    def email_user_question_tab(user)
       [:show_user_email_to.t(name: user.unique_text_name),
        emails_ask_user_question_path(user.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def user_links_for_admin(user)
+    def user_tabs_for_admin(user)
       [
-        admin_change_user_bonuses_link(user),
-        admin_destroy_user_link(user)
+        admin_change_user_bonuses_tab(user),
+        admin_destroy_user_tab(user)
       ]
     end
 
-    def admin_change_user_bonuses_link(user)
+    def admin_change_user_bonuses_tab(user)
       [:change_user_bonuses.t, edit_admin_users_path(user.id),
-       { class: __method__.to_s }]
+       { class: tab_id(__method__.to_s) }]
     end
 
-    def admin_destroy_user_link(user)
+    def admin_destroy_user_tab(user)
       [nil, admin_users_path(id: user.id), { button: :destroy }]
     end
 

--- a/app/views/account/api_keys/edit.html.erb
+++ b/app/views/account/api_keys/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:account_api_keys_title.t)
-add_tab_set(account_api_links)
+add_tab_set(account_api_tabs)
 %>
 
 <%= :account_api_keys_help.tp %>

--- a/app/views/account/api_keys/index.html.erb
+++ b/app/views/account/api_keys/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:account_api_keys_title.t)
-add_tab_set(account_api_links)
+add_tab_set(account_api_tabs)
 @container = :full
 
 javascript_include("account_api_keys")

--- a/app/views/account/preferences/edit.html.erb
+++ b/app/views/account/preferences/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:prefs_title.t)
-add_tab_set(account_preferences_edit_links)
+add_tab_set(account_preferences_edit_tabs)
 %>
 
 <%= form_with(model: @user, url: account_preferences_path,

--- a/app/views/account/profile/edit.html.erb
+++ b/app/views/account/profile/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:profile_title.t)
-add_tab_set(account_profile_edit_links)
+add_tab_set(account_profile_edit_tabs)
 %>
 
 <div class="row">

--- a/app/views/admin/donations/edit.html.erb
+++ b/app/views/admin/donations/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:review_donations_title.l)
-add_tab_set(admin_donations_form_edit_links)
+add_tab_set(admin_donations_form_edit_tabs)
 %>
 
 <%= form_with(url: admin_donations_path,

--- a/app/views/admin/donations/new.html.erb
+++ b/app/views/admin/donations/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:create_donation_title.l)
-add_tab_set(admin_donations_form_new_links)
+add_tab_set(admin_donations_form_new_tabs)
 %>
 
 <%= form_with(model: @donation, url: admin_donations_path,

--- a/app/views/admin/test.html.erb
+++ b/app/views/admin/test.html.erb
@@ -9,7 +9,7 @@
     add_page_title("This is a test page, let's give it a much longer title just to see what happens when we do something like this")
 
     add_interest_icons(@user, Observation.first)
-    add_tab_set(admin_test_links)
+    add_tab_set(admin_test_tabs)
   %>
 
   <% left_content do %>

--- a/app/views/application/content/_tab_set.html.erb
+++ b/app/views/application/content/_tab_set.html.erb
@@ -1,11 +1,11 @@
 <%#
-Plain tab set. Takes `tabs` as an array of <a> or <button> links.
+Plain tab set. Takes `links` as an array of <a> or <button> links.
 Just adds <small> and line breaks.
 %>
 
-<% tabs ||= [] %>
+<% links ||= [] %>
 <small>
-  <% tabs.reject(&:nil?).each do |tabs| %>
-    <%= tabs %><br>
+  <% links.reject(&:nil?).each do |link| %>
+    <%= link %>
   <% end %>
 </small>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,6 +1,6 @@
 <%
-add_page_title(edit_title(@article))
-add_tab_set(article_form_edit_links(article: @article))
+add_page_title(article_edit_title(@article))
+add_tab_set(article_form_edit_tabs(article: @article))
 %>
 
 <%= render(partial: "form") %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_index_title(@query, no_hits: :ARTICLES.t)
-add_tab_set(articles_index_links(user: @user))
+add_tab_set(articles_index_tabs(user: @user))
 add_sorter(@query, articles_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:create_article_title.l)
-add_tab_set(article_form_new_links)
+add_tab_set(article_form_new_tabs)
 %>
 
 <%= render(partial: "form") %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
-add_page_title(show_title(@article))
-add_tab_set(article_show_links(article: @article, user: @user))
+add_page_title(article_show_title(@article))
+add_tab_set(article_show_tabs(article: @article, user: @user))
 %>
 
 <div>

--- a/app/views/authors/reviews/show.html.erb
+++ b/app/views/authors/reviews/show.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:review_authors_title.t(name: @object.format_name))
-add_tab_set(author_review_links(obj: @object))
+add_tab_set(author_review_tabs(obj: @object))
 
 type = @object.type_tag
 %>

--- a/app/views/checklists/show.html.erb
+++ b/app/views/checklists/show.html.erb
@@ -4,7 +4,7 @@ add_page_title(checklist_show_title(user: @show_user,
                                     project: @project,
                                     list: @species_list))
 
-add_tab_set(checklist_show_links(user: @show_user,
+add_tab_set(checklist_show_tabs(user: @show_user,
                                  project: @project,
                                  list: @species_list))
 names = @data.species

--- a/app/views/collection_numbers/edit.html.erb
+++ b/app/views/collection_numbers/edit.html.erb
@@ -4,7 +4,7 @@ add_page_title(
   :edit_collection_number_title.l(name: @collection_number.format_name)
 )
 add_tab_set(
-  collection_number_form_edit_links(back: @back, c_n: @collection_number,
+  collection_number_form_edit_tabs(back: @back, c_n: @collection_number,
                                     obj: @back_object)
 )
 %>

--- a/app/views/collection_numbers/index.html.erb
+++ b/app/views/collection_numbers/index.html.erb
@@ -2,7 +2,7 @@
 @container = :wide
 # the no_hits_title.
 add_index_title(@query, no_hits: :list_collection_numbers_title.t)
-add_tab_set(collection_numbers_index_links(obs: @observation))
+add_tab_set(collection_numbers_index_tabs(obs: @observation))
 add_sorter(@query, collection_numbers_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/collection_numbers/new.html.erb
+++ b/app/views/collection_numbers/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:create_collection_number_title.l)
-add_tab_set(collection_number_form_new_links(obs: @observation))
+add_tab_set(collection_number_form_new_tabs(obs: @observation))
 %>
 
 <div class="row">

--- a/app/views/collection_numbers/show.html.erb
+++ b/app/views/collection_numbers/show.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title("#{:COLLECTION_NUMBER.t} '#{@collection_number.format_name.t}'")
 add_pager_for(@collection_number)
-add_tab_set(collection_number_show_links(c_n: @collection_number))
+add_tab_set(collection_number_show_tabs(c_n: @collection_number))
 %>
 
 <p class="mt-3">

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:comment_edit_title.t(name: @target.unique_format_name))
-add_tab_set(comment_form_edit_links(comment: @comment))
+add_tab_set(comment_form_edit_tabs(comment: @comment))
 %>
 
 <%= render(partial: "form", locals: { action: :update, local: true }) %>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:comment_add_title.t(name: @target.unique_format_name))
-add_tab_set(comment_form_new_links(target: @target))
+add_tab_set(comment_form_new_tabs(target: @target))
 %>
 
 <div class="row">

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -18,7 +18,7 @@ elsif @comment.target_type == "Name"
 end
 
 add_pager_for(@comment)
-add_tab_set(comment_show_links(comment: @comment, target: @target))
+add_tab_set(comment_show_tabs(comment: @comment, target: @target))
 %>
 
 <p><%= :comment_show_created_at.t %>: <%= @comment.created_at.web_time %></p>

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_page_title(:users_by_contribution_title.t)
-add_tab_set(contributors_index_links)
+add_tab_set(contributors_index_tabs)
 %>
 
 <div class="row">

--- a/app/views/emails/merge_request.html.erb
+++ b/app/views/emails/merge_request.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:email_merge_request_title.t(type: @model.type_tag))
 
-add_tab_set(email_merge_request_links(old_obj: @old_obj))
+add_tab_set(email_merge_request_tabs(old_obj: @old_obj))
 
 url = { action: :merge_request, type: @model.name,
         old_id: @old_obj.id, new_id: @new_obj.id }

--- a/app/views/emails/name_change_request.html.erb
+++ b/app/views/emails/name_change_request.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:email_name_change_request_title.t)
 
-add_tab_set(email_name_change_request_links(name: @name))
+add_tab_set(email_name_change_request_tabs(name: @name))
 
 url = { action: :name_change_request, name_id: @name.id, new_name: @new_name }
 %>

--- a/app/views/glossary_terms/edit.html.erb
+++ b/app/views/glossary_terms/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_glossary_term_title.t(name: @glossary_term.name))
 
-add_tab_set(glossary_term_form_edit_links(term: @glossary_term))
+add_tab_set(glossary_term_form_edit_tabs(term: @glossary_term))
 %>
 
 <%= render("form") %>

--- a/app/views/glossary_terms/images/remove.html.erb
+++ b/app/views/glossary_terms/images/remove.html.erb
@@ -2,7 +2,7 @@
 # Note totally general title and tabs based on @object target_class
 add_page_title(:image_remove_title.t(name: @object.unique_format_name))
 
-add_tab_set(glossary_term_image_form_links(term: @object))
+add_tab_set(glossary_term_image_form_tabs(term: @object))
 
 @container = :full
 form_action = { controller: "/glossary_terms/images",

--- a/app/views/glossary_terms/images/reuse.html.erb
+++ b/app/views/glossary_terms/images/reuse.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:image_reuse_title.t(name: @object.unique_format_name))
 
-add_tab_set(glossary_term_image_form_links(term: @object))
+add_tab_set(glossary_term_image_form_tabs(term: @object))
 @container = :full
 
 form_action = { controller: "/glossary_terms/images",

--- a/app/views/glossary_terms/index.html.erb
+++ b/app/views/glossary_terms/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:glossary_term_index_title.t)
-add_tab_set(glossary_term_index_links) if User.current
+add_tab_set(glossary_term_index_tabs) if User.current
 @container = :text_image
 %>
 

--- a/app/views/glossary_terms/new.html.erb
+++ b/app/views/glossary_terms/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:create_glossary_term_title.t)
 
-add_tab_set(glossary_term_form_new_links)
+add_tab_set(glossary_term_form_new_tabs)
 %>
 
 <%= render("form", button_name: :edit_glossary_term_save) do |f| %>

--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:show_glossary_term_title.t(name: @glossary_term.name))
 
-add_tab_set(glossary_term_show_links(term: @glossary_term, user: @user))
+add_tab_set(glossary_term_show_tabs(term: @glossary_term, user: @user))
 
 @container = :wide
 %>
@@ -9,7 +9,7 @@ add_tab_set(glossary_term_show_links(term: @glossary_term, user: @user))
 <div class="row mt-3">
   <div class="col-sm-8">
     <%= @glossary_term.description.tpl %>
-    <%= tag.p(search_link_to(:Wikipedia, @glossary_term.name)) %>
+    <%= tag.p(link_to(search_tab_for(:Wikipedia, @glossary_term.name))) %>
   </div>
   <% if @glossary_term.thumb_image %>
     <div class="col-sm-4">

--- a/app/views/glossary_terms/versions/show.html.erb
+++ b/app/views/glossary_terms/versions/show.html.erb
@@ -4,7 +4,7 @@ add_page_title(:show_past_glossary_term_title.t(
   name: @glossary_term.name
 ))
 
-add_tab_set(glossary_term_version_links(term: @glossary_term))
+add_tab_set(glossary_term_version_tabs(term: @glossary_term))
 %>
 
 <div class="row">

--- a/app/views/herbaria/curator_requests/new.html.erb
+++ b/app/views/herbaria/curator_requests/new.html.erb
@@ -2,7 +2,7 @@
 <%
 add_page_title(:show_herbarium_curator_request.t)
 
-add_tab_set(herbaria_curator_request_links(herbarium: @herbarium))
+add_tab_set(herbaria_curator_request_tabs(herbarium: @herbarium))
 %>
 
 <%= :show_herbarium_curator_help.tp %>

--- a/app/views/herbaria/edit.html.erb
+++ b/app/views/herbaria/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_herbarium_title.l)
 
-add_tab_set(herbarium_form_edit_links(herbarium: @herbarium))
+add_tab_set(herbarium_form_edit_tabs(herbarium: @herbarium))
 %>
 
 <%= render(partial: "form", locals: { button_name: :SAVE }) %>

--- a/app/views/herbaria/index.html.erb
+++ b/app/views/herbaria/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_index_title(@query, no_hits: :list_herbaria_title.t)
-add_tab_set(herbaria_index_links(query: @query))
+add_tab_set(herbaria_index_tabs(query: @query))
 add_sorter(@query, herbaria_index_sorts(query: @query))
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/herbaria/new.html.erb
+++ b/app/views/herbaria/new.html.erb
@@ -2,7 +2,7 @@
 <%
 add_page_title(:create_herbarium_title.l)
 
-add_tab_set(herbarium_form_new_links)
+add_tab_set(herbarium_form_new_tabs)
 %>
 
 <%= render(partial: "form", locals: { button_name: :CREATE }) %>

--- a/app/views/herbaria/show.html.erb
+++ b/app/views/herbaria/show.html.erb
@@ -2,7 +2,7 @@
 add_page_title(@herbarium.format_name.t)
 
 add_pager_for(@herbarium)
-add_tab_set(herbarium_show_links(herbarium: @herbarium, user: @user))
+add_tab_set(herbarium_show_tabs(herbarium: @herbarium, user: @user))
 
 map = @herbarium.location ? true : false
 @container = :wide

--- a/app/views/herbarium_records/edit.html.erb
+++ b/app/views/herbarium_records/edit.html.erb
@@ -3,7 +3,7 @@
 add_page_title(:edit_herbarium_record_title.l(
   herbarium_label: @herbarium_record.herbarium_label
 ))
-add_tab_set(herbarium_record_form_edit_links(back: @back,
+add_tab_set(herbarium_record_form_edit_tabs(back: @back,
                                               back_object: @back_object))
 %>
 

--- a/app/views/herbarium_records/index.html.erb
+++ b/app/views/herbarium_records/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_index_title(@query, no_hits: :list_herbarium_records_title.t)
-add_tab_set(herbarium_records_index_links(obs: @observation))
+add_tab_set(herbarium_records_index_tabs(obs: @observation))
 add_sorter(@query, herbarium_records_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/herbarium_records/new.html.erb
+++ b/app/views/herbarium_records/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:create_herbarium_record_title.l)
-add_tab_set(herbarium_record_form_new_links(obs: @observation))
+add_tab_set(herbarium_record_form_new_tabs(obs: @observation))
 %>
 
 <div class="row">

--- a/app/views/herbarium_records/show.html.erb
+++ b/app/views/herbarium_records/show.html.erb
@@ -3,7 +3,7 @@ add_page_title(:HERBARIUM_RECORD.t + " '" +
                @herbarium_record.format_name.t + "'".html_safe)
 
 add_pager_for(@herbarium_record)
-add_tab_set(herbarium_record_show_links(h_r: @herbarium_record))
+add_tab_set(herbarium_record_show_tabs(h_r: @herbarium_record))
 
 herbarium = @herbarium_record.herbarium
 %>

--- a/app/views/images/exif/show.html.erb
+++ b/app/views/images/exif/show.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:exif_data_for_image.t(image: @image.id))
-add_tab_set(images_exif_show_links(image: @image))
+add_tab_set(images_exif_show_tabs(image: @image))
 @container = :text
 %>
 

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_index_title(@query)
-add_tab_set(images_index_links(query: @query))
+add_tab_set(images_index_tabs(query: @query))
 add_sorter(@query, images_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:image_show_title.t(name: @image.unique_format_name))
 add_pager_for(@image)
-add_tab_set(show_image_links(image: @image))
+add_tab_set(show_image_tabs(image: @image))
 @container = :wide
 %>
 

--- a/app/views/images/test_add_image_report.html.erb
+++ b/app/views/images/test_add_image_report.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title("Test Add Image Report")
 
-add_tab_set(test_add_image_report_links)
+add_tab_set(test_add_image_report_tabs)
 %>
 
 <table class="table-striped table-upload-report">

--- a/app/views/info/site_stats.html.erb
+++ b/app/views/info/site_stats.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:show_site_stats_title.t)
 
-add_tab_set(info_site_stats_links)
+add_tab_set(info_site_stats_tabs)
 @container = :full
 %>
 

--- a/app/views/locations/countries/index.html.erb
+++ b/app/views/locations/countries/index.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:list_countries_title.t)
 
-add_tab_set(location_countries_links)
+add_tab_set(location_countries_tabs)
 @container = :wide
 %>
 

--- a/app/views/locations/descriptions/edit.html.erb
+++ b/app/views/locations/descriptions/edit.html.erb
@@ -3,7 +3,7 @@ add_page_title(
   :edit_location_description_title.t(name: @description.format_name)
 )
 
-add_tab_set(location_description_form_edit_links(description: @description))
+add_tab_set(location_description_form_edit_tabs(description: @description))
 %>
 
 <%= render(partial: "form", locals: { action: :update }) %>

--- a/app/views/locations/descriptions/index.html.erb
+++ b/app/views/locations/descriptions/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_index_title(@query)
-add_tab_set(location_description_index_links(query: @query))
+add_tab_set(location_description_index_tabs(query: @query))
 add_sorter(@query, descriptions_index_sorts)
 @container = :wide
 

--- a/app/views/locations/descriptions/merges/new.html.erb
+++ b/app/views/locations/descriptions/merges/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:merge_descriptions_title.t(object: @description.format_name))
 add_tab_set(
-  location_description_form_permissions_links(description: @description)
+  location_description_form_permissions_tabs(description: @description)
 )
 action = { controller: "/names/descriptions/merges", action: :create,
             id: @description.id, q: get_query_param }

--- a/app/views/locations/descriptions/moves/new.html.erb
+++ b/app/views/locations/descriptions/moves/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:merge_descriptions_title.t(object: @description.format_name))
 add_tab_set(
-  location_description_form_permissions_links(description: @description)
+  location_description_form_permissions_tabs(description: @description)
 )
 action = { controller: "/names/descriptions/moves", action: :create,
             id: @description.id, q: get_query_param }

--- a/app/views/locations/descriptions/new.html.erb
+++ b/app/views/locations/descriptions/new.html.erb
@@ -2,7 +2,7 @@
 add_page_title(
   :create_location_description_title.t(name: @location.display_name)
 )
-add_tab_set(location_description_form_new_links(description: @description))
+add_tab_set(location_description_form_new_tabs(description: @description))
 %>
 
 <%= render(partial: "form", locals: { action: :create }) %>

--- a/app/views/locations/descriptions/permissions/edit.html.erb
+++ b/app/views/locations/descriptions/permissions/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(@description.format_name.t)
 add_tab_set(
-  location_description_form_permissions_links(description: @description)
+  location_description_form_permissions_tabs(description: @description)
 )
 action = { controller: "/locations/descriptions/permissions", action: :update,
             id: @description.id, q: get_query_param }

--- a/app/views/locations/descriptions/show.html.erb
+++ b/app/views/locations/descriptions/show.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(@description.format_name.t)
 add_pager_for(@description)
-add_tab_set(show_description_links(description: @description))
+add_tab_set(show_description_tabs(description: @description))
 @container = :wide
 %>
 

--- a/app/views/locations/descriptions/versions/show.html.erb
+++ b/app/views/locations/descriptions/versions/show.html.erb
@@ -3,7 +3,7 @@ desc_title = description_title(@description)
 add_page_title(:show_past_location_description_title.t(
   num: @description.version, name: desc_title
 ))
-add_tab_set(location_description_version_links(description: @description,
+add_tab_set(location_description_version_tabs(description: @description,
                                                desc_title: desc_title))
 %>
 

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_location_title.t(name: @location.display_name))
 add_pager_for(@image)
-add_tab_set(location_form_edit_links(location: @location))
+add_tab_set(location_form_edit_tabs(location: @location))
 
 @container = :full
 action = { action: :update, id: @location.id,

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_index_title(@query, no_hits: "")
-add_tab_set(locations_index_links(query: @query))
+add_tab_set(locations_index_tabs(query: @query))
 all_links = if (params[:id].present? ||
                 params[:by].present? ||
                 params[:by_user].present?)

--- a/app/views/locations/maps/show.html.erb
+++ b/app/views/locations/maps/show.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_page_title(location_map_title(query: @query))
-add_tab_set(location_map_links(query: @query))
+add_tab_set(location_map_tabs(query: @query))
 %>
 
 <%= render(partial: "shared/map",

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:create_location_title.t)
-add_tab_set(location_form_new_links(location: @location))
+add_tab_set(location_form_new_tabs(location: @location))
 
 action = {
   action: :create,

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -2,7 +2,7 @@
 add_page_title(:show_location_title.t(name: @location.display_name))
 add_pager_for(@location)
 add_interest_icons(@user, @location)
-add_tab_set(location_show_links(location: @location))
+add_tab_set(location_show_tabs(location: @location))
 @container = :wide
 %>
 

--- a/app/views/locations/versions/show.html.erb
+++ b/app/views/locations/versions/show.html.erb
@@ -2,7 +2,7 @@
 add_page_title(:show_past_location_title.t(
   num: @location.version, name: @location.display_name
 ))
-add_tab_set(location_version_links(location: @location))
+add_tab_set(location_version_tabs(location: @location))
 %>
 
 <%= show_past_versions(@location) %>

--- a/app/views/names/classification/edit.html.erb
+++ b/app/views/names/classification/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_classification_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 
 rank = rank_as_lower_string(@name.rank)
 action = { controller: "/names/classification", action: :update,

--- a/app/views/names/classification/inherit/new.html.erb
+++ b/app/views/names/classification/inherit/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:inherit_classification_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/classification/inherit", action: :create,
             id: @name.id, q: get_query_param }

--- a/app/views/names/descriptions/edit.html.erb
+++ b/app/views/names/descriptions/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:edit_name_description_title.t(name: @description.format_name))
-add_tab_set(name_description_form_edit_links(description: @description,
+add_tab_set(name_description_form_edit_tabs(description: @description,
                                              user: @user))
 
 action = { controller: "/names/descriptions", action: :update,

--- a/app/views/names/descriptions/index.html.erb
+++ b/app/views/names/descriptions/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_index_title(@query)
-add_tab_set(name_description_index_links(query: @query))
+add_tab_set(name_description_index_tabs(query: @query))
 add_sorter(@query, descriptions_index_sorts)
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/names/descriptions/merges/new.html.erb
+++ b/app/views/names/descriptions/merges/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:merge_descriptions_title.t(object: @description.format_name))
-add_tab_set(name_description_form_permissions_links(description: @description))
+add_tab_set(name_description_form_permissions_tabs(description: @description))
 
 action = { controller: "/names/descriptions/merges", action: :create,
             id: @description.id }

--- a/app/views/names/descriptions/moves/new.html.erb
+++ b/app/views/names/descriptions/moves/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:merge_descriptions_title.t(object: @description.format_name))
-add_tab_set(name_description_form_permissions_links(description: @description))
+add_tab_set(name_description_form_permissions_tabs(description: @description))
 
 action = { controller: "/names/descriptions/moves", action: :create,
             id: @description.id }

--- a/app/views/names/descriptions/new.html.erb
+++ b/app/views/names/descriptions/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:create_name_description_title.t(name: @name.display_name))
-add_tab_set(name_description_form_new_links(description: @description))
+add_tab_set(name_description_form_new_tabs(description: @description))
 
 action = { controller: "/names/descriptions", action: :create,
            id: @description.name_id, q: get_query_param }

--- a/app/views/names/descriptions/permissions/edit.html.erb
+++ b/app/views/names/descriptions/permissions/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(@description.format_name.t)
-add_tab_set(name_description_form_permissions_links(description: @description))
+add_tab_set(name_description_form_permissions_tabs(description: @description))
 
 action = { controller: "/names/descriptions/permissions", action: :update,
             id: @description.id, q: get_query_param }

--- a/app/views/names/descriptions/show.html.erb
+++ b/app/views/names/descriptions/show.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(@description.format_name.t)
-add_tab_set(show_description_links(description: @description))
+add_tab_set(show_description_tabs(description: @description))
 @container = :wide
 %>
 

--- a/app/views/names/descriptions/versions/show.html.erb
+++ b/app/views/names/descriptions/versions/show.html.erb
@@ -6,7 +6,7 @@ add_page_title(:show_past_name_description_title.t(
   name: desc_title
 ))
 
-add_tab_set(name_description_version_links(description: @description,
+add_tab_set(name_description_version_tabs(description: @description,
                                            desc_title: desc_title))
 
 Textile.register_name(@name)

--- a/app/views/names/edit.html.erb
+++ b/app/views/names/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:edit_name_title.t(name: @name.display_name))
-add_tab_set(name_form_edit_links(name: @name))
+add_tab_set(name_form_edit_tabs(name: @name))
 action = { controller: "/names", action: :update, id: @name.id }
 %>
 

--- a/app/views/names/index.html.erb
+++ b/app/views/names/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_index_title(@query, no_hits: "")
-add_tab_set(names_index_links(query: @query))
+add_tab_set(names_index_tabs(query: @query))
 add_sorter(@query, names_index_sorts(query: @query))
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/names/lifeforms/edit.html.erb
+++ b/app/views/names/lifeforms/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_lifeform_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 @container = :text_image
 
 action = { controller: "/names/lifeforms", action: :update,

--- a/app/views/names/lifeforms/propagate/edit.html.erb
+++ b/app/views/names/lifeforms/propagate/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:propagate_lifeform_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 @container = :text_image
 action = { controller: "/names/lifeforms/propagate", action: :update,
            id: @name.id, q: get_query_param }

--- a/app/views/names/maps/show.html.erb
+++ b/app/views/names/maps/show.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_page_title(:name_map_title.t(name: @name.display_name))
-add_tab_set(name_map_links(name: @name, query: @query))
+add_tab_set(name_map_tabs(name: @name, query: @query))
 %>
 
 <%= render(partial: "shared/map",

--- a/app/views/names/new.html.erb
+++ b/app/views/names/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:create_name_title.t)
-add_tab_set(name_form_new_links)
+add_tab_set(name_form_new_tabs)
 action = add_query_param({ controller: "/names", action: :create })
 %>
 

--- a/app/views/names/show.html.erb
+++ b/app/views/names/show.html.erb
@@ -4,7 +4,7 @@ add_page_title(:show_name_title.t(name: @name.display_name))
 Textile.register_name(@name)
 add_pager_for(@name)
 add_interest_icons(@user, @name)
-add_tab_set(name_show_links(name: @name, user: @user))
+add_tab_set(name_show_tabs(name: @name, user: @user))
 
 @container = :wide
 %>

--- a/app/views/names/synonyms/approve/new.html.erb
+++ b/app/views/names/synonyms/approve/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:name_approve_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/synonyms/approve", action: :create,
             id: @name.id }

--- a/app/views/names/synonyms/deprecate/new.html.erb
+++ b/app/views/names/synonyms/deprecate/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:name_deprecate_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/synonyms/deprecate", action: :create,
             id: @name.id, approved_name: @what }

--- a/app/views/names/synonyms/edit.html.erb
+++ b/app/views/names/synonyms/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:name_change_synonyms_title.t(name: @name.display_name))
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 @container = :text_image
 
 url = { controller: "/names/synonyms", action: :update, id: @name.id,

--- a/app/views/names/trackers/edit.html.erb
+++ b/app/views/names/trackers/edit.html.erb
@@ -3,7 +3,7 @@
 
 add_page_title(:email_tracking_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/trackers", action: :update, id: @name.id,
             q: get_query_param }

--- a/app/views/names/trackers/new.html.erb
+++ b/app/views/names/trackers/new.html.erb
@@ -3,7 +3,7 @@
 
 add_page_title(:email_tracking_title.t(name: @name.display_name))
 
-add_tab_set(name_forms_return_links(name: @name))
+add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/trackers", action: :create, id: @name.id,
             q: get_query_param }

--- a/app/views/names/versions/show.html.erb
+++ b/app/views/names/versions/show.html.erb
@@ -2,7 +2,7 @@
 add_page_title(:show_past_name_title.t(
   num:  @name.version, name: @name.display_name
 ))
-add_tab_set(name_versions_links(name: @name))
+add_tab_set(name_version_tabs(name: @name))
 @container = :text
 %>
 

--- a/app/views/observations/downloads/new.html.erb
+++ b/app/views/observations/downloads/new.html.erb
@@ -2,7 +2,7 @@
 # The form partial is also called by species_lists/downloads
 add_page_title(:download_observations_title.t)
 
-# add_tab_set(observation_download_links)
+# add_tab_set(observation_download_tabs)
 %>
 
 <%= render(partial: "observations/downloads/form",

--- a/app/views/observations/edit.html.erb
+++ b/app/views/observations/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_observation_title.t(name: @observation.unique_format_name))
 
-add_tab_set(observation_form_edit_links(obs: @observation))
+add_tab_set(observation_form_edit_tabs(obs: @observation))
 @container = :wide
 %>
 

--- a/app/views/observations/images/edit.html.erb
+++ b/app/views/observations/images/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:image_edit_title.t(name: @image.unique_format_name))
 
-add_tab_set(observation_images_edit_links(image: @image))
+add_tab_set(observation_images_edit_tabs(image: @image))
 @container = :wide
 form_action = { controller: "/observations/images",
                 action: :update,

--- a/app/views/observations/images/new.html.erb
+++ b/app/views/observations/images/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:image_add_title.t(name: @observation.unique_format_name))
 
-add_tab_set(observation_images_new_links(obs: @observation))
+add_tab_set(observation_images_new_tabs(obs: @observation))
 %>
 
 <%= form_with(model: @image,

--- a/app/views/observations/images/remove.html.erb
+++ b/app/views/observations/images/remove.html.erb
@@ -6,7 +6,7 @@
 # Note totally general title and tabs based on @object target_class
 add_page_title(:image_remove_title.t(name: @object.unique_format_name))
 
-add_tab_set(observation_images_remove_links(obj: @object))
+add_tab_set(observation_images_remove_tabs(obj: @object))
 
 @container = :full
 form_action = { controller: "/observations/images",

--- a/app/views/observations/images/reuse.html.erb
+++ b/app/views/observations/images/reuse.html.erb
@@ -4,7 +4,7 @@
 # Partial should be in shared
 add_page_title(:image_reuse_title.t(name: @observation.unique_format_name))
 
-add_tab_set(observation_images_reuse_links(obs: @observation))
+add_tab_set(observation_images_reuse_tabs(obs: @observation))
 @container = :full
 # Use a path here:
 form_action = { controller: "/observations/images",

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,7 +1,7 @@
 <%
 no_hits = params[:pattern].present? ? :title_for_observation_search.l : ""
 add_index_title(@query, no_hits: no_hits) # note default above is non-nil
-add_tab_set(observations_index_links(query: @query)) if @objects.any?
+add_tab_set(observations_index_tabs(query: @query)) if @objects.any?
 add_sorter(@query, observations_index_sorts)
 @container = :full
 

--- a/app/views/observations/maps/index.html.erb
+++ b/app/views/observations/maps/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_page_title(:map_locations_title.t(locations: @query.title))
-add_tab_set(observation_maps_links(query: @query))
+add_tab_set(observation_maps_tabs(query: @query))
 
 objects = @observations
 objects += @locations if @locations.any?

--- a/app/views/observations/maps/show.html.erb
+++ b/app/views/observations/maps/show.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_page_title(:map_observation_title.t(id: @observation.id))
-add_tab_set(observation_maps_links(query: @query))
+add_tab_set(observation_maps_tabs(query: @query))
 %>
 
 <%= render(partial: "shared/map",

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :double
 add_page_title(:edit_naming_title.t(id: @observation.id))
-add_tab_set(edit_naming_links(obs: @observation))
+add_tab_set(edit_naming_tabs(obs: @observation))
 %>
 
 <div class="row">

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :double
 add_page_title(:create_naming_title.t(id: @observation.id))
-add_tab_set(new_naming_links(obs: @observation))
+add_tab_set(new_naming_tabs(obs: @observation))
 %>
 
 <div class="row">

--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -3,7 +3,7 @@
 add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
 num_images = @observation.images.length
 
-add_tab_set(naming_suggestion_links(obs: @observation))
+add_tab_set(naming_suggestion_tabs(obs: @observation))
 @container = :double
 %>
 

--- a/app/views/observations/new.html.erb
+++ b/app/views/observations/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:create_observation_title.t)
 
-add_tab_set(observation_form_new_links)
+add_tab_set(observation_form_new_tabs)
 @container = :wide
 %>
 

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -4,7 +4,7 @@ add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
 add_owner_naming(@owner_naming)
 add_pager_for(@observation)
 add_interest_icons(@user, @observation)
-add_tab_set(show_observation_links(obs: @observation, user: @user))
+add_tab_set(show_observation_tabs(obs: @observation, user: @user))
 
 @container = :double
 

--- a/app/views/observations/species_lists/edit.html.erb
+++ b/app/views/observations/species_lists/edit.html.erb
@@ -4,7 +4,7 @@ add_page_title(
   :species_list_manage_title.t(name: @observation.unique_format_name)
 )
 
-add_tab_set(observation_list_links(obs: @observation))
+add_tab_set(observation_list_tabs(obs: @observation))
 
 obs_lists = []
 other_lists = []

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:edit_project_title.t(title: @project.title))
-add_tab_set(project_form_edit_links(project: @project))
+add_tab_set(project_form_edit_tabs(project: @project))
 
 button = :SAVE_EDITS.l
 %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_index_title(@query, no_hits: :list_projects_title.t)
-add_tab_set(projects_index_links)
+add_tab_set(projects_index_tabs)
 add_sorter(@query, projects_index_sorts)
 
 flash_error(@error) if @error && @objects.empty?

--- a/app/views/projects/members/edit.html.erb
+++ b/app/views/projects/members/edit.html.erb
@@ -3,7 +3,7 @@ add_page_title(:change_member_status_title.t(
   name: @candidate.legal_name,
   title: @project.title
 ))
-add_tab_set(project_member_form_edit_links(project: @project))
+add_tab_set(project_member_form_edit_tabs(project: @project))
 
 action = { controller: "/projects/members", action: :update,
             project_id: @project.id, candidate: @candidate.id,

--- a/app/views/projects/members/new.html.erb
+++ b/app/views/projects/members/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:add_members_title.t(title: @project.title))
 
-add_tab_set(project_members_form_new_links(project: @project))
+add_tab_set(project_members_form_new_tabs(project: @project))
 @container = :wide
 
 action = { controller: "/projects/members", action: :create,

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:add_project_title.t)
-add_tab_set(project_form_new_links)
+add_tab_set(project_form_new_tabs)
 
 button = :CREATE.l
 %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -2,7 +2,7 @@
 add_page_title(:show_project_title.t(title: @project.title))
 add_pager_for(@project)
 add_interest_icons(@user, @project)
-add_tab_set(project_show_links(project: @project, user: @user))
+add_tab_set(project_show_tabs(project: @project, user: @user))
 %>
 
 <div class="row">

--- a/app/views/publications/edit.html.erb
+++ b/app/views/publications/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:edit_publication_title.l)
 
-add_tab_set(publication_form_edit_links(pub: @publication))
+add_tab_set(publication_form_edit_tabs(pub: @publication))
 %>
 
 <%= render(partial: "form", locals: { action: :update }) %>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(:publication_index_title.l)
-add_tab_set(publications_index_links)
+add_tab_set(publications_index_tabs)
 @container = :wide
 %>
 

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:create_publication_title.l)
 
-add_tab_set(publication_form_new_links)
+add_tab_set(publication_form_new_tabs)
 %>
 
 <%= render(partial: "form", locals: { action: :create }) %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:show_publication_title.l)
 
-add_tab_set(publication_show_links(pub: @publication, user: @user))
+add_tab_set(publication_show_tabs(pub: @publication, user: @user))
 %>
 
 <p>

--- a/app/views/rss_logs/index.html.erb
+++ b/app/views/rss_logs/index.html.erb
@@ -1,6 +1,6 @@
 <%
 add_page_title(tag.span(:rss_log_title.t, class: "text-nowrap"))
-add_tab_set(rss_logs_index_links(user: @user, types: @types))
+add_tab_set(rss_logs_index_tabs(user: @user, types: @types))
 add_type_filters
 
 @container = :full

--- a/app/views/sequences/edit.html.erb
+++ b/app/views/sequences/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :wide
 add_page_title(:sequence_edit_title.t(name: @sequence.unique_format_name))
-add_tab_set(sequence_form_links(obj: @back_object))
+add_tab_set(sequence_form_tabs(obj: @back_object))
 
 obs = @sequence.observation
 %>

--- a/app/views/sequences/new.html.erb
+++ b/app/views/sequences/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :full
 add_page_title(:sequence_add_title.t)
-add_tab_set(sequence_form_links(obj: @observation))
+add_tab_set(sequence_form_tabs(obj: @observation))
 %>
 
 <div class="row">

--- a/app/views/sequences/show.html.erb
+++ b/app/views/sequences/show.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(@sequence.unique_format_name)
 add_pager_for(@sequence)
-add_tab_set(sequence_show_links(seq: @sequence))
+add_tab_set(sequence_show_tabs(seq: @sequence))
 @container = :wide
 %>
 

--- a/app/views/species_lists/downloads/new.html.erb
+++ b/app/views/species_lists/downloads/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:species_list_download_title.t)
 
-add_tab_set(species_list_download_links(list: @list))
+add_tab_set(species_list_download_tabs(list: @list))
 
 query_param = get_query_param(@query)
 %>

--- a/app/views/species_lists/edit.html.erb
+++ b/app/views/species_lists/edit.html.erb
@@ -2,7 +2,7 @@
 add_page_title(
   :species_list_edit_title.t(name: @species_list.unique_format_name)
 )
-add_tab_set(species_list_form_edit_links(list: @species_list))
+add_tab_set(species_list_form_edit_tabs(list: @species_list))
 @container = :text
 
 action = species_list_path(@species_list, approved_where: @place_name)

--- a/app/views/species_lists/name_lists/new.html.erb
+++ b/app/views/species_lists/name_lists/new.html.erb
@@ -1,7 +1,7 @@
 <%
   add_page_title(:name_lister_title.t)
 
-  add_tab_set(species_list_form_name_list_links)
+  add_tab_set(species_list_form_name_list_tabs)
   @container = :wide
 
   javascript_include "name_lister"

--- a/app/views/species_lists/new.html.erb
+++ b/app/views/species_lists/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:species_list_create_title.t)
 
-add_tab_set(species_list_form_new_links)
+add_tab_set(species_list_form_new_tabs)
 @container = :text
 
 action = species_lists_path(approved_where: @place_name)

--- a/app/views/species_lists/observations/edit.html.erb
+++ b/app/views/species_lists/observations/edit.html.erb
@@ -4,7 +4,7 @@
 # for adding or removing a *query* of obs (not 1 by 1)
 add_page_title(:species_list_add_remove_title.t)
 
-add_tab_set(species_list_form_observations_links)
+add_tab_set(species_list_form_observations_tabs)
 
 # action = species_list_observations_path(q: get_query_param)
 %>

--- a/app/views/species_lists/projects/edit.html.erb
+++ b/app/views/species_lists/projects/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:species_list_projects_title.t(list: @list.title))
 
-add_tab_set(species_list_edit_project_links(list: @list))
+add_tab_set(species_list_edit_project_tabs(list: @list))
 
 action = { controller: "/species_lists/projects",
            action: :update, id: @list.id }

--- a/app/views/species_lists/show.html.erb
+++ b/app/views/species_lists/show.html.erb
@@ -4,7 +4,7 @@ add_page_title(
 )
 add_pager_for(@species_list)
 add_interest_icons(@user, @species_list)
-add_tab_set(species_list_show_links(list: @species_list))
+add_tab_set(species_list_show_tabs(list: @species_list))
 @container = :text_image
 %>
 

--- a/app/views/support/donate.html.erb
+++ b/app/views/support/donate.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:donate_title.l)
 
-add_tab_set(support_donate_links)
+add_tab_set(support_donate_tabs)
 
 amounts = [25.00, 50.00, 100.00, 200.00].freeze
 

--- a/app/views/support/donors.html.erb
+++ b/app/views/support/donors.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:donors_title.l)
 
-add_tab_set(support_donors_links)
+add_tab_set(support_donors_tabs)
 %>
 
 <div class="text-center">

--- a/app/views/support/governance.html.erb
+++ b/app/views/support/governance.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:governance_title.l)
 
-add_tab_set(support_governance_links)
+add_tab_set(support_governance_tabs)
 %>
 
 <%= :governance.tp %>

--- a/app/views/support/letter.html.erb
+++ b/app/views/support/letter.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:letter_title.l)
 
-add_tab_set(support_governance_links)
+add_tab_set(support_governance_tabs)
 %>
 
 <%= :letter_body.tp %>

--- a/app/views/support/thanks.html.erb
+++ b/app/views/support/thanks.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:thanks_title.l)
 
-add_tab_set(support_governance_links)
+add_tab_set(support_governance_tabs)
 %>
 
 <%= :thanks_note.tp %>

--- a/app/views/support/wrapup_2011.html.erb
+++ b/app/views/support/wrapup_2011.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:wrapup_2011_title.l)
 
-add_tab_set(support_governance_links)
+add_tab_set(support_governance_tabs)
 %>
 
 <%= :wrapup_2011_body.tp %>

--- a/app/views/support/wrapup_2012.html.erb
+++ b/app/views/support/wrapup_2012.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:wrapup_2012_title.l)
 
-add_tab_set(support_governance_links)
+add_tab_set(support_governance_tabs)
 %>
 
 <%= :wrapup_2012_body.tp %>

--- a/app/views/theme/Agaricus.html.erb
+++ b/app/views/theme/Agaricus.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:theme_agaricus.tl)
 
-add_tab_set(theme_show_links)
+add_tab_set(theme_show_tabs)
 %>
 
 <%= :theme_agaricus_campestris.tp(link: "XXX").sub("XXX", link_to("**__Agaricus campestris__**".t, image_path(id: 694))).html_safe %>

--- a/app/views/theme/Amanita.html.erb
+++ b/app/views/theme/Amanita.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:theme_amanita.tl)
 
-add_tab_set(theme_show_links)
+add_tab_set(theme_show_tabs)
 %>
 
 <%= :theme_amanita_pachycolea.tp(link: "XXX").sub("XXX", link_to("**__Amanita pachycolea__**".t, image_path(id: 644))).html_safe %>

--- a/app/views/theme/BlackOnWhite.html.erb
+++ b/app/views/theme/BlackOnWhite.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:theme_black_on_white.tl)
 
-tabs = add_tab_set(theme_show_links)
+tabs = add_tab_set(theme_show_tabs)
 %>
 
 <%= :theme_black_on_white_description.tp(link: "XXX").sub("XXX", link_to("**__Amanita__**".t, action: :Amanita)).html_safe %>

--- a/app/views/theme/Cantharellaceae.html.erb
+++ b/app/views/theme/Cantharellaceae.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:theme_cantharellaceae.tl)
 
-add_tab_set(theme_show_links)
+add_tab_set(theme_show_tabs)
 %>
 
 <%= :theme_cantharellaceae_californicus.tp(link: "XXX").sub("XXX", link_to("**__Cantharellus californicus__**".t, image_path(id: 557))).html_safe %>

--- a/app/views/theme/Hygrocybe.html.erb
+++ b/app/views/theme/Hygrocybe.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:theme_hygrocybe.tl)
 
-add_tab_set(theme_show_links)
+add_tab_set(theme_show_tabs)
 %>
 
 <%= :theme_hygrocybe_miniata.tp(link: "XXX").sub("XXX", link_to("**__Hygrocybe miniata__**".t, image_path(id: 369))).html_safe %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@ id = @show_user.id
 name = @show_user.unique_text_name
 add_page_title(:show_user_title.t(user: name))
 add_pager_for(@show_user)
-add_tab_set(user_show_links(show_user: @show_user, user: @user))
+add_tab_set(user_show_tabs(show_user: @show_user, user: @user))
 
 @container = :full
 


### PR DESCRIPTION
MO makes pretty good use of a type of object i’m calling “link attribute arrays” in the helpers, things like this:
   `[label, path, **args]`
(I can’t remember if MO used the `args` much prior to all this refactoring, but i started adding them so i could put identifying classes on links for integration tests). These objects are called `links`, but they're not quite links. They are arrays, with the minimum attributes one needs to pass to `link_to` or `button_to` to create HTML for the templates. 

The separation of attributes from markup is great for refactoring, because the arrays can be rendered as text links, buttons, icons, or whatever.

Confusion arises, however, when passing these methods around in helpers. Some methods called "blahblah_link" being passed around are in fact links, but most of these are attribute arrays. This PR hopes to make it more obvious which is which at a glance, by standardizing the naming. Hopefully, we can get used to the flip in terminology.

Up til now, the term `tab` was used on MO for fully-formed HTML links in the title bar. Together they make up a "tab set". I'm going to move to call these "link sets" and reserve the word `tab` for methods that assemble these link attribute arrays. I'll use `link` for HTML links and buttons, only.

Side note: In the wild, `tabs` often refer to a JS-facilitated navigation pattern where different panels of info in the same area of the page are shown/hidden by clicking "tab" labels at the top or side of the panels. Neither of our "tabs" are this type of "tabs".