### PR TITLE
Remove `PLATFORMS - arm64-darwin-22`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
-  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
I think it's wise to remove this line immediately from `Gemfile.lock` so it doesn't sneak into any branches and disable production. 

It's on `main` now, so it appeared on one of my branches when I merged `main` into it. It doesn't seem very foolproof to have to keep checking that.