### PR TITLE
Serve images locally if they don't get transferred.

### DIFF
--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -105,6 +105,7 @@ module ImageHelper
                       votes: true) + image_copyright(obs.thumb_image, obs)
   end
 
+  # pass an image instance if possible, to ensure access to fallback image.url
   def original_image_link(image_or_image_id, classes)
     url = if image_or_image_id.is_a?(Image)
             image_or_image_id.url(:original)

--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -105,12 +105,22 @@ module ImageHelper
                       votes: true) + image_copyright(obs.thumb_image, obs)
   end
 
-  def original_image_link(image_id, classes)
-    link_to(:image_show_original.t, Image.url(:original, image_id),
+  def original_image_link(image_or_image_id, classes)
+    url = if image_or_image_id.is_a?(Image)
+            image_or_image_id.url(:original)
+          else
+            Image.url(:original, image_or_image_id)
+          end
+    link_to(:image_show_original.t, url,
             { class: classes, target: "_blank", rel: "noopener" })
   end
 
-  def image_exif_link(image_id, classes)
+  def image_exif_link(image_or_image_id, classes)
+    image_id = if image_or_image_id.is_a?(Image)
+                 image_or_image_id.id
+               else
+                 image_or_image_id
+               end
     link_to(:image_show_exif.t, exif_image_path(image_id),
             { class: classes, remote: true, onclick: "MOEvents.whirly();" })
   end

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -19,7 +19,7 @@ module LightboxHelper
     if obs_data[:id].present?
       html = lightbox_obs_caption(html, obs_data, lightbox_data[:identify])
     end
-    html << caption_image_links(lightbox_data[:image_id])
+    html << caption_image_links(lightbox_data[:image] || lightbox_data[:image_id])
     safe_join(html)
   end
 
@@ -43,11 +43,11 @@ module LightboxHelper
   end
 
   # links relating to the image object, pre-joined as a div
-  def caption_image_links(image_id)
+  def caption_image_links(image_or_image_id)
     links = []
-    links << original_image_link(image_id, "lightbox_link")
+    links << original_image_link(image_or_image_id, "lightbox_link")
     links << " | "
-    links << image_exif_link(image_id, "lightbox_link")
+    links << image_exif_link(image_or_image_id, "lightbox_link")
     tag.div(class: "caption-image-links my-3") do
       safe_join(links)
     end

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -19,7 +19,8 @@ module LightboxHelper
     if obs_data[:id].present?
       html = lightbox_obs_caption(html, obs_data, lightbox_data[:identify])
     end
-    html << caption_image_links(lightbox_data[:image] || lightbox_data[:image_id])
+    html << caption_image_links(lightbox_data[:image] ||
+                                lightbox_data[:image_id])
     safe_join(html)
   end
 

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -44,6 +44,7 @@ module LightboxHelper
   end
 
   # links relating to the image object, pre-joined as a div
+  # pass an image instance if possible, to ensure access to fallback image.url
   def caption_image_links(image_or_image_id)
     links = []
     links << original_image_link(image_or_image_id, "lightbox_link")

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -18,7 +18,9 @@ class ImagePresenter < BasePresenter
   def initialize(image, args = {})
     super
 
-    # Sometimes it's prohibitive to do the extra join to images table,
+    # Pass an image instance (not id) whenever possible, to ensure access to
+    # the fallback image.url if the image server is unavailable. Sometimes it's
+    # prohibitive to do the extra join to images table, as when parsing Textile,
     # so we only have image_id. It's still possible to render the image with
     # nothing but the image_id. (But not votes, original name, etc.)
     image, image_id = image.is_a?(Image) ? [image, image.id] : [nil, image]

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -50,11 +50,11 @@ class ImagePresenter < BasePresenter
       context: false # false to constrain width
     }
     args = default_args.merge(args)
-    img_urls = Image.all_urls(image_id)
+    img_urls = image&.all_urls || Image.all_urls(image_id)
 
     args_to_presenter(image, image_id, img_urls, args)
     sizing_info_to_presenter(image, args)
-    lightbox_args_to_presenter(image_id, img_urls, args)
+    lightbox_args_to_presenter(image, image_id, img_urls, args)
   end
 
   def args_to_presenter(image, image_id, img_urls, args)
@@ -121,13 +121,14 @@ class ImagePresenter < BasePresenter
     end
   end
 
-  def lightbox_args_to_presenter(image_id, img_urls, args)
+  def lightbox_args_to_presenter(image, image_id, img_urls, args)
     # The src size appearing in the lightbox is a user pref
     lb_size = User.current&.image_size&.to_sym || :huge
 
     self.lightbox_data = {
       url: img_urls[lb_size],
       id: args[:is_set] ? "observation-set" : SecureRandom.uuid,
+      image: image,
       image_id: image_id,
       obs_data: args[:obs_data],
       identify: args[:identify]

--- a/app/views/images/show/_image_panel.html.erb
+++ b/app/views/images/show/_image_panel.html.erb
@@ -19,7 +19,7 @@
                                                   q: get_query_param,
                                                   size: @size)) %> |
       <% end %>
-      <%= original_image_link(@image.id, "") %> |
+      <%= original_image_link(@image, "") %> |
       <%= image_exif_link(@image.id, "") %>
 
     </div><!--.text-center-->
@@ -40,7 +40,7 @@
       function load_huge() {
         if (!huge_loaded && jQuery(window).width() >= 1200) {
           huge_loaded = true;
-          jQuery("img.huge-image").attr("src", "#{j Image.url(:huge, @image.id)}");
+          jQuery("img.huge-image").attr("src", "#{j @image.url(:huge)}");
         }
       }
       jQuery(window).resize(load_huge);

--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -159,6 +159,16 @@ http {
 
       # track progress of all POST requests at this location, MUST BE LAST!
       # track_uploads upload 10s;
+
+      # serve old originals from digitalocean object store
+      # rewrite "^/images/orig/((\d{1,6}|1[0]\d\d\d\d\d)\.\w+)$" https://mushroomobserver.nyc3.digitaloceanspaces.com/orig/$1?;
+
+      # serve old originals from google object store
+      rewrite "^/images/orig/((\d{1,6}|1[01]\d\d\d\d\d)\.\w+)$" https://storage.googleapis.com/mo-image-archive-bucket/orig/$1?;
+
+      # serve all the rest of the images from Alan's image server
+      # being careful to permit routes like `/images/21345/vote`
+      rewrite "^/images/(\w*)/(\d*\.\w+)$" https://images.mushroomobserver.org/$1/$2?;
     }
 
     # hijack this URL and have it return the state of a current upload,
@@ -188,16 +198,6 @@ http {
       add_header  ETag "";
       break;
     }
-
-    # serve old originals from digitalocean object store
-    # rewrite "^/images/orig/((\d{1,6}|1[0]\d\d\d\d\d)\.\w+)$" https://mushroomobserver.nyc3.digitaloceanspaces.com/orig/$1?;
-
-    # serve old originals from google object store
-    rewrite "^/images/orig/((\d{1,6}|1[01]\d\d\d\d\d)\.\w+)$" https://storage.googleapis.com/mo-image-archive-bucket/orig/$1?;
-
-    # serve all the rest of the images from Alan's image server
-    # being careful to permit routes like `/images/21345/vote`
-    rewrite "^/images/(\w*)/(\d*\.\w+)$" https://images.mushroomobserver.org/$1/$2?;
 
     # SSL stuff.
     ssl_certificate /etc/letsencrypt/live/mushroomobserver.org/fullchain.pem; # managed by Certbot


### PR DESCRIPTION
In particular, this fixes the rails side.  There's an independent fix on the nginx side.

Here, we just need to make sure the entire `Image` instance is passed all the way in to the point where we calculate the image URL.  At least whenever possible.  There are still some cases (e.g. in textile markup such as `!image 1234!` where we do not have access to the instance and we just fall back on the default source.  But in the standard cases like the activity log and show obs page, we've eager-loaded the images already, so there is no reason not to pass it all the way in.