### PR TITLE
Add links to mobile phone article

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -198,7 +198,8 @@ module LinkHelper
     chevron_up: "chevron-up",
     chevron_left: "chevron-left",
     chevron_right: "chevron-right",
-    qrcode: "qrcode"
+    qrcode: "qrcode",
+    mobile: "phone"
   }.freeze
 
   # button to destroy object

--- a/app/views/controllers/application/sidebar/_login.html.erb
+++ b/app/views/controllers/application/sidebar/_login.html.erb
@@ -8,3 +8,5 @@ end %>
                    class: classes[:indent], id: "nav_login_link") %>
 <%= active_link_to(:app_create_account.t, account_signup_path,
                    class: classes[:indent], id: "nav_signup_link") %>
+<%= active_link_to(:app_mobile.t, article_path(34),
+                   class: classes[:indent], id: "nav_mobile_link") %>

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -9,6 +9,16 @@ end %>
               { class: class_names("btn", "btn-link", classes[:indent],
                                    classes[:mobile_only]),
                 id: "nav_user_logout_link" }) %>
+
+<%= active_link_to(:app_qrcode.t,
+                   field_slips_qr_reader_new_path,
+                   class: class_names(classes[:indent], classes[:mobile_only]),
+                   id: "nav_mobile_qr_reader") %>
+<%= active_link_to(:app_mobile.t,
+                   article_path(34),
+                   class: class_names(classes[:indent], classes[:mobile_only]),
+                   id: "nav_mobile_mobile_link") %>
+
 <%= active_link_to(:app_comments_for_you.t,
                    comments_path(for_user: @user.id),
                    class: class_names(classes[:indent], classes[:mobile_only]),

--- a/app/views/controllers/application/top_nav/_user_nav.html.erb
+++ b/app/views/controllers/application/top_nav/_user_nav.html.erb
@@ -22,6 +22,13 @@ admin_mode_args = in_admin_mode? ? { turn_off: true } : { turn_on: true }
   </li>
   <li>
     <%= icon_link_to(
+          :app_mobile.l, article_path(34),
+          { icon: :mobile, id: "user_nav_mobile_link",
+            data: { placement: "bottom" } }
+        ) %>
+  </li>
+  <li>
+    <%= icon_link_to(
           :app_comments_for_you.l, comments_path(for_user: @user.id),
           { icon: :inbox, id: "user_nav_inbox_link",
             data: { placement: "bottom" } }

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1368,6 +1368,7 @@
   app_create_account: Create Account
   app_current_user: Current User
   app_comments_for_you: Comments for You
+  app_mobile: Get Mobile App
   app_qrcode: Enter Field Slip Code
   app_your_observations: Your Observations
   app_your_lists: Your Lists


### PR DESCRIPTION
Appears as "Get Mobile App" when you are logged out and as a phone icon in the header icons at the top of most pages.