### PR TITLE
Rewrite range scopes signatures like Query

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -59,11 +59,10 @@ class InfoController < ApplicationController
     @site_data = SiteData.new.get_site_data
 
     # Get the last six observations whose thumbnails are highly rated.
-    query = Query.lookup(:Observation,
-                         by: :updated_at,
-                         where: "images.vote_cache >= 3",
-                         join: :"images.thumb_image")
-    @observations = query.results(limit: 6,
-                                  include: { thumb_image: :image_votes })
+    # This is a pricey query any way you cut it. Limiting recency speeds it up.
+    @observations = Observation.updated_at(4.months.ago.strftime("%Y-%m-%d")).
+                    joins(:thumb_image).merge(Image.quality(3)).
+                    includes(thumb_image: :image_votes).
+                    order(updated_at: :desc).limit(6)
   end
 end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -171,8 +171,8 @@
 #  with_synonyms
 #  without_synonyms
 #  ok_for_export
+#  rank(ranks)
 #  with_rank(rank)
-#  with_rank_between(ranks)
 #  with_rank_below(rank)
 #  with_rank_and_name_in_classification(rank, text_name)
 #  with_rank_at_or_below_genus

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -124,13 +124,15 @@ module Name::Scopes # rubocop:disable Metrics/ModuleLength
           ->(phrase) { search_columns(Name[:notes], phrase) }
 
     ### Module Name::Taxonomy. Rank scopes take text values, e.g. "Genus"
-    scope :with_rank,
-          ->(rank) { where(rank: ranks[rank]) if rank }
-    scope :with_rank_between, lambda { |min, max = min|
+    # Query's scope: rank at or between
+    scope :rank, lambda { |min, max = min|
+      min, max = min if min.is_a?(Array) && min.size == 2
       return with_rank(min) if min == max
 
       where(Name[:rank].in(rank_range(min, max)))
     }
+    scope :with_rank,
+          ->(rank) { where(rank: ranks[rank]) if rank }
     scope :with_rank_below, lambda { |rank|
       where(Name[:rank] < ranks[rank]) if rank
     }

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -604,7 +604,7 @@ class PatternSearchTest < UnitTestCase
   end
 
   def test_observation_search_confidence
-    expect = Observation.confidence(90)
+    expect = Observation.confidence(3)
     assert(expect.count.positive?)
     x = PatternSearch::Observation.new("confidence:90")
     assert_obj_arrays_equal(expect, x.query.results, :sort)

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -56,17 +56,21 @@ class Query::ImagesTest < UnitTestCase
   end
 
   def test_image_quality
-    expects = Image.index_order.with_quality(50)
-    assert_query(expects, :Image, quality: 50)
-    expects = Image.index_order.with_quality(30, 50)
-    assert_query(expects, :Image, quality: [30, 50])
+    expects = Image.index_order.quality(3)
+    assert_query(expects, :Image, quality: 3)
+    expects = Image.index_order.quality(3, 3.6)
+    assert_query(expects, :Image, quality: [3, 3.6])
+    expects = Image.index_order.quality([3, 3.6]) # array
+    assert_query(expects, :Image, quality: [3, 3.6])
   end
 
   def test_image_confidence
-    expects = Image.index_order.with_confidence(50)
-    assert_query(expects, :Image, confidence: 50)
-    expects = Image.index_order.with_confidence(30, 50)
-    assert_query(expects, :Image, confidence: [30, 50])
+    expects = Image.index_order.confidence(2.1)
+    assert_query(expects, :Image, confidence: 2.1)
+    expects = Image.index_order.confidence(1.2, 2.7)
+    assert_query(expects, :Image, confidence: [1.2, 2.7])
+    expects = Image.index_order.confidence([1.2, 2.7]) # array
+    assert_query(expects, :Image, confidence: [1.2, 2.7])
   end
 
   def test_image_ok_for_export

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -176,17 +176,16 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_rank_single
-    expects = Name.with_correct_spelling.with_rank("Family").index_order
+    expects = Name.with_correct_spelling.rank("Family").index_order
     assert_query(expects, :Name, rank: "Family")
   end
 
   # NOTE: Something is wrong in the fixtures between Genus and Family
   def test_name_rank_range
-    expects = Name.with_correct_spelling.
-              with_rank_between("Genus", "Kingdom").index_order
+    expects = Name.with_correct_spelling.rank("Genus", "Kingdom").index_order
     assert_query(expects, :Name, rank: %w[Genus Kingdom])
 
-    expects = Name.with_correct_spelling.with_rank("Family").index_order
+    expects = Name.with_correct_spelling.rank("Family").index_order
     assert_query(expects, :Name, rank: %w[Family Family])
   end
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1447,10 +1447,12 @@ class ObservationTest < UnitTestCase
                     observations(:minimal_unknown_obs))
     assert_includes(Observation.confidence(0, 1),
                     observations(:minimal_unknown_obs))
-    assert_includes(Observation.confidence(75, 100),
+    assert_includes(Observation.confidence(2.4, 3),
                     observations(:peltigera_obs))
-    assert_equal(Observation.count, Observation.confidence(-100, 100).count)
-    assert_empty(Observation.confidence(102, 103))
+    assert_includes(Observation.confidence([2.4, 3]), # array
+                    observations(:peltigera_obs))
+    assert_equal(Observation.count, Observation.confidence(-3, 3).count)
+    assert_empty(Observation.confidence(3.1, 3.2))
   end
 
   def test_scope_without_comments


### PR DESCRIPTION
Rewrites `confidence`, `quality` and `rank` range scopes closer to Query usage, adds tests for accuracy.
____
#### Info controller Site Stats image query change:
This is a minor but expensive query that grabs 6 recent images of confident observations having high image_votes. The images appear on the top of the info/site_stats page.

Rewriting the query here in AR because 
- it currently is the only Query lookup using two special params that will soon be sunsetted. (They are not used for AR queries.)
- the current query casts a wide net and is very expensive; the new query only checks the last 4 months of images of confident observations and runs 4x faster.
- it uses the new `confidence` scope, which had an untested bug previously.