### PR TITLE
Remove env.test? dependency

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -259,7 +259,7 @@ class InatImportJob < ApplicationJob
   def add_inat_images(inat_obs_photos)
     inat_obs_photos.each do |obs_photo|
       photo = Inat::ObsPhoto.new(obs_photo)
-      api = Inat::PhotoImporter.new(photo_importer_params(photo)).api
+      Inat::PhotoImporter.new(photo_importer_params(photo)).api
     end
   end
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -260,19 +260,6 @@ class InatImportJob < ApplicationJob
     inat_obs_photos.each do |obs_photo|
       photo = Inat::ObsPhoto.new(obs_photo)
       api = Inat::PhotoImporter.new(photo_importer_params(photo)).api
-      next unless Rails.env.test?
-
-      # NOTE: 2025-04-01 jdc
-      # A hack faking the side effect of the above API call
-      # The API adds the imported image to the MO observation
-      image = api.results.first
-      ObservationImage.create!(
-        observation: @observation,
-        image: image
-      )
-      # NOTE: 2025-04-01 jdc. This line might be doable via stub/mock.
-      # I'm just tired of fighting with mocks//stubs I don't understand.
-      image.update(original_name: photo.original_name)
     end
   end
 

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -48,6 +48,11 @@ dick_inat_api_key:
   user: dick
   notes: inat import # required to find the user's key for inat jobs
 
+inat_importer_inat_api_key:
+  <<: *DEFAULTS
+  user: inat_importer
+  notes: inat import # required to find the user's key for inat jobs
+
 # The next 3 fixtures are used to test whether sql collates accented letters.
 # Has nothing to do with APIs; This is just a convenient spot to add fixtures.
 api_key_u_1:

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -25,3 +25,8 @@ mary_inat_import:
   <<: *DEFAULTS
   user: mary
   inat_username: mary_inat_username
+
+inat_importer_inat_import:
+  <<: *DEFAULTS
+  user: inat_importer
+  inat_username: inat_importer_inat_username

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -212,3 +212,7 @@ ann_user:
   <<: *DEFAULTS
   login: user
   name: Ann User
+
+inat_importer:
+  <<: *DEFAULTS
+  keep_filenames: <%= User.keep_filenames[:keep_and_show] %>

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -258,7 +258,6 @@ class InatImportJobTest < ActiveJob::TestCase
           "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
-debugger
     assert_difference("Observation.count", 1,
                       "Failed to create observation") do
       InatImportJob.perform_now(inat_import)

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -205,12 +205,9 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -229,7 +226,7 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_equal(
       "iNat photo_id: #{inat_photo["photo_id"]}, uuid: #{inat_photo["uuid"]}",
       imported_img.original_name
-    )
+    ) unless @default_user.keep_filenames == "toss"
 
     assert(obs.sequences.none?)
   end
@@ -249,13 +246,19 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
+    stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/377332865/original.jpeg").
+      with(
+        headers: {
+          'Accept'=>'image/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: image_for_stubs, headers: {})
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -282,12 +285,9 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -329,13 +329,19 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
+    stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/413872439/original.jpeg").
+      with(
+        headers: {
+          'Accept'=>'image/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: image_for_stubs, headers: {})
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -359,13 +365,28 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
+    stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/381894665/original.jpeg").
+      with(
+        headers: {
+          'Accept'=>'image/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: image_for_stubs, headers: {})
+    stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/381894686/original.jpeg").
+      with(
+        headers: {
+          'Accept'=>'image/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: image_for_stubs, headers: {})
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -393,12 +414,19 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/321536915/original.jpeg").
+      with(
+        headers: {
+          'Accept'=>'image/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: image_for_stubs, headers: {})
+
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -423,10 +451,17 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      InatImportJob.perform_now(inat_import)
-    end
+    stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/321536915/original.jpeg").
+      with(
+        headers: {
+          'Accept'=>'image/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: image_for_stubs, headers: {})
+
+    InatImportJob.perform_now(inat_import)
 
     obs = Observation.last
     name = Name.find_by(text_name: "Arrhenia sp. 'NY02'")
@@ -457,6 +492,25 @@ class InatImportJobTest < ActiveJob::TestCase
     assert(obs.sequences.one?, "Obs should have one sequence")
   end
 
+  def image_for_stubs
+    @image_for_stubs ||= Rails.root.join("test/images/test_image.jpg").read
+  end
+
+  def image_stubs(image_ids)
+    image_data = image_for_stubs
+    image_ids.each do |id|
+      stub_request(:get, "https://static.inaturalist.org/photos/#{id}/original.jpg").
+        with(
+          headers: {
+            'Accept'=>'image/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Host'=>'static.inaturalist.org',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: image_data, headers: {})
+    end
+  end
+
   def test_import_job_prov_name_pnw_style
     file_name = "donadinia_PNW01"
     mock_inat_response = File.read("test/inat/#{file_name}.txt")
@@ -466,13 +520,11 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
+    image_stubs([375217770, 375216871, 375217919])
 
-    Inat::PhotoImporter.stub(:new,
-                             stub_mo_photo_importer(mock_inat_response)) do
-      assert_difference("Observation.count", 1,
-                        "Failed to create observation") do
-        InatImportJob.perform_now(inat_import)
-      end
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(inat_import)
     end
 
     obs = Observation.last
@@ -816,7 +868,7 @@ class InatImportJobTest < ActiveJob::TestCase
               "User-Agent" => "Ruby"
             }
           ).
-          to_return(status: 200, body: "", headers: {}))
+          to_return(status: 200, body: image_for_stubs, headers: {}))
       end
     end
   end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -225,10 +225,12 @@ class InatImportJobTest < ActiveJob::TestCase
     imported_img = obs.images.first
     assert_equal(@default_user, imported_img.user,
                  "Image should belong to importing user")
-    assert_equal(
-      "iNat photo_id: #{inat_photo["photo_id"]}, uuid: #{inat_photo["uuid"]}",
-      imported_img.original_name
-    ) unless @default_user.keep_filenames == "toss"
+    unless @default_user.keep_filenames == "toss"
+      assert_equal(
+        "iNat photo_id: #{inat_photo["photo_id"]}, uuid: #{inat_photo["uuid"]}",
+        imported_img.original_name
+      )
+    end
 
     assert(obs.sequences.none?)
   end
@@ -252,11 +254,12 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/377332865/original.jpeg").
       with(
         headers: {
-          "Accept"=>"image/*",
-          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
-          "User-Agent"=>"Ruby"
-        }).
+          "Accept" => "image/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent" => "Ruby"
+        }
+      ).
       to_return(status: 200, body: image_for_stubs, headers: {})
     assert_difference("Observation.count", 1,
                       "Failed to create observation") do
@@ -334,11 +337,12 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/413872439/original.jpeg").
       with(
         headers: {
-          "Accept"=>"image/*",
-          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
-          "User-Agent"=>"Ruby"
-        }).
+          "Accept" => "image/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent" => "Ruby"
+        }
+      ).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
     assert_difference("Observation.count", 1,
@@ -370,20 +374,22 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/381894665/original.jpeg").
       with(
         headers: {
-          "Accept"=>"image/*",
-          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
-          "User-Agent"=>"Ruby"
-        }).
+          "Accept" => "image/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent" => "Ruby"
+        }
+      ).
       to_return(status: 200, body: image_for_stubs, headers: {})
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/381894686/original.jpeg").
       with(
         headers: {
-          "Accept"=>"image/*",
-          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
-          "User-Agent"=>"Ruby"
-        }).
+          "Accept" => "image/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent" => "Ruby"
+        }
+      ).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
     assert_difference("Observation.count", 1,
@@ -419,11 +425,12 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/321536915/original.jpeg").
       with(
         headers: {
-          "Accept"=>"image/*",
-          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
-          "User-Agent"=>"Ruby"
-        }).
+          "Accept" => "image/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent" => "Ruby"
+        }
+      ).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
     assert_difference("Observation.count", 1,
@@ -456,11 +463,12 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/321536915/original.jpeg").
       with(
         headers: {
-          "Accept"=>"image/*",
-          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
-          "User-Agent"=>"Ruby"
-        }).
+          "Accept" => "image/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent" => "Ruby"
+        }
+      ).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
     InatImportJob.perform_now(inat_import)
@@ -504,11 +512,12 @@ class InatImportJobTest < ActiveJob::TestCase
       stub_request(:get, "https://static.inaturalist.org/photos/#{id}/original.jpg").
         with(
           headers: {
-            "Accept"=>"image/*",
-            "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-            "Host"=>"static.inaturalist.org",
-            "User-Agent"=>"Ruby"
-          }).
+            "Accept" => "image/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Host" => "static.inaturalist.org",
+            "User-Agent" => "Ruby"
+          }
+        ).
         to_return(status: 200, body: image_data, headers: {})
     end
   end
@@ -522,7 +531,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
-    image_stubs([375217770, 375216871, 375217919])
+    image_stubs([375_217_770, 375_216_871, 375_217_919])
 
     assert_difference("Observation.count", 1,
                       "Failed to create observation") do

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -38,6 +38,8 @@ class InatImportJobTest < ActiveJob::TestCase
   def setup
     @default_user = users(:rolf)
     @stubs = []
+    directory_path = Rails.public_path.join("test_images/orig")
+    FileUtils.mkdir_p(directory_path) unless Dir.exist?(directory_path)
   end
 
   def add_stub(stub)
@@ -246,16 +248,17 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions(inat_import: inat_import,
                            mock_inat_response: mock_inat_response)
+
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/377332865/original.jpeg").
       with(
         headers: {
-          'Accept'=>'image/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
-          'User-Agent'=>'Ruby'
+          "Accept"=>"image/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
-
+debugger
     assert_difference("Observation.count", 1,
                       "Failed to create observation") do
       InatImportJob.perform_now(inat_import)
@@ -332,10 +335,10 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/413872439/original.jpeg").
       with(
         headers: {
-          'Accept'=>'image/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
-          'User-Agent'=>'Ruby'
+          "Accept"=>"image/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
@@ -368,19 +371,19 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/381894665/original.jpeg").
       with(
         headers: {
-          'Accept'=>'image/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
-          'User-Agent'=>'Ruby'
+          "Accept"=>"image/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/381894686/original.jpeg").
       with(
         headers: {
-          'Accept'=>'image/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
-          'User-Agent'=>'Ruby'
+          "Accept"=>"image/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
@@ -417,10 +420,10 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/321536915/original.jpeg").
       with(
         headers: {
-          'Accept'=>'image/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
-          'User-Agent'=>'Ruby'
+          "Accept"=>"image/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
@@ -454,10 +457,10 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_request(:get, "https://inaturalist-open-data.s3.amazonaws.com/photos/321536915/original.jpeg").
       with(
         headers: {
-          'Accept'=>'image/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>'inaturalist-open-data.s3.amazonaws.com',
-          'User-Agent'=>'Ruby'
+          "Accept"=>"image/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host"=>"inaturalist-open-data.s3.amazonaws.com",
+          "User-Agent"=>"Ruby"
         }).
       to_return(status: 200, body: image_for_stubs, headers: {})
 
@@ -502,10 +505,10 @@ class InatImportJobTest < ActiveJob::TestCase
       stub_request(:get, "https://static.inaturalist.org/photos/#{id}/original.jpg").
         with(
           headers: {
-            'Accept'=>'image/*',
-            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Host'=>'static.inaturalist.org',
-            'User-Agent'=>'Ruby'
+            "Accept"=>"image/*",
+            "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Host"=>"static.inaturalist.org",
+            "User-Agent"=>"Ruby"
           }).
         to_return(status: 200, body: image_data, headers: {})
     end


### PR DESCRIPTION
Re-creates #2889 without my messed up commits and pushes.

- Removes the dependency on `Rails.env.test` in `InatImportJob`;
- Makes `InatImportJobTest` pass without that dependency.