### PR TITLE
Try to fix AR in checklist.rb

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -123,7 +123,7 @@ class Checklist
          Name[:id].cast("char") + "," +
          Name[:rank].cast("char")).minimum
       ).group(
-        Name[:synonym_id].when(nil).then(Name[:id]).else(Name[:synonym_id])
+        Name[:synonym_id].when(present?).then(Name[:synonym_id]).else(Name[:id])
       )
     )
     synonyms.each do |row|


### PR DESCRIPTION
For reference, this was the original SQL:
```ruby
    synonyms = Name.connection.select_rows(%(
    SELECT GROUP_CONCAT(n.id),
      MIN(CONCAT(n.deprecated, ',', n.text_name, ',', n.id, ',', n.rank))
    FROM names n
    GROUP BY IF(synonym_id, synonym_id, -id);
    ))
```

I don't know what the `-id` means in the last line (specifically the `-`).

This PR is trying this rewrite and it runs locally without error where the other one failed. 
But i'm not sure it's right:
```ruby
    synonyms = Name.connection.select_rows(
      Name.select(
        Arel.sql("GROUP_CONCAT(names.id)"),
        (Name[:deprecated].cast("char") + "," +
         Name[:text_name].cast("char") + "," +
         Name[:id].cast("char") + "," +
         Name[:rank].cast("char")).minimum
      ).group(
        Name[:synonym_id].when(present?).then(Name[:synonym_id]).else(Name[:id])
      )
    )
```

Note that `GROUP_CONCAT` is apparently not accessible via Arel extensions, possibly because it's MySQL specific. 