### PR TITLE
New route param to allow removing a single image from observation

### DIFF
--- a/app/controllers/observations/images_controller.rb
+++ b/app/controllers/observations/images_controller.rb
@@ -346,7 +346,9 @@ module Observations
       unless check_permission!(@object)
         return redirect_with_query(permanent_observation_path(@object.id))
       end
-      return unless (images = params[:selected])
+
+      images = params[:selected] || [{ params[:image_id] => "yes" }]
+      return unless images
 
       remove_images_from_object(images)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -606,8 +606,8 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
                             as: "attach_image_to")
       get("images/remove", to: "observations/images#remove",
                            as: "remove_images_from")
-      put("images/detach", to: "observations/images#detach",
-                           as: "detach_images_from")
+      put("images(/:image_id)/detach", to: "observations/images#detach",
+                                       as: "detach_images_from")
     end
 
     collection do

--- a/test/controllers/observations/images_controller_test.rb
+++ b/test/controllers/observations/images_controller_test.rb
@@ -490,5 +490,19 @@ module Observations
 
       assert_empty(obs.reload.images)
     end
+
+    def test_remove_image_by_id
+      obs = observations(:detailed_unknown_obs)
+      images = obs.images
+      assert(images.size > 1,
+             "Use Observation fixture with multiple images for best coverage")
+      user = obs.user
+      params = { id: obs.id, image_id: images.first.id }
+
+      login(user.login)
+      put(:detach, params: params)
+
+      assert_equal(obs.images.except(obs.images.first), obs.reload.images)
+    end
   end
 end

--- a/test/controllers/observations/images_controller_test.rb
+++ b/test/controllers/observations/images_controller_test.rb
@@ -497,9 +497,14 @@ module Observations
       assert(images.size > 1,
              "Use Observation fixture with multiple images for best coverage")
       user = obs.user
-      params = { id: obs.id, image_id: images.first.id }
-
       login(user.login)
+
+      params = { id: obs.id, image_id: "bad_id" }
+      # It will just skip a bad image id.
+      put(:detach, params: params)
+      assert_equal(obs.images, obs.reload.images)
+
+      params[:image_id] = images.first.id
       put(:detach, params: params)
 
       assert_equal(obs.images.except(obs.images.first), obs.reload.images)


### PR DESCRIPTION
Preparation for revised obs form - this route is as yet unused in the front end.

Allows detaching an image from an obs by sending a simple PUT request to
`/observations/:id/images/:image_id/detach`
with no other parameters.

Includes new test.