### PR TITLE
Glossary wikipedia search

### DIFF
--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -9,10 +9,7 @@ add_tab_set(glossary_term_show_tabs(term: @glossary_term, user: @user))
 <div class="row mt-3">
   <div class="col-sm-8">
     <%= @glossary_term.description.tpl %>
-    <%= tag.p(
-      link_to("Wikipedia search for '#{@glossary_term.name}'",
-              "https://en.wikipedia.org/w/index.php?search=#{@glossary_term.name.tr(" ", "+")}")
-    ) %>
+    <%= tag.p(link_to(*search_tab_for(:Wikipedia, @glossary_term.name))) %>
   </div>
   <% if @glossary_term.thumb_image %>
     <div class="col-sm-4">

--- a/app/views/glossary_terms/show.html.erb
+++ b/app/views/glossary_terms/show.html.erb
@@ -9,7 +9,10 @@ add_tab_set(glossary_term_show_tabs(term: @glossary_term, user: @user))
 <div class="row mt-3">
   <div class="col-sm-8">
     <%= @glossary_term.description.tpl %>
-    <%= tag.p(link_to(search_tab_for(:Wikipedia, @glossary_term.name))) %>
+    <%= tag.p(
+      link_to("Wikipedia search for '#{@glossary_term.name}'",
+              "https://en.wikipedia.org/w/index.php?search=#{@glossary_term.name.tr(" ", "+")}")
+    ) %>
   </div>
   <% if @glossary_term.thumb_image %>
     <div class="col-sm-4">

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -90,6 +90,10 @@ class GlossaryTermsControllerTest < FunctionalTestCase
       { count: 1,
         text: /Creator.*: #{rolf.name}Editors: #{mary.name}, #{katrina.name}/ }
     )
+    assert_select(
+      "a[href='https://en.wikipedia.org/w/index.php?search=#{term.name}']", true,
+      "Glossary Term page should have link to Wikipedia search for the Term"
+    )
   end
 
   def test_show_admin_delete

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -91,7 +91,8 @@ class GlossaryTermsControllerTest < FunctionalTestCase
         text: /Creator.*: #{rolf.name}Editors: #{mary.name}, #{katrina.name}/ }
     )
     assert_select(
-      "a[href='https://en.wikipedia.org/w/index.php?search=#{term.name}']", true,
+      "a[href='https://en.wikipedia.org/w/index.php?search=#{term.name}']",
+      true,
       "Glossary Term page should have link to Wikipedia search for the Term"
     )
   end


### PR DESCRIPTION
A super-simple fix for the broken link to a Wikipedia search for a Glossary Term,
which link appears on the Term pages.

Delivers https://www.pivotaltracker.com/story/show/185904998

### Manual test
* Go to any Glossary Term page, e.g., http://localhost:3000/glossary_terms/451
Result: Page should include a link to a Wikipedia search for the Term