### PR TITLE
Fix string comparison in deploy.sh

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -42,7 +42,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ $STASH_RESULT -ne 'No local changes to save' ]; then
+if [ $STASH_RESULT != 'No local changes to save' ]; then
     echo Reapply local changes... && git stash pop
     if [ $? -ne 0 ]; then
 	echo Applying the stashed changes failed.


### PR DESCRIPTION
This should fix the reported error: `script/deploy.sh: line 45: [: too many arguments`