### PR TITLE
Notes link to iNat when recording Field Slip

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1707,7 +1707,7 @@ class ApplicationController < ActionController::Base
   end
 
   def name_flash_for_project(name, project)
-    return unless name
+    return unless name && project
 
     count = project.count_collections(name)
     if count == 1

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -205,9 +205,16 @@ class FieldSlipsController < ApplicationController
     notes[:Collector] = collector
     notes[:Field_Slip_ID] = field_slip_id
     notes[:Field_Slip_ID_By] = field_slip_id_by
-    notes[:Other_Codes] = params[:field_slip][:other_codes]
+    notes[:Other_Codes] = other_codes
     update_notes_fields(notes)
     notes
+  end
+
+  def other_codes
+    codes = params[:field_slip][:other_codes]
+    return codes unless params[:field_slip][:inat] == "1"
+
+    "\"iNat ##{codes}\":https://www.inaturalist.org/observations/#{codes}"
   end
 
   def update_notes_fields(notes)
@@ -219,13 +226,9 @@ class FieldSlipsController < ApplicationController
     end
   end
 
-  def collector
-    user_str(params[:field_slip][:collector])
-  end
+  def collector = user_str(params[:field_slip][:collector])
 
-  def field_slip_id_by
-    user_str(params[:field_slip][:field_slip_id_by])
-  end
+  def field_slip_id_by = user_str(params[:field_slip][:field_slip_id_by])
 
   def field_slip_id
     str = params[:field_slip][:field_slip_name]
@@ -262,8 +265,7 @@ class FieldSlipsController < ApplicationController
     flash_notice(:field_slip_welcome.t(title: project.title))
     return if project_member
 
-    ProjectMember.create(project:, user:,
-                         trust_level: "hidden_gps")
+    ProjectMember.create(project:, user:, trust_level: "hidden_gps")
     flash_notice(:add_members_with_gps_trust.l)
   end
 

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -40,6 +40,8 @@
                             label: :ID_BY.t + ":", type: :user) %>
     <%= text_field_with_label(form:, field: :other_codes,
                               label: "#{:field_slip_other_codes.t} (#{:field_slip_other_example.t}):") %>
+    <%= check_box_with_label(form:, field: :inat,
+                             label: :field_slip_other_inat.t ) %>
 
     <%= submit_button(form:, button: :field_slip_quick_create_obs.t, class: "mb-5") if action == "new" %>
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2855,6 +2855,7 @@
   field_slip_nil_project: "(No Project)"
   field_slip_other_codes: Other Codes
   field_slip_other_example: e.g., iNat ID
+  field_slip_other_inat: Check if [:field_slip_other_codes] is an iNat ID
   field_slip_project_success: Field Slip associated with the [TITLE] Project
   field_slip_qr_intro: This page is primarily intended for scanning "MO Field Slips":https://mushroomobserver.org/articles/37 using a QR code scanner. It should work with QR codes that only contain the field slip code.  You can also enter the code by hand into the text box and hit return.
   field_slip_quick_no_location: Quick create requires an existing location

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -167,6 +167,27 @@ class FieldSlipsControllerTest < FunctionalTestCase
     obs = Observation.last
     assert_redirected_to observation_url(obs.id)
   end
+  test "should create obs with link to inat" do
+    login(@field_slip.user.login)
+    code = "Z#{@field_slip.code}"
+    assert_difference("Observation.count") do
+      post(:create,
+           params: {
+             commit: :field_slip_quick_create_obs.t,
+             field_slip: {
+               code: code,
+               location: locations(:albion).name,
+               field_slip_name: names(:coprinus_comatus).text_name,
+               project_id: projects(:eol_project).id,
+               other_codes: "12345",
+               inat: "1"
+             }
+           })
+    end
+    obs = Observation.last
+    assert_match("https://www.inaturalist.org/observations",
+                 obs.notes[:Other_Codes])
+  end
 
   test "should try to create obs and redirect to create obs" do
     login(@field_slip.user.login)

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -178,7 +178,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
                code: code,
                location: locations(:albion).name,
                field_slip_name: names(:coprinus_comatus).text_name,
-               project_id: projects(:eol_project).id,
+               # project_id: projects(:eol_project).id,
                other_codes: "12345",
                inat: "1"
              }


### PR DESCRIPTION
- Adds a checkbox to the field_slip form. (See below.)
- Links notes[:Other_Codes] to iNat if the user checks that box
<img width="417" alt="Screenshot 2024-09-30 at 7 20 37 AM" src="https://github.com/user-attachments/assets/e5a03001-82cb-495f-8ef0-6148f4867ed1">
<img width="247" alt="Screenshot 2024-09-30 at 7 30 52 AM" src="https://github.com/user-attachments/assets/339e247c-a41c-40a6-a3f6-7ae36b8dfead">


### Manual Test
- http://localhost:3000/field_slips/qr_reader/new
- enter a valid Field Slip Code
- complete the form, including Location, ID, and a number in Other Codes,
- check the box
- Quick Create
Expected Result: It shows a new Observation whose Notes[:Other_Codes] is a link to an iNat observation.