### PR TITLE
Restore formatting to log output on production!

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,10 +111,9 @@ MushroomObserver::Application.configure do
   #   .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
   #   .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
-  # Log to STDOUT and production.log. New 7.1 logging uses BroadcastLogger
+  # Log to production.log. New 7.1 logging uses BroadcastLogger
   # Not using TaggedLogging yet.
   loggers = [
-    STDOUT,
     "log/production.log"
   ].map do |output|
     ActiveSupport::Logger.new(output).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,6 +111,18 @@ MushroomObserver::Application.configure do
   #   .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
   #   .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
+  # Log to STDOUT and production.log. New 7.1 logging uses BroadcastLogger
+  # Not using TaggedLogging yet.
+  loggers = [
+    STDOUT,
+    "log/production.log"
+  ].map do |output|
+    ActiveSupport::Logger.new(output).
+      tap { |logger| logger.formatter = Logger::Formatter.new }
+    # .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  end
+  config.logger = ActiveSupport::BroadcastLogger.new(*loggers)
+
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :request_id, :subdomain, :uuid ]
 


### PR DESCRIPTION
A config change in Rails 7.1.2 changed how to apply the default formatter to log output.

We do want that formatting, which adds timestamp and PID to our logging. Not having it flatlined our MRTG logging for the last 24+ hours.