### PR TITLE
Minor display fix for comments 

### DIFF
--- a/app/views/controllers/comments/_comments_for_object.erb
+++ b/app/views/controllers/comments/_comments_for_object.erb
@@ -25,13 +25,13 @@ tag.div(
             class: "list-group list-group-flush comments",
             data: { controller: "section-update",
                     updated_by: "modal_comment" }) do
-      concat(tag.div(:show_comments_no_comments_yet.t,
-                     class: "list-group-item none-yet"))
       unless comments.empty?
         comments.each do |comment|
           concat(render(partial: "comments/comment", object: comment))
         end
       end
+      concat(tag.div(:show_comments_no_comments_yet.t,
+                     class: "list-group-item none-yet"))
     end
   ].safe_join)
   concat(

--- a/test/system/observation_comment_system_test.rb
+++ b/test/system/observation_comment_system_test.rb
@@ -152,10 +152,10 @@ class ObservationCommentSystemTest < ApplicationSystemTestCase
 
     # UFO test: comment incoming via the API!
     create_params = {
+      api_key: api_keys(:marys_api_key).key,
       method: :post,
       action: :comment,
       target: "observation ##{obs.id}",
-      api_key: api_keys(:marys_api_key).key,
       summary: "UFO",
       content: "I am a UFO!"
     }


### PR DESCRIPTION
This just puts the `.none-yet` message at the end (when hidden) so that the borders of the comments are not doubled on top.