### PR TITLE
Fix for "/activity_logs/501723?flow=prev"

### DIFF
--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -88,15 +88,16 @@ class RssLogsController < ApplicationController
 
   # Show a single RssLog.
   def show
+    pass_query_params
+    store_location
     case params[:flow]
     when "next"
       redirect_to_next_object(:next, RssLog, params[:id].to_s)
     when "prev"
       redirect_to_next_object(:prev, RssLog, params[:id].to_s)
+    else
+      @rss_log = find_or_goto_index(RssLog, params["id"])
     end
-    pass_query_params
-    store_location
-    @rss_log = find_or_goto_index(RssLog, params["id"])
   end
 
   # This is the site's rss feed.

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -123,4 +123,14 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_match(activity_log_path(logs.first.id),
                  @response.header["Location"], "Redirected to wrong page")
   end
+
+  def test_missing_rss_log
+    log = RssLog.order(id: :desc).first
+    missing_id = log.id + 1
+    login
+    get(:show, params: { flow: "prev", id: missing_id })
+    assert_response(:redirect)
+    assert_match(activity_logs_path,
+                 @response.header["Location"], "Redirected to wrong page")
+  end
 end


### PR DESCRIPTION
We've been getting reports of 500s for URLs like /activity_logs/501723?flow=prev.

E.g.,
```
INFO -- : Started GET "/activity_logs/501723?flow=prev" for 66.249.70.6 at 2025-03-08 20:17:33 +0000
INFO -- : Processing by RssLogsController#show as HTML
INFO -- :   Parameters: {"flow"=>"prev", "id"=>"501723"}
WARN -- : user=0 robot=N ip=66.249.70.6
INFO -- : Redirected to https://mushroomobserver.org/activity_logs
INFO -- : Redirected to
INFO -- : Completed 500 Internal Server Error in 11ms (ActiveRecord: 3.8ms (4 queries, 2 cached) | GC: 0.0ms)
E, [2025-03-08T20:17:33.284860 #737555] ERROR -- :   
AbstractController::DoubleRenderError (Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...); return".):

app/controllers/application_controller/queries.rb:312:in `redirect_to'
app/controllers/application_controller/queries.rb:256:in `redirect_with_query'
app/controllers/application_controller/indexes.rb:366:in `flash_error_and_goto_index'
app/controllers/application_controller/indexes.rb:353:in `find_or_goto_index'
app/controllers/rss_logs_controller.rb:99:in `show'
app/controllers/application_controller.rb:218:in `catch_errors_and_log_request_stats'
```

The issue was that the referenced log did not exist any longer which was causing it to both try to render the "previous" page (not there was one) and to try to report that error and redirect to the index page.