### PR TITLE
Fix for `ProjectsController#create` calling `render` if invalid

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -76,14 +76,14 @@ class ProjectsController < ApplicationController
 
   def create
     title = params[:project][:title].to_s
-    @project = Project.find_by_title(title)
+    project = Project.find_by_title(title)
     user_group = UserGroup.find_by_name(title)
     admin_name = "#{title}.admin"
     admin_group = UserGroup.find_by_name(admin_name)
     if title.blank?
       flash_error(:add_project_need_title.t)
-    elsif @project
-      flash_error(:add_project_already_exists.t(title: @project.title))
+    elsif project
+      flash_error(:add_project_already_exists.t(title: project.title))
     elsif user_group
       flash_error(:add_project_group_exists.t(group: title))
     elsif admin_group
@@ -91,7 +91,8 @@ class ProjectsController < ApplicationController
     else
       return create_project(title, admin_name)
     end
-    redirect_to(new_project_path(q: get_query_param))
+    @project = Project.new
+    render(:new, location: new_project_path(q: get_query_param))
   end
 
   def update

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -12,7 +12,7 @@ class ProjectsControllerTest < FunctionalTestCase
       }
     }
     post_requires_login(:create, params)
-    assert_redirected_to(new_project_path) # Failure
+    assert_form_action(action: :create, id: nil) # Failure
   end
 
   def edit_project_helper(title, project)


### PR DESCRIPTION
After a Nimmo refactor, this controller action was not working as expected.  Nathan restored the expected behavior by making the action `redirect` to `#new` if the form had errors. 

>I made this change because the previous version of things did not work correctly. The problem was that after adding the @project stuff the create process turned into an update if you used the name of an already existing project. The behavior was very surprising and in my view wrong. For example, if you use the name of someone else's project, when the page gets re-render it has data from the other project (summary and other widgets) and when you hit "create" after changing the title, it rejects it since you don't have permission. If you instead happen to reuse the name of your own project, then change the title, it changes the title of the already existing project and does not create a new one. As far as I can tell, the redirect behaves much better since it restarts the process. 

I've been adjusting CRUD actions to get all our forms to `render` rather than `redirect` if invalid, in part so they will work with Turbo, which always `renders`. In general that means my refactors must ensure that the "form errors path" of any create action must set up the form as the `new` action would do (likewise, a failed `update` must set up the form again as the `edit` action would do) before calling `render`. 

In this case that means setting `@project = Project.new` before calling `render(:new)`. I missed that when refactoring, which caused the weirdness. But even worse, now that I look over Nathan's PR, i can see that a test caught my error, and I modified the test expectation to allow the weird behavior to pass, because i didn't understand what was happening. Not good!

This PR keeps behavior as restored by Nathan, but reverts to render with the above tweak.