### PR TITLE
Simplify Query for undefined locations

### DIFF
--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -37,7 +37,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
       in_box: { north: :float, south: :float, east: :float, west: :float },
       is_collection_location: :boolean,
       has_public_lat_lng: :boolean,
-      locations_undefined: { boolean: [true] },
+      location_undefined: { boolean: [true] },
       has_notes: :boolean,
       notes_has: :string,
       has_notes_fields: [:string],
@@ -93,7 +93,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
   def initialize_association_parameters # rubocop:disable Metrics/AbcSize
     initialize_locations_parameter(:observations, params[:locations])
-    initialize_locations_undefined_parameter
+    initialize_location_undefined_parameter
     initialize_herbaria_parameter
     initialize_herbarium_records_parameter
     initialize_projects_parameter(:project_observations)
@@ -277,8 +277,8 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     add_subquery_condition(:sequence_query, :sequences)
   end
 
-  def initialize_locations_undefined_parameter
-    return unless params[:locations_undefined]
+  def initialize_location_undefined_parameter
+    return unless params[:location_undefined]
     return if params[:regexp] || params[:by_editor]
 
     @where << "observations.location_id IS NULL"

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -284,6 +284,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     @where << "observations.location_id IS NULL"
     @where << "observations.where IS NOT NULL"
     @group = "observations.where"
+    @order = "COUNT(observations.where)"
   end
 
   def initialize_project_lists_parameter

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -37,6 +37,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
       in_box: { north: :float, south: :float, east: :float, west: :float },
       is_collection_location: :boolean,
       has_public_lat_lng: :boolean,
+      location_undefined: { boolean: [true] },
       has_notes: :boolean,
       notes_has: :string,
       has_notes_fields: [:string],

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -179,7 +179,7 @@ class LocationsController < ApplicationController
     end
 
     # Create query if okay.  (Still need to tweak select and group clauses.)
-    result = create_query(:Observation, args.merge(locations_undefined: true))
+    result = create_query(:Observation, args.merge(location_undefined: true))
 
     # Also make sure it doesn't reference locations anywhere.  This would
     # presumably be the result of customization of one of the above.

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -48,21 +48,20 @@ module Observations
     def clade(term)
       # return unless (clade = Name.find_by(text_name: term))
 
-      query = create_query(:Observation,
-                           needs_naming: true, by: :rss_log, in_clade: term)
+      query = create_query(:Observation, needs_naming: true, in_clade: term,
+                                         by: :rss_log)
       [query, {}]
     end
 
     def region(term)
-      query = create_query(:Observation,
-                           needs_naming: true, by: :rss_log, in_region: term)
+      query = create_query(:Observation, needs_naming: true, in_region: term,
+                                         by: :rss_log)
       [query, {}]
     end
 
     # def user_filter(term)
-    #   query = create_query(:Observation,
-    #                        needs_naming: true, by: :rss_log,
-    #                        by_user: params[:user])
+    #   query = create_query(:Observation, needs_naming: true, by_users: term,
+    #                                      by: :rss_log)
     #   [query, {}]
     # end
 

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -103,30 +103,26 @@ class ObservationsController
     # Displays matrix of Observations with the given name proposed but not
     # actually that name.
     def look_alikes
-      query = create_query(:Observation,
-                           names: [params[:name]],
-                           include_synonyms: true,
-                           include_all_name_proposals: true,
-                           exclude_consensus: true,
-                           by: :confidence)
+      query = create_query(:Observation, names: [params[:name]],
+                                         include_synonyms: true,
+                                         include_all_name_proposals: true,
+                                         exclude_consensus: true,
+                                         by: :confidence)
       [query, {}]
     end
 
     # Displays matrix of Observations of subtaxa of the parent of given name.
     def related_taxa
-      query = create_query(:Observation,
-                           names: parents(params[:name]),
-                           include_subtaxa: true,
-                           by: :confidence)
+      query = create_query(:Observation, names: parents(params[:name]),
+                                         include_subtaxa: true, by: :confidence)
       [query, {}]
     end
 
     # Displays matrix of Observations with the given text_name (or search_name).
     def name
-      query = create_query(:Observation,
-                           names: [params[:name]],
-                           include_synonyms: true,
-                           by: :confidence)
+      query = create_query(:Observation, names: [params[:name]],
+                                         include_synonyms: true,
+                                         by: :confidence)
       [query, {}]
     end
 

--- a/app/controllers/species_lists/uploads_controller.rb
+++ b/app/controllers/species_lists/uploads_controller.rb
@@ -9,9 +9,8 @@ module SpeciesLists
       return unless (@species_list = find_species_list!)
 
       if check_permission!(@species_list)
-        query = create_query(
-          :Observation, species_lists: @species_list, by: :name
-        )
+        query = create_query( :Observation, species_lists: @species_list,
+                                            by: :name)
         @observation_list = query.results
       else
         redirect_to(species_list_path(@species_list))

--- a/app/controllers/species_lists/uploads_controller.rb
+++ b/app/controllers/species_lists/uploads_controller.rb
@@ -9,8 +9,8 @@ module SpeciesLists
       return unless (@species_list = find_species_list!)
 
       if check_permission!(@species_list)
-        query = create_query( :Observation, species_lists: @species_list,
-                                            by: :name)
+        query = create_query(:Observation, species_lists: @species_list,
+                                           by: :name)
         @observation_list = query.results
       else
         redirect_to(species_list_path(@species_list))

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -145,9 +145,8 @@ module MapHelper
     query_type = type.to_s.camelize.to_sym
     path_helper = :"#{type.to_s.pluralize}_path"
     # probably already have a query, from the index that got us here. add box
-    query = controller.find_or_create_query(
-      query_type, in_box: mapset_box_params(set)
-    )
+    query = controller.
+            find_or_create_query(query_type, in_box: mapset_box_params(set))
     [link_to(:show_all.t, add_query_param(send(path_helper), query)),
      link_to(:map_all.t, add_query_param(send(:"map_#{path_helper}"), query))]
   end

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -81,41 +81,31 @@ module NamesHelper
   # These don't run queries... it's query.select_count above, that does.
 
   def obss_of_taxon_this_name(name)
-    Query.lookup(:Observation,
-                 names: name.id,
-                 by: :confidence)
+    Query.lookup(:Observation, names: name.id, by: :confidence)
   end
 
   def obss_of_taxon_other_names(name)
-    Query.lookup(:Observation,
-                 names: name.id,
-                 include_synonyms: true,
-                 exclude_original_names: true,
-                 by: :confidence)
+    Query.lookup(:Observation, names: name.id, include_synonyms: true,
+                               exclude_original_names: true,
+                               by: :confidence)
   end
 
   def obss_of_taxon_any_name(name)
-    Query.lookup(:Observation,
-                 names: name.id,
-                 include_synonyms: true,
-                 by: :confidence)
+    Query.lookup(:Observation, names: name.id, include_synonyms: true,
+                               by: :confidence)
   end
 
   # These two do joins to Namings. Unbelievably, it's faster than the above?
   def obss_other_taxa_this_taxon_proposed(name)
-    Query.lookup(:Observation,
-                 names: name.id,
-                 include_synonyms: true,
-                 include_all_name_proposals: true,
-                 exclude_consensus: true,
-                 by: :confidence)
+    Query.lookup(:Observation, names: name.id, include_synonyms: true,
+                               include_all_name_proposals: true,
+                               exclude_consensus: true,
+                               by: :confidence)
   end
 
   def obss_this_name_proposed(name)
-    Query.lookup(:Observation,
-                 names: name.id,
-                 include_all_name_proposals: true,
-                 by: :confidence)
+    Query.lookup(:Observation, names: name.id, include_all_name_proposals: true,
+                               by: :confidence)
   end
 
   #############################################################################

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -104,6 +104,8 @@ module AbstractModel::Scopes
         date_between(early, late, col)
       end
     }
+    scope :on_date,
+          ->(date, col = :when) { date_compare(nil, date, col) }
     scope :date_after,
           ->(date, col = :when) { date_compare(:gt, date, col) }
     scope :date_before,
@@ -138,10 +140,11 @@ module AbstractModel::Scopes
         where(arel_table[col].month.send(:"#{dir}eq", val))
       end
     }
-    # Compare only the year
+    # Compare full date, or only the year.
+    # date_condition_formatted fills out min/max dates for year or year-month.
     scope :date_compare_year, lambda { |dir, val, col|
       date = date_condition_formatted(dir, val)
-      where(arel_table[col].send(dir, date))
+      where(arel_table[col].send(:"#{dir}eq", date))
     }
     # Compare only the month and day, any year (i.e. "season")
     scope :date_compare_month_and_day, lambda { |dir, val, col|

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -19,19 +19,19 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :by_activity,
           -> { order_by_rss_log }
 
-    # Extra timestamp scopes for when Observation found:
+    # Extra timestamp scopes for when Observation found.
+    # These are mostly aliases for `date` scopes.
     scope :found_on, lambda { |ymd_string|
-      where(arel_table[:when].format("%Y-%m-%d").eq(ymd_string))
+      on_date(ymd_string)
     }
     scope :found_after, lambda { |ymd_string|
-      where(arel_table[:when].format("%Y-%m-%d") >= ymd_string)
+      date(ymd_string)
     }
     scope :found_before, lambda { |ymd_string|
-      where(arel_table[:when].format("%Y-%m-%d") <= ymd_string)
+      date_before(ymd_string)
     }
     scope :found_between, lambda { |early, late|
-      where(arel_table[:when].format("%Y-%m-%d") >= early).
-        where(arel_table[:when].format("%Y-%m-%d") <= late)
+      date(early, late)
     }
 
     scope :is_collection_location, lambda { |bool = true|
@@ -278,7 +278,8 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     scope :has_no_public_lat_lng,
           -> { where(gps_hidden: true).or(where(lat: nil)) }
-    scope :locations_undefined, lambda {
+
+    scope :location_undefined, lambda {
       has_no_location.where.not(where: nil).group(:where).
         order(Observation[:where].count.desc, Observation[:id].desc)
     }

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -152,26 +152,25 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           -> { where(name_id: Name.with_rank_above_genus) }
     scope :has_no_confident_name,
           -> { where(vote_cache: ..0) }
-    scope :with_name_correctly_spelled, lambda { |bool = true|
-      if bool.to_s.to_boolean == true
-        joins({ namings: :name }).
-          where(names: { correct_spelling: nil }).distinct
-      else
-        with_misspelled_name
-      end
-    }
-    scope :with_misspelled_name, lambda {
-      joins({ namings: :name }).
-        where.not(names: { correct_spelling: nil }).distinct
-    }
+    # scope :with_name_correctly_spelled, lambda { |bool = true|
+    #   if bool.to_s.to_boolean == true
+    #     joins({ namings: :name }).
+    #       where(names: { correct_spelling: nil }).distinct
+    #   else
+    #     with_misspelled_name
+    #   end
+    # }
+    # scope :with_misspelled_name, lambda {
+    #   joins({ namings: :name }).
+    #     where.not(names: { correct_spelling: nil }).distinct
+    # }
 
     scope :with_vote_by_user, lambda { |user|
       user_id = user.is_a?(Integer) ? user : user&.id
       joins(:votes).where(votes: { user_id: user_id })
     }
     scope :without_vote_by_user, lambda { |user|
-      user_id = user.is_a?(Integer) ? user : user&.id
-      where.not(id: Vote.where(user_id: user_id))
+      where.not(id: Observation.with_vote_by_user(user))
     }
     scope :reviewed_by_user, lambda { |user|
       user_id = user.is_a?(Integer) ? user : user&.id

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -251,12 +251,22 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           -> { where.not(location: nil).or(where.not(lat: nil)) }
     scope :unmappable,
           -> { where(location: nil).and(where(lat: nil)) }
-    scope :has_location,
-          -> { where.not(location: nil) }
+    scope :has_location, lambda { |bool = true|
+      if bool.to_s.to_boolean == true
+        where.not(location: nil)
+      else
+        has_no_location
+      end
+    }
     scope :has_no_location,
           -> { where(location: nil) }
-    scope :has_geolocation,
-          -> { where.not(lat: nil) }
+    scope :has_geolocation, lambda { |bool = true|
+      if bool.to_s.to_boolean == true
+        where.not(lat: nil)
+      else
+        has_no_geolocation
+      end
+    }
     scope :has_no_geolocation,
           -> { where(lat: nil) }
     scope :has_public_lat_lng, lambda { |bool = true|
@@ -268,6 +278,10 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     scope :has_no_public_lat_lng,
           -> { where(gps_hidden: true).or(where(lat: nil)) }
+    scope :locations_undefined, lambda {
+      has_no_location.where.not(where: nil).group(:where).
+        order(Observation[:where].count.desc, Observation[:id].desc)
+    }
 
     scope :at_locations, lambda { |locations|
       location_ids = Lookup::Locations.new(locations).ids

--- a/app/views/controllers/locations/index.html.erb
+++ b/app/views/controllers/locations/index.html.erb
@@ -50,7 +50,8 @@ flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
       </div>
       <%= paginate_block(@undef_pages, { html_id: "locations_undefined" }) do %>
         <div class="list-group">
-          <% @undef_data.each do |location_name, count| %>
+          <% @undef_data.each do |obs, count| 
+            location_name = obs[:where] %>
             <div class="list-group-item">
               <%= location_link(location_name, nil, count) %>
               <%= 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1183,6 +1183,12 @@ class ObservationTest < UnitTestCase
                         observations(:peltigera_obs))
   end
 
+  def test_scope_without_vote_by_user
+    obs = Observation.without_vote_by_user(users(:rolf))
+    assert_not_includes(obs, observations(:coprinus_comatus_obs))
+    assert_includes(obs, observations(:peltigera_obs))
+  end
+
   # There are no observation views in the fixtures
   def test_scope_reviewed_by_user
     ObservationView.create({ observation_id: observations(:fungi_obs).id,
@@ -1269,6 +1275,48 @@ class ObservationTest < UnitTestCase
       tremella_obs,
       "Observations of look-alikes of <Name> should include " \
       "Observations of other Names for which <Name> was proposed"
+    )
+  end
+
+  def test_scope_has_location
+    loc = Observation.where(location_id: locations(:nybg_location)).first
+    no_loc = Observation.where(location_id: nil).first
+    assert_includes(
+      Observation.has_location, loc,
+      "Observations has_location should include obs at defined location."
+    )
+    assert_not_includes(
+      Observation.has_location, no_loc,
+      "Observations has_location should not include obs with no location."
+    )
+    assert_includes(
+      Observation.has_location(false), no_loc,
+      "Observations has_location(false) should include obs with no location."
+    )
+    assert_not_includes(
+      Observation.has_location(false), loc,
+      "Observations has_location(false) should not include obs with location."
+    )
+  end
+
+  def test_scope_has_geolocation
+    geoloc = Observation.where.not(lat: nil).first
+    no_geoloc = Observation.where(lat: nil).first
+    assert_includes(
+      Observation.has_geolocation, geoloc,
+      "Observations has_geolocation should include obs with latitude."
+    )
+    assert_not_includes(
+      Observation.has_geolocation, no_geoloc,
+      "Observations has_geolocation should not include obs with no latitude."
+    )
+    assert_includes(
+      Observation.has_geolocation(false), no_geoloc,
+      "Observations has_geolocation(false) should include obs with no latitude."
+    )
+    assert_not_includes(
+      Observation.has_geolocation(false), geoloc,
+      "Observations has_geolocation(false) should not include obs with latitude."
     )
   end
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1133,7 +1133,7 @@ class ObservationTest < UnitTestCase
   #  Scopes: Tests of scopes not completely covered elsewhere
   # ----------------------------------------------------------
 
-  def four_hundred_years_ago
+  def long_ago
     (Time.zone.today - 400.years).strftime("%Y-%m-%d")
   end
 
@@ -1153,23 +1153,23 @@ class ObservationTest < UnitTestCase
 
   def test_scope_found_after
     assert_equal(Observation.count,
-                 Observation.found_after(four_hundred_years_ago).count)
+                 Observation.found_after(long_ago).count)
     assert_empty(Observation.found_after(two_centuries_from_now))
   end
 
   def test_scope_found_before
     assert_equal(Observation.count,
                  Observation.found_before(two_centuries_from_now).count)
-    assert_empty(Observation.found_before(four_hundred_years_ago))
+    assert_empty(Observation.found_before(long_ago))
   end
 
   def test_scope_found_between
     assert_equal(
       Observation.count,
-      Observation.found_between(start_of_time, two_centuries_from_now).count
+      Observation.found_between(long_ago, two_centuries_from_now).count
     )
     assert_empty(
-      Observation.found_between(two_centuries_from_now, start_of_time)
+      Observation.found_between(two_centuries_from_now, long_ago)
     )
   end
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1316,7 +1316,7 @@ class ObservationTest < UnitTestCase
     )
     assert_not_includes(
       Observation.has_geolocation(false), geoloc,
-      "Observations has_geolocation(false) should not include obs with latitude."
+      "Observations has_geolocation(false) shouldn't include obs with latitude."
     )
   end
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1133,8 +1133,8 @@ class ObservationTest < UnitTestCase
   #  Scopes: Tests of scopes not completely covered elsewhere
   # ----------------------------------------------------------
 
-  def start_of_time
-    Date.jd(0).strftime("%Y-%m-%d")
+  def four_hundred_years_ago
+    (Time.zone.today - 400.years).strftime("%Y-%m-%d")
   end
 
   def a_century_from_now
@@ -1147,20 +1147,20 @@ class ObservationTest < UnitTestCase
 
   def test_scope_found_on
     obs = observations(:minimal_unknown_obs)
-    assert_includes(Observation.found_on(obs.when), obs)
+    assert_includes(Observation.found_on(obs.when.to_s), obs)
     assert_empty(Observation.found_on(two_centuries_from_now))
   end
 
   def test_scope_found_after
     assert_equal(Observation.count,
-                 Observation.found_after(start_of_time).count)
+                 Observation.found_after(four_hundred_years_ago).count)
     assert_empty(Observation.found_after(two_centuries_from_now))
   end
 
   def test_scope_found_before
     assert_equal(Observation.count,
                  Observation.found_before(two_centuries_from_now).count)
-    assert_empty(Observation.found_before(start_of_time))
+    assert_empty(Observation.found_before(four_hundred_years_ago))
   end
 
   def test_scope_found_between
@@ -1269,6 +1269,17 @@ class ObservationTest < UnitTestCase
       tremella_obs,
       "Observations of look-alikes of <Name> should include " \
       "Observations of other Names for which <Name> was proposed"
+    )
+  end
+
+  def test_scope_location_undefined
+    results = Observation.location_undefined
+    top_undefined = "Briceland, California, USA"
+    # results.count gives counts of each result
+    assert_equal(top_undefined, results.first.where)
+    assert_equal(
+      results.count.first[1],
+      Observation.where(where: top_undefined).has_no_location.count
     )
   end
 


### PR DESCRIPTION
This query was the sort of example of a very customized call to `create_query` that made Query seem confusing to deal with. It seems to date from the days when there were many more undefined locations than now. Thanks to Joe and Igor, that is no longer the case.

This simplifies that query by putting most of it into a single new param handler for an Observation query, `:location_undefined`, and I think it does everything the old query did except for respect user re-sorting of the list. This doesn't seem too important when there are only a few undefined locations total.

Query is extremely customizable, kind of like AR, and you can send all sorts of params to get any conceivable paginated results. However, at the point where you're doing a custom query for a frequently visited page, it's probably time to create a new query param that returns exactly what you want with a simpler call, and is testable. 

The PR also includes a bunch more housekeeping, tests, and scope refactoring.