### PR TITLE
Speed up Lookup::Names

### DIFF
--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -47,6 +47,18 @@ class Lookup::Names < Lookup
 
   # Matches for the given vals, from the db.
   def original_matches
+    @original_matches ||= if numeric_list?(@vals)
+                            numeric_matches
+                          else
+                            map_matches
+                          end
+  end
+
+  def numeric_matches
+    Name.where(id: @vals).distinct.select(*minimal_name_columns)
+  end
+
+  def map_matches
     @original_matches ||= @vals.map do |val|
       if val.is_a?(@model)
         val
@@ -58,6 +70,20 @@ class Lookup::Names < Lookup
         find_matching_names(val)
       end
     end.flatten.uniq.compact
+  end
+
+  def numeric_list?(list)
+    list.all? do |item|
+      case item
+      when Numeric
+        true
+      when String
+        # Handles integers, floats, scientific notation, and negative numbers
+        item.match?(/\A-?\d*\.?\d+(?:[eE][-+]?\d+)?\z/)
+      else
+        false
+      end
+    end
   end
 
   # NOTE: Name.parse_name returns a ParsedName instance, not an Name instance.

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -59,7 +59,7 @@ class Lookup::Names < Lookup
   end
 
   def map_matches
-    @original_matches ||= @vals.map do |val|
+    @vals.map do |val|
       if val.is_a?(@model)
         val
       elsif val.is_a?(AbstractModel)
@@ -79,7 +79,7 @@ class Lookup::Names < Lookup
         true
       when String
         # Handles integers only
-        item.match?(/^-?\d+$/)
+        item.match?(/^\d+$/)
       else
         false
       end

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -78,8 +78,8 @@ class Lookup::Names < Lookup
       when Numeric
         true
       when String
-        # Handles integers, floats, scientific notation, and negative numbers
-        item.match?(/\A-?\d*\.?\d+(?:[eE][-+]?\d+)?\z/)
+        # Handles integers only
+        item.match?(/^-?\d+$/)
       else
         false
       end

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -27,7 +27,7 @@ module Query::Modules::Validation
 
   def validate_value(param_type, param, val)
     if param_type.is_a?(Array)
-      array_validate(param, val, param_type.first).flatten
+      array_validate(param, val, param_type.first).flatten.uniq
     else
       # scalar_validate with ambiguous lookup could return an array
       val = scalar_validate(param, val, param_type)

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -27,7 +27,7 @@ module Query::Modules::Validation
 
   def validate_value(param_type, param, val)
     if param_type.is_a?(Array)
-      array_validate(param, val, param_type.first).flatten.uniq
+      array_validate(param, val, param_type.first).flatten
     else
       # scalar_validate with ambiguous lookup could return an array
       val = scalar_validate(param, val, param_type)

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -108,6 +108,15 @@ class LookupTest < UnitTestCase
                                 include_subtaxa: true)
   end
 
+  def test_lookup_names_by_id
+    User.current = rolf
+
+    name1 = names(:coprinus_comatus)
+    name2 = names(:coprinus_sensu_lato)
+    assert_lookup_names_by_name([name1, name2],
+                                [name1.text_name, name2.id.to_s])
+  end
+
   def test_lookup_names_by_name_classifications
     User.current = rolf
 


### PR DESCRIPTION
To test from a database dump from Feb 5:
```
% rails c
mushroom-observer(dev)> ids = QueryRecord.find("1yzec".dealphabetize).description.split(",#")[1...]
mushroom-observer(dev)> Lookup::Names.new(ids, include_synonyms: true, include_subtaxa: true).ids.count
```

On current main this will generate over 500 SQL queries.  On the branch it will generate 5.