### PR TITLE
Fix iNat photo deletion

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -415,8 +415,12 @@ class InatImportJob < ApplicationJob
                                ignore_photos: 1 } }
     headers = { authorization: "Bearer #{@inat_import.token}",
                 content_type: :json, accept: :json }
-    response = RestClient.put("#{API_BASE}/observations/#{@inat_obs[:id]}",
-                              payload.to_json, headers)
+    # iNat API uses PUT + ignore_photos, not PATCH, to update an observation
+    # https://api.inaturalist.org/v1/docs/#!/Observations/put_observations_id
+    response = RestClient.put(
+      "#{API_BASE}/observations/#{@inat_obs[:id]}?ignore_photos=1",
+      payload.to_json, headers
+    )
     JSON.parse(response.body)
   rescue RestClient::ExceptionWithResponse => e
     @inat_import.add_response_error(e.response)

--- a/app/views/controllers/observations/new.html.erb
+++ b/app/views/controllers/observations/new.html.erb
@@ -1,7 +1,7 @@
 <%
 add_page_title(:create_observation_title.t)
 
-# add_tab_set(observation_form_new_tabs)
+add_tab_set(observation_form_new_tabs)
 @container = :wide
 %>
 

--- a/test/controllers/observations_controller/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller/observations_controller_create_test.rb
@@ -103,8 +103,8 @@ class ObservationsControllerCreateTest < FunctionalTestCase
                        users(:rolf).preferred_herbarium_name)
     assert_input_value(:herbarium_record_accession_number, "")
     assert_true(@response.body.include?("Albion, Mendocino Co., California"))
-    # assert_link_in_html(:create_observation_inat_import_link.l,
-    #                     new_observations_inat_import_path)
+    assert_link_in_html(:create_observation_inat_import_link.l,
+                        new_observations_inat_import_path)
 
     users(:rolf).update(location_format: "scientific")
     get(:new)

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -695,9 +695,13 @@ class InatImportJobTest < ActiveJob::TestCase
       }
       headers = { authorization: "Bearer",
                   content_type: "application/json", accept: "application/json" }
-      add_stub(stub_request(:put, "#{API_BASE}/observations/#{obs["id"]}").
+      add_stub(
+        stub_request(
+          :put, "#{API_BASE}/observations/#{obs["id"]}?ignore_photos=1"
+        ).
         with(body: body.to_json, headers: headers).
-        to_return(status: 200, body: "".to_json, headers: {}))
+        to_return(status: 200, body: "".to_json, headers: {})
+      )
     end
   end
 


### PR DESCRIPTION
- Prevents iNat photos from being deleted when updating iNat observation
- Corrects use of iNat API `ignore_photos` parameter
- Corrects stub of updating iNat obs description
- Restores the temporarily hidden link to Import from iNat