### PR TITLE
Fix typo in migration for indexes for observation views

### DIFF
--- a/db/migrate/20240126233636_redo_indexes_for_observation_views.rb
+++ b/db/migrate/20240126233636_redo_indexes_for_observation_views.rb
@@ -8,7 +8,7 @@ class RedoIndexesForObservationViews < ActiveRecord::Migration[7.1]
 
   def down
     remove_index :observation_views, :observation_id, name: :observation_index
-    remove_index :observation_views, :observation_id, name: :user_index
+    remove_index :observation_views, :user_id, name: :user_index
     add_index :observation_views, [:observation_id, :user_id],
               name: :user_observation_index
   end


### PR DESCRIPTION
Yikes - there was a typo that made this migration `down` action not work.