### PR TITLE
 InatImportsController#create ABC

### DIFF
--- a/app/controllers/observations/inat_imports_controller_validators.rb
+++ b/app/controllers/observations/inat_imports_controller_validators.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Observations::InatImportsControllerValidators
+  private
+
+  SITE = "https://www.inaturalist.org"
+
+  def params_valid?
+    username_present? &&
+      valid_inat_ids_param? &&
+      imports_designated? &&
+      fresh_import? &&
+      unmirrored? &&
+      consented?
+  end
+
+  def username_present?
+    return true if params[:inat_username].present?
+
+    flash_warning(:inat_missing_username.l)
+    false
+  end
+
+  def valid_inat_ids_param?
+    return true unless contains_illegal_characters?
+
+    flash_warning(:runtime_illegal_inat_id.l)
+    false
+  end
+
+  def contains_illegal_characters?
+    /[^\d ,]/.match?(params[:inat_ids])
+  end
+
+  def imports_designated?
+    return true if params[:all] == "1" || params[:inat_ids].present?
+
+    flash_warning(:inat_no_imports_designated.t)
+    false
+  end
+
+  def fresh_import?
+    previous_imports =
+      inat_id_list.each_with_object([]) do |inat_id, ary|
+        ary << Observation.find_by(inat_id: inat_id)
+      end
+    return true if previous_imports.none?
+
+    previous_imports.each do |import|
+      flash_warning(:inat_previous_import.t(inat_id: import.inat_id,
+                                            mo_obs_id: import.id))
+    end
+    false
+  end
+
+  def inat_id_list
+    params[:inat_ids].delete(" ").split(",").map(&:to_i)
+  end
+
+  def unmirrored?
+    previously_mirrored =
+      inat_id_list.each_with_object([]) do |inat_id, ary|
+        mirrored = Observation.notes_include(
+          "Mirrored on iNaturalist as <a href=\"https://www.inaturalist.org/observations/#{inat_id}\">"
+        ).first
+        ary << mirrored if mirrored
+      end
+    return true if previously_mirrored.blank?
+
+    previously_mirrored.each do |obs|
+      flash_warning(:inat_previous_mirror.t(inat_id: mirrored_inat_id(obs),
+                                            mo_obs_id: obs.id))
+    end
+    false
+  end
+
+  # When Pulk's `mirror`Python script copies an MO Obs to iNat,
+  # it adds a link to the iNat obs in the MO Observation notes
+  def mirrored_inat_id(obs)
+    match = %r{#{SITE}/observations/(?'inat_id'\d+)}o.match(obs.notes.to_s)
+    match[:inat_id]
+  end
+
+  def consented?
+    return true if params[:consent] == "1"
+
+    flash_warning(:inat_consent_required.t)
+    false
+  end
+end


### PR DESCRIPTION
- Fixes InatImportsController#create ABC offense See https://github.com/MushroomObserver/mushroom-observer/pull/2150#discussion_r1762022208
- Extracts InatImportsController validators to a module