### PR TITLE
iNat photos original_name

### DIFF
--- a/app/classes/inat/obs_photo.rb
+++ b/app/classes/inat/obs_photo.rb
@@ -54,9 +54,12 @@ class Inat
       "Imported from iNat #{DateTime.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")}"
     end
 
-    # iNat doesn't preserve (or maybe reveal) user's original filename
-    # so map it to an iNat uuid
-    def original_name = "iNat photo uuid #{@photo[:uuid]}"
+    # iNat doesn't preserve user's original filename
+    # Preserve photo_id and uuid for purposed of syncing updates
+    def original_name
+      "iNat photo_id: #{@photo[:photo_id]}, uuid: #{@photo[:uuid]}"
+    end
+
     def url = @photo[:photo][:url].sub("/square.", "/original.")
   end
 end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -261,14 +261,12 @@ class InatImportJob < ApplicationJob
       image = Image.find(api.results.first.id)
 
       # Imaage attributes to potentially update manually
-      # t.boolean "ok_for_export", default: true, null: false
       # t.boolean "gps_stripped", default: false, null: false
-      # t.boolean "diagnostic", default: true, null: false
       image.update(
-        user_id: @user.id, # throws Error if done as API param above
-        # NOTE: 2024-09-09 get when from image EXIF instead of @observation.when
-        # https://github.com/MushroomObserver/mushroom-observer/issues/2379
-        when: @observation.when # throws Error if done as API param above
+        # These throw errors if done as API params above
+        user_id: @user.id,
+        when: @observation.when,
+        original_name: photo.original_name
       )
       @observation.add_image(image)
     end

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -136,3 +136,6 @@ lone_wolf_image:
 lone_wolf_image2:
   <<: *DEFAULTS
   user: lone_wolf
+
+mock_imported_inat_image: # used in inat_import_job_test.rb
+  <<: *DEFAULTS

--- a/test/models/inat_obs_photo_test.rb
+++ b/test/models/inat_obs_photo_test.rb
@@ -18,8 +18,11 @@ class InatObsPhotoTest < UnitTestCase
     assert_equal("img/jpeg", photo.content_type)
     assert_equal("(c) Tim C., some rights reserved (CC BY-NC)",
                  photo.copyright_holder)
-    assert_equal("iNat photo uuid 6c223538-04d6-404c-8e84-b7d881dbe550",
-                 photo.original_name)
+    inat_photo = inat_obs[:observation_photos].first
+    assert_equal(
+      "iNat photo_id: #{inat_photo[:photo_id]}, uuid: #{inat_photo[:uuid]}",
+      photo.original_name
+    )
     assert_equal(
       "Imported from iNat #{DateTime.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")}",
       photo.notes


### PR DESCRIPTION
- Includes iNat `photo_id` and `uuid` in the imported Image's `original_name`.
This (or something close) is needed in the future to efficiently sync imported Obss with updated iNat obss.
(I thought it was already doing something like this, but I was wrong.)


