### PR TITLE
Tighten up date scopes, test more cases

### DIFF
--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -7,23 +7,6 @@
 #
 #  type_tag::           Language tag, e.g., :observation, :rss_log, etc.
 #
-#  == Scopes
-#
-#  Scopes for collecting objects created (or updated) on, before, after or
-#  between a given "%Y-%m-%d" string(s).
-#
-#  Examples: Observation.created_between("2006-09-01", "2012-09-01")
-#            Name.updated_after("2016-12-01")
-#
-#  created_on::
-#  created_after::
-#  created_before::
-#  created_between::
-#  updated_on::
-#  updated_after::
-#  updated_before::
-#  updated_between::
-#
 #  ==== Extensions to "find"
 #  safe_find::          Same as <tt>find(id)</tt> but return nil if not found.
 #  find_object::        Look up an object by class name and id.

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -483,13 +483,13 @@ module AbstractModel::Scopes
       end
     end
 
-    def boolean_condition(table_column, val, bool: true)
-      if bool.to_s.to_boolean == true
-        where(table_column.eq(val))
-      else
-        where(table_column.not_eq(val))
-      end
-    end
+    # def boolean_condition(table_column, val, bool: true)
+    #   if bool.to_s.to_boolean == true
+    #     where(table_column.eq(val))
+    #   else
+    #     where(table_column.not_eq(val))
+    #   end
+    # end
 
     # Try not_blank_condition before uncommenting this
     # def coalesce_presence_condition(table_column, bool: true)

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -483,13 +483,14 @@ module AbstractModel::Scopes
       end
     end
 
-    # def boolean_condition(table_column, val, bool: true)
-    #   if bool.to_s.to_boolean == true
-    #     where(table_column.eq(val))
-    #   else
-    #     where(table_column.not_eq(val))
-    #   end
-    # end
+    # This tolerates text values for "true" and "false"
+    def boolean_condition(table_column, bool: true)
+      if bool.to_s.to_boolean == true
+        where(table_column.eq(true))
+      else
+        where(table_column.not_eq(true))
+      end
+    end
 
     # Try not_blank_condition before uncommenting this
     # def coalesce_presence_condition(table_column, bool: true)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -60,14 +60,8 @@
 #
 #  ==== Scopes
 #
-#  created_on("yyyymmdd")
-#  created_after("yyyymmdd")
-#  created_before("yyyymmdd")
-#  created_between(start, end)
-#  updated_on("yyyymmdd")
-#  updated_after("yyyymmdd")
-#  updated_before("yyyymmdd")
-#  updated_between(start, end)
+#  created_at("yyyy-mm-dd", "yyyy-mm-dd")
+#  updated_at("yyyy-mm-dd", "yyyy-mm-dd")
 #  by_user(user)
 #  for_user(user)
 #  target(target)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -38,14 +38,8 @@
 #
 #  == Scopes
 #
-#  created_on("yyyymmdd")
-#  created_after("yyyymmdd")
-#  created_before("yyyymmdd")
-#  created_between(start, end)
-#  updated_on("yyyymmdd")
-#  updated_after("yyyymmdd")
-#  updated_before("yyyymmdd")
-#  updated_between(start, end)
+#  created_at("yyyy-mm-dd", "yyyy-mm-dd")
+#  updated_at("yyyy-mm-dd", "yyyy-mm-dd")
 #  name_has(place_name)
 #  region(place_name)
 #  in_box(north:, south:, east:, west:)

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -146,14 +146,8 @@
 #  alt_ranks::               Ranks: map alternatives to our values.
 #
 #  ==== Scopes
-#  created_on("yyyymmdd")
-#  created_after("yyyymmdd")
-#  created_before("yyyymmdd")
-#  created_between(start, end)
-#  updated_on("yyyymmdd")
-#  updated_after("yyyymmdd")
-#  updated_before("yyyymmdd")
-#  updated_between(start, end)
+#  created_at("yyyy-mm-dd", "yyyy-mm-dd")
+#  updated_at("yyyy-mm-dd", "yyyy-mm-dd")
 #  deprecated
 #  has_description
 #  description_has

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -52,7 +52,7 @@ module Name::Scopes
     }
 
     scope :deprecated,
-          ->(bool = true) { where(deprecated: bool) }
+          ->(bool = true) { boolean_condition(Name[:deprecated], bool:) }
     scope :not_deprecated,
           -> { where(deprecated: false) }
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -79,14 +79,8 @@
 #
 #  ==== Scopes
 #
-#  created_on("yyyymmdd")
-#  created_after("yyyymmdd")
-#  created_before("yyyymmdd")
-#  created_between(start, end)
-#  updated_on("yyyymmdd")
-#  updated_after("yyyymmdd")
-#  updated_before("yyyymmdd")
-#  updated_between(start, end)
+#  created_at("yyyy-mm-dd", "yyyy-mm-dd")
+#  updated_at("yyyy-mm-dd", "yyyy-mm-dd")
 #  found_on("yyyymmdd")
 #  found_after("yyyymmdd")
 #  found_before("yyyymmdd")

--- a/test/classes/query/collection_numbers_test.rb
+++ b/test/classes/query/collection_numbers_test.rb
@@ -12,18 +12,37 @@ class Query::CollectionNumbersTest < UnitTestCase
     assert_query(expects, :CollectionNumber)
   end
 
-  def test_collection_number_created_at
+  def test_collection_number_created_at_range
     expects = [collection_numbers(:minimal_unknown_coll_num)]
     early = "2005-01-01"
     late = "2005-12-31"
     scope = CollectionNumber.created_at(early, late)
     assert_query_scope(expects, scope,
                        :CollectionNumber, created_at: [early, late])
+    # check that scope tolerates an array at first position
+    scope = CollectionNumber.created_at([early, late])
+    assert_query_scope(expects, scope,
+                       :CollectionNumber, created_at: [early, late])
+  end
+
+  def test_collection_number_created_after_date
     expects = [collection_numbers(:coprinus_comatus_coll_num)]
     date = "2012-01-01"
     scope = CollectionNumber.created_at(date)
+    assert_query_scope(expects, scope, :CollectionNumber, created_at: date)
+  end
+
+  def test_collection_number_created_on_date
+    expects = [collection_numbers(:coprinus_comatus_coll_num)]
+    early = "2012-12-08"
+    late = "2012-12-08"
+    scope = CollectionNumber.created_at(early, late)
     assert_query_scope(expects, scope,
-                       :CollectionNumber, created_at: date)
+                       :CollectionNumber, created_at: [early, late])
+    # check that scope tolerates an array at first position
+    scope = CollectionNumber.created_at([early, late])
+    assert_query_scope(expects, scope,
+                       :CollectionNumber, created_at: [early, late])
   end
 
   def test_collection_number_id_in_set

--- a/test/classes/query/collection_numbers_test.rb
+++ b/test/classes/query/collection_numbers_test.rb
@@ -45,6 +45,19 @@ class Query::CollectionNumbersTest < UnitTestCase
                        :CollectionNumber, created_at: [early, late])
   end
 
+  def test_collection_number_created_at_datetime
+    expects = [collection_numbers(:coprinus_comatus_coll_num)]
+    early = "2012-12-08-14-23-00"
+    late = "2012-12-08-14-23-00"
+    scope = CollectionNumber.created_at(early, late)
+    assert_query_scope(expects, scope,
+                       :CollectionNumber, created_at: [early, late])
+    # check that scope tolerates an array at first position
+    scope = CollectionNumber.created_at([early, late])
+    assert_query_scope(expects, scope,
+                       :CollectionNumber, created_at: [early, late])
+  end
+
   def test_collection_number_id_in_set
     set = CollectionNumber.order(id: :asc).last(3).pluck(:id)
     scope = CollectionNumber.id_in_set(set)

--- a/test/classes/query/collection_numbers_test.rb
+++ b/test/classes/query/collection_numbers_test.rb
@@ -12,6 +12,20 @@ class Query::CollectionNumbersTest < UnitTestCase
     assert_query(expects, :CollectionNumber)
   end
 
+  def test_collection_number_created_at
+    expects = [collection_numbers(:minimal_unknown_coll_num)]
+    early = "2005-01-01"
+    late = "2005-12-31"
+    scope = CollectionNumber.created_at(early, late)
+    assert_query_scope(expects, scope,
+                       :CollectionNumber, created_at: [early, late])
+    expects = [collection_numbers(:coprinus_comatus_coll_num)]
+    date = "2012-01-01"
+    scope = CollectionNumber.created_at(date)
+    assert_query_scope(expects, scope,
+                       :CollectionNumber, created_at: date)
+  end
+
   def test_collection_number_id_in_set
     set = CollectionNumber.order(id: :asc).last(3).pluck(:id)
     scope = CollectionNumber.id_in_set(set)

--- a/test/classes/query/collection_numbers_test.rb
+++ b/test/classes/query/collection_numbers_test.rb
@@ -94,6 +94,10 @@ class Query::CollectionNumbersTest < UnitTestCase
     expects = [collection_numbers(:agaricus_campestris_coll_num)]
     scope = CollectionNumber.numbers("07-123a").index_order
     assert_query_scope(expects, scope, :CollectionNumber, numbers: "07-123a")
+    expects = [collection_numbers(:minimal_unknown_coll_num),
+               collection_numbers(:detailed_unknown_coll_num_one)]
+    scope = CollectionNumber.numbers(%w[173 174]).index_order
+    assert_query_scope(expects, scope, :CollectionNumber, numbers: %w[173 174])
   end
 
   def test_collection_number_number_has

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -26,7 +26,7 @@ class Query::CommentsTest < UnitTestCase
   def test_comment_for_target
     obs = observations(:minimal_unknown_obs)
     expects = [comments(:minimal_unknown_obs_comment_2),
-               comments(:minimal_unknown_obs_comment_2)]
+               comments(:minimal_unknown_obs_comment_1)]
     scope = Comment.index_order.target(obs).distinct
     assert_query_scope(expects, scope,
                        :Comment, target: { type: :Observation, id: obs.id })
@@ -36,15 +36,16 @@ class Query::CommentsTest < UnitTestCase
                        :Comment, target: { type: :Observation, id: obs.id })
   end
 
-  def test_comment_for_invalid_target
-    glo = glossary_terms(:convex_glossary_term)
-    scope = Comment.target(glo)
-    assert_query_scope([], scope,
-                       :Comment, target: { type: :GlossaryTerm, id: glo.id })
-    scope = Comment.target(type: "GlossaryTerm", id: glo.id)
-    assert_query_scope([], scope,
-                       :Comment, target: { type: :GlossaryTerm, id: glo.id })
-  end
+  # Query currently raises on invalid params, so we can't test this yet.
+  # def test_comment_for_invalid_target
+  #   glo = glossary_terms(:convex_glossary_term)
+  #   scope = Comment.target(glo)
+  #   assert_query_scope([], scope,
+  #                      :Comment, target: { type: :GlossaryTerm, id: glo.id })
+  #   scope = Comment.target(type: "GlossaryTerm", id: glo.id)
+  #   assert_query_scope([], scope,
+  #                      :Comment, target: { type: :GlossaryTerm, id: glo.id })
+  # end
 
   def test_comment_types
     expects = [comments(:fungi_comment)]

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -25,10 +25,25 @@ class Query::CommentsTest < UnitTestCase
 
   def test_comment_for_target
     obs = observations(:minimal_unknown_obs)
-    expects = Comment.index_order.where(target_id: obs.id).distinct
-    assert_query(expects, :Comment, target: { type: :Observation, id: obs })
-    expects = Comment.index_order.target(obs).distinct
-    assert_query(expects, :Comment, target: { type: :Observation, id: obs })
+    expects = [comments(:minimal_unknown_obs_comment_2),
+               comments(:minimal_unknown_obs_comment_2)]
+    scope = Comment.index_order.target(obs).distinct
+    assert_query_scope(expects, scope,
+                       :Comment, target: { type: :Observation, id: obs.id })
+    scope = Comment.index_order.
+            target(type: "Observation", id: obs.id).distinct
+    assert_query_scope(expects, scope,
+                       :Comment, target: { type: :Observation, id: obs.id })
+  end
+
+  def test_comment_for_invalid_target
+    glo = glossary_terms(:convex_glossary_term)
+    scope = Comment.target(glo)
+    assert_query_scope([], scope,
+                       :Comment, target: { type: :GlossaryTerm, id: glo.id })
+    scope = Comment.target(type: "GlossaryTerm", id: glo.id)
+    assert_query_scope([], scope,
+                       :Comment, target: { type: :GlossaryTerm, id: glo.id })
   end
 
   def test_comment_types

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -205,8 +205,24 @@ class Query::NamesTest < UnitTestCase
   def test_name_deprecated
     expects = Name.with_correct_spelling.deprecated.index_order
     assert_query(expects, :Name, deprecated: true)
-    expects = Name.with_correct_spelling.not_deprecated.index_order
-    assert_query(expects, :Name, deprecated: false)
+
+    trues = [true, "true", 1, "1"]
+    trues.each do |val|
+      expects = Name.with_correct_spelling.deprecated(val).index_order
+      assert_query(expects, :Name, deprecated: true)
+
+      expects = Name.with_correct_spelling.deprecated.index_order
+      assert_query(expects, :Name, deprecated: val)
+    end
+
+    falses = [false, "false", 0, "0"]
+    falses.each do |val|
+      expects = Name.with_correct_spelling.deprecated(val).index_order
+      assert_query(expects, :Name, deprecated: false)
+
+      expects = Name.with_correct_spelling.deprecated(false).index_order
+      assert_query(expects, :Name, deprecated: val)
+    end
   end
 
   def test_name_has_synonyms

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -503,9 +503,12 @@ class Query::ObservationsTest < UnitTestCase
     # single date should return after
     assert_query(Observation.index_order.send(col, "2011-05-12"),
                  :Observation, "#{col}": "2011-05-12")
-    # year should return after
-    assert_query(Observation.index_order.send(col, "2005"),
+    # year should return after 01/01
+    assert_query(Observation.index_order.send(col, "2005-01-01"),
                  :Observation, "#{col}": "2005")
+    # month should return after 01
+    assert_query(Observation.index_order.send(col, "2007-05-01"),
+                 :Observation, "#{col}": "2007-05")
     # years should return between
     assert_query(Observation.index_order.send(col, "2005", "2009"),
                  :Observation, "#{col}": %w[2005 2009])

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -490,46 +490,66 @@ class AbstractModelTest < UnitTestCase
   end
 
   def test_scope_created_after
-    assert_equal(Observation.count,
-                 Observation.created_after(improbably_early).count)
-    assert_empty(Observation.created_after(a_century_from_now))
+    assert_equal(
+      Observation.count,
+      Observation.datetime_after(improbably_early, col: :created_at).count
+    )
+    assert_empty(
+      Observation.datetime_after(a_century_from_now, col: :created_at)
+    )
   end
 
   def test_scope_created_before
-    assert_equal(Observation.count,
-                 Observation.created_before(a_century_from_now).count)
-    assert_empty(Observation.created_before(improbably_early))
+    assert_equal(
+      Observation.count,
+      Observation.datetime_before(a_century_from_now, col: :created_at).count
+    )
+    assert_empty(
+      Observation.datetime_before(improbably_early, col: :created_at)
+    )
   end
 
   def test_scope_created_between
     assert_equal(
       Observation.count,
-      Observation.created_between(improbably_early, a_century_from_now).count
+      Observation.datetime_between(improbably_early, a_century_from_now,
+                                   col: :created_at).count
     )
     assert_empty(
-      Observation.created_between(a_century_from_now, two_centuries_from_now)
+      Observation.datetime_between(a_century_from_now, two_centuries_from_now,
+                                   col: :created_at)
     )
   end
 
   def test_scope_updated_after
-    assert_equal(Observation.count,
-                 Observation.updated_after(improbably_early).count)
-    assert_empty(Observation.updated_after(a_century_from_now))
+    assert_equal(
+      Observation.count,
+      Observation.datetime_after(improbably_early, col: :updated_at).count
+    )
+    assert_empty(
+      Observation.datetime_after(a_century_from_now, col: :updated_at)
+    )
   end
 
   def test_scope_updated_before
-    assert_equal(Observation.count,
-                 Observation.updated_before(a_century_from_now).count)
-    assert_empty(Observation.updated_before(improbably_early))
+    assert_equal(
+      Observation.count,
+      Observation.datetime_before(a_century_from_now, col: :updated_at).count
+    )
+    assert_empty(
+      Observation.datetime_before(improbably_early, col: :updated_at)
+    )
   end
 
   def test_scope_updated_between
     assert_equal(
       Observation.count,
-      Observation.updated_between(improbably_early, a_century_from_now).count
+      Observation.datetime_between(improbably_early, a_century_from_now,
+                                   col: :updated_at).count
     )
     assert_empty(
-      Observation.updated_between(a_century_from_now, two_centuries_from_now)
+      Observation.datetime_between(a_century_from_now, two_centuries_from_now,
+                                   col: :updated_at)
     )
   end
 

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -553,12 +553,11 @@ class AbstractModelTest < UnitTestCase
     )
   end
 
-  # Query currently parses a year as "datetime_after" Jan 01 of that year, but
-  # the scope enables this more useful parsing of "within the year".
+  # the scope enables this parsing of "within the year".
   def test_scope_created_in_year
     expects = Observation.where(Observation[:created_at].year.eq("2007")).
               index_order
-    assert_equal(expects, Observation.index_order.created_at("2007"))
+    assert_equal(expects, Observation.index_order.created_at("2007", "2007"))
   end
 
   # Ditto for month.
@@ -567,7 +566,8 @@ class AbstractModelTest < UnitTestCase
               where(Observation[:created_at].year.eq("2007").
                     and(Observation[:created_at].month.eq("08"))).
               index_order
-    assert_equal(expects, Observation.index_order.created_at("2007-08"))
+    assert_equal(expects,
+                 Observation.index_order.created_at("2007-08", "2007-08"))
   end
 
   def test_scope_by_editor

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -553,6 +553,23 @@ class AbstractModelTest < UnitTestCase
     )
   end
 
+  # Query currently parses a year as "datetime_after" Jan 01 of that year, but
+  # the scope enables this more useful parsing of "within the year".
+  def test_scope_created_in_year
+    expects = Observation.where(Observation[:created_at].year.eq("2007")).
+              index_order
+    assert_equal(expects, Observation.index_order.created_at("2007"))
+  end
+
+  # Ditto for month.
+  def test_scope_created_in_month
+    expects = Observation.
+              where(Observation[:created_at].year.eq("2007").
+                    and(Observation[:created_at].month.eq("08"))).
+              index_order
+    assert_equal(expects, Observation.index_order.created_at("2007-08"))
+  end
+
   def test_scope_by_editor
     # if no version table, should return all
     assert_equal(


### PR DESCRIPTION
Working on Query branch exposed some cases where these scopes did not behave as expected by Query.
- :created_at
- :updated_at
- :target (comments)
- :deprecated (names)

Obviously the way they behave is open to revision, but for the transition to AR my goal is to get all scopes behaving exactly as currently expected, with the same args.