### PR TITLE
Switch create error to redirect

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -91,7 +91,7 @@ class ProjectsController < ApplicationController
     else
       return create_project(title, admin_name)
     end
-    render(:new, location: new_project_path(q: get_query_param))
+    redirect_to(new_project_path(q: get_query_param))
   end
 
   def update

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class ProjectsControllerTest < FunctionalTestCase
   ##### Helpers (which also assert) ############################################
-  def add_project_helper(title, summary, action = :create, id = nil)
+  def add_project_helper(title, summary)
     params = {
       project: {
         title: title,
@@ -12,7 +12,7 @@ class ProjectsControllerTest < FunctionalTestCase
       }
     }
     post_requires_login(:create, params)
-    assert_form_action(action: action, id: id) # Failure
+    assert_redirected_to(new_project_path) # Failure
   end
 
   def edit_project_helper(title, project)
@@ -172,8 +172,7 @@ class ProjectsControllerTest < FunctionalTestCase
   def test_add_project_existing
     project = projects(:eol_project)
     add_project_helper(project.title,
-                       "The Entoloma On Line Project",
-                       :update, project.id)
+                       "The Entoloma On Line Project")
   end
 
   def test_add_project_empty_name


### PR DESCRIPTION
While the previous PR stopped an error from happening it was still confusing since it switched over to an update when it should be creating something new.