### PR TITLE
Rename autocompleter arg `hidden` -> `hidden_value`

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -214,7 +214,7 @@ module FormsHelper
       placeholder: :start_typing.l, autocomplete: "off",
       data: { autocompleter_target: "input" }
     }.deep_merge(args.except(:type, :separator, :textarea,
-                             :hidden, :hidden_data, :create_text,
+                             :hidden_value, :hidden_data, :create_text,
                              :keep_text, :edit_text, :find_text))
     ac_args[:class] = class_names("dropdown", args[:class])
     ac_args[:wrap_data] = { controller: :autocompleter, type: args[:type],
@@ -298,7 +298,7 @@ module FormsHelper
 
     model = autocompleter_type_to_model(args[:type])
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
-    args[:form].hidden_field(:"#{model}_id", value: args[:hidden], data:)
+    args[:form].hidden_field(:"#{model}_id", value: args[:hidden_value], data:)
   end
 
   def autocompleter_type_to_model(type)

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -66,7 +66,7 @@ t_s = {
                   tag.span("#{:form_observations_create_locality.l}:",
                            class: "create-label")].safe_join(" "),
           help: observation_location_help,
-          hidden: location&.id,
+          hidden_value: location&.id,
           hidden_data: { map_target: "locationId",
                          north: location&.north, south: location&.south,
                          east: location&.east, west: location&.west },

--- a/app/views/controllers/observations/form/_herbarium_record.html.erb
+++ b/app/views/controllers/observations/form/_herbarium_record.html.erb
@@ -4,7 +4,7 @@
   <% fields_for(:herbarium_record) do |fhr| %>
     <%= autocompleter_field(
       form: fhr, field: :herbarium_name, type: :herbarium,
-      value: @herbarium_name, hidden: @herbarium_id,
+      value: @herbarium_name, hidden_value: @herbarium_id,
       label: "#{:herbarium_record_herbarium_name.t}:",
       help: :form_observations_herbarium_record_help.t
     ) %>


### PR DESCRIPTION
In cases where the autocompleter value can be prefilled and we have the record ID.