### PR TITLE
Correct the field name for `accession_number` on the obs form

### DIFF
--- a/app/controllers/observations_controller/form_helpers.rb
+++ b/app/controllers/observations_controller/form_helpers.rb
@@ -63,7 +63,7 @@ module ObservationsController::FormHelpers
     @collectors_name   = @user.legal_name
     @collectors_number = ""
     @herbarium_name    = @user.preferred_herbarium_name
-    @herbarium_id      = ""
+    @accession_number  = ""
   end
 
   def init_specimen_vars_for_reload
@@ -74,8 +74,8 @@ module ObservationsController::FormHelpers
     end
     return unless params[:herbarium_record]
 
-    @herbarium_name = params[:herbarium_record][:herbarium_name]
-    @herbarium_id   = params[:herbarium_record][:herbarium_id]
+    @herbarium_name   = params[:herbarium_record][:herbarium_name]
+    @accession_number = params[:herbarium_record][:accession_number]
   end
 
   def init_project_vars

--- a/app/controllers/observations_controller/new_and_create.rb
+++ b/app/controllers/observations_controller/new_and_create.rb
@@ -241,7 +241,7 @@ module ObservationsController::NewAndCreate
     herbarium = params2[:herbarium_name].to_s.strip_html.strip_squeeze
     herbarium = lookup_herbarium(herbarium)
     init_det  = initial_determination(obs)
-    accession = params2[:herbarium_id].to_s.strip_html.strip_squeeze
+    accession = params2[:accession_number].to_s.strip_html.strip_squeeze
     accession = default_accession_number(obs, params) if accession.blank?
     notes = params2[:herbarium_record_notes]
     [herbarium, init_det, accession, notes]
@@ -297,7 +297,7 @@ module ObservationsController::NewAndCreate
     # If user checks specimen box and nothing else, do not create record.
     obs.collection_numbers.empty? &&
       herbarium == @user.preferred_herbarium &&
-      params[:herbarium_record][:herbarium_id].blank?
+      params[:herbarium_record][:accession_number].blank?
   end
 
   def redirect_to_next_page

--- a/app/views/controllers/observations/form/_herbarium_record.html.erb
+++ b/app/views/controllers/observations/form/_herbarium_record.html.erb
@@ -11,7 +11,7 @@
       ) %>
 
       <%= text_field_with_label(
-        form: fhr, field: :herbarium_id, value: @herbarium_id,
+        form: fhr, field: :accession_number, value: @accession_number,
         label: "#{:herbarium_record_accession_number.t}:",
         data: { action: "specimen#checkCheckbox" }
       ) %>

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -31,7 +31,7 @@ class ObservationsControllerTest < FunctionalTestCase
   end
 
   def default_herbarium_record_fields
-    { herbarium_name: "", herbarium_id: "" }
+    { herbarium_name: "", accession_number: "" }
   end
 
   def location_exists_or_place_name_blank(params)
@@ -1436,7 +1436,7 @@ class ObservationsControllerTest < FunctionalTestCase
     assert_input_value(:collection_number_number, "")
     assert_input_value(:herbarium_record_herbarium_name,
                        users(:rolf).preferred_herbarium_name)
-    assert_input_value(:herbarium_record_herbarium_id, "")
+    assert_input_value(:herbarium_record_accession_number, "")
     assert_true(@response.body.include?("Albion, Mendocino Co., California"))
     users(:rolf).update(location_format: "scientific")
     get(:new)
@@ -1577,7 +1577,7 @@ class ObservationsControllerTest < FunctionalTestCase
       { observation: { specimen: "1" },
         herbarium_record: {
           herbarium_name: herbaria(:nybg_herbarium).auto_complete_name,
-          herbarium_id: "1234"
+          accession_number: "1234"
         },
         naming: { name: "Coprinus comatus" } },
       1, 1, 0
@@ -1592,14 +1592,14 @@ class ObservationsControllerTest < FunctionalTestCase
       { observation: { specimen: "1" },
         herbarium_record: {
           herbarium_name: herbaria(:nybg_herbarium).auto_complete_name,
-          herbarium_id: "1234"
+          accession_number: "1234"
         },
         naming: { name: "Cortinarius sp." } },
       0, 0, 0
     )
     assert_input_value(:herbarium_record_herbarium_name,
                        "NY - The New York Botanical Garden")
-    assert_input_value(:herbarium_record_herbarium_id, "1234")
+    assert_input_value(:herbarium_record_accession_number, "1234")
   end
 
   def test_create_observation_with_herbarium_no_id
@@ -1608,7 +1608,7 @@ class ObservationsControllerTest < FunctionalTestCase
       { observation: { specimen: "1" },
         herbarium_record: {
           herbarium_name: herbaria(:nybg_herbarium).auto_complete_name,
-          herbarium_id: ""
+          accession_number: ""
         },
         naming: { name: name } },
       1, 1, 0
@@ -1620,11 +1620,10 @@ class ObservationsControllerTest < FunctionalTestCase
 
   def test_create_observation_with_herbarium_but_no_specimen
     generic_construct_observation(
-      { herbarium_record:
-                          { herbarium_name: herbaria(
-                            :nybg_herbarium
-                          ).auto_complete_name,
-                            herbarium_id: "1234" },
+      { herbarium_record: {
+          herbarium_name: herbaria(:nybg_herbarium).auto_complete_name,
+          accession_number: "1234"
+        },
         naming: { name: "Coprinus comatus" } },
       1, 1, 0
     )
@@ -1637,7 +1636,7 @@ class ObservationsControllerTest < FunctionalTestCase
     generic_construct_observation(
       { observation: { specimen: "1" },
         herbarium_record: { herbarium_name: "A Brand New Herbarium",
-                            herbarium_id: "" },
+                            accession_number: "" },
         naming: { name: "Coprinus comatus" } },
       1, 1, 0
     )
@@ -1650,7 +1649,7 @@ class ObservationsControllerTest < FunctionalTestCase
     generic_construct_observation(
       { observation: { specimen: "1" },
         herbarium_record: { herbarium_name: katrina.personal_herbarium_name,
-                            herbarium_id: "12345" },
+                            accession_number: "12345" },
         naming: { name: "Coprinus comatus" } },
       1, 1, 0, katrina
     )


### PR DESCRIPTION
We've been calling this field `herbarium_id` as a shorthand, but it's actually the field for the HR `accession_number`. This PR just renames the field, and the ivar `@herbarium_id` generated in the context of the `ObservationsController` (only) to `@accession_number`.

`herbarium_id` will conflict with a new hidden field for "herbarium" autocompleters that is generated with the more accurate use of the name `herbarium_id`.