### PR TITLE
Remove iNat Import link temporarily 

### DIFF
--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -200,7 +200,7 @@ module Tabs
 
     def observation_form_new_tabs
       # [new_inat_import_tab, new_herbarium_tab]
-      [new_inat_import_tab]
+      # [new_inat_import_tab]
     end
 
     def observation_form_edit_tabs(obs:)

--- a/test/controllers/observations_controller/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller/observations_controller_create_test.rb
@@ -103,8 +103,8 @@ class ObservationsControllerCreateTest < FunctionalTestCase
                        users(:rolf).preferred_herbarium_name)
     assert_input_value(:herbarium_record_accession_number, "")
     assert_true(@response.body.include?("Albion, Mendocino Co., California"))
-    assert_link_in_html(:create_observation_inat_import_link.l,
-                        new_observations_inat_import_path)
+    # assert_link_in_html(:create_observation_inat_import_link.l,
+    #                    new_observations_inat_import_path)
 
     users(:rolf).update(location_format: "scientific")
     get(:new)


### PR DESCRIPTION
- Comments out the tab on the Observation form because
iNat import does not work on the webserver. See attached screenshot.
(The route is still in place so that I can test it. https://mushroomobserver.org/observations/inat_imports/new)

<img width="452" alt="Screenshot 2024-09-22 at 8 09 11 PM" src="https://github.com/user-attachments/assets/7d748bdf-e6e3-4de1-8d0a-7c09f7337556">
