### PR TITLE
Make MO User (not webmaster) owner of Namings

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -190,14 +190,14 @@ class InatImportJob < ApplicationJob
     # Ensure this Name wins consensus_calc ties
     # by creating this naming and vote first
     name = @observation.name
-    user =
+    naming_user =
       if suggested?(name) &&
          (suggester = User.find_by(inat_username: suggester(suggestion(name))))
         suggester
       else
         @user
       end
-    add_naming_with_vote(name: @observation.name, user: user)
+    add_naming_with_vote(name: @observation.name, user: naming_user)
     @observation.log(:log_observation_created)
   end
 
@@ -263,7 +263,8 @@ class InatImportJob < ApplicationJob
       # Imaage attributes to potentially update manually
       # t.boolean "gps_stripped", default: false, null: false
       image.update(
-        # These throw errors if done as API params above
+        # NOTE: jdc 20250328 This throw errors if done via API params above
+        # because api key owner is webmaster, rather than the importing user
         user_id: @user.id,
         when: @observation.when,
         original_name: photo.original_name

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -195,7 +195,7 @@ class InatImportJob < ApplicationJob
          (suggester = User.find_by(inat_username: suggester(suggestion(name))))
         suggester
       else
-        @inat_manager
+        @user
       end
     add_naming_with_vote(name: @observation.name, user: user)
     @observation.log(:log_observation_created)
@@ -298,7 +298,7 @@ class InatImportJob < ApplicationJob
     Observation::NamingConsensus.new(@observation).calc_consensus
   end
 
-  def add_naming_with_vote(name:, user: @inat_manager,
+  def add_naming_with_vote(name:, user: @user,
                            value: Vote::MAXIMUM_VOTE)
     used_references = 2
     explanation = used_references_explanation(name)
@@ -362,7 +362,7 @@ class InatImportJob < ApplicationJob
 
     if naming.nil?
       add_naming_with_vote(name: @observation.name,
-                           user: @inat_manager, value: Vote::MAXIMUM_VOTE)
+                           user: @user, value: Vote::MAXIMUM_VOTE)
     else
       vote = Vote.find_by(naming: naming, observation: @observation)
       vote.update(value: Vote::MAXIMUM_VOTE)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -263,7 +263,7 @@ class InatImportJob < ApplicationJob
       # Imaage attributes to potentially update manually
       # t.boolean "gps_stripped", default: false, null: false
       image.update(
-        # NOTE: jdc 20250328 This throw errors if done via API params above
+        # NOTE: jdc 20250328 This throws errors if done via API params above
         # because api key owner is webmaster, rather than the importing user
         user_id: @user.id,
         when: @observation.when,

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -438,8 +438,9 @@ class InatImportJobTest < ActiveJob::TestCase
     standard_assertions(obs: obs, name: name)
 
     proposed_name = obs.namings.first
-    assert_equal(inat_manager, proposed_name.user,
-                 "Name should be proposed by #{inat_manager.login}")
+    proposer = obs.user
+    assert_equal(proposer, proposed_name.user,
+                 "Name should be proposed by #{proposer.login}")
     used_references = 2
     assert(
       proposed_name.reasons.key?(used_references),
@@ -884,7 +885,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
   # -------- Standard Test assertions
 
-  def standard_assertions(obs:, user: inat_manager, name: nil, loc: nil)
+  def standard_assertions(obs:, user: obs.user, name: nil, loc: nil)
     assert_not_nil(obs.rss_log, "Failed to log Observation")
     assert_equal("mo_inat_import", obs.source)
     assert_equal(loc, obs.location) if loc
@@ -925,7 +926,7 @@ class InatImportJobTest < ActiveJob::TestCase
     assert(obs_comments.where(Comment[:summary] =~ /iNat Data/).present?,
            "Missing Initial Commment (#{:inat_data_comment.l})")
     assert_equal(
-      obs.user, obs_comments.first.user,
+      user, obs_comments.first.user,
       "Comment user should be user who creates the MO Observation"
     )
     inat_data_comment = obs_comments.first.comment


### PR DESCRIPTION
In iNat Imports, makes Name Proposals  and Votes belong to either:
- an MO User other than the importing @user, If that other MO User suggested the id on iNat;
- else @user.
- NEVER webmaster.

Delivers #2847
