### PR TITLE
Quick fix for advanced search user search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -100,8 +100,8 @@ class SearchController < ApplicationController
       user = User.find_by(id: params[:user_id])
       return user.login if user
     end
-    match = params[:user].match(/\((.*?)\)$/)
-    return match[1] if match
+    user = User.lookup_unique_text_name(params[:user])
+    return user.login if user
 
     params[:user]
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -90,9 +90,20 @@ class SearchController < ApplicationController
 
       # Treat User field differently; remove angle-bracketed user name,
       # since it was included by the auto-completer only as a hint.
-      val = val.sub(/ <.*/, "") if field == :user
+      val = user_login(params[:search]) if field == :user
       query_params[field] = val
     end
+  end
+
+  def user_login(params)
+    if params.include?(:user_id)
+      user = User.find_by(id: params[:user_id])
+      return user.login if user
+    end
+    match = params[:user].match(/\((.*?)\)$/)
+    return match[1] if match
+
+    params[:user]
   end
 
   def add_applicable_filter_parameters(query_params, model)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -49,7 +49,7 @@ class SearchControllerTest < FunctionalTestCase
     params = {
       search: {
         model: "observation",
-        user: users(:rolf).unique_text_name,
+        user: users(:rolf).unique_text_name
       },
       content_filter: {
         with_images: "",
@@ -61,7 +61,7 @@ class SearchControllerTest < FunctionalTestCase
     }
     get(:advanced, params: params)
     query = QueryRecord.last.query
-    assert_true(query.num_results > 0)
+    assert_true(query.num_results.positive?)
     assert_equal("", query.params[:with_images])
     assert_true(query.params[:with_specimen])
     assert_false(query.params[:lichen])

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -49,7 +49,8 @@ class SearchControllerTest < FunctionalTestCase
     params = {
       search: {
         model: "observation",
-        user: users(:rolf).unique_text_name
+        user: users(:rolf).unique_text_name,
+        user_id: users(:rolf).id
       },
       content_filter: {
         with_images: "",

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -49,7 +49,7 @@ class SearchControllerTest < FunctionalTestCase
     params = {
       search: {
         model: "observation",
-        user: "rolf"
+        user: users(:rolf).unique_text_name,
       },
       content_filter: {
         with_images: "",
@@ -61,6 +61,7 @@ class SearchControllerTest < FunctionalTestCase
     }
     get(:advanced, params: params)
     query = QueryRecord.last.query
+    assert_true(query.num_results > 0)
     assert_equal("", query.params[:with_images])
     assert_true(query.params[:with_specimen])
     assert_false(query.params[:lichen])

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -197,3 +197,18 @@ webmaster:
   login: "MO Webmaster" # must match production
   name: "webmaster" # must match production
   user_groups: all_users, $LABEL_only, super_importers_admin
+
+paren_login:
+  <<: *DEFAULTS
+  login: Paren (user)
+  name: nil
+
+alt_user:
+  <<: *DEFAULTS
+  login: User
+  name: Alt User
+
+ann_user:
+  <<: *DEFAULTS
+  login: user
+  name: Ann User

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -593,4 +593,10 @@ class UserTest < UnitTestCase
     assert_equal("Deleted 1 unverified user(s).", msgs.first)
     assert_nil(User.find_by(id: unverified.id))
   end
+
+  def test_lookup_unique_text_name
+    User.all.find_each do |user|
+      assert_equal(user, User.lookup_unique_text_name(user.unique_text_name))
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -595,7 +595,7 @@ class UserTest < UnitTestCase
   end
 
   def test_lookup_unique_text_name
-    User.all.find_each do |user|
+    User.find_each do |user|
       assert_equal(user, User.lookup_unique_text_name(user.unique_text_name))
     end
   end


### PR DESCRIPTION
This is a bit slap dash and the parsing of the new name format would be better done by the parser in the Project alias PR.  There should also be tests for this.  In the process of testing this, I noticed that even if I select my name via autocomplete (now "Nathan Wilson (nathan)" it still returns all observation for users whose login contains "nathan" which it shouldn't.  However, I think that gets into getting query to use :user_id rather than :user which didn't work when I tried it naively.  I don't know how deep that rabbit hole is.  The behavior in this PR seems to return us to the old behavior.