### PR TITLE
Make a couple system tests less brittle

### DIFF
--- a/test/system/help_identify_system_test.rb
+++ b/test/system/help_identify_system_test.rb
@@ -58,8 +58,8 @@ class HelpIdentifySystemTest < ApplicationSystemTestCase
     login!(rolf)
 
     within("#navigation") do
-      assert_link("Help Identify")
-      click_on("Help Identify")
+      assert_link(id: "nav_identify_observations_link")
+      click_link(id: "nav_identify_observations_link")
     end
     assert_selector("body.identify__index")
 

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -371,7 +371,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # open_edit_observation_form
     # This is more robust in case the link becomes an icon:
     new_obs = Observation.last
-    click_link(class: "edit_observation_link_#{new_obs.id}")
+    first(class: "edit_observation_link_#{new_obs.id}").trigger("click")
     # click_link("Edit Observation")
     assert_selector("body.observations__edit")
 

--- a/test/test_helpers/system/cuprite_setup.rb
+++ b/test/test_helpers/system/cuprite_setup.rb
@@ -17,7 +17,7 @@ Capybara.register_driver(:mo_cuprite) do |app|
     # section of this article
     browser_options: {},
     # Increase Chrome startup wait time (required for stable CI builds)
-    process_timeout: 10,
+    process_timeout: 15,
     # Enable debugging capabilities
     inspector: true,
     # Allow running Chrome in a headful mode by setting HEADLESS env


### PR DESCRIPTION
In certain repeated trouble spots they ain't finding links that are definitely on the page.

This sends them to the link with a handwritten address in hand.