### PR TITLE
Fix `Name#synonym_ids`, `other_synonym_ids`, lookups and Queries for subtaxa

### DIFF
--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -4,7 +4,10 @@ class Lookup::Names < Lookup
   MODEL = Name
   TITLE_METHOD = :text_name
 
-  def initialize(vals, params = {})
+  # Currently defaults to include misspellings in the returned list of ids
+  # even when `include_synonyms: false`, unless you explicitly override by
+  # passing `include_misspellings: false` or `exclude_original_names: true`.
+  def initialize(vals, params = { include_misspellings: true })
     super
   end
 
@@ -106,7 +109,8 @@ class Lookup::Names < Lookup
   def add_synonyms_if_necessary(names)
     if @params[:include_synonyms]
       add_synonyms(names)
-    elsif !@params[:exclude_original_names]
+    elsif @params[:include_misspellings] &&
+          !@params[:exclude_original_names]
       add_other_spellings(names)
     else
       names

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -7,7 +7,8 @@ class Lookup::Names < Lookup
   # Currently defaults to include misspellings in the returned list of ids
   # even when `include_synonyms: false`, unless you explicitly override by
   # passing `include_misspellings: false` or `exclude_original_names: true`.
-  def initialize(vals, params = { include_misspellings: true })
+  def initialize(vals, params = {})
+    params[:include_misspellings] = true if params[:include_misspellings].nil?
     super
   end
 

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -84,8 +84,10 @@ class Query::Names < Query::Base
 
   # Much simpler form for non-observation-based name queries.
   def initialize_related_names_parameters
-    ids = lookup_names_by_name(params.dig(:names, :lookup),
-                               related_names_parameters)
+    names = params.dig(:names, :lookup)
+    return if names.blank?
+
+    ids = lookup_names_by_name(names, related_names_parameters)
     return force_empty_results if ids.blank?
 
     add_association_condition("names.id", ids)

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -86,6 +86,8 @@ class Query::Names < Query::Base
   def initialize_related_names_parameters
     ids = lookup_names_by_name(params.dig(:names, :lookup),
                                related_names_parameters)
+    return force_empty_results if ids.blank?
+
     add_association_condition("names.id", ids)
   end
 

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -194,13 +194,11 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
   def initialize_names_and_related_names_parameters
     return force_empty_results if irreconcilable_naming_parameters?
 
-    table = if params.dig(:names, :include_all_name_proposals)
-              "namings"
-            else
-              "observations"
-            end
+    table = table_for_names
     ids = lookup_names_by_name(params.dig(:names, :lookup),
                                related_names_parameters)
+    return force_empty_results if ids.blank?
+
     add_association_condition("#{table}.name_id", ids)
 
     if params.dig(:names, :include_all_name_proposals)
@@ -209,6 +207,14 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     return unless params.dig(:names, :exclude_consensus)
 
     add_not_associated_condition("observations.name_id", ids)
+  end
+
+  def table_for_names
+    if params.dig(:names, :include_all_name_proposals)
+      "namings"
+    else
+      "observations"
+    end
   end
 
   NAMES_EXPANDER_PARAMS = [

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -233,7 +233,7 @@ class NamesController < ApplicationController
     # show query to include_immediate_subtaxa (would need to write a complicated
     # scope, but it's outlined in app/classes/query/modules/lookup_names.rb).
     # Could select @name from those results using the original name.id, then
-    # select@first_child from the rest.
+    # select @first_child from the rest.
     @first_child = @children_query.results(limit: 1).first
 
     # Possible query: Synonyms of name? Incompatible with first query.

--- a/app/extensions/hash_extensions.rb
+++ b/app/extensions/hash_extensions.rb
@@ -34,7 +34,7 @@ class Hash
     found.flatten.compact
   end
 
-  # each_with_object doesn't work here in Hash
+  # rubocop is off: each_with_object doesn't work here in Hash.
   # rubocop:disable Style/EachWithObject
   def deep_compact
     reduce({}) do |new_hash, (k, v)|
@@ -45,13 +45,14 @@ class Hash
     end
   end
 
+  # Calls compact_blank on final hash in case top level params are {}.
   def deep_compact_blank
     reduce({}) do |new_hash, (k, v)|
       if v.present?
         new_hash[k] = v.is_a?(Hash) ? v.deep_compact_blank : v
       end
       new_hash
-    end
+    end.compact_blank
   end
   # rubocop:enable Style/EachWithObject
 

--- a/app/extensions/hash_extensions.rb
+++ b/app/extensions/hash_extensions.rb
@@ -34,6 +34,27 @@ class Hash
     found.flatten.compact
   end
 
+  # each_with_object doesn't work here in Hash
+  # rubocop:disable Style/EachWithObject
+  def deep_compact
+    reduce({}) do |new_hash, (k, v)|
+      unless v.nil?
+        new_hash[k] = v.is_a?(Hash) ? v.deep_compact : v
+      end
+      new_hash
+    end
+  end
+
+  def deep_compact_blank
+    reduce({}) do |new_hash, (k, v)|
+      if v.present?
+        new_hash[k] = v.is_a?(Hash) ? v.deep_compact_blank : v
+      end
+      new_hash
+    end
+  end
+  # rubocop:enable Style/EachWithObject
+
   # Remove keys whose value is nil.
   def remove_nils!
     delete_if { |_k, v| v.nil? }

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -82,34 +82,32 @@ module NamesHelper
   # These don't run queries... it's query.select_count above, that does.
 
   def obss_of_taxon_this_name(name)
-    Query.lookup(:Observation, names: { lookup: name.id }, by: :confidence)
+    Query.new(:Observation, names: { lookup: name.id }, by: :confidence)
   end
 
   def obss_of_taxon_other_names(name)
-    Query.lookup(:Observation, names: { lookup: name.id, include_synonyms: true,
-                                        exclude_original_names: true },
-                               by: :confidence)
+    Query.new(:Observation, names: { lookup: name.id, include_synonyms: true,
+                                     exclude_original_names: true },
+                            by: :confidence)
   end
 
   def obss_of_taxon_any_name(name)
-    Query.lookup(:Observation, names: { lookup: name.id,
-                                        include_synonyms: true },
-                               by: :confidence)
+    Query.new(:Observation, names: { lookup: name.id, include_synonyms: true },
+                            by: :confidence)
   end
 
   # These two do joins to Namings. Unbelievably, it's faster than the above?
   def obss_other_taxa_this_taxon_proposed(name)
-    Query.lookup(:Observation, names: { lookup: name.id,
-                                        include_synonyms: true,
-                                        include_all_name_proposals: true,
-                                        exclude_consensus: true },
-                               by: :confidence)
+    Query.new(:Observation, names: { lookup: name.id, include_synonyms: true,
+                                     include_all_name_proposals: true,
+                                     exclude_consensus: true },
+                            by: :confidence)
   end
 
   def obss_this_name_proposed(name)
-    Query.lookup(:Observation, names: { lookup: name.id,
-                                        include_all_name_proposals: true },
-                               by: :confidence)
+    Query.new(:Observation, names: { lookup: name.id,
+                                     include_all_name_proposals: true },
+                            by: :confidence)
   end
 
   #############################################################################

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -72,7 +72,7 @@ module NamesHelper
     link_to(
       title,
       add_query_param(observations_path, query),
-      data: { query_params: query.params.compact_blank.to_json }
+      data: { query_params: query.params.deep_compact_blank.to_json }
     ) + " (#{count})"
   end
 

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -72,7 +72,8 @@ module NamesHelper
     link_to(
       title,
       add_query_param(observations_path, query),
-      data: { query_params: query.params.deep_compact_blank.to_json }
+      data: { query_params: query.params.deep_compact_blank.to_json,
+              query_record: query.record.id, alph: query.record.id.alphabetize }
     ) + " (#{count})"
   end
 

--- a/app/helpers/title_helper.rb
+++ b/app/helpers/title_helper.rb
@@ -61,7 +61,11 @@ module TitleHelper
     return unless query&.params
 
     content_for(:filters) do
-      tag.div(id: "filters", data: { controller: "filter-caption" }) do
+      tag.div(id: "filters",
+              data: { controller: "filter-caption",
+                      query_params: query.params.to_json,
+                      query_record: query.record.id,
+                      query_alph: query.record.id.alphabetize }) do
         concat(caption_truncated(query))
         concat(caption_full(query))
       end
@@ -245,8 +249,10 @@ module TitleHelper
               else
                 ids
               end
-    lookup_class = "Lookup::#{PARAM_LOOKUPS[param]}".constantize
-    joined_vals = lookup_class.new(lookups).titles.join(", ")
+    subclass = PARAM_LOOKUPS[param]
+    lookup = "Lookup::#{subclass}".constantize
+    joined_vals = lookup.new(lookups, include_misspellings: false).
+                  titles.join(", ")
     return joined_vals unless truncate
 
     truncate_joined_string(joined_vals, ids)

--- a/app/models/name/observations.rb
+++ b/app/models/name/observations.rb
@@ -10,7 +10,7 @@ class Name
   # separately counted to show the number of results for each variant,
   # without intitiating any other queries.
   class Observations
-    # attr_reader :has_images, :of_taxon_this_name, :of_taxon_other_names
+    attr_reader :all, :name, :name_ids, :other_name_ids
 
     def initialize(name)
       @name = name

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -14,6 +14,8 @@ module Name::Scopes
 
     scope :names, lambda { |lookup:, **related_name_args|
       ids = lookup_names_by_name(lookup, related_name_args.compact)
+      return none unless ids
+
       where(id: ids).with_correct_spelling.distinct
     }
     scope :text_name_has,

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -6,20 +6,6 @@ module Name::Synonymy
     deprecated ? :DEPRECATED.l : :ACCEPTED.l
   end
 
-  # Same as synonyms, but returns ids.
-  def synonym_ids
-    synonym ? synonym.name_ids.to_a : [id]
-  end
-
-  # Same as synonyms, but excludes self
-  def other_synonyms
-    synonyms.drop(1)
-  end
-
-  def other_synonym_ids
-    synonym ? synonym.name_ids.to_a.drop(1) : []
-  end
-
   # Returns an Array of all synonym Name's including itself at front of list.
   # (This looks screwy, but I think it is the safest way to handle it.
   # Note that synonym.names does include self, but it's a different instance.
@@ -27,7 +13,27 @@ module Name::Synonymy
   # not show up in self itself.  So this ensures that self itself will be
   # included at the beginning of the list of synonyms.)
   def synonyms
-    synonym ? [self] + (synonym.names.to_a - [self]) : [self]
+    return [self] unless synonym
+
+    [self] + (synonym.names - [self])
+  end
+
+  # Same as synonyms, but excludes self.
+  def other_synonyms
+    synonyms.drop(1)
+  end
+
+  # Same as synonyms, but returns ids. Resorted so current id is first.
+  def synonym_ids
+    return [id] unless synonym
+
+    [id] + (synonym.name_ids - [id])
+  end
+
+  def other_synonym_ids
+    return [] unless synonym
+
+    synonym_ids.drop(1)
   end
 
   # Returns an Array of all _approved_ Synonym Name's, potentially including

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -190,10 +190,12 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :names, lambda { |lookup:, **args|
       # First, lookup names, plus synonyms and subtaxa if requested
       lookup_args = args.slice(:include_synonyms,
+                               :include_misspellings,
                                :include_subtaxa,
                                :include_immediate_subtaxa,
                                :exclude_original_names)
       name_ids = Lookup::Names.new(lookup, **lookup_args).ids
+      return none unless name_ids
 
       # Query, with possible join to Naming. Mutually exclusive options:
       if args[:include_all_name_proposals]

--- a/test/classes/hash_extensions_test.rb
+++ b/test/classes/hash_extensions_test.rb
@@ -14,4 +14,14 @@ class HashExtensionsTest < UnitTestCase
     h = { a: 1, b: nil, c: 3 }
     assert_equal({ a: 1, c: 3 }, h.remove_nils!)
   end
+
+  def test_deep_compact
+    h = { a: 1, b: { d: nil, e: 2, f: { g: nil, h: nil } }, c: 3 }
+    assert_equal({ a: 1, b: { e: 2, f: {} }, c: 3 }, h.deep_compact)
+  end
+
+  def test_deep_compact_blank
+    h = { a: 1, b: { d: nil, e: false, f: { g: nil, h: false } }, c: 3, i: [] }
+    assert_equal({ a: 1, c: 3 }, h.deep_compact_blank)
+  end
 end

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -85,8 +85,8 @@ class LookupTest < UnitTestCase
                         include_synonyms: true)
     assert_lookup_names([name3, name5],
                         ["Macrolepiota rachodes"],
-                        include_synonyms: true,
-                        exclude_original_names: true)
+                        include_synonyms: "yes", # test boolean
+                        exclude_original_names: "yes")
     assert_lookup_names([name1, name2, name3],
                         ["Macrolepiota"],
                         include_subtaxa: true)
@@ -95,8 +95,8 @@ class LookupTest < UnitTestCase
                         include_immediate_subtaxa: true)
     assert_lookup_names([name1, name2, name3, name4, name5],
                         ["Macrolepiota"],
-                        include_synonyms: true,
-                        include_subtaxa: true)
+                        include_synonyms: 1, # test boolean
+                        include_subtaxa: 1)
     assert_lookup_names([name2, name3, name4, name5],
                         ["Macrolepiota"],
                         include_synonyms: true,
@@ -138,6 +138,10 @@ class LookupTest < UnitTestCase
 
     assert_lookup_names([name2, name3], ["Peltigera"])
     assert_lookup_names([name2, name3], ["Petigera"])
+    assert_lookup_names([name2], ["Peltigera"],
+                        include_misspellings: false)
+    assert_lookup_names([name3], ["Petigera"],
+                        include_misspellings: false)
     assert_lookup_names([name1, name2, name3, name4, name5, name6, name7],
                         ["Peltigeraceae"],
                         include_subtaxa: true)

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -146,13 +146,24 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_names_include_subtaxa_exclude_original
+    name = names(:agaricus)
     assert_query(
-      Name.index_order.names(lookup: names(:agaricus),
+      Name.index_order.names(lookup: name.id,
                              include_subtaxa: true,
                              exclude_original_names: true),
-      :Name, names: { lookup: [names(:agaricus).id],
+      :Name, names: { lookup: [name.id],
                       include_subtaxa: true,
                       exclude_original_names: true }
+    )
+  end
+
+  # This test ensures we force empty results when the lookup gets no ids.
+  def test_name_of_subtaxa_excluding_original_no_children
+    name = names(:tubaria_furfuracea)
+    assert_query(
+      [], :Observation, names: { lookup: name.id,
+                                 include_subtaxa: true,
+                                 exclude_original_names: true }
     )
   end
 

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -160,10 +160,14 @@ class Query::NamesTest < UnitTestCase
   # This test ensures we force empty results when the lookup gets no ids.
   def test_name_of_subtaxa_excluding_original_no_children
     name = names(:tubaria_furfuracea)
-    assert_query(
-      [], :Observation, names: { lookup: name.id,
-                                 include_subtaxa: true,
-                                 exclude_original_names: true }
+    assert_query_scope(
+      [],
+      Name.index_order.names(lookup: name.id,
+                             include_subtaxa: true,
+                             exclude_original_names: true),
+      :Name, names: { lookup: name.id,
+                      include_subtaxa: true,
+                      exclude_original_names: true }
     )
   end
 

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -250,7 +250,7 @@ class Query::ObservationsTest < UnitTestCase
       [],
       Observation.index_order.names(lookup: name.id,
                                     include_subtaxa: true,
-                                    exclude_original_names: true ),
+                                    exclude_original_names: true),
       :Observation, names: { lookup: name.id,
                              include_subtaxa: true,
                              exclude_original_names: true }

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -246,10 +246,14 @@ class Query::ObservationsTest < UnitTestCase
   # This test ensures we force empty results when the lookup gets no ids.
   def test_observation_of_subtaxa_excluding_original_no_children
     name = names(:tubaria_furfuracea)
-    assert_query(
-      [], :Observation, names: { lookup: name.id,
-                                 include_subtaxa: true,
-                                 exclude_original_names: true }
+    assert_query_scope(
+      [],
+      Observation.index_order.names(lookup: name.id,
+                                    include_subtaxa: true,
+                                    exclude_original_names: true ),
+      :Observation, names: { lookup: name.id,
+                             include_subtaxa: true,
+                             exclude_original_names: true }
     )
   end
 

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -243,6 +243,16 @@ class Query::ObservationsTest < UnitTestCase
                                                  include_subtaxa: true })
   end
 
+  # This test ensures we force empty results when the lookup gets no ids.
+  def test_observation_of_subtaxa_excluding_original_no_children
+    name = names(:tubaria_furfuracea)
+    assert_query(
+      [], :Observation, names: { lookup: name.id,
+                                 include_subtaxa: true,
+                                 exclude_original_names: true }
+    )
+  end
+
   def test_observation_names_with_modifiers
     User.current = rolf
     expects = Observation.index_order.names(lookup: names(:fungi)).distinct


### PR DESCRIPTION
#### Filter caption, extra names appearing on "Observations of Name" for single name
Issue is in `Lookup::Names`
- This is the class we use to turn the original name ids into strings for the Query filter caption. The lookup unexpectedly defaults to returning the names **plus misspellings of the original names**, even when you’re not requesting synonyms. 
- PR introduces an extra param to the lookup, `include_misspellings` , that defaults to `true` but can be overridden e.g. by the filter caption. Adds tests.
___ 

#### Show name - related name counts
Issue is in `Name` instance methods:
- `Name#synonym_ids`, unlike `Name#synonyms`, has not been putting the original name first in the array
- `Name#other_synonym_ids`, as a result, might pop the wrong value off when excluding the original name, because it drops the **lowest** id (sorted by `id: :asc`) rather than the current name's id
- Counts of related queries were way off because they weren't counting the right names.
- Fixes `synonym_ids` and adds tests
___ 

#### Show name - subtaxa count
Issue is in `Query::Names` and `Query::Observations`
- When looking up names with expanders, it is possible to get zero results if the original name is excluded and it has no children. This possibility was not tested.
- In this case, `Query` should return empty results, but it was returning an unfiltered name query. This was reflected in the `subtaxa` count, which was the count of all Names. The issue undoubtedly affected other name queries, but i don't believe we've heard about it yet.
- Fixes Query and adds tests
- Fixes corresponding scopes and adds tests