### PR TITLE
Remove system tests from ci

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         env:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        run: bundle exec rails test:all
+        run: bundle exec rails test
 
       # https://github.com/marketplace/actions/coveralls-github-action
       - name: Coveralls GitHub Action

--- a/test/system/location_form_system_test.rb
+++ b/test/system/location_form_system_test.rb
@@ -4,7 +4,6 @@ require("application_system_test_case")
 
 class LocationFormSystemTest < ApplicationSystemTestCase
   def test_format_new_location_name
-    skip("This test is inconsistent when run in CI")
     # browser = page.driver.browser
     rolf = users("rolf")
     login!(rolf)

--- a/test/system/observation_comment_system_test.rb
+++ b/test/system/observation_comment_system_test.rb
@@ -8,7 +8,6 @@ class ObservationCommentSystemTest < ApplicationSystemTestCase
   # Katrina edits the comment, rolf should get the change immediately.
   # Katrina deletes the comment, rolf should get the deletion immediately.
   def test_add_and_edit_comment
-    skip("This test is inconsistent when run in CI")
     rolf = users("rolf")
     katrina = users("katrina")
     obs = observations(:coprinus_comatus_obs)

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -119,7 +119,6 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
   end
 
   def test_autofill_location_from_geotagged_image_nothing_matches
-    skip("This test is inconsistent when run in CI")
     setup_image_dirs # in general_extensions
     login!(katrina)
 
@@ -229,8 +228,6 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
   end
 
   def test_post_edit_and_destroy_with_details_and_location
-    skip("This test is inconsistent when run in CI")
-
     # browser = page.driver.browser
     setup_image_dirs # in general_extensions
 


### PR DESCRIPTION
And un-skip them locally.

The coverage loss here I believe mostly comes from 
- helper methods  
- Turbo branches of form actions in controllers

It's not easy (and not possible, in the second case) to exercise these without front-end tests, currently. 