### PR TITLE
Try to add Turbo gems to Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,13 @@ group :rails do
   # gem("activestorage", "~> 6.1")
   gem("activesupport", "~> 6.1")
   gem("bundler")
-  gem("railties", "~> 6.1")
-  gem("sprockets-rails")
+  gem("importmap-rails")
   # gem irb now depends on psych, but version 5 will not bundle currently
   gem("psych", "~> 4")
+  gem("railties", "~> 6.1")
+  # gem("redis", "~> 4.0")
+  gem("sprockets-rails")
+  # gem("turbo-rails")
 end
 
 # Security fix updates via Dependabot

--- a/Gemfile
+++ b/Gemfile
@@ -31,14 +31,15 @@ group :rails do
   # gem("activestorage", "~> 6.1")
   gem("activesupport", "~> 6.1")
   gem("bundler")
-  gem("importmap-rails")
-  # gem irb now depends on psych, but version 5 will not bundle currently
-  gem("psych", "~> 4")
   gem("railties", "~> 6.1")
-  # gem("redis", "~> 4.0")
-  gem("sprockets-rails")
-  # gem("turbo-rails")
 end
+
+gem("importmap-rails")
+# gem irb now depends on psych, but version 5 will not bundle currently
+gem("psych", "~> 4")
+# gem("redis", "~> 4.0")
+gem("sprockets-rails")
+# gem("turbo-rails")
 
 # Security fix updates via Dependabot
 # CVE-2021-41817 regex denial of service vulnerability

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    importmap-rails (1.2.1)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.6.0)
     irb (1.8.0)
       rdoc (~> 6.5)
@@ -307,6 +310,7 @@ DEPENDENCIES
   debug (>= 1.0.0)
   fastimage
   i18n
+  importmap-rails
   jbuilder
   jquery-rails
   loofah (>= 2.19.1)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -24,3 +24,5 @@
 //= link Cantharellaceae.css
 //= link Hygrocybe.css
 //= link Sudo.css
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,1 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@ body_class = whos_calling + theme_class
 <html>
 <head>
   <%= render(partial: "application/app/head") %>
+    <%= javascript_importmap_tags %>
 </head>
 
 <body class="<%= body_class %>">

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,3 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application", preload: true


### PR DESCRIPTION
This is a trial PR that is giving me a lot of trouble. The goal is not to use this on Rails 6 but to troubleshoot adding these gems.

The first gem `importmap-rails` bundles, but the class does not load.

- the install task, `rails importmap:install`, is “not found”
- a view helper, `<%= javascript_import_tags %>`, is “not defined”
- in Rails console, the whole class instantiated by the gem, `Importmap`, is an uninitialized constant. By comparison the class `Uglifier` instantiated by that gem is accessible. (Prior to this i didn’t know you could check gem classes!)

Requiring the class in `config/application.rb` did not work.

`require("importmap/engine")`

There seems to be no railtie for it.