### PR TITLE
Put a "print label" button on show_obs

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -127,7 +127,7 @@ module ContentHelper
 
     tag.div(
       class: class_names("panel panel-default", args[:class]),
-      **args.except(:class, :inner_class, :inner_id, :heading)
+      **args.except(:class, :inner_class, :inner_id, :heading, :heading_links)
     ) do
       concat(heading)
       if content.present?

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -207,9 +207,10 @@ module LinkHelper
     end
   end
 
+  # Attempts to put together some common button attributes. Overrides available.
   def button_atts(action, target, args, name)
-    if target.is_a?(String) # ignores action
-      path = target
+    if target.is_a?(String) || target.is_a?(Hash) # eg { controller:, action: }
+      path = target # ignores `action`
       identifier = "" # can send one via args[:class]
     else
       prefix = action == :destroy ? "" : "#{action}_"

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -208,7 +208,7 @@ module LinkHelper
   end
 
   def button_atts(action, target, args, name)
-    if target.is_a?(String)
+    if target.is_a?(String) # ignores action
       path = target
       identifier = "" # can send one via args[:class]
     else
@@ -283,14 +283,15 @@ module LinkHelper
   # NOTE: button_to with block generates a button, not an input #quirksmode
   def any_method_button(name:, path:, method: :post, **args, &block)
     content = block ? capture(&block) : name
-    tip = content ? { toggle: "tooltip", placement: "top", title: name } : {}
+    path, identifier, icon, content = button_atts(method, path, args, name)
+
     html_options = {
       method: method,
-      class: "",
+      class: class_names(identifier, args[:class]), # usually also btn
       form: { data: { turbo: true } },
-      data: tip
+      data: { toggle: "tooltip", placement: "top", title: name }
     }.merge(args) # currently don't have to merge class arg upstream
 
-    button_to(path, html_options) { content }
+    button_to(path, html_options) { [content, icon].safe_join }
   end
 end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -159,7 +159,8 @@ module LinkHelper
     synonyms: "random",
     tracking: "bullhorn",
     manage_lists: "indent-left",
-    observations: "tags"
+    observations: "tags",
+    print: "print"
   }.freeze
 
   # button to destroy object

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -94,11 +94,9 @@ module Tabs
     end
 
     def observation_web_name_tabs(name)
-      [
-        mycoportal_name_tab(name),
-        mycobank_name_search_tab(name),
-        google_images_for_name_tab(name)
-      ]
+      [mycoportal_name_tab(name),
+       mycobank_name_search_tab(name),
+       google_images_for_name_tab(name)]
     end
 
     def observation_hide_thumbnail_map_tab(obs)
@@ -151,11 +149,9 @@ module Tabs
       # undefined location.
       return [] unless query.flavor == :at_where
 
-      [
-        define_location_tab(query),
-        assign_undefined_location_tab(query),
-        locations_index_tab
-      ]
+      [define_location_tab(query),
+       assign_undefined_location_tab(query),
+       locations_index_tab]
     end
 
     # these are from the observations form
@@ -174,18 +170,16 @@ module Tabs
     end
 
     def observations_index_sorts
-      [
-        ["rss_log", :sort_by_activity.l],
-        ["date", :sort_by_date.l],
-        ["created_at", :sort_by_posted.l],
-        # kind of redundant to sort by rss_logs, though not strictly ===
-        # ["updated_at", :sort_by_updated_at.l],
-        ["name", :sort_by_name.l],
-        ["user", :sort_by_user.l],
-        ["confidence", :sort_by_confidence.l],
-        ["thumbnail_quality", :sort_by_thumbnail_quality.l],
-        ["num_views", :sort_by_num_views.l]
-      ].freeze
+      [["rss_log", :sort_by_activity.l],
+       ["date", :sort_by_date.l],
+       ["created_at", :sort_by_posted.l],
+       # kind of redundant to sort by rss_logs, though not strictly ===
+       # ["updated_at", :sort_by_updated_at.l],
+       ["name", :sort_by_name.l],
+       ["user", :sort_by_user.l],
+       ["confidence", :sort_by_confidence.l],
+       ["thumbnail_quality", :sort_by_thumbnail_quality.l],
+       ["num_views", :sort_by_num_views.l]].freeze
     end
 
     def map_observations_tab(query)
@@ -196,11 +190,9 @@ module Tabs
 
     # NOTE: coerced_query_tab returns an array
     def observations_coerced_query_tabs(query)
-      [
-        coerced_location_query_tab(query),
-        coerced_name_query_tab(query),
-        coerced_image_query_tab(query)
-      ]
+      [coerced_location_query_tab(query),
+       coerced_name_query_tab(query),
+       coerced_image_query_tab(query)]
     end
 
     def observations_add_to_list_tab(query)
@@ -227,10 +219,8 @@ module Tabs
     end
 
     def observation_maps_tabs(query:)
-      [
-        coerced_observation_query_tab(query),
-        coerced_location_query_tab(query)
-      ]
+      [coerced_observation_query_tab(query),
+       coerced_location_query_tab(query)]
     end
 
     def naming_form_new_title(obs:)
@@ -262,25 +252,19 @@ module Tabs
     end
 
     def observation_images_new_tabs(obs:)
-      [
-        object_return_tab(obs),
-        edit_observation_tab(obs)
-      ]
+      [object_return_tab(obs),
+       edit_observation_tab(obs)]
     end
 
     # Note this takes `obj:` not `obs:`
     def observation_images_remove_tabs(obj:)
-      [
-        object_return_tab(obj),
-        edit_observation_tab(obj)
-      ]
+      [object_return_tab(obj),
+       edit_observation_tab(obj)]
     end
 
     def observation_images_reuse_tabs(obs:)
-      [
-        object_return_tab(obs),
-        edit_observation_tab(obs)
-      ]
+      [object_return_tab(obs),
+       edit_observation_tab(obs)]
     end
 
     def observation_download_tabs
@@ -296,29 +280,23 @@ module Tabs
     def obs_change_tabs(obs)
       return unless check_permission(obs)
 
-      [
-        edit_observation_tab(obs),
-        destroy_observation_tab(obs)
-      ]
+      [edit_observation_tab(obs),
+       destroy_observation_tab(obs)]
     end
 
     def obs_details_links(obs)
       return unless check_permission(obs)
 
-      [
-        print_labels_button(obs),
-        obs_change_links(obs)
-      ].safe_join(" | ")
+      [print_labels_button(obs),
+       obs_change_links(obs)].safe_join(" | ")
     end
 
     # Buttons in "Details" panel header
     def obs_change_links(obs)
       return unless check_permission(obs)
 
-      [
-        edit_button(target: obs, icon: :edit),
-        destroy_button(target: obs, icon: :delete)
-      ].safe_join(" | ")
+      [edit_button(target: obs, icon: :edit),
+       destroy_button(target: obs, icon: :delete)].safe_join(" | ")
     end
 
     def edit_observation_tab(obs)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -306,8 +306,8 @@ module Tabs
       return unless check_permission(obs)
 
       [
-        obs_change_links(obs),
-        print_labels_button(obs)
+        print_labels_button(obs),
+        obs_change_links(obs)
       ].safe_join(" | ")
     end
 
@@ -335,14 +335,11 @@ module Tabs
     def print_labels_button(obs)
       name = :download_observations_print_labels.l
       query = Query.lookup(Observation, :in_set, ids: [obs.id])
-      label = tag.span(name, class: "sr-only")
+      path = add_query_param(observations_downloads_path(commit: name), query)
 
-      button_to(
-        [label, link_icon(:print)].safe_join,
-        add_query_param(observations_downloads_path(commit: name), query),
-        data: { turbo: false, toggle: "tooltip", placement: "top",
-                title: name }
-      )
+      post_button(name: name, path: path, icon: :print,
+                  class: "print_label_observation_#{obs.id}",
+                  form: { data: { turbo: false } })
     end
   end
 end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -302,6 +302,15 @@ module Tabs
       ]
     end
 
+    def obs_details_links(obs)
+      return unless check_permission(obs)
+
+      [
+        obs_change_links(obs),
+        print_labels_button(obs)
+      ].safe_join(" | ")
+    end
+
     # Buttons in "Details" panel header
     def obs_change_links(obs)
       return unless check_permission(obs)
@@ -320,6 +329,20 @@ module Tabs
 
     def destroy_observation_tab(obs)
       [nil, obs, { button: :destroy }]
+    end
+
+    # for show_obs - query is for a single obs label
+    def print_labels_button(obs)
+      name = :download_observations_print_labels.l
+      query = Query.lookup(Observation, :in_set, ids: [obs.id])
+      label = tag.span(name, class: "sr-only")
+
+      button_to(
+        [label, link_icon(:print)].safe_join,
+        add_query_param(observations_downloads_path(commit: name), query),
+        data: { turbo: false, toggle: "tooltip", placement: "top",
+                title: name }
+      )
     end
   end
 end

--- a/app/views/controllers/observations/show/_observation_details.erb
+++ b/app/views/controllers/observations/show/_observation_details.erb
@@ -4,7 +4,7 @@
 
 <%= panel_block(id: "observation_details",
                 heading: :show_observation_details.l,
-                heading_links: obs_change_links(obs),
+                heading_links: obs_details_links(obs),
                 class: "name-section") do %>
 
   <%= observation_details_when_where_who(obs: obs) %>

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -3,20 +3,30 @@
 require("application_system_test_case")
 
 class ObservationShowSystemTest < ApplicationSystemTestCase
-  def test_add_and_edit_associated_records
-    obs = observations(:peltigera_obs)
+  setup do
+    @obs = observations(:peltigera_obs)
+  end
 
-    # browser = page.driver.browser
+  def test_visit_show_observation
+    # # browser = page.driver.browser
     rolf = users("rolf")
     login!(rolf)
 
     assert_link("Your Observations")
     click_on("Your Observations")
-    # obs = observations(:peltigera_obs)
 
     assert_selector("body.observations__index")
-    assert_link(text: /#{obs.text_name}/)
-    click_link(text: /#{obs.text_name}/)
+    assert_link(text: /#{@obs.text_name}/)
+    click_link(text: /#{@obs.text_name}/)
+    assert_selector("body.observations__show")
+
+    assert_selector(".print_label_observation_#{@obs.id}")
+  end
+
+  def test_add_and_edit_collection_numbers
+    rolf = users("rolf")
+    login!(rolf)
+    visit(observation_path(@obs))
     assert_selector("body.observations__show")
 
     scroll_to(find("#observation_collection_numbers"), align: :center)
@@ -57,6 +67,28 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
 
     assert_equal(c_n.reload.number, "021345")
 
+    # try remove links
+    # collection_number
+    within("#observation_collection_numbers") do
+      assert_link(:REMOVE.l)
+      find(:css, ".remove_collection_number_link_#{c_n.id}").trigger("click")
+    end
+    # confirm is in modal
+    assert_selector("#modal_collection_number_observation")
+    within("#modal_collection_number_observation") do
+      assert_button(:REMOVE.l)
+      find(:css, ".remove_collection_number_link_#{c_n.id}").trigger("click")
+    end
+    assert_no_selector("#modal_collection_number_observation")
+    assert_no_link(text: /021345/)
+  end
+
+  def test_add_and_edit_herbarium_records
+    rolf = users("rolf")
+    login!(rolf)
+    visit(observation_path(@obs))
+    assert_selector("body.observations__show")
+
     # Has a fungarium record: :field_museum_record. Try edit
     fmr = herbarium_records(:field_museum_record)
     within("#observation_herbarium_records") do
@@ -77,6 +109,28 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     within("#observation_herbarium_records") do
       assert_link(text: /6234234/)
     end
+
+    # try remove links
+    # herbarium_record
+    within("#observation_herbarium_records") do
+      assert_link(:REMOVE.l)
+      find(:css, ".remove_herbarium_record_link_#{fmr.id}").trigger("click")
+    end
+    # confirm is in modal
+    assert_selector("#modal_herbarium_record_observation")
+    within("#modal_herbarium_record_observation") do
+      assert_button(:REMOVE.l)
+      find(:css, ".remove_herbarium_record_link_#{fmr.id}").trigger("click")
+    end
+    assert_no_selector("#modal_herbarium_record_observation")
+    assert_no_link(text: /6234234/)
+  end
+
+  def test_add_and_edit_sequences
+    rolf = users("rolf")
+    login!(rolf)
+    visit(observation_path(@obs))
+    assert_selector("body.observations__show")
 
     # new sequence
     assert_link(:show_observation_add_sequence.l)
@@ -124,6 +178,23 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     assert_equal(seq.reload.notes, "Oh yea.")
     assert_no_selector("#modal_sequence_#{seq.id}")
 
+    # try remove links
+    # sequence
+    within("#observation_sequences") do
+      assert_button(:destroy_object.t(type: :sequence))
+      accept_confirm do
+        find(:css, ".destroy_sequence_link_#{seq.id}").trigger("click")
+      end
+      assert_no_link(text: /LSU/)
+    end
+  end
+
+  def test_add_and_edit_external_links
+    rolf = users("rolf")
+    login!(rolf)
+    visit(observation_path(@obs))
+    assert_selector("body.observations__show")
+
     # new external link
     site = external_sites(:mycoportal)
     within("#observation_external_links") do
@@ -157,43 +228,6 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     assert_equal(link.reload.url, "https://wedont.validatethese.urls/yet")
 
     # try remove links
-    # collection_number
-    within("#observation_collection_numbers") do
-      assert_link(:REMOVE.l)
-      find(:css, ".remove_collection_number_link_#{c_n.id}").trigger("click")
-    end
-    # confirm is in modal
-    assert_selector("#modal_collection_number_observation")
-    within("#modal_collection_number_observation") do
-      assert_button(:REMOVE.l)
-      find(:css, ".remove_collection_number_link_#{c_n.id}").trigger("click")
-    end
-    assert_no_selector("#modal_collection_number_observation")
-    assert_no_link(text: /021345/)
-
-    # herbarium_record
-    within("#observation_herbarium_records") do
-      assert_link(:REMOVE.l)
-      find(:css, ".remove_herbarium_record_link_#{fmr.id}").trigger("click")
-    end
-    # confirm is in modal
-    assert_selector("#modal_herbarium_record_observation")
-    within("#modal_herbarium_record_observation") do
-      assert_button(:REMOVE.l)
-      find(:css, ".remove_herbarium_record_link_#{fmr.id}").trigger("click")
-    end
-    assert_no_selector("#modal_herbarium_record_observation")
-    assert_no_link(text: /6234234/)
-
-    # sequence
-    within("#observation_sequences") do
-      assert_button(:destroy_object.t(type: :sequence))
-      accept_confirm do
-        find(:css, ".destroy_sequence_link_#{seq.id}").trigger("click")
-      end
-      assert_no_link(text: /LSU/)
-    end
-
     # external_link
     within("#observation_external_links") do
       assert_button(text: :destroy_object.t(type: :external_link))


### PR DESCRIPTION
Adds a print_label button to the "Details" header.
![Screen Shot 2024-06-26 at 10 23 24 PM](https://github.com/MushroomObserver/mushroom-observer/assets/1948095/209e5eea-5efe-4b8f-b51a-6873add279b6)

Note: the edit/delete buttons will soon move to the show-observation title bar and get bigger.