### PR TITLE
Use CSS to show/hide image vote UI, simplify cached partials

### DIFF
--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -13,9 +13,15 @@
   }
 }
 
-// logged-in-user or no-user are the body classes
+// content that requires a user, or for not-logged-in users
 .no-user {
   .require-user {
+    display: none;
+  }
+}
+
+.logged-in-user {
+  .not-logged-in {
     display: none;
   }
 }

--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -1,3 +1,4 @@
+// Cached content display/hide
 // location format, when both are printed
 
 .location-format-postal {
@@ -8,6 +9,13 @@
 
 .location-format-scientific {
   .location-postal {
+    display: none;
+  }
+}
+
+// logged-in-user or no-user are the body classes
+.no-user {
+  .require-user {
     display: none;
   }
 }

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -105,7 +105,7 @@ class GlossaryTermsController < ApplicationController
 
   # Show selected list of glossary_terms.
   def show_selected_glossary_terms(query, args = {})
-    includes = @user ? { thumb_image: :image_votes } : :thumb_image
+    includes = { thumb_image: :image_votes }
     args = {
       action: :index,
       letters: "glossary_terms.name",

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -153,7 +153,7 @@ module ImagesHelper
   # This is now a helper to avoid nested partials in loops - AN 2023
   # called in interactive_image above
   def image_vote_section_html(image, votes)
-    return "" unless votes && image && User.current
+    return "" unless votes && image
 
     tag.div(class: "vote-section require-user",
             id: "image_vote_#{image.id}") do

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -155,7 +155,8 @@ module ImagesHelper
   def image_vote_section_html(image, votes)
     return "" unless votes && image && User.current
 
-    tag.div(class: "vote-section", id: "image_vote_#{image.id}") do
+    tag.div(class: "vote-section require-user",
+            id: "image_vote_#{image.id}") do
       image_vote_meter_and_links(image)
     end
   end

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -29,9 +29,10 @@ module MatrixBoxHelper
   end
 
   def render_cached_matrix_boxes(objects, locals)
-    # matrix box has two versions (image vote UI, or no)
+    # matrix box has one version except langs.
+    # css hides image vote ui when body.no-user
     objects.each do |object|
-      cache([object, logged_in_status]) do
+      cache(object) do
         concat(render(partial: "shared/matrix_box",
                       locals: { object: object }.merge(locals)))
       end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -522,7 +522,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :not_logged_in_show_includes, lambda {
     strict_loading.includes(
       { comments: :user },
-      { images: [:license, :user] },
+      { images: [:image_votes, :license, :user] },
       :location,
       { name: { synonym: :names } },
       { namings: [:name, :user, { votes: [:observation, :user] }] },

--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -2,10 +2,11 @@
 @css_theme = css_theme
 
 html_class = (Rails.env == "test") ? "" : "scroll-behavior-smooth"
-whos_calling = "#{controller.controller_name}__#{controller.action_name}"
-theme_class = "theme-#{@css_theme.underscore.dasherize}"
-location_class = "location-format-#{User.current_location_format}"
-body_class = class_names(whos_calling, theme_class, location_class)
+ctrlr_action = "#{controller.controller_name}__#{controller.action_name}"
+theme = "theme-#{@css_theme.underscore.dasherize}"
+location_format = "location-format-#{User.current_location_format}"
+logged_in = User.current ? "logged-in-user" : "no-user"
+body_class = class_names(ctrlr_action, theme, location_format, logged_in)
 %>
 <!DOCTYPE html>
 <html class="<%= html_class %>">


### PR DESCRIPTION
Adds a body class `logged-in-user`/`no-user`, and an element class `require-user`. 

Changes `interactive_image` helper to print the `image_vote_section` in all cases, and show/hide via CSS.

Allows us to cache only 16 versions of each matrix-box partial (one for each lang), instead of 32.