### PR TITLE
Add method `to_boolean` to `String`, `NilClass`, `TrueClass`, `FalseClass`

### DIFF
--- a/app/extensions/false_class_extensions.rb
+++ b/app/extensions/false_class_extensions.rb
@@ -1,26 +1,21 @@
 # frozen_string_literal: true
 
 #
-#  = Extensions to NilClass
+#  = Extensions to FalseClass
 #
 #  == Instance Methods
 #
-#  any?::         Returns false.
-#  empty?::       Returns true.
 #  to_boolean::   Returns false.
+#  to_i::         Returns 0.
 #
 ################################################################################
 
-class NilClass
-  def any?(*_args)
-    false
-  end
-
-  def empty?
-    true
-  end
-
+class FalseClass
   def to_boolean
     false
+  end
+
+  def to_i
+    0
   end
 end

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -23,8 +23,10 @@
 #  gsub_html_special_chars:: auxiliary to html_to_ascii
 #  unescape_html::      Render special encoded characters as regular characters
 #  as_displayed::       Render everything humanly legible, for integration tests
+#  ---
 #  break_name::         Break a taxon name at the author
 #  small_author::       Wrap the author in a <small> span
+#  ---
 #  nowrap::             Surround HTML string inside '<nowrap>' span.
 #  strip_squeeze::      Strip and squeeze spaces.
 #  rand_char::          Pick a single random character from the string.
@@ -33,7 +35,9 @@
 #  is_nonascii_character?:: Does string start with non-ASCII character?
 #  percent_match::      Measure how closely this String matches another String.
 #  unindent::           Remove indentation (e.g., from here docs).
+#  ---
 #  md5sum::             Calculate MD5 sum.
+#  to_boolean::         Evaluates and returns a Boolean.
 #
 ################################################################################
 
@@ -720,5 +724,9 @@ class String
   #
   def print_thing(thing)
     print("#{self}: #{thing.class}: #{thing}\n")
+  end
+
+  def to_boolean
+    ActiveRecord::Type::Boolean.new.cast(self)
   end
 end

--- a/app/extensions/true_class_extensions.rb
+++ b/app/extensions/true_class_extensions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#
+#  = Extensions to TrueClass
+#
+#  == Instance Methods
+#
+#  to_boolean::   Returns true.
+#  to_i::         Returns 1.
+#
+################################################################################
+
+class TrueClass
+  def to_boolean
+    true
+  end
+
+  def to_i
+    1
+  end
+end

--- a/test/models/string_extensions_test.rb
+++ b/test/models/string_extensions_test.rb
@@ -18,6 +18,14 @@ class StringExtensionsTest < UnitTestCase
     assert_raises(RuntimeError) { "Z".dealphabetize("ABC") }
   end
 
+  def test_to_boolean
+    assert_equal(true, "true".to_boolean)
+    assert_equal(true, "tabbouleh".to_boolean)
+    assert_equal(false, "false".to_boolean)
+    assert_equal(true, "1".to_boolean)
+    assert_equal(false, "0".to_boolean)
+  end
+
   def test_random_no_seed_string
     srand(314_159)
     random_str = String.random(10)


### PR DESCRIPTION
Utility for script params (and maybe others) where the params have to be strings, but we want to evaluate as Booleans, e.g. "false".