### PR TITLE
`SiteData` - Fix inaccurate count of versions

### DIFF
--- a/app/classes/site_data.rb
+++ b/app/classes/site_data.rb
@@ -307,9 +307,9 @@ class SiteData
     parent_id = "#{parent_table}_id"
 
     parent_class.joins(:versions).
-      where(user_id: user_id).
+      where(version_class.arel_table[:user_id].eq(user_id)).
       where.not(
-        parent_class[:user_id].eq(version_class.arel_table[:user_id])
+        version_class.arel_table[:user_id].eq(parent_class[:user_id])
       ).distinct.select(version_class.arel_table[:"#{parent_id}"]).count
   end
 


### PR DESCRIPTION
Fixes a version join that's checking the wrong columns, resulting in inaccurate counts. 

Pointed out by @pellaea 