### PR TITLE
Restrict SpeciesList "Remove"

### DIFF
--- a/app/views/species_lists/show.html.erb
+++ b/app/views/species_lists/show.html.erb
@@ -70,14 +70,16 @@ add_tab_set(species_list_show_tabs(list: @species_list))
                   <span><%= user_link(observation.user) %></span>:
                   <span><%= observation.when.web_date %></span>
                 </p>
-                <%= put_button(name: :REMOVE.t,
-                              path: observation_species_list_path(
-                                id: observation.id,
-                                species_list_id: @species_list.id,
-                                commit: "remove"
-                              ),
-                              class: "btn btn-default",
-                              data: { confirm: :are_you_sure.l }) %>
+                <% if check_permission(@species_list) %>
+                  <%= put_button(name: :REMOVE.t,
+                                 path: observation_species_list_path(
+                                   id: observation.id,
+                                   species_list_id: @species_list.id,
+                                   commit: "remove"
+                                 ),
+                                 class: "btn btn-default",
+                                 data: { confirm: :are_you_sure.l }) %>
+                <% end %>
               </div>
             </div>
           </div>

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -308,7 +308,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     assert_select(
       "form:match('action', ?)",
       %r{/observations/\d+/species_lists/#{list.id}/remove},
-      { count: 2 },
+      { count: observations.size },
       "Species List owner should get 1 Remove button per Observation"
     )
   end


### PR DESCRIPTION
Displays "Remove" Observation buttons only to the SpeciesList creator (and in admin mode).

I noticed this morning that the show SpeciesList page has "Remove" Observation buttons visible to all users. 
But they work only for the list owner. (Other users get "Permission denied" if they click the button.

This PR therefore displays the button only to the owner.