### PR TITLE
Location.contains Scope 

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -243,8 +243,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             # Location straddles 180
             #   Location 100% wrap; necessarily straddles w/e
             and(Location[:west] == Location[:east] - 360).
-            #   Location < 100% wrap-around
-            or((Location[:west].gt(Location[:east])). # rubocop:disable Style/RedundantParentheses
+            #  Location < 100% wrap-around
+            or(Location[:west].gt(Location[:east]).
               and(Location[:west] <= shrunk_w).
               and(Location[:east] >= shrunk_e)))
           end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -150,7 +150,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  ROUND_ERROR = 0.00001
+  ROUND_ERROR = 0.0005
 
   # NOTE: To improve Coveralls display, do not use one-line stabby lambda scopes
   scope :name_includes,

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -258,7 +258,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
               Location[:west] == Location[:east] - 360).
               or(
                 # Location < 100% wrap-around
-                (Location[:west].gt(Location[:east])).
+                (Location[:west].gt(Location[:east])). # rubocop:disable Style/RedundantParentheses
                 and(Location[:west] <= shrunk_w).
                 and(Location[:east] >= shrunk_e)
               )

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -232,13 +232,19 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
                 and(Location[:north].gteq(shrunk_n)).
               and(
                 # Location doesn't straddle 180
-                (Location[:west] <= Location[:east]).
+                ( # rubocop:disable Style/RedundantParentheses
+                  Location[:west].lteq(Location[:east]).
                   and(Location[:west] <= shrunk_w).
-                  and(Location[:east] >= shrunk_e).
+                  and(Location[:east] >= shrunk_e)
+                ).
                 # Location straddles 180
-                or(Location[:west] > Location[:east]).
-                  and(Location[:west] <= shrunk_w).
-                  or(Location[:east] >= shrunk_e)
+                or(
+                  Location[:west].gt(Location[:east]).
+                  and(
+                    (Location[:west] <= shrunk_w).
+                    or(Location[:east] >= shrunk_e)
+                  )
+                )
               )
             )
           else

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -213,18 +213,17 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
           end
 
           # Correct for possible floating point rounding
-          # Shift points by 180 degrees to simplify east/west comparisons
-          # (Avoids issues with locations straddling 180)
-          shrunk_n = n - ROUND_ERROR + 180
-          shrunk_s = s + ROUND_ERROR + 180
-          shrunk_e = e - ROUND_ERROR + 180
-          shrunk_w = w + ROUND_ERROR + 180
+          shrunk_n = n - ROUND_ERROR
+          shrunk_s = s + ROUND_ERROR
+          shrunk_e = e - ROUND_ERROR
+          shrunk_w = w + ROUND_ERROR
 
           where(
             Location[:south].lteq(shrunk_s).
-            and(Location[:north].lteq(shrunk_n)).
-            and((Location[:west] + 180) <= shrunk_w).
-            and((Location[:east] + 180) >= shrunk_e)
+            and(Location[:north].gteq(shrunk_n)).
+            # Simplify e/w comparisons, avoiding straddling 180)
+            and((Location[:west] + 180) <= shrunk_w + 180).
+            and((Location[:east] + 180) >= shrunk_e + 180)
           )
         }
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -150,7 +150,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  ROUND_ERROR = 0.0005
+  FLOAT_ERROR = 0.0005
 
   # NOTE: To improve Coveralls display, do not use one-line stabby lambda scopes
   scope :name_includes,
@@ -206,10 +206,10 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
           args => {n:, s:, e:, w:}
 
           # Correct for possible floating point rounding
-          shrunk_n = n - ROUND_ERROR
-          shrunk_s = s + ROUND_ERROR
-          shrunk_e = e - ROUND_ERROR
-          shrunk_w = w + ROUND_ERROR
+          shrunk_n = n - FLOAT_ERROR
+          shrunk_s = s + FLOAT_ERROR
+          shrunk_e = e - FLOAT_ERROR
+          shrunk_w = w + FLOAT_ERROR
 
           # w/e    | Location     | Location contains w/e
           # ______ | ____________ | ______________________

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -252,10 +252,16 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             where(
               Location[:south].lteq(shrunk_s).
                 and(Location[:north].gteq(shrunk_n)).
-              # Location straddles 180
-              and(Location[:west] > Location[:east]).
+            # Location straddles 180
+            and(
+              # Location 100% wrap-around; necessary bounds w/e
+              Location[:west] == Location[:east] - 360).
+              or(
+                # Location < 100% wrap-around
+                (Location[:west].gt(Location[:east])).
                 and(Location[:west] <= shrunk_w).
                 and(Location[:east] >= shrunk_e)
+              )
             )
           end
         }

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -224,8 +224,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
           # w > e  | west <= east | none
           # w > e  | west > east  | west <= w && e <= east
 
-          if w <= e
-            # w / e don't straddle 180
+          if w <= e # w / e don't straddle 180
             where(Location[:south].lteq(shrunk_s).
                     and(Location[:north].gteq(shrunk_n)).
                   #   Location doesn't straddle 180
@@ -238,8 +237,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
                       and((Location[:west] <= shrunk_w).
                         #  need not check w for same reason
                         or(Location[:east] >= shrunk_e)))))
-          else
-            # w / e straddle 180
+          else # w / e straddle 180
             where(Location[:south].lteq(shrunk_s).
                   and(Location[:north].gteq(shrunk_n)).
             # Location straddles 180

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -201,15 +201,9 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     )
   }
 
-  scope :contains, # Use named parameters (lat:, lng:, or n:, s:, e:, w:)
+  scope :contains_box, # Use named parameters, n:, s:, e:, w:
         lambda { |**args|
-          if args[:lat] && args[:lng]
-            args => {lat:, lng:}
-            n = s = lat
-            e = w = lng
-          elsif args[:n]
-            args => {n:, s:, e:, w:}
-          end
+          args => {n:, s:, e:, w:}
 
           # Correct for possible floating point rounding
           shrunk_n = n - ROUND_ERROR

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -255,13 +255,11 @@ east_lt_west_location:
 perkatkun:
   <<: *DEFAULTS
   name: Perkatkun, Wrangel Island, Russia
+  # NOTE: MySQL rounds the following. jdc 2024-07-06
   north: 71.154802
   west: -179.809370
   south: 71.104900
-  # NOTE: jdc 2024-07-04
-  # Next line causes failures. Due to AR/Ruby truncation/rounding??
-  # east: -179.613214
-  east: -179.613
+  east: -179.613214
 
 loc_edited_by_katrina:
   <<: *DEFAULTS

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -258,7 +258,10 @@ perkatkun:
   north: 71.154802
   west: -179.809370
   south: 71.104900
-  east: -179.613214
+  # NOTE: jdc 2024-07-04
+  # Next line causes failures. Due to AR/Ruby truncation/rounding??
+  # east: -179.613214
+  east: -179.613
 
 loc_edited_by_katrina:
   <<: *DEFAULTS

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -561,6 +561,7 @@ class LocationTest < UnitTestCase
                         regions: [california, earth])
     do_contains_lat_lng(loc: perkatkun, external_loc: albion,
                         regions: [wrangel, earth])
+    do_contains_lat_lng(loc: california, regions: [earth])
   end
 
   def albion
@@ -680,6 +681,10 @@ class LocationTest < UnitTestCase
         west: wrangel.west + 0.05
       )
     do_contains_box(loc: wrangel, external_loc: overlaps_wrangel_east)
+
+    # These failed depending on the rounding correction used by `contains_box`
+    do_contains_box(loc: perkatkun, regions: [wrangel, earth])
+    do_contains_box(loc: california, regions: [earth])
   end
 
   def do_contains_box(loc:, external_loc: nil,

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -596,7 +596,7 @@ class LocationTest < UnitTestCase
       Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
     assert_includes(
       containers, loc,
-      " #{loc.name} should contain its NE corner"
+      "#{loc.name} should contain its NE corner"
     )
     assert_not_includes(
       containers, external_loc,
@@ -608,7 +608,7 @@ class LocationTest < UnitTestCase
       Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
     assert_includes(
       containers, loc,
-      " #{loc.name} should contain its SW corner"
+      "#{loc.name} should contain its SW corner"
     )
     assert_not_includes(
       containers, external_loc,
@@ -644,7 +644,7 @@ class LocationTest < UnitTestCase
     end
     assert_not_includes(
       containers, external_loc,
-      "#{external_loc.name} shouldn't contain SW corner of #{loc.name}"
+      "#{external_loc.name} shouldn't contain #{loc.name}"
     )
   end
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -654,6 +654,32 @@ class LocationTest < UnitTestCase
     #   potential br (bounding rectangle) entirely to "right" of loc
     nybg = locations(:nybg_location)
     do_contains_box(loc: albion, external_loc: nybg)
+
+    # loc straddles 180
+    #   potential br entirely outside of loc
+    russia = Location.create(
+      name: "russia", user: users(:rolf),
+      north: 86.217, south: 38.083, west: 27.370116, east: -168.995128
+    )
+    do_contains_box(loc: wrangel, external_loc: albion,
+                    regions: [russia, earth])
+    #   potential br overlaps only "left" side of loc
+    overlaps_wrangel_west =
+      Location.create(
+        name: "overlaps_wrangel_west", user: users(:rolf),
+        north: wrangel.north, south: wrangel.south, east: wrangel.east - 0.05,
+        west: wrangel.west - 0.05
+      )
+    do_contains_box(loc: wrangel, external_loc: overlaps_wrangel_west)
+
+    #   potential br (bounding rectangle) overlaps only "right" side of loc
+    overlaps_wrangel_east =
+      Location.create(
+        name: "overlaps_wrangel_east", user: users(:rolf),
+        north: wrangel.north, south: wrangel.south, east: wrangel.east + 0.05,
+        west: wrangel.west + 0.05
+      )
+    do_contains_box(loc: wrangel, external_loc: overlaps_wrangel_east)
   end
 
   def do_contains_box(loc:, external_loc: nil,

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -628,10 +628,32 @@ class LocationTest < UnitTestCase
   end
 
   def test_scope_contains_box
+    # loc doesn't straddle 180
+    #   potential br (bounding rectangle) entirely to "left" of loc
     do_contains_box(loc: albion, external_loc: perkatkun,
                     regions: [california, earth])
-    do_contains_box(loc: perkatkun, external_loc: albion,
-                    regions: [wrangel, earth])
+
+    #   potential br (bounding rectangle) overlaps only "left" side of loc
+    overlaps_albion_west =
+      Location.create(
+        name: "overlaps_albion_west", user: users(:rolf),
+        north: albion.north, south: albion.south, east: albion.east - 0.05,
+        west: albion.west - 0.05
+      )
+    do_contains_box(loc: albion, external_loc: overlaps_albion_west)
+
+    #   potential br (bounding rectangle) overlaps only "right" side of loc
+    overlaps_albion_east =
+      Location.create(
+        name: "overlaps_albion_east", user: users(:rolf),
+        north: albion.north, south: albion.south, west: albion.west + 0.05,
+        east: albion.east + 0.05
+      )
+    do_contains_box(loc: albion, external_loc: overlaps_albion_east)
+
+    #   potential br (bounding rectangle) entirely to "right" of loc
+    nybg = locations(:nybg_location)
+    do_contains_box(loc: albion, external_loc: nybg)
   end
 
   def do_contains_box(loc:, external_loc: nil,

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -583,48 +583,44 @@ class LocationTest < UnitTestCase
     locations(:east_lt_west_location)
   end
 
-  def do_contains_lat_lng(loc:, external_loc:,
+  def do_contains_lat_lng(loc:, external_loc: nil,
                           regions: [locations(:unknown_location)])
     center =
       { lat: loc.south + (loc.north - loc.south) / 2,
         lng: loc.east + (loc.west - loc.east) / 2 }
     containers =
       Location.contains(lat: center[:lat], lng: center[:lng])
-    assert_includes(
-      containers, loc,
-      "#{loc.name} should contain its center"
-    )
-    regions.each do |region|
-      assert_includes(
-        containers, region,
-        "#{region.name} should contain #{loc.name}"
-      )
-    end
 
-    assert_not_includes(
-      containers, external_loc,
-      "#{loc.name} should not contain #{external_loc.name}"
-    )
+    assert_includes(containers, loc,
+                    "#{loc.name} should contain its center")
+    regions.each do |region|
+      assert_includes(containers, region,
+                      "#{region.name} should contain #{loc.name}")
+    end
+    if external_loc.present?
+      assert_not_includes(containers, external_loc,
+                          "#{loc.name} should not contain #{external_loc.name}")
+    end
 
     ne_corner = { lat: loc.north, lng: loc.east }
     containers =
       Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
-    assert_includes(
-      containers, loc,
-      "#{loc.name} should contain its NE corner"
-    )
-    assert_not_includes(
-      containers, external_loc,
-      "#{external_loc.name} shouldn't contain NE corner of #{loc.name}"
-    )
+    assert_includes(containers, loc,
+                    "#{loc.name} should contain its NE corner")
+    if external_loc.present?
+      assert_not_includes(
+        containers, external_loc,
+        "#{external_loc.name} shouldn't contain NE corner of #{loc.name}"
+      )
+    end
 
     sw_corner = { lat: loc.south, lng: loc.west }
     containers =
       Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
-    assert_includes(
-      containers, loc,
-      "#{loc.name} should contain its SW corner"
-    )
+    assert_includes(containers, loc,
+                    "#{loc.name} should contain its SW corner")
+    return if external_loc.blank?
+
     assert_not_includes(
       containers, external_loc,
       "#{external_loc.name} shouldn't contain SW corner of #{loc.name}"
@@ -638,7 +634,7 @@ class LocationTest < UnitTestCase
                     regions: [wrangel, earth])
   end
 
-  def do_contains_box(loc:, external_loc:,
+  def do_contains_box(loc:, external_loc: nil,
                       regions: [locations(:unknown_location)])
     containers =
       Location.contains(n: loc.north, s: loc.south, e: loc.east, w: loc.west)
@@ -651,6 +647,8 @@ class LocationTest < UnitTestCase
         "#{region.name} should contain #{loc.name}"
       )
     end
+    return if external_loc.blank?
+
     assert_not_includes(
       containers, external_loc,
       "#{external_loc.name} shouldn't contain #{loc.name}"

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -575,7 +575,6 @@ class LocationTest < UnitTestCase
 
     containing_locs =
       Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
-
     assert_includes(containing_locs, loc,
                     "Location should `contain` its NE corner")
     assert_not_includes(containing_locs, external_loc,
@@ -589,32 +588,6 @@ class LocationTest < UnitTestCase
     assert_not_includes(containing_locs, external_loc,
                         "Non-intersecting Location should not `contain` point")
 
-    skip("Scope `contains` under construction")
-
-    loc = locations(:perkatkun)
-    external_loc = locations(:albion)
-    ne_corner = { lat: loc.north, lng: loc.east }
-    sw_corner = { lat: loc.south, lng: loc.west }
-
-    containing_locs =
-      Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
-
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` its NE corner")
-    assert_not_includes(containing_locs, external_loc,
-                        "Non-intersecting Location should not `contain` point")
-
-    containing_locs =
-      Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
-
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` its SW corner")
-    assert_not_includes(containing_locs, external_loc,
-                        "Non-intersecting Location should not `contain` point")
-  end
-
-  # Isolated portion of another test
-  def test_scope_contains_foo
     loc = locations(:perkatkun)
     external_loc = locations(:albion)
     ne_corner = { lat: loc.north, lng: loc.east }
@@ -650,8 +623,6 @@ class LocationTest < UnitTestCase
       containing_locs, external_loc,
       "Containing Locations should exclude non-intersecting Locations"
     )
-
-    skip("Scope `contains` under construction")
 
     loc = locations(:perkatkun)
     external_loc = locations(:albion)

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -554,87 +554,14 @@ class LocationTest < UnitTestCase
     )
   end
 
-  def test_scope_contains_point
-    do_contains_lat_lng(loc: albion, external_loc: locations(:gualala),
-                        regions: [california, earth])
-    do_contains_lat_lng(loc: albion, external_loc: perkatkun,
-                        regions: [california, earth])
-    do_contains_lat_lng(loc: perkatkun, external_loc: albion,
-                        regions: [wrangel, earth])
-    do_contains_lat_lng(loc: california, regions: [earth])
-  end
-
-  def albion
-    locations(:albion)
-  end
-
-  def california
-    locations(:california)
-  end
-
-  def earth
-    locations(:unknown_location)
-  end
-
-  def perkatkun
-    locations(:perkatkun)
-  end
-
-  def wrangel
-    locations(:east_lt_west_location)
-  end
-
-  def do_contains_lat_lng(loc:, external_loc: nil,
-                          regions: [locations(:unknown_location)])
-    center =
-      { lat: loc.south + (loc.north - loc.south) / 2,
-        lng: loc.east + (loc.west - loc.east) / 2 }
-    containers =
-      Location.contains(lat: center[:lat], lng: center[:lng])
-
-    assert_includes(containers, loc,
-                    "#{loc.name} should contain its center")
-    regions.each do |region|
-      assert_includes(containers, region,
-                      "#{region.name} should contain #{loc.name}")
-    end
-    if external_loc.present?
-      assert_not_includes(containers, external_loc,
-                          "#{loc.name} should not contain #{external_loc.name}")
-    end
-
-    ne_corner = { lat: loc.north, lng: loc.east }
-    containers =
-      Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
-    assert_includes(containers, loc,
-                    "#{loc.name} should contain its NE corner")
-    if external_loc.present?
-      assert_not_includes(
-        containers, external_loc,
-        "#{external_loc.name} shouldn't contain NE corner of #{loc.name}"
-      )
-    end
-
-    sw_corner = { lat: loc.south, lng: loc.west }
-    containers =
-      Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
-    assert_includes(containers, loc,
-                    "#{loc.name} should contain its SW corner")
-    return if external_loc.blank?
-
-    assert_not_includes(
-      containers, external_loc,
-      "#{external_loc.name} shouldn't contain SW corner of #{loc.name}"
-    )
-  end
-
   def test_scope_contains_box
+    debugger
     # loc doesn't straddle 180
-    #   potential br (bounding rectangle) entirely to "left" of loc
+    #   potential br (bounding rectangle, external_loc) to "left" of loc
     do_contains_box(loc: albion, external_loc: perkatkun,
                     regions: [california, earth])
 
-    #   potential br (bounding rectangle) overlaps only "left" side of loc
+    #   potential br overlaps only "left" side of loc
     overlaps_albion_west =
       Location.create(
         name: "overlaps_albion_west", user: users(:rolf),
@@ -643,7 +570,7 @@ class LocationTest < UnitTestCase
       )
     do_contains_box(loc: albion, external_loc: overlaps_albion_west)
 
-    #   potential br (bounding rectangle) overlaps only "right" side of loc
+    #   potential br overlaps only "right" side of loc
     overlaps_albion_east =
       Location.create(
         name: "overlaps_albion_east", user: users(:rolf),
@@ -673,7 +600,7 @@ class LocationTest < UnitTestCase
       )
     do_contains_box(loc: wrangel, external_loc: overlaps_wrangel_west)
 
-    #   potential br (bounding rectangle) overlaps only "right" side of loc
+    #   potential br overlaps only "right" side of loc
     overlaps_wrangel_east =
       Location.create(
         name: "overlaps_wrangel_east", user: users(:rolf),
@@ -687,10 +614,31 @@ class LocationTest < UnitTestCase
     do_contains_box(loc: california, regions: [earth])
   end
 
+  def albion
+    locations(:albion)
+  end
+
+  def california
+    locations(:california)
+  end
+
+  def earth
+    locations(:unknown_location)
+  end
+
+  def perkatkun
+    locations(:perkatkun)
+  end
+
+  def wrangel
+    locations(:east_lt_west_location)
+  end
+
   def do_contains_box(loc:, external_loc: nil,
                       regions: [locations(:unknown_location)])
     containers =
-      Location.contains(n: loc.north, s: loc.south, e: loc.east, w: loc.west)
+      Location.contains_box(n: loc.north, s: loc.south,
+                            e: loc.east, w: loc.west)
 
     assert_includes(containers, loc,
                     "Location #{loc.name} should contain itself")

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -555,7 +555,6 @@ class LocationTest < UnitTestCase
   end
 
   def test_scope_contains_box
-    debugger
     # loc doesn't straddle 180
     #   potential br (bounding rectangle, external_loc) to "left" of loc
     do_contains_box(loc: albion, external_loc: perkatkun,

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -554,6 +554,119 @@ class LocationTest < UnitTestCase
     )
   end
 
+  def test_scope_contains_centrum
+    albion = locations(:albion)
+    centrum =
+      { lat: albion.south + (albion.north - albion.south) / 2,
+        lng: albion.east + (albion.west - albion.east) / 2 }
+    locs_containing_centrum =
+      Location.contains(lat: centrum[:lat], lng: centrum[:lng])
+    assert_includes(locs_containing_centrum, locations(:albion),
+                    "Location should `contain`` its centrum")
+    assert_not_includes(locs_containing_centrum, locations(:gualala),
+                        "Location should not `contain` external point")
+  end
+
+  def test_scope_contains_corners
+    loc = locations(:albion)
+    external_loc = locations(:perkatkun)
+    ne_corner = { lat: loc.north, lng: loc.east }
+    sw_corner = { lat: loc.south, lng: loc.west }
+
+    containing_locs =
+      Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` its NE corner")
+    assert_not_includes(containing_locs, external_loc,
+                        "Non-intersecting Location should not `contain` point")
+
+    containing_locs =
+      Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` its SW corner")
+    assert_not_includes(containing_locs, external_loc,
+                        "Non-intersecting Location should not `contain` point")
+
+    skip("Scope `contains` under construction")
+
+    loc = locations(:perkatkun)
+    external_loc = locations(:albion)
+    ne_corner = { lat: loc.north, lng: loc.east }
+    sw_corner = { lat: loc.south, lng: loc.west }
+
+    containing_locs =
+      Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` its NE corner")
+    assert_not_includes(containing_locs, external_loc,
+                        "Non-intersecting Location should not `contain` point")
+
+    containing_locs =
+      Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` its SW corner")
+    assert_not_includes(containing_locs, external_loc,
+                        "Non-intersecting Location should not `contain` point")
+  end
+
+  # Isolated portion of another test
+  def test_scope_contains_foo
+    loc = locations(:perkatkun)
+    external_loc = locations(:albion)
+    ne_corner = { lat: loc.north, lng: loc.east }
+    sw_corner = { lat: loc.south, lng: loc.west }
+
+    containing_locs =
+      Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` its NE corner")
+    assert_not_includes(containing_locs, external_loc,
+                        "Non-intersecting Location should not `contain` point")
+
+    containing_locs =
+      Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` its SW corner")
+    assert_not_includes(containing_locs, external_loc,
+                        "Non-intersecting Location should not `contain` point")
+  end
+
+  def test_scope_contains_box
+    loc = locations(:albion)
+    external_loc = locations(:perkatkun)
+
+    containing_locs =
+      Location.contains(n: loc.north, s: loc.south, e: loc.east, w: loc.west)
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` itself")
+    assert_not_includes(
+      containing_locs, external_loc,
+      "Containing Locations should exclude non-intersecting Locations"
+    )
+
+    skip("Scope `contains` under construction")
+
+    loc = locations(:perkatkun)
+    external_loc = locations(:albion)
+
+    containing_locs =
+      Location.contains(n: loc.north, s: loc.south, e: loc.east, w: loc.west)
+
+    assert_includes(containing_locs, loc,
+                    "Location should `contain` itself")
+    assert_not_includes(
+      containing_locs, external_loc,
+      "Containing Locations should exclude non-intersecting Locations"
+    )
+  end
+
   def test_hidden
     User.current = mary
     high = 60.234

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -554,19 +554,33 @@ class LocationTest < UnitTestCase
     )
   end
 
-  def test_scope_contains_lat_lng
-    albion = locations(:albion)
-    perkatkun = locations(:perkatkun)
-    california = locations(:california)
-    earth = locations(:unknown_location)
-    wrangel = locations(:east_lt_west_location)
-
+  def test_scope_contains_point
     do_contains_lat_lng(loc: albion, external_loc: locations(:gualala),
                         regions: [california, earth])
     do_contains_lat_lng(loc: albion, external_loc: perkatkun,
                         regions: [california, earth])
     do_contains_lat_lng(loc: perkatkun, external_loc: albion,
                         regions: [wrangel, earth])
+  end
+
+  def albion
+    locations(:albion)
+  end
+
+  def california
+    locations(:california)
+  end
+
+  def earth
+    locations(:unknown_location)
+  end
+
+  def perkatkun
+    locations(:perkatkun)
+  end
+
+  def wrangel
+    locations(:east_lt_west_location)
   end
 
   def do_contains_lat_lng(loc:, external_loc:,
@@ -586,6 +600,7 @@ class LocationTest < UnitTestCase
         "#{region.name} should contain #{loc.name}"
       )
     end
+
     assert_not_includes(
       containers, external_loc,
       "#{loc.name} should not contain #{external_loc.name}"
@@ -617,12 +632,6 @@ class LocationTest < UnitTestCase
   end
 
   def test_scope_contains_box
-    albion = locations(:albion)
-    perkatkun = locations(:perkatkun)
-    california = locations(:california)
-    earth = locations(:unknown_location)
-    wrangel = locations(:east_lt_west_location)
-
     do_contains_box(loc: albion, external_loc: perkatkun,
                     regions: [california, earth])
     do_contains_box(loc: perkatkun, external_loc: albion,

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -554,87 +554,97 @@ class LocationTest < UnitTestCase
     )
   end
 
-  def test_scope_contains_centrum
+  def test_scope_contains_lat_lng
     albion = locations(:albion)
-    centrum =
-      { lat: albion.south + (albion.north - albion.south) / 2,
-        lng: albion.east + (albion.west - albion.east) / 2 }
-    locs_containing_centrum =
-      Location.contains(lat: centrum[:lat], lng: centrum[:lng])
-    assert_includes(locs_containing_centrum, locations(:albion),
-                    "Location should `contain`` its centrum")
-    assert_not_includes(locs_containing_centrum, locations(:gualala),
-                        "Location should not `contain` external point")
+    perkatkun = locations(:perkatkun)
+    california = locations(:california)
+    earth = locations(:unknown_location)
+    wrangel = locations(:east_lt_west_location)
+
+    do_contains_lat_lng(loc: albion, external_loc: locations(:gualala),
+                        regions: [california, earth])
+    do_contains_lat_lng(loc: albion, external_loc: perkatkun,
+                        regions: [california, earth])
+    do_contains_lat_lng(loc: perkatkun, external_loc: albion,
+                        regions: [wrangel, earth])
   end
 
-  def test_scope_contains_corners
-    loc = locations(:albion)
-    external_loc = locations(:perkatkun)
+  def do_contains_lat_lng(loc:, external_loc:,
+                          regions: [locations(:unknown_location)])
+    center =
+      { lat: loc.south + (loc.north - loc.south) / 2,
+        lng: loc.east + (loc.west - loc.east) / 2 }
+    containers =
+      Location.contains(lat: center[:lat], lng: center[:lng])
+    assert_includes(
+      containers, loc,
+      "#{loc.name} should contain its center"
+    )
+    regions.each do |region|
+      assert_includes(
+        containers, region,
+        "#{region.name} should contain #{loc.name}"
+      )
+    end
+    assert_not_includes(
+      containers, external_loc,
+      "#{loc.name} should not contain #{external_loc.name}"
+    )
+
     ne_corner = { lat: loc.north, lng: loc.east }
-    sw_corner = { lat: loc.south, lng: loc.west }
-
-    containing_locs =
+    containers =
       Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` its NE corner")
-    assert_not_includes(containing_locs, external_loc,
-                        "Non-intersecting Location should not `contain` point")
+    assert_includes(
+      containers, loc,
+      " #{loc.name} should contain its NE corner"
+    )
+    assert_not_includes(
+      containers, external_loc,
+      "#{external_loc.name} shouldn't contain NE corner of #{loc.name}"
+    )
 
-    containing_locs =
-      Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
-
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` its SW corner")
-    assert_not_includes(containing_locs, external_loc,
-                        "Non-intersecting Location should not `contain` point")
-
-    loc = locations(:perkatkun)
-    external_loc = locations(:albion)
-    ne_corner = { lat: loc.north, lng: loc.east }
     sw_corner = { lat: loc.south, lng: loc.west }
-
-    containing_locs =
-      Location.contains(lat: ne_corner[:lat], lng: ne_corner[:lng])
-
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` its NE corner")
-    assert_not_includes(containing_locs, external_loc,
-                        "Non-intersecting Location should not `contain` point")
-
-    containing_locs =
+    containers =
       Location.contains(lat: sw_corner[:lat], lng: sw_corner[:lng])
-
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` its SW corner")
-    assert_not_includes(containing_locs, external_loc,
-                        "Non-intersecting Location should not `contain` point")
+    assert_includes(
+      containers, loc,
+      " #{loc.name} should contain its SW corner"
+    )
+    assert_not_includes(
+      containers, external_loc,
+      "#{external_loc.name} shouldn't contain SW corner of #{loc.name}"
+    )
   end
 
   def test_scope_contains_box
-    loc = locations(:albion)
-    external_loc = locations(:perkatkun)
+    albion = locations(:albion)
+    perkatkun = locations(:perkatkun)
+    california = locations(:california)
+    earth = locations(:unknown_location)
+    wrangel = locations(:east_lt_west_location)
 
-    containing_locs =
+    do_contains_box(loc: albion, external_loc: perkatkun,
+                    regions: [california, earth])
+    do_contains_box(loc: perkatkun, external_loc: albion,
+                    regions: [wrangel, earth])
+  end
+
+  def do_contains_box(loc:, external_loc:,
+                      regions: [locations(:unknown_location)])
+    containers =
       Location.contains(n: loc.north, s: loc.south, e: loc.east, w: loc.west)
 
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` itself")
+    assert_includes(containers, loc,
+                    "Location #{loc.name} should contain itself")
+    regions.each do |region|
+      assert_includes(
+        containers, region,
+        "#{region.name} should contain #{loc.name}"
+      )
+    end
     assert_not_includes(
-      containing_locs, external_loc,
-      "Containing Locations should exclude non-intersecting Locations"
-    )
-
-    loc = locations(:perkatkun)
-    external_loc = locations(:albion)
-
-    containing_locs =
-      Location.contains(n: loc.north, s: loc.south, e: loc.east, w: loc.west)
-
-    assert_includes(containing_locs, loc,
-                    "Location should `contain` itself")
-    assert_not_includes(
-      containing_locs, external_loc,
-      "Containing Locations should exclude non-intersecting Locations"
+      containers, external_loc,
+      "#{external_loc.name} shouldn't contain SW corner of #{loc.name}"
     )
   end
 


### PR DESCRIPTION
Adds a new Location scope.
`Location.contains_box(n: a, s: b, e: c, w: d)` returns all Locations which bound the defined rectangle.

This is a small, but necessary step, in dealing with iNat places as part of importing iNat observations.