### PR TITLE
Remove default values for UserStats created_at and updated_at

### DIFF
--- a/db/migrate/20240415115711_user_stats_no_default_timestamp.rb
+++ b/db/migrate/20240415115711_user_stats_no_default_timestamp.rb
@@ -1,0 +1,6 @@
+class UserStatsNoDefaultTimestamp < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default(:user_stats, :created_at, nil)
+    change_column_default(:user_stats, :updated_at, nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_212247) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_15_115711) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -689,8 +689,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_212247) do
     t.string "languages"
     t.string "bonuses"
     t.string "checklist"
-    t.datetime "created_at", default: "2024-03-09 22:56:06", null: false
-    t.datetime "updated_at", default: "2024-03-09 22:56:06", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "user_index"
   end
 


### PR DESCRIPTION
The original UserStats migration was using Time.zone.now as the default for the created_at and updated_at fields.  This creates instability with db/schema.rb since any time the migration gets run it will use a different value.  This will create a maintenance burden for developers.  This PR eliminates that need since I see no evidence that it is required despite the title of this commit: https://github.com/MushroomObserver/mushroom-observer/commit/43d8757914c204d4c084e2d82bc620075f40d0e9.  If it required (please provide documentation), then we should set it to some explicit date like '2024-01-01 00:00:00' rather than a dynamic value like Time.zone.now.