### PR TITLE
Simplify circuitous Name and Location subqueries

### DIFF
--- a/app/classes/api2/name_description_api.rb
+++ b/app/classes/api2/name_description_api.rb
@@ -37,9 +37,8 @@ class API2
         created_at: parse_range(:time, :created_at),
         updated_at: parse_range(:time, :updated_at),
         by_users: parse_array(:user, :user, help: :first_user),
-        names: parse_array(:name, :name),
         is_public: true
-      }
+      }.merge(parse_names_parameters)
     end
 
     def post

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -65,11 +65,11 @@ class Query::Base
 
   delegate :content_filter_parameters, to: :class
 
-  def self.subquery_parameters
-    parameter_declarations.select { |key, _v| key.to_s.include?("_query") }
-  end
+  # def self.subquery_parameters
+  #   parameter_declarations.select { |key, _v| key.to_s.include?("_query") }
+  # end
 
-  delegate :subquery_parameters, to: :class
+  # delegate :subquery_parameters, to: :class
 
   # Can the current class be called as a subquery of the target Query class?
   def relatable?(target)

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -65,6 +65,12 @@ class Query::Base
 
   delegate :content_filter_parameters, to: :class
 
+  def self.subquery_parameters
+    parameter_declarations.select { |key, _v| key.to_s.include?("_query") }
+  end
+
+  delegate :subquery_parameters, to: :class
+
   # Can the current class be called as a subquery of the target Query class?
   def relatable?(target)
     self.class.related?(target, model.name.to_sym)

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -95,7 +95,7 @@ module Query::Modules::Initialization
   # just run that on the outer query.
   # The Name scopes have been adjusted to skip any `:names` param in a subquery.
   def check_for_nested_names_params
-    return unless model == Name && (names_filter = nested_names_params)
+    return unless model == Name && (names_filter = nested_names_params).present?
 
     @scopes = @scopes.send(:names, **names_filter[:filter])
   end

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -84,10 +84,19 @@ module Query::Modules::Initialization
   private
 
   def initialize_scopes
+    check_for_nested_names_param
     initialize_parameter_set
     filter_misspellings_for_name_queries
     apply_rss_log_content_filters
     add_default_order_if_none_specified
+  end
+
+  # If it's a Name query, and one of the subqueries has a `names` param,
+  # just run that on the outer query and set a flag to skip it on the subquery.
+  def check_for_nested_names_param
+    return unless model == Name && (names = params.deep_find(:names))
+    debugger
+    @scopes.send(names: names)
   end
 
   def initialize_parameter_set

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -109,6 +109,7 @@ module Query::Modules::Initialization
   end
 
   # Take the first one, if present. More than one names param would be nuts.
+  # Could just return params.deep_find(:names).first, but this gives more info.
   # Returns a hash containing the name of the subquery, and the names params.
   def names_params_from_subquery
     filter = {}

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -84,46 +84,10 @@ module Query::Modules::Initialization
   private
 
   def initialize_scopes
-    check_for_nested_names_params
     initialize_parameter_set
     filter_misspellings_for_name_queries
     apply_rss_log_content_filters
     add_default_order_if_none_specified
-  end
-
-  # If it's a Name query, and one of the subqueries has a `names` param,
-  # just run that on the outer query.
-  # The Name scopes have been adjusted to skip any `:names` param in a subquery.
-  def check_for_nested_names_params
-    return unless model == Name && (names_filter = nested_names_params).present?
-
-    @scopes = @scopes.send(:names, **names_filter[:filter])
-  end
-
-  def nested_names_params
-    if params.slice(*subquery_parameters.keys).blank? ||
-       params.deep_find(:names).blank?
-      return false
-    end
-
-    names_params_from_subquery
-  end
-
-  # Take the first one, if present. More than one names param would be nuts.
-  # Could just return params.deep_find(:names).first, but this gives more info.
-  # Returns a hash containing the name of the subquery, and the names params.
-  def names_params_from_subquery
-    filter = {}
-    subquery_parameters.each_key do |subquery|
-      next unless params[subquery].present? &&
-                  params[subquery].key?(:names) &&
-                  (names_params = params.dig(subquery, :names)).present?
-
-      filter[:subquery] = subquery
-      filter[:filter] = names_params
-      break
-    end
-    filter
   end
 
   def initialize_parameter_set

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -92,11 +92,12 @@ module Query::Modules::Initialization
   end
 
   # If it's a Name query, and one of the subqueries has a `names` param,
-  # just run that on the outer query and set a flag to skip it on the subquery.
+  # just run that on the outer query.
+  # The Name scopes have been adjusted to skip any `:names` param in a subquery.
   def check_for_nested_names_params
     return unless model == Name && (names_filter = nested_names_params)
 
-    @scopes.send(:names, **names_filter[:filter])
+    @scopes = @scopes.send(:names, **names_filter[:filter])
   end
 
   def nested_names_params

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -13,7 +13,11 @@ class Query::NameDescriptions < Query::Base
       sources: [{ string: Description::ALL_SOURCE_TYPES }],
       ok_for_export: :boolean,
       content_has: :string,
-      names: [Name],
+      names: { lookup: [Name],
+               include_synonyms: :boolean,
+               include_subtaxa: :boolean,
+               include_immediate_subtaxa: :boolean,
+               exclude_original_names: :boolean },
       projects: [Project],
       name_query: { subquery: :Name }
     )

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -275,6 +275,8 @@ module AbstractModel::Scopes
   module ClassMethods
     # Utility for all subqueries, which are defined on the model
     def subquery(model_name, params)
+      return all if params.blank?
+
       subquery = Query.new(model_name, **params).scope.reorder("")
       merge(subquery).distinct
     end

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -274,6 +274,8 @@ module AbstractModel::Scopes
   # class methods here, `self` included
   module ClassMethods
     # Utility for all subqueries, which are defined on the model
+    # Callers must do their own joins to `model_name` because we can't know
+    # whether the association (has_one, has_many) is singular or plural.
     def subquery(model_name, params)
       return all if params.blank?
 

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -164,7 +164,8 @@ module Location::Scopes
     scope :description_query, lambda { |hash|
       joins(:descriptions).subquery(:LocationDescription, hash)
     }
-    # Filter region directly in the outer query, not via observations.
+    # Filter locations and region directly in the outer Location query,
+    # not via observations.
     scope :observation_query, lambda { |hash|
       scope = all
       locations = hash.delete(:locations)

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -164,7 +164,7 @@ module Location::Scopes
     scope :description_query, lambda { |hash|
       joins(:descriptions).subquery(:LocationDescription, hash)
     }
-    # Filter locations and region directly in the outer Location query,
+    # Filter :locations and :region directly in the outer Location query,
     # not via observations.
     scope :observation_query, lambda { |hash|
       scope = all

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -93,12 +93,12 @@ class LocationDescription < Description
   }
   scope :by_author, lambda { |user|
     ids = lookup_users_by_name(user)
-    joins(:location_description_authors).
+    joins(:location_description_authors).distinct.
       where(location_description_authors: { user_id: ids })
   }
   scope :by_editor, lambda { |user|
     ids = lookup_users_by_name(user)
-    joins(:location_description_editors).
+    joins(:location_description_editors).distinct.
       where(location_description_editors: { user_id: ids })
   }
   scope :locations, lambda { |loc|

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -303,19 +303,20 @@ module Name::Scopes
       end
     }
 
-    # Query pulls any :names param out to the Name query, so we can skip it in
-    # subqueries, where it would be inefficient and redundant.
+    # Pull any :names param out to the main Name query.
+    # Skip it in subqueries, where it would be inefficient and redundant.
+    # (We don't need to query indirectly for "Names of Observations of Names".)
     scope :description_query, lambda { |hash|
-      hash = hash.except(:names)
-      return joins(:descriptions) if hash.blank?
-
-      joins(:descriptions).subquery(:NameDescription, hash)
+      scope = all
+      names_params = hash.delete(:names)
+      scope = scope.names(**names_params) if names_params.present?
+      scope.joins(:descriptions).subquery(:NameDescription, hash)
     }
     scope :observation_query, lambda { |hash|
-      hash = hash.except(:names)
-      return joins(:observations) if hash.blank?
-
-      joins(:observations).subquery(:Observation, hash)
+      scope = all
+      names_params = hash.delete(:names)
+      scope = scope.names(**names_params) if names_params.present?
+      scope.joins(:observations).subquery(:Observation, hash)
     }
 
     scope :show_includes, lambda {

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -304,10 +304,10 @@ module Name::Scopes
     }
 
     scope :description_query, lambda { |hash|
-      joins(:descriptions).subquery(:NameDescription, hash)
+      joins(:descriptions).subquery(:NameDescription, hash.except(:names))
     }
     scope :observation_query, lambda { |hash|
-      joins(:observations).subquery(:Observation, hash)
+      joins(:observations).subquery(:Observation, hash.except(:names))
     }
 
     scope :show_includes, lambda {

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -303,6 +303,8 @@ module Name::Scopes
       end
     }
 
+    # Query pulls any :names param to the outer query, so we can skip it in
+    # subqueries, where it would be inefficient and redundant.
     scope :description_query, lambda { |hash|
       joins(:descriptions).subquery(:NameDescription, hash.except(:names))
     }

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -312,10 +312,15 @@ module Name::Scopes
       scope = scope.names(**names_params) if names_params.present?
       scope.joins(:descriptions).subquery(:NameDescription, hash)
     }
+    # Likewise here, filter :clade or :lichen directly, not the circuitous way.
     scope :observation_query, lambda { |hash|
       scope = all
       names_params = hash.delete(:names)
       scope = scope.names(**names_params) if names_params.present?
+      clades = hash.delete(:clade)
+      scope = scope.clade(clades) if clades.present?
+      lichens = hash.delete(:lichen)
+      scope = scope.lichen(lichens) if lichens.present?
       scope.joins(:observations).subquery(:Observation, hash)
     }
 

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -303,13 +303,19 @@ module Name::Scopes
       end
     }
 
-    # Query pulls any :names param to the outer query, so we can skip it in
+    # Query pulls any :names param out to the Name query, so we can skip it in
     # subqueries, where it would be inefficient and redundant.
     scope :description_query, lambda { |hash|
-      joins(:descriptions).subquery(:NameDescription, hash.except(:names))
+      hash = hash.except(:names)
+      return joins(:descriptions) if hash.blank?
+
+      joins(:descriptions).subquery(:NameDescription, hash)
     }
     scope :observation_query, lambda { |hash|
-      joins(:observations).subquery(:Observation, hash.except(:names))
+      hash = hash.except(:names)
+      return joins(:observations) if hash.blank?
+
+      joins(:observations).subquery(:Observation, hash)
     }
 
     scope :show_includes, lambda {

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -107,12 +107,12 @@ class NameDescription < Description
 
   scope :by_author, lambda { |user|
     ids = lookup_users_by_name(user)
-    joins(:name_description_authors).
+    joins(:name_description_authors).distinct.
       where(name_description_authors: { user_id: ids })
   }
   scope :by_editor, lambda { |user|
     ids = lookup_users_by_name(user)
-    joins(:name_description_editors).
+    joins(:name_description_editors).distinct.
       where(name_description_editors: { user_id: ids })
   }
 
@@ -123,10 +123,13 @@ class NameDescription < Description
   scope :ok_for_export,
         ->(bool = true) { where(ok_for_export: bool) }
 
-  scope :names, lambda { |names|
-    ids = lookup_names_by_name(names)
-    where(name: ids)
+  scope :names, lambda { |lookup:, **related_name_args|
+    ids = lookup_names_by_name(lookup, related_name_args.compact)
+    return none unless ids
+
+    where(name_id: ids).distinct
   }
+
   scope :projects, lambda { |projects|
     ids = lookup_projects_by_name(projects)
     where(project: ids)

--- a/test/classes/api2/name_descriptions_test.rb
+++ b/test/classes/api2/name_descriptions_test.rb
@@ -9,4 +9,16 @@ class API2::NameDescriptionsTest < UnitTestCase
   def test_basic_name_description_get
     do_basic_get_test(NameDescription, public: true)
   end
+
+  def params_get(**)
+    { method: :get, action: :name_description }.merge(**)
+  end
+
+  def test_name_description_get_names
+    public = [name_descriptions(:peltigera_alt_desc),
+              name_descriptions(:peltigera_desc),
+              name_descriptions(:peltigera_source_desc)]
+    assert_api_pass(params_get(name: "Peltigera", include_synonyms: "yes"))
+    assert_api_results(public)
+  end
 end

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -345,9 +345,8 @@ class Query::LocationsTest < UnitTestCase
   # Test that a :region subquery param is likewise moved to the Location query.
   def test_location_with_observations_regions
     region = "California, USA"
-    locations = [
-      locations(:mitrula_marsh), locations(:albion), locations(:burbank),
-      locations(:california), locations(:gualala), locations(:howarth_park),
+    locations_with_obs = [
+      locations(:burbank), locations(:california),
       locations(:point_reyes), locations(:salt_point)
     ]
     expects = Location.region(region).
@@ -356,7 +355,7 @@ class Query::LocationsTest < UnitTestCase
     assert_query_scope(
       expects, scope, :Location, observation_query: { region: }
     )
-    assert_equal(expects, locations)
+    assert_equal(locations_with_obs.map(&:id), expects.map(&:id))
   end
 
   def test_location_with_observations_projects

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -8,21 +8,21 @@ class Query::NameDescriptionsTest < UnitTestCase
   include QueryExtensions
 
   def test_name_description_all
-    all_descs = NameDescription.all
-    all_pelt_descs = NameDescription.names(lookup: "Peltigera")
-    public_pelt_descs = all_pelt_descs.is_public
+    all_descs = NameDescription.order_by_default
+    all_pelt_descs = NameDescription.names(lookup: "Peltigera").order_by_default
+    public_pelt_descs = all_pelt_descs.is_public.order_by_default
     assert(all_pelt_descs.length < all_descs.length)
     assert(public_pelt_descs.length < all_pelt_descs.length)
 
-    assert_query(all_descs, :NameDescription, order_by: :id)
+    assert_query(all_descs, :NameDescription)
     assert_query(
       all_pelt_descs,
-      :NameDescription, names: { lookup: "Peltigera" }, order_by: :id
+      :NameDescription, names: { lookup: "Peltigera" }
     )
     assert_query(
       public_pelt_descs,
-      :NameDescription, names: { lookup: "Peltigera" }, is_public: "yes",
-                        order_by: :id)
+      :NameDescription, names: { lookup: "Peltigera" }, is_public: "yes"
+    )
   end
 
   def test_name_description_order_by_name

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -129,4 +129,17 @@ class Query::NameDescriptionsTest < UnitTestCase
     assert_query(NameDescription.is_public(0).order_by_default,
                  :NameDescription, is_public: 0)
   end
+
+  def test_name_description_names
+    expects = [name_descriptions(:peltigera_desc),
+               name_descriptions(:peltigera_alt_desc),
+               name_descriptions(:peltigera_user_desc),
+               name_descriptions(:peltigera_source_desc)]
+    scope = NameDescription.names(lookup: "Peltigera", include_synonyms: true).
+            order_by_default
+    assert_query_scope(
+      expects, scope,
+      :NameDescription, names: { lookup: "Peltigera", include_synonyms: true }
+    )
+  end
 end

--- a/test/classes/query/name_descriptions_test.rb
+++ b/test/classes/query/name_descriptions_test.rb
@@ -8,17 +8,21 @@ class Query::NameDescriptionsTest < UnitTestCase
   include QueryExtensions
 
   def test_name_description_all
-    pelt = names(:peltigera)
     all_descs = NameDescription.all
-    all_pelt_descs = NameDescription.names(pelt)
+    all_pelt_descs = NameDescription.names(lookup: "Peltigera")
     public_pelt_descs = all_pelt_descs.is_public
     assert(all_pelt_descs.length < all_descs.length)
     assert(public_pelt_descs.length < all_pelt_descs.length)
 
     assert_query(all_descs, :NameDescription, order_by: :id)
-    assert_query(all_pelt_descs, :NameDescription, order_by: :id, names: pelt)
-    assert_query(public_pelt_descs,
-                 :NameDescription, order_by: :id, names: pelt, is_public: "yes")
+    assert_query(
+      all_pelt_descs,
+      :NameDescription, names: { lookup: "Peltigera" }, order_by: :id
+    )
+    assert_query(
+      public_pelt_descs,
+      :NameDescription, names: { lookup: "Peltigera" }, is_public: "yes",
+                        order_by: :id)
   end
 
   def test_name_description_order_by_name
@@ -131,10 +135,10 @@ class Query::NameDescriptionsTest < UnitTestCase
   end
 
   def test_name_description_names
-    expects = [name_descriptions(:peltigera_desc),
-               name_descriptions(:peltigera_alt_desc),
-               name_descriptions(:peltigera_user_desc),
-               name_descriptions(:peltigera_source_desc)]
+    expects = [name_descriptions(:peltigera_alt_desc),
+               name_descriptions(:peltigera_source_desc),
+               name_descriptions(:peltigera_desc),
+               name_descriptions(:peltigera_user_desc)]
     scope = NameDescription.names(lookup: "Peltigera", include_synonyms: true).
             order_by_default
     assert_query_scope(

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -741,12 +741,40 @@ class Query::NamesTest < UnitTestCase
               joins(:observations).distinct.order_by_default
     scope = Name.with_correct_spelling.observation_query(
       names: { lookup: "Peltigera", include_synonyms: true }
-    )
+    ).order_by_default
     assert_query_scope(
       expects, scope,
       :Name, observation_query: {
         names: { lookup: "Peltigera", include_synonyms: true }
       }
     )
+  end
+
+  # Test that the :clade parameter is likewise applied to the Name query.
+  def test_name_with_observation_subquery_of_clade
+    clades = %w[Agaricales Tremellales]
+    clades.each do |clade|
+      expects = Name.with_correct_spelling.clade(clade).
+                joins(:observations).distinct.order_by_default
+      scope = Name.with_correct_spelling.observation_query(clade:).
+              order_by_default
+      assert_query_scope(
+        expects, scope, :Name, observation_query: { clade: }
+      )
+    end
+  end
+
+  # Test that the :lichen parameter is likewise applied to the Name query.
+  def test_name_with_observation_subquery_of_lichen
+    prefs = [true, false]
+    prefs.each do |pref|
+      expects = Name.with_correct_spelling.lichen(pref).
+                joins(:observations).distinct.order_by_default
+      scope = Name.with_correct_spelling.observation_query(lichen: pref).
+              order_by_default
+      assert_query_scope(
+        expects, scope, :Name, observation_query: { lichen: pref }
+      )
+    end
   end
 end

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -478,8 +478,8 @@ class Query::NamesTest < UnitTestCase
                        :Name, description_query: { id_in_set: set })
   end
 
-  # NOTE: Name.description_query moves any :names sub-param to the main query,
-  # because it is way more efficient.
+  # Test that Name.description_query moves any :names sub-params to the main
+  # query, because it is way more efficient than a circuitous join.
   def test_name_with_description_subquery_of_names
     expects = Name.names(lookup: "Peltigera", include_synonyms: true).
               joins(:descriptions).distinct.order_by_default
@@ -734,6 +734,8 @@ class Query::NamesTest < UnitTestCase
     )
   end
 
+  # Test that Name.observation_query moves any :names sub-params to the main
+  # query, because it is way more efficient than a circuitous join.
   def test_name_with_observation_subquery_of_names
     expects = Name.names(lookup: "Peltigera", include_synonyms: true).
               joins(:observations).distinct.order_by_default

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -478,19 +478,14 @@ class Query::NamesTest < UnitTestCase
                        :Name, description_query: { id_in_set: set })
   end
 
+  # NOTE: Name.description_query moves any :names sub-param to the main query,
+  # because it is way more efficient.
   def test_name_with_description_subquery_of_names
-    desc = NameDescription.names(lookup: "Peltigera", include_synonyms: true)
-    expects = Name.with_correct_spelling.joins(:descriptions).distinct.
-              merge(desc).order_by_default
-    # NOTE: Name.description_query ignores any :names sub-param, because
-    # Query applies the :names to the Name scope more efficiently.
-    # So, we don't assert:
-    # scope = Name.with_correct_spelling.description_query(
-    #   names: { lookup: "Peltigera", include_synonyms: true }
-    # )
-    # but rather:
-    scope = Name.names(lookup: "Peltigera", include_synonyms: true).
-            joins(:descriptions).distinct.order_by_default
+    expects = Name.names(lookup: "Peltigera", include_synonyms: true).
+              joins(:descriptions).distinct.order_by_default
+    scope = Name.with_correct_spelling.description_query(
+      names: { lookup: "Peltigera", include_synonyms: true }
+    )
     assert_query_scope(
       expects, scope,
       :Name, description_query: {
@@ -740,18 +735,11 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_with_observation_subquery_of_names
-    obs = Observation.names(lookup: "Peltigera", include_synonyms: true)
-    expects = Name.with_correct_spelling.joins(:observations).distinct.
-              merge(obs).order_by_default
-    # NOTE: Name.observation_query ignores any :names sub-param, because
-    # Query applies the :names to the Name scope more efficiently.
-    # So, we don't assert:
-    # scope = Name.with_correct_spelling.observation_query(
-    #   names: { lookup: "Peltigera", include_synonyms: true }
-    # )
-    # but rather:
-    scope = Name.names(lookup: "Peltigera", include_synonyms: true).
-            joins(:observations).distinct.order_by_default
+    expects = Name.names(lookup: "Peltigera", include_synonyms: true).
+              joins(:observations).distinct.order_by_default
+    scope = Name.with_correct_spelling.observation_query(
+      names: { lookup: "Peltigera", include_synonyms: true }
+    )
     assert_query_scope(
       expects, scope,
       :Name, observation_query: {

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -717,4 +717,19 @@ class Query::NamesTest < UnitTestCase
       expects, scope, :Name, observation_query: { id_in_set: three_amigos }
     )
   end
+
+  def test_name_with_observation_subquery_of_names
+    obs = Observation.names(lookup: "Peltigera", include_synonyms: true)
+    expects = Name.with_correct_spelling.joins(:observations).distinct.
+              merge(obs).order_by_default
+    scope = Name.with_correct_spelling.observation_query(
+      names: { lookup: "Peltigera", include_synonyms: true }
+    )
+    assert_query_scope(
+      expects, scope,
+      :Name, observation_query: {
+        names: { lookup: "Peltigera", include_synonyms: true }
+      }
+    )
+  end
 end


### PR DESCRIPTION
### Name subqueries

`:observation_query` — `:names`, `:clade`, `:lichen`

This changes Name subquery scopes to apply any `:names`,  `:clade`, or `:lichen` param within an `:observation_query` to the outer Name scope directly. In the case where the subquery has that param, it is made to ignore these "sub-params".

#### The issue:
If a user's query starts out as a Name query, and the user clicks "Observations of these names", and then "Names of these observations", our link builders would return them to the original query, because the name params would be cached in the query description as a `subquery`. Our link builder just restores the original Name params. 

But in the case where the query originates as an Observation query, a user's filtering params like `:names`, `:clade` or `:lichen`  are essentially pseudo-subqueries of Name. If the user clicks on "Names of these observations", these params could be more efficiently used as Name filters, when converting the Observation query to a Name query.

Currently an automatically generated link for "Names of Observations (from a user's previous names filter)" calls:
```ruby
Name.observation_query(names: { lookup: "Peltigera", include_synonyms: true })
```
Obviously this is a ridiculous query, but it's possible given the UI, which must be agnostic about query params in providing "related records" links, because any filter could be in the subquery. So the link in this circumstance is currently producing the AR:
```ruby
Name.joins(:observations).distinct.
merge(Observation.names(lookup: "Peltigera", include_synonyms: true))
```
Note the double lookup of names through observations. This is producing a heavy query:
```
  Name Load (863.5ms)  
SELECT `names`.`id`, `names`.`correct_spelling_id`, `names`.`synonym_id`, `names`.`text_name` 
FROM `names` INNER JOIN `observations` ON `observations`.`name_id` = `names`.`id` 
WHERE `names`.`text_name` = 'Peltigera'

  Name Load (248.6ms)  
SELECT DISTINCT `names`.`id`, `names`.`correct_spelling_id`, `names`.`synonym_id`, `names`.`text_name` 
FROM `names` INNER JOIN `observations` ON `observations`.`name_id` = `names`.`id` 
WHERE `names`.`synonym_id` = 1878

  Name Load (239.6ms)  
SELECT DISTINCT `names`.* 
FROM `names` INNER JOIN `observations` ON `observations`.`name_id` = `names`.`id` 
WHERE `observations`.`name_id` = 5077
```
#### Proposed solution:

This PR changes the behavior of `observation_query` so the same call,
```ruby
Name.observation_query(names: { lookup: "Peltigera", include_synonyms: true })
```
now generates:
```ruby
Name.names(lookup: "Peltigera", include_synonyms: true).joins(:observations).distinct
```
producing a much lighter
```
  Name Load (27.6ms)  
SELECT `names`.`id`, `names`.`correct_spelling_id`, `names`.`synonym_id`, `names`.`text_name` 
FROM `names` WHERE `names`.`text_name` = 'Peltigera'

  Name Load (0.3ms)  
SELECT DISTINCT `names`.`id`, `names`.`correct_spelling_id`, `names`.`synonym_id`, `names`.`text_name` 
FROM `names` WHERE `names`.`synonym_id` = 1878

  Name Load (261.9ms) 
 SELECT DISTINCT `names`.* 
FROM `names` INNER JOIN `observations` ON `observations`.`name_id` = `names`.`id` 
WHERE (`names`.`id` IN (5077, 9794)) AND (`names`.`correct_spelling_id` IS NULL)
```
___
`:description_query` — `:names`

Although a `:description_query` is cheap compared to an `:observation_query`, this treats them both the same to simplify the code. It also fixes how `NameDescription` queries parse a `:names` param. (This wasn't working, or tested, for subqueries as currently set up).

Makes sure the `NameDescriptionAPI` sends that param the same way it is sent to `Query` by other models of the API. 
NOTE: This does not change any outward-facing behavior in the API, it only changes its internal communication with `Query`.
___
### Location subqueries

`:observation_query` — `:locations`, `:region` Same idea here.