### PR TITLE
Location#merge fix

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -697,18 +697,10 @@ class Location < AbstractModel
       obs.save
     end
 
-    # Move species lists over.
-    SpeciesList.where(location_id: old_loc.id).find_each do |spl|
-      spl.update_attribute(:location, self)
-    end
-
-    # Update any users who call this location their primary location.
-    User.where(location_id: old_loc.id).find_each do |user|
-      user.update_attribute(:location, self)
-    end
-
-    Herbarium.where(location_id: old_loc.id).find_each do |herbarium|
-      herbarium.update_attribute(:location, self)
+    [Herbarium, Project, SpeciesList, User].each do |klass|
+      klass.where(location_id: old_loc.id).find_each do |obj|
+        obj.update_attribute(:location, self)
+      end
     end
 
     # Move over any interest in the old name.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -105,6 +105,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   has_many :comments,  as: :target, dependent: :destroy, inverse_of: :target
   has_many :interests, as: :target, dependent: :destroy, inverse_of: :target
   has_many :observations
+  has_many :projects
   has_many :species_lists
   has_many :herbaria     # should be at most one, but nothing preventing more
   has_many :users        # via profile location

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -92,8 +92,7 @@
 #  notify_users::       After save: send email notification.
 #
 ################################################################################
-# rubocop:disable Metrics/ClassLength
-class Location < AbstractModel
+class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   require "acts_as_versioned"
 
   belongs_to :description, class_name: "LocationDescription" # (main one)
@@ -697,18 +696,11 @@ class Location < AbstractModel
       obs.save
     end
 
-    # Move species lists over.
-    SpeciesList.where(location_id: old_loc.id).find_each do |spl|
-      spl.update_attribute(:location, self)
-    end
-
-    # Update any users who call this location their primary location.
-    User.where(location_id: old_loc.id).find_each do |user|
-      user.update_attribute(:location, self)
-    end
-
-    Herbarium.where(location_id: old_loc.id).find_each do |herbarium|
-      herbarium.update_attribute(:location, self)
+    # change object.location without verification
+    [Herbarium, Project, SpeciesList, User].each do |klass|
+      klass.where(location_id: old_loc.id).find_each do |obj|
+        obj.update_attribute(:location, self)
+      end
     end
 
     # Move over any interest in the old name.
@@ -718,30 +710,9 @@ class Location < AbstractModel
       int.save
     end
 
-    # Add note to explain the merge
-    # Intentionally not translated
-    add_note("[admin - #{Time.zone.now}]: Merged with #{old_loc.name}: " \
-             "North: #{old_loc.north}, South: #{old_loc.south}, " \
-             "West: #{old_loc.west}, East: #{old_loc.east}")
+    add_note(explain_merge(old_loc))
 
-    # Merge the two "main" descriptions if it can.
-    if description && old_loc.description &&
-       (description.source_type == :public) &&
-       (old_loc.description.source_type == :public)
-      description.merge(old_loc.description)
-    end
-
-    # If this one doesn't have a primary description and the other does,
-    # then make it this one's.
-    if !description && old_loc.description
-      self.description = old_loc.description
-    end
-
-    # Move over any remaining descriptions.
-    old_loc.descriptions.each do |desc|
-      desc.location_id = id
-      desc.save
-    end
+    update_location_descriptions(old_loc)
 
     # Log the action.
     old_loc.rss_log&.orphan(old_loc.name, :log_location_merged,
@@ -764,6 +735,41 @@ class Location < AbstractModel
     # Finally destroy the location.
     old_loc.destroy
   end
+
+  private
+
+  def explain_merge(old_loc)
+    # Intentionally not translated
+    <<~EXPLANATION.tr("\n", " ")
+      [admin - #{Time.zone.now}]: Merged with #{old_loc.name}
+      (was Location ##{old_loc.id}):
+      North: #{old_loc.north}, South: #{old_loc.south},
+      West: #{old_loc.west}, East: #{old_loc.east}
+    EXPLANATION
+  end
+
+  def update_location_descriptions(old_loc)
+    # Merge the two "main" descriptions if it can.
+    if description && old_loc.description &&
+       (description.source_type == :public) &&
+       (old_loc.description.source_type == :public)
+      description.merge(old_loc.description)
+    end
+
+    # If this one doesn't have a primary description and the other does,
+    # then make it this one's.
+    if !description && old_loc.description
+      self.description = old_loc.description
+    end
+
+    # Move over any remaining descriptions.
+    old_loc.descriptions.each do |desc|
+      desc.location_id = id
+      desc.save
+    end
+  end
+
+  public
 
   ##############################################################################
   #
@@ -862,4 +868,3 @@ class Location < AbstractModel
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -707,6 +707,10 @@ class Location < AbstractModel
       user.update_attribute(:location, self)
     end
 
+    Herbarium.where(location_id: old_loc.id).find_each do |herbarium|
+      herbarium.update_attribute(:location, self)
+    end
+
     # Move over any interest in the old name.
     Interest.where(target_type: "Location",
                    target_id: old_loc.id).find_each do |int|

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -735,6 +735,8 @@ class LocationsControllerTest < FunctionalTestCase
     past_locs_to_go = to_go.versions.length
     past_descs_to_go = 0
 
+    herbarium = Herbarium.create(name: "Herbarium to move", location: to_go)
+
     make_admin("rolf")
     put(:update, params: params)
 
@@ -745,6 +747,7 @@ class LocationsControllerTest < FunctionalTestCase
     assert_equal(past_loc_count + 1 - past_locs_to_go, Location::Version.count)
     assert_equal(past_desc_count - past_descs_to_go,
                  LocationDescription::Version.count)
+    assert_equal(to_stay, herbarium.reload.location)
   end
 
   def test_post_edit_location_locked

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -753,23 +753,6 @@ class LocationsControllerTest < FunctionalTestCase
     assert_equal(to_stay, project.reload.location)
   end
 
-  def test_merge_covers_relevant_models
-    Dir[Rails.root.join("app/models/*.rb").to_s].each do |filename|
-      model_name = File.basename(filename, ".rb").camelize.constantize
-
-      next unless model_name.ancestors.include?(ActiveRecord::Base)
-      next if model_name.abstract_class?
-      next unless model_name.column_names.include?("location_id")
-
-      assert(
-        [Herbarium, Interest, Location, LocationDescription, NameDescription,
-         Observation, Project, RssLog, SpeciesList, User].include?(model_name),
-        "Update `Location#merge` to handle #{model_name.name}. " \
-        "Then update this assertion."
-      )
-    end
-  end
-
   def test_post_edit_location_locked
     location = locations(:unknown_location)
     params = {

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -710,13 +710,21 @@ class LocationsControllerTest < FunctionalTestCase
     desc_count = LocationDescription.count
     past_loc_count = Location::Version.count
     past_desc_count = LocationDescription::Version.count
+    herbarium = herbaria(:burbank_herbarium)
+    assert_equal(to_go, herbarium.location,
+                 "Test needs a Herbarium with Location that will be merged")
+
     put_requires_login(:update, params)
+
     assert_redirected_to(location_path(to_go.id))
     assert_equal(loc_count - 1, Location.count)
     assert_equal(desc_count, LocationDescription.count)
     assert_equal(past_loc_count - 1, Location::Version.count)
     assert_equal(past_desc_count, LocationDescription::Version.count)
     assert_equal(10 - @new_pts, rolf.reload.contribution)
+    assert_equal(
+      to_stay, herbarium.location,
+      "Merge failed to update Herbarium location to surviving Location")
   end
 
   def test_update_location_admin_merge

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -710,7 +710,6 @@ class LocationsControllerTest < FunctionalTestCase
     desc_count = LocationDescription.count
     past_loc_count = Location::Version.count
     past_desc_count = LocationDescription::Version.count
-    herbarium = herbaria(:burbank_herbarium)
 
     put_requires_login(:update, params)
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -759,10 +759,7 @@ class LocationsControllerTest < FunctionalTestCase
 
       next unless model_name.ancestors.include?(ActiveRecord::Base)
       next if model_name.abstract_class?
-      unless model_name.column_names.include?("location_id") ||
-             model_name.column_names.include?("location")
-        next
-      end
+      next unless model_name.column_names.include?("location_id")
 
       assert(
         [Herbarium, Interest, Location, LocationDescription, NameDescription,

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -734,9 +734,10 @@ class LocationsControllerTest < FunctionalTestCase
     past_locs_to_go = to_go.versions.length
     past_descs_to_go = 0
 
-    # Cannot use a herbarium fixture here --
-    # A fixture with location `alibion` breaks API2Test#test_patching_locations
+    # Cannot use fixture here -- in these classes
+    # fixtures with location `alibion` break API2Test#test_patching_locations
     herbarium = Herbarium.create(name: "Herbarium to move", location: to_go)
+    project = Project.create(title: "Project to move", location: to_go)
 
     make_admin("rolf")
     put(:update, params: params)
@@ -749,6 +750,7 @@ class LocationsControllerTest < FunctionalTestCase
     assert_equal(past_desc_count - past_descs_to_go,
                  LocationDescription::Version.count)
     assert_equal(to_stay, herbarium.reload.location)
+    assert_equal(to_stay, project.reload.location)
   end
 
   def test_post_edit_location_locked

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -734,6 +734,8 @@ class LocationsControllerTest < FunctionalTestCase
     past_locs_to_go = to_go.versions.length
     past_descs_to_go = 0
 
+    # Cannot use a herbarium fixture here --
+    # A fixture with location `alibion` breaks API2Test#test_patching_locations
     herbarium = Herbarium.create(name: "Herbarium to move", location: to_go)
 
     make_admin("rolf")

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -711,8 +711,6 @@ class LocationsControllerTest < FunctionalTestCase
     past_loc_count = Location::Version.count
     past_desc_count = LocationDescription::Version.count
     herbarium = herbaria(:burbank_herbarium)
-    assert_equal(to_go, herbarium.location,
-                 "Test needs a Herbarium with Location that will be merged")
 
     put_requires_login(:update, params)
 
@@ -722,9 +720,6 @@ class LocationsControllerTest < FunctionalTestCase
     assert_equal(past_loc_count - 1, Location::Version.count)
     assert_equal(past_desc_count, LocationDescription::Version.count)
     assert_equal(10 - @new_pts, rolf.reload.contribution)
-    assert_equal(
-      to_stay, herbarium.location,
-      "Merge failed to update Herbarium location to surviving Location")
   end
 
   def test_update_location_admin_merge

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -753,6 +753,26 @@ class LocationsControllerTest < FunctionalTestCase
     assert_equal(to_stay, project.reload.location)
   end
 
+  def test_merge_covers_relevant_models
+    Dir[Rails.root.join("app/models/*.rb").to_s].each do |filename|
+      model_name = File.basename(filename, ".rb").camelize.constantize
+
+      next unless model_name.ancestors.include?(ActiveRecord::Base)
+      next if model_name.abstract_class?
+      unless model_name.column_names.include?("location_id") ||
+             model_name.column_names.include?("location")
+        next
+      end
+
+      assert(
+        [Herbarium, Interest, Location, LocationDescription, NameDescription,
+         Observation, Project, RssLog, SpeciesList, User].include?(model_name),
+        "Update `Location#merge` to handle #{model_name.name}. " \
+        "Then update this assertion."
+      )
+    end
+  end
+
   def test_post_edit_location_locked
     location = locations(:unknown_location)
     params = {

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -37,7 +37,3 @@ field_museum:
 
 curatorless_herbarium:
   name: $LABEL
-
-burbank_herbarium:
-  name: $LABEL
-  location: burbank

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -37,3 +37,7 @@ field_museum:
 
 curatorless_herbarium:
   name: $LABEL
+
+burbank_herbarium:
+  name: $LABEL
+  location: burbank

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -3,6 +3,8 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+# DO NOT USE `albion` as a location; it breaks API2Test#test_patching_locations
+
 nybg_herbarium:
   # api tests rely on these dates, and nybg must be older than field_museum
   created_at: 2012-10-21 12:14:00

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -4,36 +4,36 @@
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 nybg_herbarium:
-    # api tests rely on these dates, and nybg must be older than field_museum
-    created_at: 2012-10-21 12:14:00
-    updated_at: 2012-10-21 12:14:00
-    name: The New York Botanical Garden
-    mailing_address: The New York Botanical Herbarium & Garden, Bronx, New York, USA
-    location: nybg_location
-    email: nybg@collectivesource.com
-    description: An awesome & world famous herbarium.
-    code: NY
-    curators: rolf, roy
+  # api tests rely on these dates, and nybg must be older than field_museum
+  created_at: 2012-10-21 12:14:00
+  updated_at: 2012-10-21 12:14:00
+  name: The New York Botanical Garden
+  mailing_address: The New York Botanical Herbarium & Garden, Bronx, New York, USA
+  location: nybg_location
+  email: nybg@collectivesource.com
+  description: An awesome & world famous herbarium.
+  code: NY
+  curators: rolf, roy
 
 rolf_herbarium:
-    name: "Uncle Rolf's Personal Herbarium"
-    personal_user: rolf
-    curators: rolf
+  name: "Uncle Rolf's Personal Herbarium"
+  personal_user: rolf
+  curators: rolf
 
 # Empty herbarium
 dick_herbarium:
-    name: "Dick's Personal Herbarium"
-    personal_user: dick
-    curators: dick
+  name: "Dick's Personal Herbarium"
+  personal_user: dick
+  curators: dick
 
 fundis_herbarium:
-    name: "Fungal Diversity Survey"
+  name: "Fungal Diversity Survey"
 
 field_museum:
-    name: The Field Museum
-    mailing_address: 1400 S. Lake Shore Drive, Chicago, IL, 60605-2496, USA
-    code: F
-    curators: rolf, thorsten
+  name: The Field Museum
+  mailing_address: 1400 S. Lake Shore Drive, Chicago, IL, 60605-2496, USA
+  code: F
+  curators: rolf, thorsten
 
 curatorless_herbarium:
-    name: $LABEL
+  name: $LABEL

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -3,6 +3,10 @@
 # in a fixture on the opposite side of the association.
 # See https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+# IMPORTANT
+# Update LocationsControllerTest#test_update_location_admin_merge Location#merge
+# when adding a Class that has a `location` attribute
+
 DEFAULTS:
   &DEFAULTS
   locked: false
@@ -15,6 +19,8 @@ DEFAULTS:
   east: 1
   south: -1
 
+# AVOID albion as the location for other fixtures because
+# it may break API2Test#test_patching_locations.
 # no observations, 1 descsription and 2 versions all by rolf
 albion:
   <<: *DEFAULTS

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -10,8 +10,10 @@
 #   where: somewhere
 #   location:
 
-# IMPORTANT: When creating a new observation fixture, you need to also create a
-# corresponding rss_log, since the observation index now sorts by rss_log.
+# IMPORTANT:
+# - When creating a new observation fixture, you need to also create a
+#   corresponding rss_log, since the observation index now sorts by rss_log.
+# - DO NOT USE albion as a location; it breaks API2Test#test_patching_locations
 
 # Instead of writing simple one-off fixtures for new tests, consider creating
 # records on the fly within the test. This will generate both obs and rss_log.

--- a/test/fixtures/species_lists.yml
+++ b/test/fixtures/species_lists.yml
@@ -3,6 +3,8 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+# DO NOT USE `albion` as a location; it breaks API2Test#test_patching_locations
+
 DEFAULTS: &DEFAULTS
   user:     mary
   where:    "Burbank, California, USA"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,6 +3,9 @@
 # in a fixture on the opposite side of the association.
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+# DO NOT USE `albion` as an account profile primary_location;
+# it breaks API2Test#test_patching_locations
+
 DEFAULTS: &DEFAULTS
   auth_code:      cb0b1a56ab378a7c4f8ecd172dccf8b3c4a7f0ba
   contribution:   10


### PR DESCRIPTION
Prevents certain broken references, i.e. references to Locations that are deleted via a merge: 
- Updates herbarium.location if the location has been merged.
- Ditto for project.location

Fixes the bug described in #2084

