### PR TITLE
Change the "Observation Activity" query title

### DIFF
--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -61,19 +61,9 @@ module TitleAndTabsetHelper
             elsif query.num_results.zero? && !no_hits.nil?
               no_hits
             else
-              index_default_title(query)
+              query.title
             end
     add_page_title(title)
-  end
-
-  # Special title for new obs default home page query
-  def index_default_title(query)
-    if query.title_args[:type] == :observation &&
-       query.title_args[:order] == :sort_by_rss_log
-      return :query_title_observations_by_activity_log.l
-    end
-
-    query.title
   end
 
   # Used by several indexes that can be filtered based on user prefs

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4162,7 +4162,6 @@
   query_title_all: "[TYPE] Index"
   query_title_all_by: "[TYPES] by [ORDER]"
   query_title_all_filtered: "Matching [TYPES]"
-  query_title_observations_by_activity_log: "Observation Activity"
   query_title_at_location: "[TYPES] from [LOCATION]"
   query_title_at_where: "[TYPES] from '[USER_WHERE]'"
   query_title_by_author: "[TYPES] Authored by [USER]"
@@ -4332,7 +4331,7 @@
   sort_by_posted: Date Posted
   sort_by_records: "#Records"
   sort_by_reverse: Reverse Order
-  sort_by_rss_log: "[:sort_by_updated_at]"
+  sort_by_rss_log: Recent Activity
   sort_by_summary: "[:SUMMARY]"
   sort_by_thumbnail_quality: Thumbnail Quality
   sort_by_title: "[:TITLE]"

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -175,7 +175,7 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:index)
 
     assert_template("shared/_matrix_box")
-    assert_displayed_title(:query_title_observations_by_activity_log.l)
+    assert_displayed_title("Observations by #{:sort_by_rss_log.l}")
   end
 
   def test_index_sorted_by_name
@@ -234,7 +234,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title(:query_title_observations_by_activity_log.l)
+    assert_displayed_title("Observations by #{:sort_by_rss_log.l}")
   end
 
   def test_index_useless_param_page2
@@ -243,7 +243,7 @@ class ObservationsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
 
-    assert_displayed_title(:query_title_observations_by_activity_log.l)
+    assert_displayed_title("Observations by #{:sort_by_rss_log.l}")
     assert_select("#results a", { text: "« Prev" },
                   "Wrong page or display is missing a link to Prev page")
   end

--- a/test/integration/capybara/lurker_test.rb
+++ b/test/integration/capybara/lurker_test.rb
@@ -341,9 +341,8 @@ class LurkerTest < CapybaraIntegrationTestCase
 
     # Following gives more informative error message than
     # assert(page.has_title?("#{:app_title.l }: Activity Log"), "Wrong page")
-    # assert_equal("#{:app_title.l}: Activity Log", page.title, "Login failed")
     assert_equal(
-      "#{:app_title.l}: #{:query_title_observations_by_activity_log.l}",
+      "#{:app_title.l}: Observations by #{:sort_by_rss_log.l}",
       page.title, "Login failed"
     )
   end


### PR DESCRIPTION
The home page query title is currently defined as `"Observation Activity"`, in a special method that overrides the query title in a helper for this query only. While this title is admirably brief, the override makes it harder to grasp the query title methods, which are already labyrinthine.

This PR eliminates the override, so this index can use the same composed translation string as other indexes with a `sort_by` order, and allows the title to be defined upstream by the `Query` class as all other index titles are. 

The main change is that the string for an index sorted by `:rss_log` is now `"Recent Activity"`, not `"Time Last Modified"`. So the homepage title effectively changes to `"Observations by Recent Activity"`.

> The context here is that i'm trying to potentially move the title into a different div of the layout in Bootstrap branch, and to do that I may want to get the components of the index titles returned separately by `Query`, for example `{Observations} {of Boletus edulis}`. This would be easier to accomplish without any overrides of the `Query` title methods.