### PR TITLE
RuboCop 1.74 Unsafe Correctables 3/3 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 # RuboCop configuration
 # https://docs.rubocop.org/rubocop/configuration.html
 
-inherit_from: .rubocop_todo.yml
+# inherit_from: .rubocop_todo.yml
 inherit_mode:
   merge:
     - Exclude

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 # RuboCop configuration
 # https://docs.rubocop.org/rubocop/configuration.html
 
-# inherit_from: .rubocop_todo.yml
+inherit_from: .rubocop_todo.yml
 inherit_mode:
   merge:
     - Exclude

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -750,7 +750,6 @@ Style/SafeNavigationChainLength:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:
   Exclude:
-    - 'app/classes/pattern_search/term.rb'
     - 'app/models/location.rb'
     - 'app/models/name/spelling.rb'
     - 'app/models/name_parse.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -750,7 +750,6 @@ Style/SafeNavigationChainLength:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:
   Exclude:
-    - 'app/models/name/spelling.rb'
     - 'app/models/name_parse.rb'
     - 'test/models/comment_test.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -594,14 +594,6 @@ Rails/OutputSafety:
     - 'app/helpers/namings_helper.rb'
     - 'config/application.rb'
 
-# Offense count: 4
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Include.
-# Include: **/Rakefile, **/*.rake
-Rails/RakeEnvironment:
-  Exclude:
-    - 'lib/tasks/lang.rake'
-
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowedReceivers.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -746,12 +746,6 @@ Style/SafeNavigationChainLength:
     - 'app/controllers/locations_controller.rb'
     - 'app/models/location.rb'
 
-# Offense count: 6
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/SlicingWithRange:
-  Exclude:
-    - 'test/models/comment_test.rb'
-
 # Offense count: 32
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Mode.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -732,7 +732,6 @@ Style/OptionalBooleanParameter:
 # AllowedMethods: present?, blank?, presence, try, try!
 Style/SafeNavigation:
   Exclude:
-    - 'app/controllers/account/profile_controller.rb'
     - 'app/controllers/names/eol_data_controller.rb'
     - 'app/models/name/create.rb'
     - 'app/models/name/spelling.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -750,7 +750,6 @@ Style/SafeNavigationChainLength:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:
   Exclude:
-    - 'app/models/location.rb'
     - 'app/models/name/spelling.rb'
     - 'app/models/name_parse.rb'
     - 'test/models/comment_test.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -609,12 +609,6 @@ Style/ClassVars:
     - 'test/language_extensions.rb'
     - 'test/test_helper.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/FileNull:
-  Exclude:
-    - 'test/models/queued_email_test.rb'
-
 # Offense count: 9
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/MapIntoArray:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -591,7 +591,6 @@ Rails/OutputSafety:
 # AllowedReceivers: ActionMailer::Preview, ActiveSupport::TimeZone
 Rails/RedundantActiveRecordAllMethod:
   Exclude:
-    - 'lib/tasks/email.rake'
     - 'script/check_links.rb'
 
 # Offense count: 1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -603,14 +603,6 @@ Rails/RedundantActiveRecordAllMethod:
     - 'lib/tasks/email.rake'
     - 'script/check_links.rb'
 
-# Offense count: 4
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Include.
-# Include: spec/controllers/**/*.rb, spec/requests/**/*.rb, test/controllers/**/*.rb, test/integration/**/*.rb
-Rails/ResponseParsedBody:
-  Exclude:
-    - 'test/controllers/api2_controller_test.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RootPathnameMethods:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -585,14 +585,6 @@ Rails/OutputSafety:
     - 'app/helpers/namings_helper.rb'
     - 'config/application.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedReceivers.
-# AllowedReceivers: ActionMailer::Preview, ActiveSupport::TimeZone
-Rails/RedundantActiveRecordAllMethod:
-  Exclude:
-    - 'script/check_links.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RootPathnameMethods:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -534,13 +534,6 @@ Naming/VariableNumber:
     - 'test/models/observation_test.rb'
     - 'test/system/observation_naming_system_test.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: NilOrEmpty, NotPresent, UnlessPresent.
-Rails/Blank:
-  Exclude:
-    - 'app/models/image.rb'
-
 # Offense count: 24
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -591,12 +591,6 @@ Security/Eval:
   Exclude:
     - 'script/config.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/BitwisePredicate:
-  Exclude:
-    - 'app/models/name/spelling.rb'
-
 # Offense count: 63
 Style/ClassVars:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -640,7 +640,6 @@ Style/FileNull:
 # AllowedReceivers: Thread.current
 Style/HashEachMethods:
   Exclude:
-    - 'app/classes/eol_data.rb'
     - 'script/slowest_pages'
 
 # Offense count: 9

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -634,14 +634,6 @@ Style/FileNull:
   Exclude:
     - 'test/models/queued_email_test.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedReceivers.
-# AllowedReceivers: Thread.current
-Style/HashEachMethods:
-  Exclude:
-    - 'script/slowest_pages'
-
 # Offense count: 9
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/MapIntoArray:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -576,15 +576,6 @@ Rails/HelperInstanceVariable:
   Exclude:
     - 'app/helpers/application_helper.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Include.
-# Include: app/**/*.rb, config/**/*.rb, db/**/*.rb, lib/**/*.rb
-Rails/Output:
-  Exclude:
-    - 'app/extensions/string.rb'
-    - 'app/models/language_exporter.rb'
-
 # Offense count: 7
 Rails/OutputSafety:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -582,7 +582,6 @@ Rails/HelperInstanceVariable:
 # Include: app/**/*.rb, config/**/*.rb, db/**/*.rb, lib/**/*.rb
 Rails/Output:
   Exclude:
-    - 'app/extensions/string.rb'
     - 'app/models/language_exporter.rb'
 
 # Offense count: 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -592,12 +592,6 @@ Rails/RootPathnameMethods:
     - 'config/initializers/monkey_patches.rb'
 
 # Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/SelectMap:
-  Exclude:
-    - 'test/controllers/species_lists/observations_controller_test.rb'
-
-# Offense count: 2
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
 Rails/UniqueValidationWithoutIndex:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -750,7 +750,6 @@ Style/SafeNavigationChainLength:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:
   Exclude:
-    - 'app/models/name_parse.rb'
     - 'test/models/comment_test.rb'
 
 # Offense count: 32

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -732,7 +732,6 @@ Style/OptionalBooleanParameter:
 # AllowedMethods: present?, blank?, presence, try, try!
 Style/SafeNavigation:
   Exclude:
-    - 'app/models/name/spelling.rb'
     - 'app/models/observation/naming_consensus.rb'
 
 # Offense count: 3

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -672,7 +672,6 @@ Style/ClassVars:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/CombinableLoops:
   Exclude:
-    - 'script/check_enum_values'
     - 'script/mushroom_mapper.rb'
 
 # Offense count: 1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -578,12 +578,6 @@ Rails/OutputSafety:
     - 'app/helpers/namings_helper.rb'
     - 'config/application.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/RootPathnameMethods:
-  Exclude:
-    - 'config/initializers/monkey_patches.rb'
-
 # Offense count: 2
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -726,14 +726,6 @@ Style/OptionalBooleanParameter:
     - 'test/session_extensions.rb'
     - 'test/session_form_extensions.rb'
 
-# Offense count: 5
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
-# AllowedMethods: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Exclude:
-    - 'app/models/observation/naming_consensus.rb'
-
 # Offense count: 3
 # Configuration parameters: Max.
 Style/SafeNavigationChainLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -668,12 +668,6 @@ Style/ClassVars:
     - 'test/language_extensions.rb'
     - 'test/test_helper.rb'
 
-# Offense count: 7
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/CombinableLoops:
-  Exclude:
-    - 'script/mushroom_mapper.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/FileNull:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -732,7 +732,6 @@ Style/OptionalBooleanParameter:
 # AllowedMethods: present?, blank?, presence, try, try!
 Style/SafeNavigation:
   Exclude:
-    - 'app/controllers/names/eol_data_controller.rb'
     - 'app/models/name/create.rb'
     - 'app/models/name/spelling.rb'
     - 'app/models/observation/naming_consensus.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -732,7 +732,6 @@ Style/OptionalBooleanParameter:
 # AllowedMethods: present?, blank?, presence, try, try!
 Style/SafeNavigation:
   Exclude:
-    - 'app/models/name/create.rb'
     - 'app/models/name/spelling.rb'
     - 'app/models/observation/naming_consensus.rb'
 

--- a/app/classes/eol_data.rb
+++ b/app/classes/eol_data.rb
@@ -111,7 +111,7 @@ class EolData
       synonyms[name.synonym_id] << name if name.synonym_id
     end
     names_to_keep = {}
-    synonyms.each do |_synonym_id, name_list|
+    synonyms.each_value do |name_list|
       name = most_desirable_name(name_list)
       names_to_keep[name.id] = true
     end

--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -21,7 +21,7 @@ module PatternSearch
     def <<(val)
       while val.to_s =~ CONTAINS_QUOTES
         vals << dequote(Regexp.last_match(1))
-        val = val.to_s[Regexp.last_match(0).length..-1]
+        val = val.to_s[Regexp.last_match(0).length..]
         break if val.blank?
       end
     end

--- a/app/controllers/account/profile_controller.rb
+++ b/app/controllers/account/profile_controller.rb
@@ -14,7 +14,7 @@ module Account
       else
         @copyright_holder  = @user.legal_name
         @copyright_year    = Time.zone.now.year
-        @upload_license_id = @user.license ? @user.license.id : nil
+        @upload_license_id = @user&.license&.id
       end
     end
 

--- a/app/controllers/names/eol_data_controller.rb
+++ b/app/controllers/names/eol_data_controller.rb
@@ -13,7 +13,7 @@ module Names
 
     # Send stuff to eol.
     def show
-      @max_secs = params[:max_secs] ? params[:max_secs].to_i : nil
+      @max_secs = params[:max_secs]&.to_i
       @timer_start = Time.current
       @data = ::EolData.new
       render_xml(layout: false)

--- a/app/extensions/string.rb
+++ b/app/extensions/string.rb
@@ -739,10 +739,6 @@ class String
 
   ### Misc Utilities ###
   #
-  def print_thing(thing)
-    print("#{self}: #{thing.class}: #{thing}\n")
-  end
-
   def to_boolean
     ActiveRecord::Type::Boolean.new.cast(self)
   end

--- a/app/extensions/string.rb
+++ b/app/extensions/string.rb
@@ -738,7 +738,12 @@ class String
   end
 
   ### Misc Utilities ###
-  #
+
+  # Disable cop because it seems like we really want to priint, not just log
+  def print_thing(thing)
+    print("#{self}: #{thing.class}: #{thing}\n") # rubocop:disable Rails/Output
+  end
+
   def to_boolean
     ActiveRecord::Type::Boolean.new.cast(self)
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -662,7 +662,10 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # to the :image field.  Returns true if the file is successfully saved.
   def save_to_temp_file
     result = true
-    unless upload_temp_file.present?
+    # disable cop; In theory upload_temp_file could be
+    # a blank non-empty string (e.g. " ").
+    # Don't fix unless...present?; it isn't broken.
+    unless upload_temp_file.present? # rubocop:disable Rails/Blank
 
       # Image is supplied in a input stream.  This can happen in a variety of
       # cases, including during testing, and also when the image comes in as

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -662,10 +662,7 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # to the :image field.  Returns true if the file is successfully saved.
   def save_to_temp_file
     result = true
-    # disable cop; In theory upload_temp_file could be
-    # a blank non-empty string (e.g. " ").
-    # Don't fix unless...present?; it isn't broken.
-    unless upload_temp_file.present? # rubocop:disable Rails/Blank
+    if upload_temp_file.blank?
 
       # Image is supplied in a input stream.  This can happen in a variety of
       # cases, including during testing, and also when the image comes in as

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -54,7 +54,8 @@ module LanguageExporter
   end
 
   def verbose(msg)
-    puts(msg) if Language.verbose
+    # Cop disabled; seems like we want to print the message, not just log it.
+    puts(msg) if Language.verbose # rubocop:disable Rails/Output
   end
 
   delegate :safe_mode, to: :Language

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -511,7 +511,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
       if OK_PREFIXES.member?(s)
         count += 1
       else
-        trimmed = tokens[count..-1].join(" ")
+        trimmed = tokens[count..].join(" ")
         return trimmed if understood_places.member?(trimmed)
       end
     end

--- a/app/models/name/create.rb
+++ b/app/models/name/create.rb
@@ -84,7 +84,7 @@ module Name::Create
       if parsed_name.parent_name
         result = find_or_create_name_and_parents(parsed_name.parent_name)
       end
-      deprecate = result.any? && result.last && result.last.deprecated
+      deprecate = result.any? && result.last&.deprecated
       result << find_or_create_parsed_name(parsed_name, deprecate)
     end
     result

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -111,8 +111,14 @@ module Name::Spelling
     ############################################################################
 
     # Guess correct name of partial string.
-    # This method should be private.
-    # See https://www.pivotaltracker.com/story/show/176098819
+    # NOTE: jdc 20250324 (copied from pivotaltracker)
+    # guess_word and guess_with_errors should be private.
+    # They were intended to be private
+    # and had been placed after a call to private.
+    # But that call was ineffective, so it was removed.
+    # https://docs.rubocop.org/rubocop/1.0/cops_lint.html#lintuselessaccessmodifier
+    # Furthermore, they can't be privatized because they are tested directly.
+    # So the tests should be fixed first.
     def guess_word(prefix, word)
       str = "#{prefix} #{word}"
       results = guess_with_errors(str, 1)
@@ -122,8 +128,6 @@ module Name::Spelling
     end
 
     # Look up name replacing n letters at a time with a star.
-    # This method should be private.
-    # See https://www.pivotaltracker.com/story/show/176098819
     def guess_with_errors(name, count)
       patterns = []
 
@@ -144,7 +148,7 @@ module Name::Spelling
               sub = ""
               sub += word[0..(j - 1)] if j.positive?
               sub += "%"
-              sub += word[(j + count)..-1] if j + count < word.length
+              sub += word[(j + count)..] if j + count < word.length
               patterns << guess_pattern(words, i, sub)
             end
           end

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -55,7 +55,7 @@ module Name::Spelling
     def parent_if_parent_deprecated(str)
       result = nil
       names = find_or_create_name_and_parents(str)
-      if names.any? && names.last && names.last.deprecated
+      if names.any? && names.last&.deprecated
         names.reverse_each do |name|
           return name if name.id
         end

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -35,7 +35,7 @@ module Name::Spelling
         results = guess_word("", words.first)
         (2..num).each do |i|
           next unless results.any?
-          next unless (i & 1).zero?
+          next unless i.even?
 
           prefixes = results.map(&:text_name).uniq
           results = []

--- a/app/models/name_parse.rb
+++ b/app/models/name_parse.rb
@@ -70,7 +70,7 @@ class NameParse
     equal_pos = @line_str.index("=")
     if equal_pos
       @name = @line_str[0..equal_pos - 1].strip
-      @synonym = @line_str[equal_pos + 1..-1].strip
+      @synonym = @line_str[equal_pos + 1..].strip
       @synonym_comment = nil
       if (match = COMMENT_PAT.match(@synonym))
         @synonym = match[1]
@@ -113,7 +113,7 @@ class NameParse
     space_pos = str.index(" ")
     if space_pos
       rank = str[0..space_pos - 1]
-      result = [rank, str[space_pos..-1].strip] if Name.all_ranks.member?(rank)
+      result = [rank, str[space_pos..].strip] if Name.all_ranks.member?(rank)
     end
     result
   end

--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -351,7 +351,7 @@ class Observation
       matches = @namings.select { |n| n.name_id == @observation.name_id }
       # n+1 - be sure observation name is eager loaded
       name = @observation.name
-      return matches unless matches == [] && name && name.synonym_id
+      return matches unless matches == [] && name&.synonym_id
 
       @namings.select { |n| name.synonyms.include?(n.name) }
     end

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -6,7 +6,7 @@
 require("action_view/log_subscriber")
 
 # Require all Ruby files in the core_extensions directory
-Dir[Rails.root.join("lib/core_extensions/**/*.rb")].each { |f| require f }
+Rails.root.glob("lib/core_extensions/**/*.rb").each { |f| require f }
 
 # Does not work
 # ActiveSupport.on_load(:action_view) do

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -4,9 +4,9 @@ namespace :email do
   desc "List queued emails"
   task(list: :environment) do
     print "#{MO.http_domain}, #{Rails.env}\n"
-    QueuedEmail.all.includes(:queued_email_integers,
-                             :queued_email_note,
-                             :queued_email_strings, :user).each(&:dump)
+    QueuedEmail.includes(:queued_email_integers,
+                         :queued_email_note,
+                         :queued_email_strings, :user).each(&:dump)
   end
 
   desc "Send queued emails"

--- a/lib/tasks/lang.rake
+++ b/lib/tasks/lang.rake
@@ -81,7 +81,7 @@ namespace :lang do
   # See https://github.com/MushroomObserver/mushroom-observer/pull/2838/commits/fcf75b4c57ac7c6f0a3046c870236ceeda50e50f#r2011104991
   # rubocop:disable Rails/RakeEnvironment
   desc "Log in user for import tasks."
-  task(login) do
+  task(:login) do
     User.current = if ENV.include?("user_name")
                      User.find_by(login: ENV["user_name"])
                    elsif ENV.include?("user_id")
@@ -90,17 +90,17 @@ namespace :lang do
   end
 
   desc "Log in admin for import tasks."
-  task(login_admin) do
+  task(:login_admin) do
     User.current = User.find(0)
   end
 
   desc 'Turn off verbosity if include "silent=yes".'
-  task(verbose) do
+  task(:verbose) do
     Language.verbose = true unless ENV.include?("silent")
   end
 
   desc 'Turn on safe mode if include "safe=yes".'
-  task(safe_mode) do
+  task(:safe_mode) do
     if ENV.include?("safe")
       Language.safe_mode = true
       puts("*** SAFE MODE ***")

--- a/lib/tasks/lang.rake
+++ b/lib/tasks/lang.rake
@@ -78,7 +78,7 @@ namespace :lang do
   task setup: [:environment, :login, :verbose, :safe_mode]
 
   desc "Log in user for import tasks."
-  task(:login) do
+  task(login: :environment) do
     User.current = if ENV.include?("user_name")
                      User.find_by(login: ENV["user_name"])
                    elsif ENV.include?("user_id")
@@ -87,17 +87,17 @@ namespace :lang do
   end
 
   desc "Log in admin for import tasks."
-  task(:login_admin) do
+  task(login_admin: :environment) do
     User.current = User.find(0)
   end
 
   desc 'Turn off verbosity if include "silent=yes".'
-  task(:verbose) do
+  task(verbose: :environment) do
     Language.verbose = true unless ENV.include?("silent")
   end
 
   desc 'Turn on safe mode if include "safe=yes".'
-  task(:safe_mode) do
+  task(safe_mode: :environment) do
     if ENV.include?("safe")
       Language.safe_mode = true
       puts("*** SAFE MODE ***")

--- a/lib/tasks/lang.rake
+++ b/lib/tasks/lang.rake
@@ -77,8 +77,11 @@ namespace :lang do
   desc "Setup environment for language tasks."
   task setup: [:environment, :login, :verbose, :safe_mode]
 
+  # Disable cop out of caution; our translation stuff is kind of wonky
+  # See https://github.com/MushroomObserver/mushroom-observer/pull/2838/commits/fcf75b4c57ac7c6f0a3046c870236ceeda50e50f#r2011104991
+  # rubocop:disable Rails/RakeEnvironment
   desc "Log in user for import tasks."
-  task(login: :environment) do
+  task(login) do
     User.current = if ENV.include?("user_name")
                      User.find_by(login: ENV["user_name"])
                    elsif ENV.include?("user_id")
@@ -87,20 +90,21 @@ namespace :lang do
   end
 
   desc "Log in admin for import tasks."
-  task(login_admin: :environment) do
+  task(login_admin) do
     User.current = User.find(0)
   end
 
   desc 'Turn off verbosity if include "silent=yes".'
-  task(verbose: :environment) do
+  task(verbose) do
     Language.verbose = true unless ENV.include?("silent")
   end
 
   desc 'Turn on safe mode if include "safe=yes".'
-  task(safe_mode: :environment) do
+  task(safe_mode) do
     if ENV.include?("safe")
       Language.safe_mode = true
       puts("*** SAFE MODE ***")
     end
   end
+  # rubocop:enable Rails/RakeEnvironment
 end

--- a/script/check_enum_values
+++ b/script/check_enum_values
@@ -6,16 +6,18 @@ require_relative("../config/environment")
 
 LocationDescription.all.
   each { |x| puts "LocationDescription #{x.id} #{x.source_type.inspect}" }
-NameDescription.all.
-  each { |x| puts "NameDescription #{x.id} #{x.review_status.inspect}" }
-NameDescription.all.
-  each { |x| puts "NameDescription #{x.id} #{x.source_type.inspect}" }
+NameDescription.all.each do |x|
+  puts "NameDescription #{x.id} #{x.review_status.inspect}"
+  puts "NameDescription #{x.id} #{x.source_type.inspect}"
+end
 Name.all.each { |x| puts "Name #{x.id} #{x.rank.inspect}" }
 Name::Version.all.each { |x| puts "Name::Version #{x.id} #{x.rank.inspect}" }
 Query.all.each { |x| puts "Query #{x.id} #{x.model_symbol.inspect}" }
-User.all.each { |x| puts "User #{x.id} #{x.thumbnail_size.inspect}" }
-User.all.each { |x| puts "User #{x.id} #{x.image_size.inspect}" }
-User.all.each { |x| puts "User #{x.id} #{x.votes_anonymous.inspect}" }
-User.all.each { |x| puts "User #{x.id} #{x.location_format.inspect}" }
-User.all.each { |x| puts "User #{x.id} #{x.hide_authors.inspect}" }
-User.all.each { |x| puts "User #{x.id} #{x.keep_filenames.inspect}" }
+User.all.each do |x|
+  puts "User #{x.id} #{x.thumbnail_size.inspect}"
+  puts "User #{x.id} #{x.image_size.inspect}"
+  puts "User #{x.id} #{x.votes_anonymous.inspect}"
+  puts "User #{x.id} #{x.location_format.inspect}"
+  puts "User #{x.id} #{x.hide_authors.inspect}"
+  puts "User #{x.id} #{x.keep_filenames.inspect}"
+end

--- a/script/check_links.rb
+++ b/script/check_links.rb
@@ -39,7 +39,7 @@ table = ARGV[0]
 column = ARGV[1]
 
 model = table.classify.constantize
-model.all.pluck("id", column).each do |id, val|
+model.pluck("id", column).each do |id, val|
   find_links(val).each { |link| test_link!(id, link) } if val.present?
 end
 

--- a/script/mushroom_mapper.rb
+++ b/script/mushroom_mapper.rb
@@ -66,7 +66,8 @@ name_data.
   each do |id, _text_name, _rank, deprecated, synonym_id, _correct_spelling_id|
     synonyms[synonym_id] = id if synonym_id && !deprecated
   end
-name_data.
+# disable cop because 2nd loop uses result of 1st loop
+name_data. # rubocop:disable Style/CombinableLoops
   each do |id, text_name, rank, deprecated, synonym_id, correct_spelling_id|
     real_id = id
     real_id = correct_spelling_id if correct_spelling_id

--- a/script/slowest_pages
+++ b/script/slowest_pages
@@ -38,7 +38,7 @@ File.open(FILE).readlines.each do |line|
   rec[3] += 1 if robot
 end
 
-data.each do |_path, rec|
+data.each_value do |rec|
   sum, ssq, num = *rec
   rec[0] = avg = sum / num
   rec[1] = Math.sqrt(ssq / num - avg * avg)

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -138,7 +138,7 @@ class API2ControllerTest < FunctionalTestCase
 
   def test_num_of_pages
     get(:observations, params: { detail: :high, format: :json })
-    json = JSON.parse(response.body)
+    json = response.parsed_body
     assert_equal((Observation.count / 100.0).ceil, json["number_of_pages"],
                  "Number of pages was not correctly calculated.")
   end
@@ -282,7 +282,7 @@ class API2ControllerTest < FunctionalTestCase
     end
     assert_no_api_errors
     assert_equal(count + 1, Image.count)
-    json = JSON.parse(response.body)
+    json = response.parsed_body
     checksum_returned = json["results"][0]["md5sum"].to_s
     assert_equal(checksum, checksum_returned, "Didn't get the right checksum.")
   end
@@ -484,7 +484,7 @@ class API2ControllerTest < FunctionalTestCase
 
     params[:format] = :json
     get(:observations, params: params.merge(api_key: rolfs_key.key))
-    json = JSON.parse(response.body)
+    json = response.parsed_body
     votes = json["results"][0]["votes"]
     assert_equal(
       "rolf",
@@ -496,7 +496,7 @@ class API2ControllerTest < FunctionalTestCase
     )
 
     get(:observations, params: params.merge(api_key: marys_key.key))
-    json = JSON.parse(response.body)
+    json = response.parsed_body
     votes = json["results"][0]["votes"]
     assert_equal(
       :anonymous.l,

--- a/test/controllers/species_lists/observations_controller_test.rb
+++ b/test/controllers/species_lists/observations_controller_test.rb
@@ -110,10 +110,10 @@ module SpeciesLists
     def test_post_add_remove_double_observations
       spl = species_lists(:unknown_species_list)
       old_obs_list =
-        SpeciesListObservation.select(:observation_id).
+        SpeciesListObservation.
         where(species_list: spl.id).
         order(observation_id: :asc).
-        map(&:observation_id)
+        pluck(:observation_id)
       dup_obs = spl.observations.first
       new_obs = (Observation.all - spl.observations).first
       ids = [dup_obs.id, new_obs.id]
@@ -127,10 +127,10 @@ module SpeciesLists
       assert_response(:redirect)
       assert_flash_success
       new_obs_list =
-        SpeciesListObservation.select(:observation_id).
+        SpeciesListObservation.
         where(species_list: spl.id).
         order(observation_id: :asc).
-        map(&:observation_id)
+        pluck(:observation_id)
       assert_equal(new_obs_list.length, old_obs_list.length + 1)
       assert_equal((new_obs_list - old_obs_list).first, new_obs.id)
     end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -145,7 +145,7 @@ class CommentTest < UnitTestCase
   def queued_emails(start)
     return "No emails were queued" if num_emails == start
 
-    strs = QueuedEmail.all[start..-1].map do |mail|
+    strs = QueuedEmail.all[start..].map do |mail|
       to_user = mail&.to_user_id ? User.find(mail.to_user_id)&.login : nil
       email = mail&.id ? QueuedEmail.find(mail.id) : nil
       "to: #{to_user}, email: #{email}"

--- a/test/models/queued_email_test.rb
+++ b/test/models/queued_email_test.rb
@@ -25,7 +25,7 @@ class QueuedEmailTest < UnitTestCase
     email = QueuedEmail::NameChange.new(user: rolf, to_user: mary)
     email.stub(:deliver_email, raises_exception) do
       original_stderr = $stderr.clone
-      $stderr.reopen(File.new("/dev/null", "w"))
+      $stderr.reopen(File.new(File::NULL, "w"))
       assert_not(email.send_email)
       $stderr.reopen(original_stderr)
     end


### PR DESCRIPTION
Fixes unsafe correctable offenses. Part 3 of 3. 
Broken into 3 parts for ease of review. This part includes cops linked below. 
For each putative offense:
- Accepts the fix if safe, or disables the cop if unsafe
- Makes follow-on changes to avoid new offenses. (Ex: removes `.to_s` inside string interpolation, divides long lines.)
- Updates .rubocop_todo

#### Cops in this PR
Check the linked documentation for comments about cop safety.
> [Rails/Blank](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsblank)
[Rails/Output](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsoutput)
[Rails/RakeEnvironment](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrakeenvironment)
[Rails/RedundantActiveRecordAllMethod](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundantactiverecordallmethod)
[Rails/ResponseParsedBody](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsresponseparsedbody)
[Rails/RootPathnameMethods](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrootpathnamemethods)
[Rails/SelectMap](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsselectmap)
[Style/BitwisePredicate](https://docs.rubocop.org/rubocop/1.74/cops_style.html#stylebitwisepredicate)
[Style/CombinableLoops](https://docs.rubocop.org/rubocop/1.74/cops_style.html#stylecombinableloops)
[Style/FileNull](https://docs.rubocop.org/rubocop/1.74/cops_style.html#stylefilenull)[Style/SlicingWithRange](https://docs.rubocop.org/rubocop/1.74/cops_style.html#styleslicingwithrange)
[Style/HashEachMethods](https://docs.rubocop.org/rubocop/1.74/cops_style.html#stylehasheachmethods)
[Style/SafeNavigation](https://docs.rubocop.org/rubocop/1.74/cops_style.html#stylesafenavigation)
