### PR TITLE
Change params of scopes `in_box`, `contains_box`, `not_in_box`

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -101,10 +101,10 @@ class Inat
 
     # min bounding rectangle of iNat location blurred by public accuracy
     def location
-      ::Location.contains_box(n: blurred_north,
-                              s: blurred_south,
-                              e: blurred_east,
-                              w: blurred_west).
+      ::Location.contains_box(north: blurred_north,
+                              south: blurred_south,
+                              east: blurred_east,
+                              west: blurred_west).
         min_by { |loc| location_box(loc).calculate_area }
     end
 

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -57,14 +57,14 @@ module Mappable
     end
 
     # Return center latitude.
-    def lat
+    def calculate_lat
       (north + south) / 2.0
     rescue StandardError
       nil
     end
 
     # Return center longitude for MapSet. (Google Maps takes `lng`, not `long`)
-    def lng
+    def calculate_lng
       lng = (east + west) / 2.0
       if west > east && lng.negative?
         lng += 180
@@ -76,9 +76,9 @@ module Mappable
       nil
     end
 
-    # Return center as [lat, long].
+    # Return center as [lat, lng].
     def center
-      [lat, lng]
+      [calculate_lat, calculate_lng]
     end
 
     # Returns [north, south, east, west].

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -182,16 +182,18 @@ module Mappable
 
     # loc may be an observation, MinimalObservation or a set (with lng)
     def round_lat_lng_to_precision(loc, prec)
+      lat = loc.calculate_lat
+      lng = loc.calculate_lng
       if prec > MIN_PRECISION
-        return [round_number(loc.lat, prec), round_number(loc.lng, prec)]
+        return [round_number(lat, prec), round_number(lng, prec)]
       end
 
-      [if loc.lat >= 45
+      [if lat >= 45
          90
        else
-         loc.lat <= -45 ? -90 : 0
+         lat <= -45 ? -90 : 0
        end,
-       loc.lng >= 150 || loc.lng <= -150 ? 180 : round_number(loc.lng, prec)]
+       lng >= 150 || lng <= -150 ? 180 : round_number(lng, prec)]
     end
 
     def calc_extents

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -182,8 +182,13 @@ module Mappable
 
     # loc may be an observation, MinimalObservation or a set (with lng)
     def round_lat_lng_to_precision(loc, prec)
-      lat = loc.calculate_lat
-      lng = loc.calculate_lng
+      if loc.is_a?(Location) || loc.is_a?(MinimalLocation)
+        lat = loc.calculate_lat
+        lng = loc.calculate_lng
+      else
+        lat = loc.lat
+        lng = loc.lng
+      end
       if prec > MIN_PRECISION
         return [round_number(lat, prec), round_number(lng, prec)]
       end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -358,6 +358,11 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     contains?(loc.north, loc.west) && contains?(loc.south, loc.east)
   end
 
+  # Returns a hash representing the location's bounding box
+  def bounding_box
+    attributes.symbolize_keys.slice(:north, :south, :west, :east)
+  end
+
   ##############################################################################
   #
   #  :section: Name Stuff

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -47,7 +47,7 @@
 #  updated_between(start, end)
 #  name_includes(place_name)
 #  in_region(place_name)
-#  in_box(n,s,e,w)
+#  in_box(north:, south:, east:, west:)
 #
 #  == Instance methods
 #

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -157,11 +157,9 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
         ->(place_name) { where(Location[:name].matches("%#{place_name}%")) }
   scope :in_region,
         ->(place_name) { where(Location[:name].matches("%#{place_name}")) }
-  scope :in_box, # Use named parameters (n, s, e, w), any order
+  scope :in_box, # Use named parameters (north, south, east, west), any order
         lambda { |**args|
-          box = Mappable::Box.new(
-            north: args[:n], south: args[:s], east: args[:e], west: args[:w]
-          )
+          box = Mappable::Box.new(**args)
           return none unless box.valid?
 
           # expand box by epsilon to create leeway for Float rounding
@@ -218,15 +216,15 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
           )
         }
 
-  scope :contains_box, # Use named parameters, n:, s:, e:, w:
+  scope :contains_box, # Use named parameters, north:, south:, east:, west:
         lambda { |**args|
-          args => {n:, s:, e:, w:}
+          args => { north:, south:, east:, west: }
 
           # Correct for possible floating point rounding
-          shrunk_n = n - FLOAT_ERROR
-          shrunk_s = s + FLOAT_ERROR
-          shrunk_e = e - FLOAT_ERROR
-          shrunk_w = w + FLOAT_ERROR
+          shrunk_n = north - FLOAT_ERROR
+          shrunk_s = south + FLOAT_ERROR
+          shrunk_e = east - FLOAT_ERROR
+          shrunk_w = west + FLOAT_ERROR
 
           # w/e    | Location     | Location contains w/e
           # ______ | ____________ | ______________________
@@ -235,7 +233,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
           # w > e  | west <= east | none
           # w > e  | west > east  | west <= w && e <= east
 
-          if w <= e # w / e don't straddle 180
+          if west <= east # w / e don't straddle 180
             where(Location[:south].lteq(shrunk_s).
                     and(Location[:north].gteq(shrunk_n)).
                   #   Location doesn't straddle 180

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -627,7 +627,7 @@ class Name < AbstractModel
           end
         }
   # Names with Observations whose lat/lon are in a box
-  scope :in_box, # Use named parameters (n, s, e, w), any order
+  scope :in_box, # Use named parameters (north, south, east, west), any order
         lambda { |**args|
           joins(:observations).
             merge(Observation.in_box(**args)).

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -198,7 +198,7 @@
 #  comments_include(summary)
 #  on_species_list(species_list)
 #  at_location(location)
-#  in_box(n:, s:, e:, w:)
+#  in_box(north:, south:, east:, west:)
 #
 #  ==== Classification
 #  validate_classification:: Make sure +classification+ syntax is valid.
@@ -629,9 +629,7 @@ class Name < AbstractModel
   # Names with Observations whose lat/lon are in a box
   scope :in_box, # Use named parameters (north, south, east, west), any order
         lambda { |**args|
-          joins(:observations).
-            merge(Observation.in_box(**args)).
-            distinct
+          joins(:observations).merge(Observation.in_box(**args)).distinct
         }
 
   ### Specialized Scopes for Name::Create

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -399,11 +399,9 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
             where(Observation[:where].matches("%#{region}"))
           end
         }
-  scope :in_box, # Use named parameters (n, s, e, w), any order
+  scope :in_box, # Use named parameters (north, south, east, west), any order
         lambda { |**args|
-          box = Mappable::Box.new(
-            north: args[:n], south: args[:s], east: args[:e], west: args[:w]
-          )
+          box = Mappable::Box.new(**args)
           return none unless box.valid?
 
           # resize box by epsilon to create leeway for Float rounding
@@ -427,11 +425,9 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
             )
           end
         }
-  scope :not_in_box, # Use named parameters (n, s, e, w), any order
+  scope :not_in_box, # Use named parameters (north, south, east, west)
         lambda { |**args|
-          box = Mappable::Box.new(
-            north: args[:n], south: args[:s], east: args[:e], west: args[:w]
-          )
+          box = Mappable::Box.new(**args)
 
           return Observation.all unless box.valid?
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -100,8 +100,8 @@
 #  without_location
 #  at_location(location)
 #  in_region(where)
-#  in_box(n,s,e,w) geoloc is in the box
-#  outside(n,s,e,w) geoloc is outside the box
+#  in_box(north:, south:, east:, west:) geoloc is in the box
+#  not_in_box(north:, south:, east:, west:) geoloc is outside the box
 #  is_collection_location
 #  not_collection_location
 #  with_images

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -495,15 +495,13 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   def obs_geoloc_outside_project_location
     observations.
       where.not(observations: { lat: nil }).
-      not_in_box(n: location.north, s: location.south,
-                 e: location.east, w: location.west)
+      not_in_box(**location.attributes.symbolize_keys)
   end
 
   def obs_without_geoloc_location_not_contained_in_location
     observations.where(lat: nil).joins(:location).
       merge(
-        Location.in_box(n: location.north, s: location.south,
-                        e: location.east, w: location.west).
+        Location.in_box(**location.attributes.symbolize_keys).
                  # This is safe (doesn't invert observations.where(lat: nil))
                  invert_where
       )

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -494,16 +494,14 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   def obs_geoloc_outside_project_location
     observations.
-      where.not(observations: { lat: nil }).
-      not_in_box(**location.attributes.symbolize_keys)
+      where.not(observations: { lat: nil }).not_in_box(**location.bounding_box)
   end
 
   def obs_without_geoloc_location_not_contained_in_location
     observations.where(lat: nil).joins(:location).
       merge(
-        Location.in_box(**location.attributes.symbolize_keys).
-                 # This is safe (doesn't invert observations.where(lat: nil))
-                 invert_where
+        # invert_where is safe (doesn't invert observations.where(lat: nil))
+        Location.in_box(**location.bounding_box).invert_where
       )
   end
 end

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -1551,7 +1551,7 @@ class API2Test < UnitTestCase
     assert_api_pass(params.merge(user: "rolf"))
     assert_api_results(locs)
 
-    locs = Location.in_box(n: 40, s: 39, e: -123, w: -124)
+    locs = Location.in_box(north: 40, south: 39, east: -123, west: -124)
 
     assert_not_empty(locs)
     assert_api_fail(params.merge(south: 39, east: -123, west: -124))
@@ -2308,7 +2308,7 @@ class API2Test < UnitTestCase
     assert_api_results(obses)
 
     obses = Observation.where(lat: [34..35], lng: [-119..-118])
-    locs = Location.in_box(n: 35, s: 34, e: -118, w: -119)
+    locs = Location.in_box(north: 35, south: 34, east: -118, west: -119)
 
     obses = (obses + locs.map(&:observations)).flatten.uniq.sort_by(&:id)
     assert_not_empty(obses)
@@ -3039,7 +3039,7 @@ class API2Test < UnitTestCase
     assert_api_results(obses.map(&:sequences).flatten.sort_by(&:id))
 
     obses = Observation.where(lat: [34..35], lng: [-119..-118])
-    locs = Location.in_box(n: 35, s: 34, e: -118, w: -119)
+    locs = Location.in_box(north: 35, south: 34, east: -118, west: -119)
 
     obses = (obses + locs.map(&:observations)).flatten.uniq.sort_by(&:id)
     assert_not_empty(obses)

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -251,9 +251,7 @@ class InatObsTest < UnitTestCase
 
   def test_public_location
     loc = locations(:albion)
-    all_bounding_boxes =
-      Location.contains_box(n: loc.north, s: loc.south,
-                            e: loc.east, w: loc.west)
+    all_bounding_boxes = Location.contains_box(**loc.bounding_box)
     phony_locs = Location.where(north: 90, south: -90,
                                 west: -180, east: 180).
                  where.not(name: "Earth")

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -490,9 +490,9 @@ class LocationTest < UnitTestCase
   def test_lat_lng_close
     loc = locations(:east_lt_west_location)
     # The centrum of the location is provided by BoxMethods#center, lat, lng
-    assert_true(loc.lat_lng_close?(loc.lat, loc.lng),
+    assert_true(loc.lat_lng_close?(loc.calculate_lat, loc.calculate_lng),
                 "Location's centrum should be 'close' to Location.")
-    assert_false(loc.lat_lng_close?(loc.lat, loc.lng + 180),
+    assert_false(loc.lat_lng_close?(loc.calculate_lat, loc.calculate_lng + 180),
                  "Opposite side of globe should not be 'close' to Location.")
   end
 
@@ -648,9 +648,7 @@ class LocationTest < UnitTestCase
 
   def do_contains_box(loc:, external_loc: nil,
                       regions: [locations(:unknown_location)])
-    containers =
-      Location.contains_box(n: loc.north, s: loc.south,
-                            e: loc.east, w: loc.west)
+    containers = Location.contains_box(**loc.bounding_box)
 
     assert_includes(containers, loc,
                     "Location #{loc.name} should contain itself")

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -540,30 +540,28 @@ class LocationTest < UnitTestCase
   # supplements API tests
   def test_scope_in_box
     cal = locations(:california)
-    locs_in_cal_box = Location.in_box(
-      n: cal.north, s: cal.south, e: cal.east, w: cal.west
-    )
+    locs_in_cal_box = Location.in_box(**cal.attributes.symbolize_keys)
     assert_includes(locs_in_cal_box, locations(:albion))
     assert_includes(locs_in_cal_box, cal)
 
     wrangel = locations(:east_lt_west_location)
-    locs_in_wrangel_box = Location.in_box(
-      n: wrangel.north, s: wrangel.south, e: wrangel.east, w: wrangel.west
-    )
+    locs_in_wrangel_box = Location.in_box(**wrangel.attributes.symbolize_keys)
     assert_includes(locs_in_wrangel_box, wrangel)
     assert_not_includes(locs_in_wrangel_box, cal)
 
     assert_empty(
-      Location.in_box(n: cal.north, s: cal.south, e: cal.east),
+      Location.in_box(north: cal.north, south: cal.south, east: cal.east),
       "`scope: in_box` should be empty if an argument is missing"
     )
     assert_empty(
-      Location.in_box(n: 91, s: cal.south, e: cal.east, w: cal.west),
+      Location.in_box(
+        north: 91, south: cal.south, east: cal.east, west: cal.west
+      ),
       "`scope: in_box` should be empty if an argument is out of bounds"
     )
     assert_empty(
       Location.in_box(
-        n: cal.south - 10, s: cal.south, e: cal.east, w: cal.west
+        north: cal.south - 10, south: cal.south, east: cal.east, west: cal.west
       ),
       "`scope: in_box` should be empty if N < S"
     )

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -540,12 +540,12 @@ class LocationTest < UnitTestCase
   # supplements API tests
   def test_scope_in_box
     cal = locations(:california)
-    locs_in_cal_box = Location.in_box(**cal.attributes.symbolize_keys)
+    locs_in_cal_box = Location.in_box(**cal.bounding_box)
     assert_includes(locs_in_cal_box, locations(:albion))
     assert_includes(locs_in_cal_box, cal)
 
     wrangel = locations(:east_lt_west_location)
-    locs_in_wrangel_box = Location.in_box(**wrangel.attributes.symbolize_keys)
+    locs_in_wrangel_box = Location.in_box(**wrangel.bounding_box)
     assert_includes(locs_in_wrangel_box, wrangel)
     assert_not_includes(locs_in_wrangel_box, cal)
 

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3640,8 +3640,7 @@ class NameTest < UnitTestCase
 
   def test_scope_in_box
     cal = locations(:california)
-    names_in_cal_box =
-      Name.in_box(n: cal.north, s: cal.south, e: cal.east, w: cal.west)
+    names_in_cal_box = Name.in_box(**cal.attributes.symbolize_keys)
     # Grab a couple of Names that are unused in Observation fixtures
     names_without_observations =
       Name.where.not(id: Name.joins(:observations)).distinct.limit(2).to_a
@@ -3664,7 +3663,7 @@ class NameTest < UnitTestCase
       obs_in_cal_without_lat_lng.name,
       "Name.in_box should exclude Names whose only Observations lack lat/long"
     )
-    assert_empty(Name.in_box(n: 0.0001, s: 0, e: 0.0001, w: 0))
+    assert_empty(Name.in_box(north: 0.0001, south: 0, east: 0.0001, west: 0))
   end
 
   def test_more_brief_authors

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3640,7 +3640,7 @@ class NameTest < UnitTestCase
 
   def test_scope_in_box
     cal = locations(:california)
-    names_in_cal_box = Name.in_box(**cal.attributes.symbolize_keys)
+    names_in_cal_box = Name.in_box(**cal.bounding_box)
     # Grab a couple of Names that are unused in Observation fixtures
     names_without_observations =
       Name.where.not(id: Name.joins(:observations)).distinct.limit(2).to_a

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1265,9 +1265,9 @@ class ObservationTest < UnitTestCase
 
   def test_scope_in_box
     cal = locations(:california)
-    obss_in_cal_box = Observation.in_box(**cal.attributes.symbolize_keys)
+    obss_in_cal_box = Observation.in_box(**cal.bounding_box)
     nybg = locations(:nybg_location)
-    obss_in_nybg_box = Observation.in_box(**nybg.attributes.symbolize_keys)
+    obss_in_nybg_box = Observation.in_box(**nybg.bounding_box)
     obss_in_ecuador_box = Observation.in_box(**ecuador_box)
     quito_obs =
       Observation.create!(
@@ -1283,17 +1283,12 @@ class ObservationTest < UnitTestCase
         lat: (wrangel.north + wrangel.south) / 2,
         lng: (wrangel.east + wrangel.west) / 2 + wrangel.west
       )
-    obss_in_wrangel_box = Observation.in_box(
-      **wrangel.attributes.symbolize_keys
-    )
+    obss_in_wrangel_box = Observation.in_box(**wrangel.bounding_box)
 
     # boxes not straddling 180 deg
-    assert_includes(obss_in_cal_box,
-                    observations(:unknown_with_lat_lng))
-    assert_includes(obss_in_ecuador_box,
-                    quito_obs)
-    assert_not_includes(obss_in_nybg_box,
-                        observations(:unknown_with_lat_lng))
+    assert_includes(obss_in_cal_box, observations(:unknown_with_lat_lng))
+    assert_includes(obss_in_ecuador_box, quito_obs)
+    assert_not_includes(obss_in_nybg_box, observations(:unknown_with_lat_lng))
     assert_not_includes(obss_in_cal_box,
                         observations(:minimal_unknown_obs),
                         "Observation without lat/lon should not be in box")
@@ -1330,15 +1325,11 @@ class ObservationTest < UnitTestCase
 
   def test_scope_not_in_box
     cal = locations(:california)
-    obss_not_in_cal_box = Observation.not_in_box(
-      **cal.attributes.symbolize_keys
-    )
+    obss_not_in_cal_box = Observation.not_in_box(**cal.bounding_box)
     obs_with_burbank_geoloc = observations(:unknown_with_lat_lng)
 
     nybg = locations(:nybg_location)
-    obss_not_in_nybg_box = Observation.not_in_box(
-      **nybg.attributes.symbolize_keys
-    )
+    obss_not_in_nybg_box = Observation.not_in_box(**nybg.bounding_box)
 
     obss_not_in_ecuador_box = Observation.not_in_box(**ecuador_box)
     quito_obs =
@@ -1356,9 +1347,7 @@ class ObservationTest < UnitTestCase
         lat: (wrangel.north + wrangel.south) / 2,
         lng: (wrangel.east + wrangel.west) / 2 + wrangel.west
       )
-    obss_not_in_wrangel_box = Observation.not_in_box(
-      **wrangel.attributes.symbolize_keys
-    )
+    obss_not_in_wrangel_box = Observation.not_in_box(**wrangel.bounding_box)
 
     # boxes not straddling 180 deg
     assert_not_includes(obss_not_in_cal_box, obs_with_burbank_geoloc)


### PR DESCRIPTION
1. Renames keyword params from `n, s, e, w` to `north, south, east, west`. 
2. Adds a new `Location` method `bounding_box` that grabs these location attributes via `location.attributes.symbolize_keys.slice(:north, :south, :east, :west)`. This allows passing `**location.bounding_box` as the `scope` args, much easier.
3. Renames `BoxMethods` `lat` and `lng` to `calculate_lat` and `calculate_lng` to differentiate them from the upcoming columns on `Location`
