### PR TITLE
Sort out current `rss_logs` fixture situation 

### DIFF
--- a/app/extensions/fixture_set_extensions.rb
+++ b/app/extensions/fixture_set_extensions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ActiveRecord::FixtureSet
+  # Reverse lookup of fixture label (how we refer to fixtures) by id.
+  def self.reverse_lookup(table, id)
+    ActiveRecord::FixtureSet.all_loaded_fixtures[table.to_s].
+      fixtures.each_key do |key|
+      return key if ActiveRecord::FixtureSet.identify(key) == id
+    end
+    nil
+  end
+end

--- a/app/extensions/fixture_set_extensions.rb
+++ b/app/extensions/fixture_set_extensions.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class ActiveRecord::FixtureSet
-  # Reverse lookup of fixture label (how we refer to fixtures) by id.
+  # Reverse lookup of a fixture's label (e.g. `deprecated_name_obs`) by its id.
+  # For better fixture test messages.
+  # https://stackoverflow.com/a/32322296/3357635
   def self.reverse_lookup(table, id)
     ActiveRecord::FixtureSet.all_loaded_fixtures[table.to_s].
       fixtures.each_key do |key|

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -1249,10 +1249,10 @@ class SpeciesListsControllerTest < FunctionalTestCase
 
     login("rolf")
     get(:new)
-    assert_project_checks(@proj1.id => :checked, @proj2.id => :no_field)
-    post(:create,
-         params: { project: { "id_#{@proj1.id}" => "0" } })
     assert_project_checks(@proj1.id => :unchecked, @proj2.id => :no_field)
+    post(:create,
+         params: { project: { "id_#{@proj1.id}" => "1" } })
+    assert_project_checks(@proj1.id => :checked, @proj2.id => :no_field)
 
     # should have different default if recently create list attached to project
     obs = Observation.create!

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -206,39 +206,39 @@ no_mushrooms_location:
   user_id: 0
   name: No Mushrooms
   scientific_name: No Mushrooms
-  north: .0001
-  west: 0
-  east: .0001
-  south: .00007
+  north: 0.0001
+  west: 3
+  east: 3.0001
+  south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 0.00005
+  center_lng: 3.00005
 
 collection_location:
   <<: *DEFAULTS
   user_id: 0
   name: Collection Location
   scientific_name: Collection Location
-  north: .0001
-  west: 3
-  east: 3.0001
-  south: .00007
+  north: 0.0001
+  west: 6
+  east: 6.0001
+  south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 3.00005
+  center_lng: 6.00005
 
 display_location:
   <<: *DEFAULTS
   user_id: 0
   name: Display Location
   scientific_name: Display Location
-  north: .0001
-  west: 6
-  east: 6.0001
-  south: .00007
+  north: 0.0001
+  west: 9
+  east: 9.0001
+  south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 6.00005
+  center_lng: 9.00005
 
 sortable_observation_user_location:
   <<: *DEFAULTS

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -207,12 +207,12 @@ no_mushrooms_location:
   name: No Mushrooms
   scientific_name: No Mushrooms
   north: 0.0001
-  west: 3
-  east: 3.0001
+  west: 9
+  east: 9.0001
   south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 3.00005
+  center_lng: 9.00005
 
 collection_location:
   <<: *DEFAULTS
@@ -220,12 +220,12 @@ collection_location:
   name: Collection Location
   scientific_name: Collection Location
   north: 0.0001
-  west: 6
-  east: 6.0001
+  west: 10.5
+  east: 10.5001
   south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 6.00005
+  center_lng: 10.50005
 
 display_location:
   <<: *DEFAULTS
@@ -233,12 +233,12 @@ display_location:
   name: Display Location
   scientific_name: Display Location
   north: 0.0001
-  west: 9
-  east: 9.0001
+  west: 12
+  east: 12.0001
   south: 0.00007
   box_area: 3.710458035376616e-05
   center_lat: 0.000085
-  center_lng: 9.00005
+  center_lng: 12.00005
 
 sortable_observation_user_location:
   <<: *DEFAULTS

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -206,39 +206,39 @@ no_mushrooms_location:
   user_id: 0
   name: No Mushrooms
   scientific_name: No Mushrooms
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 0
+  east: .0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 0.00005
 
 collection_location:
   <<: *DEFAULTS
   user_id: 0
   name: Collection Location
   scientific_name: Collection Location
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 3
+  east: 3.0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 3.00005
 
 display_location:
   <<: *DEFAULTS
   user_id: 0
   name: Display Location
   scientific_name: Display Location
-  north: 90
-  west: -180
-  east: 180
-  south: -90
-  box_area: 510224605.17052704
-  center_lat: 0
-  center_lng: 0
+  north: .0001
+  west: 6
+  east: 6.0001
+  south: .00007
+  box_area: 3.710458035376616e-05
+  center_lat: 0.000085
+  center_lng: 6.00005
 
 sortable_observation_user_location:
   <<: *DEFAULTS

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -25,6 +25,9 @@ DEFAULTS: &DEFAULTS
   where: MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA
   user: dick
   vote_cache: 0.0
+  created_at: 2023-09-15 04:05:03
+  updated_at: 2023-09-15 04:05:03
+  log_updated_at: 2023-09-15 04:05:03
   when: <%= Time.now.strftime("%Y-%m-%d") %> # yyyy-mm-dd
   is_collection_location: 1
   lifeform: " "
@@ -729,16 +732,17 @@ wolf_fart:
 reused_observation:
   <<: *DEFAULTS
   user: rolf
+  created_at: 2023-11-19 04:05:03
+  log_updated_at: 2023-11-19 04:05:03
   when: 2023-11-19
   location: obs_default_location
   where: MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA
   species_lists: reused_list
-  rss_log:
+  rss_log: reused_observation_rss_log
 
 deprecated_name_obs:
   <<: *DEFAULTS
   created_at: 2014-04-04 04:05:03
-  updated_at: 2014-04-04 04:05:03
   log_updated_at: 2014-04-04 04:05:03
   when: 2012-06-07
   user: vouchered_only_user
@@ -747,17 +751,21 @@ deprecated_name_obs:
   name: petigera
   text_name: Petigera
   lifeform: " lichen "
-  rss_log:
+  rss_log: deprecated_name_obs_rss_log
 
 # meets constraints of falmouth_2023_09_project
 falmouth_2023_09_obs:
   <<: *DEFAULTS
+  created_at: 2023-09-16 04:05:03
+  log_updated_at: 2023-09-16 04:05:03
   when: 2023-09-15
   where: MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA
   location: falmouth
 
 brett_woods_2023_09_obs:
   <<: *DEFAULTS
+  created_at: 2023-09-16 04:05:03
+  log_updated_at: 2023-09-16 04:05:03
   when: 2023-09-16
   where: Brett Woods, Fairfield Co., Connecticut, USA
   lat: 41.2039
@@ -767,6 +775,8 @@ brett_woods_2023_09_obs:
 
 falmouth_2022_obs:
   <<: *DEFAULTS
+  created_at: 2022-09-15 04:05:03
+  log_updated_at: 2022-09-15 04:05:03
   when: 2022-09-15 # outside of dates of falmouth_2023_09_project
   where: MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA
   location: falmouth
@@ -796,3 +806,10 @@ newbie_obs:
 imported_inat_obs:
   <<: *DEFAULTS
   inat_id: 12345
+#
+#
+# IMPORTANT - AVOID CREATING FUTURE TEST ERRORS
+# - When creating a new observation fixture, you MUST also create a
+#   corresponding rss_log, since the observation index now sorts by rss_log.
+# - Observation fixtures require `created_at` and `log_updated_at` values.
+#   If you want to be able to find them in integration tests, give unique dates!

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -738,7 +738,6 @@ reused_observation:
   location: obs_default_location
   where: MO Inc., 68 Bay Rd., North Falmouth, Massachusetts, USA
   species_lists: reused_list
-  rss_log: reused_observation_rss_log
 
 deprecated_name_obs:
   <<: *DEFAULTS
@@ -751,7 +750,6 @@ deprecated_name_obs:
   name: petigera
   text_name: Petigera
   lifeform: " lichen "
-  rss_log: deprecated_name_obs_rss_log
 
 # meets constraints of falmouth_2023_09_project
 falmouth_2023_09_obs:

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -70,6 +70,20 @@ wolf_fart_rss_log:
   # updated_at: 2023-11-15 12:00:01
   # created_at: 2023-11-15 12:00:00
 
+reused_observation_rss_log:
+  <<: *DEFAULTS
+  observation: reused_observation
+  created_at: 2023-11-19 04:05:03
+  updated_at: 2023-11-19 04:05:03
+  # notes: " log_observation_created user \n"
+
+deprecated_name_obs_rss_log:
+  <<: *DEFAULTS
+  observation: deprecated_name_obs
+  created_at: 2014-04-04 04:05:03
+  updated_at: 2014-04-04 04:05:03
+  # notes: " log_observation_created user \n"
+
 strobilurus_diminutivus_obs_rss_log:
   <<: *DEFAULTS
   observation: strobilurus_diminutivus_obs

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -263,6 +263,9 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     assert_field("observation_location_id",
                  type: :hidden, with: last_location.id)
     assert_field("observation_place_name", with: last_location.display_name)
+    assert_field("observation_when_1i", with: Time.zone.today.year)
+    assert_field("observation_when_2i", with: Time.zone.today.month)
+    assert_field("observation_when_3i", with: Time.zone.today.day)
     check(proj_checkbox)
     assert_selector("##{proj_checkbox}[checked='checked']")
     assert_no_difference("Observation.count",
@@ -274,9 +277,10 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
       "#flash_notices",
       text: :form_observations_there_is_a_problem_with_projects.t.strip_html
     )
+
     within("#project_messages") do # out-of-range warning message
       assert(has_text?(:form_observations_projects_out_of_range.l(
-                         date: last_obs.when,
+                         date: Time.zone.today.web_date,
                          place_name: last_location.display_name
                        )),
              "Missing out-of-range warning with observation date")

--- a/test/models/fixtures_test.rb
+++ b/test/models/fixtures_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class FixturesTest < ActiveSupport::TestCase
   def test_observations_all_have_rss_logs
     Observation.find_each do |obs|
-      name = ActiveRecord::FixtureSet.reverse_lookup("observations", obs.id)
+      name = ActiveRecord::FixtureSet.reverse_lookup(:observations, obs.id)
       assert_not_nil(
         obs.rss_log_id,
         "Observation #{name} needs a corresponding RssLog fixture."

--- a/test/models/fixtures_test.rb
+++ b/test/models/fixtures_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FixturesTest < ActiveSupport::TestCase
+  def test_observations_all_have_rss_logs
+    Observation.find_each do |obs|
+      name = ActiveRecord::FixtureSet.reverse_lookup("observations", obs.id)
+      assert_not_nil(
+        obs.rss_log_id,
+        "Observation #{name} needs a corresponding RssLog fixture."
+      )
+      assert_not_nil(
+        obs.log_updated_at,
+        "Observation #{name} needs a log_updated_at value."
+      )
+    end
+  end
+end

--- a/test/models/fixtures_test.rb
+++ b/test/models/fixtures_test.rb
@@ -8,11 +8,11 @@ class FixturesTest < ActiveSupport::TestCase
       name = ActiveRecord::FixtureSet.reverse_lookup(:observations, obs.id)
       assert_not_nil(
         obs.rss_log_id,
-        "Observation #{name} needs a corresponding RssLog fixture."
+        "Observation #{name} needs a corresponding RssLog fixture"
       )
       assert_not_nil(
         obs.log_updated_at,
-        "Observation #{name} needs a log_updated_at value."
+        "Observation #{name} needs a log_updated_at value"
       )
     end
   end


### PR DESCRIPTION
This PR makes some minimal changes to the obs/rss_log fixtures to get them on a stable footing:
- adds a test to be sure all Observation fixtures have an associated RssLog fixture
- gives default values for `created_at`, `updated_at`, and `log_updated_at` for observation fixtures
- adds a method to look up a fixture's commonly used name (e.g. "roy") by its id, useful for error messages in loops where you're not sure which fixture is throwing the error
- Replaces `rss_log_id: null` values for two observation fixtures: `deprecated_name_obs` and `reused_observation`

Even these few changes (most likely the change in default dates) seems to have thrown off two integration tests regarding project constraints. I'm not very familiar with these tests, but after reading through them and debugging, i decided they still basically seem to work as intended if i simply adjust the expectations for the new reality of the fixtures. 

@mo-nathan and @JoeCohen — if you have a moment, amid everything else you're doing, please review the tests to check that these are still testing what they need to be testing. If not, this can wait til after NEMF.

