### PR TITLE
Textile link case

### DIFF
--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -28,7 +28,8 @@ require("redcloth")
 #  textilize::                   Parse the given string.
 #  textilize_without_paragraph:: Parse the first paragraph of the given string.
 #
-class Textile < String
+# TODO: un-disable Metrics/ClassLength
+class Textile < String # rubocop:disable Metrics/ClassLength
   @@name_lookup     = {}
   @@last_species    = nil
   @@last_subspecies = nil

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -333,18 +333,6 @@ class Textile < String # rubocop:disable Metrics/ClassLength
   /x
   # rubocop:enable Style/RegexpLiteral
 
-  OTHER_LINK_TYPES = [
-    ["comment"],
-    %w[glossary_term term],
-    %w[image img],
-    %w[location loc],
-    ["name"],
-    %w[observation obs ob],
-    %w[project proj],
-    %w[species_list spl],
-    ["user"]
-  ].freeze
-
   MARKED_TYPE_TO_TAGGED_TYPE = {
     comment: "COMMENT",
     glossary_term: "GLOSSARY_TERM",

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -210,19 +210,19 @@ class Textile < String
     convert_implicit_terms_to_tagged_glossary_terms!
   end
 
-  # rubocop:disable Style/RegexpLiteral
-  # cop gives false positive
-  NAME_LINK_PATTERN = /
-    (?<prefix> ^|\W)
-    (?: \**_+)
-    (?<formatted_label> [^_]+)
-    (?: _+\**)
-    (?= (?: s|ish|like)?
-    (?: \W|\Z) )
+  NAME_LINK_PATTERN =
+    %r{
+      (?<prefix> ^|\W) # capture start of string or non-word character
+      (?: \**_+) # any asterisks then at least one underscore
+      (?<formatted_label> [^_]+) # capture all non-underscores
+      (?: _+\**) # at least one underscore then any asterisks
+      (?= # not followed by
+        (?: s|ish|like)? # optional ns, ish, or like, then
+        (?: \W|\Z) # non-word char or end of string
+      )
 
-    (?! (?: <\/[a-z]+>)) # discard match if followed by html closing tag
-  /x
-  # rubocop:enable Style/RegexpLiteral
+      (?! (?: </[a-z]+>)) # discard match if followed by html closing tag
+    }x
 
   # Convert __Names__ to links in a textile string.
   def convert_name_links_to_tagged_objects!

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -316,22 +316,20 @@ class Textile < String # rubocop:disable Metrics/ClassLength
       sub(/ sp\.$/, "")
   end
 
-  # rubocop:disable Style/RegexpLiteral
-  # cop gives false positive
-  OTHER_LINK_PATTERN = /
-    (?<prefix> ^|\W)
-    (?: _+)
-    (?<marked_type>
-      [a-zA-Z]+ # model name or abbr
-      (?: _[a-zA-Z]+)? # optionally including underscores
-    )
-    \s+
-    (?<id> [^_\s](?:[^_\n]+[^_\s])?) # id -- integer or string
-    (?: _+)
+  OTHER_LINK_PATTERN =
+    %r{
+      (?<prefix> ^|\W)
+      (?: _+)
+      (?<marked_type>
+        [a-zA-Z]+ # model name or abbr
+        (?: _[a-zA-Z]+)? # optionally including underscores
+      )
+      \s+
+      (?<id> [^_\s](?:[^_\n]+[^_\s])?) # id -- integer or string
+      (?: _+)
 
-    (?! (?: \w|<\/[a-z]+>)) # discard if followed by word char or html close tag
-  /x
-  # rubocop:enable Style/RegexpLiteral
+      (?! (?: \w|</[a-z]+>)) # discard if trailed by word char or html close tag
+    }x
 
   MARKED_TYPE_TO_TAGGED_TYPE = {
     comment: "COMMENT",

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -28,7 +28,6 @@ require("redcloth")
 #  textilize::                   Parse the given string.
 #  textilize_without_paragraph:: Parse the first paragraph of the given string.
 #
-# TODO: un-disable Metrics/ClassLength
 class Textile < String
   @@name_lookup     = {}
   @@last_species    = nil

--- a/test/models/textile_test.rb
+++ b/test/models/textile_test.rb
@@ -11,6 +11,7 @@ end
 
 class TextileTest < UnitTestCase
   EXPLICIT_OBJECT_MARKUP = [
+    "_Term gill_", # non-lowercase explicit tag
     "_Amanita_",
     "_observation 123_",
     "_term bar code_"

--- a/test/models/textile_test.rb
+++ b/test/models/textile_test.rb
@@ -11,10 +11,11 @@ end
 
 class TextileTest < UnitTestCase
   EXPLICIT_OBJECT_MARKUP = [
-    "_Term gill_", # non-lowercase explicit tag
-    "_Amanita_",
-    "_observation 123_",
-    "_term bar code_"
+    "_observation 123_", # lower case explicit tag
+    "_term bar code_",
+    "_Term gill_", # non-lower case explicit tag
+    "_IMG 123",
+    "_Amanita_"
   ].freeze
 
   IMPLICIT_TERMS = [


### PR DESCRIPTION
Fixes a bug where non-lowercase user markup generated buggy Textile output
> Ex. `_Term gills_` generated garbage (while `_term gills_` correctly generated a link to lookup the GlossaryTerm "gills").

Delivers https://www.pivotaltracker.com/story/show/186064204
