### PR TITLE
Naming and comment layout for mobile

### DIFF
--- a/app/assets/stylesheets/mo/_matrix_box.scss
+++ b/app/assets/stylesheets/mo/_matrix_box.scss
@@ -65,7 +65,7 @@ h5.rss-heading {
 }
 
 .rss-detail {
-  margin-top: 5px;
+  // margin-top: 5px;
   margin-bottom: 5px;
   // text-align: center;
 }

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -614,6 +614,10 @@
 // --------------------------------------------------
 
 @media screen and (min-width: 767px) {
+  .d-sm-none {
+    display: none;
+  }
+
   .d-sm-block {
     display: block;
   }
@@ -628,6 +632,10 @@
 
   .float-sm-right {
     float: right !important;
+  }
+
+  .float-sm-none {
+    float: none !important;
   }
 
   .mt-sm-3 {

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CommentsHelper
+  # The new_comment_tab now has an icon. icon buttons send icon: true
+  def new_comment_link(object, btn_class: "btn btn-default btn-sm", icon: false)
+    name, path, args = *new_comment_tab(object, btn_class: btn_class)
+    args = args.merge({ icon: nil }) unless icon
+
+    modal_link_to("comment", name, path, args)
+  end
+end

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -50,7 +50,8 @@ module LightboxHelper
   def caption_identify_ui(obs:)
     tag.div(class: "obs-identify", id: "observation_identify_#{obs.id}") do
       [
-        propose_naming_link(obs.id, context: "lightgallery"),
+        propose_naming_link(obs.id, context: "lightgallery",
+                                    btn_class: "btn d-inline-block"),
         tag.span("&nbsp;".html_safe, class: "mx-2"),
         mark_as_reviewed_toggle(obs.id)
       ].safe_join

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -121,8 +121,9 @@ module MatrixBoxHelper
         naming_vote_form(naming, nil, context: "matrix_box")
       end
     else
-      propose_naming_link(object.id, btn_class: "btn-default mb-3",
-                                     context: "matrix_box")
+      propose_naming_link(
+        object.id, btn_class: "btn btn-default d-inline-block mb-3",
+                   context: "matrix_box")
     end
   end
 

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -10,7 +10,7 @@ module NamingsHelper
     tag.div(class: "namings-table panel panel-default mb-4",
             id: "namings_table") do
       [
-        observation_namings_table_header,
+        observation_namings_table_header(obs),
         observation_namings_table_rows(consensus), # only rows get updated
         observation_namings_table_footer(obs)
       ].safe_join
@@ -20,14 +20,19 @@ module NamingsHelper
   private
 
   # nested rows/columns parallel those in the row
-  def observation_namings_table_header
+  def observation_namings_table_header(obs)
     header = naming_header_row_content
     behavior = "flex-column justify-content-end"
+    propose_icon = propose_naming_link(
+      obs.id, text: :show_namings_propose_new_name.t,
+              btn_class: "",
+              context: "namings_table", icon: true
+    )
 
     tag.div(class: "panel-heading namings-table-header") do
       tag.div(class: "row") do
         concat(
-          tag.div(class: "col col-sm-11") do
+          tag.div(class: "col-xs-10 col-sm-11") do
             tag.div(class: "row") do
               [
                 tag.div(header[:heading],
@@ -42,7 +47,9 @@ module NamingsHelper
             end
           end
         )
-        concat(tag.div("", class: "col col-sm-1 d-none d-sm-block #{behavior}"))
+        concat(tag.div(class: "col-xs-2 col-sm-1 #{behavior}") do
+          tag.span(propose_icon, class: "float-right d-sm-none")
+        end)
       end
     end
   end
@@ -230,7 +237,8 @@ module NamingsHelper
 
   # row props have mobile-friendly labels
   def your_vote_html(naming, vote)
-    [tag.small("#{:show_namings_your_vote.t}: ", class: "visible-xs-block"),
+    [tag.small("#{:show_namings_your_vote.t}: ",
+               class: "visible-xs-inline-block"),
      naming_vote_form(naming, vote, context: "namings_table")].safe_join
   end
 
@@ -259,7 +267,8 @@ module NamingsHelper
     form_with(
       model: vote,
       url: naming_vote_form_commit_url(naming, vote), method: method,
-      id: "naming_vote_form_#{naming.id}", class: "naming-vote-form",
+      id: "naming_vote_form_#{naming.id}",
+      class: "naming-vote-form d-inline-block float-right float-sm-none",
       data: { turbo: true, controller: "naming-vote",
               localization: localizations }
     ) do |fv|
@@ -344,8 +353,8 @@ module NamingsHelper
         tag.div(class: "row") do
           tag.div(class: "col-sm-11") do
             tag.div(class: "row") do
-              concat(tag.div(buttons, class: "col-xs-6 col-md-4"))
-              concat(tag.div(help, class: "col-xs-6 col-md-8"))
+              concat(tag.div(buttons, class: "col col-md-4"))
+              concat(tag.div(help, class: "col col-md-8"))
             end
           end
         end
@@ -367,24 +376,28 @@ module NamingsHelper
 
   def observation_naming_buttons(obs, do_suggestions)
     buttons = []
-    buttons << propose_naming_link(obs.id,
-                                   text: :show_namings_propose_new_name.t,
-                                   btn_class: "btn-default btn-sm",
-                                   context: "namings_table")
+    buttons << propose_naming_link(
+      obs.id,
+      text: :show_namings_propose_new_name.t,
+      btn_class: "btn btn-default btn-sm d-none d-sm-block",
+      context: "namings_table"
+    )
     buttons << suggest_namings_link(obs) if do_suggestions
     buttons.safe_join(tag.br)
   end
 
   public
 
+  # The new_naming_tab now has an icon. icon buttons send icon: true
   def propose_naming_link(obs_id, text: :create_naming.t,
-                          context: "namings_table",
+                          context: "namings_table", icon: false,
                           btn_class: "btn-primary my-3")
-    modal_link_to(
-      "obs_#{obs_id}_naming",
-      *new_naming_tab(obs_id,
-                      text: text, btn_class: btn_class, context: context)
+    name, path, args = *new_naming_tab(
+      obs_id, text: text, btn_class: btn_class, context: context
     )
+    args = args.merge({ icon: nil }) unless icon
+
+    modal_link_to("obs_#{obs_id}_naming", name, path, args)
   end
 
   # N+1: can't move the calculation of observation.image_ids

--- a/app/helpers/tabs/comments_helper.rb
+++ b/app/helpers/tabs/comments_helper.rb
@@ -38,19 +38,19 @@ module Tabs
       ]
     end
 
-    def new_comment_tab(object)
+    def new_comment_tab(object, btn_class: nil)
       [:show_comments_add_comment.l,
        add_query_param(
          new_comment_path(target: object.id, type: object.class.name)
        ),
        { class: class_names("#{tab_id(__method__.to_s)}_#{object.id}",
-                            %w[btn btn-default btn-sm]) }]
+                            btn_class), icon: :add }]
     end
 
     def edit_comment_tab(comment)
       [:comment_show_edit.t,
        add_query_param(edit_comment_path(comment.id)),
-       { class: tab_id(__method__.to_s) }]
+       { class: "#{tab_id(__method__.to_s)}_#{comment.id}", icon: :edit }]
     end
 
     def destroy_comment_tab(comment)

--- a/app/helpers/tabs/namings_helper.rb
+++ b/app/helpers/tabs/namings_helper.rb
@@ -9,7 +9,7 @@ module Tabs
          new_observation_naming_path(observation_id: obs_id, context: context)
        ),
        { class: class_names("#{tab_id(__method__.to_s)}_#{obs_id}", btn_class,
-                            %w[btn d-inline-block propose-naming-link]) }]
+                            %w[propose-naming-link]), icon: :add }]
     end
 
     def edit_naming_tab(naming)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -24,8 +24,9 @@ module Tabs
     end
 
     # Used in the lists panel
+    # N+1: this looks up User.current.species_lists. Mercifully quick.
     def observation_manage_lists_tab(obs, user)
-      return unless user
+      return unless user&.species_list_ids&.any?
 
       [:show_observation_manage_species_lists.l,
        add_query_param(edit_observation_species_lists_path(obs.id)),

--- a/app/views/controllers/comments/_comment.erb
+++ b/app/views/controllers/comments/_comment.erb
@@ -26,10 +26,8 @@ target_type = tag.span(target.class.name.to_sym.t, class: "small") \
           concat(tag.span(class: "text-nowrap") do
             [
               "[",
-              modal_link_to("comment_#{comment.id}", :EDIT.t,
-                            edit_comment_path(comment.id),
-                            class: "edit_comment_link_#{comment.id}",
-                            icon: :edit),
+              modal_link_to("comment_#{comment.id}",
+                            *edit_comment_tab(comment)),
               "|",
               destroy_button(name: :comment_show_destroy.t, target: comment,
                              icon: :delete, data: { turbo: true }),
@@ -37,9 +35,10 @@ target_type = tag.span(target.class.name.to_sym.t, class: "small") \
             ].safe_join(" ")
           end) if check_permission(comment)
           concat(tag.div(comment.created_at.web_time,
-                         class: "float-right text-nowrap small my-0 mx-3"))
+                         class: "float-sm-right text-nowrap small"))
         end)
         unless comment.comment.blank?
+          concat(tag.div("", class: "clearfix"))
           concat(tag.div(comment.comment.tpl, class: "p-2 comment-body"))
         end
       end,

--- a/app/views/controllers/comments/_comments_for_object.erb
+++ b/app/views/controllers/comments/_comments_for_object.erb
@@ -12,7 +12,11 @@ tag.div(
 ) do
   concat([
     tag.div(class: "panel-heading") do
-      tag.h4(:COMMENTS.t, class: "panel-title")
+      tag.h4(class: "panel-title") do
+        concat(:COMMENTS.t)
+        concat(tag.span(new_comment_link(object, btn_class: nil, icon: true),
+                        class: "float-right")) if controls
+      end
     end,
     tag.div(class: "list-group list-group-flush comments") do
       if comments.empty?
@@ -26,14 +30,9 @@ tag.div(
   ].safe_join)
   concat(
     tag.div(class: "panel-footer") do
-      concat(
-        modal_link_to("comment", *new_comment_tab(object))
-      )
-      concat(
-        link_to(:show_comments_and_more.t(num: and_more),
-                comments_path(target: object.id, type: object.class.name),
-                class: "float-right")
-      ) if limit && and_more > 0
+      link_to(:show_comments_and_more.t(num: and_more),
+              comments_path(target: object.id, type: object.class.name),
+              class: "float-right")
     end
-  ) if controls
+  ) if controls && limit && and_more > 0
 end %>

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -26,7 +26,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     login(namer, session: namer_session)
     assert_false(namer_session.has_link?(class: /edit_naming/))
     assert_false(namer_session.has_selector?(class: /destroy_naming_link_/))
-    namer_session.click_link(class: "propose-naming-link")
+    namer_session.first(class: "propose-naming-link").click
 
     # naming = namer_session.create_name(obs, text_name)
     namer_session.assert_selector("body.namings__new")


### PR DESCRIPTION
Improves mobile layout legibility on show obs for namings and comments. 

Moves "Add comment" to a panel icon "+"
"Propose a name" similarly moved to panel icon, on moble only.