### PR TITLE
Enable the use of `puma-dev` locally

### DIFF
--- a/README_PUMA_DEV_INSTALL.md
+++ b/README_PUMA_DEV_INSTALL.md
@@ -1,15 +1,17 @@
-# Install `puma-dev` for local development environment.
+# Install `puma-dev` for a local development environment
 
-Puma-dev provides an SSL and domain name for the local environment, making it more like production.
+[Puma-dev](https://github.com/puma/puma-dev) provides an SSL and domain name for the local environment, making it more like production.
 
 ### Linux & MacOS instructions
-- run `brew install puma/puma/puma-dev`
-- check OS specific [further installation and setup](https://github.com/puma/puma-dev?tab=readme-ov-file#installation).
+- Stop your local rails server, if it's running
+- Run `brew install puma/puma/puma-dev`
+- Check OS specific [further installation and setup](https://github.com/puma/puma-dev?tab=readme-ov-file#installation).
   - On MacOS, it's very simple
     - `sudo puma-dev -setup`
     - `puma-dev -install`
-  - Linux is a bit more involved, but not too. It seems to be worth setting up a `systemd` service to run it in the background.
-- Both: run `puma-dev link -n mushroomobserver ~/path-to-your-local-mushroom-observer-repo-folder`. This simply sets up a symlink from your new `~/.puma-dev` folder to your folder for MO, and puma-dev resolves any symlinks in that directory using the name of the link as a domain. The first arg means it will resolve URLs at the domain ("mushroomobserver") with puma-dev's default TLD ("test") to the given directory; it will serve MO (with or without SSL) at that address.
-- restart your machine
-- start `rails s` as you normally would
-- in another window, run `ping mushroomobserver.test`
+  - Linux is a bit more involved, but not too.
+    - It seems to be worth setting up a `systemd` service to run it in the background.
+- Run `puma-dev link -n mushroomobserver ~/path-to-your-local-mushroom-observer-repo-folder`. This simply sets up a symlink from your new `~/.puma-dev` directory, to your directory for MO. Puma-dev will resolve any symlinks in that directory, using the name of the link as a domain. The first arg ("mushroomobserver") means it will resolve URLs at that domain, plus puma-dev's default TLD ("test"), to the given directory: it will serve MO (with or without SSL) at that address. (With further configuration, we could have it refuse or re-route non HTTPS requests, for testing.)
+- Restart your machine
+- Start `rails s` as you normally would
+- In another window, run `ping mushroomobserver.test`. You should get responses every second.

--- a/README_PUMA_DEV_INSTALL.md
+++ b/README_PUMA_DEV_INSTALL.md
@@ -2,7 +2,7 @@
 
 [Puma-dev](https://github.com/puma/puma-dev) provides an SSL and domain name for the local environment, making it more like production.
 
-### Linux & MacOS instructions
+## Linux & MacOS instructions
 - Stop your local rails server, if it's running
 - Run `brew install puma/puma/puma-dev`
 - Check OS specific [further installation and setup](https://github.com/puma/puma-dev?tab=readme-ov-file#installation).

--- a/README_PUMA_DEV_INSTALL.md
+++ b/README_PUMA_DEV_INSTALL.md
@@ -1,0 +1,15 @@
+# Install `puma-dev` for local development environment.
+
+Puma-dev provides an SSL and domain name for the local environment, making it more like production.
+
+### Linux & MacOS instructions
+- run `brew install puma/puma/puma-dev`
+- check OS specific [further installation and setup](https://github.com/puma/puma-dev?tab=readme-ov-file#installation).
+  - On MacOS, it's very simple
+    - `sudo puma-dev -setup`
+    - `puma-dev -install`
+  - Linux is a bit more involved, but not too. It seems to be worth setting up a `systemd` service to run it in the background.
+- Both: run `puma-dev link -n mushroomobserver ~/path-to-your-local-mushroom-observer-repo-folder`. This simply sets up a symlink from your new `~/.puma-dev` folder to your folder for MO, and puma-dev resolves any symlinks in that directory using the name of the link as a domain. The first arg means it will resolve URLs at the domain ("mushroomobserver") with puma-dev's default TLD ("test") to the given directory; it will serve MO (with or without SSL) at that address.
+- restart your machine
+- start `rails s` as you normally would
+- in another window, run `ping mushroomobserver.test`

--- a/README_PUMA_DEV_INSTALL.md
+++ b/README_PUMA_DEV_INSTALL.md
@@ -3,6 +3,7 @@
 [Puma-dev](https://github.com/puma/puma-dev) provides an SSL and domain name for the local environment, making it more like production.
 
 ## Linux & MacOS instructions
+
 - Stop your local rails server, if it's running
 - Run `brew install puma/puma/puma-dev`
 - Check OS specific [further installation and setup](https://github.com/puma/puma-dev?tab=readme-ov-file#installation).

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,9 +4,19 @@ MushroomObserver::Application.configure do
   # Settings specified here will take precedence over those in
   # config/application.rb.
 
-  # ----------------------------
-  #  MO configuration.
-  # ----------------------------
+  # https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
+  config.hosts = [
+    IPAddr.new("0.0.0.0/0"),        # All IPv4 addresses.
+    IPAddr.new("::/0"),             # All IPv6 addresses.
+    "localhost",                    # The localhost reserved domain.
+    # ENV.fetch("RAILS_DEVELOPMENT_HOSTS") # Additional comma-separated hosts.
+  ]
+  # Allow the default puma-dev host.
+  config.hosts << "mushroomobserver.test"
+
+  # ----------------------------------------------------
+  #  MO configuration. These values are used in MO code.
+  # ----------------------------------------------------
   config.domain      = "localhost"
   config.http_domain = "http://localhost:3000"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,7 @@ MushroomObserver::Application.configure do
   config.hosts = [
     IPAddr.new("0.0.0.0/0"),        # All IPv4 addresses.
     IPAddr.new("::/0"),             # All IPv6 addresses.
-    "localhost",                    # The localhost reserved domain.
+    "localhost"                     # The localhost reserved domain.
     # ENV.fetch("RAILS_DEVELOPMENT_HOSTS") # Additional comma-separated hosts.
   ]
   # Allow the default puma-dev host.


### PR DESCRIPTION
**TL;DR:** Makes local MO available at `https://mushroomobserver.test`

Some assembly required. Includes a README for how to install it. Very easy.

[puma-dev](https://github.com/puma/puma-dev) is now the Rails-recommended way to resolve local hosts with actual domains and SSL, and instructions are now [included by default for new Rails apps](https://edgeguides.rubyonrails.org/7_2_release_notes.html#suggest-puma-dev-configuration-in-bin-setup). I've read advice to use it for awhile now, and this seems like a good time to enable it. It runs in the background and I don't think you even have to restart it once it's running.

This PR has the minimum config change that makes it possible for MO developers to use `puma-dev`, but it is still (and can remain) completely optional. The development environment can always work as expected (at `localhost:3000`) without anyone installing `puma-dev`. The case where we'd maybe want to make it mandatory is if we started writing tests to ensure HTTPS-only access. I don't have any plans to do that, though.