### PR TITLE
Update `date_select_with_label` opts handling in `forms_helper.rb`

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -319,7 +319,8 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
       end)
     else
       concat(tag.div(class: selects_class, id: args[:field]) do
-        concat(select_date(args[:field], date_opts, opts))
+        concat(select_date(date_opts[:selected],
+                           date_opts.merge(prefix: args[:field]), opts))
       end)
     end
   end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -526,7 +526,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     id = [
       nested_field_id(args),
       "help"
-    ].join("_")
+    ].compact_blank.join("_")
     args[:between] = capture do
       concat(args[:between])
       concat(collapse_info_trigger(id))
@@ -542,7 +542,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
 
   def nested_field_id(args)
     [args[:form].object_name.to_s.id_of_nested_field,
-     args[:field].to_s].join("_")
+     args[:field].to_s].compact_blank.join("_")
   end
 
   # These are args that should not be passed to the field

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -276,15 +276,12 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     wrap_class = form_group_wrap_class(args)
     selects_class = "form-inline date-selects"
     selects_class += " d-inline-block" if args[:inline] == true
-    identifier = date_select_identifier(args)
     label_opts = { class: "mr-3" }
     label_opts[:index] = args[:index] if args[:index].present?
     tag.div(class: wrap_class) do
       concat(args[:form].label(args[:field], args[:label], label_opts))
       concat(args[:between]) if args[:between].present?
-      concat(tag.div(class: selects_class, id: identifier) do
-        concat(args[:form].date_select(args[:field], date_opts, opts))
-      end)
+      date_select_div(args, date_opts, opts, selects_class)
       concat(args[:append]) if args[:append].present?
     end
   end
@@ -311,12 +308,19 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     opts
   end
 
-  def date_select_identifier(args)
+  # If there's no form object, we need a non-nested name and id for the fields.
+  # Turns out you have to use a different Rails helper, select_date, for this.
+  def date_select_div(args, date_opts, opts, selects_class)
     if args[:form].object.present?
-      [args[:form]&.object_name, args[:index],
-       args[:field]].compact.join("_")
+      identifier = [args[:form]&.object_name, args[:index],
+                    args[:field]].compact.join("_")
+      concat(tag.div(class: selects_class, id: identifier) do
+        concat(args[:form].date_select(args[:field], date_opts, opts))
+      end)
     else
-      args[:field]
+      concat(tag.div(class: selects_class, id: args[:field]) do
+        concat(select_date(args[:field], date_opts, opts))
+      end)
     end
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -308,10 +308,10 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     opts
   end
 
-  # If there's no form object, we need a non-nested name and id for the fields.
+  # If there's no form object_name, we need a name and id for the fields.
   # Turns out you have to use a different Rails helper, select_date, for this.
   def date_select_div(args, date_opts, opts, selects_class)
-    if args[:form].object.present?
+    if args[:form].object_name.present?
       identifier = [args[:form]&.object_name, args[:index],
                     args[:field]].compact.join("_")
       concat(tag.div(class: selects_class, id: identifier) do

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -280,10 +280,10 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     label_opts = { class: "mr-3" }
     label_opts[:index] = args[:index] if args[:index].present?
     tag.div(class: wrap_class) do
-      concat(args[:form].label(identifier, args[:label], label_opts))
+      concat(args[:form].label(args[:field], args[:label], label_opts))
       concat(args[:between]) if args[:between].present?
       concat(tag.div(class: selects_class, id: identifier) do
-        concat(args[:form].date_select(identifier, date_opts, opts))
+        concat(args[:form].date_select(args[:field], date_opts, opts))
       end)
       concat(args[:append]) if args[:append].present?
     end

--- a/app/javascript/controllers/year-input_controller.js
+++ b/app/javascript/controllers/year-input_controller.js
@@ -8,7 +8,8 @@ export default class extends Controller {
     this.id = this.element.getAttribute("id");
     // console.log(this.id)
 
-    if (this.id && this.id.indexOf("_1i") > 0) {
+    if (this.id && (
+      this.id.indexOf("_1i") > 0 || this.id.indexOf("_year") > 0)) {
       // copy the attributes
       this.name = this.element.getAttribute("name");
       this.classList = this.element.classList || "";


### PR DESCRIPTION
Because the Rails `date_select` helper involves a lot of Rails magic, collapsing three automatically-named inputs into one parameter, the helper requires passing a form object to properly nest the params. If it doesn't get an object, it nests them anyway under nil, which makes the params unreadable.

This makes our `date_select_with_label` helper more versatile. If there's no form object, as in the case of `form_with(url: whatever)`, it now uses the Rails method `select_date` to produce a viable date select even without a form object. The nested keys are `[:year, :month, :day]` rather than `[:1i, :2i, :3i]`. 

It's used in the upcoming pattern search big form, where it will get plenty of test coverage.