### PR TITLE
Paginate Contributors index

### DIFF
--- a/app/classes/query/user_with_contribution.rb
+++ b/app/classes/query/user_with_contribution.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Query::UserWithContribution < Query::UserBase
+  def initialize_flavor
+    where << "users.contribution > 0"
+    super
+  end
+end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -6,7 +6,10 @@ class ContributorsController < ApplicationController
 
   # Contributors index
   def index
-    SiteData.new
-    @users = User.by_contribution.where(contribution: 1..)
+    # @users = User.by_contribution.where(contribution: 1..)
+    query = create_query(:User, :with_contribution, by: :contribution)
+    args = { action: :index, matrix: true, include: [:thumb_image] }
+
+    show_index_of_objects(query, args)
   end
 end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -8,7 +8,7 @@ class ContributorsController < ApplicationController
   def index
     # @users = User.by_contribution.where(contribution: 1..)
     query = create_query(:User, :with_contribution, by: :contribution)
-    args = { action: :index, matrix: true, include: [:thumb_image] }
+    args = { action: :index, matrix: true, include: [:image] }
 
     show_index_of_objects(query, args)
   end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -6,7 +6,6 @@ class ContributorsController < ApplicationController
 
   # Contributors index
   def index
-    # @users = User.by_contribution.where(contribution: 1..)
     query = create_query(:User, :with_contribution, by: :contribution)
     args = { action: :index, matrix: true, include: [:image] }
 

--- a/app/views/controllers/contributors/_contributor.html.erb
+++ b/app/views/controllers/contributors/_contributor.html.erb
@@ -1,3 +1,8 @@
+<%
+# `user_counter` is a collection property that starts at 0
+number = (user_counter + 1) + (@pages.num_per_page * (@pages.number - 1))
+%>
+
 <div class="list-group-item">
   <div class="row">
 
@@ -5,7 +10,7 @@
       <table class="w-100">
         <tr>
           <td class="align-middle col-sm-2">
-            <strong><%= user_counter %></strong>
+            <strong><%= number %></strong>
           </td>
           <td>
             <h4><%= user_link(user.id, user.legal_name) %></h4>

--- a/app/views/controllers/contributors/index.html.erb
+++ b/app/views/controllers/contributors/index.html.erb
@@ -1,52 +1,54 @@
 <%
-@container = :wide
+@container = :double
 add_page_title(:users_by_contribution_title.t)
 add_tab_set(contributors_index_tabs)
 %>
 
-<div class="row">
-  <div class="col-md-6">
-    <div class="list-group">
-      <%= render(partial: "contributors/contributor",
-                  collection: @users, as: :user) %>
-    </div>
-  </div>
-
-  <div class="col-md-6">
-    <div class="list-group">
-      <div class="list-group-item">
-
-        <%= :users_by_contribution_1.tp %>
-        <% UserStats.fields_with_weight.keys.each do |field| %>
-          <div class="row">
-            <div class="col-xs-8 col-xs-push-1"><%= "user_stats_#{field}".to_sym.t %> </div>
-            <div class="col-xs-2"><%= UserStats::ALL_FIELDS[field][:weight] %></div>
-          </div><!--.row-->
-        <% end %>
-        <p class="pt-3"><%= :users_by_contribution_2.t %></p>
-        <%
-          v1 = UserStats::ALL_FIELDS[:images][:weight]
-          v2 = UserStats::ALL_FIELDS[:name_description_editors][:weight]
-          v3 = UserStats::ALL_FIELDS[:observations][:weight]
-          v4 = UserStats::ALL_FIELDS[:namings][:weight]
-          v5 = UserStats::ALL_FIELDS[:votes][:weight]
-        %>
-        <div class="row">
-          <div class="col-xs-3 col-xs-push-1">&nbsp; &nbsp;3 * <%= v1 %></div>
-          <div class="col-xs-8">(<%= :users_by_contribution_2a.t %>)</div>
-          <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v2 %></div>
-          <div class="col-xs-8">(<%= :users_by_contribution_2b.t %>)</div>
-          <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v3 %></div>
-          <div class="col-xs-8">(<%= :users_by_contribution_2c.t %>)</div>
-          <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v4 %></div>
-          <div class="col-xs-8">(<%= :users_by_contribution_2d.t %>)</div>
-          <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v5 %></div>
-          <div class="col-xs-8">(<%= :users_by_contribution_2e.t %>)</div>
-          <div class="col-xs-11 col-xs-push-1">&nbsp; &nbsp;<%= 3*v1 + v2 + v3 + v4 + v5 %> <%= :users_by_contribution_2f.t %></div>
-        </div><!--.row-->
-        <%= :users_by_contribution_3.tp %>
-
+<%= paginate_block(@pages) do %>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="list-group">
+        <%= render(partial: "contributors/contributor",
+                   collection: @objects, as: :user) %>
       </div>
     </div>
-  </div>
-</div><!--.row-->
+
+    <div class="col-md-6">
+      <div class="list-group">
+        <div class="list-group-item">
+
+          <%= :users_by_contribution_1.tp %>
+          <% UserStats.fields_with_weight.keys.each do |field| %>
+            <div class="row">
+              <div class="col-xs-8 col-xs-push-1"><%= "user_stats_#{field}".to_sym.t %> </div>
+              <div class="col-xs-2"><%= UserStats::ALL_FIELDS[field][:weight] %></div>
+            </div><!--.row-->
+          <% end %>
+          <p class="pt-3"><%= :users_by_contribution_2.t %></p>
+          <%
+            v1 = UserStats::ALL_FIELDS[:images][:weight]
+            v2 = UserStats::ALL_FIELDS[:name_description_editors][:weight]
+            v3 = UserStats::ALL_FIELDS[:observations][:weight]
+            v4 = UserStats::ALL_FIELDS[:namings][:weight]
+            v5 = UserStats::ALL_FIELDS[:votes][:weight]
+          %>
+          <div class="row">
+            <div class="col-xs-3 col-xs-push-1">&nbsp; &nbsp;3 * <%= v1 %></div>
+            <div class="col-xs-8">(<%= :users_by_contribution_2a.t %>)</div>
+            <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v2 %></div>
+            <div class="col-xs-8">(<%= :users_by_contribution_2b.t %>)</div>
+            <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v3 %></div>
+            <div class="col-xs-8">(<%= :users_by_contribution_2c.t %>)</div>
+            <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v4 %></div>
+            <div class="col-xs-8">(<%= :users_by_contribution_2d.t %>)</div>
+            <div class="col-xs-3 col-xs-push-1">+ 1 * <%= v5 %></div>
+            <div class="col-xs-8">(<%= :users_by_contribution_2e.t %>)</div>
+            <div class="col-xs-11 col-xs-push-1">&nbsp; &nbsp;<%= 3*v1 + v2 + v3 + v4 + v5 %> <%= :users_by_contribution_2f.t %></div>
+          </div><!--.row-->
+          <%= :users_by_contribution_3.tp %>
+
+        </div>
+      </div>
+    </div>
+  </div><!--.row-->
+<% end %>


### PR DESCRIPTION
This page loads very slowly because the results are vast, and not paginated.
Here, it's paginated. 

Adds a new query flavor for `User` `by_contribution` so we can call `show_index_of_objects` to get this query order.