### PR TITLE
Map misc. NEMF obs fields

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -99,9 +99,9 @@ class Inat
     end
 
     def notes
-      return {} if self[:description].empty?
+      return { Collector: collector } if self[:description].empty?
 
-      { Other: self[:description].gsub(%r{</?p>}, "") }
+      { Collector: collector, Other: self[:description].gsub(%r{</?p>}, "") }
     end
 
     # min bounding rectangle of iNat location blurred by public accuracy

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -156,6 +156,15 @@ class Inat
 
     ########## Other mappings used in MO Observations
 
+    # This will get put into MO Observation's Notes Collector:
+    def collector
+      if inat_obs_field("Collector").present?
+        inat_obs_field("Collector")[:value]
+      else
+        self[:user][:login]
+      end
+    end
+
     def dqa
       case self[:quality_grade]
       when "research"

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -69,6 +69,11 @@ class Inat
     # convenience method with descriptive, non-cryptic name
     def inat_obs_fields = @obs[:ofvs]
 
+    # The field hash for a given field name
+    def inat_obs_field(name)
+      inat_obs_fields.find { |field| field[:name] == name }
+    end
+
     # NOTE: Fixes ABC count of `snapshot` because
     # inat_taxon_name is one fewer Branch than self[:taxon][:name]
     def inat_taxon_name = self[:taxon][:name]

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -137,6 +137,12 @@ class Inat
       end
     end
 
+    def specimen?
+      # used by iNat NEMF projects and some others
+      field = inat_obs_field("Voucher Specimen Taken")
+      field.present? && field[:value] == "Yes"
+    end
+
     def source = "mo_inat_import"
 
     def text_name = ::Name.find(name_id).text_name

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -209,6 +209,7 @@ class InatImportJob < ApplicationJob
       lng: @inat_obs.lng,
       gps_hidden: @inat_obs.gps_hidden,
       name_id: name_id,
+      specimen: @inat_obs.specimen?,
       text_name: Name.find(name_id).text_name,
       notes: @inat_obs.notes,
       source: @inat_obs.source,

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -83,6 +83,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     obs = Observation.order(created_at: :asc).last
     standard_assertions(obs: obs, name: name, loc: loc)
+    assert_not(obs.specimen, "Obs should not have a specimen")
     assert_equal(0, obs.images.length, "Obs should not have images")
     assert_match(/Observation Fields: none/, obs.comments.first.comment,
                  "Missing 'none' for Observation Fields")
@@ -283,7 +284,7 @@ class InatImportJobTest < ActiveJob::TestCase
   # `johnplischke` NEMF, DNA, notes, 2 identifications with same id;
   # 3 comments, everyone has MO account;
   # obs fields(include("Voucher Number(s)", "Voucher Specimen Taken"))
-  def test_import_job_prov_name
+  def test_import_job_nemf_plischke
     file_name = "arrhenia_sp_NY02"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")
     inat_import = create_inat_import(inat_response: mock_inat_response)
@@ -297,7 +298,6 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
-
     Inat::PhotoImporter.stub(:new,
                              stub_mo_photo_importer(mock_inat_response)) do
       assert_difference("Observation.count", 1,
@@ -309,8 +309,9 @@ class InatImportJobTest < ActiveJob::TestCase
     obs = Observation.order(created_at: :asc).last
     standard_assertions(obs: obs, name: name)
 
-    assert(obs.images.any?, "Obs should have images")
-    assert(obs.sequences.one?, "Obs should have a sequence")
+    assert(obs.images.any?, "Obs should have Images")
+    assert(obs.sequences.one?, "Obs should have a Sequence")
+    assert(obs.specimen, "Obs should show that a Specimen is available")
   end
 
   # Prove that Namings, Votes, Identification are correct

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -195,6 +195,19 @@ class InatObsTest < UnitTestCase
     assert(mock_observation("evernia").inat_obs_fields.none?)
   end
 
+  def test_inat_observation_field
+    assert(
+      mock_observation("arrhenia_sp_NY02").
+      inat_obs_field("Voucher Specimen Taken").present?,
+      "Failed to find iNat observation field"
+    )
+    assert(
+      mock_observation("somion_unicolor").
+      inat_obs_field("Voucher Specimen Taken").nil?,
+      "iNat obs should not have a Voucher Specimen Taken observation field"
+    )
+  end
+
   def test_provisional_name
     mock_inat_obs = mock_observation("arrhenia_sp_NY02")
     prov_name = mock_inat_obs.inat_prov_name

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -232,6 +232,11 @@ class InatObsTest < UnitTestCase
     )
   end
 
+  def test_specimen
+    assert(mock_observation("arrhenia_sp_NY02").specimen?)
+    assert_not(mock_observation("somion_unicolor").specimen?)
+  end
+
   def test_complex_without_mo_match
     mock_inat_obs = mock_observation("xeromphalina_campanella_complex")
     assert_equal("Xeromphalina campanella", mock_inat_obs.inat_taxon_name)

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -50,11 +50,21 @@ class InatObsTest < UnitTestCase
     )
 
     # mapping to MO Observation attributes
-    %w[gps_hidden lat lng name_id notes source text_name when where].
+    %w[gps_hidden lat lng name_id source text_name when where].
       each do |attribute|
         assert_equal(expected_mapping.send(attribute),
                      mock_inat_obs.send(attribute))
       end
+
+    expected_notes =
+      { Collector: "jdcohenesq",
+        Other: "on Quercus\n\n&#8212;\n\nOriginally posted " \
+               "to Mushroom Observer on Mar. 7, 2024." }
+
+    assert_equal(
+      expected_notes, mock_inat_obs.notes,
+      "MO notes should include: iNat Collector || login, iNat Description"
+    )
 
     expected_snapshot =
       <<~SNAPSHOT.gsub(/^\s+/, "")
@@ -115,12 +125,6 @@ class InatObsTest < UnitTestCase
 
     assert_equal(names(:coprinus).id, mock_inat_obs.name_id)
     assert_equal(names(:coprinus).text_name, mock_inat_obs.text_name)
-  end
-
-  def test_blank_notes
-    mock_inat_obs = mock_observation("coprinus")
-
-    assert_equal({}, mock_inat_obs.notes)
   end
 
   def test_infrageneric_name
@@ -362,11 +366,14 @@ class InatObsTest < UnitTestCase
   end
 
   def test_notes
+    assert_equal({ Collector: "tyler_irvin" },
+                 mock_observation("coprinus").notes,
+                 "MO Notes should always include Collector:")
     assert_equal(
-      { Other: "Collection by Heidi Randall. \nSmells like T. suaveolens. " },
-      mock_observation("trametes").notes
+      "Collection by Heidi Randall. \nSmells like T. suaveolens. ",
+      mock_observation("trametes").notes[:Other],
+      "iNat Description should be mapped to MO Notes Other"
     )
-    assert_empty(mock_observation("tremella_mesenterica").notes)
   end
 
   def test_sequences

--- a/test/models/inat_obs_test.rb
+++ b/test/models/inat_obs_test.rb
@@ -237,6 +237,18 @@ class InatObsTest < UnitTestCase
     assert_not(mock_observation("somion_unicolor").specimen?)
   end
 
+  def test_collector
+    assert_equal(
+      "Jasmine Silver & Jesse Burton",
+      mock_observation("lycoperdon").collector,
+      "Notes Collector should be iNat Collector field if that field present"
+    )
+    assert_equal(
+      "johnplischke", mock_observation("arrhenia_sp_NY02").collector,
+      "Notes Collector should be iNat user if no iNat Collector field"
+    )
+  end
+
   def test_complex_without_mo_match
     mock_inat_obs = mock_observation("xeromphalina_campanella_complex")
     assert_equal("Xeromphalina campanella", mock_inat_obs.inat_taxon_name)


### PR DESCRIPTION
Maps some iNat observation fields used by NEMF to appropriate MO fields:
| iNat | MO |
| --- | --- |
| Voucher Specimen Taken | Observation.specimen |
| Collector | notes Collector |
