### PR TITLE
Reinstated rake lang:export:unofficial.

### DIFF
--- a/lib/tasks/lang.rake
+++ b/lib/tasks/lang.rake
@@ -53,7 +53,8 @@ namespace :lang do
     "check:official",    # check syntax of official file
     "import:official",   # import any changes from official file
     "strip:all",         # strip out any strings we no longer need
-    "update:all"         # update localization (YAML) files
+    "update:all",        # update localization (YAML) files
+    "export:unofficial"  # (still needed by some tests)
   ]
 
   [


### PR DESCRIPTION
Apparently one or more of the export files are still needed by the tests.  I don't have time to figure out which tests or why, so I'm just reinstating it.  It only adds a few seconds to deploy, it's not that big of a deal.