### PR TITLE
Fix file input

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -435,8 +435,11 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
       obj,
       attr,
       opts.merge(
-        max_upload_msg: :validate_image_file_too_big.l(max: max_size_in_mb),
-        max_upload_size: max_size
+        data: {
+          controller: "file-input",
+          max_upload_msg: :validate_image_file_too_big.l(max: max_size_in_mb),
+          max_upload_size: max_size
+        }
       )
     )
     tag.span(:select_file.t + file_field, class: "file-field btn btn-default") +

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -396,6 +396,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # Bootstrap file input field with client-side size validation.
+  # This could be redone as an input group with a "browse" button, in BS4.
   def file_field_with_label(**args)
     args = check_for_help_block(args)
     opts = separate_field_options_from_args(args)
@@ -424,26 +425,6 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
       )
       concat(tag.span(:no_file_selected.t, data: { file_input_target: "name" }))
     end
-  end
-
-  # To be retired in favor of the above:
-  # Create stylable file input field with client-side size validation.
-  def custom_file_field(obj, attr, opts = {})
-    max_size = MO.image_upload_max_size
-    max_size_in_mb = (max_size.to_f / 1024 / 1024).round
-    file_field = file_field(
-      obj,
-      attr,
-      opts.merge(
-        data: {
-          controller: "file-input",
-          max_upload_msg: :validate_image_file_too_big.l(max: max_size_in_mb),
-          max_upload_size: max_size
-        }
-      )
-    )
-    tag.span(:select_file.t + file_field, class: "file-field btn btn-default") +
-      tag.span(:no_file_selected.t)
   end
 
   # Unused

--- a/app/views/controllers/images/test_add_image.html.erb
+++ b/app/views/controllers/images/test_add_image.html.erb
@@ -11,10 +11,14 @@ through this page are not saved and no database changes are made.</p>
 
 <%= form_tag({action: :test_upload_image, log_id: @log_entry.id}, {multipart: true}) do %>
   <div class="form-group form-inline">
-    <% label_tag(:upload_image1, :IMAGE.t + " 1:") %> <%= custom_file_field(:upload, :image1) %><br/>
-    <% label_tag(:upload_image2, :IMAGE.t + " 2:") %> <%= custom_file_field(:upload, :image2) %><br/>
-    <% label_tag(:upload_image3, :IMAGE.t + " 3:") %> <%= custom_file_field(:upload, :image3) %><br/>
-    <% label_tag(:upload_image4, :IMAGE.t + " 4:") %> <%= custom_file_field(:upload, :image4) %><br/>
+    <%= fields_for(:upload) do |f_u| %>
+      <% [1,2,3,4].each do |i| %>
+        <%= file_field_with_label(
+          form: f_u, field: "image#{i}".to_sym, class: "mt-3",
+          label: :image_add_image.t + " #{i}:",
+        ) %>
+      <% end %>
+    <% end %>
   </div>
 
   <%= submit_tag(:UPLOAD.l, class: "btn btn-default center-block mt-3") %>

--- a/app/views/controllers/observations/images/edit.html.erb
+++ b/app/views/controllers/observations/images/edit.html.erb
@@ -13,10 +13,10 @@ form_action = { controller: "/observations/images",
   <div class="col-xs-12 col-sm-8 col-md-6 col-lg-4">
     <%= form_with(model: @image, url: form_action, method: :put) do |f| %>
 
-      <%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>
-
       <%= render(partial: "observations/images/form/fields_for_images",
                 locals: { f: f, leave_out_original_file_name: false }) %>
+
+      <%= submit_button(form: f, button: :SAVE_EDITS.l, center: true) %>
 
       <% if @projects.any? %>
         <div class="form-group form-inline">

--- a/app/views/controllers/observations/images/form/_fields_for_upload.html.erb
+++ b/app/views/controllers/observations/images/form/_fields_for_upload.html.erb
@@ -1,16 +1,10 @@
 <div class="form-group form-inline mt-3">
   <%= fields_for(:upload) do |f_u| %>
-    <%= f_u.label(:image1, :image_add_image.t + " 1:") %>
-      <%= custom_file_field(:upload, :image1) %>
-      (<%= :image_add_default.t %>)<br/>
-    <%= f_u.label(:image2, :image_add_image.t + " 2:") %>
-      <%= custom_file_field(:upload, :image2) %>
-      (<%= :image_add_optional.t %>)<br/>
-    <%= f_u.label(:image3, :image_add_image.t + " 3:") %>
-      <%= custom_file_field(:upload, :image3) %>
-      (<%= :image_add_optional.t %>)<br/>
-    <%= f_u.label(:image4, :image_add_image.t + " 4:") %>
-      <%= custom_file_field(:upload, :image4) %>
-      (<%= :image_add_optional.t %>)<br/>
+    <% [1,2,3,4].each do |i| %>
+      <%= file_field_with_label(
+        form: f_u, field: "image#{i}".to_sym, class: "mt-3",
+        label: :image_add_image.t + " #{i}:",
+      ) %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/controllers/observations/images/new.html.erb
+++ b/app/views/controllers/observations/images/new.html.erb
@@ -14,9 +14,9 @@ add_tab_set(observation_images_new_tabs(obs: @observation))
 
   <div id="license-notice mt-3"><%= :image_add_warning.tp %></div>
 
-  <%= submit_button(form: f, button: :image_add_upload.l, center: true) %>
-
   <%= render(partial: "observations/images/form/fields_for_upload") %>
+
+  <%= submit_button(form: f, button: :image_add_upload.l, center: true) %>
 
   <%= render(partial: "observations/images/form/fields_for_images",
              locals: { f: f, leave_out_original_file_name: true }) %>


### PR DESCRIPTION
The `custom_file_field` helper has already been replaced by `file_field_with_label` in most forms, but the "add images to observation" form was still using the old helper (it should be deleted, and is in this PR). 

The "add images"/"remove images" forms for observations may be retired soon, but this way they will be retired in a functional state.