### PR TITLE
QueryRecord - convert `:description` `to_json` serialization

### DIFF
--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -43,10 +43,9 @@ module Query::Modules::ActiveRecord
     end
 
     # Matching a serialized hash is tricky. Values must match exactly.
-    # You also can't query it with QueryRecord.find_by(description: desc)
     def get_record(query)
       desc = query.serialize
-      QueryRecord.find { |rec| rec.description == desc } ||
+      QueryRecord.find_by(description: desc) ||
         QueryRecord.new(
           description: desc,
           updated_at: Time.zone.now,

--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -42,9 +42,11 @@ module Query::Modules::ActiveRecord
       query
     end
 
+    # Matching a serialized hash is tricky. Values must match exactly.
+    # You also can't query it with QueryRecord.find_by(description: desc)
     def get_record(query)
       desc = query.serialize
-      QueryRecord.find_by(description: desc) ||
+      QueryRecord.all.find { |rec| rec.description == desc } ||
         QueryRecord.new(
           description: desc,
           updated_at: Time.zone.now,

--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -42,7 +42,6 @@ module Query::Modules::ActiveRecord
       query
     end
 
-    # Matching a serialized hash is tricky. Values must match exactly.
     def get_record(query)
       desc = query.serialize
       QueryRecord.find_by(description: desc) ||

--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -46,7 +46,7 @@ module Query::Modules::ActiveRecord
     # You also can't query it with QueryRecord.find_by(description: desc)
     def get_record(query)
       desc = query.serialize
-      QueryRecord.all.find { |rec| rec.description == desc } ||
+      QueryRecord.find { |rec| rec.description == desc } ||
         QueryRecord.new(
           description: desc,
           updated_at: Time.zone.now,

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-# :description is now a serialized column, so Rails does the de/serialization.
+# :description is not a serialized column; we call `to_json` for serialization.
 module Query::Modules::Serialization
   def self.included(base)
     base.extend(ClassMethods)
   end
 
-  # Prepare the query params for saving to the db, adding the model.
-  # This description is accessed not just to recompose a query, but to identify
-  # existing query records that match current params. That's why the keys
-  # are sorted here before being stored as strings in to_json - because
+  # Prepare the query params, adding the model, for saving to the db. The
+  # :description column is accessed not just to recompose a query, but to
+  # identify existing query records that match current params. That's why the
+  # keys are sorted here before being stored as strings in to_json - because
   # when matching a serialized hash, strings must match exactly. This is
   # more efficient however than using a Rails-serialized column and comparing
   # the parsed hashes (in whatever order), because when a column is serialized

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -1,84 +1,24 @@
 # frozen_string_literal: true
 
-# Turn a query into a string and vice versa.
+# :description is now a serialized column, so Rails does the de/serialization.
 module Query::Modules::Serialization
   def self.included(base)
     base.extend(ClassMethods)
   end
 
+  # Prepare the query params for saving to the db, adding the model.
   def serialize
-    hash = params.merge(model: model.to_s.to_sym)
-    hash.keys.sort_by(&:to_s).map do |key|
-      serialize_key_value(key, hash[key])
-    end.join(";")
-  end
-
-  def serialize_key_value(key, val)
-    "#{key}=#{serialize_value(val)}"
-  end
-
-  def serialize_value(val)
-    case val
-    when Array      then "@#{val.map { |v| serialize_value(v) }.join(",")}"
-    when String     then "$#{serialize_string(val)}"
-    when Symbol     then ":#{serialize_string(val.to_s)}"
-    when Integer, Float then "##{val}"
-    when TrueClass  then "1"
-    when FalseClass then "0"
-    when NilClass   then "-"
-    end
-  end
-
-  def serialize_string(val)
-    # The "n" forces the Regexp to be in ascii 8 bit encoding = binary.
-    String.new(val).force_encoding("binary").
-      gsub(%r{[,;:#%&=/?\x00-\x1f\x7f-\xff]}n) do |char|
-      format("%%%02.2X", char.ord)
-    end
+    params.merge(model: model.name.to_sym)
   end
 
   # Class methods.
   module ClassMethods
-    def deserialize(str)
-      params = deserialize_params(str)
+    # Extract the model from the serialized params and instantiate new Query.
+    def deserialize(description)
+      params = description
       model  = params[:model]
       params.delete(:model)
       Query.new(model, params)
-    end
-
-    def deserialize_params(str)
-      params = {}
-      str.split(";").each do |line|
-        next if line !~ /^(\w+)=(.*)/
-
-        key = Regexp.last_match(1)
-        val = Regexp.last_match(2)
-        params[key.to_sym] = deserialize_value(val)
-      end
-      params
-    end
-
-    def deserialize_value(val)
-      val = val.sub(/^(.)/, "")
-      case Regexp.last_match(1)
-      when "@" then val.split(",").map { |v| deserialize_value(v) }
-      when "$" then deserialize_string(val)
-      when ":" then deserialize_string(val).to_sym
-      when "#" then deserialize_number(val)
-      when "1" then true
-      when "0" then false
-      when "-" then nil
-      end
-    end
-
-    def deserialize_string(val)
-      String.new(val).force_encoding("binary").gsub(/%(..)/) do |match|
-        match[1..2].hex.chr("binary")
-      end.force_encoding("UTF-8")
-    end
-
-    def deserialize_number(val)
-      val.include?(".") ? val.to_f : val.to_i
     end
   end
 end

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -15,10 +15,10 @@ module Query::Modules::Serialization
   module ClassMethods
     # Extract the model from the serialized params and instantiate new Query.
     def deserialize(description)
-      params = description
-      model  = params[:model]
+      params = description.symbolize_keys
+      model  = params[:model].to_sym
       params.delete(:model)
-      Query.new(model, params)
+      ::Query.new(model, params)
     end
   end
 end

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -7,16 +7,21 @@ module Query::Modules::Serialization
   end
 
   # Prepare the query params for saving to the db, adding the model.
-  # The keys are stored as strings in to_json
+  # This description is accessed not just to recompose a query, but to identify
+  # existing query records that match current params. That's why the keys
+  # are sorted here before being stored as strings in to_json - because
+  # when matching a serialized hash, strings must match exactly. This is
+  # more efficient however than using a Rails-serialized column and comparing
+  # the parsed hashes (in whatever order), because when a column is serialized
+  # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
-    params.merge(model: model.name).deep_transform_keys(&:to_s)
+    params.sort.to_h.merge(model: model.name).to_json
   end
 
-  # Class methods.
   module ClassMethods
-    # Extract the model from the serialized params and instantiate new Query.
+    # Get the model from the serialized params and instantiate new Query.
     def deserialize(description)
-      params = description.symbolize_keys
+      params = JSON.parse(description).symbolize_keys
       model  = params[:model].to_sym
       params.delete(:model)
       ::Query.new(model, params)

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -7,8 +7,9 @@ module Query::Modules::Serialization
   end
 
   # Prepare the query params for saving to the db, adding the model.
+  # The keys are stored as strings in to_json
   def serialize
-    params.merge(model: model.name.to_sym)
+    params.merge(model: model.name).deep_transform_keys(&:to_s)
   end
 
   # Class methods.

--- a/app/models/query_record.rb
+++ b/app/models/query_record.rb
@@ -14,6 +14,8 @@
 #  updated_at::     Date/time it was last updated.
 #  access_count::   Number of times the query record was accessed.
 #  description::    Serialized parameters of the query, including the model.
+#                   Not using Rails serialization because we use this column to
+#                   compare queries, and SQL matching by string is faster.
 #  outer_id::       `id` of outer query, when inner query of a nested query.
 #
 #  == Class methods
@@ -23,8 +25,6 @@
 # access query records saved in the db
 class QueryRecord < ApplicationRecord
   attr_accessor :query
-
-  serialize :description, type: Hash, coder: JSON
 
   # This method instantiates a new Query from the description.
   def query # rubocop:disable Lint/DuplicateMethods

--- a/app/models/query_record.rb
+++ b/app/models/query_record.rb
@@ -3,8 +3,8 @@
 #  = Query Record Model
 #
 #  Query Records store the parameters of recent user queries for quicker access.
-#  For nested queries, the inner and outer queries are stored as separate
-#  query_records. Inner queries store an `outer_id` of the outer query.
+#  For certain nested queries, the inner and outer queries are stored as
+#  separate query_records. Inner queries store an `outer_id` of the outer query.
 #
 #  Used by MO's Query::Modules::ActiveRecord
 #
@@ -13,7 +13,7 @@
 #  id::             Unique numerical id.
 #  updated_at::     Date/time it was last updated.
 #  access_count::   Number of times the query record was accessed.
-#  description::    Serialized parameters of the query.
+#  description::    Serialized parameters of the query, including the model.
 #  outer_id::       `id` of outer query, when inner query of a nested query.
 #
 #  == Class methods
@@ -24,6 +24,9 @@
 class QueryRecord < ApplicationRecord
   attr_accessor :query
 
+  serialize :description, type: Hash, coder: JSON
+
+  # This method instantiates a new Query from the description.
   def query # rubocop:disable Lint/DuplicateMethods
     ::Query.deserialize(description)
   end

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -3,8 +3,8 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
     QueryRecord.find_each do |record|
       str = record.instance_variable_get(:@attributes)["description"].
             value_before_type_cast
-      params = deserialize_params(str)
-      record.update_column(:description, params)
+      description = deserialize_params(str).to_json
+      record.update_column(:description, description)
     end
   end
 

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -4,7 +4,8 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
       str = record.instance_variable_get(:@attributes)["description"].
             value_before_type_cast
       old_description = deserialize(str)
-      record.description = old_description.to_json
+      debugger
+      record.description = old_description
       record.save
     end
   end
@@ -14,9 +15,7 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
   end
 
   def deserialize(str)
-    params = deserialize_params(str)
-    model  = params[:model]
-    params.delete(:model)
+    deserialize_params(str)
   end
 
   def deserialize_params(str)

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -3,10 +3,8 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
     QueryRecord.find_each do |record|
       str = record.instance_variable_get(:@attributes)["description"].
             value_before_type_cast
-      old_description = deserialize_params(str)
-      debugger
-      record.description = old_description
-      record.save
+      params = deserialize_params(str)
+      record.update(description: params)
     end
   end
 

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -1,7 +1,7 @@
 class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
   def up
     QueryRecord.find_each do |record|
-      str = record.instance_variable_get(:@attributes)['description'].
+      str = record.instance_variable_get(:@attributes)["description"].
             value_before_type_cast
       old_description = deserialize(str)
       record.description = old_description.to_json

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -3,7 +3,7 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
     QueryRecord.find_each do |record|
       str = record.instance_variable_get(:@attributes)["description"].
             value_before_type_cast
-      old_description = deserialize(str)
+      old_description = deserialize_params(str)
       debugger
       record.description = old_description
       record.save
@@ -12,10 +12,6 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
 
   def down
     QueryRecord.delete_all
-  end
-
-  def deserialize(str)
-    deserialize_params(str)
   end
 
   def deserialize_params(str)

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -4,7 +4,7 @@ class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
       str = record.instance_variable_get(:@attributes)["description"].
             value_before_type_cast
       params = deserialize_params(str)
-      record.update(description: params)
+      record.update_column(:description, params)
     end
   end
 

--- a/db/migrate/20250213084440_convert_query_record_description.rb
+++ b/db/migrate/20250213084440_convert_query_record_description.rb
@@ -1,0 +1,56 @@
+class ConvertQueryRecordDescription < ActiveRecord::Migration[7.2]
+  def up
+    QueryRecord.find_each do |record|
+      str = record.instance_variable_get(:@attributes)['description'].
+            value_before_type_cast
+      old_description = deserialize(str)
+      record.description = old_description.to_json
+      record.save
+    end
+  end
+
+  def down
+    QueryRecord.delete_all
+  end
+
+  def deserialize(str)
+    params = deserialize_params(str)
+    model  = params[:model]
+    params.delete(:model)
+  end
+
+  def deserialize_params(str)
+    params = {}
+    str.split(";").each do |line|
+      next if line !~ /^(\w+)=(.*)/
+
+      key = Regexp.last_match(1)
+      val = Regexp.last_match(2)
+      params[key.to_sym] = deserialize_value(val)
+    end
+    params
+  end
+
+  def deserialize_value(val)
+    val = val.sub(/^(.)/, "")
+    case Regexp.last_match(1)
+    when "@" then val.split(",").map { |v| deserialize_value(v) }
+    when "$" then deserialize_string(val)
+    when ":" then deserialize_string(val).to_sym
+    when "#" then deserialize_number(val)
+    when "1" then true
+    when "0" then false
+    when "-" then nil
+    end
+  end
+
+  def deserialize_string(val)
+    String.new(val).force_encoding("binary").gsub(/%(..)/) do |match|
+      match[1..2].hex.chr("binary")
+    end.force_encoding("UTF-8")
+  end
+
+  def deserialize_number(val)
+    val.include?(".") ? val.to_f : val.to_i
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_13_084440) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_09_041049) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -909,11 +909,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_13_084440) do
     t.text "alert"
     t.boolean "email_locations_admin", default: false
     t.boolean "email_names_admin", default: false
+    t.integer "thumbnail_size", default: 1
     t.integer "image_size", default: 5
     t.string "default_rss_type", limit: 40, default: "all"
     t.integer "votes_anonymous", default: 1
     t.integer "location_format", default: 1
     t.datetime "last_activity", precision: nil
+    t.integer "hide_authors", default: 1, null: false
     t.boolean "thumbnail_maps", default: true, null: false
     t.string "auth_code", limit: 40
     t.integer "keep_filenames", default: 1, null: false
@@ -927,8 +929,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_13_084440) do
     t.boolean "no_emails", default: false, null: false
     t.string "inat_username"
     t.integer "original_image_quota", default: 0
-    t.integer "hide_authors"
-    t.integer "thumbnail_size"
     t.index ["login"], name: "login_index"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_09_041049) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_13_084440) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_09_041049) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_13_084440) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -909,13 +909,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_041049) do
     t.text "alert"
     t.boolean "email_locations_admin", default: false
     t.boolean "email_names_admin", default: false
-    t.integer "thumbnail_size", default: 1
     t.integer "image_size", default: 5
     t.string "default_rss_type", limit: 40, default: "all"
     t.integer "votes_anonymous", default: 1
     t.integer "location_format", default: 1
     t.datetime "last_activity", precision: nil
-    t.integer "hide_authors", default: 1, null: false
     t.boolean "thumbnail_maps", default: true, null: false
     t.string "auth_code", limit: 40
     t.integer "keep_filenames", default: 1, null: false
@@ -929,6 +927,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_041049) do
     t.boolean "no_emails", default: false, null: false
     t.string "inat_username"
     t.integer "original_image_quota", default: 0
+    t.integer "hide_authors"
+    t.integer "thumbnail_size"
     t.index ["login"], name: "login_index"
   end
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -806,9 +806,7 @@ class QueryTest < UnitTestCase
     obs = obs_with_imgs_ids.first
     imgs = Observation.find(obs).images.reorder(id: :asc).map(&:id)
     img = imgs.first
-    qr = QueryRecord.where(
-      QueryRecord[:description].matches_regexp("observation=##{obs}")
-    ).first
+    qr = QueryRecord.all.find { |rec| rec.description["observation"] == obs }
     q = Query.deserialize(qr.description)
     q_first_query = q.first
     q_last_query = q.last

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -806,7 +806,9 @@ class QueryTest < UnitTestCase
     obs = obs_with_imgs_ids.first
     imgs = Observation.find(obs).images.reorder(id: :asc).map(&:id)
     img = imgs.first
-    qr = QueryRecord.find { |rec| rec.description["observation"] == obs }
+    qr = QueryRecord.where(
+      QueryRecord[:description].matches_regexp("observation\\\":#{obs}")
+    ).first
     q = Query.deserialize(qr.description)
     q_first_query = q.first
     q_last_query = q.last

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -806,7 +806,7 @@ class QueryTest < UnitTestCase
     obs = obs_with_imgs_ids.first
     imgs = Observation.find(obs).images.reorder(id: :asc).map(&:id)
     img = imgs.first
-    qr = QueryRecord.all.find { |rec| rec.description["observation"] == obs }
+    qr = QueryRecord.find { |rec| rec.description["observation"] == obs }
     q = Query.deserialize(qr.description)
     q_first_query = q.first
     q_last_query = q.last


### PR DESCRIPTION
There’s an issue with QueryRecords currently, and it becomes more important with the coercion-conversion PR.

Our `QueryRecord` uses a custom serializer to encode the `Query` params in the `:description` attribute, which is declared in schema as `text` and not Rails-serialized.

The custom `serialize` method in `Query::Modules::Serialization` can serialize arrays and values, but not nested hashes. That means that the current `:in_box` query param, which is a hash of `{ north:, south:, east:, west: }` is not getting saved in any QueryRecords. With my upcoming PR replacing coercions with subqueries, it means the filtering subquery is not saved.

We can solve this pretty easily by storing the query params using `to_json` instead. 

~Converting existing QRs in a reversible migration turns out to be harder, because once you declare the column `serialized`, it is possible to extract the existing string value from the column and save a Rails-serialized value back to it, but for the `down` migration I don't believe we can write a custom-serialized but not Rails-serialized string directly back to the column.~

We could try a one-way migration if we really want to ensure continuity.