### PR TITLE
Create `UserStats` on create Account, fix show nonexistent user

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -62,6 +62,7 @@ class AccountController < ApplicationController
       UserGroup.create_user(@new_user)
       flash_notice("#{:runtime_signup_success.tp} #{:email_spam_notice.tp}")
       QueuedEmail::VerifyAccount.create_email(@new_user)
+      UserStats.create({ user_id: @new_user.id })
     end
 
     redirect_back_or_default(account_welcome_path)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -80,7 +80,7 @@ class UsersController < ApplicationController
   end
 
   # Note that the full user index is unavailable except to admins.
-  # This will just redirect to "/"
+  # The index above will just redirect again, to "/"
   def find_user!
     @show_user = User.show_includes.safe_find(params[:id]) ||
                  flash_error_and_goto_index(User, params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
   def show
     store_location
     id = params[:id].to_s
-    find_user!
+    return unless find_user!
 
     case params[:flow]
     when "next"
@@ -79,11 +79,14 @@ class UsersController < ApplicationController
     show_index_of_objects(query, args)
   end
 
+  # Note that the full user index is unavailable except to admins.
+  # This will just redirect to "/"
   def find_user!
     @show_user = User.show_includes.safe_find(params[:id]) ||
                  flash_error_and_goto_index(User, params[:id])
   end
 
+  # User's best images for #show
   MAX_THUMBS = 6
 
   # set @observations whose thumbnails will display in user summary

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -37,6 +37,9 @@ class AccountControllerTest < FunctionalTestCase
     assert(UserGroup.all_users.users.include?(user))
     assert(group = UserGroup.one_user(user))
     assert_user_arrays_equal([user], group.users)
+
+    # Make sure user stats are created.
+    assert_not_nil(user.user_stats)
   end
 
   def test_bad_signup
@@ -91,7 +94,8 @@ class AccountControllerTest < FunctionalTestCase
     post(:create, params: { new_user: params })
     assert_flash_success
     assert_redirected_to("/bogus/location")
-    assert_not_nil(User.find_by(login: "newbob"))
+    assert_not_nil(user_id = User.find_by(login: "newbob"))
+    assert_not_nil(UserStats.find_by(user_id: user_id))
   end
 
   def test_signup_theme_errors

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -104,6 +104,12 @@ class UsersControllerTest < FunctionalTestCase
     )
   end
 
+  def test_show_nonexistent_user
+    login
+    get(:show, params: { id: "123456789" })
+    assert_redirected_to({ action: :index })
+  end
+
   #   ---------------
   #    admin actions
   #   ---------------


### PR DESCRIPTION
Seems like a blank `UserStats` record should get created on account creation: It's also necessary for the show user page, which a new user might try to access (before the cron that would otherwise create a missing UserStats object has run). This should solve the issue in #2078

Also fixes the redirect in UsersController#show, for a nonexistent user, #2080

Adds three tests.