### PR TITLE
Fragment-cache matrix boxes on indexes: obs, rss_logs and identify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem("turbo-rails")
 # gem("redis", "~> 4.0")
 # Compile SCSS for stylesheets
 gem("sassc-rails")
+# add locale to cache key
+gem("cache_with_locale")
 
 # Fix a version problem betw stimulus and sprockets. (not sprockets-rails)
 # Delete this dependency declaration if the issue gets resolved:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
     bullet (7.1.5)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    cache_with_locale (0.0.3)
+      actionview
+      activesupport
+      railties
     capybara (3.39.2)
       addressable
       matrix
@@ -349,6 +353,7 @@ DEPENDENCIES
   browser
   bullet
   bundler
+  cache_with_locale
   capybara (~> 3.37, >= 3.37.1)
   cuprite
   database_cleaner-active_record

--- a/app/views/controllers/observations/identify/index.html.erb
+++ b/app/views/controllers/observations/identify/index.html.erb
@@ -14,11 +14,9 @@ flash_error(@error) if @error && @objects.empty?
   <%= tag.ul(class: "row list-unstyled mt-3",
              data: { controller: "matrix-table",
                      action: "resize@window->matrix-table#rearrange" }) do %>
-    <%= render(partial: "shared/matrix_box",
+    <%= render(partial: "shared/matrix_box", layout: "shared/matrix_table",
                locals: { link_method: :get, identify: true },
-               layout: "shared/matrix_table",
-               collection: @objects,
-               as: :object) %>
+               collection: @objects, as: :object, cached: true) %>
     <div style="clear:left"></div>
   <% end %>
 <% end %>

--- a/app/views/controllers/observations/index.html.erb
+++ b/app/views/controllers/observations/index.html.erb
@@ -41,8 +41,7 @@ flash_error(@error) if @error && @objects.empty?
                      action: "resize@window->matrix-table#rearrange" }) do %>
     <%= render(partial: "shared/matrix_box",
                layout: "shared/matrix_table",
-               collection: @objects,
-               as: :object) %>
+               collection: @objects, as: :object, cached: true) %>
     <div style="clear:left"></div>
   <% end %>
 <% end %>

--- a/app/views/controllers/rss_logs/index.html.erb
+++ b/app/views/controllers/rss_logs/index.html.erb
@@ -12,10 +12,8 @@ flash_error(@error) if @error && @objects.empty?
   <%= tag.ul(class: "row list-unstyled mt-3",
              data: { controller: "matrix-table",
                      action: "resize@window->matrix-table#rearrange" }) do %>
-    <%= render(partial: "shared/matrix_box",
-               layout: "shared/matrix_table",
-               collection: @objects,
-               as: :object) %>
+    <%= render(partial: "shared/matrix_box", layout: "shared/matrix_table",
+               collection: @objects, as: :object, cached: true) %>
     <div style="clear:left"></div>
   <% end %>
 <% end %>


### PR DESCRIPTION
This is a trial run for fragment caching with translations. Locally it seems to work.

Any time _-the AR object that is used to generate the partial-_ is updated, it **should** invalidate the cache of that partial, and the next client reload of that index should regenerate that cached fragment of HTML (in that locale).