### PR TITLE
More useful `Checklist` links for "Observations of name in ___"

### DIFF
--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -10,7 +10,7 @@ module ChecklistHelper
     tag.li { link_to(link) { content } }
   end
 
-  def checklist_name_link_path(name, project, list)
+  def checklist_name_link_path(name, user, project, list)
     if user
       observations_path(pattern: "user:#{user.id} name:#{name[1]}")
     elsif project

--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -15,7 +15,7 @@ module ChecklistHelper
       observations_path(pattern: "user:#{user.id} name:#{name[1]}")
     elsif project
       observations_path(pattern: "project:#{project.id} name:#{name[1]}")
-    elsif species_list
+    elsif list
       observations_path(pattern: "list:#{list.id} name:#{name[1]}")
     else
       name_path(name[1])

--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ChecklistHelper
+  def checklist_name_link(name:, user: nil, project: nil, list: nil,
+                          counts: nil)
+    link = checklist_name_link_path(name, user, project, list)
+    content = tag.i(name[0])
+    content += " (#{counts[name[0]]})" if counts
+
+    tag.li { link_to(link) { content } }
+  end
+
+  def checklist_name_link_path(name, project, list)
+    if user
+      observations_path(pattern: "user:#{user.id} name:#{name[1]}")
+    elsif project
+      observations_path(pattern: "project:#{project.id} name:#{name[1]}")
+    elsif species_list
+      observations_path(pattern: "list:#{list.id} name:#{name[1]}")
+    else
+      name_path(name[1])
+    end
+  end
+end

--- a/app/views/controllers/checklists/show.html.erb
+++ b/app/views/controllers/checklists/show.html.erb
@@ -5,8 +5,8 @@ add_page_title(checklist_show_title(user: @show_user,
                                     list: @species_list))
 
 add_tab_set(checklist_show_tabs(user: @show_user,
-                                 project: @project,
-                                 list: @species_list))
+                                project: @project,
+                                list: @species_list))
 names = @data.taxa
 counts = @data.counts if @data.show_counts
 %>
@@ -20,12 +20,8 @@ counts = @data.counts if @data.show_counts
 <%= panel_block(inner_class: "checklist") do %>
   <ul class="list-unstyled">
     <% names.each do |name| %>
-      <li>
-        <i><%= link_to(name[0], name_path(name[1])) %></i>
-        <% if counts %>
-          (<%= counts[name[0]] %>)
-        <% end %>
-      </li>
+      <%= checklist_name_link(name:, counts:, user: @show_user,
+                              project: @project, list: @species_list) %>
     <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
@mo-nathan you may have missed my idea for @JoeCohen's [suggestion](https://github.com/MushroomObserver/mushroom-observer/pull/2370#discussion_r1748683894) on your last PR, or it may not have worked at first. I realized this needed more logic to handle the various types of checklists.

Here's a solution - gives a link to "an index of the Project's (or User's, or Species List's) Observations of the Name. The URL is made using a `PatternSearch` filtered index of Obs, which I only just recently learned how to make. Example:
```ruby
observations_path(pattern: "project:#{@project.id} name:#{name[0]")
```

Aside: It might be cool in the future to refactor this param (or do an alternate like `filter`) so we could pass stuff like this, rather than a string for the `pattern` param.
```ruby
observations_path(filter: { project: @project.id, name: name[0] })
```