### PR TITLE
Fix local defaults in naming form

### DIFF
--- a/app/views/controllers/observations/namings/_form.erb
+++ b/app/views/controllers/observations/namings/_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (local:, show_reasons: true, form_locals: {}) -%>
+<%# locals: (local: false, form_locals: {}) -%>
 
 <%
 # Fields must be separate because they're included in the obs form too.
@@ -35,7 +35,7 @@ end
 # `naming_locals`: modal forms can accept a `form_locals` local. The controller
 # may send `context` (i.e. where the form appears), which defaults to "blank".
 # `show_reasons` is false on the obs form, true on the naming form.
-naming_locals = { create:, button_name:, show_reasons: }.merge(form_locals)
+naming_locals = { create:, button_name:, show_reasons: true, context: "blank" }.merge(form_locals)
 %>
 
 <%= form_with(**form_args) do |f| %>

--- a/app/views/controllers/observations/namings/edit.html.erb
+++ b/app/views/controllers/observations/namings/edit.html.erb
@@ -13,7 +13,8 @@ add_tab_set(naming_form_edit_tabs(obs: @observation))
 
     <div class="mt-3">
       <%= render(partial: "observations/namings/form",
-                 locals: { show_reasons: true, local: true }) %>
+                 locals: { local: true,
+                           form_locals: { show_reasons: true } }) %>
     </div>
   </div><!--.col-->
 

--- a/app/views/controllers/observations/namings/new.html.erb
+++ b/app/views/controllers/observations/namings/new.html.erb
@@ -13,7 +13,8 @@ add_tab_set(naming_form_new_tabs(obs: @observation))
 
     <div class="mt-3">
       <%= render(partial: "observations/namings/form",
-                 locals: { show_reasons: true, local: true }) %>
+                 locals: { local: true,
+                           form_locals: { show_reasons: true } }) %>
     </div>
   </div><!--.col-->
 

--- a/app/views/controllers/shared/_modal_form_reload.erb
+++ b/app/views/controllers/shared/_modal_form_reload.erb
@@ -1,7 +1,8 @@
+<%# locals: (identifier:, form:, form_locals: {}) -%>
 <%
 # What to do if a form submit doesn't succeed
-# Takes locals: { identifier:, form:, form_locals: }
-form_locals ||= {}
+# Takes locals: { identifier:, form:, form_locals: {} }
+# form_locals ||= {}
 %>
 
 <%= turbo_stream.update("modal_#{identifier}_flash") do
@@ -9,5 +10,5 @@ form_locals ||= {}
 end %>
 
 <%= turbo_stream.replace("#{identifier}_form") do
-  render(partial: form, locals: { format: :turbo_stream }.merge(form_locals))
+  render(partial: form, locals: { local: false, form_locals: })
 end %>


### PR DESCRIPTION
This is a minor PR that addresses missing declared partial `locals` in the modal naming form.