### PR TITLE
Fix caching sidebar links where query is relevant

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -954,6 +954,15 @@ class ApplicationController < ActionController::Base
   end
   helper_method :passed_query
 
+  # TODO: If we're going to cache user stuff that depends on their present q,
+  # we'll need a helper to make the current QueryRecord (not just the id)
+  # available to templates as an ApplicationController ivar. Something like:
+  #
+  # def current_query_record
+  #   current_query = passed_query || query_from_session # could both be nil!
+  #   current_query_record = current_query&.record || "no_query"
+  # end
+
   # Return query parameter(s) necessary to pass query information along to
   # the next request. *NOTE*: This method is available to views.
   def query_params(query = nil)
@@ -1006,8 +1015,6 @@ class ApplicationController < ActionController::Base
   helper_method :get_query_param
 
   # NOTE: these two methods add q: param to urls built from controllers/actions.
-  # Seem to be dodgy with Rails routes path helpers. If encountering problems,
-  # try redirect_to(whatever_objects_path(q: get_query_param)) instead.
   def redirect_with_query(args, query = nil)
     redirect_to(add_query_param(args, query))
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -946,6 +946,7 @@ class ApplicationController < ActionController::Base
 
     Query.safe_find(id)
   end
+  helper_method :query_from_session
 
   # Get instance of Query which is being passed to subsequent pages.
   def passed_query

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -5,20 +5,20 @@ module Tabs
     # Moved download link into species_list_logged_in_show_tabs and
     # nixed user: kwarg
     # Can't access this page unless logged in as of 2023
-    def species_list_show_tabs(list:)
-      tabs = species_list_logged_in_show_tabs(list)
+    def species_list_show_tabs(list:, query: nil)
+      tabs = species_list_logged_in_show_tabs(list, query)
       return tabs unless check_permission(list)
 
       tabs += species_list_user_show_tabs(list)
       tabs
     end
 
-    def species_list_logged_in_show_tabs(list)
+    def species_list_logged_in_show_tabs(list, query = nil)
       [
         species_list_download_tab(list),
         species_list_set_source_tab(list),
         clone_species_list_tab(list),
-        species_list_add_remove_from_another_list_tab(list)
+        species_list_add_remove_from_another_list_tab(list, query)
       ]
     end
 
@@ -57,10 +57,10 @@ module Tabs
          help: :species_list_show_set_source_help.l }]
     end
 
-    def species_list_add_remove_from_another_list_tab(list)
+    def species_list_add_remove_from_another_list_tab(list, query = nil)
       [:species_list_show_add_remove_from_another_list.t,
        add_query_param(
-         edit_species_list_observations_path(species_list: list.id)
+         edit_species_list_observations_path(species_list: list.id), query
        ),
        { class: tab_id(__method__.to_s) }]
     end

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -9,8 +9,6 @@ classes = {
   mobile_only: "visible-xs",
   desktop_only: "hidden-xs"
 }
-# current_query = passed_query || query_from_session
-# current_query_record = current_query&.record || "no_query"
 %>
 
 <div id="navigation">

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -31,8 +31,8 @@ classes = {
       <% end %>
     <% end %>
 
-    <%# Cache customized for the user instance. %>
-    <% cache(@user) do %>
+    <%# Cache customized for the user instance, and their query. %>
+    <% cache([@user, passed_query]) do %>
       <% if @user %>
         <%= render(partial: "application/sidebar/user",
                     locals: { classes: classes }) %>

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -34,10 +34,8 @@ classes = {
     <%# If caching obs/spl, this should be keyed for both User and QueryRecord
         (i.e. cache invalidated if query record updated, or new ID). %>
     <%# cache([@user, current_query_record]) do %>
-    <% if @user %>
-      <%= render(partial: "application/sidebar/user",
-                  locals: { classes: classes }) %>
-    <% end %>
+    <%= render(partial: "application/sidebar/user",
+                locals: { classes: classes }) if @user %>
 
     <%= render(partial: "application/sidebar/observations",
                 locals: { classes: classes }) %>

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -9,6 +9,8 @@ classes = {
   mobile_only: "visible-xs",
   desktop_only: "hidden-xs"
 }
+# current_query = passed_query || query_from_session
+# current_query_record = current_query&.record || "no_query"
 %>
 
 <div id="navigation">
@@ -31,19 +33,20 @@ classes = {
       <% end %>
     <% end %>
 
-    <%# Cache customized for the user instance, and their query. %>
-    <% cache([@user, passed_query]) do %>
-      <% if @user %>
-        <%= render(partial: "application/sidebar/user",
-                    locals: { classes: classes }) %>
-      <% end %>
-
-      <%= render(partial: "application/sidebar/observations",
+    <%# Cache obs/spl should be customized for current User and QueryRecord
+        (i.e. cache invalidated if query record updated, or new ID). %>
+    <%# cache([@user, current_query_record]) do %>
+    <% if @user %>
+      <%= render(partial: "application/sidebar/user",
                   locals: { classes: classes }) %>
-
-      <%= render(partial: "application/sidebar/species_lists",
-                  locals: { classes: classes }) if @user %>
     <% end %>
+
+    <%= render(partial: "application/sidebar/observations",
+                locals: { classes: classes }) %>
+
+    <%= render(partial: "application/sidebar/species_lists",
+                locals: { classes: classes }) if @user %>
+    <%# end %>
 
     <% cache([user_status_string, "links"]) do %>
       <%= render(partial: "application/sidebar/latest",

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -20,7 +20,7 @@ classes = {
 
   <div class="<%= classes[:wrapper] %>" data-controller="nav-active">
 
-    <%# Cache depends only on user status (logged-in? admin?) %>
+    <%# This cache depends only on user status (logged-in? admin?) %>
     <% cache([user_status_string, "login"]) do %>
       <% if in_admin_mode? %>
         <%= render(partial: "application/sidebar/admin",
@@ -31,7 +31,7 @@ classes = {
       <% end %>
     <% end %>
 
-    <%# Cache obs/spl should be customized for current User and QueryRecord
+    <%# If caching obs/spl, this should be keyed for both User and QueryRecord
         (i.e. cache invalidated if query record updated, or new ID). %>
     <%# cache([@user, current_query_record]) do %>
     <% if @user %>
@@ -46,6 +46,7 @@ classes = {
                 locals: { classes: classes }) if @user %>
     <%# end %>
 
+    <%# This cache depends only on user status (logged-in? admin?) %>
     <% cache([user_status_string, "links"]) do %>
       <%= render(partial: "application/sidebar/latest",
                   locals: { classes: classes }) %>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -4,7 +4,7 @@ add_page_title(
 )
 add_pager_for(@species_list)
 add_interest_icons(@user, @species_list)
-add_tab_set(species_list_show_tabs(list: @species_list))
+add_tab_set(species_list_show_tabs(list: @species_list, query: @query))
 @container = :text_image
 %>
 

--- a/test/integration/capybara/species_lists_integration_test.rb
+++ b/test/integration/capybara/species_lists_integration_test.rb
@@ -211,4 +211,18 @@ class SpeciesListsIntegrationTest < CapybaraIntegrationTestCase
     assert_selector(".comment", text: /Slartibartfast/)
     assert_selector(".comment", text: /Steatopygia/)
   end
+
+  def test_add_remove_from_another_list
+    spl = species_lists(:unknown_species_list)
+
+    login
+    visit(species_list_path(spl))
+    click_on(:species_list_show_add_remove_from_another_list.l)
+
+    assert_match(
+      edit_species_list_observations_path, current_path,
+      "Clicking #{:species_list_show_add_remove_from_another_list.l} " \
+      "should go to #{:species_list_add_remove_title.l}"
+    )
+  end
 end


### PR DESCRIPTION
The sidebar obs and list links need to incorporate the current query, to work properly. They're currently only cached on the current user, whose query may have changed. 

Solutions: they could either (1) not be cached, or (2) cache with the current `QueryRecord` as part of the key. 

I'm going to try the former. But here's a question: how can I easily get the currently relevant `QueryRecord`? We don't seem to have a helper that gets the record instance. And does the query in the link rather use the `query_from_session` or the `passed_query`, or try one then the other?

#1849