### PR TITLE
Terminate Field Slip Status Requests

### DIFF
--- a/app/javascript/controllers/field-slip-job_controller.js
+++ b/app/javascript/controllers/field-slip-job_controller.js
@@ -36,8 +36,6 @@ export default class extends Controller {
   }
 
   // Every second, send a get request to find out the status of the PDF.
-  // NOTE: Can't call a class function from `setInterval` because it resets
-  // the context of `this`
   start_timer_sending_requests() {
     if (this.status_id != "3") {
       // Set the intervalId to the interval so we can clear it later
@@ -47,20 +45,17 @@ export default class extends Controller {
           { responseKind: "turbo-stream" });
         if (response.ok) {
           // Turbo replaces the row in the page already
+          this.check_if_we_are_done();
         } else {
           console.log(`got a ${response.status}`);
         }
       }, 1000);
-    } else {
-      // If the PDF is done, we can remove this Stimulus controller from the
-      // element and stop the timer. (NOTE: there may be other controllers.)
-      // console.log("field-slip-job is done")
-      const controllers = this.element.dataset.controller.split(" ")
-      if (controllers.includes("field-slip-job")) {
-        const idx = controllers.indexOf("field-slip-job")
-        controllers.splice(idx, 1)
-        this.element.setAttribute("data-controller", controllers.join(" "))
-      }
+    }
+  }
+
+  check_if_we_are_done() {
+    if (this.status_id == "3" && this.intervalId != null) {
+      clearInterval(this.intervalId)
     }
   }
 }


### PR DESCRIPTION
- Fixes how the js controller stops sending GET requests when the job is done.
- Contains only one commit, authored by @nimmo, (cherry picked from commit 70155d93435ed052a9a4baf77f554d60a84113ba) and effectively moved from #2702 so that it can be considered separately.