### PR TITLE
x86_64-darwin-22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Adds x86_64-darwin-22 platform to Gemfile.lock

Appears tohave been added by `bundle install` on
both my iMac and MacBookPro, both of which have
Intel processors and run macOS Ventura 13.6