### PR TITLE
Fix blocked ip message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,8 @@ class ApplicationController < ActionController::Base
     return true if is_cool?
 
     logger.warn("BLOCKED #{request.remote_ip}")
-    render(plain: :kick_out_message.t(email: MO.webmaster_email_address),
+    render(plain: :kick_out_message.t(ip: request.remote_ip,
+                                      email: MO.webmaster_email_address),
            status: :too_many_requests,
            layout: false)
     false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,10 +157,9 @@ class ApplicationController < ActionController::Base
     return true if is_cool?
 
     logger.warn("BLOCKED #{request.remote_ip}")
-    render(plain: :kick_out_message.t(ip: request.remote_ip,
-                                      email: MO.webmaster_email_address),
-           status: :too_many_requests,
-           layout: false)
+    email = MO.webmaster_email_address
+    msg = :kick_out_message.l(ip: request.remote_ip, email: email)
+    render(plain: msg, status: :too_many_requests, layout: false)
     false
   end
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3588,7 +3588,7 @@
 
   # ERROR MESSAGES
 
-  kick_out_message: "We have noticed a lot of server-intensive traffic from this IP address (#{request.remote_ip}). There may be better ways of doing what you are trying to do. Please contact the webmaster ([email]) so that we can talk about it. So that we can best help you, please:\n- include a copy of this message;\n- tell how you generally use Mushroom Observer;\n- tell us what you were doing when you received this message."
+  kick_out_message: "We have noticed a lot of server-intensive traffic from this IP address ([ip]). There may be better ways of doing what you are trying to do. Please contact the webmaster ([email]) so that we can talk about it. So that we can best help you, please:\n- include a copy of this message;\n- tell how you generally use Mushroom Observer;\n- tell us what you were doing when you received this message."
 
   unsuccessful_contributor_warning: Thanks for wanting to contribute to the Mushroom Observer. This type of contribution can only be made by users who have provided at least one observation to the system.
 


### PR DESCRIPTION
Two points:

1. `#{blah}` constructs don't get interpolated in translation strings, use the `[blah]` construct instead.
2. `:translation_string.t` yields HTML, use `:translation_string.l` instead for plain text.