### PR TITLE
Create helper `date_select_with_label`

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -239,16 +239,19 @@ module FormsHelper
     end
   end
 
+  # The index arg is for multiple date_selects in a form
   def date_select_opts(args = {})
     obj = args[:object]
     start_year = args[:start_year] || 20.years.ago.year
     end_year = args[:end_year] || Time.zone.now.year
     init_value = obj.try(&:when).try(&:year)
     start_year = init_value if init_value && init_value < start_year
-    { start_year: start_year,
-      end_year: end_year,
-      selected: obj.try(&:when) || Time.zone.today,
-      order: args[:order] || [:day, :month, :year] }
+    opts = { start_year: start_year,
+             end_year: end_year,
+             selected: obj.try(&:when) || Time.zone.today,
+             order: args[:order] || [:day, :month, :year] }
+    opts[:index] = args[:index] if args[:index].present?
+    opts
   end
 
   # Bootstrap number_field

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -217,7 +217,7 @@ module FormsHelper
   def date_select_with_label(**args)
     opts = separate_field_options_from_args(args, [:object, :data])
     opts[:class] = "form-control"
-    opts[:data] = { controller: "date-select" }.merge(args[:data] || {})
+    opts[:data] = { controller: "year-input" }.merge(args[:data] || {})
 
     wrap_class = form_group_wrap_class(args)
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -232,7 +232,7 @@ module FormsHelper
     end
   end
 
-  def date_select_opts(args)
+  def date_select_opts(args = {})
     obj = args[:object]
     start_year = args[:start_year] || 20.years.ago.year
     end_year = args[:end_year] || Time.zone.now.year

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -214,6 +214,36 @@ module FormsHelper
     args
   end
 
+  def date_select_with_label(**args)
+    opts = separate_field_options_from_args(args, [:object, :data])
+    opts[:class] = "form-control"
+    opts[:data] = { controller: "date-select" }.merge(args[:data] || {})
+
+    wrap_class = form_group_wrap_class(args)
+
+    tag.div(class: wrap_class) do
+      concat(args[:form].label("#{args[:field]}_1i", args[:label]))
+      concat(args[:between]) if args[:between].present?
+      concat(tag.div(class: "form-inline") do
+        concat(args[:form].date_select(args[:field],
+                                       date_select_opts(args), opts))
+      end)
+      concat(args[:append]) if args[:append].present?
+    end
+  end
+
+  def date_select_opts(args)
+    obj = args[:object]
+    start_year = args[:start_year] || 20.years.ago.year
+    end_year = args[:end_year] || Time.zone.now.year
+    init_value = obj.try(&:when).try(&:year)
+    start_year = init_value if init_value && init_value < start_year
+    { start_year: start_year,
+      end_year: end_year,
+      selected: obj.try(&:when) || Time.zone.today,
+      order: [:day, :month, :year] }
+  end
+
   # Bootstrap number_field
   def number_field_with_label(**args)
     args = auto_label_if_form_is_account_prefs(args)
@@ -428,16 +458,6 @@ module FormsHelper
     ] + extras
 
     args.clone.except(*exceptions)
-  end
-
-  def date_select_opts(obj = nil)
-    start_year = 20.years.ago.year
-    init_value = obj.try(&:when).try(&:year)
-    start_year = init_value if init_value && init_value < start_year
-    { start_year: start_year,
-      end_year: Time.zone.now.year,
-      selected: obj.try(&:when) || Time.zone.today,
-      order: [:day, :month, :year] }
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -215,7 +215,9 @@ module FormsHelper
   end
 
   # MO mostly uses year-input_controller to switch the year selects to
-  # text inputs, but you can pass data: { controller: "" } to get a year select
+  # text inputs, but you can pass data: { controller: "" } to get a year select.
+  # The three "selects" will always be inline, but pass inline: true to make
+  # the label and selects inline.
   def date_select_with_label(**args)
     opts = separate_field_options_from_args(args, [:object, :data])
     opts[:class] = "form-control"

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -248,7 +248,7 @@ module FormsHelper
     { start_year: start_year,
       end_year: end_year,
       selected: obj.try(&:when) || Time.zone.today,
-      order: [:day, :month, :year] }
+      order: args[:order] || [:day, :month, :year] }
   end
 
   # Bootstrap number_field

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -222,12 +222,14 @@ module FormsHelper
     opts[:data] = { controller: "year-input" }.merge(args[:data] || {})
 
     wrap_class = form_group_wrap_class(args)
+    selects_class = "form-inline"
+    selects_class += " d-inline-block" if args[:inline] == true
 
     tag.div(class: wrap_class) do
       concat(args[:form].label("#{args[:field]}_1i", args[:label],
                                class: "mr-3"))
       concat(args[:between]) if args[:between].present?
-      concat(tag.span(class: "form-inline") do
+      concat(tag.div(class: selects_class) do
         concat(args[:form].date_select(args[:field],
                                        date_select_opts(args), opts))
       end)

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -214,6 +214,8 @@ module FormsHelper
     args
   end
 
+  # MO mostly uses year-input_controller to switch the year selects to
+  # text inputs, but you can pass data: { controller: "" } to get a year select
   def date_select_with_label(**args)
     opts = separate_field_options_from_args(args, [:object, :data])
     opts[:class] = "form-control"
@@ -222,9 +224,10 @@ module FormsHelper
     wrap_class = form_group_wrap_class(args)
 
     tag.div(class: wrap_class) do
-      concat(args[:form].label("#{args[:field]}_1i", args[:label]))
+      concat(args[:form].label("#{args[:field]}_1i", args[:label],
+                               class: "mr-3"))
       concat(args[:between]) if args[:between].present?
-      concat(tag.div(class: "form-inline") do
+      concat(tag.span(class: "form-inline") do
         concat(args[:form].date_select(args[:field],
                                        date_select_opts(args), opts))
       end)

--- a/app/views/controllers/observations/form/_good_image_fields.html.erb
+++ b/app/views/controllers/observations/form/_good_image_fields.html.erb
@@ -42,7 +42,7 @@
     <td>
       <div class="form-inline">
         <%= fgi.date_select(
-          :when, date_select_opts({ object: image, index: image.id }),
+          :when, date_select_opts({ object: image }).merge(index: image.id),
           { class: "form-control form-control-sm",
             data: { controller: "year-input" } }
         ) %>

--- a/app/views/controllers/observations/form/_good_image_fields.html.erb
+++ b/app/views/controllers/observations/form/_good_image_fields.html.erb
@@ -41,8 +41,8 @@
     </td>
     <td>
       <div class="form-inline">
-        <%= fgi.date_select(:when,
-              date_select_opts(image).merge(index: image.id),
+        <%= fgi.date_select(:when, index: image.id,
+              date_select_opts({ object: image }),
               { class: "form-control form-control-sm",
                 data: { controller: "year-input" } }) %>
       </div>

--- a/app/views/controllers/observations/form/_good_image_fields.html.erb
+++ b/app/views/controllers/observations/form/_good_image_fields.html.erb
@@ -41,8 +41,8 @@
     </td>
     <td>
       <div class="form-inline">
-        <%= fgi.date_select(:when, index: image.id,
-              date_select_opts({ object: image }),
+        <%= fgi.date_select(:when,
+              date_select_opts({ object: image, index: image.id }),
               { class: "form-control form-control-sm",
                 data: { controller: "year-input" } }) %>
       </div>

--- a/app/views/controllers/observations/form/_good_image_fields.html.erb
+++ b/app/views/controllers/observations/form/_good_image_fields.html.erb
@@ -8,7 +8,7 @@
     </td>
     <td>
       <%= fgi.text_area(:notes, index: image.id, value: image.notes,
-                        rows: 1, class: "form-control form-control-sm") %>
+                        rows: 1, class: "form-control") %>
     </td>
   </tr>
   <tr>
@@ -20,7 +20,7 @@
     <td>
       <%= fgi.text_field(:original_name, index: image.id,
                          value: image.original_name,
-                         size: 40, class: "form-control form-control-sm") %>
+                         size: 40, class: "form-control") %>
     </td>
   </tr>
   <tr>
@@ -31,7 +31,7 @@
     <td>
       <%= fgi.text_field(:copyright_holder, index: image.id,
                          value: image.copyright_holder,
-                         class: "form-control form-control-sm") %>
+                         class: "form-control") %>
     </td>
   </tr>
   <tr>
@@ -43,7 +43,7 @@
       <div class="form-inline">
         <%= fgi.date_select(
           :when, date_select_opts({ object: image }).merge(index: image.id),
-          { class: "form-control form-control-sm",
+          { class: "form-control",
             data: { controller: "year-input" } }
         ) %>
       </div>
@@ -59,7 +59,7 @@
                      License.current_names_and_ids(image.license),
                      { selected: image.license_id,
                        index: image.id },
-                     { class: "form-control form-control-sm" }) %>
+                     { class: "form-control" }) %>
     </td>
   </tr>
 </table>

--- a/app/views/controllers/observations/form/_good_image_fields.html.erb
+++ b/app/views/controllers/observations/form/_good_image_fields.html.erb
@@ -41,10 +41,11 @@
     </td>
     <td>
       <div class="form-inline">
-        <%= fgi.date_select(:when,
-              date_select_opts({ object: image, index: image.id }),
-              { class: "form-control form-control-sm",
-                data: { controller: "year-input" } }) %>
+        <%= fgi.date_select(
+          :when, date_select_opts({ object: image, index: image.id }),
+          { class: "form-control form-control-sm",
+            data: { controller: "year-input" } }
+        ) %>
       </div>
     </td>
   </tr>

--- a/app/views/controllers/observations/form/_when.html.erb
+++ b/app/views/controllers/observations/form/_when.html.erb
@@ -2,16 +2,10 @@
 
 <!-- WHEN -->
 <div class="container-text">
-  <%= f.label(:when, :WHEN.t + ":") %>
-  <div class="form-group form-inline">
-    <%=
-    f.date_select(
-      :when, date_select_opts(@observation),
-      { class: "form-control mb-2",
-        data: { controller: "year-input",
-                action: "obs-form-images#updateObservationDateRadio" } }
-    ) %>
-  </div>
+  <%= date_select_with_label(
+    form: f, field: :when, object: @observation, label: :WHEN.t + ":",
+    data: { action: "obs-form-images#updateObservationDateRadio" }
+  ) %>
 </div><!--.container-text-->
 <!-- /WHEN -->
 

--- a/app/views/controllers/observations/form/images_upload/_template.erb
+++ b/app/views/controllers/observations/form/images_upload/_template.erb
@@ -85,7 +85,7 @@
             </div>
             <div class="col-sm-8 form-inline">
               <%= fti.date_select(
-                :when, date_select_opts(@temp_image),
+                :when, date_select_opts({ object: @temp_image }),
                 { class: "form-control form-control-sm",
                   data: {
                     controller: "year-input"

--- a/app/views/controllers/observations/form/images_upload/_template.erb
+++ b/app/views/controllers/observations/form/images_upload/_template.erb
@@ -58,7 +58,7 @@
 
           <div class="col-sm-8">
             <%= fti.text_area(:notes, rows: 2,
-                              class: "form-control form-control-sm") %>
+                              class: "form-control") %>
           </div><!--.col-->
 
         </div><!--.row-->
@@ -74,7 +74,7 @@
             <div class="col-sm-8">
               <%= fti.text_field(:copyright_holder,
                                  value: @image.user.legal_name,
-                                 class: "form-control form-control-sm") %>
+                                 class: "form-control") %>
             </div><!--.col-->
 
           </div><!--.row-->
@@ -86,7 +86,7 @@
             <div class="col-sm-8 form-inline">
               <%= fti.date_select(
                 :when, date_select_opts({ object: @temp_image }),
-                { class: "form-control form-control-sm",
+                { class: "form-control",
                   data: { controller: "year-input" } }
               ) %>
               <div>
@@ -104,7 +104,7 @@
             <div class="col-sm-8">
               <%= fti.select(:license_id, @licenses,
                         { selected: @user.license_id },
-                        class: "form-control form-control-sm") %>
+                        class: "form-control") %>
             </div>
           </div><!--.row-->
 

--- a/app/views/controllers/observations/form/images_upload/_template.erb
+++ b/app/views/controllers/observations/form/images_upload/_template.erb
@@ -87,9 +87,8 @@
               <%= fti.date_select(
                 :when, date_select_opts({ object: @temp_image }),
                 { class: "form-control form-control-sm",
-                  data: {
-                    controller: "year-input"
-                  } }) %>
+                  data: { controller: "year-input" } }
+              ) %>
               <div>
                 <small><%= :form_images_camera_date.t %>:</small>
                 <small><a href="javascript:"><span class="camera_date_text"></span></a></small>

--- a/app/views/controllers/observations/images/form/_fields_for_images.html.erb
+++ b/app/views/controllers/observations/images/form/_fields_for_images.html.erb
@@ -6,13 +6,9 @@
                             label: :form_images_original_name.t + ":") %>
 <% end %>
 
-<div class="form-group form-inline">
-  <%= f.label(:when_1i, :WHEN.t + ":") %>
-  <%= f.date_select(:when, date_select_opts(@image),
-                    { class: "form-control",
-                      data: { controller: "year-input" } }) %>
-  <%= help_block(:p, :form_images_when_help.t) %>
-</div>
+<%= date_select_with_label(form: f, field: :when, label: :WHEN.t + ":",
+                           object: @image, inline: true,
+                           append: help_block(:p, :form_images_when_help.t)) %>
 
 <%= select_with_label(form: f, field: :license_id, options: @licenses,
                       label: :LICENSE.t + ":",

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -22,11 +22,9 @@ name_help ||= :form_naming_name_help.t
 
 <%=
 [
-  tag.div(class: "row") do
-    tag.div(class: "col-xs-12") do
-      render(partial: "shared/form_name_feedback",
-             locals: feedback_locals) if @what.present?
-    end
+  tag.div do
+    render(partial: "shared/form_name_feedback",
+           locals: feedback_locals) if @what.present?
   end,
   fields_for(:naming) do |f_n|
     [

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -29,11 +29,13 @@
     <%= date_select_with_label(form: f, field: :start_date, inline: true,
                                label: "#{:form_projects_start_date.t}: ",
                                data: { controller: "" }, class: "mb-2",
+                               order: [:year, :month, :day],
                                start_year: Date.today.year - 10,
                                end_year: Date.today.year + 10) %>
     <%= date_select_with_label(form: f, field: :end_date, inline: true,
                                label: "#{:form_projects_end_date.t}: ",
                                data: { controller: "" },
+                               order: [:year, :month, :day],
                                start_year: Date.today.year - 10,
                                end_year: Date.today.year + 10) %>
     <%= radio_with_label(

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -24,32 +24,26 @@
     tag.p("*#{:form_projects_date_range.t}*".t) +
     tag.p(:form_projects_dates_explain.t)
   ) %>
-  <div class="container-text ml-4">
-    <div>
-      <%= date_select_with_label(form: f, field: :start_date,
-                                 label: "#{:form_projects_start_date.t}: ",
-                                 start_year: Date.today.year - 10,
-                                 end_year: Date.today.year + 10) %>
-    </div>
-    <div>
-      <%= date_select_with_label(form: f, field: :end_date,
-                                 label: "#{:form_projects_end_date.t}: ",
-                                 start_year: Date.today.year - 10,
-                                 end_year: Date.today.year + 10) %>
-    </div>
-    <div>
-      <p>
-        <%= radio_with_label(
-              form: f, field: "dates_any", value: false, checked: !@project_dates_any,
-              label: " #{:form_projects_range.t} (#{:form_projects_use_date_range.t})"
-            ) %>
-        <%= radio_with_label(
-              form: f, field: "dates_any", value: true, checked: @project_dates_any,
-              label: " #{:form_projects_any.t} (#{:form_projects_ignore_date_range.t})"
-            ) %>
-      </p>
 
-    </div>
+  <div class="container-text ml-4">
+    <%= date_select_with_label(form: f, field: :start_date, inline: true,
+                               label: "#{:form_projects_start_date.t}: ",
+                               data: { controller: "" },
+                               start_year: Date.today.year - 10,
+                               end_year: Date.today.year + 10) %>
+    <%= date_select_with_label(form: f, field: :end_date, inline: true,
+                               label: "#{:form_projects_end_date.t}: ",
+                               data: { controller: "" },
+                               start_year: Date.today.year - 10,
+                               end_year: Date.today.year + 10) %>
+    <%= radio_with_label(
+      form: f, field: "dates_any", value: false, checked: !@project_dates_any,
+      label: " #{:form_projects_range.t} (#{:form_projects_use_date_range.t})"
+    ) %>
+    <%= radio_with_label(
+      form: f, field: "dates_any", value: true, checked: @project_dates_any,
+      label: " #{:form_projects_any.t} (#{:form_projects_ignore_date_range.t})"
+    ) %>
   </div>
 
   <%= file_field_with_label(

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -26,18 +26,16 @@
   ) %>
   <div class="container-text ml-4">
     <div>
-      <%= f.label(:start_date, "#{:form_projects_start_date.t}: ") %>
-      <%= f.date_select(:start_date,
-                        { class: "form-control mb-2",
-                          start_year: Date.today.year - 10,
-                          end_year: Date.today.year + 10 }) %>
+      <%= date_select_with_label(form: f, field: :start_date,
+                                 label: "#{:form_projects_start_date.t}: "
+                                 start_year: Date.today.year - 10,
+                                 end_year: Date.today.year + 10) %>
     </div>
     <div>
-      <%= f.label(:end_date, "#{:form_projects_end_date.t}: ") %>
-      <%= f.date_select(:end_date,
-                        { class: "form-control mb-2",
-                          start_year: Date.today.year - 10,
-                          end_year: Date.today.year + 10 }) %>
+      <%= date_select_with_label(form: f, field: :end_date,
+                                 label: "#{:form_projects_end_date.t}: "
+                                 start_year: Date.today.year - 10,
+                                 end_year: Date.today.year + 10) %>
     </div>
     <div>
       <p>

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -27,13 +27,13 @@
   <div class="container-text ml-4">
     <div>
       <%= date_select_with_label(form: f, field: :start_date,
-                                 label: "#{:form_projects_start_date.t}: "
+                                 label: "#{:form_projects_start_date.t}: ",
                                  start_year: Date.today.year - 10,
                                  end_year: Date.today.year + 10) %>
     </div>
     <div>
       <%= date_select_with_label(form: f, field: :end_date,
-                                 label: "#{:form_projects_end_date.t}: "
+                                 label: "#{:form_projects_end_date.t}: ",
                                  start_year: Date.today.year - 10,
                                  end_year: Date.today.year + 10) %>
     </div>

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -28,7 +28,7 @@
   <div class="container-text ml-4">
     <%= date_select_with_label(form: f, field: :start_date, inline: true,
                                label: "#{:form_projects_start_date.t}: ",
-                               data: { controller: "" },
+                               data: { controller: "" }, class: "mb-2",
                                start_year: Date.today.year - 10,
                                end_year: Date.today.year + 10) %>
     <%= date_select_with_label(form: f, field: :end_date, inline: true,

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -25,27 +25,27 @@
     <%= fields_for(:list) do |f_l|
       autocompleter_field(
         form: f_l, field: :members, rows: 8, value: @list_members,
-        label: :form_species_lists_write_in_species.t + ":",
+        label: "#{:form_species_lists_write_in_species.t}:",
         autocomplete: :name, separator: "\n", textarea: true
       )
     end %>
   </div>
 
   <%= text_field_with_label(form: f, field: :title, between: :required,
-                            label: :form_species_lists_title.l + ":") %>
+                            label: "#{:form_species_lists_title.l}:") %>
 
   <%= text_area_with_label(form: f, field: :notes, rows: 12,
-                           label: :form_species_lists_list_notes.l + ":") %>
+                           label: "#{:form_species_lists_list_notes.l}:") %>
   <%= render(partial: "shared/textilize_help") %>
 
   <%= date_select_with_label(form: f, field: :when, object: @species_list,
-                             inline: true, label: :WHEN.l + ":") %>
+                             inline: true, label: "#{:WHEN.l}:") %>
 
   <%= render(partial: "shared/form_location_feedback",
              locals: { button: button } ) %>
 
   <%= autocompleter_field(form: f, field: :place_name, between: :required,
-                          label: :WHERE.l + ":", autocomplete: :location) %>
+                          label: "#{:WHERE.l}:", autocomplete: :location) %>
 
   <%= render(partial: "species_lists/form/fields_for_member",
              locals: { f: f }) %>

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -32,24 +32,20 @@
   </div>
 
   <%= text_field_with_label(form: f, field: :title, between: :required,
-                            label: :form_species_lists_title.t + ":") %>
+                            label: :form_species_lists_title.l + ":") %>
 
   <%= text_area_with_label(form: f, field: :notes, rows: 12,
-                           label: :form_species_lists_list_notes.t + ":") %>
+                           label: :form_species_lists_list_notes.l + ":") %>
   <%= render(partial: "shared/textilize_help") %>
 
-  <div class="form-group form-inline">
-    <%= f.label(:when, :WHEN.t + ":") %>
-    <%= f.date_select(:when, date_select_opts(@species_list),
-                      { class: "form-control",
-                        data: { controller: "year-input" } }) %>
-  </div>
+  <%= date_select_with_label(form: f, field: :when, object: @species_list,
+                             inline: true, label: :WHEN.l + ":") %>
 
   <%= render(partial: "shared/form_location_feedback",
              locals: { button: button } ) %>
 
   <%= autocompleter_field(form: f, field: :place_name, between: :required,
-                          label: :WHERE.t + ":", autocomplete: :location) %>
+                          label: :WHERE.l + ":", autocomplete: :location) %>
 
   <%= render(partial: "species_lists/form/fields_for_member",
              locals: { f: f }) %>

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -5,7 +5,7 @@
 
   <%= if !(partial = render(partial: "shared/form_list_feedback",
                             locals: { f: f })).blank?
-    content_tag(:div, partial)
+    tag.div(partial)
   end %>
 
   <%= if @checklist&.any?
@@ -35,8 +35,8 @@
                             label: "#{:form_species_lists_title.l}:") %>
 
   <%= text_area_with_label(form: f, field: :notes, rows: 12,
-                           label: "#{:form_species_lists_list_notes.l}:") %>
-  <%= render(partial: "shared/textilize_help") %>
+                           label: "#{:form_species_lists_list_notes.l}:",
+                           append: render(partial: "shared/textilize_help")) %>
 
   <%= date_select_with_label(form: f, field: :when, object: @species_list,
                              inline: true, label: "#{:WHEN.l}:") %>
@@ -50,10 +50,8 @@
   <%= render(partial: "species_lists/form/fields_for_member",
              locals: { f: f }) %>
 
-  <% if @projects.any? %>
-    <%= render(partial: "species_lists/form/fields_for_project",
-               locals: { f: f }) %>
-  <% end %>
+  <%= render(partial: "species_lists/form/fields_for_project",
+             locals: { f: f }) if @projects.any? %>
 
   <%= submit_button(form: f, button: button.l, center: true) %>
 


### PR DESCRIPTION
This one is missing from our form helpers.

The idea is to render the MO form field in a consistent style, with less hassle.