### PR TITLE
Queued emails can now have to_user == null, meaning send to webmaster.

### DIFF
--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -20,45 +20,37 @@ namespace :email do
       # Has it been queued (and unchanged) for MO.email_queue_delay or more.
       if e.queued + MO.email_queue_delay.seconds < now
 
-        # Sent successfully.  (Delete it without sending if user isn't local!
-        # This shouldn't happen, but just in case, better safe...)
-        if e.to_user
-          result = nil
-          Rails.root.join("log/email-low-level.log").open("a") do |fh|
-            fh.puts("sending #{e.id.inspect}...")
-            result = e.send_email
-            fh.puts(
-              "sent #{e.id.inspect} = #{result ? result.class.name : "false"}"
-            )
-          end
+        result = nil
+        Rails.root.join("log/email-low-level.log").open("a") do |fh|
+          fh.puts("sending #{e.id.inspect}...")
+          result = e.send_email
+          fh.puts(
+            "sent #{e.id.inspect} = #{result ? result.class.name : "false"}"
+          )
+        end
 
-          # Destroy if sent successfully.
-          if result
-            e.destroy
-            count += 1
-
-          # After a few tries give up and delete it.
-          elsif e.num_attempts && (e.num_attempts >= MO.email_num_attempts - 1)
-            File.open(MO.email_log, "a") do |fh|
-              fh.puts(format("Failed to send email #%d at %s", e.id, now))
-              fh.puts(e.dump)
-            end
-            e.destroy
-
-          # Schedule next attempt for 5 minutes later.
-          else
-            e.queued = now
-            if e.num_attempts
-              e.num_attempts += 1
-            else
-              e.num_attempts = 1
-            end
-            e.save
-          end
-        else
+        # Destroy if sent successfully.
+        if result
           e.destroy
           count += 1
 
+        # After a few tries give up and delete it.
+        elsif e.num_attempts && (e.num_attempts >= MO.email_num_attempts - 1)
+          File.open(MO.email_log, "a") do |fh|
+            fh.puts(format("Failed to send email #%d at %s", e.id, now))
+            fh.puts(e.dump)
+          end
+          e.destroy
+
+        # Schedule next attempt for 5 minutes later.
+        else
+          e.queued = now
+          if e.num_attempts
+            e.num_attempts += 1
+          else
+            e.num_attempts = 1
+          end
+          e.save
         end
       end
     end


### PR DESCRIPTION
This removes a sanity check from `rake email:send` which caused it to silently throw away emails with null recipient.  This used to make sense... sorta... at least as a way to reduce junk error messages.  But now that *all* emails, including those to webmaster, are queued, it means that recipient can legitimately be null (that means the recipient is webmaster).  The obvious solution was simply to remove the sanity check.  Hopefully this doesn't create a whole mess of cronjob error messages!

@nimmolo and @JoeCohen -- The problem here, I believe, is that rake tasks are not unit tested.  The seemingly obvious solution is to move the guts of lib/tasks/email.rb into app/models/queued_email.rb so that it can be unit tested properly.  Then the only thing in lib/tasks/email.rb is `QueuedEmail.send_emails` and really doesn't matter that it's not tested.  Does that sound like a plan?