### PR TITLE
Imported sequence user

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -379,10 +379,9 @@ class InatImportJob < ApplicationJob
                  archive: sequence[:archive],
                  accession: sequence[:accession],
                  notes: sequence[:notes] }
-
-      # NOTE: Error handling? 2024-06-19 jdc.
-      # https://github.com/MushroomObserver/mushroom-observer/issues/2382
       api = API2.execute(params)
+      next if api.errors.any?
+
       seq = api.results.first
       seq.update(user: @user)
     end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -382,7 +382,9 @@ class InatImportJob < ApplicationJob
 
       # NOTE: Error handling? 2024-06-19 jdc.
       # https://github.com/MushroomObserver/mushroom-observer/issues/2382
-      API2.execute(params)
+      api = API2.execute(params)
+      seq = api.results.first
+      seq.update(user: @user)
     end
   end
 

--- a/test/inat/README_INAT_EXAMPLES.md
+++ b/test/inat/README_INAT_EXAMPLES.md
@@ -23,7 +23,7 @@ All data as of the time of importing. (The corresponding iNat Observation may ha
 | ceanothus_cordulatus| [219631412](https://www.inaturalist.org/observations/219631412) | 1 | public | **Plant** |
 | coprinus| [213450312](https://www.inaturalist.org/observations/213450312) | 1 | **obscured** | Needs ID |
 | distantes| [215996396](https://www.inaturalist.org/observations/215996396) | 1 | `jdcohenesq` **obscured, includes confidential gps** | Needs ID, jdc Obs, taxon[:name]: "Distantes" rank:"section", rank_level:13|
-| donadinia_PNW01| [212320801](https://www.inaturalist.org/observations/212320801) | 1 | public | `danmorton` **non-mo-style Provisional Species Name (PNW)**, **DNA** |
+| donadinia_PNW01| [212320801](https://www.inaturalist.org/observations/212320801) | 1 | public | `danmorton` **non-mo-style Provisional Species Name (PNW)**, **DNA sequence** |
 | evernia| [216357655](https://www.inaturalist.org/observations/216357655) | 1 | public | user `jgerend` Casual, lichen, no fields, place: Troutdale, 1 Project |
 | fuligo_septica| [219783802](https://www.inaturalist.org/observations/219783802) | 1 | public | slime mold **Protozoa** Richmond, CA |
 | gyromitra_ancilis| [216745568](https://www.inaturalist.org/observations/216745568) | 3 | public | **cc-by license**, **many projects**, US 20, Linn Co.|

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -380,7 +380,7 @@ class InatImportJobTest < ActiveJob::TestCase
     standard_assertions(obs: obs, name: name)
 
     assert(obs.images.any?, "Obs should have Images")
-    assert(obs.sequences.one?, "Obs should have a Sequence")
+    assert(obs.sequences.one?, "Obs should have one Sequence")
     assert(obs.specimen, "Obs should show that a Specimen is available")
   end
 
@@ -412,7 +412,6 @@ class InatImportJobTest < ActiveJob::TestCase
     standard_assertions(obs: obs, name: name)
 
     proposed_name = obs.namings.first
-    inat_manager = User.find_by(login: "MO Webmaster")
     assert_equal(inat_manager, proposed_name.user,
                  "Name should be proposed by #{inat_manager.login}")
     used_references = 2
@@ -429,7 +428,7 @@ class InatImportJobTest < ActiveJob::TestCase
                  proposed_name_notes)
 
     assert(obs.images.any?, "Obs should have images")
-    assert(obs.sequences.one?, "Obs should have a sequence")
+    assert(obs.sequences.one?, "Obs should have one sequence")
   end
 
   def test_import_job_prov_name_pnw_style
@@ -459,7 +458,7 @@ class InatImportJobTest < ActiveJob::TestCase
     standard_assertions(obs: obs, name: name)
 
     assert(obs.images.any?, "Obs should have images")
-    assert(obs.sequences.one?, "Obs should have a sequence")
+    assert(obs.sequences.one?, "Obs should have one sequence")
   end
 
   def test_import_plant

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -273,6 +273,8 @@ class InatImportJobTest < ActiveJob::TestCase
 
     assert(obs.images.any?, "Obs should have images")
     assert(obs.sequences.one?, "Obs should have a sequence")
+    assert_equal(user, obs.sequences.first.user,
+                 "Sequences should belong to the user who imported the obs")
 
     ids = JSON.parse(mock_inat_response)["results"].first["identifications"]
     unique_suggested_taxon_names = ids.each_with_object([]) do |id, ary|


### PR DESCRIPTION
Makes the importing user, rather than the iNat manager, the owner of imported Sequences.

Implements enhancement requested by @AlanRockefeller. See #2581. 