### PR TITLE
Restore "year autocompleter" to the create obs form's `temp_image` UI

### DIFF
--- a/app/controllers/ajax_controller/upload_image.rb
+++ b/app/controllers/ajax_controller/upload_image.rb
@@ -8,7 +8,8 @@ module AjaxController::UploadImage
     @user = session_user!
     @licenses = License.current_names_and_ids(@user.license)
     @image = Image.new(user: @user, when: Time.zone.now)
-    render(partial: "observations/form/images_upload/template")
+    render(partial: "observations/form/images_upload/template",
+           locals: { img_number: params[:img_number] })
   end
 
   # Uploads an image object without an observation.

--- a/app/views/observations/form/images_upload/_template.erb
+++ b/app/views/observations/form/images_upload/_template.erb
@@ -1,4 +1,4 @@
-<div class="added_image_wrapper">
+<div class="added_image_wrapper" data-image-number="<%= img_number %>">
 
   <div class="added_image_name_container row">
     <!--Replaced by javascript-->
@@ -21,7 +21,8 @@
            data-role="set_as_default_thumbnail"
            class="btn btn-sm btn-default"><%= :image_set_default.t %></a>
         <label class="hidden is_default_thumbnail"><%= :image_add_default.t %></label>
-        <input type="radio" name="observation[thumb_image_id]" value="true" style="display: none;">
+        <input type="radio" name="observation[thumb_image_id]"
+          value="true" style="display: none;">
       </div>
 
       <div class="form-group">
@@ -42,7 +43,7 @@
            class="remove_image_link btn btn-sm btn-default"><%= :image_remove_remove.t %></a>
       </div>
 
-      <%= fields_for(:temp_image) do |fti| %>
+      <%= fields_for(:"#{img_number}_temp_image") do |fti| %>
 
         <div class="row">
 
@@ -79,9 +80,8 @@
             </div>
             <div class="col-sm-8 form-inline">
               <%= fti.date_select(:when, date_select_opts(@temp_image),
-                                  { class: "form-control form-control-sm" }) %>
-              <%# ,
-                                    data: { autocompleter: :year } %>
+                                  { class: "form-control form-control-sm",
+                                    data: { autocompleter: :year } }) %>
               <div>
                 <small><%= :form_images_camera_date.t %>:</small>
                 <small><a href="javascript:"><span class="camera_date_text"></span></a></small>


### PR DESCRIPTION
Fixes the bug that was hanging up the create obs form when users uploaded multiple images. (The autocompleter initializer hung if the field ID was not unique.) Gives the `temp_image_` fields unique ids, using the `img_number` local variable (a uuid) that was already available to the template.

The field IDs are ignored by the uploader script, incidentally. It's a very minor issue, but at least this restores expected behavior.

## Please test manually ##
Start to create an obs
Add multiple images to the create obs form 
Click `Create`
Should be ok