### PR TITLE
Fix iNat id list too long

### DIFF
--- a/app/controllers/observations/inat_imports_controller_validators.rb
+++ b/app/controllers/observations/inat_imports_controller_validators.rb
@@ -9,6 +9,7 @@ module Observations::InatImportsControllerValidators
     username_present? &&
       valid_inat_ids_param? &&
       imports_designated? &&
+      list_within_size_limits? &&
       fresh_import? &&
       unmirrored? &&
       consented?
@@ -36,6 +37,13 @@ module Observations::InatImportsControllerValidators
     return true if params[:all] == "1" || params[:inat_ids].present?
 
     flash_warning(:inat_no_imports_designated.t)
+    false
+  end
+
+  def list_within_size_limits?
+    return true if params[:inat_ids].length <= 255
+
+    flash_warning(:inat_too_many_ids_listed.t)
     false
   end
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3020,7 +3020,7 @@
   # observation/inat_imports
   inat_import_create_title: Import from iNat
   inat_choose_observations: "Inat Observations to Import:"
-  inat_import_list: "Comma separated list of observation #s"
+  inat_import_list: "Comma separated list of up to 10 observation #s"
   inat_import_all: Import all my iNat observations instead of a list
   inat_import_consent: (Required) I consent to creating MushroomObserver Observation(s) based on my iNaturalist observations, including their photos.
   inat_consent_required: Your consent is required to import Inat observations. Please check the checkbox to give your consent.
@@ -3030,6 +3030,7 @@
   inat_no_imports_designated: You must list the iNat observation(s) to be imported
   inat_previous_import: iNat [inat_id] previously imported as MO Observation [mo_obs_id]
   inat_previous_mirror: "iNat [inat_id] is a \"mirror\" of existing MO Observation [mo_obs_id]"
+  inat_too_many_ids_listed: "Too many ids listed"
   inat_import_started: Your import has started. Refresh page to update results.
 
   inat_no_authorization: iNat import aborted; MO did not received authorization to access iNat user data

--- a/test/controllers/observations/inat_imports_controller_test.rb
+++ b/test/controllers/observations/inat_imports_controller_test.rb
@@ -98,6 +98,20 @@ module Observations
       assert_flash_text(:inat_consent_required.l)
     end
 
+    def test_create_too_many_ids_listed
+      # generate an id list that's barely too long
+      id_list = ""
+      id = 1_234_567_890
+      id_list += "#{id += 1}," until id_list.length > 255
+      params = { inat_username: "anything", inat_ids: id_list, consent: 1 }
+
+      login
+      post(:create, params: params)
+
+      assert_form_action(action: :create)
+      assert_flash_text(:inat_too_many_ids_listed.l)
+    end
+
     def test_create_previously_imported
       user = users(:rolf)
       inat_id = "1123456"


### PR DESCRIPTION
- Flashes warning if list > 255 chars
- Specifies limit (10 ids) in form
- Delivers #2456