### PR TITLE
Remove the add/remove links from the image carousel, move obs edit/delete links

### DIFF
--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -133,11 +133,7 @@ module ObservationsHelper
   def observation_show_image_links(obs:)
     return "" unless check_permission(obs)
 
-    # [
-      # icon_link_with_query(*new_image_for_observation_tab(obs)),
     icon_link_with_query(*reuse_images_for_observation_tab(obs))
-      # icon_link_with_query(*remove_images_from_observation_tab(obs))
-    # ].safe_join(" | ")
   end
 
   # The following sections of the observation_details partial are also needed as

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -133,11 +133,11 @@ module ObservationsHelper
   def observation_show_image_links(obs:)
     return "" unless check_permission(obs)
 
-    [
-      icon_link_with_query(*new_image_for_observation_tab(obs)),
-      icon_link_with_query(*reuse_images_for_observation_tab(obs)),
-      icon_link_with_query(*remove_images_from_observation_tab(obs))
-    ].safe_join(" | ")
+    # [
+      # icon_link_with_query(*new_image_for_observation_tab(obs)),
+    icon_link_with_query(*reuse_images_for_observation_tab(obs))
+      # icon_link_with_query(*remove_images_from_observation_tab(obs))
+    # ].safe_join(" | ")
   end
 
   # The following sections of the observation_details partial are also needed as

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -111,7 +111,6 @@ module Tabs
        { class: tab_id(__method__.to_s), icon: :reuse }]
     end
 
-
     ############################################
     # INDEX
 

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -273,10 +273,7 @@ module Tabs
     end
 
     def obs_details_links(obs)
-      return print_labels_button(obs) unless check_permission(obs)
-
-      [print_labels_button(obs),
-       obs_change_links(obs)].safe_join(" | ")
+      print_labels_button(obs)
     end
 
     # Buttons in "Details" panel header

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -105,23 +105,12 @@ module Tabs
        { class: tab_id(__method__.to_s), icon: :hide }]
     end
 
-    def new_image_for_observation_tab(obs)
-      [:show_observation_add_images.l,
-       new_image_for_observation_path(obs.id),
-       { class: tab_id(__method__.to_s), icon: :add }]
-    end
-
     def reuse_images_for_observation_tab(obs)
       [:show_observation_reuse_image.l,
        reuse_images_for_observation_path(obs.id),
        { class: tab_id(__method__.to_s), icon: :reuse }]
     end
 
-    def remove_images_from_observation_tab(obs)
-      [:show_observation_remove_images.l,
-       remove_images_from_observation_path(obs.id),
-       { class: tab_id(__method__.to_s), icon: :remove }]
-    end
 
     ############################################
     # INDEX

--- a/app/views/controllers/application/content/_title_and_tab_sets.html.erb
+++ b/app/views/controllers/application/content/_title_and_tab_sets.html.erb
@@ -57,6 +57,7 @@ left_cols = add_right_tabs ? "col-xs-8 col-lg-7" : "col-xs-12"
   <%= content_tag_if(add_right_tabs, :div, id: "right_tabs",
                     class: "hidden-print text-right col-sm-4 col-lg-5 mb-3") do
         concat(yield(:interest_icons))
+        concat(yield(:edit_icons))
         concat(yield(:tab_set))
       end %>
 

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -4,6 +4,10 @@ add_page_title(show_obs_title(obs: @observation, owner_naming: @owner_naming))
 add_owner_naming(@owner_naming)
 add_pager_for(@observation)
 add_interest_icons(@user, @observation)
+content_for(:edit_icons) do
+  tag.span(obs_change_links(@observation),
+           class: "h4 ml-3 d-inline-block text-nowrap")
+end
 # add_tab_set(show_observation_tabs(obs: @observation, user: @user))
 
 @container = :double

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -299,10 +299,6 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_select("a:match('href',?)", edit_observation_path(obs.id), count: 0)
     assert_select(".destroy_observation_link_#{obs.id}", count: 0)
     assert_select("a:match('href',?)",
-                  new_image_for_observation_path(obs.id), count: 0)
-    assert_select("a:match('href',?)",
-                  remove_images_from_observation_path(obs.id), count: 0)
-    assert_select("a:match('href',?)",
                   reuse_images_for_observation_path(obs.id), count: 0)
     get(:edit, params: { id: obs.id })
     assert_response(:redirect)
@@ -315,10 +311,6 @@ class ObservationsControllerShowTest < FunctionalTestCase
     # Destroy button is in a form, not a link_to
     assert_select(".destroy_observation_link_#{obs.id}", minimum: 1)
     assert_select("a[href=?]",
-                  new_image_for_observation_path(obs.id), minimum: 1)
-    assert_select("a[href=?]",
-                  remove_images_from_observation_path(obs.id), minimum: 1)
-    assert_select("a[href=?]",
                   reuse_images_for_observation_path(obs.id), minimum: 1)
     get(:edit, params: { id: obs.id })
     assert_response(:success)
@@ -328,10 +320,6 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_select("a[href=?]", edit_observation_path(obs.id), minimum: 1)
     # Destroy button is in a form, not a link_to
     assert_select(".destroy_observation_link_#{obs.id}", minimum: 1)
-    assert_select("a[href=?]",
-                  new_image_for_observation_path(obs.id), minimum: 1)
-    assert_select("a[href=?]",
-                  remove_images_from_observation_path(obs.id), minimum: 1)
     assert_select("a[href=?]",
                   reuse_images_for_observation_path(obs.id), minimum: 1)
     get(:edit, params: { id: obs.id })


### PR DESCRIPTION
![screen_shot_2024-08-19_at_8 22 32_pm](https://github.com/user-attachments/assets/d5230c9e-faa9-49b7-929e-18faa825cb27)

Also, move the edit/delete links to the title bar:
![screen_shot_2024-08-20_at_12 20 19_pm](https://github.com/user-attachments/assets/76edd53a-22fe-4b06-ba3d-7dc1f4f9db6e)
