### PR TITLE
POST logout

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -116,5 +116,12 @@ a.filter-only {
 .name-radio {
   label {
     font-weight: normal;
-  } 
+  }
+}
+
+.btn-glyphicon-only {
+  background: none;
+  border: none;
+  padding: none;
+  top: 5px;
 }

--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -118,10 +118,3 @@ a.filter-only {
     font-weight: normal;
   }
 }
-
-.btn-glyphicon-only {
-  background: none;
-  border: none;
-  padding: none;
-  top: 5px;
-}

--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -39,6 +39,10 @@
     }
   }
 
+  .li_button {
+    margin-left: 16px;
+  }
+
   // The button_to form, not the button, needs to display: block
   #right_tabs {
     .button_to {

--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -39,8 +39,8 @@
     }
   }
 
-  .li_button {
-    margin-left: 16px;
+  .dropdown-menu li button.btn-link {
+    padding: 3px 20px;
   }
 
   // The button_to form, not the button, needs to display: block

--- a/app/views/controllers/account/welcome.html.erb
+++ b/app/views/controllers/account/welcome.html.erb
@@ -6,7 +6,7 @@ add_page_title(account_welcome_title(@user))
   <%= :welcome_note.tp %>
   <%= button_to(:app_logout.t,
                 account_logout_path,
-                { class: "btn", id: "nav_user_logout_link" }) %>
+                { class: "btn btn-default", id: "nav_user_logout_link" }) %>
 <% else %>
   <%= :welcome_no_user_note.tp %>
 <% end %>

--- a/app/views/controllers/account/welcome.html.erb
+++ b/app/views/controllers/account/welcome.html.erb
@@ -4,7 +4,9 @@ add_page_title(account_welcome_title(@user))
 
 <% if @user %>
   <%= :welcome_note.tp %>
-  <%= link_to(:welcome_logout_link.t, account_logout_path) %>
+  <%= button_to(:app_logout.t,
+                account_logout_path,
+                { class: "btn", id: "nav_user_logout_link" }) %>
 <% else %>
   <%= :welcome_no_user_note.tp %>
 <% end %>

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -2,18 +2,13 @@
   [
     tag.i("", class: "glyphicon glyphicon-user"),
     tag.span(h(@user.login), class: "ml-2"),
-    tag.span(class: "pull-right") do
-      link_to(:app_logout.t, account_logout_path, id: "nav_user_logout_link")
+    tag.span(class: "pull-left") do
+      button_to(:app_logout.t,
+                account_logout_path,
+                { class: "btn", id: "nav_user_logout_link" })
     end
   ].safe_join
 end %>
-<%# active_link_to(:app_your_observations.t,
-                   observations_path(user: @user.id),
-                   class: classes[:indent],
-                   id: "nav_your_observations_link") %>
-<%# active_link_to(:app_your_lists.t, species_lists_path(by_user: @user.id),
-                   class: classes[:indent],
-                   id: "nav_your_species_lists_link") %>
 <%= active_link_to(:app_comments_for_you.t,
                    comments_path(for_user: @user.id),
                    class: class_names(classes[:indent], classes[:mobile_only]),

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -1,14 +1,14 @@
 <%= tag.div("", class: class_names(classes[:item], classes[:mobile_only])) do
   [
     tag.i("", class: "glyphicon glyphicon-user"),
-    tag.span(h(@user.login), class: "ml-2"),
-    tag.span(class: "pull-left") do
-      button_to(:app_logout.t,
-                account_logout_path,
-                { class: "btn", id: "nav_user_logout_link" })
-    end
+    tag.span(h(@user.login), class: "ml-2")
   ].safe_join
 end %>
+<%= button_to(:app_logout.t,
+              account_logout_path,
+              { class: class_names("btn", "btn-link", classes[:indent],
+                                   classes[:mobile_only]),
+                id: "nav_user_logout_link" }) %>
 <%= active_link_to(:app_comments_for_you.t,
                    comments_path(for_user: @user.id),
                    class: class_names(classes[:indent], classes[:mobile_only]),

--- a/app/views/controllers/application/top_nav/_user_nav.html.erb
+++ b/app/views/controllers/application/top_nav/_user_nav.html.erb
@@ -70,7 +70,7 @@
       <li><%= button_to(
                 :app_logout.t,
                 account_logout_path,
-                { class: "btn li_button", id: "user_drop_logout_link" }
+                { class: "btn btn-link li_button", id: "user_drop_logout_link" }
               ) %><li>
     </ul>
   </li>

--- a/app/views/controllers/application/top_nav/_user_nav.html.erb
+++ b/app/views/controllers/application/top_nav/_user_nav.html.erb
@@ -67,16 +67,18 @@
                       edit_account_preferences_path,
                       { class: "", id: "user_drop_preferences_link" }) %></li>
       <li class="divider"></li>
-      <li><%= link_to(:app_logout.t,
-                      account_logout_path,
-                      { class: "", id: "user_drop_logout_link" }) %></li>
+      <li><%= button_to(
+                :app_logout.t,
+                account_logout_path,
+                { class: "btn li_button", id: "user_drop_logout_link" }
+              ) %><li>
     </ul>
   </li>
-  <li><%= link_to("",
-                  account_logout_path,
-                  { class: "glyphicon glyphicon-log-out",
-                    id: "user_nav_logout_link",
-                    title: :app_logout.t,
-                    data: { toggle: "tooltip", placement: "bottom" } }) %>
-  </li>
+  <li><%= button_to(
+            "",
+            account_logout_path,
+            { class: "btn btn-glyphicon-only glyphicon glyphicon-log-out",
+              id: "user_nav_logout_link",
+              title: :app_logout.t }
+          ) %></li>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,8 +277,9 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
     get("signup", to: "/account#new") # alternate path
 
     resource :login, only: [:new, :create], controller: "login"
-    unresourced_login_gets = %w[email_new_password logout test_autologin].freeze
+    unresourced_login_gets = %w[email_new_password test_autologin].freeze
     unresourced_login_gets.each { |action| get(action, controller: "login") }
+    post("logout", controller: "login")
     post("new_password_request", controller: "login")
 
     resource :preferences, only: [:edit, :update]

--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -51,10 +51,11 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
 
     # This should only be accessible if logged in.
     first(:link, text: "Preferences").click
+
     assert_selector("body.preferences__edit")
 
     # Log out and try again.
-    first(:link, text: "Logout").click
+    first(:button, text: "Logout").click
     assert_selector("body.login__logout")
     assert_no_link(text: "Preferences")
     visit("/account/preferences/edit")
@@ -113,7 +114,7 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
     visit("/")
     assert_selector("#user_drop_down")
     links = find_all("#user_drop_down a")
-    assert_equal(8, links.length)
+    assert_equal(7, links.length)
   end
 
   # ----------------------------
@@ -223,9 +224,9 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("body.verifications__new")
 
     # They should be logged in now.
-    assert_link(:app_logout.t)
+    assert_button(:app_logout.t)
     # Log out. (must use id, there are multiple links)
-    click_link(id: "nav_user_logout_link")
+    click_button(id: "nav_user_logout_link")
     assert_no_link(:app_logout.t)
 
     # Try to use that verification code again. No can do

--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -55,7 +55,7 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("body.preferences__edit")
 
     # Log out and try again.
-    first(:button, text: "Logout").click
+    first(:button, text: :app_logout.l).click
     assert_selector("body.login__logout")
     assert_no_link(text: "Preferences")
     visit("/account/preferences/edit")
@@ -239,8 +239,10 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
       fill_in("user_password", with: "Hagrid_24!")
       click_commit
     end
-    # They should still be able to log in ok.
-    assert_link(:app_logout.t)
+
+    # They should still be able to login (with a button, not a link)
+    assert_button(:app_logout.l)
+    assert_no_link(:app_logout.l)
   end
 
   def test_correct_invalid_preferences

--- a/test/integration/capybara/images_integration_test.rb
+++ b/test/integration/capybara/images_integration_test.rb
@@ -29,9 +29,7 @@ class ImagesIntegrationTest < CapybaraIntegrationTestCase
     visit(edit_image_path(img.id)) # nope
     assert_selector("body.images__show")
 
-    # logout
-    # click_button("Logout")
-    click_button(class: "glyphicon-log-out")
+    first(:button, text: :app_logout.l).click
     login!("mary")
     visit(image_path(img.id))
     assert_selector("a[href*='#{edit_image_path(img.id)}']", minimum: 1)
@@ -39,7 +37,7 @@ class ImagesIntegrationTest < CapybaraIntegrationTestCase
     visit(edit_image_path(img.id))
     assert_selector("body.images__edit")
 
-    click_button(class: "glyphicon-log-out")
+    first(:button, text: :app_logout.l).click
     login!("dick")
     visit(image_path(img.id))
     assert_selector("a[href*='#{edit_image_path(img.id)}']", minimum: 1)

--- a/test/integration/capybara/images_integration_test.rb
+++ b/test/integration/capybara/images_integration_test.rb
@@ -29,7 +29,9 @@ class ImagesIntegrationTest < CapybaraIntegrationTestCase
     visit(edit_image_path(img.id)) # nope
     assert_selector("body.images__show")
 
-    logout
+    # logout
+    # click_button("Logout")
+    click_button(class: "glyphicon-log-out")
     login!("mary")
     visit(image_path(img.id))
     assert_selector("a[href*='#{edit_image_path(img.id)}']", minimum: 1)
@@ -37,7 +39,7 @@ class ImagesIntegrationTest < CapybaraIntegrationTestCase
     visit(edit_image_path(img.id))
     assert_selector("body.images__edit")
 
-    logout
+    click_button(class: "glyphicon-log-out")
     login!("dick")
     visit(image_path(img.id))
     assert_selector("a[href*='#{edit_image_path(img.id)}']", minimum: 1)

--- a/test/integration/capybara/random_integration_test.rb
+++ b/test/integration/capybara/random_integration_test.rb
@@ -19,19 +19,22 @@ class RandomIntegrationTest < CapybaraIntegrationTestCase
     visit("/info/how_to_help")
     assert_selector("body.info__how_to_help")
     assert_no_link(href: "/account/login/new")
-    assert_link(href: "/account/logout")
+    assert_button(:app_logout.l)
+    assert_no_link(:app_logout.l)
     assert_link(href: "/users/#{rolf.id}")
 
-    first(:link, text: "Logout").click
+    first(:button, text: :app_logout.l).click
     assert_selector("body.login__logout")
     assert_link(href: "/account/login/new")
-    assert_no_link(href: "/account/logout")
+    assert_no_button(:app_logout.l)
+    assert_no_link(:app_logout.l)
     assert_no_link(href: "/users/#{rolf.id}")
 
     click_link(text: "Introduction")
     assert_selector("body.info__intro")
     assert_link(href: "/account/login/new")
-    assert_no_link(href: "/account/logout")
+    assert_no_button(:app_logout.l)
+    assert_no_link(:app_logout.l)
     assert_no_link(href: "/users/#{rolf.id}")
   end
 


### PR DESCRIPTION
- Uses POST (instead of GET) for `logout` action. 
This prevents eager loading and may solve the issue of some users being spontaneously logged out.
It requires rendering `Logout` as a button (rather than a link).

See #2042

#### TODO
- [x] Fix tests to use logout title, or preferably href, instead of funky class.
- [x] Review stylesheets

### Suggest Manual Test
- On a large screen, hover over the Logout icon for a while to see if it causes eager loading or a spontaneous logout. Then click the link to ensure that it does log you out.
- Do the equivalent on a small screen.