### PR TITLE
Change recently created scope `:index_order` to `:order_by_default`

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,7 +4,7 @@ class APIKey < AbstractModel
   belongs_to :user
   before_create :provide_defaults
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(created_at: :desc, id: :desc) }
   scope :notes_has,
         ->(phrase) { search_columns(APIKey[:notes], phrase) }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -26,7 +26,7 @@ class Article < AbstractModel
   belongs_to :user
   belongs_to :rss_log
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(created_at: :desc, id: :desc) }
   scope :title_has,
         ->(phrase) { search_columns(Article[:title], phrase) }

--- a/app/models/collection_number.rb
+++ b/app/models/collection_number.rb
@@ -58,7 +58,7 @@ class CollectionNumber < AbstractModel
   before_update :log_update
   before_destroy :log_destroy
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(name: :asc, number: :asc) }
 
   scope :collectors,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -133,7 +133,7 @@ class Comment < AbstractModel
   after_create :notify_users
   after_create :oil_and_water
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(created_at: :desc, id: :desc) }
 
   # This scope starts with a `where`, and chains subsequent `where` clauses

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -34,7 +34,7 @@ class ExternalLink < AbstractModel
   validates :url, presence: true, length: { maximum: 100 }
   validate  :check_url_syntax
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(url: :asc, id: :desc) }
   scope :url_has,
         ->(phrase) { search_columns(ExternalLink[:url], phrase) }

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -16,7 +16,7 @@ class FieldSlip < AbstractModel
     end
   end
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(code: :asc, created_at: :desc, id: :desc) }
 
   scope :projects, lambda { |projects|

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -43,7 +43,7 @@ class GlossaryTerm < AbstractModel
   )
   versioned_class.before_save { |x| x.user_id = User.current_id }
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(name: :asc, id: :desc) }
 
   scope :name_has,

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -63,7 +63,7 @@ class Herbarium < AbstractModel
   # Used by create/edit form.
   attr_accessor :place_name, :personal, :personal_user_name
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(name: :asc, id: :desc) }
 
   scope :nonpersonal, lambda { |bool = true|

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -57,7 +57,7 @@ class HerbariumRecord < AbstractModel
   before_update :log_update
   before_destroy :log_destroy
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(initial_det: :asc, accession_number: :asc, id: :desc) }
 
   scope :observations, lambda { |obs|

--- a/app/models/image/scopes.rb
+++ b/app/models/image/scopes.rb
@@ -8,7 +8,7 @@ module Image::Scopes
   # Two line stabby lambdas are OK, it's just the declaration line that will
   # always show as covered.
   included do # rubocop:disable Metrics/BlockLength
-    scope :index_order,
+    scope :order_by_default,
           -> { order(created_at: :desc, id: :desc) }
 
     scope :sizes, lambda { |min, max = min|

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -9,7 +9,7 @@ module Location::Scopes
   # always show as covered.
   included do # rubocop:disable Metrics/BlockLength
     # default ordering for index queries
-    scope :index_order,
+    scope :order_by_default,
           -> { order(name: :asc, id: :desc) }
 
     # This should really be regions/region, but changing user prefs/filters and

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -85,7 +85,7 @@ class LocationDescription < Description
   has_many :editors, through: :location_description_editors,
                      source: :user
 
-  scope :index_order, lambda {
+  scope :order_by_default, lambda {
     joins(:location).order(Location[:name].asc,
                            LocationDescription[:created_at].asc,
                            LocationDescription[:id].desc)

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -9,7 +9,7 @@ module Name::Scopes
   # always show as covered.
   included do # rubocop:disable Metrics/BlockLength
     # default ordering for index queries
-    scope :index_order,
+    scope :order_by_default,
           -> { order(sort_name: :asc, id: :desc) }
 
     scope :names, lambda { |lookup:, **related_name_args|

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -102,7 +102,7 @@ class NameDescription < Description
   has_many :editors, through: :name_description_editors,
                      source: :user
 
-  scope :index_order, lambda {
+  scope :order_by_default, lambda {
     joins(:name).order(Name[:sort_name].asc, NameDescription[:created_at].asc,
                        NameDescription[:id].desc)
   }

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -9,7 +9,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
   # always show as covered.
   included do # rubocop:disable Metrics/BlockLength
     # default ordering for index queries
-    scope :index_order,
+    scope :order_by_default,
           -> { order(when: :desc, id: :desc) }
     # overwrite the one in abstract_model, because we have it cached on a column
     scope :order_by_rss_log, lambda {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -90,7 +90,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
             format: { with: /\A[A-Z0-9][A-Z0-9-]*\z/,
                       message: proc { :alphanumerics_only.t } }
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(updated_at: :desc, id: :desc) }
 
   scope :members, lambda { |members|

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -149,7 +149,7 @@ class RssLog < AbstractModel
   belongs_to :project
   belongs_to :species_list
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(updated_at: :desc, id: :desc) }
 
   scope :type, lambda { |str|

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -41,7 +41,7 @@ class Sequence < AbstractModel
   after_update  :log_update_sequence
   after_destroy :log_destroy_sequence
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(created_at: :desc, id: :desc) }
 
   scope :observations,

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -99,7 +99,7 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
 
   attr_accessor :data
 
-  scope :index_order,
+  scope :order_by_default,
         -> { order(title: :asc, id: :desc) }
 
   scope :title_has,

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -104,7 +104,8 @@ class LookupTest < UnitTestCase
                         exclude_original_names: true)
 
     name5.update(synonym_id: nil)
-    name5 = Name.where(text_name: "Pseudolepiota rachodes").order_by_default.first
+    name5 = Name.where(text_name: "Pseudolepiota rachodes").
+            order_by_default.first
     assert_lookup_names([name1, name2, name3, name4, name5],
                         ["Macrolepiota"],
                         include_synonyms: true,
@@ -170,7 +171,8 @@ class LookupTest < UnitTestCase
     name2.update(classification: name1.classification)
     name2.save
 
-    children = Name.order_by_default.where(Name[:text_name].matches("Lactarius %"))
+    children = Name.order_by_default.
+               where(Name[:text_name].matches("Lactarius %"))
 
     assert_lookup_names([name1] + children,
                         ["Lactarius"],

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -104,7 +104,7 @@ class LookupTest < UnitTestCase
                         exclude_original_names: true)
 
     name5.update(synonym_id: nil)
-    name5 = Name.where(text_name: "Pseudolepiota rachodes").index_order.first
+    name5 = Name.where(text_name: "Pseudolepiota rachodes").order_by_default.first
     assert_lookup_names([name1, name2, name3, name4, name5],
                         ["Macrolepiota"],
                         include_synonyms: true,
@@ -170,7 +170,7 @@ class LookupTest < UnitTestCase
     name2.update(classification: name1.classification)
     name2.save
 
-    children = Name.index_order.where(Name[:text_name].matches("Lactarius %"))
+    children = Name.order_by_default.where(Name[:text_name].matches("Lactarius %"))
 
     assert_lookup_names([name1] + children,
                         ["Lactarius"],

--- a/test/classes/query/api_keys_test.rb
+++ b/test/classes/query/api_keys_test.rb
@@ -8,12 +8,12 @@ class Query::APIKeysTest < UnitTestCase
   include QueryExtensions
 
   def test_api_key_all
-    expects = APIKey.all.index_order
+    expects = APIKey.all.order_by_default
     assert_query(expects, :APIKey)
   end
 
   def test_api_key_notes_has
-    expects = APIKey.notes_has("purpose’s").index_order
+    expects = APIKey.notes_has("purpose’s").order_by_default
     assert_query(expects, :APIKey, notes_has: "purpose’s")
   end
 end

--- a/test/classes/query/articles_test.rb
+++ b/test/classes/query/articles_test.rb
@@ -9,7 +9,7 @@ class Query::ArticlesTest < UnitTestCase
 
   def test_article_all
     expects = [articles(:premier_article), articles(:second_article)]
-    scope = Article.index_order
+    scope = Article.order_by_default
     assert_query_scope(expects, scope, :Article)
   end
 
@@ -27,19 +27,19 @@ class Query::ArticlesTest < UnitTestCase
 
   def test_article_title_has
     expects = [articles(:premier_article)]
-    scope = Article.title_has("premier_article").index_order
+    scope = Article.title_has("premier_article").order_by_default
     assert_query_scope(expects, scope, :Article, title_has: "premier_article")
   end
 
   def test_article_body_has
     expects = [articles(:second_article)]
-    scope = Article.body_has("second_article").index_order
+    scope = Article.body_has("second_article").order_by_default
     assert_query_scope(expects, scope, :Article, body_has: "second_article")
   end
 
   def test_article_by_users
     expects = [articles(:premier_article)]
-    scope = Article.by_users(rolf).index_order
+    scope = Article.by_users(rolf).order_by_default
     assert_query_scope(expects, scope, :Article, by_users: rolf.id)
   end
 end

--- a/test/classes/query/collection_numbers_test.rb
+++ b/test/classes/query/collection_numbers_test.rb
@@ -8,7 +8,7 @@ class Query::CollectionNumbersTest < UnitTestCase
   include QueryExtensions
 
   def test_collection_number_all
-    expects = CollectionNumber.index_order
+    expects = CollectionNumber.order_by_default
     assert_query(expects, :CollectionNumber)
   end
 
@@ -72,43 +72,43 @@ class Query::CollectionNumbersTest < UnitTestCase
   def test_collection_number_by_users
     expects = newbie_collections <<
               collection_numbers(:detailed_unknown_coll_num_two)
-    scope = CollectionNumber.by_users(mary).index_order
+    scope = CollectionNumber.by_users(mary).order_by_default
     assert_query_scope(expects, scope, :CollectionNumber, by_users: mary)
   end
 
   def test_collection_number_collectors
     expects = newbie_collections
-    scope = CollectionNumber.collectors("Mary Newbie").index_order
+    scope = CollectionNumber.collectors("Mary Newbie").order_by_default
     assert_query_scope(expects, scope,
                        :CollectionNumber, collectors: "Mary Newbie")
   end
 
   def test_collection_number_collector_has
     expects = newbie_collections
-    scope = CollectionNumber.collector_has("Newbie").index_order
+    scope = CollectionNumber.collector_has("Newbie").order_by_default
     assert_query_scope(expects, scope,
                        :CollectionNumber, collector_has: "Newbie")
   end
 
   def test_collection_number_numbers
     expects = [collection_numbers(:agaricus_campestris_coll_num)]
-    scope = CollectionNumber.numbers("07-123a").index_order
+    scope = CollectionNumber.numbers("07-123a").order_by_default
     assert_query_scope(expects, scope, :CollectionNumber, numbers: "07-123a")
     expects = [collection_numbers(:minimal_unknown_coll_num),
                collection_numbers(:detailed_unknown_coll_num_one)]
-    scope = CollectionNumber.numbers(%w[173 174]).index_order
+    scope = CollectionNumber.numbers(%w[173 174]).order_by_default
     assert_query_scope(expects, scope, :CollectionNumber, numbers: %w[173 174])
   end
 
   def test_collection_number_number_has
     expects = [collection_numbers(:detailed_unknown_coll_num_two)]
-    scope = CollectionNumber.number_has("n").index_order
+    scope = CollectionNumber.number_has("n").order_by_default
     assert_query_scope(expects, scope, :CollectionNumber, number_has: "n")
   end
 
   def test_collection_number_observations
     obs = observations(:detailed_unknown_obs)
-    expects = CollectionNumber.index_order.observations(obs)
+    expects = CollectionNumber.order_by_default.observations(obs)
     assert_query(expects, :CollectionNumber, observations: obs.id)
   end
 

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -8,7 +8,7 @@ class Query::CommentsTest < UnitTestCase
   include QueryExtensions
 
   def test_comment_all
-    expects = Comment.index_order
+    expects = Comment.order_by_default
     assert_query(expects, :Comment)
   end
 
@@ -27,10 +27,10 @@ class Query::CommentsTest < UnitTestCase
     obs = observations(:minimal_unknown_obs)
     expects = [comments(:minimal_unknown_obs_comment_2),
                comments(:minimal_unknown_obs_comment_1)]
-    scope = Comment.index_order.target(obs).distinct
+    scope = Comment.order_by_default.target(obs).distinct
     assert_query_scope(expects, scope,
                        :Comment, target: { type: :Observation, id: obs.id })
-    scope = Comment.index_order.
+    scope = Comment.order_by_default.
             target(type: "Observation", id: obs.id).distinct
     assert_query_scope(expects, scope,
                        :Comment, target: { type: :Observation, id: obs.id })
@@ -54,7 +54,7 @@ class Query::CommentsTest < UnitTestCase
     expects = [comments(:detailed_unknown_obs_comment),
                comments(:minimal_unknown_obs_comment_2),
                comments(:minimal_unknown_obs_comment_1)]
-    scope = Comment.types(:observation).index_order
+    scope = Comment.types(:observation).order_by_default
     assert_query_scope(expects, scope, :Comment, types: :observation)
   end
 
@@ -62,13 +62,13 @@ class Query::CommentsTest < UnitTestCase
     expects = [comments(:detailed_unknown_obs_comment),
                comments(:minimal_unknown_obs_comment_2),
                comments(:minimal_unknown_obs_comment_1)]
-    scope = Comment.for_user(mary).index_order
+    scope = Comment.for_user(mary).order_by_default
     assert_query_scope(expects, scope, :Comment, for_user: mary)
     expects = [comments(:fungi_comment)]
-    scope = Comment.for_user(rolf).index_order
+    scope = Comment.for_user(rolf).order_by_default
     assert_query_scope(expects, scope, :Comment, for_user: rolf)
     expects = []
-    scope = Comment.for_user(users(:zero_user)).index_order
+    scope = Comment.for_user(users(:zero_user)).order_by_default
     assert_query_scope(expects, scope, :Comment, for_user: users(:zero_user))
   end
 
@@ -82,21 +82,21 @@ class Query::CommentsTest < UnitTestCase
   end
 
   def test_comment_pattern_search
-    expects = Comment.index_order.
+    expects = Comment.order_by_default.
               where(Comment[:summary].matches("%unknown%").
                     or(Comment[:comment].matches("%unknown%"))).uniq
     assert_query(expects, :Comment, pattern: "unknown")
-    expects = Comment.pattern("unknown").index_order
+    expects = Comment.pattern("unknown").order_by_default
     assert_query(expects, :Comment, pattern: "unknown")
   end
 
   def test_comment_summary_has
-    expects = Comment.summary_has("Let's").index_order
+    expects = Comment.summary_has("Let's").order_by_default
     assert_query(expects, :Comment, summary_has: "Let's")
   end
 
   def test_comment_content_has
-    expects = Comment.content_has("really cool").index_order
+    expects = Comment.content_has("really cool").order_by_default
     assert_query(expects, :Comment, content_has: "really cool")
   end
 end

--- a/test/classes/query/external_links_test.rb
+++ b/test/classes/query/external_links_test.rb
@@ -8,7 +8,7 @@ class Query::ExternalLinksTest < UnitTestCase
   include QueryExtensions
 
   def test_external_link_all
-    assert_query(ExternalLink.index_order, :ExternalLink)
+    assert_query(ExternalLink.order_by_default, :ExternalLink)
   end
 
   def test_external_link_id_in_set
@@ -18,7 +18,7 @@ class Query::ExternalLinksTest < UnitTestCase
   end
 
   def test_external_link_by_users
-    assert_query(ExternalLink.by_users(users(:mary)).index_order,
+    assert_query(ExternalLink.by_users(users(:mary)).order_by_default,
                  :ExternalLink, by_users: users(:mary))
     assert_query([], :ExternalLink, by_users: users(:dick))
   end
@@ -26,7 +26,7 @@ class Query::ExternalLinksTest < UnitTestCase
   def test_external_link_observations
     obs = observations(:coprinus_comatus_obs)
     expects = obs.external_links.sort_by(&:url)
-    scope = ExternalLink.observations(obs).index_order
+    scope = ExternalLink.observations(obs).order_by_default
     assert_query_scope(expects, scope, :ExternalLink, observations: obs)
     obs = observations(:detailed_unknown_obs)
     assert_query([], :ExternalLink, observations: obs)
@@ -39,7 +39,7 @@ class Query::ExternalLinksTest < UnitTestCase
     site = external_sites(:inaturalist)
     assert_query(site.external_links.sort_by(&:url),
                  :ExternalLink, external_sites: site)
-    expects = ExternalLink.external_sites(site).index_order
+    expects = ExternalLink.external_sites(site).order_by_default
     assert_query(expects, :ExternalLink, external_sites: site)
   end
 
@@ -47,7 +47,7 @@ class Query::ExternalLinksTest < UnitTestCase
     site = external_sites(:inaturalist)
     assert_query(site.external_links.sort_by(&:url),
                  :ExternalLink, url_has: "inaturalist.org")
-    expects = ExternalLink.url_has("inaturalist.org").index_order
+    expects = ExternalLink.url_has("inaturalist.org").order_by_default
     assert_query(expects, :ExternalLink, url_has: "inaturalist.org")
   end
 end

--- a/test/classes/query/field_slips_test.rb
+++ b/test/classes/query/field_slips_test.rb
@@ -8,7 +8,7 @@ class Query::FieldSlipsTest < UnitTestCase
   include QueryExtensions
 
   def test_field_slip_all
-    expects = FieldSlip.index_order
+    expects = FieldSlip.order_by_default
     assert_query(expects, :FieldSlip)
   end
 
@@ -19,7 +19,7 @@ class Query::FieldSlipsTest < UnitTestCase
 
   def test_field_slip_by_users
     expects = mary_field_slips
-    scope = FieldSlip.by_users(mary).index_order
+    scope = FieldSlip.by_users(mary).order_by_default
     assert_query_scope(expects, scope, :FieldSlip, by_users: mary)
   end
 
@@ -29,11 +29,11 @@ class Query::FieldSlipsTest < UnitTestCase
 
   def test_field_slip_for_project
     expects = eol_field_slips
-    scope = FieldSlip.projects(projects(:eol_project)).index_order
+    scope = FieldSlip.projects(projects(:eol_project)).order_by_default
     assert_query_scope(expects, scope,
                        :FieldSlip, projects: projects(:eol_project))
     # test lookup by name
-    expects = FieldSlip.projects(projects(:eol_project).title).index_order
+    expects = FieldSlip.projects(projects(:eol_project).title).order_by_default
     assert_query(expects, :FieldSlip, projects: projects(:eol_project))
   end
 end

--- a/test/classes/query/filters_test.rb
+++ b/test/classes/query/filters_test.rb
@@ -41,7 +41,8 @@ class Query::FiltersTest < UnitTestCase
   def test_filtering_content_with_lichen
     expects_obs = Observation.lichen(:yes).order_by_default.uniq
     assert_query(expects_obs, :Observation, lichen: "yes")
-    expects_names = Name.with_correct_spelling.lichen(:yes).order_by_default.uniq
+    expects_names = Name.with_correct_spelling.lichen(:yes).
+                    order_by_default.uniq
     assert_query(expects_names, :Name, lichen: "yes")
   end
 

--- a/test/classes/query/filters_test.rb
+++ b/test/classes/query/filters_test.rb
@@ -23,59 +23,59 @@ class Query::FiltersTest < UnitTestCase
   end
 
   def test_filtering_content_has_images
-    expects = Observation.has_images.index_order.uniq
+    expects = Observation.has_images.order_by_default.uniq
     assert_query(expects, :Observation, has_images: "yes")
 
-    expects = Observation.has_images(false).index_order.uniq
+    expects = Observation.has_images(false).order_by_default.uniq
     assert_query(expects, :Observation, has_images: "no")
   end
 
   def test_filtering_content_has_specimen
-    expects = Observation.has_specimen.index_order.uniq
+    expects = Observation.has_specimen.order_by_default.uniq
     assert_query(expects, :Observation, has_specimen: "yes")
 
-    expects = Observation.has_specimen(false).index_order.uniq
+    expects = Observation.has_specimen(false).order_by_default.uniq
     assert_query(expects, :Observation, has_specimen: "no")
   end
 
   def test_filtering_content_with_lichen
-    expects_obs = Observation.lichen(:yes).index_order.uniq
+    expects_obs = Observation.lichen(:yes).order_by_default.uniq
     assert_query(expects_obs, :Observation, lichen: "yes")
-    expects_names = Name.with_correct_spelling.lichen(:yes).index_order.uniq
+    expects_names = Name.with_correct_spelling.lichen(:yes).order_by_default.uniq
     assert_query(expects_names, :Name, lichen: "yes")
   end
 
   def test_filtering_content_with_non_lichen
-    expects_obs = Observation.lichen(:no).index_order.uniq
+    expects_obs = Observation.lichen(:no).order_by_default.uniq
     assert_query(expects_obs, :Observation, lichen: "no")
-    expects_names = Name.with_correct_spelling.lichen(:no).index_order.uniq
+    expects_names = Name.with_correct_spelling.lichen(:no).order_by_default.uniq
     assert_query(expects_names, :Name, lichen: "no")
   end
 
   def test_filtering_content_region
-    expects = Location.region("California, USA").index_order.uniq
+    expects = Location.region("California, USA").order_by_default.uniq
     assert_query(expects, :Location, region: "California, USA")
     assert_query(expects, :Location, region: "USA, California")
 
-    expects = Observation.region("California, USA").index_order.uniq
+    expects = Observation.region("California, USA").order_by_default.uniq
     assert_query(expects, :Observation, region: "California, USA")
 
-    expects = Location.region("North America").index_order.uniq
+    expects = Location.region("North America").order_by_default.uniq
     assert(expects.include?(locations(:albion))) # usa
     assert(expects.include?(locations(:elgin_co))) # canada
     assert_query(expects, :Location, region: "North America")
   end
 
   def test_filtering_content_clade
-    names = Name.clade("Agaricales").index_order.distinct
+    names = Name.clade("Agaricales").order_by_default.distinct
     assert_query(names, :Name, clade: "Agaricales")
-    obs = Observation.clade("Agaricales").index_order.distinct
+    obs = Observation.clade("Agaricales").order_by_default.distinct
     assert_query(obs, :Observation, clade: "Agaricales")
   end
 
   def test_filtering_content_with_subquery
     expects_names = Name.joins(:observations).
-                    merge(Observation.has_specimen).index_order.uniq
+                    merge(Observation.has_specimen).order_by_default.uniq
     assert_query(expects_names,
                  :Name, observation_query: { has_specimen: "yes" })
   end

--- a/test/classes/query/glossary_terms_test.rb
+++ b/test/classes/query/glossary_terms_test.rb
@@ -8,7 +8,7 @@ class Query::GlossaryTermsTest < UnitTestCase
   include QueryExtensions
 
   def test_glossary_term_all
-    expects = GlossaryTerm.index_order
+    expects = GlossaryTerm.order_by_default
     assert_query(expects, :GlossaryTerm)
   end
 
@@ -38,10 +38,10 @@ class Query::GlossaryTermsTest < UnitTestCase
     assert_query_scope(expects, scope,
                        :GlossaryTerm, pattern: "Cute little cone head")
     # default description, many expects
-    expects = GlossaryTerm.pattern("Description of Term").index_order
+    expects = GlossaryTerm.pattern("Description of Term").order_by_default
     assert_query(expects, :GlossaryTerm, pattern: "Description of Term")
     # blank == all
-    expects = GlossaryTerm.index_order
+    expects = GlossaryTerm.order_by_default
     assert_query(expects, :GlossaryTerm, pattern: "")
   end
 end

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -8,14 +8,14 @@ class Query::HerbariaTest < UnitTestCase
   include QueryExtensions
 
   def test_herbarium_all
-    expects = Herbarium.index_order
+    expects = Herbarium.order_by_default
     assert_query(expects.select(:id).distinct, :Herbarium)
   end
 
   def test_herbarium_nonpersonal
-    expects = Herbarium.nonpersonal.index_order
+    expects = Herbarium.nonpersonal.order_by_default
     assert_query(expects.select(:id).distinct, :Herbarium, nonpersonal: true)
-    # expects = Herbarium.nonpersonal(false).index_order
+    # expects = Herbarium.nonpersonal(false).order_by_default
     # assert_query(expects.select(:id).distinct, :Herbarium, nonpersonal: false)
   end
 
@@ -40,7 +40,7 @@ class Query::HerbariaTest < UnitTestCase
   def test_herbarium_name_has
     expects = [herbaria(:curatorless_herbarium), herbaria(:dick_herbarium),
                herbaria(:rolf_herbarium)]
-    scope = Herbarium.name_has("Herbarium").index_order
+    scope = Herbarium.name_has("Herbarium").order_by_default
     assert_query_scope(expects, scope, :Herbarium, name_has: "Herbarium")
   end
 

--- a/test/classes/query/herbarium_records_test.rb
+++ b/test/classes/query/herbarium_records_test.rb
@@ -8,7 +8,7 @@ class Query::HerbariumRecordsTest < UnitTestCase
   include QueryExtensions
 
   def test_herbarium_record_all
-    expects = HerbariumRecord.index_order
+    expects = HerbariumRecord.order_by_default
     assert_query(expects, :HerbariumRecord)
   end
 
@@ -26,34 +26,34 @@ class Query::HerbariumRecordsTest < UnitTestCase
 
   def test_herbarium_record_observations
     obs = observations(:coprinus_comatus_obs)
-    expects = HerbariumRecord.index_order.observations(obs)
+    expects = HerbariumRecord.order_by_default.observations(obs)
     assert_query(expects, :HerbariumRecord, observations: obs.id)
   end
 
   def test_herbarium_record_herbaria
     nybg = herbaria(:nybg_herbarium)
-    expects = HerbariumRecord.index_order.herbaria(nybg)
+    expects = HerbariumRecord.order_by_default.herbaria(nybg)
     assert_query(expects, :HerbariumRecord, herbaria: nybg.id)
   end
 
   def test_herbarium_record_has_notes
-    expects = HerbariumRecord.index_order.has_notes
+    expects = HerbariumRecord.order_by_default.has_notes
     assert(expects.include?(herbarium_records(:interesting_unknown)))
     assert_query(expects, :HerbariumRecord, has_notes: true)
-    expects = HerbariumRecord.index_order.has_notes(false)
+    expects = HerbariumRecord.order_by_default.has_notes(false)
     assert(expects.include?(herbarium_records(:coprinus_comatus_nybg_spec)))
     assert_query(expects, :HerbariumRecord, has_notes: false)
   end
 
   def test_herbarium_record_notes_has
     expects = [herbarium_records(:interesting_unknown)]
-    scope = HerbariumRecord.index_order.notes_has("dried")
+    scope = HerbariumRecord.order_by_default.notes_has("dried")
     assert_query_scope(expects, scope, :HerbariumRecord, notes_has: "dried")
   end
 
   def test_herbarium_record_initial_det
     expects = [herbarium_records(:field_museum_record)]
-    scope = HerbariumRecord.index_order.initial_det("Lichen")
+    scope = HerbariumRecord.order_by_default.initial_det("Lichen")
     assert_query_scope(expects, scope, :HerbariumRecord, initial_det: "Lichen")
     assert_query_scope(expects, scope, :HerbariumRecord, initial_det: "lichen")
   end
@@ -65,47 +65,47 @@ class Query::HerbariumRecordsTest < UnitTestCase
 
   def test_herbarium_record_accession
     expects = [herbarium_records(:interesting_unknown)]
-    scope = HerbariumRecord.index_order.accession("1234")
+    scope = HerbariumRecord.order_by_default.accession("1234")
     assert_query_scope(expects, scope, :HerbariumRecord, accession: "1234")
 
     expects = [herbarium_records(:coprinus_comatus_nybg_spec)]
-    scope = HerbariumRecord.index_order.accession(4321)
+    scope = HerbariumRecord.order_by_default.accession(4321)
     assert_query_scope(expects, scope, :HerbariumRecord, accession: "4321")
   end
 
   def test_herbarium_record_accession_has
     expects = [herbarium_records(:coprinus_comatus_rolf_spec)]
-    scope = HerbariumRecord.index_order.accession_has("Rolf")
+    scope = HerbariumRecord.order_by_default.accession_has("Rolf")
     assert_query_scope(expects, scope, :HerbariumRecord, accession_has: "Rolf")
   end
 
   def test_herbarium_record_pattern_search_notes
     expects = [herbarium_records(:interesting_unknown)]
-    scope = HerbariumRecord.pattern("dried").index_order
+    scope = HerbariumRecord.pattern("dried").order_by_default
     assert_query_scope(expects, scope, :HerbariumRecord, pattern: "dried")
   end
 
   def test_herbarium_record_pattern_search_not_findable
     expects = []
-    scope = HerbariumRecord.pattern("no herbarium record has").index_order
+    scope = HerbariumRecord.pattern("no herbarium record has").order_by_default
     assert_query_scope(expects, scope,
                        :HerbariumRecord, pattern: "no herbarium record has")
   end
 
   def test_herbarium_record_pattern_search_initial_det
     expects = [herbarium_records(:agaricus_campestris_spec)]
-    scope = HerbariumRecord.pattern("Agaricus").index_order
+    scope = HerbariumRecord.pattern("Agaricus").order_by_default
     assert_query_scope(expects, scope, :HerbariumRecord, pattern: "Agaricus")
   end
 
   def test_herbarium_record_pattern_search_accession_number
     expects = [herbarium_records(:interesting_unknown)]
-    scope = HerbariumRecord.pattern("1234").index_order
+    scope = HerbariumRecord.pattern("1234").order_by_default
     assert_query_scope(expects, scope, :HerbariumRecord, pattern: "1234")
   end
 
   def test_herbarium_record_pattern_search_blank
-    expects = HerbariumRecord.index_order
+    expects = HerbariumRecord.order_by_default
     assert_query(expects, :HerbariumRecord, pattern: "")
   end
 end

--- a/test/classes/query/images_test.rb
+++ b/test/classes/query/images_test.rb
@@ -8,110 +8,110 @@ class Query::ImagesTest < UnitTestCase
   include QueryExtensions
 
   def test_image_all
-    expects = Image.index_order
+    expects = Image.order_by_default
     assert_query(expects, :Image)
   end
 
   def test_image_sizes
-    expects = Image.index_order.sizes(:thumbnail)
+    expects = Image.order_by_default.sizes(:thumbnail)
     assert_query(expects, :Image, sizes: :thumbnail)
-    expects = Image.index_order.sizes(:thumbnail, :medium)
+    expects = Image.order_by_default.sizes(:thumbnail, :medium)
     assert_query(expects, :Image, sizes: [:thumbnail, :medium])
   end
 
   def test_image_content_types
-    expects = Image.index_order.content_types(%w[jpg gif png])
+    expects = Image.order_by_default.content_types(%w[jpg gif png])
     assert_query(expects, :Image, content_types: %w[jpg gif png])
-    expects = Image.index_order.content_types(%w[raw])
+    expects = Image.order_by_default.content_types(%w[raw])
     assert_query(expects, :Image, content_types: %w[raw])
   end
 
   def test_image_has_notes
-    expects = Image.index_order.has_notes
+    expects = Image.order_by_default.has_notes
     assert_query(expects, :Image, has_notes: true)
-    expects = Image.index_order.has_notes(false)
+    expects = Image.order_by_default.has_notes(false)
     assert_query(expects, :Image, has_notes: false)
   end
 
   def test_image_notes_has
-    expects = Image.index_order.notes_has('"looked like"')
+    expects = Image.order_by_default.notes_has('"looked like"')
     assert_query(expects, :Image, notes_has: '"looked like"')
-    expects = Image.index_order.notes_has("illustration -convex")
+    expects = Image.order_by_default.notes_has("illustration -convex")
     assert_query(expects, :Image, notes_has: "illustration -convex")
   end
 
   def test_image_copyright_holder_has
-    expects = Image.index_order.copyright_holder_has('"Insil Choi"')
+    expects = Image.order_by_default.copyright_holder_has('"Insil Choi"')
     assert_query(expects, :Image, copyright_holder_has: '"Insil Choi"')
   end
 
   def test_image_license
-    expects = Image.index_order.license(License.preferred)
+    expects = Image.order_by_default.license(License.preferred)
     assert_query(expects, :Image, license: License.preferred)
   end
 
   def test_image_has_votes
-    expects = Image.index_order.has_votes
+    expects = Image.order_by_default.has_votes
     assert_query(expects, :Image, has_votes: true)
-    expects = Image.index_order.has_votes(false)
+    expects = Image.order_by_default.has_votes(false)
     assert_query(expects, :Image, has_votes: false)
   end
 
   def test_image_quality
-    expects = Image.index_order.quality(3)
+    expects = Image.order_by_default.quality(3)
     assert_query(expects, :Image, quality: 3)
-    expects = Image.index_order.quality(3, 3.6)
+    expects = Image.order_by_default.quality(3, 3.6)
     assert_query(expects, :Image, quality: [3, 3.6])
-    expects = Image.index_order.quality([3, 3.6]) # array
+    expects = Image.order_by_default.quality([3, 3.6]) # array
     assert_query(expects, :Image, quality: [3, 3.6])
   end
 
   def test_image_confidence
-    expects = Image.index_order.confidence(2.1)
+    expects = Image.order_by_default.confidence(2.1)
     assert_query(expects, :Image, confidence: 2.1)
-    expects = Image.index_order.confidence(1.2, 2.7)
+    expects = Image.order_by_default.confidence(1.2, 2.7)
     assert_query(expects, :Image, confidence: [1.2, 2.7])
-    expects = Image.index_order.confidence([1.2, 2.7]) # array
+    expects = Image.order_by_default.confidence([1.2, 2.7]) # array
     assert_query(expects, :Image, confidence: [1.2, 2.7])
   end
 
   def test_image_ok_for_export
-    expects = Image.index_order.ok_for_export
+    expects = Image.order_by_default.ok_for_export
     assert_query(expects, :Image, ok_for_export: true)
-    expects = Image.index_order.ok_for_export(false)
+    expects = Image.order_by_default.ok_for_export(false)
     assert_query(expects, :Image, ok_for_export: false)
   end
 
   def test_image_observations
     obs = observations(:two_img_obs)
-    scope = Image.observations(obs.id).index_order
+    scope = Image.observations(obs.id).order_by_default
     assert_query(scope, :Image, observations: obs)
   end
 
   def test_image_locations
-    locations = Location.index_order.last(3)
-    scope = Image.locations(locations).index_order
+    locations = Location.order_by_default.last(3)
+    scope = Image.locations(locations).order_by_default
     assert_query(scope, :Image, locations: locations)
   end
 
   def test_image_projects
     project = projects(:bolete_project)
-    scope = Image.projects(project.id).index_order
+    scope = Image.projects(project.id).order_by_default
     assert_query(scope, :Image, projects: [project.title])
   end
 
   def test_image_species_lists
     spl = species_lists(:query_first_list)
-    scope = Image.species_lists(spl.id).index_order
+    scope = Image.species_lists(spl.id).order_by_default
     assert_query(scope, :Image, species_lists: spl)
   end
 
   def test_image_by_users
-    expects = Image.by_users(rolf.id).index_order
+    expects = Image.by_users(rolf.id).order_by_default
     assert_query(expects, :Image, by_users: rolf)
-    expects = Image.by_users(mary.id).index_order
+    expects = Image.by_users(mary.id).order_by_default
     assert_query(expects, :Image, by_users: mary)
-    expects = Image.by_users(dick.id).index_order
+    expects = Image.by_users(dick.id).order_by_default
     assert_query(expects, :Image, by_users: dick)
   end
 
@@ -135,7 +135,7 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_for_project
     project = projects(:bolete_project)
-    expects = Image.index_order.joins(:project_images).
+    expects = Image.order_by_default.joins(:project_images).
               where(project_images: { project: project }).reorder(id: :asc)
     assert_query(expects, :Image, projects: project, order_by: :id)
     assert_query([], :Image, projects: projects(:empty_project))
@@ -143,13 +143,13 @@ class Query::ImagesTest < UnitTestCase
 
   # def test_image_advanced_search_name
   #   # expects = [] # [images(:agaricus_campestris_image).id]
-  #   expects = Image.index_order.joins(observations: :name).
+  #   expects = Image.order_by_default.joins(observations: :name).
   #             where(Name[:search_name].matches("%Agaricus%")).distinct
   #   assert_query(expects, :Image, search_name: "Agaricus")
   # end
 
   # def test_image_advanced_search_where
-  #   expects = Image.index_order.joins(:observations).
+  #   expects = Image.order_by_default.joins(:observations).
   #             where(Observation[:where].matches("%burbank%")).
   #             where(observations: { is_collection_location: true }).distinct
   #   assert_query(expects, :Image, search_where: "burbank")
@@ -159,17 +159,17 @@ class Query::ImagesTest < UnitTestCase
   # end
 
   # def test_image_advanced_search_user
-  #   expects = Image.index_order.joins(observations: :user).
+  #   expects = Image.order_by_default.joins(observations: :user).
   #             where(observations: { user: mary }).distinct.
   #             order(Image[:created_at].desc, Image[:id].desc)
   #   assert_query(expects, :Image, search_user: "mary")
   # end
 
   # def test_image_advanced_search_content
-  #   assert_query(Image.index_order.
+  #   assert_query(Image.order_by_default.
   #                advanced_search("little"),
   #                :Image, search_content: "little")
-  #   assert_query(Image.index_order.
+  #   assert_query(Image.order_by_default.
   #                advanced_search("fruiting"),
   #                :Image, search_content: "fruiting")
   # end
@@ -184,38 +184,38 @@ class Query::ImagesTest < UnitTestCase
   # end
 
   def test_image_pattern_search_name
-    assert_query(Image.index_order.pattern("agaricus"),
+    assert_query(Image.order_by_default.pattern("agaricus"),
                  :Image, pattern: "agaricus") # name
   end
 
   def test_image_pattern_copyright_holder
-    assert_query(Image.index_order.pattern("bob dob"),
+    assert_query(Image.order_by_default.pattern("bob dob"),
                  :Image, pattern: "bob dob") # copyright holder
   end
 
   def test_image_pattern_notes
     assert_query(
-      Image.index_order.pattern("looked gorilla OR original"),
+      Image.order_by_default.pattern("looked gorilla OR original"),
       :Image, pattern: "looked gorilla OR original" # notes
     )
-    assert_query(Image.index_order.pattern("notes some"),
+    assert_query(Image.order_by_default.pattern("notes some"),
                  :Image, pattern: "notes some") # notes
     assert_query(
-      Image.index_order.pattern("dobbs -notes"),
+      Image.order_by_default.pattern("dobbs -notes"),
       :Image, pattern: "dobbs -notes" # (c), not notes
     )
   end
 
   def test_image_pattern_original_filename
-    assert_query(Image.index_order.pattern("DSCN8835"),
+    assert_query(Image.order_by_default.pattern("DSCN8835"),
                  :Image, pattern: "DSCN8835") # original filename
   end
 
   def test_image_has_observations
-    expects = Image.index_order.includes(:observations).
+    expects = Image.order_by_default.includes(:observations).
               where.not(observations: { thumb_image: nil }).distinct
     assert_query(expects, :Image, has_observations: true)
-    expects = Image.has_observations.index_order
+    expects = Image.has_observations.order_by_default
     assert_query(expects, :Image, has_observations: true)
   end
 
@@ -232,7 +232,7 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_with_observations_created_at
     created_at = observations(:detailed_unknown_obs).created_at
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(Observation[:created_at] >= created_at).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, created_at:)
@@ -240,7 +240,7 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_with_observations_updated_at
     updated_at = observations(:detailed_unknown_obs).updated_at
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(Observation[:updated_at] >= updated_at).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, updated_at:)
@@ -248,7 +248,7 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_with_observations_date
     date = observations(:detailed_unknown_obs).when
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(Observation[:when] >= date).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, date:)
@@ -257,9 +257,9 @@ class Query::ImagesTest < UnitTestCase
   ##### list/string parameters #####
 
   def test_image_with_observations_comments_has
-    expects = Image.index_order.joins(observations: :comments).
+    expects = Image.order_by_default.joins(observations: :comments).
               where(Comment[:summary].matches("%give%")).
-              or(Image.index_order.joins(observations: :comments).
+              or(Image.order_by_default.joins(observations: :comments).
                  where(Comment[:comment].matches("%give%"))).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, comments_has: "give")
@@ -270,7 +270,7 @@ class Query::ImagesTest < UnitTestCase
     # give it some images
     obs.images = [images(:conic_image), images(:convex_image)]
     obs.save
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(Observation[:notes].matches("%:substrate:%")).uniq
     assert_not_empty(expects, "'expects` is broken; it should not be empty")
     assert_image_obs_query(expects, has_notes_fields: "substrate")
@@ -278,7 +278,7 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_with_observations_herbaria
     name = "The New York Botanical Garden"
-    expects = Image.index_order.
+    expects = Image.order_by_default.
               joins(observations: { herbarium_records: :herbarium }).
               where(herbaria: { name: name }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
@@ -287,14 +287,14 @@ class Query::ImagesTest < UnitTestCase
 
   def test_image_with_observations_projects
     project = projects(:bolete_project)
-    expects = Image.index_order.joins(observations: :projects).
+    expects = Image.order_by_default.joins(observations: :projects).
               where(projects: { title: project.title }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, projects: [project.title])
   end
 
   def test_image_with_observations_users
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(observations: { user: dick }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, by_users: dick)
@@ -307,7 +307,7 @@ class Query::ImagesTest < UnitTestCase
 
     lat = obs.lat
     lng = obs.lng
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(observations: { lat: lat }).
               where(observations: { lng: lng }).distinct
     box = { north: lat.to_f, south: lat.to_f, west: lng.to_f, east: lng.to_f }
@@ -325,7 +325,7 @@ class Query::ImagesTest < UnitTestCase
   ##### boolean parameters #####
 
   def test_image_with_observations_has_comments
-    expects = Image.index_order.joins(observations: :comments).distinct
+    expects = Image.order_by_default.joins(observations: :comments).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, has_comments: true)
   end
@@ -333,41 +333,41 @@ class Query::ImagesTest < UnitTestCase
   def test_image_with_observations_has_public_lat_lng
     give_geolocated_observation_some_images
 
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where.not(observations: { lat: false }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, has_public_lat_lng: true)
   end
 
   def test_image_with_observations_has_name
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(observations: { name_id: Name.unknown }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, has_name: false)
   end
 
   def test_image_with_observations_has_notes
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where.not(observations: { notes: Observation.no_notes }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, has_notes: true)
   end
 
   def test_image_with_observations_has_sequences
-    expects = Image.index_order.joins(observations: :sequences).distinct
+    expects = Image.order_by_default.joins(observations: :sequences).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, has_sequences: true)
   end
 
   def test_image_with_observations_is_collection_location
-    expects = Image.index_order.joins(:observations).
+    expects = Image.order_by_default.joins(:observations).
               where(observations: { is_collection_location: true }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_image_obs_query(expects, is_collection_location: true)
   end
 
   def test_image_with_observations_at_location
-    expects = Image.index_order.joins(observations: :location).
+    expects = Image.order_by_default.joins(observations: :location).
               where(observations: { location: locations(:burbank) }).
               where(observations: { is_collection_location: true }).distinct
     assert_image_obs_query(expects, locations: locations(:burbank).id)
@@ -391,13 +391,13 @@ class Query::ImagesTest < UnitTestCase
   end
 
   def image_with_observations_by_user(user)
-    Image.index_order.joins(:observations).
+    Image.order_by_default.joins(:observations).
       where(observations: { user: user }).distinct
   end
 
   def test_image_with_observations_for_project
     assert_image_obs_query([], projects: projects(:empty_project))
-    expects = observations(:two_img_obs).images.index_order.distinct
+    expects = observations(:two_img_obs).images.order_by_default.distinct
     assert_image_obs_query(expects, projects: projects(:two_img_obs_project))
   end
 
@@ -405,7 +405,7 @@ class Query::ImagesTest < UnitTestCase
     obs_ids = [observations(:detailed_unknown_obs).id,
                observations(:agaricus_campestris_obs).id]
     expects = Image.joins(:observations).where(observations: { id: obs_ids }).
-              index_order.distinct
+              order_by_default.distinct
     assert_image_obs_query(expects, id_in_set: obs_ids)
     assert_image_obs_query(
       [], id_in_set: [observations(:minimal_unknown_obs).id]
@@ -446,7 +446,7 @@ class Query::ImagesTest < UnitTestCase
   end
 
   def test_image_with_observations_of_name
-    expects = Image.index_order.joins(:observation_images, :observations).
+    expects = Image.order_by_default.joins(:observation_images, :observations).
               where(observations: { name: names(:fungi) }).distinct
     assert_image_obs_query(expects, names: { lookup: [names(:fungi).id] })
 

--- a/test/classes/query/location_descriptions_test.rb
+++ b/test/classes/query/location_descriptions_test.rb
@@ -61,7 +61,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
   end
 
   def test_location_description_order_by_default
-    loc1, loc2, loc3 = Location.index_order
+    loc1, loc2, loc3 = Location.order_by_default
     desc1 =
       loc1.description ||= LocationDescription.create!(location_id: loc1.id)
     desc2 =

--- a/test/classes/query/location_descriptions_test.rb
+++ b/test/classes/query/location_descriptions_test.rb
@@ -100,8 +100,8 @@ class Query::LocationDescriptionsTest < UnitTestCase
   end
 
   def test_location_description_content_has
-    expects = [location_descriptions(:albion_desc)]order_by_default
-    scope = LocationDescription.content_has("to play with").index_order
+    expects = [location_descriptions(:albion_desc)]
+    scope = LocationDescription.content_has("to play with").order_by_default
     assert_query_scope(expects, scope,
                        :LocationDescription, content_has: "to play with")
   end

--- a/test/classes/query/location_descriptions_test.rb
+++ b/test/classes/query/location_descriptions_test.rb
@@ -36,7 +36,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
   end
 
   def test_location_description_by_author
-    loc1, loc2, loc3 = Location.all.index_order
+    loc1, loc2, loc3 = Location.all.order_by_default
     desc1 =
       loc1.description ||= LocationDescription.create!(location_id: loc1.id)
     desc2 =
@@ -60,7 +60,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
                        :LocationDescription, by_author: users(:zero_user))
   end
 
-  def test_location_description_by_editor
+  def test_location_description_order_by_default
     loc1, loc2, loc3 = Location.index_order
     desc1 =
       loc1.description ||= LocationDescription.create!(location_id: loc1.id)
@@ -100,7 +100,7 @@ class Query::LocationDescriptionsTest < UnitTestCase
   end
 
   def test_location_description_content_has
-    expects = [location_descriptions(:albion_desc)]
+    expects = [location_descriptions(:albion_desc)]order_by_default
     scope = LocationDescription.content_has("to play with").index_order
     assert_query_scope(expects, scope,
                        :LocationDescription, content_has: "to play with")

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -62,7 +62,8 @@ class Query::LocationsTest < UnitTestCase
     scope = Location.order_by_default.notes_has('"should persist"')
     assert_query_scope(expects, scope, :Location, notes_has: '"should persist"')
     expects = [locations(:point_reyes)]
-    scope = Location.order_by_default.notes_has('"legal to collect" -"Salt Point"')
+    scope = Location.order_by_default.
+            notes_has('"legal to collect" -"Salt Point"')
     assert_query_scope(expects, scope,
                        :Location, notes_has: '"legal to collect" -"Salt Point"')
   end
@@ -303,7 +304,8 @@ class Query::LocationsTest < UnitTestCase
     names = [names(:boletus_edulis), names(:agaricus_campestris)].
             map(&:text_name)
     expects = Location.joins(observations: :name).
-              where(observations: { text_name: names }).order_by_default.distinct
+              where(observations: { text_name: names }).
+              order_by_default.distinct
     assert_query(
       expects, :Location, observation_query: { names: { lookup: names } }
     )
@@ -403,7 +405,8 @@ class Query::LocationsTest < UnitTestCase
   def test_location_with_observations_has_public_lat_lng
     assert_query(
       Location.joins(:observations).where(observations: { gps_hidden: false }).
-               where.not(observations: { lat: false }).order_by_default.distinct,
+               where.not(observations: { lat: false }).
+               order_by_default.distinct,
       :Location, observation_query: { has_public_lat_lng: true }
     )
   end

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -8,7 +8,7 @@ class Query::LocationsTest < UnitTestCase
   include QueryExtensions
 
   def test_location_all
-    expects = Location.index_order
+    expects = Location.order_by_default
     assert_query(expects, :Location)
     expects = Location.reorder(id: :asc)
     assert_query(expects, :Location, order_by: :id)
@@ -23,7 +23,7 @@ class Query::LocationsTest < UnitTestCase
   def test_location_by_editor
     assert_query([], :Location, by_editor: rolf)
     User.current = mary
-    loc = Location.where.not(user: mary).index_order.first
+    loc = Location.where.not(user: mary).order_by_default.first
     loc.display_name = "new name"
     loc.save
     assert_query_scope([loc], Location.by_editor(mary),
@@ -51,18 +51,18 @@ class Query::LocationsTest < UnitTestCase
   end
 
   def test_location_has_notes
-    expects = Location.index_order.has_notes
+    expects = Location.order_by_default.has_notes
     assert_query(expects, :Location, has_notes: true)
-    expects = Location.index_order.has_notes(false)
+    expects = Location.order_by_default.has_notes(false)
     assert_query(expects, :Location, has_notes: false)
   end
 
   def test_location_notes_has
     expects = [locations(:burbank)]
-    scope = Location.index_order.notes_has('"should persist"')
+    scope = Location.order_by_default.notes_has('"should persist"')
     assert_query_scope(expects, scope, :Location, notes_has: '"should persist"')
     expects = [locations(:point_reyes)]
-    scope = Location.index_order.notes_has('"legal to collect" -"Salt Point"')
+    scope = Location.order_by_default.notes_has('"legal to collect" -"Salt Point"')
     assert_query_scope(expects, scope,
                        :Location, notes_has: '"legal to collect" -"Salt Point"')
   end
@@ -70,7 +70,7 @@ class Query::LocationsTest < UnitTestCase
   def test_location_in_box
     expects = [locations(:burbank)]
     box = { north: 35, south: 34, east: -118, west: -119 }
-    scope = Location.index_order.in_box(**box)
+    scope = Location.order_by_default.in_box(**box)
     assert_query_scope(expects, scope, :Location, in_box: box)
   end
 
@@ -100,14 +100,14 @@ class Query::LocationsTest < UnitTestCase
   end
 
   def test_location_advanced_search_user
-    expects = Location.index_order.joins(observations: :user).
+    expects = Location.order_by_default.joins(observations: :user).
               where(observations: { user: rolf }).distinct
-    scope = Location.index_order.search_user("rolf")
+    scope = Location.order_by_default.search_user("rolf")
     assert_query_scope(expects, scope, :Location, search_user: "rolf")
 
-    expects = Location.index_order.joins(observations: :user).
+    expects = Location.order_by_default.joins(observations: :user).
               where(observations: { user: dick }).distinct
-    scope = Location.index_order.search_user("dick")
+    scope = Location.order_by_default.search_user("dick")
     assert_query_scope(expects, scope, :Location, search_user: "dick")
   end
 
@@ -147,18 +147,18 @@ class Query::LocationsTest < UnitTestCase
   end
 
   def test_location_regexp_search
-    expects = Location.regexp("California").index_order.distinct
+    expects = Location.regexp("California").order_by_default.distinct
     assert_query(expects, :Location, regexp: ".alifornia")
   end
 
   def test_location_has_descriptions
-    expects = Location.joins(:descriptions).index_order.distinct
+    expects = Location.joins(:descriptions).order_by_default.distinct
     assert_query(expects, :Location, has_descriptions: 1)
   end
 
   def test_location_has_descriptions_by_user
     expects = Location.joins(:descriptions).
-              where(descriptions: { user: rolf }).index_order.distinct
+              where(descriptions: { user: rolf }).order_by_default.distinct
     assert_query(expects, :Location, description_query: { by_users: rolf })
 
     assert_query([], :Location, description_query: { by_users: mary })
@@ -167,7 +167,7 @@ class Query::LocationsTest < UnitTestCase
   def test_location_has_descriptions_by_author
     expects = Location.joins(descriptions: :location_description_authors).
               where(location_description_authors: { user: rolf }).
-              index_order.distinct
+              order_by_default.distinct
     assert_query(expects, :Location, description_query: { by_author: rolf })
     assert_query([], :Location, description_query: { by_author: mary })
   end
@@ -181,7 +181,7 @@ class Query::LocationsTest < UnitTestCase
 
     expects = Location.joins(descriptions: :location_description_editors).
               where(location_description_editors: { user: mary }).
-              index_order.distinct
+              order_by_default.distinct
     assert_query(expects, :Location, description_query: { by_editor: mary })
   end
 
@@ -200,7 +200,7 @@ class Query::LocationsTest < UnitTestCase
   end
 
   def test_location_has_observations
-    expects = Location.has_observations.index_order.distinct
+    expects = Location.has_observations.order_by_default.distinct
     assert_query(expects, :Location, has_observations: 1)
   end
 
@@ -213,21 +213,21 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_with_observations_created_at
     created_at = observations(:california_obs).created_at
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(Observation[:created_at] >= created_at).distinct
     assert_query(expects, :Location, observation_query: { created_at: })
   end
 
   def test_location_with_observations_updated_at
     updated_at = observations(:california_obs).updated_at
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(Observation[:updated_at] >= updated_at).distinct
     assert_query(expects, :Location, observation_query: { updated_at: })
   end
 
   def test_location_with_observations_date
     date = observations(:california_obs).when
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(Observation[:when] >= date).distinct
     assert_query(expects, :Location, observation_query: { date: })
   end
@@ -247,10 +247,10 @@ class Query::LocationsTest < UnitTestCase
       target: observations(:vouchered_obs)
     )
     assert_query(
-      Location.index_order.joins(observations: :comments).
+      Location.order_by_default.joins(observations: :comments).
                where(Comment[:summary].matches("%cool%")).
                or(
-                 Location.index_order.joins(observations: :comments).
+                 Location.order_by_default.joins(observations: :comments).
                           where(Comment[:comment].matches("%cool%"))
                ).distinct,
       :Location, observation_query: { comments_has: "cool" }
@@ -259,7 +259,7 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_with_observations_has_notes_fields
     assert_query(
-      Location.index_order.joins(:observations).
+      Location.order_by_default.joins(:observations).
                where(Observation[:notes].matches("%:substrate:%")).distinct,
       :Location, observation_query: { has_notes_fields: "substrate" }
     )
@@ -268,12 +268,12 @@ class Query::LocationsTest < UnitTestCase
   def test_location_with_observations_herbaria
     name = "The New York Botanical Garden"
     expects = Location.joins(observations: { herbarium_records: :herbarium }).
-              where(herbaria: { name: name }).index_order.distinct
+              where(herbaria: { name: name }).order_by_default.distinct
     assert_query(expects, :Location, observation_query: { herbaria: name })
   end
 
   def test_location_with_observations_notes_has
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(Observation[:notes].matches("%somewhere%")).distinct
     assert_query(
       expects, :Location, observation_query: { notes_has: "somewhere" }
@@ -293,7 +293,7 @@ class Query::LocationsTest < UnitTestCase
   def test_location_with_observations_projects
     project = projects(:bolete_project)
     assert_query(
-      Location.index_order.joins(observations: :projects).
+      Location.order_by_default.joins(observations: :projects).
                where(projects: { title: project.title }).distinct,
       :Location, observation_query: { projects: project.title }
     )
@@ -303,7 +303,7 @@ class Query::LocationsTest < UnitTestCase
     names = [names(:boletus_edulis), names(:agaricus_campestris)].
             map(&:text_name)
     expects = Location.joins(observations: :name).
-              where(observations: { text_name: names }).index_order.distinct
+              where(observations: { text_name: names }).order_by_default.distinct
     assert_query(
       expects, :Location, observation_query: { names: { lookup: names } }
     )
@@ -311,7 +311,7 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_with_observations_include_subtaxa
     parent = names(:agaricus)
-    children = Name.index_order.
+    children = Name.order_by_default.
                where(Name[:text_name].matches_regexp(parent.text_name))
     assert_query(
       Location.joins(:observations).
@@ -371,7 +371,7 @@ class Query::LocationsTest < UnitTestCase
 
   def test_location_with_observations_users
     assert_query(
-      Location.index_order.joins(:observations).
+      Location.order_by_default.joins(:observations).
       where(observations: { user: dick }).distinct,
       :Location, observation_query: { by_users: dick }
     )
@@ -383,9 +383,9 @@ class Query::LocationsTest < UnitTestCase
     # Create Observations with both vote_cache and location, because:
     # (a) there aren't Observation fixtures like that, and
     # (b) tests are brittle, so adding or modifying a fixture will break them.
-    obses = Observation.index_order.where(vote_cache: 1..3)
+    obses = Observation.order_by_default.where(vote_cache: 1..3)
     obses.each { |obs| obs.update!(location: locations(:albion)) }
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(observations: { vote_cache: 1..3 }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_query(expects,
@@ -395,7 +395,7 @@ class Query::LocationsTest < UnitTestCase
   ##### boolean parameters #####
   def test_location_with_observations_has_comments
     assert_query(
-      Location.index_order.joins(observations: :comments).distinct,
+      Location.order_by_default.joins(observations: :comments).distinct,
       :Location, observation_query: { has_comments: true }
     )
   end
@@ -403,31 +403,31 @@ class Query::LocationsTest < UnitTestCase
   def test_location_with_observations_has_public_lat_lng
     assert_query(
       Location.joins(:observations).where(observations: { gps_hidden: false }).
-               where.not(observations: { lat: false }).index_order.distinct,
+               where.not(observations: { lat: false }).order_by_default.distinct,
       :Location, observation_query: { has_public_lat_lng: true }
     )
   end
 
   def test_location_with_observations_has_name
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(observations: { name: Name.unknown }).distinct
     assert_query(expects, :Location, observation_query: { has_name: false })
   end
 
   def test_location_with_observations_has_notes
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where.not(observations: { notes: Observation.no_notes }).distinct
     assert_query(expects, :Location, observation_query: { has_notes: true })
   end
 
   def test_location_with_observations_has_sequences
-    expects = Location.index_order.joins(observations: :sequences).distinct
+    expects = Location.order_by_default.joins(observations: :sequences).distinct
     assert_query(expects,
                  :Location, observation_query: { has_sequences: true })
   end
 
   def test_location_with_observations_is_collection_location
-    expects = Location.index_order.joins(:observations).
+    expects = Location.order_by_default.joins(:observations).
               where(observations: { is_collection_location: true }).distinct
     assert_query(
       expects, :Location, observation_query: { is_collection_location: true }
@@ -446,7 +446,7 @@ class Query::LocationsTest < UnitTestCase
 
   def location_with_observations_by_user(user)
     Location.joins(:observations).where(observations: { user: user }).
-      index_order.distinct
+      order_by_default.distinct
   end
 
   def test_location_with_observations_for_project_empty

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -85,7 +85,8 @@ class Query::NameDescriptionsTest < UnitTestCase
   end
 
   def test_name_description_projects
-    assert_query(NameDescription.projects(projects(:eol_project)).order_by_default,
+    assert_query(NameDescription.projects(projects(:eol_project)).
+                 order_by_default,
                  :NameDescription, projects: projects(:eol_project).id)
   end
 

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -68,45 +68,45 @@ class Query::NameDescriptionsTest < UnitTestCase
   end
 
   def test_name_description_has_default_description
-    assert_query(NameDescription.is_default.index_order,
+    assert_query(NameDescription.is_default.order_by_default,
                  :NameDescription, name_query: { has_default_description: 1 })
-    assert_query(NameDescription.is_not_default.index_order,
+    assert_query(NameDescription.is_not_default.order_by_default,
                  :NameDescription, name_query: { has_default_description: 0 })
   end
 
   def test_name_description_desc_sources_user
-    assert_query(NameDescription.sources(5).index_order,
+    assert_query(NameDescription.sources(5).order_by_default,
                  :NameDescription, sources: "user")
   end
 
   def test_name_description_type_project
-    assert_query(NameDescription.sources(3).index_order,
+    assert_query(NameDescription.sources(3).order_by_default,
                  :NameDescription, sources: "project")
   end
 
   def test_name_description_projects
-    assert_query(NameDescription.projects(projects(:eol_project)).index_order,
+    assert_query(NameDescription.projects(projects(:eol_project)).order_by_default,
                  :NameDescription, projects: projects(:eol_project).id)
   end
 
   # waiting on a new AbstractModel scope for searches,
   # plus a specific NameDescription scope coalescing the fields.
   def test_name_description_content_has
-    assert_query(NameDescription.content_has('"some notes"').index_order,
+    assert_query(NameDescription.content_has('"some notes"').order_by_default,
                  :NameDescription, content_has: '"some notes"')
   end
 
   def test_name_description_ok_for_export
-    assert_query(NameDescription.ok_for_export(1).index_order,
+    assert_query(NameDescription.ok_for_export(1).order_by_default,
                  :NameDescription, ok_for_export: 1)
-    assert_query(NameDescription.ok_for_export(0).index_order,
+    assert_query(NameDescription.ok_for_export(0).order_by_default,
                  :NameDescription, ok_for_export: 0)
   end
 
   def test_name_description_is_public
-    assert_query(NameDescription.is_public(1).index_order,
+    assert_query(NameDescription.is_public(1).order_by_default,
                  :NameDescription, is_public: 1)
-    assert_query(NameDescription.is_public(0).index_order,
+    assert_query(NameDescription.is_public(0).order_by_default,
                  :NameDescription, is_public: 0)
   end
 end

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -9,8 +9,8 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_all
     # NOTE: misspellings are modified by `do_test_name_all`
-    # This saves looking up Name.index_order a bunch of times.
-    expect = Name.index_order
+    # This saves looking up Name.order_by_default a bunch of times.
+    expect = Name.order_by_default
     expects = expect.to_a
     # SQL does not sort 'Kuhner' and 'Kühner'
     do_test_name_all(expect) if sql_collates_accents?
@@ -55,13 +55,13 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_by_user
-    assert_query(Name.index_order.where(user: mary).with_correct_spelling,
+    assert_query(Name.order_by_default.where(user: mary).with_correct_spelling,
                  :Name, by_users: mary)
-    assert_query(Name.index_order.where(user: mary).with_correct_spelling,
+    assert_query(Name.order_by_default.where(user: mary).with_correct_spelling,
                  :Name, by_users: "mary")
-    assert_query(Name.index_order.where(user: dick).with_correct_spelling,
+    assert_query(Name.order_by_default.where(user: dick).with_correct_spelling,
                  :Name, by_users: dick)
-    assert_query(Name.index_order.where(user: rolf).with_correct_spelling,
+    assert_query(Name.order_by_default.where(user: rolf).with_correct_spelling,
                  :Name, by_users: rolf)
     assert_query([], :Name, by_users: users(:zero_user))
   end
@@ -76,33 +76,33 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_users_login
     # single
-    expects = Name.where(user: users(:rolf)).index_order
+    expects = Name.where(user: users(:rolf)).order_by_default
     assert_query(expects, :Name, by_users: users(:rolf).login)
     # array
     users = [users(:rolf), users(:mary)]
-    expects = Name.where(user: users).index_order
+    expects = Name.where(user: users).order_by_default
     assert_query(expects, :Name, by_users: users.map(&:login))
   end
 
   def test_name_users_id
     # single
     users = users(:rolf).id
-    expects = Name.where(user: users).index_order
+    expects = Name.where(user: users).order_by_default
     assert_query(expects, :Name, by_users: users)
     # array
     users = [users(:rolf), users(:mary)].map(&:id)
-    expects = Name.where(user: users).index_order
+    expects = Name.where(user: users).order_by_default
     assert_query(expects, :Name, by_users: users)
   end
 
   def test_name_users_instance
     # single
     users = users(:rolf)
-    expects = Name.where(user: users).index_order
+    expects = Name.where(user: users).order_by_default
     assert_query(expects, :Name, by_users: users)
     # array
     users = [users(:rolf), users(:mary)]
-    expects = Name.where(user: users).index_order
+    expects = Name.where(user: users).order_by_default
     assert_query(expects, :Name, by_users: users)
   end
 
@@ -110,19 +110,19 @@ class Query::NamesTest < UnitTestCase
   def test_name_locations
     locations = [locations(:salt_point), locations(:gualala)].
                 map { |x| x.id.to_s }
-    expects = Name.locations(locations).index_order
+    expects = Name.locations(locations).order_by_default
     assert_query(expects, :Name, locations: locations)
     # locations = [locations(:salt_point), locations(:gualala)]
     # assert_query(expects, :Name, locations: locations)
 
     locations = ["Sonoma Co., California, USA"]
-    expects = Name.locations(locations).index_order
+    expects = Name.locations(locations).order_by_default
     assert_query(expects, :Name, locations: locations)
   end
 
   def test_name_species_lists
     spl = [species_lists(:unknown_species_list).title]
-    expects = Name.species_lists(spl).index_order
+    expects = Name.species_lists(spl).order_by_default
     assert_query(expects, :Name, species_lists: spl)
   end
 
@@ -139,7 +139,7 @@ class Query::NamesTest < UnitTestCase
       names(:coprinus_comatus),
       names(:macrocybe_titans)
     ]
-    scope = Name.names(lookup: set, include_subtaxa: true).index_order
+    scope = Name.names(lookup: set, include_subtaxa: true).order_by_default
     assert_query_scope(
       expects, scope, :Name, names: { lookup: set, include_subtaxa: true }
     )
@@ -148,7 +148,7 @@ class Query::NamesTest < UnitTestCase
   def test_name_names_include_subtaxa_exclude_original
     name = names(:agaricus)
     assert_query(
-      Name.index_order.names(lookup: name.id,
+      Name.order_by_default.names(lookup: name.id,
                              include_subtaxa: true,
                              exclude_original_names: true),
       :Name, names: { lookup: [name.id],
@@ -162,7 +162,7 @@ class Query::NamesTest < UnitTestCase
     name = names(:tubaria_furfuracea)
     assert_query_scope(
       [],
-      Name.index_order.names(lookup: name.id,
+      Name.order_by_default.names(lookup: name.id,
                              include_subtaxa: true,
                              exclude_original_names: true),
       :Name, names: { lookup: name.id,
@@ -173,7 +173,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_names_include_subtaxa_include_original
     assert_query(
-      Name.index_order.names(lookup: names(:agaricus),
+      Name.order_by_default.names(lookup: names(:agaricus),
                              include_subtaxa: true,
                              exclude_original_names: false),
       :Name, names: { lookup: [names(:agaricus).id],
@@ -184,7 +184,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_names_include_immediate_subtaxa
     assert_query(
-      Name.index_order.names(lookup: names(:agaricus),
+      Name.order_by_default.names(lookup: names(:agaricus),
                              include_immediate_subtaxa: true,
                              exclude_original_names: false),
       :Name, names: { lookup: [names(:agaricus).id],
@@ -194,129 +194,129 @@ class Query::NamesTest < UnitTestCase
   end
 
   # def test_name_deprecated_only
-  #   expects = Name.with_correct_spelling.deprecated.index_order
+  #   expects = Name.with_correct_spelling.deprecated.order_by_default
   #   assert_query(expects, :Name, deprecated: :only)
-  #   expects = Name.with_correct_spelling.not_deprecated.index_order
+  #   expects = Name.with_correct_spelling.not_deprecated.order_by_default
   #   assert_query(expects, :Name, deprecated: :no)
-  #   expects = Name.with_correct_spelling.index_order
+  #   expects = Name.with_correct_spelling.order_by_default
   #   assert_query(expects, :Name, deprecated: :either)
   # end
 
   def test_name_deprecated
-    expects = Name.with_correct_spelling.deprecated.index_order
+    expects = Name.with_correct_spelling.deprecated.order_by_default
     assert_query(expects, :Name, deprecated: true)
 
     trues = [true, "true", 1, "1"]
     trues.each do |val|
-      expects = Name.with_correct_spelling.deprecated(val).index_order
+      expects = Name.with_correct_spelling.deprecated(val).order_by_default
       assert_query(expects, :Name, deprecated: true)
 
-      expects = Name.with_correct_spelling.deprecated.index_order
+      expects = Name.with_correct_spelling.deprecated.order_by_default
       assert_query(expects, :Name, deprecated: val)
     end
 
     falses = [false, "false", 0, "0"]
     falses.each do |val|
-      expects = Name.with_correct_spelling.deprecated(val).index_order
+      expects = Name.with_correct_spelling.deprecated(val).order_by_default
       assert_query(expects, :Name, deprecated: false)
 
-      expects = Name.with_correct_spelling.deprecated(false).index_order
+      expects = Name.with_correct_spelling.deprecated(false).order_by_default
       assert_query(expects, :Name, deprecated: val)
     end
   end
 
   def test_name_has_synonyms
-    expects = Name.with_correct_spelling.has_synonyms.index_order
+    expects = Name.with_correct_spelling.has_synonyms.order_by_default
     assert_query(expects, :Name, has_synonyms: true)
-    expects = Name.with_correct_spelling.has_synonyms(false).index_order
+    expects = Name.with_correct_spelling.has_synonyms(false).order_by_default
     assert_query(expects, :Name, has_synonyms: false)
   end
 
   def test_name_rank_single
-    expects = Name.with_correct_spelling.rank("Family").index_order
+    expects = Name.with_correct_spelling.rank("Family").order_by_default
     assert_query(expects, :Name, rank: "Family")
   end
 
   # NOTE: Something is wrong in the fixtures between Genus and Family
   def test_name_rank_range
-    expects = Name.with_correct_spelling.rank("Genus", "Kingdom").index_order
+    expects = Name.with_correct_spelling.rank("Genus", "Kingdom").order_by_default
     assert_query(expects, :Name, rank: %w[Genus Kingdom])
 
-    expects = Name.with_correct_spelling.rank("Family").index_order
+    expects = Name.with_correct_spelling.rank("Family").order_by_default
     assert_query(expects, :Name, rank: %w[Family Family])
   end
 
   def test_name_text_name_has
     expects = Name.with_correct_spelling.
-              text_name_has("Agaricus").index_order
+              text_name_has("Agaricus").order_by_default
     assert_query(expects, :Name, text_name_has: "Agaricus")
   end
 
   def test_name_has_author
-    expects = Name.with_correct_spelling.has_author.index_order
+    expects = Name.with_correct_spelling.has_author.order_by_default
     assert_query(expects, :Name, has_author: true)
-    expects = Name.with_correct_spelling.has_author(false).index_order
+    expects = Name.with_correct_spelling.has_author(false).order_by_default
     assert_query(expects, :Name, has_author: false)
   end
 
   def test_name_author_has
-    expects = Name.with_correct_spelling.author_has("Pers.").index_order
+    expects = Name.with_correct_spelling.author_has("Pers.").order_by_default
     assert_query(expects, :Name, author_has: "Pers.")
   end
 
   def test_name_has_citation
-    expects = Name.with_correct_spelling.has_citation.index_order
+    expects = Name.with_correct_spelling.has_citation.order_by_default
     assert_query(expects, :Name, has_citation: true)
-    expects = Name.with_correct_spelling.has_citation(false).index_order
+    expects = Name.with_correct_spelling.has_citation(false).order_by_default
     assert_query(expects, :Name, has_citation: false)
   end
 
   def test_name_citation_has
     expects = Name.with_correct_spelling.
-              citation_has("Lichenes").index_order
+              citation_has("Lichenes").order_by_default
     assert_query(expects, :Name, citation_has: "Lichenes")
   end
 
   def test_name_has_classification
-    expects = Name.with_correct_spelling.has_classification.index_order
+    expects = Name.with_correct_spelling.has_classification.order_by_default
     assert_query(expects, :Name, has_classification: true)
-    expects = Name.with_correct_spelling.has_classification(false).index_order
+    expects = Name.with_correct_spelling.has_classification(false).order_by_default
     assert_query(expects, :Name, has_classification: false)
   end
 
   def test_name_classification_has
     expects = Name.with_correct_spelling.
-              classification_has("Tremellales").index_order
+              classification_has("Tremellales").order_by_default
     assert_query(expects, :Name, classification_has: "Tremellales")
   end
 
   def test_name_has_notes
-    expects = Name.with_correct_spelling.has_notes.index_order
+    expects = Name.with_correct_spelling.has_notes.order_by_default
     assert_query(expects, :Name, has_notes: true)
-    expects = Name.with_correct_spelling.has_notes(false).index_order
+    expects = Name.with_correct_spelling.has_notes(false).order_by_default
     assert_query(expects, :Name, has_notes: false)
   end
 
   def test_name_notes_has
     expects = Name.with_correct_spelling.
-              notes_has('"at least one"').index_order
+              notes_has('"at least one"').order_by_default
     assert_query(expects, :Name, notes_has: '"at least one"')
   end
 
   def test_name_has_comments_true
-    expects = Name.with_correct_spelling.has_comments.index_order
+    expects = Name.with_correct_spelling.has_comments.order_by_default
     assert_query(expects, :Name, has_comments: true)
   end
 
   # Note that this is not a withOUT comments condition
   def test_name_has_comments_false
-    expects = Name.with_correct_spelling.index_order
+    expects = Name.with_correct_spelling.order_by_default
     assert_query(expects, :Name, has_comments: false)
   end
 
   def test_name_comments_has
     expects = Name.with_correct_spelling.
-              comments_has('"messes things up"').index_order
+              comments_has('"messes things up"').order_by_default
     assert_query(expects, :Name, comments_has: '"messes things up"')
   end
 
@@ -368,17 +368,17 @@ class Query::NamesTest < UnitTestCase
     assert_query_scope([names(:coprinus_comatus).id],
                        Name.search_where("glendale"),
                        :Name, search_where: "glendale")
-    expects = Name.index_order.joins(:observations).
+    expects = Name.order_by_default.joins(:observations).
               where(Observation[:location_id].eq(locations(:burbank).id)).
               distinct
-    scope = Name.index_order.search_where("burbank")
+    scope = Name.order_by_default.search_where("burbank")
     assert_query_scope(expects, scope, :Name, search_where: "burbank")
   end
 
   def test_name_advanced_search_user
-    expects = Name.index_order.joins(:observations).
+    expects = Name.order_by_default.joins(:observations).
               where(Observation[:user_id].eq(rolf.id)).distinct
-    scope = Name.index_order.search_user("rolf")
+    scope = Name.order_by_default.search_user("rolf")
     assert_query_scope(expects, scope, :Name, search_user: "rolf")
   end
 
@@ -397,12 +397,12 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_has_default_description
-    scope = Name.index_order.has_default_description
+    scope = Name.order_by_default.has_default_description
     assert_query(scope, :Name, has_default_description: 1)
   end
 
   def test_name_has_descriptions
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               has_descriptions.distinct
     assert_query(expects, :Name, has_descriptions: 1)
   end
@@ -417,7 +417,7 @@ class Query::NamesTest < UnitTestCase
 
   def name_has_descriptions_by_user(user)
     Name.with_correct_spelling.joins(:descriptions).
-      where(name_descriptions: { user: user }).index_order.distinct
+      where(name_descriptions: { user: user }).order_by_default.distinct
   end
 
   def test_name_has_descriptions_by_author
@@ -434,7 +434,7 @@ class Query::NamesTest < UnitTestCase
   def name_has_descriptions_by_author(user)
     Name.with_correct_spelling.
       joins(descriptions: :name_description_authors).
-      where(name_description_authors: { user: user }).index_order.distinct
+      where(name_description_authors: { user: user }).order_by_default.distinct
   end
 
   def test_name_has_descriptions_by_editor
@@ -452,7 +452,7 @@ class Query::NamesTest < UnitTestCase
   def name_has_descriptions_by_editor(user)
     Name.with_correct_spelling.
       joins(descriptions: :name_description_editors).
-      where(name_description_editors: { user: user }).index_order.distinct
+      where(name_description_editors: { user: user }).order_by_default.distinct
   end
 
   def test_name_has_descriptions_in_set
@@ -480,21 +480,21 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_with_observations_created_at
     created_at = observations(:california_obs).created_at
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(Observation[:created_at] >= created_at).distinct
     assert_query(expects, :Name, observation_query: { created_at: created_at })
   end
 
   def test_name_with_observations_updated_at
     updated_at = observations(:california_obs).updated_at
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(Observation[:updated_at] >= updated_at).distinct
     assert_query(expects, :Name, observation_query: { updated_at: updated_at })
   end
 
   def test_name_with_observations_date
     date = observations(:california_obs).when
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(Observation[:when] >= date).distinct
     assert_query(expects, :Name, observation_query: { date: date })
   end
@@ -502,7 +502,7 @@ class Query::NamesTest < UnitTestCase
   ##### list/string parameters #####
 
   def test_name_with_observations_has_notes_fields
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(Observation[:notes].matches("%:substrate:%")).distinct
     assert_query(
       expects, :Name, observation_query: { has_notes_fields: "substrate" }
@@ -511,7 +511,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_with_observations_herbaria
     name = "The New York Botanical Garden"
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               joins(observations: { herbarium_records: :herbarium }).
               where(herbaria: { name: name }).distinct
     assert_query(expects, :Name, observation_query: { herbaria: name })
@@ -519,7 +519,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_with_observations_projects
     project = projects(:bolete_project)
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               joins({ observations: :project_observations }).
               where(project_observations: { project: project }).distinct
     # project.observations.map(&:name).uniq
@@ -529,7 +529,7 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_with_observations_users
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(observations: { user: dick }).distinct
     assert_query(expects, :Name, observation_query: { by_users: dick })
   end
@@ -537,7 +537,7 @@ class Query::NamesTest < UnitTestCase
   ##### numeric parameters #####
 
   def test_name_with_observations_confidence
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(observations: { vote_cache: 1..3 }).distinct
     assert_not_empty(expects, "'expect` is broken; it should not be empty")
     assert_query(expects, :Name, observation_query: { confidence: [1, 3] })
@@ -548,7 +548,7 @@ class Query::NamesTest < UnitTestCase
     obs = observations(:unknown_with_lat_lng)
     lat = obs.lat
     lng = obs.lng
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(observations: { lat: lat, lng: lng }).distinct
     box = { north: lat.to_f, south: lat.to_f,
             west: lat.to_f, east: lat.to_f }
@@ -558,13 +558,13 @@ class Query::NamesTest < UnitTestCase
   ##### boolean parameters #####
 
   def test_name_with_observations_has_comments
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               joins(observations: :comments).distinct
     assert_query(expects, :Name, observation_query: { has_comments: true })
   end
 
   def test_name_with_observations_has_public_lat_lng
-    expects = Name.index_order.joins(:observations).
+    expects = Name.order_by_default.joins(:observations).
               where.not(observations: { lat: false }).distinct
     assert_query(
       expects, :Name, observation_query: { has_public_lat_lng: true }
@@ -572,25 +572,25 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_with_observations_with_name
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(observations: { name_id: Name.unknown }).distinct
     assert_query(expects, :Name, observation_query: { has_name: false })
   end
 
   def test_name_with_observations_has_notes
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where.not(observations: { notes: Observation.no_notes }).distinct
     assert_query(expects, :Name, observation_query: { has_notes: true })
   end
 
   def test_name_with_observations_has_sequences
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               joins(observations: :sequences).distinct
     assert_query(expects, :Name, observation_query: { has_sequences: true })
   end
 
   def test_name_with_observations_is_collection_location
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(observations: { is_collection_location: true }).distinct
     assert_query(
       expects, :Name, observation_query: { is_collection_location: true }
@@ -599,7 +599,7 @@ class Query::NamesTest < UnitTestCase
 
   def test_name_with_observations_at_location
     loc = locations(:burbank)
-    expects = Name.index_order.with_correct_spelling.joins(:observations).
+    expects = Name.order_by_default.with_correct_spelling.joins(:observations).
               where(observations: { location: loc }).distinct
     assert_query(expects, :Name, observation_query: { locations: loc })
   end
@@ -618,7 +618,7 @@ class Query::NamesTest < UnitTestCase
   end
 
   def name_with_observations_by_user(user)
-    Name.index_order.with_correct_spelling.joins(:observations).
+    Name.order_by_default.with_correct_spelling.joins(:observations).
       where(observations: { user: user }).distinct
   end
 
@@ -627,7 +627,7 @@ class Query::NamesTest < UnitTestCase
     assert_query([], :Name, observation_query: { projects: project })
 
     project2 = projects(:two_img_obs_project)
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               joins({ observations: :project_observations }).
               where(project_observations: { project: project2 }).distinct
     assert_query(expects, :Name, observation_query: { projects: project2 })
@@ -644,13 +644,13 @@ class Query::NamesTest < UnitTestCase
   def test_name_with_observations_in_set
     expects = Name.with_correct_spelling.joins(:observations).
               where(observations: { id: three_amigos }).
-              index_order.distinct
+              order_by_default.distinct
     assert_query(expects, :Name, observation_query: { id_in_set: three_amigos })
   end
 
   def test_name_with_observations_in_species_list
     spl = species_lists(:unknown_species_list)
-    expects = Name.index_order.with_correct_spelling.
+    expects = Name.order_by_default.with_correct_spelling.
               joins({ observations: :species_list_observations }).
               where(species_list_observations: { species_list: spl }).uniq
     assert_query(expects, :Name, observation_query: { species_lists: spl })

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -149,8 +149,8 @@ class Query::NamesTest < UnitTestCase
     name = names(:agaricus)
     assert_query(
       Name.order_by_default.names(lookup: name.id,
-                             include_subtaxa: true,
-                             exclude_original_names: true),
+                                  include_subtaxa: true,
+                                  exclude_original_names: true),
       :Name, names: { lookup: [name.id],
                       include_subtaxa: true,
                       exclude_original_names: true }
@@ -163,8 +163,8 @@ class Query::NamesTest < UnitTestCase
     assert_query_scope(
       [],
       Name.order_by_default.names(lookup: name.id,
-                             include_subtaxa: true,
-                             exclude_original_names: true),
+                                  include_subtaxa: true,
+                                  exclude_original_names: true),
       :Name, names: { lookup: name.id,
                       include_subtaxa: true,
                       exclude_original_names: true }
@@ -174,8 +174,8 @@ class Query::NamesTest < UnitTestCase
   def test_name_names_include_subtaxa_include_original
     assert_query(
       Name.order_by_default.names(lookup: names(:agaricus),
-                             include_subtaxa: true,
-                             exclude_original_names: false),
+                                  include_subtaxa: true,
+                                  exclude_original_names: false),
       :Name, names: { lookup: [names(:agaricus).id],
                       include_subtaxa: true,
                       exclude_original_names: false }
@@ -185,8 +185,8 @@ class Query::NamesTest < UnitTestCase
   def test_name_names_include_immediate_subtaxa
     assert_query(
       Name.order_by_default.names(lookup: names(:agaricus),
-                             include_immediate_subtaxa: true,
-                             exclude_original_names: false),
+                                  include_immediate_subtaxa: true,
+                                  exclude_original_names: false),
       :Name, names: { lookup: [names(:agaricus).id],
                       include_immediate_subtaxa: true,
                       exclude_original_names: false }
@@ -239,7 +239,8 @@ class Query::NamesTest < UnitTestCase
 
   # NOTE: Something is wrong in the fixtures between Genus and Family
   def test_name_rank_range
-    expects = Name.with_correct_spelling.rank("Genus", "Kingdom").order_by_default
+    expects = Name.with_correct_spelling.rank("Genus", "Kingdom").
+              order_by_default
     assert_query(expects, :Name, rank: %w[Genus Kingdom])
 
     expects = Name.with_correct_spelling.rank("Family").order_by_default
@@ -280,7 +281,8 @@ class Query::NamesTest < UnitTestCase
   def test_name_has_classification
     expects = Name.with_correct_spelling.has_classification.order_by_default
     assert_query(expects, :Name, has_classification: true)
-    expects = Name.with_correct_spelling.has_classification(false).order_by_default
+    expects = Name.with_correct_spelling.has_classification(false).
+              order_by_default
     assert_query(expects, :Name, has_classification: false)
   end
 

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -8,7 +8,7 @@ class Query::ObservationsTest < UnitTestCase
   include QueryExtensions
 
   def test_observation_all
-    expects = Observation.index_order
+    expects = Observation.order_by_default
     assert_query(expects, :Observation)
   end
 
@@ -51,84 +51,84 @@ class Query::ObservationsTest < UnitTestCase
   end
 
   def test_observation_confidence
-    assert_query(Observation.index_order.confidence(50, 70),
+    assert_query(Observation.order_by_default.confidence(50, 70),
                  :Observation, confidence: [50, 70])
-    assert_query(Observation.index_order.confidence(100),
+    assert_query(Observation.order_by_default.confidence(100),
                  :Observation, confidence: [100])
   end
 
   def test_observation_has_public_lat_lng
-    assert_query(Observation.index_order.has_public_lat_lng(true),
+    assert_query(Observation.order_by_default.has_public_lat_lng(true),
                  :Observation, has_public_lat_lng: true)
-    assert_query(Observation.index_order.has_public_lat_lng(false),
+    assert_query(Observation.order_by_default.has_public_lat_lng(false),
                  :Observation, has_public_lat_lng: false)
   end
 
   def test_observation_is_collection_location
-    assert_query(Observation.index_order.is_collection_location(true),
+    assert_query(Observation.order_by_default.is_collection_location(true),
                  :Observation, is_collection_location: true)
-    assert_query(Observation.index_order.is_collection_location(false),
+    assert_query(Observation.order_by_default.is_collection_location(false),
                  :Observation, is_collection_location: false)
   end
 
   def test_observation_has_notes
-    assert_query(Observation.index_order.has_notes(true),
+    assert_query(Observation.order_by_default.has_notes(true),
                  :Observation, has_notes: true)
-    assert_query(Observation.index_order.has_notes(false),
+    assert_query(Observation.order_by_default.has_notes(false),
                  :Observation, has_notes: false)
   end
 
   def test_observation_notes_has
-    assert_query(Observation.index_order.notes_has("strange place"),
+    assert_query(Observation.order_by_default.notes_has("strange place"),
                  :Observation, notes_has: "strange place")
-    assert_query(Observation.index_order.notes_has("From"),
+    assert_query(Observation.order_by_default.notes_has("From"),
                  :Observation, notes_has: "From")
-    assert_query(Observation.index_order.notes_has("Growing"),
+    assert_query(Observation.order_by_default.notes_has("Growing"),
                  :Observation, notes_has: "Growing")
   end
 
   def test_observation_has_notes_fields
     # the single version
-    assert_query(Observation.index_order.has_notes_field("substrate"),
+    assert_query(Observation.order_by_default.has_notes_field("substrate"),
                  :Observation, has_notes_fields: "substrate")
-    assert_query(Observation.index_order.
+    assert_query(Observation.order_by_default.
                  has_notes_fields(%w[substrate cap]),
                  :Observation, has_notes_fields: %w[substrate cap])
   end
 
   def test_observation_has_comments
-    assert_query(Observation.index_order.has_comments(true),
+    assert_query(Observation.order_by_default.has_comments(true),
                  :Observation, has_comments: true)
-    assert_query(Observation.index_order,
+    assert_query(Observation.order_by_default,
                  :Observation, has_comments: false)
   end
 
   def test_observation_comments_has
-    assert_query(Observation.index_order.comments_has("comment"),
+    assert_query(Observation.order_by_default.comments_has("comment"),
                  :Observation, comments_has: "comment")
-    assert_query(Observation.index_order.
+    assert_query(Observation.order_by_default.
                  comments_has("Agaricus campestris"),
                  :Observation, comments_has: "Agaricus campestris")
   end
 
   def test_observation_has_sequences
-    assert_query(Observation.index_order.has_sequences(true),
+    assert_query(Observation.order_by_default.has_sequences(true),
                  :Observation, has_sequences: true)
-    assert_query(Observation.index_order,
+    assert_query(Observation.order_by_default,
                  :Observation, has_sequences: false)
   end
 
   def test_observation_has_images
-    assert_query(Observation.index_order.has_images(true),
+    assert_query(Observation.order_by_default.has_images(true),
                  :Observation, has_images: true)
-    assert_query(Observation.index_order.has_images(false),
+    assert_query(Observation.order_by_default.has_images(false),
                  :Observation, has_images: false)
   end
 
   def test_observation_has_specimen
-    assert_query(Observation.index_order.has_specimen(true),
+    assert_query(Observation.order_by_default.has_specimen(true),
                  :Observation, has_specimen: true)
-    assert_query(Observation.index_order.has_specimen(false),
+    assert_query(Observation.order_by_default.has_specimen(false),
                  :Observation, has_specimen: false)
   end
 
@@ -140,9 +140,9 @@ class Query::ObservationsTest < UnitTestCase
     assert_query([observations(:falmouth_2022_obs),
                   observations(:minimal_unknown_obs)],
                  :Observation, field_slips: [f_s.id, fs2.id])
-    assert_query(Observation.index_order.field_slips([f_s.code, fs2.code]),
+    assert_query(Observation.order_by_default.field_slips([f_s.code, fs2.code]),
                  :Observation, field_slips: [f_s.code, fs2.code])
-    assert_query(Observation.index_order.field_slips([f_s.id, fs2.id]),
+    assert_query(Observation.order_by_default.field_slips([f_s.id, fs2.id]),
                  :Observation, field_slips: [f_s.id, fs2.id])
   end
 
@@ -151,7 +151,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query([observations(:detailed_unknown_obs),
                   observations(:minimal_unknown_obs)],
                  :Observation, herbarium_records: h_r.id)
-    assert_query(Observation.index_order.herbarium_records(h_r),
+    assert_query(Observation.order_by_default.herbarium_records(h_r),
                  :Observation, herbarium_records: h_r.id)
   end
 
@@ -159,21 +159,21 @@ class Query::ObservationsTest < UnitTestCase
     herb = herbaria(:fundis_herbarium)
     assert_query([observations(:detailed_unknown_obs)],
                  :Observation, herbaria: herb.name)
-    assert_query(Observation.index_order.herbaria(herb.name),
+    assert_query(Observation.order_by_default.herbaria(herb.name),
                  :Observation, herbaria: herb.name)
     herb = herbaria(:nybg_herbarium)
-    assert_query(Observation.index_order.herbaria(herb.name),
+    assert_query(Observation.order_by_default.herbaria(herb.name),
                  :Observation, herbaria: herb.id)
   end
 
   def test_observation_on_project_lists
     projects = [projects(:bolete_project), projects(:eol_project)]
-    expects = Observation.index_order.project_lists(projects)
+    expects = Observation.order_by_default.project_lists(projects)
     assert_query(expects, :Observation, project_lists: projects.map(&:title))
   end
 
   def test_observation_locations
-    expects = Observation.index_order.locations(locations(:burbank)).distinct
+    expects = Observation.order_by_default.locations(locations(:burbank)).distinct
     assert_query(expects, :Observation, locations: locations(:burbank))
   end
 
@@ -182,7 +182,7 @@ class Query::ObservationsTest < UnitTestCase
                  :Observation, projects: projects(:empty_project))
     project = projects(:bolete_project)
     assert_query(project.observations, :Observation, projects: project)
-    assert_query(Observation.index_order.projects(project.title),
+    assert_query(Observation.order_by_default.projects(project.title),
                  :Observation, projects: project)
   end
 
@@ -200,30 +200,30 @@ class Query::ObservationsTest < UnitTestCase
     assert_query([observations(:detailed_unknown_obs).id,
                   observations(:minimal_unknown_obs).id],
                  :Observation, species_lists: spl.id)
-    assert_query(Observation.index_order.species_lists(spl),
+    assert_query(Observation.order_by_default.species_lists(spl),
                  :Observation, species_lists: spl.id)
     # check the other param!
-    assert_query(Observation.index_order.species_lists(spl),
+    assert_query(Observation.order_by_default.species_lists(spl),
                  :Observation, species_lists: spl.id)
     spl2 = species_lists(:one_genus_three_species_list)
-    assert_query(Observation.index_order.species_lists([spl, spl2]).distinct,
+    assert_query(Observation.order_by_default.species_lists([spl, spl2]).distinct,
                  :Observation, species_lists: [spl.title, spl2.title])
   end
 
   def test_observation_clade
-    assert_query(Observation.index_order.clade("Agaricales"),
+    assert_query(Observation.order_by_default.clade("Agaricales"),
                  :Observation, clade: "Agaricales")
-    assert_query(Observation.index_order.clade("Tremellales"),
+    assert_query(Observation.order_by_default.clade("Tremellales"),
                  :Observation, clade: "Tremellales")
   end
 
   def test_observation_region
-    assert_query(Observation.index_order.
+    assert_query(Observation.order_by_default.
                  region("Sonoma Co., California, USA"),
                  :Observation, region: "Sonoma Co., California, USA")
-    assert_query(Observation.index_order.region("Massachusetts, USA"),
+    assert_query(Observation.order_by_default.region("Massachusetts, USA"),
                  :Observation, region: "Massachusetts, USA")
-    assert_query(Observation.index_order.region("North America"),
+    assert_query(Observation.order_by_default.region("North America"),
                  :Observation, region: "North America")
   end
 
@@ -231,13 +231,13 @@ class Query::ObservationsTest < UnitTestCase
     # Have to do this, otherwise columns not populated
     Location.update_box_area_and_center_columns
     box = { north: 35, south: 34, east: -118, west: -119 }
-    assert_query(Observation.index_order.in_box(**box),
+    assert_query(Observation.order_by_default.in_box(**box),
                  :Observation, in_box: box)
   end
 
   def test_observation_of_children
     name = names(:agaricus)
-    expects = Observation.index_order.
+    expects = Observation.order_by_default.
               names(lookup: name, include_subtaxa: true).distinct
     assert_query(expects, :Observation, names: { lookup: [name.id],
                                                  include_subtaxa: true })
@@ -248,7 +248,7 @@ class Query::ObservationsTest < UnitTestCase
     name = names(:tubaria_furfuracea)
     assert_query_scope(
       [],
-      Observation.index_order.names(lookup: name.id,
+      Observation.order_by_default.names(lookup: name.id,
                                     include_subtaxa: true,
                                     exclude_original_names: true),
       :Observation, names: { lookup: name.id,
@@ -259,7 +259,7 @@ class Query::ObservationsTest < UnitTestCase
 
   def test_observation_names_with_modifiers
     User.current = rolf
-    expects = Observation.index_order.names(lookup: names(:fungi)).distinct
+    expects = Observation.order_by_default.names(lookup: names(:fungi)).distinct
     assert_query(expects, :Observation, names: { lookup: [names(:fungi).id] })
     assert_query(
       [],
@@ -268,7 +268,7 @@ class Query::ObservationsTest < UnitTestCase
 
     # test all truthy/falsy combinations of these boolean parameters:
     #  include_synonyms, include_all_name_proposals, exclude_consensus
-    names = Name.index_order.
+    names = Name.order_by_default.
             where(Name[:text_name].matches("Agaricus camp%")).to_a
     agaricus_ssp = names.clone
     name = names.pop
@@ -412,7 +412,7 @@ class Query::ObservationsTest < UnitTestCase
   end
 
   def observation_pattern_search(pattern)
-    Observation.index_order.pattern(pattern).distinct
+    Observation.order_by_default.pattern(pattern).distinct
   end
 
   def test_observation_advanced_search_name
@@ -454,44 +454,44 @@ class Query::ObservationsTest < UnitTestCase
 
   def test_observation_date
     # blank should return all
-    assert_query(Observation.index_order, :Observation, date: nil)
+    assert_query(Observation.order_by_default, :Observation, date: nil)
     # impossible dates should return none
     assert_query([], :Observation, date: %w[1550 1551])
     # single date should return after
-    assert_query(Observation.index_order.date("2011-05-12"),
+    assert_query(Observation.order_by_default.date("2011-05-12"),
                  :Observation, date: "2011-05-12")
     # single date within array should also return after
-    assert_query(Observation.index_order.date(["2011-05-12"]),
+    assert_query(Observation.order_by_default.date(["2011-05-12"]),
                  :Observation, date: "2011-05-12")
     # year should return after
-    assert_query(Observation.index_order.date("2005"),
+    assert_query(Observation.order_by_default.date("2005"),
                  :Observation, date: "2005")
     # years should return between
-    assert_query(Observation.index_order.date("2005", "2009"),
+    assert_query(Observation.order_by_default.date("2005", "2009"),
                  :Observation, date: %w[2005 2009])
     # test scope accepts array values
-    assert_query(Observation.index_order.date(%w[2005 2009]),
+    assert_query(Observation.order_by_default.date(%w[2005 2009]),
                  :Observation, date: %w[2005 2009])
     # in a month range, any year
-    assert_query(Observation.index_order.date("05", "12"),
+    assert_query(Observation.order_by_default.date("05", "12"),
                  :Observation, date: %w[05 12])
     # in a month range, any year, within array
-    assert_query(Observation.index_order.date(%w[05 12]),
+    assert_query(Observation.order_by_default.date(%w[05 12]),
                  :Observation, date: %w[05 12])
     # in a date range, any year
-    assert_query(Observation.index_order.date("02-22", "08-22"),
+    assert_query(Observation.order_by_default.date("02-22", "08-22"),
                  :Observation, date: %w[02-22 08-22])
     # period wraps around the new year
-    assert_query(Observation.index_order.date("08-22", "02-22"),
+    assert_query(Observation.order_by_default.date("08-22", "02-22"),
                  :Observation, date: %w[08-22 02-22])
     # full dates
-    assert_query(Observation.index_order.date("2009-08-22", "2009-10-20"),
+    assert_query(Observation.order_by_default.date("2009-08-22", "2009-10-20"),
                  :Observation, date: %w[2009-08-22 2009-10-20])
     # date wraps around the new year
-    assert_query(Observation.index_order.date("2015-08-22", "2016-02-22"),
+    assert_query(Observation.order_by_default.date("2015-08-22", "2016-02-22"),
                  :Observation, date: %w[2015-08-22 2016-02-22])
     # as array
-    assert_query(Observation.index_order.date(%w[2015-08-22 2016-02-22]),
+    assert_query(Observation.order_by_default.date(%w[2015-08-22 2016-02-22]),
                  :Observation, date: %w[2015-08-22 2016-02-22])
   end
 
@@ -505,40 +505,40 @@ class Query::ObservationsTest < UnitTestCase
 
   def do_datetime_test(col)
     # blank should return all
-    assert_query(Observation.index_order, :Observation, "#{col}": nil)
+    assert_query(Observation.order_by_default, :Observation, "#{col}": nil)
     # impossible dates should return none
     assert_query([], :Observation, "#{col}": %w[2000 2001])
     # single datetime should return after
-    assert_query(Observation.index_order.send(col, "2011-05-12-12-59-57"),
+    assert_query(Observation.order_by_default.send(col, "2011-05-12-12-59-57"),
                  :Observation, "#{col}": "2011-05-12-12-59-57")
     # single date should return after
-    assert_query(Observation.index_order.send(col, "2011-05-12"),
+    assert_query(Observation.order_by_default.send(col, "2011-05-12"),
                  :Observation, "#{col}": "2011-05-12")
     # year should return after 01/01
-    assert_query(Observation.index_order.send(col, "2005-01-01"),
+    assert_query(Observation.order_by_default.send(col, "2005-01-01"),
                  :Observation, "#{col}": "2005")
     # month should return after 01
-    assert_query(Observation.index_order.send(col, "2007-05-01"),
+    assert_query(Observation.order_by_default.send(col, "2007-05-01"),
                  :Observation, "#{col}": "2007-05")
     # years should return between
-    assert_query(Observation.index_order.send(col, "2005", "2009"),
+    assert_query(Observation.order_by_default.send(col, "2005", "2009"),
                  :Observation, "#{col}": %w[2005 2009])
     # test scope accepts array values
-    assert_query(Observation.index_order.send(col, %w[2005 2009]),
+    assert_query(Observation.order_by_default.send(col, %w[2005 2009]),
                  :Observation, "#{col}": %w[2005 2009])
     # test that reversed value order works in scope
-    assert_query(Observation.index_order.send(col, %w[2009 2005]),
+    assert_query(Observation.order_by_default.send(col, %w[2009 2005]),
                  :Observation, "#{col}": %w[2005 2009])
     # full dates
-    assert_query(Observation.index_order.send(col, "2009-08-22", "2009-10-20"),
+    assert_query(Observation.order_by_default.send(col, "2009-08-22", "2009-10-20"),
                  :Observation, "#{col}": %w[2009-08-22 2009-10-20])
     # full datetimes
-    assert_query(Observation.index_order.
+    assert_query(Observation.order_by_default.
                  send(col, "2009-08-22-03-04-22", "2009-10-20-03-04-22"),
                  :Observation,
                  "#{col}": %w[2009-08-22-03-04-22 2009-10-20-03-04-22])
     # as array
-    assert_query(Observation.index_order.
+    assert_query(Observation.order_by_default.
                  send(col, %w[2009-08-22-03-04-22 2009-10-20-03-04-22]),
                  :Observation,
                  "#{col}": %w[2009-08-22-03-04-22 2009-10-20-03-04-22])

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -173,7 +173,7 @@ class Query::ObservationsTest < UnitTestCase
   end
 
   def test_observation_locations
-    expects = Observation.order_by_default.locations(locations(:burbank)).distinct
+    expects = Observation.order_by_default.locations(locations(:burbank))
     assert_query(expects, :Observation, locations: locations(:burbank))
   end
 
@@ -206,7 +206,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query(Observation.order_by_default.species_lists(spl),
                  :Observation, species_lists: spl.id)
     spl2 = species_lists(:one_genus_three_species_list)
-    assert_query(Observation.order_by_default.species_lists([spl, spl2]).distinct,
+    assert_query(Observation.order_by_default.species_lists([spl, spl2]),
                  :Observation, species_lists: [spl.title, spl2.title])
   end
 
@@ -249,8 +249,8 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [],
       Observation.order_by_default.names(lookup: name.id,
-                                    include_subtaxa: true,
-                                    exclude_original_names: true),
+                                         include_subtaxa: true,
+                                         exclude_original_names: true),
       :Observation, names: { lookup: name.id,
                              include_subtaxa: true,
                              exclude_original_names: true }
@@ -530,7 +530,8 @@ class Query::ObservationsTest < UnitTestCase
     assert_query(Observation.order_by_default.send(col, %w[2009 2005]),
                  :Observation, "#{col}": %w[2005 2009])
     # full dates
-    assert_query(Observation.order_by_default.send(col, "2009-08-22", "2009-10-20"),
+    assert_query(Observation.order_by_default.
+                 send(col, "2009-08-22", "2009-10-20"),
                  :Observation, "#{col}": %w[2009-08-22 2009-10-20])
     # full datetimes
     assert_query(Observation.order_by_default.

--- a/test/classes/query/projects_test.rb
+++ b/test/classes/query/projects_test.rb
@@ -8,7 +8,7 @@ class Query::ProjectsTest < UnitTestCase
   include QueryExtensions
 
   def test_project_all
-    expects = Project.index_order
+    expects = Project.order_by_default
     assert_query(expects, :Project)
   end
 
@@ -24,11 +24,11 @@ class Query::ProjectsTest < UnitTestCase
   end
 
   def test_project_members
-    assert_query(Project.index_order.members(rolf),
+    assert_query(Project.order_by_default.members(rolf),
                  :Project, members: [rolf])
-    assert_query(Project.index_order.members(mary),
+    assert_query(Project.order_by_default.members(mary),
                  :Project, members: [mary])
-    assert_query(Project.index_order.members(dick),
+    assert_query(Project.order_by_default.members(dick),
                  :Project, members: [dick])
   end
 
@@ -43,9 +43,9 @@ class Query::ProjectsTest < UnitTestCase
                projects(:two_list_project), projects(:lone_wolf_project),
                projects(:open_membership_project), projects(:bolete_project),
                projects(:eol_project)]
-    scope = Project.has_summary.index_order
+    scope = Project.has_summary.order_by_default
     assert_query_scope(expects, scope, :Project, has_summary: "yes")
-    scope = Project.has_summary(false).index_order
+    scope = Project.has_summary(false).order_by_default
     assert_query(scope, :Project, has_summary: "no")
   end
 
@@ -57,7 +57,7 @@ class Query::ProjectsTest < UnitTestCase
 
   def test_project_field_slip_prefix_has
     expects = [projects(:eol_project)]
-    scope = Project.field_slip_prefix_has("EOL").index_order
+    scope = Project.field_slip_prefix_has("EOL").order_by_default
     assert_query_scope(expects, scope, :Project, field_slip_prefix_has: "EOL")
   end
 
@@ -77,23 +77,23 @@ class Query::ProjectsTest < UnitTestCase
     scope = project_pattern_search("CURR")
     assert_query_scope(expects, scope, :Project, pattern: "CURR")
 
-    expects = Project.index_order
+    expects = Project.order_by_default
     assert_query(expects, :Project, pattern: "")
   end
 
   def project_pattern_search(pattern)
-    Project.pattern(pattern).index_order.distinct
+    Project.pattern(pattern).order_by_default.distinct
   end
 
   # These next four only handle a `true` condition
   def test_project_has_images
     expects = [projects(:lone_wolf_project), projects(:bolete_project)]
-    scope = Project.has_images.index_order
+    scope = Project.has_images.order_by_default
     assert_query_scope(expects, scope, :Project, has_images: true)
   end
 
   def test_project_has_observations
-    scope = Project.has_observations.index_order
+    scope = Project.has_observations.order_by_default
     assert_query(scope, :Project, has_observations: true)
   end
 
@@ -101,13 +101,13 @@ class Query::ProjectsTest < UnitTestCase
     expects = [projects(:two_list_project), projects(:lone_wolf_project),
                projects(:open_membership_project), projects(:bolete_project),
                projects(:eol_project)]
-    scope = Project.has_species_lists.index_order
+    scope = Project.has_species_lists.order_by_default
     assert_query_scope(expects, scope, :Project, has_species_lists: "yes")
   end
 
   def test_project_has_comments
     expects = []
-    scope = Project.has_comments.index_order
+    scope = Project.has_comments.order_by_default
     assert_query_scope(expects, scope, :Project, has_comments: "yes")
   end
 end

--- a/test/classes/query/rss_logs_test.rb
+++ b/test/classes/query/rss_logs_test.rb
@@ -8,7 +8,7 @@ class Query::RssLogsTest < UnitTestCase
   include QueryExtensions
 
   def test_rss_log_all
-    ids = RssLog.index_order
+    ids = RssLog.order_by_default
     assert_query(ids, :RssLog)
   end
 
@@ -25,7 +25,7 @@ class Query::RssLogsTest < UnitTestCase
     assert_query_scope(ids, scope, :RssLog, type: :species_list)
     ids = [rss_logs(:project_rss_log),
            rss_logs(:species_list_rss_log)]
-    scope = RssLog.type("species_list project").index_order
+    scope = RssLog.type("species_list project").order_by_default
     assert_query_scope(ids, scope, :RssLog, type: "species_list project")
   end
 end

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -8,20 +8,20 @@ class Query::SequencesTest < UnitTestCase
   include QueryExtensions
 
   def test_sequence_all
-    expects = Sequence.index_order
+    expects = Sequence.order_by_default
     assert_query(expects, :Sequence)
   end
 
   def test_sequence_id_in_set
     ids = [sequences(:fasta_formatted_sequence).id,
            sequences(:bare_formatted_sequence).id]
-    scope = Sequence.id_in_set(ids).index_order
+    scope = Sequence.id_in_set(ids).order_by_default
     assert_query_scope(ids, scope, :Sequence, id_in_set: ids)
   end
 
   def test_sequence_locus
     ids = [sequences(:fasta_formatted_sequence)]
-    scope = Sequence.locus("ITS1F").index_order
+    scope = Sequence.locus("ITS1F").order_by_default
     assert_query_scope(ids, scope, :Sequence, locus: "ITS1F")
   end
 
@@ -35,38 +35,38 @@ class Query::SequencesTest < UnitTestCase
 
   def test_sequence_locus_has
     ids = sequences_with_its_locus.map(&:id)
-    scope = Sequence.locus_has("ITS").index_order
+    scope = Sequence.locus_has("ITS").order_by_default
     assert_query_scope(ids, scope, :Sequence, locus_has: "ITS")
   end
 
   def test_sequence_archive
     ids = [sequences(:alternate_archive)]
-    scope = Sequence.archive("UNITE").index_order
+    scope = Sequence.archive("UNITE").order_by_default
     assert_query_scope(ids, scope, :Sequence, archive: "UNITE")
   end
 
   def test_sequence_accession
     ids = [sequences(:deposited_sequence)]
-    scope = Sequence.accession("KT968605").index_order
+    scope = Sequence.accession("KT968605").order_by_default
     assert_query_scope(ids, scope, :Sequence, accession: "KT968605")
   end
 
   def test_sequence_accession_has
     ids = [sequences(:deposited_sequence)]
-    scope = Sequence.accession_has("968605").index_order
+    scope = Sequence.accession_has("968605").order_by_default
     assert_query_scope(ids, scope, :Sequence, accession_has: "968605")
   end
 
   def test_sequence_notes_has
     ids = [sequences(:deposited_sequence)]
-    scope = Sequence.notes_has("deposited_sequence").index_order
+    scope = Sequence.notes_has("deposited_sequence").order_by_default
     assert_query_scope(ids, scope, :Sequence, notes_has: "deposited_sequence")
   end
 
   def test_sequence_for_observations
     obs = observations(:locally_sequenced_obs)
     ids = [sequences(:local_sequence)]
-    scope = Sequence.observations(obs).index_order
+    scope = Sequence.observations(obs).order_by_default
     assert_query_scope(ids, scope, :Sequence, observations: [obs.id])
   end
 
@@ -74,7 +74,7 @@ class Query::SequencesTest < UnitTestCase
     assert_query([], :Sequence, pattern: "nonexistent")
 
     ids = sequences_with_its_locus.map(&:id)
-    scope = Sequence.pattern("ITS").index_order
+    scope = Sequence.pattern("ITS").order_by_default
     assert_query_scope(ids, scope, :Sequence, pattern: "ITS")
 
     assert_query([sequences(:alternate_archive)],
@@ -104,9 +104,9 @@ class Query::SequencesTest < UnitTestCase
         names: { lookup: "Petigera", include_synonyms: true }
       }
     )
-    expects = Sequence.index_order.joins(:observation).
+    expects = Sequence.order_by_default.joins(:observation).
               where(observations: { location: locations(:burbank) }).
-              or(Sequence.index_order.joins(:observation).
+              or(Sequence.order_by_default.joins(:observation).
                  where(Observation[:where].matches("Burbank"))).distinct
     assert_query(expects,
                  :Sequence, observation_query: { locations: "Burbank" })

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -8,7 +8,7 @@ class Query::SpeciesListsTest < UnitTestCase
   include QueryExtensions
 
   def test_species_list_all
-    ids = SpeciesList.index_order
+    ids = SpeciesList.order_by_default
     assert_query(ids, :SpeciesList)
   end
 
@@ -32,7 +32,7 @@ class Query::SpeciesListsTest < UnitTestCase
   end
 
   def test_species_list_by_users
-    ids = SpeciesList.by_users(mary).index_order
+    ids = SpeciesList.by_users(mary).order_by_default
     assert_query(ids, :SpeciesList, by_users: mary)
     assert_query([], :SpeciesList, by_users: dick)
   end
@@ -43,7 +43,7 @@ class Query::SpeciesListsTest < UnitTestCase
   end
 
   def test_species_list_locations
-    scope = SpeciesList.locations(locations(:burbank)).index_order
+    scope = SpeciesList.locations(locations(:burbank)).order_by_default
     assert_query(scope, :SpeciesList, locations: locations(:burbank))
     assert_query(
       [], :SpeciesList, locations: locations(:unused_location)
@@ -54,11 +54,11 @@ class Query::SpeciesListsTest < UnitTestCase
     assert_query([],
                  :SpeciesList, projects: projects(:empty_project))
     ids = projects(:bolete_project).species_lists
-    scope = SpeciesList.projects(projects(:bolete_project)).index_order
+    scope = SpeciesList.projects(projects(:bolete_project)).order_by_default
     assert_query_scope(ids, scope,
                        :SpeciesList, projects: projects(:bolete_project))
     ids = projects(:two_list_project).species_lists
-    scope = SpeciesList.projects(projects(:two_list_project)).index_order
+    scope = SpeciesList.projects(projects(:two_list_project)).order_by_default
     assert_query_scope(ids, scope,
                        :SpeciesList, projects: projects(:two_list_project))
   end
@@ -66,32 +66,32 @@ class Query::SpeciesListsTest < UnitTestCase
   def test_species_list_id_in_set
     ids = [species_lists(:first_species_list).id,
            species_lists(:unknown_species_list).id]
-    scope = SpeciesList.id_in_set(ids).index_order
+    scope = SpeciesList.id_in_set(ids).order_by_default
     assert_query_scope(ids, scope, :SpeciesList, id_in_set: ids)
   end
 
   def test_species_list_title_has
     ids = [species_lists(:first_species_list).id,
            species_lists(:another_species_list).id]
-    scope = SpeciesList.title_has("A Species List").index_order
+    scope = SpeciesList.title_has("A Species List").order_by_default
     assert_query_scope(ids, scope, :SpeciesList, title_has: "A Species List")
   end
 
   def test_species_list_has_notes
-    scope = SpeciesList.has_notes.index_order
+    scope = SpeciesList.has_notes.order_by_default
     assert_query(scope, :SpeciesList, has_notes: true)
   end
 
   def test_species_list_notes_has
     ids = [species_lists(:first_species_list).id,
            species_lists(:another_species_list).id]
-    scope = SpeciesList.notes_has("Skunked").index_order
+    scope = SpeciesList.notes_has("Skunked").order_by_default
     assert_query_scope(ids, scope, :SpeciesList, notes_has: "Skunked")
   end
 
   def test_species_list_search_where
     ids = [species_lists(:where_no_mushrooms_list).id]
-    scope = SpeciesList.search_where("No Mushrooms").index_order
+    scope = SpeciesList.search_where("No Mushrooms").order_by_default
     assert_query_scope(ids, scope, :SpeciesList, search_where: "No Mushrooms")
   end
 
@@ -114,11 +114,11 @@ class Query::SpeciesListsTest < UnitTestCase
     expects = species_list_pattern_search(pattern)
     assert_query(expects, :SpeciesList, pattern: pattern)
 
-    expects = SpeciesList.index_order
+    expects = SpeciesList.order_by_default
     assert_query(expects, :SpeciesList, pattern: "")
   end
 
   def species_list_pattern_search(pattern)
-    SpeciesList.pattern(pattern).index_order
+    SpeciesList.pattern(pattern).order_by_default
   end
 end

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -556,8 +556,8 @@ class AbstractModelTest < UnitTestCase
   # the scope enables this parsing of "within the year".
   def test_scope_created_in_year
     expects = Observation.where(Observation[:created_at].year.eq("2007")).
-              index_order
-    assert_equal(expects, Observation.index_order.created_at("2007", "2007"))
+              order_by_default
+    assert_equal(expects, Observation.order_by_default.created_at("2007", "2007"))
   end
 
   # Ditto for month.
@@ -565,9 +565,9 @@ class AbstractModelTest < UnitTestCase
     expects = Observation.
               where(Observation[:created_at].year.eq("2007").
                     and(Observation[:created_at].month.eq("08"))).
-              index_order
+              order_by_default
     assert_equal(expects,
-                 Observation.index_order.created_at("2007-08", "2007-08"))
+                 Observation.order_by_default.created_at("2007-08", "2007-08"))
   end
 
   def test_scope_by_editor

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -557,7 +557,8 @@ class AbstractModelTest < UnitTestCase
   def test_scope_created_in_year
     expects = Observation.where(Observation[:created_at].year.eq("2007")).
               order_by_default
-    assert_equal(expects, Observation.order_by_default.created_at("2007", "2007"))
+    assert_equal(expects,
+                 Observation.order_by_default.created_at("2007", "2007"))
   end
 
   # Ditto for month.


### PR DESCRIPTION
My goal here is to have the default order work seamlessly within a simple base `AbstractModel` scope dispatcher, where all ordering scope names begin with `:order_by_#{method_name}`. 

Admittedly `:order_by_default` is not my ideal name, I'd prefer `:default_order`, but I feel like the payoff in logical simplicity is worth it. Sticking to this naming convention makes the all ordering scopes easier to find, too. 