### PR TITLE
Split stimulus map controller into map/geolocation controllers

### DIFF
--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -217,7 +217,7 @@ export default class extends Controller {
     if (!AUTOCOMPLETER_TYPES.hasOwnProperty(type)) {
       alert("MOAutocompleter: Invalid type: \"" + type + "\"");
     } else {
-      this.verbose("swapping autocompleter type " + type);
+      this.verbose("autocompleter:swap " + type);
       this.TYPE = type;
       this.element.setAttribute("data-type", type)
       // add dependent properties and allow overrides
@@ -247,7 +247,7 @@ export default class extends Controller {
         this.element.classList.remove('create');
       } else {
         this.inputTarget.closest("form").classList.remove('map-outlet');
-        this.verbose("regular swap");
+        this.verbose("autocompleter: regular swap");
         this.scheduleRefresh();
         this.element.classList.remove('constrained', 'create');
       }
@@ -261,7 +261,7 @@ export default class extends Controller {
 
   // Connects the location_google autocompleter to call map controller methods
   mapOutletConnected(outlet, element) {
-    this.verbose("mapOutletConnected()");
+    this.verbose("autocompleter:mapOutletConnected()");
     // open the map if not already open
     if (!outlet.opened) outlet.toggleMapBtnTarget.click();
     // set the map type so box is editable
@@ -279,7 +279,7 @@ export default class extends Controller {
   }
 
   mapOutletDisconnected(outlet, element) {
-    this.verbose("map outlet disconnected");
+    this.verbose("autocompleter: map outlet disconnected");
     outlet.map_type = "observation";
     if (outlet.rectangle) outlet.rectangle.setEditable(false);
 
@@ -462,7 +462,7 @@ export default class extends Controller {
     if (new_val != old_val) {
       this.old_value = new_val;
       if (do_refresh) {
-        this.verbose("ourChange()");
+        this.verbose("autocompleter:ourChange()");
         this.scheduleRefresh();
       }
     }
@@ -471,14 +471,14 @@ export default class extends Controller {
   // User clicked into text field.
   ourClick(event) {
     if (this.ACT_LIKE_SELECT)
-      this.verbose("ourClick()");
+      this.verbose("autocompleter:ourClick()");
     this.scheduleRefresh();
     return false;
   }
 
   // User entered text field.
   ourFocus(event) {
-    // this.debug("ourFocus()");
+    // this.debug("autocompleter:ourFocus()");
     if (!this.ROW_HEIGHT)
       this.getRowHeight();
     this.focused = true;
@@ -486,7 +486,7 @@ export default class extends Controller {
 
   // User left the text field.
   ourBlur(event) {
-    // this.debug("ourBlur()");
+    // this.debug("autocompleter:ourBlur()");
     this.scheduleHide();
     this.focused = false;
   }
@@ -526,10 +526,10 @@ export default class extends Controller {
     if (this.TYPE === "location_google") {
       this.scheduleGoogleRefresh();
     } else {
-      this.verbose("scheduleRefresh()");
+      this.verbose("autocompleter:scheduleRefresh()");
       this.clearRefresh();
       this.refresh_timer = setTimeout((() => {
-        this.verbose("doing_refresh()");
+        this.verbose("autocompleter:doing_refresh()");
         // this.debug("refresh_timer(" + this.inputTarget.value + ")");
         this.old_value = this.inputTarget.value;
         // async, anything after this executes immediately
@@ -555,10 +555,10 @@ export default class extends Controller {
       return;
     }
 
-    this.verbose("scheduleGoogleRefresh()");
+    this.verbose("autocompleter:scheduleGoogleRefresh()");
     this.clearRefresh();
     this.refresh_timer = setTimeout((() => {
-      this.verbose("doing_google_refresh()");
+      this.verbose("autocompleter:doing_google_refresh()");
       this.old_value = this.inputTarget.value;
       // async, anything after this executes immediately
       this.mapOutlet.geolocatePlaceName(true);
@@ -626,7 +626,7 @@ export default class extends Controller {
   goHome() { this.moveCursor(-this.matches.length) }
   goEnd() { this.moveCursor(this.matches.length) }
   moveCursor(rows) {
-    this.verbose("moveCursor()");
+    // this.verbose("autocompleter: moveCursor()");
     const old_row = this.current_row,
       old_scr = this.scroll_offset;
     let new_row = old_row + rows,
@@ -658,7 +658,7 @@ export default class extends Controller {
   // User has tabbed or arrowDown/Up to a menu item.
   // (mouseover handled by CSS)
   highlightRow(new_hl) {
-    this.verbose("highlightRow()");
+    // this.verbose("autocompleter: highlightRow()");
     const rows = this.listTarget.children,
       old_hl = this.current_highlight;
 
@@ -677,7 +677,7 @@ export default class extends Controller {
 
   // Called when users scrolls via scrollbar.
   scrollList() {
-    this.verbose("scrollList()");
+    this.verbose("autocompleter:scrollList()");
     const old_scr = this.scroll_offset,
       new_scr = Math.round(this.pulldownTarget.scrollTop / this.ROW_HEIGHT),
       old_row = this.current_row;
@@ -699,7 +699,7 @@ export default class extends Controller {
   // may be called from a Stimulus target action or a listener in this class, so
   // the index may be an integer, or have to be derived from the event.target.
   selectRow(idx) {
-    this.verbose("selectRow()");
+    // this.verbose("autocompleter: selectRow()");
     if (this.matches.length === 0) return;
 
     if (idx instanceof Event) { idx = parseInt(idx.target.dataset.row); }
@@ -771,7 +771,7 @@ export default class extends Controller {
   // is essential for making the page responsive.
   // Called after populateMatches()
   drawPulldown() {
-    this.verbose("drawPulldown()");
+    // this.verbose("autocompleter: drawPulldown()");
     const rows = this.listTarget.children,
       scroll = this.scroll_offset;
 
@@ -798,7 +798,7 @@ export default class extends Controller {
   // as needed, as the user scrolls. rows are the <li> elements in the pulldown.
   //  Called from drawPulldown().
   updateRows(rows) {
-    this.verbose("updateRows(rows)");
+    // this.verbose("autocompleter: updateRows(rows)");
     let i, text;
     for (i = 0; i < this.PULLDOWN_SIZE; i++) {
       let row = rows.item(i),
@@ -847,21 +847,10 @@ export default class extends Controller {
     }
   }
 
-  // Add a link to create a new record: changes href and data-action.
-  // addCreateLink(row) {
-  //   const link = row.children[0];
-  //   link.setAttribute('href',
-  //     this.create_link + this.inputTarget.value
-  //   );
-  //   delete link.dataset?.action;
-  //   link.dataset.turboStream = "true";
-  //   link.classList.remove('d-none');
-  // }
-
   // Highlight that row (CSS only - does not populate hidden ID).
   //  Called from drawPulldown().
   highlightNewRow(rows) {
-    this.verbose("highlightNewRow(rows)");
+    // this.verbose("autocompleter: highlightNewRow(rows)");
     const old_hl = this.current_highlight;
     let new_hl = this.current_row - this.scroll_offset;
 
@@ -881,7 +870,7 @@ export default class extends Controller {
   // wrapping .form-group which must have class .dropdown.
   //  Called from drawPulldown().
   makePulldownVisible() {
-    this.verbose("makePulldownVisible()");
+    // this.verbose("autocompleter: makePulldownVisible()");
     const matches = this.matches,
       offset = this.scroll_offset,
       size = this.PULLDOWN_SIZE,
@@ -923,7 +912,7 @@ export default class extends Controller {
   // This guards against user selecting a match, then, say, deleting a letter
   // and retyping the letter. Without this, an exact match would lose its ID.
   updateHiddenId() {
-    this.verbose("updateHiddenId()");
+    this.verbose("autocompleter:updateHiddenId()");
     if (this.COLLAPSE > 0) return;
 
     const perfect_match =
@@ -943,13 +932,14 @@ export default class extends Controller {
   ignoringTextInput() {
     if (!this.hasMapOutlet) return false;
 
+    this.verbose("autocompleter:ignoringTextInput()");
     return this.mapOutlet.ignorePlaceInput;
   }
 
   // Assigns not only the ID, but also any data attributes of selected row.
   // Data is stored as numbers and floats, not strings.
   assignHiddenId(match) {
-    this.verbose("assignHiddenId()");
+    this.verbose("autocompleter:assignHiddenId()");
     this.verbose(match);
     if (!match) return;
     // Before we change the hidden input, store the old value and data
@@ -972,7 +962,7 @@ export default class extends Controller {
   // Clears not only the ID, but also any data attributes of selected row.
   // Don't remove target data-attributes.
   clearHiddenId() {
-    this.verbose("clearHiddenId()");
+    this.verbose("autocompleter:clearHiddenId()");
     // Before we change the hidden input, store the old value and data
     this.storeCurrentHiddenData();
 
@@ -986,7 +976,7 @@ export default class extends Controller {
   }
 
   storeCurrentHiddenData() {
-    this.verbose("storeCurrentHiddenData()");
+    this.verbose("autocompleter:storeCurrentHiddenData()");
     this.stored_id = parseInt(this.hiddenTarget.value); // value is a string
     let { north, south, east, west } = this.hiddenTarget.dataset;
     this.stored_data = { id: this.stored_id, north, south, east, west };
@@ -1000,14 +990,14 @@ export default class extends Controller {
       { north, south, east, west } = this.hiddenTarget.dataset,
       hidden_data = { id: hidden_id, north, south, east, west };
 
-    this.verbose("hidden_data: " + JSON.stringify(hidden_data));
+    this.verbose("autocompleter:hidden_data: " + JSON.stringify(hidden_data));
     // comparing data, not just ids, because google locations have same -1 id
     if (JSON.stringify(hidden_data) == JSON.stringify(this.stored_data)) {
-      this.verbose("not dispatching hiddenIdDataChanged");
+      this.verbose("autocompleter: not dispatching hiddenIdDataChanged");
     } else {
       clearTimeout(this.data_timer);
       this.data_timer = setTimeout(() => {
-        this.verbose("dispatching hiddenIdDataChanged");
+        this.verbose("autocompleter: dispatching hiddenIdDataChanged");
         this.wrapTarget.classList.remove('has-id');
         if (this.hasKeepBtnTarget) {
           this.keepBtnTarget.classList.remove('active');
@@ -1022,14 +1012,14 @@ export default class extends Controller {
 
   // Hide pulldown options.
   hidePulldown() {
-    this.verbose("hidePulldown()");
+    // this.verbose("hidePulldown()");
     this.wrapTarget?.classList?.remove('open');
     this.menu_up = false;
   }
 
   // Update width of pulldown.
   updateWidth() {
-    this.verbose("updateWidth()");
+    // this.verbose("updateWidth()");
     let w = this.listTarget.offsetWidth;
     if (this.matches.length > this.PULLDOWN_SIZE)
       w += this.SCROLLBAR_WIDTH;
@@ -1041,7 +1031,7 @@ export default class extends Controller {
 
   // Set width of pulldown.
   setWidth() {
-    this.verbose("setWidth()");
+    // this.verbose("setWidth()");
     const w1 = this.current_width;
     let w2 = w1;
     if (this.matches.length > this.PULLDOWN_SIZE)
@@ -1057,7 +1047,7 @@ export default class extends Controller {
   // functions maintain the evolving `matches` list based on the user's input.
   // There are four strategies for refining the list, below.
   populateMatches() {
-    this.verbose("populateMatches()");
+    this.verbose("autocompleter:populateMatches()");
 
     // Remember which option used to be highlighted.
     const last = this.current_row < 0 ? null : this.matches[this.current_row];
@@ -1231,7 +1221,7 @@ export default class extends Controller {
   // Look for 'token' in list of matches and highlight it,
   // otherwise highlight first match.
   updateCurrentRow(token) {
-    this.verbose("updateCurrentRow()");
+    this.verbose("autocompleter:updateCurrentRow()");
     const matches = this.matches,
       size = this.PULLDOWN_SIZE;
     let exact = -1,
@@ -1338,7 +1328,7 @@ export default class extends Controller {
 
   // Send request for updated primer.
   refreshPrimer() {
-    this.verbose("refreshPrimer()");
+    this.verbose("autocompleter:refreshPrimer()");
 
     // token may be refined within this function, so it's a variable.
     let token = this.getSearchToken().toLowerCase(),
@@ -1350,7 +1340,7 @@ export default class extends Controller {
     // selection already made in act_like_select.
     if (!this.ACT_LIKE_SELECT &&
       (last_request == token || (!token || token.length < 1))) {
-      this.verbose("same request, bailing");
+      this.verbose("autocompleter: same request, bailing");
       return;
     }
 
@@ -1365,7 +1355,7 @@ export default class extends Controller {
     if (!this.last_fetch_incomplete &&
       last_request && (last_request.length > 0) &&
       new_val_refines_last_request) {
-      this.verbose("got all results last time, bailing");
+      this.verbose("autocompleter: got all results last time, bailing");
       return;
     }
 
@@ -1373,7 +1363,7 @@ export default class extends Controller {
     // refining the request, just in case it returns complete results
     // (rendering the more refined request unnecessary).
     if (this.fetch_request && new_val_refines_last_request) {
-      this.verbose("request pending, bailing");
+      this.verbose("autocompleter: request pending, bailing");
       return;
     }
 
@@ -1395,7 +1385,7 @@ export default class extends Controller {
     const { string, ...new_params } = query_params;
     if (this.last_fetch_params && this.ACT_LIKE_SELECT &&
       (JSON.stringify(new_params) === this.last_fetch_params)) {
-      this.verbose("params haven't changed, bailing");
+      this.verbose("autocompleter: params haven't changed, bailing");
       this.verbose(new_params)
       return;
     }
@@ -1406,7 +1396,7 @@ export default class extends Controller {
 
   // Send fetch request for more matching strings.
   async sendFetchRequest(query_params) {
-    this.verbose("sendFetchRequest()");
+    this.verbose("autocompleter:sendFetchRequest()");
     this.verbose(query_params);
 
     if (this.log) {
@@ -1457,7 +1447,7 @@ export default class extends Controller {
   // token as it is typed out. The pulldown menu is populated with the matches.
   //
   processFetchResponse(new_primer) {
-    this.verbose("processFetchResponse()");
+    this.verbose("autocompleter:processFetchResponse()");
 
     // Clear flag telling us request is pending.
     this.fetch_request = null;
@@ -1487,7 +1477,7 @@ export default class extends Controller {
         (this.last_fetch_incomplete ? "incomplete" : "complete") + ").");
     }
 
-    this.verbose("new_primer length:" + new_primer.length)
+    this.verbose("autocompleter:new_primer length:" + new_primer.length)
     if (new_primer.length === 0) {
       // this.has_create_link = true;
       // this.primer = [{ name: this.create_text, id: 0 }];

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -1,0 +1,422 @@
+import { Controller } from "@hotwired/stimulus"
+import { Loader } from "@googlemaps/js-api-loader"
+import { convert } from "geo-coordinates-parser"
+
+// Connects to data-controller="geocode"
+// The connected element should contain a location autocompleter and
+// bounding box/elevation inputs.
+export default class extends Controller {
+  static targets = ["southInput", "westInput", "northInput", "eastInput",
+    "highInput", "lowInput", "placeInput", "locationId",
+    "latInput", "lngInput", "altInput", "getElevation"]
+
+  connect() {
+    this.element.dataset.stimulus = "connected"
+
+    // These private vars are for keeping track of user inputs to a form
+    // that should update the form after a timeout.
+    this.old_location = null
+    this.autocomplete_buffer = 0
+    this.geolocate_buffer = 0
+    this.ignorePlaceInput = false
+    this.lastGeocodedLatLng = { lat: null, lng: null }
+    this.lastGeolocatedAddress = ""
+
+    const loader = new Loader({
+      apiKey: "AIzaSyCxT5WScc3b99_2h2Qfy5SX6sTnE1CX3FA",
+      version: "quarterly",
+      libraries: ["maps", "geocoding", "marker", "elevation"]
+    })
+
+    loader
+      .load()
+      .then((google) => {
+        this.elevationService = new google.maps.ElevationService()
+        this.geocoder = new google.maps.Geocoder()
+        // Everything except the obs form map: draw the map.
+        if (!(this.map_type === "observation" && this.editable)) {
+          this.drawMap()
+          this.buildOverlays()
+        }
+      })
+      .catch((e) => {
+        console.error("error loading gmaps: " + e)
+      })
+  }
+
+  // Geocode a lat/lng location. If we have multiple results, we'll dispatch
+  // Send the location from validateLatLngInputs(false) to avoid duplicate calls
+  geocodeLatLng(location) {
+    if (JSON.stringify(location) == JSON.stringify(this.lastGeocodedLatLng))
+      return
+
+    this.lastGeocodedLatLng = location
+    this.verbose("geocodeLatLng(location)")
+    this.verbose(location)
+    this.geocoder
+      .geocode({ location: location })
+      .then((result) => {
+        let { results } = result // destructure, results is part of the result
+        results = this.siftResults(results)
+        this.ignorePlaceInput = true
+        this.dispatchPrimer(results)
+        this.respondToGeocode(results)
+      })
+      .catch((e) => {
+        console.log("Geocode was not successful: " + e)
+        // alert("Geocode was not successful for the following reason: " + e)
+      });
+  }
+
+  // Remove certain types of results from the geocoder response:
+  // both too precise and too general.
+  siftResults(results) {
+    this.verbose("siftResults")
+    if (results.length == 0) return results
+    const _skip_types = ["plus_code", "establishment", "premise",
+      "subpremise", "point_of_interest", "street_address", "street_number",
+      "route", "postal_code", "country"]
+    let sifted = []
+    results.forEach((result) => {
+      if (!_skip_types.some(t => result.types.includes(t))) {
+        sifted.push(result)
+      }
+    })
+    return sifted
+  }
+
+  // Build a primer for the autocompleter with bounding box data, but -1 id
+  dispatchPrimer(results) {
+    this.verbose("dispatchPrimer")
+    let north, south, east, west, name, id = -1
+
+    // Prefer geometry.bounds, but bounds do not exist for point locations.
+    // MO locations must be boxes, so use viewport if bounds null.
+    // Viewport should exist on all results. The box is editable, after all.
+    const primer = results.map((result) => {
+      if (result.geometry?.bounds) {
+        ({ north, south, east, west } = result.geometry.bounds.toJSON())
+      } else {
+        ({ north, south, east, west } = result.geometry.viewport.toJSON())
+      }
+      name = this.formatMOPlaceName(result)
+      return { name, north, south, east, west, id }
+    })
+    this.dispatch("googlePrimer", { detail: { primer } })
+  }
+
+  // Format the address components for MO style.
+  formatMOPlaceName(result) {
+    let name_components = [], usa_location = false
+    result.address_components.forEach((component) => {
+      if (component.types.includes("country") && component.short_name == "US") {
+        // MO uses "USA" for US
+        usa_location = true
+        name_components.push("USA")
+      } else if (component.types.includes("administrative_area_level_2") &&
+        component.long_name.includes("County")) {
+        // MO uses "Co." for County
+        name_components.push(component.long_name.replace("County", "Co."))
+      } else if (component.types.includes("postal_code")) {
+        // skip it for all. non-US countries it's an important differentiator?
+      } else {
+        name_components.push(component.long_name)
+      }
+    })
+    if (this.location_format == "scientific") {
+      name_components.reverse()
+    }
+    return name_components.join(", ")
+  }
+
+  geolocatePlaceName(multiple = false) {
+    let address = this.placeInputTarget.value
+    if (address === this.lastGeolocatedAddress) return
+
+    this.lastGeolocatedAddress = address
+    this.verbose("geolocatePlaceName(address)")
+    this.verbose(address)
+    if (this.location_format == "scientific") {
+      address = address.split(/, */).reverse().join(", ")
+    }
+    this.geocoder
+      .geocode({ address: address })
+      .then((result) => {
+        const { results } = result // destructure, results is part of the result
+        this.dispatchPrimer(results) // will be ignored by non-autocompleters
+        this.respondToGeocode(results)
+      })
+      .catch((e) => {
+        console.log("Geocode was not successful: " + e)
+        // alert("Geocode was not successful for the following reason: " + e)
+      });
+  }
+
+  // Called from the geocoder response, to update the map and inputs. If
+  // geolocating a string, this only grabs the first result. If geocoding a
+  // lat/lng, there may be several. NOTE: SETS LAT/LNG INPUTS if observation.
+  // https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingResponses
+  respondToGeocode(results) {
+    if (results.length == 0) return false
+
+    this.verbose("respondToGeocode, map_type: " + this.map_type)
+
+    const viewport = results[0].geometry.viewport.toJSON()
+    const extents = results[0].geometry.bounds?.toJSON() // may not exist
+    const center = results[0].geometry.location.toJSON()
+
+    if (viewport)
+      this.map.fitBounds(viewport)
+    if (this.map)
+      this.placeClosestRectangle(viewport, extents)
+    this.updateFields(viewport, extents, center)
+    // this.showBoxBtnTarget.disabled = false
+  }
+
+  // NOTE: Second branch of conditional is for map controller
+  updateFields(viewport, extents, center) {
+    this.verbose("updateFields")
+    let points = [], type = "" // for elevation
+    if (this.hasNorthInputTarget) {
+      // Prefer extents for rectangle, fallback to viewport
+      let bounds = extents || viewport
+      if (bounds != undefined && bounds?.north) {
+        this.updateBoundsInputs(bounds)
+        points = this.sampleElevationPointsOf(bounds)
+      }
+      // else if (center) {
+      //   this.updateBoundsInputs(this.boundsOfPoint(center))
+      //   points = [center] // this.sampleElevationCenterOf(center)
+      // }
+      type = "rectangle"
+    } else if (this.hasLatInputTarget) {
+      if (center != undefined && center?.lat) {
+        this.updateLatLngInputs(center)
+        points = [center] // this.sampleElevationCenterOf(center)
+      }
+      type = "point"
+    }
+    if (points && type)
+      this.getElevations(points, type) // updates inputs
+  }
+
+  // Action can be attached to the "Get Elevation" button.
+  // `points` is then the event
+  getElevations(points, type = "") {
+    this.verbose("getElevations")
+    // "Get Elevation" button on a form sends this param
+    if (this.hasGetElevationTarget &&
+      points.hasOwnProperty('params') && points.params?.points === "input") {
+      points = this.sampleElevationPoints() // from marker or rectangle
+      type = points.params?.type
+    }
+
+    const locationElevationRequest = { locations: points }
+
+    this.elevationService.getElevationForLocations(locationElevationRequest,
+      (results, status) => {
+        if (status === google.maps.ElevationStatus.OK) {
+          if (results[0]) {
+            this.updateElevationInputs(results, type)
+          } else {
+            console.log({ status })
+          }
+        }
+      })
+  }
+
+  // defined in the map controller
+  sampleElevationPoints() {
+  }
+
+  // defined in the map controller
+  placeClosestRectangle(viewport, extents) {
+  }
+
+  // Computes an array of arrays of [lat, lng] from a set of bounds on the fly
+  // Returns array of Google Map points {lat:, lng:} LatLngLiteral objects
+  sampleElevationPointsOf(bounds) {
+    return [
+      { lat: bounds?.south, lng: bounds?.west },
+      { lat: bounds?.north, lng: bounds?.west },
+      { lat: bounds?.north, lng: bounds?.east },
+      { lat: bounds?.south, lng: bounds?.east },
+      this.centerFromBounds(bounds)
+    ]
+  }
+
+  // takes a LatLngBoundsLiteral object {south:, west:, north:, east:}
+  updateBoundsInputs(bounds) {
+    if (!this.hasSouthInputTarget) return false
+
+    this.verbose("updateBoundsInputs")
+    this.southInputTarget.value = this.roundOff(bounds?.south)
+    this.westInputTarget.value = this.roundOff(bounds?.west)
+    this.northInputTarget.value = this.roundOff(bounds?.north)
+    this.eastInputTarget.value = this.roundOff(bounds?.east)
+  }
+
+  // requires an array of results from this.getElevations(points, type) above
+  //   result objects have the form {elevation:, location:, resolution:}
+  updateElevationInputs(results, type) {
+    this.verbose("updateElevationInputs")
+    if (this.hasLowInputTarget && type === "rectangle") {
+      const hiLo = this.highAndLowOf(results)
+      // this.verbose({ hiLo })
+      this.lowInputTarget.value = this.roundOff(parseFloat(hiLo.low))
+      this.highInputTarget.value = this.roundOff(parseFloat(hiLo.high))
+    }
+    if (this.hasAltInputTarget && type === "point") {
+      // should just need one result
+      this.altInputTarget.value =
+        this.roundOff(parseFloat(results[0].elevation))
+    }
+    if (this.hasGetElevationTarget)
+      this.getElevationTarget.disabled = true
+  }
+
+  // Convert from human readable and do a rough check if they make sense
+  validateLatLngInputs(update = false) {
+    if (!this.hasLatInputTarget || !this.hasLngInputTarget ||
+      !this.latInputTarget.value || !this.lngInputTarget.value)
+      return false
+
+    const origLat = this.latInputTarget.value,
+      origLng = this.lngInputTarget.value
+    let lat, lng
+
+    try {
+      let coords = convert(origLat + " " + origLng)
+      lat = coords.decimalLatitude,
+        lng = coords.decimalLongitude
+    }
+    // Toss any degree-minute-second notation and just take the first number
+    catch {
+      lat = parseFloat(origLat)
+      lng = parseFloat(origLng)
+    }
+
+    if (!lat || !lng)
+      return false
+    if (lat > 90 || lat < -90 || lng > 180 || lng < -180)
+      return false
+    const location = { lat: lat, lng: lng }
+
+    if (update) this.updateLatLngInputs(location)
+    return location
+  }
+
+  // For reference:
+  // This is the regex used on the Ruby side to convert degree-minute-second
+  // geocoordinates to decimal degrees when saving raw values to db:
+  // lxxxitudeRegex() {
+  //   /^\s*(-?\d+(?:\.\d+)?)\s*(?:°|°|o|d|deg|,\s)?\s*(?:(?<![\d.])(\d+(?:\.\d+)?)\s*(?:'|‘|’|′|′|m|min)?\s*)?(?:(?<![\d.])(\d+(?:\.\d+)?)\s*(?:"|“|”|″|″|s|sec)?\s*)?([NSEW]?)\s*$/i
+  // }
+
+  // Update inputs with a point's location from map UI
+  updateLatLngInputs(center) {
+    // This is like toFixed(5), but faster and returns a number
+    this.latInputTarget.value = this.roundOff(center.lat)
+    this.lngInputTarget.value = this.roundOff(center.lng)
+    // If we're here, we have a lat and a lng.
+    if (this.ignorePlaceInput !== false)
+      this.dispatchPointChanged(center)
+  }
+
+  // Call the swap event on the autocompleter and send the type we need
+  dispatchPointChanged({ lat, lng }) {
+    this.clearAutocompleterSwapBuffer()
+
+    if (lat && lng) {
+      this.autocomplete_buffer = setTimeout(() => {
+        this.dispatch("pointChanged", {
+          detail: {
+            type: "location_containing",
+            request_params: { lat, lng },
+          }
+        })
+        // this.verbose("dispatchPointChanged")
+      }, 1000)
+
+      // if (this.placeInputTarget.value === '') {
+      //   this.geocoder.geocode({ location: center }, (results, status) => {
+      //     if (status === "OK") {
+      //       if (results[0]) {
+      //         this.placeInputTarget.value = results[0].formatted_address
+      //       }
+      //     }
+      //   })
+      // }
+    } else {
+      this.autocomplete_buffer = setTimeout(() => {
+        this.dispatch("pointChanged", { detail: { type: "location" } })
+      }, 1000)
+    }
+  }
+
+  // Sorts the LocationElevationResponse.results.elevation objects and
+  // computes the high and low of these results using bounds and center
+  highAndLowOf(results) {
+    let altitudesArray = results.map((result) => {
+      return result.elevation
+    }).sort((a, b) => { return a - b })
+    const last = altitudesArray.length - 1
+    return { high: altitudesArray[last], low: altitudesArray[0] }
+  }
+
+  // Round to 4 decimal places
+  roundOff(number) {
+    const rounded = Math.round(number * 10000) / 10000
+    return rounded
+  }
+
+  // Fetches a location from the MO API and maps the bounds
+  // async fetchMOLocation(id) {
+  //   if (!id) return
+
+  //   const url = this.LOCATION_API_URL + id,
+  //     response = await get(url, {
+  //       query: { detail: "low" },
+  //       responseKind: "json"
+  //     })
+
+  //   if (response.ok) {
+  //     const json = await response.json
+  //     if (json) {
+  //       // this.verbose(json)
+  //       this.mapLocationBounds(json)
+  //     }
+  //   } else {
+  //     this.verbose(`got a ${response.status}: ${response.text}`);
+  //   }
+  // }
+
+  // Attributes are particular to the MO API response,
+  // note they are different from the Location db column names.
+  // mapLocationBounds(json) {
+  //   if (json.results.length == 0 || !json.results[0].latitude_north)
+  //     return false
+
+  //   const location = json.results[0],
+  //     bounds = {
+  //       north: location.latitude_north,
+  //       south: location.latitude_south,
+  //       east: location.longitude_east,
+  //       west: location.longitude_west
+  //     }
+
+  //   this.placeClosestRectangle(bounds, null)
+  // }
+
+  // ------------------------------- DEBUGGING ------------------------------
+
+  helpDebug() {
+    debugger
+  }
+
+  verbose(str) {
+    // console.log(str);
+    // document.getElementById("log").
+    //   insertAdjacentText("beforeend", str + "<br/>");
+  }
+}

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -184,6 +184,7 @@ export default class extends Controller {
 
     this.verbose("geocode:updatePlaceInputTarget")
     this.placeInputTarget.value = this.formatMOPlaceName(result)
+    this.placeInputTarget.classList.add("geocoded")
   }
 
   // NOTE: Second branch of conditional is for map controller

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,19 +1,16 @@
-import { Controller } from "@hotwired/stimulus"
+import GeocodeController from "geocode_controller.js"
 import { Loader } from "@googlemaps/js-api-loader"
-import { convert } from "geo-coordinates-parser"
-import { get } from '@rails/request.js'
 
 // Connects to data-controller="map"
 // The connected element can be a map, or in the case of a form with a map UI,
 // the whole section of the form including the inputs that should alter the map.
 // Either way, mapDivTarget should have the dataset, not the connected element.
 // map_types: info (collection), location (rectangle), observation (marker)
-export default class extends Controller {
+export default class extends GeocodeController {
   // it may or may not be the root element of the controller.
   static targets = ["mapDiv", "southInput", "westInput", "northInput",
     "eastInput", "highInput", "lowInput", "placeInput", "locationId",
     "getElevation", "mapClearBtn", "controlWrap", "toggleMapBtn",
-    // "showPointBtn",
     "latInput", "lngInput", "altInput", "showBoxBtn", "lockBoxBtn"]
 
   connect() {
@@ -365,9 +362,6 @@ export default class extends Controller {
     }
   }
 
-  trackingLatLngInputs() {
-  }
-
   clearAutocompleterSwapBuffer() {
     if (this.ac_buffer) {
       clearTimeout(this.ac_buffer)
@@ -432,209 +426,6 @@ export default class extends Controller {
     this.placeClosestRectangle(bounds, null)
   }
 
-  // Geocode a lat/lng location. If we have multiple results, we'll dispatch
-  // Send the location from validateLatLngInputs(false) to avoid duplicate calls
-  geocodeLatLng(location) {
-    if (JSON.stringify(location) == JSON.stringify(this.lastGeocodedLatLng))
-      return
-
-    this.lastGeocodedLatLng = location
-    this.verbose("geocodeLatLng(location)")
-    this.verbose(location)
-    this.geocoder
-      .geocode({ location: location })
-      .then((result) => {
-        let { results } = result // destructure, results is part of the result
-        results = this.siftResults(results)
-        this.ignorePlaceInput = true
-        this.dispatchPrimer(results)
-        this.respondToGeocode(results)
-      })
-      .catch((e) => {
-        console.log("Geocode was not successful: " + e)
-        // alert("Geocode was not successful for the following reason: " + e)
-      });
-  }
-
-  // Remove certain types of results from the geocoder response:
-  // both too precise and too general.
-  siftResults(results) {
-    this.verbose("siftResults")
-    if (results.length == 0) return results
-    const _skip_types = ["plus_code", "establishment", "premise",
-      "subpremise", "point_of_interest", "street_address", "street_number",
-      "route", "postal_code", "country"]
-    let sifted = []
-    results.forEach((result) => {
-      if (!_skip_types.some(t => result.types.includes(t))) {
-        sifted.push(result)
-      }
-    })
-    return sifted
-  }
-
-  // Build a primer for the autocompleter with bounding box data, but -1 id
-  dispatchPrimer(results) {
-    this.verbose("dispatchPrimer")
-    let north, south, east, west, name, id = -1
-
-    // Prefer geometry.bounds, but bounds do not exist for point locations.
-    // MO locations must be boxes, so use viewport if bounds null.
-    // Viewport should exist on all results. The box is editable, after all.
-    const primer = results.map((result) => {
-      if (result.geometry?.bounds) {
-        ({ north, south, east, west } = result.geometry.bounds.toJSON())
-      } else {
-        ({ north, south, east, west } = result.geometry.viewport.toJSON())
-      }
-      name = this.formatMOPlaceName(result)
-      return { name, north, south, east, west, id }
-    })
-    this.dispatch("googlePrimer", { detail: { primer } })
-  }
-
-  // Format the address components for MO style.
-  formatMOPlaceName(result) {
-    let name_components = [], usa_location = false
-    result.address_components.forEach((component) => {
-      if (component.types.includes("country") && component.short_name == "US") {
-        // MO uses "USA" for US
-        usa_location = true
-        name_components.push("USA")
-      } else if (component.types.includes("administrative_area_level_2") &&
-        component.long_name.includes("County")) {
-        // MO uses "Co." for County
-        name_components.push(component.long_name.replace("County", "Co."))
-      } else if (component.types.includes("postal_code")) {
-        // skip it for all. non-US countries it's an important differentiator?
-      } else {
-        name_components.push(component.long_name)
-      }
-    })
-    if (this.location_format == "scientific") {
-      name_components.reverse()
-    }
-    return name_components.join(", ")
-  }
-
-  geolocatePlaceName(multiple = false) {
-    let address = this.placeInputTarget.value
-    if (address === this.lastGeolocatedAddress) return
-
-    this.lastGeolocatedAddress = address
-    this.verbose("geolocatePlaceName(address)")
-    this.verbose(address)
-    if (this.location_format == "scientific") {
-      address = address.split(/, */).reverse().join(", ")
-    }
-    this.geocoder
-      .geocode({ address: address })
-      .then((result) => {
-        const { results } = result // destructure, results is part of the result
-        this.dispatchPrimer(results) // will be ignored by non-autocompleters
-        this.respondToGeocode(results)
-      })
-      .catch((e) => {
-        console.log("Geocode was not successful: " + e)
-        // alert("Geocode was not successful for the following reason: " + e)
-      });
-  }
-
-  // Called from the geocoder response, to update the map and inputs. If
-  // geolocating a string, this only grabs the first result. If geocoding a
-  // lat/lng, there may be several. NOTE: SETS LAT/LNG INPUTS if observation.
-  // https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingResponses
-  respondToGeocode(results) {
-    if (results.length == 0) return false
-
-    this.verbose("respondToGeocode, map_type: " + this.map_type)
-
-    const viewport = results[0].geometry.viewport.toJSON()
-    const extents = results[0].geometry.bounds?.toJSON() // may not exist
-    const center = results[0].geometry.location.toJSON()
-
-    if (viewport)
-      this.map.fitBounds(viewport)
-    // if (["observation", "hybrid"].includes(this.map_type)) {
-    //   // this.placeMarker(center)
-    //   this.placeClosestRectangle(viewport, extents)
-    // } else if (this.map_type === "location") {
-    // }
-    this.placeClosestRectangle(viewport, extents)
-    this.updateFields(viewport, extents, center)
-    // this.showBoxBtnTarget.disabled = false
-  }
-
-  // NOTE: Currently we're not going to allow Google API geocoded places that
-  // are returned as points to be locations. We're forcing them to be rectangles
-  updateFields(viewport, extents, center) {
-    this.verbose("updateFields")
-    let points = [], type = "" // for elevation
-    if (this.hasNorthInputTarget) {
-      // Prefer extents for rectangle, fallback to viewport
-      let bounds = extents || viewport
-      if (bounds != undefined && bounds?.north) {
-        this.updateBoundsInputs(bounds)
-        points = this.sampleElevationPointsOf(bounds)
-      }
-      // else if (center) {
-      //   this.updateBoundsInputs(this.boundsOfPoint(center))
-      //   points = [center] // this.sampleElevationCenterOf(center)
-      // }
-      type = "rectangle"
-    } else if (this.hasLatInputTarget) {
-      if (center != undefined && center?.lat) {
-        this.updateLatLngInputs(center)
-        points = [center] // this.sampleElevationCenterOf(center)
-      }
-      type = "point"
-    }
-    if (points && type)
-      this.getElevations(points, type) // updates inputs
-  }
-
-  // Action attached to the "Get Elevation" button. (points is then the event)
-  getElevations(points, type = "") {
-    this.verbose("getElevations")
-    // "Get Elevation" button on a form sends this param
-    if (points.hasOwnProperty('params') && points.params?.points === "input") {
-      points = this.sampleElevationPoints() // from marker or rectangle
-      type = points.params?.type
-    }
-
-    const locationElevationRequest = { locations: points }
-
-    this.elevationService.getElevationForLocations(locationElevationRequest,
-      (results, status) => {
-        if (status === google.maps.ElevationStatus.OK) {
-          if (results[0]) {
-            this.updateElevationInputs(results, type)
-          } else {
-            console.log({ status })
-          }
-        }
-      })
-  }
-
-  // requires an array of results from this.getElevations(points, type) above
-  //   result objects have the form {elevation:, location:, resolution:}
-  updateElevationInputs(results, type) {
-    this.verbose("updateElevationInputs")
-    if (this.hasLowInputTarget && type === "rectangle") {
-      const hiLo = this.highAndLowOf(results)
-      // this.verbose({ hiLo })
-      this.lowInputTarget.value = this.roundOff(parseFloat(hiLo.low))
-      this.highInputTarget.value = this.roundOff(parseFloat(hiLo.high))
-    }
-    if (this.hasAltInputTarget && type === "point") {
-      // should just need one result
-      this.altInputTarget.value =
-        this.roundOff(parseFloat(results[0].elevation))
-    }
-    if (this.hasGetElevationTarget)
-      this.getElevationTarget.disabled = true
-  }
-
   //
   //  LOCATION FORM
   //
@@ -670,17 +461,6 @@ export default class extends Controller {
     // }
   }
 
-  // takes a LatLngBoundsLiteral object {south:, west:, north:, east:}
-  updateBoundsInputs(bounds) {
-    if (!this.hasSouthInputTarget) return false
-
-    this.verbose("updateBoundsInputs")
-    this.southInputTarget.value = this.roundOff(bounds?.south)
-    this.westInputTarget.value = this.roundOff(bounds?.west)
-    this.northInputTarget.value = this.roundOff(bounds?.north)
-    this.eastInputTarget.value = this.roundOff(bounds?.east)
-  }
-
   //
   //  OBSERVATION FORM
   //
@@ -714,85 +494,6 @@ export default class extends Controller {
       this.placeMarker(location)
       this.map.setCenter(location)
       this.map.setZoom(9)
-    }
-  }
-
-  // Convert from human readable and do a rough check if they make sense
-  validateLatLngInputs(update = false) {
-    if (!this.hasLatInputTarget || !this.hasLngInputTarget ||
-      !this.latInputTarget.value || !this.lngInputTarget.value)
-      return false
-
-    const origLat = this.latInputTarget.value,
-      origLng = this.lngInputTarget.value
-    let lat, lng
-
-    try {
-      let coords = convert(origLat + " " + origLng)
-      lat = coords.decimalLatitude,
-        lng = coords.decimalLongitude
-    }
-    // Toss any degree-minute-second notation and just take the first number
-    catch {
-      lat = parseFloat(origLat)
-      lng = parseFloat(origLng)
-    }
-
-    if (!lat || !lng)
-      return false
-    if (lat > 90 || lat < -90 || lng > 180 || lng < -180)
-      return false
-    const location = { lat: lat, lng: lng }
-
-    if (update) this.updateLatLngInputs(location)
-    return location
-  }
-
-  // For reference:
-  // This is the regex used on the Ruby side to convert degree-minute-second
-  // geocoordinates to decimal degrees when saving raw values to db:
-  // lxxxitudeRegex() {
-  //   /^\s*(-?\d+(?:\.\d+)?)\s*(?:°|°|o|d|deg|,\s)?\s*(?:(?<![\d.])(\d+(?:\.\d+)?)\s*(?:'|‘|’|′|′|m|min)?\s*)?(?:(?<![\d.])(\d+(?:\.\d+)?)\s*(?:"|“|”|″|″|s|sec)?\s*)?([NSEW]?)\s*$/i
-  // }
-
-  // Update inputs with a point's location from map UI
-  updateLatLngInputs(center) {
-    // This is like toFixed(5), but faster and returns a number
-    this.latInputTarget.value = this.roundOff(center.lat)
-    this.lngInputTarget.value = this.roundOff(center.lng)
-    // If we're here, we have a lat and a lng.
-    if (this.ignorePlaceInput !== false)
-      this.dispatchPointChanged(center)
-  }
-
-  // Call the swap event on the autocompleter and send the type we need
-  dispatchPointChanged({ lat, lng }) {
-    this.clearAutocompleterSwapBuffer()
-
-    if (lat && lng) {
-      this.ac_buffer = setTimeout(() => {
-        this.dispatch("pointChanged", {
-          detail: {
-            type: "location_containing",
-            request_params: { lat, lng },
-          }
-        })
-        // this.verbose("dispatchPointChanged")
-      }, 1000)
-
-      // if (this.placeInputTarget.value === '') {
-      //   this.geocoder.geocode({ location: center }, (results, status) => {
-      //     if (status === "OK") {
-      //       if (results[0]) {
-      //         this.placeInputTarget.value = results[0].formatted_address
-      //       }
-      //     }
-      //   })
-      // }
-    } else {
-      this.ac_buffer = setTimeout(() => {
-        this.dispatch("pointChanged", { detail: { type: "location" } })
-      }, 1000)
     }
   }
 
@@ -929,83 +630,5 @@ export default class extends Controller {
       points = this.sampleElevationPointsOf(bounds)
     }
     return points
-  }
-
-  // Computes an array of arrays of [lat, lng] from a set of bounds on the fly
-  // Returns array of Google Map points {lat:, lng:} LatLngLiteral objects
-  sampleElevationPointsOf(bounds) {
-    return [
-      { lat: bounds?.south, lng: bounds?.west },
-      { lat: bounds?.north, lng: bounds?.west },
-      { lat: bounds?.north, lng: bounds?.east },
-      { lat: bounds?.south, lng: bounds?.east },
-      this.centerFromBounds(bounds)
-    ]
-  }
-
-  // Sorts the LocationElevationResponse.results.elevation objects and
-  // computes the high and low of these results using bounds and center
-  highAndLowOf(results) {
-    let altitudesArray = results.map((result) => {
-      return result.elevation
-    }).sort((a, b) => { return a - b })
-    const last = altitudesArray.length - 1
-    return { high: altitudesArray[last], low: altitudesArray[0] }
-  }
-
-  // Round to 4 decimal places
-  roundOff(number) {
-    const rounded = Math.round(number * 10000) / 10000
-    return rounded
-  }
-
-  // Fetches a location from the MO API and maps the bounds
-  // async fetchMOLocation(id) {
-  //   if (!id) return
-
-  //   const url = this.LOCATION_API_URL + id,
-  //     response = await get(url, {
-  //       query: { detail: "low" },
-  //       responseKind: "json"
-  //     })
-
-  //   if (response.ok) {
-  //     const json = await response.json
-  //     if (json) {
-  //       // this.verbose(json)
-  //       this.mapLocationBounds(json)
-  //     }
-  //   } else {
-  //     this.verbose(`got a ${response.status}: ${response.text}`);
-  //   }
-  // }
-
-  // Attributes are particular to the MO API response,
-  // note they are different from the Location db column names.
-  // mapLocationBounds(json) {
-  //   if (json.results.length == 0 || !json.results[0].latitude_north)
-  //     return false
-
-  //   const location = json.results[0],
-  //     bounds = {
-  //       north: location.latitude_north,
-  //       south: location.latitude_south,
-  //       east: location.longitude_east,
-  //       west: location.longitude_west
-  //     }
-
-  //   this.placeClosestRectangle(bounds, null)
-  // }
-
-  // ------------------------------- DEBUGGING ------------------------------
-
-  helpDebug() {
-    debugger
-  }
-
-  verbose(str) {
-    // console.log(str);
-    // document.getElementById("log").
-    //   insertAdjacentText("beforeend", str + "<br/>");
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -160,11 +160,11 @@ export default class extends GeocodeController {
 
   // There may not be a marker yet.
   placeMarker(location) {
-    this.verbose("placeMarker")
+    this.verbose("map:placeMarker")
     if (!this.marker) {
       this.drawMarker(location)
     } else {
-      this.verbose("marker.setPosition")
+      this.verbose("map:marker.setPosition")
       this.marker.setPosition(location)
       this.map.panTo(location)
     }
@@ -172,7 +172,7 @@ export default class extends GeocodeController {
   }
 
   drawMarker(set) {
-    this.verbose("drawMarker")
+    this.verbose("map:drawMarker")
     const markerOptions = {
       position: { lat: set.lat, lng: set.lng },
       map: this.map,
@@ -198,7 +198,7 @@ export default class extends GeocodeController {
   makeMarkerEditable() {
     if (!this.marker) return
 
-    this.verbose("makeMarkerEditable")
+    this.verbose("map:makeMarkerEditable")
     // clearTimeout(this.marker_edit_buffer)
     // this.marker_edit_buffer = setTimeout(() => {
     const events = ["position_changed", "dragend"]
@@ -231,7 +231,7 @@ export default class extends GeocodeController {
 
   // For point markers: make a clickable InfoWindow
   giveMarkerInfoWindow(set) {
-    this.verbose("giveMarkerInfoWindow")
+    this.verbose("map:giveMarkerInfoWindow")
     const info_window = new google.maps.InfoWindow({
       content: set.caption
     })
@@ -248,7 +248,7 @@ export default class extends GeocodeController {
   //
 
   placeRectangle(extents) {
-    this.verbose("placeRectangle()")
+    this.verbose("map:placeRectangle()")
     this.verbose(extents)
     if (!this.rectangle) {
       this.drawRectangle(extents)
@@ -262,7 +262,7 @@ export default class extends GeocodeController {
   }
 
   drawRectangle(set) {
-    this.verbose("drawRectangle()")
+    this.verbose("map:drawRectangle()")
     this.verbose(set)
     const bounds = this.boundsOf(set),
       editable = this.editable && this.map_type !== "observation",
@@ -296,7 +296,7 @@ export default class extends GeocodeController {
   // listen to "dragstart", "drag" ? not necessary). If we're just switching to
   // location mode, we need a buffer or it's too fast
   makeRectangleEditable() {
-    this.verbose("makeRectangleEditable")
+    this.verbose("map:makeRectangleEditable")
     // clearTimeout(this.rectangle_buffer)
     // this.rectangle_buffer = setTimeout(() => {
     const events = ["bounds_changed", "dragend"]
@@ -315,7 +315,7 @@ export default class extends GeocodeController {
   // For rectangles: make a clickable info window
   // https://stackoverflow.com/questions/26171285/googlemaps-api-rectangle-and-infowindow-coupling-issue
   giveRectangleInfoWindow(set) {
-    this.verbose("giveRectangleInfoWindow")
+    this.verbose("map:giveRectangleInfoWindow")
     const center = this.rectangle.getBounds().getCenter()
     const info_window = new google.maps.InfoWindow({
       content: set.caption,
@@ -343,7 +343,7 @@ export default class extends GeocodeController {
       }
     }
     if (["observation", "hybrid"].includes(this.map_type)) {
-      // this.verbose("pointChanged")
+      // this.verbose("map:pointChanged")
       // If they just cleared the inputs, swap back to a location autocompleter
       const center = this.validateLatLngInputs(false)
       if (!center) return
@@ -384,7 +384,7 @@ export default class extends GeocodeController {
       !this.hasPlaceInputTarget || !this.placeInputTarget.value)
       return false
 
-    this.verbose("showBox")
+    this.verbose("map:showBox")
     // buffer inputs if they're still typing
     clearTimeout(this.marker_draw_buffer)
     this.marker_draw_buffer = setTimeout(this.checkForBox(), 1000)
@@ -393,7 +393,7 @@ export default class extends GeocodeController {
   // Check what kind of input we have and call the appropriate function
   checkForBox() {
     // this.showBoxBtnTarget.disabled = true
-    this.verbose("checkForBox")
+    this.verbose("map:checkForBox")
     let id, location
     if (this.hasLocationIdTarget && (id = this.locationIdTarget.value)) {
       this.mapLocationBounds()
@@ -438,7 +438,7 @@ export default class extends GeocodeController {
     const west = parseFloat(this.westInputTarget.value)
 
     if (!(isNaN(north) || isNaN(south) || isNaN(east) || isNaN(west))) {
-      this.verbose("calculateRectangle")
+      this.verbose("map:calculateRectangle")
       const bounds = { north: north, south: south, east: east, west: west }
       if (this.rectangle) {
         this.rectangle.setBounds(bounds)
@@ -452,7 +452,7 @@ export default class extends GeocodeController {
     // Prefer extents for rectangle, fallback to viewport
     let bounds = extents || viewport
     if (bounds != undefined && bounds?.north) {
-      this.verbose("placeClosestRectangle")
+      this.verbose("map:placeClosestRectangle")
       this.placeRectangle(bounds)
     }
     // else if (center) {
@@ -479,7 +479,7 @@ export default class extends GeocodeController {
   // so, drops a pin on that location and center. Otherwise, checks if place
   // input has been prepopulated and uses that to focus map and drop a marker.
   calculateMarker(event) {
-    this.verbose("calculateMarker")
+    this.verbose("map:calculateMarker")
     if (this.map == undefined ||
       this.latInputTarget.value === '' || this.lngInputTarget.value === ''
     ) return false
@@ -500,7 +500,7 @@ export default class extends GeocodeController {
   // Action called by the "Open Map" button only.
   // open/close handled by BS collapse
   toggleMap() {
-    // this.verbose("toggleMap")
+    // this.verbose("map:toggleMap")
 
     if (this.opened) {
       this.opened = false
@@ -630,5 +630,17 @@ export default class extends GeocodeController {
       points = this.sampleElevationPointsOf(bounds)
     }
     return points
+  }
+
+  // ------------------------------- DEBUGGING ------------------------------
+
+  helpDebug() {
+    debugger
+  }
+
+  verbose(str) {
+    // console.log(str);
+    // document.getElementById("log").
+    //   insertAdjacentText("beforeend", str + "<br/>");
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,4 +1,4 @@
-import GeocodeController from "geocode_controller.js"
+import GeocodeController from "./geocode_controller.js"
 import { Loader } from "@googlemaps/js-api-loader"
 
 // Connects to data-controller="map"
@@ -39,7 +39,7 @@ export default class extends GeocodeController {
     // that should update the form after a timeout.
     this.old_location = null
     this.marker_draw_buffer = 0
-    this.ac_buffer = 0
+    this.autocomplete_buffer = 0
     this.geolocate_buffer = 0
     this.marker_edit_buffer = 0
     this.rectangle_edit_buffer = 0
@@ -363,9 +363,9 @@ export default class extends GeocodeController {
   }
 
   clearAutocompleterSwapBuffer() {
-    if (this.ac_buffer) {
-      clearTimeout(this.ac_buffer)
-      this.ac_buffer = 0
+    if (this.autocomplete_buffer) {
+      clearTimeout(this.autocomplete_buffer)
+      this.autocomplete_buffer = 0
     }
   }
 

--- a/app/views/controllers/locations/form/_fields.erb
+++ b/app/views/controllers/locations/form/_fields.erb
@@ -4,7 +4,7 @@
   form: f, field: :display_name, value: display_name,
   label: "#{:WHERE.t}:", help: :form_locations_help.t,
   data: { autofocus: true, map_target: "placeInput" },
-  button: :form_locations_find_on_map.t,
+  button: :form_locations_find_on_map.l,
   button_data: { map_target: "showBoxBtn", action: "map#showBox" }
 ) %>
 

--- a/test/system/location_form_system_test.rb
+++ b/test/system/location_form_system_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+class LocationFormSystemTest < ApplicationSystemTestCase
+  def test_format_new_location_name
+    # browser = page.driver.browser
+    rolf = users("rolf")
+    login!(rolf)
+
+    visit("/locations/new")
+    assert_selector("body.locations__new")
+
+    assert_selector("#location_display_name")
+    assert_button(:form_locations_find_on_map.l)
+    # be sure the map is loaded!
+    assert_selector("#map_div div div")
+    fill_in("location_display_name", with: "genohlac gard france")
+    click_button(:form_locations_find_on_map.l)
+
+    assert_selector("#location_display_name.geocoded")
+    assert_field("location_display_name",
+                 with: "Génolhac, Gard, Occitanie, France")
+
+    assert_field("location_north", with: "44.3726")
+    assert_field("location_east", with: "3.985")
+    assert_field("location_south", with: "44.3055")
+    assert_field("location_west", with: "3.9113")
+    assert_field("location_high", with: "1388.2098")
+    assert_field("location_low", with: "287.8201")
+  end
+end


### PR DESCRIPTION
Preparation for using Google place suggestions directly in the fungarium, user profile, species list and project forms, where it would be nice to be able to create a location on the spot (using google data) if MO doesn't have the location yet, but the forms have no maps. 

Splits the geocoding part of the map controller off into its own controller, `geocode_controller.js`. `map_controller.js` now inherits from `geocode_controller.js`, avoiding duplication (you can do that!). `geocode` handles the lookups by name or lat/lng and updating the inputs, `map` handles markers and rectangles on the map, which may also affect input values.

Also, fixes a new bug in Locations form where the correct Google bounding box is returned, but the formatted name is not filled out. Adds a test.

#### Location form:
Fill out the place name with something like a real place. The form should now format the place name MO-style and fill it out in the field for you. Example: type in "richmond virginia", should return "Richmond, Virginia, USA"