### PR TITLE
Added ultra-lightweight access point for uptime probe.

### DIFF
--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class TestController < ApplicationController
+  disable_filters
+
+  # Used to test if the server is up.
+  def index
+    render(plain: "hello")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -801,6 +801,9 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
         via: [:put, :patch],
         as: "species_list_projects")
 
+  # ----- Test if server is up  -------------------------------------
+  resources :test, only: [:index], controller: "test"
+
   # ----- Test pages  -------------------------------------------
   namespace :test_pages do
     resource :flash_redirection, only: [:show], controller: "flash_redirection"

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Controller tests for info pages
+class TestControllerTest < FunctionalTestCase
+  def test_tester
+    get(:index)
+    assert_equal(200, @response.status)
+  end
+end

--- a/test/integration/capybara/random_integration_test.rb
+++ b/test/integration/capybara/random_integration_test.rb
@@ -9,6 +9,10 @@ class RandomIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("body.observations__index")
   end
 
+  def test_uptime_probe
+    visit("/test")
+  end
+
   def test_login_and_logout
     login!(rolf)
 


### PR DESCRIPTION
Just plain old `/test`.  Responds with "hello" status 200.  Filters disabled.  I think this as light-weight as possible?