### PR TITLE
Clear up console warnings about cookie "Same Site" attribute

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -38,7 +38,8 @@ jQuery(document).ready(function () {
     var d = new Date();
     d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
     var expires = "expires=" + d.toUTCString();
-    document.cookie = cname + "=" + cvalue + "; " + expires + ";path=/";
+    document.cookie = cname + "=" + cvalue + "; " + expires
+      + ";samesite=lax;path=/";
   }
 
   jQuery('.file-field :file').on('change', function () {

--- a/app/assets/stylesheets/mo/_lightbox.scss
+++ b/app/assets/stylesheets/mo/_lightbox.scss
@@ -54,7 +54,7 @@ body:after {
 .lb-outerContainer {
   position: relative;
   background-color: transparent;
-  *zoom: 1;
+  // *zoom: 1;
   width: 250px;
   height: 250px;
   margin: 0 auto;
@@ -157,7 +157,7 @@ body:after {
 .lb-dataContainer {
   margin: 0 auto;
   padding-top: 5px;
-  *zoom: 1;
+  // *zoom: 1;
   width: 100%;
   -moz-border-radius-bottomleft: 4px;
   -webkit-border-bottom-left-radius: 4px;

--- a/app/assets/stylesheets/mo/_lightbox.scss
+++ b/app/assets/stylesheets/mo/_lightbox.scss
@@ -223,3 +223,9 @@ body:after {
     }
   }
 }
+
+// Bootstrap 3, nonstandard prop. Revert to default. Does not work
+// .media,
+// .media-body {
+//   zoom: auto;
+// }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -523,7 +523,8 @@ class ApplicationController < ActionController::Base
   def autologin_cookie_set(user)
     cookies["mo_user"] = {
       value: "#{user.id} #{user.auth_code}",
-      expires: 1.month.from_now
+      expires: 1.month.from_now,
+      same_site: :lax
     }
   end
 

--- a/app/views/application/app/_javascript_footer.html.erb
+++ b/app/views/application/app/_javascript_footer.html.erb
@@ -1,6 +1,6 @@
 <!--JAVASCRIPT-->
 <%= javascript_includes.map { |f| javascript_include_tag(f) }.safe_join %>
-<%= javascript_tag('try { document.cookie = "tz=" + jstz.determine().name() } catch(err) {}') %>
+<%= javascript_tag('try { document.cookie = "tz=" + jstz.determine().name() + ";samesite=lax" } catch(err) {}') %>
 <% injected_javascripts.each do |script| %>
   <%= javascript_tag(script) %>
 <% end %>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,4 +3,5 @@
 # Be sure to restart your server when you modify this file.
 
 MushroomObserver::Application.
-  config.session_store(:cookie_store, key: "_mushroom-observer_session_3.1")
+  config.session_store(:cookie_store, key: "_mushroom-observer_session_3.1",
+                                      same_site: :lax)


### PR DESCRIPTION
...by explicitly assigning all our cookies the default value, "lax". That will keep behavior exactly as it is currently.

I think we could maybe switch to "strict", because we don't do much cookie passing with other domains, but this PR is not aiming to change cookies, just get rid of console warnings for the sake of JS debugging.

It also tries, but does not succeed, in eliminating the nonstandard CSS `zoom` property that throws a warning in FF. That won't go away until we're off Bootstrap 3.