### PR TITLE
Refactor iNat error handling

### DIFF
--- a/app/controllers/observations/inat_imports_controller.rb
+++ b/app/controllers/observations/inat_imports_controller.rb
@@ -101,8 +101,8 @@ module Observations
       @inat_import.update(token: auth_code, state: "Authenticating")
       tracker = InatImportJobTracker.create(inat_import: @inat_import.id)
 
-      InatImportJob.perform_now(@inat_import) # for manual testing
-      # InatImportJob.perform_later(@inat_import)
+      # InatImportJob.perform_now(@inat_import) # for manual testing
+      InatImportJob.perform_later(@inat_import)
 
       redirect_to(inat_import_job_tracker_path(tracker.id))
     end

--- a/app/controllers/observations/inat_imports_controller.rb
+++ b/app/controllers/observations/inat_imports_controller.rb
@@ -101,8 +101,8 @@ module Observations
       @inat_import.update(token: auth_code, state: "Authenticating")
       tracker = InatImportJobTracker.create(inat_import: @inat_import.id)
 
-      # InatImportJob.perform_now(@inat_import) # for manual testing
-      InatImportJob.perform_later(@inat_import)
+      InatImportJob.perform_now(@inat_import) # for manual testing
+      # InatImportJob.perform_later(@inat_import)
 
       redirect_to(inat_import_job_tracker_path(tracker.id))
     end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -151,9 +151,6 @@ class InatImportJob < ApplicationJob
     @inat = RestClient::Request.execute(
       method: :get, url: "#{API_BASE}/observations?#{query}", headers: headers
     )
-  rescue RestClient::ExceptionWithResponse => e
-    @inat_import.add_response_error(e.response)
-    e.response
   end
 
   def response_bad?(response)
@@ -408,8 +405,6 @@ class InatImportJob < ApplicationJob
     response = RestClient.post("#{API_BASE}/observation_field_values",
                                payload.to_json, headers)
     JSON.parse(response.body)
-  rescue RestClient::ExceptionWithResponse => e
-    @inat_import.add_response_error(e.response)
   end
 
   def update_description
@@ -429,8 +424,6 @@ class InatImportJob < ApplicationJob
       payload.to_json, headers
     )
     JSON.parse(response.body)
-  rescue RestClient::ExceptionWithResponse => e
-    @inat_import.add_response_error(e.response)
   end
 
   def increment_imported_count

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -443,8 +443,9 @@ class InatImportJob < ApplicationJob
     @inat_import.user.update(inat_username: @inat_import.inat_username)
   end
 
-  # job was successful enough to justify updating the MO user's iNat user_name
+  # job successful enough to justify updating the MO user's iNat user_name
   def job_successful_enough?
-    @inat_import.response_errors.empty? || @inat_import.imported_count.positive?
+    @inat_import.response_errors.empty? ||
+      @inat_import.imported_count&.positive?
   end
 end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -18,6 +18,8 @@ class InatImportJob < ApplicationJob
 
   def perform(inat_import)
     @inat_import = inat_import
+    @super_importers = InatImport.super_importers
+    @user = @inat_import.user
 
     begin
       access_token =
@@ -96,7 +98,7 @@ class InatImportJob < ApplicationJob
   end
 
   def super_importer?
-    InatImport.super_importers.include?(@inat_import.user_id)
+    @super_importers.include?(@user)
   end
 
   def right_user?(response)
@@ -223,7 +225,7 @@ class InatImportJob < ApplicationJob
 
   def new_obs_params
     name_id = adjust_for_provisional
-    { user: @inat_import.user,
+    { user: @user,
       when: @inat_obs.when,
       location: @inat_obs.location,
       where: @inat_obs.where,
@@ -285,7 +287,7 @@ class InatImportJob < ApplicationJob
       # t.boolean "gps_stripped", default: false, null: false
       # t.boolean "diagnostic", default: true, null: false
       image.update(
-        user_id: @inat_import.user_id, # throws Error if done as API param above
+        user_id: @user.id, # throws Error if done as API param above
         # NOTE: 2024-09-09 get when from image EXIF instead of @observation.when
         # https://github.com/MushroomObserver/mushroom-observer/issues/2379
         when: @observation.when # throws Error if done as API param above

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -30,10 +30,11 @@ class InatImportJob < ApplicationJob
       import_requested_observations
     rescue StandardError => e
       @inat_import.add_response_error(e)
+    ensure
+      done
     end
 
     done
-    update_user_inat_username
   end
 
   private
@@ -57,6 +58,7 @@ class InatImportJob < ApplicationJob
 
   def done
     @inat_import.update(state: "Done")
+    update_user_inat_username
   end
 
   # https://www.inaturalist.org/pages/api+recommended+practices

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -31,4 +31,8 @@ class InatImport < ApplicationRecord
     response_errors << "#{error.class.name}: #{error.message}\n"
     save
   end
+
+  def self.super_importers
+    [1, 4468, 38_275]
+  end
 end

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -33,6 +33,6 @@ class InatImport < ApplicationRecord
   end
 
   def self.super_importers
-    [1, 4468, 38_275]
+    Project.find_by(title: "SuperImporters").user_group.users
   end
 end

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -28,8 +28,10 @@ class InatImport < ApplicationRecord
   belongs_to :user
 
   def add_response_error(response)
-    # internal non-Ruby messages. Ex: { status: 401, body: "error message" }
-    if response.is_a?(Hash)
+    if response.is_a?(RuntimeError)
+      code = nil
+      body_text = response.message
+    elsif response.is_a?(Hash)
       # for internal messages to be displayed as erros in tracker show
       # Ex: { status: 401, body: "error message" }
       code = response[:status]

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -27,26 +27,8 @@ class InatImport < ApplicationRecord
 
   belongs_to :user
 
-  def add_response_error(response)
-    if response.is_a?(RuntimeError)
-      code = nil
-      body_text = response.message
-    elsif response.is_a?(Hash)
-      # for internal messages to be displayed as erros in tracker show
-      # Ex: { status: 401, body: "error message" }
-      code = response[:status]
-      body_text = response[:body]
-    else
-      code = response.code
-      begin
-        doc = Nokogiri::HTML(response.body)
-        body_text = doc.at("body").text.strip
-      rescue StandardError
-        body_text == ""
-      end
-    end
-
-    response_errors << "#{code} #{body_text}\n"
+  def add_response_error(error)
+    response_errors << "#{error.class.name}: #{error.message}\n"
     save
   end
 end

--- a/app/views/controllers/inat_import_job_trackers/show.html.erb
+++ b/app/views/controllers/inat_import_job_trackers/show.html.erb
@@ -11,7 +11,7 @@ add_page_title(:inat_import_tracker.t)
 <% if @inat_import.response_errors.present? %>
   <p>
     <b><%= :ERRORS.t %>: </b>
-    <%= tag.span(id: "errors") do %>
+    <%= tag.span(id: "errors", class: "violation-highlight") do %>
       <% @inat_import.response_errors.each_line do |error| %>
         <%= error %></br>
       <% end %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3036,6 +3036,7 @@
 
   inat_no_authorization: iNat import aborted; MO did not received authorization to access iNat user data
   inat_wrong_user: You cannot import an iNat observation created by someone else. To import your own observation, make sure that noone else is logged into iNat on your device and that you entered the correct iNat username.
+  inat_page_of_obs_failed: Failed to get page of observations from iNat API
 
   inat_data_comment: Snapshot of Imported iNat Data
   inat_dqa_casual: Casual

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -251,3 +251,10 @@ nowhere_2023_09_project:
   end_date: 2023-09-30
   # location: nil
   observations: brett_woods_2023_09_obs, falmouth_2023_09_obs, falmouth_2022_obs, nybg_2023_09_obs # roy (non-admin) owns nybg_2023_09_obs
+
+super_importers_project:
+  <<: *DEFAULTS
+  title: SuperImporters # should track production
+  user: webmaster # should track production
+  admin_group: webmaster_only # should track production
+  user_group: super_importers_users

--- a/test/fixtures/user_groups.yml
+++ b/test/fixtures/user_groups.yml
@@ -77,3 +77,12 @@ article_writers:
 
 thorsten_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:thorsten) %>
+
+webmaster_only:
+  name: user <%= ActiveRecord::FixtureSet.identify(:webmaster) %>
+
+super_importers_users:
+  name: SuperImporters Project
+
+super_importers_admin:
+  name: SuperImporters Project.admin

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -58,7 +58,7 @@ dick:
   name: Tricky Dick
   email_general_question: false
   verified: 2006-03-02 21:14:00
-  user_groups: all_users, bolete_users, bolete_admins, albion_users, albion_admins, dick_only, falmouth_2023_09_users
+  user_groups: all_users, bolete_users, bolete_admins, albion_users, albion_admins, dick_only, falmouth_2023_09_users, super_importers_users
 
 lone_wolf:
   <<: *DEFAULTS
@@ -191,7 +191,9 @@ foray_newbie:
   <<: *DEFAULTS
   user_groups: all_users, burbank_users, foray_newbie_only
 
-# manages iNat imports; name and login must mirror production
+# manages iNat imports; name and login must track production
 webmaster:
   <<: *DEFAULTS
-  login: "MO Webmaster"
+  login: "MO Webmaster" # must match production
+  name: "webmaster" # must match production
+  user_groups: all_users, $LABEL_only, super_importers_admin


### PR DESCRIPTION
Uses just Ruby exceptions, instead of funky roll-your-own response errors, for problematic responses from iNat.
- rescues problematic responses
- raises them as exceptions
- `perform` adds a message to `inat_import.response_errors`.
- job_tracker displays any messages, and highlights them.
- delivers #2382
