### PR TITLE
Turn off fragment cache logging on production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,6 +72,8 @@ MushroomObserver::Application.configure do
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
+    # debugging: log fragment reads/writes
+    # (it will show [cache hit] even if set to false)
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store # :mem_cache_store via application.rb

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,9 +61,9 @@ MushroomObserver::Application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
-  # debugging: check if cache is being hit
-  # (it should show [cache hit] even if set to false)
-  config.action_controller.enable_fragment_cache_logging = true
+  # debugging: log fragment reads/writes
+  # (it will show [cache hit] even if set to false)
+  config.action_controller.enable_fragment_cache_logging = false
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.


### PR DESCRIPTION
This is a config that logs reads and writes to the fragment cache. Can be quite noisy.