### PR TITLE
UTF8 character sets

### DIFF
--- a/db/migrate/20240117180824_latin1_to_utf8.rb
+++ b/db/migrate/20240117180824_latin1_to_utf8.rb
@@ -6,10 +6,5 @@ class Latin1ToUtf8 < ActiveRecord::Migration[7.1]
       execute("ALTER TABLE sequences CONVERT TO CHARACTER SET utf8mb4;")
   end
 
-  def down
-    Article.connection.
-      execute("ALTER TABLE articles CONVERT TO CHARACTER SET latin1;")
-    Sequence.connection.
-      execute("ALTER TABLE sequences CONVERT TO CHARACTER SET latin1;")
-  end
+  def down; end
 end

--- a/db/migrate/20240117180824_latin1_to_utf8.rb
+++ b/db/migrate/20240117180824_latin1_to_utf8.rb
@@ -1,0 +1,15 @@
+class Latin1ToUtf8 < ActiveRecord::Migration[7.1]
+  def up
+    Article.connection.
+      execute("ALTER TABLE articles CONVERT TO CHARACTER SET utf8mb4;")
+    Sequence.connection.
+      execute("ALTER TABLE sequences CONVERT TO CHARACTER SET utf8mb4;")
+  end
+
+  def down
+    Article.connection.
+      execute("ALTER TABLE articles CONVERT TO CHARACTER SET latin1;")
+    Sequence.connection.
+      execute("ALTER TABLE sequences CONVERT TO CHARACTER SET latin1;")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_27_170054) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_17_180824) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -21,9 +21,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_27_170054) do
     t.datetime "verified", precision: nil
   end
 
-  create_table "articles", id: :integer, charset: "latin1", force: :cascade do |t|
+  create_table "articles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
-    t.text "body"
+    t.text "body", size: :long
     t.integer "user_id"
     t.integer "rss_log_id"
     t.datetime "created_at", precision: nil, null: false
@@ -490,7 +490,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_27_170054) do
     t.integer "project_id", null: false
   end
 
-  create_table "project_members", charset: "utf8mb3", force: :cascade do |t|
+  create_table "project_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "project_id"
     t.integer "user_id"
     t.datetime "created_at", null: false
@@ -580,14 +580,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_27_170054) do
     t.datetime "created_at", precision: nil, null: false
   end
 
-  create_table "sequences", id: :integer, charset: "latin1", force: :cascade do |t|
+  create_table "sequences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "observation_id"
     t.integer "user_id"
-    t.text "locus"
-    t.text "bases"
+    t.text "locus", size: :long
+    t.text "bases", size: :long
     t.string "archive"
     t.string "accession"
-    t.text "notes"
+    t.text "notes", size: :long
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
@@ -734,5 +734,4 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_27_170054) do
     t.boolean "favorite"
     t.float "value"
   end
-
 end

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -294,6 +294,27 @@ class SequencesControllerTest < FunctionalTestCase
                          "User should go to last query after creating Sequence")
   end
 
+  # See https://github.com/MushroomObserver/mushroom-observer/issues/1808
+  def test_create_notes_with_caron
+    obs = observations(:detailed_unknown_obs)
+    locus = "ITS"
+    bases = ITS_BASES
+    caron = "ň"
+    params = {
+      observation_id: obs.id,
+      sequence: { locus: locus,
+                  bases: bases,
+                  notes: caron }
+    }
+
+    login
+    post(:create, params: params)
+
+    assert_flash_success
+    assert_equal(caron, Sequence.last.notes,
+                 "Failed to include utf8 caron (#{caron}) in Sequence Notes")
+  end
+
   def test_edit
     sequence = sequences(:local_sequence)
     obs      = sequence.observation


### PR DESCRIPTION
- Changes Articles and Sequences  default character sets  to `utf8mb4`  from `latin1`.  (They the only tables that used a latin charset.)
- Fixes #1808 