### PR TITLE
More refactoring and minor simplifications for Naming validations,  `ObservationsController`

### DIFF
--- a/app/controllers/names/synonyms/deprecate_controller.rb
+++ b/app/controllers/names/synonyms/deprecate_controller.rb
@@ -12,7 +12,6 @@ module Names::Synonyms
       return unless find_name!
       return if abort_if_name_locked!(@name)
 
-      init_params_for_new
       init_ivars_for_new
     end
 
@@ -21,7 +20,6 @@ module Names::Synonyms
 
       return if abort_if_name_locked!(@name)
 
-      init_params_for_new
       init_ivars_for_new
 
       return unless we_have_a_what!
@@ -67,14 +65,8 @@ module Names::Synonyms
       render_new
     end
 
-    def init_params_for_new
-      # These parameters aren't always provided.
-      params[:chosen_name] ||= {}
-      params[:is]          ||= {}
-    end
-
     def init_ivars_for_new
-      @given_name = params[:proposed_name].to_s.strip_squeeze
+      @given_name       = params[:proposed_name].to_s.strip_squeeze
       @comment          = params[:comment].to_s.strip_squeeze
       @list_members     = nil
       @new_names        = []
@@ -82,12 +74,12 @@ module Names::Synonyms
       @synonym_names    = []
       @deprecate_all    = "1"
       @names            = []
-      @misspelling      = (params[:is][:misspelling] == "1")
+      @misspelling      = (params.dig(:is, :misspelling) == "1")
     end
 
     def try_to_set_names_from_chosen_name
-      @names = if params[:chosen_name][:name_id] &&
-                  (name = Name.safe_find(params[:chosen_name][:name_id]))
+      @names = if (chosen_id = params.dig(:chosen_name, :name_id)) &&
+                  (name = Name.safe_find(chosen_id))
                  [name]
                else
                  Name.find_names_filling_in_authors(@given_name)

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -170,13 +170,13 @@ module Observations
     def rough_draft
       @naming = Naming.construct({}, @observation)
       @vote = Vote.construct(params.dig(:naming, :vote), @naming)
-      result = if name_args[:given_name]
-                 resolve_name(**name_args)
-               else
-                 true
-               end
+      success = if name_args[:given_name]
+                  resolve_name(**name_args)
+                else
+                  true
+                end
       @naming.name = @name
-      result
+      success && @name
     end
 
     # We should have a @name by this point

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -4,6 +4,8 @@
 
 module Observations
   class NamingsController < ApplicationController # rubocop:disable Metrics/ClassLength
+    include ObservationsController::Validators
+
     before_action :login_required
     before_action :pass_query_params
 
@@ -163,50 +165,18 @@ module Observations
     ##########################################################################
     #    CREATE
 
-    # returns Boolean
+    # returns Boolean. Also called by create_new_naming.
+    # Uses name_args, resolve_name from ObservationsController::Validators
     def rough_draft
-      args = {
-        naming_args: {},
-        vote_args: params.dig(:naming, :vote),
-        given_name: params.dig(:naming, :name),
-        approved_name: params[:approved_name],
-        chosen_name: params.dig(:chosen_name, :name_id).to_s
-      }
-      resolve_ivars_for_validation(**args)
-    end
-
-    # returns Boolean. Was @params.rough_draft
-    def resolve_ivars_for_validation(**args)
-      @naming = Naming.construct(args[:naming_args], @observation)
-      @vote = Vote.construct(args[:vote_args], @naming)
-      result = if args[:given_name]
-                 resolve_name(args[:given_name], args[:approved_name],
-                              args[:chosen_name])
+      @naming = Naming.construct({}, @observation)
+      @vote = Vote.construct(params.dig(:naming, :vote), @naming)
+      result = if name_args[:given_name]
+                 resolve_name(**name_args)
                else
                  true
                end
       @naming.name = @name
       result
-    end
-
-    # Set the ivars for the form, and potentially form_name_feedback
-    # in the case the name is not resolved unambiguously
-    def resolve_name(given_name, approved_name, chosen_name)
-      @resolver = Naming::NameResolver.new(
-        given_name, approved_name, chosen_name
-      )
-      # NOTE: views could be refactored to access properties of the @resolver,
-      # e.g. `@resolver.valid_names`, instead of these ivars.
-      # All but success, @given_name, @name are only used by form_name_feedback.
-      success = false
-      @resolver.results.each do |ivar, value|
-        if ivar == :success
-          success = value
-        else
-          instance_variable_set(:"@#{ivar}", value)
-        end
-      end
-      success && @name
     end
 
     # We should have a @name by this point
@@ -310,10 +280,7 @@ module Observations
     end
 
     def validate_name
-      given_name = params.dig(:naming, :name)
-      success = resolve_name(given_name,
-                             params[:approved_name],
-                             params.dig(:chosen_name, :name_id).to_s)
+      success = resolve_name(**name_args)
       flash_naming_errors
       success
     end
@@ -347,8 +314,7 @@ module Observations
     # because that would bring the other people's votes along with it.
     # We make a new one, reusing the user's previously stated vote and reasons.
     def create_new_naming
-      resolve_ivars_for_validation(naming_args: {},
-                                   vote_args: params.dig(:naming, :vote))
+      rough_draft
       return unless validate_object(@naming) && validate_object(@vote)
 
       update_naming(params.dig(:naming, :reasons), params[:was_js_on] == "yes")

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -119,10 +119,9 @@ module ObservationsController::EditAndUpdate
   end
 
   def try_to_upload_images
-    @good_images = update_good_images(params[:good_images])
-    @bad_images  = create_image_objects(params[:image],
-                                        @observation, @good_images)
-    attach_good_images(@observation, @good_images)
+    update_good_images
+    create_image_objects_and_update_bad_images
+    attach_good_images
     @any_errors = true if @bad_images.any?
   end
 
@@ -130,7 +129,7 @@ module ObservationsController::EditAndUpdate
     return unless @dubious_where_reasons == [] && @observation.changed?
 
     @observation.updated_at = Time.zone.now
-    if save_observation(@observation)
+    if save_observation
       id = @observation.id
       flash_notice(:runtime_edit_observation_success.t(id: id))
       touch = params[:log_change] == "1"
@@ -144,53 +143,14 @@ module ObservationsController::EditAndUpdate
     @images         = @bad_images
     @new_image.when = @observation.when
     init_project_vars
-    init_project_vars_for_reload(@observation)
-    init_list_vars_for_reload(@observation)
+    init_project_vars_for_reload
+    init_list_vars_for_reload
     render(action: :edit)
   end
 
   def update_project_and_species_list_attachments
-    update_projects(@observation, params[:project])
-    update_species_lists(@observation, params[:list])
-  end
-
-  def update_projects(obs, checks)
-    return unless checks
-
-    User.current.projects_member(include: :observations).each do |project|
-      before = obs.projects.include?(project)
-      after = checks["id_#{project.id}"] == "1"
-      next unless before != after
-
-      if after
-        project.add_observation(obs)
-        flash_notice(:attached_to_project.t(object: :observation,
-                                            project: project.title))
-      else
-        project.remove_observation(obs)
-        flash_notice(:removed_from_project.t(object: :observation,
-                                             project: project.title))
-      end
-    end
-  end
-
-  def update_species_lists(obs, checks)
-    return unless checks
-
-    User.current.all_editable_species_lists.includes(:observations).
-      find_each do |list|
-      before = obs.species_lists.include?(list)
-      after = checks["id_#{list.id}"] == "1"
-      next unless before != after
-
-      if after
-        list.add_observation(obs)
-        flash_notice(:added_to_list.t(list: list.title))
-      else
-        list.remove_observation(obs)
-        flash_notice(:removed_from_list.t(list: list.title))
-      end
-    end
+    update_projects
+    update_species_lists
   end
 
   def redirect_to_observation_or_create_location

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -2,7 +2,7 @@
 
 # see observations_controller.rb
 module ObservationsController::EditAndUpdate
-  include ObservationsController::FormHelpers
+  include ObservationsController::SharedFormMethods
   include ObservationsController::Validators
 
   # Form to edit an existing observation.
@@ -113,7 +113,7 @@ module ObservationsController::EditAndUpdate
   end
 
   def validate_edit_place_name
-    return if validate_place_name(params) && validate_projects(params)
+    return if validate_place_name && validate_projects
 
     @any_errors = true
   end

--- a/app/controllers/observations_controller/new_and_create.rb
+++ b/app/controllers/observations_controller/new_and_create.rb
@@ -152,10 +152,7 @@ module ObservationsController::NewAndCreate
     end
   end
 
-  # Only set location if it is not already set by the autocompleter.
   def determine_observation_location(observation)
-    return observation if observation.location_id
-
     if Location.is_unknown?(observation.place_name) ||
        (observation.lat && observation.lng && observation.place_name.blank?)
       observation.location = Location.unknown

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -18,7 +18,7 @@ module ObservationsController::SharedFormMethods
 
   # NOTE: potential gotcha... Any nested attributes must come last.
   def permitted_observation_args
-    [:place_name, :location_id, :where, :lat, :lng, :alt,
+    [:place_name, :where, :lat, :lng, :alt, # :location_id,
      :when, "when(1i)", "when(2i)", "when(3i)", :notes, :specimen,
      :thumb_image_id, :is_collection_location, :gps_hidden]
   end

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -13,14 +13,14 @@
 #    update_good_images(...)
 #    attach_good_images(...)
 
-module ObservationsController::FormHelpers
+module ObservationsController::SharedFormMethods
   private
 
   # NOTE: potential gotcha... Any nested attributes must come last.
   def permitted_observation_args
-    [:place_name, :where, :lat, :lng, :alt, :when, "when(1i)", "when(2i)",
-     "when(3i)", :notes, :specimen, :thumb_image_id, :is_collection_location,
-     :gps_hidden]
+    [:place_name, :location_id, :where, :lat, :lng, :alt,
+     :when, "when(1i)", "when(2i)", "when(3i)", :notes, :specimen,
+     :thumb_image_id, :is_collection_location, :gps_hidden]
   end
 
   def update_permitted_observation_attributes

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-#  :section: Helpers
+#  :section: Validators
 #
-#    create_observation_object(...)     create rough first-drafts.
+#    validate_params
 #
-#    save_observation(...)              Save validated objects.
+#    validate_name
+#      name_args
+#      resolve_name(...)
 #
-#    update_observation_object(...)     Update and save existing objects.
+#    validate_place_name
 #
-#    init_image()                       Handle image uploads.
-#    create_image_objects(...)
-#    update_good_images(...)
-#    attach_good_images(...)
+#    validate_projects
+#      checked_project_conflicts
 
 # Included in both ObservationsController and NamingsController
 module ObservationsController::Validators

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -50,6 +50,7 @@ module ObservationsController::Validators
   # Set the ivars for the form: @given_name, @name - and potentially ivars for
   # form_name_feedback in the case the name is not resolved unambiguously:
   # @names, @valid_names, @parent_deprecated, @suggest_corrections.
+  # Returns true if the name is resolved unambiguously.
   def resolve_name(**)
     resolver = Naming::NameResolver.new(**)
     success = false

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -13,6 +13,7 @@
 #    update_good_images(...)
 #    attach_good_images(...)
 
+# Included in both ObservationsController and NamingsController
 module ObservationsController::Validators
   private
 
@@ -22,8 +23,6 @@ module ObservationsController::Validators
       validate_projects
   end
 
-  # Maybe move this to a shared NamingsController::Validators module,
-  # or just include in both ObservationsController and NamingsController
   def validate_name
     success = resolve_name(**name_args)
     if @name

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -16,14 +16,16 @@
 module ObservationsController::Validators
   private
 
-  def validate_params(params)
-    validate_name(params) &&
-      validate_place_name(params) &&
-      validate_projects(params)
+  def validate_params
+    validate_name &&
+      validate_place_name &&
+      validate_projects
   end
 
-  def validate_name(params)
-    success = resolve_name_ivars(params)
+  # Maybe move this to a shared NamingsController::Validators module,
+  # or just include in both ObservationsController and NamingsController
+  def validate_name
+    success = resolve_name(**name_args)
     if @name
       @naming.name = @name
     elsif !success
@@ -34,17 +36,25 @@ module ObservationsController::Validators
     success
   end
 
-  def resolve_name_ivars(params)
-    given_name = params.dig(:naming, :name).to_s
-    chosen_name = params.dig(:chosen_name, :name_id).to_s
-    @resolver = Naming::NameResolver.new(
-      given_name, params[:approved_name], chosen_name
-    )
-    # NOTE: views could be refactored to access properties of the @resolver,
-    # e.g. `@resolver.valid_names`, instead of these ivars.
-    # All but success, @given_name, @name are only used by form_name_feedback.
+  # given_name, given_id from observation/naming/fields. Note: nil.to_i == 0
+  # approved_name, chosen_name from form_name_feedback
+  # also used in namings_controller
+  def name_args
+    {
+      given_name: params.dig(:naming, :name).to_s,
+      # given_id: params.dig(:naming, :name_id).to_i,
+      approved_name: params[:approved_name].to_s,
+      chosen_name: params.dig(:chosen_name, :name_id).to_s
+    }
+  end
+
+  # Set the ivars for the form: @given_name, @name - and potentially ivars for
+  # form_name_feedback in the case the name is not resolved unambiguously:
+  # @names, @valid_names, @parent_deprecated, @suggest_corrections.
+  def resolve_name(**)
+    resolver = Naming::NameResolver.new(**)
     success = false
-    @resolver.results.each do |ivar, value|
+    resolver.results.each do |ivar, value|
       if ivar == :success
         success = value
       else
@@ -54,7 +64,7 @@ module ObservationsController::Validators
     success
   end
 
-  def validate_place_name(params)
+  def validate_place_name
     success = true
     @place_name = @observation.place_name
     @dubious_where_reasons = []
@@ -66,7 +76,7 @@ module ObservationsController::Validators
     success
   end
 
-  def validate_projects(params)
+  def validate_projects
     return true if params[:project].empty? ||
                    params[:project][:ignore_proj_conflicts]
 

--- a/app/models/naming/name_resolver.rb
+++ b/app/models/naming/name_resolver.rb
@@ -35,7 +35,8 @@ class Naming
     attr_reader :success, :name, :names, :valid_names, :parent_deprecated,
                 :suggest_corrections
 
-    def initialize(given_name, approved_name, chosen_name)
+    def initialize(given_name: "", approved_name: "",
+                   chosen_name: "")
       @success = true
       @given_name = given_name
       @name = nil
@@ -44,11 +45,11 @@ class Naming
       @parent_deprecated = nil
       @suggest_corrections = false
 
-      resolve(given_name, approved_name, chosen_name)
+      resolve(given_name:, approved_name:, chosen_name:)
     end
 
     # rubocop:disable Metrics/MethodLength
-    def resolve(given_name, approved_name, chosen_name)
+    def resolve(given_name:, approved_name:, chosen_name:)
       corrected = given_name.to_s.tr("_", " ").strip_squeeze
       approved_name2 = approved_name.to_s.tr("_", " ").strip_squeeze
       if corrected.blank? || Name.names_for_unknown.member?(corrected.downcase)
@@ -56,22 +57,26 @@ class Naming
       end
 
       @success = false
-
       ignore_approved_name = false
       # Has user chosen among multiple matching names or among
       # multiple approved names?
       if chosen_name.blank?
+        # If it's an autocompleted match, take that directly.
+        # (It could still be deprecated, but we'll deal with that below.)
+        # if given_id.is_a?(Integer) && given_id.nonzero?
+        #   @names = [Name.find(given_id)]
+        # else
         corrected = Name.fix_capitalized_species_epithet(corrected)
 
         # Look up name: can return zero (unrecognized), one
         # (unambiguous match), or many (multiple authors match).
         @names = Name.find_names_filling_in_authors(corrected)
+        # end
       else
         @names = [Name.find(chosen_name)]
-        # This tells it to check if this name is deprecated below EVEN
-        # IF the user didn't change the what field.  This will solve
-        # the problem of multiple matching deprecated names discussed
-        # below.
+        # This tells it to check if this name is deprecated (below) EVEN IF the
+        # user didn't change the what field.  This will solve the problem of
+        # multiple matching deprecated names discussed below.
         ignore_approved_name = true
       end
 


### PR DESCRIPTION
- DRYs up name resolver methods shared between the `ObservationsController` and the `NamingsController`
- Simplifies a bunch of obs controller methods, eliminates unnecessary arg passing
- Clears up 3 ABC violations
- Renames `ObservationsController::FormHelpers` to `ObservationsController::SharedFormMethods`