### PR TITLE
Actually show projects on Observation#show page and add a test for it

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 

--- a/app/views/observations/show/_observation_details.html.erb
+++ b/app/views/observations/show/_observation_details.html.erb
@@ -4,12 +4,12 @@
 
 <%= observation_details_when_where_who(obs: obs) %>
 
-<% if @user
-  obs.projects.each do |project| %>
-    <%= "#{:PROJECT.t}: " %>
-    <%= link_to_object(project) %>
-    <br/>
-  <% end
+<%= tag.div(class: "obs-projects", id: "observation_projects") do
+  concat([tag.span("#{:PROJECTS.t}:")), tag.br].safe_join)
+  obs.projects.each do |project|
+    concat(tag.div(link_to_object(project), class: "indent"))
+  end
+end %>
 end %>
 
 <%= tag.p(class: "obs-specimen", id: "observation_specimen_available") do

--- a/app/views/observations/show/_observation_details.html.erb
+++ b/app/views/observations/show/_observation_details.html.erb
@@ -5,11 +5,10 @@
 <%= observation_details_when_where_who(obs: obs) %>
 
 <%= tag.div(class: "obs-projects", id: "observation_projects") do
-  concat([tag.span("#{:PROJECTS.t}:")), tag.br].safe_join)
+  concat([tag.span("#{:PROJECTS.t}:"), tag.br].safe_join)
   obs.projects.each do |project|
     concat(tag.div(link_to_object(project), class: "indent"))
   end
-end %>
 end %>
 
 <%= tag.p(class: "obs-specimen", id: "observation_specimen_available") do

--- a/app/views/observations/show/_observation_details.html.erb
+++ b/app/views/observations/show/_observation_details.html.erb
@@ -4,12 +4,12 @@
 
 <%= observation_details_when_where_who(obs: obs) %>
 
-<%= if @user
-  tag.div(class: "obs-projects", id: "observation_projects") do
-    obs.projects.each do |project|
-      tag.p("#{:PROJECT.t}: #{link_to_object(project)}")
-    end
-  end
+<% if @user
+  obs.projects.each do |project| %>
+    <%= "#{:PROJECT.t}: " %>
+    <%= link_to_object(project) %>
+    <br/>
+  <% end
 end %>
 
 <%= tag.p(class: "obs-specimen", id: "observation_specimen_available") do

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -102,6 +102,14 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:show, params: { id: obs.id })
   end
 
+  def test_show_project_observation
+    login
+    obs = observations(:owner_accepts_general_questions)
+    project = obs.projects[0]
+    get(:show, params: { id: obs.id })
+    assert_match(project.title, @response.body)
+  end
+
   def test_show_observation_change_thumbnail_size
     user = users(:small_thumbnail_user)
     login(user.name)


### PR DESCRIPTION
There was code that was supposed to display an observation's projects, but it didn't work.  This makes it visible.  I wasn't able to get the surrounding "<div>" to render so I got rid of it since it didn't seem to be providing any value.

Is there any good reason to only show projects only if `@user` is truthy?