### PR TITLE
Disambiguate Query "ids" conditions

### DIFF
--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -19,7 +19,7 @@ class Query::Articles < Query::Base
   def initialize_flavor
     add_sort_order_to_title
     add_owner_and_time_stamp_conditions
-    add_ids_condition
+    add_id_in_set_condition
     add_search_condition("articles.title", params[:title_has])
     add_search_condition("articles.body", params[:body_has])
     super

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -23,7 +23,7 @@ class Query::CollectionNumbers < Query::Base
   def initialize_flavor
     add_sort_order_to_title
     add_owner_and_time_stamp_conditions
-    add_ids_condition
+    add_id_in_set_condition
     add_collection_number_conditions
     initialize_observations_parameter
     add_pattern_condition

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -24,7 +24,7 @@ class Query::Comments < Query::Base
   def initialize_flavor
     add_sort_order_to_title
     add_owner_and_time_stamp_conditions
-    add_ids_condition
+    add_id_in_set_condition
     add_for_user_condition
     add_for_target_condition
     add_pattern_condition

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -20,10 +20,10 @@ class Query::ExternalLinks < Query::Base
   def initialize_flavor
     add_sort_order_to_title
     add_owner_and_time_stamp_conditions
-    add_ids_condition
+    add_id_in_set_condition
     initialize_observations_parameter(:external_links)
     ids = lookup_external_sites_by_name(params[:external_sites])
-    add_id_condition("external_links.external_site_id", ids)
+    add_key_condition("external_links.external_site_id", ids)
     add_search_condition("external_links.url", params[:url])
     super
   end

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -23,7 +23,7 @@ class Query::ExternalLinks < Query::Base
     add_id_in_set_condition
     initialize_observations_parameter(:external_links)
     ids = lookup_external_sites_by_name(params[:external_sites])
-    add_key_condition("external_links.external_site_id", ids)
+    add_association_condition("external_links.external_site_id", ids)
     add_search_condition("external_links.url", params[:url])
     super
   end

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -14,7 +14,7 @@ class Query::ExternalSites < Query::Base
 
   def initialize_flavor
     add_sort_order_to_title
-    add_ids_condition
+    add_id_in_set_condition
     add_search_condition("external_sites.name", params[:name])
     super
   end

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -28,7 +28,7 @@ class Query::Herbaria < Query::Base
     add_search_condition("herbaria.name", params[:name])
     add_search_condition("herbaria.description", params[:description])
     add_search_condition("herbaria.mailing_address", params[:address])
-    add_ids_condition
+    add_id_in_set_condition
     add_pattern_condition
     add_nonpersonal_condition
     super

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -12,8 +12,6 @@ class Query::HerbariumRecords < Query::Base
       ids: [HerbariumRecord],
       by_users: [User],
       herbaria: [Herbarium],
-      herbarium: Herbarium,
-      observation: Observation,
       observations: [Observation],
       pattern: :string,
       with_notes: :boolean,
@@ -40,17 +38,7 @@ class Query::HerbariumRecords < Query::Base
   def initialize_association_parameters
     add_in_herbarium_condition
     initialize_herbaria_parameter([])
-    add_for_observation_condition
     initialize_observations_parameter
-  end
-
-  def add_in_herbarium_condition
-    return if params[:herbarium].blank?
-
-    herbarium = find_cached_parameter_instance(Herbarium, :herbarium)
-    @title_tag = :query_title_in_herbarium
-    @title_args[:herbarium] = herbarium.name
-    where << "herbarium_records.herbarium_id = '#{herbarium.id}'"
   end
 
   def initialize_boolean_parameters

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -36,7 +36,6 @@ class Query::HerbariumRecords < Query::Base
   end
 
   def initialize_association_parameters
-    add_in_herbarium_condition
     initialize_herbaria_parameter([])
     initialize_observations_parameter
   end

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -28,7 +28,7 @@ class Query::HerbariumRecords < Query::Base
   def initialize_flavor
     add_sort_order_to_title
     add_owner_and_time_stamp_conditions
-    add_ids_condition
+    add_id_in_set_condition
     add_pattern_condition
     initialize_association_parameters
     initialize_boolean_parameters

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -124,7 +124,7 @@ class Query::Images < Query::Base
       :species_list_observations,
       [:observation_images, :observations, :species_list_observations]
     )
-    add_key_condition("images.license_id", params[:license])
+    add_association_condition("images.license_id", params[:license])
   end
 
   def initialize_image_vote_parameters

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -49,7 +49,7 @@ class Query::Images < Query::Base
   end
 
   def initialize_image_parameters
-    add_ids_condition
+    add_id_in_set_condition
     add_owner_and_time_stamp_conditions
     add_date_condition("images.when", params[:date])
     initialize_img_notes_parameters
@@ -124,7 +124,7 @@ class Query::Images < Query::Base
       :species_list_observations,
       [:observation_images, :observations, :species_list_observations]
     )
-    add_id_condition("images.license_id", params[:license])
+    add_key_condition("images.license_id", params[:license])
   end
 
   def initialize_image_vote_parameters

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -73,12 +73,12 @@ module Query::Initializers::Descriptions
 
   def initialize_desc_project_parameter(type)
     ids = lookup_projects_by_name(params[:desc_project])
-    add_key_condition("#{type}_descriptions.project_id", ids)
+    add_association_condition("#{type}_descriptions.project_id", ids)
   end
 
   def initialize_desc_creator_parameter(type)
     ids = lookup_users_by_name(params[:desc_creator])
-    add_key_condition("#{type}_descriptions.user_id", ids)
+    add_association_condition("#{type}_descriptions.user_id", ids)
   end
 
   def initialize_desc_content_parameter(type)

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -73,12 +73,12 @@ module Query::Initializers::Descriptions
 
   def initialize_desc_project_parameter(type)
     ids = lookup_projects_by_name(params[:desc_project])
-    add_id_condition("#{type}_descriptions.project_id", ids)
+    add_key_condition("#{type}_descriptions.project_id", ids)
   end
 
   def initialize_desc_creator_parameter(type)
     ids = lookup_users_by_name(params[:desc_creator])
-    add_id_condition("#{type}_descriptions.user_id", ids)
+    add_key_condition("#{type}_descriptions.user_id", ids)
   end
 
   def initialize_desc_content_parameter(type)

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -5,21 +5,19 @@ module Query::Initializers::Names
     return force_empty_results if irreconcilable_name_parameters?
 
     table = params[:include_all_name_proposals] ? "namings" : "observations"
-    column = "#{table}.name_id"
     ids = lookup_names_by_name(params[:names], names_parameters)
-    add_id_condition(column, ids, *joins)
+    add_key_condition("#{table}.name_id", ids, *joins)
 
     add_join(:observations, :namings) if params[:include_all_name_proposals]
     return unless params[:exclude_consensus]
 
-    column = "observations.name_id"
-    add_not_id_condition(column, ids, *joins)
+    add_key_not_condition("observations.name_id", ids, *joins)
   end
 
   # Much simpler form for non-observation-based name queries.
   def initialize_name_parameters_for_name_queries
     ids = lookup_names_by_name(params[:names], names_parameters)
-    add_id_condition("names.id", ids)
+    add_key_condition("names.id", ids)
   end
 
   # ------------------------------------------------------------------------

--- a/app/classes/query/initializers/names.rb
+++ b/app/classes/query/initializers/names.rb
@@ -6,18 +6,18 @@ module Query::Initializers::Names
 
     table = params[:include_all_name_proposals] ? "namings" : "observations"
     ids = lookup_names_by_name(params[:names], names_parameters)
-    add_key_condition("#{table}.name_id", ids, *joins)
+    add_association_condition("#{table}.name_id", ids, *joins)
 
     add_join(:observations, :namings) if params[:include_all_name_proposals]
     return unless params[:exclude_consensus]
 
-    add_key_not_condition("observations.name_id", ids, *joins)
+    add_not_associated_condition("observations.name_id", ids, *joins)
   end
 
   # Much simpler form for non-observation-based name queries.
   def initialize_name_parameters_for_name_queries
     ids = lookup_names_by_name(params[:names], names_parameters)
-    add_key_condition("names.id", ids)
+    add_association_condition("names.id", ids)
   end
 
   # ------------------------------------------------------------------------

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -23,12 +23,12 @@ class Query::LocationDescriptions < Query::Base
 
   def initialize_flavor
     add_sort_order_to_title
-    add_ids_condition
+    add_id_in_set_condition
     add_owner_and_time_stamp_conditions
     add_desc_by_author_condition(:location)
     add_desc_by_editor_condition(:location)
     ids = lookup_locations_by_name(params[:locations])
-    add_id_condition("location_descriptions.location_id", ids)
+    add_key_condition("location_descriptions.location_id", ids)
     initialize_description_public_parameter(:location)
     add_subquery_condition(:location_query, :locations)
     super

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -28,7 +28,7 @@ class Query::LocationDescriptions < Query::Base
     add_desc_by_author_condition(:location)
     add_desc_by_editor_condition(:location)
     ids = lookup_locations_by_name(params[:locations])
-    add_key_condition("location_descriptions.location_id", ids)
+    add_association_condition("location_descriptions.location_id", ids)
     initialize_description_public_parameter(:location)
     add_subquery_condition(:location_query, :locations)
     super

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -55,7 +55,7 @@ class Query::Locations < Query::Base
   end
 
   def initialize_locations_only_parameters
-    add_ids_condition
+    add_id_in_set_condition
     add_owner_and_time_stamp_conditions
     add_by_editor_condition
     initialize_location_notes_parameters

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -4,7 +4,9 @@
 module Query::Modules::Associations
   def initialize_users_parameter(table = model.table_name)
     ids = lookup_users_by_name(params[:by_users])
-    add_key_condition("#{table}.user_id", ids, title_method: :set_by_user_title)
+    add_association_condition(
+      "#{table}.user_id", ids, title_method: :set_by_user_title
+    )
   end
 
   def set_by_user_title
@@ -31,13 +33,15 @@ module Query::Modules::Associations
     joins = [:observations, :observation_herbarium_records, :herbarium_records]
   )
     ids = lookup_herbaria_by_name(params[:herbaria])
-    add_key_condition("herbarium_records.herbarium_id", ids, *joins)
+    add_association_condition("herbarium_records.herbarium_id", ids, *joins)
   end
 
   def initialize_herbarium_records_parameter
     ids = lookup_herbarium_records_by_name(params[:herbarium_records])
-    add_key_condition("observation_herbarium_records.herbarium_record_id", ids,
-                      :observations, :observation_herbarium_records)
+    add_association_condition(
+      "observation_herbarium_records.herbarium_record_id", ids,
+      :observations, :observation_herbarium_records
+    )
   end
 
   # This adds conditions both matching location ids, and where strings.
@@ -75,8 +79,8 @@ module Query::Modules::Associations
   def initialize_observations_parameter(
     table = :"observation_#{model.table_name}", joins = [table]
   )
-    add_key_condition("#{table}.observation_id", params[:observations],
-                      *joins, title_method: :set_for_observation_title)
+    add_association_condition("#{table}.observation_id", params[:observations],
+                              *joins, title_method: :set_for_observation_title)
   end
 
   # Possible issue: the second arg below is the param name.
@@ -92,8 +96,8 @@ module Query::Modules::Associations
   def initialize_projects_parameter(table = :project_observations,
                                     joins = [:observations, table])
     ids = lookup_projects_by_name(params[:projects])
-    add_key_condition("#{table}.project_id", ids,
-                      *joins, title_method: :set_for_project_title)
+    add_association_condition("#{table}.project_id", ids,
+                              *joins, title_method: :set_for_project_title)
   end
 
   def set_for_project_title
@@ -107,8 +111,8 @@ module Query::Modules::Associations
     table = :species_list_observations, joins = [:observations, table]
   )
     ids = lookup_species_lists_by_name(params[:species_lists])
-    add_key_condition("#{table}.species_list_id", ids,
-                      *joins, title_method: :set_in_species_list_title)
+    add_association_condition("#{table}.species_list_id", ids,
+                              *joins, title_method: :set_in_species_list_title)
   end
 
   def set_in_species_list_title

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -33,7 +33,15 @@ module Query::Modules::Associations
     joins = [:observations, :observation_herbarium_records, :herbarium_records]
   )
     ids = lookup_herbaria_by_name(params[:herbaria])
-    add_association_condition("herbarium_records.herbarium_id", ids, *joins)
+    add_association_condition("herbarium_records.herbarium_id", ids, *joins,
+                              title_method: :set_herbarium_title)
+  end
+
+  def set_herbarium_title
+    herbarium = find_cached_parameter_instance(Herbarium, :herbarium)
+    @title_tag = :query_title_in_herbarium
+    @title_args[:herbarium] = herbarium.name
+    herbarium
   end
 
   def initialize_herbarium_records_parameter

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -72,15 +72,11 @@ module Query::Modules::Associations
     where << "observations.is_collection_location IS TRUE"
   end
 
-  # TO BE REMOVED
-  def add_for_observation_condition(
+  def initialize_observations_parameter(
     table = :"observation_#{model.table_name}", joins = [table]
   )
-    return if params[:observation].blank?
-
-    obs = set_for_observation_title
-    where << "#{table}.observation_id = '#{obs.id}'"
-    add_join(*joins)
+    add_id_condition("#{table}.observation_id", params[:observations],
+                     *joins, title_method: :set_for_observation_title)
   end
 
   # Possible issue: the second arg below is the param name.
@@ -91,13 +87,6 @@ module Query::Modules::Associations
     @title_tag = :query_title_for_observation
     @title_args[:observation] = obs.unique_format_name
     obs
-  end
-
-  def initialize_observations_parameter(
-    table = :"observation_#{model.table_name}", joins = [table]
-  )
-    add_id_condition("#{table}.observation_id", params[:observations],
-                     *joins, title_method: :set_for_observation_title)
   end
 
   def initialize_projects_parameter(table = :project_observations,

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -4,7 +4,7 @@
 module Query::Modules::Associations
   def initialize_users_parameter(table = model.table_name)
     ids = lookup_users_by_name(params[:by_users])
-    add_id_condition("#{table}.user_id", ids, title_method: :set_by_user_title)
+    add_key_condition("#{table}.user_id", ids, title_method: :set_by_user_title)
   end
 
   def set_by_user_title
@@ -31,13 +31,13 @@ module Query::Modules::Associations
     joins = [:observations, :observation_herbarium_records, :herbarium_records]
   )
     ids = lookup_herbaria_by_name(params[:herbaria])
-    add_id_condition("herbarium_records.herbarium_id", ids, *joins)
+    add_key_condition("herbarium_records.herbarium_id", ids, *joins)
   end
 
   def initialize_herbarium_records_parameter
     ids = lookup_herbarium_records_by_name(params[:herbarium_records])
-    add_id_condition("observation_herbarium_records.herbarium_record_id", ids,
-                     :observations, :observation_herbarium_records)
+    add_key_condition("observation_herbarium_records.herbarium_record_id", ids,
+                      :observations, :observation_herbarium_records)
   end
 
   # This adds conditions both matching location ids, and where strings.
@@ -75,8 +75,8 @@ module Query::Modules::Associations
   def initialize_observations_parameter(
     table = :"observation_#{model.table_name}", joins = [table]
   )
-    add_id_condition("#{table}.observation_id", params[:observations],
-                     *joins, title_method: :set_for_observation_title)
+    add_key_condition("#{table}.observation_id", params[:observations],
+                      *joins, title_method: :set_for_observation_title)
   end
 
   # Possible issue: the second arg below is the param name.
@@ -92,8 +92,8 @@ module Query::Modules::Associations
   def initialize_projects_parameter(table = :project_observations,
                                     joins = [:observations, table])
     ids = lookup_projects_by_name(params[:projects])
-    add_id_condition("#{table}.project_id", ids,
-                     *joins, title_method: :set_for_project_title)
+    add_key_condition("#{table}.project_id", ids,
+                      *joins, title_method: :set_for_project_title)
   end
 
   def set_for_project_title
@@ -107,8 +107,8 @@ module Query::Modules::Associations
     table = :species_list_observations, joins = [:observations, table]
   )
     ids = lookup_species_lists_by_name(params[:species_lists])
-    add_id_condition("#{table}.species_list_id", ids,
-                     *joins, title_method: :set_in_species_list_title)
+    add_key_condition("#{table}.species_list_id", ids,
+                      *joins, title_method: :set_in_species_list_title)
   end
 
   def set_in_species_list_title

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -84,34 +84,33 @@ module Query::Modules::Conditions
     add_joins(*)
   end
 
-  # Generalized so the param can be :obs_ids or :desc_ids
-  def add_ids_condition(table = model.table_name, ids = :ids)
+  # The method that all classes use for queries of their own ids.
+  # Can accept an empty array of ids and respond accordingly.
+  def add_id_in_set_condition(table = model.table_name, ids = :ids)
     return if params[ids].nil? # [] is valid
 
     set = clean_id_set(params[ids])
     @where << "#{table}.id IN (#{set})"
-    @order = "FIND_IN_SET(#{table}.id,'#{set}') ASC"
+    @order = "FIND_IN_SET(#{table}.id,'#{set}') ASC" unless params[:order]
 
     @title_tag = :query_title_in_set.t(type: table.singularize.to_sym)
-    # @title_args[:by] = :query_sorted_by.t(field: :original_name)
-    # @title_args[:descriptions] =
-    #   :query_title_in_set.t(type: table.singularize.to_sym)
   end
 
-  def add_id_condition(col, ids, *, title_method: nil)
+  # table_col = foreign key of an association, e.g. `observations.location_id`
+  def add_key_condition(table_col, ids, *, title_method: nil)
     return if ids.empty?
 
     if ids.size == 1
       send(title_method) if title_method && ids.first.present?
-      @where << "#{col} = '#{ids.first}'"
+      @where << "#{table_col} = '#{ids.first}'"
     else
       set = clean_id_set(ids) # this produces a joined string!
-      @where << "#{col} IN (#{set})"
+      @where << "#{table_col} IN (#{set})"
     end
     add_joins(*)
   end
 
-  def add_not_id_condition(col, ids, *)
+  def add_key_not_condition(col, ids, *)
     return if ids.empty?
 
     set = clean_id_set(ids)

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -97,7 +97,7 @@ module Query::Modules::Conditions
   end
 
   # table_col = foreign key of an association, e.g. `observations.location_id`
-  def add_key_condition(table_col, ids, *, title_method: nil)
+  def add_association_condition(table_col, ids, *, title_method: nil)
     return if ids.empty?
 
     if ids.size == 1
@@ -110,7 +110,7 @@ module Query::Modules::Conditions
     add_joins(*)
   end
 
-  def add_key_not_condition(col, ids, *)
+  def add_not_associated_condition(col, ids, *)
     return if ids.empty?
 
     set = clean_id_set(ids)

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -34,7 +34,7 @@ class Query::NameDescriptions < Query::Base
     add_desc_by_author_condition(:name)
     add_desc_by_editor_condition(:name)
     ids = lookup_names_by_name(params[:names])
-    add_key_condition("name_descriptions.name_id", ids)
+    add_association_condition("name_descriptions.name_id", ids)
     initialize_description_public_parameter(:name)
     initialize_name_descriptions_parameters
     add_subquery_condition(:name_query, :names)

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -29,12 +29,12 @@ class Query::NameDescriptions < Query::Base
 
   def initialize_flavor
     add_sort_order_to_title
-    add_ids_condition
+    add_id_in_set_condition
     add_owner_and_time_stamp_conditions
     add_desc_by_author_condition(:name)
     add_desc_by_editor_condition(:name)
     ids = lookup_names_by_name(params[:names])
-    add_id_condition("name_descriptions.name_id", ids)
+    add_key_condition("name_descriptions.name_id", ids)
     initialize_description_public_parameter(:name)
     initialize_name_descriptions_parameters
     add_subquery_condition(:name_query, :names)

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -146,7 +146,9 @@ class Query::Names < Query::Base
   end
 
   def initialize_name_association_parameters
-    add_key_condition("observations.id", params[:observations], :observations)
+    add_association_condition(
+      "observations.id", params[:observations], :observations
+    )
     initialize_locations_parameter(
       :observations, params[:locations], :observations
     )

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -68,7 +68,7 @@ class Query::Names < Query::Base
   end
 
   def initialize_names_only_parameters
-    add_ids_condition
+    add_id_in_set_condition
     add_owner_and_time_stamp_conditions
     add_by_editor_condition
     initialize_name_comments_and_notes_parameters
@@ -146,7 +146,7 @@ class Query::Names < Query::Base
   end
 
   def initialize_name_association_parameters
-    add_id_condition("observations.id", params[:observations], :observations)
+    add_key_condition("observations.id", params[:observations], :observations)
     initialize_locations_parameter(
       :observations, params[:locations], :observations
     )

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -294,8 +294,8 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
   def initialize_project_lists_parameter
     ids = lookup_lists_for_projects_by_name(params[:project_lists])
-    add_key_condition("species_list_observations.species_list_id", ids,
-                      :observations, :species_list_observations)
+    add_association_condition("species_list_observations.species_list_id", ids,
+                              :observations, :species_list_observations)
   end
 
   def initialize_field_slips_parameter
@@ -303,7 +303,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
     add_join(:field_slips)
     ids = lookup_field_slips_by_name(params[:field_slips])
-    add_key_condition("field_slips.id", ids, :observations)
+    add_association_condition("field_slips.id", ids, :observations)
   end
 
   def add_join_to_names

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -78,7 +78,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
   def initialize_obs_basic_parameters
     ids_param = model == Observation ? :ids : :obs_ids
-    add_ids_condition("observations", ids_param)
+    add_id_in_set_condition("observations", ids_param)
     add_owner_and_time_stamp_conditions("observations")
     initialize_obs_date_parameter(:date)
   end
@@ -106,7 +106,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
   # This is just to allow the additional location conditions
   # to be added FOR coerced queries.
-  def add_ids_condition(table = model.table_name, ids = :ids)
+  def add_id_in_set_condition(table = model.table_name, ids = :ids)
     super
     return if model != Observation
 
@@ -293,11 +293,9 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
   end
 
   def initialize_project_lists_parameter
-    add_id_condition(
-      "species_list_observations.species_list_id",
-      lookup_lists_for_projects_by_name(params[:project_lists]),
-      :observations, :species_list_observations
-    )
+    ids = lookup_lists_for_projects_by_name(params[:project_lists])
+    add_key_condition("species_list_observations.species_list_id", ids,
+                      :observations, :species_list_observations)
   end
 
   def initialize_field_slips_parameter
@@ -305,7 +303,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
     add_join(:field_slips)
     ids = lookup_field_slips_by_name(params[:field_slips])
-    add_id_condition("field_slips.id", ids, :observations)
+    add_key_condition("field_slips.id", ids, :observations)
   end
 
   def add_join_to_names

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -31,7 +31,7 @@ class Query::Projects < Query::Base
     initialize_association_parameters
     initialize_boolean_parameters
     initialize_search_parameters
-    add_ids_condition
+    add_id_in_set_condition
     add_pattern_condition
     super
   end
@@ -43,8 +43,9 @@ class Query::Projects < Query::Base
     # add_join(:"user_group_users.members")
     # where << "user_group_users.user_id = '#{params[:member]}'"
     ids = lookup_users_by_name(params[:members])
-    add_id_condition("user_group_users.user_id", ids,
-                     :"user_group_users.members")
+    add_key_condition(
+      "user_group_users.user_id", ids, :"user_group_users.members"
+    )
   end
 
   def initialize_boolean_parameters

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -43,7 +43,7 @@ class Query::Projects < Query::Base
     # add_join(:"user_group_users.members")
     # where << "user_group_users.user_id = '#{params[:member]}'"
     ids = lookup_users_by_name(params[:members])
-    add_key_condition(
+    add_association_condition(
       "user_group_users.user_id", ids, :"user_group_users.members"
     )
   end

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -21,7 +21,7 @@ class Query::RssLogs < Query::Base
     add_sort_order_to_title
     add_time_condition("rss_logs.updated_at", params[:updated_at])
     initialize_type_parameter
-    add_ids_condition
+    add_id_in_set_condition
     initialize_content_filters_for_rss_log(Observation)
     initialize_content_filters_for_rss_log(Location)
     super

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -31,7 +31,7 @@ class Query::Sequences < Query::Base
     # some sequences because of this.
     add_owner_and_time_stamp_conditions
     add_pattern_condition
-    add_ids_condition
+    add_id_in_set_condition
     initialize_observations_parameter(:sequences)
     add_subquery_condition(:observation_query, :observations)
     initialize_exact_match_parameters

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -30,7 +30,7 @@ class Query::SpeciesLists < Query::Base
     add_owner_and_time_stamp_conditions
     add_date_condition("species_lists.when", params[:date])
     add_pattern_condition
-    add_ids_condition
+    add_id_in_set_condition
     add_subquery_condition(:observation_query, :species_list_observations,
                            table: :species_list_observations,
                            col: :observation_id)

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -19,7 +19,7 @@ class Query::Users < Query::Base
     add_sort_order_to_title
     add_time_condition("users.created_at", params[:created_at])
     add_time_condition("users.updated_at", params[:updated_at])
-    add_ids_condition
+    add_id_in_set_condition
     add_pattern_condition
     add_contribution_condition
     super

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -29,7 +29,7 @@ class HerbariumRecordsController < ApplicationController
   def herbarium
     store_location
     query = create_query(:HerbariumRecord,
-                         herbarium: params[:herbarium].to_s,
+                         herbaria: params[:herbarium].to_s,
                          by: :herbarium_label)
     [query, { always_index: true }]
   end
@@ -38,7 +38,7 @@ class HerbariumRecordsController < ApplicationController
     @observation = Observation.find(params[:observation])
     store_location
     query = create_query(:HerbariumRecord,
-                         observation: params[:observation].to_s,
+                         observations: params[:observation].to_s,
                          by: :herbarium_label)
     [query, { always_index: true }]
   end

--- a/test/classes/query/herbarium_records_test.rb
+++ b/test/classes/query/herbarium_records_test.rb
@@ -15,13 +15,13 @@ class Query::HerbariumRecordsTest < UnitTestCase
   def test_herbarium_record_for_observation
     obs = observations(:coprinus_comatus_obs)
     expects = HerbariumRecord.index_order.for_observation(obs)
-    assert_query(expects, :HerbariumRecord, observation: obs.id)
+    assert_query(expects, :HerbariumRecord, observations: obs.id)
   end
 
   def test_herbarium_record_in_herbarium
     nybg = herbaria(:nybg_herbarium)
     expects = HerbariumRecord.index_order.where(herbarium: nybg)
-    assert_query(expects, :HerbariumRecord, herbarium: nybg.id)
+    assert_query(expects, :HerbariumRecord, herbaria: nybg.id)
   end
 
   def test_herbarium_record_pattern_search_notes
@@ -30,8 +30,7 @@ class Query::HerbariumRecordsTest < UnitTestCase
   end
 
   def test_herbarium_record_pattern_search_not_findable
-    assert_query([], :HerbariumRecord,
-                 pattern: "no herbarium record has this")
+    assert_query([], :HerbariumRecord, pattern: "no herbarium record has this")
   end
 
   def test_herbarium_record_pattern_search_initial_det


### PR DESCRIPTION
One is a query of ids of the current model.
e.g. `names.id`
The other is a query of the ids of an associated model, on the "foreign key".
e.g. `observations.name_id`.
___
Cleans up some stuff missed in previous Query PRs.