### PR TITLE
Brakeman 6.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (6.1.2)
+    brakeman (6.2.1)
       racc
     browser (6.0.0)
     builder (3.3.0)


### PR DESCRIPTION
- Bumps Brakeman to v 6.2.1. See https://github.com/presidentbeef/brakeman/releases/tag/v6.2.1
- Hopefully a side effect (after merger) will be that Dependablot PR's stop failing.