### PR TITLE
Separate Query params from initializers

### DIFF
--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
 class Query::Images < Query::Base
+  include Query::Params::Images
+  include Query::Params::Names
+  include Query::Params::Locations
+  include Query::Params::Observations
+  include Query::Params::AdvancedSearch
+  include Query::Params::ContentFilters
   include Query::Initializers::Images
   include Query::Initializers::Names
-  include Query::Initializers::AdvancedSearch
-  include Query::Initializers::Observations
   include Query::Initializers::Locations
+  include Query::Initializers::Observations
+  include Query::Initializers::AdvancedSearch
   include Query::Initializers::ContentFilters
-  include Query::Initializers::ObservationsQueryDescriptions
+  include Query::Titles::Observations
 
   def model
     Image

--- a/app/classes/query/initializers/advanced_search.rb
+++ b/app/classes/query/initializers/advanced_search.rb
@@ -1,28 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::AdvancedSearch
-  # NOTE: The autocomplaters for name, location, and user all make the ids
-  # available now, so this could be a lot more efficient.
-  # But sometimes you're looking for strings that aren't ids.
-  def advanced_search_parameter_declarations
-    {
-      name?: :string,
-      user_where?: :string,
-      user?: :string,
-      content?: :string,
-      search_location_notes?: :boolean
-    }
-  end
-
-  # These are the ones that if present, are definitive of advanced_search.
-  def self.advanced_search_params
-    [:name, :user, :user_where, :content]
-  end
-
-  def advanced_search_params
-    [:name, :user, :user_where, :content]
-  end
-
   def initialize_advanced_search
     name, user, location, content = google_parse_params
     make_sure_user_entered_something(name, user, location, content)

--- a/app/classes/query/initializers/content_filters.rb
+++ b/app/classes/query/initializers/content_filters.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::ContentFilters
-  def content_filter_parameter_declarations(model)
-    ContentFilter.by_model(model).each_with_object({}) do |fltr, decs|
-      decs[:"#{fltr.sym}?"] = fltr.type
-    end
-  end
-
   def initialize_content_filters_for_rss_log(model)
     conds = content_filter_sql_conds(model)
     return unless conds.any?

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -1,28 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::Descriptions
-  def descriptions_parameter_declarations
-    {
-      with_default_desc?: :boolean,
-      join_desc?: { string: [:default, :any] },
-      desc_type?: [{ string: [Description.all_source_types] }],
-      desc_project?: [:string],
-      desc_creator?: [User],
-      desc_content?: :string,
-      ok_for_export?: :boolean
-    }
-  end
-
-  def descriptions_coercion_parameter_declarations
-    desc_model = "#{model}Description".constantize
-    {
-      old_title?: :string,
-      old_by?: :string,
-      by_author?: User,
-      desc_ids?: [desc_model]
-    }
-  end
-
   def initialize_description_public_parameter(type)
     add_boolean_condition(
       "#{type}_descriptions.public IS TRUE",

--- a/app/classes/query/initializers/images.rb
+++ b/app/classes/query/initializers/images.rb
@@ -1,37 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::Images
-  def images_per_se_parameter_declarations
-    {
-      created_at?: [:time],
-      updated_at?: [:time],
-      date?: [:date],
-      ids?: [Image],
-      by_user?: User,
-      users?: [User],
-      locations?: [:string],
-      outer?: :query, # for images inside observations
-      observation?: Observation, # for images inside observations
-      observations?: [Observation],
-      project?: Project,
-      projects?: [:string],
-      species_lists?: [:string],
-      with_observation?: { boolean: [true] },
-      size?: { string: Image::ALL_SIZES - [:full_size] },
-      content_types?: [{ string: Image::ALL_EXTENSIONS }],
-      with_notes?: :boolean,
-      notes_has?: :string,
-      copyright_holder_has?: :string,
-      license?: [License],
-      with_votes?: :boolean,
-      quality?: [:float],
-      confidence?: [:float],
-      ok_for_export?: :boolean,
-      pattern?: :string,
-      with_observations?: :boolean
-    }
-  end
-
   def initialize_img_notes_parameters
     add_boolean_condition("LENGTH(COALESCE(images.notes,'')) > 0",
                           "LENGTH(COALESCE(images.notes,'')) = 0",

--- a/app/classes/query/initializers/images.rb
+++ b/app/classes/query/initializers/images.rb
@@ -10,7 +10,7 @@ module Query::Initializers::Images
 
   def initialize_img_association_parameters
     initialize_observations_parameter
-    add_where_condition("observations", params[:locations],
+    add_where_condition(:observations, params[:locations],
                         :observation_images, :observations)
     add_for_project_condition(:project_images)
     initialize_projects_parameter(:project_images, [:project_images])

--- a/app/classes/query/initializers/locations.rb
+++ b/app/classes/query/initializers/locations.rb
@@ -1,32 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::Locations
-  # The basic Location parameters.
-  def locations_per_se_parameter_declarations
-    {
-      created_at?: [:time],
-      updated_at?: [:time],
-      ids?: [Location],
-      by_user?: User,
-      by_editor?: User,
-      users?: [User],
-      pattern?: :string,
-      regexp?: :string,
-      with_descriptions?: :boolean,
-      with_observations?: :boolean
-    }
-  end
-
-  # Used in coerced queries for obs, plus observation queries
-  def bounding_box_parameter_declarations
-    {
-      north?: :float,
-      south?: :float,
-      east?: :float,
-      west?: :float
-    }
-  end
-
   def add_regexp_condition
     return if params[:regexp].blank?
 

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -1,57 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::Names
-  def names_per_se_parameter_declarations
-    {
-      created_at?: [:time],
-      updated_at?: [:time],
-      ids?: [Name],
-      by_user?: User,
-      by_editor?: User,
-      users?: [User],
-      misspellings?: { string: [:no, :either, :only] },
-      deprecated?: { string: [:either, :no, :only] },
-      with_synonyms?: :boolean,
-      locations?: [:string],
-      species_lists?: [:string],
-      rank?: [{ string: Name.all_ranks }],
-      is_deprecated?: :boolean,
-      pattern?: :string,
-      text_name_has?: :string,
-      with_author?: :boolean,
-      author_has?: :string,
-      with_citation?: :boolean,
-      citation_has?: :string,
-      with_classification?: :boolean,
-      classification_has?: :string,
-      with_notes?: :boolean,
-      notes_has?: :string,
-      with_comments?: { boolean: [true] },
-      comments_has?: :string,
-      need_description?: :boolean,
-      with_descriptions?: :boolean,
-      with_observations?: { boolean: [true] }
-    }
-  end
-
-  # Used in coerced queries for obs, plus sequence and species_list queries
-  def names_parameter_declarations
-    {
-      names?: [:string],
-      include_synonyms?: :boolean,
-      include_subtaxa?: :boolean,
-      include_immediate_subtaxa?: :boolean,
-      exclude_original_names?: :boolean
-    }
-  end
-
-  def naming_consensus_parameter_declarations
-    {
-      include_all_name_proposals?: :boolean,
-      exclude_consensus?: :boolean
-    }
-  end
-
   def initialize_name_comments_and_notes_parameters
     add_boolean_condition(
       "LENGTH(COALESCE(names.notes,'')) > 0",

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -56,7 +56,7 @@ module Query::Initializers::Names
 
   def initialize_name_association_parameters
     add_id_condition("observations.id", params[:observations], :observations)
-    add_where_condition("observations", params[:locations], :observations)
+    add_where_condition(:observations, params[:locations], :observations)
     initialize_species_lists_parameter
   end
 

--- a/app/classes/query/initializers/observations.rb
+++ b/app/classes/query/initializers/observations.rb
@@ -1,66 +1,6 @@
 # frozen_string_literal: true
 
 module Query::Initializers::Observations
-  def observations_only_parameter_declarations
-    {
-      # dates/times
-      date?: [:date],
-      created_at?: [:time],
-      updated_at?: [:time],
-
-      ids?: [Observation],
-      herbarium_records?: [:string],
-      project_lists?: [:string],
-      by_user?: User,
-      by_editor?: User, # for coercions from name/location
-      users?: [User],
-      field_slips?: [:string],
-      pattern?: :string,
-      regexp?: :string, # for coercions from location
-      needs_naming?: :boolean,
-      in_clade?: :string,
-      in_region?: :string
-    }
-  end
-
-  # for observations, or coercions to observations.
-  def observations_parameter_declarations
-    {
-      notes_has?: :string,
-      with_notes_fields?: [:string],
-      comments_has?: :string,
-      herbaria?: [:string],
-      user_where?: :string,
-      by_user?: User,
-      location?: Location,
-      locations?: [:string],
-      project?: Project,
-      projects?: [:string],
-      species_list?: SpeciesList,
-      species_lists?: [:string],
-
-      # boolean
-      with_comments?: { boolean: [true] },
-      with_public_lat_lng?: :boolean,
-      with_name?: :boolean,
-      with_notes?: :boolean,
-      with_sequences?: { boolean: [true] },
-      is_collection_location?: :boolean,
-
-      # numeric
-      confidence?: [:float]
-    }
-  end
-
-  def observations_coercion_parameter_declarations
-    {
-      old_title?: :string,
-      old_by?: :string,
-      date?: [:date],
-      obs_ids?: [Observation]
-    }
-  end
-
   def initialize_obs_basic_parameters
     ids_param = model == Observation ? :ids : :obs_ids
     add_ids_condition("observations", ids_param)

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Query::LocationDescriptions < Query::Base
+  include Query::Params::Descriptions
   include Query::Initializers::Descriptions
 
   def model

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
 class Query::Locations < Query::Base
+  include Query::Params::Locations
+  include Query::Params::Descriptions
+  include Query::Params::Names
+  include Query::Params::Observations
+  include Query::Params::AdvancedSearch
+  include Query::Params::ContentFilters
   include Query::Initializers::Locations
   include Query::Initializers::Descriptions
-  include Query::Initializers::AdvancedSearch
   include Query::Initializers::Names
   include Query::Initializers::Observations
+  include Query::Initializers::AdvancedSearch
   include Query::Initializers::ContentFilters
-  include Query::Initializers::ObservationsQueryDescriptions
+  include Query::Titles::Observations
 
   def model
     Location

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Query::NameDescriptions < Query::Base
+  include Query::Params::Descriptions
   include Query::Initializers::Descriptions
 
   def model

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -2,13 +2,19 @@
 
 # base class for Query's which return Names
 class Query::Names < Query::Base
+  include Query::Params::Names
+  include Query::Params::Descriptions
+  include Query::Params::Locations
+  include Query::Params::Observations
+  include Query::Params::AdvancedSearch
+  include Query::Params::ContentFilters
   include Query::Initializers::Names
   include Query::Initializers::Descriptions
-  include Query::Initializers::AdvancedSearch
-  include Query::Initializers::Observations
   include Query::Initializers::Locations
+  include Query::Initializers::Observations
+  include Query::Initializers::AdvancedSearch
   include Query::Initializers::ContentFilters
-  include Query::Initializers::ObservationsQueryDescriptions
+  include Query::Titles::Observations
 
   def model
     Name

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -57,7 +57,7 @@ class Query::Observations < Query::Base
   end
 
   def initialize_association_parameters
-    add_where_condition("observations", params[:locations])
+    add_where_condition(:observations, params[:locations])
     add_at_location_condition
     initialize_herbaria_parameter
     initialize_herbarium_records_parameter

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
 class Query::Observations < Query::Base
+  include Query::Params::Observations
+  include Query::Params::Locations
+  include Query::Params::Names
+  include Query::Params::AdvancedSearch
+  include Query::Params::ContentFilters
   include Query::Initializers::Names
   include Query::Initializers::Observations
   include Query::Initializers::Locations
   include Query::Initializers::ContentFilters
   include Query::Initializers::AdvancedSearch
-  include Query::Initializers::ObservationsQueryDescriptions
+  include Query::Titles::Observations
 
   def model
     Observation
   end
 
   def parameter_declarations
-    super.merge(observations_only_parameter_declarations).
+    super.merge(observations_per_se_parameter_declarations).
       merge(observations_parameter_declarations).
       merge(bounding_box_parameter_declarations).
       merge(content_filter_parameter_declarations(Observation)).

--- a/app/classes/query/params/advanced_search.rb
+++ b/app/classes/query/params/advanced_search.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Query::Params::AdvancedSearch
+  # NOTE: The autocomplaters for name, location, and user all make the ids
+  # available now, so this could be a lot more efficient.
+  # But sometimes you're looking for strings that aren't ids.
+  def advanced_search_parameter_declarations
+    {
+      name?: :string,
+      user_where?: :string,
+      user?: :string,
+      content?: :string,
+      search_location_notes?: :boolean
+    }
+  end
+
+  # These are the ones that if present, are definitive of advanced_search.
+  def self.advanced_search_params
+    [:name, :user, :user_where, :content]
+  end
+
+  def advanced_search_params
+    [:name, :user, :user_where, :content]
+  end
+end

--- a/app/classes/query/params/content_filters.rb
+++ b/app/classes/query/params/content_filters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Query::Params::ContentFilters
+  def content_filter_parameter_declarations(model)
+    ContentFilter.by_model(model).each_with_object({}) do |fltr, decs|
+      decs[:"#{fltr.sym}?"] = fltr.type
+    end
+  end
+end

--- a/app/classes/query/params/descriptions.rb
+++ b/app/classes/query/params/descriptions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Query::Params::Descriptions
+  def descriptions_parameter_declarations
+    {
+      with_default_desc?: :boolean,
+      join_desc?: { string: [:default, :any] },
+      desc_type?: [{ string: [Description.all_source_types] }],
+      desc_project?: [:string],
+      desc_creator?: [User],
+      desc_content?: :string,
+      ok_for_export?: :boolean
+    }
+  end
+
+  def descriptions_coercion_parameter_declarations
+    desc_model = "#{model}Description".constantize
+    {
+      old_title?: :string,
+      old_by?: :string,
+      by_author?: User,
+      desc_ids?: [desc_model]
+    }
+  end
+end

--- a/app/classes/query/params/images.rb
+++ b/app/classes/query/params/images.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Query::Params::Images
+  def images_per_se_parameter_declarations
+    {
+      created_at?: [:time],
+      updated_at?: [:time],
+      date?: [:date],
+      ids?: [Image],
+      by_user?: User,
+      users?: [User],
+      locations?: [:string],
+      outer?: :query, # for images inside observations
+      observation?: Observation, # for images inside observations
+      observations?: [Observation],
+      project?: Project,
+      projects?: [:string],
+      species_lists?: [:string],
+      with_observation?: { boolean: [true] },
+      size?: { string: Image::ALL_SIZES - [:full_size] },
+      content_types?: [{ string: Image::ALL_EXTENSIONS }],
+      with_notes?: :boolean,
+      notes_has?: :string,
+      copyright_holder_has?: :string,
+      license?: [License],
+      with_votes?: :boolean,
+      quality?: [:float],
+      confidence?: [:float],
+      ok_for_export?: :boolean,
+      pattern?: :string,
+      with_observations?: :boolean
+    }
+  end
+end

--- a/app/classes/query/params/locations.rb
+++ b/app/classes/query/params/locations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Query::Params::Locations
+  # The basic Location parameters.
+  def locations_per_se_parameter_declarations
+    {
+      created_at?: [:time],
+      updated_at?: [:time],
+      ids?: [Location],
+      by_user?: User,
+      by_editor?: User,
+      users?: [User],
+      pattern?: :string,
+      regexp?: :string,
+      with_descriptions?: :boolean,
+      with_observations?: :boolean
+    }
+  end
+
+  # Used in coerced queries for obs, plus observation queries
+  def bounding_box_parameter_declarations
+    {
+      north?: :float,
+      south?: :float,
+      east?: :float,
+      west?: :float
+    }
+  end
+end

--- a/app/classes/query/params/names.rb
+++ b/app/classes/query/params/names.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Query::Params::Names
+  def names_per_se_parameter_declarations
+    {
+      created_at?: [:time],
+      updated_at?: [:time],
+      ids?: [Name],
+      by_user?: User,
+      by_editor?: User,
+      users?: [User],
+      misspellings?: { string: [:no, :either, :only] },
+      deprecated?: { string: [:either, :no, :only] },
+      with_synonyms?: :boolean,
+      locations?: [:string],
+      species_lists?: [:string],
+      rank?: [{ string: Name.all_ranks }],
+      is_deprecated?: :boolean,
+      pattern?: :string,
+      text_name_has?: :string,
+      with_author?: :boolean,
+      author_has?: :string,
+      with_citation?: :boolean,
+      citation_has?: :string,
+      with_classification?: :boolean,
+      classification_has?: :string,
+      with_notes?: :boolean,
+      notes_has?: :string,
+      with_comments?: { boolean: [true] },
+      comments_has?: :string,
+      need_description?: :boolean,
+      with_descriptions?: :boolean,
+      with_observations?: { boolean: [true] }
+    }
+  end
+
+  # Used in coerced queries for obs, plus sequence and species_list queries
+  def names_parameter_declarations
+    {
+      names?: [:string],
+      include_synonyms?: :boolean,
+      include_subtaxa?: :boolean,
+      include_immediate_subtaxa?: :boolean,
+      exclude_original_names?: :boolean
+    }
+  end
+
+  def naming_consensus_parameter_declarations
+    {
+      include_all_name_proposals?: :boolean,
+      exclude_consensus?: :boolean
+    }
+  end
+end

--- a/app/classes/query/params/observations.rb
+++ b/app/classes/query/params/observations.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Query::Params::Observations
+  def observations_per_se_parameter_declarations
+    {
+      # dates/times
+      date?: [:date],
+      created_at?: [:time],
+      updated_at?: [:time],
+
+      ids?: [Observation],
+      herbarium_records?: [:string],
+      project_lists?: [:string],
+      by_user?: User,
+      by_editor?: User, # for coercions from name/location
+      users?: [User],
+      field_slips?: [:string],
+      pattern?: :string,
+      regexp?: :string, # for coercions from location
+      needs_naming?: :boolean,
+      in_clade?: :string,
+      in_region?: :string
+    }
+  end
+
+  # for observations, or coercions to observations.
+  def observations_parameter_declarations
+    {
+      notes_has?: :string,
+      with_notes_fields?: [:string],
+      comments_has?: :string,
+      herbaria?: [:string],
+      user_where?: :string,
+      by_user?: User,
+      location?: Location,
+      locations?: [:string],
+      project?: Project,
+      projects?: [:string],
+      species_list?: SpeciesList,
+      species_lists?: [:string],
+
+      # boolean
+      with_comments?: { boolean: [true] },
+      with_public_lat_lng?: :boolean,
+      with_name?: :boolean,
+      with_notes?: :boolean,
+      with_sequences?: { boolean: [true] },
+      is_collection_location?: :boolean,
+
+      # numeric
+      confidence?: [:float]
+    }
+  end
+
+  def observations_coercion_parameter_declarations
+    {
+      old_title?: :string,
+      old_by?: :string,
+      date?: [:date],
+      obs_ids?: [Observation]
+    }
+  end
+end

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Query::RssLogs < Query::Base
+  include Query::Params::ContentFilters
   include Query::Initializers::ContentFilters
 
   def model

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -91,7 +91,7 @@ class Query::Sequences < Query::Base
   def initialize_association_parameters
     initialize_observations_parameter(:sequences)
     initialize_observers_parameter
-    add_where_condition("observations", params[:locations], :observations)
+    add_where_condition(:observations, params[:locations], :observations)
     initialize_herbaria_parameter
     initialize_herbarium_records_parameter
     initialize_projects_parameter

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Query::Sequences < Query::Base
+  include Query::Params::Names
+  include Query::Params::Observations
   include Query::Initializers::Names
   include Query::Initializers::Observations
 

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Query::SpeciesLists < Query::Base
+  include Query::Params::Names
   include Query::Initializers::Names
 
   def model

--- a/app/classes/query/titles/observations.rb
+++ b/app/classes/query/titles/observations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Query::Initializers::ObservationsQueryDescriptions
+module Query::Titles::Observations
   def with_observations_query_description
     return nil unless (description = observation_query_description)
 

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -58,7 +58,7 @@ class ObservationsController
     end
 
     def advanced_search_params
-      Query::Initializers::AdvancedSearch.advanced_search_params
+      Query::Params::AdvancedSearch.advanced_search_params
     end
 
     # Display matrix of Observations whose notes, etc. match a string pattern.


### PR DESCRIPTION
Within Query, a new `BaseAR` class would reuse the param declarations, but would have its own initializers to build AR scopes rather than SQL. This PR separates the param declarations from the initializers, so they can be included in both `Base` and `BaseAR`.