### PR TITLE
Added script to show entire context of the parse_log errors.

### DIFF
--- a/script/extract_log
+++ b/script/extract_log
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+app_root = File.expand_path("..", __dir__)
+
+HELP_ARGS = ["-h", "--help"].freeze
+abort(<<HELP) if ARGV.any? { |arg| HELP_ARGS.include?(arg) }
+
+  USAGE::
+
+    script/extract_log <string>
+      --or--
+    grep errors log/production.log | script/extract_log
+
+  DESCRIPTION::
+
+    Locates the given string or strings in the log, pulls all of the related
+    log messages and prints the results.
+
+  PARAMETERS::
+
+    --help     Print this message.
+    <string>   String to search for.
+
+HELP
+
+# Get search string(s) from command line or from stdin.
+strings = ARGV.length > 0 ? ARGV : readlines
+
+string = strings.shift # string we're looking for next
+bundles = {}           # accumulates de-interlaced lines for each request
+pid = nil              # pid of last line
+found = nil            # when the string is found, this is set to the pid,
+                       # tells it to print the bundle for this pid when done
+
+file = "#{app_root}/production.log"
+File.open(file).readlines.each do |line|
+  match = line.match(/#(\d+)/)
+  pid = match[1] if match
+  if line.match(/: Started [A-Z]{3,}/)
+    if found == pid
+      puts bundles[found].join("")
+      exit(0) if strings.empty?
+      string = strings.shift
+      found = nil
+      bundles[pid] = []
+    else
+      bundles[pid] = []
+    end
+  end
+  bundles[pid] ||= []
+  bundles[pid] << line.sub(/^[A-Z], \[[^\[\]]*\]  /, "")
+  found = pid if line.include?(string)
+end
+
+if found
+  puts bundles[found].join("")
+  exit(0) if strings.empty?
+  string = strings.shift
+end
+
+([string] + strings).each do |str|
+  warn "Unable to find: #{str}\n"
+end
+exit(1)

--- a/script/extract_log
+++ b/script/extract_log
@@ -25,28 +25,29 @@ abort(<<HELP) if ARGV.any? { |arg| HELP_ARGS.include?(arg) }
 HELP
 
 # Get search string(s) from command line or from stdin.
+# rubocop:disable Style/NumericPredicate
+# rubocop:disable Style/ZeroLengthPredicate
 strings = ARGV.length > 0 ? ARGV : readlines
+# rubocop:enable Style/NumericPredicate
+# rubocop:enable Style/ZeroLengthPredicate
 
 string = strings.shift # string we're looking for next
 bundles = {}           # accumulates de-interlaced lines for each request
 pid = nil              # pid of last line
-found = nil            # when the string is found, this is set to the pid,
-                       # tells it to print the bundle for this pid when done
+found = nil            # when the string is found, this is set to the pid
 
 file = "#{app_root}/production.log"
 File.open(file).readlines.each do |line|
   match = line.match(/#(\d+)/)
   pid = match[1] if match
-  if line.match(/: Started [A-Z]{3,}/)
+  if line.match?(/: Started [A-Z]{3,}/)
     if found == pid
-      puts bundles[found].join("")
+      puts bundles[found].join
       exit(0) if strings.empty?
       string = strings.shift
       found = nil
-      bundles[pid] = []
-    else
-      bundles[pid] = []
     end
+    bundles[pid] = []
   end
   bundles[pid] ||= []
   bundles[pid] << line.sub(/^[A-Z], \[[^\[\]]*\]  /, "")
@@ -54,7 +55,7 @@ File.open(file).readlines.each do |line|
 end
 
 if found
-  puts bundles[found].join("")
+  puts bundles[found].join
   exit(0) if strings.empty?
   string = strings.shift
 end

--- a/script/parse_log
+++ b/script/parse_log
@@ -31,7 +31,8 @@ grep -v 'ActionView::Template::Error .Character not in alphabet' \
   > $new_errors || true
 
 touch $old_errors
-diff $new_errors $old_errors || true
+(diff $new_errors $old_errors || true) |
+  grep -v '^<' | sed 's/^< //' | $app_root/script/extract_log
 mv $new_errors $old_errors
 
 exit 0


### PR DESCRIPTION
Usage:

script/extract_log DoubleRenderError

Output shows all of the lines of log/production.log for the first request which contains that string, nicely de-interlaced, and with the timestamp stripped off.

Also, script/parse_log is updated to automatically pipe its output through this new script.