### PR TITLE
Try to quiet SASS deprecation warnings on deploy in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,6 +95,11 @@ MushroomObserver::Application.configure do
   # Generate digests for assets URLs
   config.assets.digest = true
 
+  # Combine files using the "require" directives at the top of included files
+  # See http://guides.rubyonrails.org/asset_pipeline.html#turning-debugging-off
+  config.assets.debug = false
+  config.sass.quiet_deps = true
+
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = "1.0"
 
@@ -159,10 +164,6 @@ MushroomObserver::Application.configure do
 
   # Don't log any deprecations.
   # config.active_support.report_deprecations = false
-
-  # Combine files using the "require" directives at the top of included files
-  # See http://guides.rubyonrails.org/asset_pipeline.html#turning-debugging-off
-  config.assets.debug = false
 
   config.bot_enabled = true
 end


### PR DESCRIPTION
Adds a config attempting to silence the VERY numerous SASS deprecation warnings that now appear during deploy on production. This config is undocumented and it's likely it will just be ignored, but it is part of the dart-sass API.

If this doesn't work and bothers anyone, we have three options:
- switch to gem `dartsass-rails`, it does offer the `--quiet-deps` option
- submit a PR on the gem `dartsass-sprockets` that will implement this config
- Update to Boostrap 4. The deprecations are because BS3 uses outdated SASS syntax within the gem.