### PR TITLE
Zeitwerk issue with autoloading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,6 @@ module MushroomObserver
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W[
       #{config.root}/app/classes
-      #{config.root}/app/extensions
     ]
     config.eager_load_paths += %W[
       #{config.root}/app/classes

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,13 +32,14 @@ module MushroomObserver
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W[
-      #{config.root}/app/classes
-    ]
-    config.eager_load_paths += %W[
-      #{config.root}/app/classes
-      #{config.root}/app/extensions
-    ]
+    # config.autoload_paths += %W[
+    #   #{config.root}/app/classes
+    #   #{config.root}/app/extensions
+    # ]
+    # config.eager_load_paths += %W[
+    #   #{config.root}/app/classes
+    #   #{config.root}/app/extensions
+    # ]
 
     # Uncomment this after migrating to all recommended default configs for 7.1
     # config/initializers/new_framework_defaults_7_1.rb


### PR DESCRIPTION
Will try a couple things before reverting #2807.

The error on deploy is this:
```
Checking for migrations...
rake aborted!
NameError: uninitialized constant ArrayExtensions (NameError)

    @mod.const_get(@cname, false)
        ^^^^^^^^^^
Did you mean?  ArelExtensions
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/cref.rb:63:in `const_get'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/cref.rb:63:in `get'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:173:in `block in actual_eager_load_dir'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/helpers.rb:47:in `block in ls'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/helpers.rb:25:in `each'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/helpers.rb:25:in `ls'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:168:in `actual_eager_load_dir'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:16:in `each'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader.rb:430:in `block in eager_load_all'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader.rb:428:in `each'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/loader.rb:428:in `eager_load_all'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/application/finisher.rb:80:in `block in <module:Finisher>'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/initializable.rb:32:in `instance_exec'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/initializable.rb:32:in `run'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/initializable.rb:60:in `run_initializers'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/application.rb:435:in `initialize!'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/railtie.rb:226:in `public_send'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/railtie.rb:226:in `method_missing'
/var/web/mo/config/environment.rb:7:in `<top (required)>'
/home/mo/.gem/ruby/3.3.6/gems/zeitwerk-2.7.2/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/application.rb:411:in `require_environment!'
/home/mo/.gem/ruby/3.3.6/gems/railties-7.2.2.1/lib/rails/application.rb:559:in `block in run_tasks_blocks'
/home/mo/.gem/ruby/3.3.6/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => db:migrate => db:load_config => environment
(See full trace by running task with --trace)
```

We have directives for `config.autoload_paths` and `config.eager_load_paths` that are incompatible with Zeitwerk in the first place. Commenting these out now.