### PR TITLE
Open the Obs homepage for not-logged-in visitors

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -10,7 +10,8 @@ class ObservationsController < ApplicationController
   # Disable cop: all these methods are defined in files included above.
   # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :login_required, except: [
-    :show
+    :show,
+    :index
   ]
   before_action :pass_query_params, only: [
     :show,

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -6,7 +6,7 @@ class RssLogsController < ApplicationController
   require "set"
 
   before_action :login_required, except: [
-    :index,
+    # :index,
     :rss,
     :show
   ]

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -175,8 +175,9 @@ class ObservationsControllerTest < FunctionalTestCase
   # other subactions in order of @index_subaction_param_keys
   # miscellaneous tests using get(:index)
 
-  def test_index
-    login
+  # First, test that the index does not require login - AN 20230923
+  def test_index_no_login
+    # login
     get(:index)
 
     assert_template("shared/_matrix_box")

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -4,6 +4,9 @@ require("test_helper")
 
 class RssLogsControllerTest < FunctionalTestCase
   def test_page_loads
+    get(:index)
+    assert_redirected_to(new_account_login_path)
+
     login
     get(:index)
     assert_template("shared/_matrix_box")


### PR DESCRIPTION
This is a very belated change that ideally should have happened when we switched homepages. This should finally permit metrics to start happening on the homepage!

Conversely, requires login on Activity Logs, no longer the homepage.
