### PR TITLE
Fix screwy logged-out layouts

### DIFF
--- a/app/views/application/top_nav/_login.html.erb
+++ b/app/views/application/top_nav/_login.html.erb
@@ -1,4 +1,4 @@
-<div class="nav navbar-nav navbar-form navbar-right hidden-xs m-0">
+<div class="nav navbar-nav navbar-form navbar-right hidden-xs m-0 px-0">
   <p class="form-control-static">
     <%= link_to(
           :app_login.t, new_account_login_path,

--- a/app/views/comments/_comments_for_object.erb
+++ b/app/views/comments/_comments_for_object.erb
@@ -11,7 +11,7 @@ tag.div(
   class: "panel panel-default", id: "comments_for_object",
   data: { controller: "section-update", updated_by: "modal_comment" }
 ) do
-  [
+  concat([
     tag.div(class: "panel-heading") do
       tag.h4(:COMMENTS.t, class: "panel-title")
     end,
@@ -23,16 +23,18 @@ tag.div(
           concat(render(partial: "comments/comment", object: comment))
         end
       end
-    end,
+    end
+  ].safe_join)
+  concat(
     tag.div(class: "panel-footer") do
       concat(
         modal_link_to("comment", *new_comment_tab(object))
-      ) if controls
+      )
       concat(
         link_to(:show_comments_and_more.t(num: and_more),
                 comments_path(target: object.id, type: object.class.name),
                 class: "float-right")
       ) if limit && and_more > 0
     end
-  ].safe_join
+  ) if controls
 end %>

--- a/app/views/comments/_update_comments_for_object.erb
+++ b/app/views/comments/_update_comments_for_object.erb
@@ -1,5 +1,5 @@
 <%#
-// Re-render the whole comments_for_object block and hide the modal.
+// Re-render the whole comments_for_object block.
 // comments_for_object needs locals: object, controls, limit
 // create or update should provide.
 %>
@@ -7,17 +7,7 @@
 <%= turbo_stream.replace("comments_for_object") do
   render(
     partial: "comments/comments_for_object",
-    locals: { object: @target, controls: true, limit: nil },
+    locals: { object: @target, controls: @user, limit: nil },
     layout: false
   )
 end %>
-
-<%#
-Need a controller to close the modal here?
-section_update handles it for any other section, but not this one.
-// Finally, remove the modal if present (not in delete)
-var modal = $("#modal_comment")
-if(modal.length) {
-  $(".modal").attr('data-busy', 'false').modal('hide');
-}
-%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,9 +46,9 @@ body_class = class_names(whos_calling, theme_class)
       <main id="content" class="<%= container_class %>"
             data-controller="lightgallery">
 
-        <% unless @user&.verified? %>
-          <%= render(partial: "application/content/login_layout") %>
-        <% end %>
+        <%# unless @user&.verified? %>
+          <%# render(partial: "application/content/login_layout") %>
+        <%# end %>
 
         <!--MAIN_PAGE_CONTENT-->
         <%= yield %>

--- a/app/views/locations/descriptions/show.html.erb
+++ b/app/views/locations/descriptions/show.html.erb
@@ -19,6 +19,6 @@ add_tab_set(show_description_tabs(description: @description))
   <%= render(partial: "locations/descriptions/show/location_description",
              object: @description) %>
   <%= render(partial: "comments/comments_for_object",
-              locals: {object: @description, controls: true, limit: 10}) %>
+              locals: {object: @description, controls: @user, limit: 10}) %>
   <%= show_object_footer(@description) %>
 </div><!--.container-text-->

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -20,7 +20,7 @@ add_tab_set(location_show_tabs(location: @location))
 <%= render(partial: "locations/show/location", object: @location) %>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @location, controls: true, limit: 2 }) %>
+           locals: { object: @location, controls: @user, limit: 2 }) %>
 
 <div class="container-text">
   <% if @description&.notes? %>
@@ -29,7 +29,7 @@ add_tab_set(location_show_tabs(location: @location))
     <%= render(partial: "locations/descriptions/show/location_description",
                object: @description) %>
     <%= render(partial: "comments/comments_for_object",
-               locals: { object: @description, controls: true, limit: 2 }) %>
+               locals: { object: @description, controls: @user, limit: 2 }) %>
     <hr/>
   <% end %>
 

--- a/app/views/names/descriptions/show.html.erb
+++ b/app/views/names/descriptions/show.html.erb
@@ -22,6 +22,6 @@ add_tab_set(show_description_tabs(description: @description))
 <%= render(partial: "names/descriptions/show/name_description",
            object: @description, locals: { review: true }) %>
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @description, controls: true, limit: 10 }
+           locals: { object: @description, controls: @user, limit: 10 }
           ) if false%>
 <%= show_object_footer(@description) %>

--- a/app/views/names/show.html.erb
+++ b/app/views/names/show.html.erb
@@ -63,6 +63,6 @@ add_tab_set(name_show_tabs(name: @name, user: @user))
   # ----------------------------------------
 %>
 <%= render(partial: "comments/comments_for_object",
-           locals: {object: @name, controls: true, limit: nil}) %>
+           locals: {object: @name, controls: @user, limit: nil}) %>
 <%= :show_name_num_notifications.t(num: @name.interests) %>
 <%= show_object_footer(@name) %>

--- a/app/views/observations/show.html.erb
+++ b/app/views/observations/show.html.erb
@@ -53,7 +53,7 @@ carousel_locals = {
     <% end %>
 
     <%= render(partial: "comments/comments_for_object",
-               locals: { object: @observation, controls: true, limit: nil }) %>
+               locals: { object: @observation, controls: @user, limit: nil }) %>
 
     <%= @observation.source_credit.tpl if @observation.source_noteworthy? %>
   </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -98,6 +98,6 @@ add_project_banner(@project)
 </p>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @project, controls: true, limit: nil }) %>
+           locals: { object: @project, controls: @user, limit: nil }) %>
 
 <%= show_object_footer(@project) %>

--- a/app/views/species_lists/show.html.erb
+++ b/app/views/species_lists/show.html.erb
@@ -96,6 +96,6 @@ add_tab_set(species_list_show_tabs(list: @species_list))
 <% end %>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @species_list, controls: true, limit: nil }) %>
+           locals: { object: @species_list, controls: @user, limit: nil }) %>
 
 <%= show_object_footer(@species_list) %>

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -76,9 +76,7 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     find("#content_filter_region").click
     browser.keyboard.type("USA, Calif")
     assert_selector(".auto_complete") # wait
-    # assert_selector(".auto_complete ul li", count: 10)
     browser.keyboard.type(:down, :tab)
-    # sleep(1)
     assert_field("content_filter_region", with: "USA, California")
 
     # Autocompleter's OR separator not working yet.
@@ -95,9 +93,10 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     visit(observation_path(obs.id))
 
     scroll_to(find("#observation_namings"), align: :center)
-    click_on("Propose")
-    assert_selector("#modal_naming_#{obs.id}", wait: 6)
-    assert_selector("#naming_#{obs.id}_form")
+    assert_link(text: /Propose/)
+    click_link(text: /Propose/)
+    assert_selector("#modal_naming_#{obs.id}", wait: 9)
+    assert_selector("#naming_#{obs.id}_form", wait: 9)
     find_field("naming_name").click
     browser.keyboard.type("Peltige")
     assert_selector(".auto_complete", wait: 3) # wait

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -230,6 +230,7 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     end
 
     assert_selector("#modal_naming_#{obs.id}", wait: 9)
+    assert_selector("#naming_#{obs.id}_form", wait: 9)
     within("#naming_#{obs.id}_form") do
       assert_field("naming_name", wait: 4)
       # fill_in("naming_name", with: nd1.text_name)


### PR DESCRIPTION
### login_layout ###
Try navigating around the production site as a logged-out visitor.  There's an old partial being displayed above the page title that interrupts page layout and "introduces the site", but seems inappropriate. 

![Screen Shot 2023-12-13 at 12 35 42 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/e3a22b9b-0d43-4278-b5b9-b5848a697f5d)

This PR removes it,  but temporarily keeps it as a comment, in case we can figure out what to use it for. If you need to log in, the app redirects you to the login page, but I don't think it should display this partial if you're just poking around.

### Comments ###
Removes the inappropriate "Add Comment" button on all layouts for logged-out visitors

![Screen Shot 2023-12-13 at 12 51 49 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/6ac5fac3-24b6-4adf-98cf-449577586d8f)
