### PR TITLE
Print both location formats in a `location_link`, and show/hide via CSS class

### DIFF
--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -1,3 +1,17 @@
+// location format, when both are printed
+
+.location-format-postal {
+  .location-scientific {
+    display: none;
+  }
+}
+
+.location-format-scientific {
+  .location-postal {
+    display: none;
+  }
+}
+
 //
 // interest eyes
 // --------------------------------------------------

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -7,9 +7,23 @@ module ObjectLinkHelper
   #   Where: <%= where_string(obs.place_name) %>
   #
   def where_string(where, count = nil)
-    result = where.t
-    result += " (#{count})" if count
-    content_tag(:span, result)
+    versions = which_where(where)
+    postal = tag.span(versions[:postal], class: "location-postal")
+    scientific = tag.span(versions[:scientific],
+                          class: "location-scientific")
+
+    add_count = count ? " (#{count})" : ""
+    tag.span { [postal, scientific, add_count].safe_join }
+  end
+
+  # Returns a hash of { postal:, scientific: } versions of where.
+  def which_where(where)
+    reverse = Location.reverse_name(where)
+    if User.current_location_format == "scientific"
+      { postal: reverse, scientific: where }
+    else
+      { postal: where, scientific: reverse }
+    end
   end
 
   # Wrap location name in link to show_location / observations/index.

--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -4,7 +4,8 @@
 html_class = (Rails.env == "test") ? "" : "scroll-behavior-smooth"
 whos_calling = "#{controller.controller_name}__#{controller.action_name}"
 theme_class = "theme-#{@css_theme.underscore.dasherize}"
-body_class = class_names(whos_calling, theme_class)
+location_class = "location-format-#{User.current_location_format}"
+body_class = class_names(whos_calling, theme_class, location_class)
 %>
 <!DOCTYPE html>
 <html class="<%= html_class %>">


### PR DESCRIPTION
Adds the `User.current_location_format` preference as a CSS class on the body of every page, which allows `location_links` (and potentially other location strings) to be location-format-agnostic. 

Links contain both versions of the location text with special CSS classes, and CSS inheritance governs which one displays and which is hidden. This PR does not affect any non-link Location text. 

It should clear up cache issues where Scientific users are getting cached partials with Postal addresses, without making the cache less efficient.

#1860 