### PR TITLE
Temporarily remove caching

### DIFF
--- a/app/views/controllers/observations/identify/index.html.erb
+++ b/app/views/controllers/observations/identify/index.html.erb
@@ -14,9 +14,10 @@ flash_error(@error) if @error && @objects.empty?
   <%= tag.ul(class: "row list-unstyled mt-3",
              data: { controller: "matrix-table",
                      action: "resize@window->matrix-table#rearrange" }) do %>
-    <%= render(partial: "shared/matrix_box", layout: "shared/matrix_table",
+    <%= render(partial: "shared/matrix_box",
+               layout: "shared/matrix_table",
                locals: { link_method: :get, identify: true },
-               collection: @objects, as: :object, cached: true) %>
+               collection: @objects, as: :object) %>
     <div style="clear:left"></div>
   <% end %>
 <% end %>

--- a/app/views/controllers/observations/index.html.erb
+++ b/app/views/controllers/observations/index.html.erb
@@ -41,7 +41,7 @@ flash_error(@error) if @error && @objects.empty?
                      action: "resize@window->matrix-table#rearrange" }) do %>
     <%= render(partial: "shared/matrix_box",
                layout: "shared/matrix_table",
-               collection: @objects, as: :object, cached: true) %>
+               collection: @objects, as: :object) %>
     <div style="clear:left"></div>
   <% end %>
 <% end %>

--- a/app/views/controllers/rss_logs/index.html.erb
+++ b/app/views/controllers/rss_logs/index.html.erb
@@ -12,8 +12,9 @@ flash_error(@error) if @error && @objects.empty?
   <%= tag.ul(class: "row list-unstyled mt-3",
              data: { controller: "matrix-table",
                      action: "resize@window->matrix-table#rearrange" }) do %>
-    <%= render(partial: "shared/matrix_box", layout: "shared/matrix_table",
-               collection: @objects, as: :object, cached: true) %>
+    <%= render(partial: "shared/matrix_box",
+               layout: "shared/matrix_table",
+               collection: @objects, as: :object) %>
     <div style="clear:left"></div>
   <% end %>
 <% end %>


### PR DESCRIPTION
Issue: Rails caches not only the matrix_boxes, but also the matrix_box "spacers" added for Bootstrap 3 layout. 
![Screen Shot 2024-01-12 at 10 50 48 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/166b1d85-6373-406a-97bf-d10b6fb1f95c)

We need to move the code that adds the spacers out of the layout, and into JS so they don't get cached.

In Bootstrap 4, there's no need for the spacers.