### PR TITLE
Cache the sidebar nav

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -321,6 +321,14 @@
   margin-left: 10px !important;
 }
 
+.ml-1 {
+  margin-left: 0.25rem !important;
+}
+
+.ml-2 {
+  margin-left: 0.5rem !important;
+}
+
 .ml-3 {
   margin-left: 1rem !important;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,21 @@ module ApplicationHelper
                      class: class_names("alert mt-3", alert_class))
   end
 
+  # Returns a string that indicates the current user/logged_in/admin status.
+  # Used as a simple cache key for templates that may have three
+  # possible versions of cached HTML
+  def user_status_string
+    if in_admin_mode?
+      "admin_mode"
+    elsif browser.bot?
+      "robot"
+    elsif !@user.nil?
+      "logged_in"
+    else
+      "no_user"
+    end
+  end
+
   # ----------------------------------------------------------------------------
 
   # Take URL that got us to this page and add one or more parameters to it.

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -31,7 +31,7 @@ module LinkHelper
   def active_link_to(text = nil, path = nil, **opts, &block)
     link = block ? text : path # because positional
     content = block ? capture(&block) : text
-    opts[:data] = opts[:data].merge(
+    opts[:data] = (opts[:data] || {}).merge(
       { nav_active_target: "link", action: "nav-active#navigate" }
     )
 

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -24,11 +24,15 @@ module LinkHelper
   end
 
   # https://stackoverflow.com/questions/18642001/add-an-active-class-to-all-active-links-in-rails
-  # make a link that has .active class if it's a link to the current page
+  # https://stackoverflow.com/questions/75742517/how-to-highlight-active-nav-link-when-using-hotwire
+  # Make a link that is a target for the stimulus "nav-active_controller"
+  # (The controller adds .active class if it's a link to the current page,
+  # and updates the active link when navigating. Allows nav to be cached!)
   def active_link_to(text = nil, path = nil, **opts, &block)
     link = block ? text : path # because positional
     content = block ? capture(&block) : text
-    opts[:class] = class_names(opts[:class], { active: current_page?(link) })
+    opts[:class] = class_names(opts[:class]) #, { active: current_page?(link) })
+    opts[:data] = { nav_active_target: "link", action: "nav-active#navigate" }
 
     link_to(link, opts) { content }
   end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -31,8 +31,9 @@ module LinkHelper
   def active_link_to(text = nil, path = nil, **opts, &block)
     link = block ? text : path # because positional
     content = block ? capture(&block) : text
-    opts[:class] = class_names(opts[:class]) #, { active: current_page?(link) })
-    opts[:data] = { nav_active_target: "link", action: "nav-active#navigate" }
+    opts[:data] = opts[:data].merge(
+      { nav_active_target: "link", action: "nav-active#navigate" }
+    )
 
     link_to(link, opts) { content }
   end

--- a/app/javascript/controllers/nav-active_controller.js
+++ b/app/javascript/controllers/nav-active_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="nav-active"
+// Adds CSS class "active" to a nav link if it matches the current location
+export default class extends Controller {
+  static targets = ['link']
+
+  connect() {
+    this.element.dataset.stimulus = "connected";
+    this.pickActive();
+  }
+
+  pickActive() {
+    this.linkTargets.forEach((link) => {
+      if ((link.pathname + link.search) ==
+        (location.pathname + location.search)) {
+        link.classList.add('active')
+      }
+    })
+  }
+
+  navigate(e) {
+    const activeButton = this.element.querySelector('.active')
+
+    if (activeButton) {
+      activeButton.classList.remove('active')
+    }
+
+    e.target.classList.add('active')
+  }
+}

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -10,47 +10,49 @@ classes = {
 }
 %>
 
-<div id="navigation">
+<% cache([user_status_string]) do %>
+  <div id="navigation">
 
-  <a id="logo_link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
-    <img class="logo-trim img-responsive py-10px" alt="Mushroom Observer Logo"
-          src="/logo-trim.png"/>
-  </a><!-- #logo_link -->
+    <a id="logo_link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
+      <img class="logo-trim img-responsive py-10px" alt="Mushroom Observer Logo"
+            src="/logo-trim.png"/>
+    </a><!-- #logo_link -->
 
-  <div class="<%= classes[:wrapper] %>" data-controller="nav-active">
+    <div class="<%= classes[:wrapper] %>" data-controller="nav-active">
 
-    <% if in_admin_mode? %>
-      <%= render(partial: "application/sidebar/admin",
+      <% if in_admin_mode? %>
+        <%= render(partial: "application/sidebar/admin",
+                    locals: { classes: classes }) %>
+      <% end %>
+
+      <% if @user.nil? %>
+        <%= render(partial: "application/sidebar/login",
+                    locals: { classes: classes }) %>
+      <% else %>
+        <%= render(partial: "application/sidebar/user",
+                    locals: { classes: classes }) %>
+      <% end %>
+
+      <%= render(partial: "application/sidebar/observations",
                   locals: { classes: classes }) %>
-    <% end %>
 
-    <% if @user.nil? %>
-      <%= render(partial: "application/sidebar/login",
+      <%= render(partial: "application/sidebar/latest",
+                  locals: { classes: classes }) if @user %>
+
+      <%= render(partial: "application/sidebar/species_lists",
+                  locals: { classes: classes }) if @user %>
+
+      <%= render(partial: "application/sidebar/indexes",
+                  locals: { classes: classes }) if @user %>
+
+      <%= render(partial: "application/sidebar/info",
                   locals: { classes: classes }) %>
-    <% else %>
-      <%= render(partial: "application/sidebar/user",
+
+      <%= render(partial: "application/sidebar/languages",
                   locals: { classes: classes }) %>
-    <% end %>
 
-    <%= render(partial: "application/sidebar/observations",
-                locals: { classes: classes }) %>
+    </div><!-- .sidebar-nav -->
 
-    <%= render(partial: "application/sidebar/latest",
-                locals: { classes: classes }) if @user %>
-
-    <%= render(partial: "application/sidebar/species_lists",
-                locals: { classes: classes }) if @user %>
-
-    <%= render(partial: "application/sidebar/indexes",
-                locals: { classes: classes }) if @user %>
-
-    <%= render(partial: "application/sidebar/info",
-                locals: { classes: classes }) %>
-
-    <%= render(partial: "application/sidebar/languages",
-                locals: { classes: classes }) %>
-
-  </div><!-- .sidebar-nav -->
-
-</div><!-- #navigation -->
-<!--/SIDEBAR LOGO AND NAVIGATION-->
+  </div><!-- #navigation -->
+  <!--/SIDEBAR LOGO AND NAVIGATION-->
+<% end %>

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -10,26 +10,30 @@ classes = {
 }
 %>
 
-<% cache([user_status_string]) do %>
-  <div id="navigation">
+<div id="navigation">
 
-    <a id="logo_link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
-      <img class="logo-trim img-responsive py-10px" alt="Mushroom Observer Logo"
-            src="/logo-trim.png"/>
-    </a><!-- #logo_link -->
+  <a id="logo_link" href="<%= browser.bot? ? "/sitemap/index.html" : "/" %>">
+    <img class="logo-trim img-responsive py-10px" alt="Mushroom Observer Logo"
+          src="/logo-trim.png"/>
+  </a><!-- #logo_link -->
 
-    <div class="<%= classes[:wrapper] %>" data-controller="nav-active">
+  <div class="<%= classes[:wrapper] %>" data-controller="nav-active">
 
+    <%# Cache customized for the user instance. %>
+    <% cache(@user) do %>
+      <% if @user %>
+        <%= render(partial: "application/sidebar/user",
+                    locals: { classes: classes }) %>
+      <% end %>
+    <% end if user %>
+
+    <%# Cache depends only on user status (logged-in? admin?) %>
+    <% cache([user_status_string]) do %>
       <% if in_admin_mode? %>
         <%= render(partial: "application/sidebar/admin",
                     locals: { classes: classes }) %>
-      <% end %>
-
-      <% if @user.nil? %>
+      <% elsif @user.nil? %>
         <%= render(partial: "application/sidebar/login",
-                    locals: { classes: classes }) %>
-      <% else %>
-        <%= render(partial: "application/sidebar/user",
                     locals: { classes: classes }) %>
       <% end %>
 
@@ -50,6 +54,7 @@ classes = {
 
       <%= render(partial: "application/sidebar/languages",
                   locals: { classes: classes }) %>
+    <% end %>
 
     </div><!-- .sidebar-nav -->
 

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -36,7 +36,7 @@ classes = {
                 locals: { classes: classes }) %>
 
     <%= render(partial: "application/sidebar/latest",
-                locals: { classes: classes }) if @user %>
+                locals: { classes: classes }) %>
 
     <%= render(partial: "application/sidebar/species_lists",
                 locals: { classes: classes }) if @user %>

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -6,7 +6,8 @@ classes = {
   item: "list-group-item",
   admin: "list-group-item list-group-item-danger indent",
   indent: "list-group-item indent",
-  mobile_only: "list-group-item visible-xs"
+  mobile_only: "visible-xs",
+  desktop_only: "hidden-xs"
 }
 %>
 
@@ -25,7 +26,7 @@ classes = {
         <%= render(partial: "application/sidebar/user",
                     locals: { classes: classes }) %>
       <% end %>
-    <% end if user %>
+    <% end %>
 
     <%# Cache depends only on user status (logged-in? admin?) %>
     <% cache([user_status_string]) do %>
@@ -56,8 +57,7 @@ classes = {
                   locals: { classes: classes }) %>
     <% end %>
 
-    </div><!-- .sidebar-nav -->
+  </div><!-- .sidebar-nav -->
 
-  </div><!-- #navigation -->
-  <!--/SIDEBAR LOGO AND NAVIGATION-->
-<% end %>
+</div><!-- #navigation -->
+<!--/SIDEBAR LOGO AND NAVIGATION-->

--- a/app/views/controllers/application/sidebar/_latest.html.erb
+++ b/app/views/controllers/application/sidebar/_latest.html.erb
@@ -1,13 +1,16 @@
 <%= tag.div("#{:app_latest.t}:", class: classes[:heading]) %>
+<%= active_link_to(:NEWS.t, articles_path,
+               class: classes[:indent], id: "nav_articles_link") %>
 <%=
 [
-active_link_to(:NEWS.t, articles_path,
-               class: classes[:indent], id: "nav_articles_link"),
-active_link_to(:app_latest_changes.t, activity_logs_path,
-               class: classes[:indent], id: "nav_activity_logs_link"),
-active_link_to(:app_newest_images.t, images_path,
-               class: classes[:indent], id: "nav_images_link"),
-active_link_to(:app_comments.t, comments_path,
-               class: classes[:indent], id: "nav_comments_link")
-].safe_join
+  active_link_to(:app_latest_changes.t, activity_logs_path,
+                class: classes[:indent],
+                id: "nav_activity_logs_link"),
+  active_link_to(:app_newest_images.t, images_path,
+                class: classes[:indent],
+                id: "nav_images_link"),
+  active_link_to(:app_comments.t, comments_path,
+                class: classes[:indent],
+                id: "nav_comments_link")
+].safe_join if @user
 %>

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -1,7 +1,7 @@
-<%= tag.div("", class: classes[:mobile_only]) do
+<%= tag.div("", class: class_names(classes[:item], classes[:mobile_only])) do
   [
     tag.i("", class: "glyphicon glyphicon-user"),
-    tag.span(h(@user.login)),
+    tag.span(h(@user.login), class: "ml-2"),
     tag.span(class: "pull-right") do
       link_to(:app_logout.t, account_logout_path,
                   { id: "nav_user_logout_link" })
@@ -10,27 +10,24 @@
 end %>
 <%= active_link_to(:app_comments_for_you.t,
                    comments_path(for_user: @user.id),
-                   class: classes[:mobile_only],
+                   class: class_names(classes[:indent], classes[:mobile_only]),
                    id: "nav_mobile_your_comments_link") %>
-<%= active_link_to(:app_your_observations.t,
-                   observations_path(user: @user.id),
-                   class: classes[:mobile_only],
-                   id: "nav_mobile_your_observations_link") %>
 <%= active_link_to(:app_your_interests.t, interests_path,
-                   class: classes[:mobile_only],
+                   class: class_names(classes[:indent], classes[:mobile_only]),
                    id: "nav_mobile_interests_link") %>
 <%= active_link_to(:app_your_summary.t, user_path(@user.id),
-                   class: classes[:mobile_only],
+                   class: class_names(classes[:indent], classes[:mobile_only]),
                    id: "nav_mobile_profile_link") %>
 <%= active_link_to(:app_preferences.t, edit_account_preferences_path,
-                   class: classes[:mobile_only],
+                   class: class_names(classes[:indent], classes[:mobile_only]),
                    id: "nav_mobile_preferences_link") %>
 <%= link_to(:app_join_mailing_list.t,
             "https://groups.google.com/forum/?fromgroups=#!forum/mo-general",
-            class: classes[:mobile_only],
+            class: class_names(classes[:indent], classes[:mobile_only]),
             id: "nav_mobile_mailing_list_link") %>
 <% if @user.admin && !in_admin_mode? %>
   <%= active_link_to(:app_turn_admin_on.t, admin_mode_path(turn_on: true),
-                     class: classes[:mobile_only],
+                     class: class_names(classes[:indent],
+                                        classes[:mobile_only]),
                      id: "nav_mobile_admin_link" ) %>
 <% end %>


### PR DESCRIPTION
Caches the nav partials as two fragments.

User sub-nav, for "logged in user nav on mobile", keyed by user.id. This will cache a different "user" sub-nav per user, so that Joe doesn't get a cached menu with Nathan's name. (Note that this cached version, even if Joe did get it, still wouldn't let him impersonate Nathan, because the controllers access the session user. But it would be disorienting.)
![Screen Shot 2024-01-18 at 8 36 03 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/04cc24c9-8abd-47b3-a907-b570e1e5b3e9)

The rest of the nav is keyed by `user_status_string`, so there is much less to cache. Four different "user stati" generate potentially different nav links more or less throughout the rest of the menu.
- admin_mode
- browser.bot?
- logged_in (cache by user id)
- no_user