### PR TITLE
Fix collection number link

### DIFF
--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -55,9 +55,10 @@ module Tabs
 
     def show_collection_number_tab(c_n, obs)
       cn_query = Query.lookup(:CollectionNumber, :all, observations: obs.id)
+      q_id = cn_query.id ? cn_query.id.alphabetize : nil
 
       [tag.i(c_n.format_name.t),
-       collection_number_path(id: c_n.id, q: cn_query),
+       collection_number_path(id: c_n.id, q: q_id),
        { class: "#{tab_id(__method__.to_s)}_#{c_n.id}" }]
     end
 

--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -55,12 +55,12 @@ module Tabs
 
     def show_collection_number_tab(c_n, obs)
       cn_query = Query.lookup(:CollectionNumber, :all, observations: obs.id)
-      q_id = cn_query.id ? cn_query.id.alphabetize : nil
+      q_id = cn_query.id&.alphabetize
 
       [tag.i(c_n.format_name.t),
        collection_number_path(id: c_n.id, q: q_id),
        { class: "#{tab_id(__method__.to_s)}_#{c_n.id}",
-         data: { turbo_frame: "_top" }}]
+         data: { turbo_frame: "_top" } }]
     end
 
     def collection_number_mod_tabs(c_n)

--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -59,7 +59,8 @@ module Tabs
 
       [tag.i(c_n.format_name.t),
        collection_number_path(id: c_n.id, q: q_id),
-       { class: "#{tab_id(__method__.to_s)}_#{c_n.id}" }]
+       { class: "#{tab_id(__method__.to_s)}_#{c_n.id}",
+         data: { turbo_frame: "_top" }}]
     end
 
     def collection_number_mod_tabs(c_n)


### PR DESCRIPTION
To reproduce:
Go to an observation page with a collection number (e.g., https://mushroomobserver.org/observations/489292)
Note that if you hover over the collection number link the URL is really weird (e.g., https://mushroomobserver.org/collection_numbers/9848?q=%23%3CQuery%3A%3ACollectionNumberAll%3A0x00007f4ee4c74748%3E)
This PR fixed that by alphabetizing the id of the query rather than encoding the query as above.
However, even after that fix, if you click on the link it does not in fact go where it claims it will, but instead the name of the collection number is replaced by "Content missing".
Weirder still "Content missing" is not in our code base.