### PR TITLE
Add index keys to images controller

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -34,11 +34,15 @@ class ImagesController < ApplicationController
     :pattern,
     :by_user,
     :for_project,
-    :by
+    :by,
+    :q,
+    :id
   ].freeze
 
   @index_subaction_dispatch_table = {
-    by: :index_query_results
+    by: :index_query_results,
+    q: :index_query_results,
+    id: :index_query_results
   }.freeze
 
   #############################################


### PR DESCRIPTION
"fixes" #1904. 

I believe the `q` and `id` query params may have been overlooked in Joe's DRY refactor of the Index actions.

Could use a test, but i'm not going to write it.