### PR TITLE
Enables recorders to go directly to the field slip edit page

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -22,7 +22,11 @@ class FieldSlipsController < ApplicationController
       obs = @field_slip&.observation
     end
     if @field_slip
-      redirect_to(observation_url(id: obs.id)) if obs
+      if foray_recorder?
+        redirect_to(edit_field_slip_url(id: @field_slip.id)) if obs
+      else
+        redirect_to(observation_url(id: obs.id)) if obs
+      end
     else
       redirect_to(new_field_slip_url(code: params[:id].upcase))
     end
@@ -115,10 +119,17 @@ class FieldSlipsController < ApplicationController
 
   private
 
+  def foray_recorder?
+    project = @field_slip&.project
+    return false unless project
+
+    return project.is_admin?(User.current) && project.happening?
+  end
+
   def html_create
     if params[:commit] == :field_slip_quick_create_obs.t
       quick_create_observation
-    elsif params[:commit] == :field_slip_create_obs.t
+    elsif params[:commit] == :field_slip_add_images.t
       redirect_to(new_observation_url(
                     field_code: @field_slip.code,
                     place_name: params[:field_slip][:location],

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -22,11 +22,7 @@ class FieldSlipsController < ApplicationController
       obs = @field_slip&.observation
     end
     if @field_slip
-      if foray_recorder?
-        redirect_to(edit_field_slip_url(id: @field_slip.id)) if obs
-      elsif obs
-        redirect_to(observation_url(id: obs.id))
-      end
+      field_slip_redirect(obs.id) if obs
     else
       redirect_to(new_field_slip_url(code: params[:id].upcase))
     end
@@ -118,6 +114,14 @@ class FieldSlipsController < ApplicationController
   end
 
   private
+
+  def field_slip_redirect(obs_id)
+    if foray_recorder?
+      redirect_to(edit_field_slip_url(id: @field_slip.id))
+    else
+      redirect_to(observation_url(id: obs_id))
+    end
+  end
 
   def foray_recorder?
     project = @field_slip&.project

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -24,8 +24,8 @@ class FieldSlipsController < ApplicationController
     if @field_slip
       if foray_recorder?
         redirect_to(edit_field_slip_url(id: @field_slip.id)) if obs
-      else
-        redirect_to(observation_url(id: obs.id)) if obs
+      elsif obs
+        redirect_to(observation_url(id: obs.id))
       end
     else
       redirect_to(new_field_slip_url(code: params[:id].upcase))
@@ -123,7 +123,7 @@ class FieldSlipsController < ApplicationController
     project = @field_slip&.project
     return false unless project
 
-    return project.is_admin?(User.current) && project.happening?
+    project.is_admin?(User.current) && project.happening?
   end
 
   def html_create

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -421,6 +421,14 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   ##############################################################################
 
+  def happening?
+    now = Time.zone.now
+    return false if start_date.present? && now < start_date
+    return false if end_date.present? && now > end_date
+
+    true
+  end
+
   def out_of_range_observations
     if start_date.nil? && end_date.nil?
       # performant query that returns empty ActiveRecord_Relation

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -45,7 +45,7 @@
     <%= render(partial: "shared/notes_fields",
                locals: { form:, fields: field_slip.notes_fields }) %>
 
-    <%= submit_button(form: form, button: :field_slip_create_obs.t, class: "mt-5") if action == "new" %>
+    <%= submit_button(form: form, button: :field_slip_add_images.t, class: "mt-5") if action == "new" %>
 
     <div class="row mt-5">
       <% if field_slip.observation %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2810,12 +2810,13 @@
   destroy_visual_model_success: "[:VISUAL_MODEL] [:destroyed]"
 
   # Field Slips
+  field_slip_add_images: Add Images or Other Data
   field_slip_cant_join_project: Either no Project was found or you are unable to join the associated Project
   field_slip_code: Code
   field_slip_code_format_error: code must have non-numeric characters other than period (.) and dash (-)
   field_slip_constraint_violation: The selected observation violates one or more project constraints
   field_slip_created: Field slip was successfully created.
-  field_slip_create_obs: Add Images or Other Data
+  field_slip_create_obs: Create New Observation
   field_slip_quick_create_obs: Quick Create
   field_slip_creator: Creator
   field_slip_destroy: Destroy this field slip

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -139,7 +139,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_difference("FieldSlip.count") do
       post(:create,
            params: {
-             commit: :field_slip_create_obs.t,
+             commit: :field_slip_add_images.t,
              field_slip: {
                code: code,
                project_id: projects(:eol_project).id
@@ -252,9 +252,16 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_response :success
   end
 
-  test "should show field_slip and allow owner to change" do
+  test "should take admin to edit" do
     login(@field_slip.user.login)
-    get(:show, params: { id: @field_slip.id })
+    get(:show, params: { id: @field_slip.code })
+    assert_redirected_to edit_field_slip_url(id: @field_slip.id)
+  end
+
+  test "should show field_slip and allow owner to change" do
+    field_slip = field_slips(:field_slip_no_trust)
+    login(field_slip.user.login)
+    get(:show, params: { id: field_slip.id })
     assert_response :success
     assert(response.body.include?(:field_slip_edit.t))
   end

--- a/test/integration/capybara/field_slips_integration_test.rb
+++ b/test/integration/capybara/field_slips_integration_test.rb
@@ -51,7 +51,7 @@ class FieldSlipsIntegrationTest < CapybaraIntegrationTestCase
 
     login(user)
     visit("/qr/NFAL-0001")
-    click_on(:field_slip_create_obs.l)
+    click_on(:field_slip_add_images.l)
 
     project_checkbox = "project_id_#{project.id}"
     check(project_checkbox)


### PR DESCRIPTION
Recorders are currently defined as project admins during the project's date range.  To test:

1) Create a project whose current date range includes todays date (including projects with no date range).
2) Go to a QR code URL for an existing observation that uses the field slip prefix for that project.
3) This PR should take you directly to the field slip edit page rather than the corresponding observation (where you used to have to do two more clicks to get to the field slip edit page).

When the current time is outside the project's date range (or if the current user isn't a project admin), the QR code should take you to the corresponding observation.

This PR also switches back to saying "Create New Observation" on the edit field slip page vs. "Add Images and Other Data" to contrast with "Quick Create" when you are creating a new field slip.