### PR TITLE
Change name of `Mappable::BoxMethods` method `box_area`

### DIFF
--- a/app/classes/auto_complete/for_location_containing.rb
+++ b/app/classes/auto_complete/for_location_containing.rb
@@ -22,7 +22,7 @@ class AutoComplete::ForLocationContaining < AutoComplete::ByWord
       contains_point(lat: lat.to_f, lng: lng.to_f).reject do |loc|
         location_box(loc).vague?
       end.sort_by! do |loc|
-        location_box(loc).box_area
+        location_box(loc).calculate_area
       end
 
     matches_array(locations)

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -215,7 +215,7 @@ class Inat
                               s: blurred_south,
                               e: blurred_east,
                               w: blurred_west).
-        min_by { |loc| location_box(loc).box_area }
+        min_by { |loc| location_box(loc).calculate_area }
     end
 
     # location seems simplest source for lat/lng

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -15,7 +15,7 @@
 #  north_south_distance:: Returns north - south.
 #  east_west_distance::   Returns east - west (adjusting if straddles dateline).
 #  straddles_180_deg?::   Returns true if box straddles 180 degrees.
-#  box_area::             Returns the area described by a box, in kmˆ2.
+#  calculate_area::       Returns the area described by a box, in kmˆ2.
 #  vague?::       Arbitrary test for whether a box covers too large an area to
 #                 be useful on a map.
 #  delta_lat::    Returns north_south_distance * DELTA.
@@ -118,7 +118,7 @@ module Mappable
     #   Formula for `the area of a patch of a sphere`:
     #     area = Rˆ2 * (long2 - long1) * (sin(lat2) - sin(lat1))
     #   where lat/lng in radians, R in km, Earth R rounded to 6372km
-    def box_area
+    def calculate_area
       6372 * 6372 * east_west_distance.to_radians *
         (Math.sin(north.to_radians) - Math.sin(south.to_radians)).abs
     end
@@ -126,7 +126,7 @@ module Mappable
     # Arbitrary test for whether a box covers too large an area to be useful on
     # a map with other boxes. Large boxes can obscure more precise locations.
     def vague?
-      box_area > 24_000 # kmˆ2
+      calculate_area > 24_000 # kmˆ2
     end
 
     # NOTE: DELTA = 0.20 is way too strict a limit for remote locations.


### PR DESCRIPTION
Ahead of a planned `box_area` column addition to `locations`.

The `Location` class includes `Mappable::BoxMethods` so the method name would conflict with the new model attribute. If both exist, `box_area` seems the better name for the attribute, where `calculate_area` more accurately describes a method that does a fresh calculation.