### PR TITLE
Show obs - convert `turbo-frame` tags to `div`

### DIFF
--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -59,8 +59,7 @@ module Tabs
 
       [tag.i(c_n.format_name.t),
        collection_number_path(id: c_n.id, q: q_id),
-       { class: "#{tab_id(__method__.to_s)}_#{c_n.id}",
-         data: { turbo_frame: "_top" } }]
+       { class: "#{tab_id(__method__.to_s)}_#{c_n.id}" }]
     end
 
     def collection_number_mod_tabs(c_n)

--- a/app/helpers/tabs/collection_numbers_helper.rb
+++ b/app/helpers/tabs/collection_numbers_helper.rb
@@ -54,11 +54,11 @@ module Tabs
     end
 
     def show_collection_number_tab(c_n, obs)
+      # This is passed in to show_collection_number, allowing users to do prev,
+      # next and index from there to navigate through all the rest for this obs.
       cn_query = Query.lookup(:CollectionNumber, :all, observations: obs.id)
-      q_id = cn_query.id&.alphabetize
 
-      [tag.i(c_n.format_name.t),
-       collection_number_path(id: c_n.id, q: q_id),
+      [tag.i(c_n.format_name.t), add_query_param(c_n.show_link_args, cn_query),
        { class: "#{tab_id(__method__.to_s)}_#{c_n.id}" }]
     end
 

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -10,7 +10,7 @@ module Tabs
       if obs.present?
         links = [
           object_return_tab(obs),
-          new_herbarium_record_tab
+          new_herbarium_record_tab(obs)
         ]
       end
       links << new_herbarium_tab
@@ -67,15 +67,19 @@ module Tabs
       links << nonpersonal_herbaria_index_tab
     end
 
-    def show_herbarium_record_tab(h_r)
+    def show_herbarium_record_tab(h_r, obs)
+      # This is passed in to show_herbarium_record, allowing users to do prev,
+      # next and index from there to navigate through all the rest for this obs.
+      hr_query = Query.lookup(:HerbariumRecord, :all, observations: obs.id)
+
       [h_r.accession_at_herbarium.t,
-       herbarium_record_path(id: h_r.id, q: get_query_param),
+       add_query_param(h_r.show_link_args, hr_query),
        { class: "#{tab_id(__method__.to_s)}_#{h_r.id}" }]
     end
 
-    def new_herbarium_record_tab
+    def new_herbarium_record_tab(obs)
       [:create_herbarium_record.l,
-       new_herbarium_record_path(observation_id: params[:id]),
+       add_query_param(new_herbarium_record_path(observation_id: obs.id)),
        { class: tab_id(__method__.to_s), icon: :add }]
     end
 

--- a/app/helpers/tabs/sequences_helper.rb
+++ b/app/helpers/tabs/sequences_helper.rb
@@ -25,6 +25,31 @@ module Tabs
       [object_return_tab(obj)]
     end
 
+    def show_sequence_tab(seq, obs)
+      # This is passed in to show_sequence, allowing users to do prev,
+      # next and index from there to navigate through all the rest for this obs.
+      sq_query = Query.lookup(:Sequence, :all, observations: obs.id)
+      locus = seq.locus.truncate(seq.locus_width)
+      txt = if seq.deposit?
+              "#{locus} - #{seq.archive} ##{seq.accession}"
+            else
+              "#{locus} - MO ##{seq.id}"
+            end
+
+      [txt.t, add_query_param(seq.show_link_args, sq_query),
+       { class: "#{tab_id(__method__.to_s)}_#{seq.id}" }]
+    end
+
+    def sequence_archive_tab(seq)
+      [:show_observation_archive_link.t, seq.accession_url,
+       { class: "#{tab_id(__method__.to_s)}_#{seq.id}", target: "_blank" }]
+    end
+
+    def sequence_blast_tab(seq)
+      [:show_observation_blast_link.t, seq.blast_url,
+       { class: "#{tab_id(__method__.to_s)}_#{seq.id}", target: "_blank" }]
+    end
+
     def sequence_mod_tabs(seq)
       [edit_sequence_and_back_tab(seq),
        destroy_sequence_tab(seq)]

--- a/app/views/controllers/observations/show/_collection_numbers.erb
+++ b/app/views/controllers/observations/show/_collection_numbers.erb
@@ -10,7 +10,7 @@ obs_id = obs.id
 <%=
 unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
 
-  tag.turbo_frame(
+  tag.div(
     id: "observation_collection_numbers",
     class: "obs-collection",
     data: { controller: "section-update",

--- a/app/views/controllers/observations/show/_collection_numbers.erb
+++ b/app/views/controllers/observations/show/_collection_numbers.erb
@@ -1,10 +1,6 @@
 <%
 numbers  = obs.collection_numbers
 can_edit = in_admin_mode? || obs.can_edit?
-obs_id = obs.id
-# This is passed in to show_collection_number, allowing users to do prev,
-# next and index from there to navigate through all the rest for this obs.
-# cn_query = Query.lookup(:CollectionNumber, :all, observations: obs.id)
 %>
 
 <%=

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -11,7 +11,7 @@ query = Query.lookup(:HerbariumRecord, :all, observations: obs.id)
 <%=
 unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
 
-  tag.turbo_frame(
+  tag.div(
     id: "observation_herbarium_records",
     class: "obs-herbarium",
     data: { controller: "section-update",

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -2,10 +2,6 @@
 records = obs.herbarium_records
 can_add = in_admin_mode? || obs.can_edit? ||
           @user && @user.curated_herbaria.any?
-obs_id = obs.id
-# This is passed in to show_herbarium_record, allowing users to do prev,
-# next and index from there to navigate through all the rest for this obs.
-query = Query.lookup(:HerbariumRecord, :all, observations: obs.id)
 %>
 
 <%=
@@ -25,7 +21,8 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
             "#{:Herbarium_records.t}:",
             [ # any html helper has to be safe_joined separately
               "[",
-              modal_link_to("herbarium_record", *new_herbarium_record_tab),
+              modal_link_to("herbarium_record",
+                            *new_herbarium_record_tab(obs)),
               "]"
             ].safe_join
           ].safe_join(" ")
@@ -33,7 +30,7 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
         tag.ul(class: "tight-list") do
           records.map do |record|
             tag.li(id: "herbarium_record_#{record.id}") do
-              concat(link_to(*show_herbarium_record_tab(record)))
+              concat(link_to(*show_herbarium_record_tab(record, obs)))
               if record.can_edit? || in_admin_mode?
                 concat(
                   [
@@ -60,7 +57,7 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
         end,
         tag.ul(class: "tight-list") do
           records.map do |record|
-            tag.li { link_to(*show_herbarium_record_tab(record)) }
+            tag.li { link_to(*show_herbarium_record_tab(record, obs)) }
           end.safe_join
         end
       ].safe_join(" ")
@@ -69,7 +66,8 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
       [
         :show_observation_no_herbarium_records.t,
         " [",
-        modal_link_to("herbarium_record", *new_herbarium_record_tab),
+        modal_link_to("herbarium_record",
+                      *new_herbarium_record_tab(obs)),
         "]"
       ].safe_join
     end

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -1,10 +1,6 @@
 <%
 sequences = obs.sequences
 can_edit  = in_admin_mode? || obs.can_edit?
-
-# This is passed in to show_sequence, allowing users to do prev,
-# next and index from there to navigate through all the rest for this obs.
-query = Query.lookup(:Sequence, :all, observations: obs.id)
 %>
 
 <% unless @user.try(&:hide_specimen_stuff?) ||
@@ -28,25 +24,11 @@ query = Query.lookup(:Sequence, :all, observations: obs.id)
     concat(tag.ul(class:"tight-list") do
       sequences.each do |sequence|
         concat(tag.li(id: "sequence_#{sequence.id}") do
-          locus = sequence.locus.truncate(sequence.locus_width)
-          if sequence.deposit?
-            concat(link_to(
-              "#{locus} - #{sequence.archive} ##{sequence.accession}".t,
-              add_query_param(sequence.show_link_args, query),
-              class: "show_sequence_link_#{sequence.id}"
-            ))
-          else
-            concat(link_to(
-              "#{locus} - MO ##{sequence.id}".t,
-              add_query_param(sequence.show_link_args, query),
-              class: "show_sequence_link_#{sequence.id}"
-            ))
-          end
+          concat(link_to(*show_sequence_tab(sequence, obs)))
 
           links = []
           if sequence.deposit?
-            links << link_to(:show_observation_archive_link.t,
-                             sequence.accession_url, target: "_blank")
+            links << link_to(*sequence_archive_tab(sequence))
           end
           if in_admin_mode? || sequence.can_edit?(@user)
             links << modal_link_to(
@@ -61,8 +43,7 @@ query = Query.lookup(:Sequence, :all, observations: obs.id)
             )
           end
           if sequence.blastable?
-            links << link_to(:show_observation_blast_link.t,
-                            sequence.blast_url, target: "_blank")
+            links << link_to(*sequence_blast_tab(sequence))
           end
           concat(" [#{links.safe_join(' | ')}]".html_safe) if links.any?
         end)


### PR DESCRIPTION
Lower-maintenance solution for turbo updates on the show obs page:

We don't have to use `<turbo-frame>` tags for "surgical" updates to the DOM. `<div>` with an `id` is enough.

Switching to `<div>`s also means we don't need any special data attributes on nested `<a>` links. That's because links within a `turbo-frame` expect a response that replaces the `turbo-frame` they are nested within, and not a new page. (#2036) It seems like a gotcha that will confuse future developers. 

Note: there's a separate existing issue here, and I don't know how or if it's related: #2039
Update: it wasn't related, but this PR fixes the issue. The obs id wasn't getting passed to the re-rendered `new` HR/CN links, so the links didn't work.