### PR TITLE
Fix clearing map rectangle and hiding "keep location" button

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -535,6 +535,7 @@ export default class extends GeocodeController {
 
   // Action called from the "Clear Map" button
   clearMap() {
+    this.verbose("map:clearMap")
     const inputTargets = [
       this.placeInputTarget, this.northInputTarget, this.southInputTarget,
       this.eastInputTarget, this.westInputTarget, this.highInputTarget,
@@ -547,17 +548,28 @@ export default class extends GeocodeController {
     inputTargets.forEach((element) => { element.value = '' })
     this.ignorePlaceInput = false // turn string geolocation back on
 
-    if (this.marker) {
-      this.marker.setMap(null)
-      this.marker = null
-    }
-    if (this.rectangle) {
-      this.rectangle.setMap(null)
-      this.rectangle = null
-      // this.showBoxBtnTarget.disabled = false
-    }
+    this.clearMarker()
+    this.clearRectangle()
     this.dispatch("reenableBtns")
     this.sendPointChanged({ lat: null, lng: null })
+  }
+
+  clearMarker() {
+    if (!this.marker) return false
+
+    this.verbose("map:clearMarker")
+    this.marker.setMap(null)
+    this.marker = null
+  }
+
+  clearRectangle() {
+    if (!this.rectangle) return false
+
+    this.verbose("map:clearRectangle")
+    this.rectangle.setVisible(false)
+    this.rectangle.setMap(null)
+    this.rectangle = null
+    return true
   }
 
   //


### PR DESCRIPTION
Clearing the location input on the observation form should probably reset the form to the initial "MO locations" autocompletion state. Currently, once you start playing with creating a location, it stays stuck in a "google location" limbo, and unless you know to click the "Clear location" button, you can't seem to get out of it.

Another bug is that the "keep this location" button was persisting when it should be hidden. (That's the little button that appears beside the "Match found" indicator, and is useful when you're creating a location and have adjusted the bounds to your satisfaction. If you want to then be able to click a point within the bounds, you need to lock the box, otherwise it still thinks you're trying to adjust the box.) When you've cleared the location input, it should clear the box and hide that button.