### PR TITLE
Persist Location Notes

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -765,7 +765,7 @@ class AbstractModel < ApplicationRecord
 
   # Add a note to the notes field with paragraph break between different notes.
   def add_note(note)
-    self.notes = notes.present? ? "\n\n#{note}" : note
+    self.notes = notes.present? ? "#{notes}\n\n#{note}" : note
     save
   end
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -723,6 +723,7 @@ class LocationsControllerTest < FunctionalTestCase
   def test_update_location_admin_merge
     to_go = locations(:albion)
     to_stay = locations(:burbank)
+    old_notes = to_stay.notes
     params = update_params_from_loc(to_go)
     params[:location][:display_name] = to_stay.display_name
 
@@ -750,6 +751,8 @@ class LocationsControllerTest < FunctionalTestCase
                  LocationDescription::Version.count)
     assert_equal(to_stay, herbarium.reload.location)
     assert_equal(to_stay, project.reload.location)
+    assert_match(old_notes, to_stay.reload.notes,
+                 "Location.notes should include pre-merger notes")
   end
 
   def test_post_edit_location_locked

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -51,6 +51,7 @@ burbank:
   south: 34.15
   high: 294.0
   low: 148.0
+  notes: These should persist after another location is merged into this one.
 
 mitrula_marsh:
   <<: *DEFAULTS


### PR DESCRIPTION
- Prevents an admin comment from overwriting existing Location notes during a Location merge.
- Fixes #2415
