### PR TITLE
Further reduce queries on show name

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -255,6 +255,7 @@ class NamesController < ApplicationController
     @has_subtaxa = 0
     # Query for names of subtaxa, used in special query link
     # Note this is only creating a schematic of a query, used in the link.
+
     # Create query for immediate children.
     @children_query = create_query(:Name, :all,
                                    names: @name.id,
@@ -293,12 +294,14 @@ class NamesController < ApplicationController
       # Don't run if there aren't any children.
       @has_subtaxa = @first_child ? @subtaxa_query.select_count : 0
     end
+
     # NOTE: `_observation_menu` makes many select_count queries like this!
     # That is where most of the heavy loading is. Check helpers/show_name_helper
     #
     # Third query (maybe combine with second)
     @obss = Name::Observations.new(@name)
-    @best_images = @obss.with_images.take(6).map(&:thumb_image)
+    # This initiates a query for the images of only the most confident obs
+    @best_images = @obss.best_images
 
     # This seems like it queries the NameDescription table.
     # Would be better to eager load descriptions and derive @best_description

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -169,9 +169,9 @@ module FooterHelper
     # latest_user = User.safe_find(versions.latest.user_id)
     html = html_created_by(obj)
 
-    if versions.latest.user_id && obj.updated_at
+    if versions.last.user_id && obj.updated_at
       html << :footer_last_updated_by.t(
-        user: user_link(versions.latest.user_id),
+        user: user_link(versions.last.user_id),
         date: obj.updated_at.web_time
       )
     elsif obj.updated_at

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -14,7 +14,7 @@ module VersionsHelper
   #   Previous Version: N-1<br/>
   #
   def show_previous_version(obj, versions)
-    previous_version = versions.latest&.previous
+    previous_version = versions&.last(2)&.first
     if previous_version
       previous_version_link(previous_version, obj)
     else

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -260,6 +260,12 @@ class Image < AbstractModel
   after_update :track_copyright_changes
   before_destroy :update_thumbnails
 
+  scope :interactive_includes, lambda {
+    strict_loading.includes(
+      :image_votes, :license, :projects, :user
+    )
+  }
+
   # Array of all observations, users and glossary terms using this image.
   def all_subjects
     observations + profile_users + glossary_terms

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -667,14 +667,14 @@ class Name < AbstractModel
   }
   scope :show_includes, lambda {
     strict_loading.includes(
-      :comments,
+      # :comments,
       :correct_spelling,
       { description: [:authors, :reviewer] },
       { descriptions: [:authors, :editors, :reviewer, :writer_groups] },
       { interests: :user },
       :misspellings,
-      { namings: [:user] },
-      { observations: [:location, :thumb_image, :user] },
+      # { namings: [:user] },
+      # { observations: [:location, :thumb_image, :user] },
       :rss_log,
       { synonym: :names },
       :user,

--- a/app/models/name/observations.rb
+++ b/app/models/name/observations.rb
@@ -36,5 +36,11 @@ class Name
     def with_images
       of_taxon_this_name.reject { |obs| obs&.thumb_image_id.nil? }
     end
+
+    def best_images
+      image_ids = with_images.take(6).map(&:thumb_image_id)
+      # One new lookup for the images.
+      Image.interactive_includes.where(id: image_ids).order(vote_cache: :desc)
+    end
   end
 end

--- a/app/models/name/observations.rb
+++ b/app/models/name/observations.rb
@@ -39,7 +39,7 @@ class Name
 
     def best_images
       image_ids = with_images.take(6).map(&:thumb_image_id)
-      # One new lookup for the images.
+      # One new lookup for the images. Order these by image votes
       Image.interactive_includes.where(id: image_ids).order(vote_cache: :desc)
     end
   end

--- a/app/views/controllers/names/show.html.erb
+++ b/app/views/controllers/names/show.html.erb
@@ -55,14 +55,27 @@ add_tab_set(name_show_tabs(name: @name, user: @user))
       <%= render(partial: "names/show/projects_panel") %>
     <% end %>
 
+    <% footer = tag.div(id: "name_previous_export") do
+      puts("show_previous_version")
+      concat(show_previous_version(@name, @versions))
+      puts("show_previous_version")
+      concat(export_status_controls(@name))
+    end %>
+
+    <%= panel_block(id: "name_footer", footer: footer) do
+      concat(tag.div(id: "name_authors_editors") do
+        puts("show_authors_and_editors")
+        show_authors_and_editors(obj: @name, versions: @versions, user: @user)
+        puts("show_authors_and_editors")
+      end)
+      concat(:show_name_num_notifications.t(num: @name.interests))
+    end %>
+
   </div><!--RIGHT COLUMN-->
 </div><!--.row-->
 
-<%# ----------------------------------------
-  #  Show comments
-  # ----------------------------------------
+<%=
+puts("show_object_footer")
+show_object_footer(@name, @versions)
+puts("show_object_footer")
 %>
-<%= render(partial: "comments/comments_for_object",
-           locals: {object: @name, controls: @user, limit: nil}) %>
-<%= :show_name_num_notifications.t(num: @name.interests) %>
-<%= show_object_footer(@name, @versions) %>

--- a/app/views/controllers/names/show.html.erb
+++ b/app/views/controllers/names/show.html.erb
@@ -49,17 +49,13 @@ add_tab_set(name_show_tabs(name: @name))
     <% end %>
 
     <% footer = tag.div(id: "name_previous_export") do
-      puts("show_previous_version")
       concat(show_previous_version(@name, @versions))
-      puts("show_previous_version")
       concat(export_status_controls(@name))
     end %>
 
     <%= panel_block(id: "name_footer", footer: footer) do
       concat(tag.div(id: "name_authors_editors") do
-        puts("show_authors_and_editors")
         show_authors_and_editors(obj: @name, versions: @versions, user: @user)
-        puts("show_authors_and_editors")
       end)
       concat(:show_name_num_notifications.t(num: @name.interests))
     end %>
@@ -68,7 +64,5 @@ add_tab_set(name_show_tabs(name: @name))
 </div><!--.row-->
 
 <%=
-puts("show_object_footer")
 show_object_footer(@name, @versions)
-puts("show_object_footer")
 %>


### PR DESCRIPTION
#### Further reduces the versions table lookups by calling `last` instead of `latest`. ####

The `acts_as_versioned` method `latest` always initiates a new lookup, even when called on a complete query of all `@versions`, and version lookups are slow. With our db setup, though, `last` should reliably be equivalent to the latest record.

#### Batches and eager-loads most confident images. ####

Most confident images pulls the `thumb_image_id` from the most confident "obs of name" query, but then the carousel helper had to look up the images separately. It's really a query of a query.

The new `Name::Observations` PORO already has the first query, though. Here the images are eager loaded with their associations from that existing query, and passed to the helper in one eager-loaded batch. 

Adds a new `Image` scope `interactive_includes` for the associations needed for an `interactive_image` (notes, votes, copyright, link, etc).