### PR TITLE
Apply `uniq` to `Name.parents`

### DIFF
--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -219,7 +219,7 @@ module Name::Taxonomy
     parents.reject!(&:deprecated) unless parents.all?(&:deprecated)
 
     # Return single parent as an array for backwards compatibility.
-    return parents if all
+    return parents.uniq if all
     return [] unless parents.any?
 
     [parents.first]


### PR DESCRIPTION
This method in `Name::Taxonomy` counterintuitively may not return uniq values, with the test fixtures.

I'm debugging my branch to consolidate lookups in `Name.parents`, and discovered this.