### PR TITLE
Add a `field_slip` keyword to Observations PatternSearch

### DIFF
--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -27,6 +27,7 @@ module PatternSearch
       project_lists: [:project_lists, :parse_list_of_projects],
       region: [:region, :parse_list_of_strings],
       user: [:users, :parse_list_of_users],
+      field_slips: [:field_slips, :parse_list_of_strings],
 
       # numeric
       confidence: [:confidence, :parse_confidence],

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -27,7 +27,7 @@ module PatternSearch
       project_lists: [:project_lists, :parse_list_of_projects],
       region: [:region, :parse_list_of_strings],
       user: [:users, :parse_list_of_users],
-      field_slips: [:field_slips, :parse_list_of_strings],
+      field_slip: [:field_slips, :parse_list_of_strings],
 
       # numeric
       confidence: [:confidence, :parse_confidence],

--- a/app/classes/query/modules/joining.rb
+++ b/app/classes/query/modules/joining.rb
@@ -40,6 +40,9 @@ module Query
         external_sites: {
           projects: :project_id
         },
+        field_slips: {
+          observations: :observation_id
+        },
         glossary_terms: {
           "images.thumb_image": :thumb_image_id,
           rss_logs: :rss_log_id,

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -112,6 +112,8 @@ module Query
     end
 
     def initialize_field_slips_parameter
+      return unless params[:field_slips]
+
       add_join(:field_slips)
       add_exact_match_condition(
         "field_slips.code",

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -27,6 +27,7 @@ module Query
         project_lists?: [:string],
         species_lists?: [:string],
         users?: [User],
+        field_slips?: [:string],
 
         # numeric
         confidence?: [:float],
@@ -67,6 +68,7 @@ module Query
       initialize_projects_parameter
       initialize_project_lists_parameter
       initialize_species_lists_parameter
+      initialize_field_slips_parameter
     end
 
     def initialize_herbaria_parameter
@@ -106,6 +108,14 @@ module Query
         "species_list_observations.species_list_id",
         lookup_species_lists_by_name(params[:species_lists]),
         :species_list_observations
+      )
+    end
+
+    def initialize_field_slips_parameter
+      add_join(:field_slips)
+      add_search_condition(
+        "field_slips.code",
+        params[:field_slips]
       )
     end
 

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -113,7 +113,7 @@ module Query
 
     def initialize_field_slips_parameter
       add_join(:field_slips)
-      add_search_condition(
+      add_exact_match_condition(
         "field_slips.code",
         params[:field_slips]
       )

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Attributes:
+# code:    string, unique code for field slip, starts with project prefix
+
 class FieldSlip < AbstractModel
   belongs_to :observation
   belongs_to :project

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1105,6 +1105,7 @@
   search_term_deprecated: deprecated
   search_term_east: east
   search_term_exclude_consensus: exclude_consensus
+  search_term_field_slip: field_slip
   search_term_has_author: has_author
   search_term_has_citation: has_citation
   search_term_has_classification: has_classification
@@ -3546,6 +3547,7 @@
   observation_term_user: Observation created by one of these users.
   observation_term_notes: Notes contains the given string.
   observation_term_comments: Comments contain the given string.
+  observation_term_field_slip: Observation corresponds to this field slip.
   observation_term_confidence: Confidence is in this range.
   observation_term_east: Longitude of eastern edge of search region.
   observation_term_west: Longitude of western edge of search region.

--- a/test/models/pattern_search_test.rb
+++ b/test/models/pattern_search_test.rb
@@ -599,6 +599,13 @@ class PatternSearchTest < UnitTestCase
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 
+  def test_observation_search_field_slip
+    expect = Observation.comments_include("complicated")
+    assert(expect.count.positive?)
+    x = PatternSearch::Observation.new("comments:complicated")
+    assert_obj_arrays_equal(expect, x.query.results, :sort)
+  end
+
   def test_observation_search_confidence
     expect = Observation.where(vote_cache: 3)
     assert(expect.count.positive?)

--- a/test/models/pattern_search_test.rb
+++ b/test/models/pattern_search_test.rb
@@ -600,9 +600,11 @@ class PatternSearchTest < UnitTestCase
   end
 
   def test_observation_search_field_slip
-    expect = Observation.comments_include("complicated")
+    code_val = field_slips(:field_slip_one).code
+    expect = Observation.joins(:field_slips).
+             where(FieldSlip[:code].eq(code_val))
     assert(expect.count.positive?)
-    x = PatternSearch::Observation.new("comments:complicated")
+    x = PatternSearch::Observation.new("field_slip:#{code_val}")
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 


### PR DESCRIPTION
Allows users to type this in the search field and get back the relevant observation:

`field_slip:ATEST-0001`