### PR TITLE
iNat hung diagnosis tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem("solid_cache")
 gem("cache_with_locale")
 # solid_queue for jobs
 gem("solid_queue")
+# https://github.com/rails/mission_control-jobs
+# Rails-based frontend to Active Job adapters for monitoring jobs
+gem("mission_control-jobs")
 
 # sprockets for asset compilation and versioning
 gem("sprockets-rails")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,16 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    mission_control-jobs (0.6.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.2.0)
@@ -473,6 +483,7 @@ DEPENDENCIES
   mini_racer
   minitest
   minitest-reporters
+  mission_control-jobs
   mo_acts_as_versioned (>= 0.6.6)!
   newrelic_rpm
   oauth2

--- a/app/controllers/observations/inat_imports_controller.rb
+++ b/app/controllers/observations/inat_imports_controller.rb
@@ -101,6 +101,9 @@ module Observations
       @inat_import.update(token: auth_code, state: "Authenticating")
       tracker = InatImportJobTracker.create(inat_import: @inat_import.id)
 
+      Rails.logger.info(
+        "Enqueuing InatImportJob for InatImport id: #{@inat_import.id}"
+      )
       # InatImportJob.perform_now(@inat_import) # for manual testing
       InatImportJob.perform_later(@inat_import)
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -503,7 +503,7 @@ class InatImportJob < ApplicationJob
   end
 
   def log(str)
-    time = Time.zone.now.to_s
+    time = Time.now.utc.to_s
     log_entry = "#{time}: InatImportJob #{@inat_import.id} #{str}"
 
     # Add log entry to job_log

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -17,9 +17,9 @@ class InatImportJob < ApplicationJob
   queue_as :default
 
   def perform(inat_import)
+    @inat_import = inat_import
     log("InatImportJob #{inat_import.id} started, " \
     "user #{inat_import.user_id}")
-    @inat_import = inat_import
 
     log("Getting SuperImporters")
     @super_importers = InatImport.super_importers
@@ -504,6 +504,7 @@ class InatImportJob < ApplicationJob
 
   def log(str)
     time = Time.now.utc.to_s
+    debugger
     log_entry = "#{time}: InatImportJob #{@inat_import.id} #{str}"
 
     # Add log entry to job_log

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -510,10 +510,5 @@ class InatImportJob < ApplicationJob
     open("log/job.log", "a") do |f|
       f.write("#{log_entry}\n")
     end
-
-    # Add log entry to @inat_import.log
-    @inat_import.log ||= []
-    @inat_import.log << log_entry
-    @inat_import.save
   end
 end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -17,9 +17,10 @@ class InatImportJob < ApplicationJob
   queue_as :default
 
   def perform(inat_import)
+    log("InatImportJob #{inat_import.id} started, " \
+    "user #{inat_import.user_id}")
     @inat_import = inat_import
-    log("InatImportJob #{@inat_import.id} started, " \
-        "user #{@inat_import.user_id}")
+
     log("Getting SuperImporters")
     @super_importers = InatImport.super_importers
     log("Got SuperImporters: #{@super_importers.map(&:login)}")

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -504,7 +504,6 @@ class InatImportJob < ApplicationJob
 
   def log(str)
     time = Time.now.utc.to_s
-    debugger
     log_entry = "#{time}: InatImportJob #{@inat_import.id} #{str}"
 
     # Add log entry to job_log

--- a/app/views/controllers/application/sidebar/_admin.html.erb
+++ b/app/views/controllers/application/sidebar/_admin.html.erb
@@ -2,6 +2,10 @@
 tag.div("#{:app_admin.t}:", class: classes[:heading])
 %>
 <%=
+active_link_to(:app_jobs.t, "/jobs",
+               class: classes[:admin], id: "nav_admin_jobs_link")
+%>
+<%=
 active_link_to(:app_blocked_ips.t, edit_admin_blocked_ips_path,
                class: classes[:admin], id: "nav_admin_blocked_ips_link")
 %>

--- a/config/initializers/mission_control_jobs.rb
+++ b/config/initializers/mission_control_jobs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Limit /jobs to admins
+# https://github.com/rails/mission_control-jobs?tab=readme-ov-file#authentication-and-base-controller-class
+Rails.application.configure do
+  MissionControl::Jobs.base_controller_class = "AdminController"
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1383,6 +1383,7 @@
   app_join_mailing_list: Join Mailing List
   app_logout: Logout
   app_admin: Admin
+  app_jobs: Jobs
   app_blocked_ips: Blocked IPs
   app_switch_users: Switch Users
   app_users: "[:list_objects(type=:user)]"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -928,4 +928,8 @@ MushroomObserver::Application.routes.draw do
 
   # routes for actions that Rails automatically creates from view templates
   MO.themes.each { |scheme| get "/theme/#{scheme}" }
+
+  # Make Mission Control Job's UI available to MO app
+  # https://github.com/rails/mission_control-jobs?tab=readme-ov-file#basic-configuration
+  mount MissionControl::Jobs::Engine, at: "/jobs"
 end

--- a/db/migrate/20241116222241_remove_log_from_inat_imports.rb
+++ b/db/migrate/20241116222241_remove_log_from_inat_imports.rb
@@ -1,0 +1,5 @@
+class RemoveLogFromInatImports < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :inat_imports, :log, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_01_233907) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_16_222241) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -209,7 +209,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_01_233907) do
     t.integer "importables"
     t.integer "imported_count"
     t.string "response_errors"
-    t.text "log"
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
Improves tools for diagnosing hung iNat Job

- Explicitly logs (to Rails.log) job enqueuing
- Uses UTC for job.log entries
- Removes redundant InatImport.log
- Adds [mission_control-jobs gem](https://github.com/rails/mission_control-jobs)
- Adds an Admin menu link to the Mission Control UI

### Manual Test
- Go into Admin Mode
- Click the `Jobs` link in the LH Navbar
Expected result: Takes you to the Mission Control UI
(For basic usage, see https://github.com/rails/mission_control-jobs?tab=readme-ov-file#basic-ui-usage)