### PR TITLE
Consolidate content filter params and scopes

### DIFF
--- a/app/classes/autocomplete/for_region.rb
+++ b/app/classes/autocomplete/for_region.rb
@@ -14,7 +14,7 @@ class Autocomplete::ForRegion < Autocomplete::ByWord
   # "scientific" format users will have the country first, so reverse words
   def rough_matches(words)
     words = Location.reverse_name(words) if reverse
-    regions = Observation.in_region(words).select(:where, :location_id)
+    regions = Observation.region(words).select(:where, :location_id)
 
     matches_array(regions)
   end
@@ -22,7 +22,7 @@ class Autocomplete::ForRegion < Autocomplete::ByWord
   # Doesn't make sense to have an exact match for a region.
   # def exact_match(words)
   #   words = Location.reverse_name(words) if reverse
-  #   region = Observation.in_region(words).select(:where, :location_id).first
+  #   region = Observation.region(words).select(:where, :location_id).first
   #   return [] unless region
 
   #   matches_array([region])

--- a/app/classes/lookup/regions.rb
+++ b/app/classes/lookup/regions.rb
@@ -9,6 +9,6 @@ class Lookup::Regions < Lookup
   end
 
   def lookup_method(name)
-    Location.in_region(name.to_s.clean_pattern)
+    Location.region(name.to_s.clean_pattern)
   end
 end

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -19,6 +19,7 @@ class Query::Locations < Query::Base
       by_users: [User],
       by_editor: User,
       in_box: { north: :float, south: :float, east: :float, west: :float },
+      # region: :string, # content filter
       pattern: :string,
       regexp: :string,
       has_notes: :boolean,

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -25,6 +25,8 @@ class Query::Names < Query::Base # rubocop:disable Metrics/ClassLength
                include_immediate_subtaxa: :boolean,
                exclude_original_names: :boolean },
       text_name_has: :string,
+      # clade: :string, # content_filter
+      # lichen: :boolean, # content_filter
       misspellings: { string: [:no, :either, :only] },
       deprecated: :boolean,
       has_synonyms: :boolean,

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -48,13 +48,13 @@ module Observations
     def clade(term)
       # return unless (clade = Name.find_by(text_name: term))
 
-      query = create_query(:Observation, needs_naming: true, in_clade: term,
+      query = create_query(:Observation, needs_naming: true, clade: term,
                                          by: :rss_log)
       [query, {}]
     end
 
     def region(term)
-      query = create_query(:Observation, needs_naming: true, in_region: term,
+      query = create_query(:Observation, needs_naming: true, region: term,
                                          by: :rss_log)
       [query, {}]
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -47,7 +47,7 @@
 #  updated_before("yyyymmdd")
 #  updated_between(start, end)
 #  name_has(place_name)
-#  in_region(place_name)
+#  region(place_name)
 #  in_box(north:, south:, east:, west:)
 #
 #  == Instance methods

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -12,18 +12,18 @@ module Location::Scopes
     scope :index_order,
           -> { order(name: :asc, id: :desc) }
 
-    scope :in_regions, lambda { |place_names|
+    scope :regions, lambda { |place_names|
       place_names = [place_names].flatten
       if place_names.length > 1
-        starting = in_region(place_names.shift)
+        starting = region(place_names.shift)
         place_names.reduce(starting) do |result, place_name|
-          result.or(Location.in_region(place_name))
+          result.or(Location.region(place_name))
         end
       else
-        in_region(place_names.first)
+        region(place_names.first)
       end
     }
-    scope :in_region, lambda { |place_name|
+    scope :region, lambda { |place_name|
       region = Location.reverse_name_if_necessary(place_name)
 
       if understood_continent?(region)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -175,7 +175,7 @@
 #  subtaxa_of_genus_or_below(genus)
 #  subtaxa_of(name)
 #  include_synonyms_of(name)
-#  in_clade(name)
+#  clade(name)
 #  text_name_has(text_name)
 #  search_name_has(phrase)
 #  has_classification

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -132,11 +132,11 @@ module Name::Scopes
     scope :include_synonyms_of, lambda { |name|
       with_correct_spelling.where(id: name.synonyms.map(&:id))
     }
-    scope :in_clade, lambda { |names|
+    scope :clade, lambda { |names|
       names(lookup: names, include_subtaxa: true).misspellings(:no)
     }
-    # scope :in_clade_above_genus,
-    #       ->(name) { in_clade(name).with_rank_above_genus }
+    # scope :clade_above_genus,
+    #       ->(name) { clade(name).with_rank_above_genus }
 
     # # A search of all searchable Name fields, concatenated.
     # scope :search_content, lambda { |phrase|

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -97,7 +97,7 @@
 #  by_user(user)
 #  has_location
 #  locations(location)
-#  in_region(where)
+#  region(where)
 #  in_box(north:, south:, east:, west:) geoloc is in the box
 #  not_in_box(north:, south:, east:, west:) geoloc is outside the box
 #  is_collection_location

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1260,7 +1260,7 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # i.e. the end of a location name string
   def check_content_filter_region
     return if content_filter[:region].blank?
-    return if Location.in_region(content_filter[:region]).any?
+    return if Location.region(content_filter[:region]).any?
 
     # If we're here, there are no MO locations in that region.
     errors.add(:region, :advanced_search_filter_region.t)

--- a/test/classes/api2/observations_test.rb
+++ b/test/classes/api2/observations_test.rb
@@ -257,8 +257,8 @@ class API2::ObservationsTest < UnitTestCase
     assert_api_results(obses)
   end
 
-  def test_getting_observations_in_region
-    obses = Observation.in_region("California, USA")
+  def test_getting_observations_region
+    obses = Observation.region("California, USA")
     assert_not_empty(obses)
     assert_api_pass(params_get(region: "California, USA"))
     assert_api_results(obses)

--- a/test/classes/pattern_search/observation_test.rb
+++ b/test/classes/pattern_search/observation_test.rb
@@ -322,7 +322,7 @@ class PatternSearch::ObservationTest < UnitTestCase
   end
 
   def test_observation_search_region
-    expect = Observation.in_region("California, USA")
+    expect = Observation.region("California, USA")
     cal = locations(:california).observations.first
     assert_not_nil(cal)
     assert_includes(expect, cal)
@@ -331,7 +331,7 @@ class PatternSearch::ObservationTest < UnitTestCase
   end
 
   def test_observation_search_multiple_regions
-    expect = Observation.in_regions(["California, USA", "New York, USA"]).
+    expect = Observation.regions(["California, USA", "New York, USA"]).
              reorder(id: :asc).to_a
     assert(expect.any? { |obs| obs.where.include?("California, USA") })
     assert(expect.any? { |obs| obs.where.include?("New York, USA") })

--- a/test/classes/query/filters_test.rb
+++ b/test/classes/query/filters_test.rb
@@ -53,23 +53,23 @@ class Query::FiltersTest < UnitTestCase
   end
 
   def test_filtering_content_region
-    expects = Location.in_region("California, USA").index_order.uniq
+    expects = Location.region("California, USA").index_order.uniq
     assert_query(expects, :Location, region: "California, USA")
     assert_query(expects, :Location, region: "USA, California")
 
-    expects = Observation.in_region("California, USA").index_order.uniq
+    expects = Observation.region("California, USA").index_order.uniq
     assert_query(expects, :Observation, region: "California, USA")
 
-    expects = Location.in_region("North America").index_order.uniq
+    expects = Location.region("North America").index_order.uniq
     assert(expects.include?(locations(:albion))) # usa
     assert(expects.include?(locations(:elgin_co))) # canada
     assert_query(expects, :Location, region: "North America")
   end
 
   def test_filtering_content_clade
-    names = Name.in_clade("Agaricales").index_order.distinct
+    names = Name.clade("Agaricales").index_order.distinct
     assert_query(names, :Name, clade: "Agaricales")
-    obs = Observation.in_clade("Agaricales").index_order.distinct
+    obs = Observation.clade("Agaricales").index_order.distinct
     assert_query(obs, :Observation, clade: "Agaricales")
   end
 

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -210,25 +210,20 @@ class Query::ObservationsTest < UnitTestCase
                  :Observation, species_lists: [spl.title, spl2.title])
   end
 
-  def test_observation_in_clade
-    assert_query(Observation.index_order.in_clade("Agaricales"),
-                 :Observation, in_clade: "Agaricales")
-    assert_query(Observation.index_order.in_clade("Tremellales"),
-                 :Observation, in_clade: "Tremellales")
+  def test_observation_clade
+    assert_query(Observation.index_order.clade("Agaricales"),
+                 :Observation, clade: "Agaricales")
+    assert_query(Observation.index_order.clade("Tremellales"),
+                 :Observation, clade: "Tremellales")
   end
 
-  def test_observation_in_region
+  def test_observation_region
     assert_query(Observation.index_order.
-                 in_region("Sonoma Co., California, USA"),
-                 :Observation, in_region: "Sonoma Co., California, USA")
-    assert_query(Observation.index_order.in_region("Massachusetts, USA"),
-                 :Observation, in_region: "Massachusetts, USA")
-    assert_query(Observation.index_order.in_region("North America"),
-                 :Observation, in_region: "North America")
-    # test equivalence of "content filter"
-    assert_query(Observation.index_order.in_region("Massachusetts, USA"),
+                 region("Sonoma Co., California, USA"),
+                 :Observation, region: "Sonoma Co., California, USA")
+    assert_query(Observation.index_order.region("Massachusetts, USA"),
                  :Observation, region: "Massachusetts, USA")
-    assert_query(Observation.index_order.in_region("North America"),
+    assert_query(Observation.index_order.region("North America"),
                  :Observation, region: "North America")
   end
 

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -25,9 +25,9 @@ module Observations
       # CLADE
       # make a query, and test that the query results match obs scope
       aga_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
-                in_clade("Agaricales")
+                clade("Agaricales")
       query = Query.lookup_and_save(:Observation, needs_naming: true,
-                                                  in_clade: "Agaricales")
+                                                  clade: "Agaricales")
 
       # # get(:index, params: { q: QueryRecord.last.id.alphabetize })
       assert_equal(query.num_results, aga_obs.count)
@@ -37,27 +37,27 @@ module Observations
       assert_select(".matrix-box", aga_obs.count)
 
       bol_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
-                in_clade("Boletus")
+                clade("Boletus")
       query = Query.lookup_and_save(:Observation, needs_naming: true,
-                                                  in_clade: "Boletus")
+                                                  clade: "Boletus")
       assert_equal(query.num_results, bol_obs.count)
 
       # REGION
       # make a query, and test that the query results match obs scope
       # start with continent
       sam_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
-                in_region("South America")
+                region("South America")
       query = Query.lookup_and_save(
-        :Observation, needs_naming: true, in_region: "South America"
+        :Observation, needs_naming: true, region: "South America"
       )
       assert_equal(query.num_results, sam_obs.count)
 
       cal_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
-                in_region("California, USA")
+                region("California, USA")
       # remember the original count, will change
       cal_obs_count = cal_obs.count
       query = Query.lookup_and_save(
-        :Observation, needs_naming: true, in_region: "California, USA"
+        :Observation, needs_naming: true, region: "California, USA"
       )
       assert_equal(query.num_results, cal_obs_count)
 
@@ -91,7 +91,7 @@ module Observations
       # Vote on the first unconfident naming and check the new obs_count
       # On the site, this happens via JS, so we'll do it directly
       new_cal_obs = Observation.needs_naming_and_not_reviewed_by_user(mary).
-                    in_region("California, USA")
+                    region("California, USA")
       # Have to check for an actual naming, because some obs have no namings,
       # and obs.name_id.present? doesn't necessarily mean there's a naming
       not_confident = new_cal_obs.where(vote_cache: ..0)

--- a/test/controllers/observations_controller/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller/observations_controller_index_test.rb
@@ -623,7 +623,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
   def test_index_with_region_filter
     observations_in_region =
-      Observation.reorder(id: :asc).in_region("California, USA")
+      Observation.reorder(id: :asc).region("California, USA")
 
     user = users(:californian)
     # Make sure the fixture is still okay

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -564,17 +564,17 @@ class LocationTest < UnitTestCase
     assert_empty(Location.name_has(ARBITRARY_SHA))
   end
 
-  def test_scope_in_region
+  def test_scope_region
     assert_includes(
-      Location.in_region("New York, USA"),
+      Location.region("New York, USA"),
       locations(:nybg_location)
     )
     assert_not_includes(
-      Location.in_region("York"),
+      Location.region("York"),
       locations(:nybg_location),
       "Entire trailing part of Location name should match region"
     )
-    assert_empty(Location.in_region(ARBITRARY_SHA))
+    assert_empty(Location.region(ARBITRARY_SHA))
   end
 
   def test_contains_edges

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -577,6 +577,16 @@ class LocationTest < UnitTestCase
     assert_empty(Location.region(ARBITRARY_SHA))
   end
 
+  def test_scope_regions
+    expects = Location.regions(["California, USA", "New York, USA"]).
+              reorder(id: :asc)
+    assert_includes(expects, locations(:nybg_location))
+    assert_includes(expects, albion)
+    assert_includes(expects, california)
+    assert_not_includes(expects, wrangel)
+    assert_not_includes(expects, perkatkun)
+  end
+
   def test_contains_edges
     loc = albion
     assert(loc.contains_lat?(loc.north), "Location should contain its N edge")

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1225,22 +1225,22 @@ class ObservationTest < UnitTestCase
                         observations(:peltigera_obs))
   end
 
-  def test_scope_in_clade
-    assert_includes(Observation.in_clade("Agaricales"),
+  def test_scope_clade
+    assert_includes(Observation.clade("Agaricales"),
                     observations(:coprinus_comatus_obs))
-    assert_not_includes(Observation.in_clade("Agaricales"),
+    assert_not_includes(Observation.clade("Agaricales"),
                         observations(:peltigera_obs))
     # test the scope can handle a genus
-    assert_includes(Observation.in_clade("Tremella"),
+    assert_includes(Observation.clade("Tremella"),
                     observations(:owner_only_favorite_ne_consensus))
-    assert_includes(Observation.in_clade("Tremella"),
+    assert_includes(Observation.clade("Tremella"),
                     observations(:sortable_obs_users_first_obs))
-    assert_includes(Observation.in_clade("Tremella"),
+    assert_includes(Observation.clade("Tremella"),
                     observations(:sortable_obs_users_second_obs))
-    assert_not_includes(Observation.in_clade("Tremella"),
+    assert_not_includes(Observation.clade("Tremella"),
                         observations(:chlorophyllum_rachodes_obs))
     # test the scope can handle a name instance
-    assert_includes(Observation.in_clade(names(:coprinus)),
+    assert_includes(Observation.clade(names(:coprinus)),
                     observations(:coprinus_comatus_obs))
   end
 


### PR DESCRIPTION
There were duplicates:
```
region
in_region
clade
in_clade
```
Also adds comment references to these params in the relevant Query classes, because they're added in a "clever", but unexpected way. 

When refactoring, it's been hard not to forget they're part of the params.