### PR TITLE
Adjust lookups to return caption strings

### DIFF
--- a/app/classes/lookup.rb
+++ b/app/classes/lookup.rb
@@ -37,7 +37,7 @@
 #   (defined in subclass)
 #
 # MODEL:
-# TITLE_COLUMN:
+# TITLE_METHOD:
 #
 class Lookup
   attr_reader :vals, :params
@@ -48,7 +48,7 @@ class Lookup
     end
 
     @model = self.class::MODEL
-    @title_column = self.class::TITLE_COLUMN
+    @title_method = self.class::TITLE_METHOD
     @vals = prepare_vals(vals)
     @params = params
   end
@@ -87,7 +87,7 @@ class Lookup
   def lookup_titles
     return [] if @vals.blank?
 
-    instances.map(&:"#{@title_column}")
+    instances.map(&:"#{@title_method}")
   end
 
   def evaluate_values_as_ids

--- a/app/classes/lookup/external_sites.rb
+++ b/app/classes/lookup/external_sites.rb
@@ -2,7 +2,7 @@
 
 class Lookup::ExternalSites < Lookup
   MODEL = ExternalSite
-  TITLE_COLUMN = :name
+  TITLE_METHOD = :name
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/field_slips.rb
+++ b/app/classes/lookup/field_slips.rb
@@ -2,7 +2,7 @@
 
 class Lookup::FieldSlips < Lookup
   MODEL = FieldSlip
-  TITLE_COLUMN = :code
+  TITLE_METHOD = :code
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/herbaria.rb
+++ b/app/classes/lookup/herbaria.rb
@@ -2,7 +2,7 @@
 
 class Lookup::Herbaria < Lookup
   MODEL = Herbarium
-  TITLE_COLUMN = :name
+  TITLE_METHOD = :name
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/herbarium_records.rb
+++ b/app/classes/lookup/herbarium_records.rb
@@ -2,7 +2,7 @@
 
 class Lookup::HerbariumRecords < Lookup
   MODEL = HerbariumRecord
-  TITLE_COLUMN = :id
+  TITLE_METHOD = :id
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/locations.rb
+++ b/app/classes/lookup/locations.rb
@@ -2,7 +2,7 @@
 
 class Lookup::Locations < Lookup
   MODEL = Location
-  TITLE_COLUMN = :name
+  TITLE_METHOD = :display_name
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -2,7 +2,7 @@
 
 class Lookup::Names < Lookup
   MODEL = Name
-  TITLE_COLUMN = :search_name
+  TITLE_METHOD = :text_name
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/observations.rb
+++ b/app/classes/lookup/observations.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# NOTE: Not intended to be used to lookup observations by name.
+# The class exists for reverse lookups: getting titles from a list of ids.
+class Lookup::Observations < Lookup
+  MODEL = Observation
+  TITLE_METHOD = :unique_text_name
+
+  def initialize(vals, params = {})
+    super
+  end
+
+  # for compatibility only
+  def lookup_method(name)
+    Observation.where(title: name)
+  end
+end

--- a/app/classes/lookup/project_species_lists.rb
+++ b/app/classes/lookup/project_species_lists.rb
@@ -2,7 +2,7 @@
 
 class Lookup::ProjectSpeciesLists < Lookup
   MODEL = SpeciesList
-  TITLE_COLUMN = :title
+  TITLE_METHOD = :title
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/projects.rb
+++ b/app/classes/lookup/projects.rb
@@ -2,7 +2,7 @@
 
 class Lookup::Projects < Lookup
   MODEL = Project
-  TITLE_COLUMN = :title
+  TITLE_METHOD = :title
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/regions.rb
+++ b/app/classes/lookup/regions.rb
@@ -2,7 +2,7 @@
 
 class Lookup::Regions < Lookup
   MODEL = Location
-  TITLE_COLUMN = :name
+  TITLE_METHOD = :name
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/species_lists.rb
+++ b/app/classes/lookup/species_lists.rb
@@ -2,7 +2,7 @@
 
 class Lookup::SpeciesLists < Lookup
   MODEL = SpeciesList
-  TITLE_COLUMN = :title
+  TITLE_METHOD = :title
 
   def initialize(vals, params = {})
     super

--- a/app/classes/lookup/users.rb
+++ b/app/classes/lookup/users.rb
@@ -2,7 +2,7 @@
 
 class Lookup::Users < Lookup
   MODEL = User
-  TITLE_COLUMN = :login
+  TITLE_METHOD = :login
 
   def initialize(vals, params = {})
     super

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -3,58 +3,61 @@
 require("test_helper")
 
 class LookupTest < UnitTestCase
-  def assert_lookup_objects_by_name(type, expects, vals, **)
+  def assert_lookup_objects(type, expects, vals, **)
     lookup = "Lookup::#{type}".constantize
     actual = lookup.new(vals, **).titles.sort
-    expects = expects.map(&:"#{lookup::TITLE_COLUMN}").sort
+    expects = expects.map(&:"#{lookup::TITLE_METHOD}").sort
     assert_arrays_equal(expects, actual)
   end
 
-  def assert_lookup_names_by_name(expects, vals, **)
-    assert_lookup_objects_by_name(:Names, expects, vals, **)
+  def assert_lookup_names(expects, vals, **)
+    assert_lookup_objects(:Names, expects, vals, **)
   end
 
   def test_lookup_external_sites_by_name
     expects = [external_sites(:inaturalist)]
-    assert_lookup_objects_by_name(:ExternalSites, expects, "iNaturalist")
+    assert_lookup_objects(:ExternalSites, expects, "iNaturalist")
   end
 
   def test_lookup_herbaria_by_name
     expects = [herbaria(:rolf_herbarium), herbaria(:dick_herbarium)]
-    assert_lookup_objects_by_name(:Herbaria, expects, expects.map(&:name))
+    assert_lookup_objects(:Herbaria, expects, expects.map(&:name))
   end
 
   def test_lookup_herbarium_records_by_name
     expects = [herbarium_records(:coprinus_comatus_nybg_spec),
                herbarium_records(:coprinus_comatus_rolf_spec)]
-    assert_lookup_objects_by_name(:HerbariumRecords, expects, expects.map(&:id))
+    assert_lookup_objects(:HerbariumRecords, expects, expects.map(&:id))
   end
 
   def test_lookup_locations_by_name
     expects = [locations(:salt_point), locations(:burbank)]
-    assert_lookup_objects_by_name(:Locations, expects, expects.map(&:name))
+    assert_lookup_objects(:Locations, expects, expects.map(&:name))
   end
 
   def test_lookup_projects_by_name
     expects = [projects(:bolete_project)]
-    assert_lookup_objects_by_name(:Projects, expects, expects.map(&:title))
+    assert_lookup_objects(:Projects, expects, expects.map(&:title))
   end
 
   def test_lookup_project_species_lists_by_name
     expects = [species_lists(:unknown_species_list)]
-    assert_lookup_objects_by_name(:ProjectSpeciesLists, expects,
-                                  "Bolete Project")
+    assert_lookup_objects(:ProjectSpeciesLists, expects, "Bolete Project")
   end
 
   def test_lookup_regions_by_name
     expects = [locations(:point_reyes)]
-    assert_lookup_objects_by_name(:Regions, expects,
-                                  "Marin Co., California, USA")
+    assert_lookup_objects(:Regions, expects, "Marin Co., California, USA")
   end
 
   def test_lookup_species_lists_by_name
     expects = [species_lists(:unknown_species_list)]
-    assert_lookup_objects_by_name(:SpeciesLists, expects, "List of mysteries")
+    assert_lookup_objects(:SpeciesLists, expects, "List of mysteries")
+  end
+
+  def test_lookup_observation_titles_by_id
+    expects = Observation.take(6)
+    assert_lookup_objects(:Observations, expects, expects.map(&:id))
   end
 
   ########################################################################
@@ -73,39 +76,39 @@ class LookupTest < UnitTestCase
     name4.update(synonym_id: name1.synonym_id)
     name5.update(synonym_id: name2.synonym_id)
 
-    assert_lookup_names_by_name([name1], ["Macrolepiota"])
-    assert_lookup_names_by_name([name2], ["Macrolepiota rachodes"])
-    assert_lookup_names_by_name([name1, name4], ["Macrolepiota"],
-                                include_synonyms: true)
-    assert_lookup_names_by_name([name2, name3, name5],
-                                ["Macrolepiota rachodes"],
-                                include_synonyms: true)
-    assert_lookup_names_by_name([name3, name5],
-                                ["Macrolepiota rachodes"],
-                                include_synonyms: true,
-                                exclude_original_names: true)
-    assert_lookup_names_by_name([name1, name2, name3],
-                                ["Macrolepiota"],
-                                include_subtaxa: true)
-    assert_lookup_names_by_name([name1, name2, name3],
-                                ["Macrolepiota"],
-                                include_immediate_subtaxa: true)
-    assert_lookup_names_by_name([name1, name2, name3, name4, name5],
-                                ["Macrolepiota"],
-                                include_synonyms: true,
-                                include_subtaxa: true)
-    assert_lookup_names_by_name([name2, name3, name4, name5],
-                                ["Macrolepiota"],
-                                include_synonyms: true,
-                                include_subtaxa: true,
-                                exclude_original_names: true)
+    assert_lookup_names([name1], ["Macrolepiota"])
+    assert_lookup_names([name2], ["Macrolepiota rachodes"])
+    assert_lookup_names([name1, name4], ["Macrolepiota"],
+                        include_synonyms: true)
+    assert_lookup_names([name2, name3, name5],
+                        ["Macrolepiota rachodes"],
+                        include_synonyms: true)
+    assert_lookup_names([name3, name5],
+                        ["Macrolepiota rachodes"],
+                        include_synonyms: true,
+                        exclude_original_names: true)
+    assert_lookup_names([name1, name2, name3],
+                        ["Macrolepiota"],
+                        include_subtaxa: true)
+    assert_lookup_names([name1, name2, name3],
+                        ["Macrolepiota"],
+                        include_immediate_subtaxa: true)
+    assert_lookup_names([name1, name2, name3, name4, name5],
+                        ["Macrolepiota"],
+                        include_synonyms: true,
+                        include_subtaxa: true)
+    assert_lookup_names([name2, name3, name4, name5],
+                        ["Macrolepiota"],
+                        include_synonyms: true,
+                        include_subtaxa: true,
+                        exclude_original_names: true)
 
     name5.update(synonym_id: nil)
     name5 = Name.where(text_name: "Pseudolepiota rachodes").index_order.first
-    assert_lookup_names_by_name([name1, name2, name3, name4, name5],
-                                ["Macrolepiota"],
-                                include_synonyms: true,
-                                include_subtaxa: true)
+    assert_lookup_names([name1, name2, name3, name4, name5],
+                        ["Macrolepiota"],
+                        include_synonyms: true,
+                        include_subtaxa: true)
   end
 
   def test_lookup_names_by_id
@@ -113,8 +116,8 @@ class LookupTest < UnitTestCase
 
     name1 = names(:coprinus_comatus)
     name2 = names(:coprinus_sensu_lato)
-    assert_lookup_names_by_name([name1, name2],
-                                [name1.text_name, name2.id.to_s])
+    assert_lookup_names([name1, name2],
+                        [name1.text_name, name2.id.to_s])
   end
 
   def test_lookup_names_by_name_classifications
@@ -133,27 +136,26 @@ class LookupTest < UnitTestCase
     name6.update(classification: name2.classification)
     name7.update(classification: name2.classification)
 
-    assert_lookup_names_by_name([name2, name3], ["Peltigera"])
-    assert_lookup_names_by_name([name2, name3], ["Petigera"])
-    assert_lookup_names_by_name([name1, name2, name3, name4, name5, name6,
-                                 name7],
-                                ["Peltigeraceae"],
-                                include_subtaxa: true)
-    assert_lookup_names_by_name([name1, name2, name3],
-                                ["Peltigeraceae"],
-                                include_immediate_subtaxa: true)
-    assert_lookup_names_by_name([name2, name3, name4, name5, name6, name7],
-                                ["Peltigera"],
-                                include_subtaxa: true)
-    assert_lookup_names_by_name([name2, name3, name4, name6],
-                                ["Peltigera"],
-                                include_immediate_subtaxa: true)
-    assert_lookup_names_by_name([name6, name7],
-                                ["Peltigera subg. Foo"],
-                                include_immediate_subtaxa: true)
-    assert_lookup_names_by_name([name4, name5],
-                                ["Peltigera canina"],
-                                include_immediate_subtaxa: true)
+    assert_lookup_names([name2, name3], ["Peltigera"])
+    assert_lookup_names([name2, name3], ["Petigera"])
+    assert_lookup_names([name1, name2, name3, name4, name5, name6, name7],
+                        ["Peltigeraceae"],
+                        include_subtaxa: true)
+    assert_lookup_names([name1, name2, name3],
+                        ["Peltigeraceae"],
+                        include_immediate_subtaxa: true)
+    assert_lookup_names([name2, name3, name4, name5, name6, name7],
+                        ["Peltigera"],
+                        include_subtaxa: true)
+    assert_lookup_names([name2, name3, name4, name6],
+                        ["Peltigera"],
+                        include_immediate_subtaxa: true)
+    assert_lookup_names([name6, name7],
+                        ["Peltigera subg. Foo"],
+                        include_immediate_subtaxa: true)
+    assert_lookup_names([name4, name5],
+                        ["Peltigera canina"],
+                        include_immediate_subtaxa: true)
   end
 
   def test_lookup_names_by_name_invalid_classification
@@ -166,18 +168,18 @@ class LookupTest < UnitTestCase
 
     children = Name.index_order.where(Name[:text_name].matches("Lactarius %"))
 
-    assert_lookup_names_by_name([name1] + children,
-                                ["Lactarius"],
-                                include_subtaxa: true)
+    assert_lookup_names([name1] + children,
+                        ["Lactarius"],
+                        include_subtaxa: true)
 
-    assert_lookup_names_by_name(children,
-                                ["Lactarius"],
-                                include_immediate_subtaxa: true,
-                                exclude_original_names: true)
+    assert_lookup_names(children,
+                        ["Lactarius"],
+                        include_immediate_subtaxa: true,
+                        exclude_original_names: true)
   end
 
   def test_lookup_names_by_name_invalid
-    assert_lookup_names_by_name([], ["¡not a name!"])
+    assert_lookup_names([], ["¡not a name!"])
   end
 
   def create_test_name(name)


### PR DESCRIPTION
The recently added `Lookup` classes are so far used only for finding records from a mixed array of strings, ids and instances. But I had made a `titles` accessor for them, thinking it might be useful, and here is the use. 

Send a list of ids, and it will return strings for the records (good enough for the filter captions). 
 `Lookup::Model.new(ids).titles`
This PR tweaks the classes to return the "title" methods we want for captions.

Also adds a new `Lookup::Observations` to return observation titles from ids.

Note: hopefully `login` is ok for users, authors, editors, and `text_name` (no author) is good for Names.