### PR TITLE
Query::Comments - combine target and type params

### DIFF
--- a/app/classes/api2/comment_api.rb
+++ b/app/classes/api2/comment_api.rb
@@ -37,7 +37,7 @@ class API2
         types: parse_array(:enum, :type, limit: Comment::ALL_TYPE_TAGS),
         summary_has: parse(:string, :summary_has, help: 1),
         content_has: parse(:string, :content_has, help: 1),
-        target: @target ? { id: @target.id, type: @target.class.name } : nil,
+        target: @target ? { id: @target.id, type: @target.class.name } : nil
       }
     end
 

--- a/app/classes/api2/comment_api.rb
+++ b/app/classes/api2/comment_api.rb
@@ -37,8 +37,7 @@ class API2
         types: parse_array(:enum, :type, limit: Comment::ALL_TYPE_TAGS),
         summary_has: parse(:string, :summary_has, help: 1),
         content_has: parse(:string, :content_has, help: 1),
-        target: @target ? @target.id : nil,
-        type: @target ? @target.class.name : nil
+        target: @target ? { id: @target.id, type: @target.class.name } : nil,
       }
     end
 

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -16,8 +16,7 @@ class Query::Comments < Query::Base
       summary_has: :string,
       content_has: :string,
       pattern: :string,
-      target: AbstractModel,
-      type: :string
+      target: { id: AbstractModel, type: :string }
     )
   end
 
@@ -46,7 +45,7 @@ class Query::Comments < Query::Base
   end
 
   def add_for_target_condition
-    return if params[:target].blank? || params[:type].blank?
+    return if params[:target].blank?
 
     target = target_instance
     @title_tag = :query_title_for_target
@@ -56,11 +55,12 @@ class Query::Comments < Query::Base
   end
 
   def target_instance
-    unless (type = Comment.safe_model_from_name(params[:type]))
-      raise("The model #{params[:type].inspect} does not support comments!")
+    type_param = params.dig(:target, :type)
+    unless (type = Comment.safe_model_from_name(type_param))
+      raise("The model #{type_param.inspect} does not support comments!")
     end
 
-    find_cached_parameter_instance(type, :target)
+    type.safe_find(params.dig(:target, :id))
   end
 
   def search_fields

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -49,7 +49,7 @@ class Query::Comments < Query::Base
 
     target = target_instance
     @title_tag = :query_title_for_target
-    @title_args[:object] = target.unique_format_name
+    @title_args[:target] = target.unique_format_name
     where << "comments.target_id = '#{target.id}'"
     where << "comments.target_type = '#{target.class.name}'"
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -74,7 +74,8 @@ class CommentsController < ApplicationController
     return no_model unless (model = Comment.safe_model_from_name(params[:type]))
     return unless (target = find_or_goto_index(model, params[:target].to_s))
 
-    query = create_query(:Comment, target: target.id, type: target.class.name)
+    query = create_query(:Comment, target: { id: target.id,
+                                             type: target.class.name })
     [query, {}]
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -148,7 +148,7 @@ class Comment < AbstractModel
   #   end
   #   where(target_id: target_ids)
   #
-  # ...this `inject` iteration only generates one very complex sql statement,
+  # ...this `reduce` iteration only generates one very complex sql statement,
   # with inner selects, and it's faster because AR can figure out that all the
   # chained selects constitute one giant SELECT, and SQL is faster than Ruby.
   #
@@ -158,13 +158,14 @@ class Comment < AbstractModel
   #   or(where(target_type: :name,
   #            target_id: Name.where(user: user))) etc.
   scope :for_user, lambda { |user|
-    ALL_TYPES.inject(nil) do |scope, model|
+    ALL_TYPES.reduce(nil) do |scope, model|
       scope2 = where(target_type: model.name.underscore.to_sym,
                      target_id: model.where(user: user))
       scope ? scope.or(scope2) : scope2
     end
   }
-  scope :for_target, ->(target) { where(target: target) }
+  scope :for_target,
+        ->(target) { where(target: target) }
 
   scope :search_content, lambda { |phrase|
     # `or` is 10-20% faster than concatenating the columns
@@ -212,7 +213,7 @@ class Comment < AbstractModel
   # Return model if params[:type] is the name of a commentable model
   # Else nil
   def self.safe_model_from_name(name)
-    ALL_TYPES.find { |m| m.name == name }
+    ALL_TYPES.find { |m| m.name == name.to_s }
   end
 
   ############################################################################

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -20,7 +20,7 @@ class Query::CommentsTest < UnitTestCase
   def test_comment_for_target
     obs = observations(:minimal_unknown_obs)
     expects = Comment.index_order.where(target_id: obs.id).distinct
-    assert_query(expects, :Comment, target: obs, type: "Observation")
+    assert_query(expects, :Comment, target: { id: obs, type: :Observation })
   end
 
   def test_comment_for_user

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -29,7 +29,9 @@ class CommentsControllerTest < FunctionalTestCase
     login
     get(:index, params: params)
     assert_select(".comment", count: comments.size)
-    assert_displayed_title("Comments on #{target.id}")
+    assert_displayed_title(
+      "Comments on #{target.unique_format_name.t.as_displayed}"
+    )
   end
 
   def test_index_target_valid_target_without_comments

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -158,4 +158,16 @@ class CommentTest < UnitTestCase
       assert_true(Comment.joins(type_tag))
     end
   end
+
+  def test_scope_for_target
+    obss = Observation.has_comments
+    assert(obss.size > 1)
+    obs1 = obss.first
+    obs2 = obss.last
+    assert_not_equal(obs1.id, obs2.id)
+    assert_equal(obs1.id, Comment.for_target(obs1.id).first.target_id)
+    assert_equal(obs1.id, Comment.for_target(obs1).first.target_id)
+    assert_equal(obs2.id, Comment.for_target(obs2.id).first.target_id)
+    assert_equal(obs2.id, Comment.for_target(obs2).first.target_id)
+  end
 end


### PR DESCRIPTION
This continues in the vein of the `in_box` scope, combining params that are invalid without each other into a single hash param that's validated once (iteratively).