### PR TITLE
Clean up after `UserStats`: Remove `User.bonuses`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,7 +88,6 @@
 #  email::              Email address.
 #  admin::              Allowed to enter admin mode?
 #  alert::              Alert message we need to display for User. (serialized)
-#  bonuses::            List of zero or more contribution bonuses. (serialized)
 #  contribution::       Contribution score (integer).
 #
 #  ==== Profile
@@ -155,7 +154,6 @@
 #
 #  ==== Profile
 #  percent_complete::   How much of profile has User finished?
-#  sum_bonuses::        Add up all the bonuses User has earned.
 #
 #  ==== Object ownership
 #  comments::           Comment's they've posted.
@@ -724,16 +722,6 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     result += 1 if location_id
     result += 1 if image_id
     result * 100 / max
-  end
-
-  # Sum up all the bonuses the User has earned.
-  #
-  #   contribution += user.sum_bonuses
-  #
-  def sum_bonuses
-    return nil unless bonuses
-
-    bonuses.inject(0) { |acc, elem| acc + elem[0] }
   end
 
   def successful_contributor?

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -233,12 +233,10 @@ class UserStats < ApplicationRecord
 
     # This runs after the migration, to copy columns from users to user_stats
     # It's a batch insert, so it's fast.
-    # TODO: After the initial population, drop the column `bonuses` from User,
-    # and remove references to bonuses in `pluck` and the hash here.
     def create_user_stats_for_all_users_without
       records = User.where.missing(:user_stats).
-                pluck(:id, :bonuses).map do |id, bonuses|
-                  { user_id: id, bonuses: bonuses }
+                pluck(:id).map do |id|
+                  { user_id: id }
                 end
 
       UserStats.insert_all(records)

--- a/db/migrate/20240416050340_users_remove_bonuses_column.rb
+++ b/db/migrate/20240416050340_users_remove_bonuses_column.rb
@@ -1,0 +1,5 @@
+class UsersRemoveBonusesColumn < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :bonuses
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_15_115711) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_16_050340) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -708,7 +708,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_15_115711) do
     t.integer "location_id"
     t.integer "image_id"
     t.string "locale", limit: 5
-    t.text "bonuses"
     t.boolean "email_comments_owner", default: true, null: false
     t.boolean "email_comments_response", default: true, null: false
     t.boolean "email_comments_all", default: false, null: false


### PR DESCRIPTION
`bonuses` values were migrated from `User` to `UserStats` when that table was created.

This is the follow-up step to clean up the column from the `User` table.