### PR TITLE
Hash lookup for Inat::Obs attributes

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -73,16 +73,14 @@ class Inat
       @obs[:ofvs]
     end
 
-    def inat_taxon
-      @obs[:taxon]
-    end
-
+    # NOTE: Fixes the ABC count of `snapshot` because
+    # inat_taxon_name is one fewer Branch than self[:taxon][:name]
     def inat_taxon_name
-      inat_taxon[:name]
+      self[:taxon][:name]
     end
 
     def inat_taxon_rank
-      inat_taxon[:rank]
+      self[:taxon][:rank]
     end
 
     ########## MO attributes
@@ -304,15 +302,15 @@ class Inat
         insert_rank_between_species_and_final_epithet
       elsif complex?
         # iNat doesn't include "complex" in the name, MO does
-        "#{inat_taxon[:name]} complex"
+        "#{inat_taxon_name} complex"
       else
-        inat_taxon[:name]
+        inat_taxon_name
       end
     end
 
     def infrageneric?
       %w[subgenus section subsection stirps series subseries].
-        include?(inat_taxon[:rank])
+        include?(inat_taxon_rank)
     end
 
     def prepend_genus_and_rank
@@ -327,22 +325,22 @@ class Inat
 
           #  return a string comprising Genus rank epithet
           #  ex: "Morchella section Distantes"
-          return "#{ancestor[:name]} #{inat_taxon[:rank]} #{inat_taxon[:name]}"
+          return "#{ancestor[:name]} #{inat_taxon_rank} #{inat_taxon_name}"
         end
       end
     end
 
     def infraspecific?
-      %w[subspecies variety form].include?(inat_taxon[:rank])
+      %w[subspecies variety form].include?(inat_taxon_rank)
     end
 
     def insert_rank_between_species_and_final_epithet
-      words = inat_taxon[:name].split
-      "#{words[0..1].join(" ")} #{inat_taxon[:rank]} #{words[2]}"
+      words = inat_taxon_name.split
+      "#{words[0..1].join(" ")} #{inat_taxon_rank} #{words[2]}"
     end
 
     def identifies_this_obs?(identification)
-      identification[:taxon][:id] == inat_taxon[:id]
+      identification[:taxon][:id] == self[:taxon][:id]
     end
 
     def matching_group_names
@@ -357,7 +355,7 @@ class Inat
         # parse it to get MO's text_name rank abbreviation
         # E.g. "sect." instead of "section"
         text_name: ::Name.parse_name(full_name).text_name,
-        rank: inat_taxon[:rank].titleize,
+        rank: inat_taxon_rank.titleize,
         correct_spelling_id: nil
       ).
         # iNat lacks taxa "sensu xxx", so ignore MO Names sensu xxx

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -17,7 +17,7 @@
 #                        Cf. [:private_location]
 #                        https://help.inaturalist.org/en/support/solutions/articles/151000169938-what-is-geoprivacy-what-does-it-mean-for-an-observation-to-be-obscured-
 #  inat_obs_fields::       array of fields, each field a hash. == [:ofvs]
-#  [:photos]               array of observation_photos
+#  [:observation_photos]   array of photos
 #  [:place_guess]          iNat's best guess at the location
 #  [:private_location]     lat, lng. Cf. [:location]
 #  inat_prov_name::        provisional species name

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -57,10 +57,8 @@ class Inat
       @obs = JSON.parse(imported_inat_obs_data, symbolize_names: true)
     end
 
-    # Allow hash-like access to the iNat observation data
-    def [](key)
-      @obs[key]
-    end
+    # Allow hash key access to the iNat observation data
+    def [](key) = @obs[key]
 
     def []=(key, value)
       @obs[key] = value
@@ -69,29 +67,19 @@ class Inat
     ########## iNat attributes
 
     # convenience method with descriptive, non-cryptic name
-    def inat_obs_fields
-      @obs[:ofvs]
-    end
+    def inat_obs_fields = @obs[:ofvs]
 
-    # NOTE: Fixes the ABC count of `snapshot` because
+    # NOTE: Fixes ABC count of `snapshot` because
     # inat_taxon_name is one fewer Branch than self[:taxon][:name]
-    def inat_taxon_name
-      self[:taxon][:name]
-    end
+    def inat_taxon_name = self[:taxon][:name]
 
-    def inat_taxon_rank
-      self[:taxon][:rank]
-    end
+    def inat_taxon_rank = self[:taxon][:rank]
 
     ########## MO attributes
 
-    def gps_hidden
-      @obs[:geoprivacy].present?
-    end
+    def gps_hidden = @obs[:geoprivacy].present?
 
-    def license
-      Inat::License.new(@obs[:license_code]).mo_license
-    end
+    def license = Inat::License.new(@obs[:license_code]).mo_license
 
     def name_id
       names =
@@ -144,24 +132,16 @@ class Inat
       end
     end
 
-    def source
-      "mo_inat_import"
-    end
+    def source = "mo_inat_import"
 
-    def text_name
-      ::Name.find(name_id).text_name
-    end
+    def text_name = ::Name.find(name_id).text_name
 
     def when
       observed_on = @obs[:observed_on_details]
       ::Date.new(observed_on[:year], observed_on[:month], observed_on[:day])
     end
 
-    def where
-      # NOTE: Make it the name of a real MO Location
-      # https://github.com/MushroomObserver/mushroom-observer/issues/2383
-      self[:place_guess]
-    end
+    def where = self[:place_guess]
 
     ########## Other mappings used in MO Observations
 
@@ -250,13 +230,9 @@ class Inat
         lng: accuracy_in_meters / 111_111 * Math.cos(to_rad(lat)) }
     end
 
-    def importable?
-      taxon_importable?
-    end
+    def importable? = taxon_importable?
 
-    def taxon_importable?
-      fungi? || slime_mold?
-    end
+    def taxon_importable? = fungi? || slime_mold?
 
     ##########
 
@@ -265,13 +241,9 @@ class Inat
     # ----- location-related
 
     # These give a good approximation of the iNat blurred bounding box
-    def blurred_north
-      [lat + public_accuracy_in_degrees[:lat] / 2, 90].min
-    end
+    def blurred_north = [lat + public_accuracy_in_degrees[:lat] / 2, 90].min
 
-    def blurred_south
-      [lat - public_accuracy_in_degrees[:lat] / 2, -90].max
-    end
+    def blurred_south = [lat - public_accuracy_in_degrees[:lat] / 2, -90].max
 
     def blurred_east
       ((lng + public_accuracy_in_degrees[:lng] / 2 + 180) % 360) - 180
@@ -281,9 +253,7 @@ class Inat
       ((lng - public_accuracy_in_degrees[:lng] / 2 + 180) % 360) - 180
     end
 
-    def to_rad(degrees)
-      degrees * Math::PI / 180.0
-    end
+    def to_rad(degrees) = degrees * Math::PI / 180.0
 
     # copied from AutoComplete::ForLocationContaining
     def location_box(loc)
@@ -330,9 +300,7 @@ class Inat
       end
     end
 
-    def infraspecific?
-      %w[subspecies variety form].include?(inat_taxon_rank)
-    end
+    def infraspecific? = %w[subspecies variety form].include?(inat_taxon_rank)
 
     def insert_rank_between_species_and_final_epithet
       words = inat_taxon_name.split
@@ -378,39 +346,23 @@ class Inat
 
     # ----- Other
 
-    def complex?
-      inat_taxon_rank == "complex"
-    end
+    def complex? = (inat_taxon_rank == "complex")
 
-    def description
-      @obs[:description]
-    end
-
-    def fungi?
-      @obs.dig(:taxon, :iconic_taxon_name) == "Fungi"
-    end
-
-    # NOTE: 2024-09-09 jdc. Can this be improved?
-    # https://github.com/MushroomObserver/mushroom-observer/issues/2245
-    def inat_projects
-      @obs[:project_observations]
-    end
+    def fungi? = (@obs.dig(:taxon, :iconic_taxon_name) == "Fungi")
 
     def sequence_field?(field)
       field[:datatype] == "dna" ||
         field[:name] =~ /DNA/ && field[:value] =~ /^[ACTG]{,10}/
     end
 
-    def slime_mold?
-      # NOTE: 2024-06-01 jdc
-      # slime molds are polypheletic https://en.wikipedia.org/wiki/Slime_mold
-      # Protoza is paraphyletic for slime molds,
-      # but it's how they are classified in MO and MB
-      # Can this be improved by checking multiple inat [:taxon][:ancestor_ids]?
-      # I.e., is there A combination (ANDs) of higher ranks (>= Class)
-      # that's monophyletic for slime molds?
-      # Another solution: use IF API to see if IF includes the name.
-      @obs.dig(:taxon, :iconic_taxon_name) == "Protozoa"
-    end
+    # NOTE: 2024-06-01 jdc
+    # slime molds are polypheletic https://en.wikipedia.org/wiki/Slime_mold
+    # Protoza is paraphyletic for slime molds,
+    # but it's how they are classified in MO and MB
+    # Can this be improved by checking multiple inat [:taxon][:ancestor_ids]?
+    # I.e., is there A combination (ANDs) of higher ranks (>= Class)
+    # that's monophyletic for slime molds?
+    # Another solution: use IF API to see if IF includes the name.
+    def slime_mold? = (@obs.dig(:taxon, :iconic_taxon_name) == "Protozoa")
   end
 end

--- a/app/classes/inat/obs_photo.rb
+++ b/app/classes/inat/obs_photo.rb
@@ -1,5 +1,35 @@
 # frozen_string_literal: true
 
+#
+## iNat iobervation_photo key/values
+# {:id=>351481052,
+#  :position=>0,
+#  :uuid=>"6c223538-04d6-404c-8e84-b7d881dbe550",
+#  :photo_id=>377332865,
+#  :photo=>
+#   {:id=>377332865,
+#    :license_code=>"cc-by-nc",
+#    :original_dimensions=>{:width=>2048, :height=>1534},
+#    :url=>"https://inaturalist-open-data.s3.amazonaws.com/photos/377332865/square.jpeg",
+#    :attribution=>"(c) Tim C., some rights reserved (CC BY-NC)",
+#    :flags=>[],
+#    :moderator_actions=>[],
+#    :hidden=>false}}
+
+# some MO image attributes
+#  string "content_type", limit: 100
+#  integer "user_id"
+#  date "when"
+#  text "notes"
+#  string "copyright_holder", limit: 100
+#  integer "license_id", default: 1, null: false
+#  integer "width"
+#  integer "height"
+#  boolean "ok_for_export", default: true, null: false
+#  string "original_name", limit: 120, default: ""
+#  boolean "gps_stripped", default: false, null: false
+#  boolean "diagnostic", default: true, null: false
+
 # Describes one iNat observation photo (derived from an Inat::Obs)
 # mapping iNat key/values to MO Image attributes and associations
 # Example use:
@@ -10,19 +40,12 @@ class Inat
       @photo = inat_obs_photo_data
     end
 
-    def copyright_holder
-      @photo[:attribution]
-    end
+    def copyright_holder = @photo[:photo][:attribution]
 
     # https://www.iana.org/assignments/media-types/media-types.xhtml#image
-    def content_type
-      "img/jpeg"
-    end
+    def content_type = "img/jpeg"
 
-    def license
-      Inat::License.new(@photo[:license_code]).mo_license
-    end
-
+    def license = Inat::License.new(@photo[:photo][:license_code]).mo_license
     delegate :id, to: :license, prefix: true
 
     # Repurpose MO Image.notes to include some iNat photo data
@@ -33,12 +56,7 @@ class Inat
 
     # iNat doesn't preserve (or maybe reveal) user's original filename
     # so map it to an iNat uuid
-    def original_name
-      "iNat photo uuid #{@photo[:uuid]}"
-    end
-
-    def url
-      @photo[:url].sub("/square.", "/original.")
-    end
+    def original_name = "iNat photo uuid #{@photo[:uuid]}"
+    def url = @photo[:photo][:url].sub("/square.", "/original.")
   end
 end

--- a/app/classes/inat/obs_photo.rb
+++ b/app/classes/inat/obs_photo.rb
@@ -6,12 +6,12 @@
 # Inat::ObsPhoto.new(<imported_inat_obs>.observation_photos.first)
 class Inat
   class ObsPhoto
-    def initialize(inat_obs_photo_ary)
-      @inat_obs_photo = inat_obs_photo_ary
+    def initialize(inat_obs_photo_data)
+      @photo = inat_obs_photo_data
     end
 
     def copyright_holder
-      photo[:attribution]
+      @photo[:attribution]
     end
 
     # https://www.iana.org/assignments/media-types/media-types.xhtml#image
@@ -20,7 +20,7 @@ class Inat
     end
 
     def license
-      Inat::License.new(photo[:license_code]).mo_license
+      Inat::License.new(@photo[:license_code]).mo_license
     end
 
     delegate :id, to: :license, prefix: true
@@ -34,19 +34,11 @@ class Inat
     # iNat doesn't preserve (or maybe reveal) user's original filename
     # so map it to an iNat uuid
     def original_name
-      "iNat photo uuid #{@inat_obs_photo[:uuid]}"
+      "iNat photo uuid #{@photo[:uuid]}"
     end
 
     def url
-      photo[:url].sub("/square.", "/original.")
-    end
-
-    ##########
-
-    private
-
-    def photo
-      @inat_obs_photo[:photo]
+      @photo[:url].sub("/square.", "/original.")
     end
   end
 end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -181,7 +181,7 @@ class InatImportJob < ApplicationJob
     return unless @inat_obs.importable?
 
     create_observation
-    add_inat_images(@inat_obs.inat_obs_photos)
+    add_inat_images(@inat_obs[:photos])
     update_names_and_proposals
     add_inat_sequences
     add_snapshot_of_import_comment
@@ -212,7 +212,7 @@ class InatImportJob < ApplicationJob
       text_name: Name.find(name_id).text_name,
       notes: @inat_obs.notes,
       source: @inat_obs.source,
-      inat_id: @inat_obs.inat_id }
+      inat_id: @inat_obs[:id] }
   end
 
   # NOTE: 1. iNat users seem to add a prov name only if there's a sequence.
@@ -304,7 +304,7 @@ class InatImportJob < ApplicationJob
   end
 
   def add_identifications_with_namings
-    @inat_obs.inat_identifications.each do |identification|
+    @inat_obs[:identifications].each do |identification|
       inat_taxon = ::Inat::Taxon.new(identification[:taxon])
       next if name_already_proposed?(inat_taxon.name)
 
@@ -406,7 +406,7 @@ class InatImportJob < ApplicationJob
   end
 
   def update_description
-    description = @inat_obs.inat_description
+    description = @inat_obs[:description]
     updated_description =
       "#{IMPORTED_BY_MO} #{Time.zone.today.strftime(MO.web_date_format)}"
     updated_description.prepend("#{description}\n\n") if description.present?
@@ -415,7 +415,7 @@ class InatImportJob < ApplicationJob
                                ignore_photos: 1 } }
     headers = { authorization: "Bearer #{@inat_import.token}",
                 content_type: :json, accept: :json }
-    response = RestClient.put("#{API_BASE}/observations/#{@inat_obs.inat_id}",
+    response = RestClient.put("#{API_BASE}/observations/#{@inat_obs[:id]}",
                               payload.to_json, headers)
     JSON.parse(response.body)
   rescue RestClient::ExceptionWithResponse => e

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -181,7 +181,7 @@ class InatImportJob < ApplicationJob
     return unless @inat_obs.importable?
 
     create_observation
-    add_inat_images(@inat_obs[:photos])
+    add_inat_images(@inat_obs[:observation_photos])
     update_names_and_proposals
     add_inat_sequences
     add_snapshot_of_import_comment

--- a/test/models/inat_obs_photo_test.rb
+++ b/test/models/inat_obs_photo_test.rb
@@ -2,35 +2,6 @@
 
 require("test_helper")
 
-# iNat inat_obs_photo key/values
-# {:id=>351481052,
-#  :position=>0,
-#  :uuid=>"6c223538-04d6-404c-8e84-b7d881dbe550",
-#  :photo_id=>377332865,
-#  :photo=>
-#   {:id=>377332865,
-#    :license_code=>"cc-by-nc",
-#    :original_dimensions=>{:width=>2048, :height=>1534},
-#    :url=>"https://inaturalist-open-data.s3.amazonaws.com/photos/377332865/square.jpeg",
-#    :attribution=>"(c) Tim C., some rights reserved (CC BY-NC)",
-#    :flags=>[],
-#    :moderator_actions=>[],
-#    :hidden=>false}}
-
-# some MO image attributes
-#  string "content_type", limit: 100
-#  integer "user_id"
-#  date "when"
-#  text "notes"
-#  string "copyright_holder", limit: 100
-#  integer "license_id", default: 1, null: false
-#  integer "width"
-#  integer "height"
-#  boolean "ok_for_export", default: true, null: false
-#  string "original_name", limit: 120, default: ""
-#  boolean "gps_stripped", default: false, null: false
-#  boolean "diagnostic", default: true, null: false
-
 # test mapping of iNat observation photo key/values to MO Image attributes
 class InatObsPhotoTest < UnitTestCase
   def test_simple_photo
@@ -38,28 +9,25 @@ class InatObsPhotoTest < UnitTestCase
     inat_obs = Inat::Obs.new(
       JSON.generate(JSON.parse(mock_search)["results"].first)
     )
-    inat_obs_photo = Inat::ObsPhoto.new(
-      inat_obs[:photos].first
-    )
+    photo = Inat::ObsPhoto.new(inat_obs[:observation_photos].first)
+
     expected_license =
       License.where(License[:url] =~ "/by-nc/").where(deprecated: false).
       order(id: :asc).last
 
-    assert_equal("img/jpeg", inat_obs_photo.content_type)
+    assert_equal("img/jpeg", photo.content_type)
     assert_equal("(c) Tim C., some rights reserved (CC BY-NC)",
-                 inat_obs_photo.copyright_holder)
+                 photo.copyright_holder)
     assert_equal("iNat photo uuid 6c223538-04d6-404c-8e84-b7d881dbe550",
-                 inat_obs_photo.original_name)
-    # assert_equal("original dimensions: 2048 x 1534",
+                 photo.original_name)
     assert_equal(
       "Imported from iNat #{DateTime.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")}",
-      inat_obs_photo.notes
+      photo.notes
     )
 
-    assert_equal(expected_license,
-                 inat_obs_photo.license,
+    assert_equal(expected_license, photo.license,
                  "Wrong license, expecting #{expected_license.display_name}")
     assert_equal("https://inaturalist-open-data.s3.amazonaws.com/photos/377332865/original.jpeg",
-                 inat_obs_photo.url)
+                 photo.url)
   end
 end

--- a/test/models/inat_obs_photo_test.rb
+++ b/test/models/inat_obs_photo_test.rb
@@ -39,7 +39,7 @@ class InatObsPhotoTest < UnitTestCase
       JSON.generate(JSON.parse(mock_search)["results"].first)
     )
     inat_obs_photo = Inat::ObsPhoto.new(
-      inat_obs.inat_obs_photos.first
+      inat_obs[:photos].first
     )
     expected_license =
       License.where(License[:url] =~ "/by-nc/").where(deprecated: false).

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -58,10 +58,10 @@ class InatObsTest < UnitTestCase
 
     expected_snapshot =
       <<~SNAPSHOT.gsub(/^\s+/, "")
-        #{:USER.t}: #{mock_inat_obs.inat_user_login}\n
+        #{:USER.t}: #{mock_inat_obs[:user][:login]}\n
         #{:OBSERVED.t}: #{mock_inat_obs.when}\n
         #{:show_observation_inat_lat_lng.t}: #{mock_inat_obs.lat_lon_accuracy}\n
-        #{:PLACE.t}: #{mock_inat_obs.inat_place_guess}\n
+        #{:PLACE.t}: #{mock_inat_obs[:place_guess]}\n
         #{:ID.t}: #{mock_inat_obs.inat_taxon_name}\n
         #{:DQA.t}: #{mock_inat_obs.dqa}\n
         #{:OBSERVATION_FIELDS.t}: #{mock_inat_obs.obs_fields(mock_inat_obs.inat_obs_fields)}\n
@@ -90,16 +90,16 @@ class InatObsTest < UnitTestCase
     # iNat attributes
     # NOTE: jdc 2024-06-13
     # Might seem circular, but need to insure it works with different iNat APIs
-    assert_equal(202555552, mock_inat_obs.inat_id)
-    assert_equal("31.8813,-109.244", mock_inat_obs.inat_location)
-    assert_equal("Cochise Co., Arizona, USA", mock_inat_obs.inat_place_guess)
-    assert_equal(20, mock_inat_obs.inat_public_positional_accuracy)
-    assert_equal("research", mock_inat_obs.inat_quality_grade)
+    assert_equal(202555552, mock_inat_obs[:id])
+    assert_equal("31.8813,-109.244", mock_inat_obs[:location])
+    assert_equal("Cochise Co., Arizona, USA", mock_inat_obs[:place_guess])
+    assert_equal(20, mock_inat_obs[:public_positional_accuracy])
+    assert_equal("research", mock_inat_obs[:quality_grade])
     assert_equal("Somion unicolor", mock_inat_obs.inat_taxon_name)
-    assert_equal("jdcohenesq", mock_inat_obs.inat_user_login)
+    assert_equal("jdcohenesq", mock_inat_obs[:user][:login])
     # Inocutis dryophila suggested once
     # then Somion unicolor suggested twice
-    assert_equal(3, mock_inat_obs.inat_identifications.size)
+    assert_equal(3, mock_inat_obs[:identifications].size)
   end
   # rubocop:enable Style/NumericLiterals
 
@@ -237,9 +237,9 @@ class InatObsTest < UnitTestCase
     assert_equal(name.text_name, mock_inat_obs.text_name)
   end
 
-  def test_inat_tags
-    assert(2, mock_observation("inocybe").inat_tags.length)
-    assert_empty(mock_observation("evernia").inat_tags)
+  def test_tags
+    assert(2, mock_observation("inocybe")[:tags].length)
+    assert_empty(mock_observation("evernia")[:tags])
   end
 
   def test_dqa
@@ -266,14 +266,14 @@ class InatObsTest < UnitTestCase
     mock_inat_obs = mock_observation("somion_unicolor")
     loc_center = "#{loc.south + ((loc.north - loc.south) / 2)}," \
           "#{loc.west + ((loc.east - loc.west) / 2)}"
-    mock_inat_obs.inat_location = loc_center
+    mock_inat_obs[:location] = loc_center
 
     assert_equal(loc, mock_inat_obs.location)
 
     # Simulate nil accuracy, which is the case for some iNat obss
     # e.g., https://www.inaturalist.org/observations/230672879
-    mock_inat_obs.inat_positional_accuracy = nil
-    mock_inat_obs.inat_public_positional_accuracy = nil
+    mock_inat_obs[:positional_accuracy] = nil
+    mock_inat_obs[:public_positional_accuracy] = nil
 
     assert_equal(loc, mock_inat_obs.location)
   end
@@ -356,8 +356,8 @@ class InatObsTest < UnitTestCase
   end
 
   def test_inat_obs_photos
-    assert(mock_observation("amanita_flavorubens").inat_obs_photos.none?)
-    assert(mock_observation("coprinus").inat_obs_photos.one?)
+    assert(mock_observation("amanita_flavorubens")[:photos].none?)
+    assert(mock_observation("coprinus")[:photos].one?)
   end
 
   def mock_observation(filename)

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -356,8 +356,8 @@ class InatObsTest < UnitTestCase
   end
 
   def test_inat_obs_photos
-    assert(mock_observation("amanita_flavorubens")[:photos].none?)
-    assert(mock_observation("coprinus")[:photos].one?)
+    assert(mock_observation("amanita_flavorubens")[:observation_photos].none?)
+    assert(mock_observation("coprinus")[:observation_photos].one?)
   end
 
   def mock_observation(filename)

--- a/test/models/inat_taxon_test.rb
+++ b/test/models/inat_taxon_test.rb
@@ -6,7 +6,7 @@ require("test_helper")
 class InatTaxonTest < UnitTestCase
   def test_name_basic
     mock_inat_obs = mock_observation("somion_unicolor")
-    inat_taxon = Inat::Taxon.new(mock_inat_obs.inat_taxon)
+    inat_taxon = Inat::Taxon.new(mock_inat_obs[:taxon])
 
     assert_equal(inat_taxon.name, names(:somion_unicolor),
                  "Incorrect MO Name for iNat community id")
@@ -33,7 +33,7 @@ class InatTaxonTest < UnitTestCase
     x_campanella_group.save
 
     mock_inat_obs = mock_observation("xeromphalina_campanella_complex")
-    inat_taxon = Inat::Taxon.new(mock_inat_obs.inat_taxon)
+    inat_taxon = Inat::Taxon.new(mock_inat_obs[:taxon])
 
     assert_equal(x_campanella_group, inat_taxon.name,
                  "Incorrect MO Name for iNat community id")

--- a/test/models/inat_taxon_test.rb
+++ b/test/models/inat_taxon_test.rb
@@ -11,7 +11,7 @@ class InatTaxonTest < UnitTestCase
     assert_equal(inat_taxon.name, names(:somion_unicolor),
                  "Incorrect MO Name for iNat community id")
 
-    last_id = mock_inat_obs.inat_identifications.last
+    last_id = mock_inat_obs[:identifications].last
     inat_taxon = Inat::Taxon.new(last_id[:taxon])
 
     assert_equal(inat_taxon.name, names(:somion_unicolor),


### PR DESCRIPTION
- Uses hash lookup to access `Inat::Obs` attributes.
- Removes needless, repetitive pattern of defined methods.
Ex: `inat_obs[:id]` instead of `inat_obs.inat_id`
- Fixes `Inat::Obs` class length metric offense.
- Responds to [@mo-nathan suggestion](https://github.com/MushroomObserver/mushroom-observer/pull/2150#discussion_r1762039634).
- Replaces #2416 


There is no manual test.