### PR TITLE
Restore "image notes" caption in lightbox

### DIFF
--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -18,6 +18,8 @@ module LightboxHelper
     html = []
     if obs.is_a?(Observation)
       html += lightbox_obs_caption(obs, lightbox_data[:identify])
+    elsif lightbox_data[:image]&.notes.present?
+      html << lightbox_image_caption(lightbox_data[:image])
     end
     html << caption_image_links(lightbox_data[:image] ||
                                 lightbox_data[:image_id])
@@ -34,6 +36,14 @@ module LightboxHelper
     html << observation_details_when_where_who(obs: obs)
     html << caption_truncated_notes(obs: obs)
     html
+  end
+
+  # This is the same caption that goes after the copyright info,
+  # but we are skipping that here because it is slow as hell
+  # (requires extra joins all over the place, as far afield as projects,
+  # on every page where an image appears!)
+  def lightbox_image_caption(image)
+    tag.div(image.notes.tl.truncate_html(300), class: "image-notes")
   end
 
   # This gets removed on successful propose


### PR DESCRIPTION
Alan's request. Without this, the image notes are only available to the owner on the edit image screen.

Previously they appeared with the image copyright info, but printing this in the lightbox on every image requires tons of superfluous eager loading (extra joins, for example to projects!) on every page where images appear.