### PR TITLE
Herbarium Record link in email

### DIFF
--- a/app/views/mailers/add_herbarium_record_mailer/build.html.erb
+++ b/app/views/mailers/add_herbarium_record_mailer/build.html.erb
@@ -8,12 +8,15 @@
 
   handy_links = :email_handy_links.l
 
-  links = [[:email_links_show_object.t(type: :herbarium_record),
-    "#{MO.http_domain}/herbarium_record/show_herbarium_record/#{@herbarium_record.id}"],
+  host = MO.http_domain
+  links = [
+    [:email_links_show_object.t(type: :herbarium_record),
+     herbarium_record_url(host: host, id: @herbarium_record.id)],
 		[:email_links_show_object.t(type: :herbarium),
-			"#{MO.http_domain}/herbaria/#{herbarium.id}"],
+      herbarium_url(host: MO.http_domain, id: herbarium.id)],
 		[:email_links_show_user.t(user: @user.login),
-		  "#{MO.http_domain}/users/#{@sender.id}"]]
+		  user_url(host: MO.http_domain, id: @sender.id)]
+  ]
 
 if @user.email_html %>
 <html>

--- a/test/application_mailer/add_herbarium_record_not_curator.html
+++ b/test/application_mailer/add_herbarium_record_not_curator.html
@@ -11,7 +11,7 @@ Subject: [MO] Fungarium Record Added to The New York Botanical Garden
 <p>The user, rolf, added the fungarium record, Cortinarius sp.: 1234, to the fungarium, The New York Botanical Garden, which you curate.</p></div>
 <div class="textile"><p>Here are some handy links:</p></div>
 <ul type=none>
-<li>Show this fungarium record: <a href="https://mushroomobserver.org/herbarium_record/show_herbarium_record/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %>">https://mushroomobserver.org/herbarium_record/show_herbarium_record/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %></a></li>
+<li>Show this fungarium record: <a href="https://mushroomobserver.org/herbarium_records/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %>">https://mushroomobserver.org/herbarium_records/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %></a></li>
 <li>Show this fungarium: <a href="https://mushroomobserver.org/herbaria/<%= ActiveRecord::FixtureSet.identify(:nybg_herbarium) %>">https://mushroomobserver.org/herbaria/<%= ActiveRecord::FixtureSet.identify(:nybg_herbarium) %></a></li>
 <li>Show user&#8217;s profile: <a href="https://mushroomobserver.org/users/<%= ActiveRecord::FixtureSet.identify(:mary) %>">https://mushroomobserver.org/users/<%= ActiveRecord::FixtureSet.identify(:mary) %></a></li>
 </ul>

--- a/test/application_mailer/add_herbarium_record_not_curator.text
+++ b/test/application_mailer/add_herbarium_record_not_curator.text
@@ -9,6 +9,6 @@ The user, rolf, added the fungarium record, Cortinarius sp.: 1234, to the fungar
 
 Here are some handy links:
 
-Show this fungarium record: https://mushroomobserver.org/herbarium_record/show_herbarium_record/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %>
+Show this fungarium record: https://mushroomobserver.org/herbarium_records/<%= ActiveRecord::FixtureSet.identify(:interesting_unknown) %>
 Show this fungarium: https://mushroomobserver.org/herbaria/<%= ActiveRecord::FixtureSet.identify(:nybg_herbarium) %>
 Show user's profile: https://mushroomobserver.org/users/<%= ActiveRecord::FixtureSet.identify(:mary) %>


### PR DESCRIPTION
Fixes url of link to herbarium record in email
- Uses route helper instead of (old, incorrect) hard coded url
- Ditto for other links in add_herbarium_record_mailer
- Update fixtures to use correct (hard-coded) url
- Delivers #2565
