### PR TITLE
Debug user search

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,8 +50,12 @@ class UsersController < ApplicationController
 
   # Display list of User's whose name, notes, etc. match a string pattern.
   def user_search
+    debugger
     pattern = params[:pattern].to_s
-    if pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))
+    if (pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
+       (user = User.find_by(login: pattern)) ||
+       (user = User.find_by(name: pattern)) ||
+       (user = User.find_by(email: pattern))
       redirect_to(user_path(user.id))
     else
       query = create_query(:User, :pattern_search, pattern: pattern)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
 
   private
 
-  # Display list of User's whose name, notes, etc. match a string pattern.
+  # Display list of Users whose name, notes, etc. match a string pattern.
   def user_search
     pattern = params[:pattern].to_s
     if (user = user_exact_match(pattern))
@@ -59,10 +59,11 @@ class UsersController < ApplicationController
     end
   end
 
+  # This doesn't return direct hits on the user login or name, in case fuzzy.
   def user_exact_match(pattern)
     if ((pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
-       (user = User.find_by(login: pattern)) ||
-       (user = User.find_by(name: pattern)) ||
+      #  (user = User.find_by(login: pattern)) ||
+      #  (user = User.find_by(name: pattern)) ||
        (user = User.find_by(email: pattern))) && user.verified
       return user
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,8 +62,8 @@ class UsersController < ApplicationController
   # This doesn't return direct hits on the user login or name, in case fuzzy.
   def user_exact_match(pattern)
     if ((pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
-      #  (user = User.find_by(login: pattern)) ||
-      #  (user = User.find_by(name: pattern)) ||
+       # (user = User.find_by(login: pattern)) ||
+       # (user = User.find_by(name: pattern)) ||
        (user = User.find_by(email: pattern))) && user.verified
       return user
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,17 +50,24 @@ class UsersController < ApplicationController
 
   # Display list of User's whose name, notes, etc. match a string pattern.
   def user_search
-    debugger
     pattern = params[:pattern].to_s
-    if (pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
-       (user = User.find_by(login: pattern)) ||
-       (user = User.find_by(name: pattern)) ||
-       (user = User.find_by(email: pattern))
+    if (user = user_exact_match(pattern))
       redirect_to(user_path(user.id))
     else
       query = create_query(:User, :pattern_search, pattern: pattern)
       show_selected_users(query)
     end
+  end
+
+  def user_exact_match(pattern)
+    if ((pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
+       (user = User.find_by(login: pattern)) ||
+       (user = User.find_by(name: pattern)) ||
+       (user = User.find_by(email: pattern))) && user.verified
+      return user
+    end
+
+    false
   end
 
   def show_selected_users(query, args = {})


### PR DESCRIPTION
Two issues:
- User pattern search didn't match `login`, `name`, or `email`, only `id`. I'm guessing fuzzy search is actually desirable for `login` or `name`, for example when you want to match "Roy #{something}" but you don't know what, and you don't necessarily want the first "Roy". But it seems like `email` should return an exact match.
- Even if it does match a user, if the **user is not verified** it's trying to redirect to `show_user`, which doesn't work (and shouldn't work) with an unverified user. This results in **errors on production**.