### PR TITLE
Observations Show - Add `{ name: { synonym: :names } }` to eager loads

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -248,6 +248,8 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :needs_id, lambda {
     with_name_above_genus.or(without_confident_name)
   }
+  scope :with_name_correctly_spelled,
+        -> { joins({ namings: :name }).where(names: { correct_spelling: nil }) }
 
   scope :with_vote_by_user, lambda { |user|
     user_id = user.is_a?(Integer) ? user : user&.id

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -519,7 +519,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       { comments: :user },
       { images: [:license, :user] },
       :location,
-      :name,
+      { name: { synonym: :names } },
       { namings: [:name, :user, { votes: [:observation, :user] }] },
       :projects,
       :thumb_image,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -504,7 +504,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       { images: [:image_votes, :license, :projects, :user] },
       { interests: :user },
       :location,
-      :name,
+      { name: { synonym: :names } },
       { namings: [:name, :user, { votes: [:observation, :user] }] },
       { projects: :admin_group },
       :rss_log,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -496,7 +496,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       where(ProjectSpeciesList[:project_id] == project.id).distinct
   }
   scope :show_includes, lambda {
-    includes(
+    strict_loading.includes(
       :collection_numbers,
       { comments: :user },
       { external_links: { external_site: { project: :user_group } } },

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -51,7 +51,7 @@ class ChecklistsControllerTest < FunctionalTestCase
   # Prove that Site checklist goes to correct page with correct content
   def test_checklist_for_site
     login
-    expect = Name.joins(:observations).distinct
+    expect = Name.with_correct_spelling.joins(:observations).distinct
 
     get(:show)
     assert_match(/Checklist for #{:app_title.l}/, css_select("title").text,

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -267,7 +267,7 @@ class NamesControllerTest < FunctionalTestCase
     assert_select(
       "#results a:match('href', ?)", %r{^#{names_path}/\d+},
       # need length; count & size return a hash; description_needed is grouped
-      { count: Name.description_needed.length },
+      { count: Name.with_correct_spelling.description_needed.length },
       "Wrong number of (correctly spelled) Names"
     )
   end

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -89,6 +89,12 @@ class ObservationsControllerTest < FunctionalTestCase
   #  General tests.
   # ----------------------------
 
+  # Test load a deprecated name obs, no strict_loading error
+  def test_show_observation_deprecated_name
+    obs = observations(:deprecated_name_obs)
+    get(:show, params: { id: obs.id })
+  end
+
   def test_show_observation_noteless_image
     obs = observations(:peltigera_mary_obs)
     img = images(:rolf_profile_image)

--- a/test/fixtures/namings.yml
+++ b/test/fixtures/namings.yml
@@ -145,3 +145,10 @@ same_user_owns_name_and_observation:
   observation: same_user_owns_name_and_naming_obs
   name: same_user_owns_naming_and_observation
   vote_cache: <%= Vote.next_best_vote %>
+
+# Just need an obs of deprecated name, trying to keep this out of queries
+deprecated_name_obs_naming:
+  user: vouchered_only_user
+  observation: deprecated_name_obs
+  name: petigera
+  vote_cache: <%= Vote.next_best_vote %>

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -230,7 +230,7 @@ unknown_with_lat_long:
   long: -118.3521
   alt: 123
   notes:
-    :Other: 'unknown_with_lat_long'
+    :Other: "unknown_with_lat_long"
 
 trusted_hidden:
   <<: *DEFAULTS
@@ -268,13 +268,13 @@ amateur_obs:
   when: 2010-12-30
   user: katrina
   location:
-  where: 'Pasadena, California, USA'
+  where: "Pasadena, California, USA"
   is_collection_location: 0
   name: conocybe_filaris
   text_name: Conocybe filaris
   specimen: 1
   notes:
-    :Other: 'A friend showed me this.'
+    :Other: "A friend showed me this."
   lat: 34.1622
   long: -118.3521
   source: <%= Observation.sources[:mo_iphone_app] %>
@@ -286,13 +286,13 @@ peltigera_obs:
   when: 2012-06-07
   user: rolf
   location:
-  where: 'Briceland, California, USA'
+  where: "Briceland, California, USA"
   name: peltigera
   text_name: Peltigera
   classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   specimen: 1
   notes:
-    :Other: 'Growing on a hardwood'
+    :Other: "Growing on a hardwood"
   vote_cache: 3
   thumb_image: peltigera_image
   images: peltigera_image
@@ -307,13 +307,13 @@ peltigera_mary_obs:
   when: 2013-09-08
   user: mary
   location:
-  where: 'Briceland, California, USA'
+  where: "Briceland, California, USA"
   name: peltigera
   text_name: Peltigera
   classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   specimen: 1
   notes:
-    :Other: 'Growing on a hardwood'
+    :Other: "Growing on a hardwood"
   vote_cache: 3
   thumb_image: rolf_profile_image
   images: rolf_profile_image
@@ -326,12 +326,12 @@ fungi_obs:
   when: 2013-09-15
   user: rolf
   location:
-  where: 'Briceland, California, USA'
+  where: "Briceland, California, USA"
   is_collection_location: 0
   name: fungi
   text_name: Fungi
   notes:
-    :Other: 'Observation for plane pileus'
+    :Other: "Observation for plane pileus"
   vote_cache: 3
   thumb_image: conic_image
   images: conic_image, plane_image_example
@@ -342,12 +342,12 @@ boletus_edulis_obs:
   updated_at: 2014-04-21 04:04:07
   when: 2014-04-21
   location:
-  where: 'New York, New York, USA'
+  where: "New York, New York, USA"
   name: boletus_edulis
   text_name: Boletus edulis
   is_collection_location: 0
   notes:
-    :Other: 'A tasty bolete!'
+    :Other: "A tasty bolete!"
   vote_cache: 3
   species_lists: one_genus_three_species_list
 
@@ -383,13 +383,13 @@ owner_accepts_general_questions:
   <<: *DEFAULTS
   created_at: 2020-07-08 04:06:04
   when: 2020-07-08
-  user: roy                      # roy has email_general_questions == true
+  user: roy # roy has email_general_questions == true
 
 owner_refuses_general_questions:
   <<: *DEFAULTS
   created_at: 2020-05-05 04:06:04
   when: 2020-05-05
-  user: dick                     # dick has email_general_questions == false
+  user: dick # dick has email_general_questions == false
 
 collected_at_obs:
   <<: *DEFAULTS
@@ -664,3 +664,15 @@ reused_observation:
   when: 2023-11-19
   species_lists: reused_list
   rss_log:
+
+deprecated_name_obs:
+  <<: *DEFAULTS
+  created_at: 2014-04-04 04:05:03
+  updated_at: 2014-04-04 04:05:03
+  when: 2012-06-07
+  user: rolf
+  location:
+  where: "Briceland, California, USA"
+  name: petigera
+  text_name: Petigera
+  lifeform: " lichen "

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -670,9 +670,10 @@ deprecated_name_obs:
   created_at: 2014-04-04 04:05:03
   updated_at: 2014-04-04 04:05:03
   when: 2012-06-07
-  user: rolf
+  user: vouchered_only_user
   location:
   where: "Briceland, California, USA"
   name: petigera
   text_name: Petigera
   lifeform: " lichen "
+  rss_log:

--- a/test/models/pattern_search_test.rb
+++ b/test/models/pattern_search_test.rb
@@ -534,7 +534,7 @@ class PatternSearchTest < UnitTestCase
   end
 
   def test_observation_search_include_synonyms
-    expect = Observation.where(name: names(:peltigera))
+    expect = Observation.where(name: [names(:peltigera), names(:petigera)])
     assert(expect.count.positive?)
     x = PatternSearch::Observation.new("Petigera include_synonyms:yes")
     assert_obj_arrays_equal(expect, x.query.results, :sort)

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2464,7 +2464,8 @@ class QueryTest < UnitTestCase
   end
 
   def test_name_with_observations
-    expect = Observation.select(:name).distinct.pluck(:name_id).sort
+    expect = Name.with_correct_spelling.joins(:observations).
+             select(:name).distinct.pluck(:name_id).sort
     assert_query(expect, :Name, :with_observations, by: :id)
 
     # Prove that :with_observations flavor of Name Query works with each
@@ -2477,7 +2478,7 @@ class QueryTest < UnitTestCase
     # created_at
     created_at = observations(:california_obs).created_at
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(Observation[:created_at] >= created_at).uniq,
       :Name, :with_observations, created_at: created_at
     )
@@ -2485,7 +2486,7 @@ class QueryTest < UnitTestCase
     # updated_at
     updated_at = observations(:california_obs).updated_at
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(Observation[:updated_at] >= updated_at).uniq,
       :Name, :with_observations, updated_at: updated_at
     )
@@ -2493,7 +2494,8 @@ class QueryTest < UnitTestCase
     # date
     date = observations(:california_obs).when
     assert_query(
-      Name.joins(:observations).where(Observation[:when] >= date).uniq,
+      Name.with_correct_spelling.joins(:observations).
+           where(Observation[:when] >= date).uniq,
       :Name, :with_observations, date: date
     )
 
@@ -2501,7 +2503,7 @@ class QueryTest < UnitTestCase
 
     # has_notes_fields
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(Observation[:notes].matches("%:substrate:%")).uniq,
       :Name, :with_observations, has_notes_fields: "substrate"
     )
@@ -2509,7 +2511,8 @@ class QueryTest < UnitTestCase
     # herbaria
     name = "The New York Botanical Garden"
     assert_query(
-      Name.joins(observations: { herbarium_records: :herbarium }).
+      Name.with_correct_spelling.
+           joins(observations: { herbarium_records: :herbarium }).
            where(herbaria: { name: name }).uniq,
       :Name, :with_observations, herbaria: name
     )
@@ -2523,7 +2526,8 @@ class QueryTest < UnitTestCase
 
     # users
     assert_query(
-      Name.joins(:observations).where(observations: { user: dick }).uniq,
+      Name.with_correct_spelling.joins(:observations).
+           where(observations: { user: dick }).uniq,
       :Name, :with_observations, users: dick
     )
 
@@ -2531,7 +2535,8 @@ class QueryTest < UnitTestCase
 
     # confidence
     expect =
-      Name.joins(:observations).where(observations: { vote_cache: 1..3 }).uniq
+      Name.with_correct_spelling.joins(:observations).
+           where(observations: { vote_cache: 1..3 }).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, :Name, :with_observations, confidence: [1, 3])
 
@@ -2540,7 +2545,7 @@ class QueryTest < UnitTestCase
     lat = obs.lat
     long = obs.long
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(observations: { lat: lat }).
            where(observations: { long: long }).uniq,
       :Name, :with_observations,
@@ -2551,40 +2556,40 @@ class QueryTest < UnitTestCase
 
     # :has_comments
     assert_query(
-      Name.joins(observations: :comments).uniq,
+      Name.with_correct_spelling.joins(observations: :comments).uniq,
       :Name, :with_observations, has_comments: true
     )
 
     # has_location
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where.not(observations: { location_id: false }).uniq,
       :Name, :with_observations, has_location: true
     )
 
     # has_name
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(observations: { name_id: Name.unknown }).uniq,
       :Name, :with_observations, has_name: false
     )
 
     # :has_notes
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where.not(observations: { notes: Observation.no_notes }).uniq,
       :Name, :with_observations, has_notes: true
     )
 
     # has_sequences
     assert_query(
-      Name.joins(observations: :sequences).uniq,
+      Name.with_correct_spelling.joins(observations: :sequences).uniq,
       Name, :with_observations, has_sequences: true
     )
 
     # is_collection_location
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(observations: { is_collection_location: true }).uniq,
       :Name, :with_observations, is_collection_location: true
     )
@@ -2592,7 +2597,7 @@ class QueryTest < UnitTestCase
 
   def test_name_with_observations_at_location
     assert_query(
-      Name.joins(:observations).
+      Name.with_correct_spelling.joins(:observations).
            where(observations: { location: locations(:burbank) }).distinct,
       :Name, :with_observations_at_location, location: locations(:burbank)
     )
@@ -2605,10 +2610,10 @@ class QueryTest < UnitTestCase
   end
 
   def test_name_with_observations_by_user
-    assert_query(Name.joins(:observations).
+    assert_query(Name.with_correct_spelling.joins(:observations).
                       where(observations: { user: rolf }).distinct,
                  :Name, :with_observations_by_user, user: rolf)
-    assert_query(Name.joins(:observations).
+    assert_query(Name.with_correct_spelling.joins(:observations).
                       where(observations: { user: mary }).distinct,
                  :Name, :with_observations_by_user, user: mary)
     assert_query([], :Name, :with_observations_by_user, user: users(:zero_user))

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2534,9 +2534,8 @@ class QueryTest < UnitTestCase
     ##### numeric parameters #####
 
     # confidence
-    expect =
-      Name.with_correct_spelling.joins(:observations).
-           where(observations: { vote_cache: 1..3 }).uniq
+    expect = Name.with_correct_spelling.joins(:observations).
+             where(observations: { vote_cache: 1..3 }).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, :Name, :with_observations, confidence: [1, 3])
 


### PR DESCRIPTION
#1781 `strict_loading` error, the association is marked for strict_loading for not-logged-in users only.  
Ah - it's bot access, and it errors because logged-out users get a different title. Will add a test to cover it on this PR. 

A controller/integration test just needs to load an obs of a deprecated name with synonyms. To do this, I'm adding a new fixture `deprecated_name_obs`.  Hopefully it doesn't crash other tests. (It does: test expectations adjusted accordingly.)

The test can't test a contrary case, because the eager loading of `name: :synonym` now happens no matter what. But the new test fails on current `main`, so I am satisfied it's actually testing something.

Finally, this PR makes the show_obs `strict_loading` for logged-in users, too, as desired. (This was the error i couldn't track down before!)