### PR TITLE
Exclude vague locations from `Mappable::CollapsibleCollectionOfObjects`

### DIFF
--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -66,12 +66,13 @@ module Mappable
       west <= east ? east - west : east - west + 360
     end
 
-    # Arbitrary test for whether box is "vague" (i.e., covers a large area).
-    # Uses formula for the area of a patch of a spherical earth where R = 6400.
-    # area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
-    # NOTE: Must convert degrees to radians.
+    # Arbitrary test for whether a box covers too large an area to be useful on
+    # a map with other boxes. Large boxes can obscure more precise locations.
+    # NOTE: Formula for `the area of a patch of a sphere`, lat/lng in radians:
+    #   area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
+    # Earth R rounded to 6372km
     def vague?
-      area = 6400 * 6400 * east_west_distance.to_radians *
+      area = 6372 * 6372 * east_west_distance.to_radians *
              (Math.sin(north.to_radians) - Math.sin(south.to_radians))
 
       area.to_i.abs > 24_000

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -81,10 +81,14 @@ module Mappable
       geometric_area.to_i.abs > 24_000
     end
 
-    # Is a given lat/long coordinate within or close to the bounding box?
+    # Determines if a given lat/long coordinate is within, or close to, a
+    # bounding box. Method is used to decide if an obs lat/lng is "dubious"
+    # with respect to the observation's assigned Location.
+    # NOTE: This is fairly strict. Larger delta makes more sense in rural areas.
     def lat_long_close?(lat, long)
-      delta_lat = north_south_distance * 0.20
-      delta_long = east_west_distance * 0.20
+      delta = 0.20
+      delta_lat = north_south_distance * delta
+      delta_long = east_west_distance * delta
       return false if lat > north + delta_lat
       return false if lat < south - delta_lat
 

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -66,9 +66,19 @@ module Mappable
       west <= east ? east - west : east - west + 360
     end
 
+    # Converts degrees to radians.
+    def to_radians(degrees)
+      degrees * Math::PI / 180.0
+    end
+
     # Arbitrary test for whether box is "vague" (i.e., covers a large area).
+    # Uses formula for the area of a patch of a spherical earth where R = 6400.
+    # Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
     def vague?
-      north_south_distance > 1 || east_west_distance > 1
+      area = 6400 * 6400 * to_radians(east_west_distance) *
+             (Math.sin(to_radians(north)) - Math.sin(to_radians(south)))
+
+      area.to_i.abs > 24_000
     end
 
     # Is a given lat/long coordinate within or close to the bounding box?

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -66,6 +66,11 @@ module Mappable
       west <= east ? east - west : east - west + 360
     end
 
+    # Arbitrary test for whether box is "vague" (i.e., covers a large area).
+    def vague?
+      north_south_distance > 1 || east_west_distance > 1
+    end
+
     # Is a given lat/long coordinate within or close to the bounding box?
     def lat_long_close?(lat, long)
       delta_lat = north_south_distance * 0.20

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -66,17 +66,13 @@ module Mappable
       west <= east ? east - west : east - west + 360
     end
 
-    # Converts degrees to radians.
-    def to_radians(degrees)
-      degrees * Math::PI / 180.0
-    end
-
     # Arbitrary test for whether box is "vague" (i.e., covers a large area).
     # Uses formula for the area of a patch of a spherical earth where R = 6400.
-    # Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
+    # area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
+    # NOTE: Must convert degrees to radians.
     def vague?
-      area = 6400 * 6400 * to_radians(east_west_distance) *
-             (Math.sin(to_radians(north)) - Math.sin(to_radians(south)))
+      area = 6400 * 6400 * east_west_distance.to_radians *
+             (Math.sin(north.to_radians) - Math.sin(south.to_radians))
 
       area.to_i.abs > 24_000
     end

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -66,16 +66,19 @@ module Mappable
       west <= east ? east - west : east - west + 360
     end
 
+    # Returns the area described by a box, in kmˆ2.
+    #   Formula for `the area of a patch of a sphere`:
+    #     area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
+    #   where lat/lng in radians, R in km, Earth R rounded to 6372km
+    def geometric_area
+      6372 * 6372 * east_west_distance.to_radians *
+        (Math.sin(north.to_radians) - Math.sin(south.to_radians))
+    end
+
     # Arbitrary test for whether a box covers too large an area to be useful on
     # a map with other boxes. Large boxes can obscure more precise locations.
-    # NOTE: Formula for `the area of a patch of a sphere`, lat/lng in radians:
-    #   area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
-    # Earth R rounded to 6372km
     def vague?
-      area = 6372 * 6372 * east_west_distance.to_radians *
-             (Math.sin(north.to_radians) - Math.sin(south.to_radians))
-
-      area.to_i.abs > 24_000
+      geometric_area.to_i.abs > 24_000
     end
 
     # Is a given lat/long coordinate within or close to the bounding box?

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -52,7 +52,6 @@ module Mappable
     attr_accessor :sets, :extents, :representative_points
 
     def initialize(objects, max_objects = MO.max_map_objects)
-
       @max_objects = max_objects
       init_sets(objects)
       group_objects_into_sets
@@ -142,6 +141,7 @@ module Mappable
           end
         elsif mappable
           # Only raise an error if it was otherwise mappable
+          # We do want to ignore non-mappable locations
           raise("Tried to map #{obj.class} #{obj.id}.")
         end
       end
@@ -151,7 +151,6 @@ module Mappable
       prec = next_precision(MAX_PRECISION)
       while @sets.length > @max_objects && prec >= MIN_PRECISION
         old_sets = @sets.values
-        # debugger
         @sets = {}
         old_sets.each do |set|
           add_box_set(set, set.objects, prec)
@@ -165,9 +164,6 @@ module Mappable
       set = @sets[[x, y, 0, 0]] ||= Mappable::MapSet.new
       set.add_objects(objs)
       set.update_extents_with_point(loc_or_obs)
-      # debugger if set.north == 34.0105 && set.east == -119.8064
-      # this works on init_sets, but group_objects_into_sets nulls the set immediately
-      # somehow @sets is losing the set between init and the very next line
     end
 
     def add_box_set(loc, objs, prec)

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -106,16 +106,16 @@ module Mappable
       (num.to_f * prec).round.to_f / prec
     end
 
-    # Dismiss any set that has an unknown location. Also dismiss vague locations
-    # e.g. "Nova Scotia" in collections. (ok for single locations, sets of 1)
-    # Mapsets containing unknown or vague locations will obscure useful data
-    # if GPS points or useful locations are grouped with huge nonspecific areas.
+    # Dismiss any obj that has an unknown location. Also dismiss objects with
+    # vague locations (e.g. "Nova Scotia") if mapping a collection of objects.
+    # (Mapsets containing unknown or vague locations will obscure useful points
+    # if specific locations get grouped with huge nonspecific areas.)
     def mappable_location?(is_collection, obj)
       return true unless is_collection
 
       if obj.location?
         !obj.vague? && !Location.is_unknown?(obj.name)
-      elsif obj.observation?
+      else
         !obj.location&.vague? && !Location.is_unknown?(obj.location&.name)
       end
     end
@@ -141,7 +141,7 @@ module Mappable
           end
         elsif mappable
           # Only raise an error if it was otherwise mappable
-          # We do want to ignore non-mappable locations
+          # We _do_ want to ignore non-mappable locations.
           raise("Tried to map #{obj.class} #{obj.id}.")
         end
       end

--- a/app/extensions/numeric_extensions.rb
+++ b/app/extensions/numeric_extensions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+#  = Extensions to Numeric
+#
+#  == Instance Methods
+#
+#  to_radians::   Convert degrees to radians.
+#
+################################################################################
+
+class Numeric
+  def to_radians
+    self * Math::PI / 180.0
+  end
+end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -143,6 +143,7 @@ module LinkHelper
     cancel: "remove",
     email: "envelope",
     question: "question-sign",
+    alert: "alert",
     list: "list",
     clone: "duplicate",
     merge: "transfer",

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -166,9 +166,20 @@ module ObservationsHelper
            else
              :show_observation_seen_at.t
            end}:",
-        location_link(obs.where, obs.location, nil, true)
+        location_link(obs.where, obs.location, nil, true),
+        observation_where_vague_notice(obs: obs)
       ].safe_join(" ")
     end
+  end
+
+  def observation_where_vague_notice(obs:)
+    return "" unless obs.location&.vague?
+
+    title = :show_observation_vague_location.l
+    if User.current == obs.user
+      title += " #{:show_observation_improve_location.l}"
+    end
+    tag.p(class: "ml-3") { tag.em(title) }
   end
 
   def observation_details_where_gps(obs:)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2219,6 +2219,8 @@
   # This is used if this is NOT the location where the thing was growing.
   show_observation_seen_at: Seen at
   show_observation_gps_hidden: coordinates hidden from public
+  show_observation_vague_location: This observation's location will not appear on maps of this taxon because it is too vague.
+  show_observation_improve_location: If you would like it to be included in maps, choose a more precise location.
   show_observation_specimen_available: Specimen available
   show_observation_specimen_not_available: No specimen available
   show_observation_no_images: No images

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2219,7 +2219,7 @@
   # This is used if this is NOT the location where the thing was growing.
   show_observation_seen_at: Seen at
   show_observation_gps_hidden: coordinates hidden from public
-  show_observation_vague_location: This observation's location will not appear on maps of this taxon because it is too vague.
+  show_observation_vague_location: This observation will not appear on maps of its taxon because the location is too vague.
   show_observation_improve_location: If you would like it to be included in maps, choose a more precise location.
   show_observation_specimen_available: Specimen available
   show_observation_specimen_not_available: No specimen available

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -127,9 +127,13 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_show_observation_vague_location
     login
-    obs = observations(:california_obs)
-    get(:show, params: { id: obs.id })
+    obs1 = observations(:california_obs)
+    get(:show, params: { id: obs1.id })
     assert_match(:show_observation_vague_location.l, @response.body)
+    # Make sure it doesn't show for observations with non-vague location
+    obs2 = observations(:amateur_obs)
+    get(:show, params: { id: obs2.id })
+    assert_no_match(:show_observation_vague_location.l, @response.body)
   end
 
   def test_show_observation_hidden_gps

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -125,6 +125,13 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_equal("thumbnail", user.thumbnail_size)
   end
 
+  def test_show_observation_vague_location
+    login
+    obs = observations(:california_obs)
+    get(:show, params: { id: obs.id })
+    assert_match(:show_observation_vague_location.l, @response.body)
+  end
+
   def test_show_observation_hidden_gps
     obs = observations(:unknown_with_lat_long)
     login

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -131,6 +131,8 @@ class ObservationsControllerTest < FunctionalTestCase
     get(:show, params: { id: obs1.id })
     assert_match(:show_observation_vague_location.l, @response.body)
     assert_no_match(:show_observation_improve_location.l, @response.body)
+
+    # Make sure it suggests choosing a better location if owner is current user
     login("dick")
     get(:show, params: { id: obs1.id })
     assert_match(:show_observation_vague_location.l, @response.body)

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -130,6 +130,12 @@ class ObservationsControllerTest < FunctionalTestCase
     obs1 = observations(:california_obs)
     get(:show, params: { id: obs1.id })
     assert_match(:show_observation_vague_location.l, @response.body)
+    assert_no_match(:show_observation_improve_location.l, @response.body)
+    login("dick")
+    get(:show, params: { id: obs1.id })
+    assert_match(:show_observation_vague_location.l, @response.body)
+    assert_match(:show_observation_improve_location.l, @response.body)
+
     # Make sure it doesn't show for observations with non-vague location
     obs2 = observations(:amateur_obs)
     get(:show, params: { id: obs2.id })

--- a/test/models/collapsible_map_test.rb
+++ b/test/models/collapsible_map_test.rb
@@ -394,6 +394,18 @@ class CollapsibleMapTest < UnitTestCase
     assert_obj_arrays_equal([loc], mapset.underlying_locations)
   end
 
+  # CollapsibleCollection should ignore large locations and observations with
+  # vague locations like "California", when mapping multiple locations.
+  # (:california is currently one of the locations for a "Boletus edulis" obs.)
+  def test_mapping_collections_ignores_vague_locations
+    bol = observations(:boletus_edulis_obs)
+    obss = Observation.where(text_name: bol.text_name).to_a
+    coll = Mappable::CollapsibleCollectionOfObjects.new(obss)
+    coll.mapsets.each do |mapset|
+      assert_not(mapset.underlying_locations.include?(locations(:california)))
+    end
+  end
+
   def test_mapping_a_bunch_of_points
     data = [
       [10, 10],       # 0 --._____

--- a/test/models/collapsible_map_test.rb
+++ b/test/models/collapsible_map_test.rb
@@ -400,6 +400,8 @@ class CollapsibleMapTest < UnitTestCase
   def test_mapping_collections_ignores_vague_locations
     bol = observations(:boletus_edulis_obs)
     obss = Observation.where(text_name: bol.text_name).to_a
+    assert(obss.include?(observations(:california_obs)))
+    # This should toss out the location :california from the mappable set
     coll = Mappable::CollapsibleCollectionOfObjects.new(obss)
     coll.mapsets.each do |mapset|
       assert_not(mapset.underlying_locations.include?(locations(:california)))

--- a/test/models/collapsible_map_test.rb
+++ b/test/models/collapsible_map_test.rb
@@ -404,7 +404,7 @@ class CollapsibleMapTest < UnitTestCase
     # This should toss out the location :california from the mappable set
     coll = Mappable::CollapsibleCollectionOfObjects.new(obss)
     coll.mapsets.each do |mapset|
-      assert_not(mapset.underlying_locations.include?(locations(:california)))
+      assert(mapset.underlying_locations.exclude?(locations(:california)))
     end
   end
 


### PR DESCRIPTION
### Cleans up maps by getting rid of overly vague location boxes ###

Currently on the site, we exclude observations whose location is "Earth" on maps, because they mess up the interface. But an observation with a large associated Location like "USA" also obscures more specific observation data on a map, whenever _the vague location gets grouped with the more specific locations_. (See discussion #2088.)

One way to fix this might be by grouping large locations together so they don't hide the precise ones. But it's hard to control the order of grouping (it would require calculating each location's surface area from lat/lng) and ordering by this derived value. But big boxes would still make underlying boxes difficult to click.

@pellaea proposed just excluding all big locations from mapsets, because 
- they are relatively few
- they are nearly useless, and 
- they will always obscure better data. 
I believe this is the right idea. 

### First try: 1º lat/lng max box size ###

I tried excluding locations whose east-west longitude difference, or north-south latitude difference, was more than 1º either direction, and it immediately improved the legibility of the test map I used for debugging, "observations of name 5066".

Before:
`mushroomobserver.org/names/5066/map`
![Screen Shot 2024-04-10 at 4 34 54 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/5bcf23c1-b77e-4c30-aa00-fc24735972a8)

After:
`localhost:3000/names/5066/map`
![Screen Shot 2024-04-10 at 4 33 36 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/591d4507-cfc6-4d95-bfdb-a58296c49156)

However, 1º is not the same everywhere on the globe. Using a "1º rule" obscures some locations closer to the poles that may be considered marginally useful. 

For example, observations at Denali National Park and Peace River Area currently appear on the live site:

`mushroomobserver.org/names/5066/map`
![Screen Shot 2024-04-10 at 4 39 56 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/ed2adbd9-b7dd-4361-819f-4c14df4da80f)

But when limiting areas to "1º" in either direction on this branch, the observations at these locations are not shown:

`localhost:3000/names/5066/map`
![Screen Shot 2024-04-10 at 4 38 27 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/1409923b-4971-4483-be30-104c75c5b35c)

I'm going to search for a better formula for areas of these boxes so we're doing orange-to-orange comparisons of geometric area.