### PR TITLE
Delete Project#accepting_observations

### DIFF
--- a/db/migrate/20231227170054_remove_accepting_observations_from_projects.rb
+++ b/db/migrate/20231227170054_remove_accepting_observations_from_projects.rb
@@ -1,0 +1,5 @@
+class RemoveAcceptingObservationsFromProjects < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :projects, :accepting_observations, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_08_212458) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_27_170054) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -518,7 +518,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_08_212458) do
     t.datetime "updated_at", precision: nil
     t.integer "rss_log_id"
     t.boolean "open_membership", default: false, null: false
-    t.boolean "accepting_observations", default: true, null: false
     t.integer "location_id"
     t.integer "image_id"
     t.date "start_date"


### PR DESCRIPTION
Deletes column which was made obsolete by #1658

(This migration was not included in jdc-project-add-dates., in order to facilitate switching branches.)
