### PR TITLE
Use SolidQueue to run a cron job repopulating Location and Observation center_lat/center_lng

### DIFF
--- a/app/jobs/update_box_area_and_center_columns_job.rb
+++ b/app/jobs/update_box_area_and_center_columns_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    log("Starting UpdateBoxAreaAndCenterColumnsJob.perform")
+    # This should be zero, but count just in case.
+    loc_count = Location.where(box_area: nil).count
+    log("Found #{loc_count} locations without a box_area.")
+    # Count the observations associated with locations that are under the
+    # max area, but haven't got a center lat/lng, and log what we're updating.
+    obs_count = Observation.in_box_of_max_area.where(location_lat: nil).count
+    log("Found #{obs_count} observations where the associated location was " \
+        "small enough, but the obs didn't have a location_lat/lng.")
+    return if args[:dry_run]
+
+    # Do the update. This returns counts of locations/observations updated.
+    loc_updated, obs_centered, obs_center_nulled =
+      Location.update_box_area_and_center_columns
+
+    log("Updated #{loc_updated} locations' box_area and center_lat/lng.")
+    log("Updated #{obs_centered} observations' location_lat/lng.")
+    log("Nulled #{obs_center_nulled} observations' location_lat/lng.")
+  end
+end

--- a/app/jobs/update_box_area_and_center_columns_job.rb
+++ b/app/jobs/update_box_area_and_center_columns_job.rb
@@ -3,7 +3,8 @@
 class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
+  def perform(**args)
+    args ||= {}
     log("Starting UpdateBoxAreaAndCenterColumnsJob.perform")
     # This should be zero, but count just in case.
     loc_count = Location.where(box_area: nil).count
@@ -13,7 +14,7 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
     obs_count = Observation.in_box_of_max_area.where(location_lat: nil).count
     log("Found #{obs_count} observations where the associated location was " \
         "small enough, but the obs didn't have a location_lat/lng.")
-    return if args[:dry_run]
+    return [loc_count, obs_count] if args[:dry_run]
 
     # Do the update. This returns counts of locations/observations updated.
     loc_updated, obs_centered, obs_center_nulled =
@@ -22,5 +23,7 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
     log("Updated #{loc_updated} locations' box_area and center_lat/lng.")
     log("Updated #{obs_centered} observations' location_lat/lng.")
     log("Nulled #{obs_center_nulled} observations' location_lat/lng.")
+    # Return the values for debugging
+    [loc_updated, obs_centered, obs_center_nulled]
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -311,17 +311,22 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   # Can populate columns after migration, or be run as part of a recurring job.
   def self.update_box_area_and_center_columns
     # update the locations
-    update_all(update_center_and_area_sql)
+    loc_updated = update_all(update_center_and_area_sql)
     # give center points to associated observations in batches by location_id
     # Observation must be unscoped in order to join to locations.
     # (removing default_scope)
-    Observation.unscoped.in_box_of_max_area.group(:location_id).update_all(
-      location_lat: Location[:center_lat], location_lng: Location[:center_lng]
-    )
+    obs_centered = Observation.unscoped.
+                   in_box_of_max_area.group(:location_id).update_all(
+                     location_lat: Location[:center_lat],
+                     location_lng: Location[:center_lng]
+                   )
     # null center points where area is above the threshold
-    Observation.unscoped.in_box_gt_max_area.group(:location_id).update_all(
-      location_lat: nil, location_lng: nil
-    )
+    obs_center_nulled = Observation.unscoped.
+                        in_box_gt_max_area.group(:location_id).update_all(
+                          location_lat: nil, location_lng: nil
+                        )
+    # Return counts
+    [loc_updated, obs_centered, obs_center_nulled]
   end
 
   # Let attached observations update their cache if these fields changed.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -14,4 +14,4 @@
 production:
   repopulate_location_and_observation_center_lat_lng:
     class: UpdateBoxAreaAndCenterColumnsJob
-    schedule: every saturday at midnight
+    schedule: every day at midnight

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -11,3 +11,7 @@
 #   a_cleanup_task:
 #     command: "DeletedStuff.clear_all"
 #     schedule: every day at 9am
+production:
+  repopulate_location_and_observation_center_lat_lng:
+    command: "Location.update_box_area_and_center_columns"
+    schedule: every saturday at midnight

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,5 +13,5 @@
 #     schedule: every day at 9am
 production:
   repopulate_location_and_observation_center_lat_lng:
-    command: "Location.update_box_area_and_center_columns"
+    class: UpdateBoxAreaAndCenterColumnsJob
     schedule: every saturday at midnight

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -3,11 +3,28 @@
 require "test_helper"
 
 class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
-  def test_update_dry_run
-    # ?
-    # assert_difference("Observation.count", 1,
-    #                   "Failed to create observation") do
-    #   UpdateBoxAreaAndCenterColumnsJob.perform_now(dry_run: true)
-    # end
+  def test_update_box_area_and_center_columns
+    # Check that we have some obs that need updating
+    assert_not_empty(Observation.in_box_of_max_area.where(location_lat: nil))
+
+    job = UpdateBoxAreaAndCenterColumnsJob.new
+    job.perform
+
+    assert_empty(Observation.in_box_of_max_area.where(location_lat: nil))
+    # Note: All locations should already have a box_area, so this was nil before
+    assert_empty(Location.where(box_area: nil))
+  end
+
+  def test_update_box_area_dry_run
+    # Check that we have some obs that need updating
+    assert_not_empty(Observation.in_box_of_max_area.where(location_lat: nil))
+
+    job = UpdateBoxAreaAndCenterColumnsJob.new
+    _loc_count, obs_count = job.perform(dry_run: true)
+
+    # check it again
+    needs_update = Observation.in_box_of_max_area.where(location_lat: nil)
+    assert_not_empty(needs_update)
+    assert_equal(obs_count, needs_update.count)
   end
 end

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def test_update_dry_run
+    # ?
+    # assert_difference("Observation.count", 1,
+    #                   "Failed to create observation") do
+    #   UpdateBoxAreaAndCenterColumnsJob.perform_now(dry_run: true)
+    # end
+  end
 end

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -11,7 +11,7 @@ class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
     job.perform
 
     assert_empty(Observation.in_box_of_max_area.where(location_lat: nil))
-    # Note: All locations should already have a box_area, so this was nil before
+    # NOTE: All locations may already have a box_area, so probably nil before
     assert_empty(Location.where(box_area: nil))
   end
 
@@ -22,7 +22,7 @@ class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
     job = UpdateBoxAreaAndCenterColumnsJob.new
     _loc_count, obs_count = job.perform(dry_run: true)
 
-    # check it again
+    # check it again and be sure it did NOT update the obs
     needs_update = Observation.in_box_of_max_area.where(location_lat: nil)
     assert_not_empty(needs_update)
     assert_equal(obs_count, needs_update.count)


### PR DESCRIPTION
~Not sure if this config is phrased right, need to do more research. But apparently~ that's all this takes: a config and a command. **Update**: [yes, it is that simple](https://github.com/rails/solid_queue/issues/356#issuecomment-2572744366).

Also, I'm not sure we need to run it weekly. Monthly might be A-OK. There was some question initially about whether our callbacks would populate these correctly... we should check how many are currently missing in the db.

Responds to #2640 