### PR TITLE
Fix naming form default when `no_opinion`

### DIFF
--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -256,9 +256,12 @@ module NamingsHelper
   def naming_vote_form(naming, vote, context: "blank")
     vote_id = vote&.id
     method = vote_id ? :patch : :post
-    menu = Vote.confidence_menu
     can_vote = check_permission(naming)
-    menu = [Vote.no_opinion] + menu if !can_vote || !vote || vote&.value&.zero?
+    menu = if !can_vote || !vote || vote&.value&.zero?
+             Vote.opinion_menu
+           else
+             Vote.confidence_menu
+           end
     localizations = {
       lose_changes: :show_namings_lose_changes.l.tr("\n", " "),
       saving: :show_namings_saving.l

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -14,7 +14,7 @@ feedback_locals = {
   parent_deprecated: @parent_deprecated,
   names: @names
 }
-menu = unless @vote&.nonzero?
+menu = unless @vote&.value&.nonzero?
          Vote.opinion_menu
        else
          Vote.confidence_menu

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -14,7 +14,12 @@ feedback_locals = {
   parent_deprecated: @parent_deprecated,
   names: @names
 }
-confidences = options_for_select(Vote.confidence_menu, @vote&.value)
+menu = unless @vote&.nonzero?
+         Vote.opinion_menu
+       else
+         Vote.confidence_menu
+       end
+confidences = options_for_select(menu, @vote&.value)
 select_opts = { include_blank: ["new", "create"].include?(action_name) }
 context ||= "blank"
 name_help ||= :form_naming_name_help.t

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -44,6 +44,7 @@ module Observations
       assert_empty(nam.votes)
       login(nam.user.login)
       get(:edit, params: { observation_id: nam.observation_id, id: nam.id })
+      assert_select("#naming_vote_value", text: /#{:vote_no_opinion.l}/)
     end
 
     def test_update_observation_new_name


### PR DESCRIPTION
addresses #2181