### PR TITLE
Locationless Project Violations

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -86,7 +86,9 @@ module ProjectsHelper
 
     displayed_coord =
       coord_or_hidden(obs: obs, project: project, coord: obs.lat)
-    return displayed_coord if project&.location&.contains_lat?(obs.lat)
+
+    return displayed_coord if project.location.nil?
+    return displayed_coord if project.location.contains_lat?(obs.lat)
 
     tag.span(displayed_coord, class: "violation-highlight")
   end
@@ -97,7 +99,8 @@ module ProjectsHelper
     displayed_coord =
       coord_or_hidden(obs: obs, project: project, coord: obs.long)
 
-    return displayed_coord if project&.location&.contains_long?(obs.long)
+    return displayed_coord if project.location.nil?
+    return displayed_coord if project.location.contains_long?(obs.long)
 
     tag.span(displayed_coord, class: "violation-highlight")
   end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -86,7 +86,7 @@ module ProjectsHelper
 
     displayed_coord =
       coord_or_hidden(obs: obs, project: project, coord: obs.lat)
-    return displayed_coord if project.location.contains_lat?(obs.lat)
+    return displayed_coord if project&.location&.contains_lat?(obs.lat)
 
     tag.span(displayed_coord, class: "violation-highlight")
   end
@@ -97,7 +97,7 @@ module ProjectsHelper
     displayed_coord =
       coord_or_hidden(obs: obs, project: project, coord: obs.long)
 
-    return displayed_coord if project.location.contains_long?(obs.long)
+    return displayed_coord if project&.location&.contains_long?(obs.long)
 
     tag.span(displayed_coord, class: "violation-highlight")
   end
@@ -114,7 +114,7 @@ module ProjectsHelper
 
   def styled_obs_where(project, obs)
     if obs.lat.present? || # If lat/lon present, ignore Location for compliance
-       project.location.found_here?(obs)
+       project&.location&.found_here?(obs)
       location_link(obs.place_name, obs.location, nil, false)
     else
       tag.span(location_link(obs.place_name, obs.location, nil, false),

--- a/test/controllers/projects/violations_controller_test.rb
+++ b/test/controllers/projects/violations_controller_test.rb
@@ -135,23 +135,24 @@ module Projects
     end
 
     def test_index_project_without_location
-      project = projects(:unlimited_project)
-      assert_nil(project.location, "Test need Project lacking a Location")
+      project = projects(:nowhere_2023_09_project)
+      assert(project.location.nil? && project.violations.any?,
+             "Test needs Project lacking a Location, with (date) violations")
       user = project.user
 
       login(user.login)
       get(:index, params: { project_id: project.id })
 
       assert_select(
-        "#project_violations_form",
+        "#project_violations_form th",
         { text: /#{:form_violations_latitude_none.l}/ }
       )
       assert_select(
-        "#project_violations_form",
+        "#project_violations_form th",
         { text: /#{:form_violations_longitude_none.l}/ }
       )
       assert_select(
-        "#project_violations_form",
+        "#project_violations_form th",
         { text: /#{:form_violations_location_none.l}/ }
       )
     end

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -768,6 +768,8 @@ falmouth_2022_obs:
   when: 2022-09-15 # outside of dates of falmouth_2023_09_project
   where: MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA
   location: falmouth
+  lat: 41.5862
+  long: -70.5976
 
 nybg_2023_09_obs:
   <<: *DEFAULTS

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -237,3 +237,15 @@ falmouth_2023_09_project:
   end_date: 2023-09-30
   location: falmouth
   observations: brett_woods_2023_09_obs, falmouth_2023_09_obs, falmouth_2022_obs, nybg_2023_09_obs # roy (non-admin) owns nybg_2023_09_obs
+
+# includes observations that violate date constraints
+# members: roy
+nowhere_2023_09_project:
+  <<: *DEFAULTS
+  user: dick
+  admin_group: dick_only
+  user_group: falmouth_2023_09_users
+  start_date: 2023-09-01
+  end_date: 2023-09-30
+  location: nil
+  observations: brett_woods_2023_09_obs, falmouth_2023_09_obs, falmouth_2022_obs, nybg_2023_09_obs # roy (non-admin) owns nybg_2023_09_obs


### PR DESCRIPTION
- Prevents ViolationsController#index from throwing an Error if a Project without a Location has Observation(s) with geolocations. 
(Fixes #2072.)
- Prevents incorrect highlighting of Observation geolocations. The fix described above exposed a bug in which all Observation lat/lon's were incorrectly highlighted as violations in Projects without Location's.
