### PR TITLE
Change "admin_mode_path" from a GET to a POST

### DIFF
--- a/app/controllers/admin/session_controller.rb
+++ b/app/controllers/admin/session_controller.rb
@@ -15,7 +15,7 @@ module Admin
     before_action :login_required
 
     # The route to turn admin mode on or off. Takes params.
-    def show
+    def create
       if params[:turn_on]
         session[:admin] = true if @user&.admin && !in_admin_mode?
       elsif params[:turn_off]

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -27,8 +27,7 @@ end %>
             class: class_names(classes[:indent], classes[:mobile_only]),
             id: "nav_mobile_mailing_list_link") %>
 <% if @user.admin && !in_admin_mode? %>
-  <%= active_link_to(:app_turn_admin_on.t, admin_mode_path(turn_on: true),
-                     class: class_names(classes[:indent],
-                                        classes[:mobile_only]),
-                     id: "nav_mobile_admin_link" ) %>
+  <%= button_to(:app_turn_admin_on.t, admin_mode_path(turn_on: true),
+                class: class_names(classes[:indent], classes[:mobile_only]),
+                id: "nav_mobile_admin_link" ) %>
 <% end %>

--- a/app/views/controllers/application/top_nav/_user_nav.html.erb
+++ b/app/views/controllers/application/top_nav/_user_nav.html.erb
@@ -1,15 +1,16 @@
 <ul class="nav navbar-nav navbar-right hidden-xs mr-0">
   <% if @user.admin %>
     <li>
-      <%= link_to(
-        "",
+      <%= button_to(
         in_admin_mode? ?
           admin_mode_path(turn_off: true) : admin_mode_path(turn_on: true),
-        { class: "glyphicon glyphicon-text-background",
+        { class: "btn btn-link navbar-btn",
           id: "user_nav_admin_mode_link",
           title: in_admin_mode? ? :app_turn_admin_off.t : :app_turn_admin_on.t,
           data: { toggle: "tooltip", placement: "bottom" } }
-      ) %>
+      ) do
+        tag.span("", class: "glyphicon glyphicon-text-background")
+      end %>
     </li>
   <% end %>
   <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,7 +308,7 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
   # ----- Admin: resources and actions ------------------------------------
   namespace :admin do
     # controls turning admin mode on and off, and switching users
-    resource :session, only: [:show, :edit, :update], controller: "session",
+    resource :session, only: [:create, :edit, :update], controller: "session",
                        as: "mode"
     get("switch_users", to: "mode#edit") # alternate path
 

--- a/test/controllers/admin/session_controller_test.rb
+++ b/test/controllers/admin/session_controller_test.rb
@@ -5,17 +5,17 @@ require("test_helper")
 module Admin
   class SessionControllerTest < FunctionalTestCase
     def test_turn_admin_on_and_off
-      get(:show, params: { turn_on: true })
+      post(:create, params: { turn_on: true })
       assert_false(session[:admin])
       login(:rolf)
-      get(:show, params: { turn_on: true })
+      post(:create, params: { turn_on: true })
       assert_false(session[:admin])
       rolf.admin = true
       rolf.save!
-      get(:show, params: { turn_on: true })
+      post(:create, params: { turn_on: true })
       assert_true(session[:admin])
 
-      get(:show, params: { turn_off: true })
+      post(:create, params: { turn_off: true })
       assert_false(session[:admin])
     end
 

--- a/test/integration/capybara/name_descriptions_integration_test.rb
+++ b/test/integration/capybara/name_descriptions_integration_test.rb
@@ -252,7 +252,7 @@ class NameDescriptionsIntegrationTest < CapybaraIntegrationTestCase
     user.save
     sess = open_session
     login!(user, session: sess)
-    sess.first(:link, href: %r{admin/session}).click
+    sess.first(:button, id: "user_nav_admin_mode_link").click
     teach_about_name_descriptions(sess)
     sess.user = user # can't assign props to session with capybara?
     sess


### PR DESCRIPTION
#2048 - Prevent accidentally turning on Admin mode by hovering over the Admin button.

Changes the action from `show` to `create` in Admin::SessionController.