### PR TITLE
Fix query for letter pagination

### DIFF
--- a/app/classes/query/modules/results.rb
+++ b/app/classes/query/modules/results.rb
@@ -73,9 +73,9 @@ module Query::Modules::Results
   end
 
   # Tries to be light about it, by selecting only two values.
-  # NOTE: `select(:id, :title)` returns instances with the selected attributes.
-  # We have to call `connection.select_rows` to return simple arrays.
-  # `alphabetical_by` is defined in each letter-sortable Query class and
+  # NOTE: `select(:id, :title)` returns instances having only these attributes -
+  # too heavy. We have to call `connection.select_rows` to return simple arrays.
+  # NOTE: `alphabetical_by` is defined in each letter-sortable Query class and
   # returns a `Model[:column]`. We check the first four chars of that column.
   def minimal_query_of_all_records
     model.connection.select_rows(

--- a/app/classes/query/modules/results.rb
+++ b/app/classes/query/modules/results.rb
@@ -64,8 +64,7 @@ module Query::Modules::Results
   def ids_by_letter
     @letters = {}
     ids = []
-    minimal_query_of_all_records.each do |record|
-      id, title = record.values_at(:id, :title)
+    minimal_query_of_all_records.each do |id, title|
       letter = title[0, 1]
       @letters[id] = letter.upcase if /[a-zA-Z]/.match?(letter)
       ids << id
@@ -74,7 +73,10 @@ module Query::Modules::Results
   end
 
   # Tries to be light about it, by selecting only two values.
-  # `alphabetical_by` is a `Model[:column]` - checks the first four chars.
+  # NOTE: `select(:id, :title)` returns instances with the selected attributes.
+  # We have to call `connection.select_rows` to return simple arrays.
+  # `alphabetical_by` is defined in each letter-sortable Query class and
+  # returns a `Model[:column]`. We check the first four chars of that column.
   def minimal_query_of_all_records
     model.connection.select_rows(
       @scopes.select(model[:id], alphabetical_by[0..3].as("title")).distinct

--- a/app/classes/query/modules/results.rb
+++ b/app/classes/query/modules/results.rb
@@ -76,7 +76,9 @@ module Query::Modules::Results
   # Tries to be light about it, by selecting only two values.
   # `alphabetical_by` is a `Model[:column]` - checks the first four chars.
   def minimal_query_of_all_records
-    @scopes.select(model[:id], alphabetical_by[0..3].as("title")).distinct
+    model.select_rows(
+      @scopes.select(model[:id], alphabetical_by[0..3].as("title")).distinct
+    )
   end
 
   # Array of all results, instantiated.

--- a/app/classes/query/modules/results.rb
+++ b/app/classes/query/modules/results.rb
@@ -76,7 +76,7 @@ module Query::Modules::Results
   # Tries to be light about it, by selecting only two values.
   # `alphabetical_by` is a `Model[:column]` - checks the first four chars.
   def minimal_query_of_all_records
-    model.select_rows(
+    model.connection.select_rows(
       @scopes.select(model[:id], alphabetical_by[0..3].as("title")).distinct
     )
   end


### PR DESCRIPTION
The key of this PR is that calling 
```ruby
Observation.select(:id, :text_name).limit(1)
``` 
does not return tuples of `[id, text_name]` - it returns instances having only these attributes. You can try it in the console. 
```
[#<Observation:0x000000012cce73b8 id: 1, text_name: "Xylaria polymorpha group">]
```
The reason that's not ok is because the letter pagination loads all results into memory — instances are too heavy. 

We can however just load the values into arrays if we call 
```ruby
Observation.connection.select_rows(Observation.select(:id, :whatever).limit(1))
> [[1, "Xylaria polymorpha group"]]
```
This is what Jason's SQL was doing and that has been manageable on MO so far, memory-wise.

Nonetheless, letter pagination for observations still seems like something to get rid of, i will re-open that PR.