### PR TITLE
Un-owned Observation Error

### DIFF
--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -100,7 +100,7 @@ module ImagesHelper
   def show_image_copyright?(image, object)
     object.type_tag != :observation ||
       (object.type_tag == :observation &&
-       image.copyright_holder != object.user.legal_name)
+       image.copyright_holder != object.user&.legal_name)
   end
 
   def show_best_image(obs)

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -221,8 +221,8 @@ module ObservationsHelper
       "#{:WHO.t}:",
       user_link(obs_user)
     ]
-    if obs_user != User.current && !obs_user.no_emails &&
-       obs_user.email_general_question
+    if obs_user != User.current && !obs_user&.no_emails &&
+       obs_user&.email_general_question
 
       html += [
         "[",

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -373,6 +373,17 @@ class ImagesControllerTest < FunctionalTestCase
     end
   end
 
+  def test_show_image_nil_user
+    image = images(:peltigera_image)
+    image.update(user: nil)
+
+    login
+    get(:show, params: { id: image.id })
+
+    assert_response(:success)
+    assert_template("show", partial: "_form_ccbyncsa25")
+  end
+
   # Prove show works when params include obs
   def test_show_with_obs_param
     obs = observations(:peltigera_obs)

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -198,6 +198,16 @@ class ObservationsControllerShowTest < FunctionalTestCase
     )
   end
 
+  def test_show_observation_nil_user
+    obs = observations(:detailed_unknown_obs)
+    obs.update(user: nil)
+
+    get(:show, params: { id: obs.id })
+
+    assert_response(:success)
+    assert_template("observations/show")
+  end
+
   ##############################################################################
 
   # ------ Show ----------------------------------------------- #


### PR DESCRIPTION
Prevents server from throwing an Error when a user shows an Observation whose user_id == nil.

Delivers #2646 
