### PR TITLE
Hot fix for incorrect Query `indexed_enum` condition

### DIFF
--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -70,12 +70,18 @@ module Query::Initializers::Descriptions
     [Name, Location].include?(model) ? "_with_descriptions" : ""
   end
 
-  def initialize_description_parameters(type = model.type_tag)
+  # If ever generalizing, `type` should be model.parent_type
+  def initialize_name_descriptions_parameters(type = "name")
+    initialize_ok_for_export_parameter
     initialize_with_default_desc_parameter(type)
     initialize_join_desc_parameter(type)
     initialize_desc_type_parameter(type)
+    # NOTE: (AN 2025) These may now be superfluous, unless they need to be
+    # differentiated from Names parameters sent in the same request. I.e.,
+    # they could just use `add_for_project_condition` `add_by_user_condition`
     initialize_desc_project_parameter(type)
     initialize_desc_creator_parameter(type)
+    # This is a description notes content search
     initialize_desc_content_parameter(type)
   end
 
@@ -99,7 +105,7 @@ module Query::Initializers::Descriptions
     add_indexed_enum_condition(
       "#{type}_descriptions.source_type",
       params[:desc_type],
-      Description::ALL_SOURCE_TYPES
+      "#{type}_description".classify.constantize.source_types # Hash
     )
   end
 
@@ -139,5 +145,17 @@ module Query::Initializers::Descriptions
 
     pargs[:ids] = pargs.delete(:desc_ids)
     pargs
+  end
+
+  # --------------------------------------------------------------------------
+
+  private
+
+  def any_param_desc_fields?
+    params[:join_desc] == :any ||
+      params[:desc_type].present? ||
+      params[:desc_project].present? ||
+      params[:desc_creator].present? ||
+      params[:desc_content].present?
   end
 end

--- a/app/classes/query/initializers/images.rb
+++ b/app/classes/query/initializers/images.rb
@@ -26,11 +26,7 @@ module Query::Initializers::Images
                          params[:copyright_holder_has])
     add_image_size_condition(params[:size])
     add_image_type_condition(params[:content_types])
-    add_boolean_condition(
-      "images.ok_for_export IS TRUE",
-      "images.ok_for_export IS FALSE",
-      params[:ok_for_export]
-    )
+    initialize_ok_for_export_parameter
   end
 
   def add_image_size_condition(vals, *)

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -61,13 +61,6 @@ module Query::Initializers::Names
     )
   end
 
-  def initialize_ok_for_export_parameter
-    add_boolean_condition(
-      "names.ok_for_export IS TRUE", "names.ok_for_export IS FALSE",
-      params[:ok_for_export]
-    )
-  end
-
   def initialize_name_association_parameters
     add_id_condition("observations.id", params[:observations], :observations)
     add_where_condition(:observations, params[:locations], :observations)

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -86,10 +86,20 @@ module Query::Modules::Conditions
     add_joins(*)
   end
 
+  def initialize_ok_for_export_parameter
+    add_boolean_condition(
+      "#{model.table_name}.ok_for_export IS TRUE",
+      "#{model.table_name}.ok_for_export IS FALSE",
+      params[:ok_for_export]
+    )
+  end
+
+  # Send the whole enum Hash as `allowed`, so we can find the corresponding
+  # values of the keys. MO's enum values currently may not start at 0.
   def add_indexed_enum_condition(col, vals, allowed, *)
     return if vals.empty?
 
-    vals = vals.filter_map { |v| allowed.index_of(v.to_sym) }
+    vals = allowed.values_at(*vals)
     return if vals.empty?
 
     @where << "#{col} IN (#{vals.join(",")})"

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -92,7 +92,7 @@ module Query::Modules::Conditions
     vals = vals.filter_map { |v| allowed.index_of(v.to_sym) }
     return if vals.empty?
 
-    @where << "#{col} IN (#{val.join(",")})"
+    @where << "#{col} IN (#{vals.join(",")})"
     add_joins(*)
   end
 

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -21,7 +21,7 @@ class Query::NameDescriptions < Query::Base
       names?: [Name],
       public?: :boolean,
       with_descriptions?: :boolean
-    )
+    ).merge(name_descriptions_parameter_declarations)
   end
 
   def initialize_flavor
@@ -34,6 +34,7 @@ class Query::NameDescriptions < Query::Base
     names = lookup_names_by_name(names: params[:names])
     add_id_condition("name_descriptions.name_id", names)
     initialize_description_public_parameter(:name)
+    initialize_name_descriptions_parameters
     super
   end
 

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -35,7 +35,7 @@ class Query::Names < Query::Base
     names_per_se_parameter_declarations.
       merge(content_filter_parameter_declarations(Name)).
       merge(names_parameter_declarations).
-      merge(descriptions_parameter_declarations). # yes in the general
+      merge(name_descriptions_parameter_declarations). # yes in the general
       merge(advanced_search_parameter_declarations)
   end
 
@@ -63,7 +63,7 @@ class Query::Names < Query::Base
     initialize_taxonomy_parameters
     initialize_name_record_parameters
     initialize_name_search_parameters
-    initialize_description_parameters
+    initialize_name_descriptions_parameters
     initialize_content_filters(Name)
     super
   end
@@ -163,17 +163,5 @@ class Query::Names < Query::Base
     else
       default
     end
-  end
-
-  # --------------------------------------------------------------------------
-
-  private
-
-  def any_param_desc_fields?
-    params[:join_desc] == :any ||
-      params[:desc_type].present? ||
-      params[:desc_project].present? ||
-      params[:desc_creator].present? ||
-      params[:desc_content].present?
   end
 end

--- a/app/classes/query/params/descriptions.rb
+++ b/app/classes/query/params/descriptions.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Query::Params::Descriptions
-  def descriptions_parameter_declarations
+  def name_descriptions_parameter_declarations
     {
       with_default_desc?: :boolean,
       join_desc?: { string: [:default, :any] },
-      desc_type?: [{ string: [Description::ALL_SOURCE_TYPES] }],
+      desc_type?: [{ string: Description::ALL_SOURCE_TYPES }],
       desc_project?: [:string],
       desc_creator?: [User],
       desc_content?: :string,

--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -108,6 +108,10 @@ class Description < AbstractModel
     type_tag.to_s.sub("_description", "")
   end
 
+  def self.parent_type
+    type_tag.to_s.sub("_description", "")
+  end
+
   # Shorthand for "public && public_write"
   def fully_public?
     public && public_write
@@ -234,8 +238,9 @@ class Description < AbstractModel
   ##############################################################################
 
   # Return an Array of source type Strings, e.g. "public", "project", etc.
-  # Note, this is the order they will be listed in show_name descriptions
-  # panel, list_descriptions.
+  # as would `NameDescription.source_types.keys`. However, the below order is
+  # different. It is a preferred order, and is how these will be listed in
+  # the show_name descriptions panel, list_descriptions.
   ALL_SOURCE_TYPES = [
     "public",    # Public ones created by any user.
     "foreign",   # Foreign "public" description(s) written on another server.

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -100,17 +100,29 @@ class NameDescription < Description
   has_many :editors, through: :name_description_editors,
                      source: :user
 
-  scope :for_eol_export,
-        lambda {
-          where(review_status: review_statuses.values_at(
-            "unvetted", "vetted"
-          )).
-            where(NameDescription[:gen_desc].not_blank).
-            where(ok_for_export: true).
-            where(public: true)
-        }
+  scope :for_eol_export, lambda {
+    where(review_status: review_statuses.values_at(
+      "unvetted", "vetted"
+    )).
+      where(NameDescription[:gen_desc].not_blank).
+      where(ok_for_export: true).
+      where(public: true)
+  }
   scope :show_includes, lambda {
     strict_loading
+  }
+  scope :is_default, lambda {
+    joins(:name).where(Name[:description_id].not_eq(nil))
+  }
+  scope :is_not_default, lambda {
+    joins(:name).where(Name[:description_id].eq(nil))
+  }
+  # scope searching note content. must use search condition and coalesce fields
+  # scope :notes_has, lambda {
+  # }
+  scope :index_order, lambda {
+    joins(:name).order(Name[:sort_name].asc, NameDescription[:created_at].asc,
+                       NameDescription[:id].desc)
   }
 
   EOL_NOTE_FIELDS = [

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -2693,6 +2693,50 @@ class QueryTest < UnitTestCase
                  ids: [rolf.id, NameDescription.first.id])
   end
 
+  def test_name_description_with_default_desc
+    assert_query(NameDescription.is_default.index_order,
+                 :NameDescription, with_default_desc: 1)
+    assert_query(NameDescription.is_not_default.index_order,
+                 :NameDescription, with_default_desc: 0)
+  end
+
+  def test_name_description_desc_type_user
+    assert_query(NameDescription.where(source_type: 5).index_order,
+                 :NameDescription, desc_type: "user")
+  end
+
+  def test_name_description_desc_type_project
+    assert_query(NameDescription.where(source_type: 3).index_order,
+                 :NameDescription, desc_type: "project")
+  end
+
+  def test_name_description_desc_project
+    assert_query(NameDescription.
+                 where(project: projects(:eol_project)).index_order,
+                 :NameDescription, desc_project: projects(:eol_project).id)
+  end
+
+  def test_name_description_desc_creator
+    assert_query(NameDescription.where(user: rolf).index_order,
+                 :NameDescription, desc_creator: rolf.id)
+    assert_query(NameDescription.where(user: mary).index_order,
+                 :NameDescription, desc_creator: mary.id)
+  end
+
+  # waiting on a new AbstractModel scope for searches,
+  # plus a specific NameDescription scope coalescing the fields.
+  # def test_name_description_desc_content
+  #   assert_query(NameDescription.notes_has("some notes")).index_order,
+  #                :NameDescription, desc_content: "some notes")
+  # end
+
+  def test_name_description_ok_for_export
+    assert_query(NameDescription.where(ok_for_export: 1).index_order,
+                 :NameDescription, ok_for_export: 1)
+    assert_query(NameDescription.where(ok_for_export: 0).index_order,
+                 :NameDescription, ok_for_export: 0)
+  end
+
   def test_observation_all
     expects = Observation.index_order
     assert_query(expects, :Observation)


### PR DESCRIPTION
Yikes! A lot of `NameDescriptions` query stuff was unimplemented and untested. 

We may not need it, but... this was the only place we used a generalized Query condition looking up records with an enum value by the string. I'm trying to turn that into a model scope because it seems generally useful, and therefore I needed to test it.
