### PR TITLE
Fix `project_messages` alert/checkbox HTML in obs form

### DIFF
--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -65,6 +65,9 @@ module ObservationsController::Validators
 
     @suspect_checked_projects = checked_project_conflicts -
                                 @observation.projects
+    if @suspect_checked_projects.any?
+      flash_warning(:form_observations_there_is_a_problem_with_projects.t)
+    end
     @suspect_checked_projects.empty?
   end
 

--- a/app/views/controllers/observations/form/_projects.html.erb
+++ b/app/views/controllers/observations/form/_projects.html.erb
@@ -24,8 +24,7 @@
         </div>
         <%= check_box_with_label(
           form: f_p, field: :ignore_proj_conflicts,
-          label: :form_observations_projects_ignore_project_constraints.t,
-          class: "alert alert-warning"
+          label: :form_observations_projects_ignore_project_constraints.t
         ) %>
       </div>
     <% end %>

--- a/app/views/controllers/observations/form/_projects.html.erb
+++ b/app/views/controllers/observations/form/_projects.html.erb
@@ -1,39 +1,34 @@
 <%# Projects section of create_observation form %>
-<% if @suspect_checked_projects.any? %>
-  <% flash_warning(:form_observations_there_is_a_problem_with_projects.t) %>
-
-  <div class="alert alert-warning"
-       id="project_messages">
-    <%= tag.p(
-      "#{:form_observations_projects_out_of_range.t(
-         date: @observation.when,
-         place_name: @observation.place_name
-      )}:"
-    ) %>
-    <ul>
-      <% @suspect_checked_projects.each do |proj| %>
-        <%= tag.li("#{proj.title} (#{proj.constraints})") %>
-      <% end %>
-    </ul>
-    <%= tag.p(
-      :form_observations_projects_out_of_range_help.
-        t(button_name: button_name)
-    )%>
-  </div>
-<% end %>
 
 <%= fields_for(:project) do |f_p| %>
-  <% if @suspect_checked_projects.any? %>
-    <div class="mt-3 row" id="observation_projects">
-      <%= check_box_with_label(
-        form: f_p, field: :ignore_proj_conflicts,
-        label: :form_observations_projects_ignore_project_constraints.t,
-        class: "alert alert-warning"
-      ) %>
-    </div>
-  <% end %>
-
   <div class="mt-3 row" id="observation_projects">
+    <% if @suspect_checked_projects.any? %>
+      <div class="col-xs-12">
+        <div class="alert alert-warning"
+             id="project_messages">
+          <%= tag.p(
+            "#{:form_observations_projects_out_of_range.t(
+              date: @observation.when,
+              place_name: @observation.place_name
+            )}:"
+          ) %>
+          <ul>
+            <% @suspect_checked_projects.each do |proj| %>
+              <%= tag.li("#{proj.title} (#{proj.constraints})") %>
+            <% end %>
+          </ul>
+          <%= tag.p(
+            :form_observations_projects_out_of_range_help.
+              t(button_name: button_name)
+          )%>
+        </div>
+        <%= check_box_with_label(
+          form: f_p, field: :ignore_proj_conflicts,
+          label: :form_observations_projects_ignore_project_constraints.t,
+          class: "alert alert-warning"
+        ) %>
+      </div>
+    <% end %>
     <div class="col-xs-12 col-sm-6 col-sm-push-6">
       <%= help_block_with_arrow("left", id: "project_help") do %>
         <%= :form_observations_project_help.t %>


### PR DESCRIPTION
Sorry - I should have noticed this on the original PR. This doesn't change much, it just moves some things around (invisibly).

- Eliminates duplicate DOM id `observation_projects`, which is invalid HTML
- Moves `flash_warning` from the view to the controller, so flash messages are available to all rendering methods, in the case the obs form gets Turbo-ized. (Generally, flash needs to happen in the controller if we ever want to flash inside a "modal" form or use something like `ViewComponent`, but I think it's also just better practice. I'm aiming to gradually move all `flash` calls to the respective controllers when possible.)
- On the form, moves the whole message and checkbox into the `#observation_projects` div, and move the checkbox inside the `.alert` div, as it is for `form-name-feedback` et. al.