### PR TITLE
Reduce the query load for searches

### DIFF
--- a/app/classes/query/titles/observations.rb
+++ b/app/classes/query/titles/observations.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Query::Titles::Observations
+  MAX_TITLE_ITEMS = 3
+
   def with_observations_query_description
     return nil unless (description = observation_query_description)
 
@@ -89,7 +91,7 @@ module Query::Titles::Observations
   end
 
   def map_join_and_truncate(param, model, method)
-    str = params[param].map do |val|
+    str = params[param][0..(MAX_TITLE_ITEMS - 1)].map do |val|
       # Integer(val) throws ArgumentError if val is not an integer.
       # This is the most efficient way to test if a string is an
       # integer according to a very thorough and detailed blog post!
@@ -98,7 +100,11 @@ module Query::Titles::Observations
     rescue ArgumentError # rubocop:disable Layout/RescueEnsureAlignment
       val
     end.join(", ")
-    str = "#{str[0...97]}..." if str.length > 100
+    if str.length > 100
+      str = "#{str[0...97]}..."
+    elsif params[param].length > MAX_TITLE_ITEMS
+      str += ", ..."
+    end
     str
   end
 


### PR DESCRIPTION
Without this change, searching for "Amanita" on our current database runs over 1800 queries.  With this change, it runs 42.