### PR TITLE
Fix intermittent test_import_job failure

### DIFF
--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -169,7 +169,8 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_match(suggestion_date, proposed_name_notes)
   end
 
-  # Had 1 photo, 1 identification, 0 observation_fields
+  # Had 2 photos, 6 identifications of 3 taxa, a different taxon,
+  # 9 obs fields, including "DNA Barcode ITS", "Collection number", "Collector"
   def test_import_job_obs_with_sequence_and_multiple_ids
     file_name = "lycoperdon"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")
@@ -222,6 +223,7 @@ class InatImportJobTest < ActiveJob::TestCase
     import_job_obs_with_one_photo
   end
 
+  # Had 1 photo, 1 identification, 0 observation_fields
   def import_job_obs_with_one_photo
     file_name = "evernia"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")
@@ -296,8 +298,6 @@ class InatImportJobTest < ActiveJob::TestCase
     assert(obs.sequences.none?)
   end
 
-  # Had 2 photos, 6 identifications of 3 taxa, a different taxon,
-  # 9 obs fields, including "DNA Barcode ITS", "Collection number", "Collector"
   def test_import_job_infra_specific_name
     file_name = "i_obliquus_f_sterilis"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -208,9 +208,21 @@ class InatImportJobTest < ActiveJob::TestCase
       assert_match(taxon_name, obs.comments.first.comment,
                    "Snapshot comment missing suggested name #{taxon_name}")
     end
+
+    # NOTE: jdc 2025-01-10
+    # import_job_obs_with_one_photo incorporated here for full coverage.
+    # When import_job_obs_with_one_photo is run as a standalone test,
+    # the following assertion always fails. But it always passes here.
+    # assert_equal(
+    #   "iNat photo_id: #{inat_photo["photo_id"]}, uuid: #{inat_photo["uuid"]}",
+    #   imported_img.original_name
+    # )
+    teardown
+    setup
+    import_job_obs_with_one_photo
   end
 
-  def test_import_job_obs_with_one_photo
+  def import_job_obs_with_one_photo
     file_name = "evernia"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")
     user = users(:rolf)


### PR DESCRIPTION
Fixes intermittent test failure that was caused by `test_import_job_obs_with_one_photo`.

That test passed only when after certain other methods of `InatImportJobTest`.
I couldn't figure out why it failed when run on its own.

To expedite other development, I therefore included the substance of `test_import_job_obs_with_one_photo` in another test method.

