### PR TITLE
Observation `in_box` minor rewrite

### DIFF
--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -324,12 +324,14 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           or(Observation.cached_location_center_in_box_over_dateline(box))
       end
     }
+    # In these the box.east edge is in the w hemisphere, -180..
+    #      and the box.west edge is in the e hemisphere, ..180
     scope :gps_in_box_over_dateline, lambda { |box|
       where(
         (Observation[:lat] >= box.south).
         and(Observation[:lat] <= box.north).
-        and(Observation[:lng] <= box.west).
-        or(Observation[:lng] >= box.east)
+        and(Observation[:lng] >= box.west).
+        or(Observation[:lng] <= box.east)
       )
     }
     scope :cached_location_center_in_box_over_dateline, lambda { |box|
@@ -337,8 +339,8 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         Observation[:lat].eq(nil).
         and(Observation[:location_lat] >= box.south).
         and(Observation[:location_lat] <= box.north).
-        and(Observation[:location_lng] <= box.west).
-        or(Observation[:location_lng] >= box.east)
+        and(Observation[:location_lng] >= box.west).
+        or(Observation[:location_lng] <= box.east)
       )
     }
     scope :associated_location_center_in_box_over_dateline, lambda { |box|
@@ -347,8 +349,8 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           Observation[:lat].eq(nil).
           and(Location[:center_lat] >= box.south).
           and(Location[:center_lat] <= box.north).
-          and(Location[:center_lng] <= box.west).
-          or(Location[:center_lng] >= box.east)
+          and(Location[:center_lng] >= box.west).
+          or(Location[:center_lng] <= box.east)
         )
     }
     # mostly a helper for in_box

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -294,11 +294,13 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         where(Observation[:where].matches("%#{region}"))
       end
     }
-    # Pass kwargs (:north, :south, :east, :west), any order
-    # Pass mappable: false to include all obs, including with vague locations.
+    # Pass Box kwargs (:north, :south, :east, :west), any order.
+    # By default this scope selects only obs either with lat/lng or with useful
+    # locations, where we have cached the location center point on the obs.
+    # As a utility convenience, you can pass `vague: true` to include all obs,
+    # including those with vague (huge) locations.
     scope :in_box, lambda { |**args|
-      args[:mappable] ||= false
-      box = Mappable::Box.new(**args.except(:mappable))
+      box = Mappable::Box.new(**args.except(:vague))
       return none unless box.valid?
 
       if box.straddles_180_deg?
@@ -309,91 +311,102 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     # mostly a helper for in_box
     scope :in_box_straddling_dateline, lambda { |**args|
-      args[:mappable] ||= true
+      include_vague_locations = args[:vague] || false
       box = Mappable::Box.new(**args.except(:mappable))
       return none unless box.valid?
 
+      if include_vague_locations
+        # this join is necessary for the `or` condition, which requires it
+        left_outer_joins(:location).gps_in_box_over_dateline(box).
+          or(Observation.associated_location_center_in_box_over_dateline(box))
+      else
+        gps_in_box_over_dateline(box).
+          or(Observation.cached_location_center_in_box_over_dateline(box))
+      end
+    }
+    scope :gps_in_box_over_dateline, lambda { |box|
       where(
         (Observation[:lat] >= box.south).
         and(Observation[:lat] <= box.north).
-        and(Observation[:lng] >= box.west).
-        or(Observation[:lng] <= box.east)
-      ).or(Observation.location_straddling_dateline(**args))
+        and(Observation[:lng] <= box.west).
+        or(Observation[:lng] >= box.east)
+      )
     }
-    scope :location_straddling_dateline, lambda { |**args|
-      box = Mappable::Box.new(**args.except(:mappable))
-      return none unless box.valid?
-
-      if args[:mappable]
+    scope :cached_location_center_in_box_over_dateline, lambda { |box|
+      where(
+        Observation[:lat].eq(nil).
+        and(Observation[:location_lat] >= box.south).
+        and(Observation[:location_lat] <= box.north).
+        and(Observation[:location_lng] <= box.west).
+        or(Observation[:location_lng] >= box.east)
+      )
+    }
+    scope :associated_location_center_in_box_over_dateline, lambda { |box|
+      left_outer_joins(:location).
         where(
           Observation[:lat].eq(nil).
-          and(Observation[:location_lat] >= box.south).
-          and(Observation[:location_lat] <= box.north).
-          and(Observation[:location_lng] >= box.west).
-          or(Observation[:location_lng] <= box.east)
+          and(Location[:center_lat] >= box.south).
+          and(Location[:center_lat] <= box.north).
+          and(Location[:center_lng] <= box.west).
+          or(Location[:center_lng] >= box.east)
         )
-      else
-        joins(:location).
-          where(
-            Observation[:lat].eq(nil).
-            and(Location[:center_lat] >= box.south).
-            and(Location[:center_lat] <= box.north).
-            and(Location[:center_lng] <= box.east).
-            and(Location[:center_lng] >= box.west)
-          )
-      end
     }
     # mostly a helper for in_box
     scope :in_box_regular, lambda { |**args|
-      args[:mappable] ||= true
+      include_vague_locations = args[:vague] || false
       box = Mappable::Box.new(**args.except(:mappable))
       return none unless box.valid?
 
-      where(
-        (Observation[:lat] >= box.south).and(Observation[:lat] <= box.north).
-        and(Observation[:lng] >= box.west).and(Observation[:lng] <= box.east)
-      ).or(Observation.location_center_in_box(**args))
+      if include_vague_locations
+        # this join is necessary for the `or` condition, which requires it
+        left_outer_joins(:location).gps_in_box(box).
+          or(Observation.associated_location_center_in_box(box))
+      else
+        gps_in_box(box).or(Observation.cached_location_center_in_box(box))
+      end
     }
-    scope :location_center_in_box, lambda { |**args|
-      box = Mappable::Box.new(**args.except(:mappable))
-      return none unless box.valid?
-
-      # odd! will toss entire condition if below order is west, east
-      if args[:mappable]
+    scope :gps_in_box, lambda { |box|
+      where(
+        (Observation[:lat] >= box.south).
+        and(Observation[:lat] <= box.north).
+        and(Observation[:lng] <= box.east).
+        and(Observation[:lng] >= box.west)
+      )
+    }
+    scope :cached_location_center_in_box, lambda { |box|
+      # odd! AR will toss entire condition if below order is west, east
+      where(
+        Observation[:lat].eq(nil).
+        and(Observation[:location_lat] >= box.south).
+        and(Observation[:location_lat] <= box.north).
+        and(Observation[:location_lng] <= box.east).
+        and(Observation[:location_lng] >= box.west)
+      )
+    }
+    scope :associated_location_center_in_box, lambda { |box|
+      left_outer_joins(:location).
         where(
           Observation[:lat].eq(nil).
-          and(Observation[:location_lat] >= box.south).
-          and(Observation[:location_lat] <= box.north).
-          and(Observation[:location_lng] <= box.east).
-          and(Observation[:location_lng] >= box.west)
+          and(Location[:center_lat] >= box.south).
+          and(Location[:center_lat] <= box.north).
+          and(Location[:center_lng] <= box.east).
+          and(Location[:center_lng] >= box.west)
         )
-      else
-        joins(:location).
-          where(
-            Observation[:lat].eq(nil).
-            and(Location[:center_lat] >= box.south).
-            and(Location[:center_lat] <= box.north).
-            and(Location[:center_lng] <= box.east).
-            and(Location[:center_lng] >= box.west)
-          )
-      end
     }
     # Pass kwargs (:north, :south, :east, :west), any order
     scope :not_in_box, lambda { |**args|
-      args[:mappable] ||= false
       box = Mappable::Box.new(**args.except(:mappable))
       return Observation.all unless box.valid?
 
       # should be in_box(**args).invert_where
       if box.straddles_180_deg?
-        not_in_box_straddling_dateline(**args)
+        not_in_box_over_dateline(**args)
       else
         not_in_box_regular(**args)
       end
     }
     # helper for not_in_box
-    scope :not_in_box_straddling_dateline, lambda { |**args|
-      args[:mappable] ||= false
+    scope :not_in_box_over_dateline, lambda { |**args|
       box = Mappable::Box.new(**args.except(:mappable))
       return Observation.all unless box.valid?
 
@@ -405,7 +418,6 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     # helper for not_in_box
     scope :not_in_box_regular, lambda { |**args|
-      args[:mappable] ||= false
       box = Mappable::Box.new(**args.except(:mappable))
       return Observation.all unless box.valid?
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1343,6 +1343,7 @@ class ObservationTest < UnitTestCase
     minimal_unknown_obs = observations(:minimal_unknown_obs)
     obss_in_wrangel_box = Observation.in_box(**wrangel_box)
 
+    # Tests are comparing IDs so the results are legible in the event of failure
     # boxes not straddling 180 deg
     assert_includes(obss_in_cal_box.map(&:id), unknown_lat_lng_obs.id)
     assert_includes(obss_in_ecuador_box.map(&:id), quito_obs.id)
@@ -1400,6 +1401,7 @@ class ObservationTest < UnitTestCase
     minimal_unknown_obs = observations(:minimal_unknown_obs)
     obss_not_in_wrangel_box = Observation.not_in_box(**wrangel_box)
 
+    # Tests are comparing IDs so the results are legible in the event of failure
     # boxes not straddling 180 deg
     assert_not_includes(obss_not_in_cal_box.map(&:id),
                         obs_with_burbank_geoloc.id)

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1272,20 +1272,56 @@ class ObservationTest < UnitTestCase
     )
   end
 
+  def nybg
+    @nybg ||= locations(:nybg_location)
+  end
+
+  def nybg_box
+    @nybg_box ||= nybg.bounding_box
+  end
+
+  def cal
+    @cal ||= locations(:california)
+  end
+
+  def cal_box
+    @cal_box ||= cal.bounding_box
+  end
+
+  def wrangel
+    @wrangel ||= locations(:east_lt_west_location)
+  end
+
+  # { north: 71.588, south: 70.759, west: 178.648, east: -177.433 }
+  def wrangel_box
+    @wrangel_box ||= wrangel.bounding_box
+  end
+
   def ecuador_box
-    { north: 1.49397, south: -5.06906, east: -75.1904, west: -92.6038 }
+    @ecuador_box ||=
+      { north: 1.49397, south: -5.06906, east: -75.1904, west: -92.6038 }
   end
 
   def tiny_box
-    { north: 0.0001, south: 0.0001, east: 0.0001, west: 0 }
+    @tiny_box ||= { north: 0.0001, south: 0.0001, east: 0.0001, west: 0 }
+  end
+
+  def missing_west_box
+    @missing_west_box ||= { north: cal.north, south: cal.south, east: cal.east }
+  end
+
+  def outta_bounds_box
+    @outta_bounds_box ||=
+      { north: 91, south: cal.south, east: cal.east, west: cal.west }
+  end
+
+  def north_souther_than_south_box
+    @north_souther_than_south_box ||= cal_box.merge(north: cal.south - 10)
   end
 
   def test_scope_in_box
-    cal = locations(:california)
-    obss_in_cal_box = Observation.in_box(**cal.bounding_box)
-    nybg = locations(:nybg_location)
-    obss_in_nybg_box = Observation.in_box(**nybg.bounding_box)
-    obss_in_ecuador_box = Observation.in_box(**ecuador_box)
+    obss_in_cal_box = Observation.in_box(**cal_box)
+    obss_in_nybg_box = Observation.in_box(**nybg_box)
     quito_obs =
       Observation.create!(
         user: users(:rolf),
@@ -1293,27 +1329,30 @@ class ObservationTest < UnitTestCase
         lng: -78.4305382,
         where: "Quito, Ecuador"
       )
-    wrangel = locations(:east_lt_west_location)
+    obss_in_ecuador_box = Observation.in_box(**ecuador_box)
+
     wrangel_obs =
       Observation.create!(
         user: users(:rolf),
         lat: (wrangel.north + wrangel.south) / 2,
-        lng: (wrangel.east + wrangel.west) / 2 + wrangel.west
+        lng: (wrangel.east + wrangel.west) / 2 + wrangel.west,
+        where: "Wrangel Island, Russia"
       )
-    obss_in_wrangel_box = Observation.in_box(**wrangel.bounding_box)
+    # lat: 34.1622 lng: -118.3521
+    unknown_lat_lng_obs = observations(:unknown_with_lat_lng)
+    minimal_unknown_obs = observations(:minimal_unknown_obs)
+    obss_in_wrangel_box = Observation.in_box(**wrangel_box)
 
     # boxes not straddling 180 deg
-    assert_includes(obss_in_cal_box, observations(:unknown_with_lat_lng))
-    assert_includes(obss_in_ecuador_box, quito_obs)
-    assert_not_includes(obss_in_nybg_box, observations(:unknown_with_lat_lng))
-    assert_not_includes(obss_in_cal_box,
-                        observations(:minimal_unknown_obs),
+    assert_includes(obss_in_cal_box.map(&:id), unknown_lat_lng_obs.id)
+    assert_includes(obss_in_ecuador_box.map(&:id), quito_obs.id)
+    assert_not_includes(obss_in_nybg_box.map(&:id), unknown_lat_lng_obs.id)
+    assert_not_includes(obss_in_cal_box.map(&:id), minimal_unknown_obs.id,
                         "Observation without lat/lon should not be in box")
 
     # box straddling 180 deg
-    assert_includes(obss_in_wrangel_box, wrangel_obs)
-    assert_not_includes(obss_in_wrangel_box,
-                        observations(:unknown_with_lat_lng))
+    assert_includes(obss_in_wrangel_box.map(&:id), wrangel_obs.id)
+    assert_not_includes(obss_in_wrangel_box.map(&:id), unknown_lat_lng_obs.id)
 
     assert_empty(Observation.where(lat: 0.001), "Test needs different fixture")
     assert_empty(
@@ -1324,31 +1363,24 @@ class ObservationTest < UnitTestCase
 
     # invalid arguments
     assert_empty(
-      Observation.in_box(north: cal.north, south: cal.south, east: cal.east),
+      Observation.in_box(**missing_west_box),
       "`Observation.in_box` should be empty if an argument is missing"
     )
     assert_empty(
-      Observation.in_box(
-        north: 91, south: cal.south, east: cal.east, west: cal.west
-      ),
+      Observation.in_box(**outta_bounds_box),
       "`Observation.in_box` should be empty if an argument is out of bounds"
     )
     assert_empty(
-      Observation.in_box(north: cal.south - 10,
-                         south: cal.south, east: cal.east, west: cal.west),
+      Observation.in_box(**north_souther_than_south_box),
       "`Observation.in_box` should be empty if N < S"
     )
   end
 
   def test_scope_not_in_box
-    cal = locations(:california)
-    obss_not_in_cal_box = Observation.not_in_box(**cal.bounding_box)
     obs_with_burbank_geoloc = observations(:unknown_with_lat_lng)
+    obss_not_in_cal_box = Observation.not_in_box(**cal_box)
+    obss_not_in_nybg_box = Observation.not_in_box(**nybg_box)
 
-    nybg = locations(:nybg_location)
-    obss_not_in_nybg_box = Observation.not_in_box(**nybg.bounding_box)
-
-    obss_not_in_ecuador_box = Observation.not_in_box(**ecuador_box)
     quito_obs =
       Observation.create!(
         user: users(:rolf),
@@ -1356,26 +1388,30 @@ class ObservationTest < UnitTestCase
         lng: -78.4305382,
         where: "Quito, Ecuador"
       )
+    obss_not_in_ecuador_box = Observation.not_in_box(**ecuador_box)
 
-    wrangel = locations(:east_lt_west_location)
     wrangel_obs =
       Observation.create!(
         user: users(:rolf),
         lat: (wrangel.north + wrangel.south) / 2,
-        lng: (wrangel.east + wrangel.west) / 2 + wrangel.west
+        lng: (wrangel.east + wrangel.west) / 2 + wrangel.west,
+        where: "Wrangel Island, Russia"
       )
-    obss_not_in_wrangel_box = Observation.not_in_box(**wrangel.bounding_box)
+    minimal_unknown_obs = observations(:minimal_unknown_obs)
+    obss_not_in_wrangel_box = Observation.not_in_box(**wrangel_box)
 
     # boxes not straddling 180 deg
-    assert_not_includes(obss_not_in_cal_box, obs_with_burbank_geoloc)
-    assert_not_includes(obss_not_in_ecuador_box, quito_obs)
-    assert_includes(obss_not_in_nybg_box, obs_with_burbank_geoloc)
-    assert_includes(obss_not_in_cal_box, observations(:minimal_unknown_obs),
+    assert_not_includes(obss_not_in_cal_box.map(&:id),
+                        obs_with_burbank_geoloc.id)
+    assert_not_includes(obss_not_in_ecuador_box.map(&:id), quito_obs.id)
+    assert_includes(obss_not_in_nybg_box.map(&:id), obs_with_burbank_geoloc.id)
+    assert_includes(obss_not_in_cal_box.map(&:id), minimal_unknown_obs.id,
                     "Observation without lat/lon should not be in box")
 
     # box straddling 180 deg
-    assert_not_includes(obss_not_in_wrangel_box, wrangel_obs)
-    assert_includes(obss_not_in_wrangel_box, obs_with_burbank_geoloc)
+    assert_not_includes(obss_not_in_wrangel_box.map(&:id), wrangel_obs.id)
+    assert_includes(obss_not_in_wrangel_box.map(&:id),
+                    obs_with_burbank_geoloc.id)
 
     assert_equal(
       Observation.count,
@@ -1387,23 +1423,17 @@ class ObservationTest < UnitTestCase
     all_observations_count = Observation.count
     assert_equal(
       all_observations_count,
-      Observation.not_in_box(
-        north: cal.north, south: cal.south, east: cal.east
-      ).count,
+      Observation.not_in_box(**missing_west_box).count,
       "All Observations should be excluded from a box with missing boundary"
     )
     assert_equal(
       all_observations_count,
-      Observation.not_in_box(
-        north: 91, south: cal.south, east: cal.east, west: cal.west
-      ).count,
+      Observation.not_in_box(**outta_bounds_box).count,
       "All Observations should be excluded from a box with an out-of-bounds arg"
     )
     assert_equal(
       all_observations_count,
-      Observation.not_in_box(
-        north: cal.south - 10, south: cal.south, east: cal.east, west: cal.west
-      ).count,
+      Observation.not_in_box(**north_souther_than_south_box).count,
       "All Observations should be excluded from box whose N < S"
     )
   end


### PR DESCRIPTION
The `Observation.in_box(**box, mappable: false)` param wasn't working as implied, because 
- the default value `false` passed by `in_box` to its helper scopes was immediately overridden, and furthermore incorrect. The `in_box` scope should not return obs with vague locations like "Earth" or "Florida, USA", so the helper scope overrides were correct, but confusing.
- a join was not present on the `false` condition, which needs to check values in the location table, so the scope failed.
- that join needs to be an outer join, because not all observations have locations. An inner join would miss obs with gps but no location. 

Renamed the param to `Observation.in_box(**box, vague: false)` and renamed helper scopes for clarity. Refactored to break up helper scopes a bit. Now, you must intentionally pass the `vague` param to get "unmappable" observations.