### PR TITLE
Update .gitignore to ignore `checkpoint_stripped.gz`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ coverage
 /config/master.key
 
 /config/credentials/production.key
+checkpoint_stripped.gz


### PR DESCRIPTION
It's convenient to keep the snapshot in place when messing with the db.

If any objections, please don't hold back.