### PR TITLE
Enhance Name external links

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -193,7 +193,7 @@ module ObjectLinkHelper
     links = users.map { |u| user_link(u, u.legal_name) }
     # interpolating would require inefficient #sanitize
     # or dangerous #html_safe
-    title + ": " + links.safe_join(", ")
+    title + ": " + links.safe_join(", ") # rubocop:disable Style/StringConcatenation
   end
 
   # Wrap object's name in link to the object, return nil if no object

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -69,9 +69,12 @@ module ObjectLinkHelper
   end
 
   def mushroomexpert_name_search_url(name)
-    # Google it because mushroomexpert has no internal name search
-    "https://www.google.com/search?q=" \
-    "#{name.text_name.tr(" ", "+")}:www.mushroomexpert.com"
+    # Use DuckDuckGo see https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
+    name_string = name.text_name.
+                  sub(/ (group|clade)$/, "").
+                  tr(" ", "+")
+    "https://duckduckgo.com/?q=site%3Amushroomexpert.com+" \
+    "%22#{name_string}%22&ia=web"
   end
 
   def mycoguide_name_search_url(name)

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -73,6 +73,16 @@ module ObjectLinkHelper
     "https://www.gbif.org/species/search?q=#{name.sensu_stricto}"
   end
 
+  def google_name_search_url(name)
+    if name.rank == "Group"
+      # require quoted name ss, optional group/clade/complex for best results
+      "https://www.google.com/search?q=%2B%22#{name.sensu_stricto}%22+" \
+      "%28group+OR+Clade+OR+Complex%29&"
+    else
+      "https://www.google.com/search?q=%2B%22#{name.sensu_stricto}%22"
+    end
+  end
+
   def inat_name_search_url(name)
     # omit `group`, else there are no hits
     "https://www.inaturalist.org/search?q=#{name.sensu_stricto}"

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -60,6 +60,11 @@ module ObjectLinkHelper
 
   # ----- links to names and records at external websites ----------------------
 
+  def ascomycete_org_name_search_url(name)
+    "https://ascomycete.org/Search-Results?search=" \
+    "#{name.text_name.tr(" ", "+")}"
+  end
+
   def gbif_name_search_url(name)
     "https://www.gbif.org/species/search?q=#{name.text_name.tr(" ", "+")}"
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -64,6 +64,14 @@ module ObjectLinkHelper
     "https://www.gbif.org/species/search?q=#{name.text_name.tr(" ", "+")}"
   end
 
+  def inat_name_search_url(name)
+    "https://www.inaturalist.org/search?q=#{name.text_name.tr(" ", "+")}"
+  end
+
+  def ncbi_nucleotide_name_search_url(name)
+    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name.tr(" ", "+")}"
+  end
+
   # url for IF record
   def index_fungorum_record_url(record_id)
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -60,6 +60,10 @@ module ObjectLinkHelper
 
   # ----- links to names and records at external websites ----------------------
 
+  def gbif_name_search_url(name)
+    "https://www.gbif.org/species/search?q=#{name.text_name.tr(" ", "+")}"
+  end
+
   # url for IF record
   def index_fungorum_record_url(record_id)
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -61,15 +61,21 @@ module ObjectLinkHelper
   # ----- links to names and records at external websites ----------------------
 
   def ascomycete_org_name_url(name)
-    "https://ascomycete.org/Search-Results?search=#{name.text_name}"
+    # omit `group`l their search ORs all of the words
+    # The site is Euro-centric, omitting many N Amer spp.
+    # so ORing the words gives more results
+    "https://ascomycete.org/Search-Results?search=#{name.s_str}"
   end
 
   def gbif_name_search_url(name)
-    "https://www.gbif.org/species/search?q=#{name.text_name}"
+    # omit `group`, else there are no hits
+    # omit quotes around the name in order to get synonyms and cf's
+    "https://www.gbif.org/species/search?q=#{name.s_str}"
   end
 
   def inat_name_search_url(name)
-    "https://www.inaturalist.org/search?q=#{name.text_name}"
+    # omit `group`, else there are no hits
+    "https://www.inaturalist.org/search?q=#{name.s_str}"
   end
 
   # url for IF record
@@ -82,20 +88,26 @@ module ObjectLinkHelper
     # Use DuckDuckGo because the equivalent Google search results stink,
     # and Bing shows an annoying ChatBot thing
     # See https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
-    name_string = name.text_name.
-                  sub(/ (group|clade)$/, "").
-                  tr(" ", "+")
+    # Quote the name s.s. to get a list of hits that includes the right one.
+    # NOTE: jdc 2024-02-18
+    # I want a backslash between "q=" and "site",
+    # but can't figure the rigth way to do this.
+    # I can construct a link_to this url
+    # https://duckduckgo.com/?q=\site%3Aindexfungorum.org+%22#Tricholoma equestre%22&ia=web
+    # If I copy the above and paste it into a browser address bar
+    # DuckDuckGo goes straight to the first search result
+    # It works the same if I right click on the displayed link,
+    # select Copy Link Address,  and paste it into the address bar.
+    # BUT if I click on the link displayed in MO, it doesn't work.
     "https://duckduckgo.com/?q=site%3Aindexfungorum.org+" \
-    "%22#{name_string}%22&ia=web"
+    "%22#{name.s_str}%22&ia=web"
   end
 
   def mushroomexpert_name_web_search_url(name)
     # Use DuckDuckGo see https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
-    name_string = name.text_name.
-                  sub(/ (group|clade)$/, "").
-                  tr(" ", "+")
+    # quote name sensu stricto to get right # of results.
     "https://duckduckgo.com/?q=site%3Amushroomexpert.com+" \
-    "%22#{name_string}%22&ia=web"
+    "%22#{name.s_str}%22&ia=web"
   end
 
   # url for MB record by number
@@ -106,7 +118,7 @@ module ObjectLinkHelper
   # url for MycoBank name search for text_name
   def mycobank_name_search_url(name)
     "#{mycobank_basic_search_url}/field/Taxon%20name/#{
-      name.text_name.gsub(" ", "%20")
+      name.s_str.gsub(" ", "%20")
     }"
   end
 
@@ -119,13 +131,18 @@ module ObjectLinkHelper
   end
 
   # url for name search on MyCoPortal
+  # use name s.s., else group names get no results, even though
+  # on the MyCoPortal website search page, I can include "group"
+  # and all the hits will include group if hits exist
   def mycoportal_url(name)
     "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
-      "#{name.text_name}"
+      "#{name.s_str}"
   end
 
+  # Use name s.s. because including group gets 0 or few hits;
+  # i.e., only sequenquenes whose notes or other field include "group"
   def ncbi_nucleotide_term_search_url(name)
-    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name}"
+    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.s_str}"
   end
 
   # url of SF page with "official" synonyms by category
@@ -141,7 +158,9 @@ module ObjectLinkHelper
   end
 
   def wikipedia_term_search_url(name)
-    "https://en.wikipedia.org/w/index.php?search=#{name.text_name}"
+    # Use name s.s. because including "group" gets hits that
+    # don't include name s.s.
+    "https://en.wikipedia.org/w/index.php?search=#{name.s_str}"
   end
 
   # ----------------------------------------------------------------------------

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -68,6 +68,12 @@ module ObjectLinkHelper
     "https://www.inaturalist.org/search?q=#{name.text_name.tr(" ", "+")}"
   end
 
+  def mushroomexpert_name_search_url(name)
+    # Google it because mushroomexpert has no internal name search
+    "https://www.google.com/search?q=" \
+    "#{name.text_name.tr(" ", "+")}:www.mushroomexpert.com"
+  end
+
   def ncbi_nucleotide_name_search_url(name)
     "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name.tr(" ", "+")}"
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -72,27 +72,6 @@ module ObjectLinkHelper
     "https://www.inaturalist.org/search?q=#{name.text_name}"
   end
 
-  def mushroomexpert_name_search_url(name)
-    # Use DuckDuckGo see https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
-    name_string = name.text_name.
-                  sub(/ (group|clade)$/, "").
-                  tr(" ", "+")
-    "https://duckduckgo.com/?q=site%3Amushroomexpert.com+" \
-    "%22#{name_string}%22&ia=web"
-  end
-
-  def mycoguide_name_search_url(name)
-    "https://www.mycoguide.com/guide/search?q=#{name.text_name}"
-  end
-
-  def ncbi_nucleotide_term_search_url(name)
-    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name}"
-  end
-
-  def wikipedia_term_search_url(name)
-    "https://en.wikipedia.org/w/index.php?search=#{name.text_name}"
-  end
-
   # url for IF record
   def index_fungorum_record_url(record_id)
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"
@@ -107,6 +86,15 @@ module ObjectLinkHelper
                   sub(/ (group|clade)$/, "").
                   tr(" ", "+")
     "https://duckduckgo.com/?q=site%3Aindexfungorum.org+" \
+    "%22#{name_string}%22&ia=web"
+  end
+
+  def mushroomexpert_name_search_url(name)
+    # Use DuckDuckGo see https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
+    name_string = name.text_name.
+                  sub(/ (group|clade)$/, "").
+                  tr(" ", "+")
+    "https://duckduckgo.com/?q=site%3Amushroomexpert.com+" \
     "%22#{name_string}%22&ia=web"
   end
 
@@ -130,10 +118,18 @@ module ObjectLinkHelper
     "https://www.mycobank.org/"
   end
 
+  def mycoguide_name_search_url(name)
+    "https://www.mycoguide.com/guide/search?q=#{name.text_name}"
+  end
+
   # url for name search on MyCoPortal
   def mycoportal_url(name)
     "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
       "#{name.text_name}"
+  end
+
+  def ncbi_nucleotide_term_search_url(name)
+    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name}"
   end
 
   # url of SF page with "official" synonyms by category
@@ -146,6 +142,10 @@ module ObjectLinkHelper
   # works for species, genus, family
   def species_fungorum_sf_synonymy(record_id)
     "http://www.speciesfungorum.org/Names/SynSpecies.asp?RecordID=#{record_id}"
+  end
+
+  def wikipedia_term_search_url(name)
+    "https://en.wikipedia.org/w/index.php?search=#{name.text_name}"
   end
 
   # ----------------------------------------------------------------------------

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -118,10 +118,6 @@ module ObjectLinkHelper
     "https://www.mycobank.org/"
   end
 
-  def mycoguide_name_search_url(name)
-    "https://www.mycoguide.com/guide/search?q=#{name.text_name}"
-  end
-
   # url for name search on MyCoPortal
   def mycoportal_url(name)
     "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -60,7 +60,7 @@ module ObjectLinkHelper
 
   # ----- links to names and records at external websites ----------------------
 
-  def ascomycete_org_name_search_url(name)
+  def ascomycete_org_name_url(name)
     "https://ascomycete.org/Search-Results?search=" \
     "#{name.text_name.tr(" ", "+")}"
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -74,6 +74,10 @@ module ObjectLinkHelper
     "#{name.text_name.tr(" ", "+")}:www.mushroomexpert.com"
   end
 
+  def mycoguide_name_search_url(name)
+    "https://www.mycoguide.com/guide/search?q=#{name.text_name.tr(" ", "+")}"
+  end
+
   def ncbi_nucleotide_name_search_url(name)
     "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name.tr(" ", "+")}"
   end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -61,16 +61,15 @@ module ObjectLinkHelper
   # ----- links to names and records at external websites ----------------------
 
   def ascomycete_org_name_url(name)
-    "https://ascomycete.org/Search-Results?search=" \
-    "#{name.text_name.tr(" ", "+")}"
+    "https://ascomycete.org/Search-Results?search=#{name.text_name}"
   end
 
   def gbif_name_search_url(name)
-    "https://www.gbif.org/species/search?q=#{name.text_name.tr(" ", "+")}"
+    "https://www.gbif.org/species/search?q=#{name.text_name}"
   end
 
   def inat_name_search_url(name)
-    "https://www.inaturalist.org/search?q=#{name.text_name.tr(" ", "+")}"
+    "https://www.inaturalist.org/search?q=#{name.text_name}"
   end
 
   def mushroomexpert_name_search_url(name)
@@ -83,15 +82,15 @@ module ObjectLinkHelper
   end
 
   def mycoguide_name_search_url(name)
-    "https://www.mycoguide.com/guide/search?q=#{name.text_name.tr(" ", "+")}"
+    "https://www.mycoguide.com/guide/search?q=#{name.text_name}"
   end
 
   def ncbi_nucleotide_term_search_url(name)
-    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name.tr(" ", "+")}"
+    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name}"
   end
 
   def wikipedia_term_search_url(name)
-    "https://en.wikipedia.org/w/index.php?search=#{name.text_name.tr(" ", "+")}"
+    "https://en.wikipedia.org/w/index.php?search=#{name.text_name}"
   end
 
   # url for IF record
@@ -134,7 +133,7 @@ module ObjectLinkHelper
   # url for name search on MyCoPortal
   def mycoportal_url(name)
     "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
-      "#{name.text_name.tr(" ", "+")}"
+      "#{name.text_name}"
   end
 
   # url of SF page with "official" synonyms by category

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -64,18 +64,18 @@ module ObjectLinkHelper
     # omit `group`l their search ORs all of the words
     # The site is Euro-centric, omitting many N Amer spp.
     # so ORing the words gives more results
-    "https://ascomycete.org/Search-Results?search=#{name.s_str}"
+    "https://ascomycete.org/Search-Results?search=#{name.sensu_stricto}"
   end
 
   def gbif_name_search_url(name)
     # omit `group`, else there are no hits
     # omit quotes around the name in order to get synonyms and cf's
-    "https://www.gbif.org/species/search?q=#{name.s_str}"
+    "https://www.gbif.org/species/search?q=#{name.sensu_stricto}"
   end
 
   def inat_name_search_url(name)
     # omit `group`, else there are no hits
-    "https://www.inaturalist.org/search?q=#{name.s_str}"
+    "https://www.inaturalist.org/search?q=#{name.sensu_stricto}"
   end
 
   # url for IF record
@@ -93,21 +93,21 @@ module ObjectLinkHelper
     # I want a backslash between "q=" and "site",
     # but can't figure the rigth way to do this.
     # I can construct a link_to this url
-    # https://duckduckgo.com/?q=\site%3Aindexfungorum.org+%22#Tricholoma equestre%22&ia=web
-    # If I copy the above and paste it into a browser address bar
+    # https://duckduckgo.com/?q=\site%3Aindexfungorum.org+%22Tuber+liui%22
+    # If I copy it and paste it into a browser address bar
     # DuckDuckGo goes straight to the first search result
     # It works the same if I right click on the displayed link,
     # select Copy Link Address,  and paste it into the address bar.
     # BUT if I click on the link displayed in MO, it doesn't work.
     "https://duckduckgo.com/?q=site%3Aindexfungorum.org+" \
-    "%22#{name.s_str}%22&ia=web"
+    "%22#{name.sensu_stricto}%22"
   end
 
   def mushroomexpert_name_web_search_url(name)
     # Use DuckDuckGo see https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
     # quote name sensu stricto to get right # of results.
     "https://duckduckgo.com/?q=site%3Amushroomexpert.com+" \
-    "%22#{name.s_str}%22&ia=web"
+    "%22#{name.sensu_stricto}%22&ia=web"
   end
 
   # url for MB record by number
@@ -118,7 +118,7 @@ module ObjectLinkHelper
   # url for MycoBank name search for text_name
   def mycobank_name_search_url(name)
     "#{mycobank_basic_search_url}/field/Taxon%20name/#{
-      name.s_str.gsub(" ", "%20")
+      name.sensu_stricto.gsub(" ", "%20")
     }"
   end
 
@@ -136,13 +136,13 @@ module ObjectLinkHelper
   # and all the hits will include group if hits exist
   def mycoportal_url(name)
     "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
-      "#{name.s_str}"
+      "#{name.sensu_stricto}"
   end
 
   # Use name s.s. because including group gets 0 or few hits;
   # i.e., only sequenquenes whose notes or other field include "group"
   def ncbi_nucleotide_term_search_url(name)
-    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.s_str}"
+    "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.sensu_stricto}"
   end
 
   # url of SF page with "official" synonyms by category
@@ -160,7 +160,7 @@ module ObjectLinkHelper
   def wikipedia_term_search_url(name)
     # Use name s.s. because including "group" gets hits that
     # don't include name s.s.
-    "https://en.wikipedia.org/w/index.php?search=#{name.s_str}"
+    "https://en.wikipedia.org/w/index.php?search=#{name.sensu_stricto}"
   end
 
   # ----------------------------------------------------------------------------

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -78,7 +78,7 @@ module ObjectLinkHelper
   end
 
   # Use web search because IF internal search uses js form rather than a url
-  def index_fungorum_name_search_url(name)
+  def index_fungorum_name_web_search_url(name)
     # Use DuckDuckGo because the equivalent Google search results stink,
     # and Bing shows an annoying ChatBot thing
     # See https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
@@ -89,7 +89,7 @@ module ObjectLinkHelper
     "%22#{name_string}%22&ia=web"
   end
 
-  def mushroomexpert_name_search_url(name)
+  def mushroomexpert_name_web_search_url(name)
     # Use DuckDuckGo see https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
     name_string = name.text_name.
                   sub(/ (group|clade)$/, "").

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -91,10 +91,16 @@ module ObjectLinkHelper
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"
   end
 
-  # url for Index Fungorum search. This is a general search.
-  # IF lacks an entry point that includes the name to be searched.
-  def index_fungorum_basic_search_url
-    "http://www.indexfungorum.org/Names/Names.asp"
+  # Use web search because IF internal search uses js form rather than a url
+  def index_fungorum_name_search_url(name)
+    # Use DuckDuckGo because the equivalent Google search results stink,
+    # and Bing shows an annoying ChatBot thing
+    # See https://github.com/MushroomObserver/mushroom-observer/issues/1884#issuecomment-1950137454
+    name_string = name.text_name.
+                  sub(/ (group|clade)$/, "").
+                  tr(" ", "+")
+    "https://duckduckgo.com/?q=site%3Aindexfungorum.org+" \
+    "%22#{name_string}%22&ia=web"
   end
 
   # url for MB record by number

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -82,6 +82,10 @@ module ObjectLinkHelper
     "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name.tr(" ", "+")}"
   end
 
+  def wikipedia_term_search_url(name)
+    "https://en.wikipedia.org/w/index.php?search=#{name.text_name.tr(" ", "+")}"
+  end
+
   # url for IF record
   def index_fungorum_record_url(record_id)
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -78,7 +78,7 @@ module ObjectLinkHelper
     "https://www.mycoguide.com/guide/search?q=#{name.text_name.tr(" ", "+")}"
   end
 
-  def ncbi_nucleotide_name_search_url(name)
+  def ncbi_nucleotide_term_search_url(name)
     "https://www.ncbi.nlm.nih.gov/nuccore/?term=#{name.text_name.tr(" ", "+")}"
   end
 

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -177,6 +177,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def wikipedia_term_tab(name)
+      ["Wikipedia", wikipedia_term_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def occurrence_map_for_name_tab(name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: name.id)),

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -147,6 +147,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def ascomycete_org_name_search_tab(name)
+      ["Ascomycete.org", ascomycete_org_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def gbif_name_tab(name)
       ["GBIF", gbif_name_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -162,8 +162,8 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def ncbi_nucleotide_name_tab(name)
-      ["NCBI Nucleotide", ncbi_nucleotide_name_search_url(name),
+    def ncbi_nucleotide_term_tab(name)
+      ["NCBI Nucleotide", ncbi_nucleotide_term_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -86,11 +86,6 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def index_fungorum_basic_search_tab
-      [:index_fungorum_search.l, index_fungorum_basic_search_url,
-       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
-    end
-
     def mycobank_name_search_tab(name)
       [:mycobank_search.l, mycobank_name_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
@@ -159,6 +154,11 @@ module Tabs
 
     def inat_name_tab(name)
       ["iNaturalist", inat_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
+    def index_fungorum_name_search_tab(name)
+      [:index_fungorum_web_search.l, index_fungorum_name_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -167,6 +167,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def mushroomexpert_name_tab(name)
+      ["MushroomExpert", mushroomexpert_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def occurrence_map_for_name_tab(name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: name.id)),

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -157,7 +157,7 @@ module Tabs
     end
 
     def index_fungorum_name_search_tab(name)
-      [:index_fungorum_web_search.l, index_fungorum_name_search_url(name),
+      [:index_fungorum_web_search.l, index_fungorum_name_web_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
@@ -167,7 +167,7 @@ module Tabs
     end
 
     def mushroomexpert_name_tab(name)
-      ["MushroomExpert", mushroomexpert_name_search_url(name),
+      ["MushroomExpert", mushroomexpert_name_web_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -171,11 +171,6 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def mycoguide_name_tab(name)
-      ["MycoGuide", mycoguide_name_search_url(name),
-       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
-    end
-
     def mycoportal_name_tab(name)
       ["MyCoPortal", mycoportal_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -147,8 +147,8 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
-    def ascomycete_org_name_search_tab(name)
-      ["Ascomycete.org", ascomycete_org_name_search_url(name),
+    def ascomycete_org_name_tab(name)
+      ["Ascomycete.org", ascomycete_org_name_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -157,6 +157,16 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def inat_name_tab(name)
+      ["iNaturalist", inat_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
+    def ncbi_nucleotide_name_tab(name)
+      ["NCBI Nucleotide", ncbi_nucleotide_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def occurrence_map_for_name_tab(name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: name.id)),

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -130,12 +130,6 @@ module Tabs
        { class: tab_id(__method__.to_s), icon: :edit }]
     end
 
-    # Show name, obs menu. Also on Obs show, name section
-    def mycoportal_name_tab(name)
-      ["MyCoPortal", mycoportal_url(name),
-       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
-    end
-
     def eol_name_tab(name)
       ["EOL", name.eol_url,
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
@@ -179,6 +173,11 @@ module Tabs
 
     def mycoguide_name_tab(name)
       ["MycoGuide", mycoguide_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
+    def mycoportal_name_tab(name)
+      ["MyCoPortal", mycoportal_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -151,6 +151,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def google_name_tab(name)
+      [:google_name_search.l, google_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def inat_name_tab(name)
       ["iNaturalist", inat_name_search_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -172,6 +172,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def mycoguide_name_tab(name)
+      ["MycoGuide", mycoguide_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def occurrence_map_for_name_tab(name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: name.id)),

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -152,6 +152,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def gbif_name_tab(name)
+      ["GBIF", gbif_name_search_url(name),
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def occurrence_map_for_name_tab(name)
       [:show_name_distribution_map.t,
        add_query_param(map_name_path(id: name.id)),

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Name::Format
+  GROUP_ADD_ON_MATCHER = / #{Name::Parse::GROUP_ABBR}/
   # When we `include` a module, the way to add class methods is like this:
   def self.included(base)
     base.extend(ClassMethods)
@@ -78,6 +79,11 @@ module Name::Format
 
   def real_search_name
     Name.display_to_real_search(self)
+  end
+
+  def s_str
+    # sub(/ #{Name::Parse::GROUP_ABBR}/, "")
+    text_name.sub(GROUP_ADD_ON_MATCHER, "")
   end
 
   # Is this the "unknown" name?

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -81,7 +81,7 @@ module Name::Format
     Name.display_to_real_search(self)
   end
 
-  def s_str
+  def sensu_stricto
     # sub(/ #{Name::Parse::GROUP_ABBR}/, "")
     text_name.sub(GROUP_ADD_ON_MATCHER, "")
   end

--- a/app/views/controllers/names/show/_nomenclature.html.erb
+++ b/app/views/controllers/names/show/_nomenclature.html.erb
@@ -64,12 +64,12 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
             ["#{:ICN_ID.l}:",
              tag.em(:show_name_icn_id_missing.l)].safe_join(" ")
           end,
-          tag.p(link_to(*index_fungorum_basic_search_tab)),
+          tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_name_search_tab(name)))
         ].safe_join
       elsif name.searchable_in_registry?
         [
-          tag.p(link_to(*index_fungorum_basic_search_tab)),
+          tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_basic_search_tab))
         ].safe_join
       end

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -31,7 +31,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
         concat(tag.p(link_to(*mycoguide_name_tab(@name))))
         concat(tag.p(link_to(*mycoportal_name_tab(@name))))
       end
-      concat(tag.p(link_to(*ncbi_nucleotide_name_tab(@name))))
+      concat(tag.p(link_to(*ncbi_nucleotide_term_tab(@name))))
       concat(tag.p(link_to(*wikipedia_term_tab(@name))))
       concat(tag.p(link_to(*google_images_for_name_tab(@name))))
       concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -37,7 +37,6 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
         concat(tag.p(link_to(*inat_name_tab(@name))))
         if @name.searchable_in_registry?
           concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))
-          concat(tag.p(link_to(*mycoguide_name_tab(@name))))
           concat(tag.p(link_to(*mycoportal_name_tab(@name))))
         end
         concat(tag.p(link_to(*ncbi_nucleotide_term_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -9,7 +9,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
 
   tag.div(class: "row") do
 
-    concat(tag.div(class: "col-sm-7 name-section") do
+    concat(tag.div(class: "col-sm-6 name-section") do
       concat(tag.p(:show_observations_of.t))
       concat(tag.div(class: "pl-3") do
         concat(name_related_taxa_observation_links(@name, @obss))
@@ -25,7 +25,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
       end)
     end)
 
-    concat(tag.div(class: "col-sm-5 name-section") do
+    concat(tag.div(class: "col-sm-6 name-section") do
       concat(tag.p("#{:research_links.l}:"))
       concat(tag.div(class: "pl-3") do
         if @name.classification =~ /Phylum: _Ascomycota_/

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -21,7 +21,6 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
         end) if @has_subtaxa
       end)
       concat(tag.div(class: "py-3") do
-        concat(tag.p(link_to(*google_images_for_name_tab(@name))))
         concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))
       end)
     end)
@@ -34,6 +33,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
         end
         concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
         concat(tag.p(link_to(*gbif_name_tab(@name))))
+        concat(tag.p(link_to(*google_images_for_name_tab(@name))))
         concat(tag.p(link_to(*inat_name_tab(@name))))
         if @name.searchable_in_registry?
           concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -30,7 +30,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
       concat(tag.p("#{:research_links.l}:"))
       concat(tag.div(class: "pl-3") do
         if @name.classification =~ /Phylum: _Ascomycota_/
-          concat(tag.p(link_to(*ascomycete_org_name_search_tab(@name))))
+          concat(tag.p(link_to(*ascomycete_org_name_tab(@name))))
         end
         concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
         concat(tag.p(link_to(*gbif_name_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -28,6 +28,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
       concat(tag.p(link_to(*inat_name_tab(@name))))
       if @name.searchable_in_registry?
         concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))
+        concat(tag.p(link_to(*mycoguide_name_tab(@name))))
         concat(tag.p(link_to(*mycoportal_name_tab(@name))))
       end
       concat(tag.p(link_to(*ncbi_nucleotide_name_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -34,6 +34,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
         concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
         concat(tag.p(link_to(*gbif_name_tab(@name))))
         concat(tag.p(link_to(*google_images_for_name_tab(@name))))
+        concat(tag.p(link_to(*google_name_tab(@name))))
         concat(tag.p(link_to(*inat_name_tab(@name))))
         if @name.searchable_in_registry?
           concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -25,9 +25,11 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
     concat(tag.div(class: "col-sm-5 name-section") do
       concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
       concat(tag.p(link_to(*gbif_name_tab(@name))))
+      concat(tag.p(link_to(*inat_name_tab(@name))))
       if @name.searchable_in_registry?
         concat(tag.p(link_to(*mycoportal_name_tab(@name))))
       end
+      concat(tag.p(link_to(*ncbi_nucleotide_name_tab(@name))))
       concat(tag.p(link_to(*google_images_for_name_tab(@name))))
       concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))
     end)

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -32,6 +32,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
         concat(tag.p(link_to(*mycoportal_name_tab(@name))))
       end
       concat(tag.p(link_to(*ncbi_nucleotide_name_tab(@name))))
+      concat(tag.p(link_to(*wikipedia_term_tab(@name))))
       concat(tag.p(link_to(*google_images_for_name_tab(@name))))
       concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))
     end)

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -23,10 +23,11 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
     end)
 
     concat(tag.div(class: "col-sm-5 name-section") do
+      concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
+      concat(tag.p(link_to(*gbif_name_tab(@name))))
       if @name.searchable_in_registry?
         concat(tag.p(link_to(*mycoportal_name_tab(@name))))
       end
-      concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
       concat(tag.p(link_to(*google_images_for_name_tab(@name))))
       concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))
     end)

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -20,21 +20,29 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
            " (#{@has_subtaxa})"].safe_join
         end) if @has_subtaxa
       end)
+      concat(tag.div(class: "py-3") do
+        concat(tag.p(link_to(*google_images_for_name_tab(@name))))
+        concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))
+      end)
     end)
 
     concat(tag.div(class: "col-sm-5 name-section") do
-      concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
-      concat(tag.p(link_to(*gbif_name_tab(@name))))
-      concat(tag.p(link_to(*inat_name_tab(@name))))
-      if @name.searchable_in_registry?
-        concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))
-        concat(tag.p(link_to(*mycoguide_name_tab(@name))))
-        concat(tag.p(link_to(*mycoportal_name_tab(@name))))
-      end
-      concat(tag.p(link_to(*ncbi_nucleotide_term_tab(@name))))
-      concat(tag.p(link_to(*wikipedia_term_tab(@name))))
-      concat(tag.p(link_to(*google_images_for_name_tab(@name))))
-      concat(tag.p(link_to(*occurrence_map_for_name_tab(@name))))
+      concat(tag.p("#{:research_links.l}:"))
+      concat(tag.div(class: "pl-3") do
+        if @name.classification =~ "Phylum: _Ascomycota_"
+          concat(tag.p(link_to(*ascomycete_name_tab(@name))))
+        end
+        concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
+        concat(tag.p(link_to(*gbif_name_tab(@name))))
+        concat(tag.p(link_to(*inat_name_tab(@name))))
+        if @name.searchable_in_registry?
+          concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))
+          concat(tag.p(link_to(*mycoguide_name_tab(@name))))
+          concat(tag.p(link_to(*mycoportal_name_tab(@name))))
+        end
+        concat(tag.p(link_to(*ncbi_nucleotide_term_tab(@name))))
+        concat(tag.p(link_to(*wikipedia_term_tab(@name))))
+      end)
     end)
 
   end

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -29,8 +29,8 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
     concat(tag.div(class: "col-sm-5 name-section") do
       concat(tag.p("#{:research_links.l}:"))
       concat(tag.div(class: "pl-3") do
-        if @name.classification =~ "Phylum: _Ascomycota_"
-          concat(tag.p(link_to(*ascomycete_name_tab(@name))))
+        if @name.classification =~ /Phylum: _Ascomycota_/
+          concat(tag.p(link_to(*ascomycete_org_name_search_tab(@name))))
         end
         concat(tag.p(link_to(*eol_name_tab(@name)))) if @name.eol_url
         concat(tag.p(link_to(*gbif_name_tab(@name))))

--- a/app/views/controllers/names/show/_observations_menu.html.erb
+++ b/app/views/controllers/names/show/_observations_menu.html.erb
@@ -27,6 +27,7 @@ heading_link = icon_link_with_query(*name_tracker_form_tab(@name, @user))
       concat(tag.p(link_to(*gbif_name_tab(@name))))
       concat(tag.p(link_to(*inat_name_tab(@name))))
       if @name.searchable_in_registry?
+        concat(tag.p(link_to(*mushroomexpert_name_tab(@name))))
         concat(tag.p(link_to(*mycoportal_name_tab(@name))))
       end
       concat(tag.p(link_to(*ncbi_nucleotide_name_tab(@name))))

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -800,6 +800,7 @@
   show_location: Show [LOCATION]
   show_location_description: Show [DESCRIPTION]
   about_this_taxon: About this taxon
+  research_links: Research Links
   show_name: About [NAME]
   show_name_description: Show [DESCRIPTION]
   show_object: Show [TYPE]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2129,6 +2129,7 @@
   show_name_general_description: "[:form_names_gen_desc]"
   show_name_see_more: See More
   show_name_icn_id_missing: missing
+  google_name_search: Google Search
   index_fungorum: Index Fungorum
   index_fungorum_web_search: Index Fungorum web search
   mycobank: MycoBank

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2129,7 +2129,7 @@
   show_name_see_more: See More
   show_name_icn_id_missing: missing
   index_fungorum: Index Fungorum
-  index_fungorum_search: Index Fungorum search
+  index_fungorum_web_search: Index Fungorum web search
   mycobank: MycoBank
   mycobank_search: MycoBank search
   gsd_species_synonymy: GSD Species Synonymy

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -569,8 +569,20 @@ class NamesControllerTest < FunctionalTestCase
   def test_show_name_species_with_icn_id
     # Name's icn_id is filled in
     name = names(:coprinus_comatus)
+    icn_id = name.icn_id
+    assert_instance_of(Integer, icn_id,
+                       "Test needs Name fixture with icn_id (Registration #)")
+
     login
     get(:show, params: { id: name.id })
+
+    ##### Links to external taxonomy pages
+    assert_select(
+      "body a[href='#{gbif_name_search_url(name)}']", true,
+      "Page is missing a link to GBIF"
+    )
+
+    ##### Links to external nomenclature pages
     assert_select(
       "body a[href='#{index_fungorum_record_url(name.icn_id)}']", true,
       "Page is missing a link to IF record"

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -581,6 +581,7 @@ class NamesControllerTest < FunctionalTestCase
     ##### External research links
     [
       ["GBIF", gbif_name_search_url(name)],
+      ["Google Search", google_name_search_url(name)],
       ["iNat", inat_name_search_url(name)],
       ["MushroomExpert", mushroomexpert_name_web_search_url(name)],
       ["MyCoPortal", mycoportal_url(name)],

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -586,7 +586,7 @@ class NamesControllerTest < FunctionalTestCase
       "Page is missing a link to iNaturalist"
     )
     assert_select(
-      "body a[href='#{mushroomexpert_name_search_url(name)}']", true,
+      "body a[href='#{mushroomexpert_name_web_search_url(name)}']", true,
       "Page is missing a link to MushroomExpert"
     )
     assert_select(
@@ -642,7 +642,7 @@ class NamesControllerTest < FunctionalTestCase
       "'#{:show_name_icn_id_missing.l}' note"
     )
     assert_select(
-      "#nomenclature a[href='#{index_fungorum_name_search_url(name)}']", true,
+      "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']", true,
       "Nomenclature section is missing a link to Index Fungorum search"
     )
     assert_select(
@@ -672,7 +672,7 @@ class NamesControllerTest < FunctionalTestCase
 
     # but it makes sense to link to search pages in fungal registries
     assert_select(
-      "#nomenclature a[href='#{index_fungorum_name_search_url(name)}']", true,
+      "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']", true,
       "Nomenclature section is missing a link to Index Fungorum search"
     )
     assert_select(

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -576,40 +576,31 @@ class NamesControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: name.id })
 
-    ##### Links to external taxonomy pages
-    assert_select(
-      "body a[href='#{gbif_name_search_url(name)}']", true,
-      "Page is missing a link to GBIF"
-    )
-    assert_select(
-      "body a[href='#{inat_name_search_url(name)}']", true,
-      "Page is missing a link to iNaturalist"
-    )
-    assert_select(
-      "body a[href='#{mushroomexpert_name_web_search_url(name)}']", true,
-      "Page is missing a link to MushroomExpert"
-    )
-    assert_select(
-      "body a[href='#{ncbi_nucleotide_term_search_url(name)}']", true,
-      "Page is missing a link to NCBI Nucleotide"
-    )
-    assert_select(
-      "body a[href='#{wikipedia_term_search_url(name)}']", true,
-      "Page is missing a link to Wikipedia"
-    )
+    ##### External research links
+    [
+      ["GBIF", gbif_name_search_url(name)],
+      ["iNat", inat_name_search_url(name)],
+      ["MushroomExpert", mushroomexpert_name_web_search_url(name)],
+      ["NCBI", ncbi_nucleotide_term_search_url(name)],
+      ["Wikipedia", wikipedia_term_search_url(name)]
+    ].each do |site, link|
+      assert_external_link(site, link)
+    end
 
-    ##### Links to external nomenclature pages
+    ##### External nomenclature links
+    [
+      ["IF record", index_fungorum_record_url(name.icn_id)],
+      ["MB record", mycobank_record_url(name.icn_id)],
+      ["GSD Synonymy record", species_fungorum_gsd_synonymy(name.icn_id)]
+    ].each do |site, link|
+      assert_external_link(site, link)
+    end
+  end
+
+  def assert_external_link(site, link)
     assert_select(
-      "body a[href='#{index_fungorum_record_url(name.icn_id)}']", true,
-      "Page is missing a link to IF record"
-    )
-    assert_select(
-      "body a[href='#{mycobank_record_url(name.icn_id)}']", true,
-      "Page is missing a link to MB record"
-    )
-    assert_select(
-      "body a[href='#{species_fungorum_gsd_synonymy(name.icn_id)}']", true,
-      "Page is missing a link to GSD Synonymy record"
+      "body a[href='#{link}']", true,
+      "Page is missing a link to #{site}"
     )
   end
 

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -597,6 +597,10 @@ class NamesControllerTest < FunctionalTestCase
       "body a[href='#{ncbi_nucleotide_name_search_url(name)}']", true,
       "Page is missing a link to NCBI Nucleotide"
     )
+    assert_select(
+      "body a[href='#{wikipedia_term_search_url(name)}']", true,
+      "Page is missing a link to Wikipedia"
+    )
 
     ##### Links to external nomenclature pages
     assert_select(

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -572,22 +572,28 @@ class NamesControllerTest < FunctionalTestCase
     icn_id = name.icn_id
     assert_instance_of(Integer, icn_id,
                        "Test needs Name fixture with icn_id (Registration #)")
+    assert_not(name.classification =~ /Ascomycete/,
+               "Test needs a Name fixture which isn't an Ascomycete")
 
     login
     get(:show, params: { id: name.id })
 
     ##### External research links
     [
-      ["Ascomycdete.org", ascomycete_org_name_url(name)],
       ["GBIF", gbif_name_search_url(name)],
       ["iNat", inat_name_search_url(name)],
       ["MushroomExpert", mushroomexpert_name_web_search_url(name)],
-      ["MyCoPortal", mycoportal_name_tab(@name)],
+      ["MyCoPortal", mycoportal_url(name)],
       ["NCBI", ncbi_nucleotide_term_search_url(name)],
       ["Wikipedia", wikipedia_term_search_url(name)]
     ].each do |site, link|
       assert_external_link(site, link)
     end
+
+    assert_select(
+      "body a[href='#{ascomycete_org_name_url(name)}']", false,
+      "Page should not have a link to Ascomycete.org"
+    )
 
     ##### External nomenclature links
     [
@@ -604,6 +610,17 @@ class NamesControllerTest < FunctionalTestCase
       "body a[href='#{link}']", true,
       "Page is missing a link to #{site}"
     )
+  end
+
+  def test_show_name_ascomycete
+    name = names(:peltigera)
+    assert(name.classification =~ /Ascomycete/,
+           "Test needs a Name fixture that's an Ascomycete")
+
+    login
+    get(:show, params: { id: name.id })
+
+    assert_external_link("Ascomycete.org", ascomycete_org_name_url(name))
   end
 
   def test_show_name_genus_with_icn_id

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -586,6 +586,10 @@ class NamesControllerTest < FunctionalTestCase
       "Page is missing a link to iNaturalist"
     )
     assert_select(
+      "body a[href='#{mushroomexpert_name_search_url(name)}']", true,
+      "Page is missing a link to MushroomExpert"
+    )
+    assert_select(
       "body a[href='#{ncbi_nucleotide_name_search_url(name)}']", true,
       "Page is missing a link to NCBI Nucleotide"
     )

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -642,7 +642,8 @@ class NamesControllerTest < FunctionalTestCase
       "'#{:show_name_icn_id_missing.l}' note"
     )
     assert_select(
-      "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']", true,
+      "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']",
+      true,
       "Nomenclature section is missing a link to Index Fungorum search"
     )
     assert_select(
@@ -672,7 +673,8 @@ class NamesControllerTest < FunctionalTestCase
 
     # but it makes sense to link to search pages in fungal registries
     assert_select(
-      "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']", true,
+      "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']",
+      true,
       "Nomenclature section is missing a link to Index Fungorum search"
     )
     assert_select(

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -594,7 +594,7 @@ class NamesControllerTest < FunctionalTestCase
       "Page is missing a link to MycoGuide"
     )
     assert_select(
-      "body a[href='#{ncbi_nucleotide_name_search_url(name)}']", true,
+      "body a[href='#{ncbi_nucleotide_term_search_url(name)}']", true,
       "Page is missing a link to NCBI Nucleotide"
     )
     assert_select(

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -581,6 +581,14 @@ class NamesControllerTest < FunctionalTestCase
       "body a[href='#{gbif_name_search_url(name)}']", true,
       "Page is missing a link to GBIF"
     )
+    assert_select(
+      "body a[href='#{inat_name_search_url(name)}']", true,
+      "Page is missing a link to iNaturalist"
+    )
+    assert_select(
+      "body a[href='#{ncbi_nucleotide_name_search_url(name)}']", true,
+      "Page is missing a link to NCBI Nucleotide"
+    )
 
     ##### Links to external nomenclature pages
     assert_select(

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -632,6 +632,7 @@ class NamesControllerTest < FunctionalTestCase
     # Name is registrable, but icn_id is not filled in
     name = names(:coprinus)
     label = :ICN_ID.l.to_s
+
     login
     get(:show, params: { id: name.id })
 
@@ -641,10 +642,8 @@ class NamesControllerTest < FunctionalTestCase
       "'#{:show_name_icn_id_missing.l}' note"
     )
     assert_select(
-      "#nomenclature a:match('href',?)",
-      /#{index_fungorum_basic_search_url}/,
-      { count: 1 },
-      "Nomenclature section should have link to IF search"
+      "#nomenclature a[href='#{index_fungorum_name_search_url(name)}']", true,
+      "Nomenclature section is missing a link to Index Fungorum search"
     )
     assert_select(
       "#nomenclature a:match('href',?)", /#{mycobank_name_search_url(name)}/,
@@ -673,10 +672,8 @@ class NamesControllerTest < FunctionalTestCase
 
     # but it makes sense to link to search pages in fungal registries
     assert_select(
-      "#nomenclature a:match('href',?)",
-      /#{index_fungorum_basic_search_url}/,
-      { count: 1 },
-      "Nomenclature section should have link to IF search"
+      "#nomenclature a[href='#{index_fungorum_name_search_url(name)}']", true,
+      "Nomenclature section is missing a link to Index Fungorum search"
     )
     assert_select(
       "#nomenclature a:match('href',?)", /#{mycobank_basic_search_url}/,

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -590,10 +590,6 @@ class NamesControllerTest < FunctionalTestCase
       "Page is missing a link to MushroomExpert"
     )
     assert_select(
-      "body a[href='#{mycoguide_name_search_url(name)}']", true,
-      "Page is missing a link to MycoGuide"
-    )
-    assert_select(
       "body a[href='#{ncbi_nucleotide_term_search_url(name)}']", true,
       "Page is missing a link to NCBI Nucleotide"
     )

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -578,9 +578,11 @@ class NamesControllerTest < FunctionalTestCase
 
     ##### External research links
     [
+      ["Ascomycdete.org", ascomycete_org_name_url(name)],
       ["GBIF", gbif_name_search_url(name)],
       ["iNat", inat_name_search_url(name)],
       ["MushroomExpert", mushroomexpert_name_web_search_url(name)],
+      ["MyCoPortal", mycoportal_name_tab(@name)],
       ["NCBI", ncbi_nucleotide_term_search_url(name)],
       ["Wikipedia", wikipedia_term_search_url(name)]
     ].each do |site, link|

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -590,6 +590,10 @@ class NamesControllerTest < FunctionalTestCase
       "Page is missing a link to MushroomExpert"
     )
     assert_select(
+      "body a[href='#{mycoguide_name_search_url(name)}']", true,
+      "Page is missing a link to MycoGuide"
+    )
+    assert_select(
       "body a[href='#{ncbi_nucleotide_name_search_url(name)}']", true,
       "Page is missing a link to NCBI Nucleotide"
     )

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -9,6 +9,8 @@
 # Do not add a Name starting with U or Z.
 #   AjaxControllerTest#test_auto_complete_name expects 0 Names starting with U.
 #   NameControllerTest pagination tests expect 0 Names staring with Z.
+# Do not add Ascomycetes
+#   This breaks NameTest#test_ancestors_3
 # Do not use the following as part of Names
 #   Lactarius   -- Breaks NameControllerTest#test_edit_name_deprecated
 #   Strobilurus -- Break NameControllerTest#test_edit_name_add_author

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2654,9 +2654,9 @@ class NameTest < UnitTestCase
     assert_equal("__#{name.text_name}__ #{name.author}", name.display_name)
   end
 
-  def test_s_str
+  def test_sensu_stricto
     %w[group gr gr. gp gp. clade complex].each do |str|
-      assert_equal(Name.new(text_name: "Tuber #{str}").sensu_stricto,
+      assert_equal(Name.new(text_name: "Boletus #{str}").sensu_stricto,
                    "Boletus",
                    "Name s.s. should not include `#{str}`")
       assert_equal(Name.new(text_name: "Boletus#{str}").sensu_stricto,

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2656,9 +2656,11 @@ class NameTest < UnitTestCase
 
   def test_s_str
     %w[group gr gr. gp gp. clade complex].each do |str|
-      assert_equal(Name.new(text_name: "Boletus #{str}").sensu_stricto, "Boletus",
+      assert_equal(Name.new(text_name: "Tuber #{str}").sensu_stricto,
+                   "Boletus",
                    "Name s.s. should not include `#{str}`")
-      assert_equal(Name.new(text_name: "Boletus#{str}").sensu_stricto, "Boletus#{str}",
+      assert_equal(Name.new(text_name: "Boletus#{str}").sensu_stricto,
+                   "Boletus#{str}",
                    "Name ss should include `#{str}` if it's part of the genus")
     end
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2656,9 +2656,9 @@ class NameTest < UnitTestCase
 
   def test_s_str
     %w[group gr gr. gp gp. clade complex].each do |str|
-      assert_equal(Name.new(text_name: "Boletus #{str}").s_str, "Boletus",
+      assert_equal(Name.new(text_name: "Boletus #{str}").sensu_stricto, "Boletus",
                    "Name s.s. should not include `#{str}`")
-      assert_equal(Name.new(text_name: "Boletus#{str}").s_str, "Boletus#{str}",
+      assert_equal(Name.new(text_name: "Boletus#{str}").sensu_stricto, "Boletus#{str}",
                    "Name ss should include `#{str}` if it's part of the genus")
     end
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2654,6 +2654,15 @@ class NameTest < UnitTestCase
     assert_equal("__#{name.text_name}__ #{name.author}", name.display_name)
   end
 
+  def test_s_str
+    %w[group gr gr. gp gp. clade complex].each do |str|
+      assert_equal(Name.new(text_name: "Boletus #{str}").s_str, "Boletus",
+                   "Name s.s. should not include `#{str}`")
+      assert_equal(Name.new(text_name: "Boletus#{str}").s_str, "Boletus#{str}",
+                   "Name ss should include `#{str}` if it's part of the genus")
+    end
+  end
+
   # --------------------------------------
 
   # Just make sure mysql is collating accents and case correctly.


### PR DESCRIPTION
- Adds additional external search links to Name `About this taxon` panel
- Reorganizes the panel:
  - Adds a **Research Links** caption, indenting external search links under that caption.

While working on the NEMF checklist, I've been wishing I had links like this in MO. So I finally added them. Some (e.g. MushroomExpert) are also useful for beginners.
(I also have an idea about adding these and similar links to the Observation pages. I'll write that up as a discussion.)