### PR TITLE
Mute console log on `main.js` observer

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -107,10 +107,10 @@ const moObserveContent = function () {
   const callback = (mutationList, observer) => {
     for (const mutation of mutationList) {
       if (mutation.type === "childList") {
-        console.log("A child node has been added or removed.");
+        // console.log("A child node has been added or removed.");
         initializeAutocompleters();
       } else if (mutation.type === "attributes") {
-        console.log(`The ${mutation.attributeName} attribute was modified.`);
+        // console.log(`The ${mutation.attributeName} attribute was modified.`);
       }
     }
   };


### PR DESCRIPTION
I left some debugging messages on in the new observer that initializes autocompleters.