### PR TITLE
Move autocompleter's hidden_id field before the input

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -164,8 +164,11 @@ module FormsHelper
     ac_args[:wrap_data] = { controller: :autocompleter, type: args[:type],
                             separator: args[:separator],
                             autocompleter_target: "wrap" }
-    ac_args[:append] = capture do
+    ac_args[:between] = capture do
       concat(autocompleter_hidden_field(**args)) if args[:form]
+      concat(args[:between])
+    end
+    ac_args[:append] = capture do
       concat(autocompleter_dropdown)
       concat(args[:append])
     end
@@ -194,9 +197,11 @@ module FormsHelper
     end
   end
 
+  # minimum args :form, :type
   def autocompleter_hidden_field(**args)
-    type = autocompleter_type_to_model(args[:type])
-    args[:form].hidden_field(:"#{type}_id",
+    model = autocompleter_type_to_model(args[:type])
+    args[:form].hidden_field(:"#{model}_id",
+                             value: args[:hidden],
                              data: { autocompleter_target: "hidden" })
   end
 

--- a/app/views/controllers/observations/form/_where.html.erb
+++ b/app/views/controllers/observations/form/_where.html.erb
@@ -15,7 +15,7 @@
     <div class="col-xs-12 col-sm-6">
       <%= autocompleter_field(
         form: f, field: :place_name, type: :location, label: "#{:WHERE.t}:",
-        between: :required, data: { map_target: "placeInput" }
+        hidden: @observation.location_id, data: { map_target: "placeInput" }
       ) %>
     </div>
     <div class="col-xs-12 col-sm-6">

--- a/app/views/controllers/observations/form/_where.html.erb
+++ b/app/views/controllers/observations/form/_where.html.erb
@@ -15,7 +15,7 @@
     <div class="col-xs-12 col-sm-6">
       <%= autocompleter_field(
         form: f, field: :place_name, type: :location, label: "#{:WHERE.t}:",
-        hidden: @observation.location_id, data: { map_target: "placeInput" }
+        data: { map_target: "placeInput" }
       ) %>
     </div>
     <div class="col-xs-12 col-sm-6">

--- a/app/views/controllers/observations/identify/_form_identify_filter.html.erb
+++ b/app/views/controllers/observations/identify/_form_identify_filter.html.erb
@@ -27,6 +27,7 @@ options = [
       "", class: "glyphicon glyphicon-search form-control-feedback"
     ) %>
     <%# f.label(:term, "Filter by:") %>
+    <%= autocompleter_hidden_field(form: f, type: :clade) %>
     <%= f.text_field(
       :term, value: value, placeholder: :filter_by.l,
       class: "form-control", size: 42, autocomplete: "one-time-code",


### PR DESCRIPTION
Easier to debug id autocomplete this way... temporarily turn it into a "text_field" and it will show right after the label