### PR TITLE
Make `bin/dev` available (but not necessary) to run `solid_queue`

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,1 @@
+solidqueueworker: bundle exec rake solid_queue:start

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
This makes the Rails 7 standard script `./bin/dev` available, and adds a `Procfile.dev` with one task that will start `solid_queue` in dev.

> [!NOTE] 
> Unlike the Rails 7 default behavior, this MO `bin/dev` does **not** start the dev server, because running the server via `foreman` makes `debug` unusable. So if someone wanted to start solid_queue locally, they could call `rails s` in one window, and `bin/dev` in another.

Admittedly, typing `bundle exec rake solid_queue:start` is not that much harder than typing `./bin/dev`. But the Procfile can potentially have a list of tasks that run when the dev server starts. In the future this is likely what we will want to use to build the SCSS, start redis, action_cable, etc.

The idea of the PR is to make bin/dev an option, and simplify my current branch switching, where these files keep disappearing.  