### PR TITLE
Clean up date handling for field slips

### DIFF
--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -53,6 +53,7 @@ module ObservationsController::New
     init_project_vars_for_new
     init_list_vars
     defaults_from_last_observation_created
+    @observation.when = params[:date] if params[:date]
     add_field_slip_project(@field_code)
   end
 

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -152,14 +152,16 @@ class FieldSlipsControllerTest < FunctionalTestCase
   test "should create field_slip and obs and redirect to show obs" do
     login(@field_slip.user.login)
     code = "Z#{@field_slip.code}"
-    date = "2000-01-01"
+    date = Date.new(2000, 1, 2)
     assert_difference("FieldSlip.count") do
       post(:create,
            params: {
              commit: :field_slip_quick_create_obs.t,
              field_slip: {
                code: code,
-               date:,
+               "date(1i)" => date.year.to_s,
+               "date(2i)" => date.month.to_s,
+               "date(3i)" => date.day.to_s,
                location: locations(:albion).name,
                field_slip_name: names(:coprinus_comatus).text_name,
                project_id: projects(:eol_project).id
@@ -385,16 +387,21 @@ class FieldSlipsControllerTest < FunctionalTestCase
     login
     initial = @field_slip.observation_id
     notes = "Some notes"
+    date = Date.new(2000, 1, 2)
     patch(:update,
           params: { id: @field_slip.id,
                     commit: :field_slip_keep_obs.t,
                     field_slip: { code: @field_slip.code,
+                                  "date(1i)" => date.year.to_s,
+                                  "date(2i)" => date.month.to_s,
+                                  "date(3i)" => date.day.to_s,
                                   observation_id: @field_slip.observation_id,
                                   project_id: @field_slip.project_id,
                                   notes: { Other: notes } } })
     assert_redirected_to field_slip_url(@field_slip)
     assert_equal(@field_slip.observation_id, initial)
     assert_equal(@field_slip.observation.notes[:Other], notes)
+    assert_equal(date, @field_slip.observation.when)
   end
 
   test "should update field_slip with new name" do

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -152,12 +152,14 @@ class FieldSlipsControllerTest < FunctionalTestCase
   test "should create field_slip and obs and redirect to show obs" do
     login(@field_slip.user.login)
     code = "Z#{@field_slip.code}"
+    date = "2000-01-01"
     assert_difference("FieldSlip.count") do
       post(:create,
            params: {
              commit: :field_slip_quick_create_obs.t,
              field_slip: {
                code: code,
+               date:,
                location: locations(:albion).name,
                field_slip_name: names(:coprinus_comatus).text_name,
                project_id: projects(:eol_project).id
@@ -165,6 +167,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
            })
     end
     obs = Observation.last
+    assert_equal(date, obs.when)
     assert_redirected_to observation_url(obs.id)
   end
 


### PR DESCRIPTION
Should allow date updates to observations from the field slip edit page.
Field slip date widgets should get correctly communicated to both quick created observations and observations that require more data including images.
