### PR TITLE
Fix a cron error message, couple other things

### DIFF
--- a/app/assets/stylesheets/mo/_matrix_box.scss
+++ b/app/assets/stylesheets/mo/_matrix_box.scss
@@ -103,6 +103,10 @@ h5.rss-heading {
     background: transparent;
   }
 
+  .table-hover > tbody > tr:hover {
+    background-color: rgba($panel-bg, 0.45);
+  }
+
   // .panel-footer {
   //   background: none;
   // }

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -126,12 +126,12 @@ module ContentHelper
     content = capture(&block).to_s
 
     tag.div(
-      class: "panel panel-default #{args[:class]}",
+      class: class_names("panel panel-default", args[:class]),
       **args.except(:class, :inner_class, :inner_id, :heading)
     ) do
       concat(heading)
       if content.present?
-        concat(tag.div(class: "panel-body #{args[:inner_class]}",
+        concat(tag.div(class: class_names("panel-body", args[:inner_class]),
                        id: args[:inner_id]) do
                  concat(content)
                end)

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -38,7 +38,7 @@ module VersionsHelper
   def show_past_versions(obj, versions, args = {})
     panel_block(heading: :VERSIONS.t, id: "#{obj.type_tag}_versions") do
       make_table(rows: build_version_table(obj, versions, args),
-                 table_opts: { class: "mb-0" })
+                 table_opts: { class: "table-hover mb-0" })
     end
   end
 

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -226,7 +226,7 @@ class UserStats < ApplicationRecord
 
       msgs = ["UserStats updated for #{entries.size} users."]
       msgs << "Dry run: no changes made." if dry_run
-      msgs.join(" ")
+      msgs
     end
 
     private


### PR DESCRIPTION
Refresh cron jobs should return an array of messages, not joined. `UserStats` was joining the messages.

Also - missed a few changes in last PR.
- `panel_block` - use `class_names` to concat css classes
- versions table - use `.table-hover`