### PR TITLE
Stop assuming lat and lng are in degree, minute, second

### DIFF
--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -320,6 +320,11 @@ export default class extends Controller {
       this.getElevationTarget.disabled = true
   }
 
+  // Using a regular expression
+  isValidDecimal(str) {
+    return /^-?\d*\.?\d+$/.test(str);
+  }
+
   // Convert from human readable and do a rough check if they make sense
   validateLatLngInputs(update = false) {
     this.verbose("geocode:validateLatLngInputs")
@@ -331,9 +336,21 @@ export default class extends Controller {
       origLng = this.lngInputTarget.value
     let lat, lng
 
-    lat = parseFloat(origLat)
-    lng = parseFloat(origLng)
-
+    if (this.isValidDecimal(origLat) && this.isValidDecimal(origLng)) {
+      lat = parseFloat(origLat)
+      lng = parseFloat(origLng)
+    } else {
+      try {
+        let coords = convert(origLat + " " + origLng)
+        lat = coords.decimalLatitude,
+          lng = coords.decimalLongitude
+      }
+      // Toss any degree-minute-second notation and just take the first number
+      catch {
+        lat = parseFloat(origLat)
+        lng = parseFloat(origLng)
+      }
+    }
     if (!lat || !lng)
       return false
     if (lat > 90 || lat < -90 || lng > 180 || lng < -180)

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -331,16 +331,8 @@ export default class extends Controller {
       origLng = this.lngInputTarget.value
     let lat, lng
 
-    try {
-      let coords = convert(origLat + " " + origLng)
-      lat = coords.decimalLatitude,
-        lng = coords.decimalLongitude
-    }
-    // Toss any degree-minute-second notation and just take the first number
-    catch {
-      lat = parseFloat(origLat)
-      lng = parseFloat(origLng)
-    }
+    lat = parseFloat(origLat)
+    lng = parseFloat(origLng)
 
     if (!lat || !lng)
       return false


### PR DESCRIPTION
Addresses #2594.

Old bad behavior:
1. Go to Create Observation
2. Clear out any location string
3. Enter the following as lat/long: 41.63, -70.62 (which is in North Falmouth)
4. Note that the map updates to somewhere south of Nantucket (which is wrong) [Fixed on branch so the rest doesn't happen]
5. Note that if you move the pin, it updates the lat/long to something around 41.1, -70.1 (which is south of Nantucket)
6. If you move the pin to North Falmouth, it updates the lat/long to something close to 41.63/-70.62.
7. Now select “North Falmouth” from the “New Locality” drop down.
8. If you now try to edit the latitude to 41.63, it will again jump to somewhere south of Nantucket.
9. For me, it updates the lat/long to 41.1008/-70.1083.