### PR TITLE
Hot fix for `??` not recognized

### DIFF
--- a/app/assets/javascripts/mo_multi_image_uploader.js
+++ b/app/assets/javascripts/mo_multi_image_uploader.js
@@ -640,7 +640,7 @@ class MOMultiImageUploader {
   // add the image to `good_images` and maybe set the thumb_image_id
   updateObsImages(item, image) {
     // #good_images is a hidden field
-    const _good_image_vals = this.good_images.value ?? "";
+    const _good_image_vals = this.good_images.value || "";
 
     // add id to the good images form field.
     this.good_images.value =


### PR DESCRIPTION
I guess the nullish coalescing operator is not supported by uglifier.

Switching to `||` which should work fine in this case, since `''` evaluates to falsey and will yield the default, which is also `''`.