### PR TITLE
Update to `turbo-rails` v2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem("requestjs-rails")
 # turbo for partial page updates
 gem("turbo-rails")
 # redis for combining actioncable broadcasts with turbo_stream
-# gem("redis", "~> 4.0")
+gem("redis", "~> 4.0")
 # dalli to run the memcached server
 gem("dalli", "~> 3.2")
 # solid_cache for cache store db

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
     rbtree (0.4.6)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    redis (4.8.1)
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -385,6 +386,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-html-sanitizer (>= 1.4.4)
   railties (~> 7.1.2)
+  redis (~> 4.0)
   requestjs-rails
   rtf
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,8 +136,8 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.7.1)
-    irb (1.11.1)
+    io-console (0.7.2)
+    irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
     jbuilder (2.11.5)
@@ -198,7 +198,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (2.2.8)
+    rack (2.2.8.1)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.1.0)
@@ -231,7 +231,7 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
-    reline (0.4.2)
+    reline (0.4.3)
       io-console (~> 0.5)
     requestjs-rails (0.0.11)
       railties (>= 6.1.0)
@@ -296,10 +296,10 @@ GEM
     stringio (3.1.0)
     terser (1.1.20)
       execjs (>= 0.3.0, < 3)
-    thor (1.3.0)
+    thor (1.3.1)
     tilt (2.3.0)
     timeout (0.4.1)
-    turbo-rails (1.5.0)
+    turbo-rails (2.0.4)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -324,7 +324,7 @@ GEM
       webrick
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   arm64-darwin-21


### PR DESCRIPTION
I thought this update would mean we could remove our partial page updates for namings and votes in `format.turbo_stream` responses, except those having to do with modals, but our turbo_stream updates are conditional on context (matrix_box or show_obs), so I don't believe we want to get rid of them.

Also adds gem `redis` - now required for `turbo-rails`.
