### PR TITLE
Update some inat table charsets & collations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,13 +191,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_01_233907) do
     t.boolean "diagnostic", default: true, null: false
   end
 
-  create_table "inat_import_job_trackers", charset: "utf8mb3", force: :cascade do |t|
+  create_table "inat_import_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "inat_import"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "inat_imports", charset: "utf8mb3", force: :cascade do |t|
+  create_table "inat_imports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "state", default: 0
     t.string "inat_ids"


### PR DESCRIPTION
- Changes some iNat table charsets and collations as follows:
  - Loaded 20241006 snapshot to my local (laptop) db
  - migrated
  - committed the changed schema
I hope this will fix the schema differences I keep seeing when I download a db snapshot, then migrate.