### PR TITLE
Fix identify UI for proposing or voting on names

### DIFF
--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -35,10 +35,10 @@ module LightboxHelper
   def lightbox_obs_caption(obs, identify)
     html = []
 
-    html << caption_identify_ui(obs: obs) if identify
-    html << caption_obs_title(obs: obs)
-    html << observation_details_when_where_who(obs: obs)
-    html << caption_truncated_notes(obs: obs)
+    html << caption_identify_ui(obs:) if identify
+    html << caption_obs_title(obs:, identify:)
+    html << observation_details_when_where_who(obs:)
+    html << caption_truncated_notes(obs:)
     html
   end
 
@@ -52,7 +52,7 @@ module LightboxHelper
 
   # This gets removed on successful propose
   def caption_identify_ui(obs:)
-    tag.div(class: "obs-identify", id: "observation_identify_#{obs.id}") do
+    tag.div(class: "obs-identify mb-3", id: "observation_identify_#{obs.id}") do
       [
         propose_naming_link(
           obs.id, context: "lightgallery",
@@ -65,17 +65,24 @@ module LightboxHelper
   end
 
   # This is different from show_obs_title, it's more like the matrix_box title
-  def caption_obs_title(obs:)
+  def caption_obs_title(obs:, identify:)
+    btn_style = identify ? "text-bold" : "btn btn-primary"
+    text = if identify
+             tag.span("#{:OBSERVATION.l}: ", class: "font-weight-normal")
+           else
+             ""
+           end
     tag.h4(
       class: "obs-what", id: "observation_what_#{obs.id}",
       data: { controller: "section-update" }
     ) do
       [
+        text,
         link_to(obs.id, add_query_param(obs.show_link_args),
-                class: "btn btn-primary mr-3",
+                class: "#{btn_style} mr-3",
                 id: "caption_obs_link_#{obs.id}"),
         obs.format_name.t.small_author
-      ].safe_join(" ")
+      ].compact_blank!.safe_join(" ")
     end
   end
 

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -54,8 +54,10 @@ module LightboxHelper
   def caption_identify_ui(obs:)
     tag.div(class: "obs-identify", id: "observation_identify_#{obs.id}") do
       [
-        propose_naming_link(obs.id, context: "lightgallery",
-                                    btn_class: "btn d-inline-block"),
+        propose_naming_link(
+          obs.id, context: "lightgallery",
+                  btn_class: "btn btn-primary d-inline-block"
+        ),
         tag.span("&nbsp;".html_safe, class: "mx-2"),
         mark_as_reviewed_toggle(obs.id)
       ].safe_join
@@ -64,8 +66,10 @@ module LightboxHelper
 
   # This is different from show_obs_title, it's more like the matrix_box title
   def caption_obs_title(obs:)
-    tag.h4(class: "obs-what", id: "observation_what_#{obs.id}",
-           data: { controller: "section-update" }) do
+    tag.h4(
+      class: "obs-what", id: "observation_what_#{obs.id}",
+      data: { controller: "section-update" }
+    ) do
       [
         link_to(obs.id, add_query_param(obs.show_link_args),
                 class: "btn btn-primary mr-3",

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -399,7 +399,7 @@ module NamingsHelper
   # The new_naming_tab now has an icon. icon buttons send icon: true
   def propose_naming_link(obs_id, text: :create_naming.t,
                           context: "namings_table", icon: false,
-                          btn_class: "btn-primary my-3")
+                          btn_class: "btn btn-primary my-3")
     name, path, args = *new_naming_tab(
       obs_id, text: text, btn_class: btn_class, context: context
     )

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -289,8 +289,8 @@ module NamingsHelper
       data: { turbo: true, controller: "naming-vote", naming_id: naming.id,
               localization: naming_vote_form_localizations }
     }
-    args = args.merge(model: vote) if vote
-    args
+    # Only gets the :model arg if instance exists, else :scope
+    args.merge(vote ? { model: vote } : { scope: :vote })
   end
 
   def naming_vote_form_localizations

--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -4,72 +4,72 @@
 html_class = (Rails.env == "test") ? "" : "scroll-behavior-smooth"
 ctrlr_action = "#{controller.controller_name}__#{controller.action_name}"
 theme = "theme-#{@css_theme.underscore.dasherize}"
-location_format = "location-format-#{User.current_location_format}"
+location_format = "location-format-#{User.current_location_format || "postal"}"
 logged_in = User.current ? "logged-in-user" : "no-user"
 body_class = class_names(ctrlr_action, theme, location_format, logged_in)
 %>
 <!DOCTYPE html>
 <html class="<%= html_class %>">
+
 <head>
   <%= render(partial: "application/app/head") %>
 </head>
 
 <body class="<%= body_class %>" data-controller="lazyload tooltip">
   <% if Rails.env == "production" %>
-    <%= render(partial: "application/app/gtm_iframe") %>
+  <%= render(partial: "application/app/gtm_iframe") %>
   <% end %>
 
-<div id="main_container" class="container-fluid"
-     data-controller="nav links" data-nav-target="container">
+  <div id="main_container" class="container-fluid" data-controller="nav links" data-nav-target="container">
 
-  <%= render(partial: "application/app/banners") %>
+    <%= render(partial: "application/app/banners") %>
 
-  <div class="row row-offcanvas row-offcanvas-left"
-       data-nav-target="offcanvas">
+    <div class="row row-offcanvas row-offcanvas-left" data-nav-target="offcanvas">
 
-    <nav id="sidebar" class="sidebar-offcanvas col-xs-8 col-sm-2 hidden-print">
-      <%= render(partial: "application/sidebar") %>
-    </nav><!-- #sidebar -->
+      <nav id="sidebar" class="sidebar-offcanvas col-xs-8 col-sm-2 hidden-print">
+        <%= render(partial: "application/sidebar") %>
+      </nav><!-- #sidebar -->
 
-    <div id="right_side" class="col-xs-12 col-sm-10">
+      <div id="right_side" class="col-xs-12 col-sm-10">
 
-      <%= render(partial: "application/app/hamburger") %>
+        <%= render(partial: "application/app/hamburger") %>
 
-      <%= render(partial: "application/top_nav") %>
+        <%= render(partial: "application/top_nav") %>
 
-      <%# need to print a `#page_flash` div no matter what, so js can add %>
-      <div class="container-full hidden-print" id="page_flash">
-        <%= flash_notices_html %><%# calls flash_clear %>
-      </div><!--.container-text-->
+        <%# need to print a `#page_flash` div no matter what, so js can add %>
+        <div class="container-full hidden-print" id="page_flash">
+          <%= flash_notices_html %><%# calls flash_clear %>
+        </div>
+        <!--.container-text-->
 
-      <header id="header">
-        <%= render(partial: "application/content/title_and_tab_sets") %>
-      </header>
+        <header id="header">
+          <%= render(partial: "application/content/title_and_tab_sets") %>
+        </header>
 
-      <main id="content" class="<%= container_class %>"
-            data-controller="lightgallery">
+        <main id="content" class="<%= container_class %>" data-controller="lightgallery">
 
-        <%# unless @user&.verified? %>
+          <%# unless @user&.verified? %>
           <%# render(partial: "application/content/login_layout") %>
-        <%# end %>
+          <%# end %>
 
-        <!--MAIN_PAGE_CONTENT-->
-        <%= yield %>
-        <!--/MAIN_PAGE_CONTENT-->
+          <!--MAIN_PAGE_CONTENT-->
+          <%= yield %>
+          <!--/MAIN_PAGE_CONTENT-->
 
-        <%= render(partial: "application/content/translators_credit") %>
-      </main><!-- #content -->
+          <%= render(partial: "application/content/translators_credit") %>
+        </main><!-- #content -->
 
-    </div><!-- #right_side -->
-  </div><!-- .row-offcanvas -->
-</div><!-- #main_container -->
+      </div><!-- #right_side -->
+    </div><!-- .row-offcanvas -->
+  </div><!-- #main_container -->
 
-<!--AJAX PROGRESS WHIRLY -->
-<%= render(partial: "shared/modal_ajax_progress") %>
+  <!--AJAX PROGRESS WHIRLY -->
+  <%= render(partial: "shared/modal_ajax_progress") %>
 
-<%= render(partial: "application/app/media_query_tests") %>
+  <%= render(partial: "application/app/media_query_tests") %>
 
-<%= render(partial: "application/app/javascript_footer") %>
+  <%= render(partial: "application/app/javascript_footer") %>
 
 </body>
+
 </html>

--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -20,13 +20,16 @@ body_class = class_names(ctrlr_action, theme, location_format, logged_in)
   <%= render(partial: "application/app/gtm_iframe") %>
   <% end %>
 
-  <div id="main_container" class="container-fluid" data-controller="nav links" data-nav-target="container">
+  <div id="main_container" class="container-fluid" 
+       data-controller="nav links" data-nav-target="container">
 
     <%= render(partial: "application/app/banners") %>
 
-    <div class="row row-offcanvas row-offcanvas-left" data-nav-target="offcanvas">
+    <div class="row row-offcanvas row-offcanvas-left" 
+         data-nav-target="offcanvas">
 
-      <nav id="sidebar" class="sidebar-offcanvas col-xs-8 col-sm-2 hidden-print">
+      <nav id="sidebar" 
+           class="sidebar-offcanvas col-xs-8 col-sm-2 hidden-print">
         <%= render(partial: "application/sidebar") %>
       </nav><!-- #sidebar -->
 
@@ -46,7 +49,8 @@ body_class = class_names(ctrlr_action, theme, location_format, logged_in)
           <%= render(partial: "application/content/title_and_tab_sets") %>
         </header>
 
-        <main id="content" class="<%= container_class %>" data-controller="lightgallery">
+        <main id="content" class="<%= container_class %>" 
+              data-controller="lightgallery">
 
           <%# unless @user&.verified? %>
           <%# render(partial: "application/content/login_layout") %>

--- a/app/views/controllers/observations/namings/_update_matrix_box.erb
+++ b/app/views/controllers/observations/namings/_update_matrix_box.erb
@@ -9,7 +9,7 @@ end %>
                    id: obs.id)
 end %>
 
-<%# removes modal via data-controller="section-update" on caption_obs_title %>
+<%# are not removed via data-controller="section-update" because replaced %>
 <%= turbo_stream.close_modal("modal_obs_#{obs.id}_naming") %>
 <%= turbo_stream.remove("modal_obs_#{obs.id}_naming") %>
 <%= turbo_stream.close_modal("mo_ajax_progress") %>

--- a/app/views/controllers/observations/namings/_update_matrix_box.erb
+++ b/app/views/controllers/observations/namings/_update_matrix_box.erb
@@ -1,6 +1,6 @@
 <%# Replace the title in the lightbox caption %>
 <%= turbo_stream.replace("observation_what_#{obs.id}") do
-  caption_obs_title(obs: obs)
+  caption_obs_title(obs: obs, identify: true)
 end %>
 
 <%# Replace the title in the matrix_box %>

--- a/app/views/controllers/observations/namings/_update_matrix_box.erb
+++ b/app/views/controllers/observations/namings/_update_matrix_box.erb
@@ -10,6 +10,8 @@ end %>
 end %>
 
 <%# removes modal via data-controller="section-update" on caption_obs_title %>
-<%# turbo_stream.close_modal("modal_#{obs.id}_naming") %>
-<%# turbo_stream.remove("modal_#{obs.id}_naming") %>
+<%= turbo_stream.close_modal("modal_obs_#{obs.id}_naming") %>
+<%= turbo_stream.remove("modal_obs_#{obs.id}_naming") %>
+<%= turbo_stream.close_modal("mo_ajax_progress") %>
+<%= turbo_stream.remove("mo_ajax_progress") %>
 <%= turbo_stream.remove("observation_identify_#{obs.id}") %>


### PR DESCRIPTION
Several fixes here. 
- Vote `:value` param was not properly nested (under `:vote`) when the user had not already voted. `form_with` needed `scope: :vote` in that case. It already gets `model: @vote` it they have voted.
- "Propose a name" link was hard to read in the lightbox view
- Turbo now explicitly `remove`s the modals (either vote progress spinner or propose form). Previously it was depending on the `updated` event being fired, but it does not get fired because the elements are `replace`d by Turbo, not `update`d.
- Somehow on local I seem to have lost the CSS that shows/hides the location format that is not the user's preference. This gives the CSS a fallback value.
