### PR TITLE
Fix names needing description

### DIFF
--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -28,6 +28,7 @@ module Query::Initializers::Names
       notes_has?: :string,
       with_comments?: { boolean: [true] },
       comments_has?: :string,
+      need_description?: :boolean,
       with_descriptions?: :boolean,
       with_observations?: { boolean: [true] }
     }

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -70,6 +70,7 @@ class Query::Names < Query::Base
     initialize_name_comments_and_notes_parameters
     initialize_name_parameters_for_name_queries
     add_pattern_condition
+    add_need_description_condition
     add_name_advanced_search_conditions
     initialize_name_association_parameters
   end
@@ -97,6 +98,11 @@ class Query::Names < Query::Base
     add_for_project_condition(:project_observations, project_joins)
     add_in_species_list_condition
     initialize_herbaria_parameter
+  end
+
+  def add_need_description_condition
+    add_join(:observations)
+    @where << "#{model.table_name}.description_id IS NULL"
   end
 
   def add_pattern_condition

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -105,6 +105,7 @@ class Query::Names < Query::Base
 
     add_join(:observations)
     @where << "#{model.table_name}.description_id IS NULL"
+    @title_tag = :query_title_needs_description.t(type: :name)
   end
 
   def add_pattern_condition

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -101,6 +101,8 @@ class Query::Names < Query::Base
   end
 
   def add_need_description_condition
+    return unless params[:need_description]
+
     add_join(:observations)
     @where << "#{model.table_name}.description_id IS NULL"
   end

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -83,7 +83,10 @@ class NamesController < ApplicationController
   # NOTE: all this extra info and help will be lost if user re-sorts.
   def need_descriptions
     @help = :needed_descriptions_help
-    query = Name.descriptions_needed
+    query = create_query(:Name,
+                         need_description: 1,
+                         group: "observations.name_id",
+                         order: "count(*) DESC")
     [query, { num_per_page: 100 }]
   end
 

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -22,7 +22,7 @@ class NamesController < ApplicationController
   # ApplicationController uses this to dispatch #index to a private method
   def index_active_params
     [:advanced_search, :pattern, :with_observations, :with_descriptions,
-     :need_descriptions, :by_user, :by_editor, :by, :q, :id].freeze
+     :need_description, :by_user, :by_editor, :by, :q, :id].freeze
   end
 
   # Displays list of advanced search results.
@@ -81,7 +81,7 @@ class NamesController < ApplicationController
 
   # Display list of the most popular 100 names that don't have descriptions.
   # NOTE: all this extra info and help will be lost if user re-sorts.
-  def need_descriptions
+  def need_description
     @help = :needed_descriptions_help
     query = create_query(:Name,
                          need_description: 1,

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -469,7 +469,7 @@ class Name < AbstractModel
         -> { where(description_id: nil) }
   # Names without descriptions, order by most frequently used
   scope :description_needed, lambda {
-    without_description.joins(:observations).
+    with_correct_spelling.without_description.joins(:observations).
       group(:name_id).order(Arel.star.count.desc)
   }
   scope :description_includes,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4389,6 +4389,7 @@
   query_title_in_species_list: "[TYPES] in [SPECIES_LIST]"
   query_title_inside_observation: "[TYPES] of [OBSERVATION]"
   query_title_needs_id: "[OBSERVATIONS] needing identification for [USER]"
+  query_title_needs_description: "[TYPES] needing descriptions"
   query_title_nonpersonal: List of Institutional Fungaria
   query_title_of_children: Lower Taxa under [NAME]
   query_title_of_name: "[TYPES] of [NAME]"

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -264,7 +264,7 @@ class NamesControllerTest < FunctionalTestCase
     get(:index, params: { need_description: true })
 
     assert_response(:success)
-    # assert_displayed_title("Selected Names")
+    assert_displayed_title(:query_title_needs_description.t(type: :name))
     assert_select(
       "#results a:match('href', ?)", %r{^#{names_path}/\d+},
       # need length; count & size return a hash; description_needed is grouped

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -259,9 +259,9 @@ class NamesControllerTest < FunctionalTestCase
     )
   end
 
-  def test_index_needing_descriptions
+  def test_index_needing_description
     login
-    get(:index, params: { need_descriptions: true })
+    get(:index, params: { need_description: true })
 
     assert_response(:success)
     # assert_displayed_title("Selected Names")

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -264,7 +264,7 @@ class NamesControllerTest < FunctionalTestCase
     get(:index, params: { need_descriptions: true })
 
     assert_response(:success)
-    assert_displayed_title("Selected Names")
+    # assert_displayed_title("Selected Names")
     assert_select(
       "#results a:match('href', ?)", %r{^#{names_path}/\d+},
       # need length; count & size return a hash; description_needed is grouped

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2285,6 +2285,10 @@ class QueryTest < UnitTestCase
                  exclude_original_names: true)
   end
 
+  def test_name_need_description
+    assert_query(Name.description_needed.to_a, :Name, need_description: 1)
+  end
+
   def test_name_pattern_search
     assert_query(
       [],


### PR DESCRIPTION
This available filter of the Names index `:need_descriptions` does not appear to have possibly ever worked. Probably because its author (me) did not understand how to do it.

Fixes the filter (adds a new old-school Query, and a repairs the model scope) and adds a test. Takes the opportunity to rename the param `:need_description`, which should not break anything since it is not used anywhere yet.

`/names?need_description=1`