### PR TITLE
Fix api error

### DIFF
--- a/app/classes/api2/error/abort_due_to_errors.rb
+++ b/app/classes/api2/error/abort_due_to_errors.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Error thrown when PATCH or DELETE abort from errors before doing anything.
-  class AbortDueToErrors < Error
+  class AbortDueToErrors < FatalError
   end
 end

--- a/app/classes/api2/error/ambiguous_name.rb
+++ b/app/classes/api2/error/ambiguous_name.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Name parameter has multiple matches.
-  class AmbiguousName < Error
+  class AmbiguousName < FatalError
     def initialize(name, others)
       super()
       str = others.map(&:real_search_name).join(" / ")

--- a/app/classes/api2/error/another_users_profile_location.rb
+++ b/app/classes/api2/error/another_users_profile_location.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Cannot update location if another user has made it their profile location.
-  class AnotherUsersProfileLocation < Error
+  class AnotherUsersProfileLocation < FatalError
   end
 end

--- a/app/classes/api2/error/api_key_not_verified.rb
+++ b/app/classes/api2/error/api_key_not_verified.rb
@@ -2,7 +2,7 @@
 
 class API2
   # APIKey not verified yet.
-  class APIKeyNotVerified < Error
+  class APIKeyNotVerified < FatalError
     def initialize(key)
       super()
       args.merge!(key: key.key.to_s, notes: key.notes.to_s)

--- a/app/classes/api2/error/bad_action.rb
+++ b/app/classes/api2/error/bad_action.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Endpoint doesn't exist.
-  class BadAction < Error
+  class BadAction < FatalError
     def initialize(action)
       super()
       args.merge!(action: action.to_s)

--- a/app/classes/api2/error/bad_api_key.rb
+++ b/app/classes/api2/error/bad_api_key.rb
@@ -2,7 +2,7 @@
 
 class API2
   # APIKey not valid.
-  class BadAPIKey < Error
+  class BadAPIKey < FatalError
     def initialize(str)
       super()
       args.merge!(key: str.to_s)

--- a/app/classes/api2/error/bad_classification.rb
+++ b/app/classes/api2/error/bad_classification.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Invalid classification string.
-  class BadClassification < Error
+  class BadClassification < FatalError
   end
 end

--- a/app/classes/api2/error/bad_limited_parameter_value.rb
+++ b/app/classes/api2/error/bad_limited_parameter_value.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Parameter value out of range.
-  class BadLimitedParameterValue < Error
+  class BadLimitedParameterValue < FatalError
     def initialize(str, limit)
       super()
       args.merge!(val: str.to_s, limit: limit.inspect)

--- a/app/classes/api2/error/bad_method.rb
+++ b/app/classes/api2/error/bad_method.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Request method not recognized.
-  class BadMethod < Error
+  class BadMethod < FatalError
     def initialize(method)
       super()
       args.merge!(method: method.to_s)

--- a/app/classes/api2/error/bad_notes_field_parameter.rb
+++ b/app/classes/api2/error/bad_notes_field_parameter.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Notes template field didn't parse.
-  class BadNotesFieldParameter < Error
+  class BadNotesFieldParameter < FatalError
     def initialize(str)
       super()
       args.merge!(val: str.to_s)

--- a/app/classes/api2/error/bad_parameter_value.rb
+++ b/app/classes/api2/error/bad_parameter_value.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Parameter has bad syntax.
-  class BadParameterValue < Error
+  class BadParameterValue < FatalError
     def initialize(str, type)
       super()
       args.merge!(val: str.to_s, type: type)

--- a/app/classes/api2/error/bad_version.rb
+++ b/app/classes/api2/error/bad_version.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Syntax of requested version is wrong.
-  class BadVersion < Error
+  class BadVersion < FatalError
     def initialize(str)
       super()
       args.merge!(version: str.to_s)

--- a/app/classes/api2/error/can_only_delete_your_own_account.rb
+++ b/app/classes/api2/error/can_only_delete_your_own_account.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Attempted to delete someone else's account.
-  class CanOnlyDeleteYourOwnAccount < Error
+  class CanOnlyDeleteYourOwnAccount < FatalError
   end
 end

--- a/app/classes/api2/error/can_only_synonymize_unsynonymized_names.rb
+++ b/app/classes/api2/error/can_only_synonymize_unsynonymized_names.rb
@@ -4,6 +4,6 @@ class API2
   # We're not allowing client to merge to sets of synonyms.  Even more, we're
   # only allowing them to synonymize unsynonmized names with other names.
   # (The name they synonymize it with, however, can have synonyms.)
-  class CanOnlySynonymizeUnsynonymizedNames < Error
+  class CanOnlySynonymizeUnsynonymizedNames < FatalError
   end
 end

--- a/app/classes/api2/error/can_only_use_one_of_these_fields.rb
+++ b/app/classes/api2/error/can_only_use_one_of_these_fields.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Can't set both specimen_id and herbarium_label, choose one or the other.
-  class CanOnlyUseOneOfTheseFields < Error
+  class CanOnlyUseOneOfTheseFields < FatalError
     def initialize(*fields)
       super()
       args.merge!(fields: fields.join(", "))

--- a/app/classes/api2/error/can_only_use_this_field_if_has_specimen.rb
+++ b/app/classes/api2/error/can_only_use_this_field_if_has_specimen.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to set herbarium_record info without claiming specimen present.
-  class CanOnlyUseThisFieldIfHasSpecimen < Error
+  class CanOnlyUseThisFieldIfHasSpecimen < FatalError
     def initialize(field)
       super()
       args.merge!(field: field)

--- a/app/classes/api2/error/cant_add_herbarium_record.rb
+++ b/app/classes/api2/error/cant_add_herbarium_record.rb
@@ -3,6 +3,6 @@
 class API2
   # Tried to add herbarium record to observation that you don't own, and you
   # are not a curator of the herbarium.
-  class CantAddHerbariumRecord < Error
+  class CantAddHerbariumRecord < FatalError
   end
 end

--- a/app/classes/api2/error/couldnt_download_url.rb
+++ b/app/classes/api2/error/couldnt_download_url.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Upload was supposed to be a URL, but couldn't get download it.
-  class CouldntDownloadURL < Error
+  class CouldntDownloadURL < FatalError
     def initialize(url, error)
       super()
       args.merge!(url: url.to_s, error: "#{error.class.name}: #{error}")

--- a/app/classes/api2/error/dubious_location_name.rb
+++ b/app/classes/api2/error/dubious_location_name.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Location name is "dubious".
-  class DubiousLocationName < Error
+  class DubiousLocationName < FatalError
     def initialize(reasons)
       super()
       args.merge!(reasons: reasons.join("; ").gsub(".;", ";"))

--- a/app/classes/api2/error/error.rb
+++ b/app/classes/api2/error/error.rb
@@ -26,4 +26,11 @@ class API2
       tag.t(args)
     end
   end
+
+  # API fatal exception base class.
+  class FatalError < Error
+    def initialize
+      super
+      self.fatal = true
+    end
 end

--- a/app/classes/api2/error/error.rb
+++ b/app/classes/api2/error/error.rb
@@ -26,11 +26,4 @@ class API2
       tag.t(args)
     end
   end
-
-  # API fatal exception base class.
-  class FatalError < Error
-    def initialize
-      super
-      self.fatal = true
-    end
 end

--- a/app/classes/api2/error/external_link_permission_denied.rb
+++ b/app/classes/api2/error/external_link_permission_denied.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Request to post external link requires certain permissions.
-  class ExternalLinkPermissionDenied < Error
+  class ExternalLinkPermissionDenied < FatalError
   end
 end

--- a/app/classes/api2/error/fatal_error.rb
+++ b/app/classes/api2/error/fatal_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class API2
+  # API fatal exception base class.
+  class FatalError < Error
+    def initialize
+      super
+      self.fatal = true
+    end
+  end
+end

--- a/app/classes/api2/error/file_missing.rb
+++ b/app/classes/api2/error/file_missing.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Upload was supposed to be a local file, but it doesn't exist.
-  class FileMissing < Error
+  class FileMissing < FatalError
     def initialize(file)
       super()
       args.merge(file: file.to_s)

--- a/app/classes/api2/error/herbarium_record_already_exists.rb
+++ b/app/classes/api2/error/herbarium_record_already_exists.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create herbarium record already been used by someone else.
-  class HerbariumRecordAlreadyExists < Error
+  class HerbariumRecordAlreadyExists < FatalError
     def initialize(obj)
       super()
       args.merge!(herbarium: obj.herbarium.name, number: obj.accession_number)

--- a/app/classes/api2/error/image_upload_failed.rb
+++ b/app/classes/api2/error/image_upload_failed.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Upload didn't make it.
-  class ImageUploadFailed < Error
+  class ImageUploadFailed < FatalError
     def initialize(img)
       super()
       args.merge!(error: img.dump_errors)

--- a/app/classes/api2/error/lat_long_must_both_be_set.rb
+++ b/app/classes/api2/error/lat_long_must_both_be_set.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Must supply both latitude and longitude, can't leave one out.
-  class LatLongMustBothBeSet < Error
+  class LatLongMustBothBeSet < FatalError
   end
 end

--- a/app/classes/api2/error/location_already_exists.rb
+++ b/app/classes/api2/error/location_already_exists.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create/rename a location over top of an existing one.
-  class LocationAlreadyExists < Error
+  class LocationAlreadyExists < FatalError
     def initialize(str)
       super()
       args.merge!(location: str.to_s)

--- a/app/classes/api2/error/missing_method.rb
+++ b/app/classes/api2/error/missing_method.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Missing request method.
-  class MissingMethod < Error
+  class MissingMethod < FatalError
   end
 end

--- a/app/classes/api2/error/missing_parameter.rb
+++ b/app/classes/api2/error/missing_parameter.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Missing required parameter.
-  class MissingParameter < Error
+  class MissingParameter < FatalError
     def initialize(arg)
       super()
       args.merge!(arg: arg.to_s)

--- a/app/classes/api2/error/missing_set_parameters.rb
+++ b/app/classes/api2/error/missing_set_parameters.rb
@@ -2,6 +2,6 @@
 
 class API2
   # PATCH request missing all set parameters.
-  class MissingSetParameters < Error
+  class MissingSetParameters < FatalError
   end
 end

--- a/app/classes/api2/error/missing_upload.rb
+++ b/app/classes/api2/error/missing_upload.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Request requires upload.
-  class MissingUpload < Error
+  class MissingUpload < FatalError
   end
 end

--- a/app/classes/api2/error/must_authenticate.rb
+++ b/app/classes/api2/error/must_authenticate.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Request requires valid APIKey.
-  class MustAuthenticate < Error
+  class MustAuthenticate < FatalError
   end
 end

--- a/app/classes/api2/error/must_be_admin.rb
+++ b/app/classes/api2/error/must_be_admin.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Request requires you to be project admin.
-  class MustBeAdmin < Error
+  class MustBeAdmin < FatalError
     def initialize(proj)
       super()
       args.merge!(project: proj.title)

--- a/app/classes/api2/error/must_be_creator.rb
+++ b/app/classes/api2/error/must_be_creator.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Can only update locations/names which you have created.
-  class MustBeCreator < Error
+  class MustBeCreator < FatalError
     def initialize(type)
       super()
       args.merge!(type: type)

--- a/app/classes/api2/error/must_be_only_editor.rb
+++ b/app/classes/api2/error/must_be_only_editor.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Cannot update locations/names which other users have edited.
-  class MustBeOnlyEditor < Error
+  class MustBeOnlyEditor < FatalError
     def initialize(type)
       super()
       args.merge!(type: type)

--- a/app/classes/api2/error/must_not_have_any_herbaria.rb
+++ b/app/classes/api2/error/must_not_have_any_herbaria.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Cannot update locations if there is an herbarium there.
-  class MustNotHaveAnyHerbaria < Error
+  class MustNotHaveAnyHerbaria < FatalError
   end
 end

--- a/app/classes/api2/error/must_own_all_descriptions.rb
+++ b/app/classes/api2/error/must_own_all_descriptions.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Can only update locations/names which you own all the desrciptions for.
-  class MustOwnAllDescriptions < Error
+  class MustOwnAllDescriptions < FatalError
     def initialize(type)
       super()
       args.merge!(type: type)

--- a/app/classes/api2/error/must_own_all_namings.rb
+++ b/app/classes/api2/error/must_own_all_namings.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Can only update names which no one else has proposed on any observations.
-  class MustOwnAllNamings < Error
+  class MustOwnAllNamings < FatalError
     def initialize(type)
       super()
       args.merge!(type: type)

--- a/app/classes/api2/error/must_own_all_observations.rb
+++ b/app/classes/api2/error/must_own_all_observations.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Cannot update location/name unless you own all its observations.
-  class MustOwnAllObservations < Error
+  class MustOwnAllObservations < FatalError
     def initialize(type)
       super()
       args.merge!(type: type)

--- a/app/classes/api2/error/must_own_all_species_lists.rb
+++ b/app/classes/api2/error/must_own_all_species_lists.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Cannot update location unless you own all its species lists.
-  class MustOwnAllSpeciesLists < Error
+  class MustOwnAllSpeciesLists < FatalError
     def initialize(type)
       super()
       args.merge!(type: type)

--- a/app/classes/api2/error/name_already_exists.rb
+++ b/app/classes/api2/error/name_already_exists.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create/rename a name over top of an existing one.
-  class NameAlreadyExists < Error
+  class NameAlreadyExists < FatalError
     def initialize(str)
       super()
       args.merge!(new: str.to_s, old: str.to_s)

--- a/app/classes/api2/error/name_doesnt_parse.rb
+++ b/app/classes/api2/error/name_doesnt_parse.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Taxon name isn't valid.
-  class NameDoesntParse < Error
+  class NameDoesntParse < FatalError
     def initialize(str)
       super()
       args.merge!(name: str.to_s)

--- a/app/classes/api2/error/name_wrong_for_rank.rb
+++ b/app/classes/api2/error/name_wrong_for_rank.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Taxon name isn't valid for the given rank.
-  class NameWrongForRank < Error
+  class NameWrongForRank < FatalError
     def initialize(str, rank)
       super()
       args.merge!(name: str.to_s, rank: :"rank_#{rank}")

--- a/app/classes/api2/error/need_all_four_edges.rb
+++ b/app/classes/api2/error/need_all_four_edges.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Bounding box is missing one or more edges.
-  class NeedAllFourEdges < Error
+  class NeedAllFourEdges < FatalError
   end
 end

--- a/app/classes/api2/error/no_method_for_action.rb
+++ b/app/classes/api2/error/no_method_for_action.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Method not implemented for this endpoint.
-  class NoMethodForAction < Error
+  class NoMethodForAction < FatalError
     def initialize(method, action)
       super()
       args.merge!(method: method.to_s.upcase, action: action.to_s)

--- a/app/classes/api2/error/object_error.rb
+++ b/app/classes/api2/error/object_error.rb
@@ -2,7 +2,7 @@
 
 class API2
   # API exception base class for errors having to do with database records.
-  class ObjectError < Error
+  class ObjectError < FatalError
     def initialize(obj)
       super()
       args.merge!(type: obj.type_tag, name: display_name(obj))

--- a/app/classes/api2/error/object_not_found_by_id.rb
+++ b/app/classes/api2/error/object_not_found_by_id.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Referenced object id doesn't exist.
-  class ObjectNotFoundById < Error
+  class ObjectNotFoundById < FatalError
     def initialize(id, model)
       super()
       args.merge!(id: id.to_s, type: model.type_tag)

--- a/app/classes/api2/error/object_not_found_by_string.rb
+++ b/app/classes/api2/error/object_not_found_by_string.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Referenced object name doesn't exist.
-  class ObjectNotFoundByString < Error
+  class ObjectNotFoundByString < FatalError
     def initialize(str, model)
       super()
       args.merge!(str: str.to_s, type: model.type_tag)

--- a/app/classes/api2/error/one_or_the_other.rb
+++ b/app/classes/api2/error/one_or_the_other.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to both clear synonyms and add synonyms at the same time.
-  class OneOrTheOther < Error
+  class OneOrTheOther < FatalError
     def initialize(args)
       super()
       args.merge!(args: args.map(&:to_s).join(", "))

--- a/app/classes/api2/error/parameter_cant_be_blank.rb
+++ b/app/classes/api2/error/parameter_cant_be_blank.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Some PATCH set parameters, if supplied, cannot be blank.
-  class ParameterCantBeBlank < Error
+  class ParameterCantBeBlank < FatalError
     def initialize(arg)
       super()
       args.merge!(arg: arg.to_s)

--- a/app/classes/api2/error/password_incorrect.rb
+++ b/app/classes/api2/error/password_incorrect.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Tried to create api key for user with incorrect password.
-  class PasswordIncorrect < Error
+  class PasswordIncorrect < FatalError
   end
 end

--- a/app/classes/api2/error/project_taken.rb
+++ b/app/classes/api2/error/project_taken.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create project that already exists.
-  class ProjectTaken < Error
+  class ProjectTaken < FatalError
     def initialize(title)
       super()
       args.merge!(title: title.to_s)

--- a/app/classes/api2/error/query_error.rb
+++ b/app/classes/api2/error/query_error.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Error while executing query.
-  class QueryError < Error
+  class QueryError < FatalError
     def initialize(error)
       super()
       args.merge!(error: error.to_s)

--- a/app/classes/api2/error/render_failed.rb
+++ b/app/classes/api2/error/render_failed.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Error rendering API request results.
-  class RenderFailed < Error
+  class RenderFailed < FatalError
     def initialize(error)
       super()
       msg = "#{error}\n#{error.backtrace.join("\n")}"

--- a/app/classes/api2/error/species_list_already_exists.rb
+++ b/app/classes/api2/error/species_list_already_exists.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create species list that already exists.
-  class SpeciesListAlreadyExists < Error
+  class SpeciesListAlreadyExists < FatalError
     def initialize(str)
       super()
       args.merge!(title: str)

--- a/app/classes/api2/error/string_too_long.rb
+++ b/app/classes/api2/error/string_too_long.rb
@@ -2,7 +2,7 @@
 
 class API2
   # String parameter too long.
-  class StringTooLong < Error
+  class StringTooLong < FatalError
     def initialize(str, length)
       super()
       args.merge!(val: str.to_s, limit: length.inspect)

--- a/app/classes/api2/error/too_many_uploads.rb
+++ b/app/classes/api2/error/too_many_uploads.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Request supplied too many uploads.
-  class TooManyUploads < Error
+  class TooManyUploads < FatalError
   end
 end

--- a/app/classes/api2/error/trying_to_set_multiple_locations_to_same_name.rb
+++ b/app/classes/api2/error/trying_to_set_multiple_locations_to_same_name.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Tried to update name of more than one location at once.
-  class TryingToSetMultipleLocationsToSameName < Error
+  class TryingToSetMultipleLocationsToSameName < FatalError
   end
 end

--- a/app/classes/api2/error/trying_to_set_multiple_names_at_once.rb
+++ b/app/classes/api2/error/trying_to_set_multiple_names_at_once.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Tried to update name/author/rank of more than one name at once.
-  class TryingToSetMultipleNamesAtOnce < Error
+  class TryingToSetMultipleNamesAtOnce < FatalError
   end
 end

--- a/app/classes/api2/error/unexpected_upload.rb
+++ b/app/classes/api2/error/unexpected_upload.rb
@@ -2,6 +2,6 @@
 
 class API2
   # Request includes an unexpected upload.
-  class UnexpectedUpload < Error
+  class UnexpectedUpload < FatalError
   end
 end

--- a/app/classes/api2/error/user_already_exists.rb
+++ b/app/classes/api2/error/user_already_exists.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create user that already exists.
-  class UserAlreadyExists < Error
+  class UserAlreadyExists < FatalError
     def initialize(str)
       super()
       args.merge!(login: str)

--- a/app/classes/api2/error/user_group_taken.rb
+++ b/app/classes/api2/error/user_group_taken.rb
@@ -2,7 +2,7 @@
 
 class API2
   # Tried to create a user group that already exists.
-  class UserGroupTaken < Error
+  class UserGroupTaken < FatalError
     def initialize(title)
       super()
       args.merge!(title: title.to_s)

--- a/app/classes/api2/error/user_not_verified.rb
+++ b/app/classes/api2/error/user_not_verified.rb
@@ -2,7 +2,7 @@
 
 class API2
   # User not verified yet.
-  class UserNotVerified < Error
+  class UserNotVerified < FatalError
     def initialize(user)
       super()
       args.merge!(login: user.login)

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -520,13 +520,12 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # MD5 sum, etc. afterwards before it actually processes the image.
   def image=(file)
     self.upload_handle = file
-    # Image is already stored in a local temp file. This is how Rails passes
-    # large files from the webserver.
     if local_file?(file)
       init_image_from_local_file(file)
-    # Image is given as an input stream.
     elsif input_stream?(file)
       init_image_from_stream(file)
+    else
+      raise("Unexpected image upload class, #{file.class.name}.")
     end
   end
 
@@ -696,20 +695,6 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
           errors.add(:image,
                      "Unexpected error while copying attached file " \
                      "to temp file. Error class #{e.class}: #{e}")
-          result = false
-        end
-
-      # Image is already saved to a tempfile (this is a puma thing, I guess?)
-      elsif upload_handle.is_a?(Tempfile)
-        begin
-          @file = upload_handle
-          self.upload_temp_file = @file.path
-          self.upload_length = @file.size
-          result = true
-        rescue StandardError => e
-          errors.add(:image,
-                     "Unexpected error while querying upload tempfile. " \
-                     "Error class #{e.class}: #{e}")
           result = false
         end
 


### PR DESCRIPTION
When I first wrote the API, apparently I forgot to mark the fatal errors as fatal... and somehow this issue has never come to our attention until now.  The problem is, if it throws a fatal error anywhere and results are uninitialized, it will throw a 500 error during render (and of course hide the error).