### PR TITLE
Add explanation of "Observations of Name" class

### DIFF
--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -61,13 +61,17 @@ module NamesHelper
   #   link_to_obss_of(query, :obss_of_taxon.t)
   #   => <a href="/observations?q=Q">This Taxon, any name</a> (19)
   def link_to_obss_of(query, title, count)
-    # count = query.select_count # This executes a query per link.
     return nil if count.zero?
 
     query.save
+    # Debugging: we need to execute the query first by counting `num_results`,
+    # then we can get the actual SQL it executed via `last_query`:
+    # count = query.num_results
+    # last_query = query.last_query.squish
     link_to(
       title,
       add_query_param(observations_path, query)
+      # data: { count:, last_query: }
     ) + " (#{count})"
   end
 

--- a/app/models/name/observations.rb
+++ b/app/models/name/observations.rb
@@ -21,22 +21,27 @@ class Name
              order(vote_cache: :desc).distinct
     end
 
+    # "Observations of this name"
     def of_taxon_this_name
       @all.select { |obs| obs&.name_id == @name.id }
     end
 
+    # "Observations of this taxon, other names"
     def of_taxon_other_names
       @all.select { |obs| obs&.name_id.in?(@other_name_ids) }
     end
 
+    # "Observations of this taxon, any name"
     def of_taxon_any_name
       @all.select { |obs| obs&.name_id.in?(@name_ids) }
     end
 
+    # "Observations of other taxa, this taxon proposed"
     def where_taxon_proposed
       @all.reject { |obs| obs&.name_id == @name.id }
     end
 
+    # "Observations of any taxon, this name proposed"
     def where_name_proposed
       @all
     end

--- a/app/models/name/observations.rb
+++ b/app/models/name/observations.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class Name
+  # The goal of this class is to reduce the number of repetitive queries
+  # on the Name show page that counted the results for each variant of
+  # "observations of this name". These each originally did separate queries.
+  # This class instead does a single query for `@all` observations where
+  # the name or its synonyms were proposed, and exposes methods that select
+  # the variants from within those results. Those selections can then be
+  # separately counted to show the number of results for each variant,
+  # without intitiating any other queries.
   class Observations
     # attr_reader :with_images, :of_taxon_this_name, :of_taxon_other_names
 


### PR DESCRIPTION
This explains how we're counting the results of each of the "Observations of this name..." links on the show Name page.

May help debugging #2499.