### PR TITLE
Add deleted Observation subquery scopes

### DIFF
--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -453,6 +453,19 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         where(species_list_observations: { species_list: spl_ids }).distinct
     }
 
+    scope :image_query, lambda { |hash|
+      joins(:images).subquery(:Image, hash)
+    }
+    scope :location_query, lambda { |hash|
+      joins(:location).subquery(:Location, hash)
+    }
+    scope :name_query, lambda { |hash|
+      joins(:name).subquery(:Name, hash)
+    }
+    scope :sequence_query, lambda { |hash|
+      joins(:sequences).subquery(:Sequence, hash)
+    }
+
     scope :show_includes, lambda {
       strict_loading.includes(
         :collection_numbers,

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -681,9 +681,9 @@ class Query::ObservationsTest < UnitTestCase
     assert_equal(
       # Compare ids because comparing AR objects causes FAIL
       # No visible difference in AR#inspect output.
-      Observation.where(location: locations(:burbank)).order(id: :asc).
+      Observation.where(location: locations(:burbank)).order_by_default.
                   pluck(:id),
-      Observation.location_query({ pattern: "Burbank" }).order(id: :asc).
+      Observation.location_query({ pattern: "Burbank" }).order_by_default.
                   pluck(:id)
     )
   end
@@ -692,9 +692,8 @@ class Query::ObservationsTest < UnitTestCase
     assert_equal(
       # Compare ids because comparing AR objects causes FAIL
       # No visible difference in  AR#inspect output.
-      Observation.joins(:sequences).order(id: :asc).uniq.pluck(:id),
-      Observation.sequence_query({ order_by: "created_at" }).order(id: :asc).
-                  pluck(:id)
+      Observation.joins(:sequences).order_by_default.uniq.pluck(:id),
+      Observation.sequence_query({ order_by: "created_at" }).pluck(:id)
     )
   end
 end

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -672,13 +672,9 @@ class Query::ObservationsTest < UnitTestCase
   end
 
   def test_scope_image_query
-    assert_equal(
-      # Compare ids because comparing AR objects causes FAIL
-      # No visible difference in AR#inspect output.
-      Observation.where.not(thumb_image: nil).order(id: :asc).pluck(:id),
-      Observation.image_query({ order_by: "created_at" }).order(id: :asc).
-                  pluck(:id)
-    )
+    images = Image.copyright_holder_has("rolf").pluck(:id)
+    assert_query(Observation.where(thumb_image: images).order_by_default,
+                 :Observation, image_query: { copyright_holder_has: "rolf" })
   end
 
   def test_scope_location_query

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -686,6 +686,14 @@ class Query::ObservationsTest < UnitTestCase
     )
   end
 
+  def test_scope_name_query
+    name = names(:peltigera)
+    assert_query(
+      Observation.where(name: name).order_by_default,
+      :Observation, name_query: { pattern: name.text_name }
+    )
+  end
+
   def test_scope_sequence_query
     assert_query(
       Observation.joins(:sequences).order_by_default.uniq.pluck(:id),

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -670,4 +670,35 @@ class Query::ObservationsTest < UnitTestCase
       :Observation, "#{col}": %w[2009-08-22-03-04-22 2009-10-20-03-04-22]
     )
   end
+
+  def test_scope_image_query
+    assert_equal(
+      # Compare ids because comparing AR objects causes FAIL
+      # No visible difference in AR#inspect output.
+      Observation.where.not(thumb_image: nil).order(id: :asc).pluck(:id),
+      Observation.image_query({ order_by: "created_at" }).order(id: :asc).
+                  pluck(:id)
+    )
+  end
+
+  def test_scope_location_query
+    assert_equal(
+      # Compare ids because comparing AR objects causes FAIL
+      # No visible difference in AR#inspect output.
+      Observation.where(location: locations(:burbank)).order(id: :asc).
+                  pluck(:id),
+      Observation.location_query({ pattern: "Burbank" }).order(id: :asc).
+                  pluck(:id)
+    )
+  end
+
+  def test_scope_sequence_query
+    assert_equal(
+      # Compare ids because comparing AR objects causes FAIL
+      # No visible difference in  AR#inspect output.
+      Observation.joins(:sequences).order(id: :asc).uniq.pluck(:id),
+      Observation.sequence_query({ order_by: "created_at" }).order(id: :asc).
+                  pluck(:id)
+    )
+  end
 end

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -671,7 +671,7 @@ class Query::ObservationsTest < UnitTestCase
     )
   end
 
-  def test_scope_image_query
+  def test_observation_image_query
     images = Image.copyright_holder_has("rolf").pluck(:id)
     assert_query(
       Observation.where(thumb_image: images).order_by_default,
@@ -679,14 +679,23 @@ class Query::ObservationsTest < UnitTestCase
     )
   end
 
-  def test_scope_location_query
+  def test_observation_location_query_simple
     assert_query(
       Observation.where(location: locations(:burbank)).order_by_default,
       :Observation, location_query: { pattern: "Burbank" }
     )
   end
 
-  def test_scope_name_query
+  def test_observation_location_query_in_box
+    box = { north: 35, south: 34, east: -118, west: -119 }
+    locations = Location.in_box(**box).by_users(mary)
+    expects = Observation.joins(:location).distinct.
+              where(location_id: locations).order_by_default
+    assert_query(expects,
+                 :Observation, location_query: { in_box: box, by_users: mary })
+  end
+
+  def test_observation_name_query_simple
     name = names(:peltigera)
     assert_query(
       Observation.where(name: name).order_by_default,
@@ -694,10 +703,21 @@ class Query::ObservationsTest < UnitTestCase
     )
   end
 
-  def test_scope_sequence_query
+  def test_observation_name_query_rank
+    names = Name.with_correct_spelling.rank("Genus", "Kingdom")
+    expects = Observation.joins(:name).distinct.
+              where(name_id: names).order_by_default
+    assert_query(expects,
+                 :Observation, name_query: { rank: %w[Genus Kingdom] })
+  end
+
+  def test_observation_sequence_query
+    sequences = Sequence.locus_has("LSU").by_users(dick)
+    expects = Observation.joins(:sequences).distinct.
+              merge(sequences).order_by_default
     assert_query(
-      Observation.joins(:sequences).order_by_default.uniq.pluck(:id),
-      :Observation, sequence_query: { order_by: "created_at" }
+      expects,
+      :Observation, sequence_query: { locus_has: "LSU", by_users: dick.id }
     )
   end
 end

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -673,27 +673,23 @@ class Query::ObservationsTest < UnitTestCase
 
   def test_scope_image_query
     images = Image.copyright_holder_has("rolf").pluck(:id)
-    assert_query(Observation.where(thumb_image: images).order_by_default,
-                 :Observation, image_query: { copyright_holder_has: "rolf" })
+    assert_query(
+      Observation.where(thumb_image: images).order_by_default,
+      :Observation, image_query: { copyright_holder_has: "rolf" }
+    )
   end
 
   def test_scope_location_query
-    assert_equal(
-      # Compare ids because comparing AR objects causes FAIL
-      # No visible difference in AR#inspect output.
-      Observation.where(location: locations(:burbank)).order_by_default.
-                  pluck(:id),
-      Observation.location_query({ pattern: "Burbank" }).order_by_default.
-                  pluck(:id)
+    assert_query(
+      Observation.where(location: locations(:burbank)).order_by_default,
+      :Observation, location_query: { pattern: "Burbank" }
     )
   end
 
   def test_scope_sequence_query
-    assert_equal(
-      # Compare ids because comparing AR objects causes FAIL
-      # No visible difference in  AR#inspect output.
+    assert_query(
       Observation.joins(:sequences).order_by_default.uniq.pluck(:id),
-      Observation.sequence_query({ order_by: "created_at" }).pluck(:id)
+      :Observation, sequence_query: { order_by: "created_at" }
     )
   end
 end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1332,37 +1332,6 @@ class ObservationTest < UnitTestCase
     )
   end
 
-  def test_scope_image_query
-    assert_equal(
-      # Compare ids because comparing AR objects causes FAIL
-      # No visible difference in AR#inspect output.
-      Observation.where.not(thumb_image: nil).order(id: :asc).pluck(:id),
-      Observation.image_query({ order_by: "created_at" }).order(id: :asc).
-                  pluck(:id)
-    )
-  end
-
-  def test_scope_location_query
-    assert_equal(
-      # Compare ids because comparing AR objects causes FAIL
-      # No visible difference in AR#inspect output.
-      Observation.where(location: locations(:burbank)).order(id: :asc).
-                  pluck(:id),
-      Observation.location_query({ pattern: "Burbank" }).order(id: :asc).
-                  pluck(:id)
-    )
-  end
-
-  def test_scope_sequence_query
-    assert_equal(
-      # Compare ids because comparing AR objects causes FAIL
-      # No visible difference in  AR#inspect output.
-      Observation.joins(:sequences).order(id: :asc).uniq.pluck(:id),
-      Observation.sequence_query({ order_by: "created_at" }).order(id: :asc).
-                  pluck(:id)
-    )
-  end
-
   def nybg
     @nybg ||= locations(:nybg_location)
   end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1332,6 +1332,37 @@ class ObservationTest < UnitTestCase
     )
   end
 
+  def test_scope_image_query
+    assert_equal(
+      # Compare ids because comparing AR objects causes FAIL
+      # No visible difference in AR#inspect output.
+      Observation.where.not(thumb_image: nil).order(id: :asc).pluck(:id),
+      Observation.image_query({ order_by: "created_at" }).order(id: :asc).
+                  pluck(:id)
+    )
+  end
+
+  def test_scope_location_query
+    assert_equal(
+      # Compare ids because comparing AR objects causes FAIL
+      # No visible difference in AR#inspect output.
+      Observation.where(location: locations(:burbank)).order(id: :asc).
+                  pluck(:id),
+      Observation.location_query({ pattern: "Burbank" }).order(id: :asc).
+                  pluck(:id)
+    )
+  end
+
+  def test_scope_sequence_query
+    assert_equal(
+      # Compare ids because comparing AR objects causes FAIL
+      # No visible difference in  AR#inspect output.
+      Observation.joins(:sequences).order(id: :asc).uniq.pluck(:id),
+      Observation.sequence_query({ order_by: "created_at" }).order(id: :asc).
+                  pluck(:id)
+    )
+  end
+
   def nybg
     @nybg ||= locations(:nybg_location)
   end


### PR DESCRIPTION
- The scopes were accidentally dropped in e0e8deced
- Includes tests to prevent reversion
- Fixes #2897 

### Suggested Manual tests
- Name PatternSearch for `Entoloma` (http://localhost:3000/names?pattern=Entoloma); click `Show Observations`
Result: `Observations of names: [ search pattern: Entoloma ]`
- Location PatternSearch for `Cape Cod` (http://localhost:3000/locations?pattern=Cape+Cod); click `Show Observations`
Result: `Observations of locations: [ search pattern: Cape Cod ]`
- click Latest, Images (http://localhost:3000/images), click `Show Observations`
Result: `Observations of images: [ ]`