### PR TITLE
Create Observation blank Scientific Name

### DIFF
--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -23,6 +23,19 @@ module ObservationsController::Validators
   end
 
   def validate_name(params)
+    (success, @what, @name, @names, @valid_names,
+     @parent_deprecated, @suggest_corrections) = resolve_name_ivars(params)
+    if @name
+      @naming.name = @name
+    elsif !success
+      @naming.errors.add(:name,
+                         :form_observations_there_is_a_problem_with_name.t)
+      flash_object_errors(@naming)
+    end
+    success
+  end
+
+  def resolve_name_ivars(params)
     given_name = params.dig(:naming, :name).to_s
     chosen_name = params.dig(:chosen_name, :name_id).to_s
     @resolver = Naming::NameResolver.new(
@@ -31,17 +44,7 @@ module ObservationsController::Validators
     # NOTE: views could be refactored to access properties of the @resolver,
     # e.g. `@resolver.valid_names`, instead of these ivars.
     # All but success, @what, @name are only used by form_name_feedback.
-    (success, @what, @name, @names, @valid_names,
-     @parent_deprecated, @suggest_corrections) = @resolver.ivar_array
-    if @name
-      @naming.name = @name
-    # else
-    elsif !success
-      @naming.errors.add(:name,
-                         :form_observations_there_is_a_problem_with_name.t)
-      flash_object_errors(@naming)
-    end
-    success
+    @resolver.ivar_array
   end
 
   def validate_place_name(params)

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -35,7 +35,8 @@ module ObservationsController::Validators
      @parent_deprecated, @suggest_corrections) = @resolver.ivar_array
     if @name
       @naming.name = @name
-    else
+    # else
+    elsif !success
       @naming.errors.add(:name,
                          :form_observations_there_is_a_problem_with_name.t)
       flash_object_errors(@naming)

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -454,6 +454,21 @@ module Observations
       assert_equal(3, namings(:coprinus_comatus_naming).vote_sum) # 2+1 = 3
     end
 
+    def test_propose_nothing
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: {
+          name: "",
+          vote: { value: "" }
+        }
+      }
+      login("rolf")
+
+      post(:create, params: params)
+
+      assert_no_flash("Blank Name proposal should not cause flash.")
+    end
+
     # Now see what happens when a third party proposes a name, and it wins.
     def test_propose_dicks_naming
       o_count = Observation.count

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -454,21 +454,6 @@ module Observations
       assert_equal(3, namings(:coprinus_comatus_naming).vote_sum) # 2+1 = 3
     end
 
-    def test_propose_nothing
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: {
-          name: "",
-          vote: { value: "" }
-        }
-      }
-      login("rolf")
-
-      post(:create, params: params)
-
-      assert_no_flash("Blank Name proposal should not cause flash.")
-    end
-
     # Now see what happens when a third party proposes a name, and it wins.
     def test_propose_dicks_naming
       o_count = Observation.count

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1441,10 +1441,17 @@ class ObservationsControllerTest < FunctionalTestCase
   def test_create_observation_without_scientific_name
     params = { user: rolf,
                where: locations.first.name }
+    fungi = names(:fungi)
 
     post_requires_login(:create, params)
 
-    assert_flash_success
+    assert_flash_success(
+      "Omitting Scientific Name should not cause flash error or warning."
+    )
+    assert_equal(
+      fungi, Observation.last.name,
+      "Observation should be id'd as `Fungi` if user omits Scientific Name."
+    )
   end
 
   def test_create_observation_with_unrecognized_name

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -1438,6 +1438,15 @@ class ObservationsControllerTest < FunctionalTestCase
            "Observation should have log_updated_at time")
   end
 
+  def test_create_observation_without_scientific_name
+    params = { user: rolf,
+               where: locations.first.name }
+
+    post_requires_login(:create, params)
+
+    assert_flash_success
+  end
+
   def test_create_observation_with_unrecognized_name
     text_name = "Elfin saddle"
     params = { naming: { name: text_name },


### PR DESCRIPTION
Leaving the Scientific Name blank when creating an Observation does not cause a flash error.
- Fixes  #1778.