### PR TITLE
Pattern search controllers

### DIFF
--- a/app/controllers/comments/pattern_search_controller.rb
+++ b/app/controllers/comments/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Comments pattern search form.
+#
+# Route: `new_comment_pattern_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/comments/pattern_search", action: :create }`
+module Comments
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/glossary_terms/pattern_search_controller.rb
+++ b/app/controllers/glossary_terms/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# GlossaryTerms pattern search form.
+#
+# Route: `new_glossary_term_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/glossary_terms/pattern_search", action: :create }`
+module GlossaryTerms
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/herbaria/pattern_search_controller.rb
+++ b/app/controllers/herbaria/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Herbaria pattern search form.
+#
+# Route: `new_herbarium_pattern_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/herbaria/pattern_search", action: :create }`
+module Herbaria
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/herbarium_records/pattern_search_controller.rb
+++ b/app/controllers/herbarium_records/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Herbarium record pattern search form.
+#
+# Route: `new_herbarium_record_pattern_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/herbarium_records/pattern_search", action: :create }`
+module HerbariumRecords
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/locations/pattern_search_controller.rb
+++ b/app/controllers/locations/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Locations pattern search form.
+#
+# Route: `new_location_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/locations/pattern_search", action: :create }`
+module Locations
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/names/pattern_search_controller.rb
+++ b/app/controllers/names/pattern_search_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Names pattern search form.
+#
+# Route: `new_name_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/names/pattern_search", action: :create }`
+module Names
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+      @fields = name_search_params
+    end
+
+    def create
+      @pattern = human_formatted_pattern_search_string
+      redirect_to(controller: "/names", action: :index, pattern: @pattern)
+    end
+
+    private
+
+    def permitted_search_params
+      params.permit(name_search_params)
+    end
+
+    def name_search_params
+      PatternSearch::Name.params.keys
+    end
+
+    # Roundabout: We're converting the params hash back into a normal query
+    # string to start with, and then we're translating the query string into the
+    # format that the user would have typed into the search box if they knew how
+    # to do that, because that's what the PatternSearch class expects to parse.
+    # The PatternSearch class then unpacks, validates and re-translates all
+    # these params into the actual params used by the Query class. This may seem
+    # odd: of course we do know the Query param names in advance, so we could
+    # theoretically just pass the values directly to the receiving controller.
+    # But we'd still have to be able to validate the input, and give messages
+    # for all the possible errors there. PatternSearch class handles all that.
+    def human_formatted_pattern_search_string
+      query_string = permitted_search_params.compact_blank.to_query
+      query_string.tr("=", ":").tr("&", " ").tr("%2C", "\\\\,")
+    end
+  end
+end

--- a/app/controllers/names/pattern_search_controller.rb
+++ b/app/controllers/names/pattern_search_controller.rb
@@ -35,9 +35,10 @@ module Names
     # The PatternSearch class then unpacks, validates and re-translates all
     # these params into the actual params used by the Query class. This may seem
     # odd: of course we do know the Query param names in advance, so we could
-    # theoretically just pass the values directly to the receiving controller.
-    # But we'd still have to be able to validate the input, and give messages
-    # for all the possible errors there. PatternSearch class handles all that.
+    # theoretically just pass the values directly into Query and render the
+    # index. But we'd still have to be able to validate the input, and give
+    # messages for all the possible errors there. PatternSearch class handles
+    # all that.
     def human_formatted_pattern_search_string
       query_string = permitted_search_params.compact_blank.to_query
       query_string.tr("=", ":").tr("&", " ").tr("%2C", "\\\\,")

--- a/app/controllers/observations/pattern_search_controller.rb
+++ b/app/controllers/observations/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Observations pattern search form.
+#
+# Route: `new_observation_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/observations/pattern_search", action: :create }`
+module Observations
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/projects/pattern_search_controller.rb
+++ b/app/controllers/projects/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Projects pattern search form.
+#
+# Route: `new_project_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/projects/pattern_search", action: :create }`
+module Projects
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/species_lists/pattern_search_controller.rb
+++ b/app/controllers/species_lists/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# SpeciesLists pattern search form.
+#
+# Route: `new_species_list_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/species_lists/pattern_search", action: :create }`
+module SpeciesLists
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/controllers/users/pattern_search_controller.rb
+++ b/app/controllers/users/pattern_search_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Users pattern search form.
+#
+# Route: `new_user_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/users/pattern_search", action: :create }`
+module Users
+  class PatternSearchController < ApplicationController
+    before_action :login_required
+
+    def new
+    end
+  end
+end

--- a/app/views/controllers/names/pattern_search/new.erb
+++ b/app/views/controllers/names/pattern_search/new.erb
@@ -1,0 +1,13 @@
+<%
+fields = PatternSearch::Name.params.keys
+%>
+
+<%= form_with(url: { action: :create }) do |f| %>
+
+  <% fields.each do |field| %>
+    <%= text_field_with_label(form: f, field:) %>
+  <% end %>
+
+  <%= submit_button(form: f, button: :SEARCH.l, center: true) %>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -567,6 +567,9 @@ MushroomObserver::Application.routes.draw do # rubocop:todo Metrics/BlockLength
                            as: "names_eol_preview")
   get("names/eol_expanded_review", to: "names/eol_data/expanded_review#show",
                                    as: "names_eol_expanded_review")
+  get("names/search/new", to: "names/pattern_search#new", as: "new_name_search")
+  post("names/search", to: "names/pattern_search#create", as: "name_search")
+
 
   # ----- Observations: standard actions  ----------------------------
   namespace :observations do


### PR DESCRIPTION
- This PR creates a new “pattern search” form for each model (e.g. `Comment`, `Name`). It lives at a new endpoint, `names/search/new`, with a new controller, e.g. `Names::PatternSearchController`. The forms are different per model because the keywords available in `Query` for each model are different. (Mostly just for name and observation.)
- Even though these are separate new form endpoints, we can eventually use a single modal form for pattern searches. When the user selects the model they’re searching, Stimulus calls the model’s controller endpoint to get the search form. Turbo then populates the search modal with the form. (Notice here how Turbo facilitates keeping responses in Ruby (the regular controller response) while making them appear on the page via Javascript — i.e. without separate page reloads.)
- In each form, there’s a field for each search keyword (param). The form commits to the same controller’s create action and sends the params as a regular param hash.

Conceptually it may seem straightforward to initiate a query from the form's keyword params, but they’re not ready yet: the `PatternSearch` class does validation and translating for both the values and the param keys. It translates human input values into values that are executable in AR/SQL, and translates our pattern search keywords and the actual `Query` class param names. 

So I considered two ways of handling these search params in the create action:

1. Translate the HTML param string into the type of MO pattern search string that an expert user would enter, if they knew how.
  - Reassemble the params into a query string, the way they came in: `?pattern=&date=2024-08-24&id=2345`
  - Then do a bunch of string manipulation to change this string into the type of pattern string expected by `PatternSearch.new`. Change the `&` into spaces, escape the commas in addresses, re-encode the whole string as a single pattern param, and send it to the index action at `names`, where if everything’s ok, we show the results.
2. Assemble the params directly into a sanitized, corrected `query_params` hash and initiate a query from the `create` action, then send the query to the names `index` action. Doing this without duplicating functionality would involve a new type of object in the `PatternSearch` class that could validate the native query params and instantiate a query from that hash of params, rather than parsing the string (which is what it’s set up to do currently — there’s no direct “hash outlet” to plug into).

The way i’m handling it is the first one. I actually prefer the directness of #2, and may try it in the future, but it made my head swim thinking about all the validation and error handling. #1 is a roundabout way of doing things: putting params back into a string and altering the string rather than keeping a clean param hash, but it leverages a lot of work that the `PatternSearch` class already does. The values for the params are human input, and require translation to be valid `query_params`, so even if we used the native `Query` class param keys, we’d have to translate and validate the values. 

I intend to merge this PR after testing, but before building the modal search form. That way we will be able to test each of these forms at the _un-advertised_ endpoints, and be sure they're working, before changing anything about the search UI.