### PR TITLE
Maybe fix `config.log_level`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     mini_mime (1.1.5)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
-    minitest (5.21.0)
+    minitest (5.21.1)
     minitest-reporters (1.6.1)
       ansi
       builder
@@ -185,7 +185,7 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.3.0.2)
+    parser (3.3.0.3)
       ast (~> 2.4.1)
       racc
     psych (4.0.6)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,10 +113,12 @@ MushroomObserver::Application.configure do
 
   # Log to production.log. New 7.1 logging uses BroadcastLogger
   # Not using TaggedLogging yet.
+  # NOTE: setting `level: Logger::INFO` is a temporary fix
+  # https://github.com/rails/rails/pull/50337
   loggers = [
     "log/production.log"
   ].map do |output|
-    ActiveSupport::Logger.new(output).
+    ActiveSupport::Logger.new(output, level: Logger::INFO).
       tap { |logger| logger.formatter = Logger::Formatter.new }
     # .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
   end


### PR DESCRIPTION
Rails new logger is ignoring `config.log_level`, and it's logging at the `:debug` level, which is too much. It's a known issue in Rails. This temporary fix tries to override the ignore, but it may not work.

Fix is coming in 7.1.3, but it has also been backported to `7.1 stable` as of last week.
If anybody knows a way to get that update, please enlighten me. `bundle update` didn't do it. It also may just not be pushed out yet.

https://github.com/rails/rails/pull/50337