### PR TITLE
Add debugging data to Show Name links

### DIFF
--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -35,6 +35,14 @@ class Lookup::Names < Lookup
     ids.map { |id| Name.find(id) }
   end
 
+  # Skip misspellings in any list of returned titles --
+  # even if they're part of the actual query.
+  def lookup_titles
+    return [] if @vals.blank?
+
+    instances.select { |i| i.correct_spelling_id.nil? }.map(&:text_name)
+  end
+
   # "Original" names could turn out to be quite a few more than the given vals.
   # Memoized to avoid recalculating, or passing the value around.
   def original_names

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -35,14 +35,6 @@ class Lookup::Names < Lookup
     ids.map { |id| Name.find(id) }
   end
 
-  # Skip misspellings in any list of returned titles --
-  # even if they're part of the actual query.
-  def lookup_titles
-    return [] if @vals.blank?
-
-    instances.select { |i| i.correct_spelling_id.nil? }.map(&:text_name)
-  end
-
   # "Original" names could turn out to be quite a few more than the given vals.
   # Memoized to avoid recalculating, or passing the value around.
   def original_names

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -71,8 +71,8 @@ module NamesHelper
     # last_query = query.last_query.squish
     link_to(
       title,
-      add_query_param(observations_path, query)
-      # data: { count:, last_query: }
+      add_query_param(observations_path, query),
+      data: { query_params: query.params.compact_blank.to_json }
     ) + " (#{count})"
   end
 


### PR DESCRIPTION
This PR only splats the query params into a data attribute on the links on the Show Name page.

(I removed the alteration that skips misspelled names.)