### PR TITLE
Remove letter pagination from the Observations index

### DIFF
--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -67,15 +67,6 @@ class Query::Observations < Query::Base
     @model ||= Observation
   end
 
-  def alphabetical_by
-    @alphabetical_by ||= case params[:order_by].to_s
-                         when "user", "reverse_user"
-                           User[:login]
-                         when "name", "reverse_name"
-                           Name[:sort_name]
-                         end
-  end
-
   def self.default_order
     :date
   end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -204,22 +204,11 @@ class ObservationsController
       query
     end
 
-    def index_display_opts(opts, query)
+    def index_display_opts(opts, _query)
       # We always want cached matrix boxes for observations if possible.
       # cache: true  will batch load the includes only for fragments not cached.
-      opts = {
-        matrix: true, cache: true,
-        include: observation_index_includes
-      }.merge(opts)
-
-      # Paginate by letter if sorting by user or name.
-      if %w[user reverse_user name reverse_name].include?(
-        query.params[:order_by]
-      )
-        opts[:letters] = true
-      end
-
-      opts
+      { matrix: true, cache: true,
+        include: observation_index_includes }.merge(opts)
     end
 
     # The { images: } hash is necessary for the index carousels.

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -187,9 +187,11 @@ class SpeciesListsController < ApplicationController
     store_query_in_session(@query) if params[:set_source].present?
 
     @query.need_letters = true
-    @pagination_data = letter_pagination_data(:letter, :page, 100)
-    @objects = @query.paginate(@pagination_data, include:
-                  [:user, :name, :location, { thumb_image: :image_votes }])
+    @pagination_data = number_pagination_data(:page, 100)
+    @objects = @query.paginate(
+      @pagination_data,
+      include: [:user, :name, :location, { thumb_image: :image_votes }]
+    )
     # Save a lookup in comments_for_object
     @comments = @species_list.comments&.sort_by(&:created_at)&.reverse
   end

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -186,7 +186,6 @@ class SpeciesListsController < ApplicationController
     # See documentation on the 'How to Use' page to understand this feature.
     store_query_in_session(@query) if params[:set_source].present?
 
-    @query.need_letters = true
     @pagination_data = number_pagination_data(:page, 100)
     @objects = @query.paginate(
       @pagination_data,


### PR DESCRIPTION
Letter pagination for Observations doesn't seem too useful.

The one place where it might be is on SpeciesList show pages, but still.