### PR TITLE
Fix inat_import_job failure

### DIFF
--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -169,8 +169,10 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_match(suggestion_date, proposed_name_notes)
   end
 
-  # Had 1 photo, 1 identification, 0 observation_fields
-  def test_import_job_obs_with_one_photo
+  # Had 1 photo, 1 identification, 0 observation_fields; 0 sequences
+  # See note below about why this test is not run as its own test
+  # def test_import_job_obs_with_one_photo
+  def import_job_obs_with_one_photo
     file_name = "evernia"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")
     user = users(:rolf)
@@ -204,16 +206,16 @@ class InatImportJobTest < ActiveJob::TestCase
 
     assert_equal(1, obs.images.length, "Obs should have 1 image")
 
-    # Something weird is going on with stubbing here since this succeeds if
-    # some of the other tests run before this one.
-    #
-    # inat_photo = JSON.parse(mock_inat_response)["results"].
-    #              first["observation_photos"].first
-    # imported_img = obs.images.first
-    # assert_equal(
-    #   "iNat photo_id: #{inat_photo["photo_id"]}, uuid: #{inat_photo["uuid"]}",
-    #   imported_img.original_name
-    # )
+    # JDC 2025-01-11
+    # Something weird happens with stubs if this method is run as its own test.
+    # The `assert_equal` passes only if certain other tests run before this one.
+    inat_photo = JSON.parse(mock_inat_response)["results"].
+                 first["observation_photos"].first
+    imported_img = obs.images.first
+    assert_equal(
+      "iNat photo_id: #{inat_photo["photo_id"]}, uuid: #{inat_photo["uuid"]}",
+      imported_img.original_name
+    )
 
     assert(obs.sequences.none?)
   end
@@ -288,6 +290,9 @@ class InatImportJobTest < ActiveJob::TestCase
       assert_match(taxon_name, obs.comments.first.comment,
                    "Snapshot comment missing suggested name #{taxon_name}")
     end
+
+    # See note in import_job_obs_with_one_photo
+    import_job_obs_with_one_photo
   end
 
   def test_import_job_infra_specific_name


### PR DESCRIPTION
- Follows a suggestion from the 2024-09 Tech Meeting:
  - Turns `test_import_job_obs_with_one_photo` into a non-`test` method
  - Calls it at the end of `test_import_job_obs_with_sequence_and_multiple_ids`
  - Restores the lines which caused a failure when teh method was run as its own test