### PR TITLE
Remove special treatment for Adolf's Obs pages

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -436,11 +436,6 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     "#<User #{id}: #{unique_text_name.inspect}>"
   end
 
-  # For now just special exception to keep Adolf from wasting my life.
-  def hide_specimen_stuff?
-    id == 2873
-  end
-
   ##############################################################################
   #
   #  :section: Names

--- a/app/views/controllers/observations/show/_collection_numbers.erb
+++ b/app/views/controllers/observations/show/_collection_numbers.erb
@@ -4,8 +4,6 @@ can_edit = in_admin_mode? || obs.can_edit?
 %>
 
 <%=
-unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
-
   tag.div(
     id: "observation_collection_numbers",
     class: "obs-collection",
@@ -63,5 +61,4 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
       ].safe_join
     end
   end
-end
 %>

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -5,8 +5,6 @@ can_add = in_admin_mode? || obs.can_edit? ||
 %>
 
 <%=
-unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
-
   tag.div(
     id: "observation_herbarium_records",
     class: "obs-herbarium",
@@ -91,5 +89,4 @@ unless @user.try(&:hide_specimen_stuff?) || obs.user.try(&:hide_specimen_stuff?)
       ].safe_join
     end
   end
-end
 %>

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -3,8 +3,6 @@ sequences = obs.sequences
 can_edit  = in_admin_mode? || obs.can_edit?
 %>
 
-<% unless @user.try(&:hide_specimen_stuff?) ||
-          obs.user.try(&:hide_specimen_stuff?) %>
   <%=
   tag.div(
     class: "obs-sequence", id: "observation_sequences",
@@ -51,4 +49,3 @@ can_edit  = in_admin_mode? || obs.can_edit?
     end) if sequences.any?
 
   end %>
-<% end %>


### PR DESCRIPTION
- Shows -- the same as all other users's Observations -- specimens, fungarium records, collection numbers.
- Makes it possible to automatically link to the UBC herbarium collection records on MyCoPortal.
- Simplifies code.
- Delivers #2310.