### PR TITLE
Fix field slip field order

### DIFF
--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -58,7 +58,7 @@ class FieldSlip < AbstractModel
 
   def notes_fields
     # Should we figure out a way to internationalize these tags?
-    [:"Odor/Taste", :Substrate, :Plants, :Habit, :Other].map do |field|
+    [:"Odor/Taste", :"Trees/Shrubs", :Substrate, :Habit, :Other].map do |field|
       NoteField.new(name: field, value: field_value(field))
     end
   end


### PR DESCRIPTION
Rename "Plants" to "Trees/Shrubs" and switch with "Substrate" per the current field slip form layout.