### PR TITLE
Give observation form partials explicit locals

### DIFF
--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -1,10 +1,16 @@
-<!--[form:observation]-->
+<%# locals: (action:) -%>
 <%
+create = (action == :create)
+method = create ? :post : :patch
+button_name = create ? :CREATE.l : :SAVE_EDITS.l
+include_naming = create ? true : false
+has_specimen = create ? false : @observation.herbarium_records.length > 0
+logging_optional = create ? false : true
+
 # Data for the form-images Stimulus controller.
-# Controller is on this element for the sake of image drag-and-dropzone
+# Controller element is the form, so image dropzone can cover the whole form.
 max_size = MO.image_upload_max_size
 legible_max_size = (max_size.to_f/1024/1024).round
-
 image_upload_localization = {
   uploading_text: :form_observations_uploading_images.t,
   image_too_big_text: :form_observations_image_too_big.t(max: legible_max_size),
@@ -13,7 +19,6 @@ image_upload_localization = {
   show_on_map: :show_on_map.t,
   something_went_wrong: :form_observations_upload_error.t
 }.to_json
-
 data = {
   controller: "form-images form-exif map",
   action: [
@@ -51,9 +56,7 @@ end
 
   <% ########################### Image Forms ############################## %>
 
-  <% if include_images %>
-    <%= render(partial: "observations/form/images", locals: { f: f }) %>
-  <% end %>
+  <%= render(partial: "observations/form/images", locals: { f: f }) %>
 
   <% ############################# Details ################################ %>
 
@@ -71,8 +74,6 @@ end
     <%= render(partial: "observations/form/projects_and_lists",
                locals: { f:, button_name: }) %>
   <% end %>
-
-  <%= submit_button(form: f, button: button_name, center: true) %>
 
   <% if logging_optional %>
     <%= check_box_with_label(form: f, field: :log_change, checked: "checked",

--- a/app/views/controllers/observations/edit.html.erb
+++ b/app/views/controllers/observations/edit.html.erb
@@ -5,12 +5,4 @@ add_tab_set(observation_form_edit_tabs(obs: @observation))
 @container = :wide
 %>
 
-<%= render(partial: "observations/form", locals: {
-      action: :update,
-      method: :patch,
-      logging_optional: true,
-      include_naming: false,
-      include_images: true,
-      button_name: :SAVE_EDITS.l,
-      has_specimen: (@observation.herbarium_records.length > 0)
-}) %>
+<%= render(partial: "observations/form", locals: { action: :update }) %>

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (f:, button_name:, location:) -%>
+
 <%# When and Where (location) section of create_observation form
     including location autocomplete, map, lat/long/alt %>
 

--- a/app/views/controllers/observations/form/_identification.html.erb
+++ b/app/views/controllers/observations/form/_identification.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (f:, action:, button_name:, include_naming:) -%>
+
 <%= panel_block(id: "observation_identification",
                 heading: :IDENTIFICATION.l) do %>
   <%= tag.div(class: "row mt-3") do %>
@@ -15,7 +17,7 @@
                    locals: naming_locals) %>
       <% end %>
       <%= render(partial: "observations/form/specimen_section",
-                 locals: { f:, button_name: }) %>
+                 locals: { f:, action: }) %>
     <% end %>
     <%= tag.div(class: "col-xs-12 col-sm-6") do %>
       <%= render(partial: "shared/notes_fields",

--- a/app/views/controllers/observations/form/_images.html.erb
+++ b/app/views/controllers/observations/form/_images.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (f:) -%>
 <%# Images section of create_observation form
 Gotcha: observation[thumb_image_id] is set by JS, not by radio buttons.
 Although there can be radio buttons for selecting thumb_image_id
@@ -37,7 +38,7 @@ i.e. observation[good_image_ids]. It's a top-level field. --%>
         ].safe_join
       end,
       render(partial: "observations/form/images/carousel",
-             locals: { f: f, images: @good_images, exif_data: @exif_data || {},
+             locals: { images: @good_images, exif_data: @exif_data || {},
                        thumb_id: @observation.thumb_image_id })
     ].safe_join
   end %>

--- a/app/views/controllers/observations/form/_projects.html.erb
+++ b/app/views/controllers/observations/form/_projects.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (button_name:) -%>
 <%# Projects section of create_observation form %>
 
 <%

--- a/app/views/controllers/observations/form/_projects_and_lists.html.erb
+++ b/app/views/controllers/observations/form/_projects_and_lists.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (f:, button_name:) -%>
 <%# Project and List section of create_observation form  %>
 
 <%= panel_block(id: "observation_projects_and_lists",
@@ -5,19 +6,18 @@
 
   <%= tag.div(class: "row mt-3") do %>
     <% if @projects.any? %>
-      <%= tag.div(class: "col-xs-12 col-sm-6") do %>
-        <%= render(partial: "observations/form/projects",
-                  locals: { f:, button_name: }) %>
-      <% end %>
+      <%= tag.div(class: "col-xs-12 col-sm-6") do
+        render(partial: "observations/form/projects",
+               locals: { button_name: })
+      end %>
     <% end %>
     <% if @lists.any? %>
-      <%= tag.div(class: "col-xs-12 col-sm-6") do %>
-        <%= render(partial: "observations/form/species_lists",
-              locals: { f: f }) %>
-      <% end %>
+      <%= tag.div(class: "col-xs-12 col-sm-6") do
+        render(partial: "observations/form/species_lists")
+      end %>
     <% end %>
   <% end %>
-
+  <%= submit_button(form: f, button: button_name, center: true) %>
 <% end %>
 
 

--- a/app/views/controllers/observations/form/_specimen_section.html.erb
+++ b/app/views/controllers/observations/form/_specimen_section.html.erb
@@ -1,8 +1,7 @@
-<%
-# Specimen section of create_observation form,
-# for collection_number and herbarium_record.
-# Fields hidden unless box checked.
-%>
+<%# locals: (f:, action:) -%>
+
+<%# Specimen section of create_observation form, for collection_number and
+herbarium_record. Fields hidden unless box checked. %>
 
 <%= tag.div(id: "observation_specimen_section",
             data: { controller: "specimen",
@@ -17,25 +16,21 @@
               action: "change->specimen#hideShowFields" }
     ) %>
     <!-- no_specimen_fields -->
-    <% if button_name == :SAVE_EDITS.l %>
+    <% if action == :update %>
       <%= help_block_with_arrow(nil) do
         :form_observations_edit_specimens_help.t
       end %>
-    <% end # if button_name %>
+    <% end %>
     <!-- /no_specimen_fields -->
   <% end %>
 
-  <% if button_name == :CREATE.l %>
+  <% if action == :create %>
     <!-- specimen_fields -->
     <%= tag.div(id: "specimen_fields",
                 class: ("hidden" if !@observation.specimen),
                 data: { specimen_target: "fields" }) do %>
-
-      <%= render(partial: "observations/form/collection_number",
-                 locals: { f: f } ) %>
-      <%= render(partial: "observations/form/herbarium_record",
-                 locals: { f: f } ) %>
-
+      <%= render(partial: "observations/form/collection_number") %>
+      <%= render(partial: "observations/form/herbarium_record") %>
     <% end %>
     <!-- /specimen_fields -->
   <% end %>

--- a/app/views/controllers/observations/form/images/_carousel.erb
+++ b/app/views/controllers/observations/form/images/_carousel.erb
@@ -1,4 +1,4 @@
-<%# locals: (images: nil, html_id: "observation_upload_images_carousel", thumb_id: nil, exif_data: {}, f: nil) -%>
+<%# locals: (images: nil, html_id: "observation_upload_images_carousel", thumb_id: nil, exif_data: {}) -%>
 <%=
 # NOTE: make this a component
 # Optional args:
@@ -17,7 +17,7 @@ tag.div(class: "carousel slide image-form-carousel", id: html_id,
     images&.each_with_index do |image, index|
       upload = image&.created_at == nil
       concat(render(partial: "observations/form/images/carousel_item",
-                    locals: { f: f, image:, index:, upload:, thumb_id:,
+                    locals: { image:, index:, upload:, thumb_id:,
                               camera_info: exif_data[image&.id] }))
     end
     concat(tag.div(class: "carousel-control-wrap row") do

--- a/app/views/controllers/observations/form/images/_carousel_item.erb
+++ b/app/views/controllers/observations/form/images/_carousel_item.erb
@@ -1,4 +1,4 @@
-<%# locals: (image: nil, img_id: nil, upload: false, index: "", f: nil, camera_info: {}, thumb_id: nil) -%>
+<%# locals: (image: nil, img_id: nil, upload: false, index: "", camera_info: {}, thumb_id: nil) -%>
 
 <%#
 This may be rendered by Turbo, or by the edit action

--- a/app/views/controllers/observations/new.html.erb
+++ b/app/views/controllers/observations/new.html.erb
@@ -5,12 +5,4 @@ add_tab_set(observation_form_new_tabs)
 @container = :wide
 %>
 
-<%= render(partial: "observations/form", locals: {
-      action: :create,
-      method: :post,
-      logging_optional: false,
-      include_naming: true,
-      include_images: true,
-      button_name: :CREATE.l,
-      has_specimen: false
-}) %>
+<%= render(partial: "observations/form", locals: { action: :create }) %>


### PR DESCRIPTION
(Cleaning up after my recent PRs)

Rails 7.1 allows declaring the accepted locals for a partial explicitly in a [comment at the top of the file](https://www.shakacode.com/blog/rails-7-1-allows-templates-to-define-accepted-locals/).

I like the convention, because it makes me less sloppy passing locals. Took this opportunity to refactor local args a bit in the form, too. 

Note that you don't have to declare the accepted locals in a partial, but if you do, and don't pass the locals in, or you pass a local you didn't declare, Rails will throw a missing arg error.