### PR TITLE
Removed lang:update:export:unofficial from the lang:update task.

### DIFF
--- a/lib/tasks/lang.rake
+++ b/lib/tasks/lang.rake
@@ -53,9 +53,7 @@ namespace :lang do
     "check:official",    # check syntax of official file
     "import:official",   # import any changes from official file
     "strip:all",         # strip out any strings we no longer need
-    "update:all",        # update localization (YAML) files
-    # update export (text) files (used by translation controller to build form)
-    "export:unofficial"
+    "update:all"         # update localization (YAML) files
   ]
 
   [


### PR DESCRIPTION
Just tired of waiting for `rake lang:update` to write all the export files.  Those were only ever intended to help make it easier for the initial population of a translation.  They've only ever been used once or twice, and with extreme difficulty even then.