### PR TITLE
`map`, `geocode`, `autocompleter` Stimulus refactor from `actions` to `outlets`

### DIFF
--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/AbcSize
+module AutocompleterHelper
+  # MO's autocompleter_field is a text_field that fetches suggestions from the
+  # db for the requested model. (For a textarea, pass textarea: true.)
+  #
+  # The stimulus controller handles keyboard and mouse interactions, does the
+  # fetching, and draws the dropdown menu. `args` allow incoming data attributes
+  # to deep_merge with controller data.
+  #
+  # We attempt to disable browser autocomplete via `autocomplete="off"` — the
+  # W3C standard API, but it has never been honored by Chrome or Safari. Chrome
+  # seems to be in a race to defeat the evolving hacks by developers to disable
+  # inappropriate autocompletes, and Safari is not much better - you just can't
+  # turn their crap off. (documented on SO)
+  #
+  def autocompleter_field(**args)
+    ac_args = {
+      placeholder: :start_typing.l, autocomplete: "off",
+      data: { autocompleter_target: "input" }
+    }.deep_merge(args.except(*autocompleter_outer_args))
+    ac_args[:class] = class_names("dropdown", args[:class])
+    ac_args[:wrap_data] = autocompleter_wrap_data(args)
+    ac_args[:label_after] = autocompleter_label_after(args)
+    ac_args[:label_end] = autocompleter_label_end(args)
+    ac_args[:append] = autocompleter_append(args)
+
+    if args[:textarea] == true
+      text_area_with_label(**ac_args)
+    else
+      text_field_with_label(**ac_args)
+    end
+  end
+
+  # Any arg not on this list gets sent to the text field/area.
+  def autocompleter_outer_args
+    [:wrap_data, :type, :separator, :textarea, :hidden_value, :hidden_data,
+     :create_text, :keep_text, :edit_text, :find_text, :create, :create_path,
+     :map_outlet, :geocode_outlet]
+  end
+
+  def autocompleter_wrap_data(args)
+    {
+      controller: :autocompleter, type: args[:type],
+      separator: args[:separator],
+      autocompleter_map_outlet: args[:map_outlet],
+      autocompleter_geocode_outlet: args[:geocode_outlet],
+      autocompleter_target: "wrap"
+    }.deep_merge(args[:wrap_data] || {})
+  end
+
+  def autocompleter_label_after(args)
+    capture do
+      [
+        autocompleter_has_id_indicator,
+        autocompleter_find_button(args),
+        autocompleter_keep_button(args),
+        autocompleter_hidden_field(**args)
+      ].safe_join
+    end
+  end
+
+  def autocompleter_label_end(args)
+    capture do
+      concat(autocompleter_create_button(args))
+      concat(autocompleter_modal_create_link(args))
+    end
+  end
+
+  def autocompleter_append(args)
+    capture do
+      concat(autocompleter_dropdown)
+      concat(args[:append])
+    end
+  end
+
+  def autocompleter_has_id_indicator
+    link_icon(:check, title: :autocompleter_has_id.l,
+                      class: "ml-3 px-2 text-success has-id-indicator",
+                      data: { autocompleter_target: "hasIdIndicator" })
+  end
+
+  def autocompleter_create_button(args)
+    return if !args[:create_text] || args[:create].present?
+
+    icon_link_to(
+      args[:create_text], "#",
+      icon: :plus, show_text: true, icon_class: "text-primary",
+      name: "create_#{args[:type]}", class: "ml-3 create-button",
+      data: { autocompleter_target: "createBtn",
+              action: "autocompleter#swapCreate:prevent" }
+    )
+  end
+
+  def autocompleter_modal_create_link(args)
+    return unless args[:create_text] && args[:create].present? &&
+                  args[:create_path].present?
+
+    modal_link_to(
+      args[:create], args[:create_text], args[:create_path],
+      icon: :plus, show_text: true, icon_class: "text-primary",
+      name: "create_#{args[:type]}", class: "ml-3 create-link",
+      data: { autocompleter_target: "createBtn" }
+    )
+  end
+
+  def autocompleter_find_button(args)
+    return unless args[:find_text]
+
+    icon_link_to(
+      args[:find_text], "#",
+      icon: :find_on_map, show_text: false, icon_class: "text-primary",
+      name: "find_#{args[:type]}", class: "ml-3 d-none",
+      data: { map_target: "showBoxBtn",
+              action: "map#showBox:prevent" }
+    )
+  end
+
+  def autocompleter_keep_button(args)
+    return unless args[:keep_text]
+
+    icon_link_to(
+      args[:keep_text], "#",
+      icon: :apply, show_text: false, icon_class: "text-primary",
+      active_icon: :edit, active_content: args[:edit_text],
+      name: "keep_#{args[:type]}", class: "ml-3 d-none",
+      data: { autocompleter_target: "keepBtn", map_target: "lockBoxBtn",
+              action: "map#toggleBoxLock:prevent" }
+    )
+  end
+
+  # minimum args :form, :type.
+  # Send :hidden to fill the id, :hidden_data to merge with hidden field data
+  def autocompleter_hidden_field(**args)
+    return unless args[:form].present? && args[:type].present?
+
+    model = autocompleter_type_to_model(args[:type])
+    data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
+    args[:form].hidden_field(:"#{model}_id", value: args[:hidden_value], data:)
+  end
+
+  def autocompleter_type_to_model(type)
+    case type
+    when :region
+      :location
+    when :clade
+      :name
+    else
+      type
+    end
+  end
+
+  def autocompleter_dropdown
+    tag.div(class: "auto_complete dropdown-menu",
+            data: { autocompleter_target: "pulldown",
+                    action: "scroll->autocompleter#scrollList:passive" }) do
+      tag.ul(class: "virtual_list", data: { autocompleter_target: "list" }) do
+        10.times do |i|
+          concat(tag.li(class: "dropdown-item") do
+            link_to("", "#", data: {
+                      row: i, action: "click->autocompleter#selectRow:prevent"
+                    })
+          end)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/AbcSize

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -7,7 +7,6 @@
 # helpers for form tags
 # rubocop:disable Metrics/ModuleLength
 # rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/CyclomaticComplexity
 module FormsHelper
   # Bootstrap submit button
@@ -167,7 +166,7 @@ module FormsHelper
     label_opts = field_label_opts(args)
     label_opts[:class] = class_names(label_opts[:class], args[:label_class])
 
-    tag.div(class: wrap_class, data: wrap_data) do
+    tag.div(class: wrap_class, data: wrap_data, id: args[:wrap_id]) do
       concat(text_label_row(args, label_opts))
       if args[:addon].present? # text addon, not interactive
         concat(tag.div(class: "input-group") do
@@ -222,135 +221,6 @@ module FormsHelper
       concat(tag.div do
         concat(args[:label_end]) if args[:label_end].present?
       end)
-    end
-  end
-
-  # MO's autocompleter_field is a text_field that fetches suggestions from the
-  # db for the requested model. (For a textarea, pass textarea: true.) The
-  # stimulus controller handles keyboard and mouse interactions, does the
-  # fetching, and draws the dropdown menu. `args` allow incoming data attributes
-  # to deep_merge with controller data. We attempt to disable browser
-  # autocomplete via `autocomplete="off"` — the W3C standard API, but it
-  # has never been honored by Chrome or Safari. Chrome seems to be in a race to
-  # defeat the evolving hacks by developers to disable inappropriate
-  # autocompletes, and Safari is not much better - you just can't turn their
-  # crap off. (documented on SO)
-  #
-  def autocompleter_field(**args)
-    ac_args = {
-      placeholder: :start_typing.l, autocomplete: "off",
-      data: { autocompleter_target: "input" }
-    }.deep_merge(args.except(:wrap_data, :type, :separator, :textarea,
-                             :hidden_value, :hidden_data, :create_text,
-                             :keep_text, :edit_text, :find_text))
-    ac_args[:class] = class_names("dropdown", args[:class])
-    ac_args[:wrap_data] = {
-      controller: :autocompleter, type: args[:type],
-      separator: args[:separator],
-      autocompleter_map_outlet: ".map-outlet",
-      autocompleter_geocode_outlet: ".geocode-outlet",
-      autocompleter_target: "wrap"
-    }.deep_merge(args[:wrap_data] || {})
-    ac_args[:label_after] = capture do
-      [
-        autocompleter_has_id_indicator,
-        autocompleter_find_button(args),
-        autocompleter_keep_button(args),
-        autocompleter_hidden_field(**args)
-      ].safe_join
-    end
-    ac_args[:label_end] = capture do
-      autocompleter_create_button(args)
-    end
-    ac_args[:append] = capture do
-      concat(autocompleter_dropdown)
-      concat(args[:append])
-    end
-
-    if args[:textarea] == true
-      text_area_with_label(**ac_args)
-    else
-      text_field_with_label(**ac_args)
-    end
-  end
-
-  def autocompleter_has_id_indicator
-    link_icon(:check, title: :autocompleter_has_id.l,
-                      class: "ml-3 px-2 text-success has-id-indicator",
-                      data: { autocompleter_target: "hasIdIndicator" })
-  end
-
-  def autocompleter_create_button(args)
-    return unless args[:create_text]
-
-    icon_link_to(
-      args[:create_text], "#",
-      icon: :plus, show_text: true, icon_class: "text-primary",
-      name: "create_#{args[:type]}", class: "ml-3 create-button",
-      data: { autocompleter_target: "createBtn",
-              action: "autocompleter#swapCreate:prevent" }
-    )
-  end
-
-  def autocompleter_find_button(args)
-    return unless args[:find_text]
-
-    icon_link_to(
-      args[:find_text], "#",
-      icon: :find_on_map, show_text: false, icon_class: "text-primary",
-      name: "find_#{args[:type]}", class: "ml-3 d-none",
-      data: { map_target: "showBoxBtn",
-              action: "map#showBox:prevent" }
-    )
-  end
-
-  def autocompleter_keep_button(args)
-    return unless args[:keep_text]
-
-    icon_link_to(
-      args[:keep_text], "#",
-      icon: :apply, show_text: false, icon_class: "text-primary",
-      active_icon: :edit, active_content: args[:edit_text],
-      name: "keep_#{args[:type]}", class: "ml-3 d-none",
-      data: { autocompleter_target: "keepBtn", map_target: "lockBoxBtn",
-              action: "map#toggleBoxLock:prevent" }
-    )
-  end
-
-  # minimum args :form, :type.
-  # Send :hidden to fill the id, :hidden_data to merge with hidden field data
-  def autocompleter_hidden_field(**args)
-    return unless args[:form].present? && args[:type].present?
-
-    model = autocompleter_type_to_model(args[:type])
-    data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
-    args[:form].hidden_field(:"#{model}_id", value: args[:hidden_value], data:)
-  end
-
-  def autocompleter_type_to_model(type)
-    case type
-    when :region
-      :location
-    when :clade
-      :name
-    else
-      type
-    end
-  end
-
-  def autocompleter_dropdown
-    tag.div(class: "auto_complete dropdown-menu",
-            data: { autocompleter_target: "pulldown",
-                    action: "scroll->autocompleter#scrollList:passive" }) do
-      tag.ul(class: "virtual_list", data: { autocompleter_target: "list" }) do
-        10.times do |i|
-          concat(tag.li(class: "dropdown-item") do
-            link_to("", "#", data: {
-                      row: i, action: "click->autocompleter#selectRow:prevent"
-                    })
-          end)
-        end
-      end
     end
   end
 
@@ -672,7 +542,7 @@ module FormsHelper
     exceptions = [
       :form, :field, :label, :class, :width, :inline, :between, :label_after,
       :label_end, :append, :help, :addon, :optional, :required, :monospace,
-      :type, :wrap_data, :button, :button_data
+      :type, :wrap_data, :wrap_id, :button, :button_data
     ] + extras
 
     args.clone.except(*exceptions)
@@ -680,5 +550,4 @@ module FormsHelper
 end
 # rubocop:enable Metrics/ModuleLength
 # rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/MethodLength
 # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -17,6 +17,7 @@ module MapHelper
       controller: "map",
       map_target: "mapDiv",
       map_type: "info",
+      map_open: true,
       editable: false,
       controls: [:large_map, :map_type].to_json,
       location_format: User.current_location_format # method has a default

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -229,30 +229,30 @@ export default class extends Controller {
       this.matches = [];
       this.stored_data = { id: 0 };
       this.last_fetch_params = '';
+      this.prepareInputElement();
+      this.prepareHiddenInput();
       if (!this.hasKeepBtnTarget ||
         !this.keepBtnTarget?.classList?.contains('active')) {
         this.clearHiddenId();
       }
-      this.prepareInputElement();
-      this.prepareHiddenInput();
       this.constrainedSelectionUI();
     }
   }
 
   constrainedSelectionUI() {
     if (this.TYPE === "location_google") {
-      this.verbose("autocompleter: location_google swap");
+      this.verbose("autocompleter: swapped to location_google");
       this.element.classList.add('create');
       this.element.classList.remove('offer-create');
       this.element.classList.remove('constrained');
       if (this.hasMapWrapTarget) {
         this.mapWrapTarget.classList.remove('d-none');
-        this.activateMapOutlet();
       } else {
         this.verbose("autocompleter: no map wrap");
       }
+      this.activateMapOutlet();
     } else if (this.ACT_LIKE_SELECT) {
-      this.verbose("autocompleter: ACT_LIKE_SELECT swap");
+      this.verbose("autocompleter: swapped to ACT_LIKE_SELECT");
       this.deactivateMapOutlet();
       // primer is not based on input, so go ahead and request from server.
       this.focused = true; // so it will draw the pulldown immediately
@@ -260,7 +260,7 @@ export default class extends Controller {
       this.element.classList.add('constrained');
       this.element.classList.remove('create');
     } else {
-      this.verbose("autocompleter: regular swap");
+      this.verbose("autocompleter: swapped regular");
       this.deactivateMapOutlet();
       this.scheduleRefresh();
       this.element.classList.remove('constrained', 'create');

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -232,45 +232,60 @@ export default class extends Controller {
       this.matches = [];
       this.stored_data = { id: 0 };
       this.last_fetch_params = '';
-      this.prepareInputElement();
-      this.prepareHiddenInput();
       if (!this.hasKeepBtnTarget ||
         !this.keepBtnTarget?.classList?.contains('active')) {
         this.clearHiddenId();
       }
+      this.prepareInputElement();
+      this.prepareHiddenInput();
       this.constrainedSelectionUI();
     }
   }
 
   constrainedSelectionUI() {
-    const outlet_class = this.appropriateOutletClass();
+    // const outlet_class = this.appropriateOutletClass();
     if (this.TYPE === "location_google") {
-      this.inputTarget.closest("form").classList.add(outlet_class);
+      this.verbose("autocompleter: location_google swap");
       this.element.classList.add('create');
       this.element.classList.remove('offer-create');
       this.element.classList.remove('constrained');
+      if (this.hasMapWrapTarget) {
+        this.mapWrapTarget.classList.remove('d-none');
+        // Instead of adding outlet class, call stuff in mapOutletConnected
+        this.activateMapOutlet();
+        // this.inputTarget.closest("form").classList.add(outlet_class);
+      } else {
+        this.verbose("autocompleter: no map wrap");
+      }
     } else if (this.ACT_LIKE_SELECT) {
-      this.inputTarget.closest("form").classList.remove(outlet_class);
+      this.verbose("autocompleter: ACT_LIKE_SELECT swap");
+      // Instead of removing outlet class, call stuff in mapOutletDisconnected
+      this.deactivateMapOutlet();
+      // this.inputTarget.closest("form").classList.remove(outlet_class);
       // primer is not based on input, so go ahead and request from server.
       this.focused = true; // so it will draw the pulldown immediately
       this.refreshPrimer(); // directly refresh the primer w/request_params
       this.element.classList.add('constrained');
       this.element.classList.remove('create');
     } else {
-      this.inputTarget.closest("form").classList.remove(outlet_class);
       this.verbose("autocompleter: regular swap");
+      // Instead of removing outlet class, call stuff in mapOutletDisconnected
+      this.deactivateMapOutlet();
+      // this.inputTarget.closest("form").classList.remove(outlet_class);
       this.scheduleRefresh();
       this.element.classList.remove('constrained', 'create');
     }
   }
 
-  appropriateOutletClass() {
-    if (this.hasMap) {
-      return 'map-outlet';
-    } else if (this.hasGeocode) {
-      return 'geocode-outlet';
-    }
-  }
+  // The autocompleter is paired with map controller by id, but only if this
+  // class is added. This allows us to hook events on mapOutletConnected.
+  // appropriateOutletClass() {
+  //   if (this.hasMap) {
+  //     return 'map-outlet';
+  //   } else if (this.hasGeocode) {
+  //     return 'geocode-outlet';
+  //   }
+  // }
 
   swapCreate() {
     // this.createBtnTarget.classList.add('d-none');
@@ -278,33 +293,42 @@ export default class extends Controller {
   }
 
   // Connects the location_google autocompleter to call map controller methods
-  mapOutletConnected(outlet, element) {
-    this.verbose("autocompleter:mapOutletConnected()");
+  activateMapOutlet() {
+    if (!this.hasMapOutlet) {
+      this.verbose("autocompleter: no map outlet");
+      return;
+    }
+
+    this.verbose("autocompleter:activateMapOutlet()");
     // open the map if not already open
-    if (!outlet.opened && !outlet.hasAutocompleterTarget)
-      outlet.toggleMapBtnTarget.click();
+    if (!this.mapOutlet.opened && this.mapOutlet.hasToggleMapBtnTarget) {
+      this.verbose("autocompleter: open map");
+      this.mapOutlet.toggleMapBtnTarget.click();
+    }
     // set the map type so box is editable
-    outlet.map_type = "hybrid"; // only if location_google
+    this.mapOutlet.map_type = "hybrid"; // only if location_google
 
     let location
-    if (location = outlet.validateLatLngInputs(false)) {
-      outlet.geocodeLatLng(location);
-    } else if (outlet.hasLockBoxBtnTarget) {
-      outlet.lockBoxBtnTarget.classList.remove("d-none");
+    if (location = this.mapOutlet.validateLatLngInputs(false)) {
+      this.mapOutlet.geocodeLatLng(location);
+    } else if (this.mapOutlet.hasLockBoxBtnTarget) {
+      this.mapOutlet.lockBoxBtnTarget.classList.remove("d-none");
     }
   }
 
-  mapOutletDisconnected(outlet, element) {
-    this.verbose("autocompleter: map outlet disconnected");
-    outlet.map_type = "observation";
-    if (outlet.rectangle) outlet.rectangle.setEditable(false);
+  deactivateMapOutlet() {
+    if (!this.hasMapOutlet) return;
 
-    outlet.northInputTarget.value = '';
-    outlet.southInputTarget.value = '';
-    outlet.eastInputTarget.value = '';
-    outlet.westInputTarget.value = '';
-    outlet.highInputTarget.value = '';
-    outlet.lowInputTarget.value = '';
+    this.verbose("autocompleter: deactivateMapOutlet()");
+    this.mapOutlet.map_type = "observation";
+    if (this.mapOutlet.rectangle) this.mapOutlet.rectangle.setEditable(false);
+
+    this.mapOutlet.northInputTarget.value = '';
+    this.mapOutlet.southInputTarget.value = '';
+    this.mapOutlet.eastInputTarget.value = '';
+    this.mapOutlet.westInputTarget.value = '';
+    this.mapOutlet.highInputTarget.value = '';
+    this.mapOutlet.lowInputTarget.value = '';
   }
 
   // pulldownTargetConnected() {
@@ -563,9 +587,10 @@ export default class extends Controller {
     this.verbose("autocompleter:scheduleGoogleRefresh()");
     this.clearRefresh();
     this.refresh_timer = setTimeout((() => {
-      this.verbose("autocompleter:doing_google_refresh()");
+      this.verbose("autocompleter: doing google refresh");
       this.verbose(this.inputTarget.value);
       this.old_value = this.inputTarget.value;
+      debugger;
       // async, anything after this executes immediately
       if (this.hasGeocodeOutlet) {
         this.geocodeOutlet.geolocatePlaceName(this.inputTarget.value);
@@ -1018,6 +1043,7 @@ export default class extends Controller {
   }
 
   // called on assign and clear, also when mapOutlet is connected
+  // FIXME: rename this function
   dispatchHiddenIdEvents() {
     const hidden_id = parseInt(this.hiddenTarget.value || 0),
       // stored_id = parseInt(this.stored_id || 0),
@@ -1027,19 +1053,22 @@ export default class extends Controller {
     this.verbose("autocompleter:hidden_data: " + JSON.stringify(hidden_data));
     // comparing data, not just ids, because google locations have same -1 id
     if (JSON.stringify(hidden_data) == JSON.stringify(this.stored_data)) {
-      this.verbose("autocompleter: not dispatching hiddenIdDataChanged");
+      this.verbose("autocompleter: hidden data did not change");
     } else {
       clearTimeout(this.data_timer);
       this.data_timer = setTimeout(() => {
-        this.verbose("autocompleter: dispatching hiddenIdDataChanged");
+        this.verbose("autocompleter: hidden data changed");
         this.cssHasIdOrNo(hidden_id);
         if (this.hasKeepBtnTarget) {
           this.keepBtnTarget.classList.remove('active');
         }
         this.inputTarget.focus();
-        this.dispatch('hiddenIdDataChanged', {
-          detail: { id: this.hiddenTarget.value }
-        });
+        if (this.hasMapOutlet) {
+          this.mapOutlet.showBox();
+        }
+        // this.dispatch('hiddenIdDataChanged', {
+        //   detail: { id: this.hiddenTarget.value }
+        // });
       }, 750)
     }
   }
@@ -1466,8 +1495,8 @@ export default class extends Controller {
   }
 
   // Map controller sends back a primer formatted for the autocompleter
-  refreshGooglePrimer({ detail }) {
-    this.processFetchResponse(detail.primer)
+  refreshGooglePrimer({ primer }) {
+    this.processFetchResponse(primer)
   }
 
   // Process response from server:

--- a/app/javascript/controllers/form-exif_controller.js
+++ b/app/javascript/controllers/form-exif_controller.js
@@ -178,12 +178,6 @@ export default class extends Controller {
           { detail: { request_params: { lat, lng } } }
         );
       }
-      // this.dispatch("pointChanged", {
-      //   detail: {
-      //     type: "location_containing",
-      //     request_params: { lat, lng }
-      //   }
-      // });
     }
     if (_exif_data.exif_date) {
       const _exifSimpleDate = JSON.parse(_exif_data.exif_date);

--- a/app/javascript/controllers/form-exif_controller.js
+++ b/app/javascript/controllers/form-exif_controller.js
@@ -14,6 +14,7 @@ const internalConfig = {
 // Connects to data-controller="form-exif"
 export default class extends Controller {
   static targets = ["carousel", "item", "useExifBtn"]
+  static outlets = ["autocompleter", "map"]
 
   connect() {
     this.element.dataset.stimulus = "connected";
@@ -166,13 +167,23 @@ export default class extends Controller {
       _obs_lng.value = lng == null ? lng : lng.toFixed(4);
       _obs_alt.value = alt == null ? alt : alt.toFixed(0);
 
-      // should trigger change to update the map
-      this.dispatch("pointChanged", {
-        detail: {
-          type: "location_containing",
-          request_params: { lat, lng }
-        }
-      });
+      // should trigger change to update the autocompleter and the map
+      if (this.hasAutocompleterOutlet) {
+        this.autocompleterOutlet.swap({
+          detail: { type: "location_containing", request_params: { lat, lng } }
+        });
+      }
+      if (this.hasMapOutlet) {
+        this.mapOutlet.calculateMarker(
+          { detail: { request_params: { lat, lng } } }
+        );
+      }
+      // this.dispatch("pointChanged", {
+      //   detail: {
+      //     type: "location_containing",
+      //     request_params: { lat, lng }
+      //   }
+      // });
     }
     if (_exif_data.exif_date) {
       const _exifSimpleDate = JSON.parse(_exif_data.exif_date);

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -360,46 +360,27 @@ export default class extends Controller {
     this.lngInputTarget.value = this.roundOff(center.lng)
     // If we're here, we have a lat and a lng.
     if (this.ignorePlaceInput !== false)
-      this.dispatchPointChanged(center)
+      this.sendPointChanged(center)
   }
 
   // Call the swap event on the autocompleter and send the type we need
-  // FIXME: rename this function
-  dispatchPointChanged({ lat, lng }) {
+  sendPointChanged({ lat, lng }) {
     this.clearAutocompleterSwapBuffer()
 
     if (lat && lng) {
       this.autocomplete_buffer = setTimeout(() => {
-        // FIXME: Instead of dispatching a pointChanged event, we should
-        // call the swap method in the paired autocompleter controller.
-        // this.dispatch("pointChanged", {
-        //   detail: {
-        //     type: "location_containing",
-        //     request_params: { lat, lng },
-        //   }
-        // })
         if (this.hasAutocompleterOutlet) {
-          this.autocompleterOutlet.swap(
-            { type: "location_containing", request_params: { lat, lng } }
-          )
+          this.autocompleterOutlet.swap({
+            detail:
+              { type: "location_containing", request_params: { lat, lng } }
+          })
         }
-        // this.verbose("geocode:dispatchPointChanged")
+        // this.verbose("geocode:sendPointChanged")
       }, 1000)
-
-      // if (this.placeInputTarget.value === '') {
-      //   this.geocoder.geocode({ location: center }, (results, status) => {
-      //     if (status === "OK") {
-      //       if (results[0]) {
-      //         this.placeInputTarget.value = results[0].formatted_address
-      //       }
-      //     }
-      //   })
-      // }
     } else {
       this.autocomplete_buffer = setTimeout(() => {
-        // this.dispatch("pointChanged", { detail: { type: "location" } })
         if (this.hasAutocompleterOutlet) {
-          this.autocompleterOutlet.swap({ type: "location" })
+          this.autocompleterOutlet.swap({ detail: { type: "location" } })
         }
       }, 1000)
     }
@@ -473,7 +454,7 @@ export default class extends Controller {
   }
 
   verbose(str) {
-    console.log(str);
+    // console.log(str);
     // document.getElementById("log").
     //   insertAdjacentText("beforeend", str + "<br/>");
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -18,7 +18,7 @@ export default class extends GeocodeController {
     this.element.dataset.stimulus = "connected"
     this.map_type = this.mapDivTarget.dataset.mapType
     this.editable = (this.mapDivTarget.dataset.editable === "true")
-    this.opened = this.map_type !== "observation"
+    this.opened = this.element.dataset.mapOpen === "true"
     this.marker = null // Only gets set if we're in edit mode
     this.rectangle = null // Only gets set if we're in edit mode
     this.location_format = this.mapDivTarget.dataset.locationFormat
@@ -500,7 +500,6 @@ export default class extends GeocodeController {
   // open/close handled by BS collapse
   toggleMap() {
     // this.verbose("map:toggleMap")
-
     if (this.opened) {
       this.opened = false
       this.controlWrapTarget.classList.remove("map-open")
@@ -511,7 +510,7 @@ export default class extends GeocodeController {
       if (this.map == undefined) {
         this.drawMap()
         this.makeMapClickable()
-      } else {
+      } else if (this.mapBounds) {
         this.map.fitBounds(this.mapBounds)
       }
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -632,7 +632,7 @@ export default class extends GeocodeController {
   }
 
   verbose(str) {
-    console.log(str);
+    // console.log(str);
     // document.getElementById("log").
     //   insertAdjacentText("beforeend", str + "<br/>");
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -351,7 +351,7 @@ export default class extends GeocodeController {
       const center = this.validateLatLngInputs(false)
       if (!center) return
 
-      this.dispatchPointChanged(center)
+      this.sendPointChanged(center)
 
       if (this.latInputTarget.value === "" ||
         this.lngInputTarget.value === "" && this.marker) {
@@ -557,7 +557,7 @@ export default class extends GeocodeController {
       // this.showBoxBtnTarget.disabled = false
     }
     this.dispatch("reenableBtns")
-    this.dispatchPointChanged({ lat: null, lng: null })
+    this.sendPointChanged({ lat: null, lng: null })
   }
 
   //

--- a/app/views/controllers/locations/_form.erb
+++ b/app/views/controllers/locations/_form.erb
@@ -22,7 +22,8 @@ when "edit", "update"
 end
 
 form_args = {
-  model: @location, url: url_params, id: "location_form"
+  model: @location, url: url_params, id: "location_form",
+  data: { controller: "map", map_open: true }
 }
 
 if local_assigns[:local] == true
@@ -43,7 +44,7 @@ map_args = { editable: true, map_type: "location" }
 
     <%# NOTE: All other Stimulus data is on the map div, but we need
     the fields inside the controller scope, so map has controller: nil %>
-    <%= tag.div(class: "row", data: { controller: "map" }) do %>
+    <%= tag.div(class: "row") do %>
       <%= tag.div(class: "col-md-8 col-lg-6") do %>
         <%= render(partial: "locations/form/fields",
                    locals: { f:, button:, location: @location,

--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -26,11 +26,7 @@ data = {
   map_open: false,
   form_exif_autocompleter_outlet: "#observation_location_autocompleter",
   form_exif_map_outlet: "#observation_form",
-  action: [
-    "map:reenableBtns@window->form-exif#reenableButtons",
-    # "form-exif:pointChanged@window->map#calculateMarker",
-    # "autocompleter:hiddenIdDataChanged@window->map#showBox",
-  ].join(" "),
+  action: "map:reenableBtns@window->form-exif#reenableButtons",
   upload_max_size: max_size,
   localization: image_upload_localization,
   form_images_target: "form",

--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -19,12 +19,17 @@ image_upload_localization = {
   show_on_map: :show_on_map.t,
   something_went_wrong: :form_observations_upload_error.t
 }.to_json
+# Outlets are how the stimulus controllers call each others' methods.
 data = {
   controller: "form-images form-exif map",
+  map_autocompleter_outlet: "#observation_location_autocompleter",
+  map_open: false,
+  form_exif_autocompleter_outlet: "#observation_location_autocompleter",
+  form_exif_map_outlet: "#observation_form",
   action: [
     "map:reenableBtns@window->form-exif#reenableButtons",
-    "form-exif:pointChanged@window->map#calculateMarker",
-    "autocompleter:hiddenIdDataChanged@window->map#showBox",
+    # "form-exif:pointChanged@window->map#calculateMarker",
+    # "autocompleter:hiddenIdDataChanged@window->map#showBox",
   ].join(" "),
   upload_max_size: max_size,
   localization: image_upload_localization,

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -69,7 +69,7 @@ t_s = {
           hidden_data: { map_target: "locationId",
                          north: location&.north, south: location&.south,
                          east: location&.east, west: location&.west },
-          # These are button tooltips:
+          # These text strings are the button tooltips:
           create_text: :form_observations_create_locality.l,
           keep_text: :form_observations_use_locality.l,
           edit_text: :form_observations_edit_locality.l,
@@ -77,15 +77,11 @@ t_s = {
           # Be precise about which map controller to connect to:
           map_outlet: "#observation_form",
           wrap_id: "observation_location_autocompleter",
-          # FIXME: any map action could affect this autocompleter.
-          # Map needs to use its own autocompleter outlet
+          # Action ok because there's only one form-exif controller on the page,
+          # and it should only affect this autocompleter:
           data: {
             map_target: "placeInput",
-            action: [
-              # "map:pointChanged@window->autocompleter#swap",
-              "form-exif:pointChanged@window->autocompleter#swap",
-              # "map:googlePrimer@window->autocompleter#refreshGooglePrimer"
-            ].join(" ")
+            action: "form-exif:pointChanged@window->autocompleter#swap"
           }
         ) %>
 

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -74,13 +74,17 @@ t_s = {
           keep_text: :form_observations_use_locality.l,
           edit_text: :form_observations_edit_locality.l,
           # find_text: :form_locations_find_on_map.l,
-          map_outlet: ".map-outlet",
+          # Be precise about which map controller to connect to:
+          map_outlet: "#observation_form",
+          wrap_id: "observation_location_autocompleter",
+          # FIXME: any map action could affect this autocompleter.
+          # Map needs to use its own autocompleter outlet
           data: {
             map_target: "placeInput",
             action: [
-              "map:pointChanged@window->autocompleter#swap",
+              # "map:pointChanged@window->autocompleter#swap",
               "form-exif:pointChanged@window->autocompleter#swap",
-              "map:googlePrimer@window->autocompleter#refreshGooglePrimer"
+              # "map:googlePrimer@window->autocompleter#refreshGooglePrimer"
             ].join(" ")
           }
         ) %>

--- a/app/views/controllers/shared/_form_location_map.erb
+++ b/app/views/controllers/shared/_form_location_map.erb
@@ -1,5 +1,10 @@
 <%# locals: (id: "", map_type: "location") -%>
 
+<%#
+The stimulus controller for this map should be
+on an ancestor element that also contains the inputs
+%>
+
 <%= tag.div(
   "", id:,
       class: "form-map collapse",

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -433,8 +433,8 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     click_on(:form_observations_create_locality.l)
     # lat/lng does not match Google's Pasadena, but does match South Pasadena
     assert_selector("[data-type='location_google']")
-    # assert_selector(".auto_complete", wait: 6)
     find("#observation_place_name").trigger("focus")
+    # assert_selector(".auto_complete", wait: 6)
     assert_selector(".dropdown-item a[data-id='-1']",
                     text: SOUTH_PASADENA[:name], visible: :all, wait: 6)
     # There may be more than one of these, click the first


### PR DESCRIPTION
Changes the way map form Stimulus controllers call each other's methods, so that they call the method of the specific controller instance they need. This is necessary for forms where there is more than one autocompleter/map pair on the same page, so that they don't get their signals crossed. Also just seems like better code.

Changes from `dispatch`ing JS `events`, which may be picked up by all controllers on the page (and can only be routed to controllers by _type_), to calling methods on the controller itself via that controller's `outlet` identified by a unique id.

Also moves the `autocompleter_field` helper method and its helpers to a separate file.