### PR TITLE
Refactor carousels

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -357,6 +357,14 @@
   padding: 1rem !important;
 }
 
+.p-4 {
+  padding: 1.5rem !important;
+}
+
+.p-5 {
+  padding: 3rem !important;
+}
+
 .p-5px {
   padding: 5px !important;
 }

--- a/app/controllers/account/profile/images_controller.rb
+++ b/app/controllers/account/profile/images_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Clicking on an image currently fires a GET to these actions... because it
-# comes from a link made by ImageHelper#interactive_image(link: url_args)
-# with CRUD refactor, change ImageHelper helper to fire a POST somehow?
+# comes from a link made by ImagesHelper#interactive_image(link: url_args)
+# with CRUD refactor, change ImagesHelper helper to fire a POST somehow?
 
 # No need to remove_images from Account profile: reuse_image removes image
 module Account::Profile

--- a/app/controllers/glossary_terms/images_controller.rb
+++ b/app/controllers/glossary_terms/images_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Clicking on an image currently fires a GET to these actions... because it
-# comes from a link made by thumbnail_helper#interactive_image(link: url_args)
-# with CRUD refactor, change thumbnail helper to fire a POST somehow?
+# comes from a link made by ImagesHelper#interactive_image(link: url_args)
+# with CRUD refactor, change ImagesHelper to fire a POST somehow?
 
 module GlossaryTerms
   class ImagesController < ApplicationController

--- a/app/controllers/observations/images_controller.rb
+++ b/app/controllers/observations/images_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Clicking on an image currently fires a GET to these actions... because it
-# comes from a link made by ImageHelper#interactive_image(link: url_args)
-# with CRUD refactor, change ImageHelper helper to fire a POST somehow?
+# comes from a link made by ImagesHelper#interactive_image(link: url_args)
+# with CRUD refactor, change ImagesHelper helper to fire a POST somehow?
 
 module Observations
   # Upload, attach, detach, edit Observation Images

--- a/app/helpers/carousel_helper.rb
+++ b/app/helpers/carousel_helper.rb
@@ -51,6 +51,6 @@ module CarouselHelper
 
   def carousel_no_images_message
     tag.div(:show_observation_no_images.l,
-            class: "p-4 w-100 h-100 text-center h3 text-muted")
+            class: "p-4 my-5 w-100 h-100 text-center h3 text-muted")
   end
 end

--- a/app/helpers/carousel_helper.rb
+++ b/app/helpers/carousel_helper.rb
@@ -1,72 +1,6 @@
 # frozen_string_literal: true
 
 module CarouselHelper
-  # Use this to print a carousel within a div
-  # Required args: images:
-  # Optional args: object: (the carousel is usually for an object)
-  # top_img: (defaults to first), (carousel)title:, (image_edit)links:
-  # thumbnails: true for thumbnail navigation
-  # img_args: args for ImagePresenter
-  #
-  # Note: uses concat(x) instead of [x,y].safe_join because of conditionals
-  def carousel_html(**args)
-    args[:images] ||= nil
-    args[:object] ||= nil
-    args[:size] ||= :large
-    args[:top_img] ||= args[:images].first
-    args[:title] ||= :IMAGES.t
-    args[:links] ||= ""
-    args[:thumbnails] = true if args[:thumbnails].nil?
-    type = args[:object]&.type_tag || "image"
-    args[:html_id] ||= "#{type}_#{args[:object].id}_carousel"
-
-    capture do
-      if !args[:images].nil? && args[:images].any?
-        concat(carousel_basic_html(**args))
-      else
-        if args[:thumbnails] # only need this heading on a show page
-          concat(carousel_heading(args[:title], args[:links]))
-        end
-        concat(carousel_no_images_message)
-      end
-    end
-  end
-
-  def carousel_basic_html(**args)
-    tag.div(class: "carousel slide", id: args[:html_id],
-            data: { ride: "false", interval: "false" }) do
-      concat(carousel_heading(args[:title], args[:links])) if args[:thumbnails]
-      concat(tag.div(class: "carousel-inner bg-light", role: "listbox") do
-        args[:images].each do |image|
-          concat(carousel_item(image, **args))
-        end
-        concat(carousel_controls(args[:html_id])) if args[:images].length > 1
-      end)
-      concat(carousel_thumbnails(**args)) if args[:thumbnails]
-    end
-  end
-
-  # args are leftover from template, could be used
-  def carousel_item(image, **args)
-    # Caption needs object for copyright info
-    img_args = args.except(:images, :object, :top_img, :title, :links,
-                           :thumbnails, :html_id)
-    presenter_args = img_args.merge({ fit: :contain, original: true,
-                                      extra_classes: "carousel-image" })
-    presenter = ImagePresenter.new(image, presenter_args)
-    active = image == args[:top_img] ? "active" : ""
-
-    tag.div(class: class_names("item", active)) do
-      concat(image_tag(presenter.img_src, presenter.options_lazy))
-      if presenter.image_link
-        concat(image_stretched_link(presenter.image_link,
-                                    presenter.image_link_method))
-      end
-      concat(lightbox_link(presenter.lightbox_data))
-      concat(carousel_caption(image, args[:object], presenter))
-    end
-  end
-
   # Very similar to an interactive_image caption
   def carousel_caption(image, object, presenter)
     classes = "carousel-caption"
@@ -113,27 +47,6 @@ module CarouselHelper
         concat(tag.span(links, class: "float-right"))
       end
     end
-  end
-
-  def carousel_thumbnails(**args)
-    tag.ol(class: "carousel-indicators panel-footer py-2 px-0 mb-0") do
-      args[:images].each_with_index do |image, index|
-        active = image == args[:top_img] ? "active" : ""
-
-        concat(tag.li(class: class_names("carousel-indicator mx-1", active),
-                      data: { target: "##{args[:html_id]}",
-                              slide_to: index.to_s }) do
-                 carousel_thumbnail(image)
-               end)
-      end
-    end
-  end
-
-  def carousel_thumbnail(image)
-    presenter_args = { fit: :contain, extra_classes: "carousel-thumbnail" }
-    presenter = ImagePresenter.new(image, presenter_args)
-
-    image_tag(presenter.img_src, presenter.options_lazy)
   end
 
   def carousel_no_images_message

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -3,11 +3,12 @@
 module ImagesHelper
   # Draw an image with all the fixin's. Takes either an Image instance or an id.
   #
-  # Note: this is NOT rendering a partial because nested partials have been
-  # demonstrated to be VERY slow in loops or collections.
+  # TODO: Make this a component. This should probably not be a partial: using
+  # nested partials has been demonstrated to be VERY slow in loops or
+  # collections. (Caching helps though).
   #
   # Uses ImagePresenter to assemble data.
-  #
+
   #   link::             Hash of { controller: xxx, action: xxx, etc. }
   #   size::             Size to show, default is thumbnail.
   #   votes::            Show vote buttons?
@@ -16,19 +17,15 @@ module ImagesHelper
   #   html_options::     Additional HTML attributes to add to <img> tag.
   #   notes::            Show image notes??
   #
-  # USE: interactive_image(
-  #   image,
-  #   args = {
-  #     notes: "",
-  #     extra_classes: ""
-  #   }
-  # )
+  # USE: interactive_image( image, args = { notes: "", extra_classes: "" } )
   def interactive_image(image, **args)
+    # Caption needs object for copyright info
     presenter = ImagePresenter.new(image, args)
     set_width = presenter.width.present? ? "width: #{presenter.width}px;" : ""
 
     [
-      tag.div(class: "image-sizer position-relative mx-auto",
+      tag.div(id: presenter.html_id,
+              class: "image-sizer position-relative mx-auto",
               style: set_width.to_s) do
         [
           tag.div(class: "image-lazy-sizer overflow-hidden",
@@ -48,6 +45,15 @@ module ImagesHelper
       end,
       image_owner_original_name(presenter.image, presenter.original)
     ].safe_join
+  end
+
+  # Args for the interactive image on Images#show (particular to that context)
+  def image_show_presenter_args
+    { size: :huge,
+      image_link: "#",
+      img_class: "huge-image",
+      theater_on_click: true,
+      votes: false }
   end
 
   # Needs object for copyright info

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -65,17 +65,19 @@ module MatrixBoxHelper
 
   # for matrix_box_carousels:
   # def matrix_box_images(presenter)
-  #   presenter.image_data includes context: :matrix_box where appropriate
+  #   presenter.image_data includes full_width: true where appropriate
   #   images = presenter.image_data[:images]
   #   image_args = local_assigns.
   #                except(:columns, :object, :object_counter,
   #                       :object_iteration).
   #                merge(presenter.image_data.except(:images) || {})
   #   top_img = presenter.image_data[:thumb_image] || images.first
+  #   carousel_locals = { object: object, images: images, top_img: top_img,
+  #                       thumbnails: true, **image_args }
   #
   #   tag.div(class: "thumbnail-container") do
-  #     carousel_html(object: object, images: images, top_img: top_img,
-  #                   thumbnails: false, **image_args)
+  #     # don't use a partial though, too slow. wait til we are using components
+  #     render(partial: "shared/carousel", locals: carousel_locals)
   #   end
   # end
 

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -13,7 +13,8 @@ class ImagePresenter < BasePresenter
     :image_link_method, # needed for helper
     :lightbox_data,     # contains data passed to lightbox (incl. caption)
     :votes,             # show votes? boolean
-    :original           # show original image filename? (boolean)
+    :original,          # show original image filename? (boolean)
+    :html_id            # dom_id for broadcasts (image.id added)
 
   def initialize(image, args = {})
     super
@@ -49,7 +50,8 @@ class ImagePresenter < BasePresenter
       votes: true,
       original: false,
       is_set: true,
-      context: false # false to constrain width
+      full_width: false, # false to constrain width
+      id_prefix: "interactive_image"
     }
     args = default_args.merge(args)
     img_urls = image&.all_urls || Image.all_urls(image_id)
@@ -98,6 +100,7 @@ class ImagePresenter < BasePresenter
     self.image_link_method = args[:link_method]
     self.votes = args[:votes]
     self.original = args[:original]
+    self.html_id = "#{args[:id_prefix]}_#{image_id}"
   end
 
   def sizing_info_to_presenter(image, args)
@@ -112,7 +115,7 @@ class ImagePresenter < BasePresenter
     img_padding = "133.33" if img_padding.to_i > 133 # default for tall
     self.proportion = img_padding
 
-    if args[:context] == :matrix_box
+    if args[:full_width] == true
       self.width = false
     else
       # Constrain width to expected dimensions for img size (not layout)

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -79,7 +79,7 @@ class MatrixBoxPresenter < BasePresenter
       # for matrix_box_carousels:
       # images: [image],
       image_link: image.show_link_args,
-      context: :matrix_box
+      full_width: true
     }
   end
 
@@ -112,7 +112,7 @@ class MatrixBoxPresenter < BasePresenter
       # thumb_image: thumb_image,
       image_link: observation.show_link_args, # false for thumb thru images
       obs: observation,
-      context: :matrix_box
+      full_width: true
     }
   end
 
@@ -140,7 +140,7 @@ class MatrixBoxPresenter < BasePresenter
       # images: [user.image_id],
       image_link: user.show_link_args,
       votes: false,
-      context: :matrix_box
+      full_width: true
     }
   end
 
@@ -164,7 +164,7 @@ class MatrixBoxPresenter < BasePresenter
       # images: images,
       # image_link: target.show_link_args,
       obs: obs_data(target),
-      context: :matrix_box
+      full_width: true
     }
   end
 

--- a/app/views/controllers/contributors/_contributor.erb
+++ b/app/views/controllers/contributors/_contributor.erb
@@ -10,7 +10,7 @@ columns ||= "col-xs-12 col-sm-6 col-md-4 col-lg-3"
       <%= if user.image_id
         tag.div(class: "thumbnail-container") do
           interactive_image(user.image_id, image_link: user_path(user.id),
-                            votes: false, context: :matrix_box)
+                            votes: false, full_width: true)
         end
       end %>
       <%= tag.div(class: "panel-body") do

--- a/app/views/controllers/glossary_terms/show.html.erb
+++ b/app/views/controllers/glossary_terms/show.html.erb
@@ -13,7 +13,10 @@ add_tab_set(glossary_term_show_tabs(term: @glossary_term, user: @user))
   </div>
   <% if @glossary_term.thumb_image %>
     <div class="col-sm-4">
-      <%= interactive_image(@glossary_term.thumb_image, size: :medium, votes: true) %>
+      <%= interactive_image(
+        @glossary_term.thumb_image, size: :medium, votes: true,
+                                    id_prefix: "glossary_term_image"
+      ) %>
     </div>
   <% end %>
 </div><!--.row-->
@@ -28,7 +31,9 @@ add_tab_set(glossary_term_show_tabs(term: @glossary_term, user: @user))
 <div class="row">
   <% @other_images.each do |image|  %>
     <div class="col-sm-4">
-      <%= panel_block do interactive_image(image, votes: true) end %>
+      <%= panel_block do
+        interactive_image(image, votes: true, id_prefix: "glossary_term_image")
+      end %>
     </div>
   <% end %>
 </div><!--.row-->

--- a/app/views/controllers/images/show/_image_panel.html.erb
+++ b/app/views/controllers/images/show/_image_panel.html.erb
@@ -26,7 +26,6 @@
   </div><!--.panel-heading-->
   <div class="panel-body">
 
-    <%= turbo_stream_from(@image) %>
     <%= interactive_image(@image, **image_show_presenter_args) %>
 
     <div class="mt-3 text-center">

--- a/app/views/controllers/images/show/_image_panel.html.erb
+++ b/app/views/controllers/images/show/_image_panel.html.erb
@@ -26,12 +26,8 @@
   </div><!--.panel-heading-->
   <div class="panel-body">
 
-    <%= interactive_image(@image,
-                          size: :huge,
-                          image_link: {},
-                          img_class: "huge-image",
-                          theater_on_click: true,
-                          votes: false) %>
+    <%= turbo_stream_from(@image) %>
+    <%= interactive_image(@image, **image_show_presenter_args) %>
 
     <div class="mt-3 text-center">
       <% if User.current %>

--- a/app/views/controllers/info/site_stats.html.erb
+++ b/app/views/controllers/info/site_stats.html.erb
@@ -11,9 +11,9 @@ add_tab_set(info_site_stats_tabs)
     if obs_length > 0 %>
       <% @observations[0,3].each do |obs| %>
         <div class="pb-1">
-          <%= interactive_image(obs.thumb_image,
-            image_link: observation_path(obs.id),
-            votes: true) %><br/><br/>
+          <%= interactive_image(
+            obs.thumb_image, image_link: observation_path(obs.id), votes: true
+          ) %><br/><br/>
         </div>
       <% end %>
     <% end %>
@@ -37,9 +37,9 @@ add_tab_set(info_site_stats_tabs)
   <div class="hidden-xs col-md-3">
     <% if obs_length > 3 %>
       <% @observations[3,3].each do |obs| %>
-        <%= interactive_image(obs.thumb_image,
-          image_link: observation_path(obs.id),
-          votes: true) %><br/><br/>
+        <%= interactive_image(
+          obs.thumb_image, image_link: observation_path(obs.id), votes: true
+        ) %><br/><br/>
       <% end %>
     <% end %>
   </div>

--- a/app/views/controllers/names/show/_confident_observations_panel.html.erb
+++ b/app/views/controllers/names/show/_confident_observations_panel.html.erb
@@ -8,6 +8,6 @@ carousel_locals = {
 <%= if @best_images&.length&.positive?
   tag.div(class: "panel panel-default",
           id: "name_confident_observations") do
-    carousel_html(**carousel_locals)
+    render(partial: "shared/carousel", locals: carousel_locals)
   end
 end %>

--- a/app/views/controllers/observations/namings/suggestions/show.html.erb
+++ b/app/views/controllers/observations/namings/suggestions/show.html.erb
@@ -55,9 +55,10 @@ add_tab_set(naming_suggestion_tabs(obs: @observation))
             <% end %>
           </td>
           <td>
-            <%= interactive_image(sugg.image_obs.thumb_image,
-                          image_link: image_path(id: sugg.image_obs.id)) \
-                          if sugg.image_obs.present? %>
+            <%= interactive_image(
+              sugg.image_obs.thumb_image,
+              image_link: image_path(id: sugg.image_obs.id)
+            ) if sugg.image_obs.present? %>
         </td>
       </tr>
     <% end %>

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -22,7 +22,6 @@ carousel_locals = {
 
 <div class="row">
   <div class="col-xs-12 col-md-8 col-lg-7 float-sm-left">
-    <%= turbo_stream_from(@observation, :images) %>
     <%= tag.div(class: "panel panel-default") do
       render(partial: "shared/carousel", locals: carousel_locals)
     end %>

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -15,15 +15,16 @@ show_links = @user && (@observation.external_links.any? || @other_sites.any?)
 obs_locals = { obs: @observation, consensus: @consensus, user: @user }
 carousel_locals = {
   object: @observation, images: @observation.images,
-  top_img: @observation&.thumb_image || nil,
+  top_img: @observation&.thumb_image || nil, html_id: "observation_images",
   title: :IMAGES.t, links: observation_show_image_links(obs: @observation)
 }
 %>
 
 <div class="row">
   <div class="col-xs-12 col-md-8 col-lg-7 float-sm-left">
+    <%= turbo_stream_from(@observation, :images) %>
     <%= tag.div(class: "panel panel-default") do
-      carousel_html(**carousel_locals)
+      render(partial: "shared/carousel", locals: carousel_locals)
     end %>
   </div>
 

--- a/app/views/controllers/observations/show/_images.erb
+++ b/app/views/controllers/observations/show/_images.erb
@@ -29,7 +29,8 @@ links = observation_show_image_links(obs: obs)
                 image_link: image.show_link_args.merge({ obs: obs.id }),
                 original: true,
                 is_set: true,
-                votes: true) %>
+                votes: true
+              ) %>
 
           <%=
             notes = []

--- a/app/views/controllers/projects/members/index.html.erb
+++ b/app/views/controllers/projects/members/index.html.erb
@@ -42,8 +42,9 @@ action = { controller: "/projects/members", action: :create,
       <tr>
         <td class="text-center">
 	  <%= if user.image_id
-                interactive_image(Image.find(user.image_id), votes: false,
-	                          size: :thumbnail)
+          interactive_image(
+            Image.find(user.image_id), votes: false, size: :thumbnail
+          )
 	      end %>
           <%= user_link(user, user.login) %>
         </td>

--- a/app/views/controllers/shared/_carousel.erb
+++ b/app/views/controllers/shared/_carousel.erb
@@ -1,0 +1,47 @@
+<%=
+# TODO: make this a component
+# Required args: images:
+# Optional args:
+#   object: (the carousel is usually for an object)
+#   top_img: (defaults to first), (carousel)title:, (image_edit)links:
+#   thumbnails: true for thumbnail navigation
+#   size: arg for ImagePresenter
+#   html_id: for carousel div
+#   links: button links for heading
+#
+# Note: uses concat(x) instead of [x,y].safe_join because of conditionals
+
+images ||= object&.images || nil #
+object ||= nil #
+size ||= :large
+top_img ||= images.first #
+title ||= :IMAGES.t #
+links ||= "" #
+thumbnails = true if thumbnails.nil? #
+type = object&.type_tag || "image" #
+html_id ||= "#{type}_#{object.id}_carousel" #
+
+concat(carousel_heading(title, links)) if thumbnails
+if !images.nil? && images.any?
+  tag.div(class: "carousel slide", id: html_id,
+          data: { ride: "false", interval: "false" }) do
+    concat(tag.div(class: "carousel-inner bg-light", role: "listbox") do
+      images.each do |image|
+        concat(render(partial: "shared/carousel_item",
+                      locals: { image:, size:, top_img:, object: }))
+      end
+      concat(carousel_controls(html_id)) if images.length > 1
+    end)
+    concat(
+      tag.ol(class: "carousel-indicators panel-footer py-2 px-0 mb-0") do
+        images.each_with_index do |image, index|
+          concat(render(partial: "shared/carousel_thumbnail",
+                        locals: { image:, index:, top_img:, html_id: }))
+        end
+      end
+    ) if thumbnails
+  end
+else
+  concat(carousel_no_images_message)
+end
+%>

--- a/app/views/controllers/shared/_carousel.erb
+++ b/app/views/controllers/shared/_carousel.erb
@@ -27,16 +27,18 @@ if !images.nil? && images.any?
           data: { ride: "false", interval: "false" }) do
     concat(tag.div(class: "carousel-inner bg-light", role: "listbox") do
       images.each do |image|
+        active = image == top_img ? "active" : ""
         concat(render(partial: "shared/carousel_item",
-                      locals: { image:, size:, top_img:, object: }))
+                      locals: { image:, size:, active:, object: }))
       end
       concat(carousel_controls(html_id)) if images.length > 1
     end)
     concat(
       tag.ol(class: "carousel-indicators panel-footer py-2 px-0 mb-0") do
         images.each_with_index do |image, index|
+          active = image == top_img ? "active" : ""
           concat(render(partial: "shared/carousel_thumbnail",
-                        locals: { image:, index:, top_img:, html_id: }))
+                        locals: { image:, index:, active:, html_id: }))
         end
       end
     ) if thumbnails

--- a/app/views/controllers/shared/_carousel.erb
+++ b/app/views/controllers/shared/_carousel.erb
@@ -42,6 +42,6 @@ if !images.nil? && images.any?
     ) if thumbnails
   end
 else
-  concat(carousel_no_images_message)
+  carousel_no_images_message
 end
 %>

--- a/app/views/controllers/shared/_carousel_item.erb
+++ b/app/views/controllers/shared/_carousel_item.erb
@@ -1,10 +1,10 @@
 <%=
-# Incoming locals: image, size, top_img, object
+# Incoming locals: image, size, active, object
 # Caption needs object for copyright info
 presenter_args = { size:, fit: :contain, original: true,
                    extra_classes: "carousel-image" }
 presenter = ImagePresenter.new(image, presenter_args)
-active = image == top_img ? "active" : ""
+active ||= ""
 
 tag.div(id: "carousel_item_#{image.id}",
         class: class_names("item", active)) do

--- a/app/views/controllers/shared/_carousel_item.erb
+++ b/app/views/controllers/shared/_carousel_item.erb
@@ -1,0 +1,19 @@
+<%=
+# Incoming locals: image, size, top_img, object
+# Caption needs object for copyright info
+presenter_args = { size:, fit: :contain, original: true,
+                   extra_classes: "carousel-image" }
+presenter = ImagePresenter.new(image, presenter_args)
+active = image == top_img ? "active" : ""
+
+tag.div(id: "carousel_item_#{image.id}",
+        class: class_names("item", active)) do
+  concat(image_tag(presenter.img_src, presenter.options_lazy))
+  if presenter.image_link
+    concat(image_stretched_link(presenter.image_link,
+                                presenter.image_link_method))
+  end
+  concat(lightbox_link(presenter.lightbox_data))
+  concat(carousel_caption(image, object, presenter))
+end
+%>

--- a/app/views/controllers/shared/_carousel_thumbnail.erb
+++ b/app/views/controllers/shared/_carousel_thumbnail.erb
@@ -1,8 +1,8 @@
 <%=
-# Incoming locals: image, index, top_img, html_id
+# Incoming locals: image, index, active, html_id
 presenter_args = { fit: :contain, extra_classes: "carousel-thumbnail" }
 presenter = ImagePresenter.new(image, presenter_args)
-active = image == top_img ? "active" : ""
+active ||= ""
 
 tag.li(id: "carousel_thumbnail_#{image.id}",
        class: class_names("carousel-indicator mx-1", active),

--- a/app/views/controllers/shared/_carousel_thumbnail.erb
+++ b/app/views/controllers/shared/_carousel_thumbnail.erb
@@ -1,0 +1,13 @@
+<%=
+# Incoming locals: image, index, top_img, html_id
+presenter_args = { fit: :contain, extra_classes: "carousel-thumbnail" }
+presenter = ImagePresenter.new(image, presenter_args)
+active = image == top_img ? "active" : ""
+
+tag.li(id: "carousel_thumbnail_#{image.id}",
+       class: class_names("carousel-indicator mx-1", active),
+       data: { target: "##{html_id}",
+               slide_to: index.to_s }) do
+  image_tag(presenter.img_src, presenter.options_lazy)
+end
+%>

--- a/app/views/controllers/shared/_interactive_image.erb
+++ b/app/views/controllers/shared/_interactive_image.erb
@@ -1,0 +1,7 @@
+<%=
+# This is a partial for the sake of broadcastability.
+# To make this generalizable for broadcasting to all interactive images, you'd
+# need to pass in the args from the broadcast, which probably means a separate
+# broadcast for each potential context.
+interactive_image(image, **args)
+%>

--- a/app/views/controllers/shared/_interactive_image.erb
+++ b/app/views/controllers/shared/_interactive_image.erb
@@ -1,7 +1,0 @@
-<%=
-# This is a partial for the sake of broadcastability.
-# To make this generalizable for broadcasting to all interactive images, you'd
-# need to pass in the args from the broadcast, which probably means a separate
-# broadcast for each potential context.
-interactive_image(image, **args)
-%>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -53,9 +53,11 @@ add_tab_set(species_list_show_tabs(list: @species_list, query: @query))
             <div class="row">
               <div class="col-sm-4 col-md-3">
                 <%= if observation.thumb_image_id
-                  interactive_image(observation.thumb_image,
-                            image_link: observation_path(id: observation.id),
-                            votes: true)
+                  interactive_image(
+                    observation.thumb_image,
+                    image_link: observation_path(id: observation.id),
+                    votes: true
+                  )
                 end %>
               </div>
               <div class="col-sm-8 col-md-9">

--- a/app/views/controllers/users/show/_best_images.erb
+++ b/app/views/controllers/users/show/_best_images.erb
@@ -7,6 +7,6 @@ carousel_locals = {
 
 <%= if @best_images&.length&.positive?
   tag.div(class: "panel panel-default", id: "user_best_images") do
-    carousel_html(**carousel_locals)
+    render(partial: "shared/carousel", locals: carousel_locals)
   end
 end %>

--- a/app/views/controllers/users/show/_profile.erb
+++ b/app/views/controllers/users/show/_profile.erb
@@ -30,7 +30,8 @@ footer =
 
   <%= if @show_user.image_id
     tag.div(class: "float-left mr-5 mb-3") do
-      interactive_image(Image.find(@show_user.image_id), votes: false)
+      interactive_image(Image.find(@show_user.image_id),
+                        votes: false, id_prefix: "profile_image")
     end
   end %>
 

--- a/app/views/controllers/visual_groups/_image_matrix.html.erb
+++ b/app/views/controllers/visual_groups/_image_matrix.html.erb
@@ -6,7 +6,7 @@
           tag.div(class: "panel panel-default") do
             concat(tag.div(class: "thumbnail-container") do
               interactive_image(
-                row[0], original: true, votes: false, full_width: :true
+                row[0], original: true, votes: false, full_width: true
               )
             end)
             concat(tag.div(class: "panel-body") do

--- a/app/views/controllers/visual_groups/_image_matrix.html.erb
+++ b/app/views/controllers/visual_groups/_image_matrix.html.erb
@@ -1,21 +1,22 @@
-<%= tag.div(id: "results") do %>
-  <%= paginate_block(@pages) do %>
-    <%= matrix_table do %>
-      <% @subset.each do |row| %>
-        <%= matrix_box(id: row[0]) do %>
-          <%= tag.div(class: "panel panel-default") do %>
-            <%= tag.div(class: "thumbnail-container") do
-              interactive_image(row[0], original: true, votes: false,
-                                  context: :matrix_box)
-            end %>
-            <%= tag.div(class: "panel-body") do
+<%= tag.div(id: "results") do
+  paginate_block(@pages) do
+    matrix_table do
+      @subset.each do |row|
+        concat(matrix_box(id: row[0]) do
+          tag.div(class: "panel panel-default") do
+            concat(tag.div(class: "thumbnail-container") do
+              interactive_image(
+                row[0], original: true, votes: false, full_width: :true
+              )
+            end)
+            concat(tag.div(class: "panel-body") do
               visual_group_status_links(
                 visual_group: visual_group, image_id: row[0], status: row[1]
               )
-            end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
-  <% end %>
-<% end %>
+            end)
+          end
+        end)
+      end
+    end
+  end
+end %>


### PR DESCRIPTION
Use partials instead of helpers for main carousel components (`carousel`, `carousel_item` and `carousel_thumbnail`).

Allows these to be sent as turbo responses. (may use this for create obs form)