### PR TITLE
Show previously selected archive in Sequence form

### DIFF
--- a/app/views/controllers/sequences/_form.erb
+++ b/app/views/controllers/sequences/_form.erb
@@ -50,7 +50,9 @@ end
       ) %>
 
   <%= select_with_label(form: f, field: :archive, label: :ARCHIVE.t + ":",
-                        options: sequence_archive_options, include_blank: true,
+                        options: sequence_archive_options,
+                        selected: @sequence.archive,
+                        include_blank: true,
                         inline: true, class: "ml-5") %>
 
   <%= text_field_with_label(form: f, field: :accession,

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -335,9 +335,9 @@ class SequencesControllerTest < FunctionalTestCase
     get(:edit, params: { id: sequence.id })
 
     assert_response(:success)
-    assert_select("select#sequence_archive",
+    assert_select("select#sequence_archive", true,
                   "Edit form is missing the selected Archive") do
-      assert_select("option[selected]", text: "GenBank")
+      assert_select("option[selected]", text: sequence.archive)
     end
   end
 

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -325,6 +325,22 @@ class SequencesControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  def test_edit_deposited_sequence
+    sequence = sequences(:deposited_sequence)
+    obs      = sequence.observation
+    observer = obs.user
+
+    # Prove Observation's creator can edit Sequence
+    login(observer.login)
+    get(:edit, params: { id: sequence.id })
+
+    assert_response(:success)
+    assert_select("select#sequence_archive",
+                  "Edit form is missing the selected Archive") do
+      assert_select("option[selected]", text: "GenBank")
+    end
+  end
+
   def test_edit_by_admin
     sequence = sequences(:local_sequence)
 

--- a/test/fixtures/sequences.yml
+++ b/test/fixtures/sequences.yml
@@ -21,6 +21,7 @@ local_sequence:
 deposited_sequence:
   <<: *DEFAULTS
   accession:   KT968605
+  archive:     GenBank
   bases:       ""
   created_at:  2017-01-01 17:00:00
   updated_at:  2017-01-01 17:00:00


### PR DESCRIPTION
When editing a Sequence, display the prior selection in the Archive select field
- Delivers #2759

### Manual Test
- Add a Sequence which includes a GenBank deposit, to any Observation.
Example sequence fields: Locus: test; Bases: A-CAT-A-CAT; Archive: GenBank; Accession number/code: A-Cat
- Click the Edit Sequence icon.
Result: The Archive field should be `GenBank`