### PR TITLE
Don't require login for autocompleters_controller.rb

### DIFF
--- a/app/controllers/autocompleters_controller.rb
+++ b/app/controllers/autocompleters_controller.rb
@@ -3,7 +3,7 @@
 class AutocompletersController < ApplicationController
   require "cgi"
 
-  before_action :login_required
+  # Requiring login here would mean "advanced search" must also require login.
   around_action :catch_ajax_errors
 
   layout false


### PR DESCRIPTION
@pellaea discovered a glitch - we permit not-logged-in users to access "Advanced Search", but when they type in any of the autocompleted fields, we bounce the request (silently) to the login page. 

It seems like the better way for now is to permit the autocompleter requests.