### PR TITLE
Delete bulk editor vestiges 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,7 @@ PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -825,7 +825,7 @@ class ApplicationController < ActionController::Base
   # Goes through list of names entered by user and creates (and saves) any that
   # are not in the database (but only if user has approved them).
   #
-  # Used by: bulk_name_editor, change_synonyms, create/edit_species_list
+  # Used by: change_synonyms, create/edit_species_list
   #
   # Inputs:
   #
@@ -841,7 +841,6 @@ class ApplicationController < ActionController::Base
   #   Xxx yyy sensu Blah
   #   Valid name Author = Deprecated name Author
   #   blah blah [comment]
-  #   (this is described better in views/observer/bulk_name_edit.rhtml)
   #
   def construct_approved_names(name_list, approved_names, deprecate = false)
     return unless approved_names
@@ -880,35 +879,12 @@ class ApplicationController < ActionController::Base
     # if above parse was successful
     if (name = names.last)
       name.rank = name_parse.rank if name_parse.rank
-
-      process_given_name_comments_for_bulk_editor(name_parse, name)
-
-      # Only bulk name editor allows the synonym syntax now.  Tell it to
-      # approve the left-hand name.
-      deprecate2 = (name_parse.has_synonym ? false : deprecate)
-
-      save_approved_given_names(names, deprecate2)
+      save_approved_given_names(names, deprecate)
 
     # Parse must have failed.
     else
       flash_error(:runtime_no_create_name.t(type: :name,
                                             value: name_parse.name))
-    end
-  end
-
-  def process_given_name_comments_for_bulk_editor(name_parse, name)
-    return unless (comment = name_parse.comment)
-
-    # Okay to add citation to any record without an existing citation.
-    if comment =~ /^citation: *(.*)/
-      citation = Regexp.last_match(1)
-      name.citation = citation if name.citation.blank?
-    # Only save comment if name didn't exist
-    elsif name.new_record?
-      name.notes = comment
-    else
-      flash_warning("Didn't save comment for #{name.real_search_name}, " \
-                    "name already exists. (comment = \"#{comment}\")")
     end
   end
 
@@ -923,7 +899,6 @@ class ApplicationController < ActionController::Base
     # Parse was successful
     if (synonym = synonyms.last)
       synonym.rank = name_parse.synonym_rank if name_parse.synonym_rank
-      process_synonym_comments_for_bulk_editor(name_parse, synonym)
       save_synonyms(synonym, synonyms)
 
     # Parse must have failed.
@@ -935,18 +910,6 @@ class ApplicationController < ActionController::Base
 
   def create_synonym(name_parse)
     Name.find_or_create_name_and_parents(name_parse.synonym_search_name)
-  end
-
-  def process_synonym_comments_for_bulk_editor(name_parse, synonym)
-    return unless (comment = name_parse.synonym_comment)
-
-    # Only save comment if name didn't exist
-    if synonym.new_record?
-      synonym.notes = comment
-    else
-      flash_warning("Didn't save comment for #{synonym.real_search_name}, " \
-                    "name already exists. (comment = \"#{comment}\")")
-    end
   end
 
   # Deprecate and save.

--- a/app/controllers/species_lists/shared_private_methods.rb
+++ b/app/controllers/species_lists/shared_private_methods.rb
@@ -39,8 +39,9 @@ module SpeciesLists
       # Validate place name.
       validate_place_name
 
+      list = list_without_underscores
+
       # Make sure all the names (that have been approved) exist.
-      list = check_names_on_list
       construct_approved_names(list, params[:approved_names])
 
       # Initialize NameSorter and give it all the information.
@@ -101,12 +102,8 @@ module SpeciesLists
       @dubious_where_reasons = Location.dubious_name?(db_name, true)
     end
 
-    def check_names_on_list
-      if params[:list]
-        params[:list][:members].to_s.tr("_", " ").strip_squeeze
-      else
-        ""
-      end
+    def list_without_underscores
+      params.dig(:list, :members).to_s.tr("_", " ").strip_squeeze
     end
 
     def init_name_sorter(list)

--- a/app/controllers/species_lists/shared_private_methods.rb
+++ b/app/controllers/species_lists/shared_private_methods.rb
@@ -125,7 +125,7 @@ module SpeciesLists
 
       # Does list have "Name one = Name two" type lines?
       if sorter.has_new_synonyms
-        flash_error(:runtime_species_list_need_to_use_bulk.t)
+        flash_error(:runtime_species_list_create_synonym.t)
         sorter.reset_new_names
         failed = true
       end

--- a/app/models/name_parse.rb
+++ b/app/models/name_parse.rb
@@ -5,7 +5,7 @@
 #
 #  This class is used by NameSorter and a few controllers (e.g.
 #  NameController, SpeciesListController) to help parse lists of names, such as
-#  in bulk_name_edit, create/edit_species_list, and change_synonyms.  It splits
+#  in create/edit_species_list, and change_synonyms.  It splits
 #  each line up into a name and an optional synonym:
 #
 #    Species name

--- a/app/models/name_sorter.rb
+++ b/app/models/name_sorter.rb
@@ -5,7 +5,7 @@
 #
 #  This class is used by a few controllers (e.g.  NameController,
 #  SpeciesListController) to help parse lists of names, such as in
-#  bulk_name_edit, create/edit_species_list, and change_synonyms.  It uses
+#  create/edit_species_list, and change_synonyms.  It uses
 #  NameParse to parse individual lines, then gathers unrecognized names,
 #  deprecated names, accepted names, etc.
 #

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3935,7 +3935,7 @@
   runtime_show_description_denied: You have not been given permission to see this description.
   runtime_show_draft_denied: "Permission denied: only project members can view drafts in progress."
   runtime_signup_success: Signup successful.  Verification email sent.
-  runtime_species_list_need_to_use_bulk: Synonyms can only be created from the [:name_bulk_title] page.
+  runtime_species_list_create_synonym: To create a Synonym please edit the Name.
 
   # Pattern search error messages.
   pattern_search_syntax_error: Syntax error in pattern at [string].

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1821,7 +1821,6 @@
 
   # name/name_index (and other actions using same view)
   name_index_add_name: Add Name
-  name_index_bulk_edit: "[:name_bulk_title]"
 
   # name/map
   name_map_title: Occurrence Map for [name]
@@ -2089,7 +2088,6 @@
   show_name_title: "[:NAME]: [name]"
   show_name_add_name: "[:add_object(type=:name)]"
   show_name_edit_name: "[:edit_object(type=:name)]"
-  show_name_bulk_name_edit: "[:name_bulk_title]"
   show_name_distribution_map: Occurrence Map
   show_name_change_synonyms: Change Synonyms
   show_name_email_tracking: Email Tracking
@@ -2896,12 +2894,6 @@
   merge_descriptions_delete_after: Delete old description after merge?
   merge_descriptions_merge_help: This will copy any non-blank sections from the source description into the description you select below.  If the target description already has text in any of those fields, you will be given an editing form with the text from both descriptions.  This will allow you to reconcile any conflicts by hand before saving the form and making the merger official.
   merge_descriptions_move_help: This will move the source description into a synonym.  It will just copy it if you elect not to delete the old description.  If you wish to merge with an existing description in the other name, you must first move your description into that name, then select [:show_description_merge] again from there.
-
-  # name/bulk_name_edit
-  name_bulk_help: "Each line indicates a set of changes.\n\np(bulk_text). To ensure a name is in the database, just list the name.  E.g.,\n\np(bulk_pre). Agaricus bisporus\n\np(bulk_text). To ensure a name exists with a particular author, give the name followed by the author.  E.g.,\n\np(bulk_pre). Agaricus bisporus (J.E. Lange) Pilát\n\np(bulk_text). To add a taxon above the species level, give the rank followed by the name.  E.g.,\n\np(bulk_pre). Order Agaricales\n\np(bulk_text). To make a name a deprecated synonym of another name, follow the valid name with the deprecated synonym.  E.g.,\n\np(bulk_pre). Agaricus bisporus (J.E. Lange) Pilát = Agaricus hortensis (Cke.) Imai\n\nThe changes are cumulative, so the last example by itself would ensure that the names **__@Agaricus bisporus@__** @(J.E. Lange) Pilát@ and __@Agaricus hortensis@__ @(Cke.) Imai@ exist, as well as making __@A. hortensis@__ a deprecated synononym of **__@A. bisporus@__**.  If a name exists with no author and you provide an author, then the existing name is updated. Otherwise, if the author is given and it does not match the current author, a new name is created.\n\np(bulk_text). You may include an optional one-line comment by inserting it after either the accepted or deprecated name, enclosed in square brackets. This will be saved in the notes when the name is created.\n\np(bulk_pre). Herpothallon Tobler [[citation:Aptroot, A, G Thor, ...]]"
-  name_bulk_label: Name Edits
-  name_bulk_success: All names are now in the database.
-  name_bulk_title: Bulk Name Edit
 
   # species_list/name_lister
   name_lister_bad_browser: This page will not work on your browser, sorry!


### PR DESCRIPTION
- Cleans up the vestiges of the bulk name editor, which was deleted a while back. 
See discussion at https://groups.google.com/g/mo-developers/c/C6r_km5n1G4.
- Delivers https://www.pivotaltracker.com/story/show/186776118