### PR TITLE
Query validation of nested params - `deep_symbolize_keys`

### DIFF
--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -5,7 +5,7 @@ module Query::Modules::Validation
   attr_accessor :params, :params_cache, :subqueries
 
   def validate_params
-    old_params = @params.dup&.compact&.symbolize_keys || {}
+    old_params = @params.dup&.compact&.deep_symbolize_keys || {}
     new_params = {}
     permitted_params = parameter_declarations.slice(*old_params.keys)
     permitted_params.each do |param, param_type|

--- a/test/controllers/observations/maps_controller_test.rb
+++ b/test/controllers/observations/maps_controller_test.rb
@@ -10,6 +10,14 @@ module Observations
       assert_template(:index)
     end
 
+    # Tests validation of nested params passed into Query
+    def test_map_obs_by_pattern_user_in_box
+      login
+      pattern = "user%3A123+north%3A42.3201+south%3A36.8186+" \
+                "east%3A-119.19399999999999+west%3A-123.27900000000001"
+      get(:index, params: { pattern: })
+    end
+
     # NOTE: the assigns(:observations) are Mappable::MinimalObservations!
     def test_map_observation_hidden_gps
       obs = observations(:unknown_with_lat_lng)


### PR DESCRIPTION
Most callers of Query send a hash with symbolized keys, but PatternSearch sends them through the url, and the nested keys seem to become strings. 

I may figure out why someday, but the safest thing is to have Query's validator just `deep_symbolize_keys` from the top.  Adds a test.