### PR TITLE
Revert unintentional changes to `with_description_classification_differing`

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -510,10 +510,10 @@ class Name < AbstractModel
         }
   scope :with_description_classification_differing,
         lambda {
-          joins(:descriptions).
+          joins(:description).
             where(rank: 0..Name.ranks[:Genus]).
-            where(Name[:classification].
-                  not_eq(NameDescription[:classification])).
+            where(NameDescription[:classification].
+                  not_eq(Name[:classification])).
             where(NameDescription[:classification].not_blank)
         }
   scope :by_editor,


### PR DESCRIPTION
The original scope from `refresh_classification_caches`:
```ruby
  Name.joins(:description).
    where(rank: 0..Name.ranks[:Genus]).
    where(NameDescription[:classification].not_eq(Name[:classification])).
    where(NameDescription[:classification].not_blank)
```
The recently added scope in Name:
```ruby
  scope :with_description_classification_differing,
        lambda {
          joins(:descriptions).
            where(rank: 0..Name.ranks[:Genus]).
            where(Name[:classification].
                  not_eq(NameDescription[:classification])).
            where(NameDescription[:classification].not_blank)
        }
```
It seems it should be this. Note `joins(:description)` was originally singular. I don't know if the order of `not_eq` matters but it's restored here:
```ruby
  scope :with_description_classification_differing,
        lambda {
          joins(:description).
            where(rank: 0..Name.ranks[:Genus]).
            where(NameDescription[:classification].
                  not_eq(Name[:classification])).
            where(NameDescription[:classification].not_blank)
        }
```