### PR TITLE
Move `gem(puma)` to `group :production` with instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,9 +106,6 @@ gem("jbuilder")
 # Use ActiveModel has_secure_password
 gem("bcrypt", "~> 3.1.7")
 
-# Use puma as the app server
-gem("puma")
-
 # Use Capistrano for deployment
 # gem("capistrano", group: :development)
 
@@ -236,6 +233,9 @@ group :development do
 end
 
 group :production do
+  # Use puma as the app server
+  gem("puma")
+
   # New Relic for application and other monitoring
   # https://newrelic.com/
   gem("newrelic_rpm")

--- a/Gemfile
+++ b/Gemfile
@@ -234,6 +234,8 @@ end
 
 group :production do
   # Use puma as the app server
+  # To use Webrick locally, run `bundle config set --local without 'production'`
+  # https://stackoverflow.com/a/23125762/3357635
   gem("puma")
 
   # New Relic for application and other monitoring


### PR DESCRIPTION
Because otherwise, Rails will try to run puma in dev.

After this is merged, each person has to [run this command locally](https://stackoverflow.com/questions/23125369/how-to-set-rails-dev-server-to-webbrick-instead-of-puma) (this is also a note in the Gemfile now):
`bundle config set --local without 'production'`

then `bundle`.

Then you can run `rails s` under webrick without further hassles.