### PR TITLE
`AutoComplete::ForUser` — restrict to verified users

### DIFF
--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -27,7 +27,7 @@ class AutoComplete::ForUser < AutoComplete::ByString
       name = user.unique_text_name
       user = user.attributes.symbolize_keys
       user[:name] = name
-      user.except(:login, :bonuses) # idk why this is getting bonuses                                                                                            
+      user.except(:login, :bonuses) # idk why this is getting bonuses
     end
     matches.sort_by! { |user| user[:name] }
   end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -28,7 +28,7 @@ class AutoComplete::ForUser < AutoComplete::ByString
       user[:name] = if user[:name].empty?
                       user[:login]
                     else
-                      User.unique_text_name_login_first(user)
+                      User.unique_text_name(user)
                     end
       user.except(:login, :bonuses) # idk why this is getting bonuses
     end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -28,7 +28,7 @@ class AutoComplete::ForUser < AutoComplete::ByString
       user[:name] = if user[:name].empty?
                       user[:login]
                     else
-                      user.unique_format_name
+                      user.unique_text_name_login_first
                     end
       user.except(:login, :bonuses) # idk why this is getting bonuses
     end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -24,14 +24,11 @@ class AutoComplete::ForUser < AutoComplete::ByString
   # Turn the instances into hashes, and figure out what name to display
   def matches_array(users)
     matches = users.map do |user|
+      name = user.unique_text_name
       user = user.attributes.symbolize_keys
-      user[:name] = if user[:name].empty?
-                      user[:login]
-                    else
-                      User.unique_text_name(user)
-                    end
-      user.except(:login, :bonuses) # idk why this is getting bonuses
+      user[:name] = name
+      user.except(:login, :bonuses) # idk why this is getting bonuses                                                                                            
     end
-    matches.sort_by! { |user| User.unique_text_name(user) }
+    matches.sort_by! { |user| user[:name] }
   end
 end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -28,7 +28,7 @@ class AutoComplete::ForUser < AutoComplete::ByString
       user[:name] = if user[:name].empty?
                       user[:login]
                     else
-                      user.unique_text_name_login_first
+                      User.unique_text_name_login_first(user)
                     end
       user.except(:login, :bonuses) # idk why this is getting bonuses
     end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -6,7 +6,7 @@ class AutoComplete::ForUser < AutoComplete::ByString
             where(User[:login].matches("#{letter}%").
               or(User[:name].matches("#{letter}%")).
               or(User[:name].matches("% #{letter}%"))).
-            order(login: :asc)
+            order(name: :asc, login: :asc)
 
     matches_array(users)
   end
@@ -32,6 +32,6 @@ class AutoComplete::ForUser < AutoComplete::ByString
                     end
       user.except(:login, :bonuses) # idk why this is getting bonuses
     end
-    matches.sort_by! { |user| user[:name] }
+    matches.sort_by! { |user| User.unique_text_name(user) }
   end
 end

--- a/app/classes/auto_complete/for_user.rb
+++ b/app/classes/auto_complete/for_user.rb
@@ -2,7 +2,7 @@
 
 class AutoComplete::ForUser < AutoComplete::ByString
   def rough_matches(letter)
-    users = User.select(:login, :name, :id).distinct.
+    users = User.verified.select(:login, :name, :id).distinct.
             where(User[:login].matches("#{letter}%").
               or(User[:name].matches("#{letter}%")).
               or(User[:name].matches("% #{letter}%"))).
@@ -12,10 +12,10 @@ class AutoComplete::ForUser < AutoComplete::ByString
   end
 
   def exact_match(string)
-    user = User.select(:login, :name, :id).
-           where(User[:login].eq(string)).
-           or(User.where(User[:name].eq(string))).
-           order(login: :asc).distinct.first
+    user = User.verified.select(:login, :name, :id).distinct.
+           where(User[:login].downcase.eq(string.downcase).
+             or(User[:name].downcase.eq(string.downcase))).
+           order(login: :asc).first
     return [] unless user
 
     matches_array([user])
@@ -28,7 +28,7 @@ class AutoComplete::ForUser < AutoComplete::ByString
       user[:name] = if user[:name].empty?
                       user[:login]
                     else
-                      "#{user[:login]} <#{user[:name]}>"
+                      user.unique_format_name
                     end
       user.except(:login, :bonuses) # idk why this is getting bonuses
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -314,7 +314,6 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :by_contribution, lambda {
     order(contribution: :desc, name: :asc, login: :asc)
   }
-
   # NOTE: the obs images are a separate optimized query
   scope :show_includes, lambda {
     strict_loading.includes(
@@ -322,6 +321,8 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
       :user_stats
     )
   }
+  scope :verified, -> { where.not(verified: nil) }
+  scope :unverified, -> { where(verified: nil) }
 
   # These are used by forms.
   attr_accessor :place_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -426,6 +426,11 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # Used in auto_complete, because it's ordered by login.
+  def unique_text_name_login_first
+    login + name.blank? ? "" : " <#{name}>"
+  end
+
   def format_name
     unique_text_name
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -426,20 +426,11 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # Used in auto_complete, because it's ordered by login.
-  def unique_text_name_login_first
-    if name.blank?
-      login
-    else
-      "#{login} <#{name}>"
-    end
-  end
-
-  def self.unique_text_name_login_first(user)
+  def self.unique_text_name(user)
     if user[:name].blank?
       user[:login]
     else
-      "#{user[:login]} <#{user[:name]}>"
+      "#{user[:name]} (#{user[:login]})"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -426,14 +426,6 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def self.unique_text_name(user)
-    if user[:name].blank?
-      user[:login]
-    else
-      "#{user[:name]} (#{user[:login]})"
-    end
-  end
-
   def format_name
     unique_text_name
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -428,7 +428,19 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # Used in auto_complete, because it's ordered by login.
   def unique_text_name_login_first
-    login + name.blank? ? "" : " <#{name}>"
+    if name.blank?
+      login
+    else
+      "#{login} <#{name}>"
+    end
+  end
+
+  def self.unique_text_name_login_first(user)
+    if user[:name].blank?
+      user[:login]
+    else
+      "#{user[:login]} <#{user[:name]}>"
+    end
   end
 
   def format_name

--- a/test/controllers/autocompleters_controller_test.rb
+++ b/test/controllers/autocompleters_controller_test.rb
@@ -204,15 +204,16 @@ class AutocompletersControllerTest < FunctionalTestCase
     good_autocompleter_request(type: :user, string: "Rover")
     assert_equivalent(
       [{ name: "R", id: 0 },
-       { name: "rolf <Rolf Singer>", id: rolf.id },
-       { name: "roy <Roy Halling>", id: roy.id },
-       { name: "second_roy <Roy Rogers>", id: users(:second_roy).id }],
+       { name: "Rolf Singer (rolf)", id: rolf.id },
+       { name: "Roy Halling (roy)", id: roy.id },
+       { name: "Roy Rogers (second_roy)", id: users(:second_roy).id }],
       JSON.parse(@response.body)
     )
 
     good_autocompleter_request(type: :user, string: "Dodo")
     assert_equivalent([{ name: "D", id: 0 },
-                       { name: "dick <Tricky Dick>", id: dick.id }],
+                       { name: "#{dick.name} (#{dick.login})",
+                         id: dick.id }],
                       JSON.parse(@response.body))
 
     good_autocompleter_request(type: :user, string: "Komodo")

--- a/test/controllers/autocompleters_controller_test.rb
+++ b/test/controllers/autocompleters_controller_test.rb
@@ -217,7 +217,7 @@ class AutocompletersControllerTest < FunctionalTestCase
 
     good_autocompleter_request(type: :user, string: "Komodo")
     assert_equivalent([{ name: "K", id: 0 },
-                       { name: "#{katrina.login} <#{katrina.name}>",
+                       { name: "#{katrina.name} (#{katrina.login})",
                          id: katrina.id }],
                       JSON.parse(@response.body))
 

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -432,7 +432,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
                       code: @field_slip.code,
                       observation_id: @field_slip.observation_id,
                       field_slip_name: names(:coprinus_comatus).text_name,
-                      field_slip_id_by: "#{user.login} <#{user.name}>",
+                      field_slip_id_by: "#{user.name} (#{user.login})",
                       project_id: @field_slip.project_id,
                       notes: { Other: notes }
                     } })

--- a/test/models/auto_complete_test.rb
+++ b/test/models/auto_complete_test.rb
@@ -45,7 +45,7 @@ class AutoCompleteTest < UnitTestCase
 
     auto = AutoComplete::ForUser.new(string: "Rolf Singer")
     results = auto.matching_records
-    assert(results.pluck(:name).include?("rolf <Rolf Singer>"))
+    assert(results.pluck(:name).include?("Rolf Singer (rolf)"))
   end
 
   def test_typical_use_with_exact_match
@@ -74,7 +74,7 @@ class AutoCompleteTest < UnitTestCase
 
     auto = AutoComplete::ForUser.new(string: "Rolf Singer")
     results = auto.first_matching_record
-    assert_equal("rolf <Rolf Singer>", results.first[:name])
+    assert_equal("Rolf Singer (rolf)", results.first[:name])
   end
 
   def test_truncate


### PR DESCRIPTION
Also adds User class method `unique_text_name` for combined name attributes, because the instance method is no longer available in AutoComplete when we use AR to select the columns we need (they're not instances of User anymore).