### PR TITLE
Delete spurious `XX Collection Record`

### DIFF
--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -2,7 +2,6 @@
 records = obs.herbarium_records
 can_add = in_admin_mode? || obs.can_edit? ||
           @user && @user.curated_herbaria.any?
-debugger
 %>
 <%=
   tag.div(
@@ -45,9 +44,9 @@ debugger
               concat(tag.br)
               if record.herbarium.web_searchable?
                 concat(
-                  link_to_if(
-                    record.herbarium.web_searchable?,
-                    "#{record.herbarium.code} #{:herbarium_record_collection.t}",
+                  link_to(
+                    "#{record.herbarium.code} " \
+                    "#{:herbarium_record_collection.t}",
                       record.herbarium.mcp_url(record.accession_number),
                       target: "_blank"
                   )
@@ -71,7 +70,8 @@ debugger
               if record.herbarium.web_searchable?
                 concat(
                   link_to(
-                    "#{record.herbarium.code} #{:herbarium_record_collection.t}",
+                    "#{record.herbarium.code} " \
+                    "#{:herbarium_record_collection.t}",
                     record.herbarium.mcp_url(record.accession_number),
                     target: "_blank"
                   )

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -2,8 +2,8 @@
 records = obs.herbarium_records
 can_add = in_admin_mode? || obs.can_edit? ||
           @user && @user.curated_herbaria.any?
+debugger
 %>
-
 <%=
   tag.div(
     id: "observation_herbarium_records",
@@ -43,14 +43,16 @@ can_add = in_admin_mode? || obs.can_edit? ||
                 )
               end
               concat(tag.br)
-              concat(
-                link_to_if(
-                  record.herbarium.web_searchable?,
-                  "#{record.herbarium.code} #{:herbarium_record_collection.t}",
-                     record.herbarium.mcp_url(record.accession_number),
-                     target: "_blank"
+              if record.herbarium.web_searchable?
+                concat(
+                  link_to_if(
+                    record.herbarium.web_searchable?,
+                    "#{record.herbarium.code} #{:herbarium_record_collection.t}",
+                      record.herbarium.mcp_url(record.accession_number),
+                      target: "_blank"
+                  )
                 )
-              )
+              end
             end
           end.safe_join
         end
@@ -66,14 +68,15 @@ can_add = in_admin_mode? || obs.can_edit? ||
             tag.li(id: "herbarium_record_#{record.id}") do
               concat(link_to(*herbarium_record_tab(record, obs)))
               concat(tag.br)
-              concat(
-                link_to_if(
-                  record.herbarium.web_searchable?,
-                  "#{record.herbarium.code} #{:herbarium_record_collection.t}",
-                     record.herbarium.mcp_url(record.accession_number),
-                     target: "_blank"
+              if record.herbarium.web_searchable?
+                concat(
+                  link_to(
+                    "#{record.herbarium.code} #{:herbarium_record_collection.t}",
+                    record.herbarium.mcp_url(record.accession_number),
+                    target: "_blank"
+                  )
                 )
-              )
+              end
             end
           end.safe_join
         end

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -190,7 +190,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     login(user.login)
     get(:show, params: { id: obs.id })
 
-    assert_match(:herbarium_record_collection.l, @response.body)
+    assert_no_match(:herbarium_record_collection.l, @response.body)
     assert_select(
       "a[href=?]", herbarium_record.mcp_url, false,
       "Obs shouldn't link to MyCoPortal for Herbarium Record in a Herbarium " \


### PR DESCRIPTION
- Deletes `XX Collection Record` line on show Observation page when the herbarium collection is not searchable via a web link.
