### PR TITLE
Update two form helpers

### DIFF
--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -149,7 +149,7 @@ module AutocompleterHelper
     # model = autocompleter_type_to_model(args[:type])
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
     args[:form].hidden_field(
-      :"#{args[:field]}_id",
+      :"#{nested_field_id(args)}_id",
       value: args[:hidden_value], data:, class: "form-control", readonly: true
     )
   end

--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -141,31 +141,18 @@ module AutocompleterHelper
     )
   end
 
-  # minimum args :form, :field.
-  # Send :hidden to fill the id, :hidden_data to merge with hidden field data
+  # minimum args :form, :type. Send :hidden_name to override default field name.
+  # Send :hidden_value to fill id, :hidden_data to merge with hidden field data
   def autocompleter_hidden_field(**args)
-    return unless args[:form].present? && args[:field].present?
+    return unless args[:form].present? && args[:type].present?
 
-    # model = autocompleter_type_to_model(args[:type])
+    id = args[:hidden_name] || :"#{args[:type]}_id"
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
     args[:form].hidden_field(
-      :"#{nested_field_id(args)}_id",
+      id,
       value: args[:hidden_value], data:, class: "form-control", readonly: true
     )
   end
-
-  # Hmm. On forms with both region and location autocompleters,
-  # these id fields would need to have different ids.
-  # def autocompleter_type_to_model(type)
-  #   case type
-  #   when :region
-  #     :location
-  #   when :clade
-  #     :name
-  #   else
-  #     type
-  #   end
-  # end
 
   def autocompleter_append(args)
     [autocompleter_dropdown,

--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -141,29 +141,31 @@ module AutocompleterHelper
     )
   end
 
-  # minimum args :form, :type.
+  # minimum args :form, :field.
   # Send :hidden to fill the id, :hidden_data to merge with hidden field data
   def autocompleter_hidden_field(**args)
-    return unless args[:form].present? && args[:type].present?
+    return unless args[:form].present? && args[:field].present?
 
-    model = autocompleter_type_to_model(args[:type])
+    # model = autocompleter_type_to_model(args[:type])
     data = { autocompleter_target: "hidden" }.merge(args[:hidden_data] || {})
     args[:form].hidden_field(
-      :"#{model}_id",
+      :"#{args[:field]}_id",
       value: args[:hidden_value], data:, class: "form-control", readonly: true
     )
   end
 
-  def autocompleter_type_to_model(type)
-    case type
-    when :region
-      :location
-    when :clade
-      :name
-    else
-      type
-    end
-  end
+  # Hmm. On forms with both region and location autocompleters,
+  # these id fields would need to have different ids.
+  # def autocompleter_type_to_model(type)
+  #   case type
+  #   when :region
+  #     :location
+  #   when :clade
+  #     :name
+  #   else
+  #     type
+  #   end
+  # end
 
   def autocompleter_append(args)
     [autocompleter_dropdown,

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -510,8 +510,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     end
 
     id = [
-      args[:form].object_name.to_s.id_of_nested_field,
-      args[:field].to_s,
+      nested_field_id(args),
       "help"
     ].join("_")
     args[:between] = capture do
@@ -525,6 +524,11 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
       end)
     end
     args
+  end
+
+  def nested_field_id(args)
+    [args[:form].object_name.to_s.id_of_nested_field,
+     args[:field].to_s].join("_")
   end
 
   # These are args that should not be passed to the field

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -93,7 +93,9 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
 
     tag.div(class: wrap_class) do
       concat(args[:form].label(args[:field]) do
-        concat(args[:form].check_box(args[:field], opts))
+        concat(args[:form].check_box(args[:field], opts,
+                                     args[:checked_value] || "1",
+                                     args[:unchecked_value] || "0"))
         concat(args[:label])
         if args[:between].present?
           concat(tag.div(class: "d-inline-block ml-3") { args[:between] })
@@ -532,7 +534,8 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     exceptions = [
       :form, :field, :label, :class, :width, :inline, :between, :label_after,
       :label_end, :append, :help, :addon, :optional, :required, :monospace,
-      :type, :wrap_data, :wrap_id, :button, :button_data
+      :type, :wrap_data, :wrap_id, :button, :button_data, :checked_value,
+      :unchecked_value
     ] + extras
 
     args.clone.except(*exceptions)


### PR DESCRIPTION
Allows configuration of an autocompleter hidden `id` field's name/id, and a checkbox's `checked_value` (normally "1", but we need "yes" for pattern search).