### PR TITLE
Fix "Turn off admin mode" link in nav menu

### DIFF
--- a/app/views/controllers/application/sidebar/_admin.html.erb
+++ b/app/views/controllers/application/sidebar/_admin.html.erb
@@ -30,6 +30,7 @@ active_link_to(:LICENSES.t, licenses_path,
                class: classes[:admin], id: "nav_admin_licenses_link")
 %>
 <%=
-active_link_to(:app_turn_admin_off.t, admin_mode_path(turn_off: true),
-               class: classes[:admin], id: "nav_admin_off_link")
+button_to(:app_turn_admin_off.t, admin_mode_path(turn_off: true),
+          class: [classes[:admin], "btn btn-link"], id: "nav_admin_off_link",
+          method: :post)
 %>

--- a/test/integration/capybara/admin_integration_test.rb
+++ b/test/integration/capybara/admin_integration_test.rb
@@ -3,6 +3,16 @@
 require("test_helper")
 
 class AdminIntegrationTest < CapybaraIntegrationTestCase
+  def test_turn_admin_mode_on_and_off
+    refute_selector(id: "nav_admin_on_link")
+
+    put_user_in_admin_mode(rolf)
+    assert_selector(id: "nav_admin_off_link")
+
+    click_on(id: "nav_admin_off_link")
+    assert_selector(id: "nav_mobile_admin_link")
+  end
+
   # This test is not much more than a stub.
   # Should test somebody making a donation, admin reviews.
   def test_review_donations


### PR DESCRIPTION
Fixes #2168. Adds test. 

@JoeCohen - In case you tried to fix this and got stumped, this link wasn't working because it needs to submit a "POST" request. (You can confirm that in the routes, and also in the controller — this is handled by the `:create` action.)

Here's how to build non-GET links like this:
- the link must use `button_to`, rather than a `link_to`
- the button needs a couple extra classes to style it like an `<a>` if that's what we want

Turbo supposedly allows you to do a `link_to` with `data: { turbo_method: :post }` but in reality (at least on MO) it doesn't work, the CSRF stops the link from working. Also, the [Turbo docs themselves state](https://turbo.hotwired.dev/handbook/drive#performing-visits-with-a-different-method) "you should also consider that for accessibility reasons, it’s better to use actual forms and buttons for anything that’s not a GET." The Rails `button_to` helper builds a form and a button, as you probably know.