### PR TITLE
Fix multiple autocomplete (on List form)

### DIFF
--- a/app/classes/auto_complete.rb
+++ b/app/classes/auto_complete.rb
@@ -46,6 +46,15 @@ class AutoComplete
     matches
   end
 
+  # returns an array of ONE { name:, id: } object. Uses `exact_match` which
+  # is a similar query, but searches using whole string and returns first match.
+  def first_matching_record
+    self.matches = exact_match(string) || []
+    clean_matches
+
+    matches
+  end
+
   private
 
   def clean_matches

--- a/app/classes/auto_complete/for_clade.rb
+++ b/app/classes/auto_complete/for_clade.rb
@@ -10,13 +10,14 @@ class AutoComplete::ForClade < AutoComplete::ByString
     matches_array(clades)
   end
 
-  def exact_match(string)
-    clade = Name.with_correct_spelling.with_rank_above_genus.
-            where(Name[:text_name].eq(string)).first
-    return [] unless clade
+  # Doesn't make sense to have exact match for clades
+  # def exact_match(string)
+  #   clade = Name.with_correct_spelling.with_rank_above_genus.
+  #           where(Name[:text_name].eq(string)).first
+  #   return [] unless clade
 
-    matches_array([clade])
-  end
+  #   matches_array([clade])
+  # end
 
   # Turn the instances into hashes
   def matches_array(clades)

--- a/app/classes/auto_complete/for_clade.rb
+++ b/app/classes/auto_complete/for_clade.rb
@@ -7,7 +7,19 @@ class AutoComplete::ForClade < AutoComplete::ByString
              where(Name[:text_name].matches("#{letter}%")).order(rank: :desc).
              select(:text_name, :rank, :id, :deprecated)
 
-    # Turn the instances into hashes
+    matches_array(clades)
+  end
+
+  def exact_match(string)
+    clade = Name.with_correct_spelling.with_rank_above_genus.
+            where(Name[:text_name].eq(string)).first
+    return [] unless clade
+
+    matches_array([clade])
+  end
+
+  # Turn the instances into hashes
+  def matches_array(clades)
     matches = clades.map do |clade|
       clade = clade.attributes.symbolize_keys
       clade[:deprecated] = clade[:deprecated] || false

--- a/app/classes/auto_complete/for_herbarium.rb
+++ b/app/classes/auto_complete/for_herbarium.rb
@@ -13,6 +13,18 @@ class AutoComplete::ForHerbarium < AutoComplete::ByWord
              else(Herbarium[:code]).asc, Herbarium[:name].asc
       )
 
+    matches_array(herbaria)
+  end
+
+  def exact_match(string)
+    herbarium = Herbarium.select(:code, :name, :id).distinct.
+                where(Herbarium[:name].eq(string)).first
+    return [] unless herbarium
+
+    matches_array([herbarium])
+  end
+
+  def matches_array(herbaria)
     # Turn the instances into hashes, and figure out what name to display
     matches = herbaria.map do |herbarium|
       herbarium = herbarium.attributes.symbolize_keys

--- a/app/classes/auto_complete/for_location.rb
+++ b/app/classes/auto_complete/for_location.rb
@@ -5,7 +5,7 @@
 # Any caching advantage in that? Then below, it'd be something like:
 #   Observation.rough_matches(letter).pluck_matches
 # Or would this scatter the code?
-# Thinking the scope could be useful for graphQL, or it could use this class.
+# Thinking the scope could be useful, or it could use this class.
 #
 class AutoComplete::ForLocation < AutoComplete::ByWord
   attr_accessor :reverse
@@ -22,7 +22,19 @@ class AutoComplete::ForLocation < AutoComplete::ByWord
       where(Location[:name].matches("#{letter}%").
         or(Location[:name].matches("% #{letter}%")))
 
-    # Turn the instances into hashes, and alter name order if requested
+    matches_array(locations)
+  end
+
+  def exact_match(string)
+    location = Location.select(:name, :id, :north, :south, :east, :west).
+               where(Location[:name].eq(string)).first
+    return [] unless location
+
+    matches_array([location])
+  end
+
+  # Turn the instances into hashes, and alter name order if requested
+  def matches_array(locations)
     matches = locations.map do |location|
       location = location.attributes.symbolize_keys
       location[:name] = Location.reverse_name(location[:name]) if reverse

--- a/app/classes/auto_complete/for_location_containing.rb
+++ b/app/classes/auto_complete/for_location_containing.rb
@@ -25,7 +25,16 @@ class AutoComplete::ForLocationContaining < AutoComplete::ByWord
         location_box(loc).box_area
       end
 
-    # Turn the instances into hashes, and alter name order if requested
+    matches_array(locations)
+  end
+  # rubocop:enable Style/MultilineBlockChain
+
+  def exact_match(_string)
+    [rough_matches("").first]
+  end
+
+  # Turn the instances into hashes, and alter name order if requested
+  def matches_array(locations)
     matches = locations.map do |location|
       location = location.attributes.symbolize_keys
       location[:name] = Location.reverse_name(location[:name]) if reverse
@@ -35,7 +44,6 @@ class AutoComplete::ForLocationContaining < AutoComplete::ByWord
     matches.uniq { |loc| loc[:name] }
     # matches.append({ name: " ", id: 0 }) # in case we need a blank row?
   end
-  # rubocop:enable Style/MultilineBlockChain
 
   def location_box(loc)
     Mappable::Box.new(north: loc[:north], south: loc[:south],

--- a/app/classes/auto_complete/for_name.rb
+++ b/app/classes/auto_complete/for_name.rb
@@ -6,7 +6,20 @@ class AutoComplete::ForName < AutoComplete::ByString
             select(:text_name, :id, :deprecated).distinct.
             where(Name[:text_name].matches("#{letter}%"))
 
-    # Turn the instances into hashes, and format the deprecated field
+    matches_array(names)
+  end
+
+  def exact_match(string)
+    name = Name.with_correct_spelling.
+           select(:text_name, :id, :deprecated).distinct.
+           where(Name[:text_name].eq(string)).first
+    return [] unless name
+
+    matches_array([name])
+  end
+
+  # Turn the instances into hashes, and format the deprecated field
+  def matches_array(names)
     matches = names.map do |name|
       name = name.attributes.symbolize_keys
       name[:deprecated] = name[:deprecated] || false

--- a/app/classes/auto_complete/for_project.rb
+++ b/app/classes/auto_complete/for_project.rb
@@ -7,7 +7,19 @@ class AutoComplete::ForProject < AutoComplete::ByWord
                  or(Project[:title].matches("% #{letter}%"))).
                order(title: :asc)
 
-    # Turn the instances into hashes, and alter title key
+    matches_array(projects)
+  end
+
+  def exact_match(string)
+    project = Project.select(:title, :id).distinct.
+              where(Project[:title].eq(string)).first
+    return [] unless project
+
+    matches_array([project])
+  end
+
+  # Turn the instances into hashes, and alter title key
+  def matches_array(projects)
     projects.map do |project|
       project = project.attributes.symbolize_keys
       { name: project[:title], id: project[:id] }

--- a/app/classes/auto_complete/for_region.rb
+++ b/app/classes/auto_complete/for_region.rb
@@ -19,13 +19,14 @@ class AutoComplete::ForRegion < AutoComplete::ByWord
     matches_array(regions)
   end
 
-  def exact_match(words)
-    words = Location.reverse_name(words) if reverse
-    region = Observation.in_region(words).select(:where, :location_id).first
-    return [] unless region
+  # Doesn't make sense to have an exact match for a region.
+  # def exact_match(words)
+  #   words = Location.reverse_name(words) if reverse
+  #   region = Observation.in_region(words).select(:where, :location_id).first
+  #   return [] unless region
 
-    matches_array([region])
-  end
+  #   matches_array([region])
+  # end
 
   # Turn the instances into hashes, and alter name order if requested
   # Also change the names of the hash keys.

--- a/app/classes/auto_complete/for_region.rb
+++ b/app/classes/auto_complete/for_region.rb
@@ -16,8 +16,20 @@ class AutoComplete::ForRegion < AutoComplete::ByWord
     words = Location.reverse_name(words) if reverse
     regions = Observation.in_region(words).select(:where, :location_id)
 
-    # Turn the instances into hashes, and alter name order if requested
-    # Also change the names of the hash keys.
+    matches_array(regions)
+  end
+
+  def exact_match(words)
+    words = Location.reverse_name(words) if reverse
+    region = Observation.in_region(words).select(:where, :location_id).first
+    return [] unless region
+
+    matches_array([region])
+  end
+
+  # Turn the instances into hashes, and alter name order if requested
+  # Also change the names of the hash keys.
+  def matches_array(regions)
     matches = regions.map do |region|
       region = region.attributes.symbolize_keys
       format = reverse ? Location.reverse_name(region[:where]) : region[:where]

--- a/app/classes/auto_complete/for_species_list.rb
+++ b/app/classes/auto_complete/for_species_list.rb
@@ -7,7 +7,19 @@ class AutoComplete::ForSpeciesList < AutoComplete::ByWord
               or(SpeciesList[:title].matches("% #{letter}%"))).
             order(title: :asc)
 
-    # Turn the instances into hashes, and alter title key
+    matches_array(lists)
+  end
+
+  def exact_match(string)
+    list = SpeciesList.select(:title, :id).distinct.
+           where(SpeciesList[:title].eq(string)).first
+    return [] unless list
+
+    matches_array([list])
+  end
+
+  # Turn the instances into hashes, and alter title key
+  def matches_array(lists)
     lists.map do |list|
       list = list.attributes.symbolize_keys
       { name: list[:title], id: list[:id] }

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -8,7 +8,20 @@ class AutoComplete::ForUser < AutoComplete::ByString
               or(User[:name].matches("% #{letter}%"))).
             order(login: :asc)
 
-    # Turn the instances into hashes, and figure out what name to display
+    matches_array(users)
+  end
+
+  def exact_match(string)
+    user = User.select(:login, :name, :id).distinct.
+           where(User[:login].eq(string)).or(User[:name].eq(string)).
+           order(login: :asc).first
+    return [] unless user
+
+    matches_array([user])
+  end
+
+  # Turn the instances into hashes, and figure out what name to display
+  def matches_array(users)
     matches = users.map do |user|
       user = user.attributes.symbolize_keys
       user[:name] = if user[:name].empty?

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -12,9 +12,10 @@ class AutoComplete::ForUser < AutoComplete::ByString
   end
 
   def exact_match(string)
-    user = User.select(:login, :name, :id).distinct.
-           where(User[:login].eq(string)).or(User[:name].eq(string)).
-           order(login: :asc).first
+    user = User.select(:login, :name, :id).
+           where(User[:login].eq(string)).
+           or(User.where(User[:name].eq(string))).
+           order(login: :asc).distinct.first
     return [] unless user
 
     matches_array([user])

--- a/app/controllers/autocompleters_controller.rb
+++ b/app/controllers/autocompleters_controller.rb
@@ -38,6 +38,7 @@ class AutocompletersController < ApplicationController
   end
 
   def auto_complete_results
+    # Don't pass region or clade as the @type with `exact` here.
     if params[:exact].present?
       return ::AutoComplete.subclass(@type).new(params).first_matching_record
     end

--- a/app/controllers/autocompleters_controller.rb
+++ b/app/controllers/autocompleters_controller.rb
@@ -24,16 +24,23 @@ class AutocompletersController < ApplicationController
     if params[:string].blank? && params[:all].blank?
       render(json: ActiveSupport::JSON.encode([]))
     else
+      add_context_params
       render(json: ActiveSupport::JSON.encode(auto_complete_results))
     end
   end
 
   private
 
-  def auto_complete_results
-    # add useful params that the controller knows about
+  # add useful context params that the controller knows about, but not the class
+  def add_context_params
     params[:format] = @user&.location_format
     params[:user_id] = @user&.id
+  end
+
+  def auto_complete_results
+    if params[:exact].present?
+      return ::AutoComplete.subclass(@type).new(params).first_matching_record
+    end
 
     ::AutoComplete.subclass(@type).new(params).matching_records
   end

--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -148,7 +148,10 @@ module AutocompleterHelper
 
     model = autocompleter_type_to_model(args[:type])
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
-    args[:form].text_field(:"#{model}_id", value: args[:hidden_value], data:)
+    args[:form].hidden_field(
+      :"#{model}_id",
+      value: args[:hidden_value], data:, class: "form-control", readonly: true
+    )
   end
 
   def autocompleter_type_to_model(type)

--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -148,7 +148,7 @@ module AutocompleterHelper
 
     model = autocompleter_type_to_model(args[:type])
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
-    args[:form].text_field(:"#{model}_id", value: args[:hidden_value], data:)
+    args[:form].hidden_field(:"#{model}_id", value: args[:hidden_value], data:)
   end
 
   def autocompleter_type_to_model(type)

--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -148,7 +148,7 @@ module AutocompleterHelper
 
     model = autocompleter_type_to_model(args[:type])
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
-    args[:form].hidden_field(:"#{model}_id", value: args[:hidden_value], data:)
+    args[:form].text_field(:"#{model}_id", value: args[:hidden_value], data:)
   end
 
   def autocompleter_type_to_model(type)

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -384,7 +384,6 @@ export default class extends Controller {
     this.inputTarget.addEventListener("keyup", this);
     this.inputTarget.addEventListener("keypress", this);
     this.inputTarget.addEventListener("change", this);
-    this.inputTarget.addEventListener("paste", this);
     // Turbo: check this. May need to be turbo.before_render or before_visit
     window.addEventListener("beforeunload", this);
   }
@@ -413,9 +412,6 @@ export default class extends Controller {
         break;
       case "change":
         this.ourChange(event);
-        break;
-      case "paste":
-        this.ourPaste(event);
         break;
       case "beforeunload":
         this.ourUnload(event);
@@ -514,27 +510,6 @@ export default class extends Controller {
         }
       }
     }
-  }
-
-  // User pasted into text field.
-  // When matching multiple records, needs to keep track of "keepers", and
-  // update the hidden ids if the list of matches gets edited.
-  // Assess the pasted text and stop propagation (to change event).
-  ourPaste(event) {
-    // if (this.SEPARATOR) {
-    //   event.stopPropagation();
-    //   this.verbose("autocompleter:ourPaste()");
-    //   const pasted = event.clipboardData.getData('text'),
-    //     pasted_array = pasted.split(this.SEPARATOR).map(s => s.trim());
-    //   this.addMissingKeepersAndIds(pasted_array);
-    //   // this.ourChange(true);
-
-    //   // Handle the fact this could be pasted in the middle of the input,
-    //   // or in place of selected text
-    //   const { text, start, end } = this.getActiveInputSelection();
-    //   if (start !== null)
-    //     this.inputTarget.setRangeText(text, start, end);
-    // }
   }
 
   // User clicked into text field.

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -1967,7 +1967,7 @@ export default class extends Controller {
   }
 
   verbose(str) {
-    console.log(str);
+    // console.log(str);
     // document.getElementById("log").
     //   insertAdjacentText("beforeend", str + "<br/>");
   }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -751,8 +751,8 @@ export default class extends Controller {
     if (this.matches.length === 0) return;
 
     if (idx instanceof Event) { idx = parseInt(idx.target.dataset.row); }
-    let new_data = this.matches[this.scroll_offset + idx],
-      new_val = new_data.name;
+    let new_match = this.matches[this.scroll_offset + idx],
+      new_val = new_match.name;
     // Close pulldown unless the value the user selected uncollapses into a set
     // of new options.  In that case schedule a refresh and leave it up.
     if (this.COLLAPSE > 0 &&
@@ -765,9 +765,8 @@ export default class extends Controller {
     }
     this.inputTarget.focus();
     this.focused = true;
-    this.inputTarget.value = new_val;
-    this.assignHiddenId(new_data);
-    this.setSearchToken(new_val);
+    this.assignHiddenId(new_match);
+    this.setSearchToken(new_val); // updates input field
     this.ourChange(false);
   }
 
@@ -1382,6 +1381,7 @@ export default class extends Controller {
   }
 
   // Change the token under or immediately in front of the cursor.
+  // (Updates the value of the input field, handles multiple values.)
   setSearchToken(new_val) {
     const old_str = this.inputTarget.value;
     if (this.SEPARATOR) {
@@ -1397,8 +1397,9 @@ export default class extends Controller {
       if (old_str != new_str) {
         var old_scroll = this.inputTarget.offsetTop;
         this.inputTarget.value = new_str;
-        this.setCursorPosition(this.inputTarget[0],
-          extents.start + new_val.length);
+        this.setCursorPosition(
+          this.inputTarget, extents.start + new_val.length
+        );
         this.inputTarget.offsetTop = old_scroll;
       }
     } else {
@@ -1604,6 +1605,7 @@ export default class extends Controller {
   }
 
   setCursorPosition(el, pos) {
+    debugger
     if (el.setSelectionRange) {
       el.setSelectionRange(pos, pos);
     } else if (el.createTextRange) {

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -836,8 +836,6 @@ export default class extends Controller {
       this.updateRows(rows);
       this.highlightNewRow(rows);
       this.makePulldownVisible();
-      // moving this to populateMatches()
-      // this.updateHiddenId();
     }
     // Make sure input focus stays on text field!
     this.inputTarget.focus();
@@ -960,7 +958,7 @@ export default class extends Controller {
   // Assign ID of any perfectly matching option, even if not expressly selected.
   // This guards against user selecting a match, then, say, deleting a letter
   // and retyping the letter. Without this, an exact match would lose its ID.
-  // NOTE: This doesn't handle multiple IDs when there is a separator.
+  // NOTE: Needs to handle multiple IDs when there is a separator.
   updateHiddenId() {
     this.verbose("autocompleter:updateHiddenId()");
 
@@ -975,14 +973,6 @@ export default class extends Controller {
     } else if (!this.ignoringTextInput()) {
       this.clearHiddenId();
     }
-  }
-
-  // only clear if we're not in "ignorePlaceInput" mode
-  ignoringTextInput() {
-    if (!this.hasMapOutlet) return false;
-
-    this.verbose("autocompleter:ignoringTextInput()");
-    return this.mapOutlet.ignorePlaceInput;
   }
 
   // Assigns not only the ID, but also any data attributes of selected row.
@@ -1020,6 +1010,14 @@ export default class extends Controller {
     });
 
     this.hiddenIdChanged();
+  }
+
+  // only clear if we're not in "ignorePlaceInput" mode
+  ignoringTextInput() {
+    if (!this.hasMapOutlet) return false;
+
+    this.verbose("autocompleter:ignoringTextInput()");
+    return this.mapOutlet.ignorePlaceInput;
   }
 
   // Respond to the state of the hidden input. Initially we may not have id, but

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -959,6 +959,8 @@ export default class extends Controller {
   // Assign ID of any perfectly matching option, even if not expressly selected.
   // This guards against user selecting a match, then, say, deleting a letter
   // and retyping the letter. Without this, an exact match would lose its ID.
+  // NOTE: This does not fire if the user types out the exact match(!).
+  // It also doesn't handle multiple IDs when there is a separator.
   updateHiddenId() {
     this.verbose("autocompleter:updateHiddenId()");
     if (this.COLLAPSE > 0) return;

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -836,7 +836,8 @@ export default class extends Controller {
       this.updateRows(rows);
       this.highlightNewRow(rows);
       this.makePulldownVisible();
-      this.updateHiddenId();
+      // moving this to populateMatches()
+      // this.updateHiddenId();
     }
     // Make sure input focus stays on text field!
     this.inputTarget.focus();
@@ -959,11 +960,9 @@ export default class extends Controller {
   // Assign ID of any perfectly matching option, even if not expressly selected.
   // This guards against user selecting a match, then, say, deleting a letter
   // and retyping the letter. Without this, an exact match would lose its ID.
-  // NOTE: This does not fire if the user types out the exact match(!).
-  // It also doesn't handle multiple IDs when there is a separator.
+  // NOTE: This doesn't handle multiple IDs when there is a separator.
   updateHiddenId() {
     this.verbose("autocompleter:updateHiddenId()");
-    if (this.COLLAPSE > 0) return;
 
     const perfect_match =
       this.matches.find((m) => m['name'] === this.inputTarget.value.trim());
@@ -1168,6 +1167,8 @@ export default class extends Controller {
     this.updateCurrentRow(last);
     // Reset width each time we change the options.
     this.current_width = this.inputTarget.offsetWidth;
+    // Check for a perfect match, because we now have new matches.
+    this.updateHiddenId();
   }
 
   // When "acting like a select" make it display all options in the
@@ -1293,10 +1294,11 @@ export default class extends Controller {
           }
         }
       }
-      if (matches.length == 1 &&
-        (token == matches[0]['name'].toLowerCase() ||
-          token == matches[0]['name'].toLowerCase() + ' '))
-        matches.pop();
+      // This removes our ability to match an id! We need to keep single matches
+      // if (matches.length == 1 &&
+      //   (token.trim() == matches[0]['name'].toLowerCase())) {
+      //   matches.pop();
+      // }
     }
     this.matches = matches;
   }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -168,6 +168,9 @@ export default class extends Controller {
     this.hasMap = this.inputTarget.dataset.hasOwnProperty("mapTarget");
     this.hasGeocode = this.inputTarget.dataset.hasOwnProperty("geocodeTarget");
 
+    // Assign the separator for multiple-record autocompleters
+    this.SEPARATOR = this.element.dataset.separator;
+
     // Shared MO utilities, imported at the top:
     this.EVENT_KEYS = EVENT_KEYS;
     Object.assign(this, mo_form_utilities);
@@ -1360,6 +1363,7 @@ export default class extends Controller {
   getSearchToken() {
     const val = this.inputTarget.value;
     let token = val;
+    this.verbose("autocompleter:getSearchToken() before: " + token);
 
     // If we're only looking for whole words, don't make a request unless
     // trailing space or comma, indicating a user has finished typing a word.
@@ -1371,6 +1375,7 @@ export default class extends Controller {
       const extents = this.searchTokenExtents();
       token = val.substring(extents.start, extents.end);
     }
+    this.verbose("autocompleter:getSearchToken() after: " + token);
     return token;
   }
 

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -384,6 +384,7 @@ export default class extends Controller {
     this.inputTarget.addEventListener("keyup", this);
     this.inputTarget.addEventListener("keypress", this);
     this.inputTarget.addEventListener("change", this);
+    this.inputTarget.addEventListener("paste", this);
     // Turbo: check this. May need to be turbo.before_render or before_visit
     window.addEventListener("beforeunload", this);
   }
@@ -412,6 +413,9 @@ export default class extends Controller {
         break;
       case "change":
         this.ourChange(event);
+        break;
+      case "paste":
+        this.ourPaste(event);
         break;
       case "beforeunload":
         this.ourUnload(event);
@@ -491,7 +495,6 @@ export default class extends Controller {
   }
 
   // Input field has changed.
-  // Needs to keep track of "keepers", and update the hidden ids if the list of matches gets edited
   ourChange(do_refresh) {
     const old_value = this.old_value;
     const new_value = this.inputTarget.value;
@@ -500,6 +503,7 @@ export default class extends Controller {
       this.cssCollapseFields();
       this.clearHiddenId();
       this.leaveCreate();
+      if (this.SEPARATOR) { this.removeUnusedKeepersAndIds(); }
     } else {
       this.cssUncollapseFields();
       if (new_value != old_value) {
@@ -510,6 +514,27 @@ export default class extends Controller {
         }
       }
     }
+  }
+
+  // User pasted into text field.
+  // When matching multiple records, needs to keep track of "keepers", and
+  // update the hidden ids if the list of matches gets edited.
+  // Assess the pasted text and stop propagation (to change event).
+  ourPaste(event) {
+    // if (this.SEPARATOR) {
+    //   event.stopPropagation();
+    //   this.verbose("autocompleter:ourPaste()");
+    //   const pasted = event.clipboardData.getData('text'),
+    //     pasted_array = pasted.split(this.SEPARATOR).map(s => s.trim());
+    //   this.addMissingKeepersAndIds(pasted_array);
+    //   // this.ourChange(true);
+
+    //   // Handle the fact this could be pasted in the middle of the input,
+    //   // or in place of selected text
+    //   const { text, start, end } = this.getActiveInputSelection();
+    //   if (start !== null)
+    //     this.inputTarget.setRangeText(text, start, end);
+    // }
   }
 
   // User clicked into text field.
@@ -1010,6 +1035,9 @@ export default class extends Controller {
     this.verbose("autocompleter:updateHiddenId()");
     this.verbose("autocompleter:getSearchToken().trim(): ");
     this.verbose(this.getSearchToken().trim());
+    // Fires on every change
+    if (this.SEPARATOR) { this.removeUnusedKeepersAndIds(); }
+
     const perfect_match =
       this.matches.find((m) => m['name'] === this.getSearchToken().trim());
 
@@ -1021,8 +1049,6 @@ export default class extends Controller {
     } else if (!this.ignoringTextInput()) {
       this.clearHiddenId();
     }
-    // Fires on every change!
-    if (this.SEPARATOR) { this.syncHiddenIds(); }
   }
 
   // Gets the most recent value in the hidden input, which may be an array.
@@ -1062,9 +1088,10 @@ export default class extends Controller {
     }
   }
 
+  // add the new id at the same index of the array as the search token.
+  // Converts array back to string.
   updateHiddenTargetValueMultiple(match) {
-    // add the new id at the same index of the array as the search token.
-    // Converts array back to string.
+    this.verbose("autocompleter:updateHiddenTargetValueMultiple()");
     let new_array = this.stored_ids,
       idx = this.getSearchTokenIndex(),
       { name, id } = match,
@@ -1078,6 +1105,7 @@ export default class extends Controller {
   }
 
   updateHiddenTargetValueSingle(match) {
+    this.verbose("autocompleter:updateHiddenTargetValueSingle()");
     this.hiddenTarget.value = match['id'];
     // assign the dataset of the selected row to the hidden input
     Object.keys(match).forEach(key => {
@@ -1086,13 +1114,13 @@ export default class extends Controller {
     });
   }
 
-  // Clears not only the ID, but also any data attributes of selected row.
-  // Don't remove target data-attributes.
+  // Clears not only the ID, but also any data attributes of selected row,
+  // and the most recent keeper.
   clearHiddenId() {
     this.verbose("autocompleter:clearHiddenId()");
     // Before we change the hidden input, store the old value and data
     this.storeCurrentHiddenData();
-    // Also clears data attributes.
+    // Clears hidden_id and hidden field data attributes (except `target` atts).
     this.clearLastHiddenTargetValue();
     // This checks the hidden_data against the stored_data
     this.hiddenIdChanged();
@@ -1102,30 +1130,37 @@ export default class extends Controller {
   clearLastHiddenTargetValue() {
     this.verbose("autocompleter:clearLastHiddenTargetValue()");
     if (this.SEPARATOR) {
-      this.clearLastHiddenTargetValueMultiple();
+      this.clearLastHiddenIdAndKeeper();
     } else {
-      this.clearLastHiddenTargetValueSingle();
+      this.clearHiddenIdAndData();
     }
   }
 
-  // We have to be careful here to delete only the id (of multiple) that is
+  // Multiple: We have to be careful here to delete only the id that is
   // at the same index as the search token. Otherwise it keeps deleting.
-  clearLastHiddenTargetValueMultiple() {
-    this.verbose("autocompleter:clearLastHiddenTargetValueMultiple()");
+  clearLastHiddenIdAndKeeper() {
+    this.verbose("autocompleter:clearLastHiddenIdAndKeeper()");
     // not worried about integers here
-    let old_array = this.hiddenTarget.value.split(","),
+    let hidden_ids = this.hiddenIdsAsIntegerArray(),
       idx = this.getSearchTokenIndex();
 
-    if (idx > -1 && old_array.length > idx) {
-      old_array.slice(idx, 1);
-      this.hiddenTarget.value = old_array.join(",");
+    this.verbose("autocompleter:hidden_ids: ")
+    this.verbose(JSON.stringify(hidden_ids));
+    this.verbose("autocompleter:idx: ")
+    this.verbose(idx);
+
+    if (idx > -1 && hidden_ids.length > idx) {
+      hidden_ids.slice(idx, 1);
+      this.hiddenTarget.value = hidden_ids.join(",");
       // also clear the dataset
       if (this.keepers.length > idx)
-        this.keepers.slice(idx, 1);
+        this.verbose("autocompleter:keepers: ")
+      this.verbose(JSON.stringify(this.keepers));
+      this.keepers.slice(idx, 1);
     }
   }
 
-  clearLastHiddenTargetValueSingle() {
+  clearHiddenIdAndData() {
     this.hiddenTarget.value = '';
     // clear the dataset also
     Object.keys(this.hiddenTarget.dataset).forEach(key => {
@@ -1136,11 +1171,10 @@ export default class extends Controller {
 
   // check if any names in `keepers` are not in the input values.
   // if so, remove them from the keepers and the hidden input.
-  // This still can't deal with pasted-in values, but it's a start.
-  syncHiddenIds() {
+  removeUnusedKeepersAndIds() {
     if (!this.SEPARATOR || this.keepers == []) return;
 
-    this.verbose("autocompleter:syncHiddenIds()");
+    this.verbose("autocompleter:removeUnusedKeepersAndIds()");
     this.verbose("autocompleter:keepers: ")
     this.verbose(JSON.stringify(this.keepers));
 
@@ -1163,66 +1197,80 @@ export default class extends Controller {
     });
     // update the hidden input
     this.hiddenTarget.value = hidden_ids.join(",");
-    // ONLY DO THIS ONPASTE
-    // check for names in the input that are missing from the keepers and ids
-    this.checkForMissingKeepersAndIds(input_names);
+    // also check for missing?
+    this.addMissingKeepersAndIds(input_names);
   }
 
-  // If the input names don't match the keepers, we need to add them back in.
-  checkForMissingKeepersAndIds(input_names) {
+  // If the input names don't match what's stored in our keepers or hidden ids,
+  // we need to add them in. NOTE: The fetch response that updates keepers and
+  // ids expects for the keepers and ids to be the same length and at the same
+  // index as the input names, so we can't just push things into arrays. We
+  // need to arrange them at the right index for each existing keeper and id.
+  // Account for pasting into an existing list.
+  addMissingKeepersAndIds(input_names) {
     if (input_names.length == 0) return;
 
-    this.verbose("autocompleter:checkForMissingKeepers()");
-    // The fetch response assumes the input names are the same length and in the
-    // same order as the keepers and ids, so we can't just push them back in. We
-    // need to find the right position for each existing keeper and id.
+    this.verbose("autocompleter:addMissingKeepersAndIds()");
     // Prepare null values in the array where we need to add new keepers
-    if (this.keepers.length < input_names.length) {
-      const new_keepers = new Array(input_names.length).
-        fill({ name: null, id: null });
-      if (this.keepers.length > 0) {
-        // Put current keepers in the right positions in the new array
-        input_names.forEach((n, i) => {
-          const idx = this.keepers.map((d) => d.name).indexOf(n);
-          if (idx > -1) {
-            new_keepers[i] = this.keepers[idx];
-          }
-        });
-      }
-      this.keepers = new_keepers;
-    }
-    // Do the same for the hidden IDs. We have to check against keepers for ids.
-    const hidden_ids = this.hiddenIdsAsIntegerArray();
-    if (hidden_ids.length < input_names.length) {
-      const new_ids = new Array(input_names.length).fill(null);
-      if (hidden_ids.length > 0) {
-        // Put current ids in the right positions in the new array
-        this.keepers.forEach((n, i) => {
-          const idx = hidden_ids.indexOf(n.id);
-          if (idx > -1) {
-            new_ids[i] = hidden_ids[idx];
-          }
-        });
-      }
-      this.hiddenTarget.value = new_ids.join(",");
-    }
+    this.addMissingKeepers(input_names);
+    // Do the same for the hidden IDs. Check these against the keeper ids.
+    this.addMissingHiddenIds(input_names);
+
     // Now try to fetch records for the missing input names
     const missing = input_names.filter((n) => {
       return !this.keepers.map((d) => d.name).includes(n);
     });
 
     if (missing.length > 0) {
-      this.verbose("autocompleter:missing: ")
-      this.verbose(JSON.stringify(missing));
-      // send these staggered so they don't cancel each other.
-      missing.forEach((token, i) => {
-        setTimeout(() => {
-          this.matchOneToken(token);
-        }, i * 300);
-      });
+      this.fetchMissingRecords(missing);
     }
   }
 
+  addMissingKeepers(input_names) {
+    if (!(this.keepers.length < input_names.length)) return;
+
+    const new_keepers = new Array(input_names.length).
+      fill({ name: null, id: null });
+    if (this.keepers.length > 0) {
+      // Put current keepers in the right positions in the new array
+      input_names.forEach((n, i) => {
+        const idx = this.keepers.map((d) => d.name).indexOf(n);
+        if (idx > -1) {
+          new_keepers[i] = this.keepers[idx];
+        }
+      });
+    }
+    this.keepers = new_keepers;
+  }
+
+  addMissingHiddenIds(input_names) {
+    const hidden_ids = this.hiddenIdsAsIntegerArray();
+    if (!(hidden_ids.length < input_names.length)) return;
+
+    const new_ids = new Array(input_names.length).fill(null);
+    if (hidden_ids.length > 0) {
+      // Put current ids in the right positions in the new array
+      this.keepers.forEach((n, i) => {
+        const idx = hidden_ids.indexOf(n.id);
+        if (idx > -1) {
+          new_ids[i] = hidden_ids[idx];
+        }
+      });
+    }
+    this.hiddenTarget.value = new_ids.join(",");
+  }
+
+  // Fetch records for the missing input names.
+  fetchMissingRecords(missing) {
+    this.verbose("autocompleter:fetchMissingRecords(missing): ")
+    this.verbose(JSON.stringify(missing));
+    // send these staggered so they don't cancel each other.
+    missing.forEach((token, i) => {
+      setTimeout(() => {
+        this.matchOneToken(token);
+      }, i * 450);
+    });
+  }
   // only clear if we're not in "ignorePlaceInput" mode
   ignoringTextInput() {
     if (!this.hasMapOutlet) return false;
@@ -1584,8 +1632,8 @@ export default class extends Controller {
 
     // If we're only looking for whole words, don't make a request unless
     // trailing space or comma, indicating a user has finished typing a word.
-    if (this.WHOLE_WORDS_ONLY && token.charAt(token.length - 1) != ',' &&
-      token.charAt(token.length - 1) != ' ') {
+    if (this.WHOLE_WORDS_ONLY &&
+      ![',', ' '].includes(token.charAt(token.length - 1))) {
       return '';
     }
     if (this.SEPARATOR) {
@@ -1635,27 +1683,45 @@ export default class extends Controller {
     else
       start += this.SEPARATOR.length;
 
+    // this.verbose("autocompleter:searchTokenExtents() start: " + start);
+    // this.verbose("autocompleter:searchTokenExtents() end: " + end);
     return { start, end };
   }
 
   // When there are multiple values separated by a separator.
   getSearchTokenIndex() {
-    const token = this.getSearchToken();
-    this.verbose("autocompleter:getSearchToken()");
-    this.verbose(token);
+    this.verbose("autocompleter:getSearchTokenIndex()");
+    const token = this.getLastInput();
     return this.getInputIndexOf(token);
   }
 
   getInputIndexOf(token) {
-    return this.getInputArray().indexOf(token);
+    this.verbose("autocompleter:getInputIndexOf()");
+    const idx = this.getInputArray().indexOf(token);
+    this.verbose(idx);
+    return idx;
+  }
+
+  getLastInput() {
+    this.verbose("autocompleter:getLastInput()");
+    const token = this.getInputArray().pop();
+    this.verbose(token);
+    return token;
   }
 
   getInputArray() {
-    return this.inputTarget.value.split(this.SEPARATOR).map((v) => v.trim());
+    this.verbose("autocompleter:getInputArray()");
+    const input_array =
+      this.inputTarget.value.split(this.SEPARATOR).map((v) => v.trim());
+    this.verbose(input_array);
+    return input_array;
   }
 
   getInputCount() {
-    return this.getInputArray().length;
+    this.verbose("autocompleter:getInputCount()");
+    const count = this.getInputArray().length;
+    this.verbose(count);
+    return count;
   }
 
   // ------------------------------ Fetch matches ------------------------------
@@ -1853,6 +1919,8 @@ export default class extends Controller {
   matchOneToken(token) {
     const query_params = { string: token, ...this.request_params }
     query_params["whole"] = true;
+    query_params["all"] = true;
+    query_params["exact"] = true;
 
     // Make request.
     this.sendFetchRequest(query_params, true);
@@ -1877,7 +1945,7 @@ export default class extends Controller {
       const idx = this.getInputIndexOf(exact_match['name']);
       if (idx == -1) { return; }
 
-      hidden_ids = this.hiddenIdsAsIntegerArray();
+      let hidden_ids = this.hiddenIdsAsIntegerArray();
       // if the exact match is not in the hidden ids, add it at the right index.
       if (!hidden_ids.includes(exact_match['id'])) {
         hidden_ids.splice(idx, 1, exact_match['id']);

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -1163,6 +1163,7 @@ export default class extends Controller {
     });
     // update the hidden input
     this.hiddenTarget.value = hidden_ids.join(",");
+    // ONLY DO THIS ONPASTE
     // check for names in the input that are missing from the keepers and ids
     this.checkForMissingKeepersAndIds(input_names);
   }

--- a/app/javascript/src/mo_form_utilities.js
+++ b/app/javascript/src/mo_form_utilities.js
@@ -44,6 +44,18 @@ export const mo_form_utilities = {
 
     this.scrollbar_width = w1 - w2;
     // return scroll_bar_width;
+  },
+
+  setCursorPosition(el, pos) {
+    if (el.setSelectionRange) {
+      el.setSelectionRange(pos, pos);
+    } else if (el.createTextRange) {
+      const range = el.createTextRange();
+      range.collapse(true);
+      range.moveEnd('character', pos);
+      range.moveStart('character', pos);
+      range.select();
+    }
   }
 }
 

--- a/app/javascript/src/mo_form_utilities.js
+++ b/app/javascript/src/mo_form_utilities.js
@@ -56,6 +56,19 @@ export const mo_form_utilities = {
       range.moveStart('character', pos);
       range.select();
     }
+  },
+
+  // https://stackoverflow.com/a/74602959/3357635
+  getActiveInputSelection() {
+    const el = document.activeElement,
+      selection = { start: null, end: null, text: '' };
+
+    if (typeof el != "undefined") {
+      selection.start = el.selectionStart;
+      selection.end = el.selectionEnd;
+      selection.text = el.value.substring(selection.start, selection.end);
+    }
+    return selection;
   }
 }
 

--- a/test/system/herbarium_form_system_test.rb
+++ b/test/system/herbarium_form_system_test.rb
@@ -47,7 +47,6 @@ class HerbariumFormSystemTest < ApplicationSystemTestCase
     assert_link(:form_observations_create_locality.l)
     click_link(:form_observations_create_locality.l)
 
-    assert_selector("#herbarium_place_name.geocoded")
     assert_field("herbarium_place_name",
                  with: "Génolhac, Gard, Occitanie, France")
 

--- a/test/system/list_form_system_test.rb
+++ b/test/system/list_form_system_test.rb
@@ -37,4 +37,27 @@ class ListFormSystemTest < ApplicationSystemTestCase
     assert_field("list_name_id", with: "#{name2.id},#{name1.id},#{name3.id}",
                                  type: :hidden)
   end
+
+  def test_multi_autocompleter_paste
+    @browser = page.driver.browser
+    rolf = users("rolf")
+    login!(rolf)
+
+    visit("/species_lists/new")
+    assert_selector("body.species_lists__new")
+    assert_field("list_members")
+    assert_field("list_name_id", type: :hidden)
+
+    name1 = names("coprinus_comatus")
+    name2 = names("agaricus_campestris")
+    name3 = names("stereum_hirsutum")
+    fill_in(
+      "list_members",
+      with: "Agaricus campestris\nCoprinus comatus\nStereum hirsutum"
+    )
+    assert_field("list_members", with: /Agaricus campestris/)
+    sleep(1)
+    assert_field("list_name_id", with: "#{name2.id},#{name1.id},#{name3.id}",
+                                 type: :hidden)
+  end
 end

--- a/test/system/list_form_system_test.rb
+++ b/test/system/list_form_system_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+class ListFormSystemTest < ApplicationSystemTestCase
+  def test_multi_autocompleter
+    @browser = page.driver.browser
+    rolf = users("rolf")
+    login!(rolf)
+
+    visit("/species_lists/new")
+    assert_selector("body.species_lists__new")
+    assert_field("list_members")
+    assert_field("list_name_id", type: :hidden)
+
+    name1 = names("coprinus_comatus")
+    name2 = names("agaricus_campestris")
+    name3 = names("stereum_hirsutum")
+    fill_in("list_members", with: "Agaricus campestris")
+    assert_field("list_name_id", with: name2.id, type: :hidden)
+    @browser.keyboard.type(:return)
+    assert_field("list_members", with: /Agaricus campestris/)
+    @browser.keyboard.type("Coprinus com")
+    assert_selector(".auto_complete") # wait
+    assert_selector(".auto_complete ul li a", text: "Coprinus comatus")
+    @browser.keyboard.type(:down, :tab)
+    assert_field("list_members", with: /Coprinus comatus/)
+    assert_field("list_name_id", with: "#{name2.id},#{name1.id}", type: :hidden)
+    @browser.keyboard.type(:return)
+    sleep(1)
+    @browser.keyboard.type(:return)
+    @browser.keyboard.type("Stereum hirs")
+    assert_selector(".auto_complete") # wait
+    assert_selector(".auto_complete ul li a", text: "Stereum hirsutum")
+    @browser.keyboard.type(:down, :tab)
+    assert_field("list_members", with: /Stereum hirsutum/)
+    assert_field("list_name_id", with: "#{name2.id},#{name1.id},#{name3.id}",
+                                 type: :hidden)
+  end
+end


### PR DESCRIPTION
The MO autocompleter is able to autocomplete multiple records in the same input, one after the other, if the user uses the expected "separator" (like a `\n` or `,`). Multiple autocomplete is used on the "new SpeciesList" form for a list of names. I unintentionally broke this at some point, this re-enables it.

This also (newly) gets "multiple-record" autocompleters to store the array of record ids of the matching records. That took quite a bit of refactoring of the Stimulus for autocompleters. 