### PR TITLE
Really fix `form_name_feedback`

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -112,3 +112,9 @@ a.filter-only {
 .btn.text-danger {
   color: $brand-danger !important;
 }
+
+.name-radio {
+  label {
+    font-weight: normal;
+  } 
+}

--- a/app/classes/naming_params.rb
+++ b/app/classes/naming_params.rb
@@ -44,7 +44,8 @@ class NamingParams
     if @name && @what.match(/\S/)
       false
     else
-      @naming.errors.add(:name, :validate_naming_name_missing.t)
+      @naming.errors.add(:name,
+                         :form_observations_there_is_a_problem_with_name.t)
       true
     end
   end

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -28,7 +28,13 @@ module ObservationsController::Validators
     (success, @what, @name, @names, @valid_names, @parent_deprecated,
      @suggest_corrections) =
       Name.resolve_name(given_name, params[:approved_name], chosen_name)
-    @naming.name = @name if @name
+    if @name
+      @naming.name = @name
+    else
+      @naming.errors.add(:name,
+                         :form_observations_there_is_a_problem_with_name.t)
+      flash_object_errors(@naming)
+    end
     success
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -119,6 +119,7 @@ module FormsHelper
       args[:form].label("#{args[:field]}_#{args[:value]}") do
         concat(args[:form].radio_button(args[:field], args[:value], opts))
         concat(args[:label])
+        concat(args[:append]) if args[:append].present?
       end
     end
   end

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -32,7 +32,7 @@ context ||= "blank"
 <%=
 [
   tag.div(class: "row") do
-    tag.div(class: "col-xs-12 col-sm-6") do
+    tag.div(class: "col-xs-12") do
       render(partial: "shared/form_name_feedback",
              locals: feedback_locals) if what.present?
     end

--- a/app/views/controllers/shared/_form_name_feedback.erb
+++ b/app/views/controllers/shared/_form_name_feedback.erb
@@ -20,7 +20,7 @@ when there is no longer any "problem_with_name".
 
 TODO:
 Remove `flash_warning`/`flash_error` here and add them upstream, maybe in 
-NamingParams or Name::Resolve. 
+NamingParams. 
 Differentiate warning (valid_names) from error (!valid_names)
 A conditional to watch is `if @params[:what].present?`.
 Also, views/observations/namings/fields is doing too much work, 
@@ -30,7 +30,7 @@ the multiple local_assigns for this partial should be set upstream.
 <%=
 if valid_names
   ##### Warnings #####
-  flash_warning(:form_observations_there_is_a_problem_with_name.t)
+  flash_warning(:form_observations_there_is_a_problem_with_name.l)
 
   tag.div(class: "alert alert-warning", id: "name_messages") do
     concat(tag.div do
@@ -76,7 +76,7 @@ if valid_names
 ##### Errors #####
 elsif names&.length == 0
 
-  flash_error(:form_observations_there_is_a_problem_with_name.t)
+  flash_error(:form_observations_there_is_a_problem_with_name.l)
 
   tag.div(class: "alert alert-danger", id: "name_messages") do
     concat(tag.div(:form_naming_not_recognized.t(name: what)))
@@ -87,7 +87,7 @@ elsif names&.length == 0
 
 elsif names&.length &.> 1
 
-  flash_error(:form_observations_there_is_a_problem_with_name.t)
+  flash_error(:form_observations_there_is_a_problem_with_name.l)
 
   tag.div(class: "alert alert-danger", id: "name_messages") do
     concat(tag.div([:form_naming_multiple_names.t(name: what), ":"].safe_join))

--- a/app/views/controllers/shared/_form_name_feedback.erb
+++ b/app/views/controllers/shared/_form_name_feedback.erb
@@ -30,8 +30,7 @@ the multiple local_assigns for this partial should be set upstream.
 <%=
 if valid_names
   ##### Warnings #####
-  flash_warning(:form_observations_there_is_a_problem_with_name.l)
-
+  
   tag.div(class: "alert alert-warning", id: "name_messages") do
     concat(tag.div do
       if suggest_corrections || names.blank?
@@ -76,8 +75,6 @@ if valid_names
 ##### Errors #####
 elsif names&.length == 0
 
-  flash_error(:form_observations_there_is_a_problem_with_name.l)
-
   tag.div(class: "alert alert-danger", id: "name_messages") do
     concat(tag.div(:form_naming_not_recognized.t(name: what)))
     concat(help_note(
@@ -86,8 +83,6 @@ elsif names&.length == 0
   end
 
 elsif names&.length &.> 1
-
-  flash_error(:form_observations_there_is_a_problem_with_name.l)
 
   tag.div(class: "alert alert-danger", id: "name_messages") do
     concat(tag.div([:form_naming_multiple_names.t(name: what), ":"].safe_join))

--- a/app/views/controllers/shared/_form_name_feedback.erb
+++ b/app/views/controllers/shared/_form_name_feedback.erb
@@ -13,14 +13,26 @@ valid_names - Name(s) that are valid synonyms
 suggest_corections - t/f whether to suggest correction(s)
 parent_deprecated - t/f
 button_name - text: button to complete the action, e.g. Submit, Create
+
+FIXME: The flash being added here is too late to be available for  
+Turbo updates to modal_flash and gets displayed on the next page, 
+when there is no longer any "problem_with_name".
+
+TODO:
+Remove `flash_warning`/`flash_error` here and add them upstream, maybe in 
+NamingParams or Name::Resolve. 
+Differentiate warning (valid_names) from error (!valid_names)
+A conditional to watch is `if @params[:what].present?`.
+Also, views/observations/namings/fields is doing too much work, 
+the multiple local_assigns for this partial should be set upstream.
 %>
 
 <%=
 if valid_names
   ##### Warnings #####
-  concat(flash_warning(:form_observations_there_is_a_problem_with_name.t))
+  flash_warning(:form_observations_there_is_a_problem_with_name.t)
 
-  concat(tag.div(class: "alert alert-warning", id: "name_messages") do
+  tag.div(class: "alert alert-warning", id: "name_messages") do
     concat(tag.div do
       if suggest_corrections || names.blank?
         :form_naming_not_recognized.t(name: what)
@@ -59,34 +71,34 @@ if valid_names
         :div, :form_naming_not_recognized_help.t(button: button_name)
       ))
     end
-  end)
+  end
 
 ##### Errors #####
 elsif names&.length == 0
 
-  concat(flash_error(:form_observations_there_is_a_problem_with_name.t))
+  flash_error(:form_observations_there_is_a_problem_with_name.t)
 
-  concat(tag.div(class: "alert alert-danger", id: "name_messages") do
+  tag.div(class: "alert alert-danger", id: "name_messages") do
     concat(tag.div(:form_naming_not_recognized.t(name: what)))
     concat(help_note(
       :div, :form_naming_not_recognized_help.t(button: button_name)
     ))
-  end)
+  end
 
 elsif names&.length &.> 1
 
-  concat(flash_error(:form_observations_there_is_a_problem_with_name.t))
+  flash_error(:form_observations_there_is_a_problem_with_name.t)
 
-  concat(tag.div(class: "alert alert-danger", id: "name_messages") do
+  tag.div(class: "alert alert-danger", id: "name_messages") do
     concat(tag.div([:form_naming_multiple_names.t(name: what), ":"].safe_join))
     concat(fields_for(:chosen_name) do |f_c|
       names.each do |n|
         concat(radio_with_label(form: f_c, field: :name_id, value: n.id,
-                                label: n.display_name.t, class: "ml-4"))
-        concat(tag.div("(#{n.observations.size})"))
+                                label: n.display_name.t, class: "ml-4 name-radio",
+                                append: tag.span(" (#{n.observations.size})")))
       end
     end)
     concat(help_note(:div, :form_naming_multiple_names_help.t))
-  end)
+  end
 
 end %>

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -34,7 +34,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     end
 
     assert_selector("#name_messages", text: "MO does not recognize the name")
-    assert_flash_warning(
+    assert_flash_error(
       :form_observations_there_is_a_problem_with_name.t.html_to_ascii
     )
     assert_selector("#observation_form")

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -247,7 +247,10 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       click_commit
     end
 
-    assert_selector("#modal_obs_#{obs.id}_naming_flash", text: /Missing/)
+    assert_selector(
+      "#modal_obs_#{obs.id}_naming_flash",
+      text: :form_observations_there_is_a_problem_with_name.t.html_to_ascii
+    )
     assert_selector("#name_messages", text: /deprecated/)
 
     within("#obs_#{obs.id}_naming_form") do


### PR DESCRIPTION
This fixes a bug reported by Huafang and caused by my PR the other day:`form_name_feedback` is printing double feedback.

To reproduce: 
- Create an obs, propose the name Grifola frondosa, and click "Create". There will be double suggestions:
<img width="457" alt="Screen Shot 2023-12-28 at 4 11 40 PM" src="https://github.com/MushroomObserver/mushroom-observer/assets/1948095/64175cf8-13e1-4763-b9da-1faf3ebd74b5">

- On any obs, propose the name Grifola frondosa, and click "Propose". There will be double suggestions. Pick one, and then commit the form. On show obs reload, it will flash "There are problems with the name..." although this is no longer true.
<img width="599" alt="Screen Shot 2023-12-28 at 4 13 51 PM" src="https://github.com/MushroomObserver/mushroom-observer/assets/1948095/9985ca06-b63d-4409-a823-1df6bdb0f4e2">


This PR also tries to fix what i was trying to fix originally, which is that `form_name_feedback` updates the flash too late for it to be picked up by a Turbo update. The naming error flash messages are now added upstream, either in `NamingParams#name_missing?` or `ObservationsController::Validators#validate_name`. 

Everything seems to work as before, except:

- The current "Missing name" flash message, which was only fired on Naming forms, is now replaced with the "There is a problem with the name", as on Observation forms. It seems to be superfluous because I think it only ever appears alongside "There is a problem".
- Depending if there are `valid_names` offered, `form_name_feedback` sends the flash message "There is a problem..." either as a `warning` or an `error`. But because "Missing name" is a flash error and not a warning, it is always shown as an error. There is currently (on `main`) effectively no difference between the flash messages currently shown in a modal naming form - both "Missing name" and "There is a problem..." are shown as a flash_error, even though they may be registered differently. The same seems to be true on the Observation form, but i haven't tested every case.
- Naming flash messages no longer appear inappropriately on the next page load.