### PR TITLE
Make `Mappable::CollapsibleCollectionOfObjects` attributes accessible also

### DIFF
--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -50,22 +50,23 @@
 
 module Mappable
   class CollapsibleCollectionOfObjects
+    attr_accessor :sets, :extents, :representative_points
+
     def initialize(objects, max_objects = MO.max_map_objects)
       @max_objects = max_objects
       init_sets(objects)
       group_objects_into_sets
+      init_derived_attributes
     end
 
     def mapsets
       @sets.values
     end
 
-    def extents
-      @extents ||= calc_extents
-    end
-
-    def representative_points
-      [extents.north_west, extents.center, extents.south_east]
+    def init_derived_attributes
+      @extents = calc_extents
+      @representative_points =
+        [@extents.north_west, @extents.center, @extents.south_east]
     end
 
     private


### PR DESCRIPTION
Similar to #1689 - turns out we need the collection's attributes available in JS too