### PR TITLE
Define enums by positional args

### DIFF
--- a/app/models/field_slip_job_tracker.rb
+++ b/app/models/field_slip_job_tracker.rb
@@ -5,12 +5,7 @@ class FieldSlipJobTracker < AbstractModel
   SUBDIR = "shared"
   PDF_DIR = PUBLIC_DIR + SUBDIR
 
-  enum status:
-         {
-           Starting: 1,
-           Processing: 2,
-           Done: 3
-         }
+  enum :status, { Starting: 1, Processing: 2, Done: 3 }
 
   belongs_to :user
 

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -50,7 +50,6 @@
 class LocationDescription < Description
   require "acts_as_versioned"
 
-  # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
   enum :source_type,
        { public: 1, foreign: 2, project: 3, source: 4, user: 5 },

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -52,14 +52,9 @@ class LocationDescription < Description
 
   # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
-  enum source_type:
-       {
-         public: 1,
-         foreign: 2,
-         project: 3,
-         source: 4,
-         user: 5
-       }, _suffix: :source
+  enum :source_type,
+       { public: 1, foreign: 2, project: 3, source: 4, user: 5 },
+       suffix: :source, instance_methods: false
 
   belongs_to :license
   belongs_to :location

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -348,7 +348,6 @@ class Name < AbstractModel
   extend Parse
   extend Create
 
-  # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
   enum :rank, {
     Form: 1,

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -67,21 +67,11 @@ class NameDescription < Description
 
   # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
-  enum review_status:
-        {
-          unreviewed: 1,
-          unvetted: 2,
-          vetted: 3,
-          inaccurate: 4
-        }
-  enum source_type:
-        {
-          public: 1,
-          foreign: 2,
-          project: 3,
-          source: 4,
-          user: 5
-        }, _suffix: :source
+  enum :review_status,  { unreviewed: 1, unvetted: 2, vetted: 3, inaccurate: 4 }
+
+  enum :source_type, { public: 1, foreign: 2, project: 3, source: 4, user: 5 },
+       suffix: :source, instance_methods: false
+
   belongs_to :license
   belongs_to :name
   belongs_to :project

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -67,7 +67,7 @@ class NameDescription < Description
 
   # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
-  enum :review_status,  { unreviewed: 1, unvetted: 2, vetted: 3, inaccurate: 4 }
+  enum :review_status, { unreviewed: 1, unvetted: 2, vetted: 3, inaccurate: 4 }
 
   enum :source_type, { public: 1, foreign: 2, project: 3, source: 4, user: 5 },
        suffix: :source, instance_methods: false

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -65,7 +65,6 @@
 class NameDescription < Description
   require "acts_as_versioned"
 
-  # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
   enum :review_status, { unreviewed: 1, unvetted: 2, vetted: 3, inaccurate: 4 }
 

--- a/app/models/project_member.rb
+++ b/app/models/project_member.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectMember < ApplicationRecord
-  enum trust_level:
-         {
-           no_trust: 1,
-           hidden_gps: 2,
-           editing: 3
-         }
+  enum :trust_level, { no_trust: 1, hidden_gps: 2, editing: 3 }
 
   belongs_to :project
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -202,59 +202,24 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
   # first value is the default
-  enum thumbnail_size:
-       {
-         thumbnail: 1,
-         small: 2
-       },
-       _prefix: :thumb_size,
-       _default: "thumbnail"
+  enum :thumbnail_size, { thumbnail: 1, small: 2 },
+       prefix: :thumb_size, default: "thumbnail", instance_methods: false
 
-  enum image_size:
-       {
-         thumbnail: 1,
-         small: 2,
-         medium: 3,
-         large: 4,
-         huge: 5,
-         full_size: 6
-       },
-       _prefix: true,
-       _default: "medium"
+  enum :image_size,
+       { thumbnail: 1, small: 2, medium: 3, large: 4, huge: 5, full_size: 6 },
+       prefix: true, default: "medium", instance_methods: false
 
-  enum votes_anonymous:
-       {
-         no: 1,
-         yes: 2,
-         old: 3
-       },
-       _prefix: :votes_anon,
-       _default: "no"
+  enum :votes_anonymous, { no: 1, yes: 2, old: 3 },
+       prefix: :votes_anon, default: "no", instance_methods: false
 
-  enum location_format:
-       {
-         postal: 1,
-         scientific: 2
-       },
-       _prefix: true,
-       _default: "postal"
+  enum :location_format, { postal: 1, scientific: 2 },
+       prefix: true, default: "postal", instance_methods: false
 
-  enum hide_authors:
-       {
-         none: 1,
-         above_species: 2
-       },
-       _prefix: true,
-       _default: "none"
+  enum :hide_authors, { none: 1, above_species: 2 },
+       prefix: true, default: "none", instance_methods: false
 
-  enum keep_filenames:
-       {
-         toss: 1,
-         keep_but_hide: 2,
-         keep_and_show: 3
-       },
-       _suffix: :filenames,
-       _default: "toss"
+  enum :keep_filenames, { toss: 1, keep_but_hide: 2, keep_and_show: 3 },
+       suffix: :filenames, default: "toss", instance_methods: false
 
   has_one :user_stats, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,27 +199,26 @@
 class User < AbstractModel # rubocop:disable Metrics/ClassLength
   require "digest/sha1"
 
-  # enum definitions for use by simple_enum gem
   # Do not change the integer associated with a value
-  # first value is the default
+  # First value is the default
   enum :thumbnail_size, { thumbnail: 1, small: 2 },
-       prefix: :thumb_size, default: "thumbnail", instance_methods: false
+       prefix: :thumb_size, default: :thumbnail, instance_methods: false
 
   enum :image_size,
        { thumbnail: 1, small: 2, medium: 3, large: 4, huge: 5, full_size: 6 },
-       prefix: true, default: "medium", instance_methods: false
+       prefix: true, default: :medium, instance_methods: false
 
   enum :votes_anonymous, { no: 1, yes: 2, old: 3 },
-       prefix: :votes_anon, default: "no", instance_methods: false
+       prefix: :votes_anon, default: :no, instance_methods: false
 
   enum :location_format, { postal: 1, scientific: 2 },
-       prefix: true, default: "postal", instance_methods: false
+       prefix: true, default: :postal, instance_methods: false
 
   enum :hide_authors, { none: 1, above_species: 2 },
-       prefix: true, default: "none", instance_methods: false
+       prefix: true, default: :none, instance_methods: false
 
   enum :keep_filenames, { toss: 1, keep_but_hide: 2, keep_and_show: 3 },
-       suffix: :filenames, default: "toss", instance_methods: false
+       suffix: :filenames, default: :toss, instance_methods: false
 
   has_one :user_stats, dependent: :destroy
 


### PR DESCRIPTION
THIS is all we need to do to silence the "enum" deprecation warnings in Rails 7.2. No big deal!

Instead of `enum this: { foo: 1, baz: 2 }` we just have to do `enum :this, { foo: 1, baz: 2 }`. 
Easy peasy. 

- We don't need the values to be arrays ([hashes are preferred!](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsenumhash)).
- We don't need a zero value.