### PR TITLE
Location: Improve Riparius handling

### DIFF
--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -215,6 +215,13 @@ export default class extends Controller {
     }
     if (type == undefined) { return; }
 
+    let location = false;
+    if (detail.hasOwnProperty("request_params") &&
+      detail.request_params.hasOwnProperty("lat") &&
+      detail.request_params.hasOwnProperty("lng")) {
+      location = detail.request_params;
+    }
+
     if (!AUTOCOMPLETER_TYPES.hasOwnProperty(type)) {
       alert("MOAutocompleter: Invalid type: \"" + type + "\"");
     } else {
@@ -235,11 +242,13 @@ export default class extends Controller {
         !this.keepBtnTarget?.classList?.contains('active')) {
         this.clearHiddenId();
       }
-      this.constrainedSelectionUI();
+      this.constrainedSelectionUI(location);
     }
   }
 
-  constrainedSelectionUI() {
+  // Depending on the type of autocompleter, the UI may need to change.
+  // detail may also contain request_params for lat/lng.
+  constrainedSelectionUI(location = false) {
     if (this.TYPE === "location_google") {
       this.verbose("autocompleter: swapped to location_google");
       this.element.classList.add('create');
@@ -250,7 +259,7 @@ export default class extends Controller {
       } else {
         this.verbose("autocompleter: no map wrap");
       }
-      this.activateMapOutlet();
+      this.activateMapOutlet(location);
     } else if (this.ACT_LIKE_SELECT) {
       this.verbose("autocompleter: swapped to ACT_LIKE_SELECT");
       this.deactivateMapOutlet();
@@ -272,7 +281,7 @@ export default class extends Controller {
   }
 
   // Connects the location_google autocompleter to call map controller methods
-  activateMapOutlet() {
+  activateMapOutlet(location = false) {
     if (!this.hasMapOutlet) {
       this.verbose("autocompleter: no map outlet");
       return;
@@ -289,13 +298,13 @@ export default class extends Controller {
     // set the map to stop ignoring place input
     this.mapOutlet.ignorePlaceInput = false;
 
-    // 2024-08-09: Don't geocode lat/lng when switching to location_google.
-    // This is for custom locations and should pay attention to place_name only.
-    // let location
-    // if (location = this.mapOutlet.validateLatLngInputs(false)) {
-    //   this.mapOutlet.tryToGeocode();
-    // } else
-    if (this.mapOutlet.hasLockBoxBtnTarget) {
+    // 2024-08-09: Unless the swap call (form-exif) sent request_params lat/lng,
+    // don't geocode lat/lng when switching to location_google. Usually, this is
+    // for geolocating place_names and should pay attention to text only.
+    if (location) {
+      // this.mapOutlet.geocodeLatLng(location);
+      this.mapOutlet.tryToGeocode();
+    } else if (this.mapOutlet.hasLockBoxBtnTarget) {
       this.mapOutlet.lockBoxBtnTarget.classList.remove("d-none");
     }
   }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -286,11 +286,16 @@ export default class extends Controller {
     }
     // set the map type so box is editable
     this.mapOutlet.map_type = "hybrid"; // only if location_google
+    // set the map to stop ignoring place input
+    this.mapOutlet.ignorePlaceInput = false;
 
-    let location
-    if (location = this.mapOutlet.validateLatLngInputs(false)) {
-      this.mapOutlet.geocodeLatLng(location);
-    } else if (this.mapOutlet.hasLockBoxBtnTarget) {
+    // 2024-08-09: Don't geocode lat/lng when switching to location_google.
+    // This is for custom locations and should pay attention to place_name only.
+    // let location
+    // if (location = this.mapOutlet.validateLatLngInputs(false)) {
+    //   this.mapOutlet.tryToGeocode();
+    // } else
+    if (this.mapOutlet.hasLockBoxBtnTarget) {
       this.mapOutlet.lockBoxBtnTarget.classList.remove("d-none");
     }
   }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -280,7 +280,7 @@ export default class extends Controller {
     this.swap({ detail: { type: "location_google" } });
   }
 
-  // Connects the location_google autocompleter to call map controller methods
+  // Connects autocompleter to map controller to call its methods
   activateMapOutlet(location = false) {
     if (!this.hasMapOutlet) {
       this.verbose("autocompleter: no map outlet");
@@ -298,9 +298,9 @@ export default class extends Controller {
     // set the map to stop ignoring place input
     this.mapOutlet.ignorePlaceInput = false;
 
-    // 2024-08-09: Unless the swap call (form-exif) sent request_params lat/lng,
-    // don't geocode lat/lng when switching to location_google. Usually, this is
-    // for geolocating place_names and should pay attention to text only.
+    // Often, this swap to location_google is for geolocating place_names and
+    // should pay attention to text only. But in some cases the swap (e.g., from
+    // form-exif) sends request_params lat/lng, so geocode when switching.
     if (location) {
       // this.mapOutlet.geocodeLatLng(location);
       this.mapOutlet.tryToGeocode();

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -45,9 +45,9 @@ export default class extends Controller {
   }
 
   tryToGeocode() {
-    let location
+    const location = this.validateLatLngInputs(false)
 
-    if (location = this.validateLatLngInputs(false) &&
+    if (location &&
       JSON.stringify(location) !== JSON.stringify(this.lastGeocodedLatLng)) {
       this.geocodeLatLng(location)
     }
@@ -75,10 +75,10 @@ export default class extends Controller {
   }
 
   tryToGeolocate() {
-    let address = this.placeInputTarget.value
+    const address = this.placeInputTarget.value
 
-    if (this.ignorePlaceInput === false && address !== ""
-      && address !== this.lastGeolocatedAddress) {
+    if (this.ignorePlaceInput === false &&
+      address !== "" && address !== this.lastGeolocatedAddress) {
       this.geolocatePlaceName(address)
     }
   }
@@ -449,9 +449,9 @@ export default class extends Controller {
 
   // ------------------------------- DEBUGGING ------------------------------
 
-  helpDebug() {
-    debugger
-  }
+  // helpDebug() {
+  //   debugger
+  // }
 
   verbose(str) {
     // console.log(str);

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -398,11 +398,11 @@ export default class extends GeocodeController {
     let id
     if (this.hasLocationIdTarget && (id = this.locationIdTarget.value)) {
       this.mapLocationIdData()
-      // Only geocode lat/lng if we have no location_id and not ignoring place
     } else if (["location", "hybrid"].includes(this.map_type)) {
+      // Only geocode lat/lng if we have no location_id and not ignoring place
+      // ...and only geolocate placeName if we have no lat/lng
       if (this.ignorePlaceInput !== false) {
         this.tryToGeocode() // multiple possible results
-        // ...and only geolocate placeName if we have no lat/lng
       } else {
         this.tryToGeolocate()
       }
@@ -499,7 +499,7 @@ export default class extends GeocodeController {
   // Action called by the "Open Map" button only.
   // open/close handled by BS collapse
   toggleMap() {
-    // this.verbose("map:toggleMap")
+    this.verbose("map:toggleMap")
     if (this.opened) {
       this.opened = false
       this.controlWrapTarget.classList.remove("map-open")
@@ -627,9 +627,9 @@ export default class extends GeocodeController {
 
   // ------------------------------- DEBUGGING ------------------------------
 
-  helpDebug() {
-    debugger
-  }
+  // helpDebug() {
+  //   debugger
+  // }
 
   verbose(str) {
     // console.log(str);

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -385,6 +385,8 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     all('[id^="project_id_"]', visible: :all).each do |project_checkbox|
       project_checkbox.trigger("click") if project_checkbox.checked?
     end
+    step_nav_3 = find("#step-nav-3")
+    within(step_nav_3) { click_on(:BACK.l) }
 
     # submit_observation_form_with_errors
     within("#observation_form") { click_commit }


### PR DESCRIPTION
This should make the autocompleter less eager to override a manually entered place name when there is also a lat/lng from a photo. 

It will still however retrieve Google's version of the place name formatted for MO, so for example "Riparius, New York" becomes "Riparius, Chester, Warren Co., New York, USA". 

It also hopefully fixes a JS error where the bounding box hidden fields stopped being updated by the user manually resizing the box.