### PR TITLE
Project.location nil Error

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -7,10 +7,9 @@ module ProjectsHelper
       nil, # column for checkbox
       "#{:CONSTRAINTS.l}:",
       "#{:DATES.l}: #{project.date_range}",
-      "Lat: #{project.location.north} to #{project.location.south}",
-      "Lon: #{project.location.west} to #{project.location.east} ",
-      location_link(project.location.display_name, project.location,
-                    nil, false),
+      violation_latitude_header(project),
+      violation_longitude_header(project),
+      violation_location_header(project),
       nil # column for observation.user
     ]
   end
@@ -44,6 +43,25 @@ module ProjectsHelper
   #########
 
   private
+
+  def violation_latitude_header(project)
+    return :form_violations_latitude_none.l unless project.location
+
+    "Lat: #{project.location.north} to #{project.location.south}"
+  end
+
+  def violation_longitude_header(project)
+    return :form_violations_longitude_none.l unless project.location
+
+    "Lon: #{project.location.west} to #{project.location.east}"
+  end
+
+  def violation_location_header(project)
+    return :form_violations_location_none.t unless project.location
+
+    location_link(project.location.display_name, project.location,
+                  nil, false)
+  end
 
   def violation_checkbox(form:, project:, obs:)
     if violation_checkbox_viewers(project, obs).include?(User.current.id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -433,6 +433,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Obs lat/lon is outside Project.location exor
   # Obs location is not a subset of Project.location
   def out_of_area_observations
+    return [] if location.nil?
+
     obs_geoloc_outside_project_location.to_a.union(
       obs_without_geoloc_location_not_contained_in_location
     )

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3249,9 +3249,12 @@
   show_project_user_group: User Group
   show_project_violation_count: Project has [count] constraint violation(s)
 
-  # project/violations/edit
+  # project/violations/index
   form_violations_help: Check the Observations to be removed, then Submit
   violations_index_title: "[:CONSTRAINT_VIOLATIONS]"
+  form_violations_latitude_none: "Lat: Any"
+  form_violations_location_none: "[:LOCATION]: Any"
+  form_violations_longitude_none: "Lon: Any"
   form_violations_remove_selected: Remove Selected
   form_violations_show_project: Show Project
 

--- a/test/controllers/projects/violations_controller_test.rb
+++ b/test/controllers/projects/violations_controller_test.rb
@@ -134,6 +134,28 @@ module Projects
       )
     end
 
+    def test_index_project_without_location
+      project = projects(:unlimited_project)
+      assert_nil(project.location, "Test need Project lacking a Location")
+      user = project.user
+
+      login(user.login)
+      get(:index, params: { project_id: project.id })
+
+      assert_select(
+        "#project_violations_form",
+        { text: /#{:form_violations_latitude_none.l}/ }
+      )
+      assert_select(
+        "#project_violations_form",
+        { text: /#{:form_violations_longitude_none.l}/ }
+      )
+      assert_select(
+        "#project_violations_form",
+        { text: /#{:form_violations_location_none.l}/ }
+      )
+    end
+
     def test_update
       project = projects(:falmouth_2023_09_project)
       violations = project.violations

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -202,6 +202,7 @@ unlimited_project:
   <<: *DEFAULTS
   start_date: nil
   end_date: nil
+  location: nil
   observations: peltigera_obs, agaricus_campestris_obs, boletus_edulis_obs
 
 pinned_date_range_project:
@@ -222,7 +223,6 @@ rolf_project:
   user_group: katrina_only
 
 # includes observations that violate date and or location constraints
-
 # members: roy
 falmouth_2023_09_project:
   <<: *DEFAULTS

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -160,6 +160,13 @@ class ProjectTest < UnitTestCase
     assert_equal(expect, project.in_range_observations.count)
   end
 
+  def test_out_of_area_observations
+    project = projects(:falmouth_2023_09_project)
+    assert_equal(2, project.out_of_area_observations.size)
+
+    assert_empty(projects(:unlimited_project).out_of_area_observations)
+  end
+
   def test_place_name
     proj = projects(:eol_project)
     loc = locations(:albion)


### PR DESCRIPTION
Fixes Errors thrown by ProjectsViolations#index for Projects with a nil Location.

Delivers #2033 