### PR TITLE
Prevent Error for nil Notes

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -915,6 +915,10 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     {}
   end
 
+  def notes
+    self[:notes] || {}
+  end
+
   # no_notes persisted in the db
   def self.no_notes_persisted
     no_notes.to_yaml
@@ -1172,14 +1176,13 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   ##############################################################################
 
   # Which agent created this observation?
-  enum source:
-        {
-          mo_website: 1,
-          mo_android_app: 2,
-          mo_iphone_app: 3,
-          mo_api: 4,
-          mo_inat_import: 5
-        }
+  enum :source, {
+    mo_website: 1,
+    mo_android_app: 2,
+    mo_iphone_app: 3,
+    mo_api: 4,
+    mo_inat_import: 5
+  }
 
   # Message to use to credit the agent which created this observation.
   # Intended to be used with .tpl to render as HTML:

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -917,6 +917,19 @@ class ObservationTest < UnitTestCase
     assert_equal("pine", obs.notes_part_value("Nearby trees"))
   end
 
+  def test_notes_nil
+    User.current = mary
+    obs = Observation.create!(name_id: names(:fungi).id, when_str: "2020-07-05")
+
+    assert_nothing_raised do
+      obs.notes[:Collector]
+    rescue StandardError => e
+      flunk(
+        "It shouldn't throw \"#{e.message}\" when reading part of a nil Note"
+      )
+    end
+  end
+
   def test_make_sure_no_observations_are_misspelled
     good = names(:peltigera)
     bad  = names(:petigera)


### PR DESCRIPTION
- Prevents an Error from being thrown when reading part of a `nil` Note by returning `{}` if Note is nil.
- Delivers part of #2401. See also [Slack discussion](https://mushroomobserver.slack.com/archives/C040TH9FV/p1726545439477219)

### Manual Test
Compare:
- https://mushroomobserver.org/174286 (throws Error) 
to
- http://localhost:3000/174286 (no Error)