### PR TITLE
Remove class attributes from API

### DIFF
--- a/app/classes/api2.rb
+++ b/app/classes/api2.rb
@@ -140,8 +140,7 @@ class API2
 
   ### RESULTS ###
 
-  def model
-  end
+  def model; end
 
   def high_detail_includes
     []

--- a/app/classes/api2.rb
+++ b/app/classes/api2.rb
@@ -128,15 +128,11 @@ class API2
 
   attr_accessor :params, :method, :action, :version, :user, :api_key, :errors
 
-  # Give other modules ability to do additional initialization.
-  class_attribute :initializers
-  self.initializers = []
-
   ### PARAMETERS ###
 
   attr_accessor :expected_params, :ignore_params
 
-  initializers << lambda do
+  def initialize_parameters
     self.expected_params = {}
     self.ignore_params   = {}
     parse(:string, :action)
@@ -144,20 +140,36 @@ class API2
 
   ### RESULTS ###
 
-  class_attribute :model, :table, :high_detail_includes, :low_detail_includes,
-                  :high_detail_page_length, :low_detail_page_length,
-                  :put_page_length, :delete_page_length
+  def model
+  end
 
-  self.high_detail_includes = []
-  self.low_detail_includes  = []
-  self.high_detail_page_length = 10
-  self.low_detail_page_length  = 100
-  self.put_page_length         = 1000
-  self.delete_page_length      = 1000
+  def high_detail_includes
+    []
+  end
+
+  def low_detail_includes
+    []
+  end
+
+  def high_detail_page_length
+    10
+  end
+
+  def low_detail_page_length
+    100
+  end
+
+  def put_page_length
+    1000
+  end
+
+  def delete_page_length
+    1000
+  end
 
   attr_accessor :query, :detail, :page_number
 
-  initializers << lambda do
+  def initialize_results
     self.detail = parse(:enum, :detail, limit: [:none, :low, :high]) || :none
     self.page_number = parse(:integer, :page, default: 1)
   end

--- a/app/classes/api2/api_key_api.rb
+++ b/app/classes/api2/api_key_api.rb
@@ -3,12 +3,25 @@
 class API2
   # API for APIKey
   class APIKeyAPI < ModelAPI
-    self.model = APIKey
+    def model
+      APIKey
+    end
 
-    self.high_detail_page_length = 1000
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      1000
+    end
+
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
 
     # the :user may be the mobile app. the :for_user is the user the key is for
     def create_params

--- a/app/classes/api2/collection_number_api.rb
+++ b/app/classes/api2/collection_number_api.rb
@@ -3,17 +3,32 @@
 class API2
   # API for CollectionNumber
   class CollectionNumberAPI < ModelAPI
-    self.model = CollectionNumber
+    def model
+      CollectionNumber
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :observations,
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :observations,
+        :user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/comment_api.rb
+++ b/app/classes/api2/comment_api.rb
@@ -3,16 +3,29 @@
 class API2
   # API for Comment
   class CommentAPI < ModelAPI
-    self.model = Comment
+    def model
+      Comment
+    end
 
-    self.high_detail_page_length = 1000
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      1000
+    end
 
-    self.high_detail_includes = [
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [:user]
+    end
 
     def query_params
       @target = parse(:object, :target, limit: Comment.all_types, help: 1)

--- a/app/classes/api2/core/base.rb
+++ b/app/classes/api2/core/base.rb
@@ -249,7 +249,8 @@ module API2::Base
     self.params = params
     self.action = params[:action]
     self.errors = []
-    initializers.each { |x| instance_exec(&x) }
+    initialize_parameters
+    initialize_results
   end
 
   def handle_version

--- a/app/classes/api2/external_link_api.rb
+++ b/app/classes/api2/external_link_api.rb
@@ -3,17 +3,32 @@
 class API2
   # API for ExternalLink
   class ExternalLinkAPI < ModelAPI
-    self.model = ExternalLink
+    def model
+      ExternalLink
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :external_site,
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :external_site,
+        :user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/external_site_api.rb
+++ b/app/classes/api2/external_site_api.rb
@@ -3,16 +3,29 @@
 class API2
   # API for ExternalSite
   class ExternalSiteAPI < ModelAPI
-    self.model = ExternalSite
+    def model
+      ExternalSite
+    end
 
-    self.high_detail_page_length = 1000
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      1000
+    end
 
-    self.high_detail_includes = [
-      :project
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [:project]
+    end
 
     def query_params
       {

--- a/app/classes/api2/herbarium_api.rb
+++ b/app/classes/api2/herbarium_api.rb
@@ -3,17 +3,32 @@
 class API2
   # API for Herbarium
   class HerbariumAPI < ModelAPI
-    self.model = Herbarium
+    def model
+      Herbarium
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :location,
-      :personal_user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :location,
+        :personal_user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/herbarium_record_api.rb
+++ b/app/classes/api2/herbarium_record_api.rb
@@ -3,18 +3,33 @@
 class API2
   # API for HerbariumRecord
   class HerbariumRecordAPI < ModelAPI
-    self.model = HerbariumRecord
+    def model
+      HerbariumRecord
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :observations,
-      :herbarium,
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :observations,
+        :herbarium,
+        :user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -3,22 +3,37 @@
 class API2
   # API for Image
   class ImageAPI < ModelAPI
-    self.model = Image
+    def model
+      Image
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.low_detail_includes = [
-      :license
-    ]
+    def low_detail_page_length
+      1000
+    end
 
-    self.high_detail_includes = [
-      :license,
-      :observations,
-      :user
-    ]
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def low_detail_includes
+      [:license]
+    end
+
+    def high_detail_includes
+      [
+        :license,
+        :observations,
+        :user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/location_api.rb
+++ b/app/classes/api2/location_api.rb
@@ -3,16 +3,31 @@
 class API2
   # API for Location
   class LocationAPI < ModelAPI
-    self.model = Location
+    def model
+      Location
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      { comments: :user }
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        { comments: :user }
+      ]
+    end
 
     def query_params
       n, s, e, w = parse_bounding_box!

--- a/app/classes/api2/location_description_api.rb
+++ b/app/classes/api2/location_description_api.rb
@@ -3,18 +3,33 @@
 class API2
   # API for Location Description
   class LocationDescriptionAPI < ModelAPI
-    self.model = LocationDescription
+    def model
+      LocationDescription
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 100
-    self.put_page_length         = 100
-    self.delete_page_length      = 100
+    def high_detail_page_length
+      100
+    end
 
-    self.low_detail_includes = [
-      :license
-    ]
+    def low_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = []
+    def put_page_length
+      100
+    end
+
+    def delete_page_length
+      100
+    end
+
+    def low_detail_includes
+      [:license]
+    end
+
+    def high_detail_includes
+      []
+    end
 
     def query_params
       {

--- a/app/classes/api2/name_api.rb
+++ b/app/classes/api2/name_api.rb
@@ -3,17 +3,32 @@
 class API2
   # API for Name
   class NameAPI < ModelAPI
-    self.model = Name
+    def model
+      Name
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      { comments: :user },
-      { synonym: :names }
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        { comments: :user },
+        { synonym: :names }
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/name_description_api.rb
+++ b/app/classes/api2/name_description_api.rb
@@ -3,18 +3,33 @@
 class API2
   # API for Name Description
   class NameDescriptionAPI < ModelAPI
-    self.model = NameDescription
+    def model
+      NameDescription
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 100
-    self.put_page_length         = 100
-    self.delete_page_length      = 100
+    def high_detail_page_length
+      100
+    end
 
-    self.low_detail_includes = [
-      :license
-    ]
+    def low_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = []
+    def put_page_length
+      100
+    end
+
+    def delete_page_length
+      100
+    end
+
+    def low_detail_includes
+      [:license]
+    end
+
+    def high_detail_includes
+      []
+    end
 
     def query_params
       {

--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -4,26 +4,41 @@ class API2
   # API for Observation
   # rubocop:disable Metrics/ClassLength
   class ObservationAPI < ModelAPI
-    self.model = Observation
+    def model
+      Observation
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :collection_numbers,
-      { comments: :user },
-      :external_links,
-      { herbarium_records: :herbarium },
-      { images: [:license, :user] },
-      :location,
-      :name,
-      { namings: [:name, :user] },
-      :sequences,
-      :user,
-      { votes: :user }
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :collection_numbers,
+        { comments: :user },
+        :external_links,
+        { herbarium_records: :herbarium },
+        { images: [:license, :user] },
+        :location,
+        :name,
+        { namings: [:name, :user] },
+        :sequences,
+        :user,
+        { votes: :user }
+      ]
+    end
 
     # rubocop:disable Metrics/MethodLength
     def query_params

--- a/app/classes/api2/project_api.rb
+++ b/app/classes/api2/project_api.rb
@@ -3,17 +3,32 @@
 class API2
   # API for Project
   class ProjectAPI < ModelAPI
-    self.model = Project
+    def model
+      Project
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      { comments: :user },
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        { comments: :user },
+        :user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/sequence_api.rb
+++ b/app/classes/api2/sequence_api.rb
@@ -3,16 +3,29 @@
 class API2
   # API for Sequence
   class SequenceAPI < ModelAPI
-    self.model = Sequence
+    def model
+      Sequence
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [:user]
+    end
 
     # rubocop:disable Metrics/MethodLength
     def query_params

--- a/app/classes/api2/species_list_api.rb
+++ b/app/classes/api2/species_list_api.rb
@@ -3,18 +3,33 @@
 class API2
   # API for SpeciesList
   class SpeciesListAPI < ModelAPI
-    self.model = SpeciesList
+    def model
+      SpeciesList
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      { comments: :user },
-      :location,
-      :user
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        { comments: :user },
+        :location,
+        :user
+      ]
+    end
 
     def query_params
       {

--- a/app/classes/api2/user_api.rb
+++ b/app/classes/api2/user_api.rb
@@ -3,18 +3,33 @@
 class API2
   # API for User
   class UserAPI < ModelAPI
-    self.model = User
+    def model
+      User
+    end
 
-    self.high_detail_page_length = 100
-    self.low_detail_page_length  = 1000
-    self.put_page_length         = 1000
-    self.delete_page_length      = 1000
+    def high_detail_page_length
+      100
+    end
 
-    self.high_detail_includes = [
-      :api_keys,
-      :location,
-      { image: [:license, :user] }
-    ]
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :api_keys,
+        :location,
+        { image: [:license, :user] }
+      ]
+    end
 
     def query_params
       {


### PR DESCRIPTION
I don't think API was actually thread-unsafe, but why not remove its dependence on class attributes anyway?  Easy enough.