### PR TITLE
Turn off user site stats for the day

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
   def show
     store_location
     id = params[:id].to_s
-    @show_user = find_or_goto_index(User, id)
+    return unless @show_user = find_or_goto_index(User, id)
 
     case params[:flow]
     when "next"
@@ -37,16 +37,11 @@ class UsersController < ApplicationController
     when "prev"
       redirect_to_next_object(:prev, User, id) and return
     end
-    # NOTE: Using resource routes, Rails won't route anything to this show
-    # action unless there's an id param, so this may be superfluous.
-    return unless @show_user
 
-    @user_data = SiteData.new.get_user_data(id)
+    # @user_data = SiteData.new.get_user_data(id)
     @life_list = Checklist::ForUser.new(@show_user)
     instance_vars_for_thumbnails_in_summary!
   end
-
-  alias show_user show
 
   #############################################################################
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
   def show
     store_location
     id = params[:id].to_s
-    return unless @show_user = find_or_goto_index(User, id)
+    return unless (@show_user = find_or_goto_index(User, id))
 
     case params[:flow]
     when "next"

--- a/app/views/controllers/users/show.html.erb
+++ b/app/views/controllers/users/show.html.erb
@@ -7,8 +7,8 @@ add_tab_set(user_show_tabs(show_user: @show_user, user: @user))
 
 @container = :full
 
-rows = user_stats_rows(@show_user, @user_data)
-paths = user_stats_link_paths(@show_user)
+rows = [] # user_stats_rows(@show_user, @user_data)
+paths = [] # user_stats_link_paths(@show_user)
 total = 0
 %>
 
@@ -63,6 +63,7 @@ total = 0
 
   <div class="col-sm-6">
     <div class="text-center">
+      We are working on this page. User stats will be back shortly.
       <table class="table">
         <% rows.each do |row|
           field = row[:field]
@@ -102,7 +103,7 @@ total = 0
           </tr>
         <% end %>
       </table>
-      <%= if @life_list.num_species > 0
+      <%# if @life_list.num_species > 0
         :show_user_life_list.t(genera: @life_list.num_genera,
                                species: @life_list.num_species,
                                url: paths[:life_list])

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -84,24 +84,24 @@ class UsersControllerTest < FunctionalTestCase
     get(:show, params: { id: user.id })
 
     assert_template(:show)
-    assert_select(
-      "a[href = '#{location_descriptions_path}?by_author=#{user.id}']"
-    )
-    assert_select(
-      "a[href = '#{name_descriptions_path}?by_author=#{user.id}']"
-    )
-    assert_select(
-      "a:match('href', ?)",
-      /\?.*=(\d+).*&id=\1/, # some param=n followed by id with same value
-      false,
-      "Links should not use the same value for id and another param"
-    )
-    assert_select(
-      "a:match('href', ?)",
-      /\?.*id=(\d+).*&\S+=\1/, # id=n followed by another param with same value
-      false,
-      "Links should not use the same value for id and another param"
-    )
+    # assert_select(
+    #   "a[href = '#{location_descriptions_path}?by_author=#{user.id}']"
+    # )
+    # assert_select(
+    #   "a[href = '#{name_descriptions_path}?by_author=#{user.id}']"
+    # )
+    # assert_select(
+    #   "a:match('href', ?)",
+    #   /\?.*=(\d+).*&id=\1/, # some param=n followed by id with same value
+    #   false,
+    #   "Links should not use the same value for id and another param"
+    # )
+    # assert_select(
+    #   "a:match('href', ?)",
+    #   /\?.*id=(\d+).*&\S+=\1/, # id=n followed by another param with same value
+    #   false,
+    #   "Links should not use the same value for id and another param"
+    # )
   end
 
   #   ---------------


### PR DESCRIPTION
I have a feeling that the user site stats put a considerable strain on the db server. 

One way to test this is to simply turn them off.