### PR TITLE
Translation strings for autocompleter placeholders

### DIFF
--- a/app/views/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/observations/identify/_form_identify_filter.html.erb
@@ -9,7 +9,6 @@
 filter_type = params.dig(:filter, :type) || false
 selected = filter_type ? filter_type.to_sym : :clade
 value = filter_type ? params.dig(:filter, :term) : ""
-placeholder = "Filter by:"
 options = [
   [:CLADE.l, :clade],
   [:REGION.l, :region],
@@ -28,7 +27,7 @@ options = [
     <%= f.text_field(:term,
                       # turn off browser autocomplete
                       autocomplete: "off", value: value,
-                      placeholder: placeholder,
+                      placeholder: :filter_by.l,
                       class: "form-control", size: 42,
                       data: { autofocus: true }) %>
   </div><!--.form-group-->

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1423,7 +1423,7 @@
   obs_needing_id_intro: "Here you can quickly scan unidentified observations, propose a name, or vote on a current name. Use the search bar above to filter by location, taxon or user.\n\nIf you feel you can't improve on an identification, \"[:mark_as_reviewed]\" and it won't come up again. (It will still appear for others.)\n\n*\"Lightbox\" shortcuts:*\n&lsqb;&larr;&rsqb; &lsqb;&rarr;&rsqb; move between observations, &lsqb;return&rsqb; propose a name, &lsqb;/&rsqb; mark as reviewed."
   mark_as_reviewed: Mark as reviewed
   marked_as_reviewed: Marked as reviewed
-  filter_by: Filter by:
+  filter_by: "Filter by:"
 
   # observer/create_observation
   create_observation_title: "[:create_object(type=:observation)]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1355,6 +1355,9 @@
 
   # MOST POPULAR PAGES
 
+  # autocompleters
+  start_typing: Start typing...
+
   # emails/ask_observation_question
   ask_observation_question_title: Question about [name]
   ask_observation_question_label: Enter your question below.  When you hit "[:SEND]" it will be emailed to [user].  The email will automatically include a link to this observation as well as your email address.
@@ -1420,6 +1423,7 @@
   obs_needing_id_intro: "Here you can quickly scan unidentified observations, propose a name, or vote on a current name. Use the search bar above to filter by location, taxon or user.\n\nIf you feel you can't improve on an identification, \"[:mark_as_reviewed]\" and it won't come up again. (It will still appear for others.)\n\n*\"Lightbox\" shortcuts:*\n&lsqb;&larr;&rsqb; &lsqb;&rarr;&rsqb; move between observations, &lsqb;return&rsqb; propose a name, &lsqb;/&rsqb; mark as reviewed."
   mark_as_reviewed: Mark as reviewed
   marked_as_reviewed: Marked as reviewed
+  filter_by: Filter by:
 
   # observer/create_observation
   create_observation_title: "[:create_object(type=:observation)]"


### PR DESCRIPTION
The first string is for the existing `placeholder` attribute of the "help identify" filter input.

The other is preparation for the upcoming refactor of autocomplete inputs. 

Printing a `placeholder` (part of #1610) will fix a current issue where Safari tries to autofill name and location autocomplete inputs with contacts from the user's address book.

![Screen Shot 2023-09-16 at 3 55 59 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/c94912df-14a7-4049-9597-e21187810750)
