### PR TITLE
Update `README_MACOSX_NOTES` and fix `db/strip_checkpoint`

### DIFF
--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -24,9 +24,9 @@ You will also need `homebrew` from <https://brew.sh/>:
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-If you already have `homebrew` installed you may want to upgrade.
+If you already have `homebrew` installed you may (or may not) want to upgrade your packages.
 
-Note: do not run `brew upgrade` if you're on old hardware and you already have everything below installed. Homebrew is pretty hardware-ignorant and will try to install incompatible versions, rendering your dev environment inoperable and difficult to downgrade.
+Warning: do not run `brew upgrade` if you're on very old hardware and you already have everything below installed. Homebrew is pretty hardware-ignorant and will try to upgrade you to incompatible versions, rendering your dev environment inoperable and difficult to downgrade.
 
 ```sh
 brew outdated
@@ -39,7 +39,7 @@ Install a bunch of useful stuff from `Homebrew`
 brew install git mysql exiftool libjpeg shared-mime-info openssl imagemagick findutils
 ```
 
-### Install Bash
+### Install Bash if you're not using Zsh
 
 If you haven't done so already, install a recent version of [Bash](https://www.gnu.org/software/bash/) and set
 it as the default shell. You can find your installed version like this:

--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -31,6 +31,7 @@ brew outdated
 brew upgrade
 ```
 
+Note: do not run `brew upgrade` if you're on old hardware and you already have the stuff below installed. Homebrew is pretty hardware-ignorant and will try to install incompatible versions, rendering your dev environment inoperable and difficult to downgrade.
 Install a bunch of useful stuff from `Homebrew`
 
 ```sh

--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -41,7 +41,8 @@ brew install git mysql exiftool libjpeg shared-mime-info openssl imagemagick fin
 
 ### Install Bash if you're not using Zsh
 
-If you haven't done so already, install a recent version of [Bash](https://www.gnu.org/software/bash/) and set
+If you haven't done so already, either switch your shell to zsh (supported by Apple) or
+install a recent version of [Bash](https://www.gnu.org/software/bash/) and set
 it as the default shell. You can find your installed version like this:
 
 ```sh

--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -91,14 +91,17 @@ mysql_secure_installation # sets the root password, new style.
 # mysql > 8.0 uses this new configuration wizard. It asks several questions.
 ```
 
-If you have trouble with this step, you may have an old mysql configuration
-interfering. If that is the case, it's usually more efficient to completely
-delete mysql and all configurations, and reinstall, than to debug:
+If you have trouble with that step, you may have an old mysql configuration
+interfering. It is usually more efficient to completely delete the mysql
+directory and all config files, and reinstall, than to debug.
+
+Bad installs can have all kinds of directory permissions problems that
+will prevent them from ever working properly.
 
 ```sh
 brew services stop mysql
 brew uninstall mysql
-rm -r /usr/local/var/mysql
+rm -r /usr/local/var/mysql # or wherever homebrew installed mysql
 rm /usr/local/etc/my.cnf # and any other .cnf files
 brew install mysql
 brew services start mysql

--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -102,7 +102,7 @@ will prevent them from ever working properly.
 brew services stop mysql
 brew uninstall mysql
 rm -r /usr/local/var/mysql # or wherever homebrew installed mysql
-rm /usr/local/etc/my.cnf # and any other .cnf files
+rm /usr/local/etc/my.cnf # and any other .cnf files you can find
 brew install mysql
 brew services start mysql
 mysql_secure_installation

--- a/db/strip_checkpoint
+++ b/db/strip_checkpoint
@@ -5,5 +5,5 @@ username="mo"
 password="mo"
 
 gunzip -c checkpoint.gz | mysql -u $username -p$password $database
-mysql -u $username -p$password $database -e "source clean.sql"
+mysql -u $username -p$password $database -e "source db/clean.sql"
 mysqldump -u $username -p$password $database | gzip > checkpoint_stripped.gz


### PR DESCRIPTION
Updates notes with syntax and heuristic changes to deal with mysql > 8.
Removes workarounds added by Joe and Nimmo that do not work any longer in MySQL 8 or 9.

Fixes the script `strip_checkpoint` so you can run it from your local `mushroom-observer` directory.