### PR TITLE
csv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,6 +152,9 @@ gem("prawn-svg")
 gem("prawn")
 gem("prawn-manual_builder")
 
+# csv generation support
+gem("csv")
+
 # Use puma as the app server, also available for system tests
 # To use Webrick locally, run `bundle config set --local without 'production'`
 # https://stackoverflow.com/a/23125762/3357635

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     crass (1.0.6)
     css_parser (1.19.1)
       addressable
-    csv (3.3.0)
+    csv (3.3.2)
     cuprite (0.15.1)
       capybara (~> 3.0)
       ferrum (~> 0.15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     crass (1.0.6)
     css_parser (1.19.1)
       addressable
+    csv (3.3.0)
     cuprite (0.15.1)
       capybara (~> 3.0)
       ferrum (~> 0.15.0)
@@ -519,6 +520,7 @@ DEPENDENCIES
   bundler
   cache_with_locale
   capybara
+  csv
   cuprite
   dartsass-sprockets
   database_cleaner-active_record


### PR DESCRIPTION
- Responds to warning:
> /home/mo/.gem/ruby/3.3.0/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:34: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of zeitwerk-2.7.1 to add csv into its gemspec.
(The warning started with the removal of `httparty`.)
- Should shut off stream of emails to webmaster with this warning (about 1 email every 4 minutes).
- Unfortunately restores deprecation warnings about 
  - Deprecated arel extenstion `==` and `!=`
  - `convert` command is deprecated in IMv7