### PR TITLE
Switch `@user` ivar to `User.current` in Vote and Naming classes

### DIFF
--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -72,7 +72,7 @@ class Naming < AbstractModel
     naming = Naming.new(args)
     naming.created_at = now
     naming.updated_at = now
-    naming.user = @user
+    naming.user = User.current
     naming.observation = observation
     naming
   end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -78,7 +78,7 @@ class Vote < AbstractModel
     vote.assign_attributes(args.permit(:favorite, :value)) if args
     vote.created_at = now
     vote.updated_at = now
-    vote.user = @user
+    vote.user = User.current
     vote.naming = naming
     vote.observation = naming.observation
     vote


### PR DESCRIPTION
Make usage consistent in advance of thread-safety work on `User.current`.

We don't know what our solution will be yet, but it seems right to get the ivars out of the model classes.