### PR TITLE
Eager load comments in show templates

### DIFF
--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -116,6 +116,7 @@ module Locations
       @canonical_url = description_canonical_url(@description)
       @projects = users_projects_which_dont_have_desc_of_this(@location)
       @versions = @description.versions
+      @comments = @description.comments&.sort_by(&:created_at)&.reverse
     end
 
     def new

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -275,6 +275,10 @@ class LocationsController < ApplicationController
     update_view_stats(@description) if @description
 
     @versions = @location.versions
+    # Save two lookups in comments_for_object
+    @comments = @location.comments&.sort_by { |cmt| cmt[:created_at] }&.reverse
+    @desc_comments = @description.comments&.
+                     sort_by { |cmt| cmt[:created_at] }&.reverse
     init_projects_ivar
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -276,9 +276,8 @@ class LocationsController < ApplicationController
 
     @versions = @location.versions
     # Save two lookups in comments_for_object
-    @comments = @location.comments&.sort_by { |cmt| cmt[:created_at] }&.reverse
-    @desc_comments = @description.comments&.
-                     sort_by { |cmt| cmt[:created_at] }&.reverse
+    @comments = @location.comments&.sort_by(&:created_at)&.reverse
+    @desc_comments = @description&.comments&.sort_by(&:created_at)&.reverse
     init_projects_ivar
   end
 

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -131,6 +131,7 @@ module Names
       @canonical_url = description_canonical_url(@description)
       @projects = users_projects_which_dont_have_desc_of_this(@name)
       @versions = @description.versions
+      @comments = @description.comments&.sort_by(&:created_at)&.reverse
     end
 
     ############################################################################

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -307,6 +307,8 @@ class NamesController < ApplicationController
     # Would be better to eager load descriptions and derive @best_description
     # from them. Can also derive @projects from this.
     @best_description = @name.best_brief_description
+    # Save a lookup in comments_for_object
+    @comments = @name.comments&.sort_by { |cmt| cmt[:created_at] }&.reverse
   end
 
   def init_projects_ivar

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -308,7 +308,7 @@ class NamesController < ApplicationController
     # from them. Can also derive @projects from this.
     @best_description = @name.best_brief_description
     # Save a lookup in comments_for_object
-    @comments = @name.comments&.sort_by { |cmt| cmt[:created_at] }&.reverse
+    @comments = @name.comments&.sort_by(&:created_at)&.reverse
   end
 
   def init_projects_ivar

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -40,8 +40,7 @@ module ObservationsController::Show
     @consensus     = Observation::NamingConsensus.new(@observation)
     @owner_name    = @consensus.owner_preference
     register_namings_for_textile_in_notes
-    @comments = @observation.comments&.
-                sort_by { |cmt| cmt[:created_at] }&.reverse
+    @comments = @observation.comments&.sort_by(&:created_at)&.reverse
   end
 
   def load_observation_for_show_observation_page

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -40,6 +40,8 @@ module ObservationsController::Show
     @consensus     = Observation::NamingConsensus.new(@observation)
     @owner_name    = @consensus.owner_preference
     register_namings_for_textile_in_notes
+    @comments = @observation.comments&.
+                sort_by { |cmt| cmt[:created_at] }&.reverse
   end
 
   def load_observation_for_show_observation_page

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -161,6 +161,8 @@ class ProjectsController < ApplicationController
               where("name_description_admins.user_group_id":
                     @project.admin_group_id).
               includes(:name, :user)
+    # Save a lookup in comments_for_object
+    @comments = @species_list.comments&.sort_by(&:created_at)&.reverse
   end
 
   def upload_image_if_present

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,7 +19,7 @@ class ProjectsController < ApplicationController
   # def show_project
   def show
     store_location
-    return unless (@project = find_or_goto_index(Project, params[:id].to_s))
+    return unless find_project_and_where!
 
     set_ivars_for_show
     check_constraint_violations
@@ -59,7 +59,7 @@ class ProjectsController < ApplicationController
   # def edit_project
   def edit
     image_ivars
-    return unless find_project!
+    return unless find_project_and_where!
 
     @start_date_fixed = @project.start_date.present?
     @end_date_fixed = @project.end_date.present?
@@ -94,7 +94,7 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    return unless find_project!
+    return unless find_project_and_where!
 
     unless check_permission!(@project)
       return redirect_to(project_path(@project.id, q: get_query_param))
@@ -124,7 +124,7 @@ class ProjectsController < ApplicationController
   # Outputs: none
   # def destroy_project
   def destroy
-    return unless find_project!
+    return unless find_project_and_where!
 
     if !check_permission!(@project)
       redirect_to(project_path(@project.id, q: get_query_param))
@@ -153,7 +153,6 @@ class ProjectsController < ApplicationController
   end
 
   def set_ivars_for_show
-    @where = @project&.place_name || ""
     @canonical_url = "#{MO.http_domain}/projects/#{@project.id}"
     @is_member = @project.member?(@user)
     @is_admin = @project.is_admin?(@user)
@@ -250,10 +249,11 @@ class ProjectsController < ApplicationController
              "end_date(1i)", "end_date(2i)", "end_date(3i)")
   end
 
-  def find_project!
-    @project = find_or_goto_index(Project, params[:id].to_s)
+  def find_project_and_where!
+    @project = Project.show_includes.safe_find(params[:id].to_s) ||
+               flash_error_and_goto_index(Project, params[:id].to_s)
+
     @where = @project&.location&.display_name || ""
-    @project
   end
 
   def create_members_group(title)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -162,7 +162,7 @@ class ProjectsController < ApplicationController
                     @project.admin_group_id).
               includes(:name, :user)
     # Save a lookup in comments_for_object
-    @comments = @species_list.comments&.sort_by(&:created_at)&.reverse
+    @comments = @project.comments&.sort_by(&:created_at)&.reverse
   end
 
   def upload_image_if_present

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -225,6 +225,9 @@ class SpeciesListsController < ApplicationController
     @pages = paginate_letters(:letter, :page, 100)
     @objects = @query.paginate(@pages, include:
                   [:user, :name, :location, { thumb_image: :image_votes }])
+    # Save a lookup in comments_for_object
+    @comments = @species_list.comments&.
+                sort_by { |cmt| cmt[:created_at] }&.reverse
   end
 
   ##############################################################################

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -226,8 +226,7 @@ class SpeciesListsController < ApplicationController
     @objects = @query.paginate(@pages, include:
                   [:user, :name, :location, { thumb_image: :image_votes }])
     # Save a lookup in comments_for_object
-    @comments = @species_list.comments&.
-                sort_by { |cmt| cmt[:created_at] }&.reverse
+    @comments = @species_list.comments&.sort_by(&:created_at)&.reverse
   end
 
   ##############################################################################

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -188,8 +188,8 @@ class Location < AbstractModel
         }
   scope :show_includes, lambda {
     strict_loading.includes(
-      :comments,
-      :description,
+      { comments: :user },
+      { description: { comments: :user } },
       { descriptions: [:authors, :editors] },
       :interests,
       :observations,

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -92,6 +92,7 @@ class LocationDescription < Description
   scope :show_includes, lambda {
     strict_loading.includes(
       :authors,
+      { comments: :user },
       :editors,
       :interests,
       { location: [:descriptions, :interests, :rss_log] },

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -667,7 +667,7 @@ class Name < AbstractModel
   }
   scope :show_includes, lambda {
     strict_loading.includes(
-      # :comments,
+      { comments: :user },
       :correct_spelling,
       { description: [:authors, :reviewer] },
       { descriptions: [:authors, :editors, :reviewer, :writer_groups] },

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -124,7 +124,7 @@ class NameDescription < Description
     strict_loading.includes(
       { admin_groups: { users: :user_groups } },
       :authors,
-      :comments,
+      { comments: :user },
       :editors,
       :interests,
       :license,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -75,6 +75,13 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   before_destroy :orphan_drafts
 
+  scope :show_includes, lambda {
+    strict_loading.includes(
+      { comments: :user },
+      # { observations: :namings }
+    )
+  }
+
   # Project handles all of its own logging.
   self.autolog_events = []
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -78,7 +78,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :show_includes, lambda {
     strict_loading.includes(
       { comments: :user },
-      # { observations: :namings }
+      :location
     )
   }
 

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -100,7 +100,8 @@ class SpeciesList < AbstractModel
   attr_accessor :data
 
   scope :show_includes, lambda {
-    includes(
+    strict_loading.includes(
+      { comments: :user },
       { observations: :namings }
     )
   }

--- a/app/views/controllers/comments/_comments_for_object.erb
+++ b/app/views/controllers/comments/_comments_for_object.erb
@@ -1,6 +1,5 @@
 <% #bs4
-  comments ||= object.comments.includes(:user).sort_by(&:created_at).reverse
-  if limit
+  if limit && comments
     and_more = comments.length - limit
     comments = comments[0..limit-1]
   end

--- a/app/views/controllers/comments/_comments_for_object.erb
+++ b/app/views/controllers/comments/_comments_for_object.erb
@@ -1,5 +1,5 @@
 <% #bs4
-  comments = object.comments.includes(:user).sort_by(&:created_at).reverse
+  comments ||= object.comments.includes(:user).sort_by(&:created_at).reverse
   if limit
     and_more = comments.length - limit
     comments = comments[0..limit-1]

--- a/app/views/controllers/comments/_object.html.erb
+++ b/app/views/controllers/comments/_object.html.erb
@@ -34,4 +34,5 @@
 end %>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: object, controls: false, limit: 10 }) %>
+           locals: { object: object, comments: @comments,
+                     controls: false, limit: 10 }) %>

--- a/app/views/controllers/comments/_update_comments_for_object.erb
+++ b/app/views/controllers/comments/_update_comments_for_object.erb
@@ -1,13 +1,14 @@
 <%#
 // Re-render the whole comments_for_object block.
-// comments_for_object needs locals: object, controls, limit
+// comments_for_object needs locals: object, comments, controls, limit
 // create or update should provide.
 %>
 
 <%= turbo_stream.replace("comments_for_object") do
   render(
     partial: "comments/comments_for_object",
-    locals: { object: @target, controls: @user, limit: nil },
+    locals: { object: @target, comments: @comments,
+              controls: @user, limit: nil },
     layout: false
   )
 end %>

--- a/app/views/controllers/locations/descriptions/show.html.erb
+++ b/app/views/controllers/locations/descriptions/show.html.erb
@@ -19,6 +19,6 @@ add_tab_set(show_description_tabs(description: @description))
   <%= render(partial: "locations/descriptions/show/location_description",
              object: @description) %>
   <%= render(partial: "comments/comments_for_object",
-              locals: {object: @description, controls: @user, limit: 10}) %>
+             locals: { object: @description, controls: @user, limit: 10 }) %>
   <%= show_object_footer(@description, @versions) %>
 </div><!--.container-text-->

--- a/app/views/controllers/locations/descriptions/show.html.erb
+++ b/app/views/controllers/locations/descriptions/show.html.erb
@@ -19,6 +19,7 @@ add_tab_set(show_description_tabs(description: @description))
   <%= render(partial: "locations/descriptions/show/location_description",
              object: @description) %>
   <%= render(partial: "comments/comments_for_object",
-             locals: { object: @description, controls: @user, limit: 10 }) %>
+             locals: { object: @description, comments: @comments,
+                       controls: @user, limit: 10 }) %>
   <%= show_object_footer(@description, @versions) %>
 </div><!--.container-text-->

--- a/app/views/controllers/locations/show.html.erb
+++ b/app/views/controllers/locations/show.html.erb
@@ -11,14 +11,16 @@ add_tab_set(location_show_tabs(location: @location))
 <div class="row">
   <div class="col-sm-8">
     <%= render(partial: "comments/comments_for_object",
-              locals: { object: @location, controls: @user, limit: 2 }) %>
+               locals: { object: @location, comments: @comments,
+                         controls: @user, limit: 2 }) %>
     <% if @description&.notes? %>
       <hr/>
       <%= show_embedded_description_title(@description, :location) %>
       <%= render(partial: "locations/descriptions/show/location_description",
-                object: @description) %>
+                 object: @description) %>
       <%= render(partial: "comments/comments_for_object",
-                locals: { object: @description, controls: @user, limit: 2 }) %>
+                 locals: { object: @description, comments: @desc_comments,
+                           controls: @user, limit: 2 }) %>
       <hr/>
     <% end %>
     <%= show_alt_descriptions(object: @location, projects: @projects) %>

--- a/app/views/controllers/names/descriptions/show.html.erb
+++ b/app/views/controllers/names/descriptions/show.html.erb
@@ -22,6 +22,6 @@ add_tab_set(show_description_tabs(description: @description))
 <%= render(partial: "names/descriptions/show/name_description",
            object: @description, locals: { review: true }) %>
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @description,
+           locals: { object: @description, comments: @comments,
                      controls: @user, limit: 10 }) if false %>
 <%= show_object_footer(@description, @versions) %>

--- a/app/views/controllers/names/descriptions/show.html.erb
+++ b/app/views/controllers/names/descriptions/show.html.erb
@@ -22,6 +22,6 @@ add_tab_set(show_description_tabs(description: @description))
 <%= render(partial: "names/descriptions/show/name_description",
            object: @description, locals: { review: true }) %>
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @description, controls: @user, limit: 10 }
-          ) if false%>
+           locals: { object: @description,
+                     controls: @user, limit: 10 }) if false %>
 <%= show_object_footer(@description, @versions) %>

--- a/app/views/controllers/names/show.html.erb
+++ b/app/views/controllers/names/show.html.erb
@@ -21,7 +21,8 @@ add_tab_set(name_show_tabs(name: @name))
     <% end %>
 
     <%= render(partial: "comments/comments_for_object",
-               locals: {object: @name, controls: @user, limit: nil}) %>
+               locals: { object: @name, comments: @comments,
+                         controls: @user, limit: nil }) %>
 
   </div><!--LEFT COLUMN-->
 

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -53,7 +53,8 @@ carousel_locals = {
     <% end %>
 
     <%= render(partial: "comments/comments_for_object",
-               locals: { object: @observation, controls: @user, limit: nil }) %>
+               locals: { object: @observation, comments: @comments,
+                         controls: @user, limit: nil }) %>
 
     <%= @observation.source_credit.tpl if @observation.source_noteworthy? %>
   </div>

--- a/app/views/controllers/projects/show.html.erb
+++ b/app/views/controllers/projects/show.html.erb
@@ -99,6 +99,7 @@ add_project_banner(@project)
 </p>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @project, controls: @user, limit: nil }) %>
+           locals: { object: @project, comments: @comments,
+                     controls: @user, limit: nil }) %>
 
 <%= show_object_footer(@project) %>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -96,6 +96,7 @@ add_tab_set(species_list_show_tabs(list: @species_list))
 <% end %>
 
 <%= render(partial: "comments/comments_for_object",
-           locals: { object: @species_list, controls: @user, limit: nil }) %>
+           locals: { object: @species_list, comments: @comments,
+                     controls: @user, limit: nil }) %>
 
 <%= show_object_footer(@species_list) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -92,7 +92,7 @@ module MushroomObserver
     # Unfortunately this is also added to email templates!
     # config.action_view.annotate_rendered_view_with_filenames = true
 
-    # Strict loading - just log, don't error out the page!
+    # Strict loading - either :log, or :error out the page
     config.active_record.action_on_strict_loading_violation = :log
 
     # Just starting to use Rails caching on 7.1, so we're current

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,7 +59,7 @@ MushroomObserver::Application.configure do
   # exceptions.
   # config.action_dispatch.show_exceptions = :rescuable
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
- [x] Locations
- [x] LocationDescriptions
- [x] Names
- [x] NameDescriptions
- [x] Observations
- [x] Projects
- [x] SpeciesLists
 
Loading `object.comments` in `comments_for_object.erb` was reloading the comments, even when they'd been eager loaded. I can't figure out why, because the eager-loaded object was often passed to the comments template. This PR explicitly passes the eager loaded comments and removes the query from the partial.

Callers of this template must now supply the `@comments`.