### PR TITLE
Cleanup removed calls to `restrict_query_to_box(query)`

### DIFF
--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -276,34 +276,6 @@ module ApplicationController::Queries
     result.save
   end
 
-  # Create a new query by adding a bounding box to the given one.
-  # These seem to all be coming from map_helper, so let's do it there.
-  # def restrict_query_to_box(query)
-  #   return query if params[:in_box].blank?
-
-  #   model = query.model.to_s.to_sym
-  #   query.params[:in_box] = tweaked_bounding_box_params
-  #   Query.lookup(model, query.params)
-  # end
-
-  # def tweaked_bounding_box_params
-  #   n, s, e, w = params[:in_box].values_at(:north, :south, :east, :west)
-  #   {
-  #     north: tweak_up(n, 0.001, 90),
-  #     south: tweak_down(s, 0.001, -90),
-  #     east: tweak_up(e, 0.001, 180),
-  #     west: tweak_down(w, 0.001, -180)
-  #   }
-  # end
-
-  # def tweak_up(value, amount, max)
-  #   [max, value.to_f + amount].min
-  # end
-
-  # def tweak_down(value, amount, min)
-  #   [min, value.to_f - amount].max
-  # end
-
   public ##########
 
   # Need to pass list of tags used in this action to next page if redirecting.

--- a/app/controllers/locations/maps_controller.rb
+++ b/app/controllers/locations/maps_controller.rb
@@ -11,7 +11,6 @@ module Locations
 
       apply_content_filters(@query)
 
-      # @query = restrict_query_to_box(@query)
       columns = %w[name north south east west].map { |x| "locations.#{x}" }
       args = { select: "DISTINCT(locations.id), #{columns.join(", ")}",
                limit: 10_000 }

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -115,10 +115,6 @@ class LocationsController < ApplicationController
 
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, display_opts)
-    # Restrict to subset within a geographical region (used by map
-    # if it needed to stuff multiple locations into a single marker).
-    # query = restrict_query_to_box(query)
-    # Already restricted in map_helper.
     # Matching undefined locations is meaningless in a box.
     # (Undefined locations don't have a box!)
     return query if query.params[:in_box].present?

--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -10,7 +10,6 @@ module Observations
 
       @query = find_or_create_query(:Observation)
       apply_content_filters(@query)
-      # @query = restrict_query_to_box(@query)
 
       find_locations_matching_observations
     end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -191,9 +191,6 @@ class ObservationsController
     # Hook runs before template displayed. Must return query.
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)
-      # Restrict to subset within a geographical region (used by map
-      # if it needed to stuff multiple locations into a single marker).
-      # restrict_query_to_box(query) # returns this query
       query
     end
 


### PR DESCRIPTION
Already removed in #2704 but kept as comments, forgot to delete.