### PR TITLE
Refresh user stats dry run

### DIFF
--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -183,7 +183,7 @@ class UserStats < ApplicationRecord
     # until all records have a value for each column except id and user_id.
     # At the end, we find the existing user_stats record id by user_id, and
     # add in the id and user_id, and update all records at once.
-    def refresh_all_user_stats(dry_run: true)
+    def refresh_all_user_stats(dry_run: false)
       return if dry_run
 
       create_user_stats_for_all_users_without

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -184,8 +184,6 @@ class UserStats < ApplicationRecord
     # At the end, we find the existing user_stats record id by user_id, and
     # add in the id and user_id, and update all records at once.
     def refresh_all_user_stats(dry_run: false)
-      return if dry_run
-
       create_user_stats_for_all_users_without
       # `entries` are { user_id: hash_of_attributes }
       # This method fills out the columns for each user_id where not zero.
@@ -224,7 +222,11 @@ class UserStats < ApplicationRecord
 
       # At this point all these hashes have a user_stats.id and a user_id.
       # It's safe to assume they correspond to existing user_stats records.
-      UserStats.upsert_all(entries.values)
+      UserStats.upsert_all(entries.values) unless dry_run
+
+      msgs = ["UserStats updated for #{entries.size} users."]
+      msgs << "Dry run: no changes made." if dry_run
+      msgs.join(" ")
     end
 
     private

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -183,7 +183,7 @@ class UserStats < ApplicationRecord
     # until all records have a value for each column except id and user_id.
     # At the end, we find the existing user_stats record id by user_id, and
     # add in the id and user_id, and update all records at once.
-    def refresh_all_user_stats(dry_run: false)
+    def refresh_all_user_stats(dry_run: true)
       return if dry_run
 
       create_user_stats_for_all_users_without

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -183,7 +183,9 @@ class UserStats < ApplicationRecord
     # until all records have a value for each column except id and user_id.
     # At the end, we find the existing user_stats record id by user_id, and
     # add in the id and user_id, and update all records at once.
-    def refresh_all_user_stats
+    def refresh_all_user_stats(dry_run: false)
+      return if dry_run
+
       create_user_stats_for_all_users_without
       # `entries` are { user_id: hash_of_attributes }
       # This method fills out the columns for each user_id where not zero.

--- a/test/models/user_stats_test.rb
+++ b/test/models/user_stats_test.rb
@@ -94,9 +94,6 @@ class UserStatsTest < UnitTestCase
     assert_equal(0, old_rolf_stats.species_lists)
     assert_equal(0, old_rolf_stats.votes)
 
-    # UserStats.refresh_all_user_stats
-    # rolf_stats = UserStats.find_by(user_id: rolf.id)
-
     UserStats.refresh_all_user_stats(dry_run: true)
     new_rolf_stats = UserStats.find_by(user_id: rolf.id)
 

--- a/test/models/user_stats_test.rb
+++ b/test/models/user_stats_test.rb
@@ -80,6 +80,39 @@ class UserStatsTest < UnitTestCase
     assert_equal(mary.votes.size, mary_stats.votes)
   end
 
+  def test_refresh_all_user_stats_dry_run
+    old_rolf_stats = user_stats(:rolf)
+    assert_equal(0, old_rolf_stats.comments)
+    assert_equal(0, old_rolf_stats.images)
+    assert_equal(0, old_rolf_stats.locations)
+    assert_equal(0, old_rolf_stats.names)
+    assert_equal(0, old_rolf_stats.name_description_authors)
+    assert_equal(0, old_rolf_stats.name_description_editors)
+    assert_equal(0, old_rolf_stats.name_versions)
+    assert_equal(0, old_rolf_stats.namings)
+    assert_equal(0, old_rolf_stats.observations)
+    assert_equal(0, old_rolf_stats.species_lists)
+    assert_equal(0, old_rolf_stats.votes)
+
+    # UserStats.refresh_all_user_stats
+    # rolf_stats = UserStats.find_by(user_id: rolf.id)
+
+    UserStats.refresh_all_user_stats(dry_run: true)
+    new_rolf_stats = UserStats.find_by(user_id: rolf.id)
+
+    assert_equal(0, new_rolf_stats.comments)
+    assert_equal(0, new_rolf_stats.images)
+    assert_equal(0, new_rolf_stats.locations)
+    assert_equal(0, new_rolf_stats.names)
+    assert_equal(0, new_rolf_stats.name_description_authors)
+    assert_equal(0, new_rolf_stats.name_description_editors)
+    assert_equal(0, new_rolf_stats.name_versions)
+    assert_equal(0, new_rolf_stats.namings)
+    assert_equal(0, new_rolf_stats.observations)
+    assert_equal(0, new_rolf_stats.species_lists)
+    assert_equal(0, new_rolf_stats.votes)
+  end
+
   # def test_two_tiered_observation_scoring
   #   score = rolf.contribution
   #


### PR DESCRIPTION
- Applies @pellaea's fix for #2046 by adding a `dry_run` keyword parameter to UserStats#refresh_all_user_stats. (It defaults to `false`).
