### PR TITLE
Strip blocked ip addrs

### DIFF
--- a/app/controllers/admin/blocked_ips_controller.rb
+++ b/app/controllers/admin/blocked_ips_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class BlockedIpsController < AdminController
     # This page allows editing of blocked ips via params
     # params[:add_okay] and params[:add_bad]
-    # GETting this page with params[:report] will show info about a chosen IP
+    # Using params[:report] will show info about a chosen IP
     def edit
       @ip = params[:report] if validate_ip!(params[:report])
       @blocked_ips = sort_by_ip(IpStats.read_blocked_ips)
@@ -14,6 +14,7 @@ module Admin
 
     # Render the page after an update
     def update
+      strip_params!
       process_blocked_ips_commands
       @blocked_ips = sort_by_ip(IpStats.read_blocked_ips)
       @okay_ips = sort_by_ip(IpStats.read_okay_ips)
@@ -22,6 +23,12 @@ module Admin
     end
 
     private
+
+    def strip_params!
+      [:add_bad, :remove_bad, :add_okay, :remove_okay].each do |param|
+        params[param] = params[param].strip if params[param]
+      end
+    end
 
     def sort_by_ip(ips)
       ips.sort_by do |ip|

--- a/test/controllers/admin/blocked_ips_controller_test.rb
+++ b/test/controllers/admin/blocked_ips_controller_test.rb
@@ -43,6 +43,15 @@ module Admin
       assert(time < File.mtime(MO.blocked_ips_file))
       IpStats.reset!
       assert_false(IpStats.blocked?(new_ip))
+
+      time = 1.minute.ago
+      File.utime(time.to_time, time.to_time, MO.blocked_ips_file)
+      patch(:update, params: { add_bad: " #{new_ip} " })
+      assert_no_flash
+      assert(time < File.mtime(MO.blocked_ips_file))
+      IpStats.reset!
+      assert_true(IpStats.blocked?(new_ip),
+                  "It should ignore leading & trailing spaces in ip addr")
     end
   end
 end


### PR DESCRIPTION
- Ignore leading/trailing spaces in blocked_ip Admin user interface
Removes a minor annoyance; I sometimes accidentally paste an ip addr which includes a leading or trailing space.
The UI would then complain that the ip addr was invalid.  
- Removes incorrect comment about GET (there's no corresponding route).