### PR TITLE
Restate polymorphic associations explicitly to allow joining

### DIFF
--- a/app/classes/api2/comment_api.rb
+++ b/app/classes/api2/comment_api.rb
@@ -28,13 +28,13 @@ class API2
     end
 
     def query_params
-      @target = parse(:object, :target, limit: Comment.all_types, help: 1)
+      @target = parse(:object, :target, limit: Comment::ALL_TYPES, help: 1)
       {
         where: sql_id_condition,
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         users: parse_array(:user, :user, help: :creator),
-        types: parse_array(:enum, :type, limit: Comment.all_type_tags),
+        types: parse_array(:enum, :type, limit: Comment::ALL_TYPE_TAGS),
         summary_has: parse(:string, :summary_has, help: 1),
         content_has: parse(:string, :content_has, help: 1),
         target: @target ? @target.id : nil,
@@ -44,7 +44,7 @@ class API2
 
     def create_params
       {
-        target: parse(:object, :target, limit: Comment.all_types),
+        target: parse(:object, :target, limit: Comment::ALL_TYPES),
         summary: parse(:string, :summary, limit: 100),
         comment: parse(:string, :content),
         user: @user

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -13,7 +13,7 @@ class Query::Comments < Query::Base
       by_user?: User,
       for_user?: User,
       users?: [User],
-      types?: [{ string: Comment.all_type_tags }],
+      types?: [{ string: Comment::ALL_TYPE_TAGS }],
       summary_has?: :string,
       content_has?: :string,
       pattern?: :string,
@@ -31,7 +31,7 @@ class Query::Comments < Query::Base
     add_for_target_condition
     add_pattern_condition
     add_string_enum_condition("comments.target_type", params[:types],
-                              Comment.all_type_tags)
+                              Comment::ALL_TYPE_TAGS)
     add_search_condition("comments.summary", params[:summary_has])
     add_search_condition("comments.comment", params[:content_has])
     super

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -99,7 +99,7 @@ module Query::Initializers::Descriptions
     add_indexed_enum_condition(
       "#{type}_descriptions.source_type",
       params[:desc_type],
-      Description.all_source_types
+      Description::ALL_SOURCE_TYPES
     )
   end
 

--- a/app/classes/query/params/descriptions.rb
+++ b/app/classes/query/params/descriptions.rb
@@ -5,7 +5,7 @@ module Query::Params::Descriptions
     {
       with_default_desc?: :boolean,
       join_desc?: { string: [:default, :any] },
-      desc_type?: [{ string: [Description.all_source_types] }],
+      desc_type?: [{ string: [Description::ALL_SOURCE_TYPES] }],
       desc_project?: [:string],
       desc_creator?: [User],
       desc_content?: :string,

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -35,7 +35,7 @@ class Query::RssLogs < Query::Base
     return if types.include?("all")
 
     types = self.types
-    types &= RssLog::ALL_TYPES.map(&:to_s)
+    types &= RssLog::ALL_TYPE_TAGS.map(&:to_s)
 
     where << if types.empty?
                "FALSE"

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -35,7 +35,8 @@ class Query::RssLogs < Query::Base
     return if types.include?("all")
 
     types = self.types
-    types &= RssLog.all_types
+    types &= RssLog::ALL_TYPES
+
     where << if types.empty?
                "FALSE"
              else

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -35,7 +35,7 @@ class Query::RssLogs < Query::Base
     return if types.include?("all")
 
     types = self.types
-    types &= RssLog::ALL_TYPES
+    types &= RssLog::ALL_TYPES.map(&:to_s)
 
     where << if types.empty?
                "FALSE"

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -53,8 +53,8 @@ class RssLogsController < ApplicationController
     types = ""
     if params[:type].is_a?(ActionController::Parameters)
       types = params[:type].select { |_key, value| value == "1" }.keys
-      types = RssLog::ALL_TYPES.map(&:to_s).intersection(types)
-      types = "all" if types.length == RssLog::ALL_TYPES.length
+      types = RssLog::ALL_TYPE_TAGS.map(&:to_s).intersection(types)
+      types = "all" if types.length == RssLog::ALL_TYPE_TAGS.length
       types = "none" if types.empty?
     elsif params[:type].is_a?(String)
       types = params[:type]

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -53,8 +53,10 @@ class RssLogsController < ApplicationController
     types = ""
     if params[:type].is_a?(ActionController::Parameters)
       types = params[:type].select { |_key, value| value == "1" }.keys
-      types = RssLog.all_types.intersection(types)
-      types = "all" if types.length == RssLog.all_types.length
+      types = RssLog::ALL_TYPES
+.intersection(types)
+      types = "all" if types.length == RssLog::ALL_TYPES
+.length
       types = "none" if types.empty?
       types = types.map(&:to_s).join(" ") if types.is_a?(Array)
     elsif params[:type].is_a?(String)

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -53,13 +53,13 @@ class RssLogsController < ApplicationController
     types = ""
     if params[:type].is_a?(ActionController::Parameters)
       types = params[:type].select { |_key, value| value == "1" }.keys
-      types = RssLog::ALL_TYPES.intersection(types)
+      types = RssLog::ALL_TYPES.map(&:to_s).intersection(types)
       types = "all" if types.length == RssLog::ALL_TYPES.length
       types = "none" if types.empty?
-      types = types.map(&:to_s).join(" ") if types.is_a?(Array)
     elsif params[:type].is_a?(String)
       types = params[:type]
     end
+    types = types.map(&:to_s).join(" ") if types.is_a?(Array)
     types
   end
 

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -53,10 +53,8 @@ class RssLogsController < ApplicationController
     types = ""
     if params[:type].is_a?(ActionController::Parameters)
       types = params[:type].select { |_key, value| value == "1" }.keys
-      types = RssLog::ALL_TYPES
-.intersection(types)
-      types = "all" if types.length == RssLog::ALL_TYPES
-.length
+      types = RssLog::ALL_TYPES.intersection(types)
+      types = "all" if types.length == RssLog::ALL_TYPES.length
       types = "none" if types.empty?
       types = types.map(&:to_s).join(" ") if types.is_a?(Array)
     elsif params[:type].is_a?(String)

--- a/app/helpers/descriptions_helper.rb
+++ b/app/helpers/descriptions_helper.rb
@@ -58,7 +58,7 @@ module DescriptionsHelper
   # Sort, putting the default one on top, followed by public ones, followed
   # by others ending in personal ones, sorting by "length" among groups.
   def sort_description_list(object, list)
-    type_order = Description.all_source_types
+    type_order = Description::ALL_SOURCE_TYPES
     list.sort_by! do |x|
       [
         (x.id == object.description_id ? 0 : 1),
@@ -320,7 +320,7 @@ module DescriptionsHelper
   # Source type options for description forms.
   def source_type_options_all
     options = []
-    Description.all_source_types.each do |type|
+    Description::ALL_SOURCE_TYPES.each do |type|
       options << [:"form_description_source_#{type}".l, type]
     end
     options
@@ -328,7 +328,7 @@ module DescriptionsHelper
 
   def source_type_options_basic
     options = []
-    Description.basic_source_types.each do |type|
+    Description::BASIC_SOURCE_TYPES.each do |type|
       options << [:"form_description_source_#{type}".l, type]
     end
     options

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -110,6 +110,32 @@ class Comment < AbstractModel
   belongs_to :target, polymorphic: true
   belongs_to :user
 
+  # Allow explicit joining for all polymorphic associations,
+  # e.g. `Comment.joins(:location).where(target_id: 29513)`,
+  # by restating the association below with a scope.
+  # https://veelenga.github.io/joining-polymorphic-associations/
+  belongs_to :location_description, lambda {
+    where(comments: { target_type: "LocationDescription" })
+  }, foreign_key: "target_id", inverse_of: :comments
+  belongs_to :location, lambda {
+    where(comments: { target_type: "Location" })
+  }, foreign_key: "target_id", inverse_of: :comments
+  belongs_to :name_description, lambda {
+    where(comments: { target_type: "NameDescription" })
+  }, foreign_key: "target_id", inverse_of: :comments
+  belongs_to :name, lambda {
+    where(comments: { target_type: "Name" })
+  }, foreign_key: "target_id", inverse_of: :comments
+  belongs_to :observation, lambda {
+    where(comments: { target_type: "Observation" })
+  }, foreign_key: "target_id", inverse_of: :comments
+  belongs_to :project, lambda {
+    where(comments: { target_type: "Project" })
+  }, foreign_key: "target_id", inverse_of: :comments
+  belongs_to :species_list, lambda {
+    where(comments: { target_type: "SpeciesList" })
+  }, foreign_key: "target_id", inverse_of: :comments
+
   broadcasts_to(->(comment) { [comment.target, :comments] },
                 inserts_by: :prepend, partial: "comments/comment",
                 target: "comments")

--- a/app/models/copyright_change.rb
+++ b/app/models/copyright_change.rb
@@ -26,16 +26,24 @@
 
 class CopyrightChange < AbstractModel
   belongs_to :user
-  belongs_to :target, polymorphic: true
   belongs_to :license
+  belongs_to :target, polymorphic: true
+
+  # Maintain this Array of all models (Classes) which take copyright changes.
+  ALL_TYPES = [Image].freeze
+
+  # Returns Array of all valid +target_type+ values (Symbols).
+  ALL_TYPE_TAGS = ALL_TYPES.map { |type| type.to_s.underscore.to_sym }.freeze
 
   # Allow explicit joining for all polymorphic associations,
   # e.g. `CopyrightChange.joins(:image).where(target_id: 29513)`,
   # by restating the association below with a scope.
   # https://veelenga.github.io/joining-polymorphic-associations/
-  belongs_to :image, lambda {
-    where(copyright_changes: { target_type: "Image" })
-  }, foreign_key: "target_id", inverse_of: :copyright_changes
+  ALL_TYPE_TAGS.each do |model|
+    belongs_to model, lambda {
+      where(copyright_changes: { target_type: model.to_s.camelize })
+    }, foreign_key: "target_id", inverse_of: :copyright_changes
+  end
 
   ##############################################################################
 

--- a/app/models/copyright_change.rb
+++ b/app/models/copyright_change.rb
@@ -29,6 +29,14 @@ class CopyrightChange < AbstractModel
   belongs_to :target, polymorphic: true
   belongs_to :license
 
+  # Allow explicit joining for all polymorphic associations,
+  # e.g. `CopyrightChange.joins(:image).where(target_id: 29513)`,
+  # by restating the association below with a scope.
+  # https://veelenga.github.io/joining-polymorphic-associations/
+  belongs_to :image, lambda {
+    where(copyright_changes: { target_type: "Image" })
+  }, foreign_key: "target_id", inverse_of: :copyright_changes
+
   ##############################################################################
 
   protected

--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -233,6 +233,9 @@ class Description < AbstractModel
   #
   ##############################################################################
 
+  # Return an Array of source type Strings, e.g. "public", "project", etc.
+  # Note, this is the order they will be listed in show_name descriptions
+  # panel, list_descriptions.
   ALL_SOURCE_TYPES = [
     "public",    # Public ones created by any user.
     "foreign",   # Foreign "public" description(s) written on another server.
@@ -246,21 +249,6 @@ class Description < AbstractModel
     "source",    # Derived from another source, e.g. another website or book.
     "user"       # Created by an individual user.
   ].freeze
-
-  # Return an Array of source type Strings, e.g. "public", "project", etc.
-  # Note, this is the order they will be listed in show_name descriptions
-  # panel, list_descriptions.
-  def self.all_source_types
-    ALL_SOURCE_TYPES
-    # NOTE: Why not keep this simple and just load them in order of the enums?
-    # source_types.map do |name, _integer|
-    #   name
-    # end
-  end
-
-  def self.basic_source_types
-    BASIC_SOURCE_TYPES
-  end
 
   # Retreive object representing the source (if applicable).  Presently, this
   # only works for Project drafts and User's personal descriptions.  All others
@@ -276,8 +264,7 @@ class Description < AbstractModel
 
   # Does this Description belong to a given Project?
   def belongs_to_project?(project)
-    (source_type == "project") &&
-      (project_id == project.id)
+    (source_type == "project") && (project_id == project.id)
   end
 
   ##############################################################################

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -50,34 +50,23 @@
 ################################################################################
 #
 class Interest < AbstractModel
-  belongs_to :target, polymorphic: true
   belongs_to :user
+  belongs_to :target, polymorphic: true
 
   # Allow explicit joining for all polymorphic associations,
   # e.g. `Interest.joins(:location).where(target_id: 29513)`,
   # by restating the association below with a scope.
   # https://veelenga.github.io/joining-polymorphic-associations/
-  belongs_to :location_description, lambda {
-    where(interests: { target_type: "LocationDescription" })
-  }, foreign_key: "target_id", inverse_of: :interests
-  belongs_to :location, lambda {
-    where(interests: { target_type: "Location" })
-  }, foreign_key: "target_id", inverse_of: :interests
-  belongs_to :name_description, lambda {
-    where(interests: { target_type: "NameDescription" })
-  }, foreign_key: "target_id", inverse_of: :interests
-  belongs_to :name, lambda {
-    where(interests: { target_type: "Name" })
-  }, foreign_key: "target_id", inverse_of: :interests
-  belongs_to :observation, lambda {
-    where(interests: { target_type: "Observation" })
-  }, foreign_key: "target_id", inverse_of: :interests
-  belongs_to :project, lambda {
-    where(interests: { target_type: "Project" })
-  }, foreign_key: "target_id", inverse_of: :interests
-  belongs_to :species_list, lambda {
-    where(interests: { target_type: "SpeciesList" })
-  }, foreign_key: "target_id", inverse_of: :interests
+  JOINABLE_TARGETS = [
+    :location, :location_description, :name, :name_description,
+    :observation, :project, :species_list
+  ].freeze
+
+  JOINABLE_TARGETS.each do |model_tag|
+    belongs_to model_tag, lambda {
+      where(interests: { target_type: model_tag.to_s.camelize })
+    }, foreign_key: "target_id", inverse_of: :interests
+  end
 
   scope :for_user,
         ->(user) { where(user: user) }

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -55,7 +55,7 @@ class Interest < AbstractModel
 
   # Maintain this Array of all models (targets) which take interests.
   ALL_TYPES = [
-    Location, LocationDescription, Name, NameDescription,
+    Location, LocationDescription, Name, NameDescription, NameTracker,
     Observation, Project, SpeciesList
   ].freeze
 

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -53,6 +53,32 @@ class Interest < AbstractModel
   belongs_to :target, polymorphic: true
   belongs_to :user
 
+  # Allow explicit joining for all polymorphic associations,
+  # e.g. `Interest.joins(:location).where(target_id: 29513)`,
+  # by restating the association below with a scope.
+  # https://veelenga.github.io/joining-polymorphic-associations/
+  belongs_to :location_description, lambda {
+    where(interests: { target_type: "LocationDescription" })
+  }, foreign_key: "target_id", inverse_of: :interests
+  belongs_to :location, lambda {
+    where(interests: { target_type: "Location" })
+  }, foreign_key: "target_id", inverse_of: :interests
+  belongs_to :name_description, lambda {
+    where(interests: { target_type: "NameDescription" })
+  }, foreign_key: "target_id", inverse_of: :interests
+  belongs_to :name, lambda {
+    where(interests: { target_type: "Name" })
+  }, foreign_key: "target_id", inverse_of: :interests
+  belongs_to :observation, lambda {
+    where(interests: { target_type: "Observation" })
+  }, foreign_key: "target_id", inverse_of: :interests
+  belongs_to :project, lambda {
+    where(interests: { target_type: "Project" })
+  }, foreign_key: "target_id", inverse_of: :interests
+  belongs_to :species_list, lambda {
+    where(interests: { target_type: "SpeciesList" })
+  }, foreign_key: "target_id", inverse_of: :interests
+
   scope :for_user,
         ->(user) { where(user: user) }
 

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -53,46 +53,28 @@ class Interest < AbstractModel
   belongs_to :user
   belongs_to :target, polymorphic: true
 
+  # Maintain this Array of all models (targets) which take interests.
+  ALL_TYPES = [
+    Location, LocationDescription, Name, NameDescription,
+    Observation, Project, SpeciesList
+  ].freeze
+
+  # Returns Array of all valid +target_type+ values (Symbols).
+  ALL_TYPE_TAGS = ALL_TYPES.map { |type| type.to_s.underscore.to_sym }.freeze
+
   # Allow explicit joining for all polymorphic associations,
   # e.g. `Interest.joins(:location).where(target_id: 29513)`,
   # by restating the association below with a scope.
   # https://veelenga.github.io/joining-polymorphic-associations/
-  JOINABLE_TARGETS = [
-    :location, :location_description, :name, :name_description,
-    :observation, :project, :species_list
-  ].freeze
-
-  JOINABLE_TARGETS.each do |model_tag|
+  ALL_TYPE_TAGS.each do |model_tag|
     belongs_to model_tag, lambda {
       where(interests: { target_type: model_tag.to_s.camelize })
     }, foreign_key: "target_id", inverse_of: :interests
   end
 
-  scope :for_user,
-        ->(user) { where(user: user) }
+  scope :for_user, ->(user) { where(user: user) }
 
-  ALL_INTEREST_TYPES = %w[
-    Location
-    Name
-    NameTracker
-    Observation
-    Project
-    SpeciesList
-  ].freeze
-
-  validates :target_type, inclusion: { in: ALL_INTEREST_TYPES }
-
-  # Returns Array of all models (Classes) which take interests.
-  def self.all_types
-    types = ALL_INTEREST_TYPES.dup
-    types.map(&:constantize)
-  end
-
-  # Returns Array of all valid +target_type+ values (Symbol's).
-  def self.all_type_tags
-    types = ALL_INTEREST_TYPES.dup
-    types.map { |t| t.underscore.to_sym }
-  end
+  validates :target_type, inclusion: { in: ALL_TYPES.map(&:to_s) }
 
   # Find all Interests associated with a given object.  This should really be
   # created magically like all the other find_all_by_xxx methods, but the

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -503,7 +503,7 @@ class Name < AbstractModel
   scope :with_description_of_type,
         lambda { |source|
           # Check that it's a valid source type (string enum value)
-          return none if Description.all_source_types.exclude?(source)
+          return none if Description::ALL_SOURCE_TYPES.exclude?(source)
 
           joins(:descriptions).
             merge(NameDescription.where(source_type: source))

--- a/app/models/name_tracker.rb
+++ b/app/models/name_tracker.rb
@@ -27,6 +27,7 @@
 class NameTracker < AbstractModel
   belongs_to :user
   belongs_to :name
+  has_many :interests, as: :target, dependent: :destroy, inverse_of: :target
 
   scope :for_user, ->(user) { where(user: user) }
 

--- a/app/models/name_tracker.rb
+++ b/app/models/name_tracker.rb
@@ -28,8 +28,7 @@ class NameTracker < AbstractModel
   belongs_to :user
   belongs_to :name
 
-  scope :for_user,
-        ->(user) { where(user: user) }
+  scope :for_user, ->(user) { where(user: user) }
 
   # Used as an "opt-in" check-box in the UI form.
   attr_accessor :note_template_enabled

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -157,14 +157,15 @@ class RssLog < AbstractModel
 
   # List of all object types that can have RssLog's.  (This is the order they
   # appear on the activity log page.)
-  ALL_TYPES = %w[
-    observation name location species_list project glossary_term article
+  ALL_TYPES = [
+    :observation, :name, :location, :species_list, :project,
+    :glossary_term, :article
   ].freeze
 
   # Returns the associated object, or nil if it's an orphan.
   def target
     ALL_TYPES.each do |type|
-      obj = send(type.to_sym)
+      obj = send(type)
       return obj if obj
     end
     nil
@@ -183,7 +184,7 @@ class RssLog < AbstractModel
   # or nil if it's an orphan
   def target_type
     ALL_TYPES.each do |type|
-      return type.to_sym if send(:"#{type}_id")
+      return type if send(:"#{type}_id")
     end
     nil
   end

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -48,10 +48,10 @@
 #       def unique_text_name
 #       def unique_format_name
 #
-#  3) RssLog: Create association, add type to RssLog::ALL_TYPES.
+#  3) RssLog: Create association, add type to RssLog::ALL_TYPE_TAGS.
 #
 #       belongs_to :model
-#       ALL_TYPES # add "model"
+#       ALL_TYPE_TAGS # add "model"
 #
 #  4) View: Modify MatrixBoxPresenter if who/what/when/where are nonstandard.
 #
@@ -119,7 +119,7 @@
 #
 #  == Class constants
 #
-#  ALL_TYPES::          Object types with RssLog's (Array of Symbol's).
+#  ALL_TYPE_TAGS::          Object types with RssLog's (Array of Symbol's).
 #
 #  == Instance methods
 #
@@ -155,16 +155,18 @@ class RssLog < AbstractModel
   # 65535, I think, but let's mak sure there's a safe buffer.
   MAX_LENGTH = 65_500
 
-  # List of all object types that can have RssLog's.  (This is the order they
-  # appear on the activity log page.)
+  # List of all objects (Classes) that can have RssLogs.
+  # (This is the order they appear on the activity log page.)
   ALL_TYPES = [
-    :observation, :name, :location, :species_list, :project,
-    :glossary_term, :article
+    Observation, Name, Location, SpeciesList, Project, GlossaryTerm, Article
   ].freeze
+
+  # Returns Array of type_tags (Symbols) of ALL_TYPES.
+  ALL_TYPE_TAGS = ALL_TYPES.map { |type| type.to_s.underscore.to_sym }.freeze
 
   # Returns the associated object, or nil if it's an orphan.
   def target
-    ALL_TYPES.each do |type|
+    ALL_TYPE_TAGS.each do |type|
       obj = send(type)
       return obj if obj
     end
@@ -173,7 +175,7 @@ class RssLog < AbstractModel
 
   # Returns the associated object's id, or nil if it's an orphan.
   def target_id
-    ALL_TYPES.each do |type|
+    ALL_TYPE_TAGS.each do |type|
       obj_id = send(:"#{type}_id")
       return obj_id if obj_id
     end
@@ -183,7 +185,7 @@ class RssLog < AbstractModel
   # Return the type of object of the target, e.g., :observation
   # or nil if it's an orphan
   def target_type
-    ALL_TYPES.each do |type|
+    ALL_TYPE_TAGS.each do |type|
       return type if send(:"#{type}_id")
     end
     nil
@@ -191,7 +193,7 @@ class RssLog < AbstractModel
 
   # Clear association with target.
   def clear_target_id
-    ALL_TYPES.each do |type|
+    ALL_TYPE_TAGS.each do |type|
       send(:"#{type}_id=", nil)
     end
   end

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -48,10 +48,10 @@
 #       def unique_text_name
 #       def unique_format_name
 #
-#  3) RssLog: Create association, add type to RssLog.all_types.
+#  3) RssLog: Create association, add type to RssLog::ALL_TYPES.
 #
 #       belongs_to :model
-#       self.all_types # add "model"
+#       ALL_TYPES # add "model"
 #
 #  4) View: Modify MatrixBoxPresenter if who/what/when/where are nonstandard.
 #
@@ -117,9 +117,9 @@
 #  name, name_id::      Owning Name (or nil).
 #  etc.::               (Pair of methods for each type of model.)
 #
-#  == Class methods
+#  == Class constants
 #
-#  all_types::          Object types with RssLog's (Array of Symbol's).
+#  ALL_TYPES::          Object types with RssLog's (Array of Symbol's).
 #
 #  == Instance methods
 #
@@ -157,13 +157,13 @@ class RssLog < AbstractModel
 
   # List of all object types that can have RssLog's.  (This is the order they
   # appear on the activity log page.)
-  def self.all_types
-    %w[observation name location species_list project glossary_term article]
-  end
+  ALL_TYPES = %w[
+    observation name location species_list project glossary_term article
+  ].freeze
 
   # Returns the associated object, or nil if it's an orphan.
   def target
-    RssLog.all_types.each do |type|
+    ALL_TYPES.each do |type|
       obj = send(type.to_sym)
       return obj if obj
     end
@@ -172,7 +172,7 @@ class RssLog < AbstractModel
 
   # Returns the associated object's id, or nil if it's an orphan.
   def target_id
-    RssLog.all_types.each do |type|
+    ALL_TYPES.each do |type|
       obj_id = send(:"#{type}_id")
       return obj_id if obj_id
     end
@@ -182,7 +182,7 @@ class RssLog < AbstractModel
   # Return the type of object of the target, e.g., :observation
   # or nil if it's an orphan
   def target_type
-    RssLog.all_types.each do |type|
+    ALL_TYPES.each do |type|
       return type.to_sym if send(:"#{type}_id")
     end
     nil
@@ -190,7 +190,7 @@ class RssLog < AbstractModel
 
   # Clear association with target.
   def clear_target_id
-    RssLog.all_types.each do |type|
+    ALL_TYPES.each do |type|
       send(:"#{type}_id=", nil)
     end
   end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -87,13 +87,11 @@ class Sequence < AbstractModel
   end
 
   # Default number of characters (including diaresis) for truncating locus
-  def self.locus_width
-    24
-  end
+  LOCUS_WIDTH = 24
 
   # wrapper around class method
   def locus_width
-    Sequence.locus_width
+    LOCUS_WIDTH
   end
 
   ##############################################################################

--- a/app/views/controllers/application/content/_type_filters.html.erb
+++ b/app/views/controllers/application/content/_type_filters.html.erb
@@ -19,7 +19,7 @@ https://getbootstrap.com/docs/3.4/javascript/#buttons-checkbox-radio
 
       # Tab for each type of log
       render(partial: "application/content/type",
-             collection: RssLog.all_types(&:to_s),
+             collection: RssLog::ALL_TYPES.map(&:to_s),
              locals: { f: f }),
 
       f.submit(:SUBMIT.t, class: "btn btn-default btn-sm")

--- a/app/views/controllers/application/content/_type_filters.html.erb
+++ b/app/views/controllers/application/content/_type_filters.html.erb
@@ -19,7 +19,7 @@ https://getbootstrap.com/docs/3.4/javascript/#buttons-checkbox-radio
 
       # Tab for each type of log
       render(partial: "application/content/type",
-             collection: RssLog::ALL_TYPES.map(&:to_s),
+             collection: RssLog::ALL_TYPE_TAGS.map(&:to_s),
              locals: { f: f }),
 
       f.submit(:SUBMIT.t, class: "btn btn-default btn-sm")

--- a/app/views/controllers/sequences/_form.erb
+++ b/app/views/controllers/sequences/_form.erb
@@ -28,7 +28,7 @@ end
                            between: :required) %>
   <%= help_block_with_arrow("up", id: "sequence_locus_help",
                             class: "mt-3") do
-    :form_sequence_locus_help.t(locus_width: Sequence.locus_width)
+    :form_sequence_locus_help.t(locus_width: Sequence::LOCUS_WIDTH)
   end %>
 
   <%# bases %>

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -43,7 +43,8 @@ class RssLogsControllerTest < FunctionalTestCase
 
     # Show all.
     params = {}
-    params[:type] = RssLog.all_types
+    params[:type] = RssLog::ALL_TYPES
+
     post(:index, params: params)
     assert_template(:index)
 

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -52,6 +52,9 @@ class RssLogsControllerTest < FunctionalTestCase
     get(:index, params: { type: "all" })
     assert_template("shared/_matrix_box")
 
+    get(:index, params: { type: [:article, :glossary_term] })
+    assert_template(:index)
+
     get(:index, params: { type: [] })
     assert_template(:index)
   end

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -43,7 +43,7 @@ class RssLogsControllerTest < FunctionalTestCase
 
     # Show all.
     params = {}
-    params[:type] = RssLog::ALL_TYPES
+    params[:type] = RssLog::ALL_TYPE_TAGS
 
     post(:index, params: params)
     assert_template(:index)

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -154,12 +154,8 @@ class CommentTest < UnitTestCase
   end
 
   def test_polymorphic_joins
-    assert_true(Comment.joins(:location))
-    assert_true(Comment.joins(:location_description))
-    assert_true(Comment.joins(:name))
-    assert_true(Comment.joins(:name_description))
-    assert_true(Comment.joins(:observation))
-    assert_true(Comment.joins(:project))
-    assert_true(Comment.joins(:species_list))
+    Comment::JOINABLE_TARGETS.each do |model|
+      assert_true(Comment.joins(model))
+    end
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -12,7 +12,7 @@ class CommentTest < UnitTestCase
   end
 
   def test_find_object_for_all_types
-    Comment.all_types.each do |type|
+    Comment::ALL_TYPES.each do |type|
       assert(AbstractModel.find_object(type.to_s, type.first.id),
              "Unable to use find_object to find #{type}")
     end
@@ -154,8 +154,8 @@ class CommentTest < UnitTestCase
   end
 
   def test_polymorphic_joins
-    Comment::JOINABLE_TARGETS.each do |model|
-      assert_true(Comment.joins(model))
+    Comment::ALL_TYPE_TAGS.each do |type_tag|
+      assert_true(Comment.joins(type_tag))
     end
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -152,4 +152,14 @@ class CommentTest < UnitTestCase
     end
     "These emails were queued:\n#{strs.join("\n")}"
   end
+
+  def test_polymorphic_joins
+    assert_true(Comment.joins(:location))
+    assert_true(Comment.joins(:location_description))
+    assert_true(Comment.joins(:name))
+    assert_true(Comment.joins(:name_description))
+    assert_true(Comment.joins(:observation))
+    assert_true(Comment.joins(:project))
+    assert_true(Comment.joins(:species_list))
+  end
 end

--- a/test/models/interest_test.rb
+++ b/test/models/interest_test.rb
@@ -43,4 +43,14 @@ class InterestTest < UnitTestCase
 
     assert_equal(true, dick.watching?(names(:agaricus_campestris)))
   end
+
+  def test_polymorphic_joins
+    assert_true(Interest.joins(:location))
+    assert_true(Interest.joins(:location_description))
+    assert_true(Interest.joins(:name))
+    assert_true(Interest.joins(:name_description))
+    assert_true(Interest.joins(:observation))
+    assert_true(Interest.joins(:project))
+    assert_true(Interest.joins(:species_list))
+  end
 end

--- a/test/models/interest_test.rb
+++ b/test/models/interest_test.rb
@@ -45,12 +45,8 @@ class InterestTest < UnitTestCase
   end
 
   def test_polymorphic_joins
-    assert_true(Interest.joins(:location))
-    assert_true(Interest.joins(:location_description))
-    assert_true(Interest.joins(:name))
-    assert_true(Interest.joins(:name_description))
-    assert_true(Interest.joins(:observation))
-    assert_true(Interest.joins(:project))
-    assert_true(Interest.joins(:species_list))
+    Interest::JOINABLE_TARGETS.each do |model|
+      assert_true(Interest.joins(model))
+    end
   end
 end

--- a/test/models/interest_test.rb
+++ b/test/models/interest_test.rb
@@ -45,8 +45,8 @@ class InterestTest < UnitTestCase
   end
 
   def test_polymorphic_joins
-    Interest::JOINABLE_TARGETS.each do |model|
-      assert_true(Interest.joins(model))
+    Interest::ALL_TYPE_TAGS.each do |type_tag|
+      assert_true(Interest.joins(type_tag))
     end
   end
 end

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -78,7 +78,7 @@ class RssLogTest < UnitTestCase
   # ---------- helpers ---------------------------------------------------------
 
   def model(type)
-    type.camelize.constantize
+    type.to_s.camelize.constantize
   end
 
   # rss_log factory

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -8,7 +8,7 @@ class RssLogTest < UnitTestCase
   # normalized.
   # See https://www.pivotaltracker.com/story/show/174685402
   def test_url_for_normalized_controllers
-    RssLog::ALL_TYPES.each do |type|
+    RssLog::ALL_TYPE_TAGS.each do |type|
       rss_log = create_rss_log(type)
       id = rss_log.target_id
 

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -8,7 +8,7 @@ class RssLogTest < UnitTestCase
   # normalized.
   # See https://www.pivotaltracker.com/story/show/174685402
   def test_url_for_normalized_controllers
-    normalized_rss_log_types.each do |type|
+    RssLog::ALL_TYPES.each do |type|
       rss_log = create_rss_log(type)
       id = rss_log.target_id
 
@@ -76,12 +76,6 @@ class RssLogTest < UnitTestCase
   end
 
   # ---------- helpers ---------------------------------------------------------
-
-  def normalized_rss_log_types
-    RssLog.all_types.each_with_object([]) do |type, ary|
-      ary << type if model(type).controller_normalized?
-    end
-  end
 
   def model(type)
     type.camelize.constantize


### PR DESCRIPTION
Explained [here](https://dev.to/anakbns/polymorphic-joins-in-active-record-2hoj) and here in the paragraph "[Define the association with a scope](https://veelenga.github.io/joining-polymorphic-associations/)".

Currently, both these throw an error:
```ruby
Comment.joins(:location).where(target_id: location.id)
Comment.joins(:target).where(target_id: location.id, target_type: "Location")

#<ActiveRecord::EagerLoadPolymorphicError: Cannot eagerly load the polymorphic association :target>
```
Adding explicit `belongs_to` associations with a scope and foreign_key for each `target` polymorphic relationship allows us to write:
```ruby
Comment.joins(:location).where(target_id: location.id)
```
and is far more efficient (explained in the second link) than this:
```ruby
Comment.includes(:locations).where(target_id: location.id, target_type: "Location")
```