### PR TITLE
Tab PORO Proposal

### DIFF
--- a/app/classes/coerced_query_tab.rb
+++ b/app/classes/coerced_query_tab.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CoercedQueryTab
+  def initialize(query, model, html_options: {})
+    @query = query
+    @model = model
+    @html_options = html_options
+    @html_options[:class] = html_class unless @html_options.include?(:class)
+  end
+
+  def tab
+    [:show_objects.t(type: @model.type_tag),
+     { controller: @model.show_controller,
+       action: @model.index_action,
+       q: @query.id.alphabetize },
+     @html_options]
+  end
+
+  private
+
+  def html_class
+    "coerced_#{@model.name.underscore}_query_link"
+  end
+end

--- a/app/classes/model_tab.rb
+++ b/app/classes/model_tab.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class ModelTab
+  def initialize(title, model, url, html_options: {}, alt_title: nil)
+    @model = model
+    @title = title
+    @alt_title = alt_title
+    @url = url
+    @html_options = html_options
+    @html_options[:class] = html_class unless @html_options.include?(:class)
+  end
+
+  def tab
+    [@title, @url, @html_options]
+  end
+
+  private
+
+  def html_class
+    result = if @alt_title
+               @alt_title
+             elsif @title.include?(model_name)
+               @title
+             else
+               "#{@title}_#{model_name}"
+             end.parameterize(separator: "_")
+    result += "_link"
+    return result unless @model.respond_to?(:id)
+
+    "#{result}_#{@model.id}"
+  end
+
+  def model_name
+    @model_name ||= if @model.is_a?(Class)
+                      @model
+                    else
+                      @model.class
+                    end.name.underscore
+  end
+end

--- a/app/helpers/tabs/herbaria_helper.rb
+++ b/app/helpers/tabs/herbaria_helper.rb
@@ -74,8 +74,11 @@ module Tabs
     end
 
     def new_herbarium_tab
-      [:create_herbarium.l, add_query_param(new_herbarium_path),
-       { class: tab_id(__method__.to_s) }]
+      ModelTab.new(:create_herbarium.l, Herbarium,
+                   add_query_param(new_herbarium_path),
+                   alt_title: "new_herbarium").tab
+      # [:create_herbarium.l, add_query_param(new_herbarium_path),
+      # { class: tab_id(__method__.to_s) }]
     end
 
     def edit_herbarium_tab(herbarium)
@@ -106,6 +109,9 @@ module Tabs
       [:herbarium_index.t,
        add_query_param(herbaria_path(nonpersonal: true)),
        { class: tab_id(__method__.to_s) }]
+      ModelTab.new(:herbarium_index.t, "",
+                   add_query_param(herbaria_path(nonpersonal: true)),
+                   alt_title: "nonpersonal_herbaria_index").tab
     end
 
     def labeled_nonpersonal_herbaria_index_tab

--- a/app/helpers/tabs/herbarium_records_helper.rb
+++ b/app/helpers/tabs/herbarium_records_helper.rb
@@ -72,9 +72,9 @@ module Tabs
       # next and index from there to navigate through all the rest for this obs.
       hr_query = Query.lookup(:HerbariumRecord, observations: obs.id)
 
-      [h_r.accession_at_herbarium.t,
-       add_query_param(h_r.show_link_args, hr_query),
-       { class: "#{tab_id(__method__.to_s)}_#{h_r.id}" }]
+      ModelTab.new(h_r.accession_at_herbarium.t, h_r,
+                   add_query_param(h_r.show_link_args, hr_query),
+                   alt_title: "herbarium_record").tab
     end
 
     def new_herbarium_record_tab(obs)
@@ -102,11 +102,12 @@ module Tabs
     end
 
     def remove_herbarium_record_tab(h_r, obs)
-      [:REMOVE.t,
-       add_query_param(edit_herbarium_record_remove_observation_path(
-                         herbarium_record_id: h_r.id, observation_id: obs.id
-                       )),
-       { class: "#{tab_id(__method__.to_s)}_#{h_r.id}", icon: :remove }]
+      url = add_query_param(edit_herbarium_record_remove_observation_path(
+                              herbarium_record_id: h_r.id,
+                              observation_id: obs.id
+                            ))
+      ModelTab.new(:REMOVE.t, h_r, url,
+                   html_options: { icon: :remove }).tab
     end
   end
 end

--- a/app/helpers/tabs/namings_helper.rb
+++ b/app/helpers/tabs/namings_helper.rb
@@ -13,13 +13,14 @@ module Tabs
     end
 
     def edit_naming_tab(naming)
-      [:EDIT.l,
-       add_query_param(
-         edit_observation_naming_path(
-           observation_id: naming.observation_id, id: naming.id
-         )
-       ),
-       { class: "#{tab_id(__method__.to_s)}_#{naming.id}", icon: :edit }]
+      ModelTab.new(:EDIT.l,
+                   naming,
+                   add_query_param(
+                     edit_observation_naming_path(
+                       observation_id: naming.observation_id, id: naming.id
+                     )
+                   ),
+                   html_options: { icon: :edit }).tab
     end
   end
 end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -184,7 +184,7 @@ module Tabs
 
     # NOTE: coerced_query_tab returns an array
     def observations_coerced_query_tabs(query)
-      [coerced_location_query_tab(query),
+      [CoercedQueryTab.new(query, Location).tab,
        coerced_name_query_tab(query),
        coerced_image_query_tab(query)]
     end

--- a/app/helpers/title_and_tabset_helper.rb
+++ b/app/helpers/title_and_tabset_helper.rb
@@ -400,8 +400,9 @@ module TitleAndTabsetHelper
   # Class name is useful for identifying links or buttons in integration tests.
   #   Ruby notes: delete_suffix! returns nil if the suffix is not present.
   #   (The bang method is quicker than delete_suffix according to internet.)
-  def tab_id(method_name)
-    identifier = method_name.delete_suffix!("_tab")
-    identifier ? "#{identifier}_link" : method_name
+  def tab_id(_method_name)
+    "generic_tab_id"
+    # identifier = method_name.delete_suffix!("_tab")
+    # identifier ? "#{identifier}_link" : method_name
   end
 end


### PR DESCRIPTION
This is an attempt to get away from using the pattern `tab_id(__method__.to_s)` in our code.  Currently this pattern is only really used to enable some of our test to find things in the DOM.  The current code allows all tests to pass with a generic string returned by `tab_id()`.

It introduces a couple of POROs to handle the concept of "tabs" (`ModelTab` and `CoercedQueryTab`).  Note that the `alt_title` option for `ModelTab` is a hard override used to allow all the existing tests to pass.  In at least most cases ("nonpersonal_herbaria_index" might be an exception), I would look at fixing the test to avoid the use of the `alt_title`.

If this approach is agreed upon, `tab_id` should be removed and existing cases should be switched over to this approach.