### PR TITLE
Field slip fixes

### DIFF
--- a/app/jobs/field_slip_job.rb
+++ b/app/jobs/field_slip_job.rb
@@ -7,7 +7,7 @@ class FieldSlipJob < ApplicationJob
     log("Starting FieldSlipJob.perform(#{tracker_id})")
     cleanup_old_pdfs(tracker_id)
     tracker = FieldSlipJobTracker.find(tracker_id)
-    raise(:field_slip_job_no_tracker.t(id: tracker_id)) unless tracker
+    raise(:field_slip_job_no_tracker.t) unless tracker
 
     tracker.processing
     icon = "public/logo-120.png"

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -36,8 +36,9 @@ class FieldSlip < AbstractModel
     result = Project.includes(:project_members).where(
       project_members: { user: User.current }
     ).order(:title).pluck(:title, :id)
-    return result unless project && result.exclude?([project.title, project.id])
-
-    result.unshift([project.title, project.id])
+    if project && result.exclude?([project.title, project.id])
+      result.unshift([project.title, project.id])
+    end
+    result.unshift([:field_slip_nil_project.t, nil])
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -84,7 +84,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   validates :field_slip_prefix, uniqueness: true, allow_blank: true
   validates :field_slip_prefix,
             allow_blank: true,
-            format: { with: /\A[A-Z0-9]+\z/,
+            format: { with: /\A[A-Z0-9][A-Z0-9-]*\z/,
                       message: proc { :alphanumerics_only.t } }
 
   scope :show_includes, lambda {

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3250,7 +3250,7 @@
   # project/edit_project
   edit_project_destroy: "[:destroy_object(type=:project)]"
   edit_project_title: "[:edit_object(type=:project)]: [title]"
-  alphanumerics_only: must only contain ASCII alphanumerics
+  alphanumerics_only: must only contain ASCII alphanumerics and dashes
 
   # project/_form_projects
   form_projects_any: Any

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2782,9 +2782,10 @@
   field_slip_keep_obs: Keep Current
   field_slip_last_obs: Use Last Observation
   field_slip_new: Record Field Slip
-  field_slip_no_observation: Observation not found
-  field_slip_no_project: "Project [ID] not found"
-  field_slip_job_no_tracker: "Field Slip Tracker [ID] not found"
+  field_slip_no_observation: No Observation found
+  field_slip_no_project: No Project found
+  field_slip_nil_project: (No Project)
+  field_slip_job_no_tracker: No Field Slip Tracker found
   field_slip_show: Show this field slip
   field_slip_updated: Field slip was successfully updated.
   field_slip_welcome: "Welcome to the [TITLE] Project!"


### PR DESCRIPTION
Allow field slip prefixes to have dashes.
Improve handling of field slips with no projects.