### PR TITLE
Fix test_verify_account_with_user

### DIFF
--- a/test/models/queued_email_test.rb
+++ b/test/models/queued_email_test.rb
@@ -35,9 +35,9 @@ class QueuedEmailTest < UnitTestCase
     # User.current should always be nil when the VerifyAccount email is
     # created, so this should never happen, but somehow *has* happened multiple
     # times in the wild.  It's worth testing.
-    User.current = @dick
-    QueuedEmail::VerifyAccount.create_email(@dick)
+    User.current = dick
+    QueuedEmail::VerifyAccount.create_email(dick)
     email = QueuedEmail.last
-    assert_nil(email.user)
+    assert_nil(email&.user)
   end
 end


### PR DESCRIPTION
- Creates VerifyAccount email while `User.current` is non-nil.
- Fixes 1 of the 2 test issues described in #2040.
