### PR TITLE
GitHub CI config.yml - remove Firefox, install Chromium 

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -28,8 +28,11 @@ jobs:
       - name: Install additional tools
         run: sudo apt-get install exiftool
 
-      - name: Install Firefox
-        run: sudo apt-get install firefox
+      # - name: Install Firefox
+      #   run: sudo apt-get install firefox
+
+      - name: Install Chrome/Chromium
+        run: sudo apt-get install chromium-browser
 
       # MySQL is installed but does not run by default
       # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#mysql


### PR DESCRIPTION
There's presently a CI failure related to trying to load a font dependency of Firefox, and so CI is currently erroring-out running any tests. This is a quick fix to check if i can get tests going again.

Now that I am reading our `ci_rails.yml` file, I cannot imagine how our system tests could have been running on GitHub CI at all, since Cuprite can only run in Chromium. And because I forgot to change this file when i switched our system tests to Cuprite, Chromium has not been loaded in `ci_rails.yml`, only Firefox. Maybe CI already has Chrome preconfigured? I don't get it. 