### PR TITLE
Uninstall newrelic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -223,5 +223,5 @@ end
 group :production do
   # New Relic for application and other monitoring
   # https://newrelic.com/
-  # bugem("newrelic_rpm")
+  # gem("newrelic_rpm")
 end

--- a/Gemfile
+++ b/Gemfile
@@ -223,5 +223,5 @@ end
 group :production do
   # New Relic for application and other monitoring
   # https://newrelic.com/
-  gem("newrelic_rpm")
+  # bugem("newrelic_rpm")
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,6 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
-    newrelic_rpm (9.15.0)
     nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
@@ -485,7 +484,6 @@ DEPENDENCIES
   minitest-reporters
   mission_control-jobs
   mo_acts_as_versioned (>= 0.6.6)!
-  newrelic_rpm
   oauth2
   prawn
   prawn-manual_builder


### PR DESCRIPTION
Uninstalls newrelic_rpm gem
- This is a long shot at fixing #2534. I'm trying it because:
  - newrelic is at the bottom of the stack trace of all the failed InatImportJob's;
  - It's easy to implement;
  - We aren't using the NewRelic data;
  - It;s easy to undo.