### PR TITLE
Bullet - skip new counter-cache warning

### DIFF
--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -16,7 +16,11 @@ class SpeciesListsController < ApplicationController
     # Bullet wants us to eager load synonyms for @deprecated_names in
     # edit_species_list, and I thought it would be possible, but I can't
     # get it to work.  Seems toooo minor to waste any more time on.
-    :update
+    # Also, as of 20231212, it wants a cached column for Observation.name,
+    # but this is not as simple as an AR default column_cache because count
+    # needs to be recalculated whenever an observation's consensus name
+    # changes, not just on create or destroy of the Observation.name.
+    :create, :update
   ]
 
   # Used by ApplicationController to dispatch #index to a private method

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -115,6 +115,8 @@ MushroomObserver::Application.configure do
       Bullet.unused_eager_loading_enable = false
       # Bullet.add_safelist(type: :n_plus_one_query, class_name: "Post",
       #                     association: :comments)
+      Bullet.add_safelist(type: :counter_cache, class_name: "Name",
+                          association: :observations)
     end
   end
 end


### PR DESCRIPTION
Updating the `bullet` gem brought up a new class of warning: missing counter caches on tables.

Rails counter-caches are convenient because the caching column, once generated and populated, automatically updates on `create` or `destroy` of the association. But creating one for the count of observations belonging to a name is not so easy to set up, because it must also trigger a recount every time an obs' consensus name changes.

This PR silences `bullet` notifications for this particluar association.