### PR TITLE
Initial implementation of SolidQueue for running ActiveJobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -205,3 +205,5 @@ group :production do
   # https://newrelic.com/
   gem("newrelic_rpm")
 end
+
+gem "solid_queue", "~> 0.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     docile (1.4.0)
     drb (2.2.1)
     erubi (1.12.0)
+    et-orbi (1.2.11)
+      tzinfo
     execjs (2.9.1)
     fastimage (2.3.0)
     ferrum (0.14)
@@ -132,6 +134,9 @@ GEM
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
     ffi (1.16.3)
+    fugit (1.9.0)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (4.26.0-arm64-darwin)
@@ -207,6 +212,7 @@ GEM
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.10)
     rack-session (2.0.0)
@@ -295,6 +301,12 @@ GEM
       activejob (>= 7)
       activerecord (>= 7)
       railties (>= 7)
+    solid_queue (0.3.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (~> 1.2.2)
+      fugit (~> 1.9.0)
+      railties (>= 7.1)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -400,6 +412,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   solid_cache
+  solid_queue (~> 0.3.0)
   sorted_set
   sprockets (~> 4.2.1)
   sprockets-rails

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no
+  # longer available discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/field_slip_job.rb
+++ b/app/jobs/field_slip_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class FieldSlipJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    filename = "tmp/fs-#{Time.now.to_i}.txt"
+    File.write(filename, args.to_s)
+    filename
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -146,6 +146,8 @@ MushroomObserver::Application.configure do
   config.web_console.allowed_ips = "10.0.2.2"
 
   config.bot_enabled = true
+
+  config.active_job.queue_adapter = :solid_queue
 end
 
 file = File.expand_path("../consts-site.rb", __dir__)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -165,6 +165,8 @@ MushroomObserver::Application.configure do
   # config.active_support.report_deprecations = false
 
   config.bot_enabled = true
+
+  config.active_job.queue_adapter = :solid_queue
 end
 
 file = File.expand_path("../consts-site.rb", __dir__)

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -1,0 +1,18 @@
+# default: &default
+#   dispatchers:
+#     - polling_interval: 1
+#       batch_size: 500
+#   workers:
+#     - queues: "*"
+#       threads: 5
+#       processes: 1
+#       polling_interval: 0.1
+#
+# development:
+#  <<: *default
+#
+# test:
+#  <<: *default
+#
+# production:
+#  <<: *default

--- a/db/migrate/20240330115757_create_solid_queue_tables.solid_queue.rb
+++ b/db/migrate/20240330115757_create_solid_queue_tables.solid_queue.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# This migration comes from solid_queue (originally 20231211200639)
+class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
+  # rubocop:disable Metrics/MethodLength
+  def change
+    create_table(:solid_queue_jobs) do |t|
+      t.string(:queue_name, null: false)
+      t.string(:class_name, null: false, index: true)
+      t.text(:arguments)
+      t.integer(:priority, default: 0, null: false)
+      t.string(:active_job_id, index: true)
+      t.datetime(:scheduled_at)
+      t.datetime(:finished_at, index: true)
+      t.string(:concurrency_key)
+
+      t.timestamps
+
+      t.index([:queue_name, :finished_at],
+              name: "index_solid_queue_jobs_for_filtering")
+      t.index([:scheduled_at, :finished_at],
+              name: "index_solid_queue_jobs_for_alerting")
+    end
+
+    create_table(:solid_queue_scheduled_executions) do |t|
+      t.references(:job, index: { unique: true }, null: false)
+      t.string(:queue_name, null: false)
+      t.integer(:priority, default: 0, null: false)
+      t.datetime(:scheduled_at, null: false)
+
+      t.datetime(:created_at, null: false)
+
+      t.index([:scheduled_at, :priority, :job_id],
+              name: "index_solid_queue_dispatch_all")
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    create_table(:solid_queue_ready_executions) do |t|
+      t.references(:job, index: { unique: true }, null: false)
+      t.string(:queue_name, null: false)
+      t.integer(:priority, default: 0, null: false)
+
+      t.datetime(:created_at, null: false)
+
+      t.index([:priority, :job_id], name: "index_solid_queue_poll_all")
+      t.index([:queue_name, :priority, :job_id],
+              name: "index_solid_queue_poll_by_queue")
+    end
+
+    create_table(:solid_queue_claimed_executions) do |t|
+      t.references(:job, index: { unique: true }, null: false)
+      t.bigint(:process_id)
+      t.datetime(:created_at, null: false)
+
+      t.index([:process_id, :job_id])
+    end
+
+    create_table(:solid_queue_blocked_executions) do |t|
+      t.references(:job, index: { unique: true }, null: false)
+      t.string(:queue_name, null: false)
+      t.integer(:priority, default: 0, null: false)
+      t.string(:concurrency_key, null: false)
+      t.datetime(:expires_at, null: false)
+
+      t.datetime(:created_at, null: false)
+
+      t.index([:expires_at, :concurrency_key],
+              name: "index_solid_queue_blocked_executions_for_maintenance")
+    end
+
+    create_table(:solid_queue_failed_executions) do |t|
+      t.references(:job, index: { unique: true }, null: false)
+      t.text(:error)
+      t.datetime(:created_at, null: false)
+    end
+
+    create_table(:solid_queue_pauses) do |t|
+      t.string(:queue_name, null: false, index: { unique: true })
+      t.datetime(:created_at, null: false)
+    end
+
+    create_table(:solid_queue_processes) do |t|
+      t.string(:kind, null: false)
+      t.datetime(:last_heartbeat_at, null: false, index: true)
+      t.bigint(:supervisor_id, index: true)
+
+      t.integer(:pid, null: false)
+      t.string(:hostname)
+      t.text(:metadata)
+
+      t.datetime(:created_at, null: false)
+    end
+
+    create_table(:solid_queue_semaphores) do |t|
+      t.string(:key, null: false, index: { unique: true })
+      t.integer(:value, default: 1, null: false)
+      t.datetime(:expires_at, null: false, index: true)
+
+      t.timestamps
+
+      t.index([:key, :value],
+              name: "index_solid_queue_semaphores_on_key_and_value")
+    end
+
+    add_foreign_key(:solid_queue_blocked_executions, :solid_queue_jobs,
+                    column: :job_id, on_delete: :cascade)
+    add_foreign_key(:solid_queue_claimed_executions, :solid_queue_jobs,
+                    column: :job_id, on_delete: :cascade)
+    add_foreign_key(:solid_queue_failed_executions, :solid_queue_jobs,
+                    column: :job_id, on_delete: :cascade)
+    add_foreign_key(:solid_queue_ready_executions, :solid_queue_jobs,
+                    column: :job_id, on_delete: :cascade)
+    add_foreign_key(:solid_queue_scheduled_executions, :solid_queue_jobs,
+                    column: :job_id, on_delete: :cascade)
+  end
+end

--- a/db/migrate/20240330115758_add_missing_index_to_blocked_executions.solid_queue.rb
+++ b/db/migrate/20240330115758_add_missing_index_to_blocked_executions.solid_queue.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# This migration comes from solid_queue (originally 20240110143450)
+class AddMissingIndexToBlockedExecutions < ActiveRecord::Migration[7.1]
+  def change
+    add_index(:solid_queue_blocked_executions,
+              [:concurrency_key, :priority, :job_id],
+              name: "index_solid_queue_blocked_executions_for_release")
+  end
+end

--- a/db/migrate/20240330115759_create_recurring_executions.solid_queue.rb
+++ b/db/migrate/20240330115759_create_recurring_executions.solid_queue.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This migration comes from solid_queue (originally 20240218110712)
+class CreateRecurringExecutions < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:solid_queue_recurring_executions) do |t|
+      t.references(:job, index: { unique: true }, null: false)
+      t.string(:task_key, null: false)
+      t.datetime(:run_at, null: false)
+      t.datetime(:created_at, null: false)
+
+      t.index([:task_key, :run_at], unique: true)
+    end
+
+    add_foreign_key(:solid_queue_recurring_executions, :solid_queue_jobs,
+                    column: :job_id, on_delete: :cascade)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_232703) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_30_115759) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -610,6 +610,109 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_232703) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "species_list_observations", charset: "utf8mb3", force: :cascade do |t|
     t.integer "observation_id", default: 0, null: false
     t.integer "species_list_id", default: 0, null: false
@@ -785,4 +888,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_232703) do
     t.index ["observation_id"], name: "observation_index"
   end
 
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FieldSlipJobTest < ActiveJob::TestCase
+  test "perform performs" do
+    job = FieldSlipJob.new
+    filename = job.perform(:an_arg)
+    assert(File.exist?(filename))
+    File.delete(filename)
+  end
+end


### PR DESCRIPTION
To test:
1. Run the migrations.
2. Start `bundle exec rake solid_queue:start` in a new shell.
3 .Enter the Rails console in another shell.
4. In the console, run `FieldSlipJob.perform_later(:test_arg)`.
5. `cat tmp/fs-*.txt` should show `[:test_arg]`.

After you're done test you probably want to run `rm tmp/fs-*.txt`.

To actually get this working in production we'll need run the process in step 2 in the background.  Also note that this does inflate the logs a bit since it polls the queue fairly often.
