### PR TITLE
Remove one presenter instantiation

### DIFF
--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -84,9 +84,8 @@ module Tabs
     def add_background_image(image)
       return unless image
 
-      presenter = ImagePresenter.new(image, size: :large)
       content_for(:background_image) do
-        image_tag(presenter.img_src, class: "image-title")
+        image_tag(image.large_url, class: "image-title")
       end
     end
   end


### PR DESCRIPTION
Extremely minor PR. Switches from an instantiation of an `ImagePresenter` in the Project show page (to get an image url) to using the regular old Image instance method for that, `image.large_url`.

This situation doesn't need the presenter, which is for loading up an image-esque PORO with all the data an image might need: caption, lightbox caption, vote meter, naming voting interface, glitter, sprinkles...

Found during a survey of uses of the `ImagePresenter`, which I plan to replace with a Phlex component for our `interactive_image` to make the Bootstrap upgrades easier.