### PR TITLE
Fix update_observation.js.erb and refactor observations helper

### DIFF
--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -13,12 +13,48 @@ module ObservationsHelper
   #   Observation nnn: Ccc ddd Author(s) (Site ID) (Aaa bbb)
   # Observer preference shown, consensus not deprecated:
   #   Observation nnn: Aaa bbb Author(s) (Site ID)
-  def show_obs_title(obs:, owner_naming: nil)
-    capture do
-      concat(:show_observation_header.t)
-      concat(" #{obs.id || "?"}: ")
-      concat(obs_title_consensus_id(name: obs.name, owner_naming: owner_naming))
+  def show_obs_title(obs:)
+    [
+      obs_title_id(obs),
+      obs_title_consensus_name_link(obs: obs)
+    ].safe_join(" ")
+  end
+
+  def obs_title_id(obs)
+    tag.span(class: "smaller") do
+      [:show_observation_header.t, tag.span("#{obs.id || "?"}:")].safe_join(" ")
     end
+  end
+
+  # name portion of Observation title
+  def obs_title_consensus_name_link(obs:)
+    name = obs.name
+    if name.deprecated &&
+       (prefer_name = name.best_preferred_synonym).present?
+      obs_title_with_preferred_name_link(name, prefer_name)
+    else
+      obs_title_name_link(obs, name)
+    end
+  end
+
+  def obs_title_with_preferred_name_link(name, prefer_name)
+    [
+      link_to_display_name_brief_authors(name),
+      # Differentiate deprecated consensus from preferred name
+      consensus_id_tag,
+      "(#{link_to_display_name_without_authors(prefer_name)})"
+    ].safe_join(" ")
+  end
+
+  def obs_title_name_link(obs, name)
+    text = [link_to_display_name_brief_authors(name)]
+    # Differentiate this Name from Observer Preference
+    text << consensus_id_tag if obs.owner_preference
+    text.safe_join(" ")
+  end
+
+  def consensus_id_tag
+    tag.span("(#{:show_observation_site_id.t})", class: "smaller")
   end
 
   ##### Portion of page title that includes user's naming preference #########
@@ -27,9 +63,17 @@ module ObservationsHelper
   def owner_naming_line(obs)
     return unless User.current&.view_owner_id
 
-    capture do
-      concat(:show_observation_owner_id.t + ": ")
-      concat(owner_favorite_or_explanation(obs).t)
+    [
+      "#{:show_observation_owner_id.t}:",
+      owner_favorite_or_explanation(obs).t
+    ].safe_join(" ")
+  end
+
+  def owner_favorite_or_explanation(obs)
+    if (name = obs.owner_preference)
+      link_to_display_name_brief_authors(name)
+    else
+      :show_observation_no_clear_preference
     end
   end
 
@@ -43,40 +87,6 @@ module ObservationsHelper
         Vote.new(value: 0)
     end
   end
-
-  private
-
-  # name portion of Observation title
-  def obs_title_consensus_id(name:, owner_naming: nil)
-    if name.deprecated &&
-       (current_name = name.best_preferred_synonym).present?
-      capture do
-        concat(link_to_display_name_brief_authors(name))
-        # Differentiate deprecated consensus from preferred name
-        concat(" (#{:show_observation_site_id.t})")
-        concat(" ") # concat space separately, else `.t` strips it
-        concat("(")
-        concat(link_to_display_name_without_authors(current_name))
-        concat(")")
-      end
-    else
-      capture do
-        concat(link_to_display_name_brief_authors(name))
-        # Differentiate this Name from Observer Preference
-        concat(" (#{:show_observation_site_id.t})") if owner_naming
-      end
-    end
-  end
-
-  def owner_favorite_or_explanation(obs)
-    if (name = obs.owner_preference)
-      link_to_display_name_brief_authors(name)
-    else
-      :show_observation_no_clear_preference
-    end
-  end
-
-  public
 
   def link_to_display_name_brief_authors(name)
     link_to(name.display_name_brief_authors.t,

--- a/app/views/observations/namings/_update_observation.js.erb
+++ b/app/views/observations/namings/_update_observation.js.erb
@@ -13,13 +13,13 @@
 ) %>
 
 // reset title of obs if necessary
-var title = '<%= tag.div(
-  show_obs_title(obs: @observation).break_name.small_author,
-  title: show_obs_title(obs: @observation).strip_html.html_safe
-) %>';
+var new_title = '<%= show_obs_title(obs: @observation) %>',
+    new_title_tag = '<%= tag.h1(
+      show_obs_title(obs: @observation), class: "h3", id: "title"
+    ) %>';
 
-document.title = $(title).attr('title');
-$("#title").html(title);
+document.title = new_title;
+$("#title").replaceWith(new_title_tag);
 
 // Need to redo naming table bindings and hide cast vote buttons
 VoteByAjaxModule({

--- a/app/views/observations/namings/suggestions/show.html.erb
+++ b/app/views/observations/namings/suggestions/show.html.erb
@@ -1,6 +1,6 @@
 <%
 @owner_naming = owner_naming_line(@observation) # must before show_obs_title
-add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
+add_page_title(show_obs_title(obs: @observation))
 num_images = @observation.images.length
 
 add_tab_set(naming_suggestion_tabs(obs: @observation))

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -1,6 +1,6 @@
 <%
 @owner_naming = owner_naming_line(@observation) # must before show_obs_title
-add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
+add_page_title(show_obs_title(obs: @observation))
 add_owner_naming(@owner_naming)
 add_pager_for(@observation)
 add_interest_icons(@user, @observation)

--- a/test/helpers/observations_helper_test.rb
+++ b/test/helpers/observations_helper_test.rb
@@ -10,26 +10,30 @@ class ObservationsHelperTest < ActionView::TestCase
 
     # approved name
     current_name = names(:lactarius_alpinus)
-    Observation.new(
+    obs1 = Observation.new(
       name: current_name, user: user, when: Time.current, where: location
     )
     assert_match(
       link_to(current_name.display_name_brief_authors.t,
               name_path(id: current_name.id)),
-      obs_title_consensus_name_link(name: current_name),
+      obs_title_consensus_name_link(obs: obs1),
       "Observation of a current Name should link to that Name"
     )
 
     # deprecated name
     deprecated_name = names(:lactarius_alpigenes)
-    Observation.new(
+    obs2 = Observation.new(
       name: deprecated_name, user: user, when: Time.current, where: location
     )
     assert_match(
-      "#{link_to_display_name_brief_authors(deprecated_name)} (Site ID) " \
-      "(#{link_to_display_name_without_authors(current_name)})",
-      obs_title_consensus_name_link(name: deprecated_name),
-      "Observation of deprecated Name should link to it and approved Name"
+      link_to_display_name_brief_authors(deprecated_name),
+      obs_title_consensus_name_link(obs: obs2).unescape_html,
+      "Observation of deprecated Name should link to it"
+    )
+    assert_match(
+      link_to_display_name_without_authors(current_name),
+      obs_title_consensus_name_link(obs: obs2).unescape_html,
+      "Observation of deprecated Name should link to approved Name"
     )
   end
 end

--- a/test/helpers/observations_helper_test.rb
+++ b/test/helpers/observations_helper_test.rb
@@ -16,7 +16,7 @@ class ObservationsHelperTest < ActionView::TestCase
     assert_match(
       link_to(current_name.display_name_brief_authors.t,
               name_path(id: current_name.id)),
-      obs_title_consensus_id(name: current_name),
+      obs_title_consensus_name_link(name: current_name),
       "Observation of a current Name should link to that Name"
     )
 
@@ -28,7 +28,7 @@ class ObservationsHelperTest < ActionView::TestCase
     assert_match(
       "#{link_to_display_name_brief_authors(deprecated_name)} (Site ID) " \
       "(#{link_to_display_name_without_authors(current_name)})",
-      obs_title_consensus_id(name: deprecated_name),
+      obs_title_consensus_name_link(name: deprecated_name),
       "Observation of deprecated Name should link to it and approved Name"
     )
   end


### PR DESCRIPTION
Fixes the title replacement when proposing naming and consensus changes.

Includes a refactor of `ObservationsHelper` title methods to help with BS 4 changes.

### Manual test: ###
Propose a name on an observation needing ID, giving it a vote that's enough to swing consensus to the proposed name.

Check that the page title updates as expected, with no stray tags like `</a>` displayed.

![Screenshot 2023-09-04 at 7 37 04 AM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/40f86032-bdb3-42bf-a14b-5581ef9be864)
