### PR TITLE
Test for sequence creation via Turbo

### DIFF
--- a/app/controllers/collection_numbers/remove_observations_controller.rb
+++ b/app/controllers/collection_numbers/remove_observations_controller.rb
@@ -49,7 +49,8 @@ module CollectionNumbers
         format.turbo_stream do
           render(
             partial: "observations/show/section_update",
-            locals: { identifier: "collection_numbers" }
+            locals: { identifier: "collection_numbers",
+                      obs: @observation, user: @user }
           ) and return
         end
       end

--- a/app/controllers/herbarium_records/remove_observations_controller.rb
+++ b/app/controllers/herbarium_records/remove_observations_controller.rb
@@ -48,7 +48,8 @@ module HerbariumRecords
         format.turbo_stream do
           render(
             partial: "observations/show/section_update",
-            locals: { identifier: "herbarium_records" }
+            locals: { identifier: "herbarium_records",
+                      obs: @observation, user: @user }
           ) and return
         end
       end

--- a/test/controllers/collection_numbers/remove_observations_controller_test.rb
+++ b/test/controllers/collection_numbers/remove_observations_controller_test.rb
@@ -95,7 +95,7 @@ class CollectionNumbers::RemoveObservationsControllerTest < FunctionalTestCase
     assert_redirected_to(observation_path(id: obs.id, q: q))
   end
 
-  def test_turbo_remove_collection_number
+  def test_turbo_remove_collection_number_non_owner
     obs1, _obs2, num1, _num2 = setup_test_fixtures
 
     # non-owner cannot
@@ -105,9 +105,15 @@ class CollectionNumbers::RemoveObservationsControllerTest < FunctionalTestCase
     patch(:update, params: params,
                    format: :turbo_stream)
     assert_obj_arrays_equal([num1], obs1.reload.collection_numbers)
+  end
+
+  def test_turbo_remove_collection_number_owner
+    obs1, _obs2, num1, _num2 = setup_test_fixtures
 
     # owner can
     login("rolf")
+    params = { collection_number_id: num1.id,
+               observation_id: obs1.id }
     patch(:update, params: params,
                    format: :turbo_stream)
     assert_empty(obs1.reload.collection_numbers)

--- a/test/controllers/collection_numbers/remove_observations_controller_test.rb
+++ b/test/controllers/collection_numbers/remove_observations_controller_test.rb
@@ -3,44 +3,71 @@
 require("test_helper")
 
 class CollectionNumbers::RemoveObservationsControllerTest < FunctionalTestCase
-  def test_remove_observation
+  def setup_test_fixtures
     obs1 = observations(:agaricus_campestris_obs)
     obs2 = observations(:coprinus_comatus_obs)
     num1 = collection_numbers(:agaricus_campestris_coll_num)
     num2 = collection_numbers(:coprinus_comatus_coll_num)
+    [obs1, obs2, num1, num2]
+  end
+
+  def test_fixtures_are_correct
+    obs1, obs2, num1, num2 = setup_test_fixtures
     assert_obj_arrays_equal([num1], obs1.collection_numbers)
     assert_obj_arrays_equal([num2], obs2.collection_numbers)
+  end
 
-    # Make sure user must be logged in.
+  # Make sure user must be logged in.
+  def test_must_be_logged_in
+    obs1, _obs2, num1, _num2 = setup_test_fixtures
+
     patch(:update, params: { collection_number_id: num1.id,
                              observation_id: obs1.id })
     assert_obj_arrays_equal([num1], obs1.reload.collection_numbers)
+  end
 
-    # Make sure only owner obs can remove num from it.
-    login("mary")
+  # Make sure only owner obs can remove num from it.
+  def test_only_owner_can_remove
+    obs1, _obs2, num1, _num2 = setup_test_fixtures
+
+    login("mary") # owner is rolf
     patch(:update, params: { collection_number_id: num1.id,
                              observation_id: obs1.id })
     assert_obj_arrays_equal([num1], obs1.reload.collection_numbers)
+  end
 
-    # Make sure badly-formed queries don't crash.
+  # Make sure badly-formed queries don't crash.
+  def test_badly_formed_queries_dont_crash
+    obs1, obs2, num1, num2 = setup_test_fixtures
+
     login("rolf")
-    # patch(:update) not a valid route
     patch(:update, params: { collection_number_id: -1 })
     patch(:update, params: { collection_number_id: num1.id })
     patch(:update, params: { collection_number_id: num1.id,
                              observation_id: "bogus" })
+    # wrong observation for num1
     patch(:update, params: { collection_number_id: num1.id,
                              observation_id: obs2.id })
     assert_obj_arrays_equal([num1], obs1.reload.collection_numbers)
     assert_obj_arrays_equal([num2], obs2.reload.collection_numbers)
+  end
 
-    # Removing num from last obs destroys it.
+  # Removing num from last obs destroys it.
+  def test_removing_actually_destroys_when_no_other_associations
+    obs1, _obs2, num1, _num2 = setup_test_fixtures
+
+    login("rolf")
     patch(:update, params: { collection_number_id: num1.id,
                              observation_id: obs1.id })
     assert_empty(obs1.reload.collection_numbers)
     assert_nil(CollectionNumber.safe_find(num1.id))
+  end
 
-    # Removing num from one of two obs does not destroy it.
+  # Removing num from one of two obs does not destroy it.
+  def test_removing_from_obs_does_not_destroy_when_belongs_to_two_obs
+    obs1, obs2, _num1, num2 = setup_test_fixtures
+
+    login("rolf")
     num2.add_observation(obs1)
     assert_obj_arrays_equal([num2], obs1.reload.collection_numbers)
     assert_obj_arrays_equal([num2], obs2.reload.collection_numbers)
@@ -49,8 +76,12 @@ class CollectionNumbers::RemoveObservationsControllerTest < FunctionalTestCase
     assert_obj_arrays_equal([num2], obs1.reload.collection_numbers)
     assert_empty(obs2.reload.collection_numbers)
     assert_not_nil(CollectionNumber.safe_find(num2.id))
+  end
 
-    # Finally make sure admin has permission.
+  # Finally make sure admin has permission.
+  def test_admin_can_remove
+    obs1, _obs2, _num1, num2 = setup_test_fixtures
+
     make_admin("mary")
     patch(:update, params: { collection_number_id: num2.id,
                              observation_id: obs1.id })
@@ -63,6 +94,7 @@ class CollectionNumbers::RemoveObservationsControllerTest < FunctionalTestCase
     nums  = obs.collection_numbers
     query = Query.lookup_and_save(:CollectionNumber)
     q     = query.id.alphabetize
+
     login(obs.user.login)
     assert_operator(nums.length, :>, 1)
 
@@ -70,5 +102,16 @@ class CollectionNumbers::RemoveObservationsControllerTest < FunctionalTestCase
     patch(:update, params: { collection_number_id: nums[1].id,
                              observation_id: obs.id, q: q })
     assert_redirected_to(observation_path(id: obs.id, q: q))
+  end
+
+  def test_turbo_remove_collection_number
+    obs1, _obs2, num1, _num2 = setup_test_fixtures
+
+    login("rolf")
+    params = { collection_number_id: num1.id,
+               observation_id: obs1.id }
+    patch(:update, params: params,
+                   format: :turbo_stream)
+    assert_obj_arrays_equal([num1], obs1.reload.collection_numbers)
   end
 end

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -170,6 +170,23 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  def test_create_collection_number_with_turbo
+    obs = observations(:strobilurus_diminutivus_obs)
+    user = obs.user
+    params = {
+      observation_id: obs.id,
+      collection_number: {
+        name: user.login,
+        number: "1234"
+      }
+    }
+    login(user.login)
+    assert_difference("CollectionNumber.count", 1) do
+      post(:create, params: params,
+                    format: :turbo_stream)
+    end
+  end
+
   def test_create_collection_number
     collection_number_count = CollectionNumber.count
     obs = observations(:strobilurus_diminutivus_obs)

--- a/test/controllers/herbarium_records/remove_observations_controller_test.rb
+++ b/test/controllers/herbarium_records/remove_observations_controller_test.rb
@@ -94,7 +94,7 @@ class HerbariumRecords::RemoveObservationsControllerTest < FunctionalTestCase
     assert_redirected_to(observation_path(id: obs.id, q: q))
   end
 
-  def test_turbo_remove_herbarium_record
+  def test_turbo_remove_herbarium_record_non_owner
     obs1, _obs2, rec1, _rec2 = setup_test_fixtures
 
     # non-owner cannot
@@ -104,9 +104,15 @@ class HerbariumRecords::RemoveObservationsControllerTest < FunctionalTestCase
     patch(:update, params: params,
                    format: :turbo_stream)
     assert_true(obs1.reload.herbarium_records.include?(rec1))
+  end
+
+  def test_turbo_remove_herbarium_record_owner
+    obs1, _obs2, rec1, _rec2 = setup_test_fixtures
 
     # owner can
     login("rolf")
+    params = { herbarium_record_id: rec1.id,
+               observation_id: obs1.id }
     patch(:update, params: params,
                    format: :turbo_stream)
     assert_empty(obs1.reload.herbarium_records)

--- a/test/controllers/herbarium_records/remove_observations_controller_test.rb
+++ b/test/controllers/herbarium_records/remove_observations_controller_test.rb
@@ -3,28 +3,44 @@
 require("test_helper")
 
 class HerbariumRecords::RemoveObservationsControllerTest < FunctionalTestCase
-  def test_remove_observation
+  def setup_test_fixtures
     obs1 = observations(:agaricus_campestris_obs)
     obs2 = observations(:coprinus_comatus_obs)
     rec1 = obs1.herbarium_records.first
     rec2 = obs2.herbarium_records.first
+    [obs1, obs2, rec1, rec2]
+  end
+
+  def test_fixtures_are_correct
+    obs1, obs2, rec1, rec2 = setup_test_fixtures
     assert_true(obs1.herbarium_records.include?(rec1))
     assert_true(obs2.herbarium_records.include?(rec2))
+  end
 
-    # Make sure user must be logged in.
+  # Make sure user must be logged in.
+  def test_must_be_logged_in
+    obs1, _obs2, rec1, _rec2 = setup_test_fixtures
+
     patch(:update, params: { herbarium_record_id: rec1.id,
                              observation_id: obs1.id })
     assert_true(obs1.reload.herbarium_records.include?(rec1))
+  end
 
-    # Make sure only owner obs can remove rec from it.
+  # Make sure only owner obs can remove rec from it.
+  def test_only_owner_can_remove
+    obs1, _obs2, rec1, _rec2 = setup_test_fixtures
+
     login("mary")
     patch(:update,
           params: { herbarium_record_id: rec1.id, observation_id: obs1.id })
     assert_true(obs1.reload.herbarium_records.include?(rec1))
+  end
 
-    # Make sure badly-formed queries don't crash.
+  # Make sure badly-formed queries don't crash.
+  def test_badly_formed_queries_dont_crash
+    obs1, obs2, rec1, rec2 = setup_test_fixtures
+
     login("rolf")
-    # patch(:update)
     patch(:update, params: { herbarium_record_id: -1 })
     patch(:update, params: { herbarium_record_id: rec1.id })
     patch(:update,
@@ -33,7 +49,12 @@ class HerbariumRecords::RemoveObservationsControllerTest < FunctionalTestCase
           params: { herbarium_record_id: rec1.id, observation_id: obs2.id })
     assert_true(obs1.reload.herbarium_records.include?(rec1))
     assert_true(obs2.reload.herbarium_records.include?(rec2))
+  end
 
+  def test_removing_destroys_only_when_appropriate
+    obs1, obs2, rec1, rec2 = setup_test_fixtures
+
+    login("rolf")
     # Removing rec from last obs destroys it.
     patch(:update,
           params: { herbarium_record_id: rec1.id, observation_id: obs1.id })
@@ -71,5 +92,23 @@ class HerbariumRecords::RemoveObservationsControllerTest < FunctionalTestCase
           params: { herbarium_record_id: recs[1].id, observation_id: obs.id,
                     q: q })
     assert_redirected_to(observation_path(id: obs.id, q: q))
+  end
+
+  def test_turbo_remove_herbarium_record
+    obs1, _obs2, rec1, _rec2 = setup_test_fixtures
+
+    # non-owner cannot
+    login("mary")
+    params = { herbarium_record_id: rec1.id,
+               observation_id: obs1.id }
+    patch(:update, params: params,
+                   format: :turbo_stream)
+    assert_true(obs1.reload.herbarium_records.include?(rec1))
+
+    # owner can
+    login("rolf")
+    patch(:update, params: params,
+                   format: :turbo_stream)
+    assert_empty(obs1.reload.herbarium_records)
   end
 end

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -233,6 +233,14 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  def test_create_herbarium_record_with_turbo
+    login
+    assert_difference("HerbariumRecord.count", 1) do
+      post(:create, params: herbarium_record_params,
+                    format: :turbo_stream)
+    end
+  end
+
   def test_create_herbarium_record_new_herbarium
     mary = login("mary")
     herbarium_count = mary.curated_herbaria.count

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -46,6 +46,16 @@ module Observations
       assert_equal(url, ExternalLink.last.url)
     end
 
+    # And now with Turbo...
+    def test_add_external_link_turbo
+      _, _obs2, _, _, params = setup_create_test
+      login("rolf")
+      assert_difference("ExternalLink.count", 1) do
+        post(:create, params: params,
+                      format: :turbo_stream)
+      end
+    end
+
     # bad url
     def test_add_external_link_bad_url
       _obs, _obs2, _site, _url, params = setup_create_test

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -179,8 +179,10 @@ class SequencesControllerTest < FunctionalTestCase
                   bases: ITS_BASES }
     }
     login
-    assert_difference("Sequence.count", 1) { post(:create, params: params,
-                                                  format: :turbo_stream) }
+    assert_difference("Sequence.count", 1) do
+      post(:create, params: params,
+                    format: :turbo_stream)
+    end
   end
 
   def test_create_non_repo_sequence

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -172,6 +172,17 @@ class SequencesControllerTest < FunctionalTestCase
            "Failed to include Sequence added in RssLog for Observation")
   end
 
+  def test_turbo_create
+    params = {
+      observation_id: observations(:detailed_unknown_obs).id,
+      sequence: { locus: "ITS",
+                  bases: ITS_BASES }
+    }
+    login
+    assert_difference("Sequence.count", 1) { post(:create, params: params,
+                                                  format: :turbo_stream) }
+  end
+
   def test_create_non_repo_sequence
     # Prove user can create non-repository Sequence
     obs = observations(:detailed_unknown_obs)


### PR DESCRIPTION
This test should have been part of #2876.  It confirms that sequences can be created via Turbo.  I will like add additional tests to this for collections numbers and herbarium records.