### PR TITLE
Hidden locations

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -552,7 +552,9 @@ class LocationsController < ApplicationController
 
   def permitted_location_params
     params.require(:location).
-      permit(:display_name, :north, :west, :east, :south, :high, :low, :notes)
+      permit(:display_name,
+             :north, :west, :east, :south, :high, :low,
+             :notes, :hidden)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -128,7 +128,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     "ok_for_export",
     "rss_log_id",
     "description_id",
-    "locked"
+    "locked",
+    "hidden"
   )
 
   before_update :update_observation_cache
@@ -822,6 +823,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
 
   validate :check_requirements
   def check_requirements
+    check_hidden
+
     if !north || (north > 90)
       errors.add(:north, :validate_location_north_too_high.t)
     end
@@ -852,5 +855,14 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     elsif name.empty?
       errors.add(:name, :validate_missing.t(field: :name))
     end
+  end
+
+  def check_hidden
+    return unless hidden
+
+    self.north = north.ceil(1)
+    self.south = south.floor(1)
+    self.east = east.ceil(1)
+    self.west = west.floor(1)
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -27,6 +27,7 @@
 #  high::         (V) Maximum elevation in meters, e.g. 100
 #  low::          (V) Minimum elevation in meters, e.g. 0
 #  notes::        (V) Arbitrary extra notes supplied by User.
+#  hidden::       (V) Should observation with this location be hidden
 #
 #  ('V' indicates that this attribute is versioned in past_locations table.)
 #

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1317,6 +1317,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     check_where
     check_user
     check_coordinates
+    check_hidden
 
     return unless @when_str
 
@@ -1376,6 +1377,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     # As of July 5, 2020 this statement appears to be unreachable
     # because .to_i returns 0 for unparsable strings.
     errors.add(:alt, :runtime_altitude_error.t)
+  end
+
+  def check_hidden
+    return unless location&.hidden
+
+    self.gps_hidden = true
   end
 
   def check_when

--- a/app/views/controllers/locations/_form.html.erb
+++ b/app/views/controllers/locations/_form.html.erb
@@ -12,6 +12,8 @@
     <%= tag.div(class: "row", data: { controller: "map" }) do %>
       <%= tag.div(class: "col-md-8 col-lg-6") do %>
 
+        check_box_with_label(form: f, field: :hidden, class: "mt-3",
+                             label: :form_locations_hidden.t)
         <%= if in_admin_mode?
           check_box_with_label(form: f, field: :locked, class: "mt-3",
                                label: :form_locations_locked.t)

--- a/app/views/controllers/locations/_form.html.erb
+++ b/app/views/controllers/locations/_form.html.erb
@@ -12,13 +12,16 @@
     <%= tag.div(class: "row", data: { controller: "map" }) do %>
       <%= tag.div(class: "col-md-8 col-lg-6") do %>
 
-        check_box_with_label(form: f, field: :hidden, class: "mt-3",
-                             label: :form_locations_hidden.t)
+        <% if @location.observations.empty? %>
+           <%= check_box_with_label(form: f, field: :hidden, class: "mt-3",
+               label: :form_locations_hidden.t) %>
+	   <%= :form_locations_hidden_doc.t %>
+        <% end %>
         <%= if in_admin_mode?
           check_box_with_label(form: f, field: :locked, class: "mt-3",
                                label: :form_locations_locked.t)
         end %>
-
+	<br/><br/>
         <%= tag.div do
           f.label(:display_name, :WHERE.t + ":")
         end %>

--- a/app/views/controllers/locations/show.html.erb
+++ b/app/views/controllers/locations/show.html.erb
@@ -6,6 +6,12 @@ add_tab_set(location_show_tabs)
 @container = :full
 %>
 
+<% if @location.hidden %>
+  <p>
+    <%= :show_location_hidden.t %>
+  </p>
+<% end %>
+
 <div class="row">
   <div class="col-md-7">
     <%= tag.div(class: "mb-5") { make_map(objects: [@location]) } %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2108,6 +2108,7 @@
   show_location_editors: "[:Editors]"
   show_location_reverse: Reverse Location
   show_location_locked: This location is locked. If you want to change the location of your observation, please edit the observation instead.  Changing a location name or coordinates implicitly changes all the observations at that location, too.
+  show_location_hidden: This location is considered hidden either because it is private property whose owners do not want the location revealed or because it contains sensitive habitat. It's coordinates are intentionally imprecise and all associated observations have hidden GPS coordinates.
 
   # names
   show_name_title: "[:NAME]: [name]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2110,7 +2110,7 @@
   show_location_editors: "[:Editors]"
   show_location_reverse: Reverse Location
   show_location_locked: This location is locked. If you want to change the location of your observation, please edit the observation instead.  Changing a location name or coordinates implicitly changes all the observations at that location, too.
-  show_location_hidden: This location is considered hidden either because it is private property whose owners do not want the location revealed or because it contains sensitive habitat. It's coordinates are intentionally imprecise and all associated observations have hidden GPS coordinates.
+  show_location_hidden: This location is considered hidden either because it is private property whose owners do not want the location revealed or because it contains sensitive habitat. Its coordinates are intentionally imprecise and all associated observations have hidden GPS coordinates.
 
   # names
   show_name_title: "[:NAME]: [name]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1553,6 +1553,7 @@
   form_glossary_description_help: "A concise definition matching the part of speech of the Term, without repeating another Term's definition. (Instead link to the other Term.) Details:"
 
   # location/_form_location
+  form_locations_hidden: Hide location. Checking this box will hide the GPS coordinates of any observations associated with this location.  THIS CANNOT BE UNDONE.
   form_locations_locked: Lock this location so users cannot change the name or coordinates?
   form_locations_gen_desc: General Description
   form_locations_ecology: Habitat Description

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1553,7 +1553,8 @@
   form_glossary_description_help: "A concise definition matching the part of speech of the Term, without repeating another Term's definition. (Instead link to the other Term.) Details:"
 
   # location/_form_location
-  form_locations_hidden: Hide location. Checking this box will hide the GPS coordinates of any observations associated with this location.  THIS CANNOT BE UNDONE.
+  form_locations_hidden: Hide location
+  form_locations_hidden_doc: Hidden locations will hide the GPS coordinates of associated observations.  They also cannot be more precise than 0.1 degrees.  This value cannot be changed when there are any associated observations.
   form_locations_locked: Lock this location so users cannot change the name or coordinates?
   form_locations_gen_desc: General Description
   form_locations_ecology: Habitat Description

--- a/db/migrate/20240423204346_add_hidden_to_locations.rb
+++ b/db/migrate/20240423204346_add_hidden_to_locations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHiddenToLocations < ActiveRecord::Migration[7.1]
+  def change
+    add_column(:locations, :hidden, :boolean, null: false, default: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_21_125629) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_23_204346) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -311,6 +311,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_21_125629) do
     t.string "name", limit: 1024
     t.string "scientific_name", limit: 1024
     t.boolean "locked", default: false, null: false
+    t.boolean "hidden", default: false, null: false
   end
 
   create_table "name_description_admins", charset: "utf8mb3", force: :cascade do |t|

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -271,3 +271,7 @@ loc_1_edited_by_roy:
 loc_2_edited_by_roy:
   <<: *DEFAULTS
   user: katrina
+
+loc_hidden:
+  <<: *DEFAULTS
+  hidden: true

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -553,4 +553,22 @@ class LocationTest < UnitTestCase
       "`scope: in_box` should be empty if N < S"
     )
   end
+
+  def test_hidden
+    User.current = mary
+    high = 60.234
+    low = 60.123
+    loc = Location.create!(
+      hidden: true,
+      name: "Somewhere Hidden",
+      north: high,
+      south: low,
+      east: high,
+      west: low
+    )
+    assert_equal(loc.north, high.ceil(1))
+    assert_equal(loc.south, low.floor(1))
+    assert_equal(loc.east, high.ceil(1))
+    assert_equal(loc.west, low.floor(1))
+  end
 end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1458,4 +1458,13 @@ class ObservationTest < UnitTestCase
     assert_equal("mo_iphone_app", obs.source)
     assert_equal(:source_credit_mo_iphone_app, obs.source_credit)
   end
+
+  def test_hidden_location
+    create_new_objects
+    assert_false(@cc_obs.gps_hidden)
+    @cc_obs.location = locations(:loc_hidden)
+    @cc_obs.save
+    @cc_obs.reload
+    assert(@cc_obs.gps_hidden)
+  end
 end


### PR DESCRIPTION
To test:
1) Create a new Location and set it hidden (checkbox at the top of the edit form)
2) Note that lat/long values cannot be more precise than 0.1 degrees.
3) Associate an observation with lat/long with this location.
4) Note that the observation is forced to have it's GPS hidden.

See #1945 for more notes/discussion.