### PR TITLE
Don't cleanup already-deleted TempFile

### DIFF
--- a/app/classes/api2/core/uploads.rb
+++ b/app/classes/api2/core/uploads.rb
@@ -95,7 +95,7 @@ module API2::Uploads
     end
 
     def clean_up
-      File.delete(@temp_file) if @temp_file
+      File.delete(@temp_file) if @temp_file && File.exist?(@temp_file.path)
     end
   end
 


### PR DESCRIPTION
Stops `UploadFromURL#cleanup` from throwing an Error if a TempFile has already been deleted.