### PR TITLE
Shuffle sidebar sections around to catch @user-specific content

### DIFF
--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -20,16 +20,8 @@ classes = {
 
   <div class="<%= classes[:wrapper] %>" data-controller="nav-active">
 
-    <%# Cache customized for the user instance. %>
-    <% cache(@user) do %>
-      <% if @user %>
-        <%= render(partial: "application/sidebar/user",
-                    locals: { classes: classes }) %>
-      <% end %>
-    <% end %>
-
     <%# Cache depends only on user status (logged-in? admin?) %>
-    <% cache([user_status_string]) do %>
+    <% cache([user_status_string, "login"]) do %>
       <% if in_admin_mode? %>
         <%= render(partial: "application/sidebar/admin",
                     locals: { classes: classes }) %>
@@ -37,18 +29,28 @@ classes = {
         <%= render(partial: "application/sidebar/login",
                     locals: { classes: classes }) %>
       <% end %>
+    <% end %>
+
+    <%# Cache customized for the user instance. %>
+    <% cache(@user) do %>
+      <% if @user %>
+        <%= render(partial: "application/sidebar/user",
+                    locals: { classes: classes }) %>
+      <% end %>
 
       <%= render(partial: "application/sidebar/observations",
                   locals: { classes: classes }) %>
 
+      <%= render(partial: "application/sidebar/species_lists",
+                  locals: { classes: classes }) if @user %>
+    <% end %>
+
+    <% cache([user_status_string, "links"]) do %>
       <%= render(partial: "application/sidebar/latest",
                   locals: { classes: classes }) %>
 
-      <%= render(partial: "application/sidebar/species_lists",
-                  locals: { classes: classes }) if @user %>
-
       <%= render(partial: "application/sidebar/indexes",
-                  locals: { classes: classes }) if @user %>
+                 locals: { classes: classes }) if @user %>
 
       <%= render(partial: "application/sidebar/info",
                   locals: { classes: classes }) %>

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -3,11 +3,17 @@
     tag.i("", class: "glyphicon glyphicon-user"),
     tag.span(h(@user.login), class: "ml-2"),
     tag.span(class: "pull-right") do
-      link_to(:app_logout.t, account_logout_path,
-                  { id: "nav_user_logout_link" })
+      link_to(:app_logout.t, account_logout_path, id: "nav_user_logout_link")
     end
   ].safe_join
 end %>
+<%# active_link_to(:app_your_observations.t,
+                   observations_path(user: @user.id),
+                   class: classes[:indent],
+                   id: "nav_your_observations_link") %>
+<%# active_link_to(:app_your_lists.t, species_lists_path(by_user: @user.id),
+                   class: classes[:indent],
+                   id: "nav_your_species_lists_link") %>
 <%= active_link_to(:app_comments_for_you.t,
                    comments_path(for_user: @user.id),
                    class: class_names(classes[:indent], classes[:mobile_only]),


### PR DESCRIPTION
Economizing on separate caches is a consideration. 
Moves species lists up next to observations and caches it as a group with the (mobile) user section.

Adds a text cache key to each, to hopefully bust the existing cache.