### PR TITLE
Test Index Undefined Location

### DIFF
--- a/test/controllers/observations_controller/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller/observations_controller_index_test.rb
@@ -91,6 +91,17 @@ class ObservationsControllerIndexTest < FunctionalTestCase
                   "Wrong page or display is missing a link to Prev page")
   end
 
+  # In response to a bug seen in the wild where this request
+  # threw an error
+  def test_index_undefined_location
+    params = { where: "Oakfield%2C+Halifax%2C+Nova+Scotia%2C+Canada" }
+
+    login
+    get(:index, params: params)
+
+    assert_response(:success)
+  end
+
   def test_index_advanced_search_name_and_location_multiple_hits
     name = "Agaricus"
     location = "California"


### PR DESCRIPTION
Adds a test to prevent reversion of Issue #2752
Also see PR #2753 (a hotfix for the issue)