### PR TITLE
Autocompleters: CSS and helper refactor

### DIFF
--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -4,7 +4,7 @@
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
 $LEFT_BAR_BORDER_COLOR:             #DDDDDD;
-$TOP_BAR_BORDER_COLOR:              #DDcDDD;
+$TOP_BAR_BORDER_COLOR:              #DFDDDD;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;
 $BUTTON_BG_COLOR:                   #CCCCCC;

--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -4,7 +4,7 @@
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
 $LEFT_BAR_BORDER_COLOR:             #DDDDDD;
-$TOP_BAR_BORDER_COLOR:              #DDDDDD;
+$TOP_BAR_BORDER_COLOR:              #DDDcDD;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;
 $BUTTON_BG_COLOR:                   #CCCCCC;

--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -4,7 +4,7 @@
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
 $LEFT_BAR_BORDER_COLOR:             #DDDDDD;
-$TOP_BAR_BORDER_COLOR:              #DDDcDD;
+$TOP_BAR_BORDER_COLOR:              #DDcDDD;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;
 $BUTTON_BG_COLOR:                   #CCCCCC;

--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -4,7 +4,7 @@
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
 $LEFT_BAR_BORDER_COLOR:             #DDDDDD;
-$TOP_BAR_BORDER_COLOR:              #DFDDDD;
+$TOP_BAR_BORDER_COLOR:              #EDDDDD;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;
 $BUTTON_BG_COLOR:                   #CCCCCC;

--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -2,17 +2,18 @@
 // autocompletion
 // --------------------------------------------------
 
-.auto_complete {
-  position: absolute;
-  color: $dropdown-link-color;
-  background-color: $dropdown-bg;
+.dropdown-menu.auto_complete {
+  // position: absolute;
+  // color: $dropdown-link-color;
+  // background-color: $dropdown-bg;
   margin: 0px;
-  border: 1px solid $dropdown-border;
+  // border: 1px solid $dropdown-border;
+  border-radius: 0;
   padding: 0px;
   overflow-x: hidden;
-  display: none;
-  text-align: left;
-  z-index: 100;
+  // display: none;
+  // text-align: left;
+  // z-index: 100;
 
   ul {
     margin: 0px;
@@ -40,7 +41,7 @@
         }
       }
 
-      &.selected {
+      &.active {
         a {
           color: $dropdown-link-color;
           background-color: $dropdown-link-hover-bg;

--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -14,39 +14,39 @@
   // display: none;
   // text-align: left;
   // z-index: 100;
+}
 
-  ul.virtual_list {
-    margin: 0px;
-    border: 0px;
-    padding: 0px;
-    list-style: none;
-    overflow-x: hidden;
+ul.virtual_list {
+  margin: 0px;
+  border: 0px;
+  padding: 0px;
+  list-style: none;
+  overflow-x: hidden;
+}
 
-    li {
-      margin: 0px;
-      border: 0px;
-      white-space: nowrap;
-      cursor: pointer;
+li.dropdown-item {
+  margin: 0px;
+  border: 0px;
+  white-space: nowrap;
+  cursor: pointer;
 
-      a {
-        display: block;
-        padding: 2px 4px;
-        color: $dropdown-link-color;
-        text-decoration: none;
+  a {
+    display: block;
+    padding: 2px 4px;
+    color: $dropdown-link-color;
+    text-decoration: none;
 
-        &:hover {
-          color: $dropdown-link-color;
-          background-color: $dropdown-link-hover-bg;
-          text-decoration: none;
-        }
-      }
+    &:hover {
+      color: $dropdown-link-color;
+      background-color: $dropdown-link-hover-bg;
+      text-decoration: none;
+    }
+  }
 
-      &.active {
-        a {
-          color: $dropdown-link-color;
-          background-color: $dropdown-link-hover-bg;
-        }
-      }
+  &.active {
+    a {
+      color: $dropdown-link-color;
+      background-color: $dropdown-link-hover-bg;
     }
   }
 }

--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -2,7 +2,7 @@
 // autocompletion
 // --------------------------------------------------
 
-div.auto_complete {
+.auto_complete {
   position: absolute;
   color: $dropdown-link-color;
   background-color: $dropdown-bg;
@@ -24,14 +24,28 @@ div.auto_complete {
     li {
       margin: 0px;
       border: 0px;
-      padding: 2px 4px 2px 4px;
       white-space: nowrap;
       cursor: pointer;
-    }
 
-    li.selected {
-      color: $dropdown-link-hover-color;
-      background-color: $dropdown-link-hover-bg;
+      a {
+        display: block;
+        padding: 2px 4px;
+        color: $dropdown-link-color;
+        text-decoration: none;
+
+        &:hover {
+          color: $dropdown-link-color;
+          background-color: $dropdown-link-hover-bg;
+          text-decoration: none;
+        }
+      }
+
+      &.selected {
+        a {
+          color: $dropdown-link-color;
+          background-color: $dropdown-link-hover-bg;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -15,7 +15,7 @@
   // text-align: left;
   // z-index: 100;
 
-  ul {
+  ul.virtual_list {
     margin: 0px;
     border: 0px;
     padding: 0px;

--- a/app/classes/auto_complete.rb
+++ b/app/classes/auto_complete.rb
@@ -10,7 +10,7 @@
 ################################################################################
 
 class AutoComplete
-  attr_accessor :string, :matches, :all
+  attr_accessor :string, :matches, :all, :whole
 
   PUNCTUATION = '[ -\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]'
 
@@ -27,11 +27,13 @@ class AutoComplete
   def initialize(params = {})
     self.string = params[:string].to_s.strip_squeeze
     self.all = params[:all].present?
+    self.whole = params[:whole].present?
   end
 
   def matching_strings
-    # just use the first letter of the string to define the matches
-    self.matches = rough_matches(string[0])
+    # unless 'whole', use the first letter of the string to define the matches
+    token = whole ? string : string[0]
+    self.matches = rough_matches(token)
     clean_matches
     return matches if all
 

--- a/app/classes/auto_complete/for_region.rb
+++ b/app/classes/auto_complete/for_region.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This requires Stimulus delaying the fetch until we have a complete word.
+class AutoComplete::ForRegion < AutoComplete::ByWord
+  attr_accessor :reverse
+
+  def initialize(params)
+    super
+    self.reverse = (params[:format] == "scientific")
+  end
+
+  def rough_matches(words)
+    words = Location.reverse_name(words) if reverse
+    matches = Observation.in_region(words).pluck(:where)
+
+    matches.map! { |m| Location.reverse_name(m) } if reverse
+    matches.sort.uniq
+  end
+end

--- a/app/controllers/autocompleters_controller.rb
+++ b/app/controllers/autocompleters_controller.rb
@@ -32,7 +32,7 @@ class AutocompletersController < ApplicationController
 
   def auto_complete_results
     case @type
-    when "location", "location_containing"
+    when "location", "location_containing", "region"
       params[:format] = @user&.location_format
     when "herbarium"
       params[:user_id] = @user&.id

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -143,20 +143,29 @@ module FormsHelper
     end
   end
 
-  # This allows incoming data attributes to deep_merge with autocompleter's data
-  # 2023 hack to defeat unhelpful browser autocompletes that get in the way of
-  # our autocompleter: use the browser standard autocomplete att "one-time-code"
+  # MO's autocompleter_field is a text_field that fetches suggestions from the
+  # db for the requested model. (For a textarea, pass textarea: true.) The
+  # stimulus controller handles keyboard and mouse interactions, does the
+  # fetching, and draws the dropdown menu. `args` allow incoming data attributes
+  # to deep_merge with controller data. We attempt to disable browser
+  # autocomplete via `autocomplete="off"` — the W3C standard API, but it
+  # has never been honored by Chrome or Safari. Chrome seems to be in a race to
+  # defeat the evolving hacks by developers to disable inappropriate
+  # autocompletes, and Safari is not much better - you just can't
+  # turn their crap off. (documented on SO)
+  #
   def autocompleter_field(**args)
-    autocompleter_args = {
+    ac_args = {
       placeholder: :start_typing.l, autocomplete: "off",
       data: { controller: :autocompleter, autocompleter_target: "input",
               autocomplete: args[:autocomplete], separator: args[:separator] }
     }.deep_merge(args.except(:autocomplete, :separator, :textarea))
+    ac_args[:class] = class_names("position-relative", args[:class])
 
     if args[:textarea] == true
-      text_area_with_label(**autocompleter_args)
+      text_area_with_label(**ac_args)
     else
-      text_field_with_label(**autocompleter_args)
+      text_field_with_label(**ac_args)
     end
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -151,15 +151,15 @@ module FormsHelper
   # autocomplete via `autocomplete="off"` — the W3C standard API, but it
   # has never been honored by Chrome or Safari. Chrome seems to be in a race to
   # defeat the evolving hacks by developers to disable inappropriate
-  # autocompletes, and Safari is not much better - you just can't
-  # turn their crap off. (documented on SO)
+  # autocompletes, and Safari is not much better - you just can't turn their
+  # crap off. (documented on SO)
   #
   def autocompleter_field(**args)
     ac_args = {
       placeholder: :start_typing.l, autocomplete: "off",
       data: { controller: :autocompleter, autocompleter_target: "input",
-              autocomplete: args[:autocomplete], separator: args[:separator] }
-    }.deep_merge(args.except(:autocomplete, :separator, :textarea))
+              type: args[:type], separator: args[:separator] }
+    }.deep_merge(args.except(:type, :separator, :textarea))
     ac_args[:class] = class_names("position-relative", args[:class])
 
     if args[:textarea] == true

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -160,7 +160,7 @@ module FormsHelper
       data: { controller: :autocompleter, autocompleter_target: "input",
               type: args[:type], separator: args[:separator] }
     }.deep_merge(args.except(:type, :separator, :textarea))
-    ac_args[:class] = class_names("position-relative", args[:class])
+    ac_args[:class] = class_names("dropdown", args[:class])
 
     if args[:textarea] == true
       text_area_with_label(**ac_args)

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -133,9 +133,10 @@ module FormsHelper
     opts[:class] = "form-control"
 
     wrap_class = form_group_wrap_class(args)
+    wrap_data = args[:wrap_data] || {}
     label_opts = field_label_opts(args)
 
-    tag.div(class: wrap_class) do
+    tag.div(class: wrap_class, data: wrap_data) do
       concat(args[:form].label(args[:field], args[:label], label_opts))
       concat(args[:between]) if args[:between].present?
       concat(args[:form].text_field(args[:field], opts))
@@ -157,10 +158,11 @@ module FormsHelper
   def autocompleter_field(**args)
     ac_args = {
       placeholder: :start_typing.l, autocomplete: "off",
-      data: { controller: :autocompleter, autocompleter_target: "input",
-              type: args[:type], separator: args[:separator] }
+      data: { autocompleter_target: "input" }
     }.deep_merge(args.except(:type, :separator, :textarea))
     ac_args[:class] = class_names("dropdown", args[:class])
+    ac_args[:wrap_data] = { controller: :autocompleter, type: args[:type],
+                            separator: args[:separator] }
 
     if args[:textarea] == true
       text_area_with_label(**ac_args)
@@ -178,9 +180,10 @@ module FormsHelper
     opts[:class] += " text-monospace" if args[:monospace].present?
 
     wrap_class = form_group_wrap_class(args)
+    wrap_data = args[:wrap_data] || {}
     label_opts = field_label_opts(args)
 
-    tag.div(class: wrap_class) do
+    tag.div(class: wrap_class, data: wrap_data) do
       concat(args[:form].label(args[:field], args[:label], label_opts))
       concat(args[:between]) if args[:between].present?
       concat(args[:form].text_area(args[:field], opts))
@@ -473,7 +476,7 @@ module FormsHelper
   def separate_field_options_from_args(args, extras = [])
     exceptions = [
       :form, :field, :label, :class, :width, :inline, :between, :append,
-      :optional, :required, :monospace, :type
+      :optional, :required, :monospace, :type, :wrap_data
     ] + extras
 
     args.clone.except(*exceptions)

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -97,7 +97,7 @@ const INTERNAL_OPTS = {
   key_timer: null        // timer used to emulate key repeat
 }
 
-// Connects to data-controller="autocomplete"
+// Connects to data-controller="autocompleter"
 export default class extends Controller {
   // The select target is not the input element, but a <select> that can
   // swap out the autocompleter type. The input element is the target.
@@ -109,7 +109,7 @@ export default class extends Controller {
     // Check the type of autocompleter set on the input element
     // maybe should not happen on connect, or we could be resetting type
     // Or maybe it should, and the filter swapper should just change this? no.
-    this.TYPE = this.inputTarget.dataset.autocomplete;
+    this.TYPE = this.inputTarget.dataset.type;
     if (!AUTOCOMPLETER_TYPES.hasOwnProperty(this.TYPE))
       alert("MOAutocompleter: Invalid type: \"" + this.TYPE + "\"");
 
@@ -148,7 +148,7 @@ export default class extends Controller {
       alert("MOAutocompleter: Invalid type: \"" + this.TYPE + "\"");
     } else {
       this.TYPE = type;
-      this.inputTarget.setAttribute("data-autocompleter", type)
+      this.inputTarget.setAttribute("data-type", type)
       // add dependent properties and allow overrides
       Object.assign(this, AUTOCOMPLETER_TYPES[this.TYPE]);
       Object.assign(this, opts);

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -552,18 +552,18 @@ export default class extends Controller {
     this.LIST_ELEM = list;
   }
 
-  // Add "click" and "mouseover" events to a row of the pulldown menu.
+  // Add "click" events to a row of the pulldown menu.
   // Need to do this in a separate method, otherwise row doesn't get
   // a separate value for each row!  Something to do with scope of
-  // variables inside for loops.
+  // variables inside `for` loops. By using <a>, we can skip "mouseover".
   attach_row_link_events(element, row) {
     element.addEventListener("click", ((e) => {
       e.preventDefault();
       this.select_row(row);
     }).bind(this));
-    element.addEventListener("mouseover", ((e) => {
-      this.highlight_row(row);
-    }).bind(this));
+    // element.addEventListener("mouseover", ((e) => {
+    //   this.highlight_row(row);
+    // }).bind(this));
   }
 
   // Stimulus: print this in the document already

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -520,11 +520,14 @@ export default class extends Controller {
     pulldown.classList.add(this.PULLDOWN_CLASS);
 
     const list = document.createElement('ul');
-    let i, row;
+    let i, row, link;
     for (i = 0; i < this.PULLDOWN_SIZE; i++) {
       row = document.createElement("li");
-      row.style.display = 'none';
-      this.attach_row_events(row, i);
+      link = document.createElement("a");
+      link.href = '#';
+      this.attach_row_link_events(link, i);
+      row.appendChild(link);
+      // row.style.display = 'none';
       list.append(row);
     }
     pulldown.appendChild(list)
@@ -539,11 +542,12 @@ export default class extends Controller {
   // Need to do this in a separate method, otherwise row doesn't get
   // a separate value for each row!  Something to do with scope of
   // variables inside for loops.
-  attach_row_events(e, row) {
-    e.addEventListener("click", (function () {
+  attach_row_link_events(element, row) {
+    element.addEventListener("click", ((e) => {
+      e.preventDefault();
       this.select_row(row);
     }).bind(this));
-    e.addEventListener("mouseover", (function () {
+    element.addEventListener("mouseover", ((e) => {
       this.highlight_row(row);
     }).bind(this));
   }
@@ -554,13 +558,16 @@ export default class extends Controller {
   get_row_height() {
     const div = document.createElement('div'),
       ul = document.createElement('ul'),
-      li = document.createElement('li');
+      li = document.createElement('li'),
+      a = document.createElement('a');
 
     div.className = this.PULLDOWN_CLASS;
-    div.classList.add('test');
+    div.classList.add('temp');
     div.style.display = 'block';
     div.style.border = div.style.margin = div.style.padding = '0px';
-    li.innerHTML = 'test';
+    a.href = '#';
+    a.innerHTML = 'test';
+    li.appendChild(a);
     ul.appendChild(li);
     div.appendChild(ul);
     document.body.appendChild(div);
@@ -609,23 +616,25 @@ export default class extends Controller {
     this.inputTarget.focus();
   }
 
-  // Update menu text first.
+  // Update menu text first. This is sort of a "virtual list" implementation.
+  // Keeps few elements in the DOM, but updates them as needed.
   update_rows(rows, matches, size, scroll) {
-    let i, x, y;
+    let i, text, stored;
     for (i = 0; i < size; i++) {
       let row = rows.item(i);
-      x = row.innerHTML;
+      let link = row.children[0];
+      text = link.innerHTML;
       if (i + scroll < matches.length) {
-        y = this.escapeHTML(matches[i + scroll]);
-        if (x != y) {
-          if (x == '')
-            row.style.display = 'block';
-          row.innerHTML = y;
+        stored = this.escapeHTML(matches[i + scroll]);
+        if (text != stored) {
+          // if (text == '')
+          //   row.style.display = 'block';
+          link.innerHTML = stored;
         }
       } else {
-        if (x != '') {
-          row.innerHTML = '';
-          row.style.display = 'none';
+        if (text != '') {
+          link.innerHTML = '';
+          // row.style.display = 'none';
         }
       }
     }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -121,17 +121,16 @@ const INTERNAL_OPTS = {
 
 // Connects to data-controller="autocompleter"
 export default class extends Controller {
-  // The select target is not the input element, but a <select> that can
-  // swap out the autocompleter type. The input element is the target.
+  // The root element should usually be the .form-group wrapping the <input>.
+  // The select target is not the <input> element, but a <select> that can
+  // swap out the autocompleter type. The <input> element is its target.
   static targets = ["input", "select"]
 
   initialize() {
     Object.assign(this, DEFAULT_OPTS);
 
-    // Check the type of autocompleter set on the input element
-    // maybe should not happen on connect, or we could be resetting type
-    // Or maybe it should, and the filter swapper should just change this? no.
-    this.TYPE = this.inputTarget.dataset.type;
+    // Check the type of autocompleter set on the root or input element
+    this.TYPE = this.element.dataset.type || this.inputTarget.dataset.type;
     if (!AUTOCOMPLETER_TYPES.hasOwnProperty(this.TYPE))
       alert("MOAutocompleter: Invalid type: \"" + this.TYPE + "\"");
 
@@ -151,9 +150,9 @@ export default class extends Controller {
     // Figure out a few browser-dependent dimensions.
     this.getScrollBarWidth;
 
-    // Wrap cannot be a target because it's "above" the controller scope in DOM.
-    this.dropdown_wrap = this.inputTarget.closest("." + this.WRAP_CLASS);
-    if (this.dropdown_wrap == undefined)
+    // Wrap is usually the root element with the controller, a ".form-group".
+    this.dropdown_wrap = this.element || this.inputTarget.parentElement;
+    if (this.dropdown_wrap.classList.contains(this.WRAP_CLASS) == false)
       alert("MOAutocompleter: needs a wrapping div with class: \"" +
         this.WRAP_CLASS + "\"");
 
@@ -176,6 +175,8 @@ export default class extends Controller {
     } else if (detail?.hasOwnProperty("type")) {
       type = detail.type;
     }
+    debugger
+    if (type == undefined) { return; }
 
     if (!AUTOCOMPLETER_TYPES.hasOwnProperty(type)) {
       alert("MOAutocompleter: Invalid type: \"" + type + "\"");

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -168,20 +168,23 @@ export default class extends Controller {
   // Action may be called from a <select> with
   // `data-action: "autocompleter-swap:swap->autocompleter#swap"`
   // or an event dispatched by another controller.
-  swap(opts = {}) {
-    if (!this.hasSelectTarget)
-      return;
+  swap({ detail }) {
+    let type;
 
-    const type = this.selectTarget.value;
+    if (this.hasSelectTarget) {
+      type = this.selectTarget.value;
+    } else if (detail?.hasOwnProperty("type")) {
+      type = detail.type;
+    }
 
     if (!AUTOCOMPLETER_TYPES.hasOwnProperty(type)) {
-      alert("MOAutocompleter: Invalid type: \"" + this.TYPE + "\"");
+      alert("MOAutocompleter: Invalid type: \"" + type + "\"");
     } else {
       this.TYPE = type;
       this.inputTarget.setAttribute("data-type", type)
       // add dependent properties and allow overrides
       Object.assign(this, AUTOCOMPLETER_TYPES[this.TYPE]);
-      Object.assign(this, opts);
+      Object.assign(this, detail); // type, request_params
       this.prepare_input_element();
     }
   }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -81,6 +81,7 @@ const INTERNAL_OPTS = {
   SCROLLBAR_WIDTH: null, // width of scrollbar in browser (determined below)
   focused: false,        // is user in text field?
   menu_up: false,        // is pulldown visible?
+  dropdown_wrap: null,   // wrapping div for pulldown
   old_value: null,       // previous value of input field
   primer: [],            // a server-supplied list of many options
   matches: [],           // list of options currently showing
@@ -128,6 +129,11 @@ export default class extends Controller {
 
     // Figure out a few browser-dependent dimensions.
     this.getScrollBarWidth;
+
+    // This cannot be a target because it's "above" the controller scope in DOM.
+    this.dropdown_wrap = this.inputTarget.closest('.dropdown');
+    if (this.dropdown_wrap == undefined)
+      alert("MOAutocompleter: needs a wrapping div with class: \"dropdown\"");
 
     // Create pulldown.
     this.create_pulldown();
@@ -575,9 +581,11 @@ export default class extends Controller {
       li = document.createElement('li'),
       a = document.createElement('a');
 
-    div.classList.add(...this.PULLDOWN_CLASSES, 'temp');
-    div.style.display = 'block';
-    div.style.border = div.style.margin = div.style.padding = '0px';
+    div.classList.add('test');
+    // div.style.display = 'block';
+    // div.style.border = div.style.margin = div.style.padding = '0px';
+    // ul.style.border = ul.style.margin = ul.style.padding = '0px';
+    ul.classList.add(...this.LIST_CLASSES)
     a.href = '#';
     a.innerHTML = 'test';
     li.classList.add(...this.ITEM_CLASSES);
@@ -680,7 +688,7 @@ export default class extends Controller {
 
     if (matches.length > 0) {
       // console.log("Matches:" + matches)
-      // const top = this.inputTarget.offsetTop,
+      // const top = this.dropdown_wrap.offsetTop,
       //   left = this.inputTarget.offsetLeft,
       //   hgt = this.inputTarget.offsetHeight,
       //   scr = this.inputTarget.scrollTop;
@@ -689,7 +697,9 @@ export default class extends Controller {
 
       // Set height of pulldown.
       pulldown.style.overflowY = matches.length > size ? "scroll" : "hidden";
-      pulldown.style.height = this.ROW_HEIGHT * (size < matches.length - scroll ? size : matches.length - scroll) + "px";
+      pulldown.style.height = this.ROW_HEIGHT *
+        (size < matches.length - scroll ? size : matches.length - scroll) +
+        "px";
       list.style.marginTop = this.ROW_HEIGHT * scroll + "px";
       list.style.height = this.ROW_HEIGHT * (matches.length - scroll) + "px";
       pulldown.scrollTo({ top: this.ROW_HEIGHT * scroll });
@@ -704,25 +714,23 @@ export default class extends Controller {
       // instead of style.display = 'block'
       if (matches.length > 1 || this.inputTarget.value != matches[0]) {
         this.clear_hide();
-        pulldown.style.display = 'block';
+        this.dropdown_wrap?.classList?.add('open');
         this.menu_up = true;
       } else {
-        pulldown.style.removeProperty('display');
-        this.menu_up = false;
+        hide_pulldown();
       }
     }
 
     // Hide the pulldown if it's empty now.
     else {
-      pulldown.style.removeProperty('display');
-      this.menu_up = false;
+      this.hide_pulldown();
     }
   }
 
   // Hide pulldown options.
   hide_pulldown() {
     this.verbose("hide_pulldown()");
-    this.PULLDOWN_ELEM.style.removeProperty('display');
+    this.dropdown_wrap?.classList?.remove('open');
     this.menu_up = false;
   }
 

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -14,7 +14,7 @@ const DEFAULT_OPTS = {
   // N = etc.
   COLLAPSE: 0,
   // where to request primer from
-  AJAX_URL: null,
+  AJAX_URL: "/autocompleters/new/",
   // how long to wait before sending AJAX request (seconds)
   REFRESH_DELAY: 0.10,
   // how long to wait before hiding pulldown (seconds)
@@ -28,7 +28,7 @@ const DEFAULT_OPTS = {
   // amount to move cursor on page up and down
   PAGE_SIZE: 10,
   // max length of string to send via AJAX
-  MAX_REQUEST_LINK: 50,
+  MAX_STRING_LENGTH: 50,
   // Sub-match: starts finding new matches for the string *after the separator*
   // allowed separators (e.g. " OR ")
   SEPARATOR: null,
@@ -45,34 +45,26 @@ const DEFAULT_OPTS = {
 // Allowed types of autocompleter. Sets some DEFAULT_OPTS from type
 const AUTOCOMPLETER_TYPES = {
   clade: {
-    AJAX_URL: "/autocompleters/new/clade/@",
   },
   herbarium: { // params[:user_id] handled in controller
-    AJAX_URL: "/autocompleters/new/herbarium/@",
     UNORDERED: true
   },
   location: { // params[:format] handled in controller
-    AJAX_URL: "/autocompleters/new/location/@",
     UNORDERED: true
   },
   name: {
-    AJAX_URL: "/autocompleters/new/name/@",
     COLLAPSE: 1
   },
   project: {
-    AJAX_URL: "/autocompleters/new/project/@",
     UNORDERED: true
   },
   region: {
-    AJAX_URL: "/autocompleters/new/location/@",
     UNORDERED: true
   },
   species_list: {
-    AJAX_URL: "/autocompleters/new/species_list/@",
     UNORDERED: true
   },
   user: {
-    AJAX_URL: "/autocompleters/new/user/@",
     UNORDERED: true
   }
 }
@@ -103,6 +95,8 @@ const INTERNAL_OPTS = {
 
 // Connects to data-controller="autocomplete"
 export default class extends Controller {
+  // The select target is not the input element, but a <select> that can
+  // swap out the autocompleter type. The input element is the target.
   static targets = ["input", "select"]
 
   initialize() {
@@ -167,7 +161,14 @@ export default class extends Controller {
     this.add_event_listeners();
 
     // sanity check to show which autocompleter is currently on the element
-    this.inputTarget.setAttribute("data-ajax-url", this.AJAX_URL);
+    this.inputTarget.setAttribute("data-ajax-url", this.AJAX_URL + this.TYPE);
+
+    // If the primer is not based on input, go ahead and request from server.
+    if (this.ACT_LIKE_SELECT == true) {
+      this.inputTarget.click();
+      this.inputTarget.focus();
+      this.inputTarget.value = ' ';
+    }
   }
 
   // NOTE: `this` within an event listener function refers to the element
@@ -424,30 +425,30 @@ export default class extends Controller {
   go_end() { this.move_cursor(this.matches.length) }
   move_cursor(rows) {
     this.verbose("move_cursor()");
-    const old_row = this.current_row,
-      old_scr = this.scroll_offset;
-    let new_row = old_row + rows,
-      new_scr = old_scr;
+    const _old_row = this.current_row,
+      _old_scr = this.scroll_offset;
+    let _new_row = _old_row + rows,
+      _new_scr = _old_scr;
 
     // Move cursor, but keep in bounds.
-    if (new_row < 0)
-      new_row = old_row < 0 ? -1 : 0;
-    if (new_row >= this.matches.length)
-      new_row = this.matches.length - 1;
-    this.current_row = new_row;
-    this.current_value = new_row < 0 ? null : this.matches[new_row];
+    if (_new_row < 0)
+      _new_row = _old_row < 0 ? -1 : 0;
+    if (_new_row >= this.matches.length)
+      _new_row = this.matches.length - 1;
+    this.current_row = _new_row;
+    this.current_value = _new_row < 0 ? null : this.matches[_new_row];
 
     // Scroll view so new row is visible.
-    if (new_row < new_scr)
-      new_scr = new_row;
-    if (new_scr < 0)
-      new_scr = 0;
-    if (new_row >= new_scr + this.PULLDOWN_SIZE)
-      new_scr = new_row - this.PULLDOWN_SIZE + 1;
+    if (_new_row < _new_scr)
+      _new_scr = _new_row;
+    if (_new_scr < 0)
+      _new_scr = 0;
+    if (_new_row >= _new_scr + this.PULLDOWN_SIZE)
+      _new_scr = _new_row - this.PULLDOWN_SIZE + 1;
 
     // Update if something changed.
-    if (new_row != old_row || new_scr != old_scr) {
-      this.scroll_offset = new_scr;
+    if (_new_row != _old_row || _new_scr != _old_scr) {
+      this.scroll_offset = _new_scr;
       this.draw_pulldown();
     }
   }
@@ -455,17 +456,17 @@ export default class extends Controller {
   // Mouse has moved over a menu item.
   highlight_row(new_hl) {
     this.verbose("highlight_row()");
-    const rows = this.LIST_ELEM.children,
-      old_hl = this.current_highlight;
+    const _rows = this.LIST_ELEM.children,
+      _old_hl = this.current_highlight;
 
     this.current_highlight = new_hl;
     this.current_row = this.scroll_offset + new_hl;
 
-    if (old_hl != new_hl) {
-      if (old_hl >= 0)
-        rows[old_hl].classList.remove(this.HOT_CLASS);
+    if (_old_hl != new_hl) {
+      if (_old_hl >= 0)
+        _rows[_old_hl].classList.remove(this.HOT_CLASS);
       if (new_hl >= 0)
-        rows[new_hl].classList.add(this.HOT_CLASS);
+        _rows[new_hl].classList.add(this.HOT_CLASS);
     }
     this.inputTarget.focus();
     this.update_width();
@@ -474,18 +475,18 @@ export default class extends Controller {
   // Called when users scrolls via scrollbar.
   our_scroll() {
     this.verbose("our_scroll()");
-    const old_scr = this.scroll_offset,
-      new_scr = Math.round(this.PULLDOWN_ELEM.scrollTop / this.ROW_HEIGHT),
-      old_row = this.current_row;
-    let new_row = this.current_row;
+    const _old_scr = this.scroll_offset,
+      _new_scr = Math.round(this.PULLDOWN_ELEM.scrollTop / this.ROW_HEIGHT),
+      _old_row = this.current_row;
+    let _new_row = this.current_row;
 
-    if (new_row < new_scr)
-      new_row = new_scr;
-    if (new_row >= new_scr + this.PULLDOWN_SIZE)
-      new_row = new_scr + this.PULLDOWN_SIZE - 1;
-    if (new_row != old_row || new_scr != old_scr) {
-      this.current_row = new_row;
-      this.scroll_offset = new_scr;
+    if (_new_row < _new_scr)
+      _new_row = _new_scr;
+    if (_new_row >= _new_scr + this.PULLDOWN_SIZE)
+      _new_row = _new_scr + this.PULLDOWN_SIZE - 1;
+    if (_new_row != _old_row || _new_scr != _old_scr) {
+      this.current_row = _new_row;
+      this.scroll_offset = _new_scr;
       this.draw_pulldown();
     }
   }
@@ -494,20 +495,20 @@ export default class extends Controller {
   select_row(row) {
     this.verbose("select_row()");
     // const old_val = this.inputTarget.value;
-    let new_val = this.matches[this.scroll_offset + row];
+    let _new_val = this.matches[this.scroll_offset + row];
     // Close pulldown unless the value the user selected uncollapses into a set
     // of new options.  In that case schedule a refresh and leave it up.
     if (this.COLLAPSE > 0 &&
-      (new_val.match(/ /g) || []).length < this.COLLAPSE) {
-      new_val += ' ';
+      (_new_val.match(/ /g) || []).length < this.COLLAPSE) {
+      _new_val += ' ';
       this.schedule_refresh();
     } else {
       this.schedule_hide();
     }
     this.inputTarget.focus();
     this.focused = true;
-    this.inputTarget.value = new_val;
-    this.set_search_token(new_val);
+    this.inputTarget.value = _new_val;
+    this.set_search_token(_new_val);
     this.our_change(false);
   }
 
@@ -515,23 +516,25 @@ export default class extends Controller {
 
   // Create div for pulldown. Presence of this is checked in system tests.
   create_pulldown() {
-    const div = document.createElement("div");
-    div.classList.add(this.PULLDOWN_CLASS);
+    const _pulldown = document.createElement("div");
+    _pulldown.classList.add(this.PULLDOWN_CLASS);
 
-    const list = document.createElement('ul');
-    let i, row;
+    const _list = document.createElement('ul');
+    _list.classList.add(this.LIST_CLASS);
+
+    let i, _item;
     for (i = 0; i < this.PULLDOWN_SIZE; i++) {
-      row = document.createElement("li");
-      row.style.display = 'none';
-      this.attach_row_events(row, i);
-      list.append(row);
+      _item = document.createElement("li");
+      _item.style.display = 'none';
+      this.attach_row_events(_item, i);
+      _list.append(_item);
     }
-    div.appendChild(list)
+    _pulldown.appendChild(_list)
 
-    div.addEventListener("scroll", this.our_scroll.bind(this));
-    this.inputTarget.insertAdjacentElement("afterend", div);
-    this.PULLDOWN_ELEM = div;
-    this.LIST_ELEM = list;
+    _pulldown.addEventListener("scroll", this.our_scroll.bind(this));
+    this.inputTarget.insertAdjacentElement("afterend", _pulldown);
+    this.PULLDOWN_ELEM = _pulldown;
+    this.LIST_ELEM = _list;
   }
 
   // Add "click" and "mouseover" events to a row of the pulldown menu.
@@ -582,48 +585,48 @@ export default class extends Controller {
   // Redraw the pulldown options.
   draw_pulldown() {
     this.verbose("draw_pulldown()");
-    const list = this.LIST_ELEM,
-      rows = list.children,
-      size = this.PULLDOWN_SIZE,
-      scroll = this.scroll_offset,
-      cur = this.current_row,
-      matches = this.matches;
+    const _list = this.LIST_ELEM,
+      _rows = _list.children,
+      _size = this.PULLDOWN_SIZE,
+      _scroll = this.scroll_offset,
+      _current = this.current_row,
+      _matches = this.matches;
 
     if (this.log) {
       this.debug(
-        "Redraw: matches=" + matches.length + ", scroll=" + scroll + ", cursor=" + cur
+        "Redraw: matches=" + _matches.length + ", scroll=" + _scroll + ", cursor=" + _current
       );
     }
 
     // Get row height if haven't been able to yet.
     this.get_row_height();
-    if (rows.length) {
-      this.update_rows(rows, matches, size, scroll);
-      this.highlight_new_row(rows, cur, size, scroll)
-      this.make_menu_visible(matches, size, scroll)
+    if (_rows.length) {
+      this.update_rows(_rows, _matches, _size, _scroll);
+      this.highlight_new_row(_rows, _current, _size, _scroll)
+      this.make_menu_visible(_matches, _size, _scroll)
     }
 
     // Make sure input focus stays on text field!
     this.inputTarget.focus();
   }
 
-  // Update menu text first.
+  // Update menu text first - add from stored matches.
   update_rows(rows, matches, size, scroll) {
     let i, x, y;
     for (i = 0; i < size; i++) {
-      let row = rows.item(i);
-      x = row.innerHTML;
+      let _row = rows.item(i);
+      x = _row.innerHTML;
       if (i + scroll < matches.length) {
         y = this.escapeHTML(matches[i + scroll]);
         if (x != y) {
           if (x == '')
-            row.style.display = 'block';
-          row.innerHTML = y;
+            _row.style.display = 'block';
+          _row.innerHTML = y;
         }
       } else {
         if (x != '') {
-          row.innerHTML = '';
-          row.style.display = 'none';
+          _row.innerHTML = '';
+          _row.style.display = 'none';
         }
       }
     }
@@ -631,41 +634,42 @@ export default class extends Controller {
 
   // Highlight that row.
   highlight_new_row(rows, cur, size, scroll) {
-    const old_hl = this.current_highlight;
-    let new_hl = cur - scroll;
+    const _old_hl = this.current_highlight;
+    let _new_hl = cur - scroll;
 
-    if (new_hl < 0 || new_hl >= size)
-      new_hl = -1;
-    this.current_highlight = new_hl;
-    if (new_hl != old_hl) {
-      if (old_hl >= 0)
-        rows[old_hl].classList.remove(this.HOT_CLASS);
-      if (new_hl >= 0)
-        rows[new_hl].classList.add(this.HOT_CLASS);
+    if (_new_hl < 0 || _new_hl >= size)
+      _new_hl = -1;
+    this.current_highlight = _new_hl;
+    if (_new_hl != _old_hl) {
+      if (_old_hl >= 0)
+        rows[_old_hl].classList.remove(this.HOT_CLASS);
+      if (_new_hl >= 0)
+        rows[_new_hl].classList.add(this.HOT_CLASS);
     }
   }
 
   // Make menu visible if nonempty.
   make_menu_visible(matches, size, scroll) {
-    const menu = this.PULLDOWN_ELEM,
-      inner = menu.children[0];
+    const _pulldown = this.PULLDOWN_ELEM,
+      _list = _pulldown.children[0];
 
     if (matches.length > 0) {
       // console.log("Matches:" + matches)
-      const top = this.inputTarget.offsetTop,
-        left = this.inputTarget.offsetLeft,
-        hgt = this.inputTarget.offsetHeight,
-        scr = this.inputTarget.scrollTop;
-      menu.style.top = (top + hgt + scr) + "px";
-      menu.style.left = left + "px";
+      const _top = this.inputTarget.offsetTop,
+        _left = this.inputTarget.offsetLeft,
+        _hgt = this.inputTarget.offsetHeight,
+        _scr = this.inputTarget.scrollTop;
+      _pulldown.style.top = (_top + _hgt + _scr) + "px";
+      _pulldown.style.left = _left + "px";
 
       // Set height of menu.
-      menu.style.overflowY = matches.length > size ? "scroll" : "hidden";
-      menu.style.height = this.ROW_HEIGHT * (size < matches.length - scroll ? size : matches.length - scroll) + "px";
-      inner.style.marginTop = this.ROW_HEIGHT * scroll + "px";
-      inner.style.height = this.ROW_HEIGHT * (matches.length - scroll) + "px";
-      menu.scrollTo({ top: this.ROW_HEIGHT * scroll });
-      // }
+      _pulldown.style.overflowY = matches.length > size ? "scroll" : "hidden";
+      _pulldown.style.height = this.ROW_HEIGHT *
+        (size < matches.length - scroll ? size : matches.length - scroll) +
+        "px";
+      _list.style.marginTop = this.ROW_HEIGHT * scroll + "px";
+      _list.style.height = this.ROW_HEIGHT * (matches.length - scroll) + "px";
+      _pulldown.scrollTo({ top: this.ROW_HEIGHT * scroll });
 
       // Set width of menu.
       this.set_width();
@@ -675,17 +679,17 @@ export default class extends Controller {
       // the value that's already in the text field.
       if (matches.length > 1 || this.inputTarget.value != matches[0]) {
         this.clear_hide();
-        menu.style.display = 'block';
+        _pulldown.style.display = 'block';
         this.menu_up = true;
       } else {
-        menu.style.display = 'none';
+        _pulldown.style.display = 'none';
         this.menu_up = false;
       }
     }
 
     // Hide the menu if it's empty now.
     else {
-      menu.style.display = 'none';
+      _pulldown.style.display = 'none';
       this.menu_up = false;
     }
   }
@@ -724,9 +728,10 @@ export default class extends Controller {
   // Update content of pulldown.
   update_matches() {
     this.verbose("update_matches()");
-
+    if (this.ACT_LIKE_SELECT)
+      this.current_row = 0;
     // Remember which option used to be highlighted.
-    const last = this.current_row < 0 ? null : this.matches[this.current_row];
+    const _last = this.current_row < 0 ? null : this.matches[this.current_row];
 
     // Update list of options appropriately.
     if (this.ACT_LIKE_SELECT)
@@ -738,103 +743,107 @@ export default class extends Controller {
     else
       this.update_normal();
 
-    // Sort and remove duplicates.
-    this.matches = this.remove_dups(this.matches.sort());
+    // Sort and remove duplicates, unless it's already sorted.
+    if (!this.ACT_LIKE_SELECT)
+      this.matches = this.remove_dups(this.matches.sort());
     // Try to find old highlighted row in new set of options.
-    this.update_current_row(last);
+    this.update_current_row(_last);
     // Reset width each time we change the options.
     this.current_width = this.inputTarget.offsetWidth;
   }
 
   // When "acting like a select" make it display all options in the
-  // order given right from the moment they enter the field.
+  // order given right from the moment they enter the field,
+  // and pick the first one.
   update_select() {
     this.matches = this.primer;
+    if (this.matches.length > 0)
+      this.inputTarget.value = this.matches[0];
   }
 
   // Grab all matches, doing exact match, ignoring number of words.
   update_normal() {
-    const val = this.get_search_token().normalize().toLowerCase(),
+    const _token = this.get_search_token().normalize().toLowerCase(),
       // normalize the Unicode of each string in primer for search
-      primer = this.primer.map((str) => { return str.normalize() }),
-      matches = [];
+      _primer = this.primer.map((str) => { return str.normalize() }),
+      _matches = [];
 
-    if (val != '') {
-      for (let i = 0; i < primer.length; i++) {
-        let s = primer[i + 1];
-        if (s && s.length > 0 && s.toLowerCase().indexOf(val) >= 0) {
-          matches.push(s);
+    if (_token != '') {
+      for (let i = 0; i < _primer.length; i++) {
+        let s = _primer[i + 1];
+        if (s && s.length > 0 && s.toLowerCase().indexOf(_token) >= 0) {
+          _matches.push(s);
         }
       }
     }
 
-    this.matches = matches;
+    this.matches = _matches;
   }
 
   // Grab matches ignoring order of words.
   update_unordered() {
     // regularize spacing in the input
-    const val = this.get_search_token().normalize().toLowerCase().
+    const _token = this.get_search_token().normalize().toLowerCase().
       replace(/^ */, '').replace(/  +/g, ' '),
-      // get the separate words as vals
-      vals = val.split(' '),
+      // get the separate words as _tokens
+      _tokens = _token.split(' '),
       // normalize the Unicode of each string in primer for search
-      primer = this.primer.map((str) => { return str.normalize() }),
-      matches = [];
+      _primer = this.primer.map((str) => { return str.normalize() }),
+      _matches = [];
 
-    if (val != '' && primer.length > 1) {
-      for (let i = 1; i < primer.length; i++) {
-        let s = primer[i] || '',
+    if (_token != '' && _primer.length > 1) {
+      for (let i = 1; i < _primer.length; i++) {
+        let s = _primer[i] || '',
           s2 = ' ' + s.toLowerCase() + ' ',
           k;
         // check each word in the primer entry for a matching word
-        for (k = 0; k < vals.length; k++) {
-          if (s2.indexOf(' ' + vals[k]) < 0) break;
+        for (k = 0; k < _tokens.length; k++) {
+          if (s2.indexOf(' ' + _tokens[k]) < 0) break;
         }
-        if (k >= vals.length) {
-          matches.push(s);
+        if (k >= _tokens.length) {
+          _matches.push(s);
         }
       }
     }
 
-    this.matches = matches;
+    this.matches = _matches;
   }
 
   // Grab all matches, preferring the ones with no additional words.
   // Note: order must have genera first, then species, then varieties.
   update_collapsed() {
-    const val = this.get_search_token().toLowerCase(),
-      primer = this.primer,
+    const _token = this.get_search_token().toLowerCase(),
+      _primer = this.primer,
       // make a lowercased duplicate of primer to regularize search
-      primer_lc = this.primer.map((str) => { return str.toLowerCase() }),
-      matches = [];
+      _primer_lc = this.primer.map((str) => { return str.toLowerCase() }),
+      _matches = [];
 
-    if (val != '' && primer.length > 1) {
-      let the_rest = (val.match(/ /g) || []).length >= this.COLLAPSE;
+    if (_token != '' && _primer.length > 1) {
+      let _the_rest = (_token.match(/ /g) || []).length >= this.COLLAPSE;
 
-      for (let i = 1; i < primer_lc.length; i++) {
-        if (primer_lc[i].indexOf(val) > -1) {
-          let s = primer[i];
-          if (s.length > 0) {
-            if (the_rest || s.indexOf(' ', val.length) < val.length) {
-              matches.push(s);
-            } else if (matches.length > 1) {
+      for (let i = 1; i < _primer_lc.length; i++) {
+        if (_primer_lc[i].indexOf(_token) > -1) {
+          let _s = _primer[i];
+          if (_s.length > 0) {
+            if (_the_rest || _s.indexOf(' ', _token.length) < _token.length) {
+              _matches.push(_s);
+            } else if (_matches.length > 1) {
               break;
             } else {
-              if (matches[0] == val)
-                matches.pop();
-              matches.push(s);
-              the_rest = true;
+              if (_matches[0] == _token)
+                _matches.pop();
+              _matches.push(_s);
+              _the_rest = true;
             }
           }
         }
       }
-      if (matches.length == 1 &&
-        (val == matches[0].toLowerCase() ||
-          val == matches[0].toLowerCase() + ' '))
-        matches.pop();
+      if (_matches.length == 1 &&
+        (_token == matches[0].toLowerCase() ||
+          _token == matches[0].toLowerCase() + ' '))
+        _matches.pop();
     }
-    this.matches = matches;
+    this.matches = _matches;
   }
 
   /**
@@ -870,35 +879,35 @@ export default class extends Controller {
   // otherwise highlight first match.
   update_current_row(val) {
     this.verbose("update_current_row()");
-    const matches = this.matches,
-      size = this.PULLDOWN_SIZE;
-    let exact = -1,
-      part = -1;
+    const _matches = this.matches,
+      _size = this.PULLDOWN_SIZE;
+    let _exact = -1,
+      _part = -1;
 
     if (val && val.length > 0) {
-      for (let i = 0; i < matches.length; i++) {
-        if (matches[i] == val) {
-          exact = i;
+      for (let i = 0; i < _matches.length; i++) {
+        if (_matches[i] == val) {
+          _exact = i;
           break;
         }
-        if (matches[i] == val.substr(0, matches[i].length) &&
-          (part < 0 || matches[i].length > matches[part].length))
-          part = i;
+        if (_matches[i] == val.substr(0, _matches[i].length) &&
+          (_part < 0 || _matches[i].length > _matches[_part].length))
+          _part = i;
       }
     }
-    let new_row = exact >= 0 ? exact : part >= 0 ? part : -1;
-    let new_scroll = this.scroll_offset;
-    if (new_scroll > new_row)
-      new_scroll = new_row;
-    if (new_scroll > matches.length - size)
-      new_scroll = matches.length - size;
-    if (new_scroll < new_row - size + 1)
-      new_scroll = new_row - size + 1;
-    if (new_scroll < 0)
-      new_scroll = 0;
+    let _new_row = _exact >= 0 ? _exact : _part >= 0 ? _part : -1;
+    let _new_scroll = this.scroll_offset;
+    if (_new_scroll > _new_row)
+      _new_scroll = _new_row;
+    if (_new_scroll > _matches.length - _size)
+      _new_scroll = _matches.length - _size;
+    if (_new_scroll < _new_row - _size + 1)
+      _new_scroll = _new_row - _size + 1;
+    if (_new_scroll < 0)
+      _new_scroll = 0;
 
-    this.current_row = new_row;
-    this.scroll_offset = new_scroll;
+    this.current_row = _new_row;
+    this.scroll_offset = _new_scroll;
   }
 
   /**
@@ -915,53 +924,53 @@ export default class extends Controller {
 
   // Get search token under or immediately in front of cursor.
   get_search_token() {
-    const val = this.inputTarget.value;
-    let token = val;
+    const _val = this.inputTarget.value;
+    let _token = _val;
     if (this.SEPARATOR) {
-      const s_ext = this.search_token_extents();
-      token = val.substring(s_ext.start, s_ext.end);
+      const _extents = this.search_token_extents();
+      _token = _val.substring(_extents.start, _extents.end);
     }
-    return token;
+    return _token;
   }
 
   // Change the token under or immediately in front of the cursor.
   set_search_token(new_val) {
-    const old_str = this.inputTarget.value;
+    const _old_str = this.inputTarget.value;
     if (this.SEPARATOR) {
-      let new_str = "";
-      const s_ext = this.search_token_extents();
+      let _new_str = "";
+      const _extents = this.search_token_extents();
 
-      if (s_ext.start > 0)
-        new_str += old_str.substring(0, s_ext.start);
-      new_str += new_val;
+      if (_extents.start > 0)
+        _new_str += _old_str.substring(0, _extents.start);
+      _new_str += new_val;
 
-      if (s_ext.end < old_str.length)
-        new_str += old_str.substring(s_ext.end);
-      if (old_str != new_str) {
-        var old_scroll = this.inputTarget.offsetTop;
-        this.inputTarget.value = new_str;
+      if (_extents.end < _old_str.length)
+        _new_str += _old_str.substring(_extents.end);
+      if (_old_str != _new_str) {
+        let _old_scroll = this.inputTarget.offsetTop;
+        this.inputTarget.value = _new_str;
         this.setCursorPosition(this.inputTarget[0],
-          s_ext.start + new_val.length);
-        this.inputTarget.offsetTop = old_scroll;
+          _extents.start + new_val.length);
+        this.inputTarget.offsetTop = _old_scroll;
       }
     } else {
-      if (old_str != new_val)
+      if (_old_str != new_val)
         this.inputTarget.value = new_val;
     }
   }
 
   // Get index of first character and character after last of current token.
   search_token_extents() {
-    const val = this.inputTarget.value;
-    let start = val.lastIndexOf(this.SEPARATOR),
-      end = val.length;
+    const _val = this.inputTarget.value;
+    let start = _val.lastIndexOf(this.SEPARATOR),
+      end = _val.length;
 
     if (start < 0)
       start = 0;
     else
       start += this.SEPARATOR.length;
 
-    return { start: start, end: end };
+    return { start, end };
   }
 
   // ------------------------------ Fetch matches ------------------------------
@@ -969,65 +978,69 @@ export default class extends Controller {
   // Send request for updated primer.
   refresh_primer() {
     this.verbose("refresh_primer()");
-    // let val = this.inputTarget.value.toLowerCase();
-    const val = this.get_search_token().toLowerCase(),
-      last_request = this.last_fetch_request;
+
+    const _token = this.get_search_token().toLowerCase(),
+      _last_request = this.last_fetch_request;
 
     // Don't make request on empty string!
-    if (!val || val.length < 1)
+    if (!this.ACT_LIKE_SELECT && (!_token || _token.length < 1))
       return;
 
     // Don't repeat last request accidentally!
-    if (last_request == val)
+    if (_last_request == _token)
       return;
 
-    // Memoize this condition, used twice.
-    // is the new search token an extension of the previous search string?
-    const new_val_refines_last_request =
-      (last_request.length < val.length) &&
-      (last_request == val.substr(0, last_request.length));
+    // Memoize this condition, used twice:
+    // "is the new search token an extension of the previous search string?"
+    const _new_val_refines_last_request =
+      (_last_request?.length < _token.length) &&
+      (_last_request == _token.substr(0, _last_request?.length));
 
     // No need to make more constrained request if we got all results last time.
     if (!this.last_fetch_incomplete &&
-      last_request && (last_request.length > 0) &&
-      new_val_refines_last_request)
+      _last_request && (_last_request.length > 0) &&
+      _new_val_refines_last_request)
       return;
 
     // If a less constrained request is pending, wait for it to return before
     // refining the request, just in case it returns complete results
     // (rendering the more refined request unnecessary).
-    if (this.fetch_request && new_val_refines_last_request)
+    if (this.fetch_request && _new_val_refines_last_request)
       return;
 
+    if (_token.length > this.MAX_STRING_LENGTH)
+      _token = _token.substr(0, this.MAX_STRING_LENGTH);
+
+    const _query_params = { string: _token, ...this.request_params }
+
+    // If it's a param search, ignore the search token and return all results.
+    if (this.ACT_LIKE_SELECT) { _query_params["all"] = true; }
+
     // Make request.
-    this.send_fetch_request(val);
+    this.send_fetch_request(_query_params);
   }
 
   // Send AJAX request for more matching strings.
-  async send_fetch_request(val) {
+  async send_fetch_request(query_params) {
     this.verbose("send_fetch_request()");
-    if (val.length > this.MAX_REQUEST_LINK)
-      val = val.substr(0, this.MAX_REQUEST_LINK);
 
     if (this.log) {
-      this.debug("Sending fetch request: " + val);
+      this.debug("Sending fetch request: " + query_params.string + "...");
     }
 
-    // Need to doubly-encode this to prevent router from interpreting slashes,
-    // dots, etc.
-    const url = this.AJAX_URL.replace(
-      '@', encodeURIComponent(encodeURIComponent(val.replace(/\./g, '%2e')))
-    );
+    const _url = this.AJAX_URL + this.TYPE,
+      _controller = new AbortController();
 
-    this.last_fetch_request = val;
-
-    const controller = new AbortController(),
-      signal = controller.signal;
-
+    this.last_fetch_request = query_params.string;
     if (this.fetch_request)
-      controller.abort();
+      _controller.abort();
 
-    const response = await get(url, { signal });
+    const response = await get(_url, {
+      signal: _controller.signal,
+      query: query_params,
+      responseKind: "json"
+    });
+
     if (response.ok) {
       const json = await response.json
       if (json) {
@@ -1036,7 +1049,7 @@ export default class extends Controller {
       }
     } else {
       this.fetch_request = null;
-      console.log(`got a ${response.status}`);
+      console.log(`got a ${response.status}: ${response.text}`);
     }
 
   }
@@ -1097,7 +1110,7 @@ export default class extends Controller {
   // ------------------------------- DEBUGGING ------------------------------
 
   debug(str) {
-    document.getElementById("log").insertAdjacentText("beforeend", str + "<br/>");
+    // document.getElementById("log").insertAdjacentText("beforeend", str + "<br/>");
   }
 
   verbose(str) {

--- a/app/views/controllers/account/profile/_form.html.erb
+++ b/app/views/controllers/account/profile/_form.html.erb
@@ -7,7 +7,7 @@
                             label: :profile_name.t + ":") %>
 
   <%= autocompleter_field(
-    form: f, field: :place_name, autocomplete: :location,
+    form: f, field: :place_name, type: :location,
     label: :profile_location.t + ":", between: "(33%)"
   ) %>
 

--- a/app/views/controllers/admin/session/edit.html.erb
+++ b/app/views/controllers/admin/session/edit.html.erb
@@ -9,9 +9,8 @@ add_page_title(:app_switch_users.l)
               id: "admin_switch_users_form") do |f| %>
 
   <%= autocompleter_field(
-    form: f, field: :id, value: @id,
-    label: :LOGIN_NAME.t + ":", size: 42, autofocus: true,
-    data: { autocomplete: :user }
+    form: f, field: :id, type: :user, value: @id, label: :LOGIN_NAME.t + ":",
+    size: 42, autofocus: true
   ) %>
 
   <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>

--- a/app/views/controllers/herbaria/_form.html.erb
+++ b/app/views/controllers/herbaria/_form.html.erb
@@ -9,8 +9,9 @@
                             between: :required) %>
 
   <% if in_admin_mode? %>
-    <%= autocompleter_field(form: f, field: :personal_user_name, inline: true,
-                            label: :edit_herbarium_admin_make_personal.t, autocomplete: :user) %>
+    <%= autocompleter_field(form: f, field: :personal_user_name, type: :user,
+                            label: :edit_herbarium_admin_make_personal.t,
+                            inline: true) %>
 
     <% if button_name != :CREATE %>
       <%= help_block_with_arrow("up") do %>
@@ -49,9 +50,8 @@
     <%= help_block_with_arrow("up") do :create_herbarium_code_help.t end %>
   <% end %>
 
-  <%= autocompleter_field(form: f, field: :place_name,
-                          label: :LOCATION.t + ":", between: :optional,
-                          autocomplete: :location) %>
+  <%= autocompleter_field(form: f, field: :place_name, type: :location,
+                          label: :LOCATION.t + ":", between: :optional) %>
 
   <%= text_field_with_label(form: f, field: :email,
                             label: :create_herbarium_email.t + ":",

--- a/app/views/controllers/herbaria/show.html.erb
+++ b/app/views/controllers/herbaria/show.html.erb
@@ -30,7 +30,7 @@ map = @herbarium.location ? true : false
                       id: "herbarium_curators_form") do |f| %>
           <div class="form-inline mt-3">
             <%= autocompleter_field(form: f, field: :add_curator,
-                                    autocomplete: :user) %>
+                                    type: :user) %>
             <label for="add_curator">
               <%= submit_button(form: f,
                                 button: :show_herbarium_add_curator.t) %>

--- a/app/views/controllers/herbarium_records/_form.erb
+++ b/app/views/controllers/herbarium_records/_form.erb
@@ -28,9 +28,8 @@ end
     ) %>
   <% end %>
 
-  <%= autocompleter_field(form: f, field: :herbarium_name,
-                          label: :NAME.t + ":", between: :required,
-                          autocomplete: :herbarium) %>
+  <%= autocompleter_field(form: f, field: :herbarium_name, type: :herbarium,
+                          label: :NAME.t + ":", between: :required) %>
 
   <%= text_field_with_label(form: f, field: :initial_det,
                             label: :herbarium_record_initial_det.t + ":",

--- a/app/views/controllers/names/_form.html.erb
+++ b/app/views/controllers/names/_form.html.erb
@@ -79,10 +79,10 @@ statuses = [[:ACCEPTED.l, false], [:DEPRECATED.l, true]]
                                checked: @misspelling,
                                label: :form_names_misspelling.l) %>
       <%= autocompleter_field(
-        form: f, field: :correct_spelling, value: @correct_spelling,
+        form: f, field: :correct_spelling, type: :name,
+        value: @correct_spelling,
         label: "#{:form_names_misspelling_it_should_be.l}:",
-        append: help_block(:p, :form_names_misspelling_note.l),
-        autocomplete: :name
+        append: help_block(:p, :form_names_misspelling_note.l)
       ) %>
     </div>
   <% end %>

--- a/app/views/controllers/names/synonyms/deprecate/new.html.erb
+++ b/app/views/controllers/names/synonyms/deprecate/new.html.erb
@@ -29,9 +29,9 @@ end
              locals: feedback_locals.merge({ f: f })) if @what.present? %>
 
   <%= autocompleter_field(
-    form: f, field: :proposed_name, inline: true, autocomplete: :name,
+    form: f, field: :proposed_name, type: :name,
     value: @what, label: "#{:name_deprecate_preferred.t}:", autofocus: true,
-    append: help_note(:div, :name_deprecate_preferred_help.tp)
+    append: help_note(:div, :name_deprecate_preferred_help.tp), inline: true
   ) %>
 
   <%= check_box_with_label(form: f, field: :is_misspelling,

--- a/app/views/controllers/observations/form/_herbarium_record.html.erb
+++ b/app/views/controllers/observations/form/_herbarium_record.html.erb
@@ -6,19 +6,18 @@
     <%= fields_for(:herbarium_record) do |fhr| %>
 
       <%= autocompleter_field(
-        form: fhr, field: :herbarium_name, value: @herbarium_name,
-        label: :herbarium_record_herbarium_name.t + ":",
-        autocomplete: :herbarium
+        form: fhr, field: :herbarium_name, type: :herbarium,
+        value: @herbarium_name, label: "#{:herbarium_record_herbarium_name.t}:",
       ) %>
 
       <%= text_field_with_label(
         form: fhr, field: :herbarium_id, value: @herbarium_id,
-        label: :herbarium_record_accession_number.t + ":",
+        label: "#{:herbarium_record_accession_number.t}:",
         data: { action: "specimen#checkCheckbox" }
       ) %>
 
       <%= text_field_with_label(form: fhr, field: :notes, value: "",
-                                label: :herbarium_record_notes.t + ":") %>
+                                label: "#{:herbarium_record_notes.t}:") %>
 
     <% end # fields_for(:herbarium_record) %>
   </div>

--- a/app/views/controllers/observations/form/_where.html.erb
+++ b/app/views/controllers/observations/form/_where.html.erb
@@ -14,8 +14,8 @@
   <div class="row">
     <div class="col-xs-12 col-sm-6">
       <%= autocompleter_field(
-        form: f, field: :place_name, label: :WHERE.t + ":", between: :required,
-        autocomplete: :location, data: { map_target: "placeInput" }
+        form: f, field: :place_name, type: :location, label: "#{:WHERE.t}:",
+        between: :required, data: { map_target: "placeInput" }
       ) %>
     </div>
     <div class="col-xs-12 col-sm-6">

--- a/app/views/controllers/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/controllers/observations/identify/_form_identify_filter.html.erb
@@ -21,7 +21,7 @@ options = [
               id: "identify_filter",
               data: { controller: :autocompleter }) do |f| %>
 
-  <div class="form-group has-feedback has-search">
+  <div class="form-group has-feedback has-search dropdown">
     <%= content_tag(:span, "", class: "glyphicon glyphicon-search " \
                                       "form-control-feedback") %>
     <%# f.label(:term, "Filter by:") %>

--- a/app/views/controllers/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/controllers/observations/identify/_form_identify_filter.html.erb
@@ -28,13 +28,12 @@ options = [
     <%= f.text_field(
       :term, value: value, placeholder: :filter_by.l,
       class: "form-control", size: 42, autocomplete: "one-time-code",
-      data: { controller: nil, autocompleter_target: "input",
-              autocomplete: :clade }
+      data: { controller: nil, autocompleter_target: "input", type: :clade }
     ) %>
     <%# autocompleter_field(
-      form: f, field: :term, value: value,
+      form: f, field: :term, type: :clade, value: value,
       placeholder: :filter_by.l, size: 42, autofocus: true,
-      data: { controller: nil, autocompleter: :clade,
+      data: { controller: nil,
               action: "autocompleter-swap:swap->autocompleter#swap" }) %>
 
   </div><!--.form-group-->

--- a/app/views/controllers/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/controllers/observations/identify/_form_identify_filter.html.erb
@@ -19,7 +19,7 @@ options = [
 <%= form_with(url: identify_observations_path, method: :get,
               class: "navbar-form navbar-left", scope: :filter,
               id: "identify_filter",
-              data: { controller: :autocompleter }) do |f| %>
+              data: { controller: :autocompleter, type: :clade }) do |f| %>
 
   <div class="form-group has-feedback has-search dropdown">
     <%= content_tag(:span, "", class: "glyphicon glyphicon-search " \
@@ -28,7 +28,7 @@ options = [
     <%= f.text_field(
       :term, value: value, placeholder: :filter_by.l,
       class: "form-control", size: 42, autocomplete: "one-time-code",
-      data: { controller: nil, autocompleter_target: "input", type: :clade }
+      data: { autocompleter_target: "input" }
     ) %>
     <%# autocompleter_field(
       form: f, field: :term, type: :clade, value: value,

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -37,8 +37,8 @@ name_help ||= :form_naming_name_help.t
         [
           tag.div(class: "col-xs-12 col-sm-6") do
             autocompleter_field(
-              form: f_n, field: :name, label: :WHAT.t + ":", value: @what,
-              autofocus: focus_on_name, autocomplete: :name
+              form: f_n, field: :name, type: :name, label: "#{:WHAT.t}:",
+              value: @what, autofocus: focus_on_name
             )
           end,
           tag.div(class: "col-xs-12 col-sm-6") do

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -17,8 +17,8 @@
 
   <%= render(partial: "shared/textilize_help") %>
 
-  <%= autocompleter_field(form: f, field: :place_name, label: :WHERE.t + ":",
-                          between: :required, autocomplete: :location) %>
+  <%= autocompleter_field(form: f, field: :place_name, type: :location,
+                          label: "#{:WHERE.t}:", between: :required) %>
 
   <%= tag.div(
     tag.p("*#{:form_projects_date_range.t}*".t) +

--- a/app/views/controllers/projects/members/index.html.erb
+++ b/app/views/controllers/projects/members/index.html.erb
@@ -17,9 +17,8 @@ action = { controller: "/projects/members", action: :create,
   <%= form_with(url: action, id: "project_member_form") do |f| %>
 
     <%= autocompleter_field(
-      form: f, field: :candidate, value: @candidate,
-      label: :LOGIN_NAME.t + ":", size: 42, autofocus: true,
-      data: { autocomplete: :user }
+      form: f, field: :candidate, type: :user, value: @candidate,
+      label:"#{:LOGIN_NAME.t }:", size: 42, autofocus: true,
     ) %>
 
     <%= submit_button(form: f, button: :ADD.t, class: "ml-3") %>

--- a/app/views/controllers/projects/members/new.html.erb
+++ b/app/views/controllers/projects/members/new.html.erb
@@ -13,9 +13,8 @@ action = { controller: "/projects/members", action: :create,
   <%= form_with(url: action, id: "project_member_form") do |f| %>
 
     <%= autocompleter_field(
-      form: f, field: :candidate, value: @candidate,
-      label: :LOGIN_NAME.t + ":", size: 42, autofocus: true,
-      data: { autocomplete: :user }
+      form: f, field: :candidate, type: :user, value: @candidate,
+      label: "#{:LOGIN_NAME.t}:", size: 42, autofocus: true,
     ) %>
 
     <%= submit_button(form: f, button: :ADD.t, class: "ml-3") %>

--- a/app/views/controllers/search/_advanced_search_filter_text_field.html.erb
+++ b/app/views/controllers/search/_advanced_search_filter_text_field.html.erb
@@ -7,8 +7,7 @@ autocompleter = case filter.sym.to_s
                 end
 between = help_note(:span, :"advanced_search_filter_#{filter.sym}".t)
 autocompleter_field(
-  form: f, field: filter.sym, label: filter.name + ":",
-  between: between, value: @filter_defaults[filter.sym],
-  autocomplete: autocompleter, separator: " OR "
+  form: f, field: filter.sym, type: autocompleter, label: "#{filter.name}:",
+  between: between, value: @filter_defaults[filter.sym], separator: " OR "
 )
 %>

--- a/app/views/controllers/search/advanced.html.erb
+++ b/app/views/controllers/search/advanced.html.erb
@@ -28,19 +28,19 @@
   ) %>
 
   <% nam_betw = help_note(:span, :advanced_search_name_help.t) %>
-  <%= autocompleter_field(form: f, field: :name,
-                          label: :NAME.t + ":", between: nam_betw,
-                          autocomplete: :name, separator: " OR ") %>
+  <%= autocompleter_field(form: f, field: :name, type: :name,
+                          label: "#{:NAME.t}:", between: nam_betw,
+                          separator: " OR ") %>
 
   <% usr_betw = help_note(:span, :advanced_search_observer_help.t) %>
-  <%= autocompleter_field(form: f, field: :user,
-                          label: :OBSERVER.t + ":", between: usr_betw,
-                          autocomplete: :user, separator: " OR ") %>
+  <%= autocompleter_field(form: f, field: :user, type: :user,
+                          label: "#{:OBSERVER.t}:", between: usr_betw,
+                          separator: " OR ") %>
 
   <% loc_betw = help_note(:span, :advanced_search_location_help.t) %>
-  <%= autocompleter_field(form: f, field: :location,
-                          label: :LOCATION.t + ":", between: loc_betw,
-                          autocomplete: :location, separator: " OR " ) %>
+  <%= autocompleter_field(form: f, field: :location, type: :location,
+                          label: "#{:LOCATION.t}:", between: loc_betw,
+                          separator: " OR " ) %>
 
   <% cnt_betw = help_note(:span, :advanced_search_content_help.t) %>
   <% cnt_appd = help_block(:p, :advanced_search_content_notes.t) %>

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -24,9 +24,9 @@
   <div class="form-group mt-3">
     <%= fields_for(:list) do |f_l|
       autocompleter_field(
-        form: f_l, field: :members, rows: 8, value: @list_members,
+        form: f_l, field: :members, type: :name, rows: 8, value: @list_members,
         label: "#{:form_species_lists_write_in_species.t}:",
-        autocomplete: :name, separator: "\n", textarea: true
+        separator: "\n", textarea: true
       )
     end %>
   </div>
@@ -44,8 +44,8 @@
   <%= render(partial: "shared/form_location_feedback",
              locals: { button: button } ) %>
 
-  <%= autocompleter_field(form: f, field: :place_name, between: :required,
-                          label: "#{:WHERE.l}:", autocomplete: :location) %>
+  <%= autocompleter_field(form: f, field: :place_name, type: :location,
+                          label: "#{:WHERE.l}:", between: :required) %>
 
   <%= render(partial: "species_lists/form/fields_for_member",
              locals: { f: f }) %>

--- a/app/views/controllers/species_lists/observations/_form.html.erb
+++ b/app/views/controllers/species_lists/observations/_form.html.erb
@@ -8,9 +8,10 @@ action = { controller: "/species_lists/observations", action: :update,
 
   <%= tag.p(:species_list_add_remove_body.tp(num: @query.num_results)) %>
 
-  <%= autocompleter_field(form: f, field: :species_list, value: @id,
-                          label: :species_list_add_remove_label.t + ":",
-                          autocomplete: :species_list) %>
+  <%= autocompleter_field(
+    form: f, field: :species_list, type: :species_list, value: @id,
+    label: :species_list_add_remove_label.t + ":"
+  ) %>
 
   <div class="form-group center-block">
     <%= submit_button(form: f, button: :ADD.l) %>


### PR DESCRIPTION
- Alter autocompleters to use Bootstrap "dropdown" CSS classes where possible. (Requires changing autocompleter item markup from simple `<li>Option</li>` to `<li><a href="#">Option</a></li>`, but we get hover and click events for free, and easier BS upgrades.)
- Change the arg for "autocompleter query type" in `autocompleter_field` helper from `autocomplete:` to `type:`.
- Stimulus housekeeping: Change the root element of an autocompleter controller from the `input` (whose sibling is the `.auto_complete` list) to the parent element for both.
- Better functionality for swapping the autocompleter type (to be used for new "locations_containing" lat/lng)
- New working "Region" autocompleter, for "Help Identify"

There should be nearly no change in appearance or function, otherwise.

