### PR TITLE
Make integration test names consistently end with "IntegrationTest"

### DIFF
--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class AccountTest < CapybaraIntegrationTestCase
+class AccountIntegrationTest < CapybaraIntegrationTestCase
   # -------------------------------
   #  Test basic login.
   # -------------------------------

--- a/test/integration/capybara/admin_integration_test.rb
+++ b/test/integration/capybara/admin_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class AdminTest < CapybaraIntegrationTestCase
+class AdminIntegrationTest < CapybaraIntegrationTestCase
   # This test is not much more than a stub.
   # Should test somebody making a donation, admin reviews.
   def test_review_donations

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class HerbariumCuratorTest < CapybaraIntegrationTestCase
+class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
   # ---------- Helpers ----------
 
   def nybg

--- a/test/integration/capybara/language_tracking_integration_test.rb
+++ b/test/integration/capybara/language_tracking_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class LanguageTrackingTest < CapybaraIntegrationTestCase
+class LanguageTrackingIntegrationTest < CapybaraIntegrationTestCase
   # -----------------------------------------------------------------------
   #  Need integration test to make sure tags are being tracked and passed
   #  through redirects correctly.

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 # Test typical sessions of user who never creates an account or contributes.
-class LurkerTest < CapybaraIntegrationTestCase
+class LurkerIntegrationTest < CapybaraIntegrationTestCase
   def test_poke_around
     # Start at index.
     reset_session!

--- a/test/integration/capybara/observation_form_integration_test.rb
+++ b/test/integration/capybara/observation_form_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class ObservationFormTest < CapybaraIntegrationTestCase
+class ObservationFormIntegrationTest < CapybaraIntegrationTestCase
   # Uncomment this to try running tests with firefox_headless browser
   # def setup
   #   super

--- a/test/integration/capybara/random_integration_test.rb
+++ b/test/integration/capybara/random_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class RandomTest < CapybaraIntegrationTestCase
+class RandomIntegrationTest < CapybaraIntegrationTestCase
   def test_pivotal_tracker
     login(users(:zero_user))
     visit("/")

--- a/test/integration/rails-dom-testing/autologin_integration_test.rb
+++ b/test/integration/rails-dom-testing/autologin_integration_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class AutologinTest < IntegrationTestCase
+class AutologinIntegrationTest < IntegrationTestCase
   # ----------------------------
   #  Test autologin cookies.
   # ----------------------------

--- a/test/integration/rails-dom-testing/n_plus_1_integration_test.rb
+++ b/test/integration/rails-dom-testing/n_plus_1_integration_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 # Discover potential n+1 issues by running some requests with bullet gem
-class NPlusOneTest < IntegrationTestCase
+class NPlusOneIntegrationTest < IntegrationTestCase
   include BulletHelper
 
   def test_api2

--- a/test/integration/rails-dom-testing/redirects_integration_test.rb
+++ b/test/integration/rails-dom-testing/redirects_integration_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 # Test whether actions redirected correctly
-class RedirectsTest < IntegrationTestCase
+class RedirectsIntegrationTest < IntegrationTestCase
   # helpers
   def assert_old_url_redirects_to_new_path(old_method, old_url, new_path)
     case old_method


### PR DESCRIPTION
So we can easily run them all at once with `rails t -n /IntegrationTest/`

When troubleshooting eager-loading, it's very helpful to run these all at once, because Bullet seems to only run on these tests.