### PR TITLE
Query letter pagination, minor refactor

### DIFF
--- a/app/classes/query/api_keys.rb
+++ b/app/classes/query/api_keys.rb
@@ -2,7 +2,7 @@
 
 class Query::APIKeys < Query::Base
   def model
-    APIKey
+    @model ||= APIKey
   end
 
   def self.parameter_declarations

--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -6,7 +6,7 @@ class Query::Articles < Query::Base
   end
 
   def list_by
-    @list_by ||= :title
+    @list_by ||= Article[:title]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -2,7 +2,11 @@
 
 class Query::Articles < Query::Base
   def model
-    Article
+    @model ||= Article
+  end
+
+  def list_by
+    @list_by ||= :title
   end
 
   def self.parameter_declarations

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -6,7 +6,7 @@ class Query::CollectionNumbers < Query::Base
   end
 
   def list_by
-    @list_by ||= :name
+    @list_by ||= CollectionNumber[:name]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -2,7 +2,11 @@
 
 class Query::CollectionNumbers < Query::Base
   def model
-    CollectionNumber
+    @model ||= CollectionNumber
+  end
+
+  def list_by
+    @list_by ||= :name
   end
 
   def self.parameter_declarations

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -5,6 +5,10 @@ class Query::Comments < Query::Base
     @model ||= Comment
   end
 
+  def list_by
+    @list_by ||= User[:login]
+  end
+
   def self.parameter_declarations
     super.merge(
       created_at: [:time],

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -2,7 +2,7 @@
 
 class Query::Comments < Query::Base
   def model
-    Comment
+    @model ||= Comment
   end
 
   def self.parameter_declarations

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -2,7 +2,7 @@
 
 class Query::ExternalLinks < Query::Base
   def model
-    ExternalLink
+    @model ||= ExternalLink
   end
 
   def self.parameter_declarations

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -2,7 +2,7 @@
 
 class Query::ExternalSites < Query::Base
   def model
-    ExternalSite
+    @model ||= ExternalSite
   end
 
   def self.parameter_declarations

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -2,7 +2,7 @@
 
 class Query::FieldSlips < Query::Base
   def model
-    FieldSlip
+    @model ||= FieldSlip
   end
 
   def self.parameter_declarations

--- a/app/classes/query/glossary_terms.rb
+++ b/app/classes/query/glossary_terms.rb
@@ -2,11 +2,11 @@
 
 class Query::GlossaryTerms < Query::Base
   def model
-    @model ||= ::GlossaryTerm
+    @model ||= GlossaryTerm
   end
 
   def list_by
-    @list_by ||= :name
+    @list_by ||= GlossaryTerm[:name]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/glossary_terms.rb
+++ b/app/classes/query/glossary_terms.rb
@@ -2,7 +2,11 @@
 
 class Query::GlossaryTerms < Query::Base
   def model
-    ::GlossaryTerm
+    @model ||= ::GlossaryTerm
+  end
+
+  def list_by
+    @list_by ||= :name
   end
 
   def self.parameter_declarations

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -2,7 +2,11 @@
 
 class Query::Herbaria < Query::Base
   def model
-    Herbarium
+    @model ||= Herbarium
+  end
+
+  def list_by
+    @list_by ||= :name
   end
 
   def self.parameter_declarations

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -6,7 +6,7 @@ class Query::Herbaria < Query::Base
   end
 
   def list_by
-    @list_by ||= :name
+    @list_by ||= Herbarium[:name]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -2,7 +2,11 @@
 
 class Query::HerbariumRecords < Query::Base
   def model
-    HerbariumRecord
+    @model ||= HerbariumRecord
+  end
+
+  def list_by
+    @list_by ||= :initial_det
   end
 
   def self.parameter_declarations

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -6,7 +6,7 @@ class Query::HerbariumRecords < Query::Base
   end
 
   def list_by
-    @list_by ||= :initial_det
+    @list_by ||= HerbariumRecord[:initial_det]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -7,7 +7,7 @@ class Query::Images < Query::Base
   include Query::Initializers::Filters
 
   def model
-    Image
+    @model ||= Image
   end
 
   def self.parameter_declarations

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -10,6 +10,15 @@ class Query::Images < Query::Base
     @model ||= Image
   end
 
+  def list_by
+    @list_by ||= case params[:by].to_s
+                 when "user", "reverse_user"
+                   User[:login]
+                 when "name", "reverse_name"
+                   Name[:sort_name]
+                 end
+  end
+
   def self.parameter_declarations
     super.merge(
       created_at: [:time],

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -4,7 +4,7 @@ class Query::LocationDescriptions < Query::Base
   include Query::Initializers::Descriptions
 
   def model
-    LocationDescription
+    @model ||= LocationDescription
   end
 
   def self.parameter_declarations

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -7,7 +7,7 @@ class Query::Locations < Query::Base
   include Query::Initializers::Filters
 
   def model
-    Location
+    @model ||= Location
   end
 
   def self.parameter_declarations

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -92,8 +92,8 @@ module Query::Modules::HighLevelQueries
 
   # Make sure we requery if we change the letter field.
   def need_letters=(letters)
-    unless letters.is_a?(String)
-      raise("You must pass a SQL expression to 'need_letters'.")
+    unless letters.is_a?(Boolean)
+      raise("You must pass a Boolean to 'need_letters'.")
     end
 
     return if need_letters == letters

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -45,8 +45,7 @@ module Query::Modules::HighLevelQueries
         # typically no avoiding it.  This optimizes away an extra query or two.
         @letters = {}
         ids = []
-        select = "DISTINCT #{model.table_name}.id, " \
-                 "LEFT(#{model.table_name}.#{list_by},4)"
+        select = "DISTINCT #{model.table_name}.id, LEFT(#{list_by.to_sql},4)"
         select_rows(args.merge(select: select)).each do |id, letter|
           letter = letter[0, 1]
           @letters[id.to_i] = letter.upcase if /[a-zA-Z]/.match?(letter)
@@ -92,7 +91,7 @@ module Query::Modules::HighLevelQueries
 
   # Make sure we requery if we change the letter field.
   def need_letters=(letters)
-    unless [true, false, 1, 0].include?(letters)
+    unless [true, false, 1, 0, nil].include?(letters)
       raise("You must pass a Boolean to 'need_letters'.")
     end
 

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -92,7 +92,7 @@ module Query::Modules::HighLevelQueries
 
   # Make sure we requery if we change the letter field.
   def need_letters=(letters)
-    unless letters.is_a?(Boolean)
+    unless [true, false, 1, 0].include?(letters)
       raise("You must pass a Boolean to 'need_letters'.")
     end
 

--- a/app/classes/query/modules/high_level_queries.rb
+++ b/app/classes/query/modules/high_level_queries.rb
@@ -45,7 +45,8 @@ module Query::Modules::HighLevelQueries
         # typically no avoiding it.  This optimizes away an extra query or two.
         @letters = {}
         ids = []
-        select = "DISTINCT #{model.table_name}.id, LEFT(#{need_letters},4)"
+        select = "DISTINCT #{model.table_name}.id, " \
+                 "LEFT(#{model.table_name}.#{list_by},4)"
         select_rows(args.merge(select: select)).each do |id, letter|
           letter = letter[0, 1]
           @letters[id.to_i] = letter.upcase if /[a-zA-Z]/.match?(letter)

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -4,7 +4,7 @@ class Query::NameDescriptions < Query::Base
   include Query::Initializers::Descriptions
 
   def model
-    NameDescription
+    @model ||= NameDescription
   end
 
   def self.parameter_declarations

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -12,7 +12,7 @@ class Query::Names < Query::Base
   end
 
   def list_by
-    @list_by ||= :sort_name
+    @list_by ||= Name[:sort_name]
   end
 
   def self.parameter_declarations # rubocop:disable Metrics/MethodLength

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -8,7 +8,11 @@ class Query::Names < Query::Base
   include Query::Initializers::Filters
 
   def model
-    Name
+    @model ||= Name
+  end
+
+  def list_by
+    @list_by ||= :sort_name
   end
 
   def self.parameter_declarations # rubocop:disable Metrics/MethodLength

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -7,7 +7,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
   include Query::Initializers::AdvancedSearch
 
   def model
-    Observation
+    @model ||= Observation
   end
 
   def self.parameter_declarations # rubocop:disable Metrics/MethodLength

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -10,6 +10,15 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     @model ||= Observation
   end
 
+  def list_by
+    @list_by ||= case params[:by].to_s
+                 when "user", "reverse_user"
+                   User[:login]
+                 when "name", "reverse_name"
+                   Name[:sort_name]
+                 end
+  end
+
   def self.parameter_declarations # rubocop:disable Metrics/MethodLength
     super.merge(
       date: [:date],

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -6,7 +6,7 @@ class Query::Projects < Query::Base
   end
 
   def list_by
-    @list_by ||= :title
+    @list_by ||= Project[:title]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -2,7 +2,11 @@
 
 class Query::Projects < Query::Base
   def model
-    Project
+    @model ||= Project
+  end
+
+  def list_by
+    @list_by ||= :title
   end
 
   def self.parameter_declarations

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -5,7 +5,7 @@ class Query::RssLogs < Query::Base
   include Query::Initializers::Filters
 
   def model
-    RssLog
+    @model ||= RssLog
   end
 
   def self.parameter_declarations

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -2,7 +2,11 @@
 
 class Query::Sequences < Query::Base
   def model
-    Sequence
+    @model ||= Sequence
+  end
+
+  def list_by
+    @list_by ||= :locus
   end
 
   def self.parameter_declarations

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -6,7 +6,7 @@ class Query::Sequences < Query::Base
   end
 
   def list_by
-    @list_by ||= :locus
+    @list_by ||= Sequence[:locus]
   end
 
   def self.parameter_declarations

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -2,7 +2,11 @@
 
 class Query::SpeciesLists < Query::Base
   def model
-    SpeciesList
+    @model ||= SpeciesList
+  end
+
+  def list_by
+    @list_by ||= :title
   end
 
   def self.parameter_declarations

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -5,6 +5,15 @@ class Query::SpeciesLists < Query::Base
     @model ||= SpeciesList
   end
 
+  def list_by
+    @list_by ||= case params[:by].to_s
+                 when "user", "reverse_user"
+                   User[:login]
+                 else
+                   SpeciesList[:title]
+                 end
+  end
+
   def self.parameter_declarations
     super.merge(
       created_at: [:time],

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -5,10 +5,6 @@ class Query::SpeciesLists < Query::Base
     @model ||= SpeciesList
   end
 
-  def list_by
-    @list_by ||= :title
-  end
-
   def self.parameter_declarations
     super.merge(
       created_at: [:time],

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -5,6 +5,15 @@ class Query::Users < Query::Base
     @model ||= User
   end
 
+  def list_by
+    @list_by ||= case params[:by]
+                 when "login", "reverse_login"
+                   User[:login]
+                 else
+                   User[:name]
+                 end
+  end
+
   def self.parameter_declarations
     super.merge(
       created_at: [:time],

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -2,7 +2,7 @@
 
 class Query::Users < Query::Base
   def model
-    User
+    @model ||= User
   end
 
   def self.parameter_declarations

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -438,7 +438,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   #
   #   # In controller:
   #   query  = create_query(:Name, :by_users => params[:id].to_s)
-  #   query.need_letters('names.display_name')
+  #   query.need_letters(true)
   #   @pages = paginate_letters(:letter, :page, 50)
   #   @names = query.paginate(@pages)
   #

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -36,7 +36,7 @@ class ArticlesController < ApplicationController
   end
 
   def index_display_opts(opts, _query)
-    { letters: "articles.title",
+    { letters: true,
       num_per_page: 50,
       include: :user }.merge(opts)
   end

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -41,7 +41,7 @@ class CollectionNumbersController < ApplicationController
 
   def index_display_opts(opts, _query)
     {
-      letters: "collection_numbers.name",
+      letters: true,
       num_per_page: 100
     }.merge(opts)
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -94,9 +94,7 @@ class CommentsController < ApplicationController
     }.merge(opts)
 
     # Paginate by letter if sorting by user.
-    if (query.params[:by] == "user") || (query.params[:by] == "reverse_user")
-      opts[:letters] = "users.login"
-    end
+    opts[:letters] = true if %w[user reverse_user].include?(query.params[:by])
 
     @full_detail = query.params[:target].present?
 

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -32,7 +32,7 @@ class GlossaryTermsController < ApplicationController
   end
 
   def index_display_opts(opts, _query)
-    { letters: "glossary_terms.name",
+    { letters: true,
       num_per_page: 50,
       include: { thumb_image: :image_votes } }.merge(opts)
   end

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -102,7 +102,7 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   end
 
   def index_display_opts(opts, _query)
-    { letters: "herbaria.name",
+    { letters: true,
       num_per_page: 100,
       include: [:curators, :herbarium_records, :personal_user] }.merge(opts)
   end

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -45,7 +45,7 @@ class HerbariumRecordsController < ApplicationController
 
   def index_display_opts(opts, _query)
     {
-      letters: "herbarium_records.initial_det",
+      letters: true,
       num_per_page: 100,
       include: [{ herbarium: :curators }, { observations: :name }, :user]
     }.merge(opts)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -117,13 +117,9 @@ class ImagesController < ApplicationController
                 :projects, :thumb_glossary_terms, :glossary_terms, :image_votes]
     }.merge(opts)
 
-    # Paginate by letter if sorting by user.
-    case query.params[:by]
-    when "user", "reverse_user"
-      opts[:letters] = "users.login"
-    # Paginate by letter if sorting by name.
-    when "name", "reverse_name"
-      opts[:letters] = "names.sort_name"
+    # Paginate by letter if sorting by user or name.
+    if %w[user reverse_user name reverse_name].include?(query.params[:by])
+      opts[:letters] = true
     end
 
     opts

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -124,7 +124,7 @@ class NamesController < ApplicationController
 
   def index_display_opts(opts, _query)
     {
-      letters: "names.sort_name",
+      letters: true,
       num_per_page: (/^[a-z]/i.match?(params[:letter].to_s) ? 500 : 50),
       include: [:description]
     }.merge(opts)

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -212,13 +212,9 @@ class ObservationsController
         include: observation_index_includes
       }.merge(opts)
 
-      # Paginate by letter if sorting by user.
-      case query.params[:by]
-      when "user", "reverse_user"
-        opts[:letters] = "users.login"
-      # Paginate by letter if sorting by name.
-      when "name", "reverse_name"
-        opts[:letters] = "names.sort_name"
+      # Paginate by letter if sorting by user or name.
+      if %w[user reverse_user name reverse_name].include?(query.params[:by])
+        opts[:letters] = true
       end
 
       opts

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,7 +37,7 @@ class ProjectsController < ApplicationController
   end
 
   def index_display_opts(opts, _query)
-    { letters: "projects.title",
+    { letters: true,
       num_per_page: 50,
       include: :user }.merge(opts)
   end

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -69,7 +69,7 @@ class SequencesController < ApplicationController
 
   def index_display_opts(opts, _query)
     { include: [{ observation: :name }, :user],
-      letters: "sequences.locus",
+      letters: true,
       num_per_page: 50 }.merge(opts)
   end
 

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -82,14 +82,8 @@ class SpeciesListsController < ApplicationController
     return opts if %w[date created modified].include?(query.params[:by]) ||
                    query.params[:by].blank?
 
-    # Paginate by letter if sorting by user.
-    opts[:letters] =
-      if [query.params[:by]].intersect?(%w[user reverse_user])
-        "users.login"
-      else
-        "species_lists.title"
-      end
-
+    # Paginate by letter if sorting by anything else.
+    opts[:letters] = true
     opts
   end
 
@@ -188,7 +182,7 @@ class SpeciesListsController < ApplicationController
     # See documentation on the 'How to Use' page to understand this feature.
     store_query_in_session(@query) if params[:set_source].present?
 
-    @query.need_letters = "names.sort_name"
+    @query.need_letters = true
     @pages = paginate_letters(:letter, :page, 100)
     @objects = @query.paginate(@pages, include:
                   [:user, :name, :location, { thumb_image: :image_votes }])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,20 +76,12 @@ class UsersController < ApplicationController
     query
   end
 
-  def index_display_opts(opts, query)
-    opts = {
+  def index_display_opts(opts, _query)
+    {
+      letters: true,
       include: :user_groups,
       matrix: !in_admin_mode?
     }.merge(opts)
-
-    # Paginate by "correct" letter.
-    opts[:letters] = if %w[login reverse_login].include?(query.params[:by])
-                       "users.login"
-                     else
-                       "users.name"
-                     end
-
-    opts
   end
 
   public

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -622,7 +622,7 @@ class QueryTest < UnitTestCase
 
   def paginate_test_letter_setup(number, num_per_page)
     paginate_test_setup(number, num_per_page)
-    @query.need_letters = "names.text_name"
+    @query.need_letters = true
     @letters = @names.map { |n| n.text_name[0, 1] }.uniq.sort
   end
 


### PR DESCRIPTION
#### Refactor query letter pagination to know which column to check, caller no longer sends column.
___
Query's letter pagination is only available for certain models. It checks the text values in a certain column of each record to find which letters are present, and then arranges paging by letter. 

The column it checks for a query can depend on the sort order, but it's currently the responsibility of the caller to know and send the column.

This doesn't seem refactor-friendly, so i'm switching the callers to just send `letters: true` if they want pagination by letter. This PR adds a class method to the Query subclasses that figures out the column name(s) from the sort order sent by the caller.
___
Incidentally, pagination by letter involves a duplicate, preliminary query that surveys the results and scans the letters.  Usually there are not many records, but that preliminary query is more expensive for names, and significant for images and observations.