### PR TITLE
Query validation: messages, not errors

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -213,7 +213,8 @@ class Query
 
   def self.new(model, params = {}, current = nil)
     klass = "Query::#{model.to_s.pluralize}".constantize
-    query = klass.new(params)
+    # Ignore undefined params:
+    query = klass.new(params.slice(*klass.parameter_declarations.keys))
     query.params = query.attributes # initialize params for cleaning/validation
     query.subqueries = {}
     query.current = current if current

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -213,11 +213,11 @@ class Query
 
   def self.new(model, params = {}, current = nil)
     klass = "Query::#{model.to_s.pluralize}".constantize
-    query = klass.new
-    query.params = params
+    query = klass.new(params)
+    query.params = query.attributes # initialize params for cleaning/validation
     query.subqueries = {}
-    query.validate_params
     query.current = current if current
+    query.valid = query.valid? # reinitializes params after cleaning/validation
     # query.initialize_query # if you want the attributes right away
     query
   end

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -213,7 +213,7 @@ class Query
 
   def self.new(model, params = {}, current = nil)
     klass = "Query::#{model.to_s.pluralize}".constantize
-    # Ignore undefined params:
+    # Just ignore undeclared params:
     query = klass.new(params.slice(*klass.parameter_declarations.keys))
     query.params = query.attributes # initialize params for cleaning/validation
     query.subqueries = {}

--- a/app/classes/query/api_keys.rb
+++ b/app/classes/query/api_keys.rb
@@ -13,6 +13,11 @@ class Query::APIKeys < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_time_condition("api_keys.created_at", params[:created_at])
     add_time_condition("api_keys.updated_at", params[:updated_at])

--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -20,6 +20,11 @@ class Query::Articles < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_id_in_set_condition

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -33,6 +33,7 @@ class Query::Base
     validate_params
     # eventually should be done in validate_params
     assign_attributes(**@params) if @params.present?
+    initialize_non_nil_ivars
   end
 
   delegate :parameter_declarations, to: :class

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -2,6 +2,10 @@
 
 # base class for Query searches
 class Query::Base
+  include ActiveModel::API
+  include ActiveModel::Attributes
+  include ActiveModel::Validations::Callbacks
+
   include Query::Modules::ClassMethods
   include Query::Modules::BoundingBox
   include Query::Modules::Conditions
@@ -17,6 +21,11 @@ class Query::Base
   include Query::Modules::SequenceOperators
   include Query::Modules::Sql
   include Query::Modules::Validation
+
+  validates_with Query::ScopeModules::Validator # , options
+
+  # "clean up" and reassign attributes before validation
+  before_validation :clean_params
 
   attr_writer :record
 

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -24,17 +24,11 @@ class Query::Base
 
   validates_with Query::Modules::Validator # , options
 
-  # "clean up" and reassign attributes before validation
-  before_validation :clean_params
+  # "clean up" params, store any @validation_errors,
+  # and reassign attributes, restoring blank defaults, before validation
+  before_validation :clean_and_validate_params
 
   attr_writer :record
-
-  def clean_params
-    validate_params
-    # eventually should be done in validate_params
-    assign_attributes(**params) if params.present?
-    initialize_non_nil_defaults
-  end
 
   delegate :parameter_declarations, to: :class
 

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -22,12 +22,18 @@ class Query::Base
   include Query::Modules::Sql
   include Query::Modules::Validation
 
-  validates_with Query::ScopeModules::Validator # , options
+  validates_with Query::Modules::Validator # , options
 
   # "clean up" and reassign attributes before validation
   before_validation :clean_params
 
   attr_writer :record
+
+  def clean_params
+    validate_params
+    # eventually should be done in validate_params
+    assign_attributes(**@params) if @params.present?
+  end
 
   delegate :parameter_declarations, to: :class
 

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -32,8 +32,8 @@ class Query::Base
   def clean_params
     validate_params
     # eventually should be done in validate_params
-    assign_attributes(**@params) if @params.present?
-    initialize_non_nil_ivars
+    assign_attributes(**params) if params.present?
+    initialize_non_nil_defaults
   end
 
   delegate :parameter_declarations, to: :class
@@ -114,7 +114,7 @@ class Query::Base
   # the parsed hashes (in whatever order), because when a column is serialized
   # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
-    @params.sort.to_h.merge(model: model.name).to_json
+    params.sort.to_h.merge(model: model.name).to_json
   end
 
   def record

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -114,7 +114,7 @@ class Query::Base
   # the parsed hashes (in whatever order), because when a column is serialized
   # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
-    params.sort.to_h.merge(model: model.name).to_json
+    @params.sort.to_h.merge(model: model.name).to_json
   end
 
   def record

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -24,6 +24,11 @@ class Query::CollectionNumbers < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_id_in_set_condition

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -54,15 +54,15 @@ class Query::Comments < Query::Base
                 "SELECT #{table}.id FROM #{table} " \
                 "WHERE #{table}.user_id = #{user_id}))"
     end
-    @where << or_clause(*wheres)
+    where << or_clause(*wheres)
   end
 
   def add_for_target_condition
     return if params[:target].blank?
 
     target = target_instance
-    @where << "comments.target_id = '#{target.id}'"
-    @where << "comments.target_type = '#{target.class.name}'"
+    where << "comments.target_id = '#{target.id}'"
+    where << "comments.target_type = '#{target.class.name}'"
   end
 
   def target_instance

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -24,6 +24,11 @@ class Query::Comments < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_id_in_set_condition

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -17,6 +17,11 @@ class Query::ExternalLinks < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_id_in_set_condition

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -12,6 +12,11 @@ class Query::ExternalSites < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_id_in_set_condition
     add_search_condition("external_sites.name", params[:name_has])

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -14,6 +14,11 @@ class Query::FieldSlips < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     initialize_projects_parameter(:field_slips, nil)

--- a/app/classes/query/glossary_terms.rb
+++ b/app/classes/query/glossary_terms.rb
@@ -20,6 +20,11 @@ class Query::GlossaryTerms < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_search_condition("glossary_terms.name", params[:name_has])

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -47,7 +47,7 @@ class Query::Herbaria < Query::Base
   def add_nonpersonal_condition
     return if params[:nonpersonal].blank? # false is blank
 
-    @where << "herbaria.personal_user_id IS NULL"
+    where << "herbaria.personal_user_id IS NULL"
   end
 
   def search_fields

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -23,6 +23,11 @@ class Query::Herbaria < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   # rubocop:disable Metrics/AbcSize
   def initialize_flavor
     add_time_condition("herbaria.created_at", params[:created_at])

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -27,6 +27,11 @@ class Query::HerbariumRecords < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_id_in_set_condition

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -87,11 +87,11 @@ class Query::Images < Query::Base
     pixels = Image::ALL_SIZES_IN_PIXELS
     if min
       size = pixels[sizes.index(min)]
-      @where << "images.width >= #{size} OR images.height >= #{size}"
+      where << "images.width >= #{size} OR images.height >= #{size}"
     end
     if max
       size = pixels[sizes.index(max) + 1]
-      @where << "images.width < #{size} AND images.height < #{size}"
+      where << "images.width < #{size} AND images.height < #{size}"
     end
     add_joins(*)
   end
@@ -102,13 +102,13 @@ class Query::Images < Query::Base
     types, mimes, other = parse_image_type_vals(vals)
     str1 = "images.content_type IN ('#{types.join("','")}')"
     str2 = "images.content_type NOT IN ('#{mimes.join("','")}')"
-    @where << if types.empty?
-                str2
-              elsif other
-                "#{str1} OR #{str2}"
-              else
-                str1
-              end
+    where << if types.empty?
+               str2
+             elsif other
+               "#{str1} OR #{str2}"
+             else
+               str1
+             end
     add_joins(*)
   end
 

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -46,6 +46,11 @@ class Query::Images < Query::Base
     ) # .merge(advanced_search_parameter_declarations)
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     initialize_image_parameters
     initialize_image_association_parameters

--- a/app/classes/query/initializers/advanced_search.rb
+++ b/app/classes/query/initializers/advanced_search.rb
@@ -31,21 +31,21 @@ module Query::Initializers::AdvancedSearch
   def add_name_condition(name)
     return if name.blank?
 
-    self.where += google_conditions(name, name_field)
+    @where += google_conditions(name, name_field)
     add_join_to_names
   end
 
   def add_user_condition(user)
     return if user.blank?
 
-    self.where += google_conditions(user, user_field)
+    @where += google_conditions(user, user_field)
     add_join_to_users
   end
 
   def add_location_condition(location)
     return if location.blank?
 
-    self.where += google_conditions(location, location_field)
+    @where += google_conditions(location, location_field)
     add_join_to_locations
   end
 
@@ -55,7 +55,7 @@ module Query::Initializers::AdvancedSearch
     # Cannot do left outer join from observations to comments, because it
     # will never return.  Instead, break it into two queries, one without
     # comments, and another with inner join on comments.
-    self.executor = lambda do |args|
+    @executor = lambda do |args|
       content_search_one(content, args) | content_search_two(content, args)
     end
   end

--- a/app/classes/query/initializers/advanced_search.rb
+++ b/app/classes/query/initializers/advanced_search.rb
@@ -31,21 +31,21 @@ module Query::Initializers::AdvancedSearch
   def add_name_condition(name)
     return if name.blank?
 
-    @where += google_conditions(name, name_field)
+    self.where += google_conditions(name, name_field)
     add_join_to_names
   end
 
   def add_user_condition(user)
     return if user.blank?
 
-    @where += google_conditions(user, user_field)
+    self.where += google_conditions(user, user_field)
     add_join_to_users
   end
 
   def add_location_condition(location)
     return if location.blank?
 
-    @where += google_conditions(location, location_field)
+    self.where += google_conditions(location, location_field)
     add_join_to_locations
   end
 

--- a/app/classes/query/initializers/descriptions.rb
+++ b/app/classes/query/initializers/descriptions.rb
@@ -15,7 +15,7 @@ module Query::Initializers::Descriptions
     # Change this conditional to check for :has_descriptions param
     user = find_cached_parameter_instance(User, :by_author)
     add_join(:"#{type}_descriptions", :"#{type}_description_authors")
-    @where << "#{type}_description_authors.user_id = '#{user.id}'"
+    where << "#{type}_description_authors.user_id = '#{user.id}'"
   end
 
   def add_desc_by_editor_condition(type)
@@ -24,7 +24,7 @@ module Query::Initializers::Descriptions
     # Change this conditional to check for :has_descriptions param
     user = find_cached_parameter_instance(User, :by_editor)
     add_join(:"#{type}_descriptions", :"#{type}_description_editors")
-    @where << "#{type}_description_editors.user_id = '#{user.id}'"
+    where << "#{type}_description_editors.user_id = '#{user.id}'"
   end
 
   # If ever generalizing, `type` should be model.parent_type

--- a/app/classes/query/initializers/filters.rb
+++ b/app/classes/query/initializers/filters.rb
@@ -7,11 +7,11 @@ module Query::Initializers::Filters
 
     table = model.table_name
     add_join(:"#{table}!") # "!" means left outer join
-    @where << "#{table}.id IS NULL OR (#{and_clause(*conds)})"
+    where << "#{table}.id IS NULL OR (#{and_clause(*conds)})"
   end
 
   def initialize_content_filters(model)
-    @where += content_filter_sql_conds(model)
+    self.where += content_filter_sql_conds(model)
   end
 
   def content_filter_sql_conds(model)

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -22,6 +22,11 @@ class Query::LocationDescriptions < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_id_in_set_condition
     add_owner_and_time_stamp_conditions

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -67,7 +67,7 @@ class Query::Locations < Query::Base
     return if params[:regexp].blank?
 
     regexp = escape(params[:regexp].to_s.strip_squeeze)
-    @where << "locations.name REGEXP #{regexp}"
+    where << "locations.name REGEXP #{regexp}"
   end
 
   def add_pattern_condition

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -31,6 +31,11 @@ class Query::Locations < Query::Base
       merge(advanced_search_parameter_declarations)
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     initialize_location_parameters
     add_bounding_box_conditions_for_locations

--- a/app/classes/query/modules/associations.rb
+++ b/app/classes/query/modules/associations.rb
@@ -15,8 +15,8 @@ module Query::Modules::Associations
     user = find_cached_parameter_instance(User, :by_editor)
     version_table = :"#{type}_versions"
     add_join(version_table)
-    @where << "#{version_table}.user_id = '#{user.id}'"
-    @where << "#{type}s.user_id != '#{user.id}'"
+    where << "#{version_table}.user_id = '#{user.id}'"
+    where << "#{type}s.user_id != '#{user.id}'"
   end
 
   def initialize_herbaria_parameter(
@@ -49,7 +49,7 @@ module Query::Modules::Associations
         cond += " OR #{where_col} LIKE '%#{pattern}%'"
       end
     end
-    @where << cond
+    where << cond
     add_joins(*)
   end
 

--- a/app/classes/query/modules/bounding_box.rb
+++ b/app/classes/query/modules/bounding_box.rb
@@ -6,7 +6,7 @@ module Query::Modules::BoundingBox
     return unless params[:in_box]
 
     _, cond2 = bounding_box_conditions
-    @where += cond2
+    self.where += cond2
   end
 
   def add_bounding_box_conditions_for_observations
@@ -16,7 +16,7 @@ module Query::Modules::BoundingBox
     cond0 = lat_lng_plausible
     cond1 = cond1.join(" AND ")
     cond2 = cond2.join(" AND ")
-    @where << "IF(locations.id IS NULL OR #{cond0}, #{cond1}, #{cond2})"
+    where << "IF(locations.id IS NULL OR #{cond0}, #{cond1}, #{cond2})"
     add_join_to_locations
   end
 

--- a/app/classes/query/modules/conditions.rb
+++ b/app/classes/query/modules/conditions.rb
@@ -26,7 +26,7 @@ module Query::Modules::Conditions
   def add_boolean_condition(true_cond, false_cond, val, *)
     return if val.nil?
 
-    @where << (val ? true_cond : false_cond)
+    where << (val ? true_cond : false_cond)
     add_joins(*)
   end
 
@@ -35,11 +35,11 @@ module Query::Modules::Conditions
 
     vals = [vals] unless vals.is_a?(Array)
     vals = vals.map { |v| escape(v.downcase) }
-    @where << if vals.length == 1
-                "LOWER(#{col}) = #{vals.first}"
-              else
-                "LOWER(#{col}) IN (#{vals.join(", ")})"
-              end
+    where << if vals.length == 1
+               "LOWER(#{col}) = #{vals.first}"
+             else
+               "LOWER(#{col}) IN (#{vals.join(", ")})"
+             end
     add_joins(*)
   end
 
@@ -47,7 +47,7 @@ module Query::Modules::Conditions
     return if val.blank?
 
     search = SearchParams.new(phrase: val)
-    @where += google_conditions(search, col)
+    self.where += google_conditions(search, col)
     add_joins(*)
   end
 
@@ -56,8 +56,8 @@ module Query::Modules::Conditions
     return if val[0].blank? && val[1].blank?
 
     min, max = val
-    @where << "#{col} >= #{min}" if min.present?
-    @where << "#{col} <= #{max}" if max.present?
+    where << "#{col} >= #{min}" if min.present?
+    where << "#{col} <= #{max}" if max.present?
     add_joins(*)
   end
 
@@ -67,7 +67,7 @@ module Query::Modules::Conditions
     vals = vals.map(&:to_s) & allowed.map(&:to_s)
     return if vals.empty?
 
-    @where << "#{col} IN ('#{vals.join("','")}')"
+    where << "#{col} IN ('#{vals.join("','")}')"
     add_joins(*)
   end
 
@@ -79,7 +79,7 @@ module Query::Modules::Conditions
     vals = allowed.values_at(*vals)
     return if vals.empty?
 
-    @where << "#{col} IN (#{vals.join(",")})"
+    where << "#{col} IN (#{vals.join(",")})"
     add_joins(*)
   end
 
@@ -89,8 +89,8 @@ module Query::Modules::Conditions
     return if params[param].nil? # [] is valid
 
     set = clean_id_set(params[param])
-    @where << "#{table}.id IN (#{set})"
-    @order = "FIND_IN_SET(#{table}.id,'#{set}') ASC" unless params[:order]
+    where << "#{table}.id IN (#{set})"
+    self.order = "FIND_IN_SET(#{table}.id,'#{set}') ASC" unless params[:order]
   end
 
   # table_col = foreign key of an association, e.g. `observations.location_id`
@@ -98,10 +98,10 @@ module Query::Modules::Conditions
     return if ids.empty?
 
     if ids.size == 1
-      @where << "#{table_col} = '#{ids.first}'"
+      where << "#{table_col} = '#{ids.first}'"
     else
       set = clean_id_set(ids) # this produces a joined string!
-      @where << "#{table_col} IN (#{set})"
+      where << "#{table_col} IN (#{set})"
     end
     add_joins(*)
   end
@@ -110,7 +110,7 @@ module Query::Modules::Conditions
     return if ids.empty?
 
     set = clean_id_set(ids)
-    @where << "#{col} NOT IN (#{set})"
+    where << "#{col} NOT IN (#{set})"
     add_joins(*)
   end
 
@@ -119,7 +119,7 @@ module Query::Modules::Conditions
 
     sql = subquery_from_params(param).sql
     table ||= subquery_table(param)
-    @where << "#{table}.#{col} IN (#{sql})"
+    where << "#{table}.#{col} IN (#{sql})"
     add_joins(*)
   end
 
@@ -137,6 +137,6 @@ module Query::Modules::Conditions
   end
 
   def force_empty_results
-    @where = ["FALSE"]
+    self.where = ["FALSE"]
   end
 end

--- a/app/classes/query/modules/datetime.rb
+++ b/app/classes/query/modules/datetime.rb
@@ -44,9 +44,9 @@ module Query::Modules::Datetime
     if /^\d\d\d\d/.match?(val.to_s)
       y, m, d = val.split("-")
       where << format("#{col} #{dir}= '%04d-%02d-%02d'",
-                       y.to_i,
-                       (m || (min ? 1 : 12)).to_i,
-                       (d || (min ? 1 : 31)).to_i)
+                      y.to_i,
+                      (m || (min ? 1 : 12)).to_i,
+                      (d || (min ? 1 : 31)).to_i)
     elsif /-/.match?(val.to_s)
       m, d = val.split("-")
       where << "MONTH(#{col}) #{dir} #{m} OR " \

--- a/app/classes/query/modules/datetime.rb
+++ b/app/classes/query/modules/datetime.rb
@@ -33,7 +33,7 @@ module Query::Modules::Datetime
   def add_wrapped_date_condition(col, vals)
     m1, d1 = vals[0].to_s.split("-")
     m2, d2 = vals[1].to_s.split("-")
-    @where << "MONTH(#{col}) > #{m1} OR " \
+    where << "MONTH(#{col}) > #{m1} OR " \
               "MONTH(#{col}) < #{m2} OR " \
               "(MONTH(#{col}) = #{m1} AND DAY(#{col}) >= #{d1}) OR " \
               "(MONTH(#{col}) = #{m2} AND DAY(#{col}) <= #{d2})"
@@ -43,17 +43,17 @@ module Query::Modules::Datetime
     dir = min ? ">" : "<"
     if /^\d\d\d\d/.match?(val.to_s)
       y, m, d = val.split("-")
-      @where << format("#{col} #{dir}= '%04d-%02d-%02d'",
+      where << format("#{col} #{dir}= '%04d-%02d-%02d'",
                        y.to_i,
                        (m || (min ? 1 : 12)).to_i,
                        (d || (min ? 1 : 31)).to_i)
     elsif /-/.match?(val.to_s)
       m, d = val.split("-")
-      @where << "MONTH(#{col}) #{dir} #{m} OR " \
+      where << "MONTH(#{col}) #{dir} #{m} OR " \
                 "(MONTH(#{col}) = #{m} AND " \
                 "DAY(#{col}) #{dir}= #{d})"
     elsif val.present?
-      @where << "MONTH(#{col}) #{dir}= #{val}"
+      where << "MONTH(#{col}) #{dir}= #{val}"
     end
   end
 
@@ -64,7 +64,7 @@ module Query::Modules::Datetime
     return if val.blank?
 
     y, m, d, h, n, s = val.split("-")
-    @where << format(
+    where << format(
       "#{col} #{min ? ">" : "<"}= #{DATE_FORMAT}",
       y.to_i,
       (m || (min ? 1 : 12)).to_i,

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -10,17 +10,21 @@ module Query::Modules::Initialization
 
   def initialize_query
     @initialized = true
-    @join        = []
-    @tables      = []
-    @where       = []
-    @group       = ""
-    @order       = ""
-    @selects     = ""
-    @executor    = nil
+    initialize_non_nil_ivars
+    @executor = nil
     initialize_flavor
     initialize_group
     initialize_order
     initialize_selects
+  end
+
+  def initialize_non_nil_ivars
+    @join        ||= []
+    @tables      ||= []
+    @where       ||= []
+    @group       ||= ""
+    @order       ||= ""
+    @selects     ||= ""
   end
 
   # Make a value safe for SQL.

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -10,8 +10,8 @@ module Query::Modules::Initialization
 
   def initialize_query
     @initialized = true
-    initialize_non_nil_ivars
-    @executor = nil
+    initialize_non_nil_defaults
+    self.executor = nil
     initialize_flavor
     initialize_group
     initialize_order
@@ -20,7 +20,7 @@ module Query::Modules::Initialization
 
   # Re-establish these internal param defaults so we can work with them.
   # Attributes null out these values.
-  def initialize_non_nil_ivars
+  def initialize_non_nil_defaults
     defaults = {
       "join" => [],
       "tables" => [],

--- a/app/classes/query/modules/sql.rb
+++ b/app/classes/query/modules/sql.rb
@@ -15,21 +15,21 @@ module Query::Modules::Sql
     initialize_query unless initialized?
 
     our_select  = args[:select] || selects
-    our_join    = join.dup
+    our_join    = @join.dup
     our_join += args[:join] if args[:join].is_a?(Array)
     our_join << args[:join] if args[:join].is_a?(Hash)
     our_join << args[:join] if args[:join].is_a?(Symbol)
-    our_tables = tables.dup
+    our_tables = @tables.dup
     our_tables += args[:tables] if args[:tables].is_a?(Array)
     our_tables << args[:tables] if args[:tables].is_a?(Symbol)
     our_from    = calc_from_clause(our_join, our_tables)
-    our_where   = where.dup
+    our_where   = @where.dup
     our_where += args[:where] if args[:where].is_a?(Array)
     our_where << args[:where] if args[:where].is_a?(String)
     our_where = calc_where_clause(our_where)
-    our_group = args[:group] || group
-    our_order = args[:order] || order
-    our_order = reverse_order(order) if our_order == :reverse
+    our_group = args[:group] || @group
+    our_order = args[:order] || @order
+    our_order = reverse_order(@order) if our_order == :reverse
     our_limit = args[:limit]
 
     # Tack id at end of order to disambiguate the order.
@@ -53,7 +53,7 @@ module Query::Modules::Sql
   end
 
   # Format list of conditions for WHERE clause.
-  def calc_where_clause(our_where = where)
+  def calc_where_clause(our_where = @where)
     ands = our_where.uniq.map do |x|
       # Make half-assed attempt to cut down on proliferating parens...
       if x.match(/^\(.*\)$/) || !x.match(/ or /i)
@@ -66,7 +66,7 @@ module Query::Modules::Sql
   end
 
   # Extract and format list of tables names from join tree for FROM clause.
-  def calc_from_clause(our_join = join, our_tables = tables)
+  def calc_from_clause(our_join = @join, our_tables = @tables)
     implicits = [model.table_name] + our_tables
     result = implicits.uniq.map { |x| "`#{x}`" }.join(", ")
     if our_join
@@ -79,14 +79,14 @@ module Query::Modules::Sql
   # Extract a complete list of tables being used by this query.  (Combines
   # this table (+model.table_name+) with tables from +join+ with custom-joined
   # tables from +tables+.)
-  def table_list(our_join = join, our_tables = tables)
+  def table_list(our_join = @join, our_tables = @tables)
     flatten_joins([model.table_name] + our_join + our_tables, false).uniq
   end
 
   # Flatten join "tree" into a simple Array of Strings.  Set +keep_qualifiers+
   # to +false+ to tell it to remove the ".column" qualifiers on ambiguous
   # table join specs.
-  def flatten_joins(arg = join, keep_qualifiers = true)
+  def flatten_joins(arg = @join, keep_qualifiers = true)
     result = []
     case arg
     when Hash

--- a/app/classes/query/modules/sql.rb
+++ b/app/classes/query/modules/sql.rb
@@ -14,7 +14,7 @@ module Query::Modules::Sql
   def sql(args = {})
     initialize_query unless initialized?
 
-    our_select  = args[:select] || selects
+    our_select  = args[:select] || @selects
     our_join    = @join.dup
     our_join += args[:join] if args[:join].is_a?(Array)
     our_join << args[:join] if args[:join].is_a?(Hash)

--- a/app/classes/query/modules/sql.rb
+++ b/app/classes/query/modules/sql.rb
@@ -14,22 +14,22 @@ module Query::Modules::Sql
   def sql(args = {})
     initialize_query unless initialized?
 
-    our_select  = args[:select] || @selects
-    our_join    = @join.dup
+    our_select  = args[:select] || selects
+    our_join    = join.dup
     our_join += args[:join] if args[:join].is_a?(Array)
     our_join << args[:join] if args[:join].is_a?(Hash)
     our_join << args[:join] if args[:join].is_a?(Symbol)
-    our_tables = @tables.dup
+    our_tables = tables.dup
     our_tables += args[:tables] if args[:tables].is_a?(Array)
     our_tables << args[:tables] if args[:tables].is_a?(Symbol)
     our_from    = calc_from_clause(our_join, our_tables)
-    our_where   = @where.dup
+    our_where   = where.dup
     our_where += args[:where] if args[:where].is_a?(Array)
     our_where << args[:where] if args[:where].is_a?(String)
     our_where = calc_where_clause(our_where)
-    our_group = args[:group] || @group
-    our_order = args[:order] || @order
-    our_order = reverse_order(@order) if our_order == :reverse
+    our_group = args[:group] || group
+    our_order = args[:order] || order
+    our_order = reverse_order(order) if our_order == :reverse
     our_limit = args[:limit]
 
     # Tack id at end of order to disambiguate the order.
@@ -53,7 +53,7 @@ module Query::Modules::Sql
   end
 
   # Format list of conditions for WHERE clause.
-  def calc_where_clause(our_where = @where)
+  def calc_where_clause(our_where = where)
     ands = our_where.uniq.map do |x|
       # Make half-assed attempt to cut down on proliferating parens...
       if x.match(/^\(.*\)$/) || !x.match(/ or /i)
@@ -66,7 +66,7 @@ module Query::Modules::Sql
   end
 
   # Extract and format list of tables names from join tree for FROM clause.
-  def calc_from_clause(our_join = @join, our_tables = @tables)
+  def calc_from_clause(our_join = join, our_tables = tables)
     implicits = [model.table_name] + our_tables
     result = implicits.uniq.map { |x| "`#{x}`" }.join(", ")
     if our_join
@@ -79,14 +79,14 @@ module Query::Modules::Sql
   # Extract a complete list of tables being used by this query.  (Combines
   # this table (+model.table_name+) with tables from +join+ with custom-joined
   # tables from +tables+.)
-  def table_list(our_join = @join, our_tables = @tables)
+  def table_list(our_join = join, our_tables = tables)
     flatten_joins([model.table_name] + our_join + our_tables, false).uniq
   end
 
   # Flatten join "tree" into a simple Array of Strings.  Set +keep_qualifiers+
   # to +false+ to tell it to remove the ".column" qualifiers on ambiguous
   # table join specs.
-  def flatten_joins(arg = @join, keep_qualifiers = true)
+  def flatten_joins(arg = join, keep_qualifiers = true)
     result = []
     case arg
     when Hash

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -220,14 +220,16 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def validate_date(param, val)
     if val.blank? || val.to_s == "0"
       nil
+    elsif val.acts_like?(:date) || (val2 = parse_date(val)).acts_like?(:date)
+      val2 ||= val
+      format("%04d-%02d-%02d", val2.year, val2.mon, val2.day)
     elsif /^\d\d\d\d(-\d\d?){0,2}$/i.match?(val.to_s) ||
           /^\d\d?(-\d\d?)?$/i.match?(val.to_s)
       val
-    elsif (val2 = parse_date(val)).acts_like?(:date)
-      format("%04d-%02d-%02d", val2.year, val2.mon, val2.day)
     else
       @validation_errors <<
         "Value for :#{param} should be a date (YYYY-MM-DD or MM-DD), " \
@@ -235,6 +237,7 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
       nil
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def parse_date(val)
     Date.parse(val)
@@ -245,12 +248,13 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   def validate_time(param, val)
     if val.blank? || val.to_s == "0"
       nil
-    elsif /^\d\d\d\d(-\d\d?){0,5}$/i.match?(val.to_s)
-      val
-    elsif (val2 = parse_time(val)).acts_like?(:time)
+    elsif val.acts_like?(:time) || (val2 = parse_time(val)).acts_like?(:time)
+      val2 ||= val
       val2 = val2.utc
       format("%04d-%02d-%02d-%02d-%02d-%02d",
              val2.year, val2.mon, val2.day, val2.hour, val2.min, val2.sec)
+    elsif /^\d\d\d\d(-\d\d?){0,5}$/i.match?(val.to_s)
+      val
     else
       @validation_errors <<
         "Value for :#{param} should be a UTC time (YYYY-MM-DD-HH-MM-SS), " \

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -220,16 +220,16 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def validate_date(param, val)
     if val.blank? || val.to_s == "0"
       nil
+    elsif val.acts_like?(:date)
+      format_date(val)
     elsif /^\d\d\d\d(-\d\d?){0,2}$/i.match?(val.to_s) ||
           /^\d\d?(-\d\d?)?$/i.match?(val.to_s)
       val
-    elsif val.acts_like?(:date) || (val2 = parse_date(val)).acts_like?(:date)
-      val2 ||= val
-      format("%04d-%02d-%02d", val2.year, val2.mon, val2.day)
+    elsif (val2 = parse_date(val)).acts_like?(:date)
+      format_date(val2)
     else
       @validation_errors <<
         "Value for :#{param} should be a date (YYYY-MM-DD or MM-DD), " \
@@ -237,7 +237,6 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
       nil
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def parse_date(val)
     Date.parse(val)
@@ -245,16 +244,19 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     nil
   end
 
+  def format_date(val)
+    format("%04d-%02d-%02d", val.year, val.mon, val.day)
+  end
+
   def validate_time(param, val)
     if val.blank? || val.to_s == "0"
       nil
+    elsif val.acts_like?(:time)
+      format_time(val)
     elsif /^\d\d\d\d(-\d\d?){0,5}$/i.match?(val.to_s)
       val
-    elsif val.acts_like?(:time) || (val2 = parse_time(val)).acts_like?(:time)
-      val2 ||= val
-      val2 = val2.utc
-      format("%04d-%02d-%02d-%02d-%02d-%02d",
-             val2.year, val2.mon, val2.day, val2.hour, val2.min, val2.sec)
+    elsif (val2 = parse_time(val)).acts_like?(:time)
+      format_time(val2)
     else
       @validation_errors <<
         "Value for :#{param} should be a UTC time (YYYY-MM-DD-HH-MM-SS), " \
@@ -267,6 +269,11 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     DateTime.parse(val)
   rescue ArgumentError
     nil
+  end
+
+  def format_time(val)
+    format("%04d-%02d-%02d-%02d-%02d-%02d",
+           val.year, val.mon, val.day, val.hour, val.min, val.sec)
   end
 
   def find_cached_parameter_instance(model, param)

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Validation of Query parameters.
+# Validation of Query parameters, plus substitution of ids for instances.
 module Query::Modules::Validation
   attr_accessor :params, :params_cache, :subqueries, :valid, :validation_errors
 
-  def validate_params
+  def clean_and_validate_params
     @validation_errors = []
     old_params = @params.dup&.deep_compact&.deep_symbolize_keys || {}
     new_params = {}
@@ -15,6 +15,8 @@ module Query::Modules::Validation
       new_params[param] = val
     end
     @params = new_params
+    assign_attributes(**@params) if @params.present?
+    initialize_non_nil_defaults
   end
 
   def validate_value(param_type, param, val)

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -2,7 +2,7 @@
 
 # Validation of Query parameters.
 module Query::Modules::Validation
-  attr_accessor :params, :params_cache, :subqueries
+  attr_accessor :params, :params_cache, :subqueries, :valid, :validation_errors
 
   def validate_params
     old_params = @params.dup&.deep_compact&.deep_symbolize_keys || {}

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -224,12 +224,12 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   def validate_date(param, val)
     if val.blank? || val.to_s == "0"
       nil
-    elsif val.acts_like?(:date) || (val2 = parse_date(val)).acts_like?(:date)
-      val2 ||= val
-      format("%04d-%02d-%02d", val2.year, val2.mon, val2.day)
     elsif /^\d\d\d\d(-\d\d?){0,2}$/i.match?(val.to_s) ||
           /^\d\d?(-\d\d?)?$/i.match?(val.to_s)
       val
+    elsif val.acts_like?(:date) || (val2 = parse_date(val)).acts_like?(:date)
+      val2 ||= val
+      format("%04d-%02d-%02d", val2.year, val2.mon, val2.day)
     else
       @validation_errors <<
         "Value for :#{param} should be a date (YYYY-MM-DD or MM-DD), " \
@@ -248,13 +248,13 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   def validate_time(param, val)
     if val.blank? || val.to_s == "0"
       nil
+    elsif /^\d\d\d\d(-\d\d?){0,5}$/i.match?(val.to_s)
+      val
     elsif val.acts_like?(:time) || (val2 = parse_time(val)).acts_like?(:time)
       val2 ||= val
       val2 = val2.utc
       format("%04d-%02d-%02d-%02d-%02d-%02d",
              val2.year, val2.mon, val2.day, val2.hour, val2.min, val2.sec)
-    elsif /^\d\d\d\d(-\d\d?){0,5}$/i.match?(val.to_s)
-      val
     else
       @validation_errors <<
         "Value for :#{param} should be a UTC time (YYYY-MM-DD-HH-MM-SS), " \

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -119,8 +119,8 @@ module Query::Modules::Validation
     end
 
     val2 = scalar_validate(param, val, arg_type)
-    if (arg_type == :string) && set.include?(val2.to_sym)
-      val2 = val2.to_sym
+    if (arg_type == :string) && set.include?(val2.to_s.to_sym)
+      val2 = val2.to_s.to_sym
     elsif set.exclude?(val2)
       @validation_errors <<
         "Value for :#{param} should be one of the following: #{set.inspect}."

--- a/app/classes/query/modules/validator.rb
+++ b/app/classes/query/modules/validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Validation of Query parameters.
+class Query::Modules::Validator < ActiveModel::Validator
+  def initialize(options = {})
+    super
+    options[:class].attr_accessor(:validation_errors)
+    # debugger
+    # @parameter_declarations = options[:parameter_declarations]
+    # @validation_errors = options[:validation_errors]
+  end
+
+  def validate(params)
+    return if params.validation_errors.blank?
+
+    [params.validation_errors].flatten.each do |msg|
+      params.errors.add(:base, msg)
+    end
+  end
+end

--- a/app/classes/query/modules/validator.rb
+++ b/app/classes/query/modules/validator.rb
@@ -5,9 +5,6 @@ class Query::Modules::Validator < ActiveModel::Validator
   def initialize(options = {})
     super
     options[:class].attr_accessor(:validation_errors)
-    # debugger
-    # @parameter_declarations = options[:parameter_declarations]
-    # @validation_errors = options[:validation_errors]
   end
 
   def validate(params)

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -25,6 +25,11 @@ class Query::NameDescriptions < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_id_in_set_condition
     add_owner_and_time_stamp_conditions

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -58,6 +58,11 @@ class Query::Names < Query::Base
       merge(advanced_search_parameter_declarations)
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     initialize_name_basic_parameters
     initialize_name_record_parameters

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -178,8 +178,8 @@ class Query::Names < Query::Base
 
   def initialize_misspellings_parameter
     val = params[:misspellings] || :no
-    @where << "names.correct_spelling_id IS NULL"     if val == :no
-    @where << "names.correct_spelling_id IS NOT NULL" if val == :only
+    where << "names.correct_spelling_id IS NULL"     if val == :no
+    where << "names.correct_spelling_id IS NOT NULL" if val == :only
   end
 
   def initialize_is_deprecated_parameter
@@ -193,7 +193,7 @@ class Query::Names < Query::Base
     return if vals.empty?
 
     ranks = parse_rank_parameter(vals)
-    @where << "names.`rank` IN (#{ranks.join(",")})"
+    where << "names.`rank` IN (#{ranks.join(",")})"
     add_joins(*)
   end
 
@@ -250,10 +250,10 @@ class Query::Names < Query::Base
     return unless params[:needs_description]
 
     add_join(:observations)
-    @where << "names.description_id IS NULL"
-    @selects = "DISTINCT names.id, count(observations.name_id)"
-    @group = "observations.name_id"
-    @order = "count(observations.name_id) DESC"
+    where << "names.description_id IS NULL"
+    self.selects = "DISTINCT names.id, count(observations.name_id)"
+    self.group = "observations.name_id"
+    self.order = "count(observations.name_id) DESC"
   end
 
   def add_has_default_description_condition

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -72,6 +72,11 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
       merge(advanced_search_parameter_declarations)
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     initialize_obs_basic_parameters
     initialize_obs_record_parameters

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -196,7 +196,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
   def initialize_has_name_parameter
     genus = Name.ranks[:Genus]
-    self.group = Name.ranks[:Group]
+    group = Name.ranks[:Group]
     add_boolean_condition(
       "names.`rank` <= #{genus} or names.`rank` = #{group}",
       "names.`rank` > #{genus} and names.`rank` < #{group}",

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -180,7 +180,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     return if fields.empty?
 
     conds = fields.map { |field| notes_field_presence_condition(field) }
-    @where << conds.join(" OR ")
+    where << conds.join(" OR ")
     add_joins(*)
   end
 
@@ -196,7 +196,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
 
   def initialize_has_name_parameter
     genus = Name.ranks[:Genus]
-    group = Name.ranks[:Group]
+    self.group = Name.ranks[:Group]
     add_boolean_condition(
       "names.`rank` <= #{genus} or names.`rank` = #{group}",
       "names.`rank` > #{genus} and names.`rank` < #{group}",
@@ -262,7 +262,7 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     user = lookup_users_by_name(params[:needs_naming]).first
     # 15x faster to use this AR scope to assemble the IDs vs using
     # SQL SELECT DISTINCT
-    @where << Observation.needs_naming(user).to_sql.gsub(/^.*?WHERE/, "")
+    where << Observation.needs_naming(user).to_sql.gsub(/^.*?WHERE/, "")
   end
 
   def initialize_confidence_parameter
@@ -295,10 +295,10 @@ class Query::Observations < Query::Base # rubocop:disable Metrics/ClassLength
     return unless params[:location_undefined]
     return if params[:regexp] || params[:by_editor]
 
-    @where << "observations.location_id IS NULL"
-    @where << "observations.where IS NOT NULL"
-    @group = "observations.where"
-    @order = "COUNT(observations.where)"
+    where << "observations.location_id IS NULL"
+    where << "observations.where IS NOT NULL"
+    self.group = "observations.where"
+    self.order = "COUNT(observations.where)"
   end
 
   def initialize_project_lists_parameter

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -29,6 +29,11 @@ class Query::Projects < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     initialize_association_parameters

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -17,6 +17,11 @@ class Query::RssLogs < Query::Base
       merge(content_filter_parameter_declarations(Location))
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_time_condition("rss_logs.updated_at", params[:updated_at])
     initialize_type_parameter

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -41,13 +41,13 @@ class Query::RssLogs < Query::Base
     types = self.types
     types &= RssLog::ALL_TYPE_TAGS.map(&:to_s)
 
-    @where << if types.empty?
-                "FALSE"
-              else
-                types.map do |type|
-                  "rss_logs.#{type}_id IS NOT NULL"
-                end.join(" OR ")
-              end
+    where << if types.empty?
+               "FALSE"
+             else
+               types.map do |type|
+                 "rss_logs.#{type}_id IS NOT NULL"
+               end.join(" OR ")
+             end
   end
 
   def self.default_order

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -27,6 +27,11 @@ class Query::Sequences < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     # Leaving out bases because some formats allow spaces and other "garbage"
     # delimiters which could interrupt the subsequence the user is searching

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -34,6 +34,11 @@ class Query::SpeciesLists < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_owner_and_time_stamp_conditions
     add_date_condition("species_lists.when", params[:date])

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -81,7 +81,7 @@ class Query::SpeciesLists < Query::Base
     return unless params[:search_where]
 
     location_str = params[:search_where]
-    @where << "species_lists.where LIKE '%#{clean_pattern(location_str)}%'"
+    where << "species_lists.where LIKE '%#{clean_pattern(location_str)}%'"
   end
 
   def initialize_search_parameters

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -24,6 +24,11 @@ class Query::Users < Query::Base
     )
   end
 
+  # Declare the parameters as attributes of type `query_param`
+  parameter_declarations.each_key do |param_name|
+    attribute param_name, :query_param
+  end
+
   def initialize_flavor
     add_time_condition("users.created_at", params[:created_at])
     add_time_condition("users.updated_at", params[:updated_at])

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -251,11 +251,18 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     query_params_set(query)
     query.need_letters = display_opts[:letters] if display_opts[:letters]
     set_index_view_ivars(query, display_opts)
+    flash_query_validation_errors(query)
   end
 
   ###########################################################################
   #
   # INDEX VIEW METHODS - MOVE VIEW CODE TO HELPERS
+
+  def flash_query_validation_errors(query)
+    return if query.valid || query.validation_errors.empty?
+
+    flash_warning(query.validation_errors.join("\n"))
+  end
 
   # Set some ivars used in all index views.
   # Makes @query available to the :index template for query-dependent tabs

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# https://stackoverflow.com/a/79417688/3357635
+class QueryParamType < ActiveModel::Type::Value
+  # This is required and used if you register the type
+  # instead of just passing the class
+  def type = :query_param
+end

--- a/config/initializers/active_model_types.rb
+++ b/config/initializers/active_model_types.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  ActiveModel::Type.register(:query_param, QueryParamType)
+end

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -32,11 +32,15 @@ class QueryTest < UnitTestCase
     assert_equal(0, query3.record.access_count)
   end
 
-  def test_validate_params
+  def assert_validation_errors(query)
+    assert_not_empty(query.validation_errors)
+  end
+
+  def test_validate_params_one
     # Should ignore params it doesn't recognize
-    # assert_raises(RuntimeError) { Query.lookup(:Name, xxx: true) }
-    assert_raises(RuntimeError) { Query.lookup(:Name, order_by: [1, 2, 3]) }
-    assert_raises(RuntimeError) { Query.lookup(:Name, order_by: true) }
+    assert_equal(Query.lookup(:Name, xxx: true), Query.lookup(:Name))
+    assert_validation_errors(Query.lookup(:Name, order_by: [1, 2, 3]))
+    assert_validation_errors(Query.lookup(:Name, order_by: true))
     assert_equal("id", Query.lookup(:Name, order_by: :id).params[:order_by])
 
     assert_equal(
@@ -47,20 +51,16 @@ class QueryTest < UnitTestCase
       :either,
       Query.lookup(:Name, misspellings: "either").params[:misspellings]
     )
-    assert_raises(RuntimeError) do
-      Query.lookup(:Name, misspellings: "bogus")
-    end
-    assert_raises(RuntimeError) do
-      Query.lookup(:Name, misspellings: true)
-    end
-    assert_raises(RuntimeError) { Query.lookup(:Name, misspellings: 123) }
+    assert_validation_errors(Query.lookup(:Name, misspellings: "bogus"))
+    assert_validation_errors(Query.lookup(:Name, misspellings: true))
+    assert_validation_errors(Query.lookup(:Name, misspellings: 123))
   end
 
   def test_validate_params_instances_users
     @fungi = names(:fungi)
 
-    assert_raises(RuntimeError) { Query.lookup(:Image, by_users: :bogus) }
-    assert_raises(RuntimeError) { Query.lookup(:Image, by_users: @fungi) }
+    assert_validation_errors(Query.lookup(:Image, by_users: :bogus))
+    assert_validation_errors(Query.lookup(:Image, by_users: @fungi))
     assert_equal([rolf.id],
                  Query.lookup(:Image, by_users: rolf).params[:by_users])
     assert_equal([rolf.id],
@@ -75,9 +75,9 @@ class QueryTest < UnitTestCase
     # Oops, this query is generic,
     # doesn't know to require Name instances here.
     # assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: rolf) }
-    assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: "one") }
-    assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: "1,2,3") }
-    assert_raises(RuntimeError) { Query.lookup(:Name, id_in_set: "Fungi") }
+    assert_validation_errors(Query.lookup(:Image, id_in_set: "one"))
+    assert_validation_errors(Query.lookup(:Image, id_in_set: "1,2,3"))
+    assert_validation_errors(Query.lookup(:Image, id_in_set: "Fungi"))
     assert_equal(
       [names(:fungi).id],
       Query.lookup(:Name, id_in_set: names(:fungi).id.to_s).params[:id_in_set]
@@ -110,16 +110,9 @@ class QueryTest < UnitTestCase
   end
 
   def test_validate_params_pattern
-    # assert_raises(RuntimeError) { Query.lookup(:Name) }
-    assert_raises(RuntimeError) do
-      Query.lookup(:Name, pattern: true)
-    end
-    assert_raises(RuntimeError) do
-      Query.lookup(:Name, pattern: [1, 2, 3])
-    end
-    assert_raises(RuntimeError) do
-      Query.lookup(:Name, pattern: rolf)
-    end
+    assert_validation_errors(Query.lookup(:Name, pattern: true))
+    assert_validation_errors(Query.lookup(:Name, pattern: [1, 2, 3]))
+    assert_validation_errors(Query.lookup(:Name, pattern: rolf))
     assert_equal("123",
                  Query.lookup(:Name, pattern: 123).params[:pattern])
     assert_equal("rolf",
@@ -155,13 +148,13 @@ class QueryTest < UnitTestCase
   def test_validate_params_group
     assert_equal("names.id",
                  Query.lookup(:Name, group: "names.id").params[:group])
-    assert_raises(RuntimeError) { Query.lookup(:Name, group: %w[1 2]) }
+    assert_validation_errors(Query.lookup(:Name, group: %w[1 2]))
   end
 
   def test_validate_params_order
     assert_equal("id DESC",
                  Query.lookup(:Name, order: "id DESC").params[:order])
-    assert_raises(RuntimeError) { Query.lookup(:Name, order: %w[1 2]) }
+    assert_validation_errors(Query.lookup(:Name, order: %w[1 2]))
   end
 
   def test_validate_params_hashes
@@ -169,9 +162,9 @@ class QueryTest < UnitTestCase
     assert_equal(box, Query.lookup(:Location, in_box: box).params[:in_box])
     assert_raises(TypeError) { Query.lookup(:Location, in_box: "one") }
     box = { north: "with", south: 48.558, east: -123.4307, west: -123.4763 }
-    assert_raises(RuntimeError) { Query.lookup(:Location, in_box: box) }
+    assert_validation_errors(Query.lookup(:Location, in_box: box))
     box = { south: 48.558, east: -123.4307, west: -123.4763 }
-    assert_raises(RuntimeError) { Query.lookup(:Location, in_box: box) }
+    assert_validation_errors(Query.lookup(:Location, in_box: box))
   end
 
   def test_initialize_helpers

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -33,6 +33,7 @@ class QueryTest < UnitTestCase
   end
 
   def assert_validation_errors(query)
+    assert_false(query.valid)
     assert_not_empty(query.validation_errors)
   end
 

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -26,6 +26,7 @@ class ArticlesControllerTest < FunctionalTestCase
     query = Query.lookup(:Article, id_in_set: [article.id])
     params = @controller.query_params(query)
     get(:index, params: params)
+    assert_no_flash
 
     assert_select("#content a:match('href',?)", %r{/articles/\d+},
                   { count: 1 },
@@ -34,6 +35,13 @@ class ArticlesControllerTest < FunctionalTestCase
       "a[href *= '#{article_path(article.id)}']", true,
       "filtered Article Index missing link to #{article.title} (##{article.id})"
     )
+  end
+
+  def test_index_query_validation_errors
+    query = Query.lookup(:Article, id_in_set: "one")
+    params = @controller.query_params(query)
+    get(:index, params: params)
+    assert_flash_error
   end
 
   def test_index_links_to_create


### PR DESCRIPTION
Changes Query's behavior from raising on validation errors, to storing `@validation_errors`. 

Introduces a `Validator` for Query classes that runs on `Query.new` or `create_query` and simply checks of `Query::Modules::Validation` has added any error messages to the ivar, adding them to the Validator's own error messages. Adds new tests for validation errors, and brings validation error coverage to 100%.

Both the `query.valid` state and the messages can be checked in the controller, and are shown via flash. Adds a test for the flash.

This refactor was accomplished by changing how Query is instantiated, and by including `ActiveModel::API`. The params of a Query are now attributes of the model/instance; validation can use Rails patterns.