### PR TITLE
Allow quick create with no name

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -131,7 +131,6 @@ class FieldSlipsController < ApplicationController
     location = Location.place_name_to_location(place_name)
     flash_error(:field_slip_quick_no_location.t) unless location
     name = Name.find_by(text_name: fs_params[:field_slip_name])
-    # flash_error(:field_slip_quick_no_name.t) unless name
     notes = field_slip_notes.compact_blank!
     date = nil
     if fs_params["date(1i)"]

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -131,7 +131,7 @@ class FieldSlipsController < ApplicationController
     location = Location.place_name_to_location(place_name)
     flash_error(:field_slip_quick_no_location.t) unless location
     name = Name.find_by(text_name: fs_params[:field_slip_name])
-    flash_error(:field_slip_quick_no_name.t) unless name
+    # flash_error(:field_slip_quick_no_name.t) unless name
     notes = field_slip_notes.compact_blank!
     date = nil
     if fs_params["date(1i)"]

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -656,8 +656,9 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   }
 
   def self.build_observation(location, name, notes, date)
-    return nil unless location && name
+    return nil unless location
 
+    name ||= Name.find_by(text_name: "Fungi")
     now = Time.zone.now
     user = User.current
     obs = new({ created_at: now, updated_at: now, source: "mo_website",

--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -61,6 +61,8 @@ form_element_data = {
     <%= hidden_field_tag(:field_code, @field_code) %>
   <% end %>
 
+  <%= submit_button(form: f, button: button_name, center: true) %>
+
   <%= panel_block(
     heading: "#{:IMAGES.l} + #{:show_observation_details.l}",
     id: "observation_images_details", formatted_content: true,
@@ -87,8 +89,6 @@ form_element_data = {
       end)
     end
   end %>
-
-  <%= submit_button(form: f, button: button_name, center: true) %>
 
   <%= panel_block(
     heading: :NOTES.l, id: "observation_notes",

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -167,6 +167,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     obs = Observation.last
     assert_redirected_to observation_url(obs.id)
   end
+
   test "should create obs with link to inat" do
     login(@field_slip.user.login)
     code = "Z#{@field_slip.code}"
@@ -204,6 +205,25 @@ class FieldSlipsControllerTest < FunctionalTestCase
     end
     assert_flash_error
     assert_redirected_to new_observation_url(field_code: code)
+  end
+
+  test "should create fungi obs" do
+    login(@field_slip.user.login)
+    code = "Z#{@field_slip.code}"
+    assert_difference("FieldSlip.count") do
+      post(:create,
+           params: {
+             commit: :field_slip_quick_create_obs.t,
+             field_slip: {
+               location: locations(:albion).name,
+               code: code,
+               project_id: projects(:eol_project).id
+             }
+           })
+    end
+    obs = Observation.last
+    assert_redirected_to observation_url(obs.id)
+    assert_equal(obs.text_name, "Fungi")
   end
 
   test "should attempt quick field_slip and redirect to show obs" do


### PR DESCRIPTION
Create a new field slip
Ensure that no name is specified
Click 'Quick Create'
On main it should take you to the Create Observation page with a flash error
On this branch it should just create the observation with the name "Fungi"