### PR TITLE
Convert `observation_details` partial to helper

### DIFF
--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -4,7 +4,7 @@
 module LightboxHelper
   # this link needs to contain all the data for the lightbox image
   def lightbox_link(lightbox_data)
-    icon = content_tag(:i, "", class: "glyphicon glyphicon-fullscreen")
+    icon = tag.i("", class: "glyphicon glyphicon-fullscreen")
     caption = lightbox_caption_html(lightbox_data)
 
     link_to(icon, lightbox_data[:url],
@@ -33,13 +33,13 @@ module LightboxHelper
       html << mark_as_reviewed_toggle(obs_data[:id])
     end
     html << caption_obs_title(obs_data)
-    html << render(partial: "observations/show/observation_details",
-                   locals: { obs: obs_data[:obs], caption: true })
+    html << observation_details_when_where_who(obs: obs_data[:obs])
+    html << observation_details_notes(obs: obs_data[:obs])
   end
 
   def caption_obs_title(obs_data)
-    content_tag(:h4, show_obs_title(obs: obs_data[:obs]),
-                class: "obs-what", id: "observation_what_#{obs_data[:id]}")
+    tag.h4(show_obs_title(obs: obs_data[:obs]),
+           class: "obs-what", id: "observation_what_#{obs_data[:id]}")
   end
 
   # links relating to the image object, pre-joined as a div
@@ -48,7 +48,7 @@ module LightboxHelper
     links << original_image_link(image_id, "lightbox_link")
     links << " | "
     links << image_exif_link(image_id, "lightbox_link")
-    content_tag(:div, class: "caption-image-links my-3") do
+    tag.div(class: "caption-image-links my-3") do
       safe_join(links)
     end
   end

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -130,4 +130,74 @@ module ObservationsHelper
       )
     ].safe_join
   end
+
+  # The following sections of the observation_details partial are also needed as
+  # part of the lightbox caption, so that was called on the obs_index as a
+  # sub-partial. Here they're converted to helpers to speed up loading of index
+  def observation_details_when_where_who(obs:)
+    [
+      observation_details_when(obs: obs),
+      observation_details_where(obs: obs),
+      observation_details_where_gps(obs: obs),
+      observation_details_who(obs: obs)
+    ].safe_join
+  end
+
+  def observation_details_when(obs:)
+    tag.p(class: "obs-when", id: "observation_when") do
+      ["#{:WHEN.t}:", tag.b(obs.when.web_date)].safe_join(" ")
+    end
+  end
+
+  def observation_details_where(obs:)
+    tag.p(class: "obs-where", id: "observation_where") do
+      [
+        "#{if obs.is_collection_location
+             :show_observation_collection_location.t
+           else
+             :show_observation_seen_at.t
+           end}:",
+        location_link(obs.place_name, obs.location, nil, true)
+      ].safe_join(" ")
+    end
+  end
+
+  def observation_details_where_gps(obs:)
+    gps_display_link = link_to([obs.display_lat_long.t,
+                                obs.display_alt.t,
+                                "[#{:click_for_map.t}]"].safe_join(" "),
+                               map_observation_path(id: obs.id))
+    gps_hidden_msg = tag.i("(#{:show_observation_gps_hidden.t})")
+
+    tag.p(class: "obs-where-gps", id: "observation_where_gps") do
+      concat(
+        if obs.lat && (!obs.gps_hidden || obs.can_edit?)
+          gps_display_link
+        elsif obs.lat
+          [gps_hidden_msg, obs.display_alt.t].safe_join(" ")
+        else
+          obs.display_alt.t
+        end
+      )
+      concat(
+        (gps_hidden_msg if obs.lat && obs.gps_hidden && obs.can_edit?)
+      )
+    end
+  end
+
+  def observation_details_who(obs:)
+    tag.p(class: "obs-who", id: "observation_who") do
+      ["#{:WHO.t}:", user_link(obs.user)].safe_join(" ")
+    end
+  end
+
+  def observation_details_notes(obs:)
+    return "" unless obs.notes?
+
+    tag.div(class: "obs-notes", id: "observation_notes") do
+      Textile.clear_textile_cache
+      Textile.register_name(obs.name)
+      tag.div(obs.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl)
+    end
+  end
 end

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -163,6 +163,8 @@ module ObservationsHelper
   end
 
   def observation_details_where_gps(obs:)
+    return "" unless obs.lat
+
     gps_display_link = link_to([obs.display_lat_long.t,
                                 obs.display_alt.t,
                                 "[#{:click_for_map.t}]"].safe_join(" "),
@@ -170,18 +172,8 @@ module ObservationsHelper
     gps_hidden_msg = tag.i("(#{:show_observation_gps_hidden.t})")
 
     tag.p(class: "obs-where-gps", id: "observation_where_gps") do
-      concat(
-        if obs.lat && (!obs.gps_hidden || obs.can_edit?)
-          gps_display_link
-        elsif obs.lat
-          [gps_hidden_msg, obs.display_alt.t].safe_join(" ")
-        else
-          obs.display_alt.t
-        end
-      )
-      concat(
-        (gps_hidden_msg if obs.lat && obs.gps_hidden && obs.can_edit?)
-      )
+      concat(gps_display_link) if !obs.gps_hidden || obs.can_edit?
+      concat(gps_hidden_msg) if obs.gps_hidden
     end
   end
 

--- a/app/views/observations/show/_observation_details.html.erb
+++ b/app/views/observations/show/_observation_details.html.erb
@@ -1,78 +1,34 @@
 <%
 # The content of the details box. This gets replaced by JS and is used elsewhere
-caption ||= false
 %>
 
-<p class="obs-when" id="observation_when">
-  <%= :WHEN.t %>: <span class="font-weight-bold"><%= obs.when.web_date %></span>
-</p>
+<%= observation_details_when_where_who(obs: obs) %>
 
-<p class="obs-where" id="observation_where">
-  <%= obs.is_collection_location ?
-        :show_observation_collection_location.t :
-        :show_observation_seen_at.t %>:
-  <%= location_link(obs.place_name,
-                    obs.location, nil, true) %>
-</p>
-
-<p class="obs-lat-lng" id="observation_lat_lng">
-  <%=
-    hidden = "<i>(#{:show_observation_gps_hidden.t})</i>".html_safe
-    if obs.lat &&
-        (!obs.gps_hidden || obs.can_edit?)
-      link_to("#{obs.display_lat_long.t} " \
-              "#{obs.display_alt.t} " \
-              "[#{:click_for_map.t}]".html_safe,
-              map_observation_path(id: obs.id))
-    elsif obs.lat
-      hidden + " ".html_safe + obs.display_alt.t
-    else
-      obs.display_alt.t
+<%= if @user
+  tag.div(class: "obs-projects", id: "observation_projects") do
+    obs.projects.each do |project|
+      tag.p("#{:PROJECT.t}: #{link_to_object(project)}")
     end
-  %>
-  <%=
-    if obs.lat && obs.gps_hidden && obs.can_edit?
-      hidden
-    end
-  %>
-</p>
+  end
+end %>
 
-<p class="obs-who" id="observation_who">
-  <%= :WHO.t %>: <span><%= user_link(obs.user) %></span>
-</p>
+<%= tag.p(class: "obs-specimen", id: "observation_specimen_available") do
+  if obs.specimen
+    :show_observation_specimen_available.t
+  else
+    :show_observation_specimen_not_available.t
+  end
+end %>
 
-<% if !caption %>
-  <% if @user %>
-    <div class="obs-projects" id="observation_projects">
-      <% obs.projects.each do |project| %>
-        <p><%= :PROJECT.t %>: <%= link_to_object(project) %></p>
-      <% end %>
-    </div>
-  <% end %>
+<% if @user %>
+  <%= render(partial: "observations/show/collection_numbers",
+             locals: { obs: obs }) %>
 
-  <div class="obs-specimen" id="observation_specimen_available">
-    <%= obs.specimen ? :show_observation_specimen_available.t :
-                                :show_observation_specimen_not_available.t %>
-  </div>
+  <%= render(partial: "observations/show/herbarium_records",
+             locals: { obs: obs }) %>
 
-  <% if @user %>
-    <%= render(partial: "observations/show/collection_numbers",
-              locals: { obs: obs }) %>
-
-    <%= render(partial: "observations/show/herbarium_records",
-              locals: { obs: obs }) %>
-
-    <%= render(partial: "observations/show/sequences",
-              locals: { obs: obs }) %>
-  <% end %>
+  <%= render(partial: "observations/show/sequences",
+             locals: { obs: obs }) %>
 <% end %>
 
-<div class="obs-notes" id="observation_notes">
-  <%= if obs.notes?
-    Textile.clear_textile_cache
-    Textile.register_name(obs.name)
-    content_tag(
-      :div, obs.notes_show_formatted.sub(/^\A/, "#{:NOTES.t}:\n").tpl
-    )
-  end %>
-</div><!--.obs-notes-->
+<%= observation_details_notes(obs: obs) %>


### PR DESCRIPTION
I forgot. This is another sub-partial used in the obs index, by the lightbox.

Noticed it in the render log output. (lol, I'm the one who added it!)

With this, I believe we're truly done with sub-partials on the index.