### PR TITLE
New scopes for date, datetime, user, editor

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -117,6 +117,15 @@ class AbstractModel < ApplicationRecord
       reorder(RssLog[:updated_at].desc, model.arel_table[:id].desc).distinct
   }
   scope :by_user, ->(user) { where(user: user) }
+  scope :by_editor, lambda { |user|
+    version_table = :"#{type_tag}_versions"
+    return all unless ActiveRecord::Base.connection.table_exists?(version_table)
+
+    user_id = user.is_a?(Integer) ? user : user&.id
+
+    joins(:versions).where("#{version_table}": { user_id: user_id }).
+      where.not(user: user)
+  }
   scope :created_on, lambda { |ymd_string|
     where(arel_table[:created_at].format("%Y-%m-%d").eq(ymd_string))
   }

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -145,7 +145,7 @@ class AbstractModel < ApplicationRecord
   # Allows searching for date ranges in the :when column: either within
   # a logical time range, or within a periodic time range in recurring years.
   # This is possible because the :when column already has the format("%Y-%m-%d")
-  scope :when_in_range, lambda { |earliest, latest|
+  scope :when_between, lambda { |earliest, latest|
     if wrapped_date?(earliest, latest)
       when_in_period_wrapping_new_year(earliest, latest)
     else

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -148,6 +148,8 @@ class AbstractModel < ApplicationRecord
     where(arel_table[col].format("%Y-%m-%d %H:%i:%s").send(dir, datetime))
   end
 
+  # Fills out the datetime with min/max values for month, day, hour, minute,
+  # second, as appropriate for < > comparisons. Year required.
   def self.datetime_condition_formatted(min, val)
     y, m, d, h, n, s = val.split("-").map!(&:to_i)
     return unless /^\d\d\d\d/.match?(y.to_s)
@@ -169,7 +171,7 @@ class AbstractModel < ApplicationRecord
       when_after(earliest).when_before(latest)
     end
   }
-  # scope for objects whose :when is in a certain period of the year that
+  # Scope for objects whose :when is in a certain period of the year that
   # overlaps the new year, defined by a range of months or mm-dd
   scope :when_in_period_wrapping_new_year, lambda { |earliest, latest|
     m1, d1 = earliest.to_s.split("-")
@@ -209,6 +211,8 @@ class AbstractModel < ApplicationRecord
     where(arel_table[:when].send(dir, date))
   end
 
+  # Fills out the date with min/max values for month and day as appropriate
+  # for < > comparisons. Requires year, prevalidated by `starts_with_year?`.
   def self.date_condition_formatted(min, val)
     y, m, d = val.split("-").map!(&:to_i)
     m ||= min ? 1 : 12

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -116,6 +116,7 @@ class AbstractModel < ApplicationRecord
     joins(:rss_log).
       reorder(RssLog[:updated_at].desc, model.arel_table[:id].desc).distinct
   }
+  scope :by_user, ->(user) { where(user: user) }
   scope :created_on, lambda { |ymd_string|
     where(arel_table[:created_at].format("%Y-%m-%d").eq(ymd_string))
   }

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -159,15 +159,15 @@ class AbstractModel < ApplicationRecord
   end
 
   # Fills out the datetime with min/max values for month, day, hour, minute,
-  # second, as appropriate for < > comparisons. Year required.
+  # second, as appropriate for < > comparisons. Only year is required.
   def self.datetime_condition_formatted(min, val)
     y, m, d, h, n, s = val.split("-").map!(&:to_i)
     return unless /^\d\d\d\d/.match?(y.to_s)
 
     returns = min ? [y, 1, 1, 0, 0, 0] : [y, 12, 31, 23, 59, 59]
-    vals = [m, d, h, n, s].compact
-    returns[1, vals.length] = vals
-
+    vals = [m, d, h, n, s].compact # get as many specific values as were sent
+    returns[1, vals.length] = vals # merge these into the defaults, after year
+    # reformat to "%Y-%m-%d %H:%i:%s" as expected
     [returns[0..2]&.join("-"), returns[3..5]&.join(":")].join(" ")
   end
 

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -119,30 +119,47 @@ class AbstractModel < ApplicationRecord
   scope :created_on, lambda { |ymd_string|
     where(arel_table[:created_at].format("%Y-%m-%d").eq(ymd_string))
   }
-  scope :created_after, lambda { |ymd_string|
-    where(arel_table[:created_at].format("%Y-%m-%d") >= ymd_string)
+  scope :created_after, lambda { |datetime|
+    half_datetime_condition(:created_at, true, datetime)
   }
-  scope :created_before, lambda { |ymd_string|
-    where(arel_table[:created_at].format("%Y-%m-%d") <= ymd_string)
+  scope :created_before, lambda { |datetime|
+    half_datetime_condition(:created_at, false, datetime)
   }
   scope :created_between, lambda { |earliest, latest|
-    where(arel_table[:created_at].format("%Y-%m-%d") >= earliest).
-      where(arel_table[:created_at].format("%Y-%m-%d") <= latest)
+    created_after(earliest).created_before(latest)
   }
   scope :updated_on, lambda { |ymd_string|
     where(arel_table[:updated_at].format("%Y-%m-%d").eq(ymd_string))
   }
-  scope :updated_after, lambda { |ymd_string|
-    where(arel_table[:updated_at].format("%Y-%m-%d") >= ymd_string)
+  scope :updated_after, lambda { |datetime|
+    half_datetime_condition(:updated_at, true, datetime)
   }
-  scope :updated_before, lambda { |ymd_string|
-    where(arel_table[:updated_at].format("%Y-%m-%d") <= ymd_string)
+  scope :updated_before, lambda { |datetime|
+    half_datetime_condition(:updated_at, false, datetime)
   }
   scope :updated_between, lambda { |earliest, latest|
-    where(arel_table[:updated_at].format("%Y-%m-%d") >= earliest).
-      where(arel_table[:updated_at].format("%Y-%m-%d") <= latest)
+    updated_after(earliest).updated_before(latest)
   }
-  # Allows searching for date ranges in the :when column: either within
+
+  def self.half_datetime_condition(col, min, val)
+    return unless (datetime = datetime_condition_formatted(min, val))
+
+    dir = min ? :gt : :lt
+    where(arel_table[col].format("%Y-%m-%d %H:%i:%s").send(dir, datetime))
+  end
+
+  def self.datetime_condition_formatted(min, val)
+    y, m, d, h, n, s = val.split("-").map!(&:to_i)
+    return unless /^\d\d\d\d/.match?(y.to_s)
+
+    returns = min ? [y, 1, 1, 0, 0, 0] : [y, 12, 31, 23, 59, 59]
+    vals = [m, d, h, n, s].compact
+    returns[1, vals.length] = vals
+
+    [returns[0..2]&.join("-"), returns[3..5]&.join(":")].join(" ")
+  end
+
+  # Allows searching for date ranges in the :when column, either within
   # a logical time range, or within a periodic time range in recurring years.
   # This is possible because the :when column already has the format("%Y-%m-%d")
   scope :when_between, lambda { |earliest, latest|
@@ -175,6 +192,7 @@ class AbstractModel < ApplicationRecord
       earliest.to_s > latest.to_s
   end
 
+  # NOTE: all three conditions validate numeric format
   def self.half_date_condition(min, val)
     dir = min ? :gt : :lt
     if starts_with_year?(val)
@@ -187,11 +205,15 @@ class AbstractModel < ApplicationRecord
   end
 
   def self.half_date_condition_with_year(min, dir, val)
-    y, m, d = val.split("-")
+    date = date_condition_formatted(min, val)
+    where(arel_table[:when].send(dir, date))
+  end
+
+  def self.date_condition_formatted(min, val)
+    y, m, d = val.split("-").map!(&:to_i)
     m ||= min ? 1 : 12
     d ||= min ? 1 : 31
-    date = [y.to_i, m.to_i, d.to_i].join("-")
-    where(arel_table[:when].send(dir, date))
+    [y, m, d].join("-")
   end
 
   def self.half_date_condition_with_month_and_day(dir, val)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -118,7 +118,6 @@ class Comment < AbstractModel
   after_create :oil_and_water
 
   scope :index_order, -> { order(created_at: :desc, id: :desc) }
-  scope :by_user, ->(user) { where(user: user) }
 
   # This scope starts with a `where`, and chains subsequent `where` clauses
   # with `or`. So, rather than separately assembling `target_ids`, that would

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -10,9 +10,6 @@ class FieldSlip < AbstractModel
 
   scope :index_order, -> { order(code: :asc, created_at: :desc, id: :desc) }
 
-  scope :by_user, lambda { |user|
-    where(user_id: user.id).distinct
-  }
   scope :for_project, lambda { |project|
     where(project_id: project.id).distinct
   }

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -516,11 +516,6 @@ class Name < AbstractModel
                   not_eq(Name[:classification])).
             where(NameDescription[:classification].not_blank)
         }
-  scope :by_editor,
-        lambda { |user|
-          joins(:versions).where(name_versions: { user_id: user.id }).
-            where.not(user: user)
-        }
 
   ### Module Name::Spelling
   scope :with_correct_spelling,

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -376,8 +376,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   }
 
-  scope :by_user,
-        ->(user) { where(user: user) }
   # used for preloading values in the create obs form. call with `.last`
   scope :recent_by_user,
         lambda { |user|

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -52,10 +52,6 @@ class Vote < AbstractModel
   belongs_to :naming
   belongs_to :observation
 
-  scope :by_user, lambda { |user|
-    user_id = user.is_a?(Integer) ? user : user&.id
-    where(user_id: user_id)
-  }
   # scope :not_by_user, lambda { |user|
   #   user_id = user.is_a?(Integer) ? user : user&.id
   #   where.not(user_id: user_id)

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -479,8 +479,8 @@ class AbstractModelTest < UnitTestCase
   #    Explicit tests of some scopes to improve coverage
   # ----------------------------------------------------
 
-  def start_of_time
-    Date.jd(0).strftime("%Y-%m-%d")
+  def improbably_early
+    "1600-01-01"
   end
 
   def a_century_from_now
@@ -493,20 +493,20 @@ class AbstractModelTest < UnitTestCase
 
   def test_scope_created_after
     assert_equal(Observation.count,
-                 Observation.created_after(start_of_time).count)
+                 Observation.created_after(improbably_early).count)
     assert_empty(Observation.created_after(a_century_from_now))
   end
 
   def test_scope_created_before
     assert_equal(Observation.count,
                  Observation.created_before(a_century_from_now).count)
-    assert_empty(Observation.created_before(start_of_time))
+    assert_empty(Observation.created_before(improbably_early))
   end
 
   def test_scope_created_between
     assert_equal(
       Observation.count,
-      Observation.created_between(start_of_time, a_century_from_now).count
+      Observation.created_between(improbably_early, a_century_from_now).count
     )
     assert_empty(
       Observation.created_between(a_century_from_now, two_centuries_from_now)
@@ -515,20 +515,20 @@ class AbstractModelTest < UnitTestCase
 
   def test_scope_updated_after
     assert_equal(Observation.count,
-                 Observation.updated_after(start_of_time).count)
+                 Observation.updated_after(improbably_early).count)
     assert_empty(Observation.updated_after(a_century_from_now))
   end
 
   def test_scope_updated_before
     assert_equal(Observation.count,
                  Observation.updated_before(a_century_from_now).count)
-    assert_empty(Observation.updated_before(start_of_time))
+    assert_empty(Observation.updated_before(improbably_early))
   end
 
   def test_scope_updated_between
     assert_equal(
       Observation.count,
-      Observation.updated_between(start_of_time, a_century_from_now).count
+      Observation.updated_between(improbably_early, a_century_from_now).count
     )
     assert_empty(
       Observation.updated_between(a_century_from_now, two_centuries_from_now)

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -534,4 +534,14 @@ class AbstractModelTest < UnitTestCase
       Observation.updated_between(a_century_from_now, two_centuries_from_now)
     )
   end
+
+  def test_scope_by_editor
+    # if no version table, should return all
+    assert_equal(
+      Observation.count, Observation.by_editor(rolf).count
+    )
+    assert_not_equal(
+      Name.by_user(rolf).count, Name.by_editor(rolf).count
+    )
+  end
 end

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -480,15 +480,15 @@ class AbstractModelTest < UnitTestCase
   # ----------------------------------------------------
 
   def start_of_time
-    Date.jd(0).strftime("%Y, %m, %d")
+    Date.jd(0).strftime("%Y-%m-%d")
   end
 
   def a_century_from_now
-    (Time.zone.today + 100.years).strftime("%Y, %m, %d")
+    (Time.zone.today + 100.years).strftime("%Y-%m-%d")
   end
 
   def two_centuries_from_now
-    (Time.zone.today + 200.years).strftime("%Y, %m, %d")
+    (Time.zone.today + 200.years).strftime("%Y-%m-%d")
   end
 
   def test_scope_created_after

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2938,6 +2938,8 @@ class QueryTest < UnitTestCase
   def test_observation_date
     # blank should return all
     assert_query(Observation.index_order, :Observation, date: nil)
+    # impossible dates should return none
+    assert_query([], :Observation, date: %w[1550 1551])
     # single date should return after
     assert_query(Observation.index_order.when_after("2011-05-12"),
                  :Observation, date: "2011-05-12")
@@ -2969,6 +2971,8 @@ class QueryTest < UnitTestCase
   def test_observation_created_at
     # blank should return all
     assert_query(Observation.index_order, :Observation, created_at: nil)
+    # impossible dates should return none
+    assert_query([], :Observation, created_at: %w[2000 2001])
     # single datetime should return after
     assert_query(Observation.index_order.
                  created_after("2011-05-12-12-59-57"),
@@ -2996,6 +3000,8 @@ class QueryTest < UnitTestCase
   def test_observation_updated_at
     # blank should return all
     assert_query(Observation.index_order, :Observation, updated_at: nil)
+    # impossible dates should return none
+    assert_query([], :Observation, updated_at: %w[2000 2001])
     # single datetime should return after
     assert_query(Observation.index_order.
                  updated_after("2011-05-12-12-59-57"),

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2935,6 +2935,42 @@ class QueryTest < UnitTestCase
                  :Observation, content: "agaricus") # comment
   end
 
+  def test_observation_date_years
+    assert_query(Observation.index_order.when_in_range("2005", "2009"),
+                 :Observation, date: %w[2005 2009] )
+  end
+
+  # observations in a month range, any year
+  def test_observation_date_months
+    assert_query(Observation.index_order.when_in_range("05", "12"),
+                 :Observation, date: %w[05 12] )
+  end
+
+  # observations found in a date range, any year
+  def test_observation_date_period
+    assert_query(Observation.index_order.when_in_range("02-22", "08-22"),
+                 :Observation, date: %w[02-22 08-22] )
+  end
+
+  # period wraps around the new year
+  def test_observation_date_period_wrap
+    assert_query(Observation.index_order.when_in_range("08-22", "02-22"),
+                 :Observation, date: %w[08-22 02-22] )
+  end
+
+  def test_observation_date_full
+    assert_query(Observation.index_order.
+                 when_in_range("2009-08-22", "2009-10-20"),
+                 :Observation, date: %w[2009-08-22 2009-10-20] )
+  end
+
+  # date wraps around the new year
+  def test_observation_date_wrap
+    assert_query(Observation.index_order.
+                 when_in_range("2015-08-22", "2016-02-22"),
+                 :Observation, date: %w[2015-08-22 2016-02-22] )
+  end
+
   def test_project_all
     expects = Project.index_order
     assert_query(expects, :Project)

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2935,40 +2935,89 @@ class QueryTest < UnitTestCase
                  :Observation, content: "agaricus") # comment
   end
 
-  def test_observation_date_years
+  def test_observation_date
+    # blank should return all
+    assert_query(Observation.index_order, :Observation, date: nil)
+    # single date should return after
+    assert_query(Observation.index_order.when_after("2011-05-12"),
+                 :Observation, date: "2011-05-12")
+    # year should return after
+    assert_query(Observation.index_order.when_after("2005"),
+                 :Observation, date: "2005")
+    # years should return between
     assert_query(Observation.index_order.when_between("2005", "2009"),
-                 :Observation, date: %w[2005 2009] )
-  end
-
-  # observations in a month range, any year
-  def test_observation_date_months
+                 :Observation, date: %w[2005 2009])
+    # in a month range, any year
     assert_query(Observation.index_order.when_between("05", "12"),
-                 :Observation, date: %w[05 12] )
-  end
-
-  # observations found in a date range, any year
-  def test_observation_date_period
+                 :Observation, date: %w[05 12])
+    # in a date range, any year
     assert_query(Observation.index_order.when_between("02-22", "08-22"),
-                 :Observation, date: %w[02-22 08-22] )
-  end
-
-  # period wraps around the new year
-  def test_observation_date_period_wrap
+                 :Observation, date: %w[02-22 08-22])
+    # period wraps around the new year
     assert_query(Observation.index_order.when_between("08-22", "02-22"),
-                 :Observation, date: %w[08-22 02-22] )
-  end
-
-  def test_observation_date_full
+                 :Observation, date: %w[08-22 02-22])
+    # full dates
     assert_query(Observation.index_order.
                  when_between("2009-08-22", "2009-10-20"),
-                 :Observation, date: %w[2009-08-22 2009-10-20] )
-  end
-
-  # date wraps around the new year
-  def test_observation_date_wrap
+                 :Observation, date: %w[2009-08-22 2009-10-20])
+    # date wraps around the new year
     assert_query(Observation.index_order.
                  when_between("2015-08-22", "2016-02-22"),
-                 :Observation, date: %w[2015-08-22 2016-02-22] )
+                 :Observation, date: %w[2015-08-22 2016-02-22])
+  end
+
+  def test_observation_created_at
+    # blank should return all
+    assert_query(Observation.index_order, :Observation, created_at: nil)
+    # single datetime should return after
+    assert_query(Observation.index_order.
+                 created_after("2011-05-12-12-59-57"),
+                 :Observation, created_at: "2011-05-12-12-59-57")
+    # single date should return after
+    assert_query(Observation.index_order.created_after("2011-05-12"),
+                 :Observation, created_at: "2011-05-12")
+    # year should return after
+    assert_query(Observation.index_order.created_after("2005"),
+                 :Observation, created_at: "2005")
+    # years should return between
+    assert_query(Observation.index_order.created_between("2005", "2009"),
+                 :Observation, created_at: %w[2005 2009])
+    # full dates
+    assert_query(Observation.index_order.
+                 created_between("2009-08-22", "2009-10-20"),
+                 :Observation, created_at: %w[2009-08-22 2009-10-20])
+    # full datetimes
+    assert_query(Observation.index_order.
+                 created_between("2009-08-22-03-04-22", "2009-10-20-03-04-22"),
+                 :Observation,
+                 created_at: %w[2009-08-22-03-04-22 2009-10-20-03-04-22])
+  end
+
+  def test_observation_updated_at
+    # blank should return all
+    assert_query(Observation.index_order, :Observation, updated_at: nil)
+    # single datetime should return after
+    assert_query(Observation.index_order.
+                 updated_after("2011-05-12-12-59-57"),
+                 :Observation, updated_at: "2011-05-12-12-59-57")
+    # single date should return after
+    assert_query(Observation.index_order.updated_after("2011-05-12"),
+                 :Observation, updated_at: "2011-05-12")
+    # year should return after
+    assert_query(Observation.index_order.updated_after("2005"),
+                 :Observation, updated_at: "2005")
+    # years should return between
+    assert_query(Observation.index_order.updated_between("2005", "2009"),
+                 :Observation, updated_at: %w[2005 2009])
+    # full dates
+    assert_query(Observation.index_order.
+                 updated_between("2009-08-22", "2009-10-20"),
+                 :Observation, updated_at: %w[2009-08-22 2009-10-20])
+    # full datetimes
+    assert_query(Observation.index_order.
+                 updated_between("2009-08-22-03-04-22", "2009-10-20-03-04-22"),
+                 :Observation,
+                 updated_at: %w[2009-08-22-03-04-22 2009-10-20-03-04-22])
   end
 
   def test_project_all

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2936,38 +2936,38 @@ class QueryTest < UnitTestCase
   end
 
   def test_observation_date_years
-    assert_query(Observation.index_order.when_in_range("2005", "2009"),
+    assert_query(Observation.index_order.when_between("2005", "2009"),
                  :Observation, date: %w[2005 2009] )
   end
 
   # observations in a month range, any year
   def test_observation_date_months
-    assert_query(Observation.index_order.when_in_range("05", "12"),
+    assert_query(Observation.index_order.when_between("05", "12"),
                  :Observation, date: %w[05 12] )
   end
 
   # observations found in a date range, any year
   def test_observation_date_period
-    assert_query(Observation.index_order.when_in_range("02-22", "08-22"),
+    assert_query(Observation.index_order.when_between("02-22", "08-22"),
                  :Observation, date: %w[02-22 08-22] )
   end
 
   # period wraps around the new year
   def test_observation_date_period_wrap
-    assert_query(Observation.index_order.when_in_range("08-22", "02-22"),
+    assert_query(Observation.index_order.when_between("08-22", "02-22"),
                  :Observation, date: %w[08-22 02-22] )
   end
 
   def test_observation_date_full
     assert_query(Observation.index_order.
-                 when_in_range("2009-08-22", "2009-10-20"),
+                 when_between("2009-08-22", "2009-10-20"),
                  :Observation, date: %w[2009-08-22 2009-10-20] )
   end
 
   # date wraps around the new year
   def test_observation_date_wrap
     assert_query(Observation.index_order.
-                 when_in_range("2015-08-22", "2016-02-22"),
+                 when_between("2015-08-22", "2016-02-22"),
                  :Observation, date: %w[2015-08-22 2016-02-22] )
   end
 


### PR DESCRIPTION
Fills out and updates shared scopes usable for date ranges and datetime ranges.

Changes currently unused scopes `:created_after`, `:updated_before` etc to accept the current syntax expected by Query: 
```ruby
"%Y-%m-%d-%H-%i-%s"
```
and adds tests to `QueryTest`. Updates some of the `AbstractModelTest` accordingly. (`start_of_time` didn't work as a comparison date because the year is negative, which Query's date parser doesn't handle.)

Also generalizes scopes `:by_user` and `:by_editor` (versions) for all models.