### PR TITLE
Fix modal form titles

### DIFF
--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -49,7 +49,9 @@ class CollectionNumbersController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_collection_number_form
+        render_modal_collection_number_form(
+          title: helpers.collection_number_form_new_title
+        )
       end
     end
   end
@@ -74,7 +76,11 @@ class CollectionNumbersController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_collection_number_form
+        render_modal_collection_number_form(
+          title: helpers.collection_number_form_edit_title(
+            c_n: @collection_number
+          )
+        )
       end
     end
   end
@@ -109,9 +115,9 @@ class CollectionNumbersController < ApplicationController
 
   private
 
-  def render_modal_collection_number_form
+  def render_modal_collection_number_form(title:)
     render(partial: "shared/modal_form_show",
-           locals: { identifier: "collection_number" }) and return
+           locals: { title: title, identifier: "collection_number" }) and return
   end
 
   def render_collection_numbers_section_update

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -208,7 +208,9 @@ class CommentsController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_comment_form
+        render_modal_comment_form(
+          title: helpers.comment_form_new_title(target: @target)
+        )
       end
     end
   end
@@ -222,54 +224,6 @@ class CommentsController < ApplicationController
 
     save_comment_or_flash_errors_and_redirect!
   end
-
-  private
-
-  def render_modal_comment_form
-    render(partial: "shared/modal_form_show",
-           locals: { identifier: "comment" }) and return
-  end
-
-  def render_modal_form_reload
-    render(partial: "shared/modal_form_reload",
-           locals: { identifier: "comment",
-                     form: "comments/form" }) and return true
-  end
-
-  def render_update_comments_for_object
-    render(partial: "comments/update_comments_for_object")
-  end
-
-  def permitted_comment_params
-    params[:comment].permit([:summary, :comment])
-  end
-
-  def save_comment_or_flash_errors_and_redirect!
-    unless @comment.save
-      flash_object_errors(@comment)
-      respond_to do |format|
-        format.html { render(:new) and return }
-        format.js do
-          render_modal_form_reload
-        end
-      end
-    end
-
-    @comment.log_create
-    flash_notice(:runtime_form_comments_create_success.t(id: @comment.id))
-
-    respond_to do |format|
-      format.html do
-        redirect_with_query(controller: @target.show_controller,
-                            action: @target.show_action, id: @target.id)
-      end
-      format.js do
-        render_update_comments_for_object
-      end
-    end
-  end
-
-  public
 
   # Form to edit a comment for an object..
   # Linked from: show_comment, show_object.
@@ -292,7 +246,9 @@ class CommentsController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_comment_form
+        render_modal_comment_form(
+          title: helpers.comment_form_edit_title(target: @target)
+        )
       end
     end
   end
@@ -355,6 +311,50 @@ class CommentsController < ApplicationController
   end
 
   private
+
+  def render_modal_comment_form(title:)
+    render(partial: "shared/modal_form_show",
+           locals: { title: title, identifier: "comment" }) and return
+  end
+
+  def render_modal_form_reload
+    render(partial: "shared/modal_form_reload",
+           locals: { identifier: "comment",
+                     form: "comments/form" }) and return true
+  end
+
+  def render_update_comments_for_object
+    render(partial: "comments/update_comments_for_object")
+  end
+
+  def permitted_comment_params
+    params[:comment].permit([:summary, :comment])
+  end
+
+  def save_comment_or_flash_errors_and_redirect!
+    unless @comment.save
+      flash_object_errors(@comment)
+      respond_to do |format|
+        format.html { render(:new) and return }
+        format.js do
+          render_modal_form_reload
+        end
+      end
+    end
+
+    @comment.log_create
+    flash_notice(:runtime_form_comments_create_success.t(id: @comment.id))
+
+    respond_to do |format|
+      format.html do
+        redirect_with_query(controller: @target.show_controller,
+                            action: @target.show_action, id: @target.id)
+      end
+      format.js do
+        render_update_comments_for_object
+      end
+    end
+  end
 
   def comment_target
     load_target(@comment.target_type, @comment.target_id)

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -50,7 +50,9 @@ class HerbariumRecordsController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_herbarium_record_form
+        render_modal_herbarium_record_form(
+          title: helpers.herbarium_record_form_new_title
+        )
       end
     end
   end
@@ -75,7 +77,11 @@ class HerbariumRecordsController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_herbarium_record_form
+        render_modal_herbarium_record_form(
+          title: helpers.herbarium_record_form_edit_title(
+            h_r: @herbarium_record
+          )
+        )
       end
     end
   end
@@ -122,9 +128,9 @@ class HerbariumRecordsController < ApplicationController
     @herbarium_record = find_or_goto_index(HerbariumRecord, params[:id])
   end
 
-  def render_modal_herbarium_record_form
+  def render_modal_herbarium_record_form(title:)
     render(partial: "shared/modal_form_show",
-           locals: { identifier: "herbarium_record" }) and return
+           locals: { title: title, identifier: "herbarium_record" }) and return
   end
 
   def render_herbarium_records_section_update

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -19,7 +19,9 @@ module Observations
       respond_to do |format|
         format.html
         format.js do
-          render_modal_naming_form
+          render_modal_naming_form(
+            title: helpers.naming_form_new_title(obs: @observation)
+          )
         end
       end
     end
@@ -57,7 +59,9 @@ module Observations
       respond_to do |format|
         format.html
         format.js do
-          render_modal_naming_form
+          render_modal_naming_form(
+            title: helpers.naming_form_edit_title(obs: @observation)
+          )
         end
       end
     end
@@ -96,9 +100,10 @@ module Observations
 
     private
 
-    def render_modal_naming_form
+    def render_modal_naming_form(title:)
       render(partial: "shared/modal_form_show",
              locals: {
+               title: title,
                identifier: "naming",
                form_bindings: "observations/namings/form_bindings",
                form_locals: { show_reasons: true,

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -80,7 +80,9 @@ class SequencesController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_sequence_form
+        render_modal_sequence_form(
+          title: helpers.sequence_form_new_title(obs: @observation)
+        )
       end
     end
   end
@@ -102,7 +104,9 @@ class SequencesController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        render_modal_sequence_form
+        render_modal_sequence_form(
+          title: helpers.sequence_form_edit_title(obs: @observation)
+        )
       end
     end
   end
@@ -140,9 +144,9 @@ class SequencesController < ApplicationController
     @back_object = @back == "show" ? @sequence : @sequence.observation
   end
 
-  def render_modal_sequence_form
+  def render_modal_sequence_form(title:)
     render(partial: "shared/modal_form_show",
-           locals: { identifier: "sequence" }) and return
+           locals: { title: title, identifier: "sequence" }) and return
   end
 
   def render_sequences_section_update

--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -30,6 +30,10 @@ module Tabs
       [object_return_tab(obs)]
     end
 
+    def collection_number_form_new_title
+      :create_collection_number_title.l
+    end
+
     def collection_number_form_edit_tabs(c_n:, back:, obj:)
       links = []
       links << if back == "index"
@@ -37,6 +41,10 @@ module Tabs
                else
                  object_return_tab(obj)
                end
+    end
+
+    def collection_number_form_edit_title(c_n:)
+      :edit_collection_number_title.l(name: c_n.format_name)
     end
 
     def collection_numbers_index_tab(c_n)

--- a/app/helpers/tabs/comments_helper.rb
+++ b/app/helpers/tabs/comments_helper.rb
@@ -15,8 +15,16 @@ module Tabs
       links
     end
 
+    def comment_form_new_title(target:)
+      :comment_add_title.t(name: target.unique_format_name)
+    end
+
     def comment_form_new_tabs(target:)
       [object_return_tab(target)]
+    end
+
+    def comment_form_edit_title(target:)
+      :comment_edit_title.t(name: target.unique_format_name)
     end
 
     def comment_form_edit_tabs(comment:)

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -38,12 +38,22 @@ module Tabs
       links
     end
 
+    def herbarium_record_form_new_title
+      :create_herbarium_record_title.l
+    end
+
     def herbarium_record_form_new_tabs(obs:)
       [
         object_return_tab(obs),
         new_herbarium_tab,
         nonpersonal_herbaria_index_tab
       ]
+    end
+
+    def herbarium_record_form_edit_title(h_r:)
+      :edit_herbarium_record_title.l(
+        herbarium_label: h_r.herbarium_label
+      )
     end
 
     def herbarium_record_form_edit_tabs(back:, back_object:)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -214,11 +214,17 @@ module Tabs
       ]
     end
 
-    def new_naming_tabs(obs:)
+    def naming_form_new_title(obs:)
+      :create_naming_title.t(id: obs.id)
+    end
+
+    def naming_form_new_tabs(obs:)
       [object_return_tab(obs)]
     end
 
-    def edit_naming_tabs(obs:)
+    def naming_form_edit_title(obs:); end
+
+    def naming_form_edit_tabs(obs:)
       [object_return_tab(obs)]
     end
 

--- a/app/helpers/tabs/sequences_helper.rb
+++ b/app/helpers/tabs/sequences_helper.rb
@@ -13,6 +13,14 @@ module Tabs
       links
     end
 
+    def sequence_form_new_title
+      :sequence_add_title.t
+    end
+
+    def sequence_form_edit_title(sequence:)
+      :sequence_edit_title.t(name: sequence.unique_format_name)
+    end
+
     def sequence_form_tabs(obj:)
       [object_return_tab(obj)]
     end

--- a/app/views/collection_numbers/edit.html.erb
+++ b/app/views/collection_numbers/edit.html.erb
@@ -1,8 +1,6 @@
 <%
 @container = :full
-add_page_title(
-  :edit_collection_number_title.l(name: @collection_number.format_name)
-)
+add_page_title(collection_number_form_edit_title(c_n: @collection_number))
 add_tab_set(
   collection_number_form_edit_tabs(back: @back, c_n: @collection_number,
                                     obj: @back_object)

--- a/app/views/collection_numbers/new.html.erb
+++ b/app/views/collection_numbers/new.html.erb
@@ -1,6 +1,6 @@
 <%
 @container = :full
-add_page_title(:create_collection_number_title.l)
+add_page_title(collection_number_form_new_title)
 add_tab_set(collection_number_form_new_tabs(obs: @observation))
 %>
 

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,5 +1,5 @@
 <%
-add_page_title(:comment_edit_title.t(name: @target.unique_format_name))
+add_page_title(comment_form_edit_title(target: @target))
 add_tab_set(comment_form_edit_tabs(comment: @comment))
 %>
 

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,6 +1,6 @@
 <%
 @container = :full
-add_page_title(:comment_add_title.t(name: @target.unique_format_name))
+add_page_title(comment_form_new_title(target: @target))
 add_tab_set(comment_form_new_tabs(target: @target))
 %>
 

--- a/app/views/herbarium_records/edit.html.erb
+++ b/app/views/herbarium_records/edit.html.erb
@@ -1,8 +1,6 @@
 <%
 @container = :wide
-add_page_title(:edit_herbarium_record_title.l(
-  herbarium_label: @herbarium_record.herbarium_label
-))
+add_page_title(herbarium_record_form_edit_title(h_r: @herbarium_record))
 add_tab_set(herbarium_record_form_edit_tabs(back: @back,
                                               back_object: @back_object))
 %>

--- a/app/views/herbarium_records/new.html.erb
+++ b/app/views/herbarium_records/new.html.erb
@@ -1,6 +1,6 @@
 <%
 @container = :full
-add_page_title(:create_herbarium_record_title.l)
+add_page_title(herbarium_record_form_new_title)
 add_tab_set(herbarium_record_form_new_tabs(obs: @observation))
 %>
 

--- a/app/views/observations/namings/edit.html.erb
+++ b/app/views/observations/namings/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :double
-add_page_title(:edit_naming_title.t(id: @observation.id))
-add_tab_set(edit_naming_tabs(obs: @observation))
+add_page_title(naming_form_edit_title(obs: @observation))
+add_tab_set(naming_form_edit_tabs(obs: @observation))
 %>
 
 <div class="row">

--- a/app/views/observations/namings/new.html.erb
+++ b/app/views/observations/namings/new.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :double
-add_page_title(:create_naming_title.t(id: @observation.id))
-add_tab_set(new_naming_tabs(obs: @observation))
+add_page_title(naming_form_new_title(obs: @observation))
+add_tab_set(naming_form_new_tabs(obs: @observation))
 %>
 
 <div class="row">

--- a/app/views/sequences/edit.html.erb
+++ b/app/views/sequences/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 @container = :wide
-add_page_title(:sequence_edit_title.t(name: @sequence.unique_format_name))
+add_page_title(sequence_form_edit_title(sequence: @sequence))
 add_tab_set(sequence_form_tabs(obj: @back_object))
 
 obs = @sequence.observation

--- a/app/views/sequences/new.html.erb
+++ b/app/views/sequences/new.html.erb
@@ -1,6 +1,6 @@
 <%
 @container = :full
-add_page_title(:sequence_add_title.t)
+add_page_title(sequence_form_new_title)
 add_tab_set(sequence_form_tabs(obj: @observation))
 %>
 

--- a/app/views/shared/_modal_form_show.js.erb
+++ b/app/views/shared/_modal_form_show.js.erb
@@ -1,6 +1,5 @@
 // Generalized JS handler to either open or generate new modal for
 // create/edit a section of an observation (resource)
-// checks for an existing modal to open, in case form is in progress
 <% # requires locals: identifier, form_bindings(opt), form_locals(opt)
 form_bindings ||= false
 form_locals ||= {}
@@ -17,6 +16,7 @@ form_partial =  case identifier
 var identifier = "<%= identifier %>";
 var this_modal = $('#modal_' + identifier);
 
+// check for an existing modal to open, in case form is in progress
 if(this_modal.length > 0) {
   this_modal.modal('show');
 } else {
@@ -24,7 +24,7 @@ if(this_modal.length > 0) {
     partial: "shared/modal_form",
     locals: {
       identifier: identifier,
-      title: @title,
+      title: title,
       form: form_partial,
     }.merge(form_locals)
   ) %>');


### PR DESCRIPTION
One of my sweeping recent refactors eliminated the `@title` ivar, which was set in the controller for some actions. The modal forms were depending on that ivar for their own titles, since modal forms don't have independent `js.erb` views to set the ivar: they use a shared modal form rendering partial. That partial takes a `title` local_assign, which was using `@title` (and therefore blank, as of recently).

This PR moves the title definitions to helpers, and the controller then calls the helper to send that title to the shared partial. Is that more convoluted than an ivar? Yes. I didn't realize this when i set about refactoring titles.

The better solution is via Trailblazer, but we're not there yet.