### PR TITLE
Use core_nt for BLAST

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -115,16 +115,18 @@ class Sequence < AbstractModel
 
   # url of NCBI page to set up BLAST for the Sequence
   def blast_url
-    if blastable_by_accession?
-      "#{blast_url_prefix}#{accession.gsub(/\s/, "")}"
-    else
-      "#{blast_url_prefix}#{bases_nucleotides}"
-    end
+    query =
+      if blastable_by_accession?
+        accession.gsub(/\s/, "")
+      else
+        bases_nucleotides
+      end
+    "#{blast_url_prefix}&QUERY=#{query}"
   end
 
   def self.blast_url_prefix
-    "https://blast.ncbi.nlm.nih.gov/Blast.cgi?" \
-    "CMD=Post&DATABASE=nt&PROGRAM=blastn&QUERY="
+    "https://blast.ncbi.nlm.nih.gov/Blast.cgi?PROGRAM=blastn&" \
+    "PAGE_TYPE=BlastSearch&LINK_LOC=blasthome&DATABASE=core_nt"
   end
 
   # convenience wrapper around class method of same name

--- a/test/models/sequence_test.rb
+++ b/test/models/sequence_test.rb
@@ -250,16 +250,16 @@ class SequenceTest < UnitTestCase
 
   def test_blast_url
     assert_equal(
-      %(#{Sequence.blast_url_prefix}ACGT),
+      %(#{Sequence.blast_url_prefix}&QUERY=ACGT),
       sequences(:local_sequence).blast_url
     )
     assert_equal(
-      %(#{Sequence.blast_url_prefix}KT968605),
+      %(#{Sequence.blast_url_prefix}&QUERY=KT968605),
       sequences(:deposited_sequence).blast_url
     )
     # Prove that BLAST url for UNITE sequence uses Bases instead of Accession.
     assert_equal(
-      %(#{Sequence.blast_url_prefix}ACGT),
+      %(#{Sequence.blast_url_prefix}&QUERY=ACGT),
       sequences(:alternate_archive).blast_url
     )
     # Prove that BLAST url for FASTA formatted sequence
@@ -277,7 +277,7 @@ class SequenceTest < UnitTestCase
     "GTGGGG"
 
     assert_equal(
-      %(#{Sequence.blast_url_prefix}#{expected_query}),
+      %(#{Sequence.blast_url_prefix}&QUERY=#{expected_query}),
       sequences(:fasta_formatted_sequence).blast_url
     )
 
@@ -297,7 +297,7 @@ class SequenceTest < UnitTestCase
     "aaacctttctcctagttgacctcgaatcaggtggggB"
 
     assert_equal(
-      %(#{Sequence.blast_url_prefix}#{expected_query}),
+      %(#{Sequence.blast_url_prefix}&QUERY=#{expected_query}),
       sequences(:bare_with_numbers_sequence).blast_url
     )
   end


### PR DESCRIPTION
- Uses `core_nt` database instead of `nt` for BLAST search urls.
- Should give fasater & better BLAST results. See https://mushroomobserver.slack.com/archives/C040TH9FV/p1732117497825869
- Trivial refactor of `blast_url` to better separate concerns