### PR TITLE
Fix notes for iNat import with no description

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -94,7 +94,7 @@ class Inat
     end
 
     def notes
-      return "" if self[:description].empty?
+      return {} if self[:description].empty?
 
       { Other: self[:description].gsub(%r{</?p>}, "") }
     end

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -117,6 +117,12 @@ class InatObsTest < UnitTestCase
     assert_equal(names(:coprinus).text_name, mock_inat_obs.text_name)
   end
 
+  def test_blank_notes
+    mock_inat_obs = mock_observation("coprinus")
+
+    assert_equal({}, mock_inat_obs.notes)
+  end
+
   def test_infrageneric_name
     name = Name.create(
       user: rolf,


### PR DESCRIPTION
- Sets notes to `{ }` rather than `""`.
- Delivers #2465 See generally https://mushroomobserver.slack.com/archives/C040TH9FV/p1728241575372789