### PR TITLE
Make map behavior more predictable

### DIFF
--- a/app/classes/mappable/box.rb
+++ b/app/classes/mappable/box.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
-# rectangle on the surface of the earth, with borders: north, south, east, west
-# used mostly (exclusively?) by model scopes
+# Box represents a geographic bounding box, a rectangle on the surface of the
+# earth, with borders: north, south, east, west
+# Used mostly by model scopes, and for area comparisons.
+#
+#  == Instance methods
+#
+#  valid?::              Return true if box is valid.
+#  straddles_180_deg?::  Return true if box straddles 180 degrees.
+#  expand(delta_lat, delta_lng = nil)::  Return a new box with edges expanded
+#                                        by delta (optional delta_lng)
+
 module Mappable
   class Box
     attr_reader :north, :south, :east, :west
@@ -13,6 +22,8 @@ module Mappable
       @west = west
     end
 
+    include Mappable::BoxMethods
+
     def valid?
       args_in_bounds? && south <= north
     end
@@ -21,14 +32,16 @@ module Mappable
       west > east
     end
 
-    # Return a new box with edges expanded by delta
+    # Return a new box with edges expanded by delta (optional delta_lng)
     # Useful for dealing with float rounding errors when
-    # making comparisons to edges
-    def expand(delta)
-      Box.new(north: north + delta,
-              south: south - delta,
-              east: east + delta,
-              west: west - delta)
+    # making comparisons to edges.
+    def expand(delta_lat, delta_lng = nil)
+      delta_lng ||= delta_lat
+
+      Box.new(north: north + delta_lat,
+              south: south - delta_lat,
+              east: rectify(east + delta_lng),
+              west: rectify(west - delta_lng))
     end
 
     ############################################################################
@@ -38,6 +51,17 @@ module Mappable
     def args_in_bounds?
       south&.between?(-90, 90) && north&.between?(-90, 90) &&
         west&.between?(-180, 180) && east&.between?(-180, 180)
+    end
+
+    # Return a valid longitude between -180 and 180, for `expand` method
+    def rectify(lng)
+      if lng < -180
+        lng + 360
+      elsif lng > 180
+        lng - 360
+      else
+        lng
+      end
     end
   end
 end

--- a/app/classes/mappable/box.rb
+++ b/app/classes/mappable/box.rb
@@ -7,7 +7,6 @@
 #  == Instance methods
 #
 #  valid?::              Return true if box is valid.
-#  straddles_180_deg?::  Return true if box straddles 180 degrees.
 #  expand(delta_lat, delta_lng = nil)::  Return a new box with edges expanded
 #                                        by delta (optional delta_lng)
 
@@ -26,10 +25,6 @@ module Mappable
 
     def valid?
       args_in_bounds? && south <= north
-    end
-
-    def straddles_180_deg?
-      west > east
     end
 
     # Return a new box with edges expanded by delta (optional delta_lng)

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -72,19 +72,21 @@ module Mappable
     #   where lat/lng in radians, R in km, Earth R rounded to 6372km
     def geometric_area
       6372 * 6372 * east_west_distance.to_radians *
-        (Math.sin(north.to_radians) - Math.sin(south.to_radians))
+        (Math.sin(north.to_radians) - Math.sin(south.to_radians)).abs
     end
 
     # Arbitrary test for whether a box covers too large an area to be useful on
     # a map with other boxes. Large boxes can obscure more precise locations.
     def vague?
-      geometric_area.to_i.abs > 24_000
+      geometric_area > 24_000 # kmˆ2
     end
 
     # Determines if a given lat/long coordinate is within, or close to, a
     # bounding box. Method is used to decide if an obs lat/lng is "dubious"
     # with respect to the observation's assigned Location.
-    # NOTE: This is fairly strict. Larger delta makes more sense in rural areas.
+    # NOTE: delta = 0.20 is a fairly strict limit.
+    # Larger delta would make more sense in rural areas, where the common-sense
+    # postal address may be quite far from the observed GPS location.
     def lat_long_close?(lat, long)
       delta = 0.20
       delta_lat = north_south_distance * delta

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -14,6 +14,7 @@
 #  edges::        Returns [north, south, east, west].
 #  north_south_distance:: Returns north - south.
 #  east_west_distance::   Returns east - west (adjusting if straddles dateline).
+#  straddles_180_deg?::   Returns true if box straddles 180 degrees.
 #  box_area::             Returns the area described by a box, in kmˆ2.
 #  vague?::       Arbitrary test for whether a box covers too large an area to
 #                 be useful on a map.
@@ -95,6 +96,10 @@ module Mappable
       west <= east ? east - west : east - west + 360
     end
 
+    def straddles_180_deg?
+      west > east
+    end
+
     def contains?(lat, lng)
       contains_lat?(lat) && contains_long?(lng)
     end
@@ -104,7 +109,7 @@ module Mappable
     end
 
     def contains_long?(lng)
-      return (west...east).cover?(lng) if west <= east
+      return (west...east).cover?(lng) unless straddles_180_deg?
 
       (lng >= west) || (lng <= east)
     end

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -2,21 +2,23 @@
 
 #  == Instance methods
 #
-#  north_west::  Return [north, west].
-#  north_east::  Return [north, east].
-#  south_west::  Return [south, west].
-#  south_east::  Return [south, east].
-#  lat::         Return center latitude.
-#  lng::         Return center longitude for MapSet.
-#  center::      Return center as [lat, long].
-#  edges::       Return [north, south, east, west].
-#  north_south_distance::  Return north - south.
-#  east_west_distance::    Return east - west (adjusting if straddles dateline).
-#  geometric_area::        Return the area described by a box, in kmˆ2.
-#  vague?::      Arbitrary test for whether a box covers too large an area to
-#                be useful on a map.
-#  delta_lat::   Returns north_south_distance * DELTA.
-#  delta_lng::   Returns east_west_distance * DELTA.
+#  location?::    Returns true.
+#  observation?:: Returns false.
+#  north_west::   Returns [north, west].
+#  north_east::   Returns [north, east].
+#  south_west::   Returns [south, west].
+#  south_east::   Returns [south, east].
+#  lat::          Returns center latitude.
+#  lng::          Returns center longitude for MapSet.
+#  center::       Returns center as [lat, long].
+#  edges::        Returns [north, south, east, west].
+#  north_south_distance:: Returns north - south.
+#  east_west_distance::   Returns east - west (adjusting if straddles dateline).
+#  box_area::             Returns the area described by a box, in kmˆ2.
+#  vague?::       Arbitrary test for whether a box covers too large an area to
+#                 be useful on a map.
+#  delta_lat::    Returns north_south_distance * DELTA.
+#  delta_lng::    Returns east_west_distance * DELTA.
 #  lat_long_close?::  Determines if a given lat/long coordinate is within,
 #                     or close to, a bounding box.
 #  contains?(lat, lng)::  Does box contain the given latititude and longitude
@@ -111,7 +113,7 @@ module Mappable
     #   Formula for `the area of a patch of a sphere`:
     #     area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
     #   where lat/lng in radians, R in km, Earth R rounded to 6372km
-    def geometric_area
+    def box_area
       6372 * 6372 * east_west_distance.to_radians *
         (Math.sin(north.to_radians) - Math.sin(south.to_radians)).abs
     end
@@ -119,7 +121,7 @@ module Mappable
     # Arbitrary test for whether a box covers too large an area to be useful on
     # a map with other boxes. Large boxes can obscure more precise locations.
     def vague?
-      geometric_area > 24_000 # kmˆ2
+      box_area > 24_000 # kmˆ2
     end
 
     # NOTE: DELTA = 0.20 is way too strict a limit for remote locations.

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -84,11 +84,11 @@ module Mappable
     # Determines if a given lat/long coordinate is within, or close to, a
     # bounding box. Method is used to decide if an obs lat/lng is "dubious"
     # with respect to the observation's assigned Location.
-    # NOTE: delta = 0.20 is a fairly strict limit.
-    # Larger delta would make more sense in rural areas, where the common-sense
+    # NOTE: delta = 0.20 is way too strict a limit for remote locations.
+    # Larger delta makes more sense in remote areas, where the common-sense
     # postal address may be quite far from the observed GPS location.
     def lat_long_close?(lat, long)
-      delta = 0.20
+      delta = 7.0
       delta_lat = north_south_distance * delta
       delta_long = east_west_distance * delta
       return false if lat > north + delta_lat

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -88,7 +88,7 @@ module Mappable
     # Larger delta makes more sense in remote areas, where the common-sense
     # postal address may be quite far from the observed GPS location.
     def lat_long_close?(lat, long)
-      delta = 7.0
+      delta = 2.0
       delta_lat = north_south_distance * delta
       delta_long = east_west_distance * delta
       return false if lat > north + delta_lat

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -117,8 +117,15 @@ module Mappable
     end
 
     # Similar to MapSet.init_objects_and_derive_extents
-    # These may be Mappable::MinimalLocations/Observations, whose properties
-    # are different. Names::MapsController#show sends observations though.
+    # Objects may be observations, or Mappable::MinimalLocations/Observations,
+    # whose properties are different. Names::MapsController#show sends obs.
+    #
+    # For single observations, this always returns points if we have lat/lng...
+    # ignores "dubiousness" when the point disagrees with location.
+    #
+    # For maps of multiple observations, it returns only sets of location boxes.
+    # Even though points are noticeable at any zoom, they may get collapsed with
+    # other nearby points into tiny boxes, becoming undetectable on the map.
     def init_sets(objects)
       objects = [objects] unless objects.is_a?(Array)
       raise("Tried to create empty map!") if objects.empty?
@@ -138,7 +145,7 @@ module Mappable
           end
         elsif mappable
           # Only raise an error if it was otherwise mappable
-          # We _do_ want to ignore non-mappable locations.
+          # We do want to ignore non-mappable locations.
           raise("Tried to map #{obj.class} #{obj.id}.")
         end
       end

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -131,7 +131,7 @@ module Mappable
         if obj.location? && mappable
           add_box_set(loc, [obj], MAX_PRECISION)
         elsif obj.observation?
-          if obj.lat && !obj.lat_long_dubious?
+          if !is_collection && obj.lat && !obj.lat_long_dubious?
             add_point_set(obj, [obj], MAX_PRECISION)
           elsif loc && mappable
             add_box_set(loc, [obj], MAX_PRECISION)

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -131,7 +131,7 @@ module Mappable
         if obj.location? && mappable
           add_box_set(loc, [obj], MAX_PRECISION)
         elsif obj.observation?
-          if (!is_collection || !loc) && obj.lat && !obj.lat_long_dubious?
+          if (!is_collection || !loc) && obj.lat # && !obj.lat_long_dubious?
             add_point_set(obj, [obj], MAX_PRECISION)
           elsif loc && mappable
             add_box_set(loc, [obj], MAX_PRECISION)

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -131,7 +131,7 @@ module Mappable
         if obj.location? && mappable
           add_box_set(loc, [obj], MAX_PRECISION)
         elsif obj.observation?
-          if !is_collection && obj.lat && !obj.lat_long_dubious?
+          if (!is_collection || !loc) && obj.lat && !obj.lat_long_dubious?
             add_point_set(obj, [obj], MAX_PRECISION)
           elsif loc && mappable
             add_box_set(loc, [obj], MAX_PRECISION)

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -132,13 +132,14 @@ module Mappable
 
       @sets = {}
       is_collection = objects.count > 1
+      will_be_grouped = objects.count > @max_objects
       objects.each do |obj|
         loc = obj.location? ? obj : obj.location
         mappable = mappable_location?(is_collection, loc)
         if obj.location? && mappable
           add_box_set(loc, [obj], MAX_PRECISION)
         elsif obj.observation?
-          if (!is_collection || !loc) && obj.lat # && !obj.lat_long_dubious?
+          if (!will_be_grouped || !loc) && obj.lat # && !obj.lat_long_dubious?
             add_point_set(obj, [obj], MAX_PRECISION)
           elsif loc && mappable
             add_box_set(loc, [obj], MAX_PRECISION)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -64,14 +64,17 @@ module LinkHelper
     content = block ? capture(&block) : text
     opts = block ? path : options
     icon_type = opts[:icon]
+    label_class = opts[:show_text] ? "pl-3" : "sr-only"
     return link_to(link, opts) { content } if icon_type.blank?
 
-    opts = { title: content,
-             data: { toggle: "tooltip" } }.deep_merge(opts.except(:icon))
+    opts = {
+      title: content,
+      data: { toggle: "tooltip" }
+    }.deep_merge(opts.except(:icon, :show_text))
 
     link_to(link, **opts) do
-      concat(tag.span(content, class: "sr-only"))
       concat(link_icon(icon_type))
+      concat(tag.span(content, class: label_class))
     end
   end
 
@@ -257,18 +260,18 @@ module LinkHelper
   # Refactor to accept a tab array
 
   # POST to a path; used instead of a link because POST link requires js
-  def post_button(name:, path:, **args, &block)
-    any_method_button(method: :post, name:, path:, **args, &block)
+  def post_button(name:, path:, **, &block)
+    any_method_button(method: :post, name:, path:, **, &block)
   end
 
   # PUT to a path; used instead of a link because PUT link requires js
-  def put_button(name:, path:, **args, &block)
-    any_method_button(method: :put, name:, path:, **args, &block)
+  def put_button(name:, path:, **, &block)
+    any_method_button(method: :put, name:, path:, **, &block)
   end
 
   # PATCH to a path; used instead of a link because PATCH link requires js
-  def patch_button(name:, path:, **args, &block)
-    any_method_button(method: :patch, name:, path:, **args, &block)
+  def patch_button(name:, path:, **, &block)
+    any_method_button(method: :patch, name:, path:, **, &block)
   end
 
   # any_method_button(method: :patch,

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -110,7 +110,7 @@ module Tabs
     def observations_at_location_tab(location)
       [show_obs_link_title_with_count(location),
        add_query_param(observations_path(location: location.id)),
-       { class: tab_id(__method__.to_s), icon: :observations }]
+       { class: tab_id(__method__.to_s), icon: :observations, show_text: true }]
     end
 
     def location_map_title(query:)

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -21,6 +21,7 @@ export default class extends Controller {
     this.marker = null // Only gets set if we're in edit mode
     this.rectangle = null // Only gets set if we're in edit mode
     this.location_format = this.mapDivTarget.dataset.locationFormat
+    this.marker_color = "#D95040"
 
     // Optional data that needs parsing
     this.collection = this.mapDivTarget.dataset.collection
@@ -127,7 +128,8 @@ export default class extends Controller {
     const markerOptions = {
       position: { lat: set.lat, lng: set.lng },
       map: this.map,
-      draggable: this.editable
+      draggable: this.editable,
+      background: this.marker_color
     }
 
     if (!this.editable) {
@@ -190,7 +192,7 @@ export default class extends Controller {
   drawRectangle(set) {
     const bounds = this.boundsOf(set)
     const rectangleOptions = {
-      strokeColor: "#00ff88",
+      strokeColor: this.marker_color,
       strokeOpacity: 1,
       strokeWeight: 3,
       map: this.map,

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -95,7 +95,7 @@ export default class extends Controller {
   drawMap() {
     this.map = new google.maps.Map(this.mapDivTarget, this.mapOptions)
     if (this.mapBounds) {
-      if (Object.keys(this.collection.sets).length = 1) {
+      if (Object.keys(this.collection.sets).length == 1) {
         const pt = new google.maps.LatLng(
           this.collection.extents.lat,
           this.collection.extents.lng

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -90,10 +90,22 @@ export default class extends Controller {
   }
 
   // We don't draw the map for the create obs form on load, to save on API
+  // If we only have one marker, don't use fitBounds.
+  // Call setCenter, setZoom with marker position and desired zoom level.
   drawMap() {
     this.map = new google.maps.Map(this.mapDivTarget, this.mapOptions)
-    if (this.mapBounds)
-      this.map.fitBounds(this.mapBounds)
+    if (this.mapBounds) {
+      if (Object.keys(this.collection.sets).length = 1) {
+        const pt = new google.maps.LatLng(
+          this.collection.extents.lat,
+          this.collection.extents.lng
+        )
+        this.map.setCenter(pt)
+        this.map.setZoom(12)
+      } else {
+        this.map.fitBounds(this.mapBounds)
+      }
+    }
   }
 
   //

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -67,9 +67,6 @@
 #  parse_longitude::    Validate and parse longitude from a string.
 #  parse_altitude::     Validate and parse altitude from a string.
 #  found_here?::        Was the given obs found here?
-#  contains?(lt, ln)::  Does Location contain the given latititude and longitude
-#  contains_lat?
-#  contains_long?
 #
 #  ==== Name methods
 #  display_name::       +name+ reformated based on user's preference.
@@ -295,21 +292,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     loc = obs.location
     return false unless loc
 
+    # contains? is now a method of Mappable::BoxMethods
     contains?(loc.north, loc.west) && contains?(loc.south, loc.east)
-  end
-
-  def contains?(lat, long)
-    contains_lat?(lat) && contains_long?(long)
-  end
-
-  def contains_lat?(lat)
-    (south..north).cover?(lat)
-  end
-
-  def contains_long?(long)
-    return (west...east).cover?(long) if west <= east
-
-    (long >= west) || (long <= east)
   end
 
   ##############################################################################

--- a/app/views/controllers/locations/show/_coordinates.erb
+++ b/app/views/controllers/locations/show/_coordinates.erb
@@ -5,7 +5,7 @@ if in_admin_mode?
   heading_links << destroy_button(target: @location, icon: :delete)
   heading_links << icon_link_with_query(*location_reverse_order_tab(@location))
 end
-footer = icon_link_to(*observations_at_location_tab(@location))
+footer = icon_link_with_query(*observations_at_location_tab(@location))
 %>
 <%= panel_block(id: "location_coordinates",
                 heading: :COORDINATES.l, footer: footer,

--- a/app/views/controllers/locations/show/_coordinates.erb
+++ b/app/views/controllers/locations/show/_coordinates.erb
@@ -1,14 +1,14 @@
 <% heading_links = [
-  icon_link_with_query(*observations_at_location_tab(@location)),
   icon_link_with_query(*edit_location_tab(@location))
 ]
 if in_admin_mode?
   heading_links << destroy_button(target: @location, icon: :delete)
   heading_links << icon_link_with_query(*location_reverse_order_tab(@location))
 end
+footer = icon_link_to(*observations_at_location_tab(@location))
 %>
 <%= panel_block(id: "location_coordinates",
-                heading: :COORDINATES.l,
+                heading: :COORDINATES.l, footer: footer,
                 heading_links: heading_links.safe_join(" | ")) do %>
 
   <div class="text-center mx-auto" style="max-width:30em">

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -489,11 +489,10 @@ class LocationTest < UnitTestCase
   # test BoxMethods module `lat_long_close?` method
   def test_lat_long_close
     loc = locations(:east_lt_west_location)
-    centrum = { lat: loc.south + loc.north_south_distance / 2,
-                lon: loc.east - loc.east_west_distance / 2 }
-    assert_true(loc.lat_long_close?(centrum[:lat], centrum[:lon]),
+    # The centrum of the location is provided by BoxMethods#center, lat, lng
+    assert_true(loc.lat_long_close?(loc.lat, loc.lng),
                 "Location's centrum should be 'close' to Location.")
-    assert_false(loc.lat_long_close?(centrum[:lat], centrum[:lon] + 180),
+    assert_false(loc.lat_long_close?(loc.lat, loc.lng + 180),
                  "Opposite side of globe should not be 'close' to Location.")
   end
 


### PR DESCRIPTION
- **All maps**: Make markers and boxes the same red color (!)
- **Occurrence maps**: Display _location boxes_ only, when obs get aggregated by `CollapsibleCollection`. 
Reason: There is a problem with my recent "improvement" on main, for Joanne's Santa Cruz Island observations. Two very close points that were previously aggregated into "USA" (and thus hard to detect) are now being aggregated into a box that is so small it is invisible at a zoomed-out view. Switching to displaying the associated Location boxes is the easiest way to bump up the box size to something noticeable. Links to the individual obs are still accessible via the box caption. 
- My goal is still to move to Google's `MarkerClusterer`, but I feel like this stopgap is much improved over what's currently on main.

![Screen Shot 2024-04-11 at 4 36 31 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/952aba44-ca3c-4056-9d25-d631ce902acb)

- **Single Observation map**: When there is GPS point data for an obs, favor the point, even if it's outside the bounds of the associated Location. (Increase delta for "location dubiousness" to 2.0, from 0.2). This is part of a general move towards making GPS point data definitive, and Location associations secondary.
- **Single Observation map**: Improve default zoom for points (on main, these are too zoomed in to be useful)