### PR TITLE
Write special scope for site stats images

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -59,11 +59,10 @@ class InfoController < ApplicationController
     @site_data = SiteData.new.get_site_data
 
     # Get the last six observations whose thumbnails are highly rated.
-    query = Query.lookup(:Observation,
-                         by: :updated_at,
-                         where: "images.vote_cache >= 3",
-                         join: :"images.thumb_image")
-    @observations = query.results(limit: 6,
-                                  include: { thumb_image: :image_votes })
+    # This is a pricey query any way you cut it. Limiting recency speeds it up.
+    @observations = Observation.updated_at(4.months.ago.strftime("%Y-%m-%d")).
+                    joins(:thumb_image).merge(Image.quality(3)).
+                    includes(thumb_image: :image_votes).
+                    order(updated_at: :desc).limit(6)
   end
 end


### PR DESCRIPTION
This is a minor but expensive query that grabs 6 recent images of confident observations having high image_votes. 

These images appear on the top of the info/site_stats page.

Rewriting the query here in AR because 
- it currently is the only Query lookup using two special params that will soon be sunsetted. (They are not used for AR queries.)
- the current query casts a wide net and is very expensive; the new query only checks the last 4 months of images of confident observations and runs 4x faster.