### PR TITLE
Field Slips iNat Import

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -250,7 +250,8 @@ class FieldSlipsController < ApplicationController
       state: "Authorizing",
       import_all: nil,
       inat_ids: params[:field_slip][:other_codes],
-      inat_username: params[:field_slip][:inat_username].strip
+      inat_username: params[:field_slip][:inat_username].strip,
+      project_id: params[:field_slip][:project_id]
     )
 
     redirect_to(Observations::InatImportsController::INAT_AUTHORIZATION_URL,

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -22,7 +22,7 @@ class FieldSlipsController < ApplicationController
       obs = @field_slip&.observation
     end
     if @field_slip
-      redirect_to(observation_url(id: obs.id)) if obs
+      field_slip_redirect(obs.id) if obs
     else
       redirect_to(new_field_slip_url(code: params[:id].upcase))
     end
@@ -117,10 +117,25 @@ class FieldSlipsController < ApplicationController
 
   private
 
+  def field_slip_redirect(obs_id)
+    if foray_recorder?
+      redirect_to(edit_field_slip_url(id: @field_slip.id))
+    else
+      redirect_to(observation_url(id: obs_id))
+    end
+  end
+
+  def foray_recorder?
+    project = @field_slip&.project
+    return false unless project
+
+    project.is_admin?(User.current) && project.happening?
+  end
+
   def html_create
     if params[:commit] == :field_slip_quick_create_obs.t
       quick_create_observation
-    elsif params[:commit] == :field_slip_create_obs.t
+    elsif params[:commit] == :field_slip_add_images.t
       redirect_to(new_observation_url(
                     field_code: @field_slip.code,
                     place_name: params[:field_slip][:location],

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -51,7 +51,6 @@ class FieldSlipsController < ApplicationController
   def create
     return import_inat_obs if params[:commit] == :field_slip_import_from_inat.t
 
-    debugger
     respond_to do |format|
       @field_slip = FieldSlip.new(field_slip_params)
       check_project_membership

--- a/app/controllers/observations/inat_imports_controller.rb
+++ b/app/controllers/observations/inat_imports_controller.rb
@@ -44,10 +44,16 @@ module Observations
     APP_ID = Rails.application.credentials.inat.id
     # The iNat API. Not called here, but reference in tests and ActiveJob
     API_BASE = "https://api.inaturalist.org/v1"
+    INAT_AUTHORIZATION_URL =
+      "#{SITE}/oauth/authorize" \
+      "?client_id=#{APP_ID}" \
+      "&redirect_uri=#{REDIRECT_URI}" \
+      "&response_type=code".freeze
 
     def new; end
 
     def create
+      debugger
       return username_required if params[:inat_username].blank?
       return reload_form if bad_inat_ids_param?
       return designation_required unless imports_designated?
@@ -103,14 +109,7 @@ module Observations
     end
 
     def request_inat_user_authorization
-      redirect_to(inat_authorization_url, allow_other_host: true)
-    end
-
-    def inat_authorization_url
-      "#{SITE}/oauth/authorize" \
-      "?client_id=#{APP_ID}" \
-      "&redirect_uri=#{REDIRECT_URI}" \
-      "&response_type=code"
+      redirect_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
     end
 
     # ---------------------------------
@@ -119,6 +118,7 @@ module Observations
 
     # iNat redirects here after user completes iNat authorization
     def authorization_response
+      debugger
       auth_code = params[:code]
       return not_authorized if auth_code.blank?
 

--- a/app/controllers/observations/inat_imports_controller.rb
+++ b/app/controllers/observations/inat_imports_controller.rb
@@ -134,6 +134,7 @@ module Observations
 
     private
 
+    # FIXME: Background job cannot flash or redirect
     def not_authorized
       flash_error(:inat_no_authorization.l)
       redirect_to(observations_path)

--- a/app/controllers/observations/inat_imports_controller.rb
+++ b/app/controllers/observations/inat_imports_controller.rb
@@ -53,7 +53,6 @@ module Observations
     def new; end
 
     def create
-      debugger
       return username_required if params[:inat_username].blank?
       return reload_form if bad_inat_ids_param?
       return designation_required unless imports_designated?
@@ -118,7 +117,6 @@ module Observations
 
     # iNat redirects here after user completes iNat authorization
     def authorization_response
-      debugger
       auth_code = params[:code]
       return not_authorized if auth_code.blank?
 

--- a/app/extensions/string_extensions.rb
+++ b/app/extensions/string_extensions.rb
@@ -550,8 +550,9 @@ class String
 
   # Rails generates an id for a nested field like "foo[bar]" that's snake_case
   # - no brackets. This gets you that string. (used in forms_helper)
+  # `chomp("_")` is to remove trailing underscores
   def id_of_nested_field
-    gsub(/[\[\]]+/, "_").chop
+    gsub(/[\[\]]+/, "_").chomp("_")
   end
 
   # Insert a line break between the scientific name and the author

--- a/app/helpers/field_slips_helper.rb
+++ b/app/helpers/field_slips_helper.rb
@@ -6,4 +6,11 @@ module FieldSlipsHelper
 
     ObservationView.previous(User.current, observation)
   end
+
+  def foray_recorder?(field_slip)
+    project = field_slip&.project
+    return false unless project
+
+    project.is_admin?(User.current) && project.happening?
+  end
 end

--- a/app/javascript/controllers/field-slip-job_controller.js
+++ b/app/javascript/controllers/field-slip-job_controller.js
@@ -24,6 +24,12 @@ export default class extends Controller {
 
   // Clear any intervals when the controller is disconnected
   disconnect() {
+    const stimulus = this.element.dataset.stimulus.split(" ")
+    if (stimulus.includes("field-slip-job-connected")) {
+      const idx = stimulus.indexOf("field-slip-job-connected")
+      stimulus.splice(idx, 1)
+      this.element.setAttribute("data-stimulus", stimulus.join(" "))
+    }
     if (this.intervalId != null) {
       clearInterval(this.intervalId)
     }
@@ -40,13 +46,21 @@ export default class extends Controller {
         const response = await get(this.endpoint_url,
           { responseKind: "turbo-stream" });
         if (response.ok) {
-          // turbo-stream prints the row in the page already
+          // Turbo replaces the row in the page already
         } else {
           console.log(`got a ${response.status}`);
         }
       }, 1000);
-    } else if (this.intervalId != null) {
-      clearInterval(this.intervalId)
+    } else {
+      // If the PDF is done, we can remove this Stimulus controller from the
+      // element and stop the timer. (NOTE: there may be other controllers.)
+      // console.log("field-slip-job is done")
+      const controllers = this.element.dataset.controller.split(" ")
+      if (controllers.includes("field-slip-job")) {
+        const idx = controllers.indexOf("field-slip-job")
+        controllers.splice(idx, 1)
+        this.element.setAttribute("data-controller", controllers.join(" "))
+      }
     }
   }
 }

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -23,7 +23,6 @@ class InatImportJob < ApplicationJob
 
     api_token = trade_access_token_for_jwt_api_token(@inat_import.token)
     @inat_import.update(token: api_token, state: "Importing")
-
     import_requested_observations
 
     @inat_import.update(state: "Done")

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -138,7 +138,6 @@ class InatImportJob < ApplicationJob
     # TODO: Other things done by Observations#create
     # save_everything_else(params.dig(:naming, :reasons))
     # strip_images! if @observation.gps_hidden
-    # update_field_slip(@observation, params[:field_code])
   end
 
   def create_observation(inat_obs)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -133,6 +133,7 @@ class InatImportJob < ApplicationJob
     add_inat_images(inat_obs.inat_obs_photos)
     update_names_and_proposals(inat_obs)
     add_inat_sequences(inat_obs)
+    add_field_slip(inat_obs)
     add_import_snapshot_comment(inat_obs)
     # TODO: Other things done by Observations#create
     # save_everything_else(params.dig(:naming, :reasons))
@@ -337,6 +338,13 @@ class InatImportJob < ApplicationJob
     fields.map do |field|
       "&nbsp;&nbsp;#{field[:name]}: #{field[:value]}"
     end.join("\n")
+  end
+
+  def add_field_slip(inat_obs)
+    return if @inat_import.field_slip_code.blank?
+
+    field_slip = FieldSlip.find_or_create_by(code: @inat_import.field_slip_code)
+    field_slip.update(observation_id: @observation.id)
   end
 
   def add_import_snapshot_comment(inat_obs)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -133,7 +133,7 @@ class InatImportJob < ApplicationJob
     add_inat_images(inat_obs.inat_obs_photos)
     update_names_and_proposals(inat_obs)
     add_inat_sequences(inat_obs)
-    add_field_slip(inat_obs)
+    add_field_slip
     add_import_snapshot_comment(inat_obs)
     # TODO: Other things done by Observations#create
     # save_everything_else(params.dig(:naming, :reasons))
@@ -340,11 +340,11 @@ class InatImportJob < ApplicationJob
     end.join("\n")
   end
 
-  def add_field_slip(inat_obs)
+  def add_field_slip
     return if @inat_import.field_slip_code.blank?
 
     field_slip = FieldSlip.find_or_create_by(code: @inat_import.field_slip_code)
-    field_slip.update(observation_id: @observation.id)
+    field_slip.update(observation_id: @observation.id, user: @observation.user)
   end
 
   def add_import_snapshot_comment(inat_obs)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -4,13 +4,15 @@
 #
 # == Attributes
 #
-#  user::   user who initiated the iNat import
-#  state::  state of the import
-#  token::  authenticity token supplied by iNat
-#  inat_ids:: string representing the iNat obss to be imported
-#  inat_username:: current user's iNat login
-#  import_all: whether to import all of user's relevant iNat observations
-#
+#  user::             user who initiated the iNat import
+#  state::            state of the import
+#  token::            authenticity token supplied by iNat
+#  inat_ids::         string representing the iNat obss to be imported
+#  inat_username::    iNat login of iNat user whose obss are to be imported
+#  import_all:        import all a user's relevant iNat observations?
+#  field_slip_code::  field_slip_code (only if importing a single obs)
+#  project_id::       id of Project (overrides Field Slip's Project)
+#                     (only if importing a single obs)
 class InatImport < ApplicationRecord
   enum state:
   {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -421,6 +421,14 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   ##############################################################################
 
+  def happening?
+    now = Time.zone.now
+    return false if start_date.present? && now < start_date
+    return false if end_date.present? && now > end_date
+
+    true
+  end
+
   def out_of_range_observations
     if start_date.nil? && end_date.nil?
       # performant query that returns empty ActiveRecord_Relation

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -44,9 +44,16 @@
       <%= submit_button(
         form: form, button: :field_slip_quick_create_obs.t, class: "mb-5"
       ) %>
+      <%= text_field_with_label(form: form, field: :inat_username,
+                                label: "#{:field_slip_inat_user_name.t}:") %>
+      <div class="mb-5">
       <%= submit_button(
-        form: form, button: :field_slip_import_from_inat.t, class: "mb-5"
-      ) %>
+        form: form, button: :field_slip_import_from_inat.t, class: "align-middle"
+      )
+      %>
+      <%= tag.span(:field_slip_import_use_other_codes.t,
+                            class: "font-weight-bold") %>
+      </div>
     <% end %>
 
     <%= render(partial: "shared/notes_fields",

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -59,7 +59,7 @@
     <%= render(partial: "shared/notes_fields",
                locals: { form:, fields: field_slip.notes_fields }) %>
 
-    <%= submit_button(form: form, button: :field_slip_create_obs.t, class: "mt-5") if action == "new" %>
+    <%= submit_button(form: form, button: :field_slip_add_images.t, class: "mt-5") if action == "new" %>
 
     <div class="row mt-5">
       <% if field_slip.observation %>

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -38,22 +38,30 @@
     <%= autocompleter_field(form: form, field: :field_slip_id_by,
                             label: :ID_BY.t + ":", type: :user) %>
     <%= text_field_with_label(form: form, field: :other_codes,
-                              label: "#{:field_slip_other_codes.t} (#{:field_slip_other_example.t}):") %>
+                              label: "#{:field_slip_other_codes.t}:") %>
 
     <% if action == "new" %>
       <%= submit_button(
         form: form, button: :field_slip_quick_create_obs.t, class: "mb-5"
       ) %>
-      <%= text_field_with_label(form: form, field: :inat_username,
-                                label: "#{:field_slip_inat_user_name.t}:") %>
-      <div class="mb-5">
-      <%= submit_button(
-        form: form, button: :field_slip_import_from_inat.t, class: "align-middle"
-      )
-      %>
-      <%= tag.span(:field_slip_import_use_other_codes.t,
-                            class: "font-weight-bold") %>
-      </div>
+
+      <%= panel_block(id: "inat_import",
+                      heading: :field_slip_import_from_inat.t,
+                      class: "name-section text-center") do %>
+        <%= text_field_with_label(form: form, field: :inat_id,
+                                  label: "#{:field_slip_inat_id.t}:") %>
+        <%# Foray recorder won't know the inat_username of the inat user.
+            Others should be importing their own obss, so they should know.%>
+        <% unless foray_recorder?(field_slip) %>
+          <%= text_field_with_label(
+            form: form, field: :inat_username,
+            label: "#{:field_slip_inat_user_name.t}:"
+          ) %>
+        <% end %>
+        <%= submit_button(
+          form: form, button: :IMPORT.t, class: "align-middle text-center"
+        ) %>
+      <% end %>
     <% end %>
 
     <%= render(partial: "shared/notes_fields",

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -40,7 +40,14 @@
     <%= text_field_with_label(form: form, field: :other_codes,
                               label: "#{:field_slip_other_codes.t} (#{:field_slip_other_example.t}):") %>
 
-    <%= submit_button(form: form, button: :field_slip_quick_create_obs.t, class: "mb-5") if action == "new" %>
+    <% if action == "new" %>
+      <%= submit_button(
+        form: form, button: :field_slip_quick_create_obs.t, class: "mb-5"
+      ) %>
+      <%= submit_button(
+        form: form, button: :field_slip_import_from_inat.t, class: "mb-5"
+      ) %>
+    <% end %>
 
     <%= render(partial: "shared/notes_fields",
                locals: { form:, fields: field_slip.notes_fields }) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2855,9 +2855,11 @@
   field_slip_project_success: Field Slip associated with the [TITLE] Project
   field_slip_quick_no_location: Quick create requires an existing location
   field_slip_quick_no_name: Quick create requires an existing name
-  field_slip_import_from_inat: Import from iNat
+  field_slip_import_from_inat: Import an iNat Observation
   field_slip_import_use_other_codes: uses iNat ID from Other Codes (above)
-  field_slip_inat_user_name: iNat username (if known)
+  field_slip_inat_id: "iNat observation #"
+  field_slip_inat_user_name: iNat username
+  field_slip_inat_import: Import
 
   field_slip_remove_observation: Removed [OBSERVATION] from [TITLE] Project
   field_slip_show: Show [:FIELD_SLIP]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2834,6 +2834,7 @@
   field_slip_created: Field slip was successfully created.
   field_slip_create_obs: Add Images or Other Data
   field_slip_quick_create_obs: Quick Create
+  field_slip_import_from_inat: Import from iNat
   field_slip_creator: Creator
   field_slip_destroy: Destroy this field slip
   field_slip_destroyed: Field slip was successfully destroyed.
@@ -2852,7 +2853,7 @@
   field_slip_other_codes: Other Codes
   field_slip_other_example: e.g., iNat ID
   field_slip_project_success: Field Slip associated with the [TITLE] Project
-  field_slip_quick_no_location: Quick create requires an existing location 
+  field_slip_quick_no_location: Quick create requires an existing location
   field_slip_quick_no_name: Quick create requires an existing name
 
   field_slip_remove_observation: Removed [OBSERVATION] from [TITLE] Project

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2827,12 +2827,13 @@
   destroy_visual_model_success: "[:VISUAL_MODEL] [:destroyed]"
 
   # Field Slips
+  field_slip_add_images: Add Images or Other Data
   field_slip_cant_join_project: Either no Project was found or you are unable to join the associated Project
   field_slip_code: Code
   field_slip_code_format_error: code must have non-numeric characters other than period (.) and dash (-)
   field_slip_constraint_violation: The selected observation violates one or more project constraints
   field_slip_created: Field slip was successfully created.
-  field_slip_create_obs: Add Images or Other Data
+  field_slip_create_obs: Create New Observation
   field_slip_quick_create_obs: Quick Create
   field_slip_creator: Creator
   field_slip_destroy: Destroy this field slip

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2834,7 +2834,6 @@
   field_slip_created: Field slip was successfully created.
   field_slip_create_obs: Add Images or Other Data
   field_slip_quick_create_obs: Quick Create
-  field_slip_import_from_inat: Import from iNat
   field_slip_creator: Creator
   field_slip_destroy: Destroy this field slip
   field_slip_destroyed: Field slip was successfully destroyed.
@@ -2855,6 +2854,9 @@
   field_slip_project_success: Field Slip associated with the [TITLE] Project
   field_slip_quick_no_location: Quick create requires an existing location
   field_slip_quick_no_name: Quick create requires an existing name
+  field_slip_import_from_inat: Import from iNat
+  field_slip_import_use_other_codes: uses iNat ID from Other Codes (above)
+  field_slip_inat_user_name: iNat username (if known)
 
   field_slip_remove_observation: Removed [OBSERVATION] from [TITLE] Project
   field_slip_show: Show [:FIELD_SLIP]

--- a/db/migrate/20240903143617_add_field_slip_code_to_inat_imports.rb
+++ b/db/migrate/20240903143617_add_field_slip_code_to_inat_imports.rb
@@ -1,0 +1,5 @@
+class AddFieldSlipCodeToInatImports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :inat_imports, :field_slip_code, :string
+  end
+end

--- a/db/migrate/20240903185201_add_project_id_to_inat_imports.rb
+++ b/db/migrate/20240903185201_add_project_id_to_inat_imports.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToInatImports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :inat_imports, :project_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_03_143617) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_03_185201) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -201,6 +201,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_03_143617) do
     t.string "inat_username"
     t.boolean "import_all"
     t.string "field_slip_code"
+    t.integer "project_id"
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_03_143617) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.integer "project_id"
   end
 
-  create_table "field_slip_job_trackers", charset: "utf8mb3", force: :cascade do |t|
+  create_table "field_slip_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "start"
     t.integer "count"
     t.string "prefix"
@@ -200,6 +200,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.string "token"
     t.string "inat_username"
     t.boolean "import_all"
+    t.string "field_slip_code"
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|
@@ -637,7 +638,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "solid_queue_blocked_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
@@ -649,7 +650,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_claimed_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
@@ -657,14 +658,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
-  create_table "solid_queue_failed_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_jobs", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name", null: false
     t.string "class_name", null: false
     t.text "arguments"
@@ -682,13 +683,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
-  create_table "solid_queue_pauses", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
     t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
-  create_table "solid_queue_processes", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
     t.bigint "supervisor_id"
@@ -700,7 +701,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
-  create_table "solid_queue_ready_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
@@ -710,7 +711,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
-  create_table "solid_queue_recurring_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "task_key", null: false
     t.datetime "run_at", null: false
@@ -719,7 +720,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
-  create_table "solid_queue_scheduled_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
@@ -729,7 +730,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_02_092653) do
     t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
-  create_table "solid_queue_semaphores", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "value", default: 1, null: false
     t.datetime "expires_at", null: false

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -42,7 +42,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ $STASH_RESULT != 'No local changes to save' ]; then
+if [ "$STASH_RESULT" != 'No local changes to save' ]; then
     echo Reapply local changes... && git stash pop
     if [ $? -ne 0 ]; then
 	echo Applying the stashed changes failed.

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -178,7 +178,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_difference("FieldSlip.count") do
       post(:create,
            params: {
-             commit: :field_slip_create_obs.t,
+             commit: :field_slip_add_images.t,
              field_slip: {
                code: code,
                project_id: projects(:eol_project).id
@@ -291,9 +291,16 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_response :success
   end
 
-  test "should show field_slip and allow owner to change" do
+  test "should take admin to edit" do
     login(@field_slip.user.login)
-    get(:show, params: { id: @field_slip.id })
+    get(:show, params: { id: @field_slip.code })
+    assert_redirected_to edit_field_slip_url(id: @field_slip.id)
+  end
+
+  test "should show field_slip and allow owner to change" do
+    field_slip = field_slips(:field_slip_no_trust)
+    login(field_slip.user.login)
+    get(:show, params: { id: field_slip.id })
     assert_response :success
     assert(response.body.include?(:field_slip_edit.t))
   end

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -70,7 +70,8 @@ class FieldSlipsControllerTest < FunctionalTestCase
     post(:create, params: { commit: :field_slip_import_from_inat.l,
                             field_slip: { code: field_slip_code,
                                           other_codes: inat_id,
-                                          inat_username: inat_username } })
+                                          inat_username: inat_username,
+                                          project_id: project.id } })
 
     inat_import = InatImport.find_by(user: user)
     assert(inat_import.present?, "Failed to create InatImport object")

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -44,6 +44,20 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert(response.body.include?(project.title))
   end
 
+  test "should get new with inat import" do
+    project = projects(:bolete_project)
+    login(project.user.login)
+    code = "#{project.field_slip_prefix}-1234"
+
+    get(:new, params: { code: code })
+
+    assert_response :success
+    assert_select(
+      "input[value=?]", :field_slip_import_from_inat.l, true,
+      "Field Slip Record should have option to import iNat observation"
+    )
+  end
+
   test "should create field_slip with last viewed obs" do
     login(@field_slip.user.login)
     ObservationView.update_view_stats(@field_slip.observation_id,

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -58,6 +58,31 @@ class FieldSlipsControllerTest < FunctionalTestCase
     )
   end
 
+  test "should start inat import if inat import" do
+    inat_id = "654321"
+    inat_username = "anything"
+    field_slip = field_slips(:field_slip_no_obs)
+    field_slip_code = field_slip.code
+    project = field_slip.project
+    user = project.user
+
+    login(user.login)
+    post(:create, params: { commit: :field_slip_import_from_inat.l,
+                            field_slip: { code: field_slip_code,
+                                          other_codes: inat_id,
+                                          inat_username: inat_username } })
+
+    inat_import = InatImport.find_by(user: user)
+    assert(inat_import.present?, "Failed to create InatImport object")
+    assert_equal(user, inat_import.user)
+    assert_equal(inat_id, inat_import.inat_ids)
+    assert_equal(inat_username, inat_import.inat_username)
+
+    assert_redirected_to(
+      Observations::InatImportsController::INAT_AUTHORIZATION_URL
+    )
+  end
+
   test "should create field_slip with last viewed obs" do
     login(@field_slip.user.login)
     ObservationView.update_view_stats(@field_slip.observation_id,

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -52,32 +52,27 @@ class FieldSlipsControllerTest < FunctionalTestCase
     get(:new, params: { code: code })
 
     assert_response :success
-    assert_select(
-      "input[value=?]", :field_slip_import_from_inat.l, true,
-      "Field Slip Record should have option to import iNat observation"
-    )
+    assert_select("input[value=#{:IMPORT.l}]", true,
+                  "Field Slip Record missing option to import iNat observation")
   end
 
-  test "should start inat import if inat import" do
+  test "should start inat import if inat import by project admin" do
     inat_id = "654321"
-    inat_username = "anything"
     field_slip = field_slips(:field_slip_no_obs)
     field_slip_code = field_slip.code
     project = field_slip.project
     user = project.user
-
+    debugger
     login(user.login)
     post(:create, params: { commit: :field_slip_import_from_inat.l,
                             field_slip: { code: field_slip_code,
-                                          other_codes: inat_id,
-                                          inat_username: inat_username,
+                                          inat_id: inat_id,
                                           project_id: project.id } })
 
     inat_import = InatImport.find_by(user: user)
     assert(inat_import.present?, "Failed to create InatImport object")
     assert_equal(user, inat_import.user)
     assert_equal(inat_id, inat_import.inat_ids)
-    assert_equal(inat_username, inat_import.inat_username)
 
     assert_redirected_to(
       Observations::InatImportsController::INAT_AUTHORIZATION_URL

--- a/test/controllers/observations/inat_imports_controller_test.rb
+++ b/test/controllers/observations/inat_imports_controller_test.rb
@@ -21,6 +21,8 @@ module Observations
     SITE = Observations::InatImportsController::SITE
     REDIRECT_URI = Observations::InatImportsController::REDIRECT_URI
     API_BASE = Observations::InatImportsController::API_BASE
+    INAT_AUTHORIZATION_URL =
+      Observations::InatImportsController::INAT_AUTHORIZATION_URL
 
     def test_new_inat_import
       login(users(:rolf).login)
@@ -93,7 +95,7 @@ module Observations
       assert_equal("Unstarted", inat_import.state,
                    "Need a Unstarted inat_import fixture")
 
-      stub_request(:any, authorization_url)
+      stub_request(:any, INAT_AUTHORIZATION_URL)
       login(user.login)
 
       assert_no_difference(
@@ -117,7 +119,7 @@ module Observations
       assert_equal("Unstarted", inat_import.state,
                    "Need a Unstarted inat_import fixture")
 
-      stub_request(:any, authorization_url)
+      stub_request(:any, INAT_AUTHORIZATION_URL)
       login(user.login)
 
       assert_no_difference(
@@ -177,7 +179,7 @@ module Observations
     # iNat url where user is sent in order to authorize MO access
     # to iNat confidential data
     # https://www.inaturalist.org/pages/api+reference#authorization_code_flow
-    def authorization_url
+    def INAT_AUTHORIZATION_URL
       "https://www.inaturalist.org/oauthenticate/authorize?" \
       "client_id=#{Rails.application.credentials.inat.id}" \
       "&redirect_uri=#{REDIRECT_URI}" \

--- a/test/integration/capybara/field_slips_integration_test.rb
+++ b/test/integration/capybara/field_slips_integration_test.rb
@@ -51,7 +51,7 @@ class FieldSlipsIntegrationTest < CapybaraIntegrationTestCase
 
     login(user)
     visit("/qr/NFAL-0001")
-    click_on(:field_slip_create_obs.l)
+    click_on(:field_slip_add_images.l)
 
     project_checkbox = "project_id_#{project.id}"
     check(project_checkbox)

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -433,8 +433,6 @@ class InatImportJobTest < ActiveJob::TestCase
   end
 
   def test_import_job_via_field_slip
-    inat_id = "654321"
-    inat_username = "anything"
     field_slip = field_slips(:field_slip_no_obs)
     field_slip_code = "#{field_slip.code}999"
     project = field_slip.project
@@ -477,6 +475,7 @@ class InatImportJobTest < ActiveJob::TestCase
     field_slip = FieldSlip.find_by_code(field_slip_code)
     assert_equal(obs, field_slip.observation,
                  "Failed to associate Observation with Field Slip")
+    assert_equal(user, field_slip.user)
     # assert(obs.projects.include?(project),
     #        "Failed to add Project to Observation")
     # assert obs notes include fs stuff

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -473,11 +473,9 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_equal(0, obs.images.length, "Obs should not have images")
 
     field_slip = FieldSlip.find_by_code(field_slip_code)
-    assert_equal(obs, field_slip.observation,
-                 "Failed to associate Observation with Field Slip")
-    assert_equal(user, field_slip.user)
-    # assert(obs.projects.include?(project),
-    #        "Failed to add Project to Observation")
+    assert_equal(obs, field_slip.observation, "Field Slip is missing Obs")
+    assert_equal(user, field_slip.user, "Field Slip is missing User")
+    assert(obs.projects.include?(project), "Observation missing Project")
     # assert obs notes include fs stuff
   end
 


### PR DESCRIPTION
OBSOLETE. See #2378.

Adds an **Import from iNat** option to the Record new Field Slip form.

- Lets a foray recorder import someone else's iNat obs (public data only) as an MO Observation in the recorder's MO account.
- Lets an MO User add an iNat observation to the User's MO Observations via a Field Slip.
- Delivers Issue #2312 
- Replaces #[jdc-2312-field-slips-inat-import](https://github.com/MushroomObserver/mushroom-observer/tree/jdc-2312-field-slips-inat-import)

### Tasks
- [x] merge main (it has changes to form, way to tell if someone is a recorder)
- [x] Update FieldSlip in InatImportJob if `field_slip_code.present?`
- [x] Add `field_slip_code` column to iNatImport model
- [x] Improve FieldSlip form
  - [x] Add explicit `iNat #` text_field
  - [x] Group iNat fields, spacing them from other fields
  - [x] Hide `inat_username` if recorder
- [ ] Improve parsing/validation of iNat # in FieldSlip controller
- [ ] Wipe out iNatImport.field_slip_code in `InatImportController#create`
- [ ] Different ending in `InatImportController#authorization_response` or maybe job tracker if field_slip_code.present?
