### PR TITLE
Add `action_cable` in config/application

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require("action_mailer/railtie")
 # require("action_mailbox/engine")
 # require("action_text/engine")
 require("action_view/railtie")
-# require("action_cable/engine")
+require("action_cable/engine")
 require("sprockets/railtie")
 require("rails/test_unit/railtie")
 


### PR DESCRIPTION
Could have been in the Rails 7 PR.  Not using yet, however it's part of core Rails and required for experimenting with Turbo 8.