### PR TITLE
Script to update query records

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -287,6 +287,10 @@ class Query
 
   # Delegate all these to Query::Base class.
 
+  def self.rebuild_from_description(*)
+    Query::Base.rebuild_from_description(*)
+  end
+
   def self.deserialize(*)
     Query::Base.deserialize(*)
   end

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -210,7 +210,7 @@
 #
 #  == Class Methods
 #  lookup::             Instantiate Query of given model, flavor and params.
-#  deserialize::        Instantiate Query described by a string.
+#  rebuild_from_description:: Instantiate Query described by a string.
 #
 #  ==Instance Methods
 #  serialize::          Returns string which describes the Query completely.
@@ -248,18 +248,6 @@
 #  paginate_ids::       Array of subset of results, just ids.
 #  clear_cache::        Clear results cache.
 #
-#  ==== Outer queries
-#  outer::              Outer Query (if nested).
-#  outer?::             Is this Query nested?
-#  get_outer_current_id::  Get outer Query's current id.
-#  outer_first::        Call +first+ on outer Query.
-#  outer_prev::         Call +prev+ on outer Query.
-#  outer_next::         Call +next+ on outer Query.
-#  outer_last::         Call +last+ on outer Query.
-#  new_inner::          Create new inner Query based the given outer Query.
-#  new_inner_if_necessary::
-#                       Create new inner Query if the outer Query has changed.
-#
 #  == Internal Variables
 #
 #  ==== Instance Variables
@@ -274,6 +262,8 @@
 #  @params_cache::      Hash: where instances passed in via params are cached.
 #
 class Query
+  include Query::Modules::ClassMethods
+
   def self.new(model, params = {}, current = nil)
     klass = "Query::#{model.to_s.pluralize}".constantize
     query = klass.new
@@ -283,40 +273,6 @@ class Query
     query.current = current if current
     # query.initialize_query # if you want the attributes right away
     query
-  end
-
-  # Delegate all these to Query::Base class.
-
-  def self.rebuild_from_description(*)
-    Query::Base.rebuild_from_description(*)
-  end
-
-  def self.deserialize(*)
-    Query::Base.deserialize(*)
-  end
-
-  def self.safe_find(*)
-    Query::Base.safe_find(*)
-  end
-
-  def self.find(*)
-    Query::Base.find(*)
-  end
-
-  def self.lookup_and_save(*)
-    Query::Base.lookup_and_save(*)
-  end
-
-  def self.lookup(*)
-    Query::Base.lookup(*)
-  end
-
-  def self.current_or_related_query(*)
-    Query::Base.current_or_related_query(*)
-  end
-
-  def self.related?(*)
-    Query::Base.related?(*)
   end
 
   def default_order

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -2,6 +2,7 @@
 
 # base class for Query searches
 class Query::Base
+  include Query::Modules::ClassMethods
   include Query::Modules::ActiveRecord
   include Query::Modules::RelatedQueries
   include Query::Modules::BoundingBox
@@ -14,7 +15,6 @@ class Query::Base
   include Query::Modules::Joining
   include Query::Modules::LookupObjects
   include Query::Modules::LowLevelQueries
-  # include Query::Modules::NestedQueries
   include Query::Modules::Ordering
   include Query::Modules::SequenceOperators
   include Query::Modules::Serialization

--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -18,7 +18,7 @@ module Query::Modules::ActiveRecord
 
     def find(id)
       record = QueryRecord.find(id)
-      query = Query.rebuild(record.description)
+      query = Query.rebuild_from_description(record.description)
       record.query = query
       query.record = record
       QueryRecord.cleanup

--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -18,7 +18,7 @@ module Query::Modules::ActiveRecord
 
     def find(id)
       record = QueryRecord.find(id)
-      query = Query.deserialize(record.description)
+      query = Query.rebuild(record.description)
       record.query = query
       query.record = record
       QueryRecord.cleanup

--- a/app/classes/query/modules/active_record.rb
+++ b/app/classes/query/modules/active_record.rb
@@ -4,53 +4,6 @@
 module Query::Modules::ActiveRecord
   attr_accessor :record
 
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
-
-  # Class methods.
-  module ClassMethods
-    def safe_find(id)
-      find(id)
-    rescue ::ActiveRecord::RecordNotFound
-      nil
-    end
-
-    def find(id)
-      record = QueryRecord.find(id)
-      query = Query.rebuild_from_description(record.description)
-      record.query = query
-      query.record = record
-      QueryRecord.cleanup
-      query
-    end
-
-    def lookup_and_save(*)
-      query = lookup(*)
-      query.record.save!
-      query
-    end
-
-    def lookup(*)
-      query = Query.new(*)
-      record = get_record(query)
-      record.query = query
-      query.record = record
-      QueryRecord.cleanup
-      query
-    end
-
-    def get_record(query)
-      desc = query.serialize
-      QueryRecord.find_by(description: desc) ||
-        QueryRecord.new(
-          description: desc,
-          updated_at: Time.zone.now,
-          access_count: 0
-        )
-    end
-  end
-
   def record
     # This errors out if @record is not set since it
     # cannot find Query.get_record.  If you copy the

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -78,12 +78,6 @@ module Query::Modules::Associations
     location
   end
 
-  def add_is_collection_location_condition_for_locations
-    return unless model == Location
-
-    where << "observations.is_collection_location IS TRUE"
-  end
-
   def initialize_observations_parameter(
     table = :"observation_#{model.table_name}", joins = [table]
   )

--- a/app/classes/query/modules/class_methods.rb
+++ b/app/classes/query/modules/class_methods.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# Methods that are available to instances as class methods, and to ::Query.
+# ::Query is a convenience delegator class so callers can access these methods.
+module Query::Modules::ClassMethods
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    # Query::Modules::ActiveRecord
+    def safe_find(id)
+      find(id)
+    rescue ::ActiveRecord::RecordNotFound
+      nil
+    end
+
+    def find(id)
+      record = QueryRecord.find(id)
+      query = Query.rebuild_from_description(record.description)
+      record.query = query
+      query.record = record
+      QueryRecord.cleanup
+      query
+    end
+
+    def lookup_and_save(*)
+      query = lookup(*)
+      query.record.save!
+      query
+    end
+
+    def lookup(*)
+      query = Query.new(*)
+      record = get_record(query)
+      record.query = query
+      query.record = record
+      QueryRecord.cleanup
+      query
+    end
+
+    def get_record(query)
+      desc = query.serialize
+      QueryRecord.find_by(description: desc) ||
+        QueryRecord.new(
+          description: desc,
+          updated_at: Time.zone.now,
+          access_count: 0
+        )
+    end
+
+    # Query::Modules::Serialization
+    #
+    # Get the model from the serialized params and instantiate new Query.
+    def rebuild_from_description(description)
+      model, params = deserialize(description)
+      ::Query.new(model, params)
+    end
+
+    def deserialize(description)
+      params = JSON.parse(description).deep_symbolize_keys
+      model = params.delete(:model)
+      [model, params]
+    end
+
+    # Query::Modules::RelatedQueries
+    #
+    # Query needs to know which joins are necessary to make these conversions
+    # work. Need to maintain RELATED_TYPES if the Query class is updated.
+    # These could be derived by snooping through each Query subclass's
+    # parameter_declarations, but that seems wasteful; there are not so many.
+    #
+    # target_model.name.to_sym: [:Association, :AnotherAssociation],
+    RELATED_QUERIES = {
+      Image: [:Image, :Observation],
+      Location: [:Location, :LocationDescription, :Name, :Observation],
+      LocationDescription: [:Location],
+      Name: [:Name, :NameDescription, :Observation],
+      NameDescription: [:Name],
+      Observation: [:Image, :Location, :Name, :Observation, :Sequence]
+    }.freeze
+
+    def related?(target, filter)
+      return false unless RELATED_QUERIES.key?(target)
+
+      RELATED_QUERIES[target].include?(filter)
+    end
+
+    def current_or_related_query(target, filter, current_query)
+      if target == filter
+        current_query
+      elsif (restored_query = restorable_query(target, current_query))
+        restored_query
+      elsif (new_query = new_query_with_subquery(target, filter, current_query))
+        new_query
+      end
+    end
+
+    # Check the query params for a relevant existing query nested within.
+    # This only checks for the key name of the right subquery. It would be
+    # more work to check for hash equality, because the nested hash has the
+    # :model param too, to be easily deserialized and rebuilt.
+    # NOTE: Our custom method `deep_find` returns an array of matches.
+    def restorable_query(target, current_query)
+      subquery_param = current_query.class.find_subquery_param_name(target)
+      restorable_query_params = current_query.params.deep_find(subquery_param)
+      return false if restorable_query_params.blank?
+
+      lookup(target, restorable_query_params.first)
+    end
+
+    # Make a new query using the current_query as the subquery. Note that this
+    # will continue nesting queries unless a restorable query is found above.
+    def new_query_with_subquery(target, filter, current_query)
+      query_class = "Query::#{target.to_s.pluralize}".constantize
+      return unless (subquery = query_class.find_subquery_param_name(filter))
+
+      params = current_query.params.compact
+      subquery_params = add_default_subquery_conditions(target, filter, params)
+
+      lookup(target, "#{subquery}": subquery_params)
+    end
+
+    def find_subquery_param_name(filter)
+      parameter_declarations.key({ subquery: filter })
+    end
+
+    def add_default_subquery_conditions(target, filter, params)
+      return params unless needs_is_collection_location(target, filter, params)
+
+      params.merge(is_collection_location: true)
+    end
+
+    def needs_is_collection_location(target, filter, params)
+      target == Location && filter == :Observation &&
+        (params[:project] || params[:species_list]) &&
+        params[:is_collection_location].blank?
+    end
+  end
+end

--- a/app/classes/query/modules/related_queries.rb
+++ b/app/classes/query/modules/related_queries.rb
@@ -23,89 +23,11 @@
 # not trying to become the current query, so they're not saved. - AN 2025-02
 #
 module Query::Modules::RelatedQueries
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
-
   def relatable?(target)
     self.class.related?(target, model.name.to_sym)
   end
 
   def subquery_of(target)
     self.class.current_or_related_query(target, model.name.to_sym, self)
-  end
-
-  module ClassMethods
-    # Query needs to know which joins are necessary to make these conversions
-    # work. Need to maintain RELATED_TYPES if the Query class is updated.
-    # These could be derived by snooping through each Query subclass's
-    # parameter_declarations, but that seems wasteful; there are not so many.
-    #
-    # target_model.name.to_sym: [:Association, :AnotherAssociation],
-    RELATED_QUERIES = {
-      Image: [:Image, :Observation],
-      Location: [:Location, :LocationDescription, :Name, :Observation],
-      LocationDescription: [:Location],
-      Name: [:Name, :NameDescription, :Observation],
-      NameDescription: [:Name],
-      Observation: [:Image, :Location, :Name, :Observation, :Sequence]
-    }.freeze
-
-    def related?(target, filter)
-      return false unless RELATED_QUERIES.key?(target)
-
-      RELATED_QUERIES[target].include?(filter)
-    end
-
-    def current_or_related_query(target, filter, current_query)
-      if target == filter
-        current_query
-      elsif (restored_query = restorable_query(target, current_query))
-        restored_query
-      elsif (new_query = new_query_with_subquery(target, filter, current_query))
-        new_query
-      end
-    end
-
-    # Check the query params for a relevant existing query nested within.
-    # This only checks for the key name of the right subquery. It would be
-    # more work to check for hash equality, because the nested hash has the
-    # :model param too, to be easily deserialized and rebuilt.
-    # NOTE: Our custom method `deep_find` returns an array of matches.
-    def restorable_query(target, current_query)
-      subquery_param = current_query.class.find_subquery_param_name(target)
-      restorable_query_params = current_query.params.deep_find(subquery_param)
-      return false if restorable_query_params.blank?
-
-      lookup(target, restorable_query_params.first)
-    end
-
-    # Make a new query using the current_query as the subquery. Note that this
-    # will continue nesting queries unless a restorable query is found above.
-    def new_query_with_subquery(target, filter, current_query)
-      query_class = "Query::#{target.to_s.pluralize}".constantize
-      return unless (subquery = query_class.find_subquery_param_name(filter))
-
-      params = current_query.params.compact
-      subquery_params = add_default_subquery_conditions(target, filter, params)
-
-      lookup(target, "#{subquery}": subquery_params)
-    end
-
-    def find_subquery_param_name(filter)
-      parameter_declarations.key({ subquery: filter })
-    end
-
-    def add_default_subquery_conditions(target, filter, params)
-      return params unless needs_is_collection_location(target, filter, params)
-
-      params.merge(is_collection_location: true)
-    end
-
-    def needs_is_collection_location(target, filter, params)
-      target == Location && filter == :Observation &&
-        (params[:project] || params[:species_list]) &&
-        params[:is_collection_location].blank?
-    end
   end
 end

--- a/app/classes/query/modules/related_queries.rb
+++ b/app/classes/query/modules/related_queries.rb
@@ -70,7 +70,7 @@ module Query::Modules::RelatedQueries
     # Check the query params for a relevant existing query nested within.
     # This only checks for the key name of the right subquery. It would be
     # more work to check for hash equality, because the nested hash has the
-    # :model param too, to be easily deserialized and reconstituted.
+    # :model param too, to be easily deserialized and rebuilt.
     # NOTE: Our custom method `deep_find` returns an array of matches.
     def restorable_query(target, current_query)
       subquery_param = current_query.class.find_subquery_param_name(target)

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -15,16 +15,24 @@ module Query::Modules::Serialization
   # the parsed hashes (in whatever order), because when a column is serialized
   # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
-    params.sort.to_h.merge(model: model.name).to_json
+    self.class.serialize
   end
 
   module ClassMethods
     # Get the model from the serialized params and instantiate new Query.
+    def rebuild(description)
+      model  = params[:model].to_sym
+      params = deserialize(description)
+      ::Query.new(model, params)
+    end
+
     def deserialize(description)
       params = JSON.parse(description).symbolize_keys
-      model  = params[:model].to_sym
       params.delete(:model)
-      ::Query.new(model, params)
+    end
+
+    def serialize
+      params.sort.to_h.merge(model: model.name).to_json
     end
   end
 end

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -20,7 +20,7 @@ module Query::Modules::Serialization
 
   module ClassMethods
     # Get the model from the serialized params and instantiate new Query.
-    def rebuild(description)
+    def rebuild_from_description(description)
       model  = params[:model].to_sym
       params = deserialize(description)
       ::Query.new(model, params)

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -2,10 +2,6 @@
 
 # :description is not a serialized column; we call `to_json` for serialization.
 module Query::Modules::Serialization
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
-
   # Prepare the query params, adding the model, for saving to the db. The
   # :description column is accessed not just to recompose a query, but to
   # identify existing query records that match current params. That's why the
@@ -16,20 +12,5 @@ module Query::Modules::Serialization
   # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
     params.sort.to_h.merge(model: model.name).to_json
-  end
-
-  module ClassMethods
-    # Get the model from the serialized params and instantiate new Query.
-    def rebuild_from_description(description)
-      model  = params[:model].to_sym
-      params = deserialize(description)
-      ::Query.new(model, params)
-    end
-
-    def deserialize(description)
-      params = JSON.parse(description).deep_symbolize_keys
-      params.delete(:model)
-      params
-    end
   end
 end

--- a/app/classes/query/modules/serialization.rb
+++ b/app/classes/query/modules/serialization.rb
@@ -15,7 +15,7 @@ module Query::Modules::Serialization
   # the parsed hashes (in whatever order), because when a column is serialized
   # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
-    self.class.serialize
+    params.sort.to_h.merge(model: model.name).to_json
   end
 
   module ClassMethods
@@ -27,12 +27,9 @@ module Query::Modules::Serialization
     end
 
     def deserialize(description)
-      params = JSON.parse(description).symbolize_keys
+      params = JSON.parse(description).deep_symbolize_keys
       params.delete(:model)
-    end
-
-    def serialize
-      params.sort.to_h.merge(model: model.name).to_json
+      params
     end
   end
 end

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -77,8 +77,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
   end
 
   def initialize_obs_basic_parameters
-    ids_param = model == Observation ? :ids : :obs_ids
-    add_id_in_set_condition("observations", ids_param)
+    add_id_in_set_condition
     add_owner_and_time_stamp_conditions("observations")
     initialize_obs_date_parameter(:date)
   end
@@ -102,15 +101,6 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     initialize_project_lists_parameter
     initialize_species_lists_parameter
     initialize_field_slips_parameter
-  end
-
-  # This is just to allow the additional location conditions
-  # to be added FOR coerced queries.
-  def add_id_in_set_condition(table = model.table_name, ids = :ids)
-    super
-    return if model != Observation
-
-    add_is_collection_location_condition_for_locations
   end
 
   def initialize_obs_date_parameter(param_name = :date)

--- a/app/models/query_record.rb
+++ b/app/models/query_record.rb
@@ -27,7 +27,7 @@ class QueryRecord < ApplicationRecord
 
   # This method instantiates a new Query from the description.
   def query # rubocop:disable Lint/DuplicateMethods
-    ::Query.deserialize(description)
+    ::Query.rebuild(description)
   end
 
   # Only keep states around for a day.

--- a/app/models/query_record.rb
+++ b/app/models/query_record.rb
@@ -27,7 +27,7 @@ class QueryRecord < ApplicationRecord
 
   # This method instantiates a new Query from the description.
   def query # rubocop:disable Lint/DuplicateMethods
-    ::Query.rebuild(description)
+    ::Query.rebuild_from_description(description)
   end
 
   # Only keep states around for a day.

--- a/script/update_query_records.rb
+++ b/script/update_query_records.rb
@@ -49,7 +49,7 @@ class UpdateQueryRecords
       if hsh.key?(:with_specimen)
         hsh[:has_specimen] = hsh.delete(:with_specimen)
       end
-      entries << { id: query_record_id, description: Query.serialize(hsh) }
+      entries << { id: query_record_id, description: hsh.to_json }
     end
     entries
   end

--- a/script/update_query_records.rb
+++ b/script/update_query_records.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This is a one-time script, can be modified and reused in the future if Query
+# params change and we need to purge existing QueryRecords of the old params.
+#
+# call with `script/update_query_records.rb "true"`
+
+require(File.expand_path("../config/boot.rb", __dir__))
+require(File.expand_path("../config/environment.rb", __dir__))
+require(File.expand_path("../app/extensions/extensions.rb", __dir__))
+
+abort(<<HELP) if ARGV.length != 1
+
+  USAGE::
+
+    ruby script/update_query_records.rb "true"
+
+  DESCRIPTION::
+
+    Updates the serialized description in `query_records`.`description`
+    to match the new keys in the `Query::Filter` class.
+
+  PARAMETERS::
+
+    --help     Print this message.
+
+HELP
+
+class UpdateQueryRecords
+  def self.update_query_records(dry_run)
+    dry_run = dry_run.to_boolean
+    entries = updatable_query_records
+    QueryRecord.upsert_all(entries) unless dry_run
+
+    msgs = ["description updated for #{entries.size} query_records."]
+    msgs << "Dry run: no changes made." if dry_run
+    p(msgs.join(" "))
+  end
+
+  def self.updatable_query_records
+    entries = []
+    QueryRecord.pluck(:id, :description).each do |query_record_id, description|
+      next if description.blank?
+
+      # the value is a serialized hash, already parsed here
+      hsh = Query.deserialize(description)
+      hsh[:has_images] = hsh.delete(:with_images) if hsh.key?(:with_images)
+      if hsh.key?(:with_specimen)
+        hsh[:has_specimen] = hsh.delete(:with_specimen)
+      end
+      entries << { id: query_record_id, description: Query.serialize(hsh) }
+    end
+    entries
+  end
+end
+
+# This runs the first function with the first variable supplied to the script
+UpdateQueryRecords.update_query_records(ARGV[0])


### PR DESCRIPTION
This PR also does a bit of refactoring and cleanup of Query.

Running the new `script/update_query_records.rb "true"` on production will do a dry run checking for query records that have the obsolete filter param keys `with_images` and `with_specimen`. Pass "false" to actually update the records.

None of the other changed `with_` query params seem to be present on production, only `with_images`. `with_specimen` is just there for safety.

Alternatively we could run a regex to replace any `with_` param in the description string, but it doesn't seem to be necessary.