### PR TITLE
Fix collector name on the edit field slip page

### DIFF
--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -99,7 +99,7 @@ class FieldSlip < AbstractModel
   end
 
   def collector
-    observation.collector if observation&.collector
+    return observation.collector if observation&.collector
 
     "_user #{(user || User.current).login}_"
   end

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -313,6 +313,14 @@ class FieldSlipsControllerTest < FunctionalTestCase
                  @response.body)
   end
 
+  test "should show text collector" do
+    field_slip = field_slips(:field_slip_by_recorder)
+    login(field_slip.user.login)
+    get(:edit, params: { id: field_slip.id })
+    assert_match(field_slip.observation.collector,
+                 @response.body)
+  end
+
   test "should show previous field slip location" do
     field_slip = field_slips(:field_slip_previous)
     assert_not(field_slip.location == field_slip.project.location.display_name)

--- a/test/fixtures/field_slips.yml
+++ b/test/fixtures/field_slips.yml
@@ -46,3 +46,9 @@ field_slip_previous:
   project: current_project
   code: CURR-0001
   user: katrina
+
+field_slip_by_recorder:
+  observation: recorder_obs
+  project: current_project
+  code: CURR-0002
+  user: rolf

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -803,6 +803,11 @@ newbie_obs:
   notes:
     :Collector: _user foray_newbie_
 
+recorder_obs:
+  <<: *DEFAULTS
+  notes:
+    :Collector: Foray Collector
+
 imported_inat_obs:
   <<: *DEFAULTS
   inat_id: 12345

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -466,6 +466,10 @@ newbie_obs_rss_log:
   <<: *DEFAULTS
   observation: newbie_obs
 
+recorder_obs_rss_log:
+  <<: *DEFAULTS
+  observation: recorder_obs
+
 imported_inat_obs_rss_log:
   <<: *DEFAULTS
   observation: imported_inat_obs


### PR DESCRIPTION
To test:

1) Create a field slip (e.g., enter "NEMF-123" into the QR reader page on your local) with a collector that is not an MO user.
2) Save it.
3) Edit it.
4) On main it will insert your user name.  On the branch it will have the non user name you inserted.