### PR TITLE
Hot fix for Lookup::Names

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -240,7 +240,7 @@ class NamesController < ApplicationController
     # Second query: Observations of name including (all) subtaxa.
     # This is only used for the link to "observations of this name's subtaxa".
     # We also query for obs (with images) below, so we could maybe refactor to
-    # get Observation.of_name(name.id).include_subtaxa.order(:vote_cache).
+    # get Observation.of_names(name.id).include_subtaxa.order(:vote_cache).
     # Then, select those of original name with thumb_image_id for @best_images,
     # and select_count all (excluding obs of original name) to get @has_subtaxa.
     # Would need to write include_subtaxa scope, as above.

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -91,8 +91,8 @@
 #  found_after("yyyymmdd")
 #  found_before("yyyymmdd")
 #  found_between(start, end)
-#  of_name(name)
-#  of_name_like(string)
+#  of_names(name)
+#  of_names_like(string)
 #  with_name
 #  without_name
 #  by_user(user)

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -530,22 +530,22 @@ class PatternSearchTest < UnitTestCase
   end
 
   def test_observation_search_include_synonyms
-    expect = Observation.where(name: [names(:peltigera), names(:petigera)])
+    expect = Observation.of_names([names(:peltigera), names(:petigera)])
     assert(expect.count.positive?)
     x = PatternSearch::Observation.new("Petigera include_synonyms:yes")
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_include_subtaxa
-    expect = Observation.of_name(names(:agaricus), include_subtaxa: true)
+    expect = Observation.of_names(names(:agaricus), include_subtaxa: true)
     assert(expect.count.positive?)
     x = PatternSearch::Observation.new("Agaricus include_subtaxa:yes")
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 
   def test_observation_search_include_all_name_proposals
-    expect = Observation.of_name(names(:agaricus_campestris),
-                                 include_all_name_proposals: true)
+    expect = Observation.of_names(names(:agaricus_campestris),
+                                  include_all_name_proposals: true)
     consensus = Observation.where(name: name)
     assert(consensus.count < expect.count)
     x = PatternSearch::Observation.new("Agaricus campestris " \

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -79,7 +79,7 @@ module Query::ObservationsTest
   def test_observation_of_children
     name = names(:agaricus)
     expects = Observation.index_order.
-              of_name(name, include_subtaxa: true).distinct
+              of_names(name, include_subtaxa: true).distinct
     assert_query(expects, :Observation, names: [name.id], include_subtaxa: true)
   end
 

--- a/test/models/api2_test.rb
+++ b/test/models/api2_test.rb
@@ -2221,7 +2221,7 @@ class API2Test < UnitTestCase
       Observation.where(text_name: "Agaricus"),
       "Tests won't work if there's already an Observation for genus Agaricus"
     )
-    ssp_obs = Observation.of_name_like("Agaricus")
+    ssp_obs = Observation.of_names_like("Agaricus")
     assert(ssp_obs.length > 1)
     agaricus = Name.where(text_name: "Agaricus").first # (an existing autonym)s
     agaricus_obs = Observation.create(name: agaricus, user: rolf)
@@ -3054,7 +3054,7 @@ class API2Test < UnitTestCase
       Observation.where(text_name: "Agaricus"),
       "Tests won't work if there's already an Observation for genus Agaricus"
     )
-    ssp_obs = Observation.of_name_like("Agaricus")
+    ssp_obs = Observation.of_names_like("Agaricus")
     assert(ssp_obs.length > 1)
     agaricus = Name.where(text_name: "Agaricus").first # (an existing autonym)
     agaricus_obs = Observation.create(name: agaricus, user: rolf)
@@ -3348,7 +3348,7 @@ class API2Test < UnitTestCase
       Observation.where(text_name: "Agaricus"),
       "Tests won't work if there's already an Observation for genus Agaricus"
     )
-    obses = Observation.of_name_like("Agaricus")
+    obses = Observation.of_names_like("Agaricus")
     ssp_lists = obses.map(&:species_lists).flatten.uniq.sort_by(&:id)
     assert_not_empty(ssp_lists)
     agaricus = Name.where(text_name: "Agaricus").first # (an existing autonym)

--- a/test/models/cache_test.rb
+++ b/test/models/cache_test.rb
@@ -80,18 +80,18 @@ class CacheTest < UnitTestCase
   def test_propagate_classification
     name = names(:agaricus)
     saved_obs_updated_ats =
-      Observation.of_name("Agaricus", include_subtaxa: 1).map(&:updated_at)
+      Observation.of_names("Agaricus", include_subtaxa: 1).map(&:updated_at)
     new_classification = names(:peltigera).classification
 
     name.update(classification: new_classification)
     name.propagate_classification
 
-    Observation.of_name("Agaricus", include_subtaxa: 1).each do |obs|
+    Observation.of_names("Agaricus", include_subtaxa: 1).each do |obs|
       assert_equal(new_classification, obs.classification)
     end
     assert_equal(
       saved_obs_updated_ats,
-      Observation.of_name("Agaricus", include_subtaxa: 1).map(&:updated_at)
+      Observation.of_names("Agaricus", include_subtaxa: 1).map(&:updated_at)
     )
   end
 
@@ -102,11 +102,11 @@ class CacheTest < UnitTestCase
     saved_name_updated_ats = Name.subtaxa_of_genus_or_below("Agaricus").
                              map(&:updated_at)
     saved_obs_updated_ats =
-      Observation.of_name("Agaricus", include_subtaxa: 1).map(&:updated_at)
+      Observation.of_names("Agaricus", include_subtaxa: 1).map(&:updated_at)
 
     name.propagate_add_lifeform("lichen")
 
-    Observation.of_name("Agaricus", include_subtaxa: 1).each do |obs|
+    Observation.of_names("Agaricus", include_subtaxa: 1).each do |obs|
       assert_true(obs.lifeform.include?(" lichen "))
     end
     assert_equal(
@@ -124,12 +124,12 @@ class CacheTest < UnitTestCase
 
     name.propagate_remove_lifeform("lichen")
 
-    Observation.of_name("Agaricus", include_subtaxa: 1).each do |obs|
+    Observation.of_names("Agaricus", include_subtaxa: 1).each do |obs|
       assert_false(obs.lifeform.include?(" lichen "))
     end
     assert_equal(
       saved_obs_updated_ats,
-      Observation.of_name("Agaricus", include_subtaxa: 1).map(&:updated_at)
+      Observation.of_names("Agaricus", include_subtaxa: 1).map(&:updated_at)
     )
 
     Name.subtaxa_of_genus_or_below("Agaricus").each do |nam|

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1212,10 +1212,10 @@ class ObservationTest < UnitTestCase
     )
   end
 
-  def test_scope_of_name
-    assert_includes(Observation.of_name(names(:peltigera).id),
+  def test_scope_of_names
+    assert_includes(Observation.of_names(names(:peltigera).id),
                     observations(:peltigera_obs))
-    assert_not_includes(Observation.of_name(names(:fungi)),
+    assert_not_includes(Observation.of_names(names(:fungi)),
                         observations(:peltigera_obs))
   end
 
@@ -1265,7 +1265,7 @@ class ObservationTest < UnitTestCase
                  tremella_obs,
                  "Test needs different fixture")
     assert_includes(
-      Observation.of_name(names(:tremella_mesenterica), of_look_alikes: true),
+      Observation.of_names(names(:tremella_mesenterica), of_look_alikes: true),
       tremella_obs,
       "Observations of look-alikes of <Name> should include " \
       "Observations of other Names for which <Name> was proposed"


### PR DESCRIPTION
Was not working in the case where Name instances are sent.

Adds tests and uses this lookup in the `Observation.of_names` scope.