### PR TITLE
Improve project flash messages

### DIFF
--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -263,13 +263,26 @@ module ObservationsController::SharedFormMethods
 
       if after
         project.add_observation(@observation)
-        flash_notice(:attached_to_project.t(object: :observation,
-                                            project: project.title))
+        name_flash_for_project(@observation.name, project)
       else
         project.remove_observation(@observation)
         flash_notice(:removed_from_project.t(object: :observation,
                                              project: project.title))
       end
+    end
+  end
+
+  def name_flash_for_project(name, project)
+    return unless name
+
+    count = project.count_collections(name)
+    if count == 1
+      flash_warning(:project_first_collection.t(name: name.text_name,
+                                                project: project.title))
+    else
+      flash_notice(:project_count_collections.t(count: count,
+                                                name: name.text_name,
+                                                project: project.title))
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -399,6 +399,10 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     Checklist::ForProject.new(self).num_taxa
   end
 
+  def count_collections(name)
+    observations.where(name:).count
+  end
+
   def violations
     out_of_range_observations.to_a.union(out_of_area_observations)
   end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -863,6 +863,8 @@
   on_mo: On MO
   on_the_web: On the web
   on_site: On [site]
+  project_first_collection: "**First collection of \"[name]\" for \"[project]\". Consider vouchering!**"
+  project_count_collections: "[count] collections of \"[name]\" for \"[project]\"."
   show_on_map: Show on map
   many_times: "[num] times"
   one_time: once

--- a/test/controllers/observations_controller/observations_controller_project_list_test.rb
+++ b/test/controllers/observations_controller/observations_controller_project_list_test.rb
@@ -173,7 +173,7 @@ class ObservationsControllerProjectListTest < FunctionalTestCase
         }
       }
     )
-    assert_flash_success
+    assert_flash_warning
     assert_response(:redirect)
     assert_obj_arrays_equal([project], obs.reload.projects)
   end


### PR DESCRIPTION
when adding observations.  Give a warning if the observation is for a name not previously used in this project.  Gives a count of observation with that name if there are previous matching observations.

To test:
1) Using a project with a field slip prefix, create a new field slip (e.g., http://localhost:3000/qr/ATEST-10000).
2) Enter a name not currently in the associated project and complete the observation creation process.
3) You should see a warning suggesting you voucher this collection.
4) Go through the process again with the same name.
5) You should a regular (green) flash message that tells you how many collections have been made for this project so far.