### PR TITLE
Query - rename/disambiguate advanced search params

### DIFF
--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -43,8 +43,7 @@ class Query::Base
   end
 
   def self.takes_parameter?(key)
-    parameter_declarations.key?(key) ||
-      parameter_declarations.key?(:"#{key}?")
+    parameter_declarations.key?(key)
   end
 
   def subquery_parameters

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -170,7 +170,7 @@ class Query::Images < Query::Base
   # Perform content search as an observation query, then
   # coerce into images.
   def handle_img_content_search!
-    return false if params[:content].blank?
+    return false if params[:search_content].blank?
 
     self.executor = lambda do |args|
       execute_img_content_search(args)

--- a/app/classes/query/initializers/advanced_search.rb
+++ b/app/classes/query/initializers/advanced_search.rb
@@ -14,10 +14,12 @@ module Query::Initializers::AdvancedSearch
 
   def google_parse_params
     [
-      SearchParams.new(phrase: params[:name]),
-      SearchParams.new(phrase: User.remove_bracketed_name(params[:user].to_s)),
-      SearchParams.new(phrase: params[:user_where]),
-      SearchParams.new(phrase: params[:content])
+      SearchParams.new(phrase: params[:search_name]),
+      SearchParams.new(
+        phrase: User.remove_bracketed_name(params[:search_user].to_s)
+      ),
+      SearchParams.new(phrase: params[:search_where]),
+      SearchParams.new(phrase: params[:search_content])
     ]
   end
 

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -91,7 +91,7 @@ class Query::Locations < Query::Base
   def add_advanced_search_conditions
     return if advanced_search_params.all? { |key| params[key].blank? }
 
-    add_join(:observations) if params[:content].present?
+    add_join(:observations) if params[:search_content].present?
     initialize_advanced_search
   end
 

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -203,7 +203,7 @@ class Query::Names < Query::Base
   def add_name_advanced_search_conditions
     return if advanced_search_params.all? { |key| params[key].blank? }
 
-    add_join(:observations) if params[:content].present?
+    add_join(:observations) if params[:search_content].present?
     initialize_advanced_search
   end
 

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -40,7 +40,6 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
       location: Location,
       locations: [Location],
       in_box: { north: :float, south: :float, east: :float, west: :float },
-      user_where: :string,
       is_collection_location: :boolean,
       with_public_lat_lng: :boolean,
       with_notes: :boolean,
@@ -278,7 +277,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     )
     return if model == Observation
 
-    add_search_condition("observations.where", params[:user_where])
+    add_search_condition("observations.where", params[:search_where])
   end
 
   def add_pattern_condition

--- a/app/classes/query/params/advanced_search.rb
+++ b/app/classes/query/params/advanced_search.rb
@@ -11,17 +11,17 @@ module Query::Params::AdvancedSearch
     # But sometimes you're looking for strings that aren't ids.
     def advanced_search_parameter_declarations
       {
-        name: :string,
-        user_where: :string,
-        user: :string,
-        content: :string,
+        search_name: :string,
+        search_where: :string,
+        search_user: :string,
+        search_content: :string,
         search_location_notes: :boolean
       }
     end
 
     # These are the ones that if present, are definitive of advanced_search.
     def advanced_search_params
-      [:name, :user, :user_where, :content]
+      [:search_name, :search_user, :search_where, :search_content]
     end
   end
 

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -15,7 +15,7 @@ class Query::SpeciesLists < Query::Base
       ids: [SpeciesList],
       location: Location,
       locations: [Location],
-      user_where: :string,
+      search_where: :string,
       project: Project,
       projects: [Project],
       title_has: :string,
@@ -71,9 +71,9 @@ class Query::SpeciesLists < Query::Base
   end
 
   def initialize_at_where_parameter
-    return unless params[:user_where]
+    return unless params[:search_where]
 
-    location_str = params[:user_where]
+    location_str = params[:search_where]
     title_args[:where] = location_str
     where << "species_lists.where LIKE '%#{clean_pattern(location_str)}%'"
   end
@@ -98,7 +98,7 @@ class Query::SpeciesLists < Query::Base
 
   # Only instance methods have access to params.
   def default_order
-    if params[:user_where].present? || params[:location].present?
+    if params[:search_where].present? || params[:location].present?
       "name"
     else
       "title"

--- a/app/classes/query/titles/observations.rb
+++ b/app/classes/query/titles/observations.rb
@@ -83,7 +83,8 @@ module Query::Titles::Observations
 
   # takes a search string
   def title_for_user
-    :query_title_by_user.t(type: :observation, user: params.deep_find(:user))
+    user = params.deep_find(:search_user)
+    :query_title_by_user.t(type: :observation, user:)
   end
 
   # takes a list of user_ids

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -31,7 +31,6 @@ class ObservationsController
 
     # Displays matrix of advanced search results.
     def advanced_search
-      debugger
       query = advanced_search_query
       # Have to check this here because we're not running the query yet.
       raise(:runtime_no_conditions.l) unless query.params.any?

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -31,6 +31,7 @@ class ObservationsController
 
     # Displays matrix of advanced search results.
     def advanced_search
+      debugger
       query = advanced_search_query
       # Have to check this here because we're not running the query yet.
       raise(:runtime_no_conditions.l) unless query.params.any?
@@ -157,7 +158,7 @@ class ObservationsController
 
     # Display matrix of Observations whose "where" matches a string.
     # NOTE: To consolidate flavors in Query, we're passing the possible
-    # `user_where` param from the advanced search form straight through to
+    # `search_where` param from the advanced search form straight through to
     # Query's obs advanced search class, which searches two tables (obs and
     # loc) for the fuzzy match.
     # Here we are passing the front end's `where` to the similar Query

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -90,20 +90,20 @@ class SearchController < ApplicationController
 
       # Treat User field differently; remove angle-bracketed user name,
       # since it was included by the auto-completer only as a hint.
-      val = user_login(params[:search]) if field == :user
+      val = user_login(params[:search]) if field == :search_user
       query_params[field] = val
     end
   end
 
   def user_login(params)
-    if params.include?(:user_id)
-      user = User.find_by(id: params[:user_id])
+    if params.include?(:search_user_id)
+      user = User.find_by(id: params[:search_user_id])
       return user.login if user
     end
-    user = User.lookup_unique_text_name(params[:user])
+    user = User.lookup_unique_text_name(params[:search_user])
     return user.login if user
 
-    params[:user]
+    params[:search_user]
   end
 
   def add_applicable_filter_parameters(query_params, model)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -84,7 +84,7 @@ class SearchController < ApplicationController
   # NOTE: The autocompleters for name, location, and user all make the ids
   # available now, so this could be a lot more efficient.
   def add_filled_in_text_fields(query_params)
-    [:content, :user_where, :name, :user].each do |field|
+    [:search_content, :search_where, :search_name, :search_user].each do |field|
       val = params[:search][field].to_s
       next if val.blank?
 

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -165,10 +165,10 @@ module Tabs
       ).tab
     end
 
-    # Hack to use the :locations param if it's present and the :user_where
+    # Hack to use the :locations param if it's present and the :search_where
     # param is missing.
     def where_param(query_params)
-      query_params[:user_where] || params[:where]
+      query_params[:search_where] || params[:where]
     end
 
     def assign_undefined_location_tab(query)

--- a/app/views/controllers/search/advanced.html.erb
+++ b/app/views/controllers/search/advanced.html.erb
@@ -28,23 +28,23 @@
   ) %>
 
   <% nam_betw = help_note(:span, :advanced_search_name_help.t) %>
-  <%= autocompleter_field(form: f, field: :name, type: :name,
+  <%= autocompleter_field(form: f, field: :search_name, type: :name,
                           label: "#{:NAME.t}:", between: nam_betw,
                           separator: " OR ") %>
 
   <% usr_betw = help_note(:span, :advanced_search_observer_help.t) %>
-  <%= autocompleter_field(form: f, field: :user, type: :user,
+  <%= autocompleter_field(form: f, field: :search_user, type: :user,
                           label: "#{:OBSERVER.t}:", between: usr_betw,
                           separator: " OR ") %>
 
   <% loc_betw = help_note(:span, :advanced_search_location_help.t) %>
-  <%= autocompleter_field(form: f, field: :user_where, type: :location,
+  <%= autocompleter_field(form: f, field: :search_where, type: :location,
                           label: "#{:LOCATION.t}:", between: loc_betw,
                           separator: " OR " ) %>
 
   <% cnt_betw = help_note(:span, :advanced_search_content_help.t) %>
   <% cnt_appd = help_block(:p, :advanced_search_content_notes.t) %>
-  <%= text_field_with_label(form: f, field: :content,
+  <%= text_field_with_label(form: f, field: :search_content,
                             label: :advanced_search_content.t + ":",
                             between: cnt_betw, append: cnt_appd) %>
 

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -367,8 +367,8 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_with_observations_at_where
     expects = [images(:connected_coprinus_comatus_image).id]
-    assert_image_obs_query(expects, user_where: "glendale")
-    assert_image_obs_query([], user_where: "snazzle")
+    assert_image_obs_query(expects, search_where: "glendale")
+    assert_image_obs_query([], search_where: "snazzle")
   end
 
   def test_image_with_observations_by_user

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -136,42 +136,42 @@ class Query::ImagesTest < UnitTestCase
     # expects = [] # [images(:agaricus_campestris_image).id]
     expects = Image.index_order.joins(observations: :name).
               where(Name[:search_name].matches("%Agaricus%")).distinct
-    assert_query(expects, :Image, name: "Agaricus")
+    assert_query(expects, :Image, search_name: "Agaricus")
   end
 
-  def test_image_advanced_search_user_where
+  def test_image_advanced_search_where
     expects = Image.index_order.joins(:observations).
               where(Observation[:where].matches("%burbank%")).
               where(observations: { is_collection_location: true }).distinct
-    assert_query(expects, :Image, user_where: "burbank")
+    assert_query(expects, :Image, search_where: "burbank")
 
     assert_query([images(:connected_coprinus_comatus_image).id],
-                 :Image, user_where: "glendale")
+                 :Image, search_where: "glendale")
   end
 
   def test_image_advanced_search_user
     expects = Image.index_order.joins(observations: :user).
               where(observations: { user: mary }).distinct.
               order(Image[:created_at].desc, Image[:id].desc)
-    assert_query(expects, :Image, user: "mary")
+    assert_query(expects, :Image, search_user: "mary")
   end
 
   def test_image_advanced_search_content
     assert_query(Image.index_order.
                  advanced_search("little"),
-                 :Image, content: "little")
+                 :Image, search_content: "little")
     assert_query(Image.index_order.
                  advanced_search("fruiting"),
-                 :Image, content: "fruiting")
+                 :Image, search_content: "fruiting")
   end
 
   def test_image_advanced_search_combos
     assert_query([],
-                 :Image, name: "agaricus", user_where: "glendale")
+                 :Image, search_name: "agaricus", search_where: "glendale")
     assert_query([images(:agaricus_campestris_image).id],
-                 :Image, name: "agaricus", user_where: "burbank")
+                 :Image, search_name: "agaricus", search_where: "burbank")
     assert_query([images(:turned_over_image).id, images(:in_situ_image).id],
-                 :Image, content: "little", user_where: "burbank")
+                 :Image, search_content: "little", search_where: "burbank")
   end
 
   def test_image_pattern_search_name

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -79,60 +79,61 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_advanced_search_name
     assert_query([locations(:burbank).id],
-                 :Location, name: "agaricus")
-    assert_query([], :Location, name: "coprinus")
+                 :Location, search_name: "agaricus")
+    assert_query([], :Location, search_name: "coprinus")
   end
 
-  def test_location_advanced_search_user_where
+  def test_location_advanced_search_where
     assert_query([locations(:burbank).id],
-                 :Location, user_where: "burbank")
+                 :Location, search_where: "burbank")
     assert_query([locations(:howarth_park).id,
                   locations(:salt_point).id],
-                 :Location, user_where: "park")
+                 :Location, search_where: "park")
   end
 
   def test_location_advanced_search_user
     expects = Location.index_order.joins(observations: :user).
               where(observations: { user: rolf }).distinct
-    assert_query(expects, :Location, user: "rolf")
+    assert_query(expects, :Location, search_user: "rolf")
 
     expects = Location.index_order.joins(observations: :user).
               where(observations: { user: dick }).distinct
-    assert_query(expects, :Location, user: "dick")
+    assert_query(expects, :Location, search_user: "dick")
   end
 
   # content in obs.notes
   def test_location_advanced_search_content_obs_notes
     assert_query(Location.advanced_search('"strange place"'),
-                 :Location, content: '"strange place"')
+                 :Location, search_content: '"strange place"')
   end
 
   # content in Obs Comment
   def test_location_advanced_search_content_obs_comments
     assert_query(
       Location.advanced_search('"a little of everything"'),
-      :Location, content: '"a little of everything"'
+      :Location, search_content: '"a little of everything"'
     )
   end
 
   def test_location_advanced_search_content_location_notes
     assert_query([],
-                 :Location, content: '"legal to collect"')
+                 :Location, search_content: '"legal to collect"')
   end
 
   def test_location_advanced_search_content_combos
     assert_query([locations(:burbank).id],
-                 :Location, name: "agaricus", content: '"lawn"')
+                 :Location, search_name: "agaricus", search_content: '"lawn"')
     assert_query([],
-                 :Location, name: "agaricus", content: '"play with"')
+                 :Location, search_name: "agaricus",
+                            search_content: '"play with"')
     # from observation and comment for same observation
     assert_query([locations(:burbank).id],
                  :Location,
-                 content: '"a little of everything" "strange place"')
+                 search_content: '"a little of everything" "strange place"')
     # from different comments, should fail
     assert_query([],
                  :Location,
-                 content: '"minimal unknown" "complicated"')
+                 search_content: '"minimal unknown" "complicated"')
   end
 
   def test_location_regexp_search

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -303,20 +303,20 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_advanced_search
     assert_query([names(:macrocybe_titans).id],
-                 :Name, name: "macrocybe*titans")
+                 :Name, search_name: "macrocybe*titans")
     assert_query([names(:coprinus_comatus).id],
-                 :Name, user_where: "glendale") # where
+                 :Name, search_where: "glendale") # where
     expects = Name.index_order.joins(:observations).
               where(Observation[:location_id].eq(locations(:burbank).id)).
               distinct
-    assert_query(expects, :Name, user_where: "burbank") # location
+    assert_query(expects, :Name, search_where: "burbank") # location
     expects = Name.index_order.joins(:observations).
               where(Observation[:user_id].eq(rolf.id)).distinct
-    assert_query(expects, :Name, user: "rolf")
+    assert_query(expects, :Name, search_user: "rolf")
     assert_query([names(:coprinus_comatus).id], :Name,
-                 content: "second fruiting") # notes
+                 search_content: "second fruiting") # notes
     assert_query([names(:fungi).id], :Name,
-                 content: '"a little of everything"') # comment
+                 search_content: '"a little of everything"') # comment
   end
 
   def test_name_need_description

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -529,7 +529,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_with_observations_at_where
     assert_query([names(:coprinus_comatus).id],
-                 :Name, observation_query: { user_where: "glendale" })
+                 :Name, observation_query: { search_where: "glendale" })
   end
 
   def test_name_with_observations_by_user

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -397,28 +397,28 @@ class Query::ObservationsTest < UnitTestCase
 
   def test_observation_advanced_search_name
     assert_query([observations(:strobilurus_diminutivus_obs).id],
-                 :Observation, name: "diminutivus")
+                 :Observation, search_name: "diminutivus")
   end
 
   def test_observation_advanced_search_where
     assert_query([observations(:coprinus_comatus_obs).id],
-                 :Observation, user_where: "glendale") # where
+                 :Observation, search_where: "glendale") # where
     expects = Observation.reorder(id: :asc).
               where(location: locations(:burbank)).distinct
-    assert_query(expects, :Observation,
-                 user_where: "burbank", by: :id) # location
+    assert_query(expects,
+                 :Observation, search_where: "burbank", by: :id) # location
   end
 
   def test_observation_advanced_search_user
     expects = Observation.reorder(id: :asc).where(user: rolf.id).distinct
-    assert_query(expects, :Observation, user: "rolf", by: :id)
+    assert_query(expects, :Observation, search_user: "rolf", by: :id)
   end
 
   def test_observation_advanced_search_content
     assert_query(Observation.advanced_search("second fruiting"),
-                 :Observation, content: "second fruiting") # notes
+                 :Observation, search_content: "second fruiting") # notes
     assert_query(Observation.advanced_search("agaricus"),
-                 :Observation, content: "agaricus") # comment
+                 :Observation, search_content: "agaricus") # comment
   end
 
   def test_observation_date

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -32,9 +32,9 @@ class Query::SpeciesListsTest < UnitTestCase
   end
 
   def test_species_list_at_where
-    assert_query([], :SpeciesList, user_where: "nowhere")
+    assert_query([], :SpeciesList, search_where: "nowhere")
     assert_query([species_lists(:where_no_mushrooms_list)],
-                 :SpeciesList, user_where: "no mushrooms")
+                 :SpeciesList, search_where: "no mushrooms")
   end
 
   def test_species_list_by_rss_log

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -949,9 +949,9 @@ class QueryTest < UnitTestCase
       :Observation, species_list: species_lists(:first_species_list).id
     )
     query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
-    query_a[4] = Query.lookup_and_save(:Observation, user_where: "glendale")
+    query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, location: burbank)
-    query_a[6] = Query.lookup_and_save(:Observation, user_where: "california")
+    query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
     # removed query_a[7] which searched for "somewhere else" in the notes
     # query_a[7] = Query.lookup_and_save(:Observation,
     #                                    pattern: '"somewhere else"')
@@ -972,9 +972,9 @@ class QueryTest < UnitTestCase
       :Observation, species_list: species_lists(:first_species_list).id
     )
     query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
-    query_a[4] = Query.lookup_and_save(:Observation, user_where: "glendale")
+    query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, location: burbank)
-    query_a[6] = Query.lookup_and_save(:Observation, user_where: "california")
+    query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
     assert_equal(7, QueryRecord.count)
 
     query_b = observation_subquery_assertions(query_a, :Location)
@@ -988,11 +988,11 @@ class QueryTest < UnitTestCase
                  obs_queries[2][:species_list])
     assert_equal(three_amigos, obs_queries[3][:ids])
     assert_equal(1, obs_queries[3].keys.length)
-    assert_equal("glendale", obs_queries[4][:user_where])
+    assert_equal("glendale", obs_queries[4][:search_where])
     assert_equal(1, obs_queries[4].keys.length)
     assert_equal(burbank.id, obs_queries[5][:location])
     assert_equal(1, obs_queries[5].keys.length)
-    assert_equal("california", obs_queries[6][:user_where])
+    assert_equal("california", obs_queries[6][:search_where])
     assert_equal(1, obs_queries[6].keys.length)
   end
 
@@ -1009,9 +1009,9 @@ class QueryTest < UnitTestCase
     query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
     # qa[4] = Query.lookup_and_save(:Observation,
     #                             pattern: '"somewhere else"')
-    query_a[4] = Query.lookup_and_save(:Observation, user_where: "glendale")
+    query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, location: burbank)
-    query_a[6] = Query.lookup_and_save(:Observation, user_where: "california")
+    query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
     assert_equal(7, QueryRecord.count)
 
     observation_subquery_assertions(query_a, :Name)

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -75,10 +75,11 @@ class ImagesControllerTest < FunctionalTestCase
   def test_index_advanced_search_multiple_hits
     obs = observations(:fungi_obs)
     assert(obs.images.many?)
-    query = Query.lookup_and_save(:Image,
-                                  name: obs.text_name,
-                                  user: obs.user.name,
-                                  user_where: obs.where)
+    query = Query.lookup_and_save(
+      :Image, search_name: obs.text_name,
+              search_user: obs.user.name,
+              search_where: obs.where
+    )
     assert(query.results.many?)
 
     login
@@ -94,7 +95,7 @@ class ImagesControllerTest < FunctionalTestCase
 
   def test_index_advanced_search_one_hit
     image = images(:connected_coprinus_comatus_image)
-    query = Query.lookup_and_save(:Image, name: "Coprinus comatus")
+    query = Query.lookup_and_save(:Image, search_name: "Coprinus comatus")
     assert(query.results.one?)
 
     login
@@ -106,11 +107,12 @@ class ImagesControllerTest < FunctionalTestCase
   end
 
   def test_index_advanced_search_no_hits
-    query = Query.lookup_and_save(:Image,
-                                  name: "Don't know",
-                                  user: "myself",
-                                  content: "Long pink stem and small pink cap",
-                                  user_where: "Eastern Oklahoma")
+    query = Query.lookup_and_save(
+      :Image, search_name: "Don't know",
+              search_user: "myself",
+              search_content: "Long pink stem and small pink cap",
+              search_where: "Eastern Oklahoma"
+    )
     assert(query.results.count.zero?)
 
     login

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -231,7 +231,7 @@ class LocationsControllerTest < FunctionalTestCase
   # end
 
   def test_index_advanced_search
-    query = Query.lookup_and_save(:Location, user_where: "California")
+    query = Query.lookup_and_save(:Location, search_where: "California")
     matches = Location.name_contains("California")
 
     login

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -90,7 +90,7 @@ class NamesControllerTest < FunctionalTestCase
 
   def test_index_advanced_search_multiple_hits
     search_string = "Suil"
-    query = Query.lookup_and_save(:Name, name: search_string)
+    query = Query.lookup_and_save(:Name, search_name: search_string)
 
     login
     get(:index,
@@ -108,7 +108,7 @@ class NamesControllerTest < FunctionalTestCase
 
   def test_index_advanced_search_one_hit
     search_string = "Stereum hirsutum"
-    query = Query.lookup_and_save(:Name, name: search_string)
+    query = Query.lookup_and_save(:Name, search_name: search_string)
     assert(query.results.one?,
            "Test needs a string that has exactly one hit")
 
@@ -120,11 +120,12 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def test_index_advanced_search_no_hits
-    query = Query.lookup_and_save(:Name,
-                                  name: "Don't know",
-                                  user: "myself",
-                                  content: "Long pink stem and small pink cap",
-                                  user_where: "Eastern Oklahoma")
+    query = Query.lookup_and_save(
+      :Name, search_name: "Don't know",
+             search_user: "myself",
+             search_content: "Long pink stem and small pink cap",
+             search_where: "Eastern Oklahoma"
+    )
 
     login
     get(:index,
@@ -136,11 +137,12 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def test_index_advanced_search_with_deleted_query
-    query = Query.lookup_and_save(:Name,
-                                  name: "Don't know",
-                                  user: "myself",
-                                  content: "Long pink stem and small pink cap",
-                                  user_where: "Eastern Oklahoma")
+    query = Query.lookup_and_save(
+      :Name, search_name: "Don't know",
+             search_user: "myself",
+             search_content: "Long pink stem and small pink cap",
+             search_where: "Eastern Oklahoma"
+    )
     params = @controller.query_params(query).merge(advanced_search: true)
     query.record.delete
 

--- a/test/controllers/observations_controller/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller/observations_controller_index_test.rb
@@ -99,7 +99,8 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
     login
     get(:index,
-        params: { name: name, user_where: location, advanced_search: true })
+        params: { search_name: name, search_where: location,
+                  advanced_search: true })
 
     assert_response(:success)
     assert_results(count: expected_hits.count)
@@ -109,7 +110,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
   def test_index_advanced_search_name_one_hit
     obs = observations(:strobilurus_diminutivus_obs)
     search_string = obs.text_name
-    query = Query.lookup_and_save(:Observation, name: search_string)
+    query = Query.lookup_and_save(:Observation, search_name: search_string)
     assert(query.results.one?,
            "Test needs a string that has exactly one hit")
 
@@ -122,11 +123,12 @@ class ObservationsControllerIndexTest < FunctionalTestCase
   end
 
   def test_index_advanced_search_no_hits
-    query = Query.lookup_and_save(:Observation,
-                                  name: "Don't know",
-                                  user: "myself",
-                                  content: "Long pink stem and small pink cap",
-                                  user_where: "Eastern Oklahoma")
+    query = Query.lookup_and_save(
+      :Observation, search_name: "Don't know",
+                    search_user: "myself",
+                    search_content: "Long pink stem and small pink cap",
+                    search_where: "Eastern Oklahoma"
+    )
 
     login
     get(:index,
@@ -143,8 +145,8 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     get(:index,
         params: {
           advanced_search: true,
-          name: "Fungi",
-          user_where: "String in notes"
+          search_name: "Fungi",
+          search_where: "String in notes"
           # Deliberately omit search_location_notes: 1
         })
 
@@ -165,8 +167,8 @@ class ObservationsControllerIndexTest < FunctionalTestCase
       :index,
       params: {
         advanced_search: true,
-        name: "Fungi",
-        user_where: '"String in notes"',
+        search_name: "Fungi",
+        search_where: '"String in notes"',
         search_location_notes: 1
       }
     )
@@ -195,8 +197,8 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     get(:index,
         params: {
           advanced_search: true,
-          name: "Fungi",
-          user_where: "String in notes"
+          search_name: "Fungi",
+          search_where: "String in notes"
           # Deliberately omit search_location_notes: 1
         })
 
@@ -225,8 +227,8 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     get(:index,
         params: {
           advanced_search: true,
-          name: "Fungi",
-          user_where: '"String in notes"',
+          search_name: "Fungi",
+          search_where: '"String in notes"',
           search_location_notes: 1
         })
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -50,7 +50,7 @@ class SearchControllerTest < FunctionalTestCase
       search: {
         model: "observation",
         search_user: users(:rolf).unique_text_name,
-        user_id: users(:rolf).id
+        # user_id: users(:rolf).id
       },
       content_filter: {
         with_images: "",
@@ -62,6 +62,7 @@ class SearchControllerTest < FunctionalTestCase
     }
     get(:advanced, params: params)
     query = QueryRecord.last.query
+    assert_redirected_to(observations_path(q: QueryRecord.last.id.alphabetize))
     assert_true(query.num_results.positive?)
     assert_equal("", query.params[:with_images])
     assert_true(query.params[:with_specimen])

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -11,11 +11,11 @@ class SearchControllerTest < FunctionalTestCase
         :advanced,
         params: {
           search: {
-            name: "Don't know",
-            user: "myself",
+            search_name: "Don't know",
+            search_user: "myself",
             model: model.name.underscore,
-            content: "Long pink stem and small pink cap",
-            user_where: "Eastern Oklahoma"
+            search_content: "Long pink stem and small pink cap",
+            search_where: "Eastern Oklahoma"
           },
           commit: "Search"
         }
@@ -49,7 +49,7 @@ class SearchControllerTest < FunctionalTestCase
     params = {
       search: {
         model: "observation",
-        user: users(:rolf).unique_text_name,
+        search_user: users(:rolf).unique_text_name,
         user_id: users(:rolf).id
       },
       content_filter: {

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -50,7 +50,7 @@ class SearchControllerTest < FunctionalTestCase
       search: {
         model: "observation",
         search_user: users(:rolf).unique_text_name,
-        # user_id: users(:rolf).id
+        search_user_id: users(:rolf).id
       },
       content_filter: {
         with_images: "",
@@ -62,7 +62,8 @@ class SearchControllerTest < FunctionalTestCase
     }
     get(:advanced, params: params)
     query = QueryRecord.last.query
-    assert_redirected_to(observations_path(q: QueryRecord.last.id.alphabetize))
+    q = QueryRecord.last.id.alphabetize
+    assert_redirected_to(root_path(advanced_search: 1, q:))
     assert_true(query.num_results.positive?)
     assert_equal("", query.params[:with_images])
     assert_true(query.params[:with_specimen])

--- a/test/integration/capybara/advanced_search_integration_test.rb
+++ b/test/integration/capybara/advanced_search_integration_test.rb
@@ -10,10 +10,10 @@ class AdvancedSearchIntegrationTest < CapybaraIntegrationTestCase
 
     visit(search_advanced_path)
     assert_match(:app_advanced_search.l, page.title, "Wrong page")
-    assert_field("search_name")
-    assert_field("search_user_where")
-    fill_in("search_name", with: names(:fungi).text_name)
-    fill_in("search_user_where",
+    assert_field("search_search_name")
+    assert_field("search_search_where")
+    fill_in("search_search_name", with: names(:fungi).text_name)
+    fill_in("search_search_where",
             with: locations(:falmouth).display_name)
     assert_checked_field("content_filter_with_images_")
     assert_checked_field("content_filter_with_specimen_")


### PR DESCRIPTION
Two of these params were ambiguously named and confusable with regular Query param names, whereas they behave very differently. This makes Query's search param names unambiguous.

```ruby
:name        -> :search_name
:user        -> :search_user
:user_where  -> :search_where
:content     -> :search_content 
```