### PR TITLE
Add fix_names.rb script

### DIFF
--- a/app/models/name/notify.rb
+++ b/app/models/name/notify.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 module Name::Notify
+  attr_writer :skip_notify
+
+  def skip_notify
+    @skip_notify || false
+  end
+
   # Notify webmaster that a new name was created.
   def notify_webmaster
+    return if @skip_notify
+
     user = User.current || User.admin
     QueuedEmail::Webmaster.create_email(
       sender_email: user.email,
@@ -14,6 +22,7 @@ module Name::Notify
   # This is called after saving potential changes to a Name.  It will determine
   # if the changes are important enough to notify the authors, and do so.
   def notify_users
+    return if @skip_notify
     return unless saved_version_changes?
 
     sender = User.current

--- a/app/models/name/notify.rb
+++ b/app/models/name/notify.rb
@@ -9,7 +9,7 @@ module Name::Notify
 
   # Notify webmaster that a new name was created.
   def notify_webmaster
-    return if @skip_notify
+    return if skip_notify
 
     user = User.current || User.admin
     QueuedEmail::Webmaster.create_email(
@@ -22,7 +22,7 @@ module Name::Notify
   # This is called after saving potential changes to a Name.  It will determine
   # if the changes are important enough to notify the authors, and do so.
   def notify_users
-    return if @skip_notify
+    return if skip_notify
     return unless saved_version_changes?
 
     sender = User.current

--- a/script/fix_names.rb
+++ b/script/fix_names.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Ensure that name.sort_name is consistent with
+# Name.parse(name.search_name).sort_name
+
+def update
+  Name.find_each do |name|
+    name.skip_notify = true
+    parse = Name.parse_name(name.search_name, deprecated: name.deprecated,
+                                              rank: name.rank)
+    if parse
+      changed = check_name("text_name", name, parse)
+      changed = check_name("search_name", name, parse) || changed
+      changed = check_name("display_name", name, parse) || changed
+      changed = check_name("sort_name", name, parse) || changed
+      name.save if changed
+    else
+      puts("BAD PARSE: #{name.id},#{name.search_name}")
+    end
+  end
+end
+
+def check_name(method, name, parse)
+  old_value = name.send(method)
+  new_value = parse.send(method)
+  return false if old_value == new_value
+
+  name.send(:"#{method}=", new_value)
+  puts("#{name.id},#{method},#{old_value},#{new_value},#{name.created_at}")
+  true
+end
+
+update

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2726,6 +2726,25 @@ class NameTest < UnitTestCase
     assert_equal(sort_names, sort_names.sort)
   end
 
+  def test_skip_notify
+    QueuedEmail.queue = true
+    User.current = users(:roy)
+    name = names(:coprinus_comatus)
+    name.skip_notify = true
+    assert_difference("QueuedEmail.count", 0) do
+      name.update(
+        Name.parse_name("Coprinus comatus  (O.F. Müll.) Persoon").params
+      )
+    end
+    name.skip_notify = false
+    assert_difference("QueuedEmail.count", 2) do
+      name.update(
+        Name.parse_name("Coprinus comatus  (O.F. Müll.) Pers.").params
+      )
+    end
+    QueuedEmail.queue = false
+  end
+
   # Prove that alphabetized sort_names give us names in the expected order
   # Differs from test_name_spaceship_operator in omitting "Agaricus Śliwa",
   # whose sort_name is after all the levels between genus and species,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -80,6 +80,20 @@ end
 
 I18n.enforce_available_locales = true
 
+# Function for creating a log the tests called that
+# somehow call this function.
+def trace_tests
+  regex = %r{/test/}
+  matches = caller.grep(regex)
+  return unless matches
+
+  last_match = matches.last
+  trim = last_match[last_match.index(regex) + 1..]
+  open("trace_tests.out", "a") do |f|
+    f.write("#{trim}\n")
+  end
+end
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
Adds script for ensuring that the various name strings in a Name objects are self consistent and consistent with our standard parsing rules.  This should be run against our production database to tidy up around 450 issues discovered as part of digging into supporting a new format for provisional names.  This script will also be used to support that transition once `Name.parse_name` is updated to support the new format.