### PR TITLE
Redefine `no_mushrooms_location`, `collection_location`, `display_location`

### DIFF
--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -206,39 +206,39 @@ no_mushrooms_location:
   user_id: 0
   name: No Mushrooms
   scientific_name: No Mushrooms
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 0
+  east: .0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 0.00005
 
 collection_location:
   <<: *DEFAULTS
   user_id: 0
   name: Collection Location
   scientific_name: Collection Location
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 3
+  east: 3.0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 3.00005
 
 display_location:
   <<: *DEFAULTS
   user_id: 0
   name: Display Location
   scientific_name: Display Location
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 6
+  east: 6.0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 6.00005
 
 sortable_observation_user_location:
   <<: *DEFAULTS


### PR DESCRIPTION
These three locations have been defined as "the whole Earth" by bounding box, up to now. 

They don't need to be anything in particular, but it would be helpful for debugging tests if they had a smaller defined area.  This gives all three of them tiny areas in the middle of the Atlantic.