### PR TITLE
Fix bug in the ReverseNameOrderController

### DIFF
--- a/app/controllers/locations/reverse_name_order_controller.rb
+++ b/app/controllers/locations/reverse_name_order_controller.rb
@@ -7,9 +7,9 @@ module Locations
 
     # Callback for :show
     def update
-      if (location = Location.safe_find(params[:id].to_s))
-        location.name = Location.reverse_name(location.name)
-        location.save
+      if (loc = Location.safe_find(params[:id].to_s))
+        loc.name, loc.scientific_name = loc.scientific_name, loc.name
+        loc.save
       end
       redirect_to(location_path(params[:id].to_s))
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,7 +472,7 @@ MushroomObserver::Application.routes.draw do
   # ----- Locations: a lot of actions  ----------------------------
   resources :locations, id: /\d+/, shallow: true do
     member do
-      put("reverse_name_order", to: "locations/reverse_name_order#update")
+      get("reverse_name_order", to: "locations/reverse_name_order#update")
       get("versions", to: "locations/versions#show", as: "version_of")
     end
     resources :descriptions, module: :locations, shallow_path: :locations,

--- a/test/controllers/locations/reverse_name_order_controller_test.rb
+++ b/test/controllers/locations/reverse_name_order_controller_test.rb
@@ -12,7 +12,9 @@ module Locations
       # this should reverse the name
       put(:update, params: { id: mit.id })
       assert_redirected_to(location_path(mit.id))
-      assert_equal(Location.reverse_name(mit_original_name), mit.reload.name)
+      mit.reload
+      assert_equal(mit_original_name, mit.scientific_name)
+      assert_equal(Location.reverse_name(mit_original_name), mit.name)
     end
   end
 end

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -66,7 +66,7 @@ mitrula_marsh:
   created_at: 2007-12-27 06:47:00
   updated_at: 2007-12-27 06:47:00
   name: '"Mitrula Marsh", Sand Lake, Bassetts, Yuba Co., California, USA'
-  scientific_name: "USA, California, Yuba Co., Bassetts, Sand Lake"
+  scientific_name: 'USA, California, Yuba Co., Bassetts, Sand Lake, "Mitrula Marsh"'
   north: 39.7184
   west: -120.687
   east: -120.487


### PR DESCRIPTION
To reproduce:
1) Switch to Admin mode
2) Visit a location that has more than a single term, e.g., http://localhost:3000/locations/7162
3) Click the |< icon on the right side
4) If you are in "Postal" location mode the name will change.
5) Switch to "Scientific" location mode and notice that the name is the same as in "Postal" mode.

On the branch, both modes should swtich.
