### PR TITLE
Refactor `:with_observation` and `:with_description` query parameters

### DIFF
--- a/app/classes/query/image_with_observations.rb
+++ b/app/classes/query/image_with_observations.rb
@@ -3,33 +3,21 @@
 module Query
   # Query's for Images where Observation meets specified conditions
   class ImageWithObservations < Query::ImageBase
-    include Query::Initializers::ContentFilters
     include Query::Initializers::Names
+    include Query::Initializers::Observations
+    include Query::Initializers::Locations
+    include Query::Initializers::ContentFilters
     include Query::Initializers::ObservationQueryDescriptions
 
     def parameter_declarations
       super.merge(
         old_title?: :string,
         old_by?: :string,
-        ids?: [Observation],
-        herbaria?: [:string],
-        location?: Location,
-        user_where?: :string,
-        project?: Project,
-        species_list?: SpeciesList,
-        is_collection_location?: :boolean,
-        with_public_lat_lng?: :boolean,
-        with_name?: :boolean,
-        with_comments?: { boolean: [true] },
-        with_sequences?: { boolean: [true] },
-        with_notes_fields?: [:string],
-        comments_has?: :string,
-        north?: :float,
-        south?: :float,
-        east?: :float,
-        west?: :float
-      ).merge(content_filter_parameter_declarations(Observation)).
-        merge(consensus_parameter_declarations)
+        ids?: [Observation]
+      ).merge(observations_parameter_declarations).
+        merge(bounding_box_parameter_declarations).
+        merge(content_filter_parameter_declarations(Observation)).
+        merge(naming_consensus_parameter_declarations)
     end
 
     def initialize_flavor

--- a/app/classes/query/image_with_observations.rb
+++ b/app/classes/query/image_with_observations.rb
@@ -11,10 +11,9 @@ module Query
 
     def parameter_declarations
       super.merge(
-        old_title?: :string,
-        old_by?: :string,
         ids?: [Observation]
       ).merge(observations_parameter_declarations).
+        merge(observations_coercion_parameter_declarations).
         merge(bounding_box_parameter_declarations).
         merge(content_filter_parameter_declarations(Observation)).
         merge(naming_consensus_parameter_declarations)

--- a/app/classes/query/image_with_observations.rb
+++ b/app/classes/query/image_with_observations.rb
@@ -11,7 +11,7 @@ module Query
 
     def parameter_declarations
       super.merge(
-        ids?: [Observation]
+        obs_ids?: [Observation]
       ).merge(observations_parameter_declarations).
         merge(observations_coercion_parameter_declarations).
         merge(bounding_box_parameter_declarations).
@@ -21,7 +21,7 @@ module Query
 
     def initialize_flavor
       add_join(:observation_images, :observations)
-      add_ids_condition("observations")
+      add_ids_condition("observations", :obs_ids)
       add_owner_and_time_stamp_conditions("observations")
       add_by_user_condition("observations")
       add_date_condition("observations.when", params[:date])
@@ -137,7 +137,7 @@ module Query
     end
 
     def coerce_into_observation_query
-      Query.lookup(:Observation, :all, params_with_old_by_restored)
+      Query.lookup(:Observation, :all, params_back_to_observation_params)
     end
 
     def title

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -25,6 +25,22 @@ module Query
         }
       end
 
+      def params_out_to_with_descriptions_params
+        pargs = params_plus_old_by
+        return pargs if pargs[:ids].blank?
+
+        pargs[:desc_ids] = pargs.delete(:ids)
+        pargs
+      end
+
+      def params_back_to_description_params
+        pargs = params_with_old_by_restored
+        return pargs if pargs[:desc_ids].blank?
+
+        pargs[:ids] = pargs.delete(:desc_ids)
+        pargs
+      end
+
       def initialize_description_parameters(type = :name)
         initialize_with_default_desc_parameter(type)
         initialize_join_desc_parameter(type)

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -17,6 +17,14 @@ module Query
         }
       end
 
+      def descriptions_coercion_parameter_declarations
+        {
+          old_title?: :string,
+          old_by?: :string,
+          by_author?: User
+        }
+      end
+
       def initialize_description_parameters(type = :name)
         initialize_with_default_desc_parameter(type)
         initialize_join_desc_parameter(type)

--- a/app/classes/query/initializers/locations.rb
+++ b/app/classes/query/initializers/locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Query
   module Initializers
     # initializing methods inherited by all Query's for Locations

--- a/app/classes/query/initializers/locations.rb
+++ b/app/classes/query/initializers/locations.rb
@@ -1,0 +1,15 @@
+module Query
+  module Initializers
+    # initializing methods inherited by all Query's for Locations
+    module Locations
+      def bounding_box_parameter_declarations
+        {
+          north?: :float,
+          south?: :float,
+          east?: :float,
+          west?: :float
+        }
+      end
+    end
+  end
+end

--- a/app/classes/query/initializers/observations.rb
+++ b/app/classes/query/initializers/observations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Query
   module Initializers
     # initializing methods inherited by all Query's for Observations
@@ -27,6 +29,14 @@ module Query
 
           # numeric
           confidence?: [:float]
+        }
+      end
+
+      def observations_coercion_parameter_declarations
+        {
+          old_title?: :string,
+          old_by?: :string,
+          date?: [:date]
         }
       end
     end

--- a/app/classes/query/initializers/observations.rb
+++ b/app/classes/query/initializers/observations.rb
@@ -39,6 +39,21 @@ module Query
           date?: [:date]
         }
       end
+
+      def params_out_to_with_observations_params(pargs)
+        return pargs if pargs[:ids].blank?
+
+        pargs[:obs_ids] = pargs.delete(:ids)
+        pargs
+      end
+
+      def params_back_to_observation_params
+        pargs = params_with_old_by_restored
+        return pargs if pargs[:obs_ids].blank?
+
+        pargs[:ids] = pargs.delete(:obs_ids)
+        pargs
+      end
     end
   end
 end

--- a/app/classes/query/initializers/observations.rb
+++ b/app/classes/query/initializers/observations.rb
@@ -1,0 +1,34 @@
+module Query
+  module Initializers
+    # initializing methods inherited by all Query's for Observations
+    module Observations
+      def observations_parameter_declarations
+        {
+          notes_has?: :string,
+          with_notes_fields?: [:string],
+          comments_has?: :string,
+          herbaria?: [:string],
+          user_where?: :string,
+          by_user?: User,
+          location?: Location,
+          locations?: [:string],
+          project?: Project,
+          projects?: [:string],
+          species_list?: SpeciesList,
+          species_lists?: [:string],
+
+          # boolean
+          with_comments?: { boolean: [true] },
+          with_public_lat_lng?: :boolean,
+          with_name?: :boolean,
+          with_notes?: :boolean,
+          with_sequences?: { boolean: [true] },
+          is_collection_location?: :boolean,
+
+          # numeric
+          confidence?: [:float]
+        }
+      end
+    end
+  end
+end

--- a/app/classes/query/location_base.rb
+++ b/app/classes/query/location_base.rb
@@ -2,6 +2,7 @@
 
 class Query::LocationBase < Query::Base
   include Query::Initializers::Locations
+  include Query::Initializers::Descriptions
   include Query::Initializers::ContentFilters
   include Query::Initializers::AdvancedSearch
 

--- a/app/classes/query/location_base.rb
+++ b/app/classes/query/location_base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Query::LocationBase < Query::Base
+  include Query::Initializers::Locations
   include Query::Initializers::ContentFilters
   include Query::Initializers::AdvancedSearch
 
@@ -16,13 +17,10 @@ class Query::LocationBase < Query::Base
       by_user?: User,
       by_editor?: User,
       users?: [User],
-      north?: :float,
-      south?: :float,
-      east?: :float,
-      west?: :float,
       pattern?: :string,
       regexp?: :string
-    ).merge(content_filter_parameter_declarations(Location)).
+    ).merge(bounding_box_parameter_declarations).
+      merge(content_filter_parameter_declarations(Location)).
       merge(advanced_search_parameter_declarations)
   end
 

--- a/app/classes/query/location_description_all.rb
+++ b/app/classes/query/location_description_all.rb
@@ -13,6 +13,7 @@ class Query::LocationDescriptionAll < Query::LocationDescriptionBase
   end
 
   def coerce_into_location_query
-    Query.lookup(:Location, :with_descriptions, params_plus_old_by)
+    pargs = params_out_to_with_descriptions_params
+    Query.lookup(:Location, :with_descriptions, pargs)
   end
 end

--- a/app/classes/query/location_description_base.rb
+++ b/app/classes/query/location_description_base.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Query::LocationDescriptionBase < Query::Base
+  include Query::Initializers::Descriptions
+
   def model
     LocationDescription
   end

--- a/app/classes/query/location_with_descriptions.rb
+++ b/app/classes/query/location_with_descriptions.rb
@@ -3,11 +3,8 @@
 class Query::LocationWithDescriptions < Query::LocationBase
   def parameter_declarations
     super.merge(
-      ids?: [LocationDescription],
-      old_title?: :string,
-      old_by?: :string,
-      by_author?: User
-    )
+      ids?: [LocationDescription]
+    ).merge(descriptions_coercion_parameter_declarations)
   end
 
   def initialize_flavor

--- a/app/classes/query/location_with_descriptions.rb
+++ b/app/classes/query/location_with_descriptions.rb
@@ -3,7 +3,7 @@
 class Query::LocationWithDescriptions < Query::LocationBase
   def parameter_declarations
     super.merge(
-      ids?: [LocationDescription]
+      desc_ids?: [LocationDescription]
     ).merge(descriptions_coercion_parameter_declarations)
   end
 
@@ -17,12 +17,15 @@ class Query::LocationWithDescriptions < Query::LocationBase
   end
 
   def add_ids_condition
-    return unless params[:ids]
+    return unless params[:desc_ids]
+
+    set = clean_id_set(params[:desc_ids])
+    @where << "location_descriptions.id IN (#{set})"
+    self.order = "FIND_IN_SET(location_descriptions.id,'#{set}') ASC"
 
     @title_tag = :query_title_with_descriptions.t(type: :location)
     @title_args[:descriptions] = params[:old_title] ||
                                  :query_title_in_set.t(type: :description)
-    initialize_in_set_flavor("location_descriptions")
   end
 
   def add_by_user_condition
@@ -56,6 +59,6 @@ class Query::LocationWithDescriptions < Query::LocationBase
   end
 
   def coerce_into_location_description_query
-    Query.lookup(:LocationDescription, :all, params_with_old_by_restored)
+    Query.lookup(:LocationDescription, :all, params_back_to_description_params)
   end
 end

--- a/app/classes/query/location_with_observations.rb
+++ b/app/classes/query/location_with_observations.rb
@@ -3,37 +3,21 @@
 module Query
   # Query's for Locations where Observation meets specified conditions
   class LocationWithObservations < Query::LocationBase
-    include Query::Initializers::ContentFilters
     include Query::Initializers::Names
+    include Query::Initializers::Observations
+    include Query::Initializers::ContentFilters
     include Query::Initializers::ObservationQueryDescriptions
 
     def parameter_declarations
       super.merge(
+        old_title?: :string,
         old_by?: :string,
         date?: [:date],
-        ids?: [Observation],
-        old_title?: :string,
-        locations?: [:string],
-        location?: Location,
-        user_where?: :string,
-        project?: Project,
-        projects?: [:string],
-        species_list?: SpeciesList,
-        species_lists?: [:string],
-        herbaria?: [:string],
-        confidence?: [:float],
-        is_collection_location?: :boolean,
-        with_public_lat_lng?: :boolean,
-        with_name?: :boolean,
-        with_comments?: { boolean: [true] },
-        with_sequences?: { boolean: [true] },
-        with_notes?: :boolean,
-        with_notes_fields?: [:string],
-        notes_has?: :string,
-        comments_has?: :string
-      ).merge(content_filter_parameter_declarations(Observation)).
+        ids?: [Observation]
+      ).merge(observations_parameter_declarations).
+        merge(content_filter_parameter_declarations(Observation)).
         merge(names_parameter_declarations).
-        merge(consensus_parameter_declarations)
+        merge(naming_consensus_parameter_declarations)
     end
 
     def initialize_flavor

--- a/app/classes/query/location_with_observations.rb
+++ b/app/classes/query/location_with_observations.rb
@@ -10,11 +10,9 @@ module Query
 
     def parameter_declarations
       super.merge(
-        old_title?: :string,
-        old_by?: :string,
-        date?: [:date],
         ids?: [Observation]
       ).merge(observations_parameter_declarations).
+        merge(observations_coercion_parameter_declarations).
         merge(content_filter_parameter_declarations(Observation)).
         merge(names_parameter_declarations).
         merge(naming_consensus_parameter_declarations)

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -99,22 +99,18 @@ module Query
         add_joins(*)
       end
 
-      def add_ids_condition(table = model.table_name)
-        return if params[:ids].nil? # [] is valid
+      # Generalized so the param can be :obs_ids or :desc_ids
+      def add_ids_condition(table = model.table_name, ids = :ids)
+        return if params[ids].nil? # [] is valid
 
-        initialize_in_set_flavor(table)
+        set = clean_id_set(params[ids])
+        @where << "#{table}.id IN (#{set})"
+        self.order = "FIND_IN_SET(#{table}.id,'#{set}') ASC"
 
         @title_tag = :query_title_in_set.t(type: table.singularize.to_sym)
         # @title_args[:by] = :query_sorted_by.t(field: :original_name)
         # @title_args[:descriptions] =
         #   :query_title_in_set.t(type: table.singularize.to_sym)
-      end
-
-      # move this above when all in_set flavors converted
-      def initialize_in_set_flavor(table = model.table_name)
-        set = clean_id_set(params[:ids])
-        @where << "#{table}.id IN (#{set})"
-        self.order = "FIND_IN_SET(#{table}.id,'#{set}') ASC"
       end
 
       def add_id_condition(col, ids, *)

--- a/app/classes/query/name_description_all.rb
+++ b/app/classes/query/name_description_all.rb
@@ -13,6 +13,7 @@ class Query::NameDescriptionAll < Query::NameDescriptionBase
   end
 
   def coerce_into_name_query
-    Query.lookup(:Name, :with_descriptions, params_plus_old_by)
+    pargs = params_out_to_with_descriptions_params
+    Query.lookup(:Name, :with_descriptions, pargs)
   end
 end

--- a/app/classes/query/name_description_base.rb
+++ b/app/classes/query/name_description_base.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Query::NameDescriptionBase < Query::Base
+  include Query::Initializers::Descriptions
+
   def model
     NameDescription
   end

--- a/app/classes/query/name_with_descriptions.rb
+++ b/app/classes/query/name_with_descriptions.rb
@@ -3,7 +3,7 @@
 class Query::NameWithDescriptions < Query::NameBase
   def parameter_declarations
     super.merge(
-      ids?: [NameDescription]
+      desc_ids?: [NameDescription]
     ).merge(descriptions_coercion_parameter_declarations)
   end
 
@@ -17,12 +17,15 @@ class Query::NameWithDescriptions < Query::NameBase
   end
 
   def add_ids_condition
-    return unless params[:ids]
+    return unless params[:desc_ids]
+
+    set = clean_id_set(params[:desc_ids])
+    @where << "name_descriptions.id IN (#{set})"
+    self.order = "FIND_IN_SET(name_descriptions.id,'#{set}') ASC"
 
     @title_tag = :query_title_with_descriptions.t(type: :name)
     @title_args[:descriptions] = params[:old_title] ||
                                  :query_title_in_set.t(type: :description)
-    initialize_in_set_flavor("name_descriptions")
   end
 
   def add_by_user_condition
@@ -56,6 +59,6 @@ class Query::NameWithDescriptions < Query::NameBase
   end
 
   def coerce_into_name_description_query
-    Query.lookup(:NameDescription, :all, params_with_old_by_restored)
+    Query.lookup(:NameDescription, :all, params_back_to_description_params)
   end
 end

--- a/app/classes/query/name_with_descriptions.rb
+++ b/app/classes/query/name_with_descriptions.rb
@@ -3,11 +3,8 @@
 class Query::NameWithDescriptions < Query::NameBase
   def parameter_declarations
     super.merge(
-      ids?: [NameDescription],
-      old_title?: :string,
-      old_by?: :string,
-      by_author?: User
-    )
+      ids?: [NameDescription]
+    ).merge(descriptions_coercion_parameter_declarations)
   end
 
   def initialize_flavor

--- a/app/classes/query/name_with_observations.rb
+++ b/app/classes/query/name_with_observations.rb
@@ -11,11 +11,9 @@ module Query
 
     def parameter_declarations
       super.merge(
-        old_title?: :string,
-        old_by?: :string,
-        date?: [:date],
         ids?: [Observation]
       ).merge(observations_parameter_declarations).
+        merge(observations_coercion_parameter_declarations).
         merge(bounding_box_parameter_declarations).
         merge(content_filter_parameter_declarations(Observation)).
         merge(naming_consensus_parameter_declarations)

--- a/app/classes/query/name_with_observations.rb
+++ b/app/classes/query/name_with_observations.rb
@@ -3,8 +3,10 @@
 module Query
   # Query's for Names where Observations meet specified conditions
   class NameWithObservations < Query::NameBase
-    include Query::Initializers::ContentFilters
     include Query::Initializers::Names
+    include Query::Initializers::Observations
+    include Query::Initializers::Locations
+    include Query::Initializers::ContentFilters
     include Query::Initializers::ObservationQueryDescriptions
 
     def parameter_declarations
@@ -12,26 +14,11 @@ module Query
         old_title?: :string,
         old_by?: :string,
         date?: [:date],
-        ids?: [Observation],
-        by_user?: User,
-        project?: Project,
-        projects?: [:string],
-        species_list?: SpeciesList,
-        herbaria?: [:string],
-        confidence?: [:float],
-        location?: Location,
-        user_where?: :string,
-        is_collection_location?: :boolean,
-        with_public_lat_lng?: :boolean,
-        with_name?: :boolean,
-        with_sequences?: { boolean: [true] },
-        with_notes_fields?: [:string],
-        north?: :float,
-        south?: :float,
-        east?: :float,
-        west?: :float
-      ).merge(content_filter_parameter_declarations(Observation)).
-        merge(consensus_parameter_declarations)
+        ids?: [Observation]
+      ).merge(observations_parameter_declarations).
+        merge(bounding_box_parameter_declarations).
+        merge(content_filter_parameter_declarations(Observation)).
+        merge(naming_consensus_parameter_declarations)
     end
 
     def initialize_flavor

--- a/app/classes/query/name_with_observations.rb
+++ b/app/classes/query/name_with_observations.rb
@@ -11,7 +11,7 @@ module Query
 
     def parameter_declarations
       super.merge(
-        ids?: [Observation]
+        obs_ids?: [Observation]
       ).merge(observations_parameter_declarations).
         merge(observations_coercion_parameter_declarations).
         merge(bounding_box_parameter_declarations).
@@ -21,7 +21,7 @@ module Query
 
     def initialize_flavor
       add_join(:observations)
-      add_ids_condition("observations")
+      add_ids_condition("observations", :obs_ids)
       add_owner_and_time_stamp_conditions("observations")
       add_by_user_condition("observations")
       add_date_condition("observations.when", params[:date])
@@ -133,7 +133,7 @@ module Query
     end
 
     def coerce_into_observation_query
-      Query.lookup(:Observation, :all, params_with_old_by_restored)
+      Query.lookup(:Observation, :all, params_back_to_observation_params)
     end
 
     def title

--- a/app/classes/query/observation_all.rb
+++ b/app/classes/query/observation_all.rb
@@ -23,11 +23,9 @@ class Query::ObservationAll < Query::ObservationBase
   def do_coerce(new_model)
     is_search = params[:pattern].present? ||
                 advanced_search_params.any? { |key| params[key].present? }
-    pargs = if is_search
-              add_old_title(params_plus_old_by)
-            else
-              params_plus_old_by
-            end
+    pargs = is_search ? add_old_title(params_plus_old_by) : params_plus_old_by
+    # transform :ids to :obs_ids
+    pargs = params_out_to_with_observations_params(pargs)
     Query.lookup(new_model, :with_observations, pargs)
   end
 

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -41,7 +41,7 @@ module Query
         regexp?: :string, # for coercions from location
         needs_naming?: :boolean,
         in_clade?: :string,
-        in_region?: :string,
+        in_region?: :string
       }
     end
 

--- a/app/classes/query/observation_base.rb
+++ b/app/classes/query/observation_base.rb
@@ -2,10 +2,11 @@
 
 module Query
   # methods for initializing Query's for Observations
-  # rubocop:disable Metrics/ClassLength
   class ObservationBase < Query::Base
-    include Query::Initializers::ContentFilters
     include Query::Initializers::Names
+    include Query::Initializers::Observations
+    include Query::Initializers::Locations
+    include Query::Initializers::ContentFilters
     include Query::Initializers::AdvancedSearch
 
     def model
@@ -14,13 +15,14 @@ module Query
 
     def parameter_declarations
       super.merge(local_parameter_declarations).
+        merge(observations_parameter_declarations).
+        merge(bounding_box_parameter_declarations).
         merge(content_filter_parameter_declarations(Observation)).
         merge(names_parameter_declarations).
-        merge(consensus_parameter_declarations).
+        merge(naming_consensus_parameter_declarations).
         merge(advanced_search_parameter_declarations)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def local_parameter_declarations
       {
         # dates/times
@@ -29,19 +31,8 @@ module Query
         updated_at?: [:time],
 
         ids?: [Observation],
-        comments_has?: :string,
-        with_notes_fields?: [:string],
-        herbaria?: [:string],
         herbarium_records?: [:string],
-        location?: Location,
-        user_where?: :string,
-        locations?: [:string],
-        notes_has?: :string,
-        project?: Project,
-        projects?: [:string],
         project_lists?: [:string],
-        species_list?: SpeciesList,
-        species_lists?: [:string],
         by_user?: User,
         by_editor?: User, # for coercions from name/location
         users?: [User],
@@ -51,24 +42,8 @@ module Query
         needs_naming?: :boolean,
         in_clade?: :string,
         in_region?: :string,
-
-        # numeric
-        confidence?: [:float],
-        east?: :float,
-        north?: :float,
-        south?: :float,
-        west?: :float,
-
-        # boolean
-        with_comments?: { boolean: [true] },
-        with_public_lat_lng?: :boolean,
-        with_name?: :boolean,
-        with_notes?: :boolean,
-        with_sequences?: { boolean: [true] },
-        is_collection_location?: :boolean
       }
     end
-    # rubocop:enable Metrics/MethodLength
 
     # rubocop:disable Metrics/AbcSize
     def initialize_flavor
@@ -342,5 +317,4 @@ module Query
       "date"
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1640,7 +1640,7 @@ class QueryTest < UnitTestCase
 
   ##### date/time parameters #####
 
-  def test_name_with_observations_created_at
+  def test_image_with_observations_created_at
     created_at = observations(:detailed_unknown_obs).created_at
     expect =
       Image.joins(:observations).
@@ -1649,7 +1649,7 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Image, :with_observations, created_at: created_at)
   end
 
-  def test_name_with_observations_updated_at
+  def test_image_with_observations_updated_at
     updated_at = observations(:detailed_unknown_obs).updated_at
     expect =
       Image.joins(:observations).
@@ -1658,7 +1658,7 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Image, :with_observations, updated_at: updated_at)
   end
 
-  def test_name_with_observations_date
+  def test_image_with_observations_date
     date = observations(:detailed_unknown_obs).when
     expect = Image.joins(:observations).where(Observation[:when] >= date).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
@@ -1667,7 +1667,7 @@ class QueryTest < UnitTestCase
 
   ##### list/string parameters #####
 
-  def test_name_with_observations_comments_has
+  def test_image_with_observations_comments_has
     expect =
       Image.joins(observations: :comments).
       where(Comment[:summary].matches("%give%")).
@@ -1677,7 +1677,7 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Image, :with_observations, comments_has: "give")
   end
 
-  def test_name_with_observations_with_notes_fields
+  def test_image_with_observations_with_notes_fields
     obs = observations(:substrate_notes_obs) # obs has notes substrate: field
     # give it some images
     obs.images = [images(:conic_image), images(:convex_image)]
@@ -1690,7 +1690,7 @@ class QueryTest < UnitTestCase
                  :Image, :with_observations, with_notes_fields: "substrate")
   end
 
-  def test_name_with_observations_herbaria
+  def test_image_with_observations_herbaria
     name = "The New York Botanical Garden"
     expect = Image.joins(observations: { herbarium_records: :herbarium }).
              where(herbaria: { name: name }).uniq
@@ -1698,7 +1698,7 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Image, :with_observations, herbaria: name)
   end
 
-  def test_name_with_observations_projects
+  def test_image_with_observations_projects
     project = projects(:bolete_project)
     expect = Image.joins(observations: :projects).
              where(projects: { title: project.title }).uniq
@@ -1706,7 +1706,7 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Image, :with_observations, projects: [project.title])
   end
 
-  def test_name_with_observations_users
+  def test_image_with_observations_users
     expect = Image.joins(:observations).where(observations: { user: dick }).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, Image, :with_observations, users: dick)
@@ -1714,7 +1714,7 @@ class QueryTest < UnitTestCase
 
   ##### numeric parameters #####
 
-  def test_name_with_observations_bounding_box
+  def test_image_with_observations_bounding_box
     obs = observations(:unknown_with_lat_lng) # obs has lat/lon
     # give it some images
     obs.images = [images(:conic_image), images(:convex_image)]
@@ -1733,27 +1733,27 @@ class QueryTest < UnitTestCase
 
   ##### boolean parameters #####
 
-  def test_name_with_observations_with_comments
+  def test_image_with_observations_with_comments
     expect = Image.joins(observations: :comments).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, :Image, :with_observations, with_comments: true)
   end
 
-  def test_name_with_observations_with_public_lat_lng
+  def test_image_with_observations_with_public_lat_lng
     expect = Image.joins(:observations).
              where.not(observations: { lat: false }).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, :Image, :with_observations, with_public_lat_lng: true)
   end
 
-  def test_name_with_observations_with_name
+  def test_image_with_observations_with_name
     expect = Image.joins(:observations).
              where(observations: { name_id: Name.unknown }).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, :Image, :with_observations, with_name: false)
   end
 
-  def test_name_with_observations_with_notes
+  def test_image_with_observations_with_notes
     expect =
       Image.joins(:observations).
       where.not(observations: { notes: Observation.no_notes }).uniq
@@ -1761,13 +1761,13 @@ class QueryTest < UnitTestCase
     assert_query(expect, :Image, :with_observations, with_notes: true)
   end
 
-  def test_name_with_observations_with_sequences
+  def test_image_with_observations_with_sequences
     expect = Image.joins(observations: :sequences).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")
     assert_query(expect, Image, :with_observations, with_sequences: true)
   end
 
-  def test_name_with_observations_is_collection_location
+  def test_image_with_observations_is_collection_location
     expect =
       Image.joins(:observations).
       where(observations: { is_collection_location: true }).uniq

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1715,10 +1715,8 @@ class QueryTest < UnitTestCase
   ##### numeric parameters #####
 
   def test_image_with_observations_bounding_box
-    obs = observations(:unknown_with_lat_lng) # obs has lat/lon
-    # give it some images
-    obs.images = [images(:conic_image), images(:convex_image)]
-    obs.save
+    obs = give_geolocated_observation_some_images
+
     lat = obs.lat
     lng = obs.lng
     expect = Image.joins(:observations).
@@ -1731,6 +1729,14 @@ class QueryTest < UnitTestCase
     )
   end
 
+  def give_geolocated_observation_some_images
+    obs = observations(:unknown_with_lat_lng) # obs has lat/lon
+    # give it some images
+    obs.images = [images(:conic_image), images(:convex_image)]
+    obs.save
+    obs
+  end
+
   ##### boolean parameters #####
 
   def test_image_with_observations_with_comments
@@ -1740,6 +1746,8 @@ class QueryTest < UnitTestCase
   end
 
   def test_image_with_observations_with_public_lat_lng
+    give_geolocated_observation_some_images
+
     expect = Image.joins(:observations).
              where.not(observations: { lat: false }).uniq
     assert_not_empty(expect, "'expect` is broken; it should not be empty")

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -913,320 +913,146 @@ class QueryTest < UnitTestCase
   end
 
   def test_observation_image_coercion
+    query_a = []
+
     # Several observation queries can be turned into image queries.
-    q1a = Query.lookup_and_save(:Observation, :all, by: :id)
-    q2a = Query.lookup_and_save(:Observation, :all, by_user: mary.id)
-    q3a = Query.lookup_and_save(
+    query_a[0] = Query.lookup_and_save(:Observation, :all, by: :id)
+    query_a[1] = Query.lookup_and_save(:Observation, :all, by_user: mary.id)
+    query_a[2] = Query.lookup_and_save(
       :Observation, :all, species_list: species_lists(:first_species_list).id
     )
-    q5a = Query.lookup_and_save(:Observation, :all,
-                                ids: [
-                                  observations(:detailed_unknown_obs).id,
-                                  observations(:agaricus_campestris_obs).id,
-                                  observations(:agaricus_campestras_obs).id
-                                ])
-    # removed q6a which searched for "somewhere else" in the notes
-    # q6a = Query.lookup_and_save(:Observation, :all,
-    #                             pattern: '"somewhere else"')
-    q7a = Query.lookup_and_save(:Observation, :all,
-                                user_where: "glendale")
-    q8a = Query.lookup_and_save(:Observation, :all,
-                                location: locations(:burbank))
-    q9a = Query.lookup_and_save(:Observation, :all,
-                                user_where: "california")
+    query_a[3] = Query.lookup_and_save(
+      :Observation, :all, ids: [observations(:detailed_unknown_obs).id,
+                                observations(:agaricus_campestris_obs).id,
+                                observations(:agaricus_campestras_obs).id]
+    )
+    query_a[4] = Query.lookup_and_save(:Observation, :all,
+                                       user_where: "glendale")
+    query_a[5] = Query.lookup_and_save(:Observation, :all,
+                                       location: locations(:burbank))
+    query_a[6] = Query.lookup_and_save(:Observation, :all,
+                                       user_where: "california")
+    # removed query_a[7] which searched for "somewhere else" in the notes
+    # query_a[7] = Query.lookup_and_save(:Observation, :all,
+    #                                    pattern: '"somewhere else"')
     assert_equal(7, QueryRecord.count)
 
-    # Try coercing them all.
-    assert(q1b = q1a.coerce(:Image))
-    assert(q2b = q2a.coerce(:Image))
-    assert(q3b = q3a.coerce(:Image))
-    assert(q5b = q5a.coerce(:Image))
-    # assert(q6b = q6a.coerce(:Image))
-    assert(q7b = q7a.coerce(:Image))
-    assert(q8b = q8a.coerce(:Image))
-    assert(q9b = q9a.coerce(:Image))
-
-    # They should all be new records
-    assert(q1b.record.new_record?)
-    assert_save(q1b)
-    assert(q2b.record.new_record?)
-    assert_save(q2b)
-    assert(q3b.record.new_record?)
-    assert_save(q3b)
-    assert(q5b.record.new_record?)
-    assert_save(q5b)
-    # assert(q6b.record.new_record?)
-    # assert_save(q6b)
-    assert(q7b.record.new_record?)
-    assert_save(q7b)
-    assert(q8b.record.new_record?)
-    assert_save(q8b)
-    assert(q9b.record.new_record?)
-    assert_save(q9b)
-
-    # Check their descriptions.
-    assert_equal("Image", q1b.model.to_s)
-    assert_equal("Image", q2b.model.to_s)
-    assert_equal("Image", q3b.model.to_s)
-    assert_equal("Image", q5b.model.to_s)
-    # assert_equal("Image", q6b.model.to_s)
-    assert_equal("Image", q7b.model.to_s)
-    assert_equal("Image", q8b.model.to_s)
-    assert_equal("Image", q9b.model.to_s)
-
-    assert_equal(:with_observations, q1b.flavor)
-    assert_equal(:with_observations, q2b.flavor)
-    assert_equal(:with_observations, q3b.flavor)
-    assert_equal(:with_observations, q5b.flavor)
-    # assert_equal(:with_observations, q6b.flavor)
-    assert_equal(:with_observations, q7b.flavor)
-    assert_equal(:with_observations, q8b.flavor)
-    assert_equal(:with_observations, q9b.flavor)
-
-    # Now try to coerce them back to Observation.
-    assert(q1c = q1b.coerce(:Observation))
-    assert(q2c = q2b.coerce(:Observation))
-    assert(q3c = q3b.coerce(:Observation))
-    assert(q5c = q5b.coerce(:Observation))
-    # assert(q6c = q6b.coerce(:Observation))
-    assert(q7c = q7b.coerce(:Observation))
-    assert(q8c = q8b.coerce(:Observation))
-    assert(q9c = q9b.coerce(:Observation))
-
-    # Only some should be new.
-    assert_not(q1c.record.new_record?)
-    assert_equal(q1a, q1c)
-    assert_not(q2c.record.new_record?)
-    assert_equal(q2a, q2c)
-    assert_not(q3c.record.new_record?)
-    assert_equal(q3a, q3c)
-    assert_not(q5c.record.new_record?)
-    assert_equal(q5a, q5c)
-    # assert(q6c.record.new_record?)  # (converted to in_set)
-    assert_not(q7c.record.new_record?)
-    assert_equal(q7a, q7c)
-    assert_not(q8c.record.new_record?)
-    assert_equal(q8a, q8c)
-    assert_not(q9c.record.new_record?)
-    assert_equal(q9a, q9c)
+    observation_coercion_assertions(query_a, :Image)
   end
 
   def test_observation_location_coercion
+    query_a = []
+
     # Almost any query on observations should be mappable, i.e. coercable into
     # a query on those observations' locations.
-    q1a = Query.lookup_and_save(:Observation, :all, by: :id)
-    q2a = Query.lookup_and_save(:Observation, :all, by_user: mary.id)
-    q3a = Query.lookup_and_save(
+    query_a[0] = Query.lookup_and_save(:Observation, :all, by: :id)
+    query_a[1] = Query.lookup_and_save(:Observation, :all, by_user: mary.id)
+    query_a[2] = Query.lookup_and_save(
       :Observation, :all, species_list: species_lists(:first_species_list).id
     )
-    q5a = Query.lookup_and_save(:Observation, :all,
-                                ids:
-                                  [observations(:detailed_unknown_obs).id,
-                                   observations(:agaricus_campestris_obs).id,
-                                   observations(:agaricus_campestras_obs).id])
-    # q6a = Query.lookup_and_save(:Observation, :all,
-    #                             pattern: '"somewhere else"')
-    q7a = Query.lookup_and_save(:Observation, :all,
-                                user_where: "glendale")
-    q8a = Query.lookup_and_save(:Observation, :all,
-                                location: locations(:burbank))
-    q9a = Query.lookup_and_save(:Observation, :all,
-                                user_where: "california")
+    query_a[3] = Query.lookup_and_save(
+      :Observation, :all, ids: [observations(:detailed_unknown_obs).id,
+                                observations(:agaricus_campestris_obs).id,
+                                observations(:agaricus_campestras_obs).id]
+    )
+    query_a[4] = Query.lookup_and_save(:Observation, :all,
+                                       user_where: "glendale")
+    query_a[5] = Query.lookup_and_save(:Observation, :all,
+                                       location: locations(:burbank))
+    query_a[6] = Query.lookup_and_save(:Observation, :all,
+                                       user_where: "california")
+    # query_a[7] = Query.lookup_and_save(:Observation, :all,
+    #                                    pattern: '"somewhere else"')
     assert_equal(7, QueryRecord.count)
 
-    # Try coercing them all.
-    assert(q1b = q1a.coerce(:Location))
-    assert(q2b = q2a.coerce(:Location))
-    assert(q3b = q3a.coerce(:Location))
-    assert(q5b = q5a.coerce(:Location))
-    # assert(q6b = q6a.coerce(:Location))
-    assert(q7b = q7a.coerce(:Location))
-    assert(q8b = q8a.coerce(:Location))
-    assert(q9b = q9a.coerce(:Location))
+    query_b = observation_coercion_assertions(query_a, :Location)
 
-    # They should all be new records
-    assert(q1b.record.new_record?)
-    assert_save(q1b)
-    assert(q2b.record.new_record?)
-    assert_save(q2b)
-    assert(q3b.record.new_record?)
-    assert_save(q3b)
-    assert(q5b.record.new_record?)
-    assert_save(q5b)
-    # assert(q6b.record.new_record?)
-    # assert_save(q6b)
-    assert(q7b.record.new_record?)
-    assert_save(q7b)
-    assert(q8b.record.new_record?)
-    assert_save(q8b)
-    assert(q9b.record.new_record?)
-    assert_save(q9b)
-
-    # Check their descriptions.
-    assert_equal("Location", q1b.model.to_s)
-    assert_equal("Location", q2b.model.to_s)
-    assert_equal("Location", q3b.model.to_s)
-    assert_equal("Location", q5b.model.to_s)
-    # assert_equal("Location", q6b.model.to_s)
-    assert_equal("Location", q7b.model.to_s)
-    assert_equal("Location", q8b.model.to_s)
-    assert_equal("Location", q9b.model.to_s)
-
-    assert_equal(:with_observations, q1b.flavor)
-    assert_equal(:with_observations, q2b.flavor)
-    assert_equal(:with_observations, q3b.flavor)
-    assert_equal(:with_observations, q5b.flavor)
-    # assert_equal(:with_observations, q6b.flavor)
-    assert_equal(:with_observations, q7b.flavor)
-    assert_equal(:with_observations, q8b.flavor)
-    assert_equal(:with_observations, q9b.flavor)
-
-    assert_equal({ old_by: "id" }, q1b.params)
-    assert_equal({ by_user: mary.id }, q2b.params)
+    # Now, check the parameters of those coerced queries.
+    assert_equal({ old_by: "id" }, query_b[0].params)
+    assert_equal({ by_user: mary.id }, query_b[1].params)
     assert_equal({ species_list: species_lists(:first_species_list).id },
-                 q3b.params)
-
+                 query_b[2].params)
     assert_equal([observations(:detailed_unknown_obs).id,
                   observations(:agaricus_campestris_obs).id,
                   observations(:agaricus_campestras_obs).id],
-                 q5b.params[:obs_ids])
-    assert_equal(1, q5b.params.keys.length)
-    # assert_equal(2, q6b.params.keys.length)
+                 query_b[3].params[:obs_ids])
+    assert_equal(1, query_b[3].params.keys.length)
+    assert_equal("glendale", query_b[4].params[:user_where])
+    assert_equal(2, query_b[4].params.keys.length)
+    assert_equal(locations(:burbank).id, query_b[5].params[:location])
+    assert_equal(1, query_b[5].params.keys.length)
+    assert_equal("california", query_b[6].params[:user_where])
+    assert_equal(2, query_b[6].params.keys.length)
+    # assert_equal(2, query_b[7].params.keys.length)
     # assert_equal([observations(:strobilurus_diminutivus_obs).id,
     #               observations(:agaricus_campestros_obs).id,
     #               observations(:agaricus_campestras_obs).id,
     #               observations(:agaricus_campestrus_obs).id],
-    #              q6b.params[:obs_ids])
+    #              query_b[7].params[:obs_ids])
     # assert_match(/Observations.*Matching.*somewhere.*else/,
-    #              q6b.params[:old_title])
-    assert_equal("glendale", q7b.params[:user_where])
-    assert_equal(2, q7b.params.keys.length) # advanced search gets old_title
-    assert_equal(locations(:burbank).id, q8b.params[:location])
-    assert_equal(1, q8b.params.keys.length)
-    assert_equal("california", q9b.params[:user_where])
-    assert_equal(2, q9b.params.keys.length) # advanced search gets old_title
-
-    # Now try to coerce them back to Observation.
-    assert(q1c = q1b.coerce(:Observation))
-    assert(q2c = q2b.coerce(:Observation))
-    assert(q3c = q3b.coerce(:Observation))
-    assert(q5c = q5b.coerce(:Observation))
-    # assert(q6c = q6b.coerce(:Observation))
-    assert(q7c = q7b.coerce(:Observation))
-    assert(q8c = q8b.coerce(:Observation))
-    assert(q9c = q9b.coerce(:Observation))
-
-    # Only some should be new.
-    assert_not(q1c.record.new_record?)
-    assert_equal(q1a, q1c)
-    assert_not(q2c.record.new_record?)
-    assert_equal(q2a, q2c)
-    assert_not(q3c.record.new_record?)
-    assert_equal(q3a, q3c)
-    assert_not(q5c.record.new_record?)
-    assert_equal(q5a, q5c)
-    # assert(q6c.record.new_record?)  # (converted to in_set)
-    assert_not(q7c.record.new_record?)
-    assert_not(q8c.record.new_record?)
-    assert_not(q9c.record.new_record?)
+    #              query_b[7].params[:old_title])
   end
 
   def test_observation_name_coercion
+    query_a = []
+
     # Several observation queries can be turned into name queries.
-    q1a = Query.lookup_and_save(:Observation, :all, by: :id)
-    q2a = Query.lookup_and_save(:Observation, :all, by_user: mary.id)
-    q3a = Query.lookup_and_save(
+    query_a[0] = Query.lookup_and_save(:Observation, :all, by: :id)
+    query_a[1] = Query.lookup_and_save(:Observation, :all, by_user: mary.id)
+    query_a[2] = Query.lookup_and_save(
       :Observation, :all, species_list: species_lists(:first_species_list).id
     )
-    q5a = Query.lookup_and_save(:Observation, :all,
-                                ids: [
-                                  observations(:detailed_unknown_obs).id,
-                                  observations(:agaricus_campestris_obs).id,
-                                  observations(:agaricus_campestras_obs).id
-                                ])
-    # q6a = Query.lookup_and_save(:Observation, :all,
+    query_a[3] = Query.lookup_and_save(
+      :Observation, :all, ids: [observations(:detailed_unknown_obs).id,
+                                observations(:agaricus_campestris_obs).id,
+                                observations(:agaricus_campestras_obs).id]
+    )
+    # qa[4] = Query.lookup_and_save(:Observation, :all,
     #                             pattern: '"somewhere else"')
-    q7a = Query.lookup_and_save(:Observation, :all,
-                                user_where: "glendale")
-    q8a = Query.lookup_and_save(:Observation, :all,
-                                location: locations(:burbank))
-    q9a = Query.lookup_and_save(:Observation, :all,
-                                user_where: "california")
+    query_a[4] = Query.lookup_and_save(:Observation, :all,
+                                       user_where: "glendale")
+    query_a[5] = Query.lookup_and_save(:Observation, :all,
+                                       location: locations(:burbank))
+    query_a[6] = Query.lookup_and_save(:Observation, :all,
+                                       user_where: "california")
     assert_equal(7, QueryRecord.count)
 
-    # Try coercing them all.
-    assert(q1b = q1a.coerce(:Name))
-    assert(q2b = q2a.coerce(:Name))
-    assert(q3b = q3a.coerce(:Name))
-    assert(q5b = q5a.coerce(:Name))
-    # assert(q6b = q6a.coerce(:Name))
-    assert(q7b = q7a.coerce(:Name))
-    assert(q8b = q8a.coerce(:Name))
-    assert(q9b = q9a.coerce(:Name))
+    observation_coercion_assertions(query_a, :Name)
+  end
 
-    # They should all be new records
-    assert(q1b.record.new_record?)
-    assert_save(q1b)
-    assert(q2b.record.new_record?)
-    assert_save(q2b)
-    assert(q3b.record.new_record?)
-    assert_save(q3b)
-    assert(q5b.record.new_record?)
-    assert_save(q5b)
-    # assert(q6b.record.new_record?)
-    # assert_save(q6b)
-    assert(q7b.record.new_record?)
-    assert_save(q7b)
-    assert(q8b.record.new_record?)
-    assert_save(q8b)
-    assert(q9b.record.new_record?)
-    assert_save(q9b)
+  # General purpose repetitive assertions for coercing observation queries.
+  # query_a is original, query_b is coerced, and query_c is coerced back.
+  # Returns the coerced query (query_check) for further testing
+  def observation_coercion_assertions(query_a, model)
+    query_b = query_c = []
+    len = query_a.size - 1
 
-    # Check their descriptions.
-    assert_equal("Name", q1b.model.to_s)
-    assert_equal("Name", q2b.model.to_s)
-    assert_equal("Name", q3b.model.to_s)
-    assert_equal("Name", q5b.model.to_s)
-    # assert_equal("Name", q6b.model.to_s)
-    assert_equal("Name", q7b.model.to_s)
-    assert_equal("Name", q8b.model.to_s)
-    assert_equal("Name", q9b.model.to_s)
+    [*0..len].each do |i|
+      # Try coercing them all.
+      assert(query_b[i] = query_a[i].coerce(model))
 
-    assert_equal(:with_observations, q1b.flavor)
-    assert_equal(:with_observations, q2b.flavor)
-    assert_equal(:with_observations, q3b.flavor)
-    assert_equal(:with_observations, q5b.flavor)
-    # assert_equal(:with_observations, q6b.flavor)
-    assert_equal(:with_observations, q7b.flavor)
-    assert_equal(:with_observations, q8b.flavor)
-    assert_equal(:with_observations, q9b.flavor)
+      # They should all be new records
+      assert(query_b[i].record.new_record?)
+      assert_save(query_b[i])
 
-    # Now try to coerce them back to Observation.
-    assert(q1c = q1b.coerce(:Observation))
-    assert(q2c = q2b.coerce(:Observation))
-    assert(q3c = q3b.coerce(:Observation))
-    assert(q5c = q5b.coerce(:Observation))
-    # assert(q6c = q6b.coerce(:Observation))
-    assert(q7c = q7b.coerce(:Observation))
-    assert(q8c = q8b.coerce(:Observation))
-    assert(q9c = q9b.coerce(:Observation))
+      # Check the query descriptions.
+      assert_equal(model.to_s, query_b[i].model.to_s)
+      assert_equal(:with_observations, query_b[i].flavor)
+    end
 
-    # Only some should be new.
-    assert_not(q1c.record.new_record?)
-    assert_equal(q1a, q1c)
-    assert_not(q2c.record.new_record?)
-    assert_equal(q2a, q2c)
-    assert_not(q3c.record.new_record?)
-    assert_equal(q3a, q3c)
-    assert_not(q5c.record.new_record?)
-    assert_equal(q5a, q5c)
-    # assert(q6c.record.new_record?)  # (converted to in_set)
-    assert_not(q7c.record.new_record?)
-    assert_equal(q7a, q7c)
-    assert_not(q8c.record.new_record?)
-    assert_equal(q8a, q8c)
-    assert_not(q9c.record.new_record?)
-    assert_equal(q9a, q9c)
+    # The `coerce` changes query_b, so save it for later comparison.
+    query_check = query_b.dup
+
+    [*0..len].each do |i|
+      # Now try to coerce them back to Observation.
+      assert(query_c[i] = query_b[i].coerce(:Observation))
+
+      # They should not be new records
+      assert_not(query_c[i].record.new_record?)
+      assert_equal(query_a[i], query_c[i])
+    end
+
+    query_check
   end
 
   def test_name_description_coercion

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -1089,14 +1089,14 @@ class QueryTest < UnitTestCase
     assert_equal([observations(:detailed_unknown_obs).id,
                   observations(:agaricus_campestris_obs).id,
                   observations(:agaricus_campestras_obs).id],
-                 q5b.params[:ids])
+                 q5b.params[:obs_ids])
     assert_equal(1, q5b.params.keys.length)
     # assert_equal(2, q6b.params.keys.length)
     # assert_equal([observations(:strobilurus_diminutivus_obs).id,
     #               observations(:agaricus_campestros_obs).id,
     #               observations(:agaricus_campestras_obs).id,
     #               observations(:agaricus_campestrus_obs).id],
-    #              q6b.params[:ids])
+    #              q6b.params[:obs_ids])
     # assert_match(/Observations.*Matching.*somewhere.*else/,
     #              q6b.params[:old_title])
     assert_equal("glendale", q7b.params[:user_where])
@@ -1826,10 +1826,10 @@ class QueryTest < UnitTestCase
                   images(:turned_over_image).id,
                   images(:in_situ_image).id],
                  :Image, :with_observations,
-                 ids: [observations(:detailed_unknown_obs).id,
-                       observations(:agaricus_campestris_obs).id])
+                 obs_ids: [observations(:detailed_unknown_obs).id,
+                           observations(:agaricus_campestris_obs).id])
     assert_query([], :Image, :with_observations,
-                 ids: [observations(:minimal_unknown_obs).id])
+                 obs_ids: [observations(:minimal_unknown_obs).id])
   end
 
   def test_image_with_observations_in_species_list
@@ -2001,15 +2001,17 @@ class QueryTest < UnitTestCase
   end
 
   def test_location_with_descriptions_in_set
-    assert_query([locations(:albion), locations(:no_mushrooms_location)],
-                 :Location, :with_descriptions,
-                 ids: [location_descriptions(:albion_desc).id,
-                       location_descriptions(:no_mushrooms_location_desc).id])
+    assert_query(
+      [locations(:albion), locations(:no_mushrooms_location)],
+      :Location, :with_descriptions,
+      desc_ids: [location_descriptions(:albion_desc).id,
+                 location_descriptions(:no_mushrooms_location_desc).id]
+    )
     assert_query([locations(:albion)],
                  :Location, :with_descriptions,
-                 ids: [location_descriptions(:albion_desc).id, rolf.id])
+                 desc_ids: [location_descriptions(:albion_desc).id, rolf.id])
     assert_query([],
-                 :Location, :with_descriptions, ids: [rolf.id])
+                 :Location, :with_descriptions, desc_ids: [rolf.id])
   end
 
   def test_location_with_observations
@@ -2247,9 +2249,9 @@ class QueryTest < UnitTestCase
   def test_location_with_observations_in_set
     assert_query([locations(:burbank).id],
                  :Location, :with_observations,
-                 ids: [observations(:minimal_unknown_obs).id])
+                 obs_ids: [observations(:minimal_unknown_obs).id])
     assert_query([], :Location, :with_observations,
-                 ids: [observations(:coprinus_comatus_obs).id])
+                 obs_ids: [observations(:coprinus_comatus_obs).id])
   end
 
   def test_location_with_observations_in_species_list
@@ -2501,7 +2503,7 @@ class QueryTest < UnitTestCase
     name1 = names(:peltigera)
     name2 = names(:boletus_edulis)
     assert_query([name2, name1],
-                 :Name, :with_descriptions, ids: [desc1, desc2, desc3])
+                 :Name, :with_descriptions, desc_ids: [desc1, desc2, desc3])
   end
 
   def test_name_with_observations
@@ -2687,9 +2689,9 @@ class QueryTest < UnitTestCase
                   names(:agaricus_campestris).id,
                   names(:fungi).id],
                  :Name, :with_observations,
-                 ids: [observations(:detailed_unknown_obs).id,
-                       observations(:agaricus_campestris_obs).id,
-                       observations(:agaricus_campestras_obs).id])
+                 obs_ids: [observations(:detailed_unknown_obs).id,
+                           observations(:agaricus_campestris_obs).id,
+                           observations(:agaricus_campestras_obs).id])
   end
 
   def test_name_with_observations_in_species_list


### PR DESCRIPTION
- DRYs up some repetitive parameter declarations
- Switches param names for the outer `:ids` of coerced queries. 

The latter are now named to refer to the outer table: `:obs_ids` or `:desc_ids`, to keep them distinct from the `:ids` param for the inner table. 

For example, when coercing from `Observation` to `ImageWithObservations`, the param named `:ids` is converted to `:obs_ids` to allow it to be handled differently from the param that should mean a set of image `:ids`.