### PR TITLE
Break and left-align username in namings table for legibility

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -126,6 +126,10 @@
   font-size: larger !important;
 }
 
+.text-left {
+  text-align: left !important;
+}
+
 .text-center {
   text-align: center !important;
 }

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -486,6 +486,10 @@
   white-space: nowrap !important;
 }
 
+.text-wrap {
+  white-space: normal !important;
+}
+
 .overflow-visible {
   overflow: visible !important;
 }

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -191,7 +191,7 @@ module NamingsHelper
   # N+1: naming includes user
   def naming_proposer_html(naming)
     user_link = user_link(naming.user, naming.user.login,
-                          { class: "btn btn-link text-wrap px-0" })
+                          { class: "btn btn-link text-wrap text-left px-0" })
 
     # row props have mobile-friendly labels
     [tag.small("#{:show_namings_user.t}: ", class: "visible-xs-inline mr-4"),

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -191,7 +191,7 @@ module NamingsHelper
   # N+1: naming includes user
   def naming_proposer_html(naming)
     user_link = user_link(naming.user, naming.user.login,
-                          { class: "btn btn-link px-0" })
+                          { class: "btn btn-link text-wrap px-0" })
 
     # row props have mobile-friendly labels
     [tag.small("#{:show_namings_user.t}: ", class: "visible-xs-inline mr-4"),


### PR DESCRIPTION
reported by @AlanRockefeller 

![image](https://github.com/user-attachments/assets/8819e977-c13c-44b0-8f93-3bcaee88f65d)

If anyone's curious, in the username i'm using the `btn btn-link` classes purely for spacing, to align the user's text vertically with the vote, without further futzing. The class has no background or border.

But the `btn` class assumes you want non-breaking text inside the button.