### PR TITLE
Box scopes params and methods - improved error reporting

### DIFF
--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -116,7 +116,7 @@ module PatternSearch
 
     def validate_box(box)
       validator = Mappable::Box.new(**box)
-      return if validator.valid?
+      return box if validator.valid?
 
       check_for_missing_box_params
       # Just fix the box if they've got it swapped

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -610,11 +610,23 @@ class PatternSearchTest < UnitTestCase
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 
-  def test_observation_search_gps
+  def test_observation_search_in_box
     expect = Observation.where(lat: 34.1622, lng: -118.3521)
     assert(expect.count.positive?)
     x = PatternSearch::Observation.new(
       "west:-118.4 east:-118.3 north:34.2 south:34.1"
+    )
+    assert_obj_arrays_equal(expect, x.query.results, :sort)
+
+    # missing value
+    y = PatternSearch::Observation.new(
+      "west:-118.4 east:-118.3 north:34.2"
+    )
+    assert_raises(PatternSearch::MissingValueError) { y.build_query }
+
+    # north/south inverted, but fixed by build_query
+    z = PatternSearch::Observation.new(
+      "west:-118.4 east:-118.3 north:34.1 south:34.2"
     )
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -628,7 +628,7 @@ class PatternSearchTest < UnitTestCase
     z = PatternSearch::Observation.new(
       "west:-118.4 east:-118.3 north:34.1 south:34.2"
     )
-    assert_obj_arrays_equal(expect, x.query.results, :sort)
+    assert_obj_arrays_equal(expect, z.query.results, :sort)
   end
 
   def test_observation_search_has_images_no


### PR DESCRIPTION
Add useful UI error message for any missing `PatternSearch` params in `north, south, east, west` if any others are present, rather than dropping the other params silently.  Also, automatically flop `north` and `south` if `south > north`. 

Adds new tests.