### PR TITLE
Fixed bug in "prev" / "next" on obs page.

### DIFF
--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -22,11 +22,9 @@ module ObservationsController::Show
   def show
     pass_query_params
     store_location
-    case params[:flow]
-    when "next"
-      redirect_to_next_object(:next, Observation, params[:id]) and return
-    when "prev"
-      redirect_to_next_object(:prev, Observation, params[:id]) and return
+    if params[:flow].present?
+      redirect_to_next_object(params[:flow].to_sym, Observation, params[:id])
+      return
     end
 
     check_if_user_wants_to_make_their_votes_public


### PR DESCRIPTION
I don't know how to test this.  There is already a test of this functionality.  The problem is the old code relied on `redirect_to` returning something truthy.  But this is not reliable apparently.  But reliable enough that tests were passing.