### PR TITLE
Projects bug fix

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -76,14 +76,14 @@ class ProjectsController < ApplicationController
 
   def create
     title = params[:project][:title].to_s
-    project = Project.find_by_title(title)
+    @project = Project.find_by_title(title)
     user_group = UserGroup.find_by_name(title)
     admin_name = "#{title}.admin"
     admin_group = UserGroup.find_by_name(admin_name)
     if title.blank?
       flash_error(:add_project_need_title.t)
-    elsif project
-      flash_error(:add_project_already_exists.t(title: project.title))
+    elsif @project
+      flash_error(:add_project_already_exists.t(title: @project.title))
     elsif user_group
       flash_error(:add_project_group_exists.t(group: title))
     elsif admin_group

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -386,6 +386,7 @@
   specimens: specimens
   SUPPORT: Support
   support: support
+  TEST_PAGES: Test Pages
   THEME: Theme
   TRANSLATION: Translation
   translation: translation

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class ProjectsControllerTest < FunctionalTestCase
   ##### Helpers (which also assert) ############################################
-  def add_project_helper(title, summary)
+  def add_project_helper(title, summary, action = :create, id = nil)
     params = {
       project: {
         title: title,
@@ -12,7 +12,7 @@ class ProjectsControllerTest < FunctionalTestCase
       }
     }
     post_requires_login(:create, params)
-    assert_form_action(action: :create) # Failure
+    assert_form_action(action: action, id: id) # Failure
   end
 
   def edit_project_helper(title, project)
@@ -170,8 +170,10 @@ class ProjectsControllerTest < FunctionalTestCase
   end
 
   def test_add_project_existing
-    add_project_helper(projects(:eol_project).title,
-                       "The Entoloma On Line Project")
+    project = projects(:eol_project)
+    add_project_helper(project.title,
+                       "The Entoloma On Line Project",
+                       :update, project.id)
   end
 
   def test_add_project_empty_name

--- a/test/models/localization_files_test.rb
+++ b/test/models/localization_files_test.rb
@@ -95,8 +95,9 @@ class LocalizationFilesTest < UnitTestCase
       n += 1
       line.sub!(/(^#| # ).*/, "")
       line.gsub(/:(\w+)\.(l|t|tl|tp|tpl| |#|$)(\W|$)/) do
-        unless tags.key?(Regexp.last_match(1).downcase)
-          errors << "#{file} line #{n} [:#{Regexp.last_match(1)}]\n"
+        tag = Regexp.last_match(1)
+        unless tags.key?(tag.downcase) || tag == "never_add"
+          errors << "#{file} line #{n} [:#{tag}]\n"
         end
       end
     end

--- a/test/models/symbol_extensions_test.rb
+++ b/test/models/symbol_extensions_test.rb
@@ -119,4 +119,10 @@ class SymbolExtensionsTest < UnitTestCase
     assert_equal(:AB, :aB.upcase_first)
     assert_equal(:Abc, :abc.upcase_first)
   end
+
+  def test_never_add
+    assert_equal("[:never_add]", :never_add.t)
+    assert_equal("[:never_add(an_arg=:arg)]", :never_add.t(an_arg: :arg))
+    Symbol.missing_tags = []
+  end
 end


### PR DESCRIPTION
To reproduce the original bug:
1) Go to the projects index page (https://mushroomobserver.org/projects)
2) Copy the full name of an existing project
3) Click 'Add Project' (upper right corner)
4) Paste the name into the "Title" field
5) Click "Create"
6) See the page re-render but with an error complaining about the name already exists
7) Enter a new Title
8) Click "Create"
9) Boom!

The problem was that we were not setting the @projects ivar in ProjectsController#create.

Note, this PR also attempts to fix the occasional spec failure related to TEST_PAGES.  I was able to reliably reproduce this issue locally with: `rails t --seed 10928`