### PR TITLE
Sync query links in matrix boxes

### DIFF
--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -155,7 +155,8 @@ module ImagesHelper
   def image_stretched_link(path, link_method)
     case link_method
     when :get
-      link_with_query("", path, class: stretched_link_classes)
+      link_with_query("", path, class: stretched_link_classes,
+                                data: { query_results_target: "link" })
     when :post
       post_button(name: "", path: path, class: stretched_link_classes)
     when :put

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -49,7 +49,7 @@ module MatrixBoxHelper
     wrap_args = args.except(:columns, :class, :id)
 
     tag.li(class: wrap_class, id: box_id, **wrap_args,
-           data: { controller: "query-results"}) do
+           data: { controller: "query-results" }) do
       capture(&block)
     end
   end

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -48,7 +48,8 @@ module MatrixBoxHelper
     wrap_class = "matrix-box #{columns} #{extra_classes}"
     wrap_args = args.except(:columns, :class, :id)
 
-    tag.li(class: wrap_class, id: box_id, **wrap_args) do
+    tag.li(class: wrap_class, id: box_id, **wrap_args,
+           data: { controller: "query-results"}) do
       capture(&block)
     end
   end
@@ -101,7 +102,8 @@ module MatrixBoxHelper
     tag.div(class: "rss-what") do
       [
         tag.h5(class: class_names(%w[mt-0 rss-heading], h_style)) do
-          link_with_query(what.show_link_args) do
+          link_with_query(what.show_link_args,
+                          data: { query_results_target: "link" }) do
             [
               matrix_box_id_tag(id: presenter.id),
               matrix_box_title(name: presenter.name, id: object_id)

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -17,7 +17,7 @@ module PaginationHelper
     letters = pagination_letters(pages, args)
     numbers = pagination_numbers(pages, args)
     body = capture(&block).to_s
-    content_tag(:div, id: html_id) do
+    tag.div(id: html_id, data: { q: get_query_param }) do
       letters + safe_br + numbers + body + numbers + safe_br + letters
     end
   end

--- a/app/javascript/controllers/query-results_controller.js
+++ b/app/javascript/controllers/query-results_controller.js
@@ -14,9 +14,10 @@ export default class extends Controller {
     if (this.queryString && this.hasLinkTarget) {
       this.linkTargets.forEach((link) => {
         const url = new URL(link.href);
-        url.searchParams.set("q", this.queryString)
-        link.href = url.pathname + url.search
-        link.classList.add("query-synced")
+        url.searchParams.set("q", this.queryString);
+        // We want relative URLs, so we're not calling url.toString()
+        link.href = url.pathname + url.search;
+        link.classList.add("query-synced");
       })
     }
   }

--- a/app/javascript/controllers/query-results_controller.js
+++ b/app/javascript/controllers/query-results_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="query-results"
+export default class extends Controller {
+  static targets = ['link']
+
+  connect() {
+    this.element.dataset.stimulus = "query-results-connected";
+    this.queryString = this.element.closest("#results").dataset.q;
+    this.syncQueryStringToLinks();
+  }
+
+  syncQueryStringToLinks() {
+    if (this.queryString && this.hasLinkTarget) {
+      this.linkTargets.forEach((link) => {
+        const url = new URL(link.href);
+        url.searchParams.set("q", this.queryString)
+        link.href = url.pathname + url.search
+        link.classList.add("query-synced")
+      })
+    }
+  }
+}


### PR DESCRIPTION
This hopefully resolves the issue where people are getting links to other people's queries via cached matrix boxes.
___
#### How it works

1. It prints the current query string (`q`) on the `#results` div that wraps all matrix boxes. This div is not cached and should have the current user's query string.
2. The stimulus controller is applied per matrix box, and doesn't care whether the box was cached or not. It waits for the matrix box to appear on screen (remembering these are lazy-loaded), and then copies that query string from the wrapping `#results` div to "link targets" within each matrix box. There are two: the image link and the title link. 
3. It adds a class to all “synced” links as confirmation that it has synced the link, which we can check in the console.

When we start splatting the `q` param to print all the query params, this should still work.

I don't know how we'd test it other than putting it live, because the dev environment doesn't cache.