### PR TITLE
Stimulus Autocompleter refactor

### DIFF
--- a/app/assets/stylesheets/BlackOnWhite.scss
+++ b/app/assets/stylesheets/BlackOnWhite.scss
@@ -3,7 +3,7 @@
 @import "defaults";
 
 $LOGO_BORDER_COLOR:                 #DDDDDD;
-$LEFT_BAR_BORDER_COLOR:             #DDDDDD;
+$LEFT_BAR_BORDER_COLOR:             #DEDDDD;
 $TOP_BAR_BORDER_COLOR:              #DDDDDD;
 $LIST_BORDER_COLOR:                 #DDDDDD;
 $BUTTON_HOVER_BORDER_COLOR:         #CCCCCC;

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -171,9 +171,9 @@ module FormsHelper
     end
 
     if args[:textarea] == true
-      concat(text_area_with_label(**ac_args))
+      text_area_with_label(**ac_args)
     else
-      concat(text_field_with_label(**ac_args))
+      text_field_with_label(**ac_args)
     end
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -164,10 +164,34 @@ module FormsHelper
     ac_args[:wrap_data] = { controller: :autocompleter, type: args[:type],
                             separator: args[:separator] }
 
-    if args[:textarea] == true
-      text_area_with_label(**ac_args)
+    concat(if args[:textarea] == true
+             text_area_with_label(**ac_args)
+           else
+             text_field_with_label(**ac_args)
+           end)
+    concat(autocompleter_dropdown)
+    concat(args[:form].hidden_field("#{args[:type]}_id")) if args[:form]
+  end
+
+  def autocompleter_dropdown
+    tag.div(class: "auto_complete dropdown-menu",
+            data: { autocompleter_target: "pulldown" }) do
+      tag.ul(class: "virtual_list") do
+        10.times do
+          concat(tag.li(class: "dropdown-item") { tag.a("", href: "#") })
+        end
+      end
+    end
+  end
+
+  def autocompleter_type_to_model(type)
+    case type
+    when :region
+      :location
+    when :clade
+      :name
     else
-      text_field_with_label(**ac_args)
+      type
     end
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -162,26 +162,42 @@ module FormsHelper
     }.deep_merge(args.except(:type, :separator, :textarea))
     ac_args[:class] = class_names("dropdown", args[:class])
     ac_args[:wrap_data] = { controller: :autocompleter, type: args[:type],
-                            separator: args[:separator] }
+                            separator: args[:separator],
+                            autocompleter_target: "wrap" }
+    ac_args[:append] = capture do
+      concat(autocompleter_hidden_field(**args)) if args[:form]
+      concat(autocompleter_dropdown)
+      concat(args[:append])
+    end
 
-    concat(if args[:textarea] == true
-             text_area_with_label(**ac_args)
-           else
-             text_field_with_label(**ac_args)
-           end)
-    concat(autocompleter_dropdown)
-    concat(args[:form].hidden_field("#{args[:type]}_id")) if args[:form]
+    if args[:textarea] == true
+      concat(text_area_with_label(**ac_args))
+    else
+      concat(text_field_with_label(**ac_args))
+    end
   end
 
   def autocompleter_dropdown
     tag.div(class: "auto_complete dropdown-menu",
-            data: { autocompleter_target: "pulldown" }) do
-      tag.ul(class: "virtual_list") do
-        10.times do
-          concat(tag.li(class: "dropdown-item") { tag.a("", href: "#") })
+            data: { autocompleter_target: "pulldown",
+                    action: "scroll->autocompleter#scrollList:passive" }) do
+      tag.ul(class: "virtual_list",
+             data: { autocompleter_target: "list" }) do
+        10.times do |i|
+          concat(tag.li(class: "dropdown-item") do
+            link_to("", "#", data: {
+                      row: i, action: "click->autocompleter#selectRow:prevent"
+                    })
+          end)
         end
       end
     end
+  end
+
+  def autocompleter_hidden_field(**args)
+    type = autocompleter_type_to_model(args[:type])
+    args[:form].hidden_field(:"#{type}_id",
+                             data: { autocompleter_target: "hidden" })
   end
 
   def autocompleter_type_to_model(type)

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -184,9 +184,9 @@ export default class extends Controller {
     }
   }
 
-  pulldownTargetConnected() {
-    this.getRowHeight();
-  }
+  // pulldownTargetConnected() {
+  //   this.getRowHeight();
+  // }
 
   // Prepare input element: attach elements, set properties.
   prepareInputElement() {
@@ -565,6 +565,13 @@ export default class extends Controller {
       li = this.listTarget.children[0].cloneNode(true),
       a = li.children[0];
 
+    Object.keys(ul.dataset).forEach(dataKey => {
+      delete ul.dataset[dataKey];
+    });
+    Object.keys(a.dataset).forEach(dataKey => {
+      delete a.dataset[dataKey];
+    });
+
     div.classList.add('test');
     a.innerHTML = 'test';
     ul.appendChild(li);
@@ -606,15 +613,14 @@ export default class extends Controller {
         "Redraw: matches=" + matches.length + ", scroll=" + scroll + ", cursor=" + cur
       );
     }
-
     // Get row height if haven't been able to yet.
-    this.getRowHeight();
+    if (!this.ROW_HEIGHT)
+      this.getRowHeight();
     if (rows.length) {
       this.updateRows(rows, matches, size, scroll);
       this.highlightNewRow(rows, cur, size, scroll)
       this.makePulldownVisible(matches, size, scroll)
     }
-
     // Make sure input focus stays on text field!
     this.inputTarget.focus();
   }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -333,8 +333,9 @@ export default class extends Controller {
     // this.debug("ourChange(" + this.inputTarget.value + ")");
     if (new_val != old_val) {
       this.old_value = new_val;
-      if (do_refresh)
+      if (do_refresh) {
         this.scheduleRefresh();
+      }
     }
   }
 
@@ -401,6 +402,7 @@ export default class extends Controller {
         this.refreshPrimer();
       this.populateMatches();
       this.drawPulldown();
+      this.hiddenTarget.value = '';
     }), this.REFRESH_DELAY * 1000);
   }
 
@@ -534,10 +536,12 @@ export default class extends Controller {
   selectRow(idx) {
     this.verbose("selectRow()");
     if (idx instanceof Event)
-      idx = parseInt(idx.target.parentElement.dataset.row);
+      idx = parseInt(idx.target.dataset.row);
 
     // const old_val = this.inputTarget.value;
-    let new_val = this.matches[this.scroll_offset + idx]['name'];
+    let new_data = this.matches[this.scroll_offset + idx],
+      new_val = new_data['name'],
+      new_id = new_data['id'];
     // Close pulldown unless the value the user selected uncollapses into a set
     // of new options.  In that case schedule a refresh and leave it up.
     if (this.COLLAPSE > 0 &&
@@ -550,6 +554,7 @@ export default class extends Controller {
     this.inputTarget.focus();
     this.focused = true;
     this.inputTarget.value = new_val;
+    this.hiddenTarget.value = new_id;
     this.setSearchToken(new_val);
     this.ourChange(false);
   }
@@ -648,7 +653,8 @@ export default class extends Controller {
         if (text != '') {
           link.innerHTML = '';
           Object.keys(link.dataset).forEach(key => {
-            delete link.dataset[key];
+            if (!['row', 'action'].includes(key))
+              delete link.dataset[key];
           });
         }
       }
@@ -768,7 +774,7 @@ export default class extends Controller {
 
     // Sort and remove duplicates, unless it's already sorted.
     if (!this.ACT_LIKE_SELECT)
-      this.matches = this.remove_dups(this.matches.sort(
+      this.matches = this.removeDups(this.matches.sort(
         (a, b) => (a.name || "").localeCompare(b.name || "")
       ));
     // Try to find old highlighted row in new set of options.

--- a/app/views/controllers/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/controllers/observations/identify/_form_identify_filter.html.erb
@@ -21,22 +21,25 @@ options = [
               id: "identify_filter",
               data: { controller: :autocompleter, type: :clade }) do |f| %>
 
-  <div class="form-group has-feedback has-search dropdown">
-    <%= content_tag(:span, "", class: "glyphicon glyphicon-search " \
-                                      "form-control-feedback") %>
+  <%= tag.div(class: "form-group has-feedback has-search dropdown",
+              data: { autocompleter_target: "wrap" } ) do %>
+    <%= tag.span(
+      "", class: "glyphicon glyphicon-search form-control-feedback"
+    ) %>
     <%# f.label(:term, "Filter by:") %>
     <%= f.text_field(
       :term, value: value, placeholder: :filter_by.l,
       class: "form-control", size: 42, autocomplete: "one-time-code",
       data: { autocompleter_target: "input" }
     ) %>
+    <%= autocompleter_dropdown %>
     <%# autocompleter_field(
       form: f, field: :term, type: :clade, value: value,
       placeholder: :filter_by.l, size: 42, autofocus: true,
       data: { controller: nil,
               action: "autocompleter-swap:swap->autocompleter#swap" }) %>
 
-  </div><!--.form-group-->
+  <% end %><!--.form-group-->
 
   <%= f.select(:type, options, { selected: selected },
                { class: "form-control",


### PR DESCRIPTION
Takes some of the DOM-element-building and event-binding out of the Stimulus JS controller, and puts it in the template markup, more in line with Stimulus conventions, to: 
- **minimize writing JS** (not much gain there, but a little)
- **indicate interactive elements in the HTML with data attributes**

I believe these are enough to make this worthwhile. It moves the creation of HTML markup out of the JS and into the templates as much as possible, so that HTML refactors like the Bootstrap upgrade have fewer gotchas when checking for CSS classes to update. It also clearly indicates to developers who are not familiar with the JS that this element is being watched by a Stimulus controller. (They also don't have to wonder how it got there.)

These changes do not alter the rendered HTML of the dropdown, except for the additional data attributes. It's just a different way of building out the same element — it's built in ERB, rather than JS. It's still altered and updated by the JS.

#### New functionality: 
When the user selects a match, the controller now copies the record ID, if there is one, from the data of the matched string to a hidden field. It removes the ID as soon as the user modifies the input further. 

The dependability of feature is not yet tested, because we are not trying to do anything with the ID yet.