### PR TITLE
Block IPs speed

### DIFF
--- a/app/controllers/admin/blocked_ips_controller.rb
+++ b/app/controllers/admin/blocked_ips_controller.rb
@@ -68,7 +68,7 @@ module Admin
     end
 
     def valid_ip_num(num)
-      num.to_i >= 0 && num.to_i < 256
+      (0..255).cover?(num.to_i)
     end
   end
 end

--- a/app/controllers/admin/blocked_ips_controller.rb
+++ b/app/controllers/admin/blocked_ips_controller.rb
@@ -31,9 +31,8 @@ module Admin
     end
 
     def sort_by_ip(ips)
-      ips.sort_by do |ip|
-        ip.to_s.split(".").map { |n| n.to_i + 1000 }.map(&:to_s).join(" ")
-      end
+      # convert IP addr segments to integers, sort based on those integers
+      ips.sort_by { |ip| ip.split(".").map(&:to_i) }
     end
 
     # I think this is as good as it gets: just a simple switch statement of


### PR DESCRIPTION
Makes two small improvements to BlockedIpsController:

1. A more efficient sort for lists of ip addrs
2. A more readable, and marginally more efficient test whether "nnn" is between 0 and 255.

I'm using the admin/blocked_ips interface a lot during NEMF. It (the interface) is really slow. Maybe this will help a bit.