### PR TITLE
Fix the date select helper

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -297,7 +297,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     selected = Time.zone.today
     if obj.present? && obj.respond_to?(field)
       init_value = obj.try(&field).try(&:year)
-      selected = obj.try(&field)
+      selected = obj.try(&field) || Time.zone.today
     end
     if init_value && init_value < start_year && init_value > 1900
       start_year = init_value

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -294,12 +294,15 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     obj = args[:object] || args[:form]&.object
     start_year = args[:start_year] || 20.years.ago.year
     end_year = args[:end_year] || Time.zone.now.year
-    init_value = obj.try(&field).try(&:year)
+    selected = Time.zone.today
+    if obj.present? && obj.respond_to?(field)
+      init_value = obj.try(&field).try(&:year)
+      selected = obj.try(&field)
+    end
     if init_value && init_value < start_year && init_value > 1900
       start_year = init_value
     end
-    opts = { start_year: start_year, end_year: end_year,
-             selected: obj.try(&field) || Time.zone.today,
+    opts = { start_year:, end_year:, selected:,
              order: args[:order] || [:day, :month, :year] }
     opts[:index] = args[:index] if args[:index].present?
     opts

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -295,12 +295,13 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     start_year = args[:start_year] || 20.years.ago.year
     end_year = args[:end_year] || Time.zone.now.year
     selected = Time.zone.today
+    # The field may not be an attribute of the object
     if obj.present? && obj.respond_to?(field)
-      init_value = obj.try(&field).try(&:year)
+      init_year = obj.try(&field).try(&:year)
       selected = obj.try(&field) || Time.zone.today
     end
-    if init_value && init_value < start_year && init_value > 1900
-      start_year = init_value
+    if init_year && init_year < start_year && init_year > 1900
+      start_year = init_year
     end
     opts = { start_year:, end_year:, selected:,
              order: args[:order] || [:day, :month, :year] }

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -21,13 +21,12 @@
           label: :Project.t + ":", options: field_slip.projects) %>
     <% end %>
 
+    <%= form.hidden_field(:code, value: field_slip.code) %>
     <%= date_select_with_label(form:, field: :date, label: "#{:DATE.t}:",
                                object: field_slip, inline: true,
                                order: [:year, :month, :day],
                                start_year: Date.today.year - 10,
                                end_year: Date.today.year + 10) %>
-
-
     <%= autocompleter_field(form: form, field: :collector,
                             label: :COLLECTOR.t + ":", type: :user) %>
     <%= autocompleter_field(form: form, field: :location,

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -21,12 +21,12 @@
           label: :Project.t + ":", options: field_slip.projects) %>
     <% end %>
 
-    <%= form.hidden_field(:code, value: field_slip.code) %>
-    <%= form.label(:date, "#{:DATE.t}: ") %>
-    <%= form.date_select(:date,
-                         { start_year: Date.today.year - 10,
-        end_year: Date.today.year + 10 }) %><br/>
-    <br/>
+    <%= date_select_with_label(form:, field: :date, label: "#{:DATE.t}:",
+                               object: field_slip, inline: true,
+                               order: [:year, :month, :day],
+                               start_year: Date.today.year - 10,
+                               end_year: Date.today.year + 10) %>
+
 
     <%= autocompleter_field(form: form, field: :collector,
                             label: :COLLECTOR.t + ":", type: :user) %>


### PR DESCRIPTION
Spotted this in @JoeCohen's screen share today. The `date_select_with_label` helper I wrote wasn't handling options right, which is no doubt why @mo-nathan couldn't use it on the Field Slip form.

This fixes the option handling, so the form can use our formatted date select.

(The issue was that the field name `date` used in the form is not an attribute of a `FieldSlip`, but the helper is looking for a default value there. This fixes it so the helper tries to access the attribute to get a date, but falls back to today's date, which is what the current form field defaults to.)