### PR TITLE
msql2 0.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     mutex_m (0.2.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     net-imap (0.4.9.1)
       date
       net-protocol


### PR DESCRIPTION
Bumps mysql2 version

I needed this because I could not install 0.5.5.
I got:
```ruby
bundle install
...
Installing mysql2 0.5.5 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
```