### PR TITLE
Restore IF site search link

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -94,7 +94,7 @@ module ObjectLinkHelper
   end
 
   # IF lacks an entry point that includes the name to be searched.
-  def index_fungorum_basic_search_url
+  def index_fungorum_search_page_url
     "http://www.indexfungorum.org/Names/Names.asp"
   end
 

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -93,6 +93,11 @@ module ObjectLinkHelper
     "http://www.indexfungorum.org/Names/NamesRecord.asp?RecordID=#{record_id}"
   end
 
+  # IF lacks an entry point that includes the name to be searched.
+  def index_fungorum_basic_search_url
+    "http://www.indexfungorum.org/Names/Names.asp"
+  end
+
   # Use web search because IF internal search uses js form rather than a url
   def index_fungorum_name_web_search_url(name)
     # Use DuckDuckGo because the equivalent Google search results stink,

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -66,6 +66,11 @@ module Tabs
 
     # Show name panels:
     # Nomenclature tabs
+    def index_fungorum_basic_search_tab
+      [:index_fungorum_search.l, index_fungorum_basic_search_url,
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def index_fungorum_record_tab(name)
       ["[##{name.icn_id}]", index_fungorum_record_url(name.icn_id),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -66,8 +66,8 @@ module Tabs
 
     # Show name panels:
     # Nomenclature tabs
-    def index_fungorum_basic_search_tab
-      [:index_fungorum_search.l, index_fungorum_basic_search_url,
+    def index_fungorum_search_page_tab
+      [:index_fungorum_search.l, index_fungorum_search_page_url,
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 

--- a/app/views/controllers/names/show/_nomenclature.html.erb
+++ b/app/views/controllers/names/show/_nomenclature.html.erb
@@ -64,11 +64,13 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
             ["#{:ICN_ID.l}:",
              tag.em(:show_name_icn_id_missing.l)].safe_join(" ")
           end,
+          tag.p(link_to(*index_fungorum_basic_search_tab)),
           tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_name_search_tab(name)))
         ].safe_join
       elsif name.searchable_in_registry?
         [
+          tag.p(link_to(*index_fungorum_basic_search_tab)),
           tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_basic_search_tab))
         ].safe_join

--- a/app/views/controllers/names/show/_nomenclature.html.erb
+++ b/app/views/controllers/names/show/_nomenclature.html.erb
@@ -64,13 +64,13 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
             ["#{:ICN_ID.l}:",
              tag.em(:show_name_icn_id_missing.l)].safe_join(" ")
           end,
-          tag.p(link_to(*index_fungorum_basic_search_tab)),
+          tag.p(link_to(*index_fungorum_search_page_tab)),
           tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_name_search_tab(name)))
         ].safe_join
       elsif name.searchable_in_registry?
         [
-          tag.p(link_to(*index_fungorum_basic_search_tab)),
+          tag.p(link_to(*index_fungorum_search_page_tab)),
           tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_basic_search_tab))
         ].safe_join

--- a/app/views/controllers/names/show/_nomenclature.html.erb
+++ b/app/views/controllers/names/show/_nomenclature.html.erb
@@ -35,6 +35,8 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
           concat(
             [tag.span(class: "text-nowrap ml-3") { synonyms }].safe_join
           ) if synonyms
+          concat(tag.p(["#{:AUTHORITY.l}: ", name.author.to_s.t].safe_join))
+          concat(tag.p(["#{:CITATION.l}: ", name.citation.to_s.tl].safe_join))
         end
       ].safe_join
     end)
@@ -78,9 +80,6 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
     end)
 
   end)
-
-  concat(tag.p(["#{:AUTHORITY.l}: ", name.author.to_s.t].safe_join))
-  concat(tag.p(["#{:CITATION.l}: ", name.citation.to_s.tl].safe_join))
 
   if name.is_misspelling?
     concat(tag.p do

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2131,6 +2131,7 @@
   show_name_icn_id_missing: missing
   google_name_search: Google Search
   index_fungorum: Index Fungorum
+  index_fungorum_search: Index Fungorum search page
   index_fungorum_web_search: Index Fungorum web search
   mycobank: MycoBank
   mycobank_search: MycoBank search

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -650,14 +650,14 @@ class NamesControllerTest < FunctionalTestCase
     )
     assert_select(
       "#nomenclature a:match('href',?)",
-      /#{index_fungorum_basic_search_url}/,
+      /#{index_fungorum_search_page_url}/,
       { count: 1 },
       "Nomenclature section is missing a link to IF search page"
     )
     assert_select(
       "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']",
       true,
-      "Nomenclature section is missing a link to Index Fungorum search"
+      "Nomenclature section is missing a link to Index Fungorum web search"
     )
     assert_select(
       "#nomenclature a:match('href',?)", /#{mycobank_name_search_url(name)}/,
@@ -687,14 +687,14 @@ class NamesControllerTest < FunctionalTestCase
     # but it makes sense to link to search pages in fungal registries
     assert_select(
       "#nomenclature a:match('href',?)",
-      /#{index_fungorum_basic_search_url}/,
+      /#{index_fungorum_search_page_url}/,
       { count: 1 },
-      "Nomenclature section should have link to IF search"
+      "Nomenclature section should have link to IF search page"
     )
     assert_select(
       "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']",
       true,
-      "Nomenclature section is missing a link to Index Fungorum search"
+      "Nomenclature section is missing a link to Index Fungorum web search"
     )
     assert_select(
       "#nomenclature a:match('href',?)", /#{mycobank_basic_search_url}/,

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -649,6 +649,12 @@ class NamesControllerTest < FunctionalTestCase
       "'#{:show_name_icn_id_missing.l}' note"
     )
     assert_select(
+      "#nomenclature a:match('href',?)",
+      /#{index_fungorum_basic_search_url}/,
+      { count: 1 },
+      "Nomenclature section is missing a link to IF search page"
+    )
+    assert_select(
       "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']",
       true,
       "Nomenclature section is missing a link to Index Fungorum search"
@@ -679,6 +685,12 @@ class NamesControllerTest < FunctionalTestCase
     )
 
     # but it makes sense to link to search pages in fungal registries
+    assert_select(
+      "#nomenclature a:match('href',?)",
+      /#{index_fungorum_basic_search_url}/,
+      { count: 1 },
+      "Nomenclature section should have link to IF search"
+    )
     assert_select(
       "#nomenclature a[href='#{index_fungorum_name_web_search_url(name)}']",
       true,


### PR DESCRIPTION
Restores the link to the Index Fungorum search page (for Names which lack ICN ID's).
 
The reason for restoring the link is that a web search often has no hits for Names that are in IF. Evidentally, not all IF pages are indexed by the major (or maybe any) search engines.

Delivers #1924, #1959.