### PR TITLE
Fixes error that was thrown when adding a comment to a project

### DIFF
--- a/app/views/controllers/comments/_object.html.erb
+++ b/app/views/controllers/comments/_object.html.erb
@@ -23,7 +23,7 @@
            locals: { obs: object })
 
   when "Project"
-    render(partial: "project/project", object: object)
+    render(partial: "projects/project", object: object)
 
   when "SpeciesList"
     render(partial: "species_lists/species_list", object: object)

--- a/app/views/controllers/projects/_project.html.erb
+++ b/app/views/controllers/projects/_project.html.erb
@@ -1,6 +1,6 @@
 <% # rendered only by comments/object ?? %>
 <p><%= "#{:show_project_created_at.t}: #{project.created_at.web_time}"%></p>
-<p><%= "#{:show_project_by.t}: #{user_link(project.user)}" %></p>
+<p><%= "#{:show_project_by.t}: " %><%= user_link(project.user) %></p>
 <p><%= "#{:show_project_user_group.t}: #{project.user_group.name.t}" %></p>
 <p><%= "#{:show_project_admin_group.t}: #{project.admin_group.name.t}" %></p>
 <%= (:show_project_summary.l + ": " + project.summary.to_s.html_safe).tpl %>

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -190,6 +190,12 @@ class CommentsControllerTest < FunctionalTestCase
     assert_form_action(action: :create, target: obs_id, type: "Observation")
   end
 
+  def test_add_comment_to_project
+    project_id = projects(:eol_project).id
+    requires_login(:new, target: project_id, type: "Project")
+    assert_form_action(action: :create, target: project_id, type: "Project")
+  end
+
   def test_add_comment_no_id
     login("dick")
     get(:new)


### PR DESCRIPTION
Note that you have to open the comment link in a separate window rather than using the comment popup.  To reproduce:

1) Go to a project page
2) Near the bottom of the page there is a comments sectin.
3) Right click on the "+" to open a new window (or tab)
4) On current main it will throw an error.
