### PR TITLE
Stage cache migrations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -102,7 +102,7 @@ module MushroomObserver
     config.cache_store = :mem_cache_store
     # config.cache_store = :solid_cache_store
 
-    # config.solid_cache.connects_to = { database: { writing: :cache } }
+    config.solid_cache.connects_to = { database: { writing: :cache } }
   end
 end
 

--- a/db/cache/migrate/20240203041045_create_solid_cache_entries.solid_cache.rb
+++ b/db/cache/migrate/20240203041045_create_solid_cache_entries.solid_cache.rb
@@ -1,0 +1,12 @@
+# This migration comes from solid_cache (originally 20230724121448)
+class CreateSolidCacheEntries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solid_cache_entries do |t|
+      t.binary   :key,        null: false,   limit: 1024
+      t.binary   :value,      null: false,   limit: 512.megabytes
+      t.datetime :created_at, null: false
+
+      t.index    :key,        unique: true
+    end
+  end
+end

--- a/db/cache/migrate/20240203041046_add_key_hash_and_byte_size_to_solid_cache_entries.solid_cache.rb
+++ b/db/cache/migrate/20240203041046_add_key_hash_and_byte_size_to_solid_cache_entries.solid_cache.rb
@@ -1,0 +1,9 @@
+# This migration comes from solid_cache (originally 20240108155507)
+class AddKeyHashAndByteSizeToSolidCacheEntries < ActiveRecord::Migration[7.1]
+  def change
+    change_table :solid_cache_entries do |t|
+      t.column :key_hash,  :integer, null: true, limit: 8
+      t.column :byte_size, :integer, null: true, limit: 4
+    end
+  end
+end

--- a/db/cache/migrate/20240203041047_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.solid_cache.rb
+++ b/db/cache/migrate/20240203041047_add_key_hash_and_byte_size_indexes_and_null_constraints_to_solid_cache_entries.solid_cache.rb
@@ -1,0 +1,12 @@
+# This migration comes from solid_cache (originally 20240110111600)
+class AddKeyHashAndByteSizeIndexesAndNullConstraintsToSolidCacheEntries < ActiveRecord::Migration[7.1]
+  def change
+    change_table :solid_cache_entries, bulk: true do |t|
+      t.change_null :key_hash, false
+      t.change_null :byte_size, false
+      t.index  :key_hash, unique: true
+      t.index  [:key_hash, :byte_size]
+      t.index  :byte_size
+    end
+  end
+end

--- a/db/cache/migrate/20240203041048_remove_key_index_from_solid_cache_entries.solid_cache.rb
+++ b/db/cache/migrate/20240203041048_remove_key_index_from_solid_cache_entries.solid_cache.rb
@@ -1,0 +1,8 @@
+# This migration comes from solid_cache (originally 20240110111702)
+class RemoveKeyIndexFromSolidCacheEntries < ActiveRecord::Migration[7.1]
+  def change
+    change_table :solid_cache_entries do |t|
+      t.remove_index :key, unique: true
+    end
+  end
+end

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_02_03_041048) do
+  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.binary "key", limit: 1024, null: false
+    t.binary "value", size: :long, null: false
+    t.datetime "created_at", null: false
+    t.bigint "key_hash", null: false
+    t.integer "byte_size", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+
+end


### PR DESCRIPTION
These are the default migrations that make the `solid_cache` db work.