### PR TITLE
Clean up `autologin` multiple lookups of user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -354,10 +354,13 @@ class ApplicationController < ActionController::Base
     User.current = nil
   end
 
+  # Save a lookup of the mrtg stats "user".
+  MRTG_USER_ID = 164054
+
   def try_user_autologin(user_from_session)
     if Rails.env.production? && request.remote_ip == "127.0.0.1"
       # Request from the server itself, MRTG needs to log in to test page loads.
-      login_valid_user(User.find_by(login: "mrtg"))
+      login_valid_user(User.find(id: MRTG_USER_ID))
     elsif user_verified_and_allowed?(user = user_from_session)
       # User was already logged in.
       refresh_logged_in_user_instance(user)
@@ -384,7 +387,7 @@ class ApplicationController < ActionController::Base
 
   def refresh_logged_in_user_instance(user)
     @user = user
-    @user.reload
+    # @user.reload
   end
 
   def login_valid_user(user)
@@ -528,8 +531,8 @@ class ApplicationController < ActionController::Base
     user
   end
 
-  # Retrieve the User from session.  Returns User object or nil.  (Does not
-  # check verified status or anything.)
+  # Retrieve the User from session.  Returns freshly loaded User object or nil.
+  # (Does not check verified status or anything.)
   def session_user
     User.safe_find(session[:user_id])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -361,9 +361,9 @@ class ApplicationController < ActionController::Base
     if Rails.env.production? && request.remote_ip == "127.0.0.1"
       # Request from the server itself, MRTG needs to log in to test page loads.
       login_valid_user(User.find(id: MRTG_USER_ID))
-    elsif user_verified_and_allowed?(user = user_from_session)
+    elsif user_verified_and_allowed?(user_from_session)
       # User was already logged in.
-      refresh_logged_in_user_instance(user)
+      @user = user_from_session
     elsif user_verified_and_allowed?(user = validate_user_in_autologin_cookie)
       # User had "remember me" cookie set.
       login_valid_user(user)
@@ -383,11 +383,6 @@ class ApplicationController < ActionController::Base
                   (split[1] == user.auth_code)
 
     user
-  end
-
-  def refresh_logged_in_user_instance(user)
-    @user = user
-    # @user.reload
   end
 
   def login_valid_user(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1126,8 +1126,8 @@ class User < AbstractModel
   }
 
   def user_requirements
-    user_login_requirements
-    user_password_requirements
+    user_login_requirements if new_record? || login_changed?
+    user_password_requirements if new_record? || password_changed?
     user_other_requirements
   end
 
@@ -1141,6 +1141,7 @@ class User < AbstractModel
     end
   end
 
+  # This is a pricey lookup, avoid if not changing login
   def login_already_taken?
     other = User.find_by(login: login)
     other && other.id != id


### PR DESCRIPTION
The `autologin` before_filter has been doing multiple lookups of the same user for ages:

```
Started GET "/" for ::1 at 2024-01-26 12:25:44 -0800
  ActiveRecord::SchemaMigration Load (0.2ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
Processing by ObservationsController#index as HTML
START AUTOLOGIN BEFORE FILTER
  User Load (0.3ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 7238 LIMIT 1
  ↳ app/models/abstract_model.rb:154:in `safe_find'
  User Load (0.4ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 7238 LIMIT 1
  ↳ app/models/user.rb:413:in `reload'
user=1 robot=N ip=::1
  TRANSACTION (0.2ms)  BEGIN
  ↳ app/models/user.rb:1145:in `login_already_taken?'
  User Load (31.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`login` = 'Joe Namath' LIMIT 1
  ↳ app/models/user.rb:1145:in `login_already_taken?'
  User Update (0.4ms)  UPDATE `users` SET `users`.`updated_at` = '2024-01-26 20:25:45', `users`.`last_activity` = '2024-01-26 20:25:44' WHERE `users`.`id` = 7238
  ↳ app/controllers/application_controller.rb:423:in `track_last_time_user_made_a_request'
  TRANSACTION (4.4ms)  COMMIT
  ↳ app/controllers/application_controller.rb:423:in `track_last_time_user_made_a_request'
END AUTOLOGIN BEFORE FILTER
```

This PR gets rid of the reload of the (freshly loaded!) `@user`,  and changes `User` validation to only validate the login/password if it's a new record, or they're changing. That saves the `login_already_taken?` check, which is the slower lookup.