### PR TITLE
DDD links

### DIFF
--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -67,6 +67,10 @@ module ObjectLinkHelper
     "https://ascomycete.org/Search-Results?search=#{name.sensu_stricto}"
   end
 
+  def ddd_url
+    "https://www.alpental.com/psms/ddd/index.htm"
+  end
+
   def gbif_name_search_url(name)
     # omit `group`, else there are no hits
     # omit quotes around the name in order to get synonyms and cf's

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -148,6 +148,11 @@ module Tabs
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
     end
 
+    def ddd_link_tab
+      [:show_observation_ddd.l, ddd_url,
+       { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]
+    end
+
     def ascomycete_org_name_tab(name)
       ["Ascomycete.org", ascomycete_org_name_url(name),
        { class: tab_id(__method__.to_s), target: :_blank, rel: :noopener }]

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -87,18 +87,22 @@ module Tabs
        { class: tab_id(__method__.to_s) }]
     end
 
-    def name_links_web(name:)
-      tabs = create_links_to(observation_web_name_tabs(name),
+    def name_links_web(observation:)
+      tabs = create_links_to(observation_web_name_tabs(observation),
                              { class: "d-block" })
       tabs.reject(&:empty?)
     end
 
-    def observation_web_name_tabs(name)
-      tabs = [mycoportal_name_tab(name),
-              mycobank_name_search_tab(name),
-              google_images_for_name_tab(name)]
-      tabs << ddd_link_tab if name.pnw_provisional?
+    def observation_web_name_tabs(observation)
+      tabs = [mycoportal_name_tab(observation.name),
+              mycobank_name_search_tab(observation.name),
+              google_images_for_name_tab(observation.name)]
+      tabs << ddd_link_tab if namings_pnw_provisional?(observation)
       tabs
+    end
+
+    def namings_pnw_provisional?(observation)
+      observation.namings.any? { |naming| naming.name.pnw_provisional? }
     end
 
     def observation_hide_thumbnail_map_tab(obs)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -94,9 +94,11 @@ module Tabs
     end
 
     def observation_web_name_tabs(name)
-      [mycoportal_name_tab(name),
-       mycobank_name_search_tab(name),
-       google_images_for_name_tab(name)]
+      tabs = [mycoportal_name_tab(name),
+              mycobank_name_search_tab(name),
+              google_images_for_name_tab(name)]
+      tabs << ddd_link_tab if name.pnw_provisional?
+      tabs
     end
 
     def observation_hide_thumbnail_map_tab(obs)

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -95,6 +95,10 @@ module Name::Taxonomy
       /\bcrypt temp\b/i =~ author&.delete(".")
   end
 
+  def pnw_provisional?
+    text_name.match?(/".*pnw/i) || author.match(/pnw/i)
+  end
+
   ################
 
   private

--- a/app/views/controllers/names/show/_nomenclature.html.erb
+++ b/app/views/controllers/names/show/_nomenclature.html.erb
@@ -76,6 +76,9 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
           tag.p(link_to(*index_fungorum_name_search_tab(name))),
           tag.p(link_to(*mycobank_basic_search_tab))
         ].safe_join
+      elsif name.pnw_provisional?
+        tag.p(link_to("DDD (PNW DNA-based taxa)",
+                      "https://www.alpental.com/psms/ddd/index.htm"))
       end
     end)
 

--- a/app/views/controllers/names/show/_nomenclature.html.erb
+++ b/app/views/controllers/names/show/_nomenclature.html.erb
@@ -77,8 +77,7 @@ synonym_links = [approve, deprecate].reject(&:nil?).safe_join(" | ")
           tag.p(link_to(*mycobank_basic_search_tab))
         ].safe_join
       elsif name.pnw_provisional?
-        tag.p(link_to("DDD (PNW DNA-based taxa)",
-                      "https://www.alpental.com/psms/ddd/index.htm"))
+        tag.p(link_to(:show_observation_ddd.l, ddd_url))
       end
     end)
 

--- a/app/views/controllers/observations/show/_name_info.erb
+++ b/app/views/controllers/observations/show/_name_info.erb
@@ -16,7 +16,7 @@ panel_block(
     end %>
     <%= tag.div(class: "col-xs-6") do
       concat(tag.div("#{:on_the_web.l}:", class: "font-weight-bold"))
-      concat(name_links_web(name: obs.name).safe_join)
+      concat(name_links_web(observation: @observation).safe_join)
     end %>
   <% end %>
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2316,6 +2316,7 @@
   show_observation_more_like_this: More like this
   show_observation_look_alikes: Look-alikes
   show_observation_related_taxa: Related taxa
+  show_observation_ddd: "DDD (PNW DNA-based taxa)"
   map_observation_title: "Map of Observation #[ID]"
 
   # observations/suggestions

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -624,6 +624,31 @@ class NamesControllerTest < FunctionalTestCase
     assert_external_link("Ascomycete.org", ascomycete_org_name_url(name))
   end
 
+  def test_show_name_pnw_cryptonym
+    name = Name.create(
+      user_id: rolf.id,
+      rank: "Species",
+      text_name: 'Hygrocybe "parvula-PNW01"',
+      search_name: "Hygrocybe \"parvula-PNW01\" S.D. Russell crypt. temp.",
+      display_name: '**__Hygrocybe "parvula-PNW01"__** S.D. Russell crypt. temp.',
+      sort_name: 'Hygrocybe "parvula-PNW01"  S.D. Russell crypt. temp.',
+      citation: "",
+      deprecated: false,
+      synonym_id: nil,
+      correct_spelling_id: nil,
+      classification:
+       "Domain: _Eukarya_\r\nKingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Agaricomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Hygrophoraceae_", # rubocop:disable Layout/LineLength
+      author: "S.D. Russell crypt. temp."
+    )
+
+    login
+    get(:show, params: { id: name.id })
+
+    assert_select("div#nomenclature a:match('href',?)",
+                  %r{https://www.alpental.com/psms/ddd/index.htm}, true,
+                  "Page is missing a link to PNW cryptonym page")
+  end
+
   def test_show_name_genus_with_icn_id
     # Name's icn_id is filled in
     name = names(:tubaria)

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -288,6 +288,40 @@ class ObservationsControllerShowTest < FunctionalTestCase
     end
   end
 
+  def test_observation_pnw_link_exists
+    name = Name.create(
+      user_id: rolf.id,
+      rank: "Species",
+      text_name: 'Hygrocybe "parvula-PNW01"',
+      search_name: "Hygrocybe \"parvula-PNW01\" S.D. Russell crypt. temp.",
+      display_name: '**__Hygrocybe "parvula-PNW01"__** S.D. Russell crypt. temp.',
+      sort_name: 'Hygrocybe "parvula-PNW01"  S.D. Russell crypt. temp.',
+      citation: "",
+      deprecated: false,
+      synonym_id: nil,
+      correct_spelling_id: nil,
+      classification:
+       "Domain: _Eukarya_\r\nKingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Agaricomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Hygrophoraceae_", # rubocop:disable Layout/LineLength
+      author: "S.D. Russell crypt. temp."
+    )
+    obs = Observation.create(
+      name: name,
+      location: locations(:obs_default_location),
+      where: "MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA",
+      user: rolf,
+      is_collection_location: 1,
+      text_name: name.text_name,
+      classification: "name.classification"
+    )
+
+    login
+    get(:show, params: { id: obs.id })
+
+    assert_select("a:match('href',?)",
+                  %r{https://www.alpental.com/psms/ddd/index.htm}, true,
+                  "Page is missing a link to PNW cryptonym page")
+  end
+
   def test_show_observation_edit_links
     obs = observations(:detailed_unknown_obs)
     proj = projects(:bolete_project)

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -289,6 +289,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
   end
 
   def test_observation_pnw_link_exists
+    obs = observations(:minimal_unknown_obs)
     name = Name.create(
       user_id: rolf.id,
       rank: "Species",
@@ -304,15 +305,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
        "Domain: _Eukarya_\r\nKingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Agaricomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Hygrophoraceae_", # rubocop:disable Layout/LineLength
       author: "S.D. Russell crypt. temp."
     )
-    obs = Observation.create(
-      name: name,
-      location: locations(:obs_default_location),
-      where: "MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA",
-      user: rolf,
-      is_collection_location: 1,
-      text_name: name.text_name,
-      classification: "name.classification"
-    )
+    Naming.create(observation: obs, name: name, vote_cache: 0, user: rolf)
 
     login
     get(:show, params: { id: obs.id })


### PR DESCRIPTION
Creates links from relevant Name and Observation pages to an ongoing project to document all PNW mushrooms using DNA analysis. The relevant pages are Names of the form `XXX "xxx-PNW-nnn"`, and Observations whose consensus id takes that form. (DDD = Danny's DNA Discoveries)

### TODO
- [ ] Add link to Observation pages which propose such a Name
- [ ] also check for Names whose author includes PNW, e.g. sensu PNW.