### PR TITLE
Name autocompleter - fix hyperactive refresh bug

### DIFF
--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -110,7 +110,8 @@ const INTERNAL_OPTS = {
   fetch_request: null,   // ajax request while underway
   refresh_timer: null,   // timer used to delay update after typing
   hide_timer: null,      // timer used to delay hiding of pulldown
-  key_timer: null        // timer used to emulate key repeat
+  key_timer: null,       // timer used to emulate key repeat
+  log: false             // log debug messages to console?
 }
 
 // Connects to data-controller="autocompleter"
@@ -1113,10 +1114,10 @@ export default class extends Controller {
     if (new_primer[new_primer.length - 1]['name'] == "...") {
       this.last_fetch_incomplete = true;
       new_primer = new_primer.slice(0, new_primer.length - 1);
-      if (this.focused)
-        // just in case we need to refine the request due to
-        // activity while waiting for this response
-        this.scheduleRefresh();
+      // if (this.focused)
+      //   just in case we need to refine the request due to
+      //   activity while waiting for this response
+      //   this.scheduleRefresh();
     } else {
       this.last_fetch_incomplete = false;
     }


### PR DESCRIPTION
Fixes a bug introduced by me at some point (nope... not this week, just checked, possibly much older) where the name autocompleter refreshes way too often if there is a complete word, like a Genus, already autocompleted.

By "refreshes" i mean, "fetches new data from Rails". It may appear like some kind of slow DDOS.