### PR TITLE
Quick fix to mitigate query explosion

### DIFF
--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -138,7 +138,7 @@ class Lookup::Names < Lookup
 
     names.reject { |name| name[:synonym_id] } +
       Name.where(synonym_id: limited_id_set(name_ids)).
-      select(*minimal_name_columns)
+      distinct.select(*minimal_name_columns)
   end
 
   def add_subtaxa(names)


### PR DESCRIPTION
For reasons I don't fully understand, the names table is getting joined with the observations table for every query within the definition of scope :observation_query.  This calls `subquery` which in tern tries to find all the synonyms for a name, but when joined with observations it returns over 7,000 rows rather than just 2.  This PR puts in a strategicly placed `.distinct` to avoid the rest of the code from having to thinking about more that the 2 relevant names.  This probably still puts and unnecessary burden on the database, but I don't know of a better way to approach the problem.  @nimmolo may know a better way to handle this sort of case.  Maybe Name needs to be `unscoped`?