### PR TITLE
Checklist `refresh_caches` script: Restore sorting intent of group by statement

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -111,6 +111,8 @@ class Checklist
   end
 
   # `+` here is Arel extensions shorthand for `CONCAT`
+  # The group statement intends to be sure names without synonyms are sorted
+  # at the end of the array by giving all of them negative values.
   # rubocop:disable Style/StringConcatenation
   def self.all_site_taxa_by_user
     synonym_map = {}

--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -111,8 +111,10 @@ class Checklist
   end
 
   # `+` here is Arel extensions shorthand for `CONCAT`
-  # The group statement intends to be sure names without synonyms are sorted
-  # at the end of the array by giving all of them negative values.
+  # The group statement is to be sure names without synonyms are sorted
+  # separately in the array by giving all of them negative values in the group.
+  # The idea is that we don't want those with synonyms and those without
+  # to overlap; putting them last is arbitrary.
   # rubocop:disable Style/StringConcatenation
   def self.all_site_taxa_by_user
     synonym_map = {}

--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -123,7 +123,8 @@ class Checklist
          Name[:id].cast("char") + "," +
          Name[:rank].cast("char")).minimum
       ).group(
-        Name[:synonym_id].when(present?).then(Name[:synonym_id]).else(Name[:id])
+        Name[:synonym_id].when(present?).then(Name[:synonym_id]).
+        else(Name[:id] * -1)
       )
     )
     synonyms.each do |row|


### PR DESCRIPTION
This restores the effect of the SQL conditional group statement,
```sql
GROUP BY IF(synonym_id, synonym_id, -id);
```
which is to put the ids without synonyms at the end of the list. 
At first i couldn't figure out how to do that in AR.

Here is my new attempt in AR, but check the resulting SQL. 
Is `WHEN TRUE` the same as `IF(synonym_id` above? I guess so.
```ruby
group(Name[:synonym_id].when(present?).then(Name[:synonym_id]).else(Name[:id] * -1))
=> "
  GROUP BY 
    CASE `names`.`synonym_id` 
    WHEN TRUE THEN `names`.`synonym_id`
    ELSE `names`.`id` * -1
  END"
```