### PR TITLE
Remove crazy eager loading from show name_description

### DIFF
--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -121,30 +121,7 @@ class NameDescription < Description
             where(public: true)
         }
   scope :show_includes, lambda {
-    strict_loading.includes(
-      { admin_groups: { users: :user_groups } },
-      :authors,
-      { comments: :user },
-      :editors,
-      :interests,
-      :license,
-      { name: [{ description: :reviewer },
-               { descriptions: :reviewer },
-               :interests,
-               :rss_log,
-               { synonym: :names }] },
-      { name_description_admins: :user_group },
-      { name_description_authors: :user },
-      { name_description_editors: :user },
-      { name_description_readers: :user_group },
-      { name_description_writers: :user_group },
-      :project,
-      { reader_groups: { users: :user_groups } },
-      :reviewer,
-      { user: :user_groups },
-      :versions,
-      { writer_groups: { users: :user_groups } }
-    )
+    strict_loading
   }
 
   EOL_NOTE_FIELDS = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -78,6 +78,9 @@ MushroomObserver::Application.configure do
   # https://groups.google.com/g/rubyonrails-security/c/MmFO3LYQE8U?pli=1
   config.active_record.yaml_column_permitted_classes = [Symbol]
 
+  # Debugging strict loading - either :log, or :error out the page
+  # config.active_record.action_on_strict_loading_violation = :error
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
At some point, Rails was asking for each and every one of these, but NameDescriptions currently take a whole minute to load.

I'm finding that none of them are required now. I don't understand why, but let's go.