### PR TITLE
Fungarium record MyCoPortal link

### DIFF
--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -245,10 +245,12 @@ class HerbariaController < ApplicationController
   end
 
   def normalize_parameters
-    [:name, :code, :email, :place_name, :mailing_address].each do |arg|
-      val = @herbarium.send(arg).to_s.strip_html.strip_squeeze
-      @herbarium.send(:"#{arg}=", val)
-    end
+    [:name, :code, :mycoportal_db, :email, :place_name,
+     :mailing_address].
+      each do |arg|
+        val = @herbarium.send(arg).to_s.strip_html.strip_squeeze
+        @herbarium.send(:"#{arg}=", val)
+      end
     @herbarium.description = @herbarium.description.to_s.strip
     @herbarium.code = "" if @herbarium.personal_user_id
   end
@@ -424,7 +426,8 @@ class HerbariaController < ApplicationController
     return {} unless params[:herbarium]
 
     params.require(:herbarium).
-      permit(:name, :code, :email, :mailing_address, :description, :location_id,
+      permit(:name, :code, :mycoportal_db, :email, :mailing_address,
+             :description, :location_id,
              :place_name, :personal, :personal_user_name)
   end
 end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -317,7 +317,7 @@ class Herbarium < AbstractModel
   def mcp_url(accession)
     base_url = "https://www.mycoportal.org/portal/collections/list.php"
     search_params =
-      { catnum: strip_leading_code(accession), db: MCP_COLLECTIONS[code],
+      { catnum: strip_leading_code(accession), db: mycoportal_db,
         includeothercatnum: 1 }
 
     "#{base_url}?#{search_params.to_query}"

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -32,6 +32,7 @@
 #  curator?(user)::         Check if a User is a curator.
 #  add_curator(user)::      Add User as a curator unless already is one.
 #  delete_curator(user)::   Remove User from curators.
+#  mcp_searchable?          Is this herbarium searchable via MyCoPortal?
 #  sort_name::              Stripped-down version of name for sorting.
 #  merge(other_herbarium):: merge other_herbarium into this one
 #
@@ -306,5 +307,9 @@ class Herbarium < AbstractModel
 
   def self.find_by_name_with_wildcards(str)
     find_using_wildcards("name", str)
+  end
+
+  def mcp_searchable?
+    MCP_COLLECTIONS.include?(code)
   end
 end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -32,7 +32,8 @@
 #  curator?(user)::         Check if a User is a curator.
 #  add_curator(user)::      Add User as a curator unless already is one.
 #  delete_curator(user)::   Remove User from curators.
-#  mcp_searchable?          Is this herbarium searchable via MyCoPortal?
+#  web_searchable?::        Are its digital records searchable via the internet?
+#  mcp_searchable?          Are its digital records searchable via MyCoPortal?
 #  sort_name::              Stripped-down version of name for sorting.
 #  merge(other_herbarium):: merge other_herbarium into this one
 #
@@ -308,6 +309,10 @@ class Herbarium < AbstractModel
 
   def self.find_by_name_with_wildcards(str)
     find_using_wildcards("name", str)
+  end
+
+  def web_searchable?
+    mcp_searchable? || mycoportal_db.present?
   end
 
   def mcp_searchable?

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -42,6 +42,7 @@
 #                     HerbariumRecord to an Herbarium.  Called after create.
 #
 ################################################################################
+
 class Herbarium < AbstractModel
   has_many :herbarium_records, dependent: :destroy
   belongs_to :location
@@ -59,143 +60,143 @@ class Herbarium < AbstractModel
   # Herbaria whose collections are searchable via MyCoPortal.
   # https://www.mycoportal.org/portal/collections/index.php
   # rubocop:disable Layout/LineLength
-  MCP_COLLECTIONS = [
-    "PH", # Academy of Natural Sciences of Drexel University
-    "ACAD", # Acadia University, E. C. Smith Herbarium
-    "CHSC", # Ahart Herbarium, CSU Chico - Mycological Collection
-    "N/A", # Atlas of Living Australia specimen-based fungal data
-    "BMSC", # Bamfield Marine Science Centre
-    "BISH", # Bishop Museum, Herbarium Pacificum
-    "BRIT", # Botanical Research Institute of Texas
-    "BDWR", # Bridgewater College Herbarium
-    "BRU", # Brown University Herbarium
-    "HSC-F", # Cal Poly Humboldt Fungarium
-    "CDA-Fungi", # California Department of Food and Agriculture - Fungi
-    "HAY", # California State University East Bay Fungarium
-    "AAFC-DAOM", # Canadian National Mycological Herbarium
-    "WSP", # Charles Gardner Shaw Mycological Herbarium, Washington State University
-    "CHRB", # Chrysler Herbarium - Mycological Collection
-    "CLEMS", # Clemson University Herbarium
-    "HCOA", # College of the Atlantic, Acadia National Park Herbarium
-    "CUP", # Cornell University Plant Pathology Herbarium
-    "CBBG", # Crested Butte Botanic Gardens
-    "DEWV", # Davis & Elkins College Herbarium
-    "DBG-DBG", # Denver Botanic Gardens, Sam Mitchel Herbarium of Fungi
-    "DUKE", # Duke University Herbarium Fungal Collection
-    "EIU", # Eastern Illinois University
-    "EWU", # Eastern Washington University
-    "QCAM", # Ecuador Fungi data from FungiWebEcuador
-    "TAM", # Estonian Museum of Natural History
-    "BAFC-H", # Facultad de Ciencias Exactas y Naturales
-    "F", # Field Museum of Natural History
-    "FNL", # Foray Newfoundland and Labrador Fungarium
-    "FLD", # Fort Lewis College Herbarium
-    "GLM", # Fungal Collection at the Senckenberg Museum für Naturkunde Görlitz
-    "M", # Fungal Collections at the Botanische Staatssammlung München
-    "KR", # Fungus Collections at Staatliches Museum für Naturkunde Karlsruhe
-    "FH", # Harvard University, Farlow Herbarium
-    "FR", # Herbarium Senckenbergianum
-    "IND", # Indiana University
-    "TAAM", # Institute of Agricultural and Environmental Sciences of the Estonian University of Life Sciences (TAAM)
-    "EAA", # Estonian University of Life Sciences (EAA)
-    "INEP-F", # Institute of the Industrial Ecology Problems of the North of Kola Science Center of the Russian Academy of Sciences.
-    "PACA", # Instituto Anchietano de Pesquisas/UNISINOS
-    "USU-UTC", # Intermountain Herbarium (fungi, not lichens), Utah State University
-    "ICMP", # International Collection of Microorganisms from Plants
-    "ISC", # Iowa State University, Ada Hayden Herbarium
-    "SUCO", # Jewell and Arline Moss Settle Herbarium at SUNY Oneonta
-    "LSUM-Fungi", # Louisiana State University, Bernard Lowy Mycological Herbarium
-    "MUHW", # Marshall University Herbarium - Fungi
-    "BR", # Meise Botanic Garden Herbarium
-    "MU", # Miami University, Willard Sherman Turrell Herbarium
-    "MSC", # Michigan State University Herbarium non-lichenized fungi
-    "MOR", # Morton Arboretum
-    "CORD", # Museo Botánico Córdoba Fungarium
-    "CR", # Museo Nacional de Costa Rica, specimen-based
-    "PC", # Muséum National d'Histoire Naturelle
-    "MNA", # Museum of Northern Arizona
-    "IBUNAM-MEXU:FU", # National Herbarium of Mexico Fungal Collection (Hongos del Herbario Nacional de México)
-    "TNS-F", # National Museum of Nature and Science - Japan
-    "NMC-FUNGI", # National Mushroom Centre
-    "UT-M", # Natural History Museum of Utah Fungarium
-    "L", # Naturalis Biodiversity Center
-    "NBM", # New Brunswick Museum
-    "NY", # New York Botanical Garden
-    "NYS", # New York State Museum Mycology Collection
-    "PDD", # New Zealand Fungarium
-    "NCSLG", # North Carolina State University, Larry F. Grand Mycological Herbarium
-    "OSC", # Oregon State University Herbarium
-    "OSC-Lichens", # Oregon State University Herbarium - Lichens
-    "USFWS-PRR", # Patuxent Research Refuge - Maryland
-    "PUR", # Purdue University, Arthur Fungarium
-    "PUL", # Purdue University, Kriebel Herbarium
-    "QFB", # René Pomerleau Herbarium
-    "E", # Royal Botanic Garden Edinburgh
-    "TRTC", # Royal Ontario Museum Fungarium
-    "TAES", # S.M. Tracy Herbarium Texas A&M University
-    "SFSU", # San Francisco State University, Harry D. Thiers Herbarium
-    "SBBG", # Santa Barbara Botanic Garden
-    "LJF", # Slovenian Fungal Database (Mikoteka in herbarij Gozdarskega inštituta Slovenije), specimen-based
-    "CORT", # State University of New York College at Cortland
-    "SYRF", # State University of New York, SUNY College of Environmental Science and Forestry Herbarium
-    "SWAT", # Swat University Fungarium
-    "S", # Swedish Museum of Natural History
-    "TALL", # Tallinn Botanic Garden
-    "IBUG", # Universidad de Guadalajara
-    "CMMF", # Université de Montréal, Cercle des Mycologues de Montréal Fungarium
-    "UACCC", # University of Alabama Chytrid Culture Collection
-    "ARIZ", # University of Arizona, Gilbertson Mycological Herbarium, specimen-based
-    "UARK", # University of Arkansas Fungarium
-    "UBC", # University of British Columbia Herbarium
-    "UC", # University of California Berkeley, University Herbarium
-    "UCSC", # University of California Santa Cruz Fungal Herbarium
-    "IRVC", # University of California, Irvine Fungarium
-    "LA", # University of California, Los Angeles
-    "FTU", # University of Central Florida
-    "CSU", # University of Central Oklahoma Herbarium
-    "CINC", # University of Cincinnati, Margaret H. Fulford Herbarium - Fungi
-    "C", # University of Copenhagen
-    "FLAS", # University of Florida Herbarium
-    "GAM", # University of Georgia, Julian H. Miller Mycological Herbarium
-    "GB", # University of Gothenburg
-    "HAW-F", # University of Hawaii, Joseph F. Rock Herbarium
-    "ILL", # University of Illinois Herbarium
-    "ILLS", # University of Illinois, Illinois Natural History Survey Fungarium
-    "KANU-KU-F", # University of Kansas, R. L. McGregor Herbarium
-    "MAINE", # University of Maine, Richard Homola Mycological Herbarium
-    "WIN", # University of Manitoba
-    "MICH", # University of Michigan Herbarium
-    "MIN", # University of Minnesota, Bell Museum of Natural History Herbarium Fungal Collection
-    "MISS", # University of Mississippi
-    "MONTU", # University of Montana Herbarium
-    "NEB", # University of Nebraska State Museum, C.E. Bessey Herbarium - Fungi
-    "UNM-Fungi", # University of New Mexico Herbarium Mycological Collection
-    "UNCA-UNCA", # University of North Carolina Asheville
-    "NCU-Fungi", # University of North Carolina at Chapel Hill Herbarium: Fungi
-    "O", # University of Oslo, Natural History Museum Fungarium
-    "URV", # University of Richmond
-    "USAM", # University of South Alabama Herbarium
-    "USCH-Fungi", # University of South Carolina, A. C. Moore Herbarium Fungal Collection
-    "USF", # University of South Florida Herbarium - Fungi including lichens
-    "TU", # University of Tartu Natural History Museum
-    "TENN-F", # University of Tennessee Fungal Herbarium
-    "UCHT-F", # University of Tennessee, Chattanooga
-    "TEX", # University of Texas Herbarium
-    "VT", # University of Vermont, Pringle Herbarium, Macrofungi
-    "WTU", # University of Washington Herbarium
-    "UWAL", # University of West Alabama Fungarium
-    "WIS", # University of Wisconsin-Madison Herbarium
-    "UWSP", # University of Wisconsin-Stevens Point Herbarium
-    "RMS", # University of Wyoming, Wilhelm G. Solheim Mycological Herbarium
-    "UPS-BOT", # Uppsala University, Museum of Evolution
-    "USAC-USCG Hongos", # Usac, Cecon, Herbario USCG Hongos
-    "CFMR", # USDA Forest Service, Center for Forest Mycology Research
-    "FPF", # USDA Forest Service, Rocky Mountain Research Station
-    "BPI", # USDA United States National Fungus Collections
-    "VSC", # Valdosta State University Herbarium
-    "VPI", # Virginia Tech University, Massey Herbarium - Fungi
-    "YSU-F" # Yugra State University Fungarium, specimen-based
-  ].freeze
+  MCP_COLLECTIONS = {
+    "PH" => nil, # Academy of Natural Sciences of Drexel University
+    "ACAD" => nil, # Acadia University, E. C. Smith Herbarium
+    "CHSC" => nil, # Ahart Herbarium, CSU Chico - Mycological Collection
+    "N/A" => nil, # Atlas of Living Australia specimen-based fungal data
+    "BMSC" => nil, # Bamfield Marine Science Centre
+    "BISH" => nil, # Bishop Museum, Herbarium Pacificum
+    "BRIT" => nil, # Botanical Research Institute of Texas
+    "BDWR" => nil, # Bridgewater College Herbarium
+    "BRU" => nil, # Brown University Herbarium
+    "HSC-F" => nil, # Cal Poly Humboldt Fungarium
+    "CDA-Fungi" => nil, # California Department of Food and Agriculture - Fungi
+    "HAY" => nil, # California State University East Bay Fungarium
+    "AAFC-DAOM" => nil, # Canadian National Mycological Herbarium
+    "WSP" => nil, # Charles Gardner Shaw Mycological Herbarium, Washington State University
+    "CHRB" => nil, # Chrysler Herbarium - Mycological Collection
+    "CLEMS" => nil, # Clemson University Herbarium
+    "HCOA" => nil, # College of the Atlantic, Acadia National Park Herbarium
+    "CUP" => nil, # Cornell University Plant Pathology Herbarium
+    "CBBG" => nil, # Crested Butte Botanic Gardens
+    "DEWV" => nil, # Davis & Elkins College Herbarium
+    "DBG-DBG" => nil, # Denver Botanic Gardens, Sam Mitchel Herbarium of Fungi
+    "DUKE" => nil, # Duke University Herbarium Fungal Collection
+    "EIU" => nil, # Eastern Illinois University
+    "EWU" => nil, # Eastern Washington University
+    "QCAM" => nil, # Ecuador Fungi data from FungiWebEcuador
+    "TAM" => nil, # Estonian Museum of Natural History
+    "BAFC-H" => nil, # Facultad de Ciencias Exactas y Naturales
+    "F" => nil, # Field Museum of Natural History
+    "FNL" => nil, # Foray Newfoundland and Labrador Fungarium
+    "FLD" => nil, # Fort Lewis College Herbarium
+    "GLM" => nil, # Fungal Collection at the Senckenberg Museum für Naturkunde Görlitz
+    "M" => nil, # Fungal Collections at the Botanische Staatssammlung München
+    "KR" => nil, # Fungus Collections at Staatliches Museum für Naturkunde Karlsruhe
+    "FH" => nil, # Harvard University, Farlow Herbarium
+    "FR" => nil, # Herbarium Senckenbergianum
+    "IND" => nil, # Indiana University
+    "TAAM" => nil, # Institute of Agricultural and Environmental Sciences of the Estonian University of Life Sciences (TAAM)
+    "EAA" => nil, # Estonian University of Life Sciences (EAA)
+    "INEP-F" => nil, # Institute of the Industrial Ecology Problems of the North of Kola Science Center of the Russian Academy of Sciences.
+    "PACA" => nil, # Instituto Anchietano de Pesquisas/UNISINOS
+    "USU-UTC" => nil, # Intermountain Herbarium (fungi, not lichens), Utah State University
+    "ICMP" => nil, # International Collection of Microorganisms from Plants
+    "ISC" => nil, # Iowa State University, Ada Hayden Herbarium
+    "SUCO" => nil, # Jewell and Arline Moss Settle Herbarium at SUNY Oneonta
+    "LSUM-Fungi" => nil, # Louisiana State University, Bernard Lowy Mycological Herbarium
+    "MUHW" => nil, # Marshall University Herbarium - Fungi
+    "BR" => nil, # Meise Botanic Garden Herbarium
+    "MU" => nil, # Miami University, Willard Sherman Turrell Herbarium
+    "MSC" => nil, # Michigan State University Herbarium non-lichenized fungi
+    "MOR" => nil, # Morton Arboretum
+    "CORD" => nil, # Museo Botánico Córdoba Fungarium
+    "CR" => nil, # Museo Nacional de Costa Rica, specimen-based
+    "PC" => nil, # Muséum National d'Histoire Naturelle
+    "MNA" => nil, # Museum of Northern Arizona
+    "IBUNAM-MEXU:FU" => nil, # National Herbarium of Mexico Fungal Collection (Hongos del Herbario Nacional de México)
+    "TNS-F" => nil, # National Museum of Nature and Science - Japan
+    "NMC-FUNGI" => nil, # National Mushroom Centre
+    "UT-M" => nil, # Natural History Museum of Utah Fungarium
+    "L" => nil, # Naturalis Biodiversity Center
+    "NBM" => nil, # New Brunswick Museum
+    "NY" => nil, # New York Botanical Garden
+    "NYS" => nil, # New York State Museum Mycology Collection
+    "PDD" => nil, # New Zealand Fungarium
+    "NCSLG" => nil, # North Carolina State University, Larry F. Grand Mycological Herbarium
+    "OSC" => nil, # Oregon State University Herbarium
+    "OSC-Lichens" => nil, # Oregon State University Herbarium - Lichens
+    "USFWS-PRR" => nil, # Patuxent Research Refuge - Maryland
+    "PUR" => nil, # Purdue University, Arthur Fungarium
+    "PUL" => nil, # Purdue University, Kriebel Herbarium
+    "QFB" => nil, # René Pomerleau Herbarium
+    "E" => nil, # Royal Botanic Garden Edinburgh
+    "TRTC" => nil, # Royal Ontario Museum Fungarium
+    "TAES" => nil, # S.M. Tracy Herbarium Texas A&M University
+    "SFSU" => nil, # San Francisco State University, Harry D. Thiers Herbarium
+    "SBBG" => nil, # Santa Barbara Botanic Garden
+    "LJF" => nil, # Slovenian Fungal Database (Mikoteka in herbarij Gozdarskega inštituta Slovenije), specimen-based
+    "CORT" => nil, # State University of New York College at Cortland
+    "SYRF" => nil, # State University of New York, SUNY College of Environmental Science and Forestry Herbarium
+    "SWAT" => nil, # Swat University Fungarium
+    "S" => nil, # Swedish Museum of Natural History
+    "TALL" => nil, # Tallinn Botanic Garden
+    "IBUG" => nil, # Universidad de Guadalajara
+    "CMMF" => nil, # Université de Montréal, Cercle des Mycologues de Montréal Fungarium
+    "UACCC" => nil, # University of Alabama Chytrid Culture Collection
+    "ARIZ" => nil, # University of Arizona, Gilbertson Mycological Herbarium, specimen-based
+    "UARK" => nil, # University of Arkansas Fungarium
+    "UBC" => nil, # University of British Columbia Herbarium
+    "UC" => nil, # University of California Berkeley, University Herbarium
+    "UCSC" => nil, # University of California Santa Cruz Fungal Herbarium
+    "IRVC" => nil, # University of California, Irvine Fungarium
+    "LA" => nil, # University of California, Los Angeles
+    "FTU" => nil, # University of Central Florida
+    "CSU" => nil, # University of Central Oklahoma Herbarium
+    "CINC" => nil, # University of Cincinnati, Margaret H. Fulford Herbarium - Fungi
+    "C" => nil, # University of Copenhagen
+    "FLAS" => nil, # University of Florida Herbarium
+    "GAM" => nil, # University of Georgia, Julian H. Miller Mycological Herbarium
+    "GB" => nil, # University of Gothenburg
+    "HAW-F" => nil, # University of Hawaii, Joseph F. Rock Herbarium
+    "ILL" => nil, # University of Illinois Herbarium
+    "ILLS" => nil, # University of Illinois, Illinois Natural History Survey Fungarium
+    "KANU-KU-F" => nil, # University of Kansas, R. L. McGregor Herbarium
+    "MAINE" => nil, # University of Maine, Richard Homola Mycological Herbarium
+    "WIN" => nil, # University of Manitoba
+    "MICH" => nil, # University of Michigan Herbarium
+    "MIN" => nil, # University of Minnesota, Bell Museum of Natural History Herbarium Fungal Collection
+    "MISS" => nil, # University of Mississippi
+    "MONTU" => nil, # University of Montana Herbarium
+    "NEB" => nil, # University of Nebraska State Museum, C.E. Bessey Herbarium - Fungi
+    "UNM-Fungi" => nil, # University of New Mexico Herbarium Mycological Collection
+    "UNCA-UNCA" => nil, # University of North Carolina Asheville
+    "NCU-Fungi" => nil, # University of North Carolina at Chapel Hill Herbarium: Fungi
+    "O" => nil, # University of Oslo, Natural History Museum Fungarium
+    "URV" => nil, # University of Richmond
+    "USAM" => nil, # University of South Alabama Herbarium
+    "USCH-Fungi" => nil, # University of South Carolina, A. C. Moore Herbarium Fungal Collection
+    "USF" => nil, # University of South Florida Herbarium - Fungi including lichens
+    "TU" => nil, # University of Tartu Natural History Museum
+    "TENN-F" => nil, # University of Tennessee Fungal Herbarium
+    "UCHT-F" => nil, # University of Tennessee, Chattanooga
+    "TEX" => nil, # University of Texas Herbarium
+    "VT" => nil, # University of Vermont, Pringle Herbarium, Macrofungi
+    "WTU" => nil, # University of Washington Herbarium
+    "UWAL" => nil, # University of West Alabama Fungarium
+    "WIS" => nil, # University of Wisconsin-Madison Herbarium
+    "UWSP" => nil, # University of Wisconsin-Stevens Point Herbarium
+    "RMS" => nil, # University of Wyoming, Wilhelm G. Solheim Mycological Herbarium
+    "UPS-BOT" => nil, # Uppsala University, Museum of Evolution
+    "USAC-USCG Hongos" => nil, # Usac, Cecon, Herbario USCG Hongos
+    "CFMR" => nil, # USDA Forest Service, Center for Forest Mycology Research
+    "FPF" => nil, # USDA Forest Service, Rocky Mountain Research Station
+    "BPI" => nil, # USDA United States National Fungus Collections
+    "VSC" => nil, # Valdosta State University Herbarium
+    "VPI" => nil, # Virginia Tech University, Massey Herbarium - Fungi
+    "YSU-F" => nil # Yugra State University Fungarium, specimen-based
+  }.freeze
   # rubocop:enable Layout/LineLength
 
   def can_edit?(user = User.current)
@@ -310,6 +311,21 @@ class Herbarium < AbstractModel
   end
 
   def mcp_searchable?
-    MCP_COLLECTIONS.include?(code)
+    MCP_COLLECTIONS.key?(code)
+  end
+
+  def mcp_url(accession)
+    base_url = "https://www.mycoportal.org/portal/collections/list.php?"
+    search_params =
+      { catnum: strip_leading_code(accession), db: MCP_COLLECTIONS[code],
+        includeothercatnum: 1 }
+
+    "#{base_url}?#{search_params.to_query}"
+  end
+
+  private
+
+  def strip_leading_code(accession)
+    accession.gsub(/"^#{code} "/, "")
   end
 end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -315,7 +315,7 @@ class Herbarium < AbstractModel
   end
 
   def mcp_url(accession)
-    base_url = "https://www.mycoportal.org/portal/collections/list.php?"
+    base_url = "https://www.mycoportal.org/portal/collections/list.php"
     search_params =
       { catnum: strip_leading_code(accession), db: MCP_COLLECTIONS[code],
         includeothercatnum: 1 }

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -55,6 +55,148 @@ class Herbarium < AbstractModel
   # Used by create/edit form.
   attr_accessor :place_name, :personal, :personal_user_name
 
+  # Herbaria whose collections are searchable via MyCoPortal.
+  # https://www.mycoportal.org/portal/collections/index.php
+  # rubocop:disable Layout/LineLength
+  MCP_COLLECTIONS = [
+    "PH", # Academy of Natural Sciences of Drexel University
+    "ACAD", # Acadia University, E. C. Smith Herbarium
+    "CHSC", # Ahart Herbarium, CSU Chico - Mycological Collection
+    "N/A", # Atlas of Living Australia specimen-based fungal data
+    "BMSC", # Bamfield Marine Science Centre
+    "BISH", # Bishop Museum, Herbarium Pacificum
+    "BRIT", # Botanical Research Institute of Texas
+    "BDWR", # Bridgewater College Herbarium
+    "BRU", # Brown University Herbarium
+    "HSC-F", # Cal Poly Humboldt Fungarium
+    "CDA-Fungi", # California Department of Food and Agriculture - Fungi
+    "HAY", # California State University East Bay Fungarium
+    "AAFC-DAOM", # Canadian National Mycological Herbarium
+    "WSP", # Charles Gardner Shaw Mycological Herbarium, Washington State University
+    "CHRB", # Chrysler Herbarium - Mycological Collection
+    "CLEMS", # Clemson University Herbarium
+    "HCOA", # College of the Atlantic, Acadia National Park Herbarium
+    "CUP", # Cornell University Plant Pathology Herbarium
+    "CBBG", # Crested Butte Botanic Gardens
+    "DEWV", # Davis & Elkins College Herbarium
+    "DBG-DBG", # Denver Botanic Gardens, Sam Mitchel Herbarium of Fungi
+    "DUKE", # Duke University Herbarium Fungal Collection
+    "EIU", # Eastern Illinois University
+    "EWU", # Eastern Washington University
+    "QCAM", # Ecuador Fungi data from FungiWebEcuador
+    "TAM", # Estonian Museum of Natural History
+    "BAFC-H", # Facultad de Ciencias Exactas y Naturales
+    "F", # Field Museum of Natural History
+    "FNL", # Foray Newfoundland and Labrador Fungarium
+    "FLD", # Fort Lewis College Herbarium
+    "GLM", # Fungal Collection at the Senckenberg Museum für Naturkunde Görlitz
+    "M", # Fungal Collections at the Botanische Staatssammlung München
+    "KR", # Fungus Collections at Staatliches Museum für Naturkunde Karlsruhe
+    "FH", # Harvard University, Farlow Herbarium
+    "FR", # Herbarium Senckenbergianum
+    "IND", # Indiana University
+    "TAAM", # Institute of Agricultural and Environmental Sciences of the Estonian University of Life Sciences (TAAM)
+    "EAA", # Estonian University of Life Sciences (EAA)
+    "INEP-F", # Institute of the Industrial Ecology Problems of the North of Kola Science Center of the Russian Academy of Sciences.
+    "PACA", # Instituto Anchietano de Pesquisas/UNISINOS
+    "USU-UTC", # Intermountain Herbarium (fungi, not lichens), Utah State University
+    "ICMP", # International Collection of Microorganisms from Plants
+    "ISC", # Iowa State University, Ada Hayden Herbarium
+    "SUCO", # Jewell and Arline Moss Settle Herbarium at SUNY Oneonta
+    "LSUM-Fungi", # Louisiana State University, Bernard Lowy Mycological Herbarium
+    "MUHW", # Marshall University Herbarium - Fungi
+    "BR", # Meise Botanic Garden Herbarium
+    "MU", # Miami University, Willard Sherman Turrell Herbarium
+    "MSC", # Michigan State University Herbarium non-lichenized fungi
+    "MOR", # Morton Arboretum
+    "CORD", # Museo Botánico Córdoba Fungarium
+    "CR", # Museo Nacional de Costa Rica, specimen-based
+    "PC", # Muséum National d'Histoire Naturelle
+    "MNA", # Museum of Northern Arizona
+    "IBUNAM-MEXU:FU", # National Herbarium of Mexico Fungal Collection (Hongos del Herbario Nacional de México)
+    "TNS-F", # National Museum of Nature and Science - Japan
+    "NMC-FUNGI", # National Mushroom Centre
+    "UT-M", # Natural History Museum of Utah Fungarium
+    "L", # Naturalis Biodiversity Center
+    "NBM", # New Brunswick Museum
+    "NY", # New York Botanical Garden
+    "NYS", # New York State Museum Mycology Collection
+    "PDD", # New Zealand Fungarium
+    "NCSLG", # North Carolina State University, Larry F. Grand Mycological Herbarium
+    "OSC", # Oregon State University Herbarium
+    "OSC-Lichens", # Oregon State University Herbarium - Lichens
+    "USFWS-PRR", # Patuxent Research Refuge - Maryland
+    "PUR", # Purdue University, Arthur Fungarium
+    "PUL", # Purdue University, Kriebel Herbarium
+    "QFB", # René Pomerleau Herbarium
+    "E", # Royal Botanic Garden Edinburgh
+    "TRTC", # Royal Ontario Museum Fungarium
+    "TAES", # S.M. Tracy Herbarium Texas A&M University
+    "SFSU", # San Francisco State University, Harry D. Thiers Herbarium
+    "SBBG", # Santa Barbara Botanic Garden
+    "LJF", # Slovenian Fungal Database (Mikoteka in herbarij Gozdarskega inštituta Slovenije), specimen-based
+    "CORT", # State University of New York College at Cortland
+    "SYRF", # State University of New York, SUNY College of Environmental Science and Forestry Herbarium
+    "SWAT", # Swat University Fungarium
+    "S", # Swedish Museum of Natural History
+    "TALL", # Tallinn Botanic Garden
+    "IBUG", # Universidad de Guadalajara
+    "CMMF", # Université de Montréal, Cercle des Mycologues de Montréal Fungarium
+    "UACCC", # University of Alabama Chytrid Culture Collection
+    "ARIZ", # University of Arizona, Gilbertson Mycological Herbarium, specimen-based
+    "UARK", # University of Arkansas Fungarium
+    "UBC", # University of British Columbia Herbarium
+    "UC", # University of California Berkeley, University Herbarium
+    "UCSC", # University of California Santa Cruz Fungal Herbarium
+    "IRVC", # University of California, Irvine Fungarium
+    "LA", # University of California, Los Angeles
+    "FTU", # University of Central Florida
+    "CSU", # University of Central Oklahoma Herbarium
+    "CINC", # University of Cincinnati, Margaret H. Fulford Herbarium - Fungi
+    "C", # University of Copenhagen
+    "FLAS", # University of Florida Herbarium
+    "GAM", # University of Georgia, Julian H. Miller Mycological Herbarium
+    "GB", # University of Gothenburg
+    "HAW-F", # University of Hawaii, Joseph F. Rock Herbarium
+    "ILL", # University of Illinois Herbarium
+    "ILLS", # University of Illinois, Illinois Natural History Survey Fungarium
+    "KANU-KU-F", # University of Kansas, R. L. McGregor Herbarium
+    "MAINE", # University of Maine, Richard Homola Mycological Herbarium
+    "WIN", # University of Manitoba
+    "MICH", # University of Michigan Herbarium
+    "MIN", # University of Minnesota, Bell Museum of Natural History Herbarium Fungal Collection
+    "MISS", # University of Mississippi
+    "MONTU", # University of Montana Herbarium
+    "NEB", # University of Nebraska State Museum, C.E. Bessey Herbarium - Fungi
+    "UNM-Fungi", # University of New Mexico Herbarium Mycological Collection
+    "UNCA-UNCA", # University of North Carolina Asheville
+    "NCU-Fungi", # University of North Carolina at Chapel Hill Herbarium: Fungi
+    "O", # University of Oslo, Natural History Museum Fungarium
+    "URV", # University of Richmond
+    "USAM", # University of South Alabama Herbarium
+    "USCH-Fungi", # University of South Carolina, A. C. Moore Herbarium Fungal Collection
+    "USF", # University of South Florida Herbarium - Fungi including lichens
+    "TU", # University of Tartu Natural History Museum
+    "TENN-F", # University of Tennessee Fungal Herbarium
+    "UCHT-F", # University of Tennessee, Chattanooga
+    "TEX", # University of Texas Herbarium
+    "VT", # University of Vermont, Pringle Herbarium, Macrofungi
+    "WTU", # University of Washington Herbarium
+    "UWAL", # University of West Alabama Fungarium
+    "WIS", # University of Wisconsin-Madison Herbarium
+    "UWSP", # University of Wisconsin-Stevens Point Herbarium
+    "RMS", # University of Wyoming, Wilhelm G. Solheim Mycological Herbarium
+    "UPS-BOT", # Uppsala University, Museum of Evolution
+    "USAC-USCG Hongos", # Usac, Cecon, Herbario USCG Hongos
+    "CFMR", # USDA Forest Service, Center for Forest Mycology Research
+    "FPF", # USDA Forest Service, Rocky Mountain Research Station
+    "BPI", # USDA United States National Fungus Collections
+    "VSC", # Valdosta State University Herbarium
+    "VPI", # Virginia Tech University, Massey Herbarium - Fungi
+    "YSU-F" # Yugra State University Fungarium, specimen-based
+  ].freeze
+  # rubocop:enable Layout/LineLength
+
   def can_edit?(user = User.current)
     if personal_user_id
       personal_user_id == user.try(&:id)

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -36,6 +36,7 @@
 #  herbarium_label::  Initial determination + accession number.
 #  format_name::      Same as herbarium_label.
 #  accession_at_herbarium:: Format as "spec #nnnn @ Herbarium".
+#  mcp_url::          URL for corresponding MycoPortal record
 #
 #  == Callbacks
 #
@@ -70,6 +71,10 @@ class HerbariumRecord < AbstractModel
 
   def accession_at_herbarium
     "__#{accession_number}__ @ #{herbarium.try(&:format_name)}"
+  end
+
+  def mcp_url
+    herbarium.mcp_url(accession_number)
   end
 
   # Can a given user edit this HerbariumRecord?

--- a/app/views/controllers/herbaria/_form.erb
+++ b/app/views/controllers/herbaria/_form.erb
@@ -65,10 +65,18 @@ end
   <%= submit_button(form: f, button: button_name, center: true) %>
 
   <% if !@herbarium.personal_user_id %>
-    <%= text_field_with_label(form: f, field: :code, size: 8, inline: true,
-                              label: :create_herbarium_code.l + ":",
-                              help: :create_herbarium_code_help.t,
-                              between: :optional) %>
+    <%= text_field_with_label(
+      form: f, field: :code, size: 8, inline: true,
+      label: :create_herbarium_code.l + ":",
+      help: :create_herbarium_code_help.t,
+      between: "(#{:create_herbarium_code_recommended.l}) "
+    ) %>
+    <%= text_field_with_label(
+      form: f, field: :mycoportal_db, size: 8, inline: true,
+      label: "#{:create_herbarium_mcp_db.t}:",
+      between: "(#{:create_herbarium_mcp_db_recommended.l}) ",
+      help: :create_herbarium_mcp_db_help.t
+    ) %>
   <% end %>
 
   <!-- MAP -->

--- a/app/views/controllers/herbaria/show.html.erb
+++ b/app/views/controllers/herbaria/show.html.erb
@@ -8,6 +8,17 @@ map = @herbarium.location
 @container = :wide
 %>
 
+<% if @herbarium.mcp_searchable? %>
+  <div id="mcp_number" class="mt-3">
+    <span class="font-weight-bold"><%= :herbarium_mcp_db.t %></span>:
+    <% if @herbarium.mycoportal_db.present? %>
+      <%= @herbarium.mycoportal_db.to_s %>
+    <% else %>
+      <%= :show_herbarium_mcp_db_missing.t %>
+    <% end %>
+  </div>
+<% end %>
+
 <div class="row">
   <div class="col-xs-12 col-sm-<%= map ? 8 : 12 %>">
     <div class="mt-3">
@@ -76,7 +87,7 @@ map = @herbarium.location
   <% end %>
 </div><!--.row-->
 
-<div class="mt-3 text-center" style="max-width:<%= map ? 930 : 600 %>px">
+<div class="mt-3" style="max-width:<%= map ? 930 : 600 %>px">
   <%= :CREATED_AT.t %>: <%= @herbarium.created_at.web_date %><br/>
   <%= :UPDATED_AT.t %>: <%= @herbarium.updated_at.web_date %><br/>
-</div><!-- .text-center -->
+</div>

--- a/app/views/controllers/herbarium_records/show.html.erb
+++ b/app/views/controllers/herbarium_records/show.html.erb
@@ -15,7 +15,7 @@ herbarium = @herbarium_record.herbarium
     <%= :herbarium_record_accession_number.t %>: <%= @herbarium_record.accession_number %><br/>
     <%= :herbarium_record_user.t %>: <%= user_link(@herbarium_record.user) %><br/>
     <% if herbarium.mcp_searchable? %>
-      <%= link_to("#{herbarium.name} #{:herbarium_record_collection.t}",
+      <%= link_to("#{herbarium.code} #{:herbarium_record_collection.t}",
           herbarium.mcp_url(@herbarium_record.accession_number)) %><br/>
     <% end %>
   </p>

--- a/app/views/controllers/herbarium_records/show.html.erb
+++ b/app/views/controllers/herbarium_records/show.html.erb
@@ -16,7 +16,8 @@ herbarium = @herbarium_record.herbarium
     <%= :herbarium_record_user.t %>: <%= user_link(@herbarium_record.user) %><br/>
     <% if herbarium.mcp_searchable? %>
       <%= link_to("#{herbarium.code} #{:herbarium_record_collection.t}",
-          herbarium.mcp_url(@herbarium_record.accession_number)) %><br/>
+          herbarium.mcp_url(@herbarium_record.accession_number),
+          target: "_blank") %><br/>
     <% end %>
   </p>
 

--- a/app/views/controllers/herbarium_records/show.html.erb
+++ b/app/views/controllers/herbarium_records/show.html.erb
@@ -14,7 +14,7 @@ herbarium = @herbarium_record.herbarium
     <%= :herbarium_record_initial_det.t %>: <i><%= @herbarium_record.initial_det %></i><br/>
     <%= :herbarium_record_accession_number.t %>: <%= @herbarium_record.accession_number %><br/>
     <%= :herbarium_record_user.t %>: <%= user_link(@herbarium_record.user) %><br/>
-    <% if herbarium.mcp_searchable? %>
+    <% if herbarium.web_searchable? %>
       <%= link_to("#{herbarium.code} #{:herbarium_record_collection.t}",
           herbarium.mcp_url(@herbarium_record.accession_number),
           target: "_blank") %><br/>

--- a/app/views/controllers/herbarium_records/show.html.erb
+++ b/app/views/controllers/herbarium_records/show.html.erb
@@ -14,6 +14,10 @@ herbarium = @herbarium_record.herbarium
     <%= :herbarium_record_initial_det.t %>: <i><%= @herbarium_record.initial_det %></i><br/>
     <%= :herbarium_record_accession_number.t %>: <%= @herbarium_record.accession_number %><br/>
     <%= :herbarium_record_user.t %>: <%= user_link(@herbarium_record.user) %><br/>
+    <% if herbarium.mcp_searchable? %>
+      <%= link_to("#{herbarium.name} #{:herbarium_record_collection.t}",
+          herbarium.mcp_url(@herbarium_record.accession_number)) %><br/>
+    <% end %>
   </p>
 
   <% if !@herbarium_record.notes.blank? %>

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -46,7 +46,8 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
               end
               concat(tag.br)
               concat(
-                link_to(
+                link_to_if(
+                  record.herbarium.web_searchable?,
                   "#{record.herbarium.code} #{:herbarium_record_collection.t}",
                      record.herbarium.mcp_url(record.accession_number),
                      target: "_blank"
@@ -68,7 +69,8 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
               concat(link_to(*herbarium_record_tab(record, obs)))
               concat(tag.br)
               concat(
-                link_to(
+                link_to_if(
+                  record.herbarium.web_searchable?,
                   "#{record.herbarium.code} #{:herbarium_record_collection.t}",
                      record.herbarium.mcp_url(record.accession_number),
                      target: "_blank"

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -44,6 +44,14 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
                   ].safe_join(" ")
                 )
               end
+              concat(tag.br)
+              concat(
+                link_to(
+                  "#{record.herbarium.code} #{:herbarium_record_collection.t}",
+                     record.herbarium.mcp_url(record.accession_number),
+                     target: "_blank"
+                )
+              )
             end
           end.safe_join
         end
@@ -52,12 +60,21 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
     elsif records.any? && !can_add
       [
         tag.div do
-          records.length > 1 ? "#{:Herbarium_records.t}:" :
-                               "#{:Herbarium_record.t}:"
+          records.one? ? "#{:Herbarium_record.t}:" : "#{:Herbarium_record.t}:"
         end,
         tag.ul(class: "tight-list") do
           records.map do |record|
-            tag.li { link_to(*herbarium_record_tab(record, obs)) }
+            tag.li(id: "herbarium_record_#{record.id}") do
+              concat(link_to(*herbarium_record_tab(record, obs)))
+              concat(tag.br)
+              concat(
+                link_to(
+                  "#{record.herbarium.code} #{:herbarium_record_collection.t}",
+                     record.herbarium.mcp_url(record.accession_number),
+                     target: "_blank"
+                )
+              )
+            end
           end.safe_join
         end
       ].safe_join(" ")
@@ -74,4 +91,3 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
   end
 end
 %>
-

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2688,6 +2688,8 @@
   herbarium_record_user: Record Creator
   herbarium_record_notes: Fungarium Record Notes
 
+  herbarium_record_collection: Collection
+
   # herbarium_record/create_herbarium_record
   create_herbarium_record: Add Fungarium Record
   create_herbarium_record_title: Add Fungarium Record

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2634,7 +2634,7 @@
   herbarium_curators: Curators
   herbarium_mailing_address: Mailing Address
   herbarium_code: Code
-  herbarium_mcp_db: 'MyCoPortal Collection #'
+  herbarium_mcp_db: 'MyCoPortal Collection ID'
   user_personal_herbarium: "[name]: Personal Fungarium"
 
   # herbaria/show
@@ -2652,7 +2652,11 @@
   create_herbarium_personal: Check this box if this is your personal fungarium
   create_herbarium_personal_help: Each user can have one personal fungarium that they have curator privileges for. By default it is called "[name]", but you can change that name to anything you like.
   create_herbarium_code: Standard Abbreviation
+  create_herbarium_code_recommended: recommended for Index Herbariorum-listed Fungaria
   create_herbarium_code_help: Look up the standard abbreviation for a fungarium at "Index Herbariorum":https://sweetgum.nybg.org/science/ih/.
+  create_herbarium_mcp_db: "[:herbarium_mcp_db]"
+  create_herbarium_mcp_db_recommended: recommended for MyCoPortal-searchable Fungaria
+  create_herbarium_mcp_db_help: At "MyCoPortal":https://www.mycoportal.org/portal/collections/index.php click the 'more info' link next to your Fungarium. In the browser address bar for the resulting page, the integer to the right of 'collid=' is the Collection ID.
   create_herbarium_email: Email Address
   create_herbarium_mailing_address: Mailing Address
   create_herbarium_duplicate_name: Fungarium called '[name]' already exists.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2634,10 +2634,12 @@
   herbarium_curators: Curators
   herbarium_mailing_address: Mailing Address
   herbarium_code: Code
+  herbarium_mcp_db: 'MyCoPortal Collection #'
   user_personal_herbarium: "[name]: Personal Fungarium"
 
   # herbaria/show
   show_herbarium_herbarium_record_count: This fungarium contains [count] fungarium record(s).
+  show_herbarium_mcp_db_missing: Missing
   show_herbarium_add_curator: Add Curator
   show_herbarium_no_user: Unable to find the user '[login]'.
   show_herbarium_curator_request: Request to be a Curator

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2688,7 +2688,7 @@
   herbarium_record_user: Record Creator
   herbarium_record_notes: Fungarium Record Notes
 
-  herbarium_record_collection: Collection
+  herbarium_record_collection: Collection Record
 
   # herbarium_record/create_herbarium_record
   create_herbarium_record: Add Fungarium Record

--- a/db/migrate/20241130174126_add_mycoportal_db_to_herbaria.rb
+++ b/db/migrate/20241130174126_add_mycoportal_db_to_herbaria.rb
@@ -1,0 +1,5 @@
+class AddMycoportalDbToHerbaria < ActiveRecord::Migration[7.1]
+  def change
+    add_column :herbaria, :mycoportal_db, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_17_211300) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_30_174126) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -144,6 +144,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_17_211300) do
     t.datetime "updated_at", precision: nil
     t.string "code", limit: 8, default: "", null: false
     t.integer "personal_user_id"
+    t.integer "mycoportal_db"
   end
 
   create_table "herbarium_curators", charset: "utf8mb3", force: :cascade do |t|

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -61,6 +61,43 @@ class HerbariaControllerTest < FunctionalTestCase
     )
   end
 
+  def test_show_mcp_db
+    herbarium = nybg
+    assert(herbarium.mycoportal_db.present?,
+           "Test needs herbarium with mycoportal_db")
+
+    login("mary")
+    get(:show, params: { id: herbarium.id })
+
+    assert_select(
+      "#mcp_number",
+      { text: /#{:herbarium_mcp_db.l}:\s+#{herbarium.mycoportal_db}/ }
+    )
+  end
+
+  def test_show_mcp_db_missing
+    herbarium = field_museum
+    assert(herbarium.mycoportal_db.nil?,
+           "Test needs mcp searchable herbarium whose mycoportal_db is nil")
+
+    login("mary")
+    get(:show, params: { id: herbarium.id })
+
+    assert_select(
+      "#mcp_number",
+      { text: /#{:herbarium_mcp_db.l}:\s+#{:show_herbarium_mcp_db_missing.l}/ }
+    )
+  end
+
+  def test_show_no_mcp_db
+    herbarium = dicks_personal
+
+    login("mary")
+    get(:show, params: { id: herbarium.id })
+
+    assert_select("#mcp_number", false)
+  end
+
   def test_show_destroy_buttons_presence
     herbarium = nybg
     assert(herbarium.curator?(roy))

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -134,7 +134,9 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     herbarium_record = herbarium_records(:coprinus_comatus_nybg_spec)
     assert(herbarium_record)
     login
+
     get(:show, params: { id: herbarium_record.id })
+
     assert_template(:show)
     assert_template("shared/_matrix_box")
   end
@@ -146,6 +148,21 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     get(:show, params: { id: herbarium_record.id })
     assert_template(:show)
     assert_template("shared/_matrix_box")
+  end
+
+  def test_show_herbarium_record_mcp_searchable
+    herbarium_record = herbarium_records(:agaricus_campestris_spec)
+    assert(
+      herbarium_record&.herbarium&.mcp_searchable?,
+      "Test needs HerbariumRecord fixture that's searchable via MyCoPortal"
+    )
+
+    login
+    get(:show, params: { id: herbarium_record.id })
+
+    herbarium_collection_url = herbarium_record.mcp_url
+    assert_select("a[href=?]", herbarium_collection_url,
+                  "Missing link to herbarium collection via MyCoPortal")
   end
 
   def test_next_and_prev_herbarium_record

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -150,7 +150,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_template("shared/_matrix_box")
   end
 
-  def test_show_herbarium_record_mcp_searchable
+  def test_show_herbarium_record_with_mcp_link
     herbarium_record = herbarium_records(:agaricus_campestris_spec)
     assert(
       herbarium_record&.herbarium&.mcp_searchable?,
@@ -160,9 +160,8 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: herbarium_record.id })
 
-    herbarium_collection_url = herbarium_record.mcp_url
-    assert_select("a[href=?]", herbarium_collection_url,
-                  "Missing link to herbarium collection via MyCoPortal")
+    assert_select("a[href=?]", herbarium_record.mcp_url, true,
+                  "Missing link to MyCoPortal record")
   end
 
   def test_next_and_prev_herbarium_record

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -150,12 +150,30 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_template("shared/_matrix_box")
   end
 
-  def test_show_herbarium_record_with_mcp_link
+  def test_show_herbarium_record_mcp_searchable
     herbarium_record = herbarium_records(:agaricus_campestris_spec)
     assert(
       herbarium_record&.herbarium&.mcp_searchable?,
       "Test needs HerbariumRecord fixture that's searchable via MyCoPortal"
     )
+
+    login
+    get(:show, params: { id: herbarium_record.id })
+
+    assert_select("a[href=?]", herbarium_record.mcp_url, true,
+                  "Missing link to MyCoPortal record")
+  end
+
+  def test_show_herbarium_record_mcp_only_db
+    herbarium_record = herbarium_records(:agaricus_campestris_spec)
+    herbarium = herbarium_record.herbarium
+    assert(
+      herbarium&.mycoportal_db.present?,
+      "Test needs HerbariumRecord in a Herbarium with a MyCoPortal db"
+    )
+    # Make the Herbarium code something that's not in the MyCoPortal network
+    herbarium.update(code: "notInMcp")
+    assert_not(herbarium.mcp_searchable?)
 
     login
     get(:show, params: { id: herbarium_record.id })

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -177,6 +177,27 @@ class ObservationsControllerShowTest < FunctionalTestCase
                   "Missing link to MyCoPortal record")
   end
 
+  def test_show_observation_unsearchable_coded_herbarium
+    obs = observations(:agaricus_campestris_obs)
+    herbarium_record = herbarium_records(:agaricus_campestris_spec)
+    herbarium = herbarium_record&.herbarium
+    herbarium.update(code: "notInMcp", mycoportal_db: nil)
+
+    user = users(:dick)
+    assert(user.curated_herbaria.any?,
+           "Test needs User who's a Herbarium curator")
+
+    login(user.login)
+    get(:show, params: { id: obs.id })
+
+    assert_match(:herbarium_record_collection.l, @response.body)
+    assert_select(
+      "a[href=?]", herbarium_record.mcp_url, false,
+      "Obs shouldn't link to MyCoPortal for Herbarium Record in a Herbarium " \
+      "that's not in the MCP network"
+    )
+  end
+
   ##############################################################################
 
   # ------ Show ----------------------------------------------- #

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -36,7 +36,7 @@ field_museum:
   name: The Field Museum
   mailing_address: 1400 S. Lake Shore Drive, Chicago, IL, 60605-2496, USA
   code: F
-  mycoportal_db: 11
+  mycoportal_db: nil # missing for test purposes
   curators: rolf, thorsten
 
 curatorless_herbarium:

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -15,6 +15,7 @@ nybg_herbarium:
   email: nybg@collectivesource.com
   description: An awesome & world famous herbarium.
   code: NY
+  mycoportal_db: 3
   curators: rolf, roy
 
 rolf_herbarium:
@@ -35,6 +36,7 @@ field_museum:
   name: The Field Museum
   mailing_address: 1400 S. Lake Shore Drive, Chicago, IL, 60605-2496, USA
   code: F
+  mycoportal_db: 11
   curators: rolf, thorsten
 
 curatorless_herbarium:

--- a/test/models/herbarium_test.rb
+++ b/test/models/herbarium_test.rb
@@ -62,4 +62,9 @@ class HerbariumTest < UnitTestCase
     assert_equal(curators.map(&:id).sort, curator_ids.sort)
     assert_obj_arrays_equal(herbarium_records, result.herbarium_records)
   end
+
+  def test_mcp_searchable
+    assert(herbaria(:nybg_herbarium).mcp_searchable?)
+    assert_not(herbaria(:rolf_herbarium).mcp_searchable?)
+  end
 end

--- a/test/models/herbarium_test.rb
+++ b/test/models/herbarium_test.rb
@@ -63,6 +63,16 @@ class HerbariumTest < UnitTestCase
     assert_obj_arrays_equal(herbarium_records, result.herbarium_records)
   end
 
+  def test_web_searchable?
+    nybg = herbaria(:nybg_herbarium)
+    assert(nybg.web_searchable?)
+
+    nybg.update(code: "notInMCP")
+    assert(nybg.web_searchable?)
+
+    assert_not(herbaria(:rolf_herbarium).web_searchable?)
+  end
+
   def test_mcp_searchable
     assert(herbaria(:nybg_herbarium).mcp_searchable?)
     assert_not(herbaria(:rolf_herbarium).mcp_searchable?)


### PR DESCRIPTION
Links to the fungarium's collection record on MyCoPortal.
- Delivers #2471, which is inspired by a requested from MO User pinonbistro;
- Adds a `mycoportal_db` integer column to the Herbarium table;
- Allows populating that column via the Herbarium form; 
- For MO Fungarium Records, for MO Fungaria with `mycoportal_db`, links to the fungarium's collection record (in MCP), **based on the Accession Number**:
  - on the MO Fungarium Record page; and
  - on the MO Observation page.

### Suggested Manual Test
- Enter Admin Mode;
- Edit an MO institutional Herbarium by filling in the `MyCoPortal Collection ID`;
Important:
  - I suggest the [Robert L. Gilbertson Mycological Herbarium](http://localhost:3000/herbaria/407) or [University of Tennessee ](http://localhost:3000/herbaria/66/edit) because many of their MO Herbarium Records have an accurate Accession Number.
  - To find the Collection ID, click the help icon (a question mark) to the right of `MyCoPortal Collection ID`
- Exit Admin Mode;
- Click "This fungarium contains _nnnn_  fungarium record(s).";
- Click on an Accession Number;
- Click the link which takes the form "_herbarium abbrev_ Collection Record".
Expected result:  Opens a new tab with the MyCoPortal collection record corresponding to that Accession Number.
(in many cases the result is "Your query did not return any results." because the MO Accession Number is inaccurate.)

### Notes
After deployment
- I plan to immediately fill in `MyCoPortal Collection ID` for some MO Fungaria;
- I plan to add a Article soon after deployment.
- I may directly contact some users who have many MO Fungarium Records to get feedback.



 