### PR TITLE
Update logic in `Query::Validation`

### DIFF
--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -20,8 +20,7 @@ class Query::ExternalLinks < Query::Base
     add_sort_order_to_title
     add_owner_and_time_stamp_conditions
     initialize_observations_parameter(:external_links)
-    add_id_condition("external_links.external_site_id",
-                     lookup_external_sites_by_name(params[:external_sites]))
+    add_id_condition("external_links.external_site_id", params[:external_sites])
     add_search_condition("external_links.url", params[:url])
     super
   end

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -112,14 +112,14 @@ module Query::Initializers::Descriptions
   def initialize_desc_project_parameter(type)
     add_id_condition(
       "#{type}_descriptions.project_id",
-      lookup_projects_by_name(params[:desc_project])
+      params[:desc_project]
     )
   end
 
   def initialize_desc_creator_parameter(type)
     add_id_condition(
       "#{type}_descriptions.user_id",
-      lookup_users_by_name(params[:desc_creator])
+      params[:desc_creator]
     )
   end
 

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -125,24 +125,22 @@ module Query::Initializers::Names
 
     table = params[:include_all_name_proposals] ? "namings" : "observations"
     column = "#{table}.name_id"
-    ids = lookup_names_by_name(params[:names], names_parameters)
-    add_id_condition(column, ids, *joins)
+    add_id_condition(column, params[:names], *joins)
 
     add_join(:observations, :namings) if params[:include_all_name_proposals]
     return unless params[:exclude_consensus]
 
     column = "observations.name_id"
-    add_not_id_condition(column, ids, *joins)
+    add_not_id_condition(column, params[:names], *joins)
   end
 
   def force_empty_results
     @where = ["FALSE"]
   end
 
+  # Much simpler form for non-observation-based name queries.
   def initialize_name_parameters_for_name_queries
-    # Much simpler form for non-observation-based name queries.
-    ids = lookup_names_by_name(params[:names], names_parameters)
-    add_id_condition("names.id", ids)
+    add_id_condition("names.id", params[:names])
   end
 
   # Copy only the names_parameters into a name_params hash we use here.

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -143,14 +143,6 @@ module Query::Initializers::Names
     add_id_condition("names.id", params[:names])
   end
 
-  # Copy only the names_parameters into a name_params hash we use here.
-  def names_parameters
-    name_params = names_parameter_declarations.dup
-    name_params.transform_keys! { |k| k.to_s.chomp("?").to_sym }
-    name_params.each_key { |k| name_params[k] = params[k] }
-    name_params.except(:names).compact
-  end
-
   # ------------------------------------------------------------------------
 
   private

--- a/app/classes/query/initializers/observations.rb
+++ b/app/classes/query/initializers/observations.rb
@@ -38,7 +38,7 @@ module Query::Initializers::Observations
     add_join(:field_slips)
     add_id_condition(
       "field_slips.id",
-      lookup_field_slips_by_name(params[:field_slips]),
+      params[:field_slips],
       :observations
     )
   end

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -31,8 +31,7 @@ class Query::LocationDescriptions < Query::Base
     add_by_user_condition
     add_desc_by_author_condition(:location)
     add_desc_by_editor_condition(:location)
-    locations = lookup_locations_by_name(params[:locations])
-    add_id_condition("location_descriptions.location_id", locations)
+    add_id_condition("location_descriptions.location_id", params[:locations])
     initialize_description_public_parameter(:location)
     super
   end

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -6,16 +6,14 @@ module Query::Modules::Associations
     joins = [:observations, :observation_herbarium_records, :herbarium_records]
   )
     add_id_condition(
-      "herbarium_records.herbarium_id",
-      lookup_herbaria_by_name(params[:herbaria]),
-      *joins
+      "herbarium_records.herbarium_id", params[:herbaria], *joins
     )
   end
 
   def initialize_herbarium_records_parameter
     add_id_condition(
       "observation_herbarium_records.herbarium_record_id",
-      lookup_herbarium_records_by_name(params[:herbarium_records]),
+      params[:herbarium_records],
       :observations, :observation_herbarium_records
     )
   end
@@ -25,7 +23,7 @@ module Query::Modules::Associations
 
     loc_col   = "#{table}.location_id"
     where_col = "#{table}.where"
-    ids       = clean_id_set(lookup_locations_by_name(vals))
+    ids       = clean_id_set(vals)
     cond      = "#{loc_col} IN (#{ids})"
     vals.each do |val|
       if /\D/.match?(val.to_s)
@@ -82,11 +80,7 @@ module Query::Modules::Associations
 
   def initialize_projects_parameter(table = :project_observations,
                                     joins = [:observations, table])
-    add_id_condition(
-      "#{table}.project_id",
-      lookup_projects_by_name(params[:projects]),
-      *joins
-    )
+    add_id_condition("#{table}.project_id", params[:projects], *joins)
   end
 
   def add_in_species_list_condition(table = :species_list_observations,
@@ -104,10 +98,6 @@ module Query::Modules::Associations
   def initialize_species_lists_parameter(
     table = :species_list_observations, joins = [:observations, table]
   )
-    add_id_condition(
-      "#{table}.species_list_id",
-      lookup_species_lists_by_name(params[:species_lists]),
-      *joins
-    )
+    add_id_condition("#{table}.species_list_id", params[:species_lists], *joins)
   end
 end

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -6,7 +6,7 @@ module Query::Modules::Conditions
   def add_owner_and_time_stamp_conditions(table = model.table_name)
     add_time_condition("#{table}.created_at", params[:created_at])
     add_time_condition("#{table}.updated_at", params[:updated_at])
-    add_id_condition("#{table}.user_id", lookup_users_by_name(params[:users]))
+    add_id_condition("#{table}.user_id", params[:users])
   end
 
   def add_by_user_condition(table = model.table_name)

--- a/app/classes/query/modules/lookup_objects.rb
+++ b/app/classes/query/modules/lookup_objects.rb
@@ -2,61 +2,7 @@
 
 # Helper methods to help parsing object instances from parameter strings.
 module Query::Modules::LookupObjects
-  def lookup_external_sites_by_name(vals)
-    Lookup::ExternalSites.new(vals).ids
-  end
-
-  def lookup_field_slips_by_name(vals)
-    Lookup::FieldSlips.new(vals).ids
-  end
-
-  def lookup_herbaria_by_name(vals)
-    Lookup::Herbaria.new(vals).ids
-  end
-
-  def lookup_herbarium_records_by_name(vals)
-    Lookup::HerbariumRecords.new(vals).ids
-  end
-
-  def lookup_locations_by_name(vals)
-    Lookup::Locations.new(vals).ids
-  end
-
-  def lookup_names_by_name(vals, params = {})
-    Lookup::Names.new(vals, **params).ids
-  end
-
-  def lookup_projects_by_name(vals)
-    Lookup::Projects.new(vals).ids
-  end
-
   def lookup_lists_for_projects_by_name(vals)
     Lookup::ProjectSpeciesLists.new(vals).ids
-  end
-
-  def lookup_species_lists_by_name(vals)
-    Lookup::SpeciesLists.new(vals).ids
-  end
-
-  def lookup_users_by_name(vals)
-    Lookup::Users.new(vals).ids
-  end
-
-  # ------------------------------------------------------------------------
-
-  private
-
-  # `yield` means run the block provided to this method.
-  # Only in the case it doesn't have an ID does it look up the record.
-  def lookup_object_ids_by_name(vals)
-    return unless vals
-
-    vals.map do |val|
-      if /^\d+$/.match?(val.to_s)
-        val
-      else
-        yield(val).map(&:id)
-      end
-    end.flatten.uniq.compact
   end
 end

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -7,7 +7,7 @@ module Query::Modules::Validation
   def validate_params
     old_params = @params.dup.compact.symbolize_keys
     new_params = {}
-    parameter_declarations.slice(*@params.keys).each do |param, param_type|
+    parameter_declarations.slice(*old_params.keys).each do |param, param_type|
       val = old_params[param]
       val = validate_value(param_type, param, val) if val.present?
       new_params[param] = val

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -137,15 +137,15 @@ module Query::Modules::Validation
     end
   end
 
-  def validate_integer(param, val)
-    if val.is_a?(Integer) || val.is_a?(String) && val.match(/^-?\d+$/)
-      val.to_i
-    elsif val.blank?
-      nil
-    else
-      raise("Value for :#{param} should be an integer, got: #{val.inspect}")
-    end
-  end
+  # def validate_integer(param, val)
+  #   if val.is_a?(Integer) || val.is_a?(String) && val.match(/^-?\d+$/)
+  #     val.to_i
+  #   elsif val.blank?
+  #     nil
+  #   else
+  #     raise("Value for :#{param} should be an integer, got: #{val.inspect}")
+  #   end
+  # end
 
   def validate_float(param, val)
     if val.is_a?(Integer) || val.is_a?(Float) ||
@@ -234,11 +234,6 @@ module Query::Modules::Validation
             lookup_records_by_name(param, params[param], model)
           end
     set_cached_parameter_instance(param, val)
-  end
-
-  def get_cached_parameter_instance(param)
-    @params_cache ||= {}
-    @params_cache[param]
   end
 
   # Cache the instance for later use, in case we both instantiate and

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # validation of Query parameters
-module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
+module Query::Modules::Validation
   attr_accessor :params, :params_cache
 
   def validate_params
@@ -180,35 +180,6 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     else
       raise("Value for :#{param} should be a string or symbol, " \
             "got a #{val.class}: #{val.inspect}")
-    end
-  end
-
-  def validate_id(param, val, type = ActiveRecord::Base)
-    if val.is_a?(type)
-      raise("Value for :#{param} is an unsaved #{type} instance.") unless val.id
-
-      set_cached_parameter_instance(param, val)
-      val.id
-    elsif could_be_record_id?(param, val)
-      val.to_i
-    else
-      raise("Value for :#{param} should be id or #{type} instance, " \
-            "got: #{val.inspect}")
-    end
-  end
-
-  def validate_name(param, val)
-    case val
-    when Name
-      raise("Value for :#{param} is an unsaved Name instance.") unless val.id
-
-      set_cached_parameter_instance(param, val)
-      val.id
-    when String, Integer
-      val
-    else
-      raise("Value for :#{param} should be a Name, String or Integer, " \
-            "got: #{val.class}")
     end
   end
 

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -2,6 +2,7 @@
 
 class Query::NameDescriptions < Query::Base
   include Query::Params::Descriptions
+  include Query::Params::Names
   include Query::Initializers::Descriptions
 
   def model
@@ -31,8 +32,7 @@ class Query::NameDescriptions < Query::Base
     add_by_user_condition
     add_desc_by_author_condition(:name)
     add_desc_by_editor_condition(:name)
-    names = lookup_names_by_name(params[:names])
-    add_id_condition("name_descriptions.name_id", names)
+    add_id_condition("name_descriptions.name_id", params[:names])
     initialize_description_public_parameter(:name)
     initialize_name_descriptions_parameters
     super

--- a/app/classes/query/params/locations.rb
+++ b/app/classes/query/params/locations.rb
@@ -25,7 +25,8 @@ module Query::Params::Locations
       north: :float,
       south: :float,
       east: :float,
-      west: :float
+      west: :float,
+      in_box: { north: :float, south: :float, east: :float, west: :float }
     }
   end
 end

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -98,11 +98,7 @@ class Query::Sequences < Query::Base
 
   # Different because it can take multiple users
   def initialize_observers_parameter
-    add_id_condition(
-      "observations.user_id",
-      lookup_users_by_name(params[:observers]),
-      :observations
-    )
+    add_id_condition("observations.user_id", params[:observers], :observations)
   end
 
   def initialize_observation_parameters

--- a/app/classes/query/titles/observations.rb
+++ b/app/classes/query/titles/observations.rb
@@ -88,8 +88,8 @@ module Query::Titles::Observations
     :query_title_for_user.t(type: :observation, user: str)
   end
 
-  def map_join_and_truncate(arg, model, method)
-    str = params[arg].map do |val|
+  def map_join_and_truncate(param, model, method)
+    str = params[param].map do |val|
       # Integer(val) throws ArgumentError if val is not an integer.
       # This is the most efficient way to test if a string is an
       # integer according to a very thorough and detailed blog post!
@@ -103,7 +103,7 @@ module Query::Titles::Observations
   end
 
   def ensure_integer(val, model, method)
-    # val = val[0] if val.is_a?(Array)
+    val = val.min if val.is_a?(Array)
     model.find(Integer(val)).send(method)
   end
 end

--- a/app/classes/query/titles/observations.rb
+++ b/app/classes/query/titles/observations.rb
@@ -103,6 +103,7 @@ module Query::Titles::Observations
   end
 
   def ensure_integer(val, model, method)
+    # val = val[0] if val.is_a?(Array)
     model.find(Integer(val)).send(method)
   end
 end

--- a/app/extensions/object_extensions.rb
+++ b/app/extensions/object_extensions.rb
@@ -14,4 +14,15 @@ class Object
     result = caller(2)
     result.push("main: #{File.expand_path($PROGRAM_NAME)}")
   end
+
+  # More convenient check for multiple `is_a?(klass)`. Using *klasses/flatten
+  # allows this to accept both comma separated params as well as an Array.
+  # Shut up Rubocop. This is the most idiomatic method name in this context.
+  # rubocop:disable Naming/PredicateName
+  def is_any?(*klasses)
+    klasses.flatten.any? do |klass|
+      is_a?(klass)
+    end
+  end
+  # rubocop:enable Naming/PredicateName
 end

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -172,6 +172,11 @@ class QueryTest < UnitTestCase
   def test_validate_params_hashes
     box = { north: 48.5798, south: 48.558, east: -123.4307, west: -123.4763 }
     assert_equal(box, Query.lookup(:Location, in_box: box).params[:in_box])
+    assert_raises(TypeError) { Query.lookup(:Location, in_box: "one") }
+    box = { north: "with", south: 48.558, east: -123.4307, west: -123.4763 }
+    assert_raises(RuntimeError) { Query.lookup(:Location, in_box: box) }
+    box = { south: 48.558, east: -123.4307, west: -123.4763 }
+    assert_raises(RuntimeError) { Query.lookup(:Location, in_box: box) }
   end
 
   def test_initialize_helpers

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -69,7 +69,7 @@ class QueryTest < UnitTestCase
                  Query.lookup(:Image, by_user: rolf.id).params[:by_user])
     assert_equal(rolf.id,
                  Query.lookup(:Image, by_user: rolf.id.to_s).params[:by_user])
-    assert_equal(rolf.login,
+    assert_equal(rolf.id,
                  Query.lookup(:Image, by_user: "rolf").params[:by_user])
   end
 
@@ -84,7 +84,7 @@ class QueryTest < UnitTestCase
                  Query.lookup(:Image, users: rolf.id).params[:users])
     assert_equal([rolf.id],
                  Query.lookup(:Image, users: rolf.id.to_s).params[:users])
-    assert_equal([rolf.login],
+    assert_equal([rolf.id],
                  Query.lookup(:Image, users: rolf.login).params[:users])
   end
 
@@ -167,6 +167,11 @@ class QueryTest < UnitTestCase
     assert_equal("id DESC",
                  Query.lookup(:Name, order: "id DESC").params[:order])
     assert_raises(RuntimeError) { Query.lookup(:Name, order: %w[1 2]) }
+  end
+
+  def test_validate_params_hashes
+    box = { north: 48.5798, south: 48.558, east: -123.4307, west: -123.4763 }
+    assert_equal(box, Query.lookup(:Location, in_box: box).params[:in_box])
   end
 
   def test_initialize_helpers

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -647,4 +647,12 @@ module ControllerExtensions
       assert_textarea_value(id, val)
     end
   end
+
+  # Assert index results. This measures <a> tags that link to an ID
+  def assert_results(**attributes)
+    assert_select(
+      "#results .rss-what a:match('href', ?)", %r{^/\d+}, attributes,
+      "Wrong number of results displayed"
+    )
+  end
 end

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -558,7 +558,8 @@ class NamesControllerTest < FunctionalTestCase
     assert_template("show")
     # Needs new queries this time.
     # (? Up from 7 to 9 - AN 20240107) (? Now 11 - AN 20241217)
-    assert_equal(11, QueryRecord.count)
+    # Back to 9, AN 20250203
+    assert_equal(9, QueryRecord.count)
 
     # Agarcius: has children taxa.
     get(:show, params: { id: names(:agaricus).id })


### PR DESCRIPTION
### Remove checks for required Query params
Since we removed the Query flavors, all Query params are now optional. They're just different per model class. We now just need to check for unexpected params, and validate the params that were sent according to the model's `parameter_declarations`.
___
### New Query param type: Hash of separately-validated values
New type of param accepts a hash of values that are validated separately according to type. 
First example: new unimplemented Location param `:in_box`. Tests validation.
___
### Prevalidate lookups
For fields that accept instance, id, or string, the lookup now happens in the validation, so the param initializers (and eventual scopes) can simply deal with valid record ids. Allows param values to be saved as an id or array of ids, even when they were passed as instances or strings — this is necessary if the params are to be printed in URLs.