### PR TITLE
Prevent download of all Observations

### DIFF
--- a/app/controllers/observations/downloads_controller.rb
+++ b/app/controllers/observations/downloads_controller.rb
@@ -6,6 +6,8 @@ module Observations
 
     def new
       @query = find_or_create_query(:Observation, by: params[:by])
+      return too_many_results if too_many_results?
+
       query_params_set(@query)
     end
 
@@ -30,6 +32,15 @@ module Observations
     end
 
     private
+
+    def too_many_results
+      flash_error(:download_observations_too_many_results.t)
+      redirect_to(observations_path)
+    end
+
+    def too_many_results?
+      @query.flavor == :all
+    end
 
     def download_observations_switch
       if params[:commit] == :CANCEL.l

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1479,6 +1479,7 @@
   download_observations_utf16: UTF-16 (best for Windows 7 and up)
   download_observations_print_labels_header: Or you can print labels for the selected observations
   download_observations_print_labels: Print Labels
+  download_observations_too_many_results: You are trying to download too many Observations. Please see <a href="https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md#csv-files" target="_new">CSV Files</a> for an alternative.
 
   # location/edit_location
   edit_location_title: "[:edit_object(type=:location)]"

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -154,6 +154,16 @@ module Observations
       assert_response(:success)
     end
 
+    def test_download_too_many_observations
+      query = Query.lookup_and_save(:Observation, :all)
+
+      login("mary")
+      get(:new, params: { q: query.id.alphabetize })
+
+      assert_redirected_to(observations_path)
+      assert_flash_error
+    end
+
     def test_print_labels
       login
       query = Query.lookup_and_save(:Observation, :by_user, user: mary.id)


### PR DESCRIPTION
Redirects to Observation#index with flash error if User tries to download all Observations.

- Downloading all Observations is so expensive that it causes a Downtime Alert. See [Example](https://mushroomobserver.slack.com/archives/C06FHR54EPQ/p1719681356634849). I did it accidentally, but more often it's deliberate.
- Users can get the same data using fewer resources, via the CSV files.

### Simple Manual Test
- Goto the home page
- Click `Download Observations`
Expected result: Redirects to home page with a flash error.
- Click the link in the flash.
Expected result: Opens a new window scrolled to the`CSV files` section of [README_API.md](https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md)