### PR TITLE
Fix project scope using `not_in_box`

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -199,7 +199,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             and(Location[:west] <= Location[:east])
           )
         }
-
   scope :contains_point, # Use named parameters (lat:, lng:), any order
         lambda { |**args|
           args => {lat:, lng:}
@@ -213,19 +212,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             )
           )
         }
-  scope :show_includes,
-        lambda {
-          strict_loading.includes(
-            { comments: :user },
-            { description: { comments: :user } },
-            { descriptions: [:authors, :editors] },
-            :interests,
-            :observations,
-            :rss_log,
-            :versions
-          )
-        }
-
   scope :contains_box, # Use named parameters, north:, south:, east:, west:
         lambda { |**args|
           args => { north:, south:, east:, west: }
@@ -263,6 +249,19 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
           end
         }
   scope :with_observations, -> { joins(:observations).distinct }
+
+  scope :show_includes,
+        lambda {
+          strict_loading.includes(
+            { comments: :user },
+            { description: { comments: :user } },
+            { descriptions: [:authors, :editors] },
+            :interests,
+            :observations,
+            :rss_log,
+            :versions
+          )
+        }
 
   # On save, calculate bounding box area for the `box_area` column, plus the
   # `center_lat` and `center_lng` values. If box_area is below a threshold, also

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -160,7 +160,9 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
         ->(place_name) { where(Location[:name].matches("%#{place_name}%")) }
   scope :in_region,
         ->(place_name) { where(Location[:name].matches("%#{place_name}")) }
-  scope :in_box, # Pass kwargs (:north, :south, :east, :west), any order
+  # This returns locations whose bounding box is entirely within the given box.
+  # Pass kwargs (:north, :south, :east, :west), any order
+  scope :in_box,
         lambda { |**args|
           box = Mappable::Box.new(**args)
           return none unless box.valid?
@@ -198,6 +200,13 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
               and(Location[:east] <= box.east).
             and(Location[:west] <= Location[:east])
           )
+        }
+  scope :not_in_box, # Pass kwargs (:north, :south, :east, :west), any order
+        lambda { |**args|
+          box = Mappable::Box.new(**args)
+          return none unless box.valid?
+
+          in_box(**args).invert_where
         }
   scope :contains_point, # Use named parameters (lat:, lng:), any order
         lambda { |**args|

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -499,10 +499,14 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
           box = Mappable::Box.new(**args.except(:mappable))
           return Observation.all unless box.valid?
 
+          # + is the arel_extensions gem's way of doing UNION. These must use
+          # unions because ORs will dump any prior conditions in the scope chain
           if box.straddles_180_deg?
-            not_in_box_straddling_dateline(**args)
+            not_in_box_straddling_dateline(**args) +
+              location_center_not_in_box_straddling_dateline(**args)
           else
-            not_in_box_regular(**args)
+            not_in_box_regular(**args) +
+              location_center_not_in_box_regular(**args)
           end
         }
   scope :not_in_box_straddling_dateline, # helper for not_in_box

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -554,28 +554,50 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
           box = Mappable::Box.new(**args.except(:mappable))
           return Observation.all unless box.valid?
 
-          where(
-            Observation[:lat].eq(nil).
-            and(Observation[:location_lat].not_eq(nil)).
-            and((Observation[:location_lat] < box.south).
-                or(Observation[:location_lat] > box.north).
-                or((Observation[:location_lng] < box.west).
-                    and(Observation[:location_lng] > box.east)))
-          )
+          if args[:mappable]
+            where(
+              Observation[:lat].eq(nil).
+              and(Observation[:location_lat].not_eq(nil)).
+              and((Observation[:location_lat] < box.south).
+                  or(Observation[:location_lat] > box.north).
+                  or((Observation[:location_lng] < box.west).
+                      and(Observation[:location_lng] > box.east)))
+            )
+          else
+            joins(:location).
+              where(
+                Observation[:lat].eq(nil).
+                and((Location[:center_lat] < box.south).
+                    or(Location[:center_lat] > box.north).
+                    or((Location[:center_lng] < box.west).
+                        and(Location[:center_lng] > box.east)))
+              )
+          end
         }
   scope :location_center_not_in_box_regular,
         lambda { |**args|
           box = Mappable::Box.new(**args.except(:mappable))
           return Observation.all unless box.valid?
 
-          where(
-            Observation[:lat].eq(nil).
-            and(Observation[:location_lat].not_eq(nil)).
-            and((Observation[:location_lat] < box.south).
-                or(Observation[:location_lat] > box.north).
-                or(Observation[:location_lng] < box.west).
-                or(Observation[:location_lng] > box.east))
-          )
+          if args[:mappable]
+            where(
+              Observation[:lat].eq(nil).
+              and(Observation[:location_lat].not_eq(nil)).
+              and((Observation[:location_lat] < box.south).
+                  or(Observation[:location_lat] > box.north).
+                  or(Observation[:location_lng] < box.west).
+                  or(Observation[:location_lng] > box.east))
+            )
+          else
+            joins(:location).
+              where(
+                Observation[:lat].eq(nil).
+                and((Location[:center_lat] < box.south).
+                    or(Location[:center_lat] > box.north).
+                    or(Location[:center_lng] < box.west).
+                    or(Location[:center_lng] > box.east))
+              )
+          end
         }
   scope :is_collection_location,
         -> { where(is_collection_location: true) }

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -499,7 +499,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
           box = Mappable::Box.new(**args.except(:mappable))
           return Observation.all unless box.valid?
 
-          # should be .in_box(**args).invert_where
+          # should be in_box(**args).invert_where
           if box.straddles_180_deg?
             not_in_box_straddling_dateline(**args)
           else

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -462,9 +462,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   def out_of_area_observations
     return [] if location.nil?
 
-    obs_geoloc_outside_project_location.to_a.union(
+    obs_geoloc_outside_project_location +
       obs_without_geoloc_location_not_contained_in_location
-    )
   end
 
   def violates_constraints?(observation)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -498,10 +498,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def obs_without_geoloc_location_not_contained_in_location
-    observations.where(lat: nil).joins(:location).
-      merge(
-        # invert_where is safe (doesn't invert observations.where(lat: nil))
-        Location.in_box(**location.bounding_box).invert_where
-      )
+    observations.location_center_not_in_box(**location.bounding_box)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -462,9 +462,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   def out_of_area_observations
     return [] if location.nil?
 
-    obs_geoloc_outside_project_location.to_a.union(
-      obs_without_geoloc_location_not_contained_in_location
-    )
+    observations.
+      where.not(observations: { lat: nil }).not_in_box(**location.bounding_box)
   end
 
   def violates_constraints?(observation)
@@ -488,16 +487,5 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   def can_add_field_slip(user)
     member?(user) || can_join?(user)
-  end
-
-  private ###############################
-
-  def obs_geoloc_outside_project_location
-    observations.
-      where.not(observations: { lat: nil }).not_in_box(**location.bounding_box)
-  end
-
-  def obs_without_geoloc_location_not_contained_in_location
-    observations.location_center_not_in_box(**location.bounding_box)
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -215,7 +215,7 @@ class ProjectTest < UnitTestCase
       "whose Loc is not contained in Proj location"
     )
     assert_not_includes(
-      location_violations, geoloc_in_bubank,
+      location_violations, geoloc_in_burbank,
       "Noncompliant Obss wrongly includes Obs with geoloc inside Proj location"
     )
     assert_not_includes(

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -189,7 +189,7 @@ class ProjectTest < UnitTestCase
       title: "With Location Violations",
       open_membership: true
     )
-    geoloc_in_bubank = observations(:unknown_with_lat_lng)
+    geoloc_in_burbank = observations(:unknown_with_lat_lng)
     geoloc_outside_burbank =
       observations(:trusted_hidden) # lat/lon in Falmouth
     geoloc_nil_burbank_contains_loc =
@@ -197,7 +197,7 @@ class ProjectTest < UnitTestCase
     geoloc_nil_outside_burbank = observations(:reused_observation)
 
     proj.observations = [
-      geoloc_in_bubank,
+      geoloc_in_burbank,
       geoloc_nil_burbank_contains_loc,
       geoloc_outside_burbank,
       geoloc_nil_outside_burbank


### PR DESCRIPTION
Temporarily reverts `not_in_box` so it works for project constraints.

Note: `not_in_box` will temporarily not be the inverse of `in_box`.