### PR TITLE
Fix reading notes when notes is a string

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -994,7 +994,9 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def notes
-    self[:notes] || {}
+    return self[:notes] if self[:notes].is_a?(Hash)
+
+    Observation.no_notes
   end
 
   # no_notes persisted in the db

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -341,7 +341,7 @@ class SpeciesList < AbstractModel
     args[:user] ||= User.current
     args[:when] ||= self.when
     args[:vote] ||= Vote.maximum_vote
-    args[:notes] ||= ""
+    args[:notes] ||= {}
     args[:projects] ||= projects
     if !args[:where] && !args[:location]
       args[:where]    = location ? location.name : where

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -917,15 +917,32 @@ class ObservationTest < UnitTestCase
     assert_equal("pine", obs.notes_part_value("Nearby trees"))
   end
 
+  # nil notes were seen in the wild
   def test_notes_nil
     User.current = mary
-    obs = Observation.create!(name_id: names(:fungi).id, when_str: "2020-07-05")
+    obs = Observation.create!(name_id: names(:fungi).id, when_str: "2020-07-05",
+                              notes: nil)
 
     assert_nothing_raised do
       obs.notes[:Collector]
     rescue StandardError => e
       flunk(
         "It shouldn't throw \"#{e.message}\" when reading part of a nil Note"
+      )
+    end
+  end
+
+  # empty string notes were seen in the wild
+  def test_notes_empty_string
+    User.current = mary
+    obs = Observation.create!(name_id: names(:fungi).id,
+                              when_str: "2020-07-05", notes: "")
+    assert_nothing_raised do
+      obs.notes[:Collector]
+    rescue StandardError => e
+      flunk(
+        "It shouldn't throw \"#{e.message}\" when reading part of " \
+        "a Note that's an empty string"
       )
     end
   end

--- a/test/models/species_list_test.rb
+++ b/test/models/species_list_test.rb
@@ -71,7 +71,7 @@ class SpeciesListTest < UnitTestCase
     assert_equal(spl.when, o.when)
     assert_equal(spl.where, o.where)
     assert_equal(spl.location, o.location)
-    assert_equal("", o.notes)
+    assert_equal({}, o.notes)
     assert_nil(o.alt)
     assert_nil(o.lng)
     assert_nil(o.alt)
@@ -96,7 +96,7 @@ class SpeciesListTest < UnitTestCase
       projects: [],
       when: "2012-01-13",
       where: "Undefined Location",
-      notes: "notes",
+      notes: { Other: "notes" },
       lat: " 12deg 34min N ",
       lng: " 123 45 W ",
       alt: " 123.45 ft ",
@@ -113,7 +113,7 @@ class SpeciesListTest < UnitTestCase
     assert_equal("2012-01-13", o.when.web_date)
     assert_equal("Undefined Location", o.where)
     assert_nil(o.location)
-    assert_equal("notes", o.notes)
+    assert_equal({ Other: "notes" }, o.notes)
     assert_equal(12.5667, o.lat.round(4))
     assert_equal(-123.75, o.lng.round(4))
     assert_equal(38, o.alt.round(4))


### PR DESCRIPTION
- Returns `{ }` instead of a string, so a call to notes[:key] returns `nil` instead of throwing an error.
- Prevents SpeciesList#construct_observation from creating Observation.notes == `""`.