### PR TITLE
Add test to ensure internal links are getting rendered correctly

### DIFF
--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -253,7 +253,7 @@ module ObservationsHelper
       Textile.register_name(obs.name)
       concat("<p>#{:NOTES.t}:<br>".t)
       notes.each_with_object(+"") do |(key, value), _str|
-        concat("+#{key}+: #{value}<br>".t)
+        concat("+#{key}+: #{value}<br>".tl)
       end
       concat("</p>".t)
     end

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -34,6 +34,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     obs = observations(:template_and_orphaned_notes_scrambled_obs)
     get(:show, params: { id: obs.id })
     assert_match("+photo", @response.body)
+    assert_match("/lookups/lookup_user/rolf", @response.body)
   end
 
   def test_show_project_observation

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -687,6 +687,7 @@ template_and_orphaned_notes_scrambled_obs:
     :orphaned_caption_1: orphaned notes 1
     :Other: other notes, +photo
     :orphaned_caption_2: orphaned notes 2
+    :Collector: _user rolf_
     :Cap: red
   user: notes_templater
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -905,7 +905,7 @@ class ObservationTest < UnitTestCase
     # with order scrambled in the Observation
     obs   = observations(:template_and_orphaned_notes_scrambled_obs)
     parts = ["Cap", "Nearby trees", "odor", "orphaned caption 1",
-             "orphaned caption 2", "Other"]
+             "orphaned caption 2", "Collector", "Other"]
     assert_equal(parts, obs.form_notes_parts(obs.user))
   end
 


### PR DESCRIPTION
The previous fix was causing values like "_user Dave W_" to get rendered as just _user Dave W_ rather than as a link to that user.  This fixes that.  Example observation: http://localhost:3000/observations/563669.