### PR TITLE
Remove trailing slash in Gemfile gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem("blankslate")
 # Simple version models and tables for classes
 # Use our own fork, which stores enum attrs as integers in the db
 gem("mo_acts_as_versioned", ">= 0.6.6",
-    git: "https://github.com/MushroomObserver/acts_as_versioned/")
+    git: "https://github.com/MushroomObserver/acts_as_versioned")
 
 # Use ActiveModel has_secure_password
 gem("bcrypt")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/MushroomObserver/acts_as_versioned/
+  remote: https://github.com/MushroomObserver/acts_as_versioned
   revision: 56891f7f915610e9f884e3a932bfb6934303b3b8
   specs:
     mo_acts_as_versioned (0.6.6)


### PR DESCRIPTION
Removes trailing slash in the source for acts_as_versioned in this line:
```ruby
gem("mo_acts_as_versioned", ">= 0.6.6",
    git: "https://github.com/MushroomObserver/acts_as_versioned/")
```
I hope this fixes errors in Dependabot PRs. Which complain
```
You have changed in the Gemfile:
* mo_acts_as_versioned from
`https://github.com/MushroomObserver/acts_as_versioned` to
`https://github.com/MushroomObserver/acts_as_versioned/`
```
Ex: https://github.com/MushroomObserver/mushroom-observer/actions/runs/10458112849/job/28959191755?pr=2321