### PR TITLE
Rename scopes `needs_naming`, `needs_naming_and_not_reviewed_by_user`

### DIFF
--- a/app/classes/query/observation_needs_naming.rb
+++ b/app/classes/query/observation_needs_naming.rb
@@ -14,7 +14,7 @@ module Query
     # 15x faster to use AR scope to assemble the IDs vs SQL SELECT DISTINCT!
     def initialize_flavor
       user = User.current_id
-      needs_naming = Observation.needs_naming_not_reviewed_by_user(user).
+      needs_naming = Observation.needs_naming_and_not_reviewed_by_user(user).
                      map(&:id).join(", ")
       where << "observations.id IN (#{needs_naming})" if needs_naming.present?
 

--- a/app/classes/query/observation_needs_naming.rb
+++ b/app/classes/query/observation_needs_naming.rb
@@ -2,7 +2,7 @@
 
 module Query
   # methods for initializing Queries for Observations Needing Identification
-  class ObservationNeedsId < Query::ObservationBase
+  class ObservationNeedsNaming < Query::ObservationBase
     def parameter_declarations
       super.merge(
         in_clade?: :string,
@@ -14,8 +14,9 @@ module Query
     # 15x faster to use AR scope to assemble the IDs vs SQL SELECT DISTINCT!
     def initialize_flavor
       user = User.current_id
-      needs_id = Observation.needs_id_for_user(user).map(&:id).join(", ")
-      where << "observations.id IN (#{needs_id})" if needs_id.present?
+      needs_naming = Observation.needs_naming_not_reviewed_by_user(user).
+                     map(&:id).join(", ")
+      where << "observations.id IN (#{needs_naming})" if needs_naming.present?
 
       where << name_in_clade_condition if params[:in_clade]
       where << location_in_region_condition if params[:in_region]

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -20,7 +20,7 @@ module Observations
     private
 
     def unfiltered_index
-      query = create_query(:Observation, :needs_id, {})
+      query = create_query(:Observation, :needs_naming, {})
 
       show_selected_results(query)
     end
@@ -44,19 +44,19 @@ module Observations
     def clade_filter(term)
       # return unless (clade = Name.find_by(text_name: term))
 
-      query = create_query(:Observation, :needs_id, { in_clade: term })
+      query = create_query(:Observation, :needs_naming, { in_clade: term })
 
       show_selected_results(query)
     end
 
     def region_filter(term)
-      query = create_query(:Observation, :needs_id, { in_region: term })
+      query = create_query(:Observation, :needs_naming, { in_region: term })
 
       show_selected_results(query)
     end
 
     # def user_filter(term)
-    #   query = create_query(:Observation, :needs_id, { by_user: term })
+    #   query = create_query(:Observation, :needs_naming, { by_user: term })
 
     #   show_selected_results(query)
     # end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -123,7 +123,7 @@ class ObservationsController
       return render_pattern_search_error(search) if search.errors.any?
 
       @suggest_alternate_spellings = search.query.params[:pattern]
-      if params[:needs_id]
+      if params[:needs_naming]
         redirect_to(
           identify_observations_path(q: get_query_param(search.query))
         )
@@ -134,7 +134,7 @@ class ObservationsController
 
     def render_pattern_search_error(search)
       search.errors.each { |error| flash_error(error.to_s) }
-      if params[:needs_id]
+      if params[:needs_naming]
         redirect_to(identify_observations_path(q: get_query_param))
       else
         render("index", location: observations_path)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -68,7 +68,7 @@ class SearchController < ApplicationController
     end
   end
 
-  # In the case of "needs_id", this is added to the search path params
+  # In the case of "needs_naming", this is added to the search path params
   def forward_pattern_search(type, pattern, special_params)
     case type
     when :google

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -245,7 +245,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
         -> { where(name_id: Name.with_rank_above_genus.map(&:id)) }
   scope :without_confident_name,
         -> { where(vote_cache: ..0) }
-  scope :needs_id, lambda {
+  scope :needs_naming, lambda {
     with_name_above_genus.or(without_confident_name)
   }
   scope :with_name_correctly_spelled,
@@ -269,12 +269,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     where.not(id: ObservationView.where(user_id: user_id, reviewed: 1).
               map(&:observation_id).uniq)
   }
-  scope :needs_id_for_user, lambda { |user|
-    needs_id.without_vote_by_user(user).not_reviewed_by_user(user).distinct
+  scope :needs_naming_not_reviewed_by_user, lambda { |user|
+    needs_naming.without_vote_by_user(user).not_reviewed_by_user(user).distinct
   }
   # Higher taxa: returns narrowed-down group of id'd obs,
   # in higher taxa under the given taxon
-  # scope :needs_id_by_taxon, lambda { |user, name|
+  # scope :needs_naming_by_taxon, lambda { |user, name|
   #   name_plus_subtaxa = Name.include_subtaxa_of(name)
   #   subtaxa_above_genus = name_plus_subtaxa.with_rank_above_genus.map(&:id)
   #   lower_subtaxa = name_plus_subtaxa.with_rank_at_or_below_genus.map(&:id)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -269,7 +269,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     where.not(id: ObservationView.where(user_id: user_id, reviewed: 1).
               map(&:observation_id).uniq)
   }
-  scope :needs_naming_not_reviewed_by_user, lambda { |user|
+  scope :needs_naming_and_not_reviewed_by_user, lambda { |user|
     needs_naming.without_vote_by_user(user).not_reviewed_by_user(user).distinct
   }
   # Higher taxa: returns narrowed-down group of id'd obs,

--- a/app/views/controllers/application/top_nav/_search_form.html.erb
+++ b/app/views/controllers/application/top_nav/_search_form.html.erb
@@ -46,7 +46,7 @@ identify_page = controller.controller_name == "identify"
     </div><!--.form-group-->
   <% end %>
 
-  <%= hidden_field_tag(:needs_id, true) if identify_page %>
+  <%= hidden_field_tag(:needs_naming, true) if identify_page %>
 
   <div class="form-group text-nowrap">
     <%= submit_button(form: f, button: :app_search.l, class: "mr-2") %>

--- a/app/views/controllers/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/controllers/observations/identify/_form_identify_filter.html.erb
@@ -5,7 +5,7 @@
 <%# Otherwise the records have to be looked up (several times) %>
 
 <%
-# Show the incoming `needs_id` query in the search bar if there has been one
+# Show the incoming `needs_naming` query in the search bar if there has been one
 filter_type = params.dig(:filter, :type) || false
 selected = filter_type ? filter_type.to_sym : :clade
 value = filter_type ? params.dig(:filter, :term) : ""

--- a/test/controllers/observation_views_controller_test.rb
+++ b/test/controllers/observation_views_controller_test.rb
@@ -8,7 +8,7 @@ require("test_helper")
 class ObservationViewsControllerTest < FunctionalTestCase
   def test_update
     login("mary")
-    obs = Observation.needs_id_for_user(users(:mary))
+    obs = Observation.needs_naming_not_reviewed_by_user(users(:mary))
     obs_count = obs.count
 
     # Have to create the o_v, none existing
@@ -17,7 +17,7 @@ class ObservationViewsControllerTest < FunctionalTestCase
       assert_redirected_to(identify_observations_path)
     end
 
-    now_obs = Observation.needs_id_for_user(users(:mary))
+    now_obs = Observation.needs_naming_not_reviewed_by_user(users(:mary))
     now_obs_count = now_obs.count
     assert_equal(obs_count - 5, now_obs_count)
   end

--- a/test/controllers/observation_views_controller_test.rb
+++ b/test/controllers/observation_views_controller_test.rb
@@ -8,7 +8,7 @@ require("test_helper")
 class ObservationViewsControllerTest < FunctionalTestCase
   def test_update
     login("mary")
-    obs = Observation.needs_naming_not_reviewed_by_user(users(:mary))
+    obs = Observation.needs_naming_and_not_reviewed_by_user(users(:mary))
     obs_count = obs.count
 
     # Have to create the o_v, none existing
@@ -17,7 +17,7 @@ class ObservationViewsControllerTest < FunctionalTestCase
       assert_redirected_to(identify_observations_path)
     end
 
-    now_obs = Observation.needs_naming_not_reviewed_by_user(users(:mary))
+    now_obs = Observation.needs_naming_and_not_reviewed_by_user(users(:mary))
     now_obs_count = now_obs.count
     assert_equal(obs_count - 5, now_obs_count)
   end

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -10,7 +10,7 @@ module Observations
       login("mary")
       mary = users(:mary)
       # First make sure the index is showing everything.
-      obs = Observation.needs_naming_not_reviewed_by_user(users(:mary))
+      obs = Observation.needs_naming_and_not_reviewed_by_user(users(:mary))
       obs_count = obs.count
       mary.update(layout_count: obs_count + 1)
 
@@ -23,7 +23,7 @@ module Observations
 
       # CLADE
       # make a query, and test that the query results match obs scope
-      aga_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+      aga_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
                 in_clade("Agaricales")
       query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_clade: "Agaricales")
@@ -35,7 +35,7 @@ module Observations
       assert_no_flash
       assert_select(".matrix-box", aga_obs.count)
 
-      bol_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+      bol_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
                 in_clade("Boletus")
       query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_clade: "Boletus")
@@ -44,13 +44,13 @@ module Observations
       # REGION
       # make a query, and test that the query results match obs scope
       # start with continent
-      sam_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+      sam_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
                 in_region("South America")
       query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_region: "South America")
       assert_equal(query.num_results, sam_obs.count)
 
-      cal_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+      cal_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
                 in_region("California, USA")
       # remember the original count, will change
       cal_obs_count = cal_obs.count
@@ -87,7 +87,7 @@ module Observations
 
       # Vote on the first unconfident naming and check the new obs_count
       # On the site, this happens via JS, so we'll do it directly
-      new_cal_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+      new_cal_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
                     in_region("California, USA")
       # Have to check for an actual naming, because some obs have no namings,
       # and obs.name_id.present? doesn't necessarily mean there's a naming

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -10,11 +10,11 @@ module Observations
       login("mary")
       mary = users(:mary)
       # First make sure the index is showing everything.
-      obs = Observation.needs_id_for_user(users(:mary))
+      obs = Observation.needs_naming_not_reviewed_by_user(users(:mary))
       obs_count = obs.count
       mary.update(layout_count: obs_count + 1)
 
-      query = Query.lookup_and_save(:Observation, :needs_id)
+      query = Query.lookup_and_save(:Observation, :needs_naming)
       assert_equal(query.num_results, obs_count)
       get(:index)
       assert_no_flash
@@ -23,8 +23,9 @@ module Observations
 
       # CLADE
       # make a query, and test that the query results match obs scope
-      aga_obs = Observation.needs_id_for_user(mary).in_clade("Agaricales")
-      query = Query.lookup_and_save(:Observation, :needs_id,
+      aga_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+                in_clade("Agaricales")
+      query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_clade: "Agaricales")
 
       # # get(:index, params: { q: QueryRecord.last.id.alphabetize })
@@ -34,23 +35,26 @@ module Observations
       assert_no_flash
       assert_select(".matrix-box", aga_obs.count)
 
-      bol_obs = Observation.needs_id_for_user(mary).in_clade("Boletus")
-      query = Query.lookup_and_save(:Observation, :needs_id,
+      bol_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+                in_clade("Boletus")
+      query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_clade: "Boletus")
       assert_equal(query.num_results, bol_obs.count)
 
       # REGION
       # make a query, and test that the query results match obs scope
       # start with continent
-      sam_obs = Observation.needs_id_for_user(mary).in_region("South America")
-      query = Query.lookup_and_save(:Observation, :needs_id,
+      sam_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+                in_region("South America")
+      query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_region: "South America")
       assert_equal(query.num_results, sam_obs.count)
 
-      cal_obs = Observation.needs_id_for_user(mary).in_region("California, USA")
+      cal_obs = Observation.needs_naming_not_reviewed_by_user(mary).
+                in_region("California, USA")
       # remember the original count, will change
       cal_obs_count = cal_obs.count
-      query = Query.lookup_and_save(:Observation, :needs_id,
+      query = Query.lookup_and_save(:Observation, :needs_naming,
                                     in_region: "California, USA")
       assert_equal(query.num_results, cal_obs_count)
 
@@ -83,7 +87,7 @@ module Observations
 
       # Vote on the first unconfident naming and check the new obs_count
       # On the site, this happens via JS, so we'll do it directly
-      new_cal_obs = Observation.needs_id_for_user(mary).
+      new_cal_obs = Observation.needs_naming_not_reviewed_by_user(mary).
                     in_region("California, USA")
       # Have to check for an actual naming, because some obs have no namings,
       # and obs.name_id.present? doesn't necessarily mean there's a naming

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -465,11 +465,11 @@ class ObservationsControllerTest < FunctionalTestCase
     )
   end
 
-  def test_index_pattern_needs_id_with_filter
+  def test_index_pattern_needs_naming_with_filter
     pattern = "Briceland"
 
     login
-    get(:index, params: { pattern: pattern, needs_id: true })
+    get(:index, params: { pattern: pattern, needs_naming: true })
 
     assert_displayed_title("")
     assert_match(/^#{identify_observations_url}/, redirect_to_url,
@@ -537,11 +537,11 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_select("#results", { text: "" }, "There should be no results")
   end
 
-  def test_index_pattern_bad_pattern_from_needs_id
+  def test_index_pattern_bad_pattern_from_needs_naming
     pattern = { error: "" }
 
     login
-    get(:index, params: { pattern: pattern, needs_id: true })
+    get(:index, params: { pattern: pattern, needs_naming: true })
 
     assert_redirected_to(
       identify_observations_path,

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1136,13 +1136,13 @@ class ObservationTest < UnitTestCase
                         observations(:peltigera_obs))
   end
 
-  def test_scope_needs_naming_not_reviewed_by_user
+  def test_scope_needs_naming_and_not_reviewed_by_user
     assert_includes(
-      Observation.needs_naming_not_reviewed_by_user(users(:rolf)),
+      Observation.needs_naming_and_not_reviewed_by_user(users(:rolf)),
       observations(:fungi_obs)
     )
     assert_not_includes(
-      Observation.needs_naming_not_reviewed_by_user(users(:rolf)),
+      Observation.needs_naming_and_not_reviewed_by_user(users(:rolf)),
       observations(:peltigera_obs)
     )
   end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1129,18 +1129,22 @@ class ObservationTest < UnitTestCase
                         observations(:peltigera_obs))
   end
 
-  def test_scope_needs_id
-    assert_includes(Observation.needs_id,
+  def test_scope_needs_naming
+    assert_includes(Observation.needs_naming,
                     observations(:fungi_obs))
-    assert_not_includes(Observation.needs_id,
+    assert_not_includes(Observation.needs_naming,
                         observations(:peltigera_obs))
   end
 
-  def test_scope_needs_id_for_user
-    assert_includes(Observation.needs_id_for_user(users(:rolf)),
-                    observations(:fungi_obs))
-    assert_not_includes(Observation.needs_id_for_user(users(:rolf)),
-                        observations(:peltigera_obs))
+  def test_scope_needs_naming_not_reviewed_by_user
+    assert_includes(
+      Observation.needs_naming_not_reviewed_by_user(users(:rolf)),
+      observations(:fungi_obs)
+    )
+    assert_not_includes(
+      Observation.needs_naming_not_reviewed_by_user(users(:rolf)),
+      observations(:peltigera_obs)
+    )
   end
 
   def test_scope_of_name


### PR DESCRIPTION
In preparation for new db column `needs_naming`. 

`Observation.needs_id` -> `Observation.needs_naming`
`Observation.needs_id_for_user(user)` -> `Observation.needs_naming_and_not_reviewed_by_user(user)`

It didn't seem to me like `needs_id` was unambiguous in the context of a db column.