### PR TITLE
Quick fix for help ID filter switcher

### DIFF
--- a/app/assets/javascripts/mo_events.js
+++ b/app/assets/javascripts/mo_events.js
@@ -18,9 +18,12 @@ MOEvents.rebindAutoComplete = function (type) {
   switch (type) {
     case "clade":
       AUTOCOMPLETERS[$('#ur_clade').data('uuid')].reuse(filter_term)
+      break;
     case "region":
       AUTOCOMPLETERS[$('#ur_location').data('uuid')].reuse(filter_term)
+      break;
     case "user":
       AUTOCOMPLETERS[$('#ur_user').data('uuid')].reuse(filter_term)
+      break;
   }
 }


### PR DESCRIPTION
JS `case` statement lacked `break`s

Result: the "region" filter autocompleted both `location` and `user` values on top of each other