### PR TITLE
Skip Chromium install

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -28,8 +28,10 @@ jobs:
       - name: Install additional tools
         run: sudo apt-get install exiftool
 
-      - name: Install Chrome/Chromium
-        run: sudo apt-get install chromium-browser
+      # 2025-05-12 JDC Skip this step for now because it hangs intermittently
+      # and is needed only for system tests, which are currently not run in CI.
+      # - name: Install Chrome/Chromium
+      #   run: sudo apt-get install chromium-browser
 
       # MySQL is installed but does not run by default
       # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#mysql


### PR DESCRIPTION
Skips the Chromium Install run of our CI GitHub action `test` job.

- That step has hung intermittently today, preventing completion of CI.
- The step is not currently needed because we don't (currently) run system tests in CI.