### PR TITLE
More param standardizing

### DIFF
--- a/app/classes/api2/external_link_api.rb
+++ b/app/classes/api2/external_link_api.rb
@@ -38,7 +38,7 @@ class API2
         by_users: parse_array(:user, :user, help: :creator),
         observations: parse_array(:observation, :observation),
         external_sites: parse_array(:external_site, :external_site),
-        url: parse(:string, :url)
+        url_has: parse(:string, :url)
       }
     end
 

--- a/app/classes/api2/external_site_api.rb
+++ b/app/classes/api2/external_site_api.rb
@@ -30,7 +30,7 @@ class API2
     def query_params
       {
         ids: parse_array(:external_site, :id, as: :id),
-        name: parse(:string, :name)
+        name_has: parse(:string, :name)
       }
     end
 

--- a/app/classes/api2/herbarium_api.rb
+++ b/app/classes/api2/herbarium_api.rb
@@ -38,7 +38,7 @@ class API2
         code_has: parse(:string, :code),
         name_has: parse(:string, :name),
         description_has: parse(:string, :description),
-        address_has: parse(:string, :address, help: :mailing_address)
+        mailing_address_has: parse(:string, :address, help: :mailing_address)
       }
     end
 

--- a/app/classes/api2/herbarium_api.rb
+++ b/app/classes/api2/herbarium_api.rb
@@ -35,10 +35,10 @@ class API2
         ids: parse_array(:herbarium, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
-        code: parse(:string, :code),
-        name: parse(:string, :name),
-        description: parse(:string, :description),
-        address: parse(:string, :address, help: :mailing_address)
+        code_has: parse(:string, :code),
+        name_has: parse(:string, :name),
+        description_has: parse(:string, :description),
+        address_has: parse(:string, :address, help: :mailing_address)
       }
     end
 

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -13,7 +13,7 @@ class Query::ExternalLinks < Query::Base
       by_users: [User],
       observations: [Observation],
       external_sites: [ExternalSite],
-      url: :string
+      url_has: :string
     )
   end
 
@@ -24,7 +24,7 @@ class Query::ExternalLinks < Query::Base
     initialize_observations_parameter(:external_links)
     ids = lookup_external_sites_by_name(params[:external_sites])
     add_association_condition("external_links.external_site_id", ids)
-    add_search_condition("external_links.url", params[:url])
+    add_search_condition("external_links.url", params[:url_has])
     super
   end
 

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -8,14 +8,14 @@ class Query::ExternalSites < Query::Base
   def self.parameter_declarations
     super.merge(
       ids: [ExternalSite],
-      name: :string
+      name_has: :string
     )
   end
 
   def initialize_flavor
     add_sort_order_to_title
     add_id_in_set_condition
-    add_search_condition("external_sites.name", params[:name])
+    add_search_condition("external_sites.name", params[:name_has])
     super
   end
 

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -13,7 +13,7 @@ class Query::Herbaria < Query::Base
       code_has: :string,
       name_has: :string,
       description_has: :string,
-      address_has: :string,
+      mailing_address_has: :string,
       pattern: :string,
       nonpersonal: :boolean
     )
@@ -27,7 +27,8 @@ class Query::Herbaria < Query::Base
     add_search_condition("herbaria.code", params[:code_has])
     add_search_condition("herbaria.name", params[:name_has])
     add_search_condition("herbaria.description", params[:description_has])
-    add_search_condition("herbaria.mailing_address", params[:address_has])
+    add_search_condition("herbaria.mailing_address",
+                         params[:mailing_address_has])
     add_id_in_set_condition
     add_nonpersonal_condition
     add_pattern_condition

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -9,11 +9,11 @@ class Query::Herbaria < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      code: :string,
-      name: :string,
       ids: [Herbarium],
-      description: :string,
-      address: :string,
+      code_has: :string,
+      name_has: :string,
+      description_has: :string,
+      address_has: :string,
       pattern: :string,
       nonpersonal: :boolean
     )
@@ -24,10 +24,10 @@ class Query::Herbaria < Query::Base
     add_sort_order_to_title
     add_time_condition("herbaria.created_at", params[:created_at])
     add_time_condition("herbaria.updated_at", params[:updated_at])
-    add_search_condition("herbaria.code", params[:code])
-    add_search_condition("herbaria.name", params[:name])
-    add_search_condition("herbaria.description", params[:description])
-    add_search_condition("herbaria.mailing_address", params[:address])
+    add_search_condition("herbaria.code", params[:code_has])
+    add_search_condition("herbaria.name", params[:name_has])
+    add_search_condition("herbaria.description", params[:description_has])
+    add_search_condition("herbaria.mailing_address", params[:address_has])
     add_id_in_set_condition
     add_nonpersonal_condition
     add_pattern_condition

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -44,60 +44,24 @@ module Query::Initializers::Descriptions
   # If ever generalizing, `type` should be model.parent_type
   def initialize_name_descriptions_parameters(type = "name")
     initialize_ok_for_export_parameter
-    initialize_join_desc_parameter(type)
-    initialize_desc_type_parameter(type)
-    # NOTE: (AN 2025) These may now be superfluous, unless they need to be
-    # differentiated from Names parameters sent in the same request. I.e.,
-    # they could just use `add_for_project_condition` `add_by_user_condition`
-    initialize_desc_project_parameter(type)
-    initialize_desc_creator_parameter(type)
-    # This is a description notes content search
-    initialize_desc_content_parameter(type)
+    initialize_type_parameter(type)
+    initialize_projects_parameter(:"#{type}_descriptions", nil)
+    initialize_content_has_parameter(type)
   end
 
-  def initialize_join_desc_parameter(type)
-    if params[:join_desc] == :default
-      add_join(:"#{type}_descriptions.default")
-    elsif any_param_desc_fields?
-      add_join(:"#{type}_descriptions")
-    end
-  end
-
-  def initialize_desc_type_parameter(type)
+  def initialize_type_parameter(type)
     add_indexed_enum_condition(
       "#{type}_descriptions.source_type",
-      params[:desc_type],
+      params[:type],
       "#{type}_description".classify.constantize.source_types # Hash
     )
   end
 
-  def initialize_desc_project_parameter(type)
-    ids = lookup_projects_by_name(params[:desc_project])
-    add_association_condition("#{type}_descriptions.project_id", ids)
-  end
-
-  def initialize_desc_creator_parameter(type)
-    ids = lookup_users_by_name(params[:desc_creator])
-    add_association_condition("#{type}_descriptions.user_id", ids)
-  end
-
-  def initialize_desc_content_parameter(type)
+  def initialize_content_has_parameter(type)
     model = "#{type}_descriptions".classify.constantize
     fields = model.all_note_fields
     fields = fields.map { |f| "COALESCE(#{type}_descriptions.#{f},'')" }
     fields = "CONCAT(#{fields.join(",")})"
-    add_search_condition(fields, params[:desc_content])
-  end
-
-  # --------------------------------------------------------------------------
-
-  private
-
-  def any_param_desc_fields?
-    params[:join_desc] == :any ||
-      params[:desc_type].present? ||
-      params[:desc_project].present? ||
-      params[:desc_creator].present? ||
-      params[:desc_content].present?
+    add_search_condition(fields, params[:content_has])
   end
 end

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -17,11 +17,9 @@ class Query::NameDescriptions < Query::Base
       by_editor: User,
       names: [Name],
       public: :boolean,
-      join_desc: { string: [:default, :any] },
-      desc_type: [{ string: Description::ALL_SOURCE_TYPES }],
-      desc_project: [Project],
-      desc_creator: [User],
-      desc_content: :string,
+      type: [{ string: Description::ALL_SOURCE_TYPES }],
+      projects: [Project],
+      content_has: :string,
       ok_for_export: :boolean,
       name_query: { subquery: :Name }
     )

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -137,10 +137,7 @@ class Query::Names < Query::Base
 
   def initialize_name_comments_parameters
     add_join(:comments) if params[:has_comments]
-    add_search_condition(
-      "names.notes",
-      params[:notes_has]
-    )
+    add_search_condition("names.notes", params[:notes_has])
     add_search_condition(
       "CONCAT(comments.summary,COALESCE(comments.comment,''))",
       params[:comments_has],

--- a/test/classes/query/external_links_test.rb
+++ b/test/classes/query/external_links_test.rb
@@ -24,6 +24,6 @@ class Query::ExternalLinksTest < UnitTestCase
     assert_query(site.external_links.sort_by(&:url),
                  :ExternalLink, external_sites: site)
     assert_query(site.external_links.sort_by(&:url),
-                 :ExternalLink, url: "iNaturalist")
+                 :ExternalLink, url_has: "iNaturalist")
   end
 end

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -14,8 +14,6 @@ class Query::HerbariaTest < UnitTestCase
 
   def test_herbarium_by_records
     expects = Herbarium.left_outer_joins(:herbarium_records).group(:id).
-              # Wrap known safe argument in Arel
-              # to prevent "Dangerous query method" Deprecation Warning
               order(HerbariumRecord[:id].count.desc, Herbarium[:id].desc)
     assert_query(expects, :Herbarium, by: :records)
   end

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -71,34 +71,27 @@ class Query::NameDescriptionsTest < UnitTestCase
                  :NameDescription, name_query: { has_default_desc: 0 })
   end
 
-  def test_name_description_desc_type_user
+  def test_name_description_type_user
     assert_query(NameDescription.where(source_type: 5).index_order,
-                 :NameDescription, desc_type: "user")
+                 :NameDescription, type: "user")
   end
 
-  def test_name_description_desc_type_project
+  def test_name_description_type_project
     assert_query(NameDescription.where(source_type: 3).index_order,
-                 :NameDescription, desc_type: "project")
+                 :NameDescription, type: "project")
   end
 
-  def test_name_description_desc_project
+  def test_name_description_projects
     assert_query(NameDescription.
                  where(project: projects(:eol_project)).index_order,
-                 :NameDescription, desc_project: projects(:eol_project).id)
-  end
-
-  def test_name_description_desc_creator
-    assert_query(NameDescription.where(user: rolf).index_order,
-                 :NameDescription, desc_creator: rolf.id)
-    assert_query(NameDescription.where(user: mary).index_order,
-                 :NameDescription, desc_creator: mary.id)
+                 :NameDescription, projects: projects(:eol_project).id)
   end
 
   # waiting on a new AbstractModel scope for searches,
   # plus a specific NameDescription scope coalescing the fields.
-  def test_name_description_desc_content
+  def test_name_description_content_has
     assert_query(NameDescription.search_content('"some notes"').index_order,
-                 :NameDescription, desc_content: '"some notes"')
+                 :NameDescription, content_has: '"some notes"')
   end
 
   def test_name_description_ok_for_export


### PR DESCRIPTION
Standardize search params to use `:column_has` naming format, makes Query methods easier to write.