### PR TITLE
Minor scope and test cleanups

### DIFF
--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -13,17 +13,8 @@ module Query::Modules::Validation
       val = validate_value(param_type, param, val) if val.present?
       new_params[param] = val
     end
-    # check_for_unexpected_params(old_params)
     @params = new_params
   end
-
-  # def check_for_unexpected_params(old_params)
-  #   unexpected_params = old_params.except(*parameter_declarations.keys)
-  #   return if unexpected_params.keys.empty?
-
-  #   str = unexpected_params.keys.map(&:to_s).join("', '")
-  #   raise("Unexpected parameter(s) '#{str}' for #{model} query.")
-  # end
 
   def validate_value(param_type, param, val)
     if param_type.is_a?(Array)
@@ -231,19 +222,6 @@ module Query::Modules::Validation
       )
     end
   end
-
-  # def validate_query(param, val)
-  #   case val
-  #   when Query::Base
-  #     val.record.id
-  #   when Integer
-  #     val
-  #   else
-  #     raise(
-  #       "Value for :#{param} should be a Query class, got: #{val.inspect}"
-  #     )
-  #   end
-  # end
 
   def find_cached_parameter_instance(model, param)
     return @params_cache[param] if @params_cache && @params_cache[param]

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -278,7 +278,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # mostly a helper for in_box
     scope :in_box_over_dateline, lambda { |**args|
       include_vague_locations = args[:vague] || false
-      box = Mappable::Box.new(**args.except(:mappable))
+      box = Mappable::Box.new(**args.except(:vague))
       return none unless box.valid?
 
       if include_vague_locations
@@ -322,7 +322,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # mostly a helper for in_box
     scope :in_box_regular, lambda { |**args|
       include_vague_locations = args[:vague] || false
-      box = Mappable::Box.new(**args.except(:mappable))
+      box = Mappable::Box.new(**args.except(:vague))
       return none unless box.valid?
 
       if include_vague_locations
@@ -363,7 +363,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     # Pass kwargs (:north, :south, :east, :west), any order
     scope :not_in_box, lambda { |**args|
-      box = Mappable::Box.new(**args.except(:mappable))
+      box = Mappable::Box.new(**args.except(:vague))
       return Observation.all unless box.valid?
 
       # should be in_box(**args).invert_where
@@ -375,7 +375,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     # helper for not_in_box
     scope :not_in_box_over_dateline, lambda { |**args|
-      box = Mappable::Box.new(**args.except(:mappable))
+      box = Mappable::Box.new(**args.except(:vague))
       return Observation.all unless box.valid?
 
       where(
@@ -386,7 +386,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     # helper for not_in_box
     scope :not_in_box_regular, lambda { |**args|
-      box = Mappable::Box.new(**args.except(:mappable))
+      box = Mappable::Box.new(**args.except(:vague))
       return Observation.all unless box.valid?
 
       where(

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -141,8 +141,8 @@ class Query::SequencesTest < UnitTestCase
     Location.update_box_area_and_center_columns
 
     # order_by_default seems to return random order here
-    scope = Sequence.observation_query(
-      in_box: { north: "90", south: "0", west: "-180", east: "-100" }
+    scope = Sequence.joins(:observation).merge(
+      Observation.in_box(north: "90", south: "0", west: "-180", east: "-100")
     ).order_by(:id)
     assert_query_scope(
       [seq1, seq2, seq3], scope,

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -172,10 +172,5 @@ class Query::SequencesTest < UnitTestCase
     assert_not(query.uses_join_sub({}, :location))
     assert(query.uses_join_sub({ test: :location }, :location))
     assert(query.uses_join_sub(:location, :location))
-    # scope = Sequence.observation_query(confidence: "2").order_by(:id)
-    assert_query(
-      [seq4],
-      :Sequence, observation_query: { confidence: "2" }
-    )
   end
 end

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -163,4 +163,19 @@ class Query::SequencesTest < UnitTestCase
       }, order_by: :id
     )
   end
+
+  def test_uses_join_hash
+    box = { north: "90", south: "0", west: "-180", east: "-100" }
+    query = Query.lookup(:Sequence, observation_query: { in_box: box })
+    assert_not(query.uses_join_sub([], :location))
+    assert(query.uses_join_sub([:location], :location))
+    assert_not(query.uses_join_sub({}, :location))
+    assert(query.uses_join_sub({ test: :location }, :location))
+    assert(query.uses_join_sub(:location, :location))
+    # scope = Sequence.observation_query(confidence: "2").order_by(:id)
+    assert_query(
+      [seq4],
+      :Sequence, observation_query: { confidence: "2" }
+    )
+  end
 end

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -88,7 +88,7 @@ class Query::SequencesTest < UnitTestCase
                  :Sequence, pattern: "deposited_sequence")
   end
 
-  def test_sequence_observation_query
+  def set_up_sequence_observation_query
     sequences = Sequence.reorder(id: :asc).all
     seq1 = sequences[0]
     seq2 = sequences[1]
@@ -98,6 +98,12 @@ class Query::SequencesTest < UnitTestCase
     seq2.update(observation: observations(:detailed_unknown_obs))
     seq3.update(observation: observations(:agaricus_campestris_obs))
     seq4.update(observation: observations(:peltigera_obs))
+    [seq1, seq2, seq3, seq4]
+  end
+
+  def test_sequence_observation_query_date_users_names
+    seq1, seq2, _seq3, seq4 = set_up_sequence_observation_query
+
     assert_query([seq1, seq2],
                  :Sequence, observation_query: { date: %w[2006 2006] })
     assert_query([seq1, seq2],
@@ -109,12 +115,18 @@ class Query::SequencesTest < UnitTestCase
         names: { lookup: "Petigera", include_synonyms: true }
       }
     )
-    expects = Sequence.order_by_default.joins(:observation).
+  end
+
+  def test_sequence_observation_query_locations_projects_species_lists
+    seq1, seq2, _seq3, seq4 = set_up_sequence_observation_query
+
+    expects = Sequence.joins(:observation).distinct.
               where(observations: { location: locations(:burbank) }).
-              or(Sequence.order_by_default.joins(:observation).
-                 where(Observation[:where].matches("Burbank"))).distinct
-    assert_query(expects,
-                 :Sequence, observation_query: { locations: "Burbank" })
+              or(Sequence.joins(:observation).distinct.
+                 where(Observation[:where].matches("Burbank"))).order_by_default
+    scope = Sequence.observation_query(locations: "Burbank").order_by_default
+    assert_query_scope(expects, scope,
+                       :Sequence, observation_query: { locations: "Burbank" })
     assert_query([seq2],
                  :Sequence, observation_query: { projects: "Bolete Project" })
     assert_query(
@@ -122,22 +134,21 @@ class Query::SequencesTest < UnitTestCase
       :Sequence, observation_query: { species_lists: "List of mysteries" }
     )
     assert_query([seq4], :Sequence, observation_query: { confidence: "2" })
-    # The test returns these sequences in random order, can't work.
-    # assert_query(
-    #   [seq1, seq2, seq3],
-    #   :Sequence, observation_query: {
-    #     in_box: { north: "90", south: "0", west: "-180", east: "-100" }
-    #   }
-    # )
   end
 
-  def test_uses_join_hash
-    box = { north: "90", south: "0", west: "-180", east: "-100" }
-    query = Query.lookup(:Sequence, observation_query: { in_box: box })
-    assert_not(query.uses_join_sub([], :location))
-    assert(query.uses_join_sub([:location], :location))
-    assert_not(query.uses_join_sub({}, :location))
-    assert(query.uses_join_sub({ test: :location }, :location))
-    assert(query.uses_join_sub(:location, :location))
+  def test_sequence_observation_query_in_box
+    seq1, seq2, seq3, _seq4 = set_up_sequence_observation_query
+    Location.update_box_area_and_center_columns
+
+    # order_by_default seems to return random order here
+    scope = Sequence.observation_query(
+      in_box: { north: "90", south: "0", west: "-180", east: "-100" }
+    ).order_by(:id)
+    assert_query_scope(
+      [seq1, seq2, seq3], scope,
+      :Sequence, observation_query: {
+        in_box: { north: "90", south: "0", west: "-180", east: "-100" }
+      }, order_by: :id
+    )
   end
 end


### PR DESCRIPTION
Fixes an undiscovered bug in `Observation.in_box` where it was using the wrong (undefined) arg name.
Restores and fixes Sequence Query test to test Sequences for an `Observation.in_box` subquery.