### PR TITLE
Fix date behavior in the Project edit form

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -313,7 +313,7 @@ module FormsHelper
     opts = separate_field_options_from_args(args, [:object, :data])
     opts[:class] = "form-control"
     opts[:data] = { controller: "year-input" }.merge(args[:data] || {})
-    date_select_opts = date_select_opts(args)
+    date_opts = date_select_opts(args)
     wrap_class = form_group_wrap_class(args)
     selects_class = "form-inline date-selects"
     selects_class += " d-inline-block" if args[:inline] == true
@@ -325,7 +325,7 @@ module FormsHelper
       concat(args[:form].label(args[:field], args[:label], label_opts))
       concat(args[:between]) if args[:between].present?
       concat(tag.div(class: selects_class, id: identifier) do
-        concat(args[:form].date_select(args[:field], date_select_opts, opts))
+        concat(args[:form].date_select(args[:field], date_opts, opts))
       end)
       concat(args[:append]) if args[:append].present?
     end
@@ -333,15 +333,16 @@ module FormsHelper
 
   # The index arg is for multiple date_selects in a form
   def date_select_opts(args = {})
-    obj = args[:object]
+    field = args[:field] || :when
+    obj = args[:object] || args[:form]&.object
     start_year = args[:start_year] || 20.years.ago.year
     end_year = args[:end_year] || Time.zone.now.year
-    init_value = obj.try(&:when).try(&:year)
+    init_value = obj.try(&field).try(&:year)
     if init_value && init_value < start_year && init_value > 1900
       start_year = init_value
     end
     opts = { start_year: start_year, end_year: end_year,
-             selected: obj.try(&:when) || Time.zone.today,
+             selected: obj.try(&field) || Time.zone.today,
              order: args[:order] || [:day, :month, :year] }
     opts[:index] = args[:index] if args[:index].present?
     opts

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -8,7 +8,7 @@
     <div class="col-xs-12 col-md-6">
       <!-- WHEN -->
       <%= date_select_with_label(
-        form: f, field: :when, object: @observation, label: :WHEN.t + ":",
+        form: f, field: :when, label: :WHEN.t + ":",
       ) %>
       <!-- /WHEN -->
 

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -38,7 +38,7 @@
                            label: "#{:form_species_lists_list_notes.l}:",
                            append: render(partial: "shared/textilize_help")) %>
 
-  <%= date_select_with_label(form: f, field: :when, object: @species_list,
+  <%= date_select_with_label(form: f, field: :when,
                              inline: true, label: "#{:WHEN.l}:") %>
 
   <%= render(partial: "shared/form_location_feedback",

--- a/test/integration/capybara/projects_integration_test.rb
+++ b/test/integration/capybara/projects_integration_test.rb
@@ -69,6 +69,25 @@ class ProjectsIntegrationTest < CapybaraIntegrationTestCase
     assert_nil(project.end_date, "Project Start Date should be nil")
   end
 
+  def test_project_maintain_dates
+    project = projects(:pinned_date_range_project)
+    start_date = project.start_date
+    assert(start_date < Time.zone.today)
+    end_date = project.end_date
+    assert(end_date < Time.zone.today)
+    login(project.user.login)
+
+    visit(project_path(project))
+    click_on(:show_project_edit.l)
+    click_on(:SAVE_EDITS.l)
+
+    project.reload
+    assert(project.start_date == start_date,
+           "Project Start Date should not be today")
+    assert(project.end_date == end_date,
+           "Project Start Date should not be today")
+  end
+
   def test_project_violations
     project = projects(:falmouth_2023_09_project)
 


### PR DESCRIPTION
To reproduce:

1) Edit a project
2) Select a date range, click the "Range" radio button, and save.
3) Re-edit the project
Expected behavior: New date range is shown.
Current behavior: Date is set to today

There were two issues.  1) The function `date_select_opts` only looked for the `when` field in the object.  2) The same function always expected to get the object from an explicitly provided `object:` option.  The fix uses the `field:` option and tried to look up the object from any associated form.  If it doesn't find one, then it uses the `object:` option.