### PR TITLE
Fix `id_of_nested_field` string extension

### DIFF
--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -550,8 +550,9 @@ class String
 
   # Rails generates an id for a nested field like "foo[bar]" that's snake_case
   # - no brackets. This gets you that string. (used in forms_helper)
+  # `chomp("_")` is to remove trailing underscores
   def id_of_nested_field
-    gsub(/[\[\]]+/, "_").chop
+    gsub(/[\[\]]+/, "_").chomp("_")
   end
 
   # Insert a line break between the scientific name and the author


### PR DESCRIPTION
This method is to translate a field name like `observation[name]` to a field_id `observation_name`, or a field name like `observation[naming][vote]` to the field_id `observation_naming_vote`.  It should leave a field name like `location` as is.

The simple gsub for the brackets will generate a trailing underscore that needs to be removed, if there are brackets. But if it's being run on all field names, the brackets may not be in the name, so it needs to check the last character before chomping.

`.chop` -> `.chomp("_")`