### PR TITLE
Fix bug in mrtg lookup (!)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -360,7 +360,7 @@ class ApplicationController < ActionController::Base
   def try_user_autologin(user_from_session)
     if Rails.env.production? && request.remote_ip == "127.0.0.1"
       # Request from the server itself, MRTG needs to log in to test page loads.
-      login_valid_user(User.find(id: MRTG_USER_ID))
+      login_valid_user(User.find(MRTG_USER_ID))
     elsif user_verified_and_allowed?(user_from_session)
       # User was already logged in.
       @user = user_from_session


### PR DESCRIPTION
I was doing `User.find(id: MRTG_USER_ID)` instead of `User.find(MRTG_USER_ID)`, and mrtg was not found.