### PR TITLE
Add "login" index to Users table

### DIFF
--- a/db/migrate/20240126081715_add_login_index_to_users.rb
+++ b/db/migrate/20240126081715_add_login_index_to_users.rb
@@ -1,0 +1,9 @@
+class AddLoginIndexToUsers < ActiveRecord::Migration[7.1]
+  def up
+    add_index :users, :login, name: :login_index
+  end
+
+  def down
+    remove_index :users, :login_id, name: :login_index
+  end
+end

--- a/db/migrate/20240126081715_add_login_index_to_users.rb
+++ b/db/migrate/20240126081715_add_login_index_to_users.rb
@@ -1,6 +1,6 @@
 class AddLoginIndexToUsers < ActiveRecord::Migration[7.1]
   def up
-    add_index :users, :login, name: :login_index
+    add_index :users, :login, name: :login_index, if_not_exists: true
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_081715) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_082516) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -397,6 +397,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_081715) do
     t.string "lifeform", limit: 1024, default: " ", null: false
     t.boolean "locked", default: false, null: false
     t.integer "icn_id"
+    t.index ["synonym_id"], name: "synonym_index"
   end
 
   create_table "names_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_075657) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_081715) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -704,6 +704,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_075657) do
     t.text "notes_template"
     t.boolean "blocked", default: false, null: false
     t.boolean "no_emails", default: false, null: false
+    t.index ["login"], name: "login_index"
   end
 
   create_table "visual_group_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/models/description_test.rb
+++ b/test/models/description_test.rb
@@ -225,9 +225,9 @@ class DescriptionTest < UnitTestCase
     assert_equal([rolf], desc.admins)
     assert_equal([rolf.id], desc.admin_ids)
     assert_equal(User.all, desc.writers)
-    assert_equal(User.pluck(:id), desc.writer_ids)
+    assert_equal(User.order(:id).pluck(:id), desc.writer_ids)
     assert_equal(User.all, desc.readers)
-    assert_equal(User.pluck(:id), desc.reader_ids)
+    assert_equal(User.order(:id).pluck(:id), desc.reader_ids)
 
     desc = name_descriptions(:draft_coprinus_comatus)
     assert_equal([rolf, mary, katrina], desc.admins)

--- a/test/models/description_test.rb
+++ b/test/models/description_test.rb
@@ -225,6 +225,7 @@ class DescriptionTest < UnitTestCase
     assert_equal([rolf], desc.admins)
     assert_equal([rolf.id], desc.admin_ids)
     assert_equal(User.all, desc.writers)
+    # Must order on :id because of new table index on `login`
     assert_equal(User.order(:id).pluck(:id), desc.writer_ids)
     assert_equal(User.all, desc.readers)
     assert_equal(User.order(:id).pluck(:id), desc.reader_ids)


### PR DESCRIPTION
Without index:
```
irb(main):001> User.where(login: "Margarida").explain
  User Load (155.7ms)  SELECT `users`.* FROM `users` WHERE `users`.`login` = 'Margarida'
=> 
EXPLAIN SELECT `users`.* FROM `users` WHERE `users`.`login` = 'Margarida'
+----+-------------+-------+------------+------+---------------+------+---------+------+-------+----------+-------------+
| id | select_type | table | partitions | type | possible_keys | key  | key_len | ref  | rows  | filtered | Extra       |
+----+-------------+-------+------------+------+---------------+------+---------+------+-------+----------+-------------+
|  1 | SIMPLE      | users | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 68627 |     10.0 | Using where |
+----+-------------+-------+------------+------+---------------+------+---------+------+-------+----------+-------------+
1 row in set (0.00 sec)
```
This example is actually straight out of the production log, where it took much longer:
```
User Load (512.7ms)  SELECT `users`.* FROM `users` WHERE `users`.`login` = 'Margarida' LIMIT 1
```
___
With index:
```
irb(main):001> User.where(login: "Margarida").explain
  TRANSACTION (0.1ms)  BEGIN
  User Load (0.4ms)  SELECT `users`.* FROM `users` WHERE `users`.`login` = 'Margarida'
=> 
EXPLAIN SELECT `users`.* FROM `users` WHERE `users`.`login` = 'Margarida'
+----+-------------+-------+------------+------+---------------+-------------+---------+-------+------+----------+-------+
| id | select_type | table | partitions | type | possible_keys | key         | key_len | ref   | rows | filtered | Extra |
+----+-------------+-------+------------+------+---------------+-------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | users | NULL       | ref  | login_index   | login_index | 242     | const |    1 |    100.0 | NULL  |
+----+-------------+-------+------------+------+---------------+-------------+---------+-------+------+----------+-------+
1 row in set (0.00 sec)
```