### PR TITLE
Admin destroy User UI

### DIFF
--- a/app/views/controllers/users/show/_profile.erb
+++ b/app/views/controllers/users/show/_profile.erb
@@ -63,7 +63,13 @@ footer =
       str, url, args = tab
       args ||= {}
       kwargs = merge_tab_args_with_extra_args(args, { class: "d-block" }) %>
-      <%= link_to(str, url, kwargs) %>
+      <% if args.keys.include?(:button) %>
+        <%= button_to(:destroy_object.t(type: :user), url, method: :delete,
+                      class: "d-block",
+                     ) %>
+      <% else %>
+        <%= link_to(str, url, kwargs) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/controllers/users/show/_profile.erb
+++ b/app/views/controllers/users/show/_profile.erb
@@ -63,7 +63,7 @@ footer =
       str, url, args = tab
       args ||= {}
       kwargs = merge_tab_args_with_extra_args(args, { class: "d-block" }) %>
-      <% if args.keys.include?(:button) %>
+      <% if args.any?([:button, :destroy]) %>
         <%= button_to(:destroy_object.t(type: :user), url, method: :delete,
                       class: "d-block",
                      ) %>

--- a/app/views/controllers/users/show/_profile.erb
+++ b/app/views/controllers/users/show/_profile.erb
@@ -64,9 +64,8 @@ footer =
       args ||= {}
       kwargs = merge_tab_args_with_extra_args(args, { class: "d-block" }) %>
       <% if args.any?([:button, :destroy]) %>
-        <%= button_to(:destroy_object.t(type: :user), url, method: :delete,
-                      class: "d-block",
-                     ) %>
+        <%= destroy_button(target: admin_users_path(id: @show_user.id),
+                           name: str) %>
       <% else %>
         <%= link_to(str, url, kwargs) %>
       <% end %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -191,7 +191,7 @@ class UsersControllerTest < FunctionalTestCase
     get(:show, params: { id: user.id })
 
     # Prove that the page has a Delete User button
-    assert_select("form.button_to[action *=?]", admin_users_path) do
+    assert_select("form.button_to[action =?]", admin_users_path(id: user.id)) do
       assert_select("input[value=?]", "delete")
     end
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -191,7 +191,7 @@ class UsersControllerTest < FunctionalTestCase
     get(:show, params: { id: user.id })
 
     # Prove that the page has a Delete User button
-    assert_select("form.button_to") do
+    assert_select("form.button_to[action=?]", admin_users_path) do
       assert_select("input[value=?]", "delete")
     end
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -180,4 +180,19 @@ class UsersControllerTest < FunctionalTestCase
     get(:show, params: { id: number8.id, q: q, flow: "prev" })
     assert_redirected_to(user_path(number7.id, q: q))
   end
+
+  #   ---------------
+
+  def test_admin_show_user
+    user = users(:mary)
+
+    login("rolf")
+    make_admin
+    get(:show, params: { id: user.id })
+
+    # Prove that the page has a Delete User button
+    assert_select("form.button_to") do
+      assert_select("input[value=?]", "delete")
+    end
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -191,7 +191,7 @@ class UsersControllerTest < FunctionalTestCase
     get(:show, params: { id: user.id })
 
     # Prove that the page has a Delete User button
-    assert_select("form.button_to[action=?]", admin_users_path) do
+    assert_select("form.button_to[action *=?]", admin_users_path) do
       assert_select("input[value=?]", "delete")
     end
   end


### PR DESCRIPTION
- Changes the Destroy User link (in the User show page while in admin mode) to a button.
- Delivers #2722

### Manual Test
- Turn on Admin Mode
- click List Users (in the left side menu)
- click the login of a verified user
- click Destroy User
Expected Result:
  - re-displays user index (Users by Name)
  - a flash like "Sorry, the user you tried to display (id #189894) does not exist. ..."
  - that user is toast.
 