### PR TITLE
Disable special behavior for recorders

### DIFF
--- a/app/controllers/field_slips_controller/show.rb
+++ b/app/controllers/field_slips_controller/show.rb
@@ -22,19 +22,5 @@ module FieldSlipsController::Show
 
   def field_slip_redirect(obs_id)
     redirect_to(observation_url(id: obs_id))
-    # Didn't turn out to be a big win and it's confusing for
-    # it to behave differently for recorders and regular users.
-    # if foray_recorder?
-    #   redirect_to(edit_field_slip_url(id: @field_slip.id))
-    # else
-    #   redirect_to(observation_url(id: obs_id))
-    # end
-  end
-
-  def foray_recorder?
-    project = @field_slip&.project
-    return false unless project
-
-    project.is_admin?(User.current) && project.happening?
   end
 end

--- a/app/controllers/field_slips_controller/show.rb
+++ b/app/controllers/field_slips_controller/show.rb
@@ -21,11 +21,14 @@ module FieldSlipsController::Show
   end
 
   def field_slip_redirect(obs_id)
-    if foray_recorder?
-      redirect_to(edit_field_slip_url(id: @field_slip.id))
-    else
-      redirect_to(observation_url(id: obs_id))
-    end
+    redirect_to(observation_url(id: obs_id))
+    # Didn't turn out to be a big win and it's confusing for
+    # it to behave differently for recorders and regular users.
+    # if foray_recorder?
+    #   redirect_to(edit_field_slip_url(id: @field_slip.id))
+    # else
+    #   redirect_to(observation_url(id: obs_id))
+    # end
   end
 
   def foray_recorder?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -429,14 +429,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   ##############################################################################
 
-  def happening?
-    now = Time.zone.now
-    return false if start_date.present? && now < start_date
-    return false if end_date.present? && now > end_date
-
-    true
-  end
-
   def out_of_range_observations
     if start_date.nil? && end_date.nil?
       # performant query that returns empty ActiveRecord_Relation

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -296,7 +296,8 @@ class FieldSlipsControllerTest < FunctionalTestCase
   test "should take admin to edit" do
     login(@field_slip.user.login)
     get(:show, params: { id: @field_slip.code })
-    assert_redirected_to edit_field_slip_url(id: @field_slip.id)
+    assert_redirected_to observation_url(@field_slip.observation)
+    # assert_redirected_to edit_field_slip_url(id: @field_slip.id)
   end
 
   test "should show field_slip and allow owner to change" do


### PR DESCRIPTION
Having the field slip scan go to the field slip form for recorders turned out to be a bad idea.