### PR TITLE
Disable cache for matrix boxes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1491,12 +1491,16 @@ class ApplicationController < ActionController::Base
 
   # If caching, only uncached objects need to eager_load the includes
   def objects_with_only_needed_eager_loads(query, include)
-    user = User.current ? "logged_in" : "no_user"
-    locale = I18n.locale
+    # user = User.current ? "logged_in" : "no_user"
+    # locale = I18n.locale
     objects_simple = query.paginate(@pages)
-    ids_to_eager_load = objects_simple.reject do |obj|
-      object_fragment_exist?(obj, user, locale)
-    end.pluck(:id)
+
+    # Temporarily disabling cached matrix boxes: eager load everything
+    ids_to_eager_load = objects_simple
+
+    # ids_to_eager_load = objects_simple.reject do |obj|
+    #   object_fragment_exist?(obj, user, locale)
+    # end.pluck(:id)
     # now get the heavy loaded instances:
     objects_eager = query.model.where(id: ids_to_eager_load).includes(include)
     # our Array extension: collates new instances with old, in original order

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -28,14 +28,15 @@ module MatrixBoxHelper
     ].safe_join
   end
 
+  # Temporarily disabled to fix Russian Doll issues.
   def render_cached_matrix_boxes(objects, locals)
     # matrix box has one version except langs.
     # css hides image vote ui when body.no-user
     objects.each do |object|
-      cache(object) do
+      # cache(object) do
         concat(render(partial: "shared/matrix_box",
                       locals: { object: object }.merge(locals)))
-      end
+      # end
     end
   end
 


### PR DESCRIPTION
(Temporary) This PR immediately turns off caching of all `matrix_box`es.   

Observation `matrix_box` caches were not getting properly invalidated upon update of associated records, as pointed out by Joe in #1907 (`Name` deprecations not immediately propagated to cached `Observation` partials). 
___
The relevant AR changes that should cause a `matrix_box` refresh are not limited to `Name` deprecations:
- `Name` - could be affected by Author changes, too
- `Location` - changes to the `name`
- `User` - a change to someone's `login` handle should be immediately propagated

I've had a long, constructive discussion with Jason today about it, and we have a solution that doesn't involve manually `touch`ing the obs when the association is updated. We will need to alter the caching strategy for `matrix_box`, implementing "Russian Doll" fragment caching for the nested records.