### PR TITLE
Allow collectors to edit observations

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -256,8 +256,15 @@ class FieldSlipsController < ApplicationController
     project = @field_slip&.project
     return unless project&.can_join?(User.current)
 
-    project.user_group.users << User.current
+    user = User.current
+    project.user_group.users << user
+    project_member = ProjectMember.find_by(project:, user:)
     flash_notice(:field_slip_welcome.t(title: project.title))
+    return if project_member
+
+    ProjectMember.create(project:, user:,
+                         trust_level: "hidden_gps")
+    flash_notice(:add_members_with_gps_trust.l)
   end
 
   def disconnect_observation(obs)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -607,7 +607,8 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def can_edit?(user = User.current)
-    Project.can_edit?(self, user) || notes[:Collector] == "_user #{user.login}_"
+    Project.can_edit?(self, user) ||
+      (user && notes[:Collector] == "_user #{user.login}_")
   end
 
   def project_admin?(user = User.current)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -607,8 +607,11 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def can_edit?(user = User.current)
-    Project.can_edit?(self, user) ||
-      (user && notes[:Collector] == "_user #{user.login}_")
+    Project.can_edit?(self, user) || is_collector?(user)
+  end
+
+  def is_collector?(user)
+    user && notes[:Collector] == "_user #{user.login}_"
   end
 
   def project_admin?(user = User.current)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -607,7 +607,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def can_edit?(user = User.current)
-    Project.can_edit?(self, user)
+    Project.can_edit?(self, user) || notes[:Collector] == "_user #{user.login}_"
   end
 
   def project_admin?(user = User.current)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3216,7 +3216,7 @@
   # ADMIN-TYPE PAGES
 
   # project/<id>/members/new
-  add_members_with_gps_trust: Hidden GPS data may be shared with project admins.
+  add_members_with_gps_trust: Hidden GPS data shared with project admins.
   add_members_change_status: Change Status
   add_members_denied: "Permission denied: only admins for a project can add new members."
   add_members_title: Add [:users] to [title]

--- a/test/controllers/observations_controller/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller/observations_controller_update_test.rb
@@ -25,6 +25,22 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
                   count: 1)
   end
 
+  def test_collector_can_edit_observation
+    obs = observations(:newbie_obs)
+    login("foray_newbie")
+    params = { id: obs.id }
+    get(:edit, params: params)
+    assert_response(:success)
+  end
+
+  def test_can_edit_observation
+    obs = observations(:coprinus_comatus_obs)
+    login("foray_newbie")
+    params = { id: obs.id }
+    get(:edit, params: params)
+    assert_response(:redirect)
+  end
+
   def test_update_observation
     obs = observations(:detailed_unknown_obs)
     updated_at = obs.rss_log.updated_at

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -781,3 +781,8 @@ nybg_2023_09_obs:
   when: 2023-09-15
   where: The New York Botanical Garden, Bronx, New York, USA
   location: nybg_location # outside location of falmouth_2023_09_project
+
+newbie_obs:
+  <<: *DEFAULTS
+  notes:
+    :Collector: _user foray_newbie_

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -258,7 +258,7 @@ trusted_hidden:
   when: 2023-11-05
   location: falmouth
   where: Falmouth, Massachusetts, USA
-  user: mary
+  user: ollie
   name: fungi
   text_name: Fungi
   gps_hidden: true

--- a/test/fixtures/project_members.yml
+++ b/test/fixtures/project_members.yml
@@ -25,9 +25,9 @@ bolete_mary:
   user: mary
   trust_level: <%= ProjectMember.trust_levels[:editing] %>
 
-open_member_mary:
+open_member_ollie:
   project: open_membership_project
-  user: mary
+  user: ollie
   trust_level: <%= ProjectMember.trust_levels[:hidden_gps] %>
 
 open_member_katrina:

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -444,6 +444,10 @@ nybg_2023_09_obs_rss_log:
   <<: *DEFAULTS
   observation: nybg_2023_09_obs
 
+newbie_obs_rss_log:
+  <<: *DEFAULTS
+  observation: newbie_obs
+
 species_list_rss_log:
   species_list: first_species_list
   updated_at: 2006-03-02 21:14:02

--- a/test/fixtures/user_groups.yml
+++ b/test/fixtures/user_groups.yml
@@ -63,6 +63,9 @@ dick_only:
 katrina_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:katrina) %>
 
+ollie_only:
+  name: user <%= ActiveRecord::FixtureSet.identify(:ollie) %>
+
 roy_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:roy) %>
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -79,6 +79,12 @@ roy:
   location_format: <%= User.location_formats[:scientific] %>
   user_groups: all_users, burbank_admins, burbank_users, falmouth_2023_09_users
 
+# Ollie is an open project member
+ollie:
+  <<: *DEFAULTS
+  name: Ollie
+  user_groups: all_users, burbank_users, ollie_only
+
 spammer:
   <<: *DEFAULTS
   login: spamspamspam


### PR DESCRIPTION
This allows users listed as the "Collector" in the notes field of an observation to edit that observation.  This allows foray recorders to create new observations that appropriate users can later add to and edit.

This PR also fixes a bug when users get automatically added to a Project due to scanning a field slip.  It didn't used to create the needed ProjectMember object.  It might be a bit cleaner to combine the maintenance of the Project user groups with the ProjectMembers, but for now I just took a direct approach to solving this problem.  Note that it is doing something very similar to Projects::MembersController.set_status (see `app/controllers/projects/members_controller.rb`).

Also required some fixture changes to actually replicate the bug.