### PR TITLE
Adjust script/extract_log to handle non-utf8 sequences.

### DIFF
--- a/script/extract_log
+++ b/script/extract_log
@@ -46,6 +46,7 @@ end
 
 file = "#{app_root}/log/production.log"
 File.open(file).readlines.each do |line|
+  line.scrub! # remove non-utf8 characters
   match = line.match(/#(\d+)/)
   pid = match[1] if match
   if line.match?(/: Started [A-Z]{3,}/)


### PR DESCRIPTION
The "real" problem is why are there non-utf8 sequences in the log???  But be that as it may, code should never crash, as a general rule, and I can at least fix that...