### PR TITLE
Revise `object_link_helper` class selectors

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -50,12 +50,12 @@ module ObjectLinkHelper
   def name_link(name, str = nil)
     if name.is_a?(Integer)
       str ||= "#{:NAME.t} ##{name}"
-      link_to(str, name_path(name), { id: "show_name_link_#{name}" })
+      id = name
     else
       str ||= name.display_name_brief_authors.t
-      link_to(str, name_path(name.id),
-              { id: "show_name_link_#{name.id}" })
+      id = name.id
     end
+    link_to(str, name_path(id), { class: "name_link_#{id}" })
   end
 
   # ----- links to names and records at external websites ----------------------
@@ -202,7 +202,7 @@ module ObjectLinkHelper
     link_to(
       name, user_path(user_id),
       args.merge(
-        { class: class_names("show_user_link_#{user_id}", args[:class]) }
+        { class: class_names("user_link_#{user_id}", args[:class]) }
       )
     )
   end
@@ -232,9 +232,9 @@ module ObjectLinkHelper
   def link_to_object(object, name = nil)
     return nil unless object
 
-    unique_class = "show_#{object.type_tag}_link_#{object.id}"
+    unique_class = "#{object.type_tag}_link_#{object.id}"
     link_to(name || object.title.t, object.show_link_args,
-            { id: unique_class })
+            { class: unique_class })
   end
 
   # Wrap description title in link to show_description.
@@ -246,7 +246,7 @@ module ObjectLinkHelper
     return result if result.match?("(#{:private.t})$")
 
     link_with_query(result, desc.show_link_args,
-                    id: "show_description_link_#{desc.id}")
+                    class: "description_link_#{desc.id}")
   end
 
   def observation_herbarium_record_link(obs)
@@ -255,7 +255,7 @@ module ObjectLinkHelper
 
       link_to((count == 1 ? :herbarium_record.t : :herbarium_records.t),
               herbarium_records_path(observation_id: obs.id),
-              { id: "herbarium_records_for_observation_link" })
+              { class: "herbarium_records_for_observation_link" })
     else
       return :show_observation_specimen_available.t if obs.specimen
 

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -67,7 +67,7 @@ module Tabs
       links << nonpersonal_herbaria_index_tab
     end
 
-    def show_herbarium_record_tab(h_r, obs)
+    def herbarium_record_tab(h_r, obs)
       # This is passed in to show_herbarium_record, allowing users to do prev,
       # next and index from there to navigate through all the rest for this obs.
       hr_query = Query.lookup(:HerbariumRecord, :all, observations: obs.id)

--- a/app/helpers/tabs/sequences_helper.rb
+++ b/app/helpers/tabs/sequences_helper.rb
@@ -25,7 +25,7 @@ module Tabs
       [object_return_tab(obj)]
     end
 
-    def show_sequence_tab(seq, obs)
+    def sequence_tab(seq, obs)
       # This is passed in to show_sequence, allowing users to do prev,
       # next and index from there to navigate through all the rest for this obs.
       sq_query = Query.lookup(:Sequence, :all, observations: obs.id)

--- a/app/views/controllers/herbaria/index.html.erb
+++ b/app/views/controllers/herbaria/index.html.erb
@@ -45,7 +45,7 @@ nonpersonal = (@query&.flavor == :nonpersonal)
               <% if !@merge || !@user %>
                 <%= link_with_query(
                       herbarium.name.t, herbarium_path(herbarium),
-                      id: "show_herbarium_link_#{herbarium.id}"
+                      class: "herbarium_link_#{herbarium.id}"
                     ) %>
               <% elsif @merge != herbarium %>
                 <%# Cannot POST from a link without js; Use buttons instead %>
@@ -53,7 +53,7 @@ nonpersonal = (@query&.flavor == :nonpersonal)
                       name: herbarium.name.t,
                       path: herbaria_merges_path(src: @merge.id,
                                                  dest: herbarium.id),
-                      id: "herbaria_merges_link_#{@merge.id}_#{herbarium.id}",
+                      class: "herbaria_merges_link_#{@merge.id}_#{herbarium.id}",
                       confirm: :are_you_sure.t
                     ) %>
               <% else %>
@@ -62,9 +62,9 @@ nonpersonal = (@query&.flavor == :nonpersonal)
               <% if @user && !@merge &&
                       (herbarium.can_edit? || in_admin_mode?) %>
                 [<%= link_with_query(:EDIT.t, edit_herbarium_path(herbarium),
-                    id: "edit_herbarium_link_#{herbarium.id}") %> |
+                    class: "edit_herbarium_link_#{herbarium.id}") %> |
                 <%= link_to(:MERGE.t, herbaria_path(merge: herbarium.id),
-                    id: "merge_herbarium_link_#{herbarium.id}") %>]
+                    class: "merge_herbarium_link_#{herbarium.id}") %>]
               <% end %>
             </td>
           </tr>

--- a/app/views/controllers/herbaria/show.html.erb
+++ b/app/views/controllers/herbaria/show.html.erb
@@ -15,7 +15,7 @@ map = @herbarium.location ? true : false
                     count: @herbarium.herbarium_records.length
                   ),
                   herbarium_records_path(herbarium_id: @herbarium.id),
-                  id: "herbarium_records_for_herbarium_link") %>
+                  class: "herbarium_records_for_herbarium_link") %>
     </div>
 
     <div class="mt-3">
@@ -43,7 +43,7 @@ map = @herbarium.location ? true : false
         <%= link_with_query(
               :show_herbarium_curator_request.t,
               new_herbaria_curator_request_path(id: @herbarium.id),
-              id: "new_herbaria_curator_request_link"
+              class: "new_herbaria_curator_request_link"
             ) %>
 
       <% end %>

--- a/app/views/controllers/herbarium_records/index.html.erb
+++ b/app/views/controllers/herbarium_records/index.html.erb
@@ -20,8 +20,7 @@ flash_error(@error) if @error && @objects.empty?
                     edit_herbarium_record_path(
                       id: rec.id, back: :index, q: get_query_param
                     ),
-                    class: "btn btn-default btn-sm",
-                    id: "edit_herbarium_record_link_#{rec.id}"
+                    class: "btn btn-default btn-sm edit_herbarium_record_link_#{rec.id}"
                   )
                 end %>
           </td>
@@ -34,7 +33,7 @@ flash_error(@error) if @error && @objects.empty?
             <%= link_to(rec.herbarium_label.t,
                         herbarium_record_path(id: rec.id,
                                               q: get_query_param),
-                        id: "show_herbarium_record_link_#{rec.id}") %>
+                        class: "herbarium_record_link_#{rec.id}") %>
           </td>
           <td>
             <%= rec.observations.map do |obs|
@@ -46,8 +45,7 @@ flash_error(@error) if @error && @objects.empty?
                   destroy_button(
                     name: :destroy_object.t(type: :herbarium_record),
                     target: herbarium_record_path(rec.id),
-                    class: "btn btn-default btn-sm",
-                    id: "destroy_herbarium_record_link_#{rec.id}"
+                    class: "btn btn-default btn-sm destroy_herbarium_record_link_#{rec.id}"
                   )
                 end %>
           </td>

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -30,7 +30,7 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
         tag.ul(class: "tight-list") do
           records.map do |record|
             tag.li(id: "herbarium_record_#{record.id}") do
-              concat(link_to(*show_herbarium_record_tab(record, obs)))
+              concat(link_to(*herbarium_record_tab(record, obs)))
               if record.can_edit? || in_admin_mode?
                 concat(
                   [
@@ -57,7 +57,7 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
         end,
         tag.ul(class: "tight-list") do
           records.map do |record|
-            tag.li { link_to(*show_herbarium_record_tab(record, obs)) }
+            tag.li { link_to(*herbarium_record_tab(record, obs)) }
           end.safe_join
         end
       ].safe_join(" ")

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -24,7 +24,7 @@ can_edit  = in_admin_mode? || obs.can_edit?
     concat(tag.ul(class:"tight-list") do
       sequences.each do |sequence|
         concat(tag.li(id: "sequence_#{sequence.id}") do
-          concat(link_to(*show_sequence_tab(sequence, obs)))
+          concat(link_to(*sequence_tab(sequence, obs)))
 
           links = []
           if sequence.deposit?

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -7,13 +7,13 @@ class ObjectLinkHelperTest < ActionView::TestCase
   def test_name_link
     name = names(:suillus)
     path = name_path(name.id)
-    html_id = "show_name_link_#{name.id}"
+    html_class = "name_link_#{name.id}"
 
     link_text = "#{:NAME.l} ##{name.id}"
-    assert_equal(expected_link(path, html_id, link_text), name_link(name.id))
+    assert_equal(expected_link(path, html_class, link_text), name_link(name.id))
 
     link_text = name.display_name_brief_authors.t
-    assert_equal(expected_link(path, html_id, link_text), name_link(name))
+    assert_equal(expected_link(path, html_class, link_text), name_link(name))
   end
 
   def test_link_if_object
@@ -21,20 +21,20 @@ class ObjectLinkHelperTest < ActionView::TestCase
     # pre  = '<a href="/projects/'
     proj = projects(:bolete_project)
     path = project_path(proj.id)
-    html_id = "show_project_link_#{proj.id}"
+    html_class = "project_link_#{proj.id}"
     link_text = "Bolete Project"
-    assert_equal(expected_link(path, html_id, link_text),
+    assert_equal(expected_link(path, html_class, link_text),
                  link_to_object(projects(:bolete_project)))
     # link to project, name supplied
     link_text = "BP"
-    assert_equal(expected_link(path, html_id, link_text),
+    assert_equal(expected_link(path, html_class, link_text),
                  link_to_object(projects(:bolete_project), "BP"))
     # link to species list
     spl = species_lists(:first_species_list)
     path = species_list_path(spl.id)
-    html_id = "show_species_list_link_#{spl.id}"
+    html_class = "species_list_link_#{spl.id}"
     link_text = "A Species List"
-    assert_equal(expected_link(path, html_id, link_text),
+    assert_equal(expected_link(path, html_class, link_text),
                  link_to_object(species_lists(:first_species_list)))
     # link to non-existent object, name not supplied
     assert_nil(link_to_object(nil), "Non-existent object should lack link.")
@@ -45,7 +45,7 @@ class ObjectLinkHelperTest < ActionView::TestCase
 
   # - Helper Methods -----------------------------------------------------------
 
-  def expected_link(path, html_id, link_text)
-    "<a id=\"#{html_id}\" href=\"#{path}\">#{link_text}</a>"
+  def expected_link(path, html_class, link_text)
+    "<a class=\"#{html_class}\" href=\"#{path}\">#{link_text}</a>"
   end
 end

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -108,7 +108,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     assert_selector(
       "a[href*='#{herbarium_records_path(herbarium_id: rec.herbarium.id)}']"
     )
-    click_on(id: "herbarium_records_for_herbarium_link")
+    first(class: "herbarium_records_for_herbarium_link").click
 
     assert_selector("body.herbarium_records__index")
     assert_selector("a[href*='#{edit_herbarium_record_path(id: rec.id)}']")
@@ -288,7 +288,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     login!("mary")
     visit(herbarium_path(nybg))
 
-    click_on(id: "new_herbaria_curator_request_link")
+    first(class: "new_herbaria_curator_request_link").click
     assert_selector("#title", text: :show_herbarium_curator_request.l)
 
     within("#herbarium_curator_request_form") do

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -67,7 +67,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     obs = observations(:detailed_unknown_obs)
     rec = obs.herbarium_records.find { |r| r.can_edit?(mary) }
     visit("/#{obs.id}")
-    click_link(class: "show_herbarium_record_link_#{rec.id}")
+    click_link(class: "herbarium_record_link_#{rec.id}")
 
     assert_selector("body.herbarium_records__show")
     click_on(text: "Edit Fungarium Record")
@@ -112,7 +112,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
 
     assert_selector("body.herbarium_records__index")
     assert_selector("a[href*='#{edit_herbarium_record_path(id: rec.id)}']")
-    click_on(id: "edit_herbarium_record_link_#{rec.id}")
+    click_on(class: "edit_herbarium_record_link_#{rec.id}")
 
     assert_selector("body.herbarium_records__edit")
     within("#herbarium_record_form") do
@@ -134,7 +134,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     end
 
     assert_selector("body.herbarium_records__index")
-    click_on(id: "destroy_herbarium_record_link_#{rec.id}")
+    click_on(class: "destroy_herbarium_record_link_#{rec.id}")
 
     assert_selector("body.herbarium_records__index")
     assert_not(obs.reload.herbarium_records.include?(rec))
@@ -146,7 +146,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     visit(herbaria_path(flavor: :all))
     assert_selector("body.herbaria__index")
 
-    herbaria_show_links = page.all("td > a[id*='show_herbarium_link']")
+    herbaria_show_links = page.all("td > a[class^='herbarium_link']")
 
     assert_equal(
       Herbarium.count, herbaria_show_links.size,
@@ -156,7 +156,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     first_herbarium_path = herbaria_show_links.first["href"].sub(/\?.*/, "")
     first("#sorts a", text: "Reverse Order").click
 
-    reverse_herbaria_show_links = page.all("td > a[id*='show_herbarium_link']")
+    reverse_herbaria_show_links = page.all("td > a[class^='herbarium_link']")
 
     assert_equal(
       first_herbarium_path,

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -381,7 +381,7 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     com = Comment.last
     within("#comments_for_object") do
       assert_text("A load of bollocks")
-      assert_selector(".show_user_link_#{rolf.id}")
+      assert_selector(".user_link_#{rolf.id}")
       assert_selector(".edit_comment_link_#{com.id}")
       assert_selector(".destroy_comment_link_#{com.id}")
       find(:css, ".edit_comment_link_#{com.id}").trigger("click")


### PR DESCRIPTION
#### TL;DR  Use classes, not ids, for links

These link selectors are for system tests, so you never have to use `xpath` selectors, which can be brittle if HTML is moved around. They're so you can easily get an HTML class name that selects the link.

I've been meaning to make the link helpers in `object_link_helper` produce the same identifying HTML attributes as elsewhere in the app. (These in `object_link_helper` were my first draft, and I used id's as selectors, but then discovered the links are not always unique, so I switched to classes with a unique object ID.) This also removes the word "show" from the class name of plain links to the object show page, as elsewhere. 

- Old: `<a id="show_name_link_#{name.id}">`
- New: `<a class="name_link_#{name.id}">`

Note that the selector is still "uniquely identifying" for the object link, but does not have to be literally unique, as in cases where there may be some alternative link elsewhere on the page.

