### PR TITLE
Fix `pattern_search` scopes for name and location (joining descriptions)

### DIFF
--- a/app/classes/query/initializers/advanced_search.rb
+++ b/app/classes/query/initializers/advanced_search.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Query::Initializers::AdvancedSearch
+  # Initialized only on locations, obs, names queries - note images disabled
   def initialize_advanced_search
     name, user, location, content = google_parse_params
     make_sure_user_entered_something(name, user, location, content)

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -287,7 +287,7 @@ module AbstractModel::Scopes
       end
     end
 
-    # These should be defined in the model
+    # SEARCHABLE_FIELDS should be defined in the model
     def searchable_columns
       return [] unless defined?(self::SEARCHABLE_FIELDS)
 

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -441,7 +441,7 @@ class Name < AbstractModel
   attr_accessor :misspelling
 
   SEARCHABLE_FIELDS = [
-    :text_name, :classification, :author, :citation, :notes
+    :search_name, :citation, :notes
   ].freeze
 
   # (Create should not be logged at all.  Update is already logged with more

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -264,39 +264,49 @@ class Query::NamesTest < UnitTestCase
     assert_query(expects, :Name, comments_has: '"messes things up"')
   end
 
-  def test_name_pattern_search
-    assert_query(
-      [],
-      :Name, pattern: "petigera" # search_name
-    )
-    assert_query(
-      [names(:petigera).id],
-      :Name, pattern: "petigera", misspellings: :either
-    )
-    assert_query(
-      [names(:peltigera).id],
-      :Name, pattern: "ye auld manual of lichenes" # citation
-    )
-    assert_query(
-      [names(:agaricus_campestras).id],
-      :Name, pattern: "prevent me" # description notes
-    )
-    assert_query(
-      [names(:suillus)],
-      :Name, pattern: "smell as sweet" # gen_desc
-    )
-    # Prove pattern search gets hits for description look_alikes
-    assert_query(
-      [names(:peltigera).id],
-      :Name, pattern: "superficially similar"
-    )
+  def test_name_pattern_search_search_name
+    # search_name
+    assert_query([], :Name, pattern: "petigera")
+    assert_query([names(:petigera).id],
+                 :Name, pattern: "petigera", misspellings: :either)
+    assert_query(Name.pattern_search("petigera").misspellings(:either),
+                 :Name, pattern: "petigera", misspellings: :either)
+  end
+
+  def test_name_pattern_search_citation
+    assert_query([names(:peltigera).id],
+                 :Name, pattern: "ye auld manual of lichenes")
+    assert_query(Name.pattern_search("ye auld manual of lichenes"),
+                 :Name, pattern: "ye auld manual of lichenes")
+  end
+
+  def test_name_pattern_search_description_notes
+    assert_query([names(:agaricus_campestras).id],
+                 :Name, pattern: "prevent me")
+    assert_query(Name.pattern_search("prevent me"),
+                 :Name, pattern: "prevent me")
+  end
+
+  def test_name_pattern_search_description_gen_desc
+    assert_query([names(:suillus)],
+                 :Name, pattern: "smell as sweet")
+    assert_query(Name.pattern_search("smell as sweet"),
+                 :Name, pattern: "smell as sweet")
+  end
+
+  # Prove pattern search gets hits for description look_alikes
+  def test_name_pattern_search_description_look_alikes
+    assert_query([names(:peltigera).id],
+                 :Name, pattern: "superficially similar")
+    assert_query(Name.pattern_search("superficially similar"),
+                 :Name, pattern: "superficially similar")
   end
 
   def test_name_advanced_search
-    assert_query([names(:macrocybe_titans).id], :Name,
-                 name: "macrocybe*titans")
-    assert_query([names(:coprinus_comatus).id], :Name,
-                 user_where: "glendale") # where
+    assert_query([names(:macrocybe_titans).id],
+                 :Name, name: "macrocybe*titans")
+    assert_query([names(:coprinus_comatus).id],
+                 :Name, user_where: "glendale") # where
     expects = Name.index_order.joins(:observations).
               where(Observation[:location_id].eq(locations(:burbank).id)).
               distinct


### PR DESCRIPTION
These two scopes require a non-standard join that I hadn't yet written.

Also adds annotations to help with figuring out which of these approaches should be the default `search` scope.