### PR TITLE
Add "disable-on-click" function to links for maps via Stimulus

### DIFF
--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -155,7 +155,7 @@ module Tabs
     def occurrence_map_for_name_tab(name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: name.id)),
-       { class: tab_id(__method__.to_s) }]
+       { class: tab_id(__method__.to_s), data: { action: "links#disable" } }]
     end
 
     # Others

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -132,11 +132,18 @@ module Tabs
       links = [
         *observations_at_where_tabs(query), # maybe multiple links
         map_observations_tab(query),
+        dummy_disable_tab,
         *observations_coerced_query_tabs(query), # multiple links
         observations_add_to_list_tab(query),
         observations_download_as_csv_tab(query)
       ]
       links.reject(&:empty?)
+    end
+
+    def dummy_disable_tab
+      ["Dummy link",
+       "https://google.com",
+       { class: tab_id(__method__.to_s), data: { action: "links#disable" } }]
     end
 
     def observations_at_where_tabs(query)
@@ -169,7 +176,7 @@ module Tabs
     def map_observations_tab(query)
       [:show_object.t(type: :map),
        map_observations_path(q: get_query_param(query)),
-       { class: tab_id(__method__.to_s) }]
+       { class: tab_id(__method__.to_s), data: { action: "links#disable" } }]
     end
 
     # NOTE: coerced_query_tab returns an array

--- a/app/javascript/controllers/links_controller.js
+++ b/app/javascript/controllers/links_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="links"
+export default class extends Controller {
+  connect() {
+    this.element.dataset.stimulus = "connected";
+  }
+
+  disable(e) {
+    e.preventDefault();
+    const link = e.target.href
+    e.target.removeAttribute('href');
+    e.target.style.pointerEvents = "none";
+    e.target.innerHTML = "<span class='spinner-right'></span>";
+    window.location = link
+  }
+}

--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -19,7 +19,7 @@ body_class = class_names(whos_calling, theme_class)
   <% end %>
 
 <div id="main_container" class="container-fluid"
-     data-controller="nav" data-nav-target="container">
+     data-controller="nav links" data-nav-target="container">
 
   <%= render(partial: "application/app/banners") %>
 


### PR DESCRIPTION
This at least provides some feedback to the user that we're working on their request, and disables double clicks on the link.

To add this to other links, add `data: { action: "links#disable" }` to the tab or link helper. 

The Stimulus `links_controller` will intercept any `<a>` link on the page with that attribute. Buttons for forms already get disabled via Turbo.