### PR TITLE
All Names link

### DIFF
--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -101,24 +101,7 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def name_correct_spelling_tab(name)
-      [name.correct_spelling.display_name.l,
-       add_query_param(name_path(name.correct_spelling_id)),
-       { class: tab_id(__method__.to_s) }]
-    end
-
-    def show_name_tab(name)
-      [name.display_name.l, add_query_param(name_path(name.id)),
-       { class: tab_id(__method__.to_s) }]
-    end
-
     # lifeform tabs:
-    def propagate_lifeform_form_tab(name)
-      [:show_name_propagate_lifeform.t,
-       add_query_param(propagate_name_lifeform_form_path(name.id)),
-       { class: tab_id(__method__.to_s) }]
-    end
-
     def edit_name_lifeform_tab(name)
       [:EDIT.l, add_query_param(edit_name_lifeform_path(name.id)),
        { class: tab_id(__method__.to_s), icon: :edit }]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -234,6 +234,21 @@ module Tabs
        { class: tab_id(__method__.to_s) }]
     end
 
+    def all_names_index_tabs(query:)
+      [
+        new_name_tab,
+        all_names_tab(query),
+        coerced_observation_query_tab(query)
+      ].reject(&:empty?)
+    end
+
+    def all_names_tab(query)
+      return if query&.flavor == :all || query&.flavor&.empty?
+
+      [:all_objects.t(type: :name), names_path,
+       { class: tab_id(__method__.to_s) }]
+    end
+
     def names_index_sorts(query:)
       [
         ["name", :sort_by_name.t],

--- a/app/views/controllers/names/index.html.erb
+++ b/app/views/controllers/names/index.html.erb
@@ -1,7 +1,7 @@
 <%
 @container = :text_image
 add_index_title(@query, no_hits: "")
-add_tab_set(names_index_tabs(query: @query))
+add_tab_set(all_names_index_tabs(query: @query))
 add_sorter(@query, names_index_sorts(query: @query))
 
 flash_error(@error) if @error && @objects.empty?

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -55,6 +55,8 @@ class NamesControllerTest < FunctionalTestCase
     get(:index)
 
     assert_displayed_title("Names by Name")
+    assert_select("#right_tabs a[href='#{names_path}']", { count: 0 },
+                  "right `tabs` should not link to All Names")
   end
 
   def test_index_with_non_default_sort
@@ -220,6 +222,8 @@ class NamesControllerTest < FunctionalTestCase
                     distinct.count },
       "Wrong number of (correctly spelled) Names"
     )
+    assert_select("#right_tabs a[href='#{names_path}']", { count: 1 },
+                  "right `tabs` should have a link to All Names")
   end
 
   def test_index_with_observations_by_letter


### PR DESCRIPTION
- Fixes the link to `All Names` on the Names With Observation page (fixing Issue #1841)
- Adds tests and new helpers