### PR TITLE
Fix "Remove" image button in edit obs carousel

### DIFF
--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -409,7 +409,8 @@ export default class extends Controller {
   removeAttachedItem(event) {
     const _good_images = this.goodImageIdsTarget.value,
       _good_image_vals = _good_images.split(" "),
-      _image_id = event.target.dataset.imageId,
+      // event.target may be a nested span without data, so get data directly
+      _image_id = this.removeImgTarget.dataset.imageId,
       _thumb_id = this.thumbImageIdTarget.value;
 
     const _new = _good_image_vals.filter(item => item !== _image_id).join(" ");


### PR DESCRIPTION
The click `event.target` (the thing you clicked) is likely to be the text `<span>` inside the "Remove" `<button>`. But clicking currently only works if you click the `<button>` element _outside_ the `<span>`, because it's trying to grab the `image_id` from the `event.target.dataset`, and those `data` attributes only exist on the `<button>`. It finds no `image_id` if you click on the `<span>`.

Stimulus however allows pulling the dataset directly from the button, because we made it a declared Stimulus `target` element within the carousel slide: `removeImgTarget`. 

Updates form-images_controller.js