### PR TITLE
Quick create from field slip

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -140,24 +140,15 @@ class FieldSlipsController < ApplicationController
     flash_error(:field_slip_quick_no_name.t) unless name
     notes = field_slip_notes.compact_blank!
 
-    if location && name
-      now = Time.zone.now
-      obs = Observation.new({ created_at: now,
-                              updated_at: now,
-                              user: @user,
-                              location: location,
-                              name: name,
-                              source: "mo_website",
-                              notes: notes })
-      if obs
-        @field_slip.project&.add_observation(obs)
-        @field_slip.update!(observation: obs)
-        redirect_to(observation_url(obs.id))
-        return
-      end
+    obs = Observation.build_observation(location, name, notes)
+    if obs
+      @field_slip.project&.add_observation(obs)
+      @field_slip.update!(observation: obs)
+      redirect_to(observation_url(obs.id))
+    else
+      redirect_to(new_observation_url(field_code: @field_slip.code,
+                                      place_name:, notes:))
     end
-    redirect_to(new_observation_url(field_code: @field_slip.code,
-                                    place_name:, notes:))
   end
 
   def update_observation_fields

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -468,6 +468,22 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     str.strip_squeeze.downcase
   end
 
+  # Cleans up a place_name (per Observation) and
+  # applies the current user's current_location_format
+  def self.normalize_place_name(place_name)
+    place_name = place_name&.strip_squeeze
+    if User.current_location_format == "scientific"
+      reverse_name(place_name)
+    else
+      place_name
+    end
+  end
+
+  # Returns any existing location that matches place_name
+  def self.place_name_to_location(place_name)
+    find_by_name(normalize_place_name(place_name))
+  end
+
   # Takes a location string splits on commas, reverses the order,
   # and joins it back together
   # E.g., "New York, USA" => "USA, New York"

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -723,12 +723,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # the given +display_name+.  (Fills the other in with +nil+.)
   # Adjusts for the current user's location_format as well.
   def place_name=(place_name)
-    place_name = place_name&.strip_squeeze
-    where = if User.current_location_format == "scientific"
-              Location.reverse_name(place_name)
-            else
-              place_name
-            end
+    where = Location.normalize_place_name(place_name)
     loc = Location.find_by_name(where)
     if loc
       self.where = loc.name
@@ -1150,13 +1145,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   ##############################################################################
 
   # Which agent created this observation?
-  enum source:
-        {
-          mo_website: 1,
-          mo_android_app: 2,
-          mo_iphone_app: 3,
-          mo_api: 4
-        }
+  enum :source, {
+    mo_website: 1,
+    mo_android_app: 2,
+    mo_iphone_app: 3,
+    mo_api: 4
+  }
 
   # Message to use to credit the agent which created this observation.
   # Intended to be used with .tpl to render as HTML:

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -40,11 +40,13 @@
     <%= text_field_with_label(form: form, field: :other_codes,
                               label: "#{:field_slip_other_codes.t} (#{:field_slip_other_example.t}):") %>
 
+    <% if action == "new" %>
+      <%= submit_button(form: form, button: :field_slip_quick_create_obs.t, class: "mt-5") %>
+      <%= submit_button(form: form, button: :field_slip_create_obs.t, class: "mt-5") %>
+    <% end %>
+
     <%= render(partial: "shared/notes_fields",
                locals: { form:, fields: field_slip.notes_fields }) %>
-
-    <%= submit_button(form: form, button: :field_slip_create_obs.t,
-                      class: "mt-5") if action == "new" %>
 
     <div class="row mt-5">
       <% if field_slip.observation %>

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -40,13 +40,12 @@
     <%= text_field_with_label(form: form, field: :other_codes,
                               label: "#{:field_slip_other_codes.t} (#{:field_slip_other_example.t}):") %>
 
-    <% if action == "new" %>
-      <%= submit_button(form: form, button: :field_slip_quick_create_obs.t, class: "mt-5") %>
-      <%= submit_button(form: form, button: :field_slip_create_obs.t, class: "mt-5") %>
-    <% end %>
+    <%= submit_button(form: form, button: :field_slip_quick_create_obs.t, class: "mb-5") if action == "new" %>
 
     <%= render(partial: "shared/notes_fields",
                locals: { form:, fields: field_slip.notes_fields }) %>
+
+    <%= submit_button(form: form, button: :field_slip_create_obs.t, class: "mt-5") if action == "new" %>
 
     <div class="row mt-5">
       <% if field_slip.observation %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2815,7 +2815,8 @@
   field_slip_code_format_error: code must have non-numeric characters other than period (.) and dash (-)
   field_slip_constraint_violation: The selected observation violates one or more project constraints
   field_slip_created: Field slip was successfully created.
-  field_slip_create_obs: Create New Observation
+  field_slip_create_obs: Add Images or Other Data
+  field_slip_quick_create_obs: Quick Create
   field_slip_creator: Creator
   field_slip_destroy: Destroy this field slip
   field_slip_destroyed: Field slip was successfully destroyed.
@@ -2834,6 +2835,9 @@
   field_slip_other_codes: Other Codes
   field_slip_other_example: e.g., iNat ID
   field_slip_project_success: Field Slip associated with the [TITLE] Project
+  field_slip_quick_no_location: Quick create requires an existing location 
+  field_slip_quick_no_name: Quick create requires an existing name
+
   field_slip_remove_observation: Removed [OBSERVATION] from [TITLE] Project
   field_slip_show: Show [:FIELD_SLIP]
   field_slip_updated: Field slip was successfully updated.

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -168,7 +168,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_redirected_to observation_url(obs.id)
   end
 
-  test "should create field_slip, try to create obs, and redirect to create obs" do
+  test "should try to create obs and redirect to create obs" do
     login(@field_slip.user.login)
     code = "Z#{@field_slip.code}"
     assert_difference("FieldSlip.count") do

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -149,6 +149,61 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_redirected_to new_observation_url(field_code: code)
   end
 
+  test "should create field_slip and obs and redirect to show obs" do
+    login(@field_slip.user.login)
+    code = "Z#{@field_slip.code}"
+    assert_difference("FieldSlip.count") do
+      post(:create,
+           params: {
+             commit: :field_slip_quick_create_obs.t,
+             field_slip: {
+               code: code,
+               location: locations(:albion).name,
+               field_slip_id: names(:coprinus_comatus).text_name,
+               project_id: projects(:eol_project).id
+             }
+           })
+    end
+    obs = Observation.last
+    assert_redirected_to observation_url(obs.id)
+  end
+
+  test "should create field_slip, try to create obs, and redirect to create obs" do
+    login(@field_slip.user.login)
+    code = "Z#{@field_slip.code}"
+    assert_difference("FieldSlip.count") do
+      post(:create,
+           params: {
+             commit: :field_slip_quick_create_obs.t,
+             field_slip: {
+               code: code,
+               project_id: projects(:eol_project).id
+             }
+           })
+    end
+    assert_flash_error
+    assert_redirected_to new_observation_url(field_code: code)
+  end
+
+  test "should attempt quick field_slip and redirect to show obs" do
+    login(@field_slip.user.login)
+    code = "Z#{@field_slip.code}"
+    assert_difference("FieldSlip.count") do
+      post(:create,
+           params: {
+             commit: :field_slip_quick_create_obs.t,
+             field_slip: {
+               code: code,
+               location: locations(:albion).name,
+               field_slip_id: names(:coprinus_comatus).text_name,
+               project_id: projects(:eol_project).id
+             }
+           })
+    end
+    obs = Observation.last
+    assert_redirected_to observation_url(obs.id)
+  end
+
   test "should create field_slip in project from code" do
     login
     project = projects(:eol_project)


### PR DESCRIPTION
If you create a brand new fields slip (e.g., http://localhost:3000/qr/ATEST-00101) and you provide a location name and an id, the "Quick Create" button should create the observation without going through the regular "Create Observation" workflow.  If either of those are not provided or not already in the database, then you'll get directed to the regular "Create Observation" workflow.

The purpose of this is to speed up workflow for foray recorders who typically have 100s if not 1000s of field slips to process.