### PR TITLE
Fix Run BLAST links

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -124,7 +124,7 @@ class Sequence < AbstractModel
 
   def self.blast_url_prefix
     "https://blast.ncbi.nlm.nih.gov/Blast.cgi?" \
-    "CMD=Put&DATABASE=nt&PROGRAM=blastn&QUERY="
+    "CMD=Post&DATABASE=nt&PROGRAM=blastn&QUERY="
   end
 
   # convenience wrapper around class method of same name


### PR DESCRIPTION
- Changes the HTML method for BLAST queries.
- Uses `Post` instead of `Put`. `Put` no longer works; NCBI botches the `QUERY` param when the method is `Put`.
- Delivers #2303
