### PR TITLE
Log in `MRTG` for better stats

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -60,7 +60,7 @@ class AccountController < ApplicationController
       return render(action: :new) unless validate_and_save_new_user!
 
       UserGroup.create_user(@new_user)
-      flash_notice("#{:runtime_signup_success.tp}#:{email_spam_notice.tp}")
+      flash_notice("#{:runtime_signup_success.tp}: #{email_spam_notice.tp}")
       QueuedEmail::VerifyAccount.create_email(@new_user)
     end
 

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -60,7 +60,7 @@ class AccountController < ApplicationController
       return render(action: :new) unless validate_and_save_new_user!
 
       UserGroup.create_user(@new_user)
-      flash_notice("#{:runtime_signup_success.tp}: #{email_spam_notice.tp}")
+      flash_notice("#{:runtime_signup_success.tp} #{:email_spam_notice.tp}")
       QueuedEmail::VerifyAccount.create_email(@new_user)
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -361,6 +361,9 @@ class ApplicationController < ActionController::Base
     elsif user_verified_and_allowed?(user = validate_user_in_autologin_cookie)
       # User had "remember me" cookie set.
       login_valid_user(user)
+    elsif request.remote_ip == "127.0.0.1"
+      # Request from the server itself, MRTG needs to log in to test page loads.
+      login_valid_user(User.find_by(login: "mrtg"))
     else
       delete_invalid_cookies
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -355,15 +355,15 @@ class ApplicationController < ActionController::Base
   end
 
   def try_user_autologin(user_from_session)
-    if user_verified_and_allowed?(user = user_from_session)
+    if Rails.env.production? && request.remote_ip == "127.0.0.1"
+      # Request from the server itself, MRTG needs to log in to test page loads.
+      login_valid_user(User.find_by(login: "mrtg"))
+    elsif user_verified_and_allowed?(user = user_from_session)
       # User was already logged in.
       refresh_logged_in_user_instance(user)
     elsif user_verified_and_allowed?(user = validate_user_in_autologin_cookie)
       # User had "remember me" cookie set.
       login_valid_user(user)
-    elsif request.remote_ip == "127.0.0.1"
-      # Request from the server itself, MRTG needs to log in to test page loads.
-      login_valid_user(User.find_by(login: "mrtg"))
     else
       delete_invalid_cookies
     end


### PR DESCRIPTION
Our MRTG stats are pretty useless because MRTG is not logged in, so when we're testing pretty much any page but the home page, we’re only graphing the speed at which MO says “Please log in". This PR should change that.

I've made a new MO user "mrtg", and this PR changes the "autologin" method to log in requests from "127.0.0.1" as that user so we can re-enable graphs of a show_obs page.

@JoeCohen @mo-nathan The user "mrtg" must be validated by someone with access to "webmaster@mushroomobserver.org", I can't get in.

The test load of show obs is currently disabled, will need to change the `mrtg.cfg` on the server to fix.