### PR TITLE
Avoid Earth

### DIFF
--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -372,14 +372,14 @@ class API2
       @latitude  = parse(:latitude, :latitude)
       @longitude = parse(:longitude, :longitude)
       @altitude  = parse(:altitude, :altitude)
-      prefer_minimum_bounding_rectangle_to_earth!
+      prefer_minimum_bounding_box_to_earth!
     end
 
-    def prefer_minimum_bounding_rectangle_to_earth!
+    def prefer_minimum_bounding_box_to_earth!
       return unless Location.is_unknown?(@location) &&
                     @latitude.present? && @longitude.present?
 
-      @location = Location.with_minimum_bounding_rectangle_containing_point(
+      @location = Location.with_minimum_bounding_box_containing_point(
         lat: @latitude, lng: @longitude
       ).name
     end

--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -372,6 +372,16 @@ class API2
       @latitude  = parse(:latitude, :latitude)
       @longitude = parse(:longitude, :longitude)
       @altitude  = parse(:altitude, :altitude)
+      prefer_minimum_bounding_rectangle_to_earth!
+    end
+
+    def prefer_minimum_bounding_rectangle_to_earth!
+      return unless Location.is_unknown?(@location) &&
+                    @latitude.present? && @longitude.present?
+
+      @location = Location.with_minimum_bounding_rectangle_containing_point(
+        lat: @latitude, lng: @longitude
+      ).name
     end
 
     def parse_herbarium_and_specimen!

--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -379,9 +379,13 @@ class API2
       return unless Location.is_unknown?(@location) &&
                     @latitude.present? && @longitude.present?
 
-      @location = Location.with_minimum_bounding_box_containing_point(
-        lat: @latitude, lng: @longitude
-      ).name
+      mbb =
+        Location.with_minimum_bounding_box_containing_point(
+          lat: @latitude, lng: @longitude
+        ).
+        # See comment at Observation#prefer_minimum_bounding_box_to_earth
+        presence || Location.unknown
+      @location = mbb.name
     end
 
     def parse_herbarium_and_specimen!

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -315,6 +315,10 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
       )
   end
 
+  def self.with_minimum_bounding_rectangle(lat, lng)
+    contains_point(lat: lat, lng: lng).min_by(&:box_area)
+  end
+
   # Let attached observations update their cache if these fields changed.
   # Also touch updated_at to expire obs fragment caches
   def update_observation_cache

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -221,7 +221,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             )
           )
         }
-  scope :with_minimum_bounding_rectangle_containing_point,
+  scope :with_minimum_bounding_box_containing_point,
         lambda { |**args|
           args => {lat:, lng:}
           contains_point(lat: lat, lng: lng).min_by(&:box_area)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -224,7 +224,11 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :with_minimum_bounding_box_containing_point,
         lambda { |**args|
           args => {lat:, lng:}
-          contains_point(lat: lat, lng: lng).min_by(&:box_area)
+          containers = contains_point(lat: lat, lng: lng)
+          # prevents returning all containers if contaimers empty
+          return none if containers.empty?
+
+          containers.min_by(&:box_area)
         }
   scope :contains_box, # Use named parameters, north:, south:, east:, west:
         lambda { |**args|

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -221,6 +221,11 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
             )
           )
         }
+  scope :with_minimum_bounding_rectangle_containing_point,
+        lambda { |**args|
+          args => {lat:, lng:}
+          contains_point(lat: lat, lng: lng).min_by(&:box_area)
+        }
   scope :contains_box, # Use named parameters, north:, south:, east:, west:
         lambda { |**args|
           args => { north:, south:, east:, west: }
@@ -313,10 +318,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
       group(:location_id).update_all(
         location_lat: nil, location_lng: nil
       )
-  end
-
-  def self.with_minimum_bounding_rectangle(lat, lng)
-    contains_point(lat: lat, lng: lng).min_by(&:box_area)
   end
 
   # Let attached observations update their cache if these fields changed.

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1568,6 +1568,8 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     return unless location && Location.is_unknown?(location.name) &&
                   lat.present? && lng.present?
 
-    self.location = Location.with_minimum_bounding_rectangle(lat, lng)
+    self.location = Location.with_minimum_bounding_rectangle_containing_point(
+      lat: lat, lng: lng
+    )
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1568,8 +1568,15 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     return unless location && Location.is_unknown?(location.name) &&
                   lat.present? && lng.present?
 
-    self.location = Location.with_minimum_bounding_box_containing_point(
-      lat: lat, lng: lng
-    )
+    Location.
+      with_minimum_bounding_box_containing_point(lat: lat, lng: lng).
+      # Use the unknown location if there's no minimum bounding box.
+      # NOTE: jdc As of 20241105, that's possible because the live db unknown
+      # location does not contain the entire globe. Its boundaries:
+      #             north: 89,
+      #  west: -179,          east: 179,
+      #            south: -89,
+      # Also see ObservationAPI#prefer_minimum_bounding_box_to_earth!
+      presence || Location.unknown
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -216,7 +216,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # else Rubocop says: "before_save is supposed to appear before before_destroy"
   # because a before_destroy must precede the has_many's
   before_save :cache_content_filter_data
-  before_save :avoid_unknown_location
+  before_save :prefer_minimum_bounding_box_to_earth
 
   # rubocop:enable Rails/ActiveRecordCallbacksOrder
   after_update :notify_users_after_change
@@ -1564,11 +1564,11 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
 
   private
 
-  def avoid_unknown_location
+  def prefer_minimum_bounding_box_to_earth
     return unless location && Location.is_unknown?(location.name) &&
                   lat.present? && lng.present?
 
-    self.location = Location.with_minimum_bounding_rectangle_containing_point(
+    self.location = Location.with_minimum_bounding_box_containing_point(
       lat: lat, lng: lng
     )
   end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1568,7 +1568,8 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     return unless location && Location.is_unknown?(location.name) &&
                   lat.present? && lng.present?
 
-    Location.
+    self.location =
+      Location.
       with_minimum_bounding_box_containing_point(lat: lat, lng: lng).
       # Use the unknown location if there's no minimum bounding box.
       # NOTE: jdc As of 20241105, that's possible because the live db unknown

--- a/test/controllers/observations_controller/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller/observations_controller_create_test.rb
@@ -517,15 +517,17 @@ class ObservationsControllerCreateTest < FunctionalTestCase
   end
 
   def test_create_observation_with_known_decimal_geolocation_and_unknown_name
-    lat = 34.1622
-    lng = -118.3521
+    burbank = locations(:burbank)
+    lat = burbank.center_lat
+    lng = burbank.center_lng
+
     generic_construct_observation(
       { observation: { place_name: "", lat: lat, lng: lng },
         naming: { name: "Unknown" } },
       1, 0, 0, 0
     )
-    obs = assigns(:observation)
 
+    obs = assigns(:observation)
     assert_equal(lat.to_s, obs.lat.to_s)
     assert_equal(lng.to_s, obs.lng.to_s)
     assert_objs_equal(

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -2374,6 +2374,39 @@ class API2Test < UnitTestCase
     assert_api_fail(params.except(:location))
   end
 
+  def test_post_observation_with_geoloc_and_earth
+    burbank = locations(:burbank)
+    @user = rolf
+    @name = Name.unknown
+    @loc = burbank
+    @img1 = nil
+    @img2 = nil
+    @spl = nil
+    @proj = nil
+    @date = Time.zone.today
+    @notes = Observation.no_notes
+    @vote = Vote.maximum_vote
+    @specimen = false
+    @is_col_loc = true
+    @lat = burbank.center_lat
+    @long = burbank.center_lng
+    @alt = nil
+    params = {
+      method: :post,
+      action: :observation,
+      api_key: @api_key.key,
+      latitude: @lat,
+      longitude: @long,
+      location: "Earth"
+    }
+    api = API2.execute(params)
+    assert_no_errors(api, "Errors while posting observation")
+    assert_obj_arrays_equal([Observation.last], api.results)
+    assert_last_observation_correct
+    assert_equal("mo_api", Observation.last.source)
+    assert_api_fail(params.except(:location))
+  end
+
   def test_post_maximal_observation
     @user = rolf
     @name = names(:coprinus_comatus)

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -689,7 +689,7 @@ class LocationTest < UnitTestCase
     do_contains_box(loc: california, regions: [earth])
   end
 
-  def test_with_minimum_bounding_rectangle
+  def test_scope_with_minimum_bounding_box_containing_point
     falmouth = locations(:falmouth)
     assert_equal(
       falmouth,
@@ -698,10 +698,10 @@ class LocationTest < UnitTestCase
       )
     )
 
-    assert_equal(
-      locations(:unknown_location),
-      Location.with_minimum_bounding_box_containing_point(
-        lat: -89, lng: 0
+    california_locations = Location.where(Location[:name] =~ /California, USA$/)
+    assert_empty(
+      california_locations.with_minimum_bounding_box_containing_point(
+        lat: falmouth.center_lat, lng: falmouth.center_lng
       )
     )
   end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -551,6 +551,17 @@ class LocationTest < UnitTestCase
                  "Opposite side of globe should not be 'close' to Location.")
   end
 
+  def test_with_minimum_bounding_rectangle
+    falmouth = locations(:falmouth)
+    assert_equal(
+      falmouth, Location.with_minimum_bounding_rectangle(falmouth.center_lat,
+                                                         falmouth.center_lng)
+    )
+
+    assert_equal(locations(:unknown_location),
+                 Location.with_minimum_bounding_rectangle(-89, 0))
+  end
+
   # ----------------------------------------------------
   #  Scopes
   #    Explicit tests of some scopes to improve coverage

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -551,17 +551,6 @@ class LocationTest < UnitTestCase
                  "Opposite side of globe should not be 'close' to Location.")
   end
 
-  def test_with_minimum_bounding_rectangle
-    falmouth = locations(:falmouth)
-    assert_equal(
-      falmouth, Location.with_minimum_bounding_rectangle(falmouth.center_lat,
-                                                         falmouth.center_lng)
-    )
-
-    assert_equal(locations(:unknown_location),
-                 Location.with_minimum_bounding_rectangle(-89, 0))
-  end
-
   # ----------------------------------------------------
   #  Scopes
   #    Explicit tests of some scopes to improve coverage
@@ -698,6 +687,23 @@ class LocationTest < UnitTestCase
     # These failed depending on the rounding correction used by `contains_box`
     do_contains_box(loc: perkatkun, regions: [wrangel, earth])
     do_contains_box(loc: california, regions: [earth])
+  end
+
+  def test_with_minimum_bounding_rectangle
+    falmouth = locations(:falmouth)
+    assert_equal(
+      falmouth,
+      Location.with_minimum_bounding_rectangle_containing_point(
+        lat: falmouth.center_lat, lng: falmouth.center_lng
+      )
+    )
+
+    assert_equal(
+      locations(:unknown_location),
+      Location.with_minimum_bounding_rectangle_containing_point(
+        lat: -89, lng: 0
+      )
+    )
   end
 
   def albion

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -693,14 +693,14 @@ class LocationTest < UnitTestCase
     falmouth = locations(:falmouth)
     assert_equal(
       falmouth,
-      Location.with_minimum_bounding_rectangle_containing_point(
+      Location.with_minimum_bounding_box_containing_point(
         lat: falmouth.center_lat, lng: falmouth.center_lng
       )
     )
 
     assert_equal(
       locations(:unknown_location),
-      Location.with_minimum_bounding_rectangle_containing_point(
+      Location.with_minimum_bounding_box_containing_point(
         lat: -89, lng: 0
       )
     )


### PR DESCRIPTION
Uses the smallest Location containing lat/lng instead of Earth, for Observations.

(Explanation: Many recent Observations have lat/lng with Location Earth. Most (all? 99%) of them some from the mobile app or otherwise from the API. This frustrates mobile app users. It also stops the Observation from appearing on maps of its taxon (the location is too vague). This PR aims to improve things by preferring the smallest reasonable Location to `Earth` if an Observation has a geolocation.)

The PR adds:
- a Location scope, `with_minimum_bounding_box_containing_point`
- an Observation before_save callback, `prefer_minimum_bounding_box_to_earth`
- corresponding code in the Observation API

## Suggest Manual Tests
### Using the website
- [Create Observation](http://localhost:3000/observations/new)
  - Locality: `Earth`
  - Latitude: `46.438`
  - Longitude: `-121.84`
  - `Create`
  
**Expected result: (new) Observation with Location: Cispus Environmental Learning Center**

### Using the API
- Enter the following on the unix command line, substituting a valid API Key for `xxx`
```zsh
curl -X POST "http://localhost:3000/api2/observations?api_key=xxx&location=Earth&latitude=46.438&longitude=-121.847&date=2024-11-05"
```
- The response should be something like
```xml
<?xml version="1.0" encoding="UTF-8"?>
<response xmlns="http://localhost:3000/response.xsd">
  ...
  <results number="1">
    <result id="565807" type="observation"/>
  </results>
  ...
</response>
```
- View the Observation which has the `id` displayed in the above response.

**Expected result: Observation has Location: Cispus Environmental Learning Center**

