### PR TITLE
Fix `nil?`checks for associated records: check the ID only

### DIFF
--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -358,7 +358,7 @@ class HerbariumRecordsController < ApplicationController
     if name.blank?
       flash_error(:create_herbarium_record_missing_herbarium_name.t)
       false
-    elsif !@herbarium_record.herbarium.nil?
+    elsif !@herbarium_record.herbarium_id.nil?
       true
     elsif name != @user.personal_herbarium_name || @user.personal_herbarium
       flash_warning(:create_herbarium_separately.t)

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -194,7 +194,7 @@ module ObservationsController::EditAndUpdate
   end
 
   def redirect_to_observation_or_create_location
-    if @observation.location.nil?
+    if @observation.location_id.nil?
       redirect_with_query(new_location_path(where: @observation.place_name,
                                             set_observation: @observation.id))
     else

--- a/app/controllers/observations_controller/new_and_create.rb
+++ b/app/controllers/observations_controller/new_and_create.rb
@@ -301,7 +301,7 @@ module ObservationsController::NewAndCreate
   end
 
   def redirect_to_next_page
-    if @observation.location.nil?
+    if @observation.location_id.nil?
       redirect_to(new_location_path(where: @observation.place_name,
                                     set_observation: @observation.id))
     else

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -51,7 +51,7 @@ module ObservationsController::Validators
     success = true
     @place_name = @observation.place_name
     @dubious_where_reasons = []
-    if @place_name != params[:approved_where] && @observation.location.nil?
+    if @place_name != params[:approved_where] && @observation.location_id.nil?
       db_name = Location.user_format(@user, @place_name)
       @dubious_where_reasons = Location.dubious_name?(db_name, true)
       success = false if @dubious_where_reasons != []

--- a/app/controllers/species_lists/shared_private_methods.rb
+++ b/app/controllers/species_lists/shared_private_methods.rb
@@ -95,7 +95,7 @@ module SpeciesLists
       @place_name = @species_list.place_name
       @dubious_where_reasons = []
       unless (@place_name != params[:approved_where]) &&
-             @species_list.location.nil?
+             @species_list.location_id.nil?
         return
       end
 
@@ -172,7 +172,7 @@ module SpeciesLists
       update_projects(@species_list, params[:project])
       construct_observations(@species_list, sorter)
 
-      if @species_list.location.nil?
+      if @species_list.location_id.nil?
         redirect_to(new_location_path(where: @place_name,
                                       set_species_list: @species_list.id))
       else

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -95,7 +95,7 @@ module ProjectsHelper
     displayed_coord =
       coord_or_hidden(obs: obs, project: project, coord: obs.lat)
 
-    return displayed_coord if project.location.nil?
+    return displayed_coord if project.location_id.nil?
     return displayed_coord if project.location.contains_lat?(obs.lat)
 
     tag.span(displayed_coord, class: "violation-highlight")
@@ -107,7 +107,7 @@ module ProjectsHelper
     displayed_coord =
       coord_or_hidden(obs: obs, project: project, coord: obs.lng)
 
-    return displayed_coord if project.location.nil?
+    return displayed_coord if project.location_id.nil?
     return displayed_coord if project.location.contains_lng?(obs.lng)
 
     tag.span(displayed_coord, class: "violation-highlight")

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -205,7 +205,7 @@ unlimited_project:
   <<: *DEFAULTS
   start_date: nil
   end_date: nil
-  location: nil
+  # location: nil
   observations: peltigera_obs, agaricus_campestris_obs, boletus_edulis_obs
 
 pinned_date_range_project:
@@ -247,5 +247,5 @@ nowhere_2023_09_project:
   user_group: falmouth_2023_09_users
   start_date: 2023-09-01
   end_date: 2023-09-30
-  location: nil
+  # location: nil
   observations: brett_woods_2023_09_obs, falmouth_2023_09_obs, falmouth_2022_obs, nybg_2023_09_obs # roy (non-admin) owns nybg_2023_09_obs


### PR DESCRIPTION
Housekeeping PR that came up when examining very old code involved with the feature I'm working on, auto-suggesting locations. 

Even though it's convenient and looks more elegant, it's inefficient to nil-check an associated record directly, unless it's been eager loaded — apparently, it will instantiate the record. 

Bad habit:
```ruby
@observation.location.nil?
```
Good habit:
```ruby
@observation.location_id.nil?
```