### PR TITLE
Switch to Puma for development server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,13 +206,14 @@ group :development do
   # gem("rails_db", "~> 2.5.0", path: "../local_gems/rails_db")
 end
 
-group :production do
+group :development, :production do
   # Use puma as the app server
   # To use Webrick locally, run `bundle config set --local without 'production'`
   # https://stackoverflow.com/a/23125762/3357635
   gem("puma")
-  # gem("unicorn")
+end
 
+group :production do
   # New Relic for application and other monitoring
   # https://newrelic.com/
   gem("newrelic_rpm")


### PR DESCRIPTION
This switches dev servers to run Puma instead of Webrick, bringing our dev environment a bit closer to production. @mo-nathan says he uses it at work, and seems smooth.

Puma is also the easiest way to run action cable in dev, but i wanted to merge this separately (ahead of #2107) to catch any potential issues. 

Please test by running `rails s` on this branch. You should get something like this:
```
=> Booting Puma
=> Rails 7.1.3.2 application starting in development 
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 6.4.2 (ruby 3.3.0-p0) ("The Eagle of Durango")
*  Min threads: 1
*  Max threads: 1
*  Environment: development
*          PID: 85550
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
* Starting control server on unix:///var/folders/qp/jnsw6x194nsd2fl9g91648240000gn/T/puma-status-1714705883016-85550
```
Debug should work as currently. 

I can't remember if other steps are required, but I don't believe so. I didn't make any changes in my `config/database.yml` in any case.