### PR TITLE
`Account::ProfileController` - Fix redirect to `new_location_path`

### DIFF
--- a/app/controllers/account/profile_controller.rb
+++ b/app/controllers/account/profile_controller.rb
@@ -77,8 +77,7 @@ module Account
     def maybe_update_location_and_finish
       if @need_location
         flash_notice(:runtime_profile_must_define.t)
-        redirect_to(location_create_location_path,
-                    where: @place_name, set_user: @user.id)
+        redirect_to(new_location_path(where: @place_name, set_user: @user.id))
       else
         flash_notice(:runtime_profile_success.t)
         redirect_to(user_path(@user.id))


### PR DESCRIPTION
@JoeCohen triggered this error.
> To replicate on the webserver. (I haven't tried this locally because my local environment is broken once again; I don't have time to deal with that until Tues.)
- Go to Your Summary
(Note what it lists as your Primary Location)
- Edit Profile
(NOTE: The Primary Location is displayed as blank. That's a bug.) - check `check_and_maybe_update_user_place_name`
- Type something in the Primary Location field
- Save

Result: We're sorry, but something went wrong.
