### PR TITLE
Switch to `dartsass-sprockets` for SCSS compilation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,8 +48,6 @@ gem("turbo-rails")
 gem("redis", "~> 4.0")
 # solid_cache for cache store db
 gem("solid_cache")
-# Compile SCSS for stylesheets
-gem("sassc-rails")
 # add locale to cache key
 gem("cache_with_locale")
 
@@ -57,6 +55,8 @@ gem("cache_with_locale")
 # Delete this dependency declaration if the issue gets resolved:
 # https://github.com/hotwired/stimulus-rails/issues/108
 gem("sprockets", "~>4.2.1")
+# Compile SCSS for stylesheets
+gem("dartsass-sprockets")
 
 gem("date")
 gem("loofah")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,12 @@ GEM
     cuprite (0.15)
       capybara (~> 3.0)
       ferrum (~> 0.14.0)
+    dartsass-sprockets (3.1.0)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.69)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     database_cleaner-active_record (2.1.0)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
@@ -129,6 +135,12 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.26.0-arm64-darwin)
+      rake (>= 13)
+    google-protobuf (4.26.0-x86_64-darwin)
+      rake (>= 13)
+    google-protobuf (4.26.0-x86_64-linux)
+      rake (>= 13)
     hashdiff (1.1.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -265,14 +277,16 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sass-embedded (1.72.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.72.0-x86_64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.72.0-x86_64-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sassc-embedded (1.70.1)
+      sass-embedded (~> 1.70)
     set (1.1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -363,6 +377,7 @@ DEPENDENCIES
   cache_with_locale
   capybara
   cuprite
+  dartsass-sprockets
   database_cleaner-active_record
   date
   debug (>= 1.0.0)
@@ -394,7 +409,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-thread_safety
   rubyzip (~> 2.3.0)
-  sassc-rails
   simplecov
   simplecov-lcov
   solid_cache


### PR DESCRIPTION
This is a drop-in replacement for the unmaintained `sassc-rails` and (unlike the official `dartsass-rails`) doesn't mean changing the way we run our local servers, `rails s`. 

This unblocks compilation of Bootstrap 4/5 which use current SCSS syntax.

Switching to `dartsass-rails` and dropping `sprockets` in favor of `propshaft` may be desirable in the future. `dartsass-rails` uses `foreman` and you'd run `bin/dev` to start your local server. 
