### PR TITLE
`Query::Filter` — Move `.t` from definitions to callers

### DIFF
--- a/app/classes/query/filter/clade.rb
+++ b/app/classes/query/filter/clade.rb
@@ -7,7 +7,7 @@ class Query::Filter
     def initialize
       super(
         sym: :clade,
-        name: :CLADE.t,
+        name: :CLADE,
         models: [Observation, Name]
       )
     end

--- a/app/classes/query/filter/lichen.rb
+++ b/app/classes/query/filter/lichen.rb
@@ -6,7 +6,7 @@ class Query::Filter
     def initialize
       super(
         sym: :lichen,
-        name: :LICHEN.t,
+        name: :LICHEN,
         models: [Observation, Name],
         on_vals: %w[no yes],
         prefs_vals: %w[no yes],

--- a/app/classes/query/filter/region.rb
+++ b/app/classes/query/filter/region.rb
@@ -7,7 +7,7 @@ class Query::Filter
     def initialize
       super(
         sym: :region,
-        name: :REGION.t,
+        name: :REGION,
         models: [Observation, Location]
       )
     end

--- a/app/classes/query/filter/with_images.rb
+++ b/app/classes/query/filter/with_images.rb
@@ -5,7 +5,7 @@ class Query::Filter
     def initialize
       super(
         sym: :with_images,
-        name: :IMAGES.t,
+        name: :IMAGES,
         models: [Observation],
         on_vals: %w[yes no],
         prefs_vals: ["yes"],

--- a/app/classes/query/filter/with_specimen.rb
+++ b/app/classes/query/filter/with_specimen.rb
@@ -5,7 +5,7 @@ class Query::Filter
     def initialize
       super(
         sym: :with_specimen,
-        name: :SPECIMEN.t,
+        name: :SPECIMEN,
         models: [Observation],
         on_vals: %w[yes no],
         prefs_vals: ["yes"],

--- a/app/views/controllers/search/_advanced_search_filter_text_field.html.erb
+++ b/app/views/controllers/search/_advanced_search_filter_text_field.html.erb
@@ -7,7 +7,7 @@ autocompleter = case filter.sym.to_s
                 end
 between = help_note(:span, :"advanced_search_filter_#{filter.sym}".t)
 autocompleter_field(
-  form: f, field: filter.sym, type: autocompleter, label: "#{filter.name}:",
+  form: f, field: filter.sym, type: autocompleter, label: "#{filter.name.t}:",
   between: between, value: @filter_defaults[filter.sym], separator: " OR "
 )
 %>


### PR DESCRIPTION
I think `.t` should only be called in front-end code? Anyway this should get rid of the error that happens recently when I try to instantiate a Query in the console. 

```
app/classes/query/filter/with_images.rb:8:in `initialize': private method `t' called for an instance of Symbol (NoMethodError)

        name: :IMAGES.t,
                     ^^
	from app/classes/query/filter.rb:46:in `new'
	from app/classes/query/filter.rb:46:in `all'
	from app/classes/query/filter.rb:60:in `by_model'
	from app/classes/query/params/filters.rb:12:in `content_filter_parameter_declarations'
	from app/classes/query/observations.rb:62:in `parameter_declarations'
	from app/classes/query/base.rb:26:in `parameter_declarations'
	from app/classes/query/modules/validation.rb:10:in `validate_params'
	from app/classes/query.rb:282:in `new'
	from app/classes/query/modules/validation.rb:109:in `validate_subquery'
	from app/classes/query/modules/validation.rb:85:in `validate_hash_param'
	from app/classes/query/modules/validation.rb:64:in `scalar_validate'
	from app/classes/query/modules/validation.rb:34:in `validate_value'
	from app/classes/query/modules/validation.rb:13:in `block in validate_params'
	from app/classes/query/modules/validation.rb:11:in `each'
	from app/classes/query/modules/validation.rb:11:in `validate_params'
	from app/classes/query.rb:282:in `new'
	... 2 levels...
```