### PR TITLE
Autocompleter - tab/return tweaks

### DIFF
--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -354,6 +354,7 @@ class MOAutocompleter {
           break;
         case EVENT_KEY_RETURN:
         case EVENT_KEY_TAB:
+          event.preventDefault();
           if (this.current_row >= 0)
             this.select_row(this.current_row - this.scroll_offset);
           break;


### PR DESCRIPTION
This PR restores some expected `tab`/`return` behavior to the autocompleter, that i probably messed up in the refactor.

- Prevents submitting the form if you hit `return` within an autocompleter.
- `tab` doesn't do anything if the autocompleter is active and nothing is highlighted
- If something is highlighted, `tab` fills the field with that value and waits for further input

Thanks to @mo-nathan for examining it closely and writing it up.

>I've been playing with the auto-completer as part of testing the project location work and I've noticed something I don't think is right.  Specifically, if you go to "Create Observation", click the location, and use the auto-completer from the keyboard and select an item using the arrow keys and then hit <return>, it immediately submits the form.  I expect it to just select that item and fill in the field with it.  This means I either have to remember to hit tab (which has other issues discussed below) or click on the selected item.

>This in turn has made me aware that hitting <tab> doesn't behave the way I expect it to.  I expect it to extend the text to the next ambiguous character, but instead it only adds to the text if an item is selected and regardless it moves the focus to the next item in the form.  This means I can end up with locations like "USA, Mass", when I expected it to extend the text to "USA, Massachusetts".

>This case is clearly trickier since we do more complicated matching than just against the beginning of the string.  A good example at the moment is "USA, Massachusetts, Falmouth" since there is currently a location named "USA, Massachusetts, East Falmouth, Kettle Holes Conservation Area" as well as various names starting with "USA, Massachusetts, Falmouth, North Falmouth".  If you see a way to really solve this situation, that would be great.  However, if not, in my view it would still be better if <tab> didn't do anything if the autocompleter is active and nothing is selected.  If something is selected, I think it's reasonable to fill it in with that text and move to the next item.
