### PR TITLE
Hotfix for broken sidebar links

### DIFF
--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -37,16 +37,32 @@ classes = {
         <%= render(partial: "application/sidebar/login",
                     locals: { classes: classes }) %>
       <% end %>
+    <% end %>
 
-      <%= render(partial: "application/sidebar/observations",
-                  locals: { classes: classes }) %>
+    <%# Cache customized for the user instance because of Your Observations.%>
+    <% cache(@user) do %>
+      <% if @user %>
+        <%= render(partial: "application/sidebar/observations",
+                   locals: { classes: classes }) %>
+      <% end %>
+    <% end %>
 
+    <%# Cache depends only on user status (logged-in? admin?) %>
+    <% cache([user_status_string]) do %>
       <%= render(partial: "application/sidebar/latest",
                   locals: { classes: classes }) %>
+    <% end %>
 
-      <%= render(partial: "application/sidebar/species_lists",
-                  locals: { classes: classes }) if @user %>
+    <%# Cache customized for the user instance because of Your Lists.%>
+    <% cache(@user) do %>
+      <% if @user %>
+        <%= render(partial: "application/sidebar/species_lists",
+                   locals: { classes: classes }) if @user %>
+      <% end %>
+    <% end %>
 
+    <%# Cache depends only on user status (logged-in? admin?) %>
+    <% cache([user_status_string]) do %>
       <%= render(partial: "application/sidebar/indexes",
                   locals: { classes: classes }) if @user %>
 


### PR DESCRIPTION
- Caches application/sidebar/observations and application/sidebar/species_lists at the user instance because they contain links at the user instance to Your Observations and Your Lists
- Fixes #1832 
- May need follow-up fine tuning
- It's highly desirable to find a way to test this stuff to avoid future breakage. 
- 
But I will deploy as soon as CI tests are green because:
- the website is partly broken
- it would take too for me to figure out how to fine tune (within those 2 partials)
- it would take me too long to figure out how to test it