### PR TITLE
Give interactive images an identifying CSS class for tests

### DIFF
--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -52,12 +52,12 @@ class ImagePresenter < BasePresenter
     args = default_args.merge(args)
     img_urls = Image.all_urls(image_id)
 
-    args_to_presenter(image, img_urls, args)
+    args_to_presenter(image, image_id, img_urls, args)
     sizing_info_to_presenter(image, args)
     lightbox_args_to_presenter(image_id, img_urls, args)
   end
 
-  def args_to_presenter(image, img_urls, args)
+  def args_to_presenter(image, image_id, img_urls, args)
     # Store these urls once, since they are computed
     img_src = img_urls[args[:size]]
     # img_srcset = thumbnail_srcset(img_urls[:small], img_urls[:medium],
@@ -77,13 +77,13 @@ class ImagePresenter < BasePresenter
     # <img> attributes
     html_options_lazy = {
       alt: args[:notes],
-      class: "#{img_class} lazy",
+      class: "#{img_class} lazy image_#{image_id}",
       data: img_data
     }
 
     html_options_noscript = {
       alt: args[:notes],
-      class: "#{img_class} img-noscript"
+      class: "#{img_class} img-noscript image_#{image_id}"
       #   srcset: img_srcset,
       #   sizes: img_sizes
     }

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -629,7 +629,7 @@ class ObservationsControllerTest < FunctionalTestCase
 
     assert_displayed_title("Observations created by #{user.name}")
     assert_select(
-      "#results img[src = '#{Image.url(:small, obs.thumb_image_id)}']",
+      "#results img.image_#{obs.thumb_image_id}",
       true,
       "Observation thumbnail should display although this is not an rss_log"
     )


### PR DESCRIPTION
So we don't have to look for them by src attribute. 
`<img class="image_#{img.id}" src="#{Image.url(:small, img.id)}">`