### PR TITLE
Bump up MO.query_max_array to 10,000

### DIFF
--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -36,7 +36,7 @@ module Query::Modules::Initialization
     set.presence || "-1"
   end
 
-  # array of max of 1000 unique ids for use with Arel "in"
+  # array of max of MO.query_max_array unique ids for use with Arel "in"
   #    where(<x>.in(limited_id_set(ids)))
   def limited_id_set(ids)
     ids.map(&:to_i).uniq[0, MO.query_max_array]

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -183,8 +183,13 @@ MushroomObserver::Application.configure do
   # Default number of items for an RSS page
   config.default_layout_count = 12
 
-  # Max number of results Query will put in "IN (...)" clauses.
-  config.query_max_array = 1000
+  # Max number of results Query will put in "IN (...)" clauses.  This
+  # was originally 1000, but searching for "Russula" or "Amanita" now
+  # exceeds that limit (Dec. 2024) and is causing issues.  Raising it
+  # to 10,000 allows those cases to work.  Tested a simple query with
+  # 11,000 ids on the current version of MySQL which completed in
+  # around 0.1 seconds.
+  config.query_max_array = 10_000
 
   # Filter(s) to apply to all Querys
   config.default_content_filter = nil


### PR DESCRIPTION
Addresses #2622.  You can now search for "Russula" or "Amanita" and get observations for all associated names.  Currently there are around 1700 names associated with Russula and 1800 with Amanita.  These were getting truncated to 1,000 names and the actual genus name was dropping out of the list.

Tested both my local and the production MySQL server with a query using 11,000 ids and it work with no problems.