### PR TITLE
Temporary fix for multiple image uploads throwing autocompleter initializer error

### DIFF
--- a/app/views/observations/form/images_upload/_template.erb
+++ b/app/views/observations/form/images_upload/_template.erb
@@ -79,8 +79,9 @@
             </div>
             <div class="col-sm-8 form-inline">
               <%= fti.date_select(:when, date_select_opts(@temp_image),
-                                  { class: "form-control form-control-sm",
-                                    data: { autocompleter: :year } }) %>
+                                  { class: "form-control form-control-sm" }) %>
+              <%# ,
+                                    data: { autocompleter: :year } %>
               <div>
                 <small><%= :form_images_camera_date.t %>:</small>
                 <small><a href="javascript:"><span class="camera_date_text"></span></a></small>


### PR DESCRIPTION
The error makes it impossible to create an obs with multiple images, and needs a hot fix.

The prob is that the year autocompleters for temporary images that are staged to the observation being created do not get unique IDs — nor does any field in the repeating "uploaded images" boxes. 

They all get: `temp_image_#{field}`, and in this case it's `temp_image_when_1i`. So the year autocomplete initialization fails, it's not a valid HTML ID.

A quick fix would be to temporarily disable the year autocompleters on image uploads, and let people use the dropdown for now.