### PR TITLE
Fix the `not_in_box` scope

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -201,7 +201,10 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             and(Location[:west] <= Location[:east])
           )
         }
-  scope :not_in_box, # Pass kwargs (:north, :south, :east, :west), any order
+  # Returns locations whose bounding box is not entirely within the given box.
+  # Some locations may overlap with the box, even mostly.
+  # Pass kwargs (:north, :south, :east, :west), any order
+  scope :not_in_box,
         lambda { |**args|
           box = Mappable::Box.new(**args)
           return none unless box.valid?

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -499,12 +499,13 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
           box = Mappable::Box.new(**args.except(:mappable))
           return Observation.all unless box.valid?
 
-          # should be in_box(**args).invert_where
-          if box.straddles_180_deg?
-            not_in_box_straddling_dateline(**args)
-          else
-            not_in_box_regular(**args)
-          end
+          # should be
+          merge(Observation.in_box(**args).invert_where)
+          # if box.straddles_180_deg?
+          #   not_in_box_straddling_dateline(**args)
+          # else
+          #   not_in_box_regular(**args)
+          # end
         }
   scope :not_in_box_straddling_dateline, # helper for not_in_box
         lambda { |**args|

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -500,12 +500,23 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
           return Observation.all unless box.valid?
 
           # should be
-          merge(Observation.in_box(**args).invert_where)
-          # if box.straddles_180_deg?
-          #   not_in_box_straddling_dateline(**args)
-          # else
-          #   not_in_box_regular(**args)
-          # end
+          # merge(Observation.in_box(**args).invert_where.
+          # or(Observation.where(lat: nil, location_lat: nil)))
+          if box.straddles_180_deg?
+            not_in_box_straddling_dateline(**args).
+            # merge(
+              joins(:location).
+              where(Location.contains_box(**args.except(:mappable)).
+              invert_where)
+            # )
+          else
+            not_in_box_regular(**args).
+            # merge(
+              joins(:location).
+              where(Location.contains_box(**args.except(:mappable)).
+              invert_where)
+            # )
+          end
         }
   scope :not_in_box_straddling_dateline, # helper for not_in_box
         lambda { |**args|

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -506,8 +506,9 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
             not_in_box_straddling_dateline(**args).
             # merge(
               joins(:location).
-              where(Location.contains_box(**args.except(:mappable)).
-              invert_where)
+              where.not(
+                Location[:id] = Location.contains_box(**args.except(:mappable))
+              )
             # )
           else
             not_in_box_regular(**args).

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -497,10 +497,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def obs_without_geoloc_location_not_contained_in_location
-    observations.where(lat: nil).joins(:location).
-      merge(
-        # invert_where is safe (doesn't invert observations.where(lat: nil))
-        Location.not_in_box(**location.bounding_box)
-      )
+    # observations.where(lat: nil).joins(:location).
+    #   merge(
+    #     # invert_where is safe (doesn't invert observations.where(lat: nil))
+    #     Location.not_in_box(**location.bounding_box)
+    #   )
+    observations.where(lat: nil).
+      where.not(location_id: Location.not_in_box(**location.bounding_box))
   end
 end

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -206,39 +206,39 @@ no_mushrooms_location:
   user_id: 0
   name: No Mushrooms
   scientific_name: No Mushrooms
-  north: .0001
-  west: 0
-  east: .0001
-  south: .00007
+  north: 0.0001
+  west: 3
+  east: 3.0001
+  south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 0.00005
+  center_lng: 3.00005
 
 collection_location:
   <<: *DEFAULTS
   user_id: 0
   name: Collection Location
   scientific_name: Collection Location
-  north: .0001
-  west: 3
-  east: 3.0001
-  south: .00007
+  north: 0.0001
+  west: 6
+  east: 6.0001
+  south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 3.00005
+  center_lng: 6.00005
 
 display_location:
   <<: *DEFAULTS
   user_id: 0
   name: Display Location
   scientific_name: Display Location
-  north: .0001
-  west: 6
-  east: 6.0001
-  south: .00007
+  north: 0.0001
+  west: 9
+  east: 9.0001
+  south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 6.00005
+  center_lng: 9.00005
 
 sortable_observation_user_location:
   <<: *DEFAULTS

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -206,39 +206,39 @@ no_mushrooms_location:
   user_id: 0
   name: No Mushrooms
   scientific_name: No Mushrooms
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 0
+  east: .0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 0.00005
 
 collection_location:
   <<: *DEFAULTS
   user_id: 0
   name: Collection Location
   scientific_name: Collection Location
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 3
+  east: 3.0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 3.00005
 
 display_location:
   <<: *DEFAULTS
   user_id: 0
   name: Display Location
   scientific_name: Display Location
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 6
+  east: 6.0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 6.00005
 
 sortable_observation_user_location:
   <<: *DEFAULTS

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1325,13 +1325,7 @@ class ObservationTest < UnitTestCase
 
   def test_scope_not_in_box
     cal = locations(:california)
-    obss_not_in_cal_box = Observation.not_in_box(**cal.bounding_box)
-    obs_with_burbank_geoloc = observations(:unknown_with_lat_lng)
-
     nybg = locations(:nybg_location)
-    obss_not_in_nybg_box = Observation.not_in_box(**nybg.bounding_box)
-
-    obss_not_in_ecuador_box = Observation.not_in_box(**ecuador_box)
     quito_obs =
       Observation.create!(
         user: users(:rolf),
@@ -1339,7 +1333,6 @@ class ObservationTest < UnitTestCase
         lng: -78.4305382,
         where: "Quito, Ecuador"
       )
-
     wrangel = locations(:east_lt_west_location)
     wrangel_obs =
       Observation.create!(
@@ -1347,14 +1340,23 @@ class ObservationTest < UnitTestCase
         lat: (wrangel.north + wrangel.south) / 2,
         lng: (wrangel.east + wrangel.west) / 2 + wrangel.west
       )
+    Location.update_box_area_and_center_columns
+
+    obss_not_in_cal_box = Observation.not_in_box(**cal.bounding_box)
+    obs_with_burbank_geoloc = observations(:unknown_with_lat_lng)
+
+    obss_not_in_nybg_box = Observation.not_in_box(**nybg.bounding_box)
+
+    obss_not_in_ecuador_box = Observation.not_in_box(**ecuador_box)
+
     obss_not_in_wrangel_box = Observation.not_in_box(**wrangel.bounding_box)
 
     # boxes not straddling 180 deg
     assert_not_includes(obss_not_in_cal_box, obs_with_burbank_geoloc)
     assert_not_includes(obss_not_in_ecuador_box, quito_obs)
     assert_includes(obss_not_in_nybg_box, obs_with_burbank_geoloc)
-    assert_includes(obss_not_in_cal_box, observations(:minimal_unknown_obs),
-                    "Observation without lat/lon should not be in box")
+    # assert_includes(obss_not_in_cal_box, observations(:minimal_unknown_obs),
+    #                 "Observation without lat/lon should not be in box")
 
     # box straddling 180 deg
     assert_not_includes(obss_not_in_wrangel_box, wrangel_obs)

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1344,11 +1344,8 @@ class ObservationTest < UnitTestCase
 
     obss_not_in_cal_box = Observation.not_in_box(**cal.bounding_box)
     obs_with_burbank_geoloc = observations(:unknown_with_lat_lng)
-
     obss_not_in_nybg_box = Observation.not_in_box(**nybg.bounding_box)
-
     obss_not_in_ecuador_box = Observation.not_in_box(**ecuador_box)
-
     obss_not_in_wrangel_box = Observation.not_in_box(**wrangel.bounding_box)
 
     # boxes not straddling 180 deg

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1352,8 +1352,9 @@ class ObservationTest < UnitTestCase
     assert_not_includes(obss_not_in_cal_box, obs_with_burbank_geoloc)
     assert_not_includes(obss_not_in_ecuador_box, quito_obs)
     assert_includes(obss_not_in_nybg_box, obs_with_burbank_geoloc)
-    # assert_includes(obss_not_in_cal_box, observations(:minimal_unknown_obs),
-    #                 "Observation without lat/lon should not be in box")
+    assert_not_includes(obss_not_in_cal_box, observations(:minimal_unknown_obs),
+                        "Observation without lat/lon but has location_lat " \
+                        "in box should be in box")
 
     # box straddling 180 deg
     assert_not_includes(obss_not_in_wrangel_box, wrangel_obs)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -189,6 +189,7 @@ class ProjectTest < UnitTestCase
       title: "With Location Violations",
       open_membership: true
     )
+    Location.update_box_area_and_center_columns
     geoloc_in_burbank = observations(:unknown_with_lat_lng)
     geoloc_outside_burbank =
       observations(:trusted_hidden) # lat/lon in Falmouth
@@ -204,7 +205,7 @@ class ProjectTest < UnitTestCase
     ]
 
     location_violations = proj.out_of_area_observations
-
+    debugger
     assert_includes(
       location_violations, geoloc_outside_burbank,
       "Noncompliant Obss missing Obs with geoloc outside Proj location"

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -205,7 +205,6 @@ class ProjectTest < UnitTestCase
     ]
 
     location_violations = proj.out_of_area_observations
-    debugger
     assert_includes(
       location_violations, geoloc_outside_burbank,
       "Noncompliant Obss missing Obs with geoloc outside Proj location"


### PR DESCRIPTION
- Corrects `not_in_box` to return the set of observations not within the given box as per the `in_box` definition, but leave out observations with no geolocation or location.
- Maintains the definition of Project constraint violations, which remains "if the observation is not in the box, or observation location not entirely contained in box".
