### PR TITLE
Align collations with production

### DIFF
--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_02_03_041048) do
-  create_table "solid_cache_entries", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
     t.binary "value", size: :long, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,13 +191,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_18_151140) do
     t.boolean "diagnostic", default: true, null: false
   end
 
-  create_table "inat_import_job_trackers", charset: "utf8mb3", force: :cascade do |t|
+  create_table "inat_import_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "inat_import"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "inat_imports", charset: "utf8mb3", force: :cascade do |t|
+  create_table "inat_imports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "state", default: 0
     t.string "inat_ids"


### PR DESCRIPTION
These collations are getting selected for me locally and on production.  I'm not sure why they aren't showing up for @nimmolo and @JoeCohen.  However, presumably if they reload a fresh database dump it should sort itself out.  I thought this might be a local issue for me since I'm on MySQL 8.4 and Joe was on something like 8.2, but then I noticed that production is on 8.0.  We should probably do some real testing to figure this out, but I think that will need to wait until after NEMF at this point.