### PR TITLE
Switch Query param `:ids` to `:id_in_set`, works as a scope name

### DIFF
--- a/app/classes/api2/collection_number_api.rb
+++ b/app/classes/api2/collection_number_api.rb
@@ -32,7 +32,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:collection_number, :id, as: :id),
+        id_in_set: parse_array(:collection_number, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :creator),

--- a/app/classes/api2/comment_api.rb
+++ b/app/classes/api2/comment_api.rb
@@ -30,7 +30,7 @@ class API2
     def query_params
       @target = parse(:object, :target, limit: Comment::ALL_TYPES, help: 1)
       {
-        ids: parse_array(:comment, :id, as: :id),
+        id_in_set: parse_array(:comment, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :creator),

--- a/app/classes/api2/external_link_api.rb
+++ b/app/classes/api2/external_link_api.rb
@@ -32,7 +32,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:external_link, :id, as: :id),
+        id_in_set: parse_array(:external_link, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :creator),

--- a/app/classes/api2/external_site_api.rb
+++ b/app/classes/api2/external_site_api.rb
@@ -29,7 +29,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:external_site, :id, as: :id),
+        id_in_set: parse_array(:external_site, :id, as: :id),
         name_has: parse(:string, :name)
       }
     end

--- a/app/classes/api2/herbarium_api.rb
+++ b/app/classes/api2/herbarium_api.rb
@@ -32,7 +32,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:herbarium, :id, as: :id),
+        id_in_set: parse_array(:herbarium, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         code_has: parse(:string, :code),

--- a/app/classes/api2/herbarium_record_api.rb
+++ b/app/classes/api2/herbarium_record_api.rb
@@ -33,7 +33,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:herbarium_record, :id, as: :id),
+        id_in_set: parse_array(:herbarium_record, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :creator),

--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -39,7 +39,7 @@ class API2
     # rubocop:disable Layout/MultilineOperationIndentation
     def query_params
       {
-        ids: parse_array(:image, :id, as: :id),
+        id_in_set: parse_array(:image, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         date: parse_range(:date, :date, help: :when_taken),

--- a/app/classes/api2/location_api.rb
+++ b/app/classes/api2/location_api.rb
@@ -32,7 +32,7 @@ class API2
     def query_params
       box = parse_bounding_box!
       {
-        ids: parse_array(:location, :id, as: :id),
+        id_in_set: parse_array(:location, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :first_user),

--- a/app/classes/api2/location_description_api.rb
+++ b/app/classes/api2/location_description_api.rb
@@ -33,7 +33,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:location_description, :id, as: :id),
+        id_in_set: parse_array(:location_description, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :first_user),

--- a/app/classes/api2/name_api.rb
+++ b/app/classes/api2/name_api.rb
@@ -32,7 +32,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:name, :id, as: :id),
+        id_in_set: parse_array(:name, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :first_user),

--- a/app/classes/api2/name_description_api.rb
+++ b/app/classes/api2/name_description_api.rb
@@ -33,7 +33,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:name_description, :id, as: :id),
+        id_in_set: parse_array(:name_description, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :first_user),

--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -43,7 +43,7 @@ class API2
     def query_params
       box = parse_bounding_box!
       {
-        ids: parse_array(:observation, :id, as: :id),
+        id_in_set: parse_array(:observation, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         date: parse_range(:date, :date, help: :when_seen),

--- a/app/classes/api2/project_api.rb
+++ b/app/classes/api2/project_api.rb
@@ -32,7 +32,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:project, :id, as: :id),
+        id_in_set: parse_array(:project, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :creator),

--- a/app/classes/api2/sequence_api.rb
+++ b/app/classes/api2/sequence_api.rb
@@ -29,7 +29,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:sequence, :id, as: :id),
+        id_in_set: parse_array(:sequence, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :creator),

--- a/app/classes/api2/species_list_api.rb
+++ b/app/classes/api2/species_list_api.rb
@@ -33,7 +33,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:species_list, :id, as: :id),
+        id_in_set: parse_array(:species_list, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         date: parse_range(:date, :date, help: :any_date),

--- a/app/classes/api2/user_api.rb
+++ b/app/classes/api2/user_api.rb
@@ -33,7 +33,7 @@ class API2
 
     def query_params
       {
-        ids: parse_array(:user, :id, as: :id),
+        id_in_set: parse_array(:user, :id, as: :id),
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at)
       }

--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -10,7 +10,7 @@ class Query::Articles < Query::Base
       created_at: [:time],
       updated_at: [:time],
       by_users: [User],
-      ids: [Article],
+      id_in_set: [Article],
       title_has: :string,
       body_has: :string
     )

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -9,7 +9,7 @@ class Query::CollectionNumbers < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [CollectionNumber],
+      id_in_set: [CollectionNumber],
       by_users: [User],
       observations: [Observation],
       pattern: :string,

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -9,7 +9,7 @@ class Query::Comments < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [Comment],
+      id_in_set: [Comment],
       by_users: [User],
       for_user: User,
       types: [{ string: Comment::ALL_TYPE_TAGS }],

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -9,7 +9,7 @@ class Query::ExternalLinks < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [ExternalLink],
+      id_in_set: [ExternalLink],
       by_users: [User],
       observations: [Observation],
       external_sites: [ExternalSite],

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -7,7 +7,7 @@ class Query::ExternalSites < Query::Base
 
   def self.parameter_declarations
     super.merge(
-      ids: [ExternalSite],
+      id_in_set: [ExternalSite],
       name_has: :string
     )
   end

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -9,7 +9,7 @@ class Query::Herbaria < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [Herbarium],
+      id_in_set: [Herbarium],
       code_has: :string,
       name_has: :string,
       description_has: :string,

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -9,7 +9,7 @@ class Query::HerbariumRecords < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [HerbariumRecord],
+      id_in_set: [HerbariumRecord],
       by_users: [User],
       herbaria: [Herbarium],
       observations: [Observation],

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -16,7 +16,7 @@ class Query::Images < Query::Base
       created_at: [:time],
       updated_at: [:time],
       date: [:date],
-      ids: [Image],
+      id_in_set: [Image],
       by_users: [User],
       size: [{ string: Image::ALL_SIZES - [:full_size] }],
       content_types: [{ string: Image::ALL_EXTENSIONS }],

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -11,7 +11,7 @@ class Query::LocationDescriptions < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [LocationDescription],
+      id_in_set: [LocationDescription],
       by_users: [User],
       by_author: User,
       by_editor: User,

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -15,7 +15,7 @@ class Query::Locations < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [Location],
+      id_in_set: [Location],
       by_users: [User],
       by_editor: User,
       in_box: { north: :float, south: :float, east: :float, west: :float },

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -86,10 +86,10 @@ module Query::Modules::Conditions
 
   # The method that all classes use for queries of their own ids.
   # Can accept an empty array of ids and respond accordingly.
-  def add_id_in_set_condition(table = model.table_name, ids = :ids)
-    return if params[ids].nil? # [] is valid
+  def add_id_in_set_condition(table = model.table_name, param = :id_in_set)
+    return if params[param].nil? # [] is valid
 
-    set = clean_id_set(params[ids])
+    set = clean_id_set(params[param])
     @where << "#{table}.id IN (#{set})"
     @order = "FIND_IN_SET(#{table}.id,'#{set}') ASC" unless params[:order]
 

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -181,7 +181,7 @@ module Query::Modules::Validation
       val.id
     elsif could_be_record_id?(param, val)
       val.to_i
-    elsif val.is_a?(String) && param != :ids
+    elsif val.is_a?(String) && param != :id_in_set
       val
     else
       raise("Value for :#{param} should be id, string " \

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -11,7 +11,7 @@ class Query::NameDescriptions < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [NameDescription],
+      id_in_set: [NameDescription],
       by_users: [User],
       by_author: User,
       by_editor: User,

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -17,7 +17,7 @@ class Query::Names < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [Name],
+      id_in_set: [Name],
       names: [Name], # potentially modified by the next four params
       include_synonyms: :boolean,
       include_subtaxa: :boolean,

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -18,7 +18,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
       created_at: [:time],
       updated_at: [:time],
 
-      ids: [Observation],
+      id_in_set: [Observation],
       by_users: [User],
       needs_naming: :boolean,
       in_clade: :string,

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -9,7 +9,7 @@ class Query::Projects < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [Project],
+      id_in_set: [Project],
       by_users: [User],
       members: [User],
       has_images: { boolean: [true] },

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -12,7 +12,7 @@ class Query::RssLogs < Query::Base
     super.merge(
       updated_at: [:time],
       type: :string,
-      ids: [RssLog]
+      id_in_set: [RssLog]
     ).merge(content_filter_parameter_declarations(Observation)).
       merge(content_filter_parameter_declarations(Location))
   end

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -9,7 +9,7 @@ class Query::Sequences < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [Sequence],
+      id_in_set: [Sequence],
       by_users: [User],
       observations: [Observation],
       locus: [:string],

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -10,7 +10,7 @@ class Query::SpeciesLists < Query::Base
       created_at: [:time],
       updated_at: [:time],
       date: [:date],
-      ids: [SpeciesList],
+      id_in_set: [SpeciesList],
       by_users: [User],
       locations: [Location],
       search_where: :string,

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -9,7 +9,7 @@ class Query::Users < Query::Base
     super.merge(
       created_at: [:time],
       updated_at: [:time],
-      ids: [User],
+      id_in_set: [User],
       pattern: :string,
       has_contribution: :boolean
     )

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -253,7 +253,7 @@ class LookupsController < ApplicationController
   )
     obj = matches.first || suggestions.first
 
-    query = Query.lookup(model, ids: matches + suggestions)
+    query = Query.lookup(model, id_in_set: matches + suggestions)
     if suggestions.any?
       flash_warning(
         :runtime_suggest_multiple_alternates.t(match: id, type: model.type_tag)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -329,7 +329,7 @@ module Tabs
     # for show_obs - query is for a single obs label
     def print_labels_button(obs)
       name = :download_observations_print_labels.l
-      query = Query.lookup(Observation, ids: [obs.id])
+      query = Query.lookup(Observation, id_in_set: [obs.id])
       path = add_query_param(observations_downloads_path(commit: name), query)
 
       post_button(name: name, path: path, icon: :print,

--- a/test/classes/query/articles_test.rb
+++ b/test/classes/query/articles_test.rb
@@ -17,8 +17,8 @@ class Query::ArticlesTest < UnitTestCase
   end
 
   def test_article_in_set
-    assert_query([articles(:premier_article).id], :Article,
-                 ids: [articles(:premier_article).id])
-    assert_query([], :Article, ids: [])
+    assert_query([articles(:premier_article).id],
+                 :Article, id_in_set: [articles(:premier_article).id])
+    assert_query([], :Article, id_in_set: [])
   end
 end

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -36,7 +36,8 @@ class Query::CommentsTest < UnitTestCase
       [comments(:detailed_unknown_obs_comment).id,
        comments(:minimal_unknown_obs_comment_1).id],
       :Comment, id_in_set: [comments(:detailed_unknown_obs_comment).id,
-                            comments(:minimal_unknown_obs_comment_1).id])
+                            comments(:minimal_unknown_obs_comment_1).id]
+    )
   end
 
   def test_comment_pattern_search

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -32,11 +32,11 @@ class Query::CommentsTest < UnitTestCase
   end
 
   def test_comment_in_set
-    assert_query([comments(:detailed_unknown_obs_comment).id,
-                  comments(:minimal_unknown_obs_comment_1).id],
-                 :Comment,
-                 ids: [comments(:detailed_unknown_obs_comment).id,
-                       comments(:minimal_unknown_obs_comment_1).id])
+    assert_query(
+      [comments(:detailed_unknown_obs_comment).id,
+       comments(:minimal_unknown_obs_comment_1).id],
+      :Comment, id_in_set: [comments(:detailed_unknown_obs_comment).id,
+                            comments(:minimal_unknown_obs_comment_1).id])
   end
 
   def test_comment_pattern_search

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -23,7 +23,7 @@ class Query::HerbariaTest < UnitTestCase
       herbaria(:dick_herbarium),
       herbaria(:nybg_herbarium)
     ]
-    assert_query(expects, :Herbarium, ids: expects)
+    assert_query(expects, :Herbarium, id_in_set: expects)
   end
 
   def test_herbarium_pattern_search

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -109,7 +109,7 @@ class Query::ImagesTest < UnitTestCase
     ids = [images(:turned_over_image).id,
            images(:agaricus_campestris_image).id,
            images(:disconnected_coprinus_comatus_image).id]
-    assert_query(ids, :Image, ids: ids)
+    assert_query(ids, :Image, id_in_set: ids)
   end
 
   def test_image_inside_observation
@@ -395,8 +395,10 @@ class Query::ImagesTest < UnitTestCase
                observations(:agaricus_campestris_obs).id]
     expects = Image.joins(:observations).where(observations: { id: obs_ids }).
               index_order.distinct
-    assert_image_obs_query(expects, ids: obs_ids)
-    assert_image_obs_query([], ids: [observations(:minimal_unknown_obs).id])
+    assert_image_obs_query(expects, id_in_set: obs_ids)
+    assert_image_obs_query(
+      [], id_in_set: [observations(:minimal_unknown_obs).id]
+    )
   end
 
   def test_image_with_observations_in_species_list
@@ -414,21 +416,20 @@ class Query::ImagesTest < UnitTestCase
     assert_image_obs_query(expects, **params)
   end
 
+  SORTED_BY_NAME_SET = [
+    images(:turned_over_image).id,
+    images(:connected_coprinus_comatus_image).id,
+    images(:disconnected_coprinus_comatus_image).id,
+    images(:in_situ_image).id,
+    images(:commercial_inquiry_image).id,
+    images(:agaricus_campestris_image).id
+  ].freeze
+
   def test_image_sorted_by_original_name
-    assert_query([images(:turned_over_image).id,
-                  images(:connected_coprinus_comatus_image).id,
-                  images(:disconnected_coprinus_comatus_image).id,
-                  images(:in_situ_image).id,
-                  images(:commercial_inquiry_image).id,
-                  images(:agaricus_campestris_image).id],
-                 :Image,
-                 ids: [images(:in_situ_image).id,
-                       images(:turned_over_image).id,
-                       images(:commercial_inquiry_image).id,
-                       images(:disconnected_coprinus_comatus_image).id,
-                       images(:connected_coprinus_comatus_image).id,
-                       images(:agaricus_campestris_image).id],
-                 by: :original_name)
+    assert_query(
+      SORTED_BY_NAME_SET,
+      :Image, id_in_set: SORTED_BY_NAME_SET, by: :original_name
+    )
   end
 
   def test_image_with_observations_of_name

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -416,19 +416,21 @@ class Query::ImagesTest < UnitTestCase
     assert_image_obs_query(expects, **params)
   end
 
-  SORTED_BY_NAME_SET = [
-    images(:turned_over_image).id,
-    images(:connected_coprinus_comatus_image).id,
-    images(:disconnected_coprinus_comatus_image).id,
-    images(:in_situ_image).id,
-    images(:commercial_inquiry_image).id,
-    images(:agaricus_campestris_image).id
-  ].freeze
+  def sorted_by_name_set
+    [
+      images(:turned_over_image).id,
+      images(:connected_coprinus_comatus_image).id,
+      images(:disconnected_coprinus_comatus_image).id,
+      images(:in_situ_image).id,
+      images(:commercial_inquiry_image).id,
+      images(:agaricus_campestris_image).id
+    ].freeze
+  end
 
   def test_image_sorted_by_original_name
     assert_query(
-      SORTED_BY_NAME_SET,
-      :Image, id_in_set: SORTED_BY_NAME_SET, by: :original_name
+      sorted_by_name_set,
+      :Image, id_in_set: sorted_by_name_set, by: :original_name
     )
   end
 

--- a/test/classes/query/location_descriptions_test.rb
+++ b/test/classes/query/location_descriptions_test.rb
@@ -77,14 +77,17 @@ class Query::LocationDescriptionsTest < UnitTestCase
   end
 
   def test_location_description_in_set
-    assert_query([],
-                 :LocationDescription,
-                 ids: rolf.id)
-    assert_query(LocationDescription.all,
-                 :LocationDescription,
-                 ids: LocationDescription.select(:id).to_a)
-    assert_query([location_descriptions(:albion_desc).id],
-                 :LocationDescription,
-                 ids: [rolf.id, location_descriptions(:albion_desc).id])
+    assert_query(
+      [], :LocationDescription, id_in_set: rolf.id
+    )
+    assert_query(
+      LocationDescription.all,
+      :LocationDescription, id_in_set: LocationDescription.select(:id).to_a
+    )
+    assert_query(
+      [location_descriptions(:albion_desc).id],
+      :LocationDescription, id_in_set: [rolf.id,
+                                        location_descriptions(:albion_desc).id]
+    )
   end
 end

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -35,15 +35,17 @@ class Query::LocationsTest < UnitTestCase
     assert_query(expects.to_a, :Location, by: :rss_log)
   end
 
-  LOCATION_SET = [
-    locations(:gualala).id,
-    locations(:albion).id,
-    locations(:burbank).id,
-    locations(:elgin_co).id
-  ].freeze
+  def location_set
+    [
+      locations(:gualala).id,
+      locations(:albion).id,
+      locations(:burbank).id,
+      locations(:elgin_co).id
+    ].freeze
+  end
 
   def test_location_in_set
-    assert_query(LOCATION_SET, :Location, id_in_set: LOCATION_SET)
+    assert_query(location_set, :Location, id_in_set: location_set)
   end
 
   def test_location_has_notes

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -35,16 +35,15 @@ class Query::LocationsTest < UnitTestCase
     assert_query(expects.to_a, :Location, by: :rss_log)
   end
 
+  LOCATION_SET = [
+    locations(:gualala).id,
+    locations(:albion).id,
+    locations(:burbank).id,
+    locations(:elgin_co).id
+  ].freeze
+
   def test_location_in_set
-    assert_query([locations(:gualala).id,
-                  locations(:albion).id,
-                  locations(:burbank).id,
-                  locations(:elgin_co).id],
-                 :Location,
-                 ids: [locations(:gualala).id,
-                       locations(:albion).id,
-                       locations(:burbank).id,
-                       locations(:elgin_co).id])
+    assert_query(LOCATION_SET, :Location, id_in_set: LOCATION_SET)
   end
 
   def test_location_has_notes
@@ -181,13 +180,13 @@ class Query::LocationsTest < UnitTestCase
            location_descriptions(:no_mushrooms_location_desc).id]
     assert_query(
       [locations(:albion), locations(:no_mushrooms_location)],
-      :Location, description_query: { ids: ids }
+      :Location, description_query: { id_in_set: ids }
     )
     ids = [location_descriptions(:albion_desc).id, rolf.id]
     assert_query([locations(:albion)], :Location,
-                 description_query: { ids: ids })
+                 description_query: { id_in_set: ids })
     assert_query([],
-                 :Location, description_query: { ids: [rolf.id] })
+                 :Location, description_query: { id_in_set: [rolf.id] })
   end
 
   def test_location_has_observations
@@ -428,9 +427,9 @@ class Query::LocationsTest < UnitTestCase
   def test_location_with_observations_in_set
     ids = [observations(:minimal_unknown_obs).id]
     assert_query([locations(:burbank).id],
-                 :Location, observation_query: { ids: })
+                 :Location, observation_query: { id_in_set: ids })
     ids = [observations(:coprinus_comatus_obs).id]
-    assert_query([], :Location, observation_query: { ids: })
+    assert_query([], :Location, observation_query: { id_in_set: ids })
   end
 
   def test_location_with_observations_in_species_list

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -64,7 +64,7 @@ class Query::NameDescriptionsTest < UnitTestCase
     assert_query(
       [NameDescription.first.id],
       :NameDescription, id_in_set: [rolf.id, NameDescription.first.id]
-      )
+    )
   end
 
   def test_name_description_has_default_desc

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -56,12 +56,15 @@ class Query::NameDescriptionsTest < UnitTestCase
   end
 
   def test_name_description_in_set
-    assert_query([],
-                 :NameDescription, ids: rolf.id)
-    assert_query(NameDescription.all,
-                 :NameDescription, ids: NameDescription.select(:id).to_a)
-    assert_query([NameDescription.first.id],
-                 :NameDescription, ids: [rolf.id, NameDescription.first.id])
+    assert_query([], :NameDescription, id_in_set: rolf.id)
+    assert_query(
+      NameDescription.all,
+      :NameDescription, id_in_set: NameDescription.select(:id).to_a
+    )
+    assert_query(
+      [NameDescription.first.id],
+      :NameDescription, id_in_set: [rolf.id, NameDescription.first.id]
+      )
   end
 
   def test_name_description_has_default_desc

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -552,17 +552,19 @@ class Query::NamesTest < UnitTestCase
     assert_query(expects, :Name, observation_query: { projects: project2 })
   end
 
-  THREE_AMIGOS = [
-    observations(:detailed_unknown_obs).id,
-    observations(:agaricus_campestris_obs).id,
-    observations(:agaricus_campestras_obs).id
-  ].freeze
+  def three_amigos
+    [
+      observations(:detailed_unknown_obs).id,
+      observations(:agaricus_campestris_obs).id,
+      observations(:agaricus_campestras_obs).id
+    ].freeze
+  end
 
   def test_name_with_observations_in_set
     expects = Name.with_correct_spelling.joins(:observations).
-              where(observations: { id: THREE_AMIGOS }).
+              where(observations: { id: three_amigos }).
               index_order.distinct
-    assert_query(expects, :Name, observation_query: { id_in_set: THREE_AMIGOS })
+    assert_query(expects, :Name, observation_query: { id_in_set: three_amigos })
   end
 
   def test_name_with_observations_in_species_list

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -36,20 +36,22 @@ class Query::NamesTest < UnitTestCase
     assert_query(expects, :Name, by: :rss_log)
   end
 
-  NAMES_SET = [
-    names(:fungi),
-    names(:coprinus_comatus),
-    names(:conocybe_filaris),
-    names(:lepiota_rhacodes),
-    names(:lactarius_subalpinus)
-  ].freeze
+  def names_set
+    [
+      names(:fungi),
+      names(:coprinus_comatus),
+      names(:conocybe_filaris),
+      names(:lepiota_rhacodes),
+      names(:lactarius_subalpinus)
+    ].freeze
+  end
 
   def test_name_ids_with_name_ids
-    assert_query(NAMES_SET.map(&:id), :Name, id_in_set: NAMES_SET.map(&:id))
+    assert_query(names_set.map(&:id), :Name, id_in_set: names_set.map(&:id))
   end
 
   def test_name_ids_with_name_instances
-    assert_query(NAMES_SET.map(&:id), :Name, id_in_set: NAMES_SET)
+    assert_query(names_set.map(&:id), :Name, id_in_set: names_set)
   end
 
   def test_name_by_user

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -36,22 +36,20 @@ class Query::NamesTest < UnitTestCase
     assert_query(expects, :Name, by: :rss_log)
   end
 
-  def names_set
-    [
-      names(:fungi),
-      names(:coprinus_comatus),
-      names(:conocybe_filaris),
-      names(:lepiota_rhacodes),
-      names(:lactarius_subalpinus)
-    ]
-  end
+  NAMES_SET = [
+    names(:fungi),
+    names(:coprinus_comatus),
+    names(:conocybe_filaris),
+    names(:lepiota_rhacodes),
+    names(:lactarius_subalpinus)
+  ].freeze
 
   def test_name_ids_with_name_ids
-    assert_query(names_set.map(&:id), :Name, ids: names_set.map(&:id))
+    assert_query(NAMES_SET.map(&:id), :Name, id_in_set: NAMES_SET.map(&:id))
   end
 
   def test_name_ids_with_name_instances
-    assert_query(names_set.map(&:id), :Name, ids: names_set)
+    assert_query(NAMES_SET.map(&:id), :Name, id_in_set: NAMES_SET)
   end
 
   def test_name_by_user
@@ -383,7 +381,7 @@ class Query::NamesTest < UnitTestCase
     name1 = names(:peltigera)
     name2 = names(:boletus_edulis)
     assert_query([name2, name1],
-                 :Name, description_query: { ids: [desc1, desc2, desc3] })
+                 :Name, description_query: { id_in_set: [desc1, desc2, desc3] })
   end
 
   def test_name_has_observations
@@ -556,9 +554,9 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_with_observations_in_set
     expects = Name.with_correct_spelling.joins(:observations).
-              where(observations: { id: three_amigos }).
+              where(observations: { id: THREE_AMIGOS }).
               index_order.distinct
-    assert_query(expects, :Name, observation_query: { ids: three_amigos })
+    assert_query(expects, :Name, observation_query: { id_in_set: THREE_AMIGOS })
   end
 
   def test_name_with_observations_in_species_list

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -552,6 +552,12 @@ class Query::NamesTest < UnitTestCase
     assert_query(expects, :Name, observation_query: { projects: project2 })
   end
 
+  THREE_AMIGOS = [
+    observations(:detailed_unknown_obs).id,
+    observations(:agaricus_campestris_obs).id,
+    observations(:agaricus_campestras_obs).id
+  ].freeze
+
   def test_name_with_observations_in_set
     expects = Name.with_correct_spelling.joins(:observations).
               where(observations: { id: THREE_AMIGOS }).

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -18,26 +18,26 @@ class Query::ObservationsTest < UnitTestCase
     assert_query(expects, :Observation, by: :rss_log)
   end
 
-  BIG_SET = [
-    observations(:unknown_with_no_naming),
-    observations(:minimal_unknown_obs),
-    observations(:strobilurus_diminutivus_obs),
-    observations(:detailed_unknown_obs),
-    observations(:agaricus_campestros_obs),
-    observations(:coprinus_comatus_obs),
-    observations(:agaricus_campestras_obs),
-    observations(:agaricus_campestris_obs),
-    observations(:agaricus_campestrus_obs)
-  ].freeze
+  def big_set
+    [
+      observations(:unknown_with_no_naming),
+      observations(:minimal_unknown_obs),
+      observations(:strobilurus_diminutivus_obs),
+      observations(:detailed_unknown_obs),
+      observations(:agaricus_campestros_obs),
+      observations(:coprinus_comatus_obs),
+      observations(:agaricus_campestras_obs),
+      observations(:agaricus_campestris_obs),
+      observations(:agaricus_campestrus_obs)
+    ].freeze
+  end
 
   def test_observation_ids_ids
-    assert_query(BIG_SET.map(&:id),
-                 :Observation, id_in_set: BIG_SET.map(&:id))
+    assert_query(big_set.map(&:id), :Observation, id_in_set: big_set.map(&:id))
   end
 
   def test_observation_ids_instances
-    assert_query(BIG_SET.map(&:id),
-                 :Observation, id_in_set: BIG_SET)
+    assert_query(big_set.map(&:id), :Observation, id_in_set: big_set)
   end
 
   def test_observation_by_user

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -18,28 +18,26 @@ class Query::ObservationsTest < UnitTestCase
     assert_query(expects, :Observation, by: :rss_log)
   end
 
-  def observations_set
-    [
-      observations(:unknown_with_no_naming),
-      observations(:minimal_unknown_obs),
-      observations(:strobilurus_diminutivus_obs),
-      observations(:detailed_unknown_obs),
-      observations(:agaricus_campestros_obs),
-      observations(:coprinus_comatus_obs),
-      observations(:agaricus_campestras_obs),
-      observations(:agaricus_campestris_obs),
-      observations(:agaricus_campestrus_obs)
-    ]
-  end
+  BIG_SET = [
+    observations(:unknown_with_no_naming),
+    observations(:minimal_unknown_obs),
+    observations(:strobilurus_diminutivus_obs),
+    observations(:detailed_unknown_obs),
+    observations(:agaricus_campestros_obs),
+    observations(:coprinus_comatus_obs),
+    observations(:agaricus_campestras_obs),
+    observations(:agaricus_campestris_obs),
+    observations(:agaricus_campestrus_obs)
+  ].freeze
 
   def test_observation_ids_ids
-    assert_query(observations_set.map(&:id),
-                 :Observation, ids: observations_set.map(&:id))
+    assert_query(BIG_SET.map(&:id),
+                 :Observation, id_in_set: BIG_SET.map(&:id))
   end
 
   def test_observation_ids_instances
-    assert_query(observations_set.map(&:id),
-                 :Observation, ids: observations_set)
+    assert_query(BIG_SET.map(&:id),
+                 :Observation, id_in_set: BIG_SET)
   end
 
   def test_observation_by_user

--- a/test/classes/query/projects_test.rb
+++ b/test/classes/query/projects_test.rb
@@ -19,8 +19,8 @@ class Query::ProjectsTest < UnitTestCase
 
   def test_project_in_set
     assert_query([projects(:eol_project).id],
-                 :Project, ids: [projects(:eol_project).id])
-    assert_query([], :Project, ids: [])
+                 :Project, id_in_set: [projects(:eol_project).id])
+    assert_query([], :Project, id_in_set: [])
   end
 
   def test_project_members

--- a/test/classes/query/rss_logs_test.rb
+++ b/test/classes/query/rss_logs_test.rb
@@ -20,6 +20,6 @@ class Query::RssLogsTest < UnitTestCase
   def test_rss_log_in_set
     rsslog_set_ids = [rss_logs(:species_list_rss_log).id,
                       rss_logs(:name_rss_log).id]
-    assert_query(rsslog_set_ids, :RssLog, ids: rsslog_set_ids)
+    assert_query(rsslog_set_ids, :RssLog, id_in_set: rsslog_set_ids)
   end
 end

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -92,7 +92,7 @@ class Query::SequencesTest < UnitTestCase
   def test_sequence_in_set
     list_set_ids = [sequences(:fasta_formatted_sequence).id,
                     sequences(:bare_formatted_sequence).id]
-    assert_query(list_set_ids, :Sequence, ids: list_set_ids)
+    assert_query(list_set_ids, :Sequence, id_in_set: list_set_ids)
   end
 
   def test_sequence_pattern_search

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -66,7 +66,7 @@ class Query::SpeciesListsTest < UnitTestCase
   def test_species_list_in_set
     list_set_ids = [species_lists(:first_species_list).id,
                     species_lists(:unknown_species_list).id]
-    assert_query(list_set_ids, :SpeciesList, ids: list_set_ids)
+    assert_query(list_set_ids, :SpeciesList, id_in_set: list_set_ids)
   end
 
   def test_species_list_pattern_search

--- a/test/classes/query/users_test.rb
+++ b/test/classes/query/users_test.rb
@@ -18,13 +18,14 @@ class Query::UsersTest < UnitTestCase
   end
 
   def test_user_in_set
-    assert_query([rolf.id, mary.id, junk.id],
-                 :User, ids: [junk.id, mary.id, rolf.id], by: :reverse_name)
+    assert_query(
+      [rolf.id, mary.id, junk.id],
+      :User, id_in_set: [junk.id, mary.id, rolf.id], by: :reverse_name
+    )
   end
 
   def test_user_pattern_search_nonexistent
-    assert_query([],
-                 :User, pattern: "nonexistent pattern")
+    assert_query([], :User, pattern: "nonexistent pattern")
   end
 
   def test_user_pattern_search_login

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -71,28 +71,42 @@ class QueryTest < UnitTestCase
                  Query.lookup(:Image, by_users: rolf.login).params[:by_users])
   end
 
-  def test_validate_params_ids
+  def test_validate_params_id_in_set
     # Oops, this query is generic,
     # doesn't know to require Name instances here.
-    # assert_raises(RuntimeError) { Query.lookup(:Name, ids: rolf) }
-    assert_raises(RuntimeError) { Query.lookup(:Name, ids: "one") }
-    assert_raises(RuntimeError) { Query.lookup(:Name, ids: "1,2,3") }
-    assert_raises(RuntimeError) { Query.lookup(:Name, ids: "Fungi") }
-    assert_equal([names(:fungi).id],
-                 Query.lookup(:Name, ids: names(:fungi).id.to_s).params[:ids])
+    # assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: rolf) }
+    assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: "one") }
+    assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: "1,2,3") }
+    assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: "Fungi") }
+    assert_equal(
+      [names(:fungi).id],
+      Query.lookup(:Name, id_in_set: names(:fungi).id.to_s).params[:id_in_set]
+    )
 
     # assert_raises(RuntimeError) { Query.lookup(:User) }
-    assert_equal([], Query.lookup(:User, ids: []).params[:ids])
-    assert_equal([rolf.id], Query.lookup(:User, ids: rolf.id).params[:ids])
+    assert_equal([], Query.lookup(:User, id_in_set: []).params[:id_in_set])
+    assert_equal(
+      [rolf.id], Query.lookup(:User, id_in_set: rolf.id).params[:id_in_set]
+    )
     ids = [rolf.id, mary.id]
-    assert_equal(ids, Query.lookup(:User, ids: ids).params[:ids])
-    assert_equal([1, 2], Query.lookup(:User, ids: %w[1 2]).params[:ids])
-    assert_equal(ids, Query.lookup(:User, ids: ids.map(&:to_s)).params[:ids])
-    assert_equal([rolf.id], Query.lookup(:User, ids: rolf).params[:ids])
-    assert_equal(ids, Query.lookup(:User, ids: [rolf, mary]).params[:ids])
-    assert_equal([rolf.id, mary.id, junk.id],
-                 Query.lookup(:User, ids: [rolf, mary.id, junk.id.to_s]).
-                 params[:ids])
+    assert_equal(ids, Query.lookup(:User, id_in_set: ids).params[:id_in_set])
+    assert_equal(
+      [1, 2], Query.lookup(:User, id_in_set: %w[1 2]).params[:id_in_set]
+    )
+    assert_equal(
+      ids, Query.lookup(:User, id_in_set: ids.map(&:to_s)).params[:id_in_set]
+    )
+    assert_equal(
+      [rolf.id], Query.lookup(:User, id_in_set: rolf).params[:id_in_set]
+    )
+    assert_equal(
+      ids, Query.lookup(:User, id_in_set: [rolf, mary]).params[:id_in_set]
+    )
+    rando_set = [rolf, mary.id, junk.id.to_s]
+    assert_equal(
+      [rolf.id, mary.id, junk.id],
+      Query.lookup(:User, id_in_set: rando_set).params[:id_in_set]
+    )
   end
 
   def test_validate_params_pattern
@@ -772,7 +786,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
+    query_a[3] = Query.lookup_and_save(:Observation, id_in_set: three_amigos)
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, locations: burbank)
     query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
@@ -787,7 +801,7 @@ class QueryTest < UnitTestCase
     assert_equal([mary.id], obs_queries[1][:by_users])
     assert_equal([species_lists(:first_species_list).id],
                  obs_queries[2][:species_lists])
-    assert_equal(three_amigos, obs_queries[3][:ids])
+    assert_equal(three_amigos, obs_queries[3][:id_in_set])
     assert_equal(1, obs_queries[3].keys.length)
     assert_equal("glendale", obs_queries[4][:search_where])
     assert_equal(1, obs_queries[4].keys.length)
@@ -879,7 +893,7 @@ class QueryTest < UnitTestCase
     qa[1] = Query.lookup_and_save(desc_model, by_author: rolf.id)
     qa[2] = Query.lookup_and_save(desc_model, by_editor: rolf.id)
     qa[3] = Query.lookup_and_save(desc_model, by_users: rolf.id)
-    qa[4] = Query.lookup_and_save(desc_model, ids: [ds1.id, ds2.id])
+    qa[4] = Query.lookup_and_save(desc_model, id_in_set: [ds1.id, ds2.id])
     assert_equal(5, QueryRecord.count)
 
     # Try coercing them into parent_type queries.
@@ -897,7 +911,7 @@ class QueryTest < UnitTestCase
     assert_equal(rolf.id, desc_queries[1][:by_author])
     assert_equal(rolf.id, desc_queries[2][:by_editor])
     assert_equal([rolf.id], desc_queries[3][:by_users])
-    assert_equal([ds1.id, ds2.id], desc_queries[4][:ids])
+    assert_equal([ds1.id, ds2.id], desc_queries[4][:id_in_set])
 
     # Try coercing them back.
     # None should be new records
@@ -965,7 +979,7 @@ class QueryTest < UnitTestCase
   ##############################################################################
 
   def test_whiny_nil_in_map_locations
-    query = Query.lookup(:User, ids: [rolf.id, 1000, mary.id])
+    query = Query.lookup(:User, id_in_set: [rolf.id, 1000, mary.id])
     query.sql
     assert_equal(2, query.results.length)
   end
@@ -977,12 +991,12 @@ class QueryTest < UnitTestCase
     User.current = rolf
     assert_equal("postal", User.current_location_format)
     assert_query([albion, elgin_co],
-                 :Location, ids: [albion.id, elgin_co.id], by: :name)
+                 :Location, id_in_set: [albion.id, elgin_co.id], by: :name)
 
     User.current = roy
     assert_equal("scientific", User.current_location_format)
     assert_query([elgin_co, albion],
-                 :Location, ids: [albion.id, elgin_co.id], by: :name)
+                 :Location, id_in_set: [albion.id, elgin_co.id], by: :name)
 
     obs1 = observations(:minimal_unknown_obs)
     obs2 = observations(:detailed_unknown_obs)
@@ -992,11 +1006,11 @@ class QueryTest < UnitTestCase
     User.current = rolf
     assert_equal("postal", User.current_location_format)
     assert_query([obs1, obs2],
-                 :Observation, ids: [obs1.id, obs2.id], by: :location)
+                 :Observation, id_in_set: [obs1.id, obs2.id], by: :location)
 
     User.current = roy
     assert_equal("scientific", User.current_location_format)
     assert_query([obs2, obs1],
-                 :Observation, ids: [obs1.id, obs2.id], by: :location)
+                 :Observation, id_in_set: [obs1.id, obs2.id], by: :location)
   end
 end

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -731,11 +731,13 @@ class QueryTest < UnitTestCase
     assert_equal(1, QueryRecord.count)
   end
 
-  THREE_AMIGOS = [
-    observations(:detailed_unknown_obs).id,
-    observations(:agaricus_campestris_obs).id,
-    observations(:agaricus_campestras_obs).id
-  ].freeze
+  def three_amigos
+    [
+      observations(:detailed_unknown_obs).id,
+      observations(:agaricus_campestris_obs).id,
+      observations(:agaricus_campestras_obs).id
+    ].freeze
+  end
 
   def test_observation_subquery_of_image
     burbank = locations(:burbank)
@@ -747,7 +749,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: THREE_AMIGOS)
+    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, locations: burbank)
     query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
@@ -770,7 +772,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: THREE_AMIGOS)
+    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, locations: burbank)
     query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
@@ -785,7 +787,7 @@ class QueryTest < UnitTestCase
     assert_equal([mary.id], obs_queries[1][:by_users])
     assert_equal([species_lists(:first_species_list).id],
                  obs_queries[2][:species_lists])
-    assert_equal(THREE_AMIGOS, obs_queries[3][:ids])
+    assert_equal(three_amigos, obs_queries[3][:ids])
     assert_equal(1, obs_queries[3].keys.length)
     assert_equal("glendale", obs_queries[4][:search_where])
     assert_equal(1, obs_queries[4].keys.length)
@@ -805,7 +807,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: THREE_AMIGOS)
+    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
     # qa[4] = Query.lookup_and_save(:Observation,
     #                             pattern: '"somewhere else"')
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -731,6 +731,12 @@ class QueryTest < UnitTestCase
     assert_equal(1, QueryRecord.count)
   end
 
+  THREE_AMIGOS = [
+    observations(:detailed_unknown_obs).id,
+    observations(:agaricus_campestris_obs).id,
+    observations(:agaricus_campestras_obs).id
+  ].freeze
+
   def test_observation_subquery_of_image
     burbank = locations(:burbank)
     query_a = []

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -741,7 +741,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
+    query_a[3] = Query.lookup_and_save(:Observation, ids: THREE_AMIGOS)
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, locations: burbank)
     query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
@@ -764,7 +764,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
+    query_a[3] = Query.lookup_and_save(:Observation, ids: THREE_AMIGOS)
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, locations: burbank)
     query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
@@ -779,7 +779,7 @@ class QueryTest < UnitTestCase
     assert_equal([mary.id], obs_queries[1][:by_users])
     assert_equal([species_lists(:first_species_list).id],
                  obs_queries[2][:species_lists])
-    assert_equal(three_amigos, obs_queries[3][:ids])
+    assert_equal(THREE_AMIGOS, obs_queries[3][:ids])
     assert_equal(1, obs_queries[3].keys.length)
     assert_equal("glendale", obs_queries[4][:search_where])
     assert_equal(1, obs_queries[4].keys.length)
@@ -799,7 +799,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
+    query_a[3] = Query.lookup_and_save(:Observation, ids: THREE_AMIGOS)
     # qa[4] = Query.lookup_and_save(:Observation,
     #                             pattern: '"somewhere else"')
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -763,7 +763,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
+    query_a[3] = Query.lookup_and_save(:Observation, id_in_set: three_amigos)
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")
     query_a[5] = Query.lookup_and_save(:Observation, locations: burbank)
     query_a[6] = Query.lookup_and_save(:Observation, search_where: "california")
@@ -821,7 +821,7 @@ class QueryTest < UnitTestCase
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
     )
-    query_a[3] = Query.lookup_and_save(:Observation, ids: three_amigos)
+    query_a[3] = Query.lookup_and_save(:Observation, id_in_set: three_amigos)
     # qa[4] = Query.lookup_and_save(:Observation,
     #                             pattern: '"somewhere else"')
     query_a[4] = Query.lookup_and_save(:Observation, search_where: "glendale")

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -19,7 +19,7 @@ class ArticlesControllerTest < FunctionalTestCase
 
   def test_index_filtered
     article = Article.reorder(created_at: :asc).first # oldest
-    query = Query.lookup(:Article, ids: [article.id])
+    query = Query.lookup(:Article, id_in_set: [article.id])
     params = @controller.query_params(query)
     get(:index, params: params)
 

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -131,7 +131,7 @@ class HerbariaControllerTest < FunctionalTestCase
 
   def test_index
     set = [nybg, herbaria(:rolf_herbarium)]
-    query = Query.lookup_and_save(:Herbarium, by: :name, ids: set)
+    query = Query.lookup_and_save(:Herbarium, by: :name, id_in_set: set)
     login("zero") # Does not own any herbarium in set
     get(:index, params: { q: query.record.id.alphabetize })
 

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -303,10 +303,8 @@ class ImagesControllerTest < FunctionalTestCase
   #   min_unknown =  observations(:minimal_unknown_obs).id
   #   a_campestris = observations(:agaricus_campestris_obs).id
   #   c_comatus =    observations(:coprinus_comatus_obs).id
-
-  #   outer = Query.lookup_and_save(
-  #     :Observation, ids: [det_unknown, min_unknown, a_campestris, c_comatus]
-  #   )
+  #   set = [det_unknown, min_unknown, a_campestris, c_comatus]
+  #   outer = Query.lookup_and_save(:Observation, id_in_set: set)
   #   inner = Query.lookup_and_save(
   #     :Image, observation_query: outer.params,
   #             group: "observation_images.observation_id"

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -214,7 +214,7 @@ class ImagesControllerTest < FunctionalTestCase
   #   set = [det_unknown, min_unknown, a_campestris, c_comatus].
   #         sort_by(&:id)
   #   # query 1 (outer)
-  #   outer = Query.lookup_and_save(:Observation, ids: set)
+  #   outer = Query.lookup_and_save(:Observation, id_in_set: set)
   #   # query 2 (inner for first obs)
   #   inner = Query.lookup_and_save(:Image, observation_query: outer.params)
 

--- a/test/controllers/species_lists/observations_controller_test.rb
+++ b/test/controllers/species_lists/observations_controller_test.rb
@@ -117,7 +117,7 @@ module SpeciesLists
       dup_obs = spl.observations.first
       new_obs = (Observation.all - spl.observations).first
       ids = [dup_obs.id, new_obs.id]
-      query = Query.lookup(:Observation, ids: ids)
+      query = Query.lookup(:Observation, id_in_set: ids)
       params = @controller.query_params(query).merge(
         commit: :ADD.l,
         species_list: spl.title

--- a/test/query_extensions.rb
+++ b/test/query_extensions.rb
@@ -25,9 +25,9 @@ module QueryExtensions
     str.gsub(/\s+/, " ").strip
   end
 
-  def three_amigos
-    [observations(:detailed_unknown_obs).id,
-     observations(:agaricus_campestris_obs).id,
-     observations(:agaricus_campestras_obs).id]
-  end
+  THREE_AMIGOS = [
+    observations(:detailed_unknown_obs).id,
+    observations(:agaricus_campestris_obs).id,
+    observations(:agaricus_campestras_obs).id
+  ].freeze
 end

--- a/test/query_extensions.rb
+++ b/test/query_extensions.rb
@@ -24,10 +24,4 @@ module QueryExtensions
   def clean(str)
     str.gsub(/\s+/, " ").strip
   end
-
-  THREE_AMIGOS = [
-    observations(:detailed_unknown_obs).id,
-    observations(:agaricus_campestris_obs).id,
-    observations(:agaricus_campestras_obs).id
-  ].freeze
 end


### PR DESCRIPTION
This is part of getting Query param names to align with scope names, so Query can be dumber and simpler. `:ids` cannot be used as a scope name, because is a method of all classes. e.g., `Observation.ids`.

Switches params and all callers to the more descriptive `:id_in_set`.