### PR TITLE
Fix Query `order_by`

### DIFF
--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -109,11 +109,15 @@ module Query::Modules::Initialization
     @skippable_values = ["[]", "{}", "", nil].freeze
   end
 
-  # For RssLogs, remove any content filter params before passing to scopes
+  # For most queries, these are the `scope_parameters` defined in Query::Base.
+  # Makes sure `order_by` comes "last" in the hash, because some params may
+  # reset order.
+  # For RssLogs, removes any content filter params before passing to scopes
   # since they're already handled in subqueries above.
-  # Otherwise, these are the `scope_parameters` defined in Query::Base.
   def sendable_params
     sendable = params.slice(*scope_parameters)
+    order_by = sendable.delete(:order_by)
+    sendable[:order_by] = order_by if order_by.present?
     return sendable unless model == RssLog
 
     sendable.except(*content_filter_parameters.keys)

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -32,9 +32,21 @@ class Query::ObservationsTest < UnitTestCase
     assert_query(expects, :Observation, order_by: :location)
   end
 
+  # Test that subquery `reorder("")` does not interfere with explicit order.
   def test_observation_order_by_name
-    expects = Observation.order_by(:name)
-    assert_query(expects, :Observation, order_by: :name)
+    expects = Observation.location_query(pattern: "Falmouth").order_by(:name)
+    assert_query(
+      expects,
+      :Observation, location_query: { pattern: "Falmouth" }, order_by: :name
+    )
+  end
+
+  def test_observation_order_by_user
+    expects = Observation.name_query(pattern: "Agaricus").order_by(:user)
+    assert_query(
+      expects,
+      :Observation, name_query: { pattern: "Agaricus" }, order_by: :user
+    )
   end
 
   def test_observation_order_by_num_views


### PR DESCRIPTION
Addresses #2902. 

It turns out this wasn't working simply because `order_by` needs to be applied last in the scope chain.

If there is a subquery, that resets the order, and we had `order_by` being added first.