### PR TITLE
Eager load Rake in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -178,6 +178,11 @@ MushroomObserver::Application.configure do
   config.action_cable.allowed_request_origins = [%r{http://*}, %r{https://*/}]
 
   config.active_job.queue_adapter = :solid_queue
+
+  # Fixes SolidQueue intermittent NameError uninitialized constant
+  # https://github.com/rails/solid_queue/issues/276
+  # https://github.com/MushroomObserver/mushroom-observer/issues/2534
+  config.rake_eager_load = true
 end
 
 file = File.expand_path("../consts-site.rb", __dir__)


### PR DESCRIPTION
- Ensures that all application code is eagerly loaded when running Rake tasks in production, thereby 
initializing all Constants and making them available to Rake tasks in production.
- Hopefully fixes SolidQueue intermittent NameError uninitialized constant. See #2534 