### PR TITLE
Rename the Query instance method `query` -> `sql`

### DIFF
--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -176,7 +176,7 @@ class Query::Images < Query::Base
     args2 = args.dup
     extend_join(args2) << :observation_images
     extend_where(args2) << "observation_images.observation_id IN (#{ids})"
-    model.connection.select_rows(query(args2))
+    model.connection.select_rows(sql(args2))
   end
 
   def add_pattern_condition

--- a/app/classes/query/initializers/advanced_search.rb
+++ b/app/classes/query/initializers/advanced_search.rb
@@ -65,7 +65,7 @@ module Query::Initializers::AdvancedSearch
     args2 = args.dup
     extend_where(args2)
     args2[:where] += google_conditions(content, content_field_one)
-    model.connection.select_rows(query(args2))
+    model.connection.select_rows(sql(args2))
   end
 
   def content_search_two(content, args)
@@ -73,7 +73,7 @@ module Query::Initializers::AdvancedSearch
     extend_where(args2)
     extend_join(args2) << content_join_spec
     args2[:where] += google_conditions(content, content_field_two)
-    model.connection.select_rows(query(args2))
+    model.connection.select_rows(sql(args2))
   end
 
   def name_field

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -121,7 +121,7 @@ module Query::Modules::Conditions
   def add_subquery_condition(param, *, table: nil, col: :id)
     return if params[param].blank?
 
-    sql = subquery_from_params(param).query
+    sql = subquery_from_params(param).sql
     table ||= subquery_table(param)
     @where << "#{table}.#{col} IN (#{sql})"
     add_joins(*)

--- a/app/classes/query/modules/low_level_queries.rb
+++ b/app/classes/query/modules/low_level_queries.rb
@@ -10,7 +10,7 @@ module Query::Modules::LowLevelQueries
     else
       select = args[:select] || "DISTINCT #{model.table_name}.id"
       args = args.merge(select: "COUNT(#{select})")
-      model.connection.select_value(query(args)).to_i
+      model.connection.select_value(sql(args)).to_i
     end
   end
 
@@ -20,7 +20,7 @@ module Query::Modules::LowLevelQueries
     if executor
       executor.call(args).first.first
     else
-      model.connection.select_value(query(args))
+      model.connection.select_value(sql(args))
     end
   end
 
@@ -30,7 +30,7 @@ module Query::Modules::LowLevelQueries
     if executor
       executor.call(args).map(&:first)
     else
-      model.connection.select_values(query(args))
+      model.connection.select_values(sql(args))
     end
   end
 
@@ -40,7 +40,7 @@ module Query::Modules::LowLevelQueries
     if executor
       executor.call(args)
     else
-      model.connection.select_rows(query(args))
+      model.connection.select_rows(sql(args))
     end
   end
 
@@ -50,7 +50,7 @@ module Query::Modules::LowLevelQueries
     if executor
       executor.call(args).first
     else
-      model.connection.select_one(query(args))
+      model.connection.select_one(sql(args))
     end
   end
 
@@ -59,7 +59,7 @@ module Query::Modules::LowLevelQueries
     initialize_query unless initialized?
     raise("This query doesn't support low-level access!") if executor
 
-    model.connection.select_all(query(args)).to_a
+    model.connection.select_all(sql(args)).to_a
   end
 
   # Call model.find_by_sql.
@@ -67,7 +67,7 @@ module Query::Modules::LowLevelQueries
     initialize_query unless initialized?
     raise("This query doesn't support low-level access!") if executor
 
-    model.find_by_sql(query_all(args))
+    model.find_by_sql(sql_select_all_columns(args))
   end
 
   # Return an Array of tables used in this query (Symbol's).

--- a/app/classes/query/modules/sql.rb
+++ b/app/classes/query/modules/sql.rb
@@ -5,13 +5,13 @@ module Query::Modules::Sql
 
   # Build query for <tt>model.find_by_sql</tt> -- i.e. one that returns all
   # fields from the table in question, instead just the id.
-  def query_all(args = {})
-    query(args.merge(select: "DISTINCT #{model.table_name}.*"))
+  def sql_select_all_columns(args = {})
+    sql(args.merge(select: "DISTINCT #{model.table_name}.*"))
   end
 
   # Build query, allowing the caller to override/augment the standard
   # parameters.
-  def query(args = {})
+  def sql(args = {})
     initialize_query unless initialized?
 
     our_select  = args[:select] || selects

--- a/app/classes/report/base_table.rb
+++ b/app/classes/report/base_table.rb
@@ -172,7 +172,7 @@ module Report
 
     def plain_query
       # Sometimes the default order requires unnecessary joins!
-      query.query(order: "")
+      query.sql(order: "")
     end
 
     def add_column!(rows, vals, col)

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -289,7 +289,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   # (The other place is from the template to the `matrix_box` helper, which
   # actually caches the HTML.)
   def find_objects(query, display_opts)
-    logger.warn("QUERY starting: #{query.query.inspect}")
+    logger.warn("QUERY starting: #{query.sql.inspect}")
     @timer_start = Time.current
 
     # Instantiate correct subset, with or without includes.

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -192,9 +192,9 @@ class LocationsController < ApplicationController
     # Create query if okay.  (Still need to tweak select and group clauses.)
     result = create_query(:Observation, args)
 
-    # Also make sure it doesn't reference locations anywhere.  This would
+    # Also make sure the sql doesn't reference locations anywhere.  This would
     # presumably be the result of customization of one of the above.
-    result = nil if /\Wlocations\./.match?(result.query)
+    result = nil if /\Wlocations\./.match?(result.sql)
 
     result
   end

--- a/app/views/controllers/api2/results.json.jbuilder
+++ b/app/views/controllers/api2/results.json.jbuilder
@@ -6,7 +6,7 @@ json.user(@api.user.id) if @api.user
 
 unless @api.errors.any?(&:fatal)
   if @api.query
-    json.query(@api.query.query.gsub(/\s*\n\s*/, " ").strip)
+    json.query(@api.query.sql.gsub(/\s*\n\s*/, " ").strip)
     json.number_of_records(@api.num_results)
     json.number_of_pages(@api.num_pages)
     json.page_number(@api.page_number)

--- a/app/views/controllers/api2/results.xml.builder
+++ b/app/views/controllers/api2/results.xml.builder
@@ -8,7 +8,7 @@ xml.response(xmlns: "#{MO.http_domain}/response.xsd") do
 
   unless @api.errors.any?(&:fatal)
     if @api.query
-      xml_sql_string(xml, :query, @api.query.query.gsub(/\s*\n\s*/, " ").strip)
+      xml_sql_string(xml, :query, @api.query.sql.gsub(/\s*\n\s*/, " ").strip)
       xml_integer(xml, :number_of_records, @api.num_results)
       xml_integer(xml, :number_of_pages, @api.num_pages)
       xml_integer(xml, :page_number, @api.page_number)

--- a/test/api2_extensions.rb
+++ b/test/api2_extensions.rb
@@ -46,7 +46,7 @@ module API2Extensions
 
   def assert_api_results(expect)
     msg = "API2 results wrong.\nQuery args: #{@api.query.params.inspect}\n" \
-          "Query sql: #{@api.query.query}"
+          "Query sql: #{@api.query.sql}"
     assert_obj_arrays_equal(expect, @api.results, :sort, msg)
   end
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -304,59 +304,59 @@ class QueryTest < UnitTestCase
 
     assert_equal(
       "SELECT DISTINCT names.id FROM `names`",
-      clean(query.query)
+      clean(query.sql)
     )
     assert_equal(
       "SELECT foo bar FROM `names`",
-      clean(query.query(select: "foo bar"))
+      clean(query.sql(select: "foo bar"))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` " \
       "JOIN `rss_logs` ON names.rss_log_id = rss_logs.id",
-      clean(query.query(join: :rss_logs))
+      clean(query.sql(join: :rss_logs))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` " \
       "JOIN `observations` ON observations.name_id = names.id " \
       "JOIN `rss_logs` ON observations.rss_log_id = rss_logs.id",
-      clean(query.query(join: { observations: :rss_logs }))
+      clean(query.sql(join: { observations: :rss_logs }))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names`, `rss_logs`",
-      clean(query.query(tables: :rss_logs))
+      clean(query.sql(tables: :rss_logs))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names`, `images`, `comments`",
-      clean(query.query(tables: [:images, :comments]))
+      clean(query.sql(tables: [:images, :comments]))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` WHERE shazam!",
-      clean(query.query(where: "shazam!"))
+      clean(query.sql(where: "shazam!"))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` WHERE foo AND bar",
-      clean(query.query(where: %w[foo bar]))
+      clean(query.sql(where: %w[foo bar]))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` WHERE foo AND bar",
-      clean(query.query(where: %w[foo bar]))
+      clean(query.sql(where: %w[foo bar]))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` GROUP BY blah blah blah",
-      clean(query.query(group: "blah blah blah"))
+      clean(query.sql(group: "blah blah blah"))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` ORDER BY foo, bar, names.id DESC",
       # (tacks on 'id DESC' for disambiguation)
-      clean(query.query(order: "foo, bar"))
+      clean(query.sql(order: "foo, bar"))
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` ORDER BY comments.id ASC",
-      clean(query.query(order: "comments.id ASC")) # (sees id in there already)
+      clean(query.sql(order: "comments.id ASC")) # (sees id in there already)
     )
     assert_equal(
       "SELECT DISTINCT names.id FROM `names` LIMIT 10",
-      clean(query.query(limit: 10))
+      clean(query.sql(limit: 10))
     )
 
     # Now, all together...
@@ -366,7 +366,7 @@ class QueryTest < UnitTestCase
       "JOIN `users` ON names.reviewer_id = users.id " \
       "WHERE one = two AND foo LIKE bar " \
       "GROUP BY blah.id ORDER BY names.id ASC LIMIT 10, 10",
-      clean(query.query(select: "names.*",
+      clean(query.sql(select: "names.*",
                         join: [:observations, :"users.reviewer"],
                         tables: :images,
                         where: ["one = two", "foo LIKE bar"],
@@ -379,34 +379,34 @@ class QueryTest < UnitTestCase
   def test_query_params_selects
     # defaults
     query = Query.new(:Name)
-    assert(query.query)
+    assert(query.sql)
     assert_equal(clean(query.selects), "DISTINCT names.id")
 
     query = Query.new(:Name, selects: "DISTINCT names.text_name")
-    assert(query.query)
+    assert(query.sql)
     assert_equal(clean(query.selects), "DISTINCT names.text_name")
   end
 
   def test_query_params_order
     # defaults
     query = Query.new(:Name)
-    assert(query.query)
+    assert(query.sql)
     assert_equal(query.default_order, "name")
     assert_equal(clean(query.order), "names.sort_name ASC")
 
     query = Query.new(:Name, order: "names.id ASC")
-    assert(query.query)
+    assert(query.sql)
     assert_equal(clean(query.order), "names.id ASC")
   end
 
   def test_query_params_group
     # defaults
     query = Query.new(:Observation)
-    assert(query.query)
+    assert(query.sql)
     assert_equal(clean(query.group), "")
 
     query = Query.new(:Observation, group: "observations.name_id")
-    assert(query.query)
+    assert(query.sql)
     assert_equal(clean(query.group), "observations.name_id")
   end
 
@@ -421,7 +421,7 @@ class QueryTest < UnitTestCase
     #   names => observations => comments
     #   names => observations => observation_images => images
     #   names => users (as reviewer)
-    sql = query.query(
+    sql = query.sql(
       join: [
         {
           observations: [
@@ -462,13 +462,13 @@ class QueryTest < UnitTestCase
     query = Query.lookup(:Observation)
     query.initialize_query
     query.join << :rss_logs
-    assert_match(/observations.rss_log_id = rss_logs.id/, query.query)
+    assert_match(/observations.rss_log_id = rss_logs.id/, query.sql)
 
     # And use rss_logs.observation_id = observations.id the other way.
     query = Query.lookup(:RssLog)
     query.initialize_query
     query.join << :observations
-    assert_match(/rss_logs.observation_id = observations.id/, query.query)
+    assert_match(/rss_logs.observation_id = observations.id/, query.sql)
   end
 
   def test_low_levels
@@ -958,7 +958,7 @@ class QueryTest < UnitTestCase
 
   def test_whiny_nil_in_map_locations
     query = Query.lookup(:User, ids: [rolf.id, 1000, mary.id])
-    query.query
+    query.sql
     assert_equal(2, query.results.length)
   end
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -367,12 +367,12 @@ class QueryTest < UnitTestCase
       "WHERE one = two AND foo LIKE bar " \
       "GROUP BY blah.id ORDER BY names.id ASC LIMIT 10, 10",
       clean(query.sql(select: "names.*",
-                        join: [:observations, :"users.reviewer"],
-                        tables: :images,
-                        where: ["one = two", "foo LIKE bar"],
-                        group: "blah.id",
-                        order: "names.id ASC",
-                        limit: "10, 10"))
+                      join: [:observations, :"users.reviewer"],
+                      tables: :images,
+                      where: ["one = two", "foo LIKE bar"],
+                      group: "blah.id",
+                      order: "names.id ASC",
+                      limit: "10, 10"))
     )
   end
 


### PR DESCRIPTION
This PR renames an instance method to disambiguate `Query` instances from the SQL they generate. `Query#query` does not refer to the instance or execute the query, it returns an SQL string for execution by something like: 
```ruby
model.connection.select_rows(query.query)
``` 
or for inspection in tests. Note that in this example, as most places in the code, the first `query` is the Query instance, the second `query` is the SQL string.

On the AR refactor, it may be only used for inspecting the SQL generated by the AR, so `sql` seems like the right name.
```ruby
model.connection.select_rows(query.sql)
``` 