### PR TITLE
Redo indexes of observation views

### DIFF
--- a/db/migrate/20240126233636_redo_indexes_for_observation_views.rb
+++ b/db/migrate/20240126233636_redo_indexes_for_observation_views.rb
@@ -1,0 +1,15 @@
+class RedoIndexesForObservationViews < ActiveRecord::Migration[7.1]
+  def up
+    remove_index :observation_views, [:observation_id, :user_id],
+                 name: :user_observation_index
+    add_index :observation_views, :observation_id, name: :observation_index
+    add_index :observation_views, :user_id, name: :user_index
+  end
+
+  def down
+    remove_index :observation_views, :observation_id, name: :observation_index
+    remove_index :observation_views, :observation_id, name: :user_index
+    add_index :observation_views, [:observation_id, :user_id],
+              name: :user_observation_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_082516) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_233636) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -458,7 +458,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_082516) do
     t.integer "user_id"
     t.datetime "last_view", precision: nil
     t.boolean "reviewed"
-    t.index ["observation_id", "user_id"], name: "user_observation_index"
+    t.index ["observation_id"], name: "observation_index"
+    t.index ["user_id"], name: "user_index"
   end
 
   create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
@@ -705,6 +706,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_082516) do
     t.text "notes_template"
     t.boolean "blocked", default: false, null: false
     t.boolean "no_emails", default: false, null: false
+    t.index ["login"], name: "login_index"
   end
 
   create_table "visual_group_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/models/description_test.rb
+++ b/test/models/description_test.rb
@@ -225,9 +225,9 @@ class DescriptionTest < UnitTestCase
     assert_equal([rolf], desc.admins)
     assert_equal([rolf.id], desc.admin_ids)
     assert_equal(User.all, desc.writers)
-    assert_equal(User.pluck(:id), desc.writer_ids)
+    assert_equal(User.order(:id).pluck(:id), desc.writer_ids)
     assert_equal(User.all, desc.readers)
-    assert_equal(User.pluck(:id), desc.reader_ids)
+    assert_equal(User.order(:id).pluck(:id), desc.reader_ids)
 
     desc = name_descriptions(:draft_coprinus_comatus)
     assert_equal([rolf, mary, katrina], desc.admins)


### PR DESCRIPTION
The index on two columns left out an important use case. In the show obs footer, we query both by obs_id and by obs_id, user_id But in the identify index, we query by user_id