### PR TITLE
Convert Autocompleters to send and receive JSON

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -138,7 +138,7 @@ const moObserveContent = function () {
         if (type != "year" || type == "year" && input_id.indexOf("_1i") > 0) {
           new MOAutocompleter({
             input_id: input_id,
-            token: element.dataset.autocomplete_separator
+            separator: element.dataset.autocomplete_separator
           });
         }
       }

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -884,10 +884,11 @@ class MOAutocompleter {
     const vals = val.split(' ');
     const primer = this.primer.map((str) => { return str.normalize() });
     const matches = [];
+    debugger;
     if (val != '') {
       let i, k, s, s2;
-      for (i = 0; i >= 0; i = primer.length - 1) {
-        s = primer[i + 1];
+      for (i = 0; i >= 0; i = primer.length) {
+        s = primer[i + 1] || '';
         s2 = ' ' + s.toLowerCase() + ' ';
         for (k = 0; k < vals.length; k++) {
           if (s2.indexOf(' ' + vals[k]) < 0) break;

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -106,7 +106,6 @@ class MOAutocompleter {
     const autocompleterTypes = {
       clade: {
         ajax_url: "/ajax/auto_complete/clade/@",
-        collapse: 1
       },
       herbarium: { // params[:user_id] handled in controller
         ajax_url: "/ajax/auto_complete/herbarium/@",

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -887,7 +887,7 @@ class MOAutocompleter {
       matches = [];
 
     if (val != '' && primer.length > 1) {
-      for (let i = 1; i <= primer.length; i++) {
+      for (let i = 1; i < primer.length; i++) {
         let s = primer[i] || '',
           s2 = ' ' + s.toLowerCase() + ' ',
           k;
@@ -914,10 +914,10 @@ class MOAutocompleter {
       matches = [];
 
     if (val != '' && primer.length > 1) {
-      let the_rest = (val.match(/ /g) || []).length >= this.collapse,
-        i = this.get_primer_index_of_substr(primer_lc, val);
+      let the_rest = (val.match(/ /g) || []).length >= this.collapse;
 
-      for (i; i <= primer_lc.length; i++) {
+      for (let i = this.get_primer_index_of_substr(primer_lc, val);
+        i < primer_lc.length; i++) {
         let s = primer[i];
 
         if (s.length > 0) {

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -145,9 +145,9 @@ class MOAutocompleter {
       focused: false,        // is user in text field?
       menu_up: false,        // is pulldown visible?
       old_value: {},         // previous value of input field
-      primer: '',            // initial server-supplied list of many options
+      primer: [],            // initial server-supplied list of many options
       matches: [],           // list of options currently showing
-      current_row: -1,       // number of option currently highlighted (0 = none)
+      current_row: -1,       // index of option currently highlighted (0 = none)
       current_value: null,   // value currently highlighted (null = none)
       current_highlight: -1, // row of view highlighted (-1 = none)
       current_width: 0,      // current width of menu
@@ -191,8 +191,8 @@ class MOAutocompleter {
     // Figure out a few browser-dependent dimensions.
     this.scrollbar_width = this.getScrollBarWidth();
 
-    // Initialize autocomplete primer.
-    this.primer = "\n" + this.primer;
+    // Initialize autocomplete primer with a blank newline.
+    this.primer.unshift('\n');
 
     // Create pulldown.
     this.create_pulldown();
@@ -244,13 +244,13 @@ class MOAutocompleter {
       style = old_elem.getAttribute("style"),
       value = old_elem.value,
       opts = old_elem.options,
-      options = [],
+      primer = [],
       new_elem = document.createElement("input");
     new_elem.type = "text";
     const length = opts.length > 20 ? 20 : opts.length;
 
     for (let i = 0; i < opts.length; i++)
-      options.push(opts.item(i).text);
+      primer.push(opts.item(i).text);
 
     new_elem.classList = classList;
     new_elem.style = style;
@@ -266,7 +266,7 @@ class MOAutocompleter {
     new_elem.setAttribute("name", name);
 
     this.input_elem = new_elem,
-      this.primer = options.join("\n"),
+      this.primer = primer,
       this.pulldown_size = length,
       this.act_like_select = true
 
@@ -854,7 +854,7 @@ class MOAutocompleter {
   // order given right from the moment they enter the field.
   // FIXME - make the year thing do an array
   update_select() {
-    this.matches = this.primer.split("\n");
+    this.matches = this.primer;
   }
 
   // Grab all matches, doing exact match, ignoring number of words.
@@ -1076,7 +1076,6 @@ class MOAutocompleter {
 
     // Clear flag telling us request is pending.
     this.fetch_request = null;
-    debugger;
     // console.log("new_primer: " + new_primer);
 
     // Record string actually used to do matching: might be less strict

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -884,10 +884,9 @@ class MOAutocompleter {
     const vals = val.split(' ');
     const primer = this.primer.map((str) => { return str.normalize() });
     const matches = [];
-    debugger;
     if (val != '') {
       let i, k, s, s2;
-      for (i = 0; i >= 0; i = primer.length) {
+      for (i = 0; i < primer.length; i++) {
         s = primer[i + 1] || '';
         s2 = ' ' + s.toLowerCase() + ' ';
         for (k = 0; k < vals.length; k++) {

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -915,7 +915,7 @@ class MOAutocompleter {
 
       for (let i = primer_lc.indexOf(val); i < primer_lc.length; i++) {
         let s = primer[i + 1];
-        if (s.length > 0) {
+        if (s && s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);
             // if (matches.length >= this.pulldown_size)

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -693,8 +693,7 @@ class MOAutocompleter {
 
     if (this.log) {
       this.debug(
-        "Redraw: matches=" + matches.length +
-        ", scroll=" + scroll + ", cursor=" + cur
+        "Redraw: matches=" + matches.length + ", scroll=" + scroll + ", cursor=" + cur
       );
     }
 
@@ -915,7 +914,7 @@ class MOAutocompleter {
     if (val != '' && primer.length > 1) {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse,
         // val will have a trailing space, if a word has already been matched
-        i = primer_lc.indexOf(val.trim()) + 1;
+        i = this.get_primer_index_of_substr(primer_lc, val);
 
       for (i; i <= primer_lc.length; i++) {
         let s = primer[i];
@@ -941,16 +940,27 @@ class MOAutocompleter {
     this.matches = matches;
   }
 
+  // index of substr within the primer values
+  get_primer_index_of_substr(primer, val) {
+    for (let i = 0; i < primer.length; i++) {
+      // For multidimensional this would be primer[i][0], the text
+      const index = primer[i].indexOf(val);
+      if (index > -1) {
+        return i;
+      }
+    }
+  }
+
   /**
    * Index of string in primer array with IDs
    * where primer == [[text_string, id], [text_string, id]]
    * @param primer {!Array} - the input array
-   * @param k {object} - the value to search
+   * @param val {object} - the value to search
    * @return {Array} or just i
    */
-  // get_primer_index_of(primer, k) {
+  // get_primer_index_of(primer, val) {
   //   for (let i = 0; i < primer.length; i++) {
-  //     const index = primer[i].indexOf(k);
+  //     const index = primer[i].indexOf(val);
   //     if (index > -1) {
   //       // return [i, index];
   //       return i;

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -526,10 +526,10 @@ class MOAutocompleter {
   go_end() { this.move_cursor(this.matches.length) }
   move_cursor(rows) {
     this.verbose("move_cursor()");
-    const old_row = this.current_row;
-    let new_row = old_row + rows;
-    const old_scr = this.scroll_offset;
-    let new_scr = old_scr;
+    const old_row = this.current_row,
+      old_scr = this.scroll_offset;
+    let new_row = old_row + rows,
+      new_scr = old_scr;
 
     // Move cursor, but keep in bounds.
     if (new_row < 0)
@@ -557,10 +557,12 @@ class MOAutocompleter {
   // Mouse has moved over a menu item.
   highlight_row(new_hl) {
     this.verbose("highlight_row()");
-    const rows = this.list_elem.children;
-    const old_hl = this.current_highlight;
+    const rows = this.list_elem.children,
+      old_hl = this.current_highlight;
+
     this.current_highlight = new_hl;
     this.current_row = this.scroll_offset + new_hl;
+
     if (old_hl != new_hl) {
       if (old_hl >= 0)
         rows[old_hl].classList.remove(this.hot_class);
@@ -574,10 +576,11 @@ class MOAutocompleter {
   // Called when users scrolls via scrollbar.
   our_scroll() {
     this.verbose("our_scroll()");
-    const old_scr = this.scroll_offset;
-    const new_scr = Math.round(this.pulldown_elem.scrollTop / this.row_height);
-    const old_row = this.current_row;
-    const new_row = this.current_row;
+    const old_scr = this.scroll_offset,
+      new_scr = Math.round(this.pulldown_elem.scrollTop / this.row_height),
+      old_row = this.current_row;
+    let new_row = this.current_row;
+
     if (new_row < new_scr)
       new_row = new_scr;
     if (new_row >= new_scr + this.pulldown_size)
@@ -650,7 +653,6 @@ class MOAutocompleter {
   // Get actual row height when it becomes available.
   // Experimentally creates a test row.
   get_row_height() {
-    // this.input_elem.disabled = true;
     const div = document.createElement('div'),
       ul = document.createElement('ul'),
       li = document.createElement('li');
@@ -665,7 +667,6 @@ class MOAutocompleter {
     this.temp_row = div;
     // window.setTimeout(this.set_row_height(), 100);
     this.set_row_height();
-    // this.input_elem.disabled = false;
   }
   set_row_height() {
     if (this.temp_row) {
@@ -683,12 +684,12 @@ class MOAutocompleter {
   // Redraw the pulldown options.
   draw_pulldown() {
     this.verbose("draw_pulldown()");
-    const list = this.list_elem;
-    const rows = list.children;
-    const size = this.pulldown_size;
-    const scroll = this.scroll_offset;
-    const cur = this.current_row;
-    const matches = this.matches;
+    const list = this.list_elem,
+      rows = list.children,
+      size = this.pulldown_size,
+      scroll = this.scroll_offset,
+      cur = this.current_row,
+      matches = this.matches;
 
     if (this.log) {
       this.debug(
@@ -749,15 +750,15 @@ class MOAutocompleter {
 
   // Make menu visible if nonempty.
   make_menu_visible(matches, size, scroll) {
-    const menu = this.pulldown_elem;
-    const inner = menu.children[0];
+    const menu = this.pulldown_elem,
+      inner = menu.children[0];
 
     if (matches.length > 0) {
       // console.log("Matches:" + matches)
-      const top = this.input_elem.offsetTop;
-      const left = this.input_elem.offsetLeft;
-      const hgt = this.input_elem.offsetHeight;
-      const scr = this.input_elem.scrollTop;
+      const top = this.input_elem.offsetTop,
+        left = this.input_elem.offsetLeft,
+        hgt = this.input_elem.offsetHeight,
+        scr = this.input_elem.scrollTop;
       menu.style.top = (top + hgt + scr) + "px";
       menu.style.left = left + "px";
 
@@ -842,26 +843,24 @@ class MOAutocompleter {
 
     // Sort and remove duplicates.
     this.matches = this.remove_dups(this.matches.sort());
-
     // Try to find old highlighted row in new set of options.
     this.update_current_row(last);
-
     // Reset width each time we change the options.
     this.current_width = this.input_elem.offsetWidth;
   }
 
   // When "acting like a select" make it display all options in the
   // order given right from the moment they enter the field.
-  // FIXME - make the year thing do an array
   update_select() {
     this.matches = this.primer;
   }
 
   // Grab all matches, doing exact match, ignoring number of words.
   update_normal() {
-    const val = this.input_elem.value.normalize().toLowerCase();
-    const primer = this.primer.map((str) => { return str.normalize() });
-    const matches = [];
+    const val = this.input_elem.value.normalize().toLowerCase(),
+      primer = this.primer.map((str) => { return str.normalize() }),
+      matches = [];
+
     if (val != '') {
       for (let i = 0; i < primer.length; i++) {
         let s = primer[i + 1];
@@ -870,21 +869,24 @@ class MOAutocompleter {
         }
       }
     }
+
     this.matches = matches;
   }
 
   // Grab matches ignoring order of words.
   update_unordered() {
     const val = this.input_elem.value.normalize().toLowerCase().
-      replace(/^ */, '').replace(/  +/g, ' ');
-    const vals = val.split(' ');
-    const primer = this.primer.map((str) => { return str.normalize() });
-    const matches = [];
+      replace(/^ */, '').replace(/  +/g, ' '),
+      vals = val.split(' '),
+      primer = this.primer.map((str) => { return str.normalize() }),
+      matches = [];
+
     if (val != '') {
       for (let i = 0; i < primer.length; i++) {
-        let s = primer[i + 1] || '';
-        let s2 = ' ' + s.toLowerCase() + ' ';
-        for (let k = 0; k < vals.length; k++) {
+        let s = primer[i + 1] || '',
+          s2 = ' ' + s.toLowerCase() + ' ',
+          k;
+        for (k = 0; k < vals.length; k++) {
           if (s2.indexOf(' ' + vals[k]) < 0) break;
         }
         if (k >= vals.length) {
@@ -892,17 +894,18 @@ class MOAutocompleter {
         }
       }
     }
+
     this.matches = matches;
   }
 
   // Grab all matches, preferring the ones with no additional words.
   // Note: order must have genera first, then species, then varieties.
   update_collapsed() {
-    const val = this.input_elem.value.toLowerCase();
-    const primer = this.primer;
+    const val = this.input_elem.value.toLowerCase(),
+      primer = this.primer,
+      primer_lc = this.primer.map((str) => { return str.toLowerCase() }),
+      matches = [];
 
-    const primer_lc = this.primer.map((str) => { return str.toLowerCase() });
-    const matches = [];
     if (val != "\n") {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse;
 
@@ -945,11 +948,12 @@ class MOAutocompleter {
   // otherwise highlight first match.
   update_current_row(val) {
     this.verbose("update_current_row()");
-    const matches = this.matches;
-    const size = this.pulldown_size;
-    let exact = -1;
-    let part = -1;
-    let new_scr, new_row, i;
+    const matches = this.matches,
+      size = this.pulldown_size;
+    let exact = -1,
+      part = -1,
+      new_scr, new_row, i;
+
     if (val && val.length > 0) {
       for (i = 0; i < matches.length; i++) {
         if (matches[i] == val) {
@@ -1030,8 +1034,8 @@ class MOAutocompleter {
 
     this.last_fetch_request = val;
 
-    const controller = new AbortController();
-    const signal = controller.signal;
+    const controller = new AbortController(),
+      signal = controller.signal;
 
     if (this.fetch_request)
       controller.abort();
@@ -1195,17 +1199,17 @@ class MOAutocompleter {
   }
 
   getScrollBarWidth() {
-    var inner, outer, w1, w2;
-    var body = document.body || document.getElementsByTagName("body")[0];
+    let inner, outer, w1, w2;
+    const body = document.body || document.getElementsByTagName("body")[0];
 
     if (scroll_bar_width != null)
       return scroll_bar_width;
 
-    var inner = document.createElement('p');
+    inner = document.createElement('p');
     inner.style.width = "100%";
     inner.style.height = "200px";
 
-    var outer = document.createElement('div');
+    outer = document.createElement('div');
     outer.style.position = "absolute";
     outer.style.top = "0px";
     outer.style.left = "0px";
@@ -1216,9 +1220,9 @@ class MOAutocompleter {
     outer.appendChild(inner);
 
     body.appendChild(outer);
-    var w1 = inner.offsetWidth;
+    w1 = inner.offsetWidth;
     outer.style.overflow = 'scroll';
-    var w2 = inner.offsetWidth;
+    w2 = inner.offsetWidth;
     if (w1 == w2) w2 = outer.clientWidth;
     body.removeChild(outer);
 

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -915,7 +915,6 @@ class MOAutocompleter {
 
     if (val != '' && primer.length > 1) {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse,
-        // val will have a trailing space, if a word has already been matched
         i = this.get_primer_index_of_substr(primer_lc, val);
 
       for (i; i <= primer_lc.length; i++) {
@@ -1020,10 +1019,13 @@ class MOAutocompleter {
   /**
   * ------------------------------ Search Token ------------------------------
   *
-  * This is the part of the user input for which we're currently requesting a
-  * server response for matches. In cases where the autocompleter accepts a
-  * `separator` (currently only ' OR ', on the advanced search page) the search
-  * token would be the part of the user input after that separator.
+  * The user input string for which we're currently requesting a server response
+  * for matches. Usually that's the whole string, but in cases where the
+  * autocompleter accepts a `separator` argument (currently only ' OR ', on the
+  * advanced search page) the new search token would be the segment of the user
+  * input string *after* that separator.
+  *
+  * That way, you get autocompletes for each part of "Agaricaceae OR Agaricales"
   */
 
   // Get search token under or immediately in front of cursor.

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -977,11 +977,10 @@ class MOAutocompleter {
     const matches = this.matches,
       size = this.pulldown_size;
     let exact = -1,
-      part = -1,
-      new_scr, new_row, i;
+      part = -1;
 
     if (val && val.length > 0) {
-      for (i = 0; i < matches.length; i++) {
+      for (let i = 0; i < matches.length; i++) {
         if (matches[i] == val) {
           exact = i;
           break;
@@ -991,18 +990,19 @@ class MOAutocompleter {
           part = i;
       }
     }
-    new_row = exact >= 0 ? exact : part >= 0 ? part : -1;
-    new_scr = this.scroll_offset;
-    if (new_scr > new_row)
-      new_scr = new_row;
-    if (new_scr > matches.length - size)
-      new_scr = matches.length - size;
-    if (new_scr < new_row - size + 1)
-      new_scr = new_row - size + 1;
-    if (new_scr < 0)
-      new_scr = 0;
+    let new_row = exact >= 0 ? exact : part >= 0 ? part : -1;
+    let new_scroll = this.scroll_offset;
+    if (new_scroll > new_row)
+      new_scroll = new_row;
+    if (new_scroll > matches.length - size)
+      new_scroll = matches.length - size;
+    if (new_scroll < new_row - size + 1)
+      new_scroll = new_row - size + 1;
+    if (new_scroll < 0)
+      new_scroll = 0;
+
     this.current_row = new_row;
-    this.scroll_offset = new_scr;
+    this.scroll_offset = new_scroll;
   }
 
   // ------------------------------ Fetch matches ------------------------------
@@ -1050,8 +1050,6 @@ class MOAutocompleter {
       this.debug("Sending AJAX request: " + val);
     }
 
-    // console.log("Sending AJAX request: " + val);
-
     // Need to doubly-encode this to prevent router from interpreting slashes,
     // dots, etc.
     const url = this.ajax_url.replace(
@@ -1070,7 +1068,6 @@ class MOAutocompleter {
       if (response.ok) {
         if (200 <= response.status && response.status <= 299) {
           response.json().then((json) => {
-            // console.log("json: " + json);
             this.process_fetch_response(json)
           }).catch((error) => {
             console.error("no_content:", error);
@@ -1095,7 +1092,6 @@ class MOAutocompleter {
 
     // Clear flag telling us request is pending.
     this.fetch_request = null;
-    // console.log("new_primer: " + new_primer);
 
     // Record string actually used to do matching: might be less strict
     // than one sent in request.

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -918,7 +918,7 @@ class MOAutocompleter {
         i = primer_lc.indexOf(val, i + 1)) {
         s = primer[i + 1];
         if (s.length > 0) {
-          if (the_rest || s.indexOf(' ', val.length - 1) < val.length - 1) {
+          if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);
             if (matches.length >= this.max_matches)
               break;

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -858,6 +858,7 @@ class MOAutocompleter {
   // Grab all matches, doing exact match, ignoring number of words.
   update_normal() {
     const val = this.input_elem.value.normalize().toLowerCase(),
+      // normalize the Unicode of each string in primer for search
       primer = this.primer.map((str) => { return str.normalize() }),
       matches = [];
 
@@ -875,17 +876,21 @@ class MOAutocompleter {
 
   // Grab matches ignoring order of words.
   update_unordered() {
+    // regularize spacing in the input
     const val = this.input_elem.value.normalize().toLowerCase().
       replace(/^ */, '').replace(/  +/g, ' '),
+      // get the separate words as vals
       vals = val.split(' '),
+      // normalize the Unicode of each string in primer for search
       primer = this.primer.map((str) => { return str.normalize() }),
       matches = [];
 
-    if (val != '') {
+    if (val != '' && primer.length > 1) {
       for (let i = 1; i <= primer.length; i++) {
         let s = primer[i] || '',
           s2 = ' ' + s.toLowerCase() + ' ',
           k;
+        // check each word in the primer entry for a matching word
         for (k = 0; k < vals.length; k++) {
           if (s2.indexOf(' ' + vals[k]) < 0) break;
         }
@@ -903,16 +908,19 @@ class MOAutocompleter {
   update_collapsed() {
     const val = this.input_elem.value.toLowerCase(),
       primer = this.primer,
+      // make a lowercased duplicate of primer to regularize search
       primer_lc = this.primer.map((str) => { return str.toLowerCase() }),
       matches = [];
 
-    if (val != "\n") {
-      let the_rest = (val.match(/ /g) || []).length >= this.collapse;
-      let i = primer_lc.indexOf(val.trim()) + 1;
+    if (val != '' && primer.length > 1) {
+      let the_rest = (val.match(/ /g) || []).length >= this.collapse,
+        // val will have a trailing space, if a word has already been matched
+        i = primer_lc.indexOf(val.trim()) + 1;
 
       for (i; i <= primer_lc.length; i++) {
         let s = primer[i];
-        if (s && s.length > 0) {
+
+        if (s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);
           } else if (matches.length > 1) {
@@ -927,11 +935,28 @@ class MOAutocompleter {
       }
       if (matches.length == 1 &&
         (val == matches[0].toLowerCase() ||
-          val == matches[0].toLowerCase() + " "))
+          val == matches[0].toLowerCase() + ' '))
         matches.pop();
     }
     this.matches = matches;
   }
+
+  /**
+   * Index of string in primer array with IDs
+   * where primer == [[text_string, id], [text_string, id]]
+   * @param primer {!Array} - the input array
+   * @param k {object} - the value to search
+   * @return {Array} or just i
+   */
+  // get_primer_index_of(primer, k) {
+  //   for (let i = 0; i < primer.length; i++) {
+  //     const index = primer[i].indexOf(k);
+  //     if (index > -1) {
+  //       // return [i, index];
+  //       return i;
+  //     }
+  //   }
+  // }
 
   // Remove duplicates from a sorted array.
   remove_dups(list) {

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -861,16 +861,12 @@ class MOAutocompleter {
   update_normal() {
     const val = this.input_elem.value.normalize().toLowerCase();
     const primer = this.primer.map((str) => { return str.normalize() });
-    // FIXME this iterator!
     const matches = [];
     if (val != '') {
-      let i, s;
-      for (i = 0; i < primer.length; i++) {
-        s = primer[i + 1];
-        if (s.length > 0 && s.toLowerCase().indexOf(val) >= 0) {
+      for (let i = 0; i < primer.length; i++) {
+        let s = primer[i + 1];
+        if (s && s.length > 0 && s.toLowerCase().indexOf(val) >= 0) {
           matches.push(s);
-          // if (matches.length >= this.pulldown_size)
-          //   break;
         }
       }
     }
@@ -885,17 +881,14 @@ class MOAutocompleter {
     const primer = this.primer.map((str) => { return str.normalize() });
     const matches = [];
     if (val != '') {
-      let i, k, s, s2;
-      for (i = 0; i < primer.length; i++) {
-        s = primer[i + 1] || '';
-        s2 = ' ' + s.toLowerCase() + ' ';
-        for (k = 0; k < vals.length; k++) {
+      for (let i = 0; i < primer.length; i++) {
+        let s = primer[i + 1] || '';
+        let s2 = ' ' + s.toLowerCase() + ' ';
+        for (let k = 0; k < vals.length; k++) {
           if (s2.indexOf(' ' + vals[k]) < 0) break;
         }
         if (k >= vals.length) {
           matches.push(s);
-          // if (matches.length >= this.pulldown_size)
-          //   break;
         }
       }
     }
@@ -918,16 +911,12 @@ class MOAutocompleter {
         if (s && s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);
-            // if (matches.length >= this.pulldown_size)
-            //   break;
           } else if (matches.length > 1) {
             break;
           } else {
             if (matches[0] == val)
               matches.pop();
             matches.push(s);
-            // if (matches.length >= this.pulldown_size)
-            //   break;
             the_rest = true;
           }
         }

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -865,7 +865,7 @@ class MOAutocompleter {
     const matches = [];
     if (val != '') {
       let i, s;
-      for (i = 0; i >= 0; i = primer.length - 1) {
+      for (i = 0; i < primer.length; i++) {
         s = primer[i + 1];
         if (s.length > 0 && s.toLowerCase().indexOf(val) >= 0) {
           matches.push(s);
@@ -912,9 +912,10 @@ class MOAutocompleter {
     const matches = [];
     if (val != "\n") {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse;
-      for (let i = primer_lc.indexOf(val); i >= 0;
+      let i, s;
+      for (i = primer_lc.indexOf(val); i >= 0;
         i = primer_lc.indexOf(val, i + 1)) {
-        let s = primer[i + 1];
+        s = primer[i + 1];
         if (s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length - 1) < val.length - 1) {
             matches.push(s);

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -905,14 +905,15 @@ class MOAutocompleter {
   // Grab all matches, preferring the ones with no additional words.
   // Note: order must have genera first, then species, then varieties.
   update_collapsed() {
-    const val = "\n" + this.input_elem.value.toLowerCase();
+    const val = this.input_elem.value.toLowerCase();
     const primer = this.primer;
 
-    const primer_lc = this.primer.toLowerCase();
+    const primer_lc = this.primer.map((str) => { return str.toLowerCase() });
     const matches = [];
     if (val != "\n") {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse;
       let i, s;
+      debugger;
       for (i = primer_lc.indexOf(val); i >= 0;
         i = primer_lc.indexOf(val, i + 1)) {
         s = primer[i + 1];

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -869,8 +869,8 @@ class MOAutocompleter {
         s = primer[i + 1];
         if (s.length > 0 && s.toLowerCase().indexOf(val) >= 0) {
           matches.push(s);
-          if (matches.length >= this.pulldown_size)
-            break;
+          // if (matches.length >= this.pulldown_size)
+          //   break;
         }
       }
     }
@@ -894,8 +894,8 @@ class MOAutocompleter {
         }
         if (k >= vals.length) {
           matches.push(s);
-          if (matches.length >= this.pulldown_size)
-            break;
+          // if (matches.length >= this.pulldown_size)
+          //   break;
         }
       }
     }
@@ -912,23 +912,22 @@ class MOAutocompleter {
     const matches = [];
     if (val != "\n") {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse;
-      let i, s;
-      debugger;
-      for (i = primer_lc.indexOf(val); i < primer_lc.length; i++) {
-        s = primer[i + 1];
+
+      for (let i = primer_lc.indexOf(val); i < primer_lc.length; i++) {
+        let s = primer[i + 1];
         if (s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);
-            if (matches.length >= this.pulldown_size)
-              break;
+            // if (matches.length >= this.pulldown_size)
+            //   break;
           } else if (matches.length > 1) {
             break;
           } else {
             if (matches[0] == val)
               matches.pop();
             matches.push(s);
-            if (matches.length >= this.pulldown_size)
-              break;
+            // if (matches.length >= this.pulldown_size)
+            //   break;
             the_rest = true;
           }
         }

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -882,8 +882,8 @@ class MOAutocompleter {
       matches = [];
 
     if (val != '') {
-      for (let i = 0; i < primer.length; i++) {
-        let s = primer[i + 1] || '',
+      for (let i = 1; i <= primer.length; i++) {
+        let s = primer[i] || '',
           s2 = ' ' + s.toLowerCase() + ' ',
           k;
         for (k = 0; k < vals.length; k++) {
@@ -908,9 +908,10 @@ class MOAutocompleter {
 
     if (val != "\n") {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse;
+      let i = primer_lc.indexOf(val.trim()) + 1;
 
-      for (let i = primer_lc.indexOf(val); i < primer_lc.length; i++) {
-        let s = primer[i + 1];
+      for (i; i <= primer_lc.length; i++) {
+        let s = primer[i];
         if (s && s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);

--- a/app/assets/javascripts/mo_autocompleter.js
+++ b/app/assets/javascripts/mo_autocompleter.js
@@ -869,7 +869,7 @@ class MOAutocompleter {
         s = primer[i + 1];
         if (s.length > 0 && s.toLowerCase().indexOf(val) >= 0) {
           matches.push(s);
-          if (matches.length >= this.max_matches)
+          if (matches.length >= this.pulldown_size)
             break;
         }
       }
@@ -894,7 +894,7 @@ class MOAutocompleter {
         }
         if (k >= vals.length) {
           matches.push(s);
-          if (matches.length >= this.max_matches)
+          if (matches.length >= this.pulldown_size)
             break;
         }
       }
@@ -914,13 +914,12 @@ class MOAutocompleter {
       let the_rest = (val.match(/ /g) || []).length >= this.collapse;
       let i, s;
       debugger;
-      for (i = primer_lc.indexOf(val); i >= 0;
-        i = primer_lc.indexOf(val, i + 1)) {
+      for (i = primer_lc.indexOf(val); i < primer_lc.length; i++) {
         s = primer[i + 1];
         if (s.length > 0) {
           if (the_rest || s.indexOf(' ', val.length) < val.length) {
             matches.push(s);
-            if (matches.length >= this.max_matches)
+            if (matches.length >= this.pulldown_size)
               break;
           } else if (matches.length > 1) {
             break;
@@ -928,7 +927,7 @@ class MOAutocompleter {
             if (matches[0] == val)
               matches.pop();
             matches.push(s);
-            if (matches.length >= this.max_matches)
+            if (matches.length >= this.pulldown_size)
               break;
             the_rest = true;
           }

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -16,7 +16,7 @@ module AjaxController::AutoComplete
 
     string = CGI.unescape(@id).strip_squeeze
     if string.blank?
-      render(json: ActiveSupport::JSON.encode(%W[\n \n]))
+      render(json: ActiveSupport::JSON.encode([]))
     else
       render(json: ActiveSupport::JSON.encode(auto_complete_results(string)))
     end
@@ -32,7 +32,6 @@ module AjaxController::AutoComplete
       params[:user_id] = @user&.id
     end
 
-    ::AutoComplete.subclass(@type).new(string, params).
-      matching_strings.push("\n")
+    ::AutoComplete.subclass(@type).new(string, params).matching_strings
   end
 end

--- a/app/controllers/ajax_controller/auto_complete.rb
+++ b/app/controllers/ajax_controller/auto_complete.rb
@@ -16,9 +16,9 @@ module AjaxController::AutoComplete
 
     string = CGI.unescape(@id).strip_squeeze
     if string.blank?
-      render(plain: "\n\n")
+      render(json: ActiveSupport::JSON.encode(%W[\n \n]))
     else
-      render(plain: auto_complete_results(string))
+      render(json: ActiveSupport::JSON.encode(auto_complete_results(string)))
     end
   end
 
@@ -33,6 +33,6 @@ module AjaxController::AutoComplete
     end
 
     ::AutoComplete.subclass(@type).new(string, params).
-      matching_strings.join("\n") + "\n"
+      matching_strings.push("\n")
   end
 end

--- a/app/views/search/_advanced_search_filter_text_field.html.erb
+++ b/app/views/search/_advanced_search_filter_text_field.html.erb
@@ -1,7 +1,15 @@
 <%=
+autocompleter = case filter.sym.to_s
+                when "region"
+                  "location"
+                else
+                  filter.sym.to_s
+                end
 between = help_note(:span, :"advanced_search_filter_#{filter.sym}".t)
 text_field_with_label(
   form: f, field: filter.sym, label: filter.name + ":",
-  between: between, value: @filter_defaults[filter.sym]
+  between: between, value: @filter_defaults[filter.sym],
+  data: { autocompleter: autocompleter,
+          autocomplete_separator: " OR " }
 )
 %>

--- a/test/controllers/ajax_controller_test.rb
+++ b/test/controllers/ajax_controller_test.rb
@@ -133,17 +133,17 @@ class AjaxControllerTest < FunctionalTestCase
     expect = m.sort.uniq
     expect.unshift("M")
     good_ajax_request(:auto_complete, type: :location, id: "Modesto")
-    assert_equal(expect, @response.body.split("\n"))
+    assert_equal(expect, JSON.parse(@response.body))
 
     login("roy") # prefers location_format: :scientific
     expect = m.map { |x| Location.reverse_name(x) }.sort.uniq
     expect.unshift("M")
     good_ajax_request(:auto_complete, type: :location, id: "Modesto")
-    assert_equal(expect, @response.body.split("\n"))
+    assert_equal(expect, JSON.parse(@response.body))
 
     login("mary") # prefers location_format: :postal
     good_ajax_request(:auto_complete, type: :location, id: "Xystus")
-    assert_equal(["X"], @response.body.split("\n"))
+    assert_equal(["X"], JSON.parse(@response.body))
   end
 
   def test_auto_complete_herbarium
@@ -154,18 +154,18 @@ class AjaxControllerTest < FunctionalTestCase
     expect = m.sort.uniq
     expect.unshift("D")
     good_ajax_request(:auto_complete, type: :herbarium, id: "Dick")
-    assert_equal(expect, @response.body.split("\n"))
+    assert_equal(expect, JSON.parse(@response.body))
   end
 
   def test_auto_complete_empty
     good_ajax_request(:auto_complete, type: :name, id: "")
-    assert_equal([], @response.body.split("\n"))
+    assert_equal([], JSON.parse(@response.body))
   end
 
   def test_auto_complete_name_above_genus
     expect = %w[F Fungi]
     good_ajax_request(:auto_complete, type: :clade, id: "Fung")
-    assert_equal(expect, @response.body.split("\n"))
+    assert_equal(expect, JSON.parse(@response.body))
   end
 
   def test_auto_complete_name
@@ -175,10 +175,10 @@ class AjaxControllerTest < FunctionalTestCase
     expect_species = expect.select { |n| n.include?(" ") }
     expect = ["A"] + expect_genera + expect_species
     good_ajax_request(:auto_complete, type: :name, id: "Agaricus")
-    assert_equal(expect, @response.body.split("\n"))
+    assert_equal(expect, JSON.parse(@response.body))
 
     good_ajax_request(:auto_complete, type: :name, id: "Umbilicaria")
-    assert_equal(["U"], @response.body.split("\n"))
+    assert_equal(["U"], JSON.parse(@response.body))
   end
 
   def test_auto_complete_project
@@ -186,15 +186,15 @@ class AjaxControllerTest < FunctionalTestCase
     b_titles = Project.where(Project[:title].matches_regexp("\\bB")).
                map(&:title).uniq
     good_ajax_request(:auto_complete, type: :project, id: "Babushka")
-    assert_equal((["B"] + b_titles).sort, @response.body.split("\n").sort)
+    assert_equal((["B"] + b_titles).sort, JSON.parse(@response.body).sort)
 
     p_titles = Project.where(Project[:title].matches_regexp("\\bP")).
                map(&:title).uniq
     good_ajax_request(:auto_complete, type: :project, id: "Perfidy")
-    assert_equal((["P"] + p_titles).sort, @response.body.split("\n").sort)
+    assert_equal((["P"] + p_titles).sort, JSON.parse(@response.body).sort)
 
     good_ajax_request(:auto_complete, type: :project, id: "Xystus")
-    assert_equal(["X"], @response.body.split("\n"))
+    assert_equal(["X"], JSON.parse(@response.body))
   end
 
   def test_auto_complete_species_list
@@ -205,13 +205,13 @@ class AjaxControllerTest < FunctionalTestCase
     assert_equal("List of mysteries", list3)
 
     good_ajax_request(:auto_complete, type: :species_list, id: "List")
-    assert_equal(["L", list1, list2, list3], @response.body.split("\n"))
+    assert_equal(["L", list1, list2, list3], JSON.parse(@response.body))
 
     good_ajax_request(:auto_complete, type: :species_list, id: "Mojo")
-    assert_equal(["M", list3], @response.body.split("\n"))
+    assert_equal(["M", list3], JSON.parse(@response.body))
 
     good_ajax_request(:auto_complete, type: :species_list, id: "Xystus")
-    assert_equal(["X"], @response.body.split("\n"))
+    assert_equal(["X"], JSON.parse(@response.body))
   end
 
   def test_auto_complete_user
@@ -219,18 +219,18 @@ class AjaxControllerTest < FunctionalTestCase
     assert_equal(
       ["R", "rolf <Rolf Singer>", "roy <Roy Halling>",
        "second_roy <Roy Rogers>"],
-      @response.body.split("\n")
+      JSON.parse(@response.body)
     )
 
     good_ajax_request(:auto_complete, type: :user, id: "Dodo")
-    assert_equal(["D", "dick <Tricky Dick>"], @response.body.split("\n"))
+    assert_equal(["D", "dick <Tricky Dick>"], JSON.parse(@response.body))
 
     good_ajax_request(:auto_complete, type: :user, id: "Komodo")
     assert_equal(["K", "#{katrina.login} <#{katrina.name}>"],
-                 @response.body.split("\n"))
+                 JSON.parse(@response.body))
 
     good_ajax_request(:auto_complete, type: :user, id: "Xystus")
-    assert_equal(["X"], @response.body.split("\n"))
+    assert_equal(["X"], JSON.parse(@response.body))
   end
 
   def test_auto_complete_bogus

--- a/test/integration/capybara/random_integration_test.rb
+++ b/test/integration/capybara/random_integration_test.rb
@@ -6,7 +6,7 @@ class RandomIntegrationTest < CapybaraIntegrationTestCase
   # Test "/controller/action/type/id" route used by AJAX controller.
   def test_ajax_router
     visit("/ajax/auto_complete/name/Agaricus")
-    lines = page.html.split("\n")
+    lines = JSON.parse(page.html)
     assert_equal("A", lines.first)
     assert(lines.include?("Agaricus"))
     assert(lines.include?("Agaricus campestris"))


### PR DESCRIPTION
Converts `AjaxController::AutoComplete` to send a JSON-encoded array of matching strings, rather than a `\n`-delimited string that has to be split by the `MOAutocompleter` JS. Changes test expectations accordingly.

Likewise, converts the `MOAutocompleter` to deal with the array, simplifying the JS. 

JS notes: 
- Restores the ability to use a separator between search strings, which i had deleted not understanding it.
- Changes `MOAutocompleter` internal param names.
  - for "the big list we got from the server" from `options` to `primer`
  - for the search string from `token` to `search_token`
  - for the search string separator from `token` to `separator`
