### PR TITLE
Replace deprecated arel extensions == and !=

### DIFF
--- a/app/controllers/names/eol_data/preview_controller.rb
+++ b/app/controllers/names/eol_data/preview_controller.rb
@@ -49,7 +49,7 @@ module Names::EolData
                    where(name_id: name_ids).
                    where(Observation[:vote_cache] >= 2.4).
                    where(Image[:vote_cache] >= 2).
-                   where(Image[:ok_for_export] == true).
+                   where(Image[:ok_for_export].eq(true)).
                    order(Observation[:vote_cache]).
                    select(Observation[:name_id], ObservationImage[:image_id],
                           ObservationImage[:observation_id], Image[:user_id],

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -253,7 +253,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
                   and(Location[:north].gteq(shrunk_n)).
             # Location straddles 180
             #   Location 100% wrap; necessarily straddles w/e
-            and(Location[:west] == Location[:east] - 360).
+            and(Location[:west].eq(Location[:east] - 360)).
             #  Location < 100% wrap-around
             or(Location[:west].gt(Location[:east]).
               and(Location[:west] <= shrunk_w).

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -350,25 +350,24 @@ class Name < AbstractModel
 
   # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
-  enum rank:
-        {
-          Form: 1,
-          Variety: 2,
-          Subspecies: 3,
-          Species: 4,
-          Stirps: 5,
-          Subsection: 6,
-          Section: 7,
-          Subgenus: 8,
-          Genus: 9,
-          Family: 10,
-          Order: 11,
-          Class: 12,
-          Phylum: 13,
-          Kingdom: 14,
-          Domain: 15,
-          Group: 16 # used for both "group" and "clade"
-        }
+  enum :rank, {
+    Form: 1,
+    Variety: 2,
+    Subspecies: 3,
+    Species: 4,
+    Stirps: 5,
+    Subsection: 6,
+    Section: 7,
+    Subgenus: 8,
+    Genus: 9,
+    Family: 10,
+    Order: 11,
+    Class: 12,
+    Phylum: 13,
+    Kingdom: 14,
+    Domain: 15,
+    Group: 16 # used for both "group" and "clade"
+  }
 
   belongs_to :correct_spelling, class_name: "Name"
   belongs_to :description, class_name: "NameDescription",
@@ -535,12 +534,12 @@ class Name < AbstractModel
   scope :with_rank_at_or_below_genus,
         lambda {
           where((Name[:rank] <= ranks[:Genus]).
-                or(Name[:rank] == ranks[:Group]))
+                or(Name[:rank].eq(ranks[:Group])))
         }
   scope :with_rank_above_genus,
         lambda {
           where(Name[:rank] > ranks[:Genus]).
-            where(Name[:rank] != ranks[:Group])
+            where(Name[:rank].not_eq(ranks[:Group]))
         }
   scope :subtaxa_of_genus_or_below,
         lambda { |text_name|

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -494,11 +494,11 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   }
   scope :for_project, lambda { |project|
     joins(:project_observations).
-      where(ProjectObservation[:project_id] == project.id).distinct
+      where(ProjectObservation[:project_id].eq(project.id)).distinct
   }
   scope :in_herbarium, lambda { |herbarium|
     joins(:herbarium_records).
-      where(HerbariumRecord[:herbarium_id] == herbarium.id).distinct
+      where(HerbariumRecord[:herbarium_id].eq(herbarium.id)).distinct
   }
   scope :herbarium_record_notes_include, lambda { |notes|
     joins(:herbarium_records).
@@ -506,12 +506,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   }
   scope :on_species_list, lambda { |species_list|
     joins(:species_list_observations).
-      where(SpeciesListObservation[:species_list_id] == species_list.id).
+      where(SpeciesListObservation[:species_list_id].eq(species_list.id)).
       distinct
   }
   scope :on_species_list_of_project, lambda { |project|
     joins(species_lists: :project_species_lists).
-      where(ProjectSpeciesList[:project_id] == project.id).distinct
+      where(ProjectSpeciesList[:project_id].eq(project.id)).distinct
   }
   scope :show_includes, lambda {
     strict_loading.includes(

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -2250,7 +2250,7 @@ class API2Test < UnitTestCase
 
     genus = Name.ranks[:Genus]
     group = Name.ranks[:Group]
-    names = Name.where((Name[:rank] <= genus).or(Name[:rank] == group))
+    names = Name.where((Name[:rank] <= genus).or(Name[:rank].eq(group)))
     with = Observation.where(name: names)
     without = Observation.where.not(name: names)
     assert(with.length > 1)


### PR DESCRIPTION
Replaces deprecated arel extensions `==`and `!=` with `.eq` and `.not_eq` per the test deprecation warning.

I used this regexp to find instances of the deprecated expressions:
```ruby
[A-Z]\w+\[:\w+\]( )(=|!)=
```

Unfortunately, the warning continues to appear even when there are no instances of these operators.
But this at least takes care of all known offenders
