### PR TITLE
Sensu lato propagation

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -256,6 +256,9 @@
 #  change_text_name::        Change name, updating formats.
 #  change_author::           Change author, updating formats.
 #
+#  ==== Propagation
+#  can_propagate?::          Can Classification be propagated to subtaxa?
+#
 #  ==== Taxonomy
 #  below_genus?::            Is ranked below genus?
 #  at_or_below_genus?::      Is ranked at or below genus?

--- a/app/models/name/create.rb
+++ b/app/models/name/create.rb
@@ -105,7 +105,12 @@ module Name::Create
         result.change_author(parsed_name.author)
       end
     else
-      # Try to resolve ambiguity by taking the one with author.
+      # Try to resolve ambiguity by rejecting name(s) sensu lato
+      if matches.reject { |name| name.author.match?("sensu lato") }.one?
+        return matches.reject! { |name| name.author.match?("sensu lato") }.first
+      end
+
+      # Next, to resolve ambiguity by taking the one with author.
       matches.reject! { |name| name.author.blank? }
       result = matches.first if matches.length == 1
     end

--- a/app/models/name/create.rb
+++ b/app/models/name/create.rb
@@ -71,11 +71,9 @@ module Name::Create
   #   end
   #
   def find_or_create_name_and_parents(in_str)
-    result = []
-    if (parsed_name = parse_name(in_str))
-      result = find_or_create_parsed_name_and_parents(parsed_name)
-    end
-    result
+    return [] unless (parsed_name = parse_name(in_str))
+
+    find_or_create_parsed_name_and_parents(parsed_name)
   end
 
   def find_or_create_parsed_name_and_parents(parsed_name)

--- a/app/models/name/propagate_generic_classifications.rb
+++ b/app/models/name/propagate_generic_classifications.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module Name::PropagateGenericClassifications
+  def can_propagate?
+    rank == "Genus" &&
+      # Name s.l. might have a broader classifications than name s.l.
+      # So prevent propagation in order to protect subtaxa classification
+      author.exclude?("sensu lato")
+  end
+
   # When we `include` a module, the way to add class methods is like this:
   def self.included(base)
     base.extend(ClassMethods)

--- a/app/views/controllers/names/show/_classification.html.erb
+++ b/app/views/controllers/names/show/_classification.html.erb
@@ -39,7 +39,7 @@ end %>
   end
 end %>
 
-<%= if @name.rank == "Genus" && @first_child && @name.classification.present?
+<%= if @name.can_propagate? && @first_child && @name.classification.present?
   tag.p do
     put_button(
       name: :show_name_propagate_classification.t,

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -787,6 +787,22 @@ class NamesControllerTest < FunctionalTestCase
     )
   end
 
+  def test_show_name_sensu_lato
+    name = names(:coprinus_sensu_lato)
+    assert(name.rank == "Genus" && name.author.match?(/sensu lato/) &&
+             name.classification.present?,
+           "Test needs Genus sensu lato with a Classification")
+
+    login
+    get(:show, params: { id: name.id })
+
+    assert_select(
+      "#name_classification",
+      { text: /#{:show_name_propagate_classification.l}/, count: 0 },
+      "Name sensu lato should not have propagate classification link"
+    )
+  end
+
   def assert_synonym_links(name, approve, deprecate, edit)
     assert_select("a[href*=?]", approve_name_synonym_form_path(name.id),
                   count: approve)

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -74,6 +74,16 @@ coprinus_comatus:
   classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   icn_id: 148667
 
+coprinus_sensu_lato:
+  <<: *DEFAULTS
+  text_name: Coprinus
+  author: sensu lato
+  display_name: '**__Coprinus__** sensu lato'
+  search_name: Coprinus sensu lato
+  sort_name: Coprinus  sensu lato
+  rank: <%= Name.ranks[:Genus] %>
+  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_"
+
 stereum:
   <<: *DEFAULTS
   text_name: Stereum

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3284,6 +3284,31 @@ class NameTest < UnitTestCase
     assert_names_equal(names(:stereum), names(:stereum_hirsutum).accepted_genus)
   end
 
+  def test_can_propagate
+    assert(names(:coprinus).can_propagate?,
+           "Classification of genus Names should be propagable")
+
+    assert_false(names(:coprinus_sensu_lato).can_propagate?,
+                 "Classification of Names sensu lato should not be propagable")
+    [:eukarya, :fungi, :ascomycota, :ascomycetes, :agaricales,
+     :agaricaceae].each do |name|
+      assert_false(names(name).can_propagate?,
+                   "Classification of Names above genus should be propagable")
+    end
+    assert_false(
+      names(:amanita_subgenus_lepidella).can_propagate?,
+      "Classification of infra-generic Names should not be propagable"
+    )
+    assert_false(
+      names(:amanita_boudieri_var_beillei).can_propagate?,
+      "Classification of infra-specific Names should not be propagable"
+    )
+    assert_false(
+      names(:boletus_edulis_group).can_propagate?,
+      "Classification of group or clade Names should not be propagable"
+    )
+  end
+
   def test_propagate_generic_classifications
     # This should result in the classification of Coprinus being copied to
     # Chlorophyllum rachodes.

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3286,10 +3286,10 @@ class NameTest < UnitTestCase
 
   def test_can_propagate
     assert(names(:coprinus).can_propagate?,
-           "Classification of genus Names should be propagable")
+           "Genus s.s. Classifications should be propagable")
 
     assert_false(names(:coprinus_sensu_lato).can_propagate?,
-                 "Classification of Names sensu lato should not be propagable")
+                 "Names sensu lato Classifications should not be propagable")
 
     [:eukarya, :fungi, :ascomycota, :ascomycetes, :agaricales, :agaricaceae,
      :amanita_subgenus_lepidella, :sect_agaricus, :coprinus_comatus,
@@ -3297,7 +3297,7 @@ class NameTest < UnitTestCase
       each do |name|
         assert_false(
           names(name).can_propagate?,
-          "#{names(name).rank} Classifications shouldn't be propagable"
+          "#{names(name).rank} Classifications should not be propagable"
         )
       end
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3290,23 +3290,16 @@ class NameTest < UnitTestCase
 
     assert_false(names(:coprinus_sensu_lato).can_propagate?,
                  "Classification of Names sensu lato should not be propagable")
-    [:eukarya, :fungi, :ascomycota, :ascomycetes, :agaricales,
-     :agaricaceae].each do |name|
-      assert_false(names(name).can_propagate?,
-                   "Classification of Names above genus should be propagable")
-    end
-    assert_false(
-      names(:amanita_subgenus_lepidella).can_propagate?,
-      "Classification of infra-generic Names should not be propagable"
-    )
-    assert_false(
-      names(:amanita_boudieri_var_beillei).can_propagate?,
-      "Classification of infra-specific Names should not be propagable"
-    )
-    assert_false(
-      names(:boletus_edulis_group).can_propagate?,
-      "Classification of group or clade Names should not be propagable"
-    )
+
+    [:eukarya, :fungi, :ascomycota, :ascomycetes, :agaricales, :agaricaceae,
+     :amanita_subgenus_lepidella, :sect_agaricus, :coprinus_comatus,
+     :amanita_boudieri_var_beillei, :boletus_edulis_group].
+      each do |name|
+        assert_false(
+          names(name).can_propagate?,
+          "#{names(name).rank} Classifications shouldn't be propagable"
+        )
+      end
   end
 
   def test_propagate_generic_classifications


### PR DESCRIPTION
- Does not show a classification propagation link for Names sensu lato.
- The change prevents potential propogation of an overbroad, imprecise Classification to lower ranks.
- Fixes #1817 