### PR TITLE
Allow deploy to work when there are no changes to the main branch

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -22,9 +22,34 @@ fi
 
 tag=`date "+deploy-%Y-%m-%d-%H-%M"`
 echo Going for it\!
-echo Stash local changes... && git stash && \
-echo Getting latest code from github... && git pull && \
-echo Reapply local changes... && git stash pop && \
+
+STASH_RESULT=`git stash`
+if [ $? -ne 0 ]; then
+    echo git stash failed.
+    exit 1
+fi
+
+echo $STASH_RESULT | grep 'No local changes to save'
+STASH_STATUS=$?
+
+if [ $STASH_STATUS -ne 0 ]; then
+    echo Stashed some changes...
+fi
+
+echo Getting latest code from github... && git pull
+if [ $? -ne 0 ]; then
+    echo git pull failed.
+    exit 1
+fi
+
+if [ $STASH_RESULT -ne 'No local changes to save' ]; then
+    echo Reapply local changes... && git stash pop
+    if [ $? -ne 0 ]; then
+	echo Applying the stashed changes failed.
+	exit 1
+    fi
+fi
+
 echo Installing bundle... && bundle install && \
 echo Checking for migrations... && rake db:migrate && \
 echo Updating translations... && rake lang:update && \


### PR DESCRIPTION
Testing this is change is a bit tricky and kind of self referential.  To test it, I created a separate file `script/test_deploy.h` in my local repo and commented out most of the rest of the script other than this specific logic.

This should let you see if a change on your local on the `main` branch gets stashed and restored.  It should should work with or without other stashed changes.

The other important case is when there is a conflict between what you have locally and what's on the target branch.  To test this make sure the check for `main` at the top of the script is commented out.

Then create a temporary branch that you push to GitHub.
In your usual local repo make a change that you don't check in.
Make a fresh clone of the GitHub repo in another directory and make a change that conflicts with the one you just made and push that to GitHub.
Now run the script from your usual repo.  It should fail when it tries to pop the stashed change with a conflict message.

Hopefully that's reasonably clear and paves the way for us to not require that there be differences between the `main` branch and what's on the server for the files that are managed by git.
