### PR TITLE
Switch obs search param from `date:` to `when:` 

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -66,9 +66,6 @@ jobs:
           bundle exec rake db:schema:load
           bundle exec rake db:fixtures:load
 
-      - name: Run migrations
-        run: bundle exec rake db:migrate
-
       - name: Update translation files
         run: bundle exec rake lang:update
 

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -66,6 +66,9 @@ jobs:
           bundle exec rake db:schema:load
           bundle exec rake db:fixtures:load
 
+      - name: Run migrations
+        run: bundle exec rake db:migrate
+
       - name: Update translation files
         run: bundle exec rake lang:update
 

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -5,7 +5,7 @@ module PatternSearch
   class Observation < Base
     PARAMS = {
       # dates / times
-      date: [:date, :parse_date_range],
+      when: [:date, :parse_date_range],
       created: [:created_at, :parse_date_range],
       modified: [:updated_at, :parse_date_range],
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1142,6 +1142,7 @@
   search_term_comments: comments
   search_term_confidence: confidence
   search_term_created: created
+  search_term_date: date
   search_term_when: date
   search_term_deprecated: deprecated
   search_term_east: east
@@ -3664,6 +3665,7 @@
   # Search bar help
   pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.  Recognized variables include:"
 
+  observation_term_date: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_when: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_created: Date observation was first posted.
   observation_term_modified: Date observation was last modified.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1142,7 +1142,6 @@
   search_term_comments: comments
   search_term_confidence: confidence
   search_term_created: created
-  search_term_date: date
   search_term_when: date
   search_term_deprecated: deprecated
   search_term_east: east
@@ -3665,7 +3664,6 @@
   # Search bar help
   pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.  Recognized variables include:"
 
-  observation_term_date: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_when: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_created: Date observation was first posted.
   observation_term_modified: Date observation was last modified.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1142,7 +1142,7 @@
   search_term_comments: comments
   search_term_confidence: confidence
   search_term_created: created
-  search_term_date: date
+  search_term_when: date
   search_term_deprecated: deprecated
   search_term_east: east
   search_term_exclude_consensus: exclude_consensus
@@ -3664,7 +3664,7 @@
   # Search bar help
   pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas.  Recognized variables include:"
 
-  observation_term_date: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
+  observation_term_when: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_created: Date observation was first posted.
   observation_term_modified: Date observation was last modified.
   observation_term_name: Consensus name is one of these names.

--- a/db/migrate/20240916224214_change_search_term_date_translation_tags.rb
+++ b/db/migrate/20240916224214_change_search_term_date_translation_tags.rb
@@ -1,0 +1,14 @@
+class ChangeSearchTermDateTranslationTags < ActiveRecord::Migration[7.1]
+  def up
+    TranslationString.rename_tags(
+      { search_term_date: :search_term_when,
+        observation_term_date: :observation_term_when }
+    )
+  end
+  def down
+    TranslationString.rename_tags(
+      { search_term_when: :search_term_date,
+        observation_term_when: :observation_term_date }
+    )
+  end
+end


### PR DESCRIPTION
Changes the observation search keyword from `date:` to `when:`, and changes the translation string keys that relate to this term. The point of doing it here is to move the migration out of the pattern search PR to main, so it's easier for people to test that PR without messing up their db.
 
The reason for the change is that these search params map directly onto the attributes of a new `Filter` model used in the new search form, and `date` is a reserved accessor method for any model. 

But the cool thing about doing it this way is that these params are all translated; so for people who are already in the habit of typing `date:`, it will still work — it's "the English translation of the param 'when'". Session search strings with `date` will be silently updated to `when`, without the user having to do anything. Search bar help will reflect the new term. 