### PR TITLE
Rename Query param[:by] as [:order_by]

### DIFF
--- a/app/classes/api2/model_api.rb
+++ b/app/classes/api2/model_api.rb
@@ -38,7 +38,7 @@ class API2
     def build_query
       params = query_params
       params.remove_nils!
-      params[:by] = :id
+      params[:order_by] = :id
       Query.lookup(model.name.to_sym, params)
     rescue RuntimeError => e
       raise(QueryError.new(e))

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -14,7 +14,7 @@
 #  Each model has a default search flavor (:default), which is used by the prev
 #  and next actions when the specified query no longer exists.  For example, if
 #  you click on an observation from the main index, prev and next travserse the
-#  results of an :Observation :all by: :rss_log query.  If the user comes back
+#  results of an :Observation :all order_by: :rss_log query.  If the user comes back
 #  a day later, this query will have been culled by the garbage collector (see
 #  below), so prev and next need to be able to create a default query on the
 #  fly.  In this case it may be :Observation :all (see default_flavors array

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -14,7 +14,7 @@
 #  Each model has a default search flavor (:default), which is used by the prev
 #  and next actions when the specified query no longer exists.  For example, if
 #  you click on an observation from the main index, prev and next travserse the
-#  results of an :Observation :all order_by: :rss_log query.  If the user comes back
+#  results of an :Observation order_by: :rss_log query.  If the user comes back
 #  a day later, this query will have been culled by the garbage collector (see
 #  below), so prev and next need to be able to create a default query on the
 #  fly.  In this case it may be :Observation :all (see default_flavors array

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -30,7 +30,7 @@ class Query::Base
       group: :string,
       order: :string,
       selects: :string,
-      by: :string,
+      order_by: :string,
       title: [:string]
     }
   end

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -11,7 +11,7 @@ class Query::Images < Query::Base
   end
 
   def list_by
-    @list_by ||= case params[:by].to_s
+    @list_by ||= case params[:order_by].to_s
                  when "user", "reverse_user"
                    User[:login]
                  when "name", "reverse_name"
@@ -177,7 +177,7 @@ class Query::Images < Query::Base
   #   # to survive much longer. Image searches are in desperate need of
   #   # critical revision for performance concerns, anyway. -JPH 20210809]
   #   args2 = args.except(:select, :order, :group)
-  #   params2 = params.except(:by)
+  #   params2 = params.except(:order_by)
   #   ids = Query.lookup(:Observation, params2).result_ids(args2)
   #   ids = clean_id_set(ids)
   #   args2 = args.dup

--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -32,7 +32,7 @@ module Query::Modules::Ordering
       sorting_method
     )
       raise(
-        "Can't figure out how to order #{model.name.pluralize} by :#{order_by}."
+        "Can't figure out how to sort #{model.name.pluralize} by :#{order_by}."
       )
     end
 

--- a/app/classes/query/modules/ordering.rb
+++ b/app/classes/query/modules/ordering.rb
@@ -9,30 +9,30 @@ module Query::Modules::Ordering
       return
     end
 
-    initialize_by_param
+    initialize_order_by_param
   end
 
   # Let queries define custom order spec in "order", but have explicitly
-  # passed-in "by" parameter take precedence. If neither `order` nor `by` is
-  # given, then fall back on the "default_order" finally.
-  def initialize_by_param
-    by = params[:by]
-    return unless by || order.blank?
+  # passed-in "order_by" parameter take precedence. If neither `order` nor
+  # `order_by` is given, then fall back on the "default_order" finally.
+  def initialize_order_by_param
+    order_by = params[:order_by]
+    return unless order_by || order.blank?
 
-    by ||= default_order
-    by = by.dup
-    reverse = !!by.to_s.sub!(/^reverse_/, "")
-    result = initialize_order_specs(by)
+    order_by ||= default_order
+    order_by = order_by.dup
+    reverse = order_by.to_s.sub!(/^reverse_/, "")
+    result = initialize_order_specs(order_by)
     self.order = reverse ? reverse_order(result) : result
   end
 
-  def initialize_order_specs(by)
-    sorting_method = "sort_by_#{by}"
+  def initialize_order_specs(order_by)
+    sorting_method = "order_by_#{order_by}"
     unless ::Query::Modules::Ordering.private_method_defined?(
       sorting_method
     )
       raise(
-        "Can't figure out how to sort #{model.name.pluralize} by :#{by}."
+        "Can't figure out how to order #{model.name.pluralize} by :#{order_by}."
       )
     end
 
@@ -53,31 +53,31 @@ module Query::Modules::Ordering
 
   ####### methods dispatched from initialize_order_specs
 
-  def sort_by_accession_number(model)
+  def order_by_accession_number(model)
     return unless model.column_names.include?("accession_number")
 
     "#{model.table_name}.accession_number ASC"
   end
 
-  def sort_by_box_area(_model)
+  def order_by_box_area(_model)
     "locations.box_area DESC"
   end
 
-  def sort_by_code(_model)
+  def order_by_code(_model)
     where << "herbaria.code != ''"
     "herbaria.code ASC"
   end
 
-  def sort_by_code_then_date(_model)
+  def order_by_code_then_date(_model)
     "field_slips.code ASC, field_slips.created_at DESC, " \
     "field_slips.id DESC"
   end
 
-  def sort_by_code_then_name(_model)
+  def order_by_code_then_name(_model)
     "IF(herbaria.code = '', '~', herbaria.code) ASC, herbaria.name ASC"
   end
 
-  def sort_by_confidence(model)
+  def order_by_confidence(model)
     if model == Image
       add_join(:observation_images, :observations)
       "observations.vote_cache DESC"
@@ -86,23 +86,23 @@ module Query::Modules::Ordering
     end
   end
 
-  def sort_by_contribution(model)
+  def order_by_contribution(model)
     "users.contribution DESC" if model == User
   end
 
-  def sort_by_copyright_holder(model)
+  def order_by_copyright_holder(model)
     return unless model.column_names.include?("copyright_holder")
 
     "#{model.table_name}.copyright_holder ASC"
   end
 
-  def sort_by_created_at(model)
+  def order_by_created_at(model)
     return unless model.column_names.include?("created_at")
 
     "#{model.table_name}.created_at DESC"
   end
 
-  def sort_by_date(model)
+  def order_by_date(model)
     if model.column_names.include?("when")
       "#{model.table_name}.when DESC"
     elsif model.column_names.include?("created_at")
@@ -110,79 +110,79 @@ module Query::Modules::Ordering
     end
   end
 
-  def sort_by_herbarium_label(_model)
+  def order_by_herbarium_label(_model)
     "herbarium_records.initial_det ASC, " \
     "herbarium_records.accession_number ASC"
   end
 
-  def sort_by_herbarium_name(_model)
+  def order_by_herbarium_name(_model)
     add_join(:herbaria)
     "herbaria.name ASC"
   end
 
   # (for testing)
-  def sort_by_id(model)
+  def order_by_id(model)
     "#{model.table_name}.id ASC"
   end
 
-  def sort_by_image_quality(model)
+  def order_by_image_quality(model)
     "images.vote_cache DESC" if model == Image
   end
 
-  def sort_by_initial_det(model)
+  def order_by_initial_det(model)
     return unless model.column_names.include?("initial_det")
 
     "#{model.table_name}.initial_det ASC"
   end
 
-  def sort_by_last_login(model)
+  def order_by_last_login(model)
     return unless model.column_names.include?("last_login")
 
     "#{model.table_name}.last_login DESC"
   end
 
-  def sort_by_location(model)
+  def order_by_location(model)
     return unless model.column_names.include?("location_id")
 
     # Join Users with null locations, else join records with locations
     model == User ? add_join(:locations!) : add_join(:locations)
-    sort_locations_by_name
+    order_locations_by_name
   end
 
-  def sort_by_login(model)
+  def order_by_login(model)
     "#{model.table_name}.login ASC" if model.column_names.include?("login")
   end
 
-  def sort_by_name(model)
-    sort_by_name_method = "sort_#{model.name.underscore.pluralize}_by_name"
+  def order_by_name(model)
+    order_by_name_method = "order_#{model.name.underscore.pluralize}_by_name"
     if ::Query::Modules::Ordering.private_method_defined?(
-      sort_by_name_method
+      order_by_name_method
     )
-      send(sort_by_name_method)
+      send(order_by_name_method)
     else
-      sort_other_models_by_name(model)
+      order_other_models_by_name(model)
     end
   end
 
-  def sort_by_name_and_number(_model)
+  def order_by_name_and_number(_model)
     "collection_numbers.name ASC, collection_numbers.number ASC"
   end
 
-  def sort_by_num_views(model)
+  def order_by_num_views(model)
     return unless model.column_names.include?("num_views")
 
     "#{model.table_name}.num_views DESC"
   end
 
-  def sort_by_observation(model)
+  def order_by_observation(model)
     "observation_id DESC" if model.column_names.include?("observation_id")
   end
 
-  def sort_by_original_name(model)
+  def order_by_original_name(model)
     "images.original_name ASC" if model == Image
   end
 
-  def sort_by_owners_quality(model)
+  def order_by_owners_quality(model)
     return unless model == Image
 
     add_join(:image_votes)
@@ -190,7 +190,7 @@ module Query::Modules::Ordering
     "image_votes.value DESC"
   end
 
-  def sort_by_owners_thumbnail_quality(model)
+  def order_by_owners_thumbnail_quality(model)
     return unless model == Observation
 
     add_join(:"images.thumb_image", :image_votes)
@@ -201,14 +201,14 @@ module Query::Modules::Ordering
     "observations.vote_cache DESC"
   end
 
-  def sort_by_records(_model)
+  def order_by_records(_model)
     # outer_join needed to show herbaria with no records
     add_join(:herbarium_records!)
     self.group = "herbaria.id"
     "count(herbarium_records.id) DESC"
   end
 
-  def sort_by_rss_log(model)
+  def order_by_rss_log(model)
     return unless model.column_names.include?("rss_log_id")
 
     # use cached column if exists, and don't join
@@ -221,57 +221,57 @@ module Query::Modules::Ordering
     end
   end
 
-  def sort_by_summary(model)
+  def order_by_summary(model)
     return unless model.column_names.include?("summary")
 
     "#{model.table_name}.summary ASC"
   end
 
-  def sort_by_thumbnail_quality(model)
+  def order_by_thumbnail_quality(model)
     return unless model == Observation
 
     add_join(:"images.thumb_image")
     "images.vote_cache DESC, observations.vote_cache DESC"
   end
 
-  def sort_by_title(model)
+  def order_by_title(model)
     "#{model.table_name}.title ASC" if model.column_names.include?("title")
   end
 
-  def sort_by_updated_at(model)
+  def order_by_updated_at(model)
     return unless model.column_names.include?("updated_at")
 
     "#{model.table_name}.updated_at DESC"
   end
 
-  def sort_by_url(model)
+  def order_by_url(model)
     "external_links.url ASC" if model == ExternalLink
   end
 
-  def sort_by_user(_model)
+  def order_by_user(_model)
     add_join(:users)
     'IF(users.name = "" OR users.name IS NULL, users.login, users.name) ASC'
   end
 
-  def sort_by_where(model)
+  def order_by_where(model)
     "#{model.table_name}.where ASC" if model.column_names.include?("where")
   end
 
-  ####### methods dispatched from sort_by_name
+  ####### methods dispatched from order_by_name
 
-  def sort_images_by_name
+  def order_images_by_name
     add_join(:observation_images, :observations)
     add_join(:observations, :names)
     self.group = "images.id"
     "MIN(names.sort_name) ASC, images.when DESC"
   end
 
-  def sort_location_descriptions_by_name
+  def order_location_descriptions_by_name
     add_join(:locations)
     "locations.name ASC, location_descriptions.created_at ASC"
   end
 
-  def sort_locations_by_name
+  def order_locations_by_name
     if User.current_location_format == "scientific"
       "locations.scientific_name ASC"
     else
@@ -279,21 +279,21 @@ module Query::Modules::Ordering
     end
   end
 
-  def sort_name_descriptions_by_name
+  def order_name_descriptions_by_name
     add_join(:names)
     "names.sort_name ASC, name_descriptions.created_at ASC"
   end
 
-  def sort_names_by_name
+  def order_names_by_name
     "names.sort_name ASC"
   end
 
-  def sort_observations_by_name
+  def order_observations_by_name
     add_join(:names)
     "names.sort_name ASC, observations.when DESC"
   end
 
-  def sort_other_models_by_name(model)
+  def order_other_models_by_name(model)
     if model.column_names.include?("name")
       "#{model.table_name}.name ASC"
     elsif model.column_names.include?("title")

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -11,7 +11,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
   end
 
   def list_by
-    @list_by ||= case params[:by].to_s
+    @list_by ||= case params[:order_by].to_s
                  when "user", "reverse_user"
                    User[:login]
                  when "name", "reverse_name"

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -6,7 +6,7 @@ class Query::SpeciesLists < Query::Base
   end
 
   def list_by
-    @list_by ||= case params[:by].to_s
+    @list_by ||= case params[:order_by].to_s
                  when "user", "reverse_user"
                    User[:login]
                  else

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -6,7 +6,7 @@ class Query::Users < Query::Base
   end
 
   def list_by
-    @list_by ||= case params[:by]
+    @list_by ||= case params[:order_by]
                  when "login", "reverse_login"
                    User[:login]
                  else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -404,9 +404,9 @@ class ApplicationController < ActionController::Base
   end
 
   def query_images_to_reuse(all_users, user)
-    return create_query(:Image, by: :updated_at) if all_users || !user
+    return create_query(:Image, order_by: :updated_at) if all_users || !user
 
-    create_query(:Image, by_users: user, by: :updated_at)
+    create_query(:Image, by_users: user, order_by: :updated_at)
   end
   helper_method :query_images_to_reuse
 

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -104,7 +104,9 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   def unfiltered_index
     return unless unfiltered_index_permitted?
 
-    args = { order_by: default_sort_order }.merge(unfiltered_index_opts[:query_args])
+    args = { order_by: default_sort_order }.merge(
+      unfiltered_index_opts[:query_args]
+    )
     query = create_query(controller_model_name.to_sym, **args)
 
     [query, unfiltered_index_opts[:display_opts]]

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -104,7 +104,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   def unfiltered_index
     return unless unfiltered_index_permitted?
 
-    args = { by: default_sort_order }.merge(unfiltered_index_opts[:query_args])
+    args = { order_by: default_sort_order }.merge(unfiltered_index_opts[:query_args])
     query = create_query(controller_model_name.to_sym, **args)
 
     [query, unfiltered_index_opts[:display_opts]]
@@ -135,7 +135,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   end
 
   def sorted_index_opts
-    { query_args: { by: params[:by] },
+    { query_args: { order_by: params[:by] },
       display_opts: index_display_at_id_opts }
   end
 

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -55,10 +55,7 @@ module ApplicationController::Queries
     found_query
   end
 
-  BY_MAP = {
-    "modified" => :updated_at,
-    "created" => :created_at
-  }.freeze
+  BY_MAP = { "modified" => :updated_at, "created" => :created_at }.freeze
 
   private ##########
 

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -115,7 +115,9 @@ module ApplicationController::Queries
   end
 
   def map_past_bys(args)
-    args[:by] = (BY_MAP[args[:by].to_s] || args[:by]) if args.member?(:by)
+    return unless args.member?(:order_by)
+
+    args[:order_by] = (BY_MAP[args[:order_by].to_s] || args[:order_by])
   end
 
   def add_user_content_filter_parameters(query_params, model)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -40,7 +40,7 @@ class CommentsController < ApplicationController
   # Passes explicit :by param to affect title (only).
   def sorted_index_opts
     sorted_by = params[:by] || default_sort_order
-    super.merge(query_args: { by: sorted_by })
+    super.merge(query_args: { order_by: sorted_by })
   end
 
   # Shows comments by a given user, most recent first. (Linked from show_user.)
@@ -94,7 +94,9 @@ class CommentsController < ApplicationController
     }.merge(opts)
 
     # Paginate by letter if sorting by user.
-    opts[:letters] = true if %w[user reverse_user].include?(query.params[:by])
+    if %w[user reverse_user].include?(query.params[:order_by])
+      opts[:letters] = true
+    end
 
     @full_detail = query.params[:target].present?
 

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -30,7 +30,7 @@ class ContributorsController < ApplicationController
   # (Linked from show template, next to "prev" and "next"... or will be.)
   def sorted_index_opts
     sorted_by = params[:by] || default_sort_order
-    super.merge(query_args: { has_contribution: true, by: sorted_by })
+    super.merge(query_args: { has_contribution: true, order_by: sorted_by })
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -28,7 +28,7 @@ class GlossaryTermsController < ApplicationController
   # Passes explicit :by param to affect title (only).
   def sorted_index_opts
     sorted_by = params[:by] || default_sort_order
-    super.merge(query_args: { by: sorted_by })
+    super.merge(query_args: { order_by: sorted_by })
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -92,12 +92,12 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   # Passes explicit :by param to affect title (only).
   def sorted_index_opts
     sorted_by = params[:by] || default_sort_order
-    super.merge(query_args: { by: sorted_by })
+    super.merge(query_args: { order_by: sorted_by })
   end
 
   def nonpersonal
     store_location
-    query = create_query(:Herbarium, nonpersonal: true, by: :code_then_name)
+    query = create_query(:Herbarium, nonpersonal: true, order_by: :code_then_name)
     [query, { always_index: true }]
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -97,7 +97,9 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
 
   def nonpersonal
     store_location
-    query = create_query(:Herbarium, nonpersonal: true, order_by: :code_then_name)
+    query = create_query(
+      :Herbarium, nonpersonal: true, order_by: :code_then_name
+    )
     [query, { always_index: true }]
   end
 

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -30,7 +30,7 @@ class HerbariumRecordsController < ApplicationController
     store_location
     query = create_query(:HerbariumRecord,
                          herbaria: params[:herbarium].to_s,
-                         by: :herbarium_label)
+                         order_by: :herbarium_label)
     [query, { always_index: true }]
   end
 
@@ -39,7 +39,7 @@ class HerbariumRecordsController < ApplicationController
     store_location
     query = create_query(:HerbariumRecord,
                          observations: params[:observation].to_s,
-                         by: :herbarium_label)
+                         order_by: :herbarium_label)
     [query, { always_index: true }]
   end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -118,7 +118,7 @@ class ImagesController < ApplicationController
     }.merge(opts)
 
     # Paginate by letter if sorting by user or name.
-    if %w[user reverse_user name reverse_name].include?(query.params[:by])
+    if %w[user reverse_user name reverse_name].include?(query.params[:order_by])
       opts[:letters] = true
     end
 

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -253,7 +253,7 @@ class NamesController < ApplicationController
         :Observation, names: { lookup: @name.id,
                                include_subtaxa: true,
                                exclude_original_names: true,
-                               by: :confidence }
+                               order_by: :confidence }
       )
       # Determine if relevant and count the results of running the query if so.
       # Don't run if there aren't any children.

--- a/app/controllers/observations/downloads_controller.rb
+++ b/app/controllers/observations/downloads_controller.rb
@@ -5,14 +5,14 @@ module Observations
     before_action :login_required
 
     def new
-      @query = find_or_create_query(:Observation, by: params[:by])
+      @query = find_or_create_query(:Observation, order_by: params[:by])
       return too_many_results if too_many_results?
 
       query_params_set(@query)
     end
 
     def create
-      @query = find_or_create_query(:Observation, by: params[:by])
+      @query = find_or_create_query(:Observation, order_by: params[:by])
       raise("no robots!") if browser.bot? # failsafe only!
 
       query_params_set(@query)

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -17,7 +17,7 @@ module Observations
 
     # override the default? maybe no longer necessary
     def unfiltered_index_opts
-      super.merge(query_args: { needs_naming: true, by: :rss_log })
+      super.merge(query_args: { needs_naming: true, order_by: :rss_log })
     end
 
     def index_active_params
@@ -49,19 +49,19 @@ module Observations
       # return unless (clade = Name.find_by(text_name: term))
 
       query = create_query(:Observation, needs_naming: true, clade: term,
-                                         by: :rss_log)
+                                         order_by: :rss_log)
       [query, {}]
     end
 
     def region(term)
       query = create_query(:Observation, needs_naming: true, region: term,
-                                         by: :rss_log)
+                                         order_by: :rss_log)
       [query, {}]
     end
 
     # def user_filter(term)
     #   query = create_query(:Observation, needs_naming: true, by_users: term,
-    #                                      by: :rss_log)
+    #                                      order_by: :rss_log)
     #   [query, {}]
     # end
 

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -21,7 +21,7 @@ class ObservationsController
 
     # Note all other filters of the obs index are sorted by date.
     def unfiltered_index_opts
-      super.merge(query_args: { by: :rss_log })
+      super.merge(query_args: { order_by: :rss_log })
     end
 
     # Searches come 1st because they may have the other params
@@ -110,7 +110,7 @@ class ObservationsController
                                include_synonyms: true,
                                include_all_name_proposals: true,
                                exclude_consensus: true },
-                      by: :confidence
+                      order_by: :confidence
       )
       [query, {}]
     end
@@ -120,7 +120,7 @@ class ObservationsController
       query = create_query(
         :Observation, names: { lookup: parents(params[:name]),
                                include_subtaxa: true },
-                      by: :confidence
+                      order_by: :confidence
       )
       [query, {}]
     end
@@ -130,7 +130,7 @@ class ObservationsController
       query = create_query(
         :Observation, names: { lookup: [params[:name]],
                                include_synonyms: true },
-                      by: :confidence
+                      order_by: :confidence
       )
       [query, {}]
     end
@@ -213,7 +213,9 @@ class ObservationsController
       }.merge(opts)
 
       # Paginate by letter if sorting by user or name.
-      if %w[user reverse_user name reverse_name].include?(query.params[:by])
+      if %w[user reverse_user name reverse_name].include?(
+        query.params[:order_by]
+      )
         opts[:letters] = true
       end
 

--- a/app/controllers/species_lists/uploads_controller.rb
+++ b/app/controllers/species_lists/uploads_controller.rb
@@ -10,7 +10,7 @@ module SpeciesLists
 
       if check_permission!(@species_list)
         query = create_query(:Observation, species_lists: @species_list,
-                                           by: :name)
+                                           order_by: :name)
         @observation_list = query.results
       else
         redirect_to(species_list_path(@species_list))

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -179,7 +179,9 @@ class SpeciesListsController < ApplicationController
   def init_ivars_for_show
     @canonical_url =
       "#{MO.http_domain}/species_lists/#{@species_list.id}"
-    @query = create_query(:Observation, order_by: :name, species_lists: @species_list)
+    @query = create_query(
+      :Observation, order_by: :name, species_lists: @species_list
+    )
 
     # See documentation on the 'How to Use' page to understand this feature.
     store_query_in_session(@query) if params[:set_source].present?

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -36,7 +36,7 @@ class SpeciesListsController < ApplicationController
   end
 
   def unfiltered_index_opts
-    super.merge(query_args: { by: :date })
+    super.merge(query_args: { order_by: :date })
   end
 
   # Used by ApplicationController to dispatch #index to a private method
@@ -49,7 +49,7 @@ class SpeciesListsController < ApplicationController
   # Passes explicit :by param to affect title (only).
   def sorted_index_opts
     sorted_by = params[:by] || :date
-    super.merge(query_args: { by: sorted_by })
+    super.merge(query_args: { order_by: sorted_by })
   end
 
   # Display list of user's species_lists, sorted by date.
@@ -60,7 +60,7 @@ class SpeciesListsController < ApplicationController
     )
     return unless user
 
-    query = create_query(:SpeciesList, by_users: user, by: :date)
+    query = create_query(:SpeciesList, by_users: user, order_by: :date)
     [query, {}]
   end
 
@@ -79,8 +79,10 @@ class SpeciesListsController < ApplicationController
       include: [:location, :user]
     }.merge(opts)
 
-    return opts if %w[date created modified].include?(query.params[:by]) ||
-                   query.params[:by].blank?
+    if %w[date created modified].include?(query.params[:order_by]) ||
+       query.params[:order_by].blank?
+      return opts
+    end
 
     # Paginate by letter if sorting by anything else.
     opts[:letters] = true
@@ -177,7 +179,7 @@ class SpeciesListsController < ApplicationController
   def init_ivars_for_show
     @canonical_url =
       "#{MO.http_domain}/species_lists/#{@species_list.id}"
-    @query = create_query(:Observation, by: :name, species_lists: @species_list)
+    @query = create_query(:Observation, order_by: :name, species_lists: @species_list)
 
     # See documentation on the 'How to Use' page to understand this feature.
     store_query_in_session(@query) if params[:set_source].present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,13 +128,13 @@ class UsersController < ApplicationController
     # First check the user's observation thumbnails for their own favorites
     image_includes = { thumb_image: [:image_votes, :projects, :license, :user] }
     @query = Query.lookup(:Observation, by_users: @show_user,
-                                        by: :owners_thumbnail_quality)
+                                        order_by: :owners_thumbnail_quality)
     observations = @query.results(limit: 6, include: image_includes)
 
     # If not enough, check for other people's favorites
     if (MAX_THUMBS - observations.length).positive?
       @query = Query.lookup(:Observation, by_users: @show_user,
-                                          by: :thumbnail_quality)
+                                          order_by: :thumbnail_quality)
       other_users_favorites = @query.results(limit: MAX_THUMBS,
                                              include: image_includes)
       observations = observations.union(other_users_favorites).take(MAX_THUMBS)

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -58,7 +58,7 @@ module NamesHelper
   # Use:
   #   query = Query.lookup(:Observation, names: { lookup: name.id,
   #                                               include_synonyms: true },
-  #                                      by: :confidence)
+  #                                      order_by: :confidence)
   #   link_to_obss_of(query, :obss_of_taxon.t)
   #   => <a href="/observations?q=Q">This Taxon, any name</a> (19)
   def link_to_obss_of(query, title, count)
@@ -83,18 +83,18 @@ module NamesHelper
   # These don't run queries... it's query.select_count above, that does.
 
   def obss_of_taxon_this_name(name)
-    Query.new(:Observation, names: { lookup: name.id }, by: :confidence)
+    Query.new(:Observation, names: { lookup: name.id }, order_by: :confidence)
   end
 
   def obss_of_taxon_other_names(name)
     Query.new(:Observation, names: { lookup: name.id, include_synonyms: true,
                                      exclude_original_names: true },
-                            by: :confidence)
+                            order_by: :confidence)
   end
 
   def obss_of_taxon_any_name(name)
     Query.new(:Observation, names: { lookup: name.id, include_synonyms: true },
-                            by: :confidence)
+                            order_by: :confidence)
   end
 
   # These two do joins to Namings. Unbelievably, it's faster than the above?
@@ -102,13 +102,13 @@ module NamesHelper
     Query.new(:Observation, names: { lookup: name.id, include_synonyms: true,
                                      include_all_name_proposals: true,
                                      exclude_consensus: true },
-                            by: :confidence)
+                            order_by: :confidence)
   end
 
   def obss_this_name_proposed(name)
     Query.new(:Observation, names: { lookup: name.id,
                                      include_all_name_proposals: true },
-                            by: :confidence)
+                            order_by: :confidence)
   end
 
   #############################################################################

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -155,7 +155,7 @@ module Tabs
 
     # Add some alternate sorting criteria.
     def location_index_sorts(query:)
-      rss_log = query&.params&.dig(:by) == :rss_log
+      rss_log = query&.params&.dig(:order_by) == :rss_log
       [
         ["name", :sort_by_name.t],
         ["created_at", :sort_by_created_at.t],

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -304,7 +304,7 @@ module Tabs
     end
 
     def names_index_sorts(query:)
-      rss_log = query&.params&.dig(:by) == :rss_log
+      rss_log = query&.params&.dig(:order_by) == :rss_log
       [
         ["name", :sort_by_name.t],
         ["created_at", :sort_by_created_at.t],

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -198,7 +198,7 @@ module Tabs
         ["date",        :sort_by_date.t],
         ["user",        :sort_by_user.t],
         ["created_at",  :sort_by_created_at.t],
-        [(query.params[:by] == :rss_log ? "rss_log" : "updated_at"),
+        [(query.params[:order_by] == :rss_log ? "rss_log" : "updated_at"),
          :sort_by_updated_at.t]
       ]
     end

--- a/app/helpers/title_helper.rb
+++ b/app/helpers/title_helper.rb
@@ -119,7 +119,7 @@ module TitleHelper
 
   def caption_params(query, truncate)
     tag.div(class: "small") do
-      query.params.except(:by).compact_blank.each do |key, val|
+      query.params.except(:order_by).compact_blank.each do |key, val|
         caption_one_filter_param(query, key, val, truncate:)
       end
     end
@@ -144,7 +144,7 @@ module TitleHelper
   # inside the brackets and indented.
   def caption_subquery(query, label, hash, truncate)
     concat(tag.span("#{:"query_#{label}".l}: [ "))
-    hash.except(:by).each do |key, val|
+    hash.except(:order_by).each do |key, val|
       caption_one_filter_param(query, key, val, truncate:, tag: :span)
     end
     concat(tag.span(" ] "))

--- a/app/helpers/title_sorter_filter_helper.rb
+++ b/app/helpers/title_sorter_filter_helper.rb
@@ -64,7 +64,7 @@ module TitleSorterFilterHelper
   def sort_link(label, query, by, this_by, link_all)
     path = { controller: query.model.show_controller,
              action: query.model.index_action,
-             order_by: by }.merge(query_params)
+             by: by }.merge(query_params)
     identifier = "#{query.model.to_s.pluralize.underscore}_by_#{by}_link"
     active = !link_all && (by.to_s == this_by) # boolean if current sort order
 

--- a/app/helpers/title_sorter_filter_helper.rb
+++ b/app/helpers/title_sorter_filter_helper.rb
@@ -39,7 +39,7 @@ module TitleSorterFilterHelper
 
   # Add some info to the raw sorts: path, identifier, and if is current sort_by
   def assemble_sort_links(query, sorts, link_all)
-    this_by = (query.params[:by] || query.default_order).
+    this_by = (query.params[:order_by] || query.default_order).
               to_s.sub(/^reverse_/, "")
 
     sort_links = sorts.map do |by, label|
@@ -52,7 +52,7 @@ module TitleSorterFilterHelper
   end
 
   def reverse_by(query, this_by)
-    if query.params[:by].to_s.start_with?("reverse_")
+    if query.params[:order_by].to_s.start_with?("reverse_")
       this_by
     else
       "reverse_#{this_by}"
@@ -64,7 +64,7 @@ module TitleSorterFilterHelper
   def sort_link(label, query, by, this_by, link_all)
     path = { controller: query.model.show_controller,
              action: query.model.index_action,
-             by: by }.merge(query_params)
+             order_by: by }.merge(query_params)
     identifier = "#{query.model.to_s.pluralize.underscore}_by_#{by}_link"
     active = !link_all && (by.to_s == this_by) # boolean if current sort order
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,7 +265,7 @@ MushroomObserver::Application.routes.draw do
   #     resources :products
   #   end
 
-  # Default page "/" is /observations ordered by: :rss_log
+  # Default page "/" is /observations ordered order_by: :rss_log
   root "observations#index"
 
   # Route /123 to /observations/123.

--- a/test/classes/query/articles_test.rb
+++ b/test/classes/query/articles_test.rb
@@ -14,7 +14,7 @@ class Query::ArticlesTest < UnitTestCase
   end
 
   def test_article_by_rss_log
-    assert_query(Article.order_by_rss_log, :Article, by: :rss_log)
+    assert_query(Article.order_by_rss_log, :Article, order_by: :rss_log)
   end
 
   def test_article_id_in_set

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -22,7 +22,7 @@ class Query::HerbariaTest < UnitTestCase
   def test_herbarium_by_records
     expects = Herbarium.left_outer_joins(:herbarium_records).group(:id).
               order(HerbariumRecord[:id].count.desc, Herbarium[:id].desc)
-    assert_query(expects, :Herbarium, by: :records)
+    assert_query(expects, :Herbarium, order_by: :records)
   end
 
   def test_herbarium_id_in_set

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -137,7 +137,7 @@ class Query::ImagesTest < UnitTestCase
     project = projects(:bolete_project)
     expects = Image.index_order.joins(:project_images).
               where(project_images: { project: project }).reorder(id: :asc)
-    assert_query(expects, :Image, projects: project, by: :id)
+    assert_query(expects, :Image, projects: project, order_by: :id)
     assert_query([], :Image, projects: projects(:empty_project))
   end
 
@@ -441,7 +441,7 @@ class Query::ImagesTest < UnitTestCase
   def test_image_sorted_by_original_name
     assert_query(
       sorted_by_name_set,
-      :Image, id_in_set: sorted_by_name_set, by: :original_name
+      :Image, id_in_set: sorted_by_name_set, order_by: :original_name
     )
   end
 

--- a/test/classes/query/location_descriptions_test.rb
+++ b/test/classes/query/location_descriptions_test.rb
@@ -8,7 +8,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
   include QueryExtensions
 
   def test_location_description_all
-    assert_query(LocationDescription.all, :LocationDescription, by: :id)
+    assert_query(LocationDescription.all, :LocationDescription, order_by: :id)
   end
 
   def test_location_description_locations
@@ -20,9 +20,9 @@ class Query::LocationDescriptionsTest < UnitTestCase
     assert(public_gualala_descs.length < all_gualala_descs.length)
 
     assert_query(all_gualala_descs,
-                 :LocationDescription, by: :id, locations: gualala)
+                 :LocationDescription, order_by: :id, locations: gualala)
     assert_query(public_gualala_descs,
-                 :LocationDescription, by: :id, locations: gualala,
+                 :LocationDescription, order_by: :id, locations: gualala,
                                        is_public: "yes")
   end
 
@@ -50,7 +50,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
     descs = LocationDescription.all
     assert_query_scope(descs.find_all { |d| d.authors.include?(rolf) },
                        LocationDescription.by_author(rolf),
-                       :LocationDescription, by_author: rolf.login, by: :id)
+                       :LocationDescription, by_author: rolf.login, order_by: :id)
     assert_query_scope(descs.find_all { |d| d.authors.include?(mary) },
                        LocationDescription.by_author(mary),
                        :LocationDescription, by_author: mary.login)
@@ -74,7 +74,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
     descs = LocationDescription.all
     assert_query_scope(descs.find_all { |d| d.editors.include?(rolf) },
                        LocationDescription.by_editor(rolf),
-                       :LocationDescription, by_editor: rolf, by: :id)
+                       :LocationDescription, by_editor: rolf, order_by: :id)
     assert_query_scope(descs.find_all { |d| d.editors.include?(mary) },
                        LocationDescription.by_editor(mary),
                        :LocationDescription, by_editor: mary)

--- a/test/classes/query/location_descriptions_test.rb
+++ b/test/classes/query/location_descriptions_test.rb
@@ -50,7 +50,8 @@ class Query::LocationDescriptionsTest < UnitTestCase
     descs = LocationDescription.all
     assert_query_scope(descs.find_all { |d| d.authors.include?(rolf) },
                        LocationDescription.by_author(rolf),
-                       :LocationDescription, by_author: rolf.login, order_by: :id)
+                       :LocationDescription, by_author: rolf.login,
+                                             order_by: :id)
     assert_query_scope(descs.find_all { |d| d.authors.include?(mary) },
                        LocationDescription.by_author(mary),
                        :LocationDescription, by_author: mary.login)

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -11,12 +11,12 @@ class Query::LocationsTest < UnitTestCase
     expects = Location.index_order
     assert_query(expects, :Location)
     expects = Location.reorder(id: :asc)
-    assert_query(expects, :Location, by: :id)
+    assert_query(expects, :Location, order_by: :id)
   end
 
   def test_location_by_users
     assert_query(Location.reorder(id: :asc).by_users(rolf).distinct,
-                 :Location, by_users: rolf, by: :id)
+                 :Location, by_users: rolf, order_by: :id)
     assert_query([], :Location, by_users: users(:zero_user))
   end
 
@@ -33,7 +33,7 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_by_rss_log
     expects = Location.order_by_rss_log
-    assert_query(expects.to_a, :Location, by: :rss_log)
+    assert_query(expects.to_a, :Location, order_by: :rss_log)
   end
 
   def location_set
@@ -76,7 +76,7 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_pattern_search
     expects = Location.reorder(id: :asc).pattern("California")
-    assert_query(expects, :Location, pattern: "California", by: :id)
+    assert_query(expects, :Location, pattern: "California", order_by: :id)
     assert_query_scope([locations(:elgin_co).id], Location.pattern("Canada"),
                        :Location, pattern: "Canada")
     assert_query([], :Location, pattern: "Canada -Elgin")

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -15,30 +15,30 @@ class Query::NameDescriptionsTest < UnitTestCase
     assert(all_pelt_descs.length < all_descs.length)
     assert(public_pelt_descs.length < all_pelt_descs.length)
 
-    assert_query(all_descs, :NameDescription, by: :id)
-    assert_query(all_pelt_descs, :NameDescription, by: :id, names: pelt)
+    assert_query(all_descs, :NameDescription, order_by: :id)
+    assert_query(all_pelt_descs, :NameDescription, order_by: :id, names: pelt)
     assert_query(public_pelt_descs,
-                 :NameDescription, by: :id, names: pelt, is_public: "yes")
+                 :NameDescription, order_by: :id, names: pelt, is_public: "yes")
   end
 
   def test_name_description_by_user
     expects = NameDescription.where(user: mary).order(:id)
-    assert_query(expects, :NameDescription, by_users: mary, by: :id)
+    assert_query(expects, :NameDescription, by_users: mary, order_by: :id)
 
     expects = NameDescription.where(user: katrina).order(:id)
-    assert_query(expects, :NameDescription, by_users: katrina, by: :id)
+    assert_query(expects, :NameDescription, by_users: katrina, order_by: :id)
 
-    assert_query([], :NameDescription, by_users: junk, by: :id)
+    assert_query([], :NameDescription, by_users: junk, order_by: :id)
   end
 
   def test_name_description_by_author
     expects = NameDescription.joins(:name_description_authors).
               where(name_description_authors: { user_id: rolf }).order(:id)
-    assert_query(expects, :NameDescription, by_author: rolf, by: :id)
+    assert_query(expects, :NameDescription, by_author: rolf, order_by: :id)
 
     expects = NameDescription.joins(:name_description_authors).
               where(name_description_authors: { user_id: mary }).order(:id)
-    assert_query(expects, :NameDescription, by_author: mary, by: :id)
+    assert_query(expects, :NameDescription, by_author: mary, order_by: :id)
 
     assert_query([], :NameDescription, by_author: junk)
   end

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -33,7 +33,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_by_rss_log
     expects = Name.order_by_rss_log
-    assert_query(expects, :Name, by: :rss_log)
+    assert_query(expects, :Name, order_by: :rss_log)
   end
 
   def names_set
@@ -71,7 +71,7 @@ class Query::NamesTest < UnitTestCase
     assert_query([], :Name, by_editor: mary)
     expects = Name.reorder(id: :asc).
               with_correct_spelling.by_editor(dick).distinct
-    assert_query(expects, :Name, by_editor: dick, by: :id)
+    assert_query(expects, :Name, by_editor: dick, order_by: :id)
   end
 
   def test_name_users_login
@@ -453,7 +453,7 @@ class Query::NamesTest < UnitTestCase
   def test_name_has_observations
     expects = Name.with_correct_spelling.has_observations.
               select(:name).distinct.pluck(:name_id).sort
-    assert_query(expects, :Name, has_observations: 1, by: :id)
+    assert_query(expects, :Name, has_observations: 1, order_by: :id)
   end
 
   # Prove that :has_observations param of Name Query works with each

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -15,7 +15,7 @@ class Query::ObservationsTest < UnitTestCase
   # Overwrites scope `order_by_rss_log` in abstract_model
   def test_observation_by_rss_log
     expects = Observation.order_by_rss_log
-    assert_query(expects, :Observation, by: :rss_log)
+    assert_query(expects, :Observation, order_by: :rss_log)
   end
 
   def big_set
@@ -42,12 +42,12 @@ class Query::ObservationsTest < UnitTestCase
 
   def test_observation_by_user
     expects = Observation.reorder(id: :asc).where(user: rolf.id).to_a
-    assert_query(expects, :Observation, by_users: rolf, by: :id)
+    assert_query(expects, :Observation, by_users: rolf, order_by: :id)
     expects = Observation.reorder(id: :asc).where(user: mary.id).to_a
-    assert_query(expects, :Observation, by_users: mary, by: :id)
+    assert_query(expects, :Observation, by_users: mary, order_by: :id)
     expects = Observation.reorder(id: :asc).where(user: dick.id).to_a
-    assert_query(expects, :Observation, by_users: dick, by: :id)
-    assert_query([], :Observation, by_users: junk, by: :id)
+    assert_query(expects, :Observation, by_users: dick, order_by: :id)
+    assert_query([], :Observation, by_users: junk, order_by: :id)
   end
 
   def test_observation_confidence
@@ -426,12 +426,12 @@ class Query::ObservationsTest < UnitTestCase
     expects = Observation.reorder(id: :asc).
               where(location: locations(:burbank)).distinct
     assert_query(expects,
-                 :Observation, search_where: "burbank", by: :id) # location
+                 :Observation, search_where: "burbank", order_by: :id) # location
   end
 
   def test_observation_advanced_search_user
     expects = Observation.reorder(id: :asc).where(user: rolf.id).distinct
-    assert_query(expects, :Observation, search_user: "rolf", by: :id)
+    assert_query(expects, :Observation, search_user: "rolf", order_by: :id)
   end
 
   def test_observation_advanced_search_content

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -425,8 +425,8 @@ class Query::ObservationsTest < UnitTestCase
                  :Observation, search_where: "glendale") # where
     expects = Observation.reorder(id: :asc).
               where(location: locations(:burbank)).distinct
-    assert_query(expects,
-                 :Observation, search_where: "burbank", order_by: :id) # location
+    assert_query(expects, # location
+                 :Observation, search_where: "burbank", order_by: :id)
   end
 
   def test_observation_advanced_search_user

--- a/test/classes/query/projects_test.rb
+++ b/test/classes/query/projects_test.rb
@@ -14,7 +14,7 @@ class Query::ProjectsTest < UnitTestCase
 
   def test_project_by_rss_log
     expects = Project.order_by_rss_log
-    assert_query(expects, :Project, by: :rss_log)
+    assert_query(expects, :Project, order_by: :rss_log)
   end
 
   def test_project_in_set

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -22,6 +22,11 @@ class Query::SpeciesListsTest < UnitTestCase
     assert_query(ids, :SpeciesList, order_by: :title)
   end
 
+  def test_species_list_sort_by_where
+    ids = SpeciesList.order(where: :asc, id: :desc).to_a
+    assert_query(ids, :SpeciesList, order_by: :where)
+  end
+
   def test_species_list_by_rss_log
     assert_query(SpeciesList.order_by_rss_log, :SpeciesList, order_by: :rss_log)
   end

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -14,16 +14,16 @@ class Query::SpeciesListsTest < UnitTestCase
 
   def test_species_list_sort_by_user
     ids = SpeciesList.order_by_user.to_a
-    assert_query(ids, :SpeciesList, by: :user)
+    assert_query(ids, :SpeciesList, order_by: :user)
   end
 
   def test_species_list_sort_by_title
     ids = SpeciesList.order(:title).to_a
-    assert_query(ids, :SpeciesList, by: :title)
+    assert_query(ids, :SpeciesList, order_by: :title)
   end
 
   def test_species_list_by_rss_log
-    assert_query(SpeciesList.order_by_rss_log, :SpeciesList, by: :rss_log)
+    assert_query(SpeciesList.order_by_rss_log, :SpeciesList, order_by: :rss_log)
   end
 
   def test_species_list_by_users
@@ -34,7 +34,7 @@ class Query::SpeciesListsTest < UnitTestCase
 
   def test_species_list_by_user_sort_by_id
     ids = SpeciesList.where(user: rolf).reorder(id: :asc).uniq
-    assert_query(ids, :SpeciesList, by_users: rolf, by: :id)
+    assert_query(ids, :SpeciesList, by_users: rolf, order_by: :id)
   end
 
   def test_species_list_locations

--- a/test/classes/query/users_test.rb
+++ b/test/classes/query/users_test.rb
@@ -14,14 +14,14 @@ class Query::UsersTest < UnitTestCase
 
   def test_user_all_by_login
     expects = User.order(login: :asc, id: :desc).to_a
-    assert_query(expects, :User, by: :login)
+    assert_query(expects, :User, order_by: :login)
   end
 
   def test_user_id_in_set
     ids = [rolf.id, mary.id, junk.id]
     scope = User.id_in_set(ids)
     assert_query_scope(ids, scope,
-                       :User, id_in_set: ids.reverse, by: :reverse_name)
+                       :User, id_in_set: ids.reverse, order_by: :reverse_name)
   end
 
   def test_user_pattern_search_nonexistent
@@ -50,7 +50,7 @@ class Query::UsersTest < UnitTestCase
     # (Differs from searches on other Classes or by other sort orders)
     expects = User.left_outer_joins(:location).
               order(Location[:name].asc, User[:id].desc).uniq
-    assert_query(expects, :User, pattern: "", by: "location")
+    assert_query(expects, :User, pattern: "", order_by: "location")
   end
 
   def user_pattern_search(pattern)

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -35,9 +35,9 @@ class QueryTest < UnitTestCase
   def test_validate_params
     # Should ignore params it doesn't recognize
     # assert_raises(RuntimeError) { Query.lookup(:Name, xxx: true) }
-    assert_raises(RuntimeError) { Query.lookup(:Name, by: [1, 2, 3]) }
-    assert_raises(RuntimeError) { Query.lookup(:Name, by: true) }
-    assert_equal("id", Query.lookup(:Name, by: :id).params[:by])
+    assert_raises(RuntimeError) { Query.lookup(:Name, order_by: [1, 2, 3]) }
+    assert_raises(RuntimeError) { Query.lookup(:Name, order_by: true) }
+    assert_equal("id", Query.lookup(:Name, order_by: :id).params[:order_by])
 
     assert_equal(
       :either,
@@ -261,7 +261,7 @@ class QueryTest < UnitTestCase
     assert_equal(2, QueryRecord.count)
 
     # New because params are different from q1.
-    q3 = Query.lookup_and_save(:Observation, by: :id)
+    q3 = Query.lookup_and_save(:Observation, order_by: :id)
     assert_equal(3, QueryRecord.count)
 
     # Not new because it is explicitly defaulted before validate.
@@ -270,7 +270,7 @@ class QueryTest < UnitTestCase
     assert_equal(q1, q4, QueryRecord.count)
 
     # Ditto default.
-    q5 = Query.lookup_and_save(:Observation, by: :id)
+    q5 = Query.lookup_and_save(:Observation, order_by: :id)
     assert_equal(3, QueryRecord.count)
     assert_equal(q3, q5, QueryRecord.count)
 
@@ -279,17 +279,17 @@ class QueryTest < UnitTestCase
     assert_equal(4, QueryRecord.count)
 
     # Old pattern but new order.
-    Query.lookup_and_save(:Observation, pattern: "blah", by: :date)
+    Query.lookup_and_save(:Observation, pattern: "blah", order_by: :date)
     assert_equal(5, QueryRecord.count)
 
-    # Identical, even though :by is explicitly set in one.
+    # Identical, even though :order_by is explicitly set in one.
     Query.lookup_and_save(:Observation, pattern: "blah")
     assert_equal(5, QueryRecord.count)
 
     # Identical query, but new query because order given explicitly.  Order is
     # not given default until query is initialized, thus default not stored in
     # params, so lookup doesn't know about it.
-    Query.lookup_and_save(:Observation, by: :date)
+    Query.lookup_and_save(:Observation, order_by: :date)
     assert_equal(6, QueryRecord.count)
 
     # Just a sanity check.
@@ -486,7 +486,7 @@ class QueryTest < UnitTestCase
   end
 
   def test_low_levels
-    query = Query.lookup(:Name, misspellings: :either, by: :id)
+    query = Query.lookup(:Name, misspellings: :either, order_by: :id)
 
     @fungi = names(:fungi)
     @agaricus = names(:agaricus)
@@ -537,13 +537,13 @@ class QueryTest < UnitTestCase
   end
 
   def test_tables_used
-    query = Query.lookup(:Observation, by: :id)
+    query = Query.lookup(:Observation, order_by: :id)
     assert_equal([:observations], query.tables_used)
 
-    query = Query.lookup(:Observation, by: :name)
+    query = Query.lookup(:Observation, order_by: :name)
     assert_equal([:names, :observations], query.tables_used)
 
-    query = Query.lookup(:Image, by: :name)
+    query = Query.lookup(:Image, order_by: :name)
 
     assert_equal([:images, :names, :observation_images, :observations],
                  query.tables_used)
@@ -555,7 +555,7 @@ class QueryTest < UnitTestCase
   end
 
   def test_results
-    query = Query.lookup(:User, by: :id)
+    query = Query.lookup(:User, order_by: :id)
 
     assert_equal(
       Set.new,
@@ -588,7 +588,7 @@ class QueryTest < UnitTestCase
     @names = Name.reorder(id: :asc).order(:id)
     @pages = MOPaginator.new(number: number,
                              num_per_page: num_per_page)
-    @query = Query.lookup(:Name, misspellings: :either, by: :id)
+    @query = Query.lookup(:Name, misspellings: :either, order_by: :id)
   end
 
   def paginate_test(number, num_per_page, expected_nths)
@@ -694,7 +694,7 @@ class QueryTest < UnitTestCase
   end
 
   def test_next_and_prev
-    query = Query.lookup(:Name, misspellings: :either, by: :id)
+    query = Query.lookup(:Name, misspellings: :either, order_by: :id)
     @names = Name.reorder(id: :asc)
 
     query.current = @names[2]
@@ -758,7 +758,7 @@ class QueryTest < UnitTestCase
     query_a = []
 
     # Several observation queries can be turned into image queries.
-    query_a[0] = Query.lookup_and_save(:Observation, by: :id)
+    query_a[0] = Query.lookup_and_save(:Observation, order_by: :id)
     query_a[1] = Query.lookup_and_save(:Observation, by_users: mary.id)
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
@@ -781,7 +781,7 @@ class QueryTest < UnitTestCase
 
     # Almost any query on observations should be mappable, i.e. coercable into
     # a query on those observations' locations.
-    query_a[0] = Query.lookup_and_save(:Observation, by: :id)
+    query_a[0] = Query.lookup_and_save(:Observation, order_by: :id)
     query_a[1] = Query.lookup_and_save(:Observation, by_users: mary.id)
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
@@ -797,7 +797,7 @@ class QueryTest < UnitTestCase
     # Now, check the parameters of those subqueries.
     obs_queries = query_b.map { |que| que.params[:observation_query] }
 
-    assert_equal("id", obs_queries[0][:by])
+    assert_equal("id", obs_queries[0][:order_by])
     assert_equal([mary.id], obs_queries[1][:by_users])
     assert_equal([species_lists(:first_species_list).id],
                  obs_queries[2][:species_lists])
@@ -816,7 +816,7 @@ class QueryTest < UnitTestCase
     query_a = []
 
     # Several observation queries can be turned into name queries.
-    query_a[0] = Query.lookup_and_save(:Observation, by: :id)
+    query_a[0] = Query.lookup_and_save(:Observation, order_by: :id)
     query_a[1] = Query.lookup_and_save(:Observation, by_users: mary.id)
     query_a[2] = Query.lookup_and_save(
       :Observation, species_lists: species_lists(:first_species_list).id
@@ -961,15 +961,15 @@ class QueryTest < UnitTestCase
   #   assert_equal("Observation", q4.model.to_s)
   #   assert_equal("SpeciesList", q5.model.to_s)
 
-  #   assert_equal(:rss_log, q2.params[:by].to_sym)
-  #   assert_equal(:rss_log, q3.params[:by].to_sym)
-  #   assert_equal(:rss_log, q4.params[:by].to_sym)
-  #   assert_equal(:rss_log, q5.params[:by].to_sym)
+  #   assert_equal(:rss_log, q2.params[:order_by].to_sym)
+  #   assert_equal(:rss_log, q3.params[:order_by].to_sym)
+  #   assert_equal(:rss_log, q4.params[:order_by].to_sym)
+  #   assert_equal(:rss_log, q5.params[:order_by].to_sym)
   # end
 
   def test_relatable
-    assert(Query.lookup(:Observation, by: :id).relatable?(:Image))
-    assert_not(Query.lookup(:Herbarium, by: :id).relatable?(:Project))
+    assert(Query.lookup(:Observation, order_by: :id).relatable?(:Image))
+    assert_not(Query.lookup(:Herbarium, order_by: :id).relatable?(:Project))
   end
 
   ##############################################################################
@@ -991,12 +991,12 @@ class QueryTest < UnitTestCase
     User.current = rolf
     assert_equal("postal", User.current_location_format)
     assert_query([albion, elgin_co],
-                 :Location, id_in_set: [albion.id, elgin_co.id], by: :name)
+                 :Location, id_in_set: [albion.id, elgin_co.id], order_by: :name)
 
     User.current = roy
     assert_equal("scientific", User.current_location_format)
     assert_query([elgin_co, albion],
-                 :Location, id_in_set: [albion.id, elgin_co.id], by: :name)
+                 :Location, id_in_set: [albion.id, elgin_co.id], order_by: :name)
 
     obs1 = observations(:minimal_unknown_obs)
     obs2 = observations(:detailed_unknown_obs)
@@ -1006,11 +1006,11 @@ class QueryTest < UnitTestCase
     User.current = rolf
     assert_equal("postal", User.current_location_format)
     assert_query([obs1, obs2],
-                 :Observation, id_in_set: [obs1.id, obs2.id], by: :location)
+                 :Observation, id_in_set: [obs1.id, obs2.id], order_by: :location)
 
     User.current = roy
     assert_equal("scientific", User.current_location_format)
     assert_query([obs2, obs1],
-                 :Observation, id_in_set: [obs1.id, obs2.id], by: :location)
+                 :Observation, id_in_set: [obs1.id, obs2.id], order_by: :location)
   end
 end

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -991,12 +991,14 @@ class QueryTest < UnitTestCase
     User.current = rolf
     assert_equal("postal", User.current_location_format)
     assert_query([albion, elgin_co],
-                 :Location, id_in_set: [albion.id, elgin_co.id], order_by: :name)
+                 :Location, id_in_set: [albion.id, elgin_co.id],
+                            order_by: :name)
 
     User.current = roy
     assert_equal("scientific", User.current_location_format)
     assert_query([elgin_co, albion],
-                 :Location, id_in_set: [albion.id, elgin_co.id], order_by: :name)
+                 :Location, id_in_set: [albion.id, elgin_co.id],
+                            order_by: :name)
 
     obs1 = observations(:minimal_unknown_obs)
     obs2 = observations(:detailed_unknown_obs)
@@ -1006,11 +1008,13 @@ class QueryTest < UnitTestCase
     User.current = rolf
     assert_equal("postal", User.current_location_format)
     assert_query([obs1, obs2],
-                 :Observation, id_in_set: [obs1.id, obs2.id], order_by: :location)
+                 :Observation, id_in_set: [obs1.id, obs2.id],
+                               order_by: :location)
 
     User.current = roy
     assert_equal("scientific", User.current_location_format)
     assert_query([obs2, obs1],
-                 :Observation, id_in_set: [obs1.id, obs2.id], order_by: :location)
+                 :Observation, id_in_set: [obs1.id, obs2.id],
+                               order_by: :location)
   end
 end

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -131,7 +131,7 @@ class HerbariaControllerTest < FunctionalTestCase
 
   def test_index
     set = [nybg, herbaria(:rolf_herbarium)]
-    query = Query.lookup_and_save(:Herbarium, by: :name, id_in_set: set)
+    query = Query.lookup_and_save(:Herbarium, order_by: :name, id_in_set: set)
     login("zero") # Does not own any herbarium in set
     get(:index, params: { q: query.record.id.alphabetize })
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -895,6 +895,6 @@ class LocationsControllerTest < FunctionalTestCase
   end
 
   def named_obs_query(name)
-    Query.lookup(:Observation, pattern: name, by: :name)
+    Query.lookup(:Observation, pattern: name, order_by: :name)
   end
 end

--- a/test/controllers/names_controller_test.rb
+++ b/test/controllers/names_controller_test.rb
@@ -396,7 +396,7 @@ class NamesControllerTest < FunctionalTestCase
   end
 
   def pagination_query_params
-    query = Query.lookup_and_save(:Name, by: :name)
+    query = Query.lookup_and_save(:Name, order_by: :name)
     @controller.query_params(query)
   end
 

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -654,7 +654,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     o_chron = Observation.reorder(created_at: :desc, id: :desc)
     login
     # need to save a query here to get :next in a non-standard order
-    Query.lookup_and_save(:Observation, by: :created_at)
+    Query.lookup_and_save(:Observation, order_by: :created_at)
     qr = QueryRecord.last.id.alphabetize
 
     get(:show, params: { id: o_chron.fourth.id, flow: :next, q: qr })
@@ -686,7 +686,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     # n2.
     query = Query.lookup_and_save(
       :Observation, names: { lookup: n2.id, include_synonyms: false },
-                    by: :name
+                    order_by: :name
     )
     assert_equal(1, query.num_results)
 
@@ -695,14 +695,14 @@ class ObservationsControllerShowTest < FunctionalTestCase
     query = Query.lookup_and_save(
       :Observation, names: { lookup: n2.id, include_synonyms: true,
                              exclude_original_names: true },
-                    by: :name
+                    order_by: :name
     )
     assert_equal(2, query.num_results)
 
     # But for our prev/next test, lets do the all-inclusive query.
     query = Query.lookup_and_save(
       :Observation, names: { lookup: n2.id, include_synonyms: true },
-                    by: :name
+                    order_by: :name
     )
     assert_equal(4, query.num_results)
     qp = @controller.query_params(query)

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -362,7 +362,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
 
   def test_show_flow
     login
-    query = Query.lookup_and_save(:SpeciesList, by: "reverse_user")
+    query = Query.lookup_and_save(:SpeciesList, order_by: "reverse_user")
     query_params = @controller.query_params(query)
     get(:index, params: query_params)
     assert_template(:index)
@@ -1378,9 +1378,9 @@ class SpeciesListsControllerTest < FunctionalTestCase
     spl1 = species_lists(:unknown_species_list)
     spl2 = species_lists(:one_genus_three_species_list)
     query1 = Query.lookup_and_save(:Observation,
-                                   species_lists: spl1.id, by: :name)
+                                   species_lists: spl1.id, order_by: :name)
     query2 = Query.lookup_and_save(:Observation,
-                                   species_lists: spl2.id, by: :name)
+                                   species_lists: spl2.id, order_by: :name)
 
     # make sure the "Set Source" link is on the page somewhere
     get(:show, params: { id: spl1.id })


### PR DESCRIPTION
On the AR branch, I'm thinking to move the ordering logic into scopes, with the current param[:by] delegating to a new AbstractModel scope `.by(ordering_method)` as the dispatcher to more specific ordering scopes in each appropriate model. This is part of a goal of having Query do as little logic under the hood as possible, with most of its methods accessible to any scope in AR.

However, the name `:by` seems a little newbie-ambiguous in this case, since most of our records are "by" a user. The meaning of `:order_by(ordering_method)` is clearer.