### PR TITLE
Refactor some name resolver var, ivar assignments

### DIFF
--- a/app/controllers/names/synonyms/deprecate_controller.rb
+++ b/app/controllers/names/synonyms/deprecate_controller.rb
@@ -50,7 +50,7 @@ module Names::Synonyms
     private
 
     def we_have_a_what!
-      return true if @what.present?
+      return true if @given_name.present?
 
       flash_error(:runtime_name_deprecate_must_choose.t)
       render_new
@@ -62,7 +62,7 @@ module Names::Synonyms
     end
 
     def suggest_alternate_spellings
-      @valid_names = Name.suggest_alternate_spellings(@what)
+      @valid_names = Name.suggest_alternate_spellings(@given_name)
       @suggest_corrections = true
       render_new
     end
@@ -74,7 +74,7 @@ module Names::Synonyms
     end
 
     def init_ivars_for_new
-      @what             = params[:proposed_name].to_s.strip_squeeze
+      @given_name = params[:proposed_name].to_s.strip_squeeze
       @comment          = params[:comment].to_s.strip_squeeze
       @list_members     = nil
       @new_names        = []
@@ -90,14 +90,14 @@ module Names::Synonyms
                   (name = Name.safe_find(params[:chosen_name][:name_id]))
                  [name]
                else
-                 Name.find_names_filling_in_authors(@what)
+                 Name.find_names_filling_in_authors(@given_name)
                end
     end
 
     def try_to_set_names_from_approved_name
       approved_name = params[:approved_name].to_s.strip_squeeze
       if @names.empty? &&
-         (new_name = Name.create_needed_names(approved_name, @what))
+         (new_name = Name.create_needed_names(approved_name, @given_name))
         @names = [new_name]
       end
     end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -102,8 +102,8 @@ module Observations
     def init_ivars
       @naming = Naming.new
       @vote = Vote.new
-      # @what can't be nil else rails tries to call @name.name
-      @what = params[:naming].to_s
+      # @given_name can't be nil else rails tries to call @name.name
+      @given_name = params[:naming].to_s
       @reasons = @naming.init_reasons
       fill_in_reference_for_suggestions if params[:naming].present?
 
@@ -121,7 +121,7 @@ module Observations
     end
 
     def init_edit_ivars
-      @what        = @naming.text_name
+      @given_name = @naming.text_name
       @names       = nil
       @valid_names = nil
       @reasons     = @naming.init_reasons
@@ -197,11 +197,17 @@ module Observations
       )
       # NOTE: views could be refactored to access properties of the @resolver,
       # e.g. `@resolver.valid_names`, instead of these ivars.
-      # All but success, @what, @name are only used by form_name_feedback.
+      # All but success, @given_name, @name are only used by form_name_feedback.
+      success = false
       @resolver.results.each do |ivar, value|
-        instance_variable_set(ivar, value)
+        if ivar == :success
+          # `success' is not allowed as an instance variable name
+          success = value
+        else
+          instance_variable_set(ivar, value)
+        end
       end
-      @success && @name
+      success && @name
     end
 
     # We should have a @name by this point
@@ -252,7 +258,7 @@ module Observations
     end
 
     def flash_naming_errors
-      if @what.blank?
+      if @given_name.blank?
         flash_error(:form_naming_what_missing.t)
       elsif name_missing?
         flash_object_errors(@naming)
@@ -260,7 +266,7 @@ module Observations
     end
 
     def name_missing?
-      return false if @name && @what.present?
+      return false if @name && @given_name.present?
 
       @naming.errors.
         add(:name, :form_observations_there_is_a_problem_with_name.t)

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -198,10 +198,10 @@ module Observations
       # NOTE: views could be refactored to access properties of the @resolver,
       # e.g. `@resolver.valid_names`, instead of these ivars.
       # All but success, @what, @name are only used by form_name_feedback.
-      (success, @what, @name, @names, @valid_names,
-       @parent_deprecated, @suggest_corrections) =
-        @resolver.ivar_array
-      success && @name
+      @resolver.results.each do |ivar, value|
+        instance_variable_set(ivar, value)
+      end
+      @success && @name
     end
 
     # We should have a @name by this point

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -201,7 +201,6 @@ module Observations
       success = false
       @resolver.results.each do |ivar, value|
         if ivar == :success
-          # `success' is not allowed as an instance variable name
           success = value
         else
           instance_variable_set(:"@#{ivar}", value)

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -121,7 +121,7 @@ module Observations
     end
 
     def init_edit_ivars
-      @given_name = @naming.text_name
+      @given_name  = @naming.text_name
       @names       = nil
       @valid_names = nil
       @reasons     = @naming.init_reasons
@@ -179,7 +179,7 @@ module Observations
     def resolve_ivars_for_validation(**args)
       @naming = Naming.construct(args[:naming_args], @observation)
       @vote = Vote.construct(args[:vote_args], @naming)
-      result = if name_str
+      result = if args[:given_name]
                  resolve_name(args[:given_name], args[:approved_name],
                               args[:chosen_name])
                else

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -168,7 +168,7 @@ module Observations
       args = {
         naming_args: {},
         vote_args: params.dig(:naming, :vote),
-        given_name: params.dig(:naming, :name_id) || params.dig(:naming, :name),
+        given_name: params.dig(:naming, :name),
         approved_name: params[:approved_name],
         chosen_name: params.dig(:chosen_name, :name_id).to_s
       }
@@ -310,7 +310,7 @@ module Observations
     end
 
     def validate_name
-      given_name = params.dig(:naming, :name_id) || params.dig(:naming, :name)
+      given_name = params.dig(:naming, :name)
       success = resolve_name(given_name,
                              params[:approved_name],
                              params.dig(:chosen_name, :name_id).to_s)

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -204,7 +204,7 @@ module Observations
           # `success' is not allowed as an instance variable name
           success = value
         else
-          instance_variable_set(ivar, value)
+          instance_variable_set(:"@#{ivar}", value)
         end
       end
       success && @name

--- a/app/controllers/observations_controller/new_and_create.rb
+++ b/app/controllers/observations_controller/new_and_create.rb
@@ -21,7 +21,7 @@ module ObservationsController::NewAndCreate
   #
   # Outputs:
   #   @observation, @naming, @vote      empty objects
-  #   @what, @names, @valid_names       name validation
+  #   @given_name, @names, @valid_names       name validation
   #   @reasons                          array of naming_reasons
   #   @images                           array of images
   #   @licenses                         used for image license menu
@@ -40,7 +40,7 @@ module ObservationsController::NewAndCreate
     @observation = Observation.new
     @naming      = Naming.new
     @vote        = Vote.new
-    @what        = "" # can't be nil else rails tries to call @name.name
+    @given_name = "" # can't be nil else rails tries to call @name.name
     @names       = nil
     @valid_names = nil
     @reasons     = @naming.init_reasons

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -23,7 +23,7 @@ module ObservationsController::Validators
   end
 
   def validate_name(params)
-    resolve_name_ivars(params)
+    success = resolve_name_ivars(params)
     if @name
       @naming.name = @name
     elsif !success
@@ -42,10 +42,17 @@ module ObservationsController::Validators
     )
     # NOTE: views could be refactored to access properties of the @resolver,
     # e.g. `@resolver.valid_names`, instead of these ivars.
-    # All but success, @what, @name are only used by form_name_feedback.
+    # All but success, @given_name, @name are only used by form_name_feedback.
+    success = false
     @resolver.results.each do |ivar, value|
-      instance_variable_set(ivar, value)
+      if ivar == :success
+        # `success' is not allowed as an instance variable name
+        success = value
+      else
+        instance_variable_set(ivar, value)
+      end
     end
+    success
   end
 
   def validate_place_name(params)

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -23,8 +23,7 @@ module ObservationsController::Validators
   end
 
   def validate_name(params)
-    (success, @what, @name, @names, @valid_names,
-     @parent_deprecated, @suggest_corrections) = resolve_name_ivars(params)
+    resolve_name_ivars(params)
     if @name
       @naming.name = @name
     elsif !success
@@ -44,7 +43,9 @@ module ObservationsController::Validators
     # NOTE: views could be refactored to access properties of the @resolver,
     # e.g. `@resolver.valid_names`, instead of these ivars.
     # All but success, @what, @name are only used by form_name_feedback.
-    @resolver.ivar_array
+    @resolver.results.each do |ivar, value|
+      instance_variable_set(ivar, value)
+    end
   end
 
   def validate_place_name(params)

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -46,7 +46,6 @@ module ObservationsController::Validators
     success = false
     @resolver.results.each do |ivar, value|
       if ivar == :success
-        # `success' is not allowed as an instance variable name
         success = value
       else
         instance_variable_set(:"@#{ivar}", value)

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -49,7 +49,7 @@ module ObservationsController::Validators
         # `success' is not allowed as an instance variable name
         success = value
       else
-        instance_variable_set(ivar, value)
+        instance_variable_set(:"@#{ivar}", value)
       end
     end
     success

--- a/app/models/naming/name_resolver.rb
+++ b/app/models/naming/name_resolver.rb
@@ -130,10 +130,15 @@ class Naming
     end
     # rubocop:enable Metrics/MethodLength
 
-    # Convenience method returning an array for mass ivar assignment
-    def ivar_array
-      [@success, @what, @name, @names, @valid_names, @parent_deprecated,
-       @suggest_corrections]
+    # Convenience method returning a hash for mass ivar assignment
+    def results
+      { success: @success,
+        what: @what,
+        name: @name,
+        names: @names,
+        valid_names: @valid_names,
+        parent_deprecated: @parent_deprecated,
+        suggest_corrections: @suggest_corrections }
     end
   end
 end

--- a/app/models/naming/name_resolver.rb
+++ b/app/models/naming/name_resolver.rb
@@ -135,7 +135,7 @@ class Naming
     # Convenience method returning a hash for mass ivar assignment
     def results
       { success: @success,
-        what: @given_name,
+        given_name: @given_name,
         name: @name,
         names: @names,
         valid_names: @valid_names,

--- a/app/views/controllers/names/synonyms/deprecate/new.html.erb
+++ b/app/views/controllers/names/synonyms/deprecate/new.html.erb
@@ -4,11 +4,11 @@ add_page_title(:name_deprecate_title.t(name: @name.display_name))
 add_tab_set(name_forms_return_tabs(name: @name))
 
 action = { controller: "/names/synonyms/deprecate", action: :create,
-            id: @name.id, approved_name: @what }
+            id: @name.id, approved_name: @given_name }
 
 feedback_locals = {
   button_name: :SUBMIT.l,
-  what: @what,
+  what: @given_name,
   valid_names: @valid_names,
   suggest_corrections: @suggest_corrections,
   parent_deprecated: @parent_deprecated,
@@ -26,11 +26,11 @@ end
   <%= submit_button(form: f, button: :SUBMIT.l, center: true) %>
 
   <%= render(partial: "shared/form_name_feedback",
-             locals: feedback_locals.merge({ f: f })) if @what.present? %>
+             locals: feedback_locals.merge({ f: f })) if @given_name.present? %>
 
   <%= autocompleter_field(
     form: f, field: :proposed_name, type: :name,
-    value: @what, label: "#{:name_deprecate_preferred.t}:", autofocus: true,
+    value: @given_name, label: "#{:name_deprecate_preferred.t}:", autofocus: true,
     append: help_note(:div, :name_deprecate_preferred_help.tp), inline: true
   ) %>
 

--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -18,7 +18,7 @@ image_upload_localization = {
 <%= form_with(
   model: @observation,
   url: add_query_param(action: action, id: @observation,
-                        approved_name: @what,
+                        approved_name: @given_name,
                         approved_where: @place_name),
   method: method,
   multipart: true,

--- a/app/views/controllers/observations/namings/_fields.erb
+++ b/app/views/controllers/observations/namings/_fields.erb
@@ -2,13 +2,13 @@
 # This is included by obs form, naming new/edit form + lightbox identifier
 
 unfocused ||= false
-focus_on_name = !unfocused && (button_name != :CREATE.l || @what.empty?)
-focus_on_vote = !unfocused && (button_name == :CREATE.l && @what.present?)
+focus_on_name = !unfocused && (button_name != :CREATE.l || @given_name.empty?)
+focus_on_vote = !unfocused && (button_name == :CREATE.l && @given_name.present?)
 
 feedback_locals = {
   f: f,
   button_name: button_name,
-  what: @what,
+  what: @given_name,
   valid_names: @valid_names,
   suggest_corrections: @suggest_corrections,
   parent_deprecated: @parent_deprecated,
@@ -29,7 +29,7 @@ name_help ||= :form_naming_name_help.t
 [
   tag.div do
     render(partial: "shared/form_name_feedback",
-           locals: feedback_locals) if @what.present?
+           locals: feedback_locals) if @given_name.present?
   end,
   fields_for(:naming) do |f_n|
     [
@@ -38,7 +38,7 @@ name_help ||= :form_naming_name_help.t
           tag.div(class: "col-xs-12 col-sm-6") do
             autocompleter_field(
               form: f_n, field: :name, type: :name, label: "#{:WHAT.t}:",
-              value: @what, autofocus: focus_on_name
+              value: @given_name, autofocus: focus_on_name
             )
           end,
           tag.div(class: "col-xs-12 col-sm-6") do

--- a/app/views/controllers/observations/namings/_form.erb
+++ b/app/views/controllers/observations/namings/_form.erb
@@ -8,7 +8,7 @@ when "new", "create"
   method = :post
   id = "obs_#{@observation.id}_naming_form"
   url = observation_namings_path(observation_id: @observation.id,
-                                 approved_name: @what,
+                                 approved_name: @given_name,
                                  q: get_query_param)
 when "edit", "update"
   button_name = :SAVE_EDITS.l
@@ -16,7 +16,7 @@ when "edit", "update"
   id = "obs_#{@observation.id}_naming_#{@naming.id}_form"
   url = observation_naming_path(observation_id: @observation.id,
                                 id: @naming.id,
-                                approved_name: @what,
+                                approved_name: @given_name,
                                 q: get_query_param)
 end
 

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -536,7 +536,7 @@ module Observations
       login("dick")
       post(:create, params: params)
       assert_response(:success) # really means failed
-      what = @controller.instance_variable_get(:@what)
+      what = @controller.instance_variable_get(:@given_name)
       assert_equal("Agaricus campestris L.", what)
     end
 


### PR DESCRIPTION
No big changes, same result. Minor change: renames `@what` as `@given_name`. At first i was getting an error "what is not allowed as an instance variable name" but it turned out to be due to the way i was calling `instance_variable_set`, not the var name. In any case,`@given_name` seems less ambiguous, though less cute, so i'm inclined to keep it. Often I've wondered, "what is `@what`?"