### PR TITLE
Fix simple notes

### DIFF
--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -239,7 +239,7 @@ module ObservationsHelper
   def observation_details_notes(obs:)
     notes = obs.notes
     return "" unless notes
-    return notes[:Other] if notes.keys == [:Other]
+    return "#{:NOTES.t}:\n#{notes[:Other]}" if notes.keys == [:Other]
 
     # This used to use
     #

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -239,7 +239,7 @@ module ObservationsHelper
   def observation_details_notes(obs:)
     notes = obs.notes
     return "" unless notes
-    return "#{:NOTES.t}:\n#{notes[:Other]}" if notes.keys == [:Other]
+    return "#{:NOTES.t}:\n#{notes[:Other]}".tpl if notes.keys == [:Other]
 
     # This used to use
     #

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -37,6 +37,12 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_match("/lookups/lookup_user/rolf", @response.body)
   end
 
+  def test_show_observation_with_simple_notes
+    obs = observations(:coprinus_comatus_obs)
+    get(:show, params: { id: obs.id })
+    assert_match("<p>Notes:<br />", @response.body)
+  end
+
   def test_show_project_observation
     login
     obs = observations(:owner_accepts_general_questions)


### PR DESCRIPTION
The previous fix caused simple notes to not get the proper Textile treatment or the "Notes:" header.  This fixes that.  Example observation: https://mushroomobserver.org/507459.