### PR TITLE
External Site Fix

### DIFF
--- a/app/classes/format_url.rb
+++ b/app/classes/format_url.rb
@@ -118,7 +118,7 @@ class FormatURL
 
     url = URI.parse(url)
     return false if url.host.blank?
-    return true if ENV.fetch("RAILS_ENV") == "test"
+    return true if ENV["RAILS_ENV"] == "test"
 
     request = format_request(url)
     path = url.path if url.path.present?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_174427) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "banners", charset: "utf8mb3", force: :cascade do |t|
+  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "message"
     t.integer "version"
     t.datetime "created_at", null: false
@@ -560,7 +560,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_174427) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "project_aliases", charset: "utf8mb3", force: :cascade do |t|
+  create_table "project_aliases", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "project_id", null: false
     t.integer "target_id", null: false
     t.string "target_type", null: false
@@ -918,11 +918,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_174427) do
     t.text "alert"
     t.boolean "email_locations_admin", default: false
     t.boolean "email_names_admin", default: false
+    t.integer "thumbnail_size", default: 1
     t.integer "image_size", default: 5
     t.string "default_rss_type", limit: 40, default: "all"
     t.integer "votes_anonymous", default: 1
     t.integer "location_format", default: 1
     t.datetime "last_activity", precision: nil
+    t.integer "hide_authors", default: 1, null: false
     t.boolean "thumbnail_maps", default: true, null: false
     t.string "auth_code", limit: 40
     t.integer "keep_filenames", default: 1, null: false
@@ -936,8 +938,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_174427) do
     t.boolean "no_emails", default: false, null: false
     t.string "inat_username"
     t.integer "original_image_quota", default: 0
-    t.integer "hide_authors"
-    t.integer "thumbnail_size"
     t.index ["login"], name: "login_index"
   end
 


### PR DESCRIPTION
Fixes a problem where RAILS_ENV may not be set when a migration is run so `ENV.fetch` fails.
Includes the db/schema.rb that gets generated for me locally which appears to align with what is currently in the production database.