### PR TITLE
Fix system test case host and port

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -25,8 +25,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     # needed for cuprite
     Capybara.server = :webrick
     # Capybara.current_driver = :cuprite
-    # Capybara.server_host = "localhost"
-    # Capybara.server_port = 3000
+    Capybara.server_host = "localhost"
+    Capybara.server_port = 3000
     # Normalize whitespaces when using `has_text?` and similar matchers,
     # i.e., ignore newlines, trailing spaces, etc.
     # That makes tests less dependent on slight UI changes.


### PR DESCRIPTION
The host/port settings were commented out, and just had to be uncommented. 

Caused Google Maps API not to load in a system test because the localhost was not correctly set (host defaults to 127.0.0.1, which is not authorized in our API key at google). 