### PR TITLE
Convert `#observation_namings` to a `div` (from a `turbo-frame`)

### DIFF
--- a/app/views/observations/namings/index.erb
+++ b/app/views/observations/namings/index.erb
@@ -1,5 +1,5 @@
 <%=
-tag.turbo_frame(id: "observation_namings") do
+tag.div(id: "observation_namings") do
   render(partial: "observations/namings/table",
          locals: { obs: @observation })
 end %>

--- a/app/views/observations/show/_namings.erb
+++ b/app/views/observations/show/_namings.erb
@@ -3,13 +3,7 @@
 %>
 
 <!--OBSERVATION_NAMINGS / TABLE REFRESHED BY TURBO -->
-<%= tag.turbo_frame(
-  id: "observation_namings",
-  # src: observation_namings_path(observation_id: obs.id),
-  # loading: "lazy"
-  # for lazy loading, don't put anything in the block.
-) do
-
+<%= tag.div(id: "observation_namings") do
   render(partial: "observations/namings/table",
          locals: { obs: obs, query: @query })
 end %>

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -301,7 +301,7 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     assert_selector("#title", text: /#{nam.text_name}/)
     # sleep(3)
 
-    # check that there is a vote tally with this naming
+    # check that there is a vote "index" tally with this naming
     within("#observation_namings") do
       assert_link(href: "/observations/#{obs.id}/namings/#{nam.id}/votes")
       click_link(href: "/observations/#{obs.id}/namings/#{nam.id}/votes")
@@ -313,6 +313,23 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       find(:css, ".close").click
     end
     assert_no_selector("#modal_naming_votes_#{nam.id}")
+
+    # Test the link to the naming name and user
+    within("#observation_namings") do
+      assert_link(text: /#{n_d.text_name}/)
+      click_link(text: /#{n_d.text_name}/)
+    end
+    assert_selector("body.names__show", wait: 15)
+    page.go_back
+
+    # Test the link to the naming user... whoa, this takes too long!
+    # Re-add this test when the user page is sped up.
+    # within("#observation_namings") do
+    #   assert_link(text: /#{rolf.login}/)
+    #   click(text: /#{rolf.login}/)
+    # end
+    # assert_selector("body.users__show", wait: 30)
+    # page.go_back
 
     # Test the edit naming form link. 
     within("#observation_namings") do


### PR DESCRIPTION
Fixes #1741 

Somehow, the Namings table being a `<turbo-frame>` made ordinary links within it not work, in this case the Name and User links for the naming. Modal links to edit or destroy the naming still worked.

Judging from the console errors, the plain `<a>` links seem to have been intercepted by Turbo.js, and it seems to have tried to replace the table with the returned content from the link (e.g., the show user page!). The result was the naming table was replaced by "Content missing", which is a Turbo error message. 

Turbo will not replace an element if the returned HTML doesn't have anything with a matching DOM ID — in this case, "observation_namings". 

I had it as a `<turbo-frame>` because i was playing around with lazy-loading the entire namings section. Shelved for now.