### PR TITLE
Fix issue with observations/locations URL with no where

### DIFF
--- a/app/controllers/observations/locations_controller.rb
+++ b/app/controllers/observations/locations_controller.rb
@@ -81,7 +81,7 @@ module Observations
       # Try for segments: split by comma, or by space if no commas
       places = @where.split(",")
       words = @where.split
-      return unless places.length > 1 || words.length > 1
+      return matches unless places.length > 1 || words.length > 1
 
       matches += Location.name_includes(places.first)
       # Try for specific segment matches if we have enough of them.

--- a/test/controllers/observations/locations_controller_test.rb
+++ b/test/controllers/observations/locations_controller_test.rb
@@ -28,6 +28,10 @@ module Observations
       # Case seen in the wild that causes error
       requires_login(:edit, where: "")
       assert(assigns(:matches).include?(albion))
+
+      # Another case that caused an error
+      requires_login(:edit, where: "CA")
+      assert(assigns(:matches).include?(albion))
     end
 
     def test_add_to_location

--- a/test/controllers/observations/locations_controller_test.rb
+++ b/test/controllers/observations/locations_controller_test.rb
@@ -24,6 +24,10 @@ module Observations
       # Shouldn't match anything.
       requires_login(:edit, where: "Somewhere out there")
       assert_empty(assigns(:matches))
+
+      # Case seen in the wild that causes error
+      requires_login(:edit, where: "")
+      assert(assigns(:matches).include?(albion))
     end
 
     def test_add_to_location


### PR DESCRIPTION
To test go to /observations/locations.  I believe the real way to get to this URL is through the location merge workflow.  If there is no `where` parameter or the `where parameter` is a single word, then the crash will happen on main and is fixed with this PR.