### PR TITLE
Proposed Name blank flash

### DIFF
--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # Controller for handling the naming of observations
-# rubocop:disable Metrics/ClassLength
+
 module Observations
-  class NamingsController < ApplicationController
+  class NamingsController < ApplicationController # rubocop:disable Metrics/ClassLength
     before_action :login_required
     before_action :pass_query_params
 
@@ -37,11 +37,7 @@ module Observations
         save_changes
         respond_to_successful_create
       else # If anything failed reload the form.
-        if @what.blank?
-          flash_error(:form_naming_what_missing.t)
-        elsif name_missing?
-          flash_object_errors(@naming)
-        end
+        flash_naming_errors
         add_reasons(params.dig(:naming, :reasons))
         respond_to_form_errors
       end
@@ -102,6 +98,8 @@ module Observations
         format.html { default_redirect(@observation) }
       end
     end
+
+    #########
 
     private
 
@@ -261,14 +259,20 @@ module Observations
       end
     end
 
-    def name_missing?
-      if @name && @what.match(/\S/)
-        false
-      else
-        @naming.errors.add(:name,
-                           :form_observations_there_is_a_problem_with_name.t)
-        true
+    def flash_naming_errors
+      if @what.blank?
+        flash_error(:form_naming_what_missing.t)
+      elsif name_missing?
+        flash_object_errors(@naming)
       end
+    end
+
+    def name_missing?
+      return false if @name && @what.present?
+
+      @naming.errors.
+        add(:name, :form_observations_there_is_a_problem_with_name.t)
+      true
     end
 
     def respond_to_form_errors
@@ -412,4 +416,3 @@ module Observations
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -37,7 +37,11 @@ module Observations
         save_changes
         respond_to_successful_create
       else # If anything failed reload the form.
-        flash_object_errors(@naming) if name_missing?
+        if @what.blank?
+          flash_error(:form_naming_what_missing.t)
+        elsif name_missing?
+          flash_object_errors(@naming)
+        end
         add_reasons(params.dig(:naming, :reasons))
         respond_to_form_errors
       end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -316,7 +316,7 @@ module Observations
       success = resolve_name(params.dig(:naming, :name).to_s,
                              params[:approved_name],
                              params.dig(:chosen_name, :name_id).to_s)
-      flash_object_errors(@naming) if name_missing?
+      flash_naming_errors
       success
     end
 

--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -44,7 +44,8 @@ image_upload_localization = {
       action:       action,
       button_name:  button_name,
       show_reasons: false,
-      unfocused:    true
+      unfocused:    true,
+      name_help:    :form_naming_name_help_leave_blank.t
     } %>
     <%= render(partial: "observations/namings/fields", locals: naming_locals) %>
 

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -14,10 +14,10 @@ feedback_locals = {
   parent_deprecated: @parent_deprecated,
   names: @names
 }
-
 confidences = options_for_select(Vote.confidence_menu, @vote&.value)
 select_opts = { include_blank: ["new", "create"].include?(action_name) }
 context ||= "blank"
+name_help ||= :form_naming_name_help.t
 %>
 
 <%=
@@ -40,7 +40,7 @@ context ||= "blank"
           end,
           tag.div(class: "col-xs-12 col-sm-6") do
             help_block_with_arrow("left", id: "naming_name_help") do
-              tag.p(:form_naming_name_help.t)
+              tag.p(name_help)
             end
           end
         ].safe_join

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1592,6 +1592,7 @@
   form_naming_valid_synonyms: Preferred synonyms are
   form_naming_deprecated: The name '[name]' is deprecated.
   form_naming_not_recognized: MO does not recognize the name '[name]'.
+  form_naming_what_missing: "[:WHAT] missing"
   form_naming_parent_deprecated: The [rank] [parent] is deprecated.
   form_naming_name_help: The **scientific name** (without author) that identifies this Observation. **Leave this field blank if you don't know the scientific name.**
   form_naming_deprecated_help: Select a Prefered synonym, enter another Name, or click '[button]' to use '[name]'.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -827,6 +827,7 @@
   removed_from_project: Removed [object] from "[project]".
   select_file: Select file...
   no_file_selected: No file selected.
+  SEE_MESSAGE_BELOW: See message below.
   "YES": "Yes"
   "NO": "No"
   "yes": "yes"
@@ -1642,13 +1643,13 @@
   form_observations_collection_number_help: Enter the collector's full name and their record identifier.  The identifier can be anything.  It's whatever you use to keep track of your specimens, and it is typically written on the specimen label.  This is most commonly a sequential number starting at 1 for your first specimen, and working up over your life time.  Another common format is a year or date along with a collection number for that date, e.g., "17-034".  But it can be anything you like, including letters and punctuation.
   form_observations_herbarium_record_help: If you've sent a specimen to a fungarium, you can enter that here, along with their accession number if you know it.  Otherwise let it default to your personal fungarium and leave the accession number blank.
 
-  form_observations_there_is_a_problem_with_projects: This observation violates the constraints of one or more selected projects. "+See message below.+":#project_messages
+  form_observations_there_is_a_problem_with_projects: This observation violates the constraints of one or more selected projects. "+[:SEE_MESSAGE_BELOW]+":#project_messages
   form_observations_projects_out_of_range: The observation date ([date]) or location ([place_name]) is outside the range of these checked project(s)
   form_observations_projects_out_of_range_help: "Either:\n- Uncheck out-of-range projects;\n- Change the observation date or location if it is incorrect; or\n- (undesirably) Check [:form_observations_projects_ignore_project_constraints] to ignore the project constraints.\nThen click [button_name]."
   form_observations_projects_ignore_project_constraints: Ignore Project Constraints
 
-  form_observations_there_is_a_problem_with_location: There is a problem with the location. "+See message below.+":#location_messages
-  form_observations_there_is_a_problem_with_name: There is a problem with the name. "+See message below.+":#name_messages
+  form_observations_there_is_a_problem_with_location: There is a problem with the location. "+[:SEE_MESSAGE_BELOW]+":#location_messages
+  form_observations_there_is_a_problem_with_name: There is a problem with the name. "+[:SEE_MESSAGE_BELOW]+":#name_messages
 
   # observations/_form_species_list
   form_species_lists_title: Title

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1594,7 +1594,8 @@
   form_naming_not_recognized: MO does not recognize the name '[name]'.
   form_naming_what_missing: "[:WHAT] missing"
   form_naming_parent_deprecated: The [rank] [parent] is deprecated.
-  form_naming_name_help: The **scientific name** (without author) that identifies this Observation. **Leave this field blank if you don't know the scientific name.**
+  form_naming_name_help: The **scientific name** (without author) that identifies this Observation.
+  form_naming_name_help_leave_blank: The **scientific name** (without author) that identifies this Observation. **Leave this field blank if you don't know the scientific name.**
   form_naming_deprecated_help: Select a Prefered synonym, enter another Name, or click '[button]' to use '[name]'.
   form_naming_correct_help: Did you mean one of the following names? [:form_naming_deprecated_help]
   form_naming_not_recognized_help: "To proceed: Edit the name to be a correctly spelled scientific name\n(or -- if you are creating an Observation -- erase the name).\nThen click '[button]'."

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -49,10 +49,8 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     namer_session.assert_selector("body.namings__create")
     # (I don't care so long as it says something.)
     assert_flash_text(/\S/, session: namer_session)
-    namer_session.assert_selector("#flash_notices", text: "There is a problem with the name. ")
-    namer_session.assert_selector("#flash_notices", text: "See message below")
-    namer_session.assert_selector("#name_messages", text: :form_naming_what_missing.l)
-
+    namer_session.assert_selector("#flash_notices", text: "There is a problem with the name.")
+s
     namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       form.fill_in("naming_name", with: text_name)
       form.first("input[type='submit']").click

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -49,8 +49,9 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     namer_session.assert_selector("body.namings__create")
     # (I don't care so long as it says something.)
     assert_flash_text(/\S/, session: namer_session)
-    namer_session.assert_selector("#flash_notices", text: "There is a problem with the name.")
-s
+    namer_session.assert_no_selector("#flash_notices", text: "See message below")
+    namer_session.assert_selector("#flash_notices", text: :form_naming_what_missing.l)
+
     namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       form.fill_in("naming_name", with: text_name)
       form.first("input[type='submit']").click

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -46,11 +46,12 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
       assert_true(form.has_unchecked_field?("naming_reasons_4_check"))
       form.first("input[type='submit']").click
     end
+
     namer_session.assert_selector("body.namings__create")
-    # (I don't care so long as it says something.)
-    assert_flash_text(/\S/, session: namer_session)
-    namer_session.assert_no_selector("#flash_notices", text: "See message below")
-    namer_session.assert_selector("#flash_notices", text: :form_naming_what_missing.l)
+    assert_flash_text(form_naming_what_missing.l, session: namer_session)
+    namer_session.
+      # see https://github.com/MushroomObserver/mushroom-observer/issues/1796
+      assert_no_selector("#flash_notices", text: "See message below")
 
     namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       form.fill_in("naming_name", with: text_name)

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -48,7 +48,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     end
 
     namer_session.assert_selector("body.namings__create")
-    assert_flash_text(form_naming_what_missing.l, session: namer_session)
+    assert_flash_text(:form_naming_what_missing.l, session: namer_session)
     namer_session.
       # see https://github.com/MushroomObserver/mushroom-observer/issues/1796
       assert_no_selector("#flash_notices", text: "See message below")

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -49,6 +49,9 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     namer_session.assert_selector("body.namings__create")
     # (I don't care so long as it says something.)
     assert_flash_text(/\S/, session: namer_session)
+    namer_session.assert_selector("#flash_notices", text: "There is a problem with the name. ")
+    namer_session.assert_selector("#flash_notices", text: "See message below")
+    namer_session.assert_selector("#name_messages", text: :form_naming_what_missing.l)
 
     namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       form.fill_in("naming_name", with: text_name)

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -51,7 +51,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     assert_flash_text(:form_naming_what_missing.l, session: namer_session)
     namer_session.
       # see https://github.com/MushroomObserver/mushroom-observer/issues/1796
-      assert_no_selector("#flash_notices", text: "See message below")
+      assert_no_selector("#flash_notices", text: :SEE_MESSAGE_BELOW.l)
 
     namer_session.within("#obs_#{obs.id}_naming_form") do |form|
       form.fill_in("naming_name", with: text_name)


### PR DESCRIPTION
- Displays a correct flash error if a User enters a blank Proposed Name:
Instead of
"There is a problem with the name. See message below."  (with no message below)
displays
"Scientific Name missing"
- Fixes #1796
