### PR TITLE
Convert all callers to `location_link` to pass the postal format

### DIFF
--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -139,11 +139,11 @@ module MatrixBoxHelper
   end
 
   def matrix_box_where(presenter)
-    return unless presenter.place_name
+    return unless presenter.where
 
     tag.div(class: "rss-where") do
       tag.small do
-        location_link(presenter.place_name, presenter.where)
+        location_link(presenter.where, presenter.location)
       end
     end
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -2,38 +2,20 @@
 
 # helpers for creating links in views
 module ObjectLinkHelper
-  # Wrap location name in span: "<span>where (count)</span>"
+  # Wrap location name in link to show_location OR observations/index.
   #
-  #   Where: <%= where_string(obs.place_name) %>
+  # NEW 2024-02-01 AN: Only accepts a postal format string for `where`, e.g.
+  #   Location.name, Observation.where, SpeciesList.where, User.location.name
   #
-  def where_string(where, count = nil)
-    versions = which_where(where)
-    postal = tag.span(versions[:postal], class: "location-postal")
-    scientific = tag.span(versions[:scientific],
-                          class: "location-scientific")
-
-    add_count = count ? " (#{count})" : ""
-    tag.span { [postal, scientific, add_count].safe_join }
-  end
-
-  # Returns a hash of { postal:, scientific: } versions of where.
-  def which_where(where)
-    reverse = Location.reverse_name(where)
-    if User.current_location_format == "scientific"
-      { postal: reverse, scientific: where }
-    else
-      { postal: where, scientific: reverse }
-    end
-  end
-
-  # Wrap location name in link to show_location / observations/index.
+  # This method prints both postal and scientific formats, shown/hidden with
+  # CSS, using a governing class on the <body> that has the user's preference
   #
   #   Where: <%= location_link(obs.where, obs.location) %>
   #
   def location_link(where, location, count = nil, click = false)
     if location
       location = Location.find(location) unless location.is_a?(AbstractModel)
-      link_string = where_string(location.display_name, count)
+      link_string = where_string(location.name, count)
       link_string += " [#{:click_for_map.t}]" if click
       link_to(link_string, location_path(id: location.id),
               { id: "show_location_link_#{location.id}" })
@@ -43,6 +25,22 @@ module ObjectLinkHelper
       link_to(link_string, observations_path(where: where),
               { id: "index_observations_at_where_link" })
     end
+  end
+
+  # Wrap both formats of location.name in spans,
+  #   maybe adding a count, and wrap the whole thing in a span too:
+  #   <span><span class="location-postal">where</span> \
+  #         <span class="location-scientific">where</span> (count)</span>
+  #
+  #   Where: <%= where_string(obs.where) %>
+  #
+  def where_string(where, count = nil)
+    postal = tag.span(where, class: "location-postal")
+    scientific = tag.span(Location.reverse_name(where),
+                          class: "location-scientific")
+
+    add_count = count ? " (#{count})" : ""
+    tag.span { [postal, scientific, add_count].safe_join }
   end
 
   # Wrap name in link to show_name. Takes id or object

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -166,7 +166,7 @@ module ObservationsHelper
            else
              :show_observation_seen_at.t
            end}:",
-        location_link(obs.place_name, obs.location, nil, true)
+        location_link(obs.where, obs.location, nil, true)
       ].safe_join(" ")
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -356,6 +356,10 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def where
+    location ? location.name : ""
+  end
+
   def place_name
     location ? location.display_name : ""
   end

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -11,8 +11,8 @@ class MatrixBoxPresenter < BasePresenter
     :name,       # name of object or target
     :what,       # link to object or target
     :consensus,  # object for determining the current favorite name of an obs
-    :place_name, # place name of location
-    :where,      # location (object) of object or target
+    :where,      # place name of location
+    :location,   # location (object) of object or target
     :detail,     # string with extra details
     :time        # when object or target was last modified
 
@@ -47,8 +47,8 @@ class MatrixBoxPresenter < BasePresenter
                 end
     self.what = target || rss_log
     if target.respond_to?(:location)
-      self.place_name = target.place_name
-      self.where = target.location
+      self.where = target.where
+      self.location = target.location
     end
     self.time = rss_log.updated_at
 
@@ -91,8 +91,8 @@ class MatrixBoxPresenter < BasePresenter
     self.who        = observation.user if observation.user
     self.name       = observation.format_name.t.break_name.small_author
     self.what       = observation
-    self.place_name = observation.place_name
-    self.where      = observation.location
+    self.where      = observation.where
+    self.location   = observation.location
     self.consensus  = Observation::NamingConsensus.new(observation)
     if observation.rss_log
       self.detail = observation.rss_log.detail
@@ -129,8 +129,8 @@ class MatrixBoxPresenter < BasePresenter
     # rubocop:enable Rails/OutputSafety
     self.name = user.unique_text_name
     self.what = user
-    self.place_name = nil
-    self.where = user.location if user.location
+    self.where = user.location.name if user.location
+    self.location = user.location if user.location
     return unless user.image_id
 
     # Not user.images because that's every image they've uploaded

--- a/app/views/controllers/locations/index.html.erb
+++ b/app/views/controllers/locations/index.html.erb
@@ -33,9 +33,8 @@ flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
         <div class="list-group">
           <% @known_data.each do |location| %>
             <div class="list-group-item">
-              <%= link_with_query(location.display_name.t,
-                                  location.show_link_args) %>
-              (<%= observation_counts[location.id].to_i %>)
+              <%= location_link(location.name.t, location,
+                                observation_counts[location.id].to_i) %>
             </div>
           <% end %>
         </div>
@@ -51,14 +50,16 @@ flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
       </div>
       <%= paginate_block(@undef_pages, { html_id: "locations_undefined" }) do %>
         <div class="list-group">
-          <% @undef_data.each do |location, count|
+          <% @undef_data.each do |location_name, count|
             if @undef_location_format == "scientific"
-              location = Location.reverse_name(location)
+              location_name_f = Location.reverse_name(location_name)
+            else
+              location_name_f = location_name
             end %>
             <div class="list-group-item">
-              <%= location_link(location, nil, count) %>
+              <%= location_link(location_name, nil, count) %>
               <%= link_to(:list_place_names_merge.t,
-                          location_merges_form_path(where: location)) %>
+                          location_merges_form_path(where: location_name_f)) %>
             </div>
           <% end %>
         </div>

--- a/app/views/controllers/locations/index.html.erb
+++ b/app/views/controllers/locations/index.html.erb
@@ -50,16 +50,11 @@ flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
       </div>
       <%= paginate_block(@undef_pages, { html_id: "locations_undefined" }) do %>
         <div class="list-group">
-          <% @undef_data.each do |location_name, count|
-            if @undef_location_format == "scientific"
-              location_name_f = Location.reverse_name(location_name)
-            else
-              location_name_f = location_name
-            end %>
+          <% @undef_data.each do |location_name, count| %>
             <div class="list-group-item">
               <%= location_link(location_name, nil, count) %>
               <%= link_to(:list_place_names_merge.t,
-                          location_merges_form_path(where: location_name_f)) %>
+                          location_merges_form_path(where: location_name)) %>
             </div>
           <% end %>
         </div>

--- a/app/views/controllers/species_lists/_species_list.html.erb
+++ b/app/views/controllers/species_lists/_species_list.html.erb
@@ -1,7 +1,7 @@
 <div class="mt-3">
   <%= :WHEN.t %>: <span><%= species_list.when.web_date %></span>
   </br/>
-  <%= :WHERE.t %>: <%= location_link(species_list.place_name,
+  <%= :WHERE.t %>: <%= location_link(species_list.where,
                                      species_list.location, nil, true) %>
   <br/>
   <%= :WHO.t %>: <span><%= user_link(species_list.user) %></span>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -13,7 +13,7 @@ add_tab_set(species_list_show_tabs(list: @species_list, query: @query))
     <div><b><%= :WHEN.t %>:</b> <%= @species_list.when.web_date %></div>
     <div><b><%= :OBSERVATIONS.t %>:</b> <%= @query.num_results %></div>
     <div><b><%= :WHERE.t %>:</b>
-      <%= location_link(@species_list.place_name, @species_list.location, nil, true) rescue :UNKNOWN.t %>
+      <%= location_link(@species_list.where, @species_list.location, nil, true) rescue :UNKNOWN.t %>
     </div>
     <div><b><%= :WHO.t %>:</b> <%= user_link(@species_list.user) %></div>
     <% if @species_list.projects.any? %>
@@ -65,7 +65,7 @@ add_tab_set(species_list_show_tabs(list: @species_list, query: @query))
                                                q: get_query_param(@query))) %>
                 </p>
                 <p>
-                  <b><%= location_link(observation.place_name,
+                  <b><%= location_link(observation.where,
                                        observation.location) %></b><br/>
                   <span><%= user_link(observation.user) %></span>:
                   <span><%= observation.when.web_date %></span>

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -212,7 +212,7 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     select("Locations", from: "search_type")
     click_button("Search")
     # assert_selector("#results a[href]")
-    labels = find_all("#results a[href]").map(&:text)
+    labels = find_all("#results a[href] .location-postal").map(&:text)
     assert(labels.any? { |l| l.end_with?("Canada") },
            "Expected one of the results to be in Canada.\n" \
            "Found these: #{labels.inspect}")


### PR DESCRIPTION
Simplifies the method's logic, since it's printing both formats.