### PR TITLE
Show nonexistent Project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,7 +50,7 @@ class ProjectsController < ApplicationController
   # Outputs: @project
   def show
     store_location
-    return unless find_project_and_where!
+    return if find_project_and_where!.blank?
 
     set_ivars_for_show
   end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -78,6 +78,15 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_select("form[action=?]", project_path(p_id), count: 0)
   end
 
+  def test_show_project_nonexistent
+    p_id = -1
+
+    login("zero")
+    get(:show, params: { id: p_id })
+
+    assert_redirected_to(projects_path)
+  end
+
   def test_show_project_logged_in_owner
     project = projects(:eol_project)
 


### PR DESCRIPTION
- Shows the Project Index, instead of throwing an Error, for /projects/nnn where that Project doesn't exist.
- Delivers #2652

(The problem is that `find_project_and_where!` returns `""` rather than `nil`. I don't know why.) 