### PR TITLE
Update Gemfile.lock with gems for running Rails natively on my mac

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
     kgio (2.11.4)
     language_server-protocol (3.17.0.3)
     libv8-node (18.16.0.0-arm64-darwin)
+    libv8-node (18.16.0.0-x86_64-darwin)
     libv8-node (18.16.0.0-x86_64-linux)
     loofah (2.21.3)
       crass (~> 1.0.2)
@@ -149,6 +150,8 @@ GEM
       net-protocol
     newrelic_rpm (9.4.2)
     nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
@@ -281,6 +284,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
After switching to a native Rails install, bundler adds a few extra gem versions for my hardware, so the `Gemfile.lock` changes. (Iirc this was also the case when Nathan switched to running native, because there seem to be gem versions for his M1 hardware in `Gemfile.lock`.)

This PR doesn't force anybody to switch.

### Background ###

Running Rails natively on the Mac seems like the way to go. It is _so much faster_ than running it through the VM, I don't know why i didn't try this earlier. I might be done with Vagrant and I don't know why i wasted so much time with it — both configuring the VM, and running the server. It's way way faster every time the server or a page loads, and it seems to reduce developer frustration, according to subjective biometrics available at this time.

## How to go native yourself ##
This should eventually go in a readme. (is there one already?!)

The steps are documented here: https://gorails.com/setup/macos/12-monterey (that's a link for my OS). The only tweak I did was to `brew install mysql@8.0` (rather than current 8.1). I also obviously skipped the installation of Rails, and just `bundle install` our gems instead.

These instructions use the newer `zsh` shell. `cd` to your local mushroom-observer directory (you don't have to move it out of `developer-startup` if it's there), then:
```
# install or update to current homebrew
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

# install rbenv (NOT rvm) and ruby-build
brew install rbenv ruby-build

# Add rbenv to bash so that it loads every time you open a terminal
echo 'if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi' >> ~/.zshrc
source ~/.zshrc

# install the current MO ruby version
rbenv install 3.1.2

# check that your git account is still connected in this directory (should be)
ssh -T git@github.com

# install our gems
bundle install

# install mysql
brew install mysql@8.0

# have it start automatically
brew services start mysql@8.0

# install checkpoint_stripped.gz
rake db:drop
mysql -u root -p < db/initialize.sql
gunzip -c checkpoint_stripped.gz | mysql -u mo -pmo mo_development

# finish up
rails db:migrate
rails lang:update
```

There is one more key step before running `rails s`: change the mysql socket config in `config/database.yml`. Uncomment the MacOS X line and comment out the Ubuntu/Debian line. This only applies to your system, since this file is ignored by git:

```ruby
  # Default (works for MacOS X)
  socket: /tmp/mysql.sock
  # For Ubuntu/Debian
  # socket: /var/run/mysqld/mysqld.sock
```

You'll have to halt Vagrant to free up the port before starting the server. (I restarted my machine also.)