### PR TITLE
Autocompleters: return data hashes

### DIFF
--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -4,7 +4,7 @@
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
 $LEFT_BAR_BORDER_COLOR:             #DDDDDD;
-$TOP_BAR_BORDER_COLOR:              #DDDDDD;
+$TOP_BAR_BORDER_COLOR:              #DDDDDE;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;
 $BUTTON_BG_COLOR:                   #CCCCCC;

--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -4,7 +4,7 @@
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
 $LEFT_BAR_BORDER_COLOR:             #DDDDDD;
-$TOP_BAR_BORDER_COLOR:              #DDDDDE;
+$TOP_BAR_BORDER_COLOR:              #DDDEDD;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;
 $BUTTON_BG_COLOR:                   #CCCCCC;

--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -36,6 +36,11 @@ li.dropdown-item {
     color: $dropdown-link-color;
     text-decoration: none;
 
+    // &[data-deprecated="true"] {
+    //   opacity: 0.81;
+    //   font-style: italic;
+    // }
+
     &:hover {
       color: $dropdown-link-color;
       background-color: $dropdown-link-hover-bg;

--- a/app/classes/auto_complete.rb
+++ b/app/classes/auto_complete.rb
@@ -34,24 +34,25 @@ class AutoComplete
   def matching_records
     # unless 'whole', use the first letter of the string to define the matches
     token = whole ? string : string[0]
-    self.matches = rough_matches(token)
+    self.matches = rough_matches(token) || [] # defined in type-subclass
     clean_matches
 
     unless all
       minimal_string = refine_token # defined in subclass
-      matches.unshift([minimal_string, 0])
+      matches.unshift({ name: minimal_string, id: 0 })
       truncate_matches
     end
 
-    matches.map { |name, id| { name:, id: } }
+    matches
   end
 
   private
 
   def clean_matches
-    matches.map! do |str, id|
-      clean = str.sub(/\s*[\r\n]\s*.*/m, "").sub(/\A\s+/, "").sub(/\s+\Z/, "")
-      [clean, id]
+    matches.map! do |obj|
+      obj[:name] = obj[:name].sub(/\s*[\r\n]\s*.*/m, "").
+                   sub(/\A\s+/, "").sub(/\s+\Z/, "")
+      obj
     end
     matches.uniq!
   end
@@ -60,6 +61,6 @@ class AutoComplete
     return unless matches.length > limit
 
     matches.slice!(limit..-1)
-    matches.push(["...", nil])
+    matches.push({ name: "...", id: nil })
   end
 end

--- a/app/classes/auto_complete.rb
+++ b/app/classes/auto_complete.rb
@@ -29,7 +29,7 @@ class AutoComplete
     self.all = params[:all].present?
   end
 
-  def matching_strings
+  def matching_records
     # just use the first letter of the string to define the matches
     self.matches = rough_matches(string[0])
     clean_matches
@@ -37,20 +37,23 @@ class AutoComplete
 
     minimal_string = refine_matches # defined in subclass
     truncate_matches
-    [minimal_string] + matches
-    # [[minimal_string, nil]] + matches
+    # [minimal_string] + matches
+    [[minimal_string, nil]] + matches
+    # Could be nice for JSON:
+    # this will return a hash indexed by the IDs of the records
+    # ([[minimal_string, 0]] + matches).to_h(&:reverse)
   end
 
   private
 
   def clean_matches
-    matches.map! do |str|
-      str.sub(/\s*[\r\n]\s*.*/m, "").sub(/\A\s+/, "").sub(/\s+\Z/, "")
-    end
-    # matches.map! do |str, id|
-    #   clean = str.sub(/\s*[\r\n]\s*.*/m, "").sub(/\A\s+/, "").sub(/\s+\Z/, "")
-    #   [clean, id]
+    # matches.map! do |str|
+    #   str.sub(/\s*[\r\n]\s*.*/m, "").sub(/\A\s+/, "").sub(/\s+\Z/, "")
     # end
+    matches.map! do |str, id|
+      clean = str.sub(/\s*[\r\n]\s*.*/m, "").sub(/\A\s+/, "").sub(/\s+\Z/, "")
+      [clean, id]
+    end
     matches.uniq!
   end
 
@@ -58,7 +61,7 @@ class AutoComplete
     return unless matches.length > limit
 
     matches.slice!(limit..-1)
-    matches.push("...")
-    # matches.push(["...", nil])
+    # matches.push("...")
+    matches.push(["...", nil])
   end
 end

--- a/app/classes/auto_complete/by_string.rb
+++ b/app/classes/auto_complete/by_string.rb
@@ -20,7 +20,7 @@ class AutoComplete::ByString < AutoComplete
     string.chars.each do |letter|
       used += letter
       regex = /(^|#{PUNCTUATION})#{used}/i
-      matches.select! { |m, _id| m.match(regex) }
+      matches.select! { |obj| obj[:name].match(regex) }
       break if matches.length <= limit
     end
     used

--- a/app/classes/auto_complete/by_string.rb
+++ b/app/classes/auto_complete/by_string.rb
@@ -9,8 +9,8 @@ class AutoComplete::ByString < AutoComplete
   # with the correct first letter.  Applies additional letters one at a time
   # until the number of matches falls below limit.
   #
-  # Returns the final (minimal) string actually used, and changes matches in
-  # place.  The array 'matches' is guaranteed to be <= limit.
+  # Returns the final (minimal) [string, id] actually used, and changes matches
+  # in place.  The array 'matches' is guaranteed to be <= limit.
   def refine_matches
     # Get rid of trivial case immediately.
     return string[0] if matches.length <= limit
@@ -20,7 +20,7 @@ class AutoComplete::ByString < AutoComplete
     string.chars.each do |letter|
       used += letter
       regex = /(^|#{PUNCTUATION})#{used}/i
-      matches.select! { |m| m.match(regex) }
+      matches.select! { |m, _id| m.match(regex) }
       break if matches.length <= limit
     end
     used

--- a/app/classes/auto_complete/by_string.rb
+++ b/app/classes/auto_complete/by_string.rb
@@ -11,7 +11,7 @@ class AutoComplete::ByString < AutoComplete
   #
   # Returns the final (minimal) [string, id] actually used, and changes matches
   # in place.  The array 'matches' is guaranteed to be <= limit.
-  def refine_matches
+  def refine_token
     # Get rid of trivial case immediately.
     return string[0] if matches.length <= limit
 

--- a/app/classes/auto_complete/by_word.rb
+++ b/app/classes/auto_complete/by_word.rb
@@ -5,7 +5,7 @@ class AutoComplete::ByWord < AutoComplete
   # to be out of order.
   def refine_token
     # Get rid of trivial case immediately.
-    return string[0] if matches.length <= limit
+    return string[0] if matches&.length&.<= limit
 
     # Apply words in order, requiring full word-match on all but last.
     words = string.split
@@ -17,14 +17,14 @@ class AutoComplete::ByWord < AutoComplete
       word.chars.each do |letter|
         part += letter
         regex = /(^|#{PUNCTUATION})#{part}/i
-        matches.select! { |m, _id| m.match(regex) }
-        return used + part if matches.length <= limit
+        matches&.select! { |obj| obj[:name].match(regex) }
+        return used + part if matches&.length&.<= limit
       end
       if n < words.length
         used += "#{word} "
         regex = /(^|#{PUNCTUATION})#{word}(#{PUNCTUATION}|$)/i
-        matches.select! { |m, _id| m.match(regex) }
-        return used if matches.length <= limit
+        matches&.select! { |obj| obj[:name].match(regex) }
+        return used if matches&.length&.<= limit
       else
         used += word
         return used

--- a/app/classes/auto_complete/by_word.rb
+++ b/app/classes/auto_complete/by_word.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class AutoComplete::ByWord < AutoComplete
-  # Same as AutoCompleteByString#refine_matches, except words are allowed
+  # Same as AutoCompleteByString#refine_token, except words are allowed
   # to be out of order.
-  def refine_matches
+  def refine_token
     # Get rid of trivial case immediately.
     return string[0] if matches.length <= limit
 

--- a/app/classes/auto_complete/by_word.rb
+++ b/app/classes/auto_complete/by_word.rb
@@ -17,13 +17,13 @@ class AutoComplete::ByWord < AutoComplete
       word.chars.each do |letter|
         part += letter
         regex = /(^|#{PUNCTUATION})#{part}/i
-        matches.select! { |m| m.match(regex) }
+        matches.select! { |m, _id| m.match(regex) }
         return used + part if matches.length <= limit
       end
       if n < words.length
         used += "#{word} "
         regex = /(^|#{PUNCTUATION})#{word}(#{PUNCTUATION}|$)/i
-        matches.select! { |m| m.match(regex) }
+        matches.select! { |m, _id| m.match(regex) }
         return used if matches.length <= limit
       else
         used += word

--- a/app/classes/auto_complete/for_clade.rb
+++ b/app/classes/auto_complete/for_clade.rb
@@ -5,6 +5,6 @@ class AutoComplete::ForClade < AutoComplete::ByString
     # (this sort puts higher rank on top)
     Name.with_correct_spelling.with_rank_above_genus.
       where(Name[:text_name].matches("#{letter}%")).order(rank: :desc).
-      select(:text_name, :rank, :id).pluck(:text_name, :id).uniq
+      select(:text_name, :rank, :id).pluck(:text_name, :id).uniq(&:first)
   end
 end

--- a/app/classes/auto_complete/for_clade.rb
+++ b/app/classes/auto_complete/for_clade.rb
@@ -12,5 +12,6 @@ class AutoComplete::ForClade < AutoComplete::ByString
       { name: name, id: id, deprecated: deprecated || false }
     end
     clades.sort_by! { |clade| clade[:name] }
+    clades.uniq { |clade| clade[:name] }
   end
 end

--- a/app/classes/auto_complete/for_clade.rb
+++ b/app/classes/auto_complete/for_clade.rb
@@ -5,6 +5,6 @@ class AutoComplete::ForClade < AutoComplete::ByString
     # (this sort puts higher rank on top)
     Name.with_correct_spelling.with_rank_above_genus.
       where(Name[:text_name].matches("#{letter}%")).order(rank: :desc).
-      select(:text_name, :rank).map(&:text_name).uniq
+      select(:text_name, :rank, :id).pluck(:text_name, :id).uniq
   end
 end

--- a/app/classes/auto_complete/for_clade.rb
+++ b/app/classes/auto_complete/for_clade.rb
@@ -3,8 +3,14 @@
 class AutoComplete::ForClade < AutoComplete::ByString
   def rough_matches(letter)
     # (this sort puts higher rank on top)
-    Name.with_correct_spelling.with_rank_above_genus.
-      where(Name[:text_name].matches("#{letter}%")).order(rank: :desc).
-      select(:text_name, :rank, :id).pluck(:text_name, :id).uniq(&:first)
+    clades = Name.with_correct_spelling.with_rank_above_genus.
+             where(Name[:text_name].matches("#{letter}%")).order(rank: :desc).
+             select(:text_name, :rank, :id, :deprecated).
+             pluck(:text_name, :id, :deprecated).uniq(&:first)
+
+    clades.map! do |name, id, deprecated|
+      { name: name, id: id, deprecated: deprecated || false }
+    end
+    clades.sort_by! { |clade| clade[:name] }
   end
 end

--- a/app/classes/auto_complete/for_herbarium.rb
+++ b/app/classes/auto_complete/for_herbarium.rb
@@ -11,10 +11,11 @@ class AutoComplete::ForHerbarium < AutoComplete::ByWord
       order(
         Arel.when(Herbarium[:code].is_null).then(Herbarium[:name]).
              else(Herbarium[:code]).asc, Herbarium[:name].asc
-      ).pluck(:code, :name)
+      ).pluck(:code, :name, :id)
 
-    herbaria.map do |code, name|
-      code.empty? ? name : "#{code} - #{name}"
-    end.sort
+    herbaria.map do |code, name, id|
+      composed_name = code.empty? ? name : "#{code} - #{name}"
+      [composed_name, id]
+    end.sort_by(&:first).uniq
   end
 end

--- a/app/classes/auto_complete/for_herbarium.rb
+++ b/app/classes/auto_complete/for_herbarium.rb
@@ -4,7 +4,7 @@
 class AutoComplete::ForHerbarium < AutoComplete::ByWord
   def rough_matches(letter)
     herbaria =
-      Herbarium.select(:code, :name).distinct.
+      Herbarium.select(:code, :name, :id).distinct.
       where(Herbarium[:name].matches("#{letter}%").
         or(Herbarium[:name].matches("% #{letter}%")).
         or(Herbarium[:code].matches("#{letter}%"))).
@@ -13,9 +13,9 @@ class AutoComplete::ForHerbarium < AutoComplete::ByWord
              else(Herbarium[:code]).asc, Herbarium[:name].asc
       ).pluck(:code, :name, :id)
 
-    herbaria.map do |code, name, id|
-      composed_name = code.empty? ? name : "#{code} - #{name}"
-      [composed_name, id]
-    end.sort_by(&:first).uniq(&:first)
+    herbaria.map! do |code, name, id|
+      { name: code.empty? ? name : "#{code} - #{name}", id: id }
+    end
+    herbaria.sort_by! { |herb| herb[:name] }
   end
 end

--- a/app/classes/auto_complete/for_herbarium.rb
+++ b/app/classes/auto_complete/for_herbarium.rb
@@ -16,6 +16,6 @@ class AutoComplete::ForHerbarium < AutoComplete::ByWord
     herbaria.map do |code, name, id|
       composed_name = code.empty? ? name : "#{code} - #{name}"
       [composed_name, id]
-    end.sort_by(&:first).uniq
+    end.sort_by(&:first).uniq(&:first)
   end
 end

--- a/app/classes/auto_complete/for_location.rb
+++ b/app/classes/auto_complete/for_location.rb
@@ -19,12 +19,14 @@ class AutoComplete::ForLocation < AutoComplete::ByWord
     matches =
       Observation.select(:where).distinct.
       where(Observation[:where].matches("#{letter}%").
-        or(Observation[:where].matches("% #{letter}%"))).pluck(:where) +
+        or(Observation[:where].matches("% #{letter}%"))).
+      pluck(:where, :location_id) +
       Location.select(:name).distinct.
       where(Location[:name].matches("#{letter}%").
         or(Location[:name].matches("% #{letter}%"))).pluck(:name, :id)
 
     matches.map! { |m, id| [Location.reverse_name(m), id] } if reverse
-    matches.sort.uniq
+    # remove matches without an id and sort by unique name
+    matches.reject { |m| m[1].nil? }.sort_by(&:first).uniq(&:first)
   end
 end

--- a/app/classes/auto_complete/for_location.rb
+++ b/app/classes/auto_complete/for_location.rb
@@ -22,9 +22,9 @@ class AutoComplete::ForLocation < AutoComplete::ByWord
         or(Observation[:where].matches("% #{letter}%"))).pluck(:where) +
       Location.select(:name).distinct.
       where(Location[:name].matches("#{letter}%").
-        or(Location[:name].matches("% #{letter}%"))).pluck(:name)
+        or(Location[:name].matches("% #{letter}%"))).pluck(:name, :id)
 
-    matches.map! { |m| Location.reverse_name(m) } if reverse
+    matches.map! { |m, id| [Location.reverse_name(m), id] } if reverse
     matches.sort.uniq
   end
 end

--- a/app/classes/auto_complete/for_location.rb
+++ b/app/classes/auto_complete/for_location.rb
@@ -26,7 +26,7 @@ class AutoComplete::ForLocation < AutoComplete::ByWord
         or(Location[:name].matches("% #{letter}%"))).pluck(:name, :id)
 
     matches.map! { |m, id| [Location.reverse_name(m), id] } if reverse
-    # remove matches without an id and sort by unique name
-    matches.reject { |m| m[1].nil? }.sort_by(&:first).uniq(&:first)
+    # matches without id are strings only. give id: 0, and sort by unique name
+    matches.map { |m, id| [m, id.nil? ? 0 : id] }.sort_by(&:first).uniq(&:first)
   end
 end

--- a/app/classes/auto_complete/for_location.rb
+++ b/app/classes/auto_complete/for_location.rb
@@ -34,6 +34,6 @@ class AutoComplete::ForLocation < AutoComplete::ByWord
     end
     # Sort by name and prefer those with a non-zero ID
     locations.sort_by! { |loc| [loc[:name], -loc[:id]] }
-    locations.uniq! { |loc| loc[:name] }
+    locations.uniq { |loc| loc[:name] }
   end
 end

--- a/app/classes/auto_complete/for_name.rb
+++ b/app/classes/auto_complete/for_name.rb
@@ -4,10 +4,15 @@ class AutoComplete::ForName < AutoComplete::ByString
   def rough_matches(letter)
     # (this sort puts genera and higher on top, everything else
     # on bottom, and sorts alphabetically within each group)
-    Name.with_correct_spelling.select(:text_name).distinct.
-      where(Name[:text_name].matches("#{letter}%")).
-      pluck(:text_name, :id).sort_by do |x, _id|
-        (x.match?(" ") ? "b" : "a") + x
-      end.uniq
+    names = Name.with_correct_spelling.
+            select(:text_name, :id, :deprecated).distinct.
+            where(Name[:text_name].matches("#{letter}%")).
+            pluck(:text_name, :id, :deprecated).sort_by do |x, _id, _d|
+      (x.match?(" ") ? "b" : "a") + x
+    end.uniq
+
+    names.map! do |name, id, deprecated|
+      { name: name, id: id, deprecated: deprecated || false }
+    end
   end
 end

--- a/app/classes/auto_complete/for_name.rb
+++ b/app/classes/auto_complete/for_name.rb
@@ -14,6 +14,6 @@ class AutoComplete::ForName < AutoComplete::ByString
     names.map! do |name, id, deprecated|
       { name: name, id: id, deprecated: deprecated || false }
     end
-    names.uniq! { |name| name[:name] }
+    names.uniq { |name| name[:name] }
   end
 end

--- a/app/classes/auto_complete/for_name.rb
+++ b/app/classes/auto_complete/for_name.rb
@@ -6,6 +6,8 @@ class AutoComplete::ForName < AutoComplete::ByString
     # on bottom, and sorts alphabetically within each group)
     Name.with_correct_spelling.select(:text_name).distinct.
       where(Name[:text_name].matches("#{letter}%")).
-      pluck(:text_name).sort_by { |x| (x.match?(" ") ? "b" : "a") + x }.uniq
+      pluck(:text_name, :id).sort_by do |x, _id|
+        (x.match?(" ") ? "b" : "a") + x
+      end.uniq
   end
 end

--- a/app/classes/auto_complete/for_name.rb
+++ b/app/classes/auto_complete/for_name.rb
@@ -2,17 +2,19 @@
 
 class AutoComplete::ForName < AutoComplete::ByString
   def rough_matches(letter)
-    # (this sort puts genera and higher on top, everything else
-    # on bottom, and sorts alphabetically within each group)
     names = Name.with_correct_spelling.
             select(:text_name, :id, :deprecated).distinct.
             where(Name[:text_name].matches("#{letter}%")).
-            pluck(:text_name, :id, :deprecated).sort_by do |x, _id, _d|
-      (x.match?(" ") ? "b" : "a") + x
-    end
+            pluck(:text_name, :id, :deprecated)
 
     names.map! do |name, id, deprecated|
-      { name: name, id: id, deprecated: deprecated || false }
+      dep_string = deprecated.nil? ? "false" : deprecated.to_s
+      { name: name, id: id, deprecated: dep_string }
+    end
+    # This sort puts genera and higher on top, everything else on bottom,
+    # and sorts alphabetically within each group, and non-deprecated dups first
+    names.sort_by! do |name|
+      [(name[:name].match?(" ") ? "b" : "a") + name[:name], name[:deprecated]]
     end
     names.uniq { |name| name[:name] }
   end

--- a/app/classes/auto_complete/for_name.rb
+++ b/app/classes/auto_complete/for_name.rb
@@ -9,10 +9,11 @@ class AutoComplete::ForName < AutoComplete::ByString
             where(Name[:text_name].matches("#{letter}%")).
             pluck(:text_name, :id, :deprecated).sort_by do |x, _id, _d|
       (x.match?(" ") ? "b" : "a") + x
-    end.uniq
+    end
 
     names.map! do |name, id, deprecated|
       { name: name, id: id, deprecated: deprecated || false }
     end
+    names.uniq! { |name| name[:name] }
   end
 end

--- a/app/classes/auto_complete/for_project.rb
+++ b/app/classes/auto_complete/for_project.rb
@@ -2,9 +2,11 @@
 
 class AutoComplete::ForProject < AutoComplete::ByWord
   def rough_matches(letter)
-    Project.select(:title, :id).distinct.
-      where(Project[:title].matches("#{letter}%").
-        or(Project[:title].matches("% #{letter}%"))).
-      order(title: :asc).pluck(:title, :id)
+    projects = Project.select(:title, :id).distinct.
+               where(Project[:title].matches("#{letter}%").
+                 or(Project[:title].matches("% #{letter}%"))).
+               order(title: :asc).pluck(:title, :id)
+
+    projects.map! { |name, id| { name: name, id: id } }
   end
 end

--- a/app/classes/auto_complete/for_project.rb
+++ b/app/classes/auto_complete/for_project.rb
@@ -2,9 +2,9 @@
 
 class AutoComplete::ForProject < AutoComplete::ByWord
   def rough_matches(letter)
-    Project.select(:title).distinct.
+    Project.select(:title, :id).distinct.
       where(Project[:title].matches("#{letter}%").
         or(Project[:title].matches("% #{letter}%"))).
-      order(title: :asc).pluck(:title)
+      order(title: :asc).pluck(:title, :id)
   end
 end

--- a/app/classes/auto_complete/for_region.rb
+++ b/app/classes/auto_complete/for_region.rb
@@ -22,6 +22,6 @@ class AutoComplete::ForRegion < AutoComplete::ByWord
     end
     # Sort by name and prefer those with a non-zero ID
     regions.sort_by! { |reg| [reg[:name], -reg[:id]] }
-    regions.uniq! { |reg| reg[:name] }
+    regions.uniq { |reg| reg[:name] }
   end
 end

--- a/app/classes/auto_complete/for_region.rb
+++ b/app/classes/auto_complete/for_region.rb
@@ -9,11 +9,19 @@ class AutoComplete::ForRegion < AutoComplete::ByWord
     self.reverse = (params[:format] == "scientific")
   end
 
+  # Using observation.where gives the possibility of strings with no ID.
+  # Trying to match "region" means matching the end of the postal format string.
+  # "scientific" format users will have the country first, so reverse words
   def rough_matches(words)
     words = Location.reverse_name(words) if reverse
-    matches = Observation.in_region(words).pluck(:where, :location_id)
+    regions = Observation.in_region(words).pluck(:where, :location_id)
 
-    matches.map! { |m, _id| Location.reverse_name(m) } if reverse
-    matches.reject { |m| m[1].nil? }.sort_by(&:first).uniq(&:first)
+    regions.map! do |reg, id|
+      format = reverse ? Location.reverse_name(reg) : loc
+      { name: format, id: id.nil? ? 0 : id }
+    end
+    # Sort by name and prefer those with a non-zero ID
+    regions.sort_by! { |reg| [reg[:name], -reg[:id]] }
+    regions.uniq! { |reg| reg[:name] }
   end
 end

--- a/app/classes/auto_complete/for_region.rb
+++ b/app/classes/auto_complete/for_region.rb
@@ -11,9 +11,9 @@ class AutoComplete::ForRegion < AutoComplete::ByWord
 
   def rough_matches(words)
     words = Location.reverse_name(words) if reverse
-    matches = Observation.in_region(words).pluck(:where)
+    matches = Observation.in_region(words).pluck(:where, :location_id)
 
-    matches.map! { |m| Location.reverse_name(m) } if reverse
-    matches.sort.uniq
+    matches.map! { |m, _id| Location.reverse_name(m) } if reverse
+    matches.reject { |m| m[1].nil? }.sort_by(&:first).uniq(&:first)
   end
 end

--- a/app/classes/auto_complete/for_species_list.rb
+++ b/app/classes/auto_complete/for_species_list.rb
@@ -2,9 +2,9 @@
 
 class AutoComplete::ForSpeciesList < AutoComplete::ByWord
   def rough_matches(letter)
-    SpeciesList.select(:title).distinct.
+    SpeciesList.select(:title, :id).distinct.
       where(SpeciesList[:title].matches("#{letter}%").
         or(SpeciesList[:title].matches("% #{letter}%"))).
-      order(title: :asc).pluck(:title)
+      order(title: :asc).pluck(:title, :id)
   end
 end

--- a/app/classes/auto_complete/for_species_list.rb
+++ b/app/classes/auto_complete/for_species_list.rb
@@ -2,9 +2,11 @@
 
 class AutoComplete::ForSpeciesList < AutoComplete::ByWord
   def rough_matches(letter)
-    SpeciesList.select(:title, :id).distinct.
-      where(SpeciesList[:title].matches("#{letter}%").
-        or(SpeciesList[:title].matches("% #{letter}%"))).
-      order(title: :asc).pluck(:title, :id)
+    lists = SpeciesList.select(:title, :id).distinct.
+            where(SpeciesList[:title].matches("#{letter}%").
+              or(SpeciesList[:title].matches("% #{letter}%"))).
+            order(title: :asc).pluck(:title, :id)
+
+    lists.map! { |name, id| { name:, id: } }
   end
 end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -2,14 +2,15 @@
 
 class AutoComplete::ForUser < AutoComplete::ByString
   def rough_matches(letter)
-    users = User.select(:login, :name).distinct.
+    users = User.select(:login, :name, :id).distinct.
             where(User[:login].matches("#{letter}%").
               or(User[:name].matches("#{letter}%")).
               or(User[:name].matches("% #{letter}%"))).
-            order(login: :asc).pluck(:login, :name)
+            order(login: :asc).pluck(:login, :name, :id)
 
-    users.map do |login, name|
-      name.empty? ? login : "#{login} <#{name}>"
+    users.map do |login, name, id|
+      user_name = name.empty? ? login : "#{login} <#{name}>"
+      [user_name, id]
     end.sort
   end
 end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -8,9 +8,10 @@ class AutoComplete::ForUser < AutoComplete::ByString
               or(User[:name].matches("% #{letter}%"))).
             order(login: :asc).pluck(:login, :name, :id)
 
-    users.map do |login, name, id|
+    users.map! do |login, name, id|
       user_name = name.empty? ? login : "#{login} <#{name}>"
-      [user_name, id]
-    end.sort_by(&:first)
+      { name: user_name, id: id }
+    end
+    users.sort_by! { |user| user[:name] }
   end
 end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -11,6 +11,6 @@ class AutoComplete::ForUser < AutoComplete::ByString
     users.map do |login, name, id|
       user_name = name.empty? ? login : "#{login} <#{name}>"
       [user_name, id]
-    end.sort
+    end.sort_by(&:first)
   end
 end

--- a/app/controllers/autocompleters_controller.rb
+++ b/app/controllers/autocompleters_controller.rb
@@ -37,8 +37,7 @@ class AutocompletersController < ApplicationController
     when "herbarium"
       params[:user_id] = @user&.id
     end
-
-    ::AutoComplete.subclass(@type).new(params).matching_strings
+    ::AutoComplete.subclass(@type).new(params).matching_records
   end
 
   # callback on `around_action`

--- a/app/controllers/autocompleters_controller.rb
+++ b/app/controllers/autocompleters_controller.rb
@@ -31,12 +31,10 @@ class AutocompletersController < ApplicationController
   private
 
   def auto_complete_results
-    case @type
-    when "location", "location_containing", "region"
-      params[:format] = @user&.location_format
-    when "herbarium"
-      params[:user_id] = @user&.id
-    end
+    # add useful params that the controller knows about
+    params[:format] = @user&.location_format
+    params[:user_id] = @user&.id
+
     ::AutoComplete.subclass(@type).new(params).matching_records
   end
 

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -842,17 +842,16 @@ export default class extends Controller {
   update_normal() {
     const token = this.get_search_token().normalize().toLowerCase(),
       // normalize the Unicode of each string in primer for search
-      primer = this.primer.map((obj) => {
-        obj['name'] = obj['name'].normalize();
-        return obj;
-      }),
+      primer = this.primer.map((obj) => (
+        { name: obj['name'].normalize(), id: obj['id'] }
+      )),
       matches = [];
 
-    if (token != '') {
-      for (let i = 0; i < primer.length; i++) {
-        let s = primer[i + 1]['name'];
+    if (token != '' && primer.length > 1) {
+      for (let i = 1; i < primer.length; i++) {
+        let s = primer[i]['name'];
         if (s && s.length > 0 && s.toLowerCase().indexOf(token) >= 0) {
-          matches.push(primer[i + 1]);
+          matches.push(primer[i]);
         }
       }
     }
@@ -868,10 +867,9 @@ export default class extends Controller {
       // get the separate words as tokens
       tokens = token.split(' '),
       // normalize the Unicode of each string in primer for search
-      primer = this.primer.map((obj) => {
-        obj['name'] = obj['name'].normalize();
-        return obj;
-      }),
+      primer = this.primer.map((obj) => (
+        { name: obj['name'].normalize(), id: obj['id'] }
+      )),
       matches = [];
 
     if (token != '' && primer.length > 1) {

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -900,7 +900,7 @@ export default class extends Controller {
         { name: obj['name'].toLowerCase(), id: obj['id'] }
       )),
       matches = [];
-    debugger
+
     if (token != '' && primer.length > 1) {
       let the_rest = (token.match(/ /g) || []).length >= this.COLLAPSE;
 

--- a/test/controllers/autocompleters_controller_test.rb
+++ b/test/controllers/autocompleters_controller_test.rb
@@ -46,7 +46,6 @@ class AutocompletersControllerTest < FunctionalTestCase
 
   ##############################################################################
 
-  # rubocop:disable Style/CollectionCompact
   def test_auto_complete_location
     login("rolf")
     # names of Locations whose names have words starting with "m"
@@ -60,7 +59,7 @@ class AutocompletersControllerTest < FunctionalTestCase
 
     expect = m.sort_by(&:first).uniq(&:first)
     expect.unshift(["M", 0])
-    expect = expect.reject { |_n, id| id.nil? }
+    expect = expect.map { |n, id| [n, id.nil? ? 0 : id] }
     expect = expect.map { |name, id| { name:, id: } }
     good_autocompleter_request(type: :location, string: "Modesto")
     assert_equivalent(expect, JSON.parse(@response.body))
@@ -69,7 +68,7 @@ class AutocompletersControllerTest < FunctionalTestCase
     expect = m.map { |name, id| [Location.reverse_name(name), id] }.
              sort_by(&:first).uniq(&:first)
     expect.unshift(["M", 0])
-    expect = expect.reject { |_n, id| id.nil? }
+    expect = expect.map { |n, id| [n, id.nil? ? 0 : id] }
     expect = expect.map { |name, id| { name:, id: } }
     good_autocompleter_request(type: :location, string: "Modesto")
     assert_equivalent(expect, JSON.parse(@response.body))
@@ -78,7 +77,6 @@ class AutocompletersControllerTest < FunctionalTestCase
     good_autocompleter_request(type: :location, string: "Xystus")
     assert_equivalent([{ name: "X", id: 0 }], JSON.parse(@response.body))
   end
-  # rubocop:enable Style/CollectionCompact
 
   def test_auto_complete_herbarium
     login("rolf")

--- a/test/controllers/autocompleters_controller_test.rb
+++ b/test/controllers/autocompleters_controller_test.rb
@@ -33,128 +33,169 @@ class AutocompletersControllerTest < FunctionalTestCase
     url
   end
 
+  # have to do this because it's saying the arrays of hashes are not equal with
+  # `assert_equal`, even though they are
+  def assert_equivalent(array1, array2)
+    array1 = array1.map(&:symbolize_keys)
+    array2 = array2.map(&:symbolize_keys)
+    diff = (array1 - array2) + (array2 - array1)
+    assert(diff.empty?, diff.inspect)
+    # assert_equal(array1.sort_by { |r| r[:name] },
+    #              array2.sort_by { |r| r[:name] })
+  end
+
   ##############################################################################
 
+  # rubocop:disable Style/CollectionCompact
   def test_auto_complete_location
     login("rolf")
     # names of Locations whose names have words starting with "m"
     m_loc_names = Location.where(Location[:name].matches_regexp("\\bM")).
-                  map(&:name)
+                  pluck(:name, :id)
     # wheres of Observations whose wheres have words starting with "m"
     # need extra "observation" to avoid confusing sql with bare "where".
     m_obs_wheres = Observation.where(Observation[:where].
-                   matches_regexp("\\bM")).map(&:where)
+                   matches_regexp("\\bM")).pluck(:where, :location_id)
     m = m_loc_names + m_obs_wheres
 
-    expect = m.sort.uniq
-    expect.unshift("M")
+    expect = m.sort_by(&:first).uniq(&:first)
+    expect.unshift(["M", 0])
+    expect = expect.reject { |_n, id| id.nil? }
+    expect = expect.map { |name, id| { name:, id: } }
     good_autocompleter_request(type: :location, string: "Modesto")
-    assert_equal(expect, JSON.parse(@response.body))
+    assert_equivalent(expect, JSON.parse(@response.body))
 
     login("roy") # prefers location_format: :scientific
-    expect = m.map { |x| Location.reverse_name(x) }.sort.uniq
-    expect.unshift("M")
+    expect = m.map { |name, id| [Location.reverse_name(name), id] }.
+             sort_by(&:first).uniq(&:first)
+    expect.unshift(["M", 0])
+    expect = expect.reject { |_n, id| id.nil? }
+    expect = expect.map { |name, id| { name:, id: } }
     good_autocompleter_request(type: :location, string: "Modesto")
-    assert_equal(expect, JSON.parse(@response.body))
+    assert_equivalent(expect, JSON.parse(@response.body))
 
     login("mary") # prefers location_format: :postal
     good_autocompleter_request(type: :location, string: "Xystus")
-    assert_equal(["X"], JSON.parse(@response.body))
+    assert_equivalent([{ name: "X", id: 0 }], JSON.parse(@response.body))
   end
+  # rubocop:enable Style/CollectionCompact
 
   def test_auto_complete_herbarium
     login("rolf")
     # names of Herbariums whose names have words starting with "m"
     m = Herbarium.where(Herbarium[:name].matches_regexp("\\bD")).
-        map(&:name)
+        pluck(:name, :id)
 
-    expect = m.sort.uniq
-    expect.unshift("D")
+    expect = m.sort_by(&:first).uniq(&:first)
+    expect.unshift(["D", 0])
+    expect = expect.map { |name, id| { name:, id: } }
     good_autocompleter_request(type: :herbarium, string: "Dick")
-    assert_equal(expect, JSON.parse(@response.body))
+    assert_equivalent(expect, JSON.parse(@response.body))
   end
 
   def test_auto_complete_empty
     login("rolf")
     good_autocompleter_request(type: :name, string: "")
-    assert_equal([], JSON.parse(@response.body))
+    assert_equivalent([], JSON.parse(@response.body))
   end
 
   def test_auto_complete_name_above_genus
     login("rolf")
-    expect = %w[F Fungi]
+    expect = [{ name: "F", id: 0 }, { name: "Fungi", id: names(:fungi).id }]
     good_autocompleter_request(type: :clade, string: "Fung")
-    assert_equal(expect, JSON.parse(@response.body))
+    assert_equivalent(expect, JSON.parse(@response.body))
   end
 
   def test_auto_complete_name
     login("rolf")
     expect = Name.all.reject(&:correct_spelling).
-             map(&:text_name).uniq.select { |n| n[0] == "A" }.sort
-    expect_genera = expect.reject { |n| n.include?(" ") }
-    expect_species = expect.select { |n| n.include?(" ") }
-    expect = ["A"] + expect_genera + expect_species
+             pluck(:text_name, :id).uniq.select { |n, _i| n[0] == "A" }.sort
+    expect_genera = expect.reject { |n, _i| n.include?(" ") }.map do |name, id|
+      { name:, id: }
+    end
+    expect_species = expect.select { |n, _i| n.include?(" ") }.map do |name, id|
+      { name:, id: }
+    end
+    expect = [{ name: "A", id: 0 }] + expect_genera + expect_species
     good_autocompleter_request(type: :name, string: "Agaricus")
-    assert_equal(expect, JSON.parse(@response.body))
+    assert_equivalent(expect, JSON.parse(@response.body))
 
     good_autocompleter_request(type: :name, string: "Umbilicaria")
-    assert_equal(["U"], JSON.parse(@response.body))
+    assert_equivalent([{ name: "U", id: 0 }], JSON.parse(@response.body))
   end
 
   def test_auto_complete_project
     login("rolf")
     # titles of Projects whose titles have words starting with "p"
     b_titles = Project.where(Project[:title].matches_regexp("\\bB")).
-               map(&:title).uniq
+               pluck(:title, :id).uniq.map do |name, id|
+      { name:, id: }
+    end
     good_autocompleter_request(type: :project, string: "Babushka")
-    assert_equal((["B"] + b_titles).sort, JSON.parse(@response.body).sort)
+    assert_equivalent(([{ name: "B", id: 0 }] + b_titles),
+                      JSON.parse(@response.body))
 
     p_titles = Project.where(Project[:title].matches_regexp("\\bP")).
-               map(&:title).uniq
+               pluck(:title, :id).uniq.map do |name, id|
+      { name:, id: }
+    end
     good_autocompleter_request(type: :project, string: "Perfidy")
-    assert_equal((["P"] + p_titles).sort, JSON.parse(@response.body).sort)
+    assert_equivalent(([{ name: "P", id: 0 }] + p_titles),
+                      JSON.parse(@response.body))
 
     good_autocompleter_request(type: :project, string: "Xystus")
-    assert_equal(["X"], JSON.parse(@response.body))
+    assert_equivalent([{ name: "X", id: 0 }],
+                      JSON.parse(@response.body))
   end
 
   def test_auto_complete_species_list
     login("rolf")
-    list1, list2, list3, list4 = SpeciesList.order(:title).map(&:title)
+    list1, list2, list3, list4 = SpeciesList.order(:title).pluck(:title, :id).
+                                 take(4).map { |name, id| { name:, id: } }
 
-    assert_equal("A Species List", list1)
-    assert_equal("Another Species List", list2)
-    assert_equal("List of mysteries", list3)
-    assert_equal("lone_wolf_list", list4)
+    assert_equal("A Species List", list1[:name])
+    assert_equal("Another Species List", list2[:name])
+    assert_equal("List of mysteries", list3[:name])
+    assert_equal("lone_wolf_list", list4[:name])
 
     good_autocompleter_request(type: :species_list, string: "List")
-    assert_equal(["L", list1, list2, list3, list4], JSON.parse(@response.body))
+    assert_equivalent([{ name: "L", id: 0 }, list1, list2, list3, list4],
+                      JSON.parse(@response.body))
 
     good_autocompleter_request(type: :species_list, string: "Mojo")
-    assert_equal(["M", list3], JSON.parse(@response.body))
+    assert_equivalent([{ name: "M", id: 0 }, list3],
+                      JSON.parse(@response.body))
 
     good_autocompleter_request(type: :species_list, string: "Xystus")
-    assert_equal(["X"], JSON.parse(@response.body))
+    assert_equivalent([{ name: "X", id: 0 }],
+                      JSON.parse(@response.body))
   end
 
   def test_auto_complete_user
     login("rolf")
     good_autocompleter_request(type: :user, string: "Rover")
-    assert_equal(
-      ["R", "rolf <Rolf Singer>", "roy <Roy Halling>",
-       "second_roy <Roy Rogers>"],
+    assert_equivalent(
+      [{ name: "R", id: 0 },
+       { name: "rolf <Rolf Singer>", id: rolf.id },
+       { name: "roy <Roy Halling>", id: roy.id },
+       { name: "second_roy <Roy Rogers>", id: users(:second_roy).id }],
       JSON.parse(@response.body)
     )
 
     good_autocompleter_request(type: :user, string: "Dodo")
-    assert_equal(["D", "dick <Tricky Dick>"], JSON.parse(@response.body))
+    assert_equivalent([{ name: "D", id: 0 },
+                       { name: "dick <Tricky Dick>", id: dick.id }],
+                      JSON.parse(@response.body))
 
     good_autocompleter_request(type: :user, string: "Komodo")
-    assert_equal(["K", "#{katrina.login} <#{katrina.name}>"],
-                 JSON.parse(@response.body))
+    assert_equivalent([{ name: "K", id: 0 },
+                       { name: "#{katrina.login} <#{katrina.name}>",
+                         id: katrina.id }],
+                      JSON.parse(@response.body))
 
     good_autocompleter_request(type: :user, string: "Xystus")
-    assert_equal(["X"], JSON.parse(@response.body))
+    assert_equivalent([{ name: "X", id: 0 }],
+                      JSON.parse(@response.body))
   end
 
   def test_auto_complete_bogus

--- a/test/controllers/autocompleters_controller_test.rb
+++ b/test/controllers/autocompleters_controller_test.rb
@@ -111,12 +111,14 @@ class AutocompletersControllerTest < FunctionalTestCase
     names = Name.with_correct_spelling.
             select(:text_name, :id, :deprecated).distinct.
             where(Name[:text_name].matches("A%")).
-            pluck(:text_name, :id, :deprecated).sort_by do |x, _id, _d|
-              (x.match?(" ") ? "b" : "a") + x
-            end
+            pluck(:text_name, :id, :deprecated)
 
     expect = names.map do |name, id, deprecated|
-      { name:, id:, deprecated: deprecated || false }
+      dep_string = deprecated.nil? ? "false" : deprecated.to_s
+      { name: name, id: id, deprecated: dep_string }
+    end
+    expect.sort_by! do |name|
+      [(name[:name].match?(" ") ? "b" : "a") + name[:name], name[:deprecated]]
     end
     expect.uniq! { |name| name[:name] }
     expect.unshift({ name: "A", id: 0 })

--- a/test/models/auto_complete_test.rb
+++ b/test/models/auto_complete_test.rb
@@ -45,7 +45,7 @@ class AutoCompleteTest < UnitTestCase
   end
 
   def test_truncate
-    list = %w[b0 b1 b2 b3 b4 b5 b6 b7 b8 b9].map { |str| [str, 0] }
+    list = %w[b0 b1 b2 b3 b4 b5 b6 b7 b8 b9].map { |str| { name: str, id: 0 } }
     auto = AutoCompleteMock.new(string: "blah")
     auto.matches = list
     assert_equal(list, auto.matches)
@@ -56,22 +56,23 @@ class AutoCompleteTest < UnitTestCase
 
     auto.limit = 9
     auto.truncate_matches
-    list[9] = "..."
+    list[9] = { name: "...", id: nil }
     assert_equal(list, auto.matches)
 
     auto.limit = 1
     auto.truncate_matches
-    assert_equal([["b0", 0], ["...", nil]], auto.matches)
+    assert_equal([{ name: "b0", id: 0 }, { name: "...", id: nil }],
+                 auto.matches)
   end
 
   def test_multiline_matches
     list1 = [" line one \n line two\n  ", "good match", "  padded match  "]
     list2 = ["line one", "good match", "padded match"]
     auto = AutoCompleteMock.new(string: "blah")
-    auto.matches = list1.map { |str| [str, 0] }
-    assert_equal(list1.map { |str| [str, 0] }, auto.matches)
+    auto.matches = list1.map { |str| { name: str, id: 0 } }
+    assert_equal(list1.map { |str| { name: str, id: 0 } }, auto.matches)
     auto.clean_matches
-    assert_equal(list2.map { |str| [str, 0] }, auto.matches)
+    assert_equal(list2.map { |str| { name: str, id: 0 } }, auto.matches)
   end
 
   def test_refine_token_by_string
@@ -101,7 +102,7 @@ class AutoCompleteTest < UnitTestCase
       [2, 3, "one two three"]
     ].each do |limit, expected_matches, expected_string|
       auto = AutoCompleteMock.new(string: pattern)
-      auto.matches = @list.sort_by { rand }.map { |str| [str, 0] }
+      auto.matches = @list.sort_by { rand }.map { |str| { name: str, id: 0 } }
       auto.limit = limit
       assert_refines_correctly(auto, expected_matches, expected_string)
     end
@@ -135,7 +136,7 @@ class AutoCompleteTest < UnitTestCase
       [1, 2, "one two shree"]
     ].each do |limit, expected_matches, expected_string|
       auto = AutoComplete::ForMock.new(string: pattern)
-      auto.matches = @list.sort_by { rand }.map { |str| [str, 0] }
+      auto.matches = @list.sort_by { rand }.map { |str| { name: str, id: 0 } }
       auto.limit = limit
       assert_refines_correctly(auto, expected_matches, expected_string)
     end

--- a/test/models/auto_complete_test.rb
+++ b/test/models/auto_complete_test.rb
@@ -38,14 +38,14 @@ class AutoCompleteTest < UnitTestCase
 
   def test_typical_use
     auto = AutoComplete::ForName.new(string: "Agaricus")
-    results = auto.matching_strings
-    assert_equal("A", results.first)
-    assert(results.include?("Agaricus"))
-    assert(results.include?("Agaricus campestris"))
+    results = auto.matching_records
+    assert_equal("A", results.first[:name])
+    assert(results.pluck(:name).include?("Agaricus"))
+    assert(results.pluck(:name).include?("Agaricus campestris"))
   end
 
   def test_truncate
-    list = %w[b0 b1 b2 b3 b4 b5 b6 b7 b8 b9]
+    list = %w[b0 b1 b2 b3 b4 b5 b6 b7 b8 b9].map { |str| [str, 0] }
     auto = AutoCompleteMock.new(string: "blah")
     auto.matches = list
     assert_equal(list, auto.matches)
@@ -61,20 +61,20 @@ class AutoCompleteTest < UnitTestCase
 
     auto.limit = 1
     auto.truncate_matches
-    assert_equal(["b0", "..."], auto.matches)
+    assert_equal([["b0", 0], ["...", nil]], auto.matches)
   end
 
   def test_multiline_matches
     list1 = [" line one \n line two\n  ", "good match", "  padded match  "]
     list2 = ["line one", "good match", "padded match"]
     auto = AutoCompleteMock.new(string: "blah")
-    auto.matches = list1
-    assert_equal(list1, auto.matches)
+    auto.matches = list1.map { |str| [str, 0] }
+    assert_equal(list1.map { |str| [str, 0] }, auto.matches)
     auto.clean_matches
-    assert_equal(list2, auto.matches)
+    assert_equal(list2.map { |str| [str, 0] }, auto.matches)
   end
 
-  def test_refine_matches_by_string
+  def test_refine_token_by_string
     pattern = "one two three"
     @list = [
       "one two three four", # 1
@@ -101,13 +101,13 @@ class AutoCompleteTest < UnitTestCase
       [2, 3, "one two three"]
     ].each do |limit, expected_matches, expected_string|
       auto = AutoCompleteMock.new(string: pattern)
-      auto.matches = @list.sort_by { rand }
+      auto.matches = @list.sort_by { rand }.map { |str| [str, 0] }
       auto.limit = limit
       assert_refines_correctly(auto, expected_matches, expected_string)
     end
   end
 
-  def test_refine_matches_by_word
+  def test_refine_token_by_word
     pattern = "one two shree"
     @list = [
       "one two shree four",  # 1 "one two shree"
@@ -135,14 +135,14 @@ class AutoCompleteTest < UnitTestCase
       [1, 2, "one two shree"]
     ].each do |limit, expected_matches, expected_string|
       auto = AutoComplete::ForMock.new(string: pattern)
-      auto.matches = @list.sort_by { rand }
+      auto.matches = @list.sort_by { rand }.map { |str| [str, 0] }
       auto.limit = limit
       assert_refines_correctly(auto, expected_matches, expected_string)
     end
   end
 
   def assert_refines_correctly(auto, expected_matches, expected_string)
-    string = auto.refine_matches
+    string = auto.refine_token
     if string != expected_string || auto.matches.length != expected_matches
       msg = "Didn't refine matches correctly for limit = #{auto.limit}:\n" \
             "Refined string: #{string.inspect}, " \

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -24,15 +24,15 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     find_field("search_name").click
     browser.keyboard.type("agaricus camp")
     assert_selector(".auto_complete") # wait
-    assert_selector(".auto_complete ul li", text: "Agaricus campestras")
-    assert_selector(".auto_complete ul li", text: "Agaricus campestris")
-    assert_selector(".auto_complete ul li", text: "Agaricus campestros")
-    assert_selector(".auto_complete ul li", text: "Agaricus campestrus")
-    assert_no_selector(".auto_complete ul li", text: "Agaricus campestruss")
+    assert_selector(".auto_complete ul li a", text: "Agaricus campestras")
+    assert_selector(".auto_complete ul li a", text: "Agaricus campestris")
+    assert_selector(".auto_complete ul li a", text: "Agaricus campestros")
+    assert_selector(".auto_complete ul li a", text: "Agaricus campestrus")
+    assert_no_selector(".auto_complete ul li a", text: "Agaricus campestruss")
     browser.keyboard.type(:down, :down, :down, :tab)
     assert_field("search_name", with: "Agaricus campestros")
     browser.keyboard.type(:delete, :delete)
-    assert_selector(".auto_complete ul li", text: "Agaricus campestrus")
+    assert_selector(".auto_complete ul li a", text: "Agaricus campestrus")
     browser.keyboard.type(:down, :down, :down, :down, :tab)
     assert_field("search_name", with: "Agaricus campestrus")
 
@@ -40,9 +40,9 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     find_field("search_user").click
     browser.keyboard.type("r")
     assert_selector(".auto_complete") # wait
-    assert_selector(".auto_complete ul li", text: "Rolf Singer")
-    assert_selector(".auto_complete ul li", text: "Roy Halling")
-    assert_selector(".auto_complete ul li", text: "Roy Rogers")
+    assert_selector(".auto_complete ul li a", text: "Rolf Singer")
+    assert_selector(".auto_complete ul li a", text: "Roy Halling")
+    assert_selector(".auto_complete ul li a", text: "Roy Rogers")
     browser.keyboard.type(:down, :down, :tab)
     sleep(1)
     assert_field("search_user", with: "roy <Roy Halling>")
@@ -51,7 +51,7 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     find_field("search_location").click
     browser.keyboard.type("USA, Califo")
     assert_selector(".auto_complete") # wait
-    assert_selector(".auto_complete ul li", count: 10)
+    assert_selector(".auto_complete ul li a", count: 10)
     assert_selector(
       ".auto_complete ul li",
       text: "Point Reyes National Seashore"
@@ -67,7 +67,7 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     find("#content_filter_clade").click
     browser.keyboard.type("Agari")
     assert_selector(".auto_complete") # wait
-    assert_selector(".auto_complete ul li")
+    assert_selector(".auto_complete ul li a")
     browser.keyboard.type(:down, :tab)
     sleep(1)
     assert_field("content_filter_clade", with: "Agaricaceae")
@@ -100,7 +100,7 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     find_field("naming_name").click
     browser.keyboard.type("Peltige")
     assert_selector(".auto_complete", wait: 3) # wait
-    assert_selector(".auto_complete ul li")
+    assert_selector(".auto_complete ul li a")
     browser.keyboard.type(:down, :down, :tab)
     assert_field("naming_name", with: "Peltigeraceae ")
     browser.keyboard.type(:tab)

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -25,9 +25,9 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
       browser.keyboard.type(:tab)
       assert_field("naming_name", with: "Elfin saddle")
       # start typing the location...
-      fill_in("observation_place_name", with: locations.first.name[0, 10])
+      fill_in("observation_place_name", with: locations.first.name[0, 1])
       # wait for the autocompleter...
-      assert_selector(".auto_complete")
+      assert_selector(".auto_complete", wait: 6)
       browser.keyboard.type(:down, :tab) # cursor to first match + select row
       assert_field("observation_place_name", with: locations.first.name)
       click_commit


### PR DESCRIPTION
- Refactors the `AutoComplete` class to return an array of **arbitrary hashes of data** to the controller, from the records it queries, instead of a simple array of **strings**. 
The minimum data returned for each record is `{ name:, id: }`.
- Refactors `autocompleter_controller.js` to store and maintain its `primer` and `matches` as these arrays of returned data 
  - Applies the data to items in the DOM as data attributes, e.g. `data-id`, `data-deprecated`
  - Shows the name string within active items, as before
  - Removes the data attributes when updating the virtual list

This change enables more specific handling of autocomplete choices, e.g. displaying deprecated names differently. The ability to store data attributes on the matches also allows for possibly adding new items to the list (like locations returned from Google) and storing data like bounding box lat/lngs, and potentially sending them to the controller. This could be used to create new Location records on the fly in situations where we do not have a matching Location for a lat/lng.

It also enables sending the ID of the matched record back to the controller, avoiding another lookup.