### PR TITLE
Add index to observation views

### DIFF
--- a/db/migrate/20240126075657_add_index_to_observation_views.rb
+++ b/db/migrate/20240126075657_add_index_to_observation_views.rb
@@ -1,0 +1,11 @@
+class AddIndexToObservationViews < ActiveRecord::Migration[7.1]
+  def up
+    add_index :observation_views, [:observation_id, :user_id],
+              name: :user_observation_index
+  end
+
+  def down
+    remove_index :observation_views, [:observation_id, :user_id],
+                 name: :user_observation_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_071823) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_075657) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -457,6 +457,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_071823) do
     t.integer "user_id"
     t.datetime "last_view", precision: nil
     t.boolean "reviewed"
+    t.index ["observation_id", "user_id"], name: "user_observation_index"
   end
 
   create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
Frequent queries of `observation_views` are 
- by `:observation_id`, for the show obs footer, or 
- by both `:observation_id` and `:user_id`, for the identify query.

In this case, we can use a single index on two columns for both queries, but the order matters.
___
Without index:
```
irb(main):001> ObservationView.where(observation_id: 81188).explain
  TRANSACTION (0.1ms)  BEGIN
  ObservationView Load (146.7ms)  SELECT `observation_views`.* FROM `observation_views` WHERE `observation_views`.`observation_id` = 81188
=> 
EXPLAIN SELECT `observation_views`.* FROM `observation_views` WHERE `observation_views`.`observation_id` = 81188
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
| id | select_type | table             | partitions | type | possible_keys | key  | key_len | ref  | rows   | filtered | Extra       |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
|  1 | SIMPLE      | observation_views | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 440629 |     10.0 | Using where |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
1 row in set (0.00 sec)

irb(main):004> ObservationView.where(user_id: 3477).where(observation_id: 81188).explain
  ObservationView Load (154.4ms)  SELECT `observation_views`.* FROM `observation_views` WHERE (`observation_views`.`user_id` = 3477) AND (`observation_views`.`observation_id` = 81188)
=> 
EXPLAIN SELECT `observation_views`.* FROM `observation_views` WHERE (`observation_views`.`user_id` = 3477) AND (`observation_views`.`observation_id` = 81188)
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
| id | select_type | table             | partitions | type | possible_keys | key  | key_len | ref  | rows   | filtered | Extra       |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
|  1 | SIMPLE      | observation_views | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 440629 |      1.0 | Using where |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
1 row in set (0.00 sec)
```
___
With index on `[:observation_id, :user_id]`:
```
irb(main):001> ObservationView.where(user_id: 3477).where(observation_id: 81188).explain
  TRANSACTION (0.1ms)  BEGIN
  ObservationView Load (0.5ms)  SELECT `observation_views`.* FROM `observation_views` WHERE (`observation_views`.`user_id` = 3477) AND (`observation_views`.`observation_id` = 81188)
=> 
EXPLAIN SELECT `observation_views`.* FROM `observation_views` WHERE (`observation_views`.`user_id` = 3477) AND (`observation_views`.`observation_id` = 81188)
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------------+------+----------+-------+
| id | select_type | table             | partitions | type | possible_keys          | key                    | key_len | ref         | rows | filtered | Extra |
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------------+------+----------+-------+
|  1 | SIMPLE      | observation_views | NULL       | ref  | user_observation_index | user_observation_index | 10      | const,const |    1 |    100.0 | NULL  |
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------------+------+----------+-------+
1 row in set (0.00 sec)

irb(main):002> ObservationView.where(observation_id: 81188).explain
  ObservationView Load (0.5ms)  SELECT `observation_views`.* FROM `observation_views` WHERE `observation_views`.`observation_id` = 81188
=> 
EXPLAIN SELECT `observation_views`.* FROM `observation_views` WHERE `observation_views`.`observation_id` = 81188
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------+------+----------+-------+
| id | select_type | table             | partitions | type | possible_keys          | key                    | key_len | ref   | rows | filtered | Extra |
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | observation_views | NULL       | ref  | user_observation_index | user_observation_index | 5       | const |    2 |    100.0 | NULL  |
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------+------+----------+-------+
1 row in set (0.00 sec)
```
___
With index on `[:user_id, :observation_id]`:
```
irb(main):001> ObservationView.where(user_id: 3477).where(observation_id: 81188).explain
  TRANSACTION (0.1ms)  BEGIN
  ObservationView Load (0.4ms)  SELECT `observation_views`.* FROM `observation_views` WHERE (`observation_views`.`user_id` = 3477) AND (`observation_views`.`observation_id` = 81188)
=> 
EXPLAIN SELECT `observation_views`.* FROM `observation_views` WHERE (`observation_views`.`user_id` = 3477) AND (`observation_views`.`observation_id` = 81188)
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------------+------+----------+-------+
| id | select_type | table             | partitions | type | possible_keys          | key                    | key_len | ref         | rows | filtered | Extra |
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------------+------+----------+-------+
|  1 | SIMPLE      | observation_views | NULL       | ref  | user_observation_index | user_observation_index | 10      | const,const |    1 |    100.0 | NULL  |
+----+-------------+-------------------+------------+------+------------------------+------------------------+---------+-------------+------+----------+-------+
1 row in set (0.00 sec)

irb(main):002> ObservationView.where(observation_id: 81188).explain
  ObservationView Load (148.8ms)  SELECT `observation_views`.* FROM `observation_views` WHERE `observation_views`.`observation_id` = 81188
=> 
EXPLAIN SELECT `observation_views`.* FROM `observation_views` WHERE `observation_views`.`observation_id` = 81188
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
| id | select_type | table             | partitions | type | possible_keys | key  | key_len | ref  | rows   | filtered | Extra       |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
|  1 | SIMPLE      | observation_views | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 440629 |     10.0 | Using where |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+--------+----------+-------------+
1 row in set (0.00 sec)
```
In this last case, the two-column index is not usable for `:observation_id`, because it comes second.