### PR TITLE
Form-exif geolocation opener - also check box

### DIFF
--- a/app/javascript/controllers/form-exif_controller.js
+++ b/app/javascript/controllers/form-exif_controller.js
@@ -13,7 +13,8 @@ const internalConfig = {
 // (formerly "observation_images" section of the form)
 // Connects to data-controller="form-exif"
 export default class extends Controller {
-  static targets = ["carousel", "item", "useExifBtn", "collapseFields"]
+  static targets = ["carousel", "item", "useExifBtn",
+    "collapseFields", "collapseCheck"]
   static outlets = ["autocompleter", "map"]
 
   connect() {
@@ -200,6 +201,7 @@ export default class extends Controller {
   showFields() {
     if (this.hasCollapseFieldsTarget) {
       $(this.collapseFieldsTarget).collapse('show');
+      this.collapseCheckTarget.checked = true
     }
   }
 

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -72,7 +72,8 @@ t_s = {
           form: f, field: :has_geolocation, # field is ignored
           label: "#{:GEOLOCATION.l}:",
           help: :form_observations_lat_long_help.t,
-          data: { toggle: "collapse", target: "#observation_geolocation" },
+          data: { toggle: "collapse", target: "#observation_geolocation",
+                  form_exif_target: "collapseCheck" },
           aria: { controls: "observation_geolocation",
                   expanded: @observation.lat }
         ) %>


### PR DESCRIPTION
Minor fix. When the user drops an image with geolocation, and the JS thereby opens the geolocation fields (programmatically), it should also check the "Geolocation" box so the UI doesn't get out of phase with the open/closed state of the collapsed fields.