### PR TITLE
Observations map limits

### DIFF
--- a/app/views/controllers/observations/maps/index.html.erb
+++ b/app/views/controllers/observations/maps/index.html.erb
@@ -5,6 +5,7 @@ add_tab_set(observation_maps_tabs(query: @query))
 
 objects = @observations
 objects += @locations if @locations.any?
+objects = objects.first(10_000)
 %>
 
 <%= make_map(objects: objects, # CollapsibleCollection


### PR DESCRIPTION
- Limits the number of points + locations that are mapped to 10,000
See [MO Tech Meeting Notes 2024--02-22](https://groups.google.com/g/mo-developers/c/jaPO9ZwHbxg)

We get 1-2 Digital Ocean downtime notices/day that turn out to be caused by logged-in users' mapping all Observations. It's bad to have the site be nonresponsive, even for relatively short periods. 
And I'd rather not spend time needlessly dealing with those notices. See also [@mo-nathan's Slack post](https://mushroomobserver.slack.com/archives/C06FHR54EPQ/p1709574475483929) ("We should figure [out] a process for having someone look into these failures after they happen."