### PR TITLE
Simplify the lightbox image caption

### DIFF
--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -26,20 +26,22 @@ module LightboxHelper
   # observation part of the caption. returns an array of html strings (to join)
   # template local assign "caption" skips the obs relations (projects, etc)
   def lightbox_obs_caption(html, obs_data, identify)
-    if identify ||
-       (obs_data[:obs].vote_cache.present? && obs_data[:obs].vote_cache <= 0)
+    if identify
       html << propose_naming_link(obs_data[:id], context: "lightbox")
       html << content_tag(:span, "&nbsp;".html_safe, class: "mx-2")
       html << mark_as_reviewed_toggle(obs_data[:id])
     end
     html << caption_obs_title(obs_data)
     html << observation_details_when_where_who(obs: obs_data[:obs])
-    html << observation_details_notes(obs: obs_data[:obs])
+    # html << observation_details_notes(obs: obs_data[:obs])
   end
 
+  # This is different from show_obs_title, it's more like the matrix_box title
   def caption_obs_title(obs_data)
-    tag.h4(show_obs_title(obs: obs_data[:obs]),
-           class: "obs-what", id: "observation_what_#{obs_data[:id]}")
+    tag.h4(class: "obs-what", id: "observation_what_#{obs_data[:id]}") do
+      link_with_query(obs_data[:obs].format_name.t.small_author,
+                      obs_data[:obs].show_link_args)
+    end
   end
 
   # links relating to the image object, pre-joined as a div

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -33,7 +33,7 @@ module LightboxHelper
     end
     html << caption_obs_title(obs_data)
     html << observation_details_when_where_who(obs: obs_data[:obs])
-    # html << observation_details_notes(obs: obs_data[:obs])
+    html << observation_details_notes(obs: obs_data[:obs])
   end
 
   # This is different from show_obs_title, it's more like the matrix_box title

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -41,7 +41,8 @@ module LightboxHelper
     tag.h4(class: "obs-what", id: "observation_what_#{obs_data[:id]}") do
       [
         link_to(obs_data[:id], add_query_param(obs_data[:obs].show_link_args),
-                class: "btn btn-primary mr-3"),
+                class: "btn btn-primary mr-3",
+                id: "caption_obs_link_#{obs_data[:id]}"),
         obs_data[:obs].format_name.t.small_author
       ].safe_join(" ")
     end

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -39,8 +39,11 @@ module LightboxHelper
   # This is different from show_obs_title, it's more like the matrix_box title
   def caption_obs_title(obs_data)
     tag.h4(class: "obs-what", id: "observation_what_#{obs_data[:id]}") do
-      link_with_query(obs_data[:obs].format_name.t.small_author,
-                      obs_data[:obs].show_link_args)
+      [
+        link_to(obs_data[:id], add_query_param(obs_data[:obs].show_link_args),
+                class: "btn btn-primary mr-3"),
+        obs_data[:obs].format_name.t.small_author
+      ].safe_join(" ")
     end
   end
 


### PR DESCRIPTION
To remove extra queries on the obs index.

To reproduce the issue, on `<main>` go to http://localhost:3000/505457, and then hit "Index" to be sure we're on the same page of the index. Extra queries will fire after the line

      Rendered application/content/_sorter.html.erb (Duration: 0.2ms | Allocations: 172)

If you examine the lightbox caption for observations like 505457 (it's encoded as a data-attribute in the image) you'll find the ID's of some of the associations that are firing the extra queries.

The issue is compounded on the matrix-box carousel PR #1598 because every image in every matrix box gets a lightbox caption.

Note that changes in this PR will also affect lightboxes on the show_obs page. This PR:

- Replaces the lightbox caption's use of `show_obs_title`, which has links to owner namings, deprecated names etc., and uses the shorter matrix-box-style obs `name` instead, linking to the obs.
- ~Provisionally eliminates~ the obs `notes` from the lightbox caption, because it's the only place i could think that might involve `projects`. These were some of the extra associations getting loaded.  Please let me know if that's not the case. It could be the image copyright instead, for example.

Restored the obs notes because I believe the title was causing all the problems.