### PR TITLE
Update `db/initialize.sql` to drop/create a `cache_development` db

### DIFF
--- a/db/initialize.sql
+++ b/db/initialize.sql
@@ -2,6 +2,10 @@ drop database if exists mo_development;
 create database mo_development
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
+drop database if exists cache_development;
+create database cache_development
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
 drop database if exists mo_test;
 create database mo_test
   DEFAULT CHARACTER SET utf8
@@ -30,4 +34,5 @@ use mo_test;
 drop database mo_tmp;
 
 grant all privileges on mo_development.* to 'mo'@'localhost' with grant option;
+grant all privileges on cache_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on mo_test.* to 'mo'@'localhost' with grant option;


### PR DESCRIPTION
The MO process for updating a development db snapshot will usually drop all databases, including this third `cache_development` db, which is necessary for local caching. 

The `db/initialize.sql` script is intended to prepare mysql to import a new db snapshot, but I think without the changes in this PR, people will have to create the `cache_development` db manually (and grant user `mo` privileges) every time they update their dev db, in order to use or test Solid Cache.

(Solid Queue uses tables in the main db, so that's handled by a migration.)