### PR TITLE
Add observation counts to project checklists

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -54,6 +54,8 @@ class Checklist
       raise("Expected Project instance, got #{project.inspect}.")
     end
 
+    def show_counts = true
+
     def query
       super(
         subquery_scope: Observation.joins(:project_observations).
@@ -82,8 +84,10 @@ class Checklist
   ##############################################################################
 
   def initialize
-    @genera = @species = @taxa = nil
+    @genera = @species = @taxa = @counts = nil
   end
+
+  def show_counts = false
 
   def num_genera
     calc_checklist unless @genera
@@ -113,6 +117,11 @@ class Checklist
   def taxa
     calc_checklist unless @taxa
     @taxa.values.sort
+  end
+
+  def counts
+    calc_counts unless @counts
+    @counts
   end
 
   def self.all_site_taxa_by_user
@@ -208,6 +217,12 @@ class Checklist
       @genera[g] = g
       @species[[g, s]] = ["#{g} #{s}", result[:id]]
     end
+  end
+
+  def calc_counts
+    calc_checklist unless @taxa
+
+    @counts = ProjectCounter.new(@project).counts
   end
 
   # This `query` returns concatenated strings with info about the names we want.

--- a/app/classes/checklist/project_counter.rb
+++ b/app/classes/checklist/project_counter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProjectCounter
+class Checklist::ProjectCounter
   def initialize(project)
     @project = project
     @names = Name.arel_table

--- a/app/classes/project_counter.rb
+++ b/app/classes/project_counter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class ProjectCounter
+  def initialize(project)
+    @project = project
+    @names = Name.arel_table
+    @observations = Observation.arel_table
+    @project_observations = ProjectObservation.arel_table
+  end
+
+  def joins
+    join_observations = @names.
+                        join(@observations).
+                        on(@observations[:name_id].eq(@names[:id]))
+    join_observations.
+      join(@project_observations).
+      on(@project_observations[:observation_id].eq(@observations[:id]))
+  end
+
+  def where_conditions
+    # Build the where conditions
+    @project_observations[:project_id].eq(@project.id).
+      and(@names[:id].eq(@observations[:name_id]))
+  end
+
+  def query
+    # Build the entire AREL query
+    joins.
+      where(where_conditions).
+      group(@names[:text_name]).
+      project(@names[:text_name], Arel.star.count)
+  end
+
+  def counts
+    ActiveRecord::Base.connection.execute(query.to_sql).to_h
+  end
+end

--- a/app/views/controllers/checklists/show.html.erb
+++ b/app/views/controllers/checklists/show.html.erb
@@ -8,6 +8,7 @@ add_tab_set(checklist_show_tabs(user: @show_user,
                                  project: @project,
                                  list: @species_list))
 names = @data.taxa
+counts = @data.counts if @data.show_counts
 %>
 
 <div class="my-4">
@@ -19,7 +20,12 @@ names = @data.taxa
 <%= panel_block(inner_class: "checklist") do %>
   <ul class="list-unstyled">
     <% names.each do |name| %>
-      <li><i><%= link_to(name[0], name_path(name[1])) %></i></li>
+      <li>
+        <i><%= link_to(name[0], name_path(name[1])) %></i>
+        <% if counts %>
+          (<%= counts[name[0]] %>)
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -44,7 +44,8 @@ class ChecklistsControllerTest < FunctionalTestCase
     get(:show, params: { project_id: project.id })
     assert_match(/Checklist for #{project.title}/, css_select("title").text,
                  "Wrong page")
-    assert_match(/(1)/, @response.body)
+    assert_match(/\(1\)/, @response.body)
+
     prove_checklist_content(expect)
   end
 

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -44,7 +44,7 @@ class ChecklistsControllerTest < FunctionalTestCase
     get(:show, params: { project_id: project.id })
     assert_match(/Checklist for #{project.title}/, css_select("title").text,
                  "Wrong page")
-
+    assert_match(/(1)/, @response.body)
     prove_checklist_content(expect)
   end
 


### PR DESCRIPTION
To test, view the Names tab/button from a project page.  Each name should be followed by a count of the number of times that name has been observed.