### PR TITLE
Abbreviate location title used in `observation_by_location` queries

### DIFF
--- a/app/classes/query/initializers/observation_query_descriptions.rb
+++ b/app/classes/query/initializers/observation_query_descriptions.rb
@@ -2,12 +2,11 @@
 
 module Query
   module Initializers
-    # initializing methods inherited by all Query's for Names
+    # initializing methods inherited by all Query's for Observations
     module ObservationQueryDescriptions
       def with_observations_query_description
         return nil unless (description = observation_query_description)
 
-        # binding.break
         if params[:user].blank?
           :query_title_with_observations_filtered.t(type: model.type_tag,
                                                     subtitle: description)
@@ -39,6 +38,7 @@ module Query
         :query_title_in_herbarium.t(type: :observation, herbarium: str)
       end
 
+      # NOTE: this is never used - AN 2023
       def title_for_locations
         str = map_join_and_truncate(:locations, Location, :display_name)
         :query_title_at_location.t(type: :observation, location: str)

--- a/app/classes/query/initializers/observation_query_descriptions.rb
+++ b/app/classes/query/initializers/observation_query_descriptions.rb
@@ -38,7 +38,7 @@ module Query
         :query_title_in_herbarium.t(type: :observation, herbarium: str)
       end
 
-      # NOTE: this is never used - AN 2023
+      # NOTE: used in "Locations with Observations of {name}" - AN 2023
       def title_for_locations
         str = map_join_and_truncate(:locations, Location, :display_name)
         :query_title_at_location.t(type: :observation, location: str)

--- a/app/classes/query/location_with_observations.rb
+++ b/app/classes/query/location_with_observations.rb
@@ -123,9 +123,9 @@ module Query
       Query.lookup(:Observation, :all, params_with_old_by_restored)
     end
 
-    # def title
-    #   default = super
-    #   with_observations_query_description || default
-    # end
+    def title
+      default = super
+      with_observations_query_description || default
+    end
   end
 end

--- a/app/classes/query/location_with_observations.rb
+++ b/app/classes/query/location_with_observations.rb
@@ -123,9 +123,9 @@ module Query
       Query.lookup(:Observation, :all, params_with_old_by_restored)
     end
 
-    def title
-      default = super
-      with_observations_query_description || default
-    end
+    # def title
+    #   default = super
+    #   with_observations_query_description || default
+    # end
   end
 end

--- a/app/classes/query/observation_at_location.rb
+++ b/app/classes/query/observation_at_location.rb
@@ -9,7 +9,7 @@ class Query::ObservationAtLocation < Query::ObservationBase
 
   def initialize_flavor
     location = find_cached_parameter_instance(Location, :location)
-    title_args[:location] = location.display_name
+    title_args[:location] = location.title_display_name
     where << "observations.location_id = '#{location.id}'"
     super
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -315,13 +315,11 @@ class Location < AbstractModel
   # Just the location without locality, region, country
   # Furthermore abbreviates the location if longer than 4 words
   def title_display_name
-    str = if User.current_location_format == "scientific"
-            scientific_name.split(", ").last
-          else
-            name.split(", ").first
-          end
-    str = "#{str.split.first(4).join(" ")}..." if str.split.length > 4
-    str
+    if User.current_location_format == "scientific"
+      scientific_name.split(", ").last
+    else
+      name.split(", ").first
+    end
   end
 
   def display_name

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -311,6 +311,19 @@ class Location < AbstractModel
     false
   end
 
+  # Very abbreviated description of the location for shorter query titles.
+  # Just the location without locality, region, country
+  # Furthermore abbreviates the location if longer than 4 words
+  def title_display_name
+    str = if User.current_location_format == "scientific"
+            scientific_name.split(", ").last
+          else
+            name.split(", ").first
+          end
+    str = "#{str.split.first(4).join(" ")}..." if str.split.length > 4
+    str
+  end
+
   def display_name
     User.current_location_format == "scientific" ? scientific_name : name
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -311,15 +311,10 @@ class Location < AbstractModel
     false
   end
 
-  # Very abbreviated description of the location for shorter query titles.
+  # Abbreviated description of the location for shorter query titles.
   # Just the location without locality, region, country
-  # Furthermore abbreviates the location if longer than 4 words
   def title_display_name
-    if User.current_location_format == "scientific"
-      scientific_name.split(", ").last
-    else
-      name.split(", ").first
-    end
+    name.split(", ").first
   end
 
   def display_name

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -653,7 +653,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title("Observations from #{location.name}")
+    assert_displayed_title("Observations from #{location.title_display_name}")
   end
 
   def test_index_location_without_observations

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -261,7 +261,7 @@ class LurkerTest < CapybaraIntegrationTestCase
 
     # Get a list of observations from there.  (Several so goes to index.)
     within("#right_tabs") { click_link(text: "Observations at this Location") }
-    assert_match("Observations from Burbank, California, USA",
+    assert_match("Observations from Burbank",
                  page.title, "Wrong page")
     save_results = find_all("#results a").select do |l|
       l[:href].match(%r{^/\d+})


### PR DESCRIPTION
Location strings can be quite long. For example: 
`Observations from between the Adventure Playground and University Ave. in the Berkeley Marina, Berkeley, Alameda Co., California, USA`

Name strings can be similarly long with the authors, etc., but we use `text_name` in the titles. I'd like to do the same for location titles.

This PR abbreviates the location for page titles to just the location, without locality, region or country.
`Observations from between the Adventure Playground and University Ave. in the Berkeley Marina`

I was considering furthermore abbreviating that title to however many words, if it's something like the above, it would be shortened to 
`Observations from between the Adventure Playground...`

But I think i'll leave that to a template helper to do. The only reason to do that would be to fit it in a different part of a template, and this PR is not about changing the templates. 

The argument could be made that the entire truncation should happen in a helper, but the controller is in a position to know if the location string returned is in scientific or postal order, because that depends on the `@user` preference. (That preference also is available in the view via `@user`, but this seems to me like the right place to do it.) 