### PR TITLE
Disable link prefetching sitewide

### DIFF
--- a/app/views/controllers/application/app/_head.html.erb
+++ b/app/views/controllers/application/app/_head.html.erb
@@ -12,6 +12,7 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="turbo-refresh-scroll" content="preserve">
+<meta name="turbo-prefetch" content="false">
 <%= action_cable_meta_tag %>
 <%= auto_discovery_link_tag(
   :rss, activity_logs_rss_path, { title: :app_rss.l }


### PR DESCRIPTION
Turbo (as of version 8, aka `turbo-rails` v2.0) defaults to prefetching the entire HTML of any page whose link you hover over.

This creates a ton of extra traffic and noise in the logs, and has unintended side-effects in our code, because of the way we store the last-visited observation for a user.

This PR disables link-prefetching site-wide. 

It can alternatively be disabled on an element and its descendants with `data-turbo-prefetch="false"` - for example the navbar, or any link to an obs, but for now I believe we don't need it anywhere.