### PR TITLE
Sort mapset boxes by `north` so they don't overlap

### DIFF
--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -148,6 +148,7 @@ module Mappable
         end
       end
       # Give the sets an initial sort by north value, before grouping.
+      # This gives orderly overlapping and means all boxes are clickable.
       @sets = @sets.sort_by { |_key, value| value.north }.reverse.to_h
     end
 

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -147,6 +147,8 @@ module Mappable
           raise("Tried to map #{obj.class} #{obj.id}.")
         end
       end
+      # Give the sets an initial sort by north value, before grouping.
+      @sets = @sets.sort_by { |_key, value| value.north }.reverse.to_h
     end
 
     def group_objects_into_sets


### PR DESCRIPTION
Currently on main, overlapping box mapsets can be hidden under larger boxes.

![Screen Shot 2024-04-15 at 1 01 40 AM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/2fe0f005-b6b8-4aec-95ed-70f0610b06c4)

The ones underneath are not clickable. 

@pellaea suggested sorting by the north border (any border) so that they always cascade like cards in solitaire, and remain clickable. 

![Screen Shot 2024-04-15 at 1 03 28 AM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/71fbb7b9-e9be-4890-8ed7-c1a056783a1e)

Problem solved. One-line PR.