### PR TITLE
Add RssLog scope `content_filters`

### DIFF
--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -14,7 +14,8 @@ class Query::RssLogs < Query::Base
       id_in_set: [RssLog],
       type: :string
     ).merge(content_filter_parameter_declarations(Observation)).
-      merge(content_filter_parameter_declarations(Location))
+      merge(content_filter_parameter_declarations(Location)).
+      merge(content_filter_parameter_declarations(Name))
   end
 
   # Declare the parameters as attributes of type `query_param`
@@ -28,6 +29,7 @@ class Query::RssLogs < Query::Base
     add_id_in_set_condition
     initialize_content_filters_for_rss_log(Observation)
     initialize_content_filters_for_rss_log(Location)
+    initialize_content_filters_for_rss_log(Name)
     super
   end
 

--- a/app/models/abstract_model/ordering_scopes.rb
+++ b/app/models/abstract_model/ordering_scopes.rb
@@ -37,8 +37,8 @@ module AbstractModel::OrderingScopes
       scope = :"order_by_#{method}"
       return all unless model.private_methods(false).include?(scope)
 
-      # Calls `scoping` with `model` here, because the private class methods
-      # below are otherwise inaccessible to a `scope` proc.
+      # Call `scoping` with `model.send(:method)` here, because the private
+      # class methods below are otherwise inaccessible to a `scope` proc.
       scope = scoping { model.send(scope) }
       scope = scope.reverse_order if reverse
       # Order grouped results from other scopes by adding order(id: :desc). If

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -140,7 +140,9 @@
 #
 #  None.
 #
-class RssLog < AbstractModel # rubocop:disable Metrics/ClassLength
+class RssLog < AbstractModel
+  include RssLog::Scopes
+
   belongs_to :article
   belongs_to :glossary_term
   belongs_to :location
@@ -148,114 +150,6 @@ class RssLog < AbstractModel # rubocop:disable Metrics/ClassLength
   belongs_to :observation
   belongs_to :project
   belongs_to :species_list
-
-  scope :order_by_default,
-        -> { order_by(::Query::RssLogs.default_order) }
-
-  scope :type, lambda { |types|
-    return all if types.to_s == "all"
-
-    types = types.to_s.split unless types.is_a?(Array)
-    types &= ALL_TYPE_TAGS.map(&:to_s)
-    return none if types.empty?
-
-    types.map! { |type| arel_table[:"#{type}_id"].not_eq(nil) }
-    where(or_clause(*types)).distinct
-  }
-
-  # Apply content filters to all types of RssLog requested in the current Query.
-  # NOTE: One content filter may apply to two or more types (e.g. `:region`
-  # applies to both Observations and Locations), so we need to build a query
-  # where each type of RssLog is filtered separately.
-  #
-  # Query itself calls this scope because it has all the current query params,
-  # and because Query::Filter knows what all the possible filter params are.
-  # We probably wouldn't call this scope elsewhere, except from a test.
-  #
-  # For reference:
-  # Query.new(:RssLog, region: "Canada", has_specimen: true).to_sql
-  #
-  # SELECT DISTINCT rss_logs.id
-  # FROM `rss_logs`
-  # LEFT OUTER JOIN `observations` ON rss_logs.observation_id = observations.id
-  # LEFT OUTER JOIN `locations` ON rss_logs.location_id = locations.id
-  # WHERE (observations.id IS NULL OR
-  #        ((observations.specimen IS TRUE AND
-  #          CONCAT(', ', observations.where) LIKE '%, Canada')))
-  # AND (locations.id IS NULL OR
-  #      (CONCAT(', ', locations.name) LIKE '%, Canada')))
-  # ORDER BY rss_logs.updated_at DESC, rss_logs.id DESC
-  #
-  scope :content_filters, lambda { |params|
-    return all if params.blank?
-
-    scope = all
-    # `type` here is a model
-    filterable_types_in_current_query(params).each do |type|
-      type_filters = active_filters_for_model(params, type)
-      next if type_filters.blank?
-
-      # Join association is singular for all RssLog associations
-      association = type.name.underscore
-      # Returns "logs that are not of this type, or if they are, then filtered"
-      scope = scope.
-              left_outer_joins(:"#{association}").
-              where("#{association}_id": nil).distinct.
-              or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
-    end
-    scope
-  }
-
-  def self.filtering_statements(params)
-    # `type` here is a model (var name `model` unavailable)
-    filterable_types_in_current_query(params).map do |type|
-      type_filters = active_filters_for_model(params, type)
-      next if type_filters.blank?
-
-      # Join association is singular for all RssLog associations
-      association = type.name.underscore
-      # Returns "logs that are not of this type, or if they are, then filtered"
-      left_outer_joins(:"#{association}").
-        where("#{association}_id": nil).distinct.
-        or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
-    end
-  end
-
-  # Types requested in the current RssLog query that may have content filters
-  # applied. Defaults to :all. Returns an array of model classes.
-  def self.filterable_types_in_current_query(params)
-    filterable_types = [:observation, :name, :location]
-    active_types = case params[:type]
-                   when nil, "", :all, "all"
-                     filterable_types
-                   when Array
-                     params[:type]
-                   when String
-                     params[:type].split
-                   end
-    active_types.map { |type| type.to_s.camelize.constantize }
-  end
-
-  # Find any active filters relevant to a model, using Query::Filter.by_model.
-  # Returns a hash of only the relevant params.
-  def self.active_filters_for_model(params, model)
-    ::Query::Filter.by_model(model).
-      each_with_object({}) do |fltr, filter_params|
-        next if (val = params[fltr.sym]).to_s == ""
-
-        filter_params[fltr.sym] = val
-      end
-  end
-
-  # Build a scope statement for one type (model).
-  def self.filter_conditions_for_type(type, type_filters)
-    # Condense all filters into an array of AR scope statements
-    conditions_for_type = type_filters.reduce([]) do |conds, (k, v)|
-      conds << type.send(k, v).distinct
-    end
-    # Join the array of conditions by `and`.
-    and_clause(*conditions_for_type).distinct
-  end
 
   # Maximum allowed length (in bytes) of notes column.  Actually it should be
   # 65535, I think, but let's mak sure there's a safe buffer.

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -140,7 +140,7 @@
 #
 #  None.
 #
-class RssLog < AbstractModel
+class RssLog < AbstractModel # rubocop:disable Metrics/ClassLength
   belongs_to :article
   belongs_to :glossary_term
   belongs_to :location
@@ -162,6 +162,100 @@ class RssLog < AbstractModel
     types.map! { |type| arel_table[:"#{type}_id"].not_eq(nil) }
     where(or_clause(*types)).distinct
   }
+
+  # Apply content filters to all types of RssLog requested in the current Query.
+  # NOTE: One content filter may apply to two or more types (e.g. `:region`
+  # applies to both Observations and Locations), so we need to build a query
+  # where each type of RssLog is filtered separately.
+  #
+  # Query itself calls this scope because it has all the current query params,
+  # and because Query::Filter knows what all the possible filter params are.
+  # We probably wouldn't call this scope elsewhere, except from a test.
+  #
+  # For reference:
+  # Query.new(:RssLog, region: "Canada", has_specimen: true).to_sql
+  #
+  # SELECT DISTINCT rss_logs.id
+  # FROM `rss_logs`
+  # LEFT OUTER JOIN `observations` ON rss_logs.observation_id = observations.id
+  # LEFT OUTER JOIN `locations` ON rss_logs.location_id = locations.id
+  # WHERE (observations.id IS NULL OR
+  #        ((observations.specimen IS TRUE AND
+  #          CONCAT(', ', observations.where) LIKE '%, Canada')))
+  # AND (locations.id IS NULL OR
+  #      (CONCAT(', ', locations.name) LIKE '%, Canada')))
+  # ORDER BY rss_logs.updated_at DESC, rss_logs.id DESC
+  #
+  scope :content_filters, lambda { |params|
+    return all if params.blank?
+
+    scope = all
+    # `type` here is a model
+    filterable_types_in_current_query(params).each do |type|
+      type_filters = active_filters_for_model(params, type)
+      next if type_filters.blank?
+
+      # Join association is singular for all RssLog associations
+      association = type.name.underscore
+      # Returns "logs that are not of this type, or if they are, then filtered"
+      scope = scope.
+              left_outer_joins(:"#{association}").
+              where("#{association}_id": nil).distinct.
+              or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
+    end
+    scope
+  }
+
+  def self.filtering_statements(params)
+    # `type` here is a model (var name `model` unavailable)
+    filterable_types_in_current_query(params).map do |type|
+      type_filters = active_filters_for_model(params, type)
+      next if type_filters.blank?
+
+      # Join association is singular for all RssLog associations
+      association = type.name.underscore
+      # Returns "logs that are not of this type, or if they are, then filtered"
+      left_outer_joins(:"#{association}").
+        where("#{association}_id": nil).distinct.
+        or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
+    end
+  end
+
+  # Types requested in the current RssLog query that may have content filters
+  # applied. Defaults to :all. Returns an array of model classes.
+  def self.filterable_types_in_current_query(params)
+    filterable_types = [:observation, :name, :location]
+    active_types = case params[:type]
+                   when nil, "", :all, "all"
+                     filterable_types
+                   when Array
+                     params[:type]
+                   when String
+                     params[:type].split
+                   end
+    active_types.map { |type| type.to_s.camelize.constantize }
+  end
+
+  # Find any active filters relevant to a model, using Query::Filter.by_model.
+  # Returns a hash of only the relevant params.
+  def self.active_filters_for_model(params, model)
+    ::Query::Filter.by_model(model).
+      each_with_object({}) do |fltr, filter_params|
+        next if (val = params[fltr.sym]).to_s == ""
+
+        filter_params[fltr.sym] = val
+      end
+  end
+
+  # Build a scope statement for one type (model).
+  def self.filter_conditions_for_type(type, type_filters)
+    # Condense all filters into an array of AR scope statements
+    conditions_for_type = type_filters.reduce([]) do |conds, (k, v)|
+      conds << type.send(k, v).distinct
+    end
+    # Join the array of conditions by `and`.
+    and_clause(*conditions_for_type).distinct
+  end
 
   # Maximum allowed length (in bytes) of notes column.  Actually it should be
   # 65535, I think, but let's mak sure there's a safe buffer.

--- a/app/models/rss_log/scopes.rb
+++ b/app/models/rss_log/scopes.rb
@@ -15,7 +15,7 @@ module RssLog::Scopes
       return all if types.to_s == "all"
 
       types = types.to_s.split unless types.is_a?(Array)
-      types &= ALL_TYPE_TAGS.map(&:to_s)
+      types &= ::RssLog::ALL_TYPE_TAGS.map(&:to_s)
       return none if types.empty?
 
       types.map! { |type| arel_table[:"#{type}_id"].not_eq(nil) }

--- a/app/models/rss_log/scopes.rb
+++ b/app/models/rss_log/scopes.rb
@@ -54,10 +54,10 @@ module RssLog::Scopes
         # Join association is singular for all RssLog associations
         association = type.name.underscore
         # "logs that are not of this type, or if they are, then filtered"
-        scope = scope.
-                left_outer_joins(:"#{association}").
-                where("#{association}_id": nil).distinct.
-                or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
+        scope = scope.left_outer_joins(:"#{association}").distinct.
+                where("#{association}_id": nil).or(
+                  RssLog.merge(filter_conditions_for_type(type, type_filters))
+                )
       end
       scope
     end

--- a/app/models/rss_log/scopes.rb
+++ b/app/models/rss_log/scopes.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module RssLog::Scopes
+  # This is using Concern so we can define the scopes in this included module.
+  extend ActiveSupport::Concern
+
+  # NOTE: To improve Coveralls display, avoid one-line stabby lambda scopes.
+  # Two line stabby lambdas are OK, it's just the declaration line that will
+  # always show as covered.
+  included do
+    scope :order_by_default,
+          -> { order_by(::Query::RssLogs.default_order) }
+
+    scope :type, lambda { |types|
+      return all if types.to_s == "all"
+
+      types = types.to_s.split unless types.is_a?(Array)
+      types &= ALL_TYPE_TAGS.map(&:to_s)
+      return none if types.empty?
+
+      types.map! { |type| arel_table[:"#{type}_id"].not_eq(nil) }
+      where(or_clause(*types)).distinct
+    }
+
+    # Apply content filters to all types of RssLog requested in the current
+    # Query. NOTE: One content filter may apply to two or more types (e.g.
+    # `:region` applies to both Observations and Locations), so we need to
+    # build a query where each type of RssLog is filtered separately.
+    #
+    # Query itself calls this scope because it has all the current query params,
+    # and because Query::Filter knows what all the possible filter params are.
+    # We probably wouldn't call this scope elsewhere, except from a test.
+    #
+    scope :content_filters, lambda { |params|
+      return all if params.blank?
+
+      scope = all
+      # `type` here is a model
+      filterable_types_in_current_query(params).each do |type|
+        type_filters = active_filters_for_model(params, type)
+        next if type_filters.blank?
+
+        # Join association is singular for all RssLog associations
+        association = type.name.underscore
+        # "logs that are not of this type, or if they are, then filtered"
+        scope = scope.
+                left_outer_joins(:"#{association}").
+                where("#{association}_id": nil).distinct.
+                or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
+      end
+      scope
+    }
+  end
+
+  module ClassMethods
+    # class methods here, `self` included
+    def self.filtering_statements(params)
+      # `type` here is a model (var name `model` unavailable)
+      filterable_types_in_current_query(params).map do |type|
+        type_filters = active_filters_for_model(params, type)
+        next if type_filters.blank?
+
+        # Join association is singular for all RssLog associations
+        association = type.name.underscore
+        # Returns "logs that are not of this type, or if they are, then filtered"
+        left_outer_joins(:"#{association}").
+          where("#{association}_id": nil).distinct.
+          or(RssLog.merge(filter_conditions_for_type(type, type_filters)))
+      end
+    end
+
+    # Types requested in the current RssLog query that may have content filters
+    # applied. Defaults to :all. Returns an array of model classes.
+    def self.filterable_types_in_current_query(params)
+      filterable_types = [:observation, :name, :location]
+      active_types = case params[:type]
+                     when nil, "", :all, "all"
+                       filterable_types
+                     when Array
+                       params[:type]
+                     when String
+                       params[:type].split
+                     end
+      active_types.map { |type| type.to_s.camelize.constantize }
+    end
+
+    # Find any active filters relevant to a model, using Query::Filter.by_model.
+    # Returns a hash of only the relevant params.
+    def self.active_filters_for_model(params, model)
+      ::Query::Filter.by_model(model).
+        each_with_object({}) do |fltr, filter_params|
+          next if (val = params[fltr.sym]).to_s == ""
+
+          filter_params[fltr.sym] = val
+        end
+    end
+
+    # Build a scope statement for one type (model).
+    def self.filter_conditions_for_type(type, type_filters)
+      # Condense all filters into an array of AR scope statements
+      conditions_for_type = type_filters.reduce([]) do |conds, (k, v)|
+        conds << type.send(k, v).distinct
+      end
+      # Join the array of conditions by `and`.
+      and_clause(*conditions_for_type).distinct
+    end
+  end
+end

--- a/test/classes/query/rss_logs_test.rb
+++ b/test/classes/query/rss_logs_test.rb
@@ -37,4 +37,43 @@ class Query::RssLogsTest < UnitTestCase
     scope = RssLog.type("species_list project").order_by_default
     assert_query_scope(ids, scope, :RssLog, type: "species_list project")
   end
+
+  def test_rss_log_content_filter_has_specimen
+    scope = RssLog.content_filters(has_specimen: true).order_by_default
+    assert_query(scope, :RssLog, has_specimen: true)
+    assert_equal(0, scope.where(Observation[:specimen].eq(false)).count)
+  end
+
+  def test_rss_log_content_filter_region
+    region = "California, USA"
+    scope = RssLog.content_filters(region:).order_by_default
+    assert_query(scope, :RssLog, region:)
+    # Check that the results got everything
+    expect = RssLog.joins(:location).
+             where(Location[:name].matches("%#{region}")).count
+    assert(expect.positive?)
+    assert_equal(expect,
+                 scope.where(Location[:name].matches("%#{region}")).count)
+    expect = RssLog.joins(:observation).
+             where(Observation[:where].matches("%#{region}")).count
+    assert(expect.positive?)
+    assert_equal(expect,
+                 scope.where(Observation[:where].matches("%#{region}")).count)
+  end
+
+  def test_rss_log_content_filter_lichen
+    scope = RssLog.content_filters(lichen: true).order_by_default
+    assert_query(scope, :RssLog, lichen: true)
+    # Check that the results got everything. No name RssLogs for lichen yet.
+    # expect = RssLog.joins(:name).
+    #          where(Name[:lifeform].matches("%lichen%")).count
+    # assert(expect.positive?)
+    # assert_equal(expect,
+    #              scope.where(Name[:lifeform].matches("%lichen%")).count)
+    expect = RssLog.joins(:observation).
+             where(Observation[:lifeform].matches("%lichen%")).count
+    assert(expect.positive?)
+    assert_equal(expect,
+                 scope.where(Observation[:lifeform].matches("%lichen%")).count)
+  end
 end


### PR DESCRIPTION
This will probably only be used by the Query class and tests, because it takes query params as an arg. I want to merge it ahead to test the scope against Query's current SQL.

Turns out Query does not currently honor filters like "lichen: true" for RssLog queries of Names. This PR changes that to make the behavior uniform as I believe would be expected.