### PR TITLE
More legible tooltips for all icons

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -81,16 +81,17 @@ module LinkHelper
   # Icon link with optional active state. (Tooltip title must be swapped in JS.)
   # Now also accepts active state options: active_icon, active_content
   # NOTE: Takes same args as link_to, e.g. *edit_description_tab(desc, type)
-  # icon_link_to(text, path, **args)
+  # icon_link_to(text, path, **args). Can also print a button_to.
   def icon_link_to(text = nil, path = nil, options = {}, &block)
     return unless text
 
-    link = block ? text : path # because positional
+    link_path = block ? text : path # because positional
     content = block ? capture(&block) : text
     opts = block ? path : options # because positional
     icon_type = opts[:icon]
     return link_to(link, opts) { content } if icon_type.blank?
 
+    # method = opts[:button] ? :button_to : :link_to
     active_icon = opts[:active_icon]
     active_content = options[:active_content]
     stateful = active_icon && active_content
@@ -106,13 +107,18 @@ module LinkHelper
       data: { toggle: "tooltip", title: content, # needed for swapping only
               active_title: opts[:active_content] }
     }.deep_merge(opts.except(:class, :icon, :icon_class, :show_text,
-                             :active_icon, :active_content))
+                             :active_icon, :active_content, :button_to))
 
-    link_to(link, **link_opts) do
+    html = capture do
       concat(link_icon(icon_type, class: icon_class))
       concat(link_icon(active_icon, class: icon_active_class)) if stateful
       concat(tag.span(content, class: label_class))
       concat(tag.span(active_content, class: label_active_class)) if stateful
+    end
+    if opts[:button_to]
+      button_to(html, link_path, **link_opts)
+    else
+      link_to(html, link_path, **link_opts)
     end
   end
 
@@ -137,11 +143,11 @@ module LinkHelper
 
     if args[:title].present?
       title = args[:title]
-      args[:data] = { toggle: "tooltip", title: }.merge(args[:data] || {})
+      args[:data] = { toggle: "tooltip" }.merge(args[:data] || {})
       text = tag.span(title, class: "sr-only")
     end
 
-    tag.span(text, **args.except(:title))
+    tag.span(text, **args)
   end
 
   # NOTE: Specific to glyphicons
@@ -156,6 +162,12 @@ module LinkHelper
     x: "remove",
     remove: "remove-circle",
     send: "send",
+    log_in: "log-in",
+    log_out: "log-out",
+    admin: "text-background",
+    inbox: "inbox",
+    interests: "bullhorn",
+    settings: "cog",
     ban: "ban-circle",
     plus: "plus-sign",
     minus: "minus-sign",

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="tooltip"
+// BS3 tooltips are "opt-in", so they require on-page activation
+export default class extends Controller {
+
+  connect() {
+    this.element.dataset.stimulus = "tooltip-connected";
+    this.activateTooltips();
+  }
+
+  activateTooltips() {
+    $('[data-toggle="tooltip"]').tooltip()
+  }
+}

--- a/app/views/controllers/application/top_nav/_user_nav.html.erb
+++ b/app/views/controllers/application/top_nav/_user_nav.html.erb
@@ -14,32 +14,24 @@
     </li>
   <% end %>
   <li>
-    <%= link_to(
-          "", comments_path(for_user: @user.id),
-          { class: "glyphicon glyphicon-inbox",
-            id: "user_nav_inbox_link",
-            title: :app_comments_for_you.t,
-            data: { toggle: "tooltip", placement: "bottom" } }
+    <%= icon_link_to(
+          :app_comments_for_you.l, comments_path(for_user: @user.id),
+          { icon: :inbox, id: "user_nav_inbox_link",
+            data: { placement: "bottom" } }
         ) %>
   </li>
   <li>
-    <%= link_to(
-          "",
-          interests_path,
-          { class: "glyphicon glyphicon-bullhorn",
-            id: "user_nav_interests_link",
-            title: :app_your_interests.t,
-            data: { toggle: "tooltip", placement: "bottom" } }
+    <%= icon_link_to(
+          :app_your_interests.l, interests_path,
+          { icon: :interests, id: "user_nav_interests_link",
+            data: { placement: "bottom" } }
         ) %>
   </li>
   <li>
-    <%= link_to(
-          "",
-          edit_account_preferences_path,
-          { class: "glyphicon glyphicon-cog",
-            id: "user_nav_preferences_link",
-            title: :app_preferences.t,
-            data: { toggle: "tooltip", placement: "bottom" } }
+    <%= icon_link_to(
+          :app_preferences.l, edit_account_preferences_path,
+          { icon: :settings, id: "user_nav_preferences_link",
+            data: { placement: "bottom" } }
         ) %>
   </li>
   <li id="user_drop_down" class="dropdown">
@@ -49,38 +41,37 @@
       <span class="caret"></span>
     </a>
     <ul class="dropdown-menu" role="menu">
-      <li><%= link_to(:app_your_observations.t,
+      <li><%= link_to(:app_your_observations.l,
                       observations_path(user: @user.id),
                       { class: "" } ) %></li>
-      <li><%= link_to(:app_your_projects.t,
+      <li><%= link_to(:app_your_projects.l,
                       projects_path(member: @user.id),
                       { class: "", id: "user_drop_projects_link" }) %></li>
-      <li><%= link_to(:app_your_lists.t,
+      <li><%= link_to(:app_your_lists.l,
                       species_lists_path(by_user: @user.id),
                       { class: "", id: "user_drop_species_lists_link" } ) %></li>
-      <li><%= link_to(:app_your_interests.t,
+      <li><%= link_to(:app_your_interests.l,
                       interests_path,
                       { class: "", id: "user_drop_interests_link" }) %></li>
-      <li><%= link_to(:app_your_summary.t,
+      <li><%= link_to(:app_your_summary.l,
                       user_path(@user.id),
                       { class: "", id: "user_drop_profile_link" }) %></li>
-      <li><%= link_to(:app_preferences.t,
+      <li><%= link_to(:app_preferences.l,
                       edit_account_preferences_path,
                       { class: "", id: "user_drop_preferences_link" }) %></li>
       <li class="divider"></li>
       <li><%= button_to(
-                :app_logout.t,
+                :app_logout.l,
                 account_logout_path,
                 { class: "btn btn-link", id: "user_drop_logout_link" }
               ) %><li>
     </ul>
   </li>
-  <li><%= button_to(
-            account_logout_path,
-            { class: "btn btn-link navbar-btn",
-              id: "user_nav_logout_link",
-              title: :app_logout.t }
-          ) do
-            tag.span("", class: "glyphicon glyphicon-log-out")
-          end %></li>
+  <li>
+    <%= icon_link_to(
+          :app_logout.l, account_logout_path,
+          { icon: :log_out, id: "user_nav_logout_link", button_to: true,
+            class: "btn btn-link navbar-btn", data: { placement: "bottom" } }
+        ) %>
+  </li>
 </ul>

--- a/app/views/controllers/application/top_nav/_user_nav.html.erb
+++ b/app/views/controllers/application/top_nav/_user_nav.html.erb
@@ -44,20 +44,16 @@
       <li><%= link_to(:app_your_observations.l,
                       observations_path(user: @user.id),
                       { class: "" } ) %></li>
-      <li><%= link_to(:app_your_projects.l,
-                      projects_path(member: @user.id),
+      <li><%= link_to(:app_your_projects.l, projects_path(member: @user.id),
                       { class: "", id: "user_drop_projects_link" }) %></li>
-      <li><%= link_to(:app_your_lists.l,
-                      species_lists_path(by_user: @user.id),
-                      { class: "", id: "user_drop_species_lists_link" } ) %></li>
-      <li><%= link_to(:app_your_interests.l,
-                      interests_path,
+      <li><%= link_to(:app_your_lists.l, species_lists_path(by_user: @user.id),
+                      { class: "",
+                        id: "user_drop_species_lists_link" } ) %></li>
+      <li><%= link_to(:app_your_interests.l, interests_path,
                       { class: "", id: "user_drop_interests_link" }) %></li>
-      <li><%= link_to(:app_your_summary.l,
-                      user_path(@user.id),
+      <li><%= link_to(:app_your_summary.l, user_path(@user.id),
                       { class: "", id: "user_drop_profile_link" }) %></li>
-      <li><%= link_to(:app_preferences.l,
-                      edit_account_preferences_path,
+      <li><%= link_to(:app_preferences.l, edit_account_preferences_path,
                       { class: "", id: "user_drop_preferences_link" }) %></li>
       <li class="divider"></li>
       <li><%= button_to(

--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -14,7 +14,7 @@ body_class = class_names(ctrlr_action, theme, location_format, logged_in)
   <%= render(partial: "application/app/head") %>
 </head>
 
-<body class="<%= body_class %>" data-controller="lazyload">
+<body class="<%= body_class %>" data-controller="lazyload tooltip">
   <% if Rails.env == "production" %>
     <%= render(partial: "application/app/gtm_iframe") %>
   <% end %>


### PR DESCRIPTION
Because I didn't "rtfm", I've never implemented tooltips correctly on MO. We've apparently been getting by on browser-default HTML `title` attributes the whole time.

This PR puts a tooltip activator in Stimulus (where it needs to be now) and should make the icon "tooltips" more legible. The main benefit is that the text appears much more quickly on hover than browser "title" attributes did, so the tips are more likely to be helpful to users.

Before:
![Screen Shot 2024-08-18 at 2 57 03 PM](https://github.com/user-attachments/assets/8999d4bb-a4f8-4d93-a852-0f30c2143a2a)

After:
![Screen Shot 2024-08-18 at 2 57 24 PM](https://github.com/user-attachments/assets/8c7fb7e8-fdc1-4633-81cd-539e2665e261)

The one that doesn't display nicely is "Turn Admin Mode On", but I trust that admins know what that button does at this point. The tooltip JS library is different in BS 4, so there doesn't seem to be much point spending an hour troubleshooting this private use case.

![Screen Shot 2024-08-18 at 3 03 11 PM](https://github.com/user-attachments/assets/179df05c-47dd-4f6e-b192-433d6322c832)

