### PR TITLE
Fix template for obs_title with preferred synonym

### DIFF
--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -32,29 +32,47 @@ module ObservationsHelper
   def obs_title_consensus_name_link(name:, owner_naming: nil)
     if name.deprecated &&
        (prefer_name = name.best_preferred_synonym).present?
-      obs_title_with_preferred_name_link(name, prefer_name)
+      obs_title_with_preferred_synonym_link(name, prefer_name)
     else
       obs_title_name_link(name, owner_naming)
     end
   end
 
-  def obs_title_with_preferred_name_link(name, prefer_name)
+  def obs_title_with_preferred_synonym_link(name, prefer_name)
     [
-      link_to_display_name_brief_authors(name),
+      link_to_display_name_brief_authors(
+        name, class: "obs_consensus_deprecated_synonym_link_#{name.id}"
+      ),
       # Differentiate deprecated consensus from preferred name
-      consensus_id_tag,
-      "(#{link_to_display_name_without_authors(prefer_name)})"
+      obs_consensus_id_flag,
+      obs_title_preferred_synonym(prefer_name)
     ].safe_join(" ")
   end
 
+  def obs_title_preferred_synonym(prefer_name)
+    tag.span(class: "smaller") do
+      [
+        "(",
+        link_to_display_name_without_authors(
+          prefer_name, class: "obs_preferred_synonym_link_#{prefer_name.id}"
+        ),
+        ")"
+      ].safe_join
+    end
+  end
+
   def obs_title_name_link(name, owner_naming)
-    text = [link_to_display_name_brief_authors(name)]
+    text = [
+      link_to_display_name_brief_authors(
+        name, class: "obs_consensus_naming_link_#{name.id}"
+      )
+    ]
     # Differentiate this Name from Observer Preference
-    text << consensus_id_tag if owner_naming
+    text << obs_consensus_id_flag if owner_naming
     text.safe_join(" ")
   end
 
-  def consensus_id_tag
+  def obs_consensus_id_flag
     tag.span("(#{:show_observation_site_id.t})", class: "smaller")
   end
 
@@ -72,7 +90,9 @@ module ObservationsHelper
 
   def owner_favorite_or_explanation(obs)
     if (name = obs.owner_preference)
-      link_to_display_name_brief_authors(name)
+      link_to_display_name_brief_authors(
+        name, class: "obs_owner_naming_link_#{name.id}"
+      )
     else
       :show_observation_no_clear_preference
     end
@@ -89,14 +109,14 @@ module ObservationsHelper
     end
   end
 
-  def link_to_display_name_brief_authors(name)
+  def link_to_display_name_brief_authors(name, **args)
     link_to(name.display_name_brief_authors.t,
-            name_path(id: name.id))
+            name_path(id: name.id), **args)
   end
 
-  def link_to_display_name_without_authors(name)
+  def link_to_display_name_without_authors(name, **args)
     link_to(name.display_name_without_authors.t,
-            name_path(id: name.id))
+            name_path(id: name.id), **args)
   end
 
   def observation_map_coordinates(obs:)

--- a/test/helpers/observations_helper_test.rb
+++ b/test/helpers/observations_helper_test.rb
@@ -15,7 +15,8 @@ class ObservationsHelperTest < ActionView::TestCase
     )
     assert_match(
       link_to(current_name.display_name_brief_authors.t,
-              name_path(id: current_name.id)),
+              name_path(id: current_name.id),
+              class: "obs_consensus_naming_link_#{current_name.id}"),
       obs_title_consensus_name_link(name: current_name),
       "Observation of a current Name should link to that Name"
     )
@@ -26,14 +27,20 @@ class ObservationsHelperTest < ActionView::TestCase
       name: deprecated_name, user: user, when: Time.current, where: location
     )
     assert_match(
-      link_to_display_name_brief_authors(deprecated_name),
+      link_to_display_name_brief_authors(
+        deprecated_name,
+        class: "obs_consensus_deprecated_synonym_link_#{deprecated_name.id}"
+      ),
       obs_title_consensus_name_link(name: deprecated_name).unescape_html,
       "Observation of deprecated Name should link to it"
     )
     assert_match(
-      link_to_display_name_without_authors(current_name),
+      link_to_display_name_without_authors(
+        current_name,
+        class: "obs_preferred_synonym_link_#{current_name.id}"
+      ),
       obs_title_consensus_name_link(name: deprecated_name).unescape_html,
-      "Observation of deprecated Name should link to approved Name"
+      "Observation of deprecated Name should link to preferred Name"
     )
   end
 end


### PR DESCRIPTION
@pellaea This should fix the FUBAR [title](https://github.com/MushroomObserver/mushroom-observer/pull/1598#issuecomment-1713104814) in that [Amanita lavendula group obs](https://mushroomobserver.org/505457?q=Q).

Note: It seems this PR branch prints the owner naming line in cases where current `<main>` does not. (See [504733](https://mushroomobserver.org/504733).) I don't understand why that would be, except maybe... the current helpers bail when the title gets messed up? and then the owner naming line doesn't print? This PR doesn't change anything in the owner naming line, so I really don't understand.

Furthermore, I can't remember which is the expected behavior, hope you can elucidate.