### PR TITLE
Naming modals/forms: Unique identifiers

### DIFF
--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -106,9 +106,9 @@ module Observations
     def modal_identifier
       case action_name
       when "new", "create"
-        "naming_#{@observation.id}"
+        "obs_#{@observation.id}_naming"
       when "edit", "update"
-        "naming_#{@observation.id}_#{@naming.id}"
+        "obs_#{@observation.id}_naming_#{@naming.id}"
       end
     end
 

--- a/app/helpers/identify_helper.rb
+++ b/app/helpers/identify_helper.rb
@@ -11,15 +11,17 @@ module IdentifyHelper
   # state on show, and cost an extra db lookup. Not worth it, IMO.
   # - Nimmo 20230215
   def mark_as_reviewed_toggle(id, selector = "caption_reviewed",
-                              label_class = "", reviewed = 0)
-    turbo_frame_tag("#{selector}_toggle_#{id}") do
+                              label_class = "", reviewed = nil)
+    reviewed_text = reviewed ? :marked_as_reviewed.l : :mark_as_reviewed.l
+
+    tag.div(class: "d-inline", id: "#{selector}_toggle_#{id}") do
       form_with(url: observation_view_path(id: id),
                 class: "d-inline-block", method: :put,
                 data: { turbo: true }) do |f|
         tag.div(class: "d-inline form-group form-inline") do
           f.label("#{selector}_#{id}",
                   class: "caption-reviewed-link #{label_class}") do
-            concat(reviewed ? :marked_as_reviewed.t : :mark_as_reviewed.t)
+            concat(reviewed_text)
             concat(
               f.check_box(
                 :reviewed,

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -59,7 +59,8 @@ module LightboxHelper
 
   # This is different from show_obs_title, it's more like the matrix_box title
   def caption_obs_title(obs:)
-    tag.h4(class: "obs-what", id: "observation_what_#{obs.id}") do
+    tag.h4(class: "obs-what", id: "observation_what_#{obs.id}",
+           data: { controller: "section-update" }) do
       [
         link_to(obs.id, add_query_param(obs.show_link_args),
                 class: "btn btn-primary mr-3",

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -65,7 +65,7 @@ module NamingsHelper
                           context: "namings_table",
                           btn_class: "btn-primary my-3")
     modal_link_to(
-      "naming_#{obs_id}",
+      "obs_#{obs_id}_naming",
       *new_naming_tab(obs_id,
                       text: text, btn_class: btn_class, context: context)
     )
@@ -75,8 +75,10 @@ module NamingsHelper
 
   def naming_name_html(naming)
     if check_permission(naming)
-      edit_link = modal_link_to("naming_#{naming.observation.id}_#{naming.id}",
-                                *edit_naming_tab(naming))
+      edit_link = modal_link_to(
+        "obs_#{naming.observation_id}_naming_#{naming.id}",
+        *edit_naming_tab(naming)
+      )
       delete_link = destroy_button(target: naming, icon: :remove)
       proposer_links = tag.div(class: "text-nowrap") do
         ["[", edit_link, "|", delete_link, "]"].safe_join(" ")

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,6 +14,7 @@ import "@hotwired/turbo-rails"
 // link_to with GET: set data-turbo-stream="true" to opt in
 Turbo.setFormMode("optin")
 // https://stackoverflow.com/questions/77421369/turbo-response-to-render-javascript-alert/77434363#77434363
+// use: <%= turbo_stream.close_modal("modal_#{obs.id}_naming") %>
 Turbo.StreamActions.close_modal = function () {
   $("#" + this.templateContent.textContent).modal('hide')
 };

--- a/app/views/observations/namings/_form.erb
+++ b/app/views/observations/namings/_form.erb
@@ -1,22 +1,25 @@
 <%
 # Fields must be separate because they're included in the obs form too.
+# HTML ID's may seem overly precise, but there may be more than one of
+# these forms open on a page if modal. IDs must be unique. 
 case action_name
 when "new", "create"
   button_name = :CREATE.l
   method = :post
+  id = "obs_#{@observation.id}_naming_form"
   url = observation_namings_path(observation_id: @observation.id,
                                  approved_name: @params.what,
                                  q: get_query_param)
 when "edit", "update"
   button_name = :SAVE_EDITS.l
   method = :patch
+  id = "obs_#{@observation.id}_naming_#{@naming.id}_form"
   url = naming_path(id: @params.naming.id,
                     approved_name: @params.what,
                     q: get_query_param)
 end
 
-form_args = { model: @naming, url: url, method: method,
-              id: "naming_#{@observation.id}_form" }
+form_args = { model: @naming, url: url, method: method, id: id }
 if local_assigns[:local] == true
   form_args = form_args.merge({ local: true })
 else

--- a/app/views/observations/namings/_update_matrix_box.erb
+++ b/app/views/observations/namings/_update_matrix_box.erb
@@ -1,13 +1,15 @@
-
-<%= turbo_stream.update("observation_what_#{obs.id}") do
+<%# Replace the title in the lightbox caption %>
+<%= turbo_stream.replace("observation_what_#{obs.id}") do
   caption_obs_title(obs: obs)
 end %>
 
-<%= turbo_stream.update("box_title_#{obs.id}") do
+<%# Replace the title in the matrix_box %>
+<%= turbo_stream.replace("box_title_#{obs.id}") do
   matrix_box_title(name: obs.format_name.t.break_name.small_author,
                    id: obs.id)
 end %>
 
-<%= turbo_stream.close_modal("modal_naming_#{obs.id}") %>
-<%= turbo_stream.remove("modal_naming_#{obs.id}") %>
+<%# removes modal via data-controller="section-update" on caption_obs_title %>
+<%# turbo_stream.close_modal("modal_#{obs.id}_naming") %>
+<%# turbo_stream.remove("modal_#{obs.id}_naming") %>
 <%= turbo_stream.remove("observation_identify_#{obs.id}") %>

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -37,7 +37,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     # (Make sure there is a tab to go back to observations/show.)
     assert_true(namer_session.has_link?(href: "/#{obs.id}"))
 
-    namer_session.within("#naming_#{obs.id}_form") do |form|
+    namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       assert_true(form.has_field?("naming_name", text: ""))
       assert_true(form.has_field?("naming_vote_value", text: ""))
       assert_true(form.has_unchecked_field?("naming_reasons_1_check"))
@@ -50,7 +50,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     # (I don't care so long as it says something.)
     assert_flash_text(/\S/, session: namer_session)
 
-    namer_session.within("#naming_#{obs.id}_form") do |form|
+    namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       form.fill_in("naming_name", with: text_name)
       form.first("input[type='submit']").click
     end
@@ -60,7 +60,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
                   text: /MO does not recognize the name.*#{text_name}/
                 ))
 
-    namer_session.within("#naming_#{obs.id}_form") do |form|
+    namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       assert_true(form.has_field?("naming_name", with: text_name))
       assert_true(form.has_unchecked_field?("naming_reasons_1_check"))
       assert_true(form.has_unchecked_field?("naming_reasons_2_check"))
@@ -94,7 +94,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     reason = "Test reason."
     namer_session.click_link(class: /edit_naming_link_#{naming.id}/)
     namer_session.assert_selector("body.namings__edit")
-    namer_session.within("#naming_#{obs.id}_form") do |form|
+    namer_session.within("#obs_#{obs.id}_naming_#{naming.id}_form") do |form|
       assert_true(form.has_field?("naming_name", with: text_name))
       assert_true(form.has_checked_field?("naming_reasons_1_check"))
       form.uncheck("naming_reasons_1_check")
@@ -121,7 +121,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
 
     namer_session.click_link(class: /edit_naming_link_#{naming.id}/)
     namer_session.assert_selector("body.namings__edit")
-    namer_session.within("#naming_#{obs.id}_form") do |form|
+    namer_session.within("#obs_#{obs.id}_naming_#{naming.id}_form") do |form|
       assert_true(
         form.has_field?("naming_name", with: "#{text_name} #{author}")
       )

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -95,8 +95,8 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     scroll_to(find("#observation_namings"), align: :center)
     assert_link(text: /Propose/)
     click_link(text: /Propose/)
-    assert_selector("#modal_naming_#{obs.id}", wait: 9)
-    assert_selector("#naming_#{obs.id}_form", wait: 9)
+    assert_selector("#modal_obs_#{obs.id}_naming", wait: 9)
+    assert_selector("#obs_#{obs.id}_naming_form", wait: 9)
     find_field("naming_name").click
     browser.keyboard.type("Peltige")
     assert_selector(".auto_complete", wait: 3) # wait
@@ -105,8 +105,8 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_field("naming_name", with: "Peltigeraceae ")
     browser.keyboard.type(:tab)
     assert_no_selector(".auto_complete")
-    within("#naming_#{obs.id}_form") { click_commit }
-    assert_no_selector("#modal_naming_#{obs.id}")
+    within("#obs_#{obs.id}_naming_form") { click_commit }
+    assert_no_selector("#modal_obs_#{obs.id}_naming")
     within("#namings_table") { assert_text("Peltigeraceae", wait: 6) }
   end
 end

--- a/test/system/help_identify_system_test.rb
+++ b/test/system/help_identify_system_test.rb
@@ -27,11 +27,12 @@ class HelpIdentifySystemTest < ApplicationSystemTestCase
     within(".lg-sub-html") do
       click_on("Propose a Name")
     end
-    assert_selector("#modal_naming_#{obs.id}")
+    assert_selector("#modal_obs_#{obs.id}_naming")
+    assert_selector("#obs_#{obs.id}_naming_form")
 
     ncc = names(:coprinus_comatus)
 
-    within("#modal_naming_#{obs.id}") do
+    within("#obs_#{obs.id}_naming_form") do
       fill_in("naming_name", with: ncc.text_name)
       browser.keyboard.type(:tab)
       sleep(1)
@@ -39,8 +40,9 @@ class HelpIdentifySystemTest < ApplicationSystemTestCase
       select("Promising", from: "naming_vote_value")
       click_commit
     end
-    assert_no_selector("#modal_naming_#{obs.id}")
+    assert_no_selector("#modal_obs_#{obs.id}_naming", wait: 9)
     assert_no_selector("#observation_identify_#{obs.id}")
+
     # lightgallery specific:
     assert_selector(".lg-container")
     within(".lg-container") do

--- a/test/system/help_identify_system_test.rb
+++ b/test/system/help_identify_system_test.rb
@@ -27,7 +27,7 @@ class HelpIdentifySystemTest < ApplicationSystemTestCase
     within(".lg-sub-html") do
       click_on("Propose a Name")
     end
-    assert_selector("#modal_obs_#{obs.id}_naming")
+    assert_selector("#modal_obs_#{obs.id}_naming", wait: 9)
     assert_selector("#obs_#{obs.id}_naming_form")
 
     ncc = names(:coprinus_comatus)

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -232,9 +232,9 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       click_link(text: /Propose/)
     end
 
-    assert_selector("#modal_naming_#{obs.id}", wait: 9)
-    assert_selector("#naming_#{obs.id}_form", wait: 9)
-    within("#naming_#{obs.id}_form") do
+    assert_selector("#modal_obs_#{obs.id}_naming", wait: 9)
+    assert_selector("#obs_#{obs.id}_naming_form", wait: 9)
+    within("#obs_#{obs.id}_naming_form") do
       assert_field("naming_name", wait: 4)
       # fill_in("naming_name", with: nd1.text_name)
       # Using autocomplete to slow things down here, otherwise button blocked.
@@ -247,10 +247,10 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       click_commit
     end
 
-    assert_selector("#modal_naming_#{obs.id}_flash", text: /Missing/)
+    assert_selector("#modal_obs_#{obs.id}_naming_flash", text: /Missing/)
     assert_selector("#name_messages", text: /deprecated/)
 
-    within("#naming_#{obs.id}_form") do
+    within("#obs_#{obs.id}_naming_form") do
       fill_in("naming_name", with: "")
       # fill_in("naming_name", with: n_d.text_name)
       # Using autocomplete to slow things down here, otherwise session lost.
@@ -264,7 +264,7 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       select("Doubtful", from: "naming_vote_value")
       click_commit
     end
-    assert_no_selector("#modal_naming_#{obs.id}", wait: 6)
+    assert_no_selector("#modal_obs_#{obs.id}_naming", wait: 6)
 
     # Test problems have occurred here: Something in
     # Observations::NamingsController#create seems to execute before the
@@ -320,12 +320,12 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       assert_selector(".edit_naming_link_#{nam.id}")
       find(:css, ".edit_naming_link_#{nam.id}").trigger("click")
     end
-    assert_selector("#modal_naming_#{obs.id}_#{nam.id}", wait: 9)
-    assert_selector("#naming_#{obs.id}_form", wait: 9)
-    within("#modal_naming_#{obs.id}_#{nam.id}") do
+    assert_selector("#modal_obs_#{obs.id}_naming_#{nam.id}", wait: 9)
+    assert_selector("#obs_#{obs.id}_naming_#{nam.id}_form", wait: 9)
+    within("#modal_obs_#{obs.id}_naming_#{nam.id}") do
       find(:css, ".close").click
     end
-    assert_no_selector("#modal_naming_#{obs.id}_#{nam.id}")
+    assert_no_selector("#modal_obs_#{obs.id}_naming_#{nam.id}")
 
     within("#observation_namings") do
       assert_link(text: /#{n_d.text_name}/)


### PR DESCRIPTION
This PR gives the modals and forms for namings (on show obs) truly unique DOM ids.

The modal forms are opened/closed by unique ID. There can be more than one modal form open on the page at the same time with the current UI, potentially for the same observation, so `naming_#{obs.id}` could be duplicated.

Manually testing this revealed that the "Mark as reviewed" toggle was getting the wrong text for "not reviewed". This PR also fixes that.