### PR TITLE
Make `table_helper` more versatile

### DIFF
--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -66,7 +66,7 @@ module TableHelper
     }.merge(args)
   end
 
-  # note: th are like cells, not rows
+  # <th> are cells analogous to <td>, not <tr>
   def make_col_headers(args)
     tag.tr(**args[:row_opts]) do
       if args[:headers].is_a?(Array)
@@ -74,7 +74,7 @@ module TableHelper
         th_args[:cell_opts] = th_args[:cell_opts].merge({ scope: "col" })
 
         args[:headers].map do |header|
-          make_header(header, th_args)
+          make_th(header, th_args)
         end.safe_join
       else
         args[:headers] # if a precomposed string, print as is (?)
@@ -82,7 +82,7 @@ module TableHelper
     end
   end
 
-  def make_header(header, args)
+  def make_th(header, args)
     tag.th(**args[:cell_opts]) { header.to_s }
   end
 
@@ -97,9 +97,9 @@ module TableHelper
 
         row.map.with_index do |cell, index|
           if index.zero? && args[:row_headers] == true
-            make_header(cell, th_args)
+            make_th(cell, th_args)
           else
-            make_cell(cell, args)
+            make_td(cell, args)
           end
         end.safe_join
       else
@@ -108,7 +108,7 @@ module TableHelper
     end
   end
 
-  def make_cell(cell, args)
+  def make_td(cell, args)
     tag.td(**args[:cell_opts]) { cell.to_s }
   end
 

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -37,7 +37,7 @@ module TableHelper
     table_opts = default_table_opts(args[:table_opts])
 
     tag.table(**table_opts) do
-      concat(make_col_headers(args)) if args[:header].present?
+      concat(make_col_headers(args)) if args[:headers].present?
 
       if args[:rows].present?
         concat(args[:rows].map do |row|
@@ -56,7 +56,7 @@ module TableHelper
   # table_opts defaults added above
   def default_table_args(args)
     {
-      header: [],
+      headers: [],
       rows: [],
       table_opts: {},
       header_opts: {},
@@ -66,17 +66,18 @@ module TableHelper
     }.merge(args)
   end
 
-  def make_col_headers(headers, args)
+  # note: th are like cells, not rows
+  def make_col_headers(args)
     tag.tr(**args[:row_opts]) do
-      if headers.is_a?(Array)
-        th_args = args
+      if args[:headers].is_a?(Array)
+        th_args = args.deep_dup
         th_args[:cell_opts] = th_args[:cell_opts].merge({ scope: "col" })
 
-        headers.map do |header|
+        args[:headers].map do |header|
           make_header(header, th_args)
         end.safe_join
       else
-        header
+        args[:headers] # if a precomposed string, print as is (?)
       end
     end
   end
@@ -90,7 +91,8 @@ module TableHelper
   def make_row(row, args)
     tag.tr(**args[:row_opts]) do
       if row.is_a?(Array)
-        th_args = args # don't overwrite args, keep assignment out of loop
+        # don't overwrite args, keep assignment out of loop
+        th_args = args.deep_dup
         th_args[:cell_opts] = th_args[:cell_opts].merge({ scope: "row" })
 
         row.map.with_index do |cell, index|

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -21,7 +21,7 @@ module TableHelper
   #   </table>
   #
   def make_table(rows, table_opts = {}, tr_opts = {}, td_opts = {})
-    content_tag(:table, table_opts) do
+    tag.table(table_opts) do
       rows.map do |row|
         make_row(row, tr_opts, td_opts) + make_line(row, td_opts)
       end.safe_join
@@ -41,14 +41,14 @@ module TableHelper
   end
 
   def make_cell(cell, td_opts = {})
-    content_tag(:td, cell.to_s, td_opts)
+    tag.td(cell.to_s, td_opts)
   end
 
   def make_line(_row, td_opts)
     colspan = td_opts[:colspan]
     if colspan
-      content_tag(:tr, class: "MatrixLine") do
-        content_tag(:td, tag.hr, class: "MatrixLine", colspan: colspan)
+      tag.tr(class: "MatrixLine") do
+        tag.td(tag.hr, class: "MatrixLine", colspan: colspan)
       end
     else
       safe_empty

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -23,8 +23,8 @@ module TableHelper
   # args: header, rows, table_opts, header_opts, row_opts, cell_opts
 
   def make_table(**args)
-    table_opts = default_table_opts(args[:table_opts])
     args = default_table_args(args)
+    table_opts = default_table_opts(args[:table_opts])
 
     tag.table(**table_opts) do
       if args[:header].present?
@@ -52,6 +52,7 @@ module TableHelper
     {
       header: [],
       rows: [],
+      table_opts: {},
       header_opts: {},
       row_opts: {},
       cell_opts: {}

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -3,7 +3,7 @@
 #  make_table                   # make table from list of arrays
 
 module TableHelper
-  # Create a table out of a list of Arrays.
+  # Create a table out of a list of Arrays and HTML options.
   #
   #   make_table([[1,2],[3,4]])
   #
@@ -20,19 +20,61 @@ module TableHelper
   #     </tr>
   #   </table>
   #
-  def make_table(rows, table_opts = {}, tr_opts = {}, td_opts = {})
-    tag.table(table_opts) do
-      rows.map do |row|
-        make_row(row, tr_opts, td_opts) + make_line(row, td_opts)
-      end.safe_join
+  # args: header, rows, table_opts, header_opts, row_opts, cell_opts
+
+  def make_table(**args)
+    table_opts = default_table_opts(args[:table_opts])
+    args = default_table_args(args)
+
+    tag.table(**table_opts) do
+      if args[:header].present?
+        concat(make_header(args[:header], args[:header_opts], args[:cell_opts]))
+      end
+      if args[:rows].present?
+        args[:rows].map do |row|
+          concat([
+            make_row(row, args[:row_opts], args[:cell_opts]),
+            make_line(args[:cell_opts])
+          ].safe_join)
+        end
+      end
     end
   end
 
-  def make_row(row, tr_opts = {}, td_opts = {})
-    content_tag(:tr, tr_opts) do
+  # Add the default bootstrap `table` CSS class without stomping other classes
+  def default_table_opts(table_opts = {})
+    table_opts[:class] = class_names(table_opts[:class], "table")
+    table_opts
+  end
+
+  # table_opts defaults added above
+  def default_table_args(args)
+    {
+      header: [],
+      rows: [],
+      header_opts: {},
+      row_opts: {},
+      cell_opts: {}
+    }.merge(args)
+  end
+
+  def make_header(header, header_opts, cell_opts)
+    tag.th(**header_opts) do
+      if header.is_a?(Array)
+        header.map do |cell|
+          make_cell(cell, cell_opts)
+        end.safe_join
+      else
+        header
+      end
+    end
+  end
+
+  def make_row(row, row_opts, cell_opts)
+    tag.tr(**row_opts) do
       if row.is_a?(Array)
         row.map do |cell|
-          make_cell(cell, td_opts)
+          make_cell(cell, cell_opts)
         end.safe_join
       else
         row
@@ -40,12 +82,13 @@ module TableHelper
     end
   end
 
-  def make_cell(cell, td_opts = {})
-    tag.td(cell.to_s, td_opts)
+  def make_cell(cell, cell_opts)
+    tag.td(**cell_opts) { cell.to_s }
   end
 
-  def make_line(_row, td_opts)
-    colspan = td_opts[:colspan]
+  # ?
+  def make_line(cell_opts)
+    colspan = cell_opts[:colspan]
     if colspan
       tag.tr(class: "MatrixLine") do
         tag.td(tag.hr, class: "MatrixLine", colspan: colspan)

--- a/app/helpers/table_helper.rb
+++ b/app/helpers/table_helper.rb
@@ -3,40 +3,46 @@
 #  make_table                   # make table from list of arrays
 
 module TableHelper
-  # Create a table out of a list of Arrays and HTML options.
+  # Create a table out of Arrays and HTML options.
   #
-  #   make_table([[1,2],[3,4]])
+  #   make_table(
+  #     header: ["This", "That"],
+  #     rows: [[1,2],[3,4]]),
+  #     table_opts: { class: "table-striped" },
+  #     cell_opts: { class: "mr-4" }
+  #   )
   #
   # Produces:
   #
-  #   <table>
+  #   <table class="table table-striped">
   #     <tr>
-  #       <td>1</td>
-  #       <td>2</td>
+  #       <th class="mr-4">This</td>
+  #       <th class="mr-4">That</td>
   #     </tr>
   #     <tr>
-  #       <td>3</td>
-  #       <td>4</td>
+  #       <td class="mr-4">1</td>
+  #       <td class="mr-4">2</td>
+  #     </tr>
+  #     <tr>
+  #       <td class="mr-4">3</td>
+  #       <td class="mr-4">4</td>
   #     </tr>
   #   </table>
   #
   # args: header, rows, table_opts, header_opts, row_opts, cell_opts
+  #       row_headers (bool)
 
   def make_table(**args)
     args = default_table_args(args)
     table_opts = default_table_opts(args[:table_opts])
 
     tag.table(**table_opts) do
-      if args[:header].present?
-        concat(make_header(args[:header], args[:header_opts], args[:cell_opts]))
-      end
+      concat(make_col_headers(args)) if args[:header].present?
+
       if args[:rows].present?
-        args[:rows].map do |row|
-          concat([
-            make_row(row, args[:row_opts], args[:cell_opts]),
-            make_line(args[:cell_opts])
-          ].safe_join)
-        end
+        concat(args[:rows].map do |row|
+          make_row(row, args)
+        end.safe_join)
       end
     end
   end
@@ -55,15 +61,19 @@ module TableHelper
       table_opts: {},
       header_opts: {},
       row_opts: {},
-      cell_opts: {}
+      cell_opts: {},
+      row_headers: false
     }.merge(args)
   end
 
-  def make_header(header, header_opts, cell_opts)
-    tag.th(**header_opts) do
-      if header.is_a?(Array)
-        header.map do |cell|
-          make_cell(cell, cell_opts)
+  def make_col_headers(headers, args)
+    tag.tr(**args[:row_opts]) do
+      if headers.is_a?(Array)
+        th_args = args
+        th_args[:cell_opts] = th_args[:cell_opts].merge({ scope: "col" })
+
+        headers.map do |header|
+          make_header(header, th_args)
         end.safe_join
       else
         header
@@ -71,31 +81,44 @@ module TableHelper
     end
   end
 
-  def make_row(row, row_opts, cell_opts)
-    tag.tr(**row_opts) do
+  def make_header(header, args)
+    tag.th(**args[:cell_opts]) { header.to_s }
+  end
+
+  # pass row_headers: true to get a <th scope="row"> instead of <td>
+  # at the head of each row.
+  def make_row(row, args)
+    tag.tr(**args[:row_opts]) do
       if row.is_a?(Array)
-        row.map do |cell|
-          make_cell(cell, cell_opts)
+        th_args = args # don't overwrite args, keep assignment out of loop
+        th_args[:cell_opts] = th_args[:cell_opts].merge({ scope: "row" })
+
+        row.map.with_index do |cell, index|
+          if index.zero? && args[:row_headers] == true
+            make_header(cell, th_args)
+          else
+            make_cell(cell, args)
+          end
         end.safe_join
       else
-        row
+        row # if the row is a string, we're not going to force row headers
       end
     end
   end
 
-  def make_cell(cell, cell_opts)
-    tag.td(**cell_opts) { cell.to_s }
+  def make_cell(cell, args)
+    tag.td(**args[:cell_opts]) { cell.to_s }
   end
 
   # ?
-  def make_line(cell_opts)
-    colspan = cell_opts[:colspan]
-    if colspan
-      tag.tr(class: "MatrixLine") do
-        tag.td(tag.hr, class: "MatrixLine", colspan: colspan)
-      end
-    else
-      safe_empty
-    end
-  end
+  # def make_line(cell_opts)
+  #   colspan = cell_opts[:colspan]
+  #   if colspan
+  #     tag.tr(class: "MatrixLine") do
+  #       tag.td(tag.hr, class: "MatrixLine", colspan: colspan)
+  #     end
+  #   else
+  #     safe_empty
+  #   end
+  # end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -33,11 +33,11 @@ module VersionsHelper
   #   </p>
   #
   def show_past_versions(obj, args = {})
-    table = make_table(build_version_table(obj, args),
-                       class: "table table-condensed")
-    panel = content_tag(:div, table, class: "panel-body")
+    table = make_table(rows: build_version_table(obj, args),
+                       table_opts: { class: "mb-0" })
+    panel = tag.div(table, class: "panel-body")
     tag.strong("#{:VERSIONS.t}:") +
-      content_tag(:div, panel, class: "panel panel-default")
+      tag.div(panel, class: "panel panel-default")
   end
 
   private
@@ -59,9 +59,9 @@ module VersionsHelper
 
   def build_version_table(obj, args)
     obj.versions.reverse.map do |ver|
-      [find_version_date(ver), indent,
-       find_version_user(ver), indent,
-       link_to_version(initial_version_link_text(ver, args), ver, obj), indent]
+      [find_version_date(ver),
+       find_version_user(ver),
+       link_to_version(initial_version_link_text(ver, args), ver, obj)]
     end
   end
 
@@ -92,7 +92,7 @@ module VersionsHelper
 
   def initial_version_link_text(ver, args)
     text = "#{:VERSION.t} #{ver.version}"
-    text = content_tag(:strong, text) if args[:bold]&.call(ver)
+    text = tag.strong(text) if args[:bold]&.call(ver)
     return text unless ver.respond_to?(:display_name)
 
     # keep this out of the above `strong` tag, because it has its own tags

--- a/app/views/glossary_terms/versions/show.html.erb
+++ b/app/views/glossary_terms/versions/show.html.erb
@@ -5,15 +5,16 @@ add_page_title(:show_past_glossary_term_title.t(
 ))
 
 add_tab_set(glossary_term_version_tabs(term: @glossary_term))
+@container = :wide
 %>
 
 <div class="row">
-  <div class="col-xs-8">
+  <div class="col-md-6">
     <%= render(partial: "glossary_terms/glossary_term",
                object: @glossary_term,
                locals: { synonyms: false }) %>
   </div>
-  <div class="col-xs-4">
+  <div class="col-md-6">
     <%= show_past_versions(@glossary_term) %>
   </div>
 </div><!--.row-->

--- a/app/views/images/exif/_data.html.erb
+++ b/app/views/images/exif/_data.html.erb
@@ -1,1 +1,1 @@
-<%= make_table(data, { class: "table table-striped" }) %>
+<%= make_table(rows: data, table_opts: { class: "table-striped mb-0" }) %>

--- a/test/helpers/table_helper_test.rb
+++ b/test/helpers/table_helper_test.rb
@@ -16,7 +16,7 @@ class TableHelperTest < ActionView::TestCase
   def test_make_table_with_colspan
     expect = "<table class=\"table\"><tr colspan=\"2\"><td>5</td><td>6</td>" \
              "</tr></table>"
-    table = make_table(rows:[[5, 6]], row_opts: { colspan: 2 })
+    table = make_table(rows: [[5, 6]], row_opts: { colspan: 2 })
     assert_equal(expect, table)
   end
 

--- a/test/helpers/table_helper_test.rb
+++ b/test/helpers/table_helper_test.rb
@@ -2,27 +2,68 @@
 
 require("test_helper")
 
-# test the table helpers
+# test the table helpers.
 class TableHelperTest < ActionView::TestCase
   include ContentHelper
 
   def test_make_table
-    expect = "<table class=\"table\"><tr><td>1</td><td>2</td></tr>" \
-             "<tr><td>3</td><td>4</td></tr></table>"
+    expect = "<table class=\"table\">" \
+             "<tr><td>1</td><td>2</td></tr>" \
+             "<tr><td>3</td><td>4</td></tr>" \
+             "</table>"
     table = make_table(rows: [[1, 2], [3, 4]])
     assert_equal(expect, table)
   end
 
-  def test_make_table_with_colspan
-    expect = "<table class=\"table\"><tr colspan=\"2\"><td>5</td><td>6</td>" \
-             "</tr></table>"
+  def test_make_table_with_table_opts
+    expect = "<table class=\"yama table\">" \
+             "<tr><td>1</td><td>2</td></tr>" \
+             "<tr><td>3</td><td>4</td></tr>" \
+             "</table>"
+    table = make_table(table_opts: { class: "yama" }, rows: [[1, 2], [3, 4]])
+    assert_equal(expect, table)
+  end
+
+  def test_make_table_with_row_opts
+    expect = "<table class=\"table\">" \
+             "<tr colspan=\"2\"><td>5</td><td>6</td></tr>" \
+             "</table>"
     table = make_table(rows: [[5, 6]], row_opts: { colspan: 2 })
+    assert_equal(expect, table)
+  end
+
+  def test_make_table_with_cell_opts
+    expect = "<table class=\"table\">" \
+             "<tr><td class=\"hi\">5</td><td class=\"hi\">6</td></tr>" \
+             "</table>"
+    table = make_table(rows: [[5, 6]], cell_opts: { class: "hi" })
     assert_equal(expect, table)
   end
 
   def test_make_table_row_without_columns
     expect = "<table class=\"table\"><tr>row without columns</tr></table>"
     table = make_table(rows: ["row without columns"])
+    assert_equal(expect, table)
+  end
+
+  def test_make_table_with_col_headers
+    expect = "<table class=\"table\">" \
+             "<tr><th scope=\"col\">This</th><th scope=\"col\">That</th></tr>" \
+             "<tr><td>1</td><td>2</td></tr>" \
+             "<tr><td>3</td><td>4</td></tr>" \
+             "</table>"
+    table = make_table(headers: %w[This That], rows: [[1, 2], [3, 4]])
+    assert_equal(expect, table)
+  end
+
+  def test_make_table_with_col_and_row_headers
+    expect = "<table class=\"table\">" \
+             "<tr><th scope=\"col\">This</th><th scope=\"col\">That</th></tr>" \
+             "<tr><th scope=\"row\">1</th><td>2</td></tr>" \
+             "<tr><th scope=\"row\">3</th><td>4</td></tr>" \
+             "</table>"
+    table = make_table(headers: %w[This That], rows: [[1, 2], [3, 4]],
+                       row_headers: true)
     assert_equal(expect, table)
   end
 end

--- a/test/helpers/table_helper_test.rb
+++ b/test/helpers/table_helper_test.rb
@@ -7,21 +7,22 @@ class TableHelperTest < ActionView::TestCase
   include ContentHelper
 
   def test_make_table
-    expect = "<table><tr><td>1</td><td>2</td></tr>" \
+    expect = "<table class=\"table\"><tr><td>1</td><td>2</td></tr>" \
              "<tr><td>3</td><td>4</td></tr></table>"
-    table = make_table([[1, 2], [3, 4]])
+    table = make_table(rows: [[1, 2], [3, 4]])
     assert_equal(expect, table)
   end
 
   def test_make_table_with_colspan
-    expect = '<table><tr colspan="2"><td>5</td><td>6</td></tr></table>'
-    table = make_table([[5, 6]], {}, { colspan: 2 })
+    expect = "<table class=\"table\"><tr colspan=\"2\"><td>5</td><td>6</td>" \
+             "</tr></table>"
+    table = make_table(rows:[[5, 6]], row_opts: { colspan: 2 })
     assert_equal(expect, table)
   end
 
   def test_make_table_row_without_columns
-    expect = "<table><tr>row without columns</tr></table>"
-    table = make_table(["row without columns"])
+    expect = "<table class=\"table\"><tr>row without columns</tr></table>"
+    table = make_table(rows: ["row without columns"])
     assert_equal(expect, table)
   end
 end


### PR DESCRIPTION
Adds some args and defaults to the parameters of `table_helper` so it can build headers in addition to rows, hopefully useful outside the two cases where it's currently implemented. Also: it's all `kwargs` now, so people can omit defaults they don't need (including the headers).

Adds new tests for the new args.

I have an immediate use for it on the Account/APIKeys PR.