### PR TITLE
Stop timer when field slip PDF job is done

### DIFF
--- a/app/javascript/controllers/field-slip-job_controller.js
+++ b/app/javascript/controllers/field-slip-job_controller.js
@@ -52,9 +52,6 @@ export default class extends Controller {
         }
       }, 1000);
     } else {
-      if (this.intervalId != null) {
-        clearInterval(this.intervalId)
-      }
       // If the PDF is done, we can remove this Stimulus controller from the
       // element and stop the timer. (NOTE: there may be other controllers.)
       // console.log("field-slip-job is done")

--- a/app/javascript/controllers/field-slip-job_controller.js
+++ b/app/javascript/controllers/field-slip-job_controller.js
@@ -24,6 +24,12 @@ export default class extends Controller {
 
   // Clear any intervals when the controller is disconnected
   disconnect() {
+    const stimulus = this.element.dataset.stimulus.split(" ")
+    if (stimulus.includes("field-slip-job-connected")) {
+      const idx = stimulus.indexOf("field-slip-job-connected")
+      stimulus.splice(idx, 1)
+      this.element.setAttribute("data-stimulus", stimulus.join(" "))
+    }
     if (this.intervalId != null) {
       clearInterval(this.intervalId)
     }
@@ -45,8 +51,16 @@ export default class extends Controller {
           console.log(`got a ${response.status}`);
         }
       }, 1000);
-    } else if (this.intervalId != null) {
-      clearInterval(this.intervalId)
+    } else {
+      // console.log("field-slip-job is done")
+      // If the PDF is done, we can remove this Stimulus controller from the
+      // element and stop the timer. (There may be other controllers.)
+      const controllers = this.element.dataset.controller.split(" ")
+      if (controllers.includes("field-slip-job")) {
+        const idx = controllers.indexOf("field-slip-job")
+        controllers.splice(idx, 1)
+        this.element.setAttribute("data-controller", controllers.join(" "))
+      }
     }
   }
 }

--- a/app/javascript/controllers/field-slip-job_controller.js
+++ b/app/javascript/controllers/field-slip-job_controller.js
@@ -46,15 +46,15 @@ export default class extends Controller {
         const response = await get(this.endpoint_url,
           { responseKind: "turbo-stream" });
         if (response.ok) {
-          // turbo-stream prints the row in the page already
+          // Turbo replaces the row in the page already
         } else {
           console.log(`got a ${response.status}`);
         }
       }, 1000);
     } else {
-      // console.log("field-slip-job is done")
       // If the PDF is done, we can remove this Stimulus controller from the
-      // element and stop the timer. (There may be other controllers.)
+      // element and stop the timer. (NOTE: there may be other controllers.)
+      // console.log("field-slip-job is done")
       const controllers = this.element.dataset.controller.split(" ")
       if (controllers.includes("field-slip-job")) {
         const idx = controllers.indexOf("field-slip-job")

--- a/app/javascript/controllers/field-slip-job_controller.js
+++ b/app/javascript/controllers/field-slip-job_controller.js
@@ -52,6 +52,9 @@ export default class extends Controller {
         }
       }, 1000);
     } else {
+      if (this.intervalId != null) {
+        clearInterval(this.intervalId)
+      }
       // If the PDF is done, we can remove this Stimulus controller from the
       // element and stop the timer. (NOTE: there may be other controllers.)
       // console.log("field-slip-job is done")


### PR DESCRIPTION
Our Stimulus controller that updates the UI for field slip jobs should ideally disconnect itself when it's done updating the UI. 