### PR TITLE
Reduce extra queries on Show Name observations menu using a PORO

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -295,7 +295,7 @@ class NamesController < ApplicationController
                                     by: :confidence)
     end
     # Determine if relevant and count the results of running the query if so.
-    @has_subtaxa = @subtaxa_query.select_count if @subtaxa_query
+    @has_subtaxa = @first_child ? @subtaxa_query.select_count : 0
     # NOTE: `_observation_menu` makes many select_count queries like this!
     # That is where most of the heavy loading is. Check helpers/show_name_helper
     #

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -258,6 +258,7 @@ class NamesController < ApplicationController
   #   @projects
 
   def init_related_query_ivars
+    @has_subtaxa = 0
     # Query for names of subtaxa, used in special query link
     # Note this is only creating a schematic of a query, used in the link.
     @children_query = create_query(:Name, :all,
@@ -293,9 +294,10 @@ class NamesController < ApplicationController
                                     include_subtaxa: true,
                                     exclude_original_names: true,
                                     by: :confidence)
+      # Determine if relevant and count the results of running the query if so.
+      # Don't run if there aren't any children.
+      @has_subtaxa = @first_child ? @subtaxa_query.select_count : 0
     end
-    # Determine if relevant and count the results of running the query if so.
-    @has_subtaxa = @first_child ? @subtaxa_query.select_count : 0
     # NOTE: `_observation_menu` makes many select_count queries like this!
     # That is where most of the heavy loading is. Check helpers/show_name_helper
     #

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -219,15 +219,14 @@ class NamesController < ApplicationController
   private
 
   def find_name!
-    @name = Name.includes(show_name_includes).find_by(id: params[:id]) ||
+    @name = Name.includes(show_includes).strict_loading.
+            find_by(id: params[:id]) ||
             flash_error_and_goto_index(Name, params[:id])
   end
 
-  # This seems incomplete. Synonyms, descriptions?
-  def show_name_includes
-    [
-      { observations: [:user, :thumb_image] }
-    ]
+  def show_includes
+    [:description, :descriptions, { observations: :user },
+     { synonym: :names }, :user, :versions]
   end
 
   # Possible sources of extra db lookups in partials

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -225,8 +225,18 @@ class NamesController < ApplicationController
   end
 
   def show_includes
-    [:description, :descriptions, { observations: :user },
-     { synonym: :names }, :user, :versions]
+    [:comments,
+     :correct_spelling,
+     { description: [:authors, :reviewer] },
+     { descriptions: [:authors, :editors, :reviewer, :writer_groups] },
+     { interests: :user },
+     :misspellings,
+     { namings: [:user] },
+     { observations: [:location, :user] },
+     :rss_log,
+     { synonym: :names },
+     :user,
+     :versions]
   end
 
   # Possible sources of extra db lookups in partials

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -231,7 +231,7 @@ class NamesController < ApplicationController # rubocop:disable Metrics/ClassLen
      { interests: :user },
      :misspellings,
      { namings: [:user] },
-     { observations: [:location, :user] },
+     { observations: [:location, :thumb_image, :user] },
      :rss_log,
      { synonym: :names },
      :user,

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -3,10 +3,8 @@
 # helpers for ShowName view and ShowNameInfo section of ShowObservation
 module ShowNameHelper
   ######## links to queries of observations of name... or related taxa.
-  # These are expensive and slow down the show name page a LOT.
-  # They would be nearly cost free if they didn't pre-count the results;
-  # counting means each query runs separately.
-  # One idea could be to lazy-load the counts?
+  # Counting these slows down the names#show page a LOT if done separately.
+  # Counts now derived from `obss`, an instantiation of Name::Observations
   def name_related_taxa_observation_links(name, obss)
     [
       # Observations of this name
@@ -18,8 +16,8 @@ module ShowNameHelper
       tag.p(taxon_obss_any_name(name, obss) || "#{:obss_of_taxon.t} (0)"),
       # Observations of other taxa where this taxon was proposed
       tag.p(taxon_proposed(name, obss) || "#{:obss_taxon_proposed.t} (0)"),
-      # Observations where this Nae was proposed
-      tag.p(name_proposed(name, obss) || "#{:obss_name_proposed.t} (0)"),
+      # Observations where this Name was proposed
+      tag.p(name_proposed(name, obss) || "#{:obss_name_proposed.t} (0)")
     ].safe_join
   end
 

--- a/app/helpers/show_name_helper.rb
+++ b/app/helpers/show_name_helper.rb
@@ -2,36 +2,57 @@
 
 # helpers for ShowName view and ShowNameInfo section of ShowObservation
 module ShowNameHelper
-  ######## links to searches
+  ######## links to queries of observations of name... or related taxa.
+  # These are expensive and slow down the show name page a LOT.
+  # They would be nearly cost free if they didn't pre-count the results;
+  # counting means each query runs separately.
+  # One idea could be to lazy-load the counts?
+  def name_related_taxa_observation_links(name, obss)
+    [
+      # Observations of this name
+      tag.p(taxon_obss_this_name(name, obss) || "#{:obss_of_this_name.t} (0)"),
+      # Observations of taxon under other names
+      tag.p(taxon_obss_other_names(name, obss) ||
+            "#{:taxon_obss_other_names.t} (0)"),
+      # Observations of taxon under any name
+      tag.p(taxon_obss_any_name(name, obss) || "#{:obss_of_taxon.t} (0)"),
+      # Observations of other taxa where this taxon was proposed
+      tag.p(taxon_proposed(name, obss) || "#{:obss_taxon_proposed.t} (0)"),
+      # Observations where this Nae was proposed
+      tag.p(name_proposed(name, obss) || "#{:obss_name_proposed.t} (0)"),
+    ].safe_join
+  end
 
   # link to a search for Observations of name and a count of those observations
   #   This Name (1)
-  def obss_of_name(name)
-    query = Query.lookup(:Observation, :all, names: name.id, by: :confidence)
-    link_to_obss_of(query, :obss_of_this_name.t)
-  end
-
-  # link to a search for Observations of this taxon (under any name) + count
-  def taxon_observations(name)
-    link_to_obss_of(obss_of_taxon(name), :obss_of_taxon.t)
+  def taxon_obss_this_name(name, obss)
+    link_to_obss_of(obss_of_taxon_this_name(name), :obss_of_this_name.t,
+                    obss.of_taxon_this_name.size)
   end
 
   # link to a search for observations of this taxon, under other names + count
-  def taxon_obss_other_names(name)
-    link_to_obss_of(obss_of_taxon_other_names(name), :taxon_obss_other_names.t)
+  def taxon_obss_other_names(name, obss)
+    link_to_obss_of(obss_of_taxon_other_names(name), :taxon_obss_other_names.t,
+                    obss.of_taxon_other_names.size)
+  end
+
+  # link to a search for Observations of this taxon (under any name) + count
+  def taxon_obss_any_name(name, obss)
+    link_to_obss_of(obss_of_taxon_any_name(name), :obss_of_taxon.t,
+                    obss.of_taxon_any_name.size)
   end
 
   # link to a search for observations where this taxon was proposed + count
   # (but is not the consensus)
-  def taxon_proposed(name)
+  def taxon_proposed(name, obss)
     link_to_obss_of(obss_other_taxa_this_taxon_proposed(name),
-                    :obss_taxon_proposed.t)
+                    :obss_taxon_proposed.t, obss.where_taxon_proposed.size)
   end
 
   # link to a search for observations where this name was proposed
-  def name_proposed(name)
+  def name_proposed(name, obss)
     link_to_obss_of(obss_this_name_proposed(name),
-                    :obss_name_proposed.t)
+                    :obss_name_proposed.t, obss.where_name_proposed.size)
   end
 
   # return link to a query for observations + count of results
@@ -41,8 +62,8 @@ module ShowNameHelper
   #                        include_synonyms: true)
   #   link_to_obss_of(query, :obss_of_taxon.t)
   #   => <a href="/observations?q=Q">This Taxon, any name</a> (19)
-  def link_to_obss_of(query, title)
-    count = query.select_count
+  def link_to_obss_of(query, title, count)
+    # count = query.select_count # This executes a query per link.
     return nil if count.zero?
 
     query.save
@@ -55,11 +76,11 @@ module ShowNameHelper
   ######## searches
 
   # These are extracted for isolation and to facilitate testing
+  # These don't run queries... it's query.select_count above, that does.
 
-  def obss_of_taxon(name)
+  def obss_of_taxon_this_name(name)
     Query.lookup(:Observation, :all,
                  names: name.id,
-                 include_synonyms: true,
                  by: :confidence)
   end
 
@@ -71,6 +92,14 @@ module ShowNameHelper
                  by: :confidence)
   end
 
+  def obss_of_taxon_any_name(name)
+    Query.lookup(:Observation, :all,
+                 names: name.id,
+                 include_synonyms: true,
+                 by: :confidence)
+  end
+
+  # These two do joins to Namings. Unbelievably, it's faster than the above?
   def obss_other_taxa_this_taxon_proposed(name)
     Query.lookup(:Observation, :all,
                  names: name.id,

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -277,7 +277,7 @@
 #  ==== Synonymy
 #  synonyms:                 List of all synonyms, including this Name.
 #  synonym_ids:              List of IDs of all synonyms, including this Name
-#  other_synonym_ids         List of IDs of all synonyms, excluding this Name
+#  other_synonym_ids::       List of IDs of all synonyms, excluding this Name
 #  sort_synonyms::           List of approved then deprecated synonyms.
 #  approved_synonyms::       List of approved synonyms.
 #  best_approved_synonym::   Single "best" approved synonym

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -277,6 +277,7 @@
 #  ==== Synonymy
 #  synonyms:                 List of all synonyms, including this Name.
 #  synonym_ids:              List of IDs of all synonyms, including this Name
+#  other_synonyms:           List of all synonyms, excluding this Name.
 #  other_synonym_ids::       List of IDs of all synonyms, excluding this Name
 #  sort_synonyms::           List of approved then deprecated synonyms.
 #  approved_synonyms::       List of approved synonyms.

--- a/app/models/name/observations.rb
+++ b/app/models/name/observations.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Name
+  class Observations
+    # attr_reader :with_images, :of_taxon_this_name, :of_taxon_other_names
+
+    def initialize(name)
+      @name = name
+      @name_ids = name.synonym_ids
+      @other_name_ids = name.other_synonym_ids
+      @all = Observation.joins(:namings).
+             where(namings: { name_id: @name_ids }).
+             order(vote_cache: :desc).distinct
+    end
+
+    def of_taxon_this_name
+      @all.select { |obs| obs&.name_id == @name.id }
+    end
+
+    def of_taxon_other_names
+      @all.select { |obs| obs&.name_id.in?(@other_name_ids) }
+    end
+
+    def of_taxon_any_name
+      @all.select { |obs| obs&.name_id.in?(@name_ids) }
+    end
+
+    def where_taxon_proposed
+      @all.reject { |obs| obs&.name_id == @name.id }
+    end
+
+    def where_name_proposed
+      @all
+    end
+
+    def with_images
+      of_taxon_this_name.reject { |obs| obs&.thumb_image_id.nil? }
+    end
+  end
+end

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -16,6 +16,10 @@ module Name::Synonymy
     synonyms.drop(1)
   end
 
+  def other_synonym_ids
+    synonym ? synonym.name_ids.to_a.drop(1) : []
+  end
+
   # Returns an Array of all synonym Name's including itself at front of list.
   # (This looks screwy, but I think it is the safest way to handle it.
   # Note that synonym.names does include self, but it's a different instance.

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -9,23 +9,12 @@
     concat(tag.div(class: "col-sm-7 name-section") do
       concat(tag.p(:show_observations_of.t))
       concat(tag.div(class: "pl-3") do
-        concat([
-          # Observations of this name
-          tag.p(obss_of_name(@name) || "#{:obss_of_this_name.t} (0)"),
-          # Observations of taxon under other names
-          tag.p(taxon_obss_other_names(@name) ||
-                "#{:taxon_obss_other_names.t} (0)"),
-          # Observations of taxon under any name
-          tag.p(taxon_observations(@name) || "#{:obss_of_taxon.t} (0)"),
-          # Observations of other taxa where this taxon was proposed
-          tag.p(taxon_proposed(@name) || "#{:obss_taxon_proposed.t} (0)"),
-          # Observations where this Nae was proposed
-          tag.p(name_proposed(@name) || "#{:obss_name_proposed.t} (0)"),
-        ].safe_join)
+        concat(name_related_taxa_observation_links(@name, @obss))
         # Observations of this name's subtaxa, if any
         concat(tag.p do
-          link_to(:show_subtaxa_obss.t,
-                  add_query_param(observations_path, @subtaxa_query))
+          [link_to(:show_subtaxa_obss.l,
+                   add_query_param(observations_path, @subtaxa_query)),
+           " (#{@has_subtaxa})"].safe_join
         end) if @has_subtaxa
       end)
     end)

--- a/test/helpers/name_helper_test.rb
+++ b/test/helpers/name_helper_test.rb
@@ -70,7 +70,7 @@ class NameHelperTest < ActionView::TestCase
                   user: user)
 
     # Now test the Query's
-    results = obss_of_taxon(nam).results
+    results = obss_of_taxon_any_name(nam).results
     assert(results.include?(nam_proposed_and_consensus))
     assert(results.include?(nam_proposed_syn_is_consensus))
     assert(results.include?(syn_proposed_and_consensus))


### PR DESCRIPTION
The `observations_menu` partial does a bunch of similar Observation lookups to get tallies of the number of observations of _this taxon_, _other names_, etc. It's the slowest thing on the page.

It turns out that these queries are all subsets of a single query, "Observations where any synonym of this name have been proposed". Instantiating that "mother" lookup in a PORO allows us to derive the values of each of the subsets while only performing one query.

`Subtaxa` is still a separate query. (It's conceivably a set adjacent to the above, in other words a subquery of some jumbo hypothetical superset, but i'm keeping it separate.)