### PR TITLE
Autocomplete helpers - set default params in the Ajax controller, not the caller

### DIFF
--- a/app/classes/auto_complete.rb
+++ b/app/classes/auto_complete.rb
@@ -192,6 +192,7 @@ class AutoCompleteUser < AutoCompleteByString
   end
 end
 
+# Note this gets a params[:user_id] but we're ignoring it here
 class AutoCompleteHerbarium < AutoCompleteByWord
   def rough_matches(letter)
     herbaria =
@@ -199,9 +200,10 @@ class AutoCompleteHerbarium < AutoCompleteByWord
       where(Herbarium[:name].matches("#{letter}%").
         or(Herbarium[:name].matches("% #{letter}%")).
         or(Herbarium[:code].matches("#{letter}%"))).
-      order(Herbarium[:code].
-        when(nil).then(name: :asc).else(code: :asc, name: :asc)).
-      pluck(:code, :name)
+      order(
+        Arel.when(Herbarium[:code].is_null).then(Herbarium[:name]).
+             else(Herbarium[:code]).asc, Herbarium[:name].asc
+      ).pluck(:code, :name)
 
     herbaria.map do |code, name|
       code.empty? ? name : "#{code} - #{name}"

--- a/app/controllers/ajax_controller.rb
+++ b/app/controllers/ajax_controller.rb
@@ -57,6 +57,7 @@ class AjaxController < ApplicationController
     @type  = params[:type].to_s
     @id    = params[:id].to_s
     @value = params[:value].to_s
+    @user  = session_user!
   end
 
   def backtrace(exception)

--- a/app/controllers/ajax_controller.rb
+++ b/app/controllers/ajax_controller.rb
@@ -57,7 +57,6 @@ class AjaxController < ApplicationController
     @type  = params[:type].to_s
     @id    = params[:id].to_s
     @value = params[:value].to_s
-    @user  = session_user!
   end
 
   def backtrace(exception)

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -25,11 +25,9 @@ module AjaxController::AutoComplete
   def auto_complete_results(string)
     case @type
     when "location"
-      params[:format] = if @user&.location_format == "scientific"
-                          "scientific"
-                        else
-                          ""
-                        end
+      if @user&.location_format == "scientific"
+        params[:format] = "scientific"
+      end
     when "herbarium"
       params[:user_id] = @user&.id
     end

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -21,6 +21,14 @@ module AjaxController::AutoComplete
   private
 
   def auto_complete_results(string)
+    if(@type == "location")
+      params[:format] = if @user&.location_format == "scientific"
+        "scientific"
+      else
+        ""
+      end
+    end
+
     ::AutoComplete.subclass(@type).new(string, params).
       matching_strings.join("\n") + "\n"
   end

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -10,6 +10,8 @@ module AjaxController::AutoComplete
   # type:: Type of string.
   # id::   String user has entered.
   def auto_complete
+    @user  = session_user!
+
     string = CGI.unescape(@id).strip_squeeze
     if string.blank?
       render(plain: "\n\n")

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -21,12 +21,15 @@ module AjaxController::AutoComplete
   private
 
   def auto_complete_results(string)
-    if(@type == "location")
+    case @type
+    when "location"
       params[:format] = if @user&.location_format == "scientific"
-        "scientific"
-      else
-        ""
-      end
+                          "scientific"
+                        else
+                          ""
+                        end
+    when "herbarium"
+      params[:user_id] = @user.id
     end
 
     ::AutoComplete.subclass(@type).new(string, params).

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -25,9 +25,7 @@ module AjaxController::AutoComplete
   def auto_complete_results(string)
     case @type
     when "location"
-      if @user&.location_format == "scientific"
-        params[:format] = "scientific"
-      end
+      params[:format] = "scientific" if @user&.location_format == "scientific"
     when "herbarium"
       params[:user_id] = @user&.id
     end

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -31,7 +31,7 @@ module AjaxController::AutoComplete
                           ""
                         end
     when "herbarium"
-      params[:user_id] = @user.id
+      params[:user_id] = @user&.id
     end
 
     ::AutoComplete.subclass(@type).new(string, params).

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -10,7 +10,7 @@ module AjaxController::AutoComplete
   # type:: Type of string.
   # id::   String user has entered.
   def auto_complete
-    @user  = session_user!
+    @user = User.current
 
     string = CGI.unescape(@id).strip_squeeze
     if string.blank?

--- a/app/helpers/autocomplete_helper.rb
+++ b/app/helpers/autocomplete_helper.rb
@@ -46,13 +46,13 @@ module AutocompleteHelper
 
   # Make text_field auto-complete for Location display name.
   def turn_into_location_auto_completer(id, opts = {})
-    format = if @user && @user.location_format == "scientific"
-               "?format=scientific"
-             else
-               ""
-             end
+    # format = if @user && @user.location_format == "scientific"
+    #            "?format=scientific"
+    #          else
+    #            ""
+    #          end
     turn_into_auto_completer(id, {
-      ajax_url: "/ajax/auto_complete/location/@#{format}",
+      ajax_url: "/ajax/auto_complete/location/@",
       unordered: true
     }.merge(opts))
   end

--- a/app/helpers/autocomplete_helper.rb
+++ b/app/helpers/autocomplete_helper.rb
@@ -46,11 +46,6 @@ module AutocompleteHelper
 
   # Make text_field auto-complete for Location display name.
   def turn_into_location_auto_completer(id, opts = {})
-    # format = if @user && @user.location_format == "scientific"
-    #            "?format=scientific"
-    #          else
-    #            ""
-    #          end
     turn_into_auto_completer(id, {
       ajax_url: "/ajax/auto_complete/location/@",
       unordered: true

--- a/app/helpers/autocomplete_helper.rb
+++ b/app/helpers/autocomplete_helper.rb
@@ -86,7 +86,7 @@ module AutocompleteHelper
     return unless @user
 
     turn_into_auto_completer(id, {
-      ajax_url: "/ajax/auto_complete/herbarium/@?user_id=#{@user.id}",
+      ajax_url: "/ajax/auto_complete/herbarium/@",
       unordered: true
     }.merge(opts))
   end


### PR DESCRIPTION
To reduce the verbosity of autocomplete callers.

Location and Herbarium autocomplete initializers add certain params to the url every time, but these initializers could be simpler if the `AjaxController` just added the params on reception, depending on the type of autocompleter.

This PR is preparation for refactoring the autocompleters.

Bonus: fixes the Herbarium autocompleter, which has been broken (by me) for a long time.