### PR TITLE
Add synonym index to Names table

### DIFF
--- a/db/migrate/20240126082516_add_synonym_index_to_names.rb
+++ b/db/migrate/20240126082516_add_synonym_index_to_names.rb
@@ -1,0 +1,9 @@
+class AddSynonymIndexToNames < ActiveRecord::Migration[7.1]
+  def up
+    add_index :names, :synonym_id, name: :synonym_index
+  end
+
+  def down
+    remove_index :names, :synonym_id, name: :synonym_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_075657) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_082516) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -397,6 +397,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_075657) do
     t.string "lifeform", limit: 1024, default: " ", null: false
     t.boolean "locked", default: false, null: false
     t.integer "icn_id"
+    t.index ["synonym_id"], name: "synonym_index"
   end
 
   create_table "names_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
`Name.where(synonym_id: whatever)`  is called on every obs index and show.
___
without index:
```ruby
irb(main):001> Name.where(synonym_id: 6869).explain
  Name Load (99.7ms)  SELECT `names`.* FROM `names` WHERE `names`.`synonym_id` = 6869
=> 
EXPLAIN SELECT `names`.* FROM `names` WHERE `names`.`synonym_id` = 6869
+----+-------------+-------+------------+------+---------------+------+---------+------+-------+----------+-------------+
| id | select_type | table | partitions | type | possible_keys | key  | key_len | ref  | rows  | filtered | Extra       |
+----+-------------+-------+------------+------+---------------+------+---------+------+-------+----------+-------------+
|  1 | SIMPLE      | names | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 67680 |     10.0 | Using where |
+----+-------------+-------+------------+------+---------------+------+---------+------+-------+----------+-------------+
1 row in set (0.00 sec)
```
On production, it can be quite slow:
```
Name Load (494.8ms)  SELECT `names`.* FROM `names` WHERE `names`.`synonym_id` = 6869
```
___
with index:
```ruby
irb(main):001> Name.where(synonym_id: 6869).explain
  TRANSACTION (0.1ms)  BEGIN
  Name Load (0.3ms)  SELECT `names`.* FROM `names` WHERE `names`.`synonym_id` = 6869
=> 
EXPLAIN SELECT `names`.* FROM `names` WHERE `names`.`synonym_id` = 6869
+----+-------------+-------+------------+------+---------------+---------------+---------+-------+------+----------+-------+
| id | select_type | table | partitions | type | possible_keys | key           | key_len | ref   | rows | filtered | Extra |
+----+-------------+-------+------------+------+---------------+---------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | names | NULL       | ref  | synonym_index | synonym_index | 5       | const |    2 |    100.0 | NULL  |
+----+-------------+-------+------------+------+---------------+---------------+---------+-------+------+----------+-------+
1 row in set (0.00 sec)
```