### PR TITLE
Suppress "No such file ..." in the terminal.

### DIFF
--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -85,7 +85,7 @@ class ScriptTest < UnitTestCase
   test "parse_log" do
     script = script_file("parse_log")
     tempfile = Tempfile.new("test").path
-    cmd = "#{script} 2>&1 > #{tempfile}"
+    cmd = "#{script} &>#{tempfile}"
     status = system(cmd)
     errors = File.read(tempfile)
     assert status, "Something went wrong with #{script}:\n#{errors}"


### PR DESCRIPTION
Prevents ScriptTest#parse_log from displaying the following message in the terminal when running tests.
(The message is displayed by ScriptTest#parse_log.)
```
grep: /home/runner/work/mushroom-observer/mushroom-observer/log/test.log: No such file or directory
```

Delivers #2025