### PR TITLE
Lifeform form method

### DIFF
--- a/app/views/controllers/names/lifeforms/edit.html.erb
+++ b/app/views/controllers/names/lifeforms/edit.html.erb
@@ -8,7 +8,8 @@ action = { controller: "/names/lifeforms", action: :update,
            id: @name.id, q: get_query_param }
 %>
 
-<%= form_with(url: action, scope: :lifeform, id: "name_lifeform_form") do |f| %>
+<%= form_with(url: action, method: :put, scope: :lifeform,
+              id: "name_lifeform_form") do |f| %>
 
   <p><%= :edit_lifeform_help.t %></p>
 

--- a/app/views/controllers/names/trackers/_form.html.erb
+++ b/app/views/controllers/names/trackers/_form.html.erb
@@ -2,7 +2,7 @@
 # This form can create OR update a tracker, via params[:commit]
 # Idk why rails does not recognize the model scope and nest the attributes.
 %>
-<%= form_with(model: @name_tracker, url: action,
+<%= form_with(model: @name_tracker, url: action, method: method,
               id: "name_tracker_form") do |f| %>
 
   <div class="text-center my-3">

--- a/app/views/controllers/names/trackers/edit.html.erb
+++ b/app/views/controllers/names/trackers/edit.html.erb
@@ -6,7 +6,7 @@ add_page_title(:email_tracking_title.t(name: @name.display_name))
 add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/trackers", action: :update, id: @name.id,
-            q: get_query_param }
+           q: get_query_param }
 %>
 
 <div class="mt-5 mb-5">
@@ -19,4 +19,5 @@ action = { controller: "/names/trackers", action: :update, id: @name.id,
   end %>
 </div>
 
-<%= render(partial: "names/trackers/form", locals: { action: action }) %>
+<%= render(partial: "names/trackers/form", locals: { action: action,
+                                                     method: :put }) %>

--- a/app/views/controllers/names/trackers/new.html.erb
+++ b/app/views/controllers/names/trackers/new.html.erb
@@ -19,4 +19,5 @@ action = { controller: "/names/trackers", action: :create, id: @name.id,
   end %>
 </div>
 
-<%= render(partial: "names/trackers/form", locals: { action: action }) %>
+<%= render(partial: "names/trackers/form", locals: { action: action,
+                                                     method: :post }) %>


### PR DESCRIPTION
When it's a `form_with(url:)` we have to set the `method:` arg explicitly. For edit, that's `put` or `patch`. It defaults to `post`.

@JoeCohen If you can think of a test that submits this form, please write one. I think we just need an integration test that loads and submits the form. I'm going to merge without it though, too many fish to fry right now.

Should fix #1779