### PR TITLE
Query — switch to attributes

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -13,7 +13,7 @@
 #  sorting and selection conditions.
 #
 #  To filter query results, you can send additional parameters.  For example,
-#  create_query(:Comment for_user: user.id) retrieves comments posted on a
+#  create_query(:Comment, for_user: user.id) retrieves comments posted on a
 #  given user's observations.  Query saves the parameters alongside the model,
 #  and together these fully specify a query that may be recreated and
 #  executed at a later time, even potentially by another user (e.g., if users

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -135,11 +135,13 @@ class Query
     klass = "Query::#{model.to_s.pluralize}".constantize
     # Initialize an instance, ignoring undeclared params:
     query = klass.new(params.slice(*klass.attribute_names.map(&:to_sym)))
-    # `params` are basically the active `attributes`
-    query.params = query.attributes.compact # initialize for cleaning/validation
+    # Initialize `params`, where query stores the active `attributes`.
+    query.params = query.attributes.compact
+    # Initialize `subqueries`, to store any validated subquery instances.
     query.subqueries = {}
     query.current = current if current
-    query.valid = query.valid? # reinitializes params after cleaning/validation
+    # Calling `valid?` reinitializes `params` after cleaning/validation.
+    query.valid = query.valid?
     # query.initialize_query # if you want the attributes right away
     query
   end

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -145,6 +145,4 @@ class Query
     # query.initialize_query # if you want the attributes right away
     query
   end
-
-  delegate :default_order, to: :class
 end

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -133,9 +133,10 @@ class Query
 
   def self.new(model, params = {}, current = nil)
     klass = "Query::#{model.to_s.pluralize}".constantize
-    # Just ignore undeclared params:
-    query = klass.new(params.slice(*klass.parameter_declarations.keys))
-    query.params = query.attributes # initialize params for cleaning/validation
+    # Initialize an instance, ignoring undeclared params:
+    query = klass.new(params.slice(*klass.attribute_names.map(&:to_sym)))
+    # `params` are basically the active `attributes`
+    query.params = query.attributes.compact # initialize for cleaning/validation
     query.subqueries = {}
     query.current = current if current
     query.valid = query.valid? # reinitializes params after cleaning/validation

--- a/app/classes/query/api_keys.rb
+++ b/app/classes/query/api_keys.rb
@@ -1,22 +1,9 @@
 # frozen_string_literal: true
 
 class Query::APIKeys < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      notes_has: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= APIKey
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:notes_has, :string)
 
   def self.default_order
     :created_at

--- a/app/classes/query/api_keys.rb
+++ b/app/classes/query/api_keys.rb
@@ -10,8 +10,8 @@ class Query::APIKeys < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -1,25 +1,12 @@
 # frozen_string_literal: true
 
 class Query::Articles < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Article],
-      title_has: :string,
-      body_has: :string,
-      by_users: [User]
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Article
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Article])
+  query_attr(:title_has, :string)
+  query_attr(:body_has, :string)
+  query_attr(:by_users, [User])
 
   def alphabetical_by
     @alphabetical_by ||= Article[:title]

--- a/app/classes/query/articles.rb
+++ b/app/classes/query/articles.rb
@@ -13,8 +13,8 @@ class Query::Articles < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -269,10 +269,10 @@ class Query::Base
   end
 
   # Serialize the query params, adding the model, for saving to a QueryRecord.
-  # The :description column is accessed not just to recompose a query, but to
-  # identify existing query records that match current params. That's why the
-  # keys are sorted here before being stored as strings in to_json - because
-  # when matching a serialized hash, strings must match exactly.
+  # We use this column of QueryRecord to identify an existing query record that
+  # matches current params, and sometimes to recompose a query from the string.
+  # That's why the keys are sorted here before being serialized via `to_json` -
+  # when matching, strings must match exactly.
   #
   # NOTE: QueryRecord[:description] is not a Rails-serialized column; we call
   # `to_json` here to serializate it ourselves. Using SQL to compare serialized

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -73,10 +73,13 @@
 #  the attribute should be validated. (We don't differentiate between
 #  `query_param` types at the attribute level because they are all validated
 #  recursively, and nested values may use the same methods as top-level values.)
+#  To keep this from getting too verbose, we assign Query attributes using the
+#  custom method `query_attr` whose second argument is the value of `:accepts`.
+#  See app/extensions/class.rb for the definition of `query_attr`.
 #
-#  We use a special syntax in `:accepts` to declare the validation type of each
-#  attribute. The syntax is important because it tells
-#  Query::Modules::Validation how to parse the attribute value.
+#  `:accepts` expects a special syntax that declares a validation type for each
+#  attribute, and tells Query::Modules::Validation how to parse the attribute
+#  value. It uses the following patterns:
 #
 #  ### Simple values
 #

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -11,13 +11,14 @@
 #  parameters that filter a database query of a given model, like `Name` or
 #  `Observation`. A Query instance contains as little data as possible; it does
 #  not contain AR records. When you execute the Query by calling the `results`
-#  method, each parameter of the Query instance gets sent to an ActiveRecord
-#  scope of the corresponding model; scopes are chained to return the results.
-#  Query parameters are therefore specific to each scope of the AR model.
+#  or `result_ids` methods, each non-nil attribute of the Query instance gets
+#  sent to an ActiveRecord scope of the corresponding model; scopes are chained
+#  to return the results. Query parameters must therefore each correspond to a
+#  scope of the AR model.
 #
 #  Each Query class declares the parameters it will accept, and what type of
-#  data each parameter expects, in `parameter_declarations` at the top of the
-#  class. These are the `attributes` you initialize a new Query instance with.
+#  data each parameter expects, in the attributes at the top of the class.
+#  You initialize a new Query instance with any combination of these.
 #
 #    Query::Observations.new(           or     Query.new(:Observation,
 #      has_public_lat_lng: true,                 has_public_lat_lng: true,
@@ -30,63 +31,54 @@
 #
 #  For the sake of familiarity, Query classes use ActiveModel. Each instance of
 #  a Query class is a data object with validatable attributes, instance methods
-#  and class methods. The methods are all pretty standard. They are defined
-#  either here in Query::Base, or in one of the included Query::Modules.
+#  and class methods. The methods are mostly inherited from Query::Base, and
+#  defined either here, or in one of the included Query::Modules.
 #
 #  The main difference from ActiveRecord objects (that also use ActiveModel) is
 #  attribute validation. ActiveRecord attributes must have data types that can
 #  be validated and stored in a database. _ActiveModel_ attributes are "ad hoc"
-#  and temporary. Because they don't need to be stored in a database they can
+#  and temporary. Because they don't need to be stored in a database, they can
 #  have any data type. They only need to "work" for the use case — a form, a
-#  query, etc. But we can call the same `validate` patterns as on AR models.
+#  query, etc. But we can define the same `validate` methods as on AR models.
 #
 #  In our case, we define our own validator and data type. That data type is
-#  `query_param`, and the attribute values are both checked and sanitized by
+#  `query_param`, and the attribute values are checked and sanitized by
 #  Query::Modules::Validation on initialization. Calling `valid?` uses
 #  Query::Modules::Validator to check for any validation errors that may
 #  have been stored in the Query instance by `clean_and_validate_params`.
 #
-#  So, `valid?` should mean the parameter values are usable by the corresponding
+#  `valid?` should mean the parameter values are usable by the corresponding
 #  ActiveRecord scope in each model. The scopes are what actually execute the
 #  database query and define the parameter requirements.
-#
-#  * Potential gotcha: Most query attributes, like `has_public_lat_lng` for
-#    Observation, are declared in the Query class, e.g. Query::Observations.
-#    However, for certain params like `region`, they are declared in
-#    Query::Filter. These are handled differently, because default values for
-#    these params may be automatically passed in from the current user's
-#    preferences via methods in ApplicationController::Indexes.
 #
 #  ## PARAMETER DECLARATIONS
 #
 #  Query parameter names must map to AR scope names 1:1 (with few exceptions).
-#  So the first task is to write a scope for the model that does what you want.
+#  So the first task in making a class queryable is to write scopes for the
+#  each attribute of the model that you want to be able to query.
 #
-#  For example, in the query above, the parameter `has_public_lat_lng` is first
-#  a scope of our Observation model that accepts a Boolean value. It finds
-#  observations that both have a `lat` value and where `gps_hidden` is false.
-#  `region` is a scope of Observation that accepts a string, and finds
+#  For example, in the query above, the parameter `has_public_lat_lng` is also a
+#  scope of our Observation model that accepts a Boolean value. It is defined
+#  to find observations that have a `lat` value and where `gps_hidden` is false.
+#  `region` is an Observation scope that accepts a string, and finds
 #  observations within a given region. The scope `names` finds observations in
-#  given taxa. It accepts a hash of arguments, with `lookup` being required.
+#  given taxa. `names` accepts a hash of arguments, `lookup` being required.
 #  But all of these requirements and logic are ultimately defined in the scope;
 #  Query is simply there to gather and store them, and pass them along.
 #
 #  Since the scopes can only accept certain types of data, Query needs to
 #  validate (and sometimes "clean") the attributes passed to the Query instance.
-#  Even though `query_param` is a single declared data type, it actually is
-#  the `parameter_declarations` that give the information about the way the
-#  attribute is validated. (My plan was to add that as an arg to each
-#  `query_param` and have a custom validator parse the declared arg in order
-#  to know how to validate each `query_param`s, but i couldn't figure out
-#  how to do this. This would have allowed simpler `attribute` declarations,
-#  more similar to ActiveRecord models. - AN 2025)
+#  Even though `query_param` is a single declared data type, it has a custom
+#  attribute option `:accepts` that you use to pass an argument describing how
+#  the attribute should be validated. (We don't differentiate between
+#  `query_param` types at the attribute level because they are all validated
+#  recursively, and nested values may use the same methods as top-level values.)
 #
-#  We use a special syntax to declare the data type of each Query parameter /
-#  attribute. The syntax is important because it tells our validation method in
-#  Query::Modules::Validation, `clean_and_validate_params`, how to parse the
-#  attribute value.
+#  We use a special syntax in `:accepts` to declare the validation type of each
+#  attribute. The syntax is important because it tells
+#  Query::Modules::Validation how to parse the attribute value.
 #
-#  ### Simple
+#  ### Simple values
 #
 #  The simplest data types are pretty self explanatory:
 #
@@ -98,8 +90,8 @@
 #
 #  Note that with some parameters, a `:string` may be a "Google-search" syntax
 #  of search directives like 'Amanita -muscaria "odd coloring"', but Query
-#  doesn't handle any parsing of the string. It simply forwards the string to
-#  the scope of the same name. The parsing is all done by the scope.
+#  doesn't do any parsing of the string. It simply forwards the string to the
+#  scope of the same name. The parsing is all done by the scope.
 #
 #  ### Model
 #
@@ -124,11 +116,12 @@
 #    [User]
 #    [Location]
 #
-#  In some cases the array may be ultimately parsed in the scope as a duration
-#  or range of values (e.g. a range of dates, ranks, vote values, etc.). In this
-#  case, two values is the maximum length of the array; more will be ignored.
-#  But for arrays of model instances like [Name], any number of instances or
-#  ids can be passed.
+#  In some cases the scope may be configured to parse the array as a range of
+#  values (e.g. of dates, ranks, etc.). In these scopes, passing one value
+#  is valid and usually considered as a minimum value, and any values after the
+#  second will be ignored. For arrays of model instances like [Name], any
+#  number of instances or ids can be passed, up to the limit defined in
+#  `MO.query_max_array`.
 #
 #  ### Hash
 #
@@ -136,26 +129,30 @@
 #  important.
 #
 #  If the first key in the hash is `:string` or `:boolean`, the parameter
-#  value will be parsed as an `enum`. The declaration states allowable values,
-#  and others are ignored.
+#  value will be parsed like an ActiveRecord "enum". The declaration states
+#  allowable values, and others are ignored.
 #
 #    { string: [:no, :either, :only] }
 #    { boolean: [true] } # simply a way of saying "ignore false"
 #
-#  If the first key in the hash is `:subquery`, it's parsed as a subquery of
-#  the specified model. That means any enclosed params will be sent to a new
-#  Query instance of that model, and merged into the current query.
-#  For more on this, see Query::Modules::Subqueries.
+#  If the first key in the hash is `:subquery`, the attribute is parsed as a
+#  subquery of the specified model. Subqueries validate enclosed params by
+#  instantiating a new Query of the subquery model with the enclosed params.
+#  (During execution of the query, the enclosed params are simply sent to the
+#  main model's corresponding `:#{subquery_model}_query` scope. This uses the
+#  params to call scopes of the subquery model, and merges the subquery into
+#  the current query.) For more on this, see Query::Modules::Subqueries.
 #
 #    { subquery: :Observation }
 #
 #  If neither `:string`, `:boolean`, nor `:subquery` is the first key, the hash
 #  is parsed as a hash of arguments to be sent to the scope of the same name.
-#  Each argument is independently validated as declared.
+#  Each argument is independently validated as declared. For example, this is
+#  the declaration of the attribute `in_box`:
 #
-#  For example, this is the declaration of the attribute `in_box`:
+#    { north: :float, south: :float, east: :float, west: :float }
 #
-#  in_box: { north: :float, south: :float, east: :float, west: :float }
+#  Each sub-param is validated as a :float.
 #
 #  ############################################################################
 #
@@ -199,12 +196,6 @@ class Query::Base
   end
 
   delegate :attribute_types, to: :class
-
-  def self.parameter_declarations
-    attribute_types
-  end
-
-  delegate :parameter_declarations, to: :class
 
   # Define has_attribute? here, it doesn't exist yet for ActiveModel.
   def self.has_attribute?(key) # rubocop:disable Naming/PredicateName

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -73,13 +73,14 @@
 #  the attribute should be validated. (We don't differentiate between
 #  `query_param` types at the attribute level because they are all validated
 #  recursively, and nested values may use the same methods as top-level values.)
-#  To keep this from getting too verbose, we assign Query attributes using the
-#  custom method `query_attr` whose second argument is the value of `:accepts`.
-#  See app/extensions/class.rb for the definition of `query_attr`.
 #
-#  `:accepts` expects a special syntax that declares a validation type for each
-#  attribute, and tells Query::Modules::Validation how to parse the attribute
-#  value. It uses the following patterns:
+#  To keep attribute assignment from getting too verbose, we assign them using a
+#  custom method `query_attr`, whose second argument is the value of `:accepts`.
+#  See app/extensions/class.rb for the definition of `query_attr`. This argument
+#  expects a special syntax declaring a validation type for each attribute, and
+#  telling Query::Modules::Validation how to parse the attribute value.
+#
+#  It uses the following patterns:
 #
 #  ### Simple values
 #

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -192,6 +192,10 @@ class Query::Base
 
   attr_writer :record
 
+  def attribute_types
+    self.class.attribute_types.symbolize_keys!
+  end
+
   def self.parameter_declarations
     { order_by: :string }
   end

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -196,14 +196,15 @@ class Query::Base
   include Query::Modules::Sequence
   include Query::Modules::Validation
 
+  attr_writer :record
+
+  # Declare query attributes with method defined in app/extensions/class.rb
+  query_attr(:order_by, :string)
+
   validates_with Query::Modules::Validator
 
   # "clean up" and reassign attributes before validation
   before_validation :clean_and_validate_params
-
-  attr_writer :record
-
-  query_attr(:order_by, :string)
 
   def self.attribute_types
     super.symbolize_keys!
@@ -229,8 +230,8 @@ class Query::Base
   # returns keys
   def self.content_filter_parameters
     filters = Query::Filter.all
-    @content_filter_parameters ||= filters.each_with_object([]) do |f, ary|
-      ary << f.sym
+    @content_filter_parameters ||= filters.each_with_object(Set[]) do |f, set|
+      set << f.sym
     end.freeze
   end
 

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -126,8 +126,8 @@
 #  the first, some scopes parse this as "match this value only". In all scopes
 #  expecting range arrays, any values after the second are ignored.
 #
-#  For arrays of model instances like [Project], any number of instances or ids
-#  can be passed, up to the limit defined in `MO.query_max_array`.
+#  For scopes accepting arrays of model instances like [Project], you can pass
+#  any number of objects or ids, up to a limit defined in `MO.query_max_array`.
 #
 #  ### Hash
 #

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -17,9 +17,8 @@ class Query::CollectionNumbers < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -1,29 +1,16 @@
 # frozen_string_literal: true
 
 class Query::CollectionNumbers < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [CollectionNumber],
-      collectors: [:string],
-      numbers: [:string],
-      collector_has: :string,
-      number_has: :string,
-      by_users: [User],
-      observations: [Observation],
-      pattern: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= CollectionNumber
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [CollectionNumber])
+  query_attr(:by_users, [User])
+  query_attr(:collectors, [:string])
+  query_attr(:numbers, [:string])
+  query_attr(:collector_has, :string)
+  query_attr(:number_has, :string)
+  query_attr(:observations, [Observation])
+  query_attr(:pattern, :string)
 
   def alphabetical_by
     @alphabetical_by ||= CollectionNumber[:name]

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -1,29 +1,16 @@
 # frozen_string_literal: true
 
 class Query::Comments < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Comment],
-      by_users: [User],
-      for_user: User,
-      target: { type: :string, id: AbstractModel },
-      types: [{ string: Comment::ALL_TYPE_TAGS }],
-      summary_has: :string,
-      content_has: :string,
-      pattern: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Comment
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Comment])
+  query_attr(:by_users, [User])
+  query_attr(:for_user, User)
+  query_attr(:target, { type: :string, id: AbstractModel })
+  query_attr(:types, [{ string: Comment::ALL_TYPE_TAGS }])
+  query_attr(:summary_has, :string)
+  query_attr(:content_has, :string)
+  query_attr(:pattern, :string)
 
   def alphabetical_by
     @alphabetical_by ||= User[:login]

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -17,9 +17,8 @@ class Query::Comments < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -1,26 +1,13 @@
 # frozen_string_literal: true
 
 class Query::ExternalLinks < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [ExternalLink],
-      url_has: :string,
-      by_users: [User],
-      external_sites: [ExternalSite],
-      observations: [Observation]
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= ExternalLink
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [ExternalLink])
+  query_attr(:by_users, [User])
+  query_attr(:external_sites, [ExternalSite])
+  query_attr(:observations, [Observation])
+  query_attr(:url_has, :string)
 
   def self.default_order
     :url

--- a/app/classes/query/external_links.rb
+++ b/app/classes/query/external_links.rb
@@ -14,9 +14,8 @@ class Query::ExternalLinks < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
 class Query::ExternalSites < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      id_in_set: [ExternalSite],
-      name_has: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= ExternalSite
-  end
+  query_attr(:id_in_set, [ExternalSite])
+  query_attr(:name_has, :string)
 
   def self.default_order
     :name

--- a/app/classes/query/external_sites.rb
+++ b/app/classes/query/external_sites.rb
@@ -9,9 +9,8 @@ class Query::ExternalSites < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -1,23 +1,10 @@
 # frozen_string_literal: true
 
 class Query::FieldSlips < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      by_users: [User],
-      projects: [Project]
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= FieldSlip
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:by_users, [User])
+  query_attr(:projects, [Project])
 
   def self.default_order
     :code_then_date

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -11,9 +11,8 @@ class Query::FieldSlips < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/glossary_terms.rb
+++ b/app/classes/query/glossary_terms.rb
@@ -1,25 +1,12 @@
 # frozen_string_literal: true
 
 class Query::GlossaryTerms < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      by_users: [User],
-      name_has: :string,
-      description_has: :string,
-      pattern: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= GlossaryTerm
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:by_users, [User])
+  query_attr(:name_has, :string)
+  query_attr(:description_has, :string)
+  query_attr(:pattern, :string)
 
   def alphabetical_by
     @alphabetical_by ||= GlossaryTerm[:name]

--- a/app/classes/query/glossary_terms.rb
+++ b/app/classes/query/glossary_terms.rb
@@ -13,9 +13,8 @@ class Query::GlossaryTerms < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -16,9 +16,8 @@ class Query::Herbaria < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -1,28 +1,15 @@
 # frozen_string_literal: true
 
 class Query::Herbaria < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Herbarium],
-      code_has: :string,
-      name_has: :string,
-      description_has: :string,
-      mailing_address_has: :string,
-      pattern: :string,
-      nonpersonal: :boolean
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Herbarium
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Herbarium])
+  query_attr(:code_has, :string)
+  query_attr(:name_has, :string)
+  query_attr(:description_has, :string)
+  query_attr(:mailing_address_has, :string)
+  query_attr(:pattern, :string)
+  query_attr(:nonpersonal, :boolean)
 
   def alphabetical_by
     @alphabetical_by ||= Herbarium[:name]

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -20,9 +20,8 @@ class Query::HerbariumRecords < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -1,32 +1,19 @@
 # frozen_string_literal: true
 
 class Query::HerbariumRecords < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [HerbariumRecord],
-      by_users: [User],
-      has_notes: :boolean,
-      notes_has: :string,
-      initial_det: [:string],
-      initial_det_has: :string,
-      accession: [:string],
-      accession_has: :string,
-      herbaria: [Herbarium],
-      observations: [Observation],
-      pattern: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= HerbariumRecord
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [HerbariumRecord])
+  query_attr(:by_users, [User])
+  query_attr(:has_notes, :boolean)
+  query_attr(:notes_has, :string)
+  query_attr(:initial_det, [:string])
+  query_attr(:initial_det_has, :string)
+  query_attr(:accession, [:string])
+  query_attr(:accession_has, :string)
+  query_attr(:herbaria, [Herbarium])
+  query_attr(:observations, [Herbarium])
+  query_attr(:pattern, :string)
 
   def alphabetical_by
     @alphabetical_by ||= HerbariumRecord[:initial_det]

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -29,9 +29,8 @@ class Query::Images < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -1,41 +1,28 @@
 # frozen_string_literal: true
 
 class Query::Images < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      date: [:date],
-      id_in_set: [Image],
-      by_users: [User],
-      sizes: [{ string: Image::ALL_SIZES - [:full_size] }],
-      content_types: [{ string: Image::ALL_EXTENSIONS }],
-      has_notes: :boolean,
-      notes_has: :string,
-      copyright_holder_has: :string,
-      license: [License],
-      ok_for_export: :boolean,
-      has_votes: :boolean,
-      quality: [:float],
-      confidence: [:float],
-      pattern: :string,
-      has_observations: :boolean,
-      observations: [Observation],
-      locations: [Location],
-      projects: [Project],
-      species_lists: [SpeciesList],
-      observation_query: { subquery: :Observation }
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Image
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:date, [:date])
+  query_attr(:id_in_set, [Image])
+  query_attr(:by_users, [User])
+  query_attr(:sizes, [{ string: Image::ALL_SIZES - [:full_size] }])
+  query_attr(:content_types, [{ string: Image::ALL_EXTENSIONS }])
+  query_attr(:has_notes, :boolean)
+  query_attr(:notes_has, :string)
+  query_attr(:copyright_holder_has, :string)
+  query_attr(:license, [License])
+  query_attr(:ok_for_export, :boolean)
+  query_attr(:has_votes, :boolean)
+  query_attr(:quality, [:float])
+  query_attr(:confidence, [:float])
+  query_attr(:pattern, :string)
+  query_attr(:has_observations, :boolean)
+  query_attr(:observations, [Observation])
+  query_attr(:locations, [Location])
+  query_attr(:projects, [Project])
+  query_attr(:species_lists, [SpeciesList])
+  query_attr(:observation_query, { subquery: :Observation })
 
   def alphabetical_by
     @alphabetical_by ||= case params[:order_by].to_s

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -17,9 +17,8 @@ class Query::LocationDescriptions < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -1,29 +1,16 @@
 # frozen_string_literal: true
 
 class Query::LocationDescriptions < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [LocationDescription],
-      is_public: :boolean,
-      content_has: :string,
-      by_users: [User],
-      by_author: User,
-      by_editor: User,
-      locations: [Location],
-      location_query: { subquery: :Location }
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= LocationDescription
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [LocationDescription])
+  query_attr(:by_users, [User])
+  query_attr(:by_author, User)
+  query_attr(:by_editor, User)
+  query_attr(:is_public, :boolean)
+  query_attr(:content_has, :string)
+  query_attr(:locations, [Location])
+  query_attr(:location_query, { subquery: :Location })
 
   def self.default_order
     :name

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -26,9 +26,8 @@ class Query::Locations < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -4,34 +4,36 @@ class Query::Locations < Query::Base
   include Query::Params::AdvancedSearch
   include Query::Params::Filters
 
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Location],
-      by_users: [User],
-      by_editor: User,
-      in_box: { north: :float, south: :float, east: :float, west: :float },
-      # region: :string, # content filter
-      pattern: :string,
-      regexp: :string,
-      has_notes: :boolean,
-      notes_has: :string,
-      has_descriptions: :boolean,
-      has_observations: :boolean,
-      description_query: { subquery: :LocationDescription },
-      observation_query: { subquery: :Observation }
-    ).merge(content_filter_parameter_declarations(Location)).
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Location])
+  query_attr(:by_users, [User])
+  query_attr(:by_editor, User)
+  query_attr(:in_box, { north: :float, south: :float,
+                        east: :float, west: :float })
+  # query_attr(:region, :string) # content filter
+  query_attr(:has_notes, :boolean)
+  query_attr(:notes_has, :string)
+  query_attr(:pattern, :string)
+  query_attr(:regexp, :string)
+  # query_attr(:search_name, :string) # advanced search
+  # query_attr(:search_where, :string) # advanced search
+  # query_attr(:search_user, :string) # advanced search
+  # query_attr(:search_content, :string) # advanced search
+  query_attr(:has_descriptions, :boolean)
+  query_attr(:has_observations, :boolean)
+  query_attr(:description_query, { subquery: :LocationDescription })
+  query_attr(:observation_query, { subquery: :Observation })
+
+  def self.extra_parameter_declarations
+    content_filter_parameter_declarations(Location).
       merge(advanced_search_parameter_declarations)
   end
 
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Location
+  # Declare filter and advanced search parameters as model attributes,
+  # of custom type `query_param`
+  extra_parameter_declarations.each do |param_name, accepts|
+    query_attr(param_name, accepts)
   end
 
   def self.default_order

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -4,6 +4,8 @@ class Query::Locations < Query::Base
   include Query::Params::AdvancedSearch
   include Query::Params::Filters
 
+  # Commented-out attributes are here so we don't forget they're added
+  # via `extra_parameter_declarations` below.
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Location])

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -120,7 +120,7 @@ module Query::Modules::Initialization
     sendable[:order_by] = order_by if order_by.present?
     return sendable unless model == RssLog
 
-    sendable.except(*content_filter_parameters.keys)
+    sendable.except(*content_filter_parameters)
   end
 
   # Most name queries are filtered to remove misspellings.
@@ -143,7 +143,7 @@ module Query::Modules::Initialization
   end
 
   def active_filters
-    @active_filters ||= params.slice(*content_filter_parameters.keys).compact
+    @active_filters ||= params.slice(*content_filter_parameters).compact
   end
 
   ##############################################################################

--- a/app/classes/query/modules/subqueries.rb
+++ b/app/classes/query/modules/subqueries.rb
@@ -74,7 +74,14 @@ module Query::Modules::Subqueries
     end
 
     def find_subquery_param_name(filter)
-      parameter_declarations.key({ subquery: filter })
+      key = if filter.to_s.include?("Description")
+              :description_query
+            else
+              :"#{filter.to_s.underscore}_query"
+            end
+      return key if attribute_types.symbolize_keys.key?(key)
+
+      nil
     end
 
     def add_default_subquery_conditions(target, filter, params)

--- a/app/classes/query/modules/subqueries.rb
+++ b/app/classes/query/modules/subqueries.rb
@@ -20,7 +20,7 @@ module Query::Modules::Subqueries
     # Query needs to know which joins are necessary to make these conversions
     # work. Need to maintain RELATED_TYPES if the Query class is updated.
     # These could be derived by snooping through each Query subclass's
-    # parameter_declarations, but that seems wasteful; there are not so many.
+    # attributes, but that seems wasteful; there are not so many of these.
     #
     # target_model.name.to_sym: [:Association, :AnotherAssociation],
     RELATED_QUERIES = {

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -104,6 +104,7 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     submodel = param_type.values.first
     subquery = Query.new(submodel, val)
     @subqueries[param] = subquery
+    @validation_errors += subquery.validation_errors
     subquery.params
   end
 

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -8,10 +8,10 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
     @validation_errors = []
     old_params = @params.dup&.deep_compact&.deep_symbolize_keys || {}
     new_params = {}
-    permitted_params = parameter_declarations.slice(*old_params.keys)
+    permitted_params = attribute_types.slice(*old_params.keys)
     permitted_params.each do |param, param_type|
       val = old_params[param]
-      val = validate_value(param_type, param, val) if val.present?
+      val = validate_value(param_type.accepts, param, val) if val.present?
       new_params[param] = val
     end
     @params = new_params

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -24,9 +24,8 @@ class Query::NameDescriptions < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -1,36 +1,23 @@
 # frozen_string_literal: true
 
 class Query::NameDescriptions < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [NameDescription],
-      by_users: [User],
-      by_author: User,
-      by_editor: User,
-      is_public: :boolean,
-      sources: [{ string: Description::ALL_SOURCE_TYPES }],
-      ok_for_export: :boolean,
-      content_has: :string,
-      names: { lookup: [Name],
-               include_synonyms: :boolean,
-               include_subtaxa: :boolean,
-               include_immediate_subtaxa: :boolean,
-               exclude_original_names: :boolean },
-      projects: [Project],
-      name_query: { subquery: :Name }
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= NameDescription
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [NameDescription])
+  query_attr(:by_users, [User])
+  query_attr(:by_author, User)
+  query_attr(:by_editor, User)
+  query_attr(:is_public, :boolean)
+  query_attr(:sources, [{ string: Description::ALL_SOURCE_TYPES }])
+  query_attr(:projects, [Project])
+  query_attr(:ok_for_export, :boolean)
+  query_attr(:content_has, :string)
+  query_attr(:names, { lookup: [Name],
+                       include_synonyms: :boolean,
+                       include_subtaxa: :boolean,
+                       include_immediate_subtaxa: :boolean,
+                       exclude_original_names: :boolean })
+  query_attr(:name_query, { subquery: :Name })
 
   def self.default_order
     :name

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -49,9 +49,8 @@ class Query::Names < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -5,56 +5,56 @@ class Query::Names < Query::Base
   include Query::Params::AdvancedSearch
   include Query::Params::Filters
 
-  def self.parameter_declarations # rubocop:disable Metrics/MethodLength
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Name],
-      by_users: [User],
-      by_editor: User,
-      names: { lookup: [Name],
-               include_synonyms: :boolean,
-               include_subtaxa: :boolean,
-               include_immediate_subtaxa: :boolean,
-               exclude_original_names: :boolean },
-      text_name_has: :string,
-      # clade: :string, # content_filter
-      # lichen: :boolean, # content_filter
-      misspellings: { string: [:no, :either, :only] },
-      deprecated: :boolean,
-      has_synonyms: :boolean,
-      ok_for_export: :boolean,
-      has_author: :boolean,
-      author_has: :string,
-      has_citation: :boolean,
-      citation_has: :string,
-      has_classification: :boolean,
-      classification_has: :string,
-      has_notes: :boolean,
-      notes_has: :string,
-      rank: [{ string: Name.all_ranks }],
-      has_comments: { boolean: [true] },
-      comments_has: :string,
-      pattern: :string,
-      locations: [Location],
-      species_lists: [SpeciesList],
-      needs_description: :boolean,
-      has_descriptions: :boolean,
-      has_default_description: :boolean,
-      has_observations: { boolean: [true] },
-      description_query: { subquery: :NameDescription },
-      observation_query: { subquery: :Observation }
-    ).merge(content_filter_parameter_declarations(Name)).
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Name])
+  query_attr(:by_users, [User])
+  query_attr(:by_editor, User)
+  query_attr(:names, { lookup: [Name],
+                       include_synonyms: :boolean,
+                       include_subtaxa: :boolean,
+                       include_immediate_subtaxa: :boolean,
+                       exclude_original_names: :boolean })
+  query_attr(:text_name_has, :string)
+  # query_attr(:clade, :string) # content filter
+  # query_attr(:lichen, :boolean) # content filter
+  query_attr(:misspellings, { string: [:no, :either, :only] })
+  query_attr(:deprecated, :boolean)
+  query_attr(:has_synonyms, :boolean)
+  query_attr(:ok_for_export, :boolean)
+  query_attr(:has_author, :boolean)
+  query_attr(:author_has, :string)
+  query_attr(:has_citation, :boolean)
+  query_attr(:citation_has, :string)
+  query_attr(:has_classification, :boolean)
+  query_attr(:classification_has, :string)
+  query_attr(:has_notes, :boolean)
+  query_attr(:notes_has, :string)
+  query_attr(:rank, [{ string: Name.all_ranks }])
+  query_attr(:has_comments, { boolean: [true] })
+  query_attr(:comments_has, :string)
+  query_attr(:pattern, :string)
+  # query_attr(:search_name, :string) # advanced search
+  # query_attr(:search_where, :string) # advanced search
+  # query_attr(:search_user, :string) # advanced search
+  # query_attr(:search_content, :string) # advanced search
+  query_attr(:locations, [Location])
+  query_attr(:species_lists, [SpeciesList])
+  query_attr(:needs_description, :boolean)
+  query_attr(:has_descriptions, :boolean)
+  query_attr(:has_default_description, :boolean)
+  query_attr(:has_observations, { boolean: [true] })
+  query_attr(:description_query, { subquery: :NameDescription })
+  query_attr(:observation_query, { subquery: :Observation })
+
+  def self.extra_parameter_declarations
+    content_filter_parameter_declarations(Name).
       merge(advanced_search_parameter_declarations)
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Name
+  extra_parameter_declarations.each do |param_name, accepts|
+    query_attr(param_name, accepts)
   end
 
   def alphabetical_by

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -5,6 +5,8 @@ class Query::Names < Query::Base
   include Query::Params::AdvancedSearch
   include Query::Params::Filters
 
+  # Commented-out attributes are here so we don't forget they're added
+  # via `extra_parameter_declarations` below.
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Name])

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -4,65 +4,65 @@ class Query::Observations < Query::Base
   include Query::Params::AdvancedSearch
   include Query::Params::Filters
 
-  def self.parameter_declarations # rubocop:disable Metrics/MethodLength
-    super.merge(
-      date: [:date],
-      created_at: [:time],
-      updated_at: [:time],
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:date, [:date])
+  query_attr(:id_in_set, [Observation])
+  query_attr(:by_users, [User])
+  query_attr(:has_name, :boolean)
+  query_attr(:names, { lookup: [Name],
+                       include_synonyms: :boolean,
+                       include_subtaxa: :boolean,
+                       include_immediate_subtaxa: :boolean,
+                       exclude_original_names: :boolean,
+                       include_all_name_proposals: :boolean,
+                       exclude_consensus: :boolean })
+  query_attr(:confidence, [:float])
+  query_attr(:needs_naming, User)
+  # query_attr(:clade, :string) # content filter
+  # query_attr(:lichen, :boolean) # content filter
 
-      id_in_set: [Observation],
-      by_users: [User],
-      has_name: :boolean,
-      names: { lookup: [Name],
-               include_synonyms: :boolean,
-               include_subtaxa: :boolean,
-               include_immediate_subtaxa: :boolean,
-               exclude_original_names: :boolean,
-               include_all_name_proposals: :boolean,
-               exclude_consensus: :boolean },
-      confidence: [:float],
-      needs_naming: User,
-      # clade: :string, # content_filter
-      # lichen: :boolean, # content_filter
+  query_attr(:is_collection_location, :boolean)
+  query_attr(:has_public_lat_lng, :boolean)
+  query_attr(:in_box, { north: :float, south: :float,
+                        east: :float, west: :float })
+  query_attr(:location_undefined, { boolean: [true] })
+  query_attr(:locations, [Location])
+  # query_attr(:region, :string) # content filter
 
-      is_collection_location: :boolean,
-      has_public_lat_lng: :boolean,
-      location_undefined: { boolean: [true] },
-      locations: [Location],
-      in_box: { north: :float, south: :float, east: :float, west: :float },
-      # region: :string, # content filter
+  query_attr(:has_notes, :boolean)
+  query_attr(:notes_has, :string)
+  query_attr(:has_notes_fields, [:string])
+  query_attr(:pattern, :string)
+  query_attr(:has_comments, { boolean: [true] })
+  query_attr(:comments_has, :string)
+  query_attr(:has_sequences, { boolean: [true] })
+  # query_attr(:has_specimen, :boolean) # content filter
+  # query_attr(:has_images, :boolean) # content filter
 
-      has_notes: :boolean,
-      notes_has: :string,
-      has_notes_fields: [:string],
-      pattern: :string,
-      has_comments: { boolean: [true] },
-      comments_has: :string,
-      has_sequences: { boolean: [true] },
-      # has_specimen: :boolean, # content filter
-      # has_images: :boolean, # content filter
+  query_attr(:field_slips, [FieldSlip])
+  query_attr(:herbaria, [Herbarium])
+  query_attr(:herbarium_records, [HerbariumRecord])
+  query_attr(:projects, [Project])
+  query_attr(:project_lists, [Project])
+  query_attr(:species_lists, [SpeciesList])
+  # query_attr(:search_name, :string) # advanced search
+  # query_attr(:search_where, :string) # advanced search
+  # query_attr(:search_user, :string) # advanced search
+  # query_attr(:search_content, :string) # advanced search
+  query_attr(:image_query, { subquery: :Image })
+  query_attr(:location_query, { subquery: :Location })
+  query_attr(:name_query, { subquery: :Name })
+  query_attr(:sequence_query, { subquery: :Sequence })
 
-      field_slips: [FieldSlip],
-      herbaria: [Herbarium],
-      herbarium_records: [HerbariumRecord],
-      projects: [Project],
-      project_lists: [Project],
-      species_lists: [SpeciesList],
-      image_query: { subquery: :Image },
-      location_query: { subquery: :Location },
-      name_query: { subquery: :Name },
-      sequence_query: { subquery: :Sequence }
-    ).merge(content_filter_parameter_declarations(Observation)).
+  def self.extra_parameter_declarations
+    content_filter_parameter_declarations(Observation).
       merge(advanced_search_parameter_declarations)
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Observation
+  extra_parameter_declarations.each do |param_name, accepts|
+    query_attr(param_name, accepts)
   end
 
   def alphabetical_by

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -52,15 +52,13 @@ class Query::Observations < Query::Base
       location_query: { subquery: :Location },
       name_query: { subquery: :Name },
       sequence_query: { subquery: :Sequence }
-    ).
-      merge(content_filter_parameter_declarations(Observation)).
+    ).merge(content_filter_parameter_declarations(Observation)).
       merge(advanced_search_parameter_declarations)
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -4,6 +4,8 @@ class Query::Observations < Query::Base
   include Query::Params::AdvancedSearch
   include Query::Params::Filters
 
+  # Commented-out attributes are here so we don't forget they're added
+  # via `extra_parameter_declarations` below.
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:date, [:date])

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -1,34 +1,21 @@
 # frozen_string_literal: true
 
 class Query::Projects < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Project],
-      by_users: [User],
-      members: [User],
-      title_has: :string,
-      has_summary: :boolean,
-      summary_has: :string,
-      field_slip_prefix_has: :string,
-      has_images: { boolean: [true] },
-      has_observations: { boolean: [true] },
-      has_species_lists: { boolean: [true] },
-      has_comments: { boolean: [true] },
-      comments_has: :string,
-      pattern: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Project
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Project])
+  query_attr(:by_users, [User])
+  query_attr(:members, [User])
+  query_attr(:title_has, :string)
+  query_attr(:has_summary, :boolean)
+  query_attr(:summary_has, :string)
+  query_attr(:field_slip_prefix_has, :string)
+  query_attr(:has_images, { boolean: [true] })
+  query_attr(:has_observations, { boolean: [true] })
+  query_attr(:has_species_lists, { boolean: [true] })
+  query_attr(:has_comments, { boolean: [true] })
+  query_attr(:comments_has, :string)
+  query_attr(:pattern, :string)
 
   def alphabetical_by
     @alphabetical_by ||= Project[:title]

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -22,9 +22,8 @@ class Query::Projects < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -3,23 +3,24 @@
 class Query::RssLogs < Query::Base
   include Query::Params::Filters
 
-  def self.parameter_declarations
-    super.merge(
-      updated_at: [:time],
-      id_in_set: [RssLog],
-      type: :string
-    ).merge(content_filter_parameter_declarations(Observation)).
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [RssLog])
+  query_attr(:type, :string)
+  # query_attr(:clade, :string) # content filter
+  # query_attr(:lichen, :boolean) # content filter
+  # query_attr(:region, :string) # content filter
+  # query_attr(:has_specimen, :boolean) # content filter
+  # query_attr(:has_images, :boolean) # content filter
+
+  def self.extra_parameter_declarations
+    content_filter_parameter_declarations(Observation).
       merge(content_filter_parameter_declarations(Location)).
       merge(content_filter_parameter_declarations(Name))
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
+  extra_parameter_declarations.each do |param_name, accepts|
     attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= RssLog
   end
 
   def self.default_order

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -3,6 +3,8 @@
 class Query::RssLogs < Query::Base
   include Query::Params::Filters
 
+  # Commented-out attributes are here so we don't forget they're added
+  # via `extra_parameter_declarations` below.
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [RssLog])
   query_attr(:type, :string)

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -14,9 +14,8 @@ class Query::RssLogs < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -20,9 +20,8 @@ class Query::Sequences < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/sequences.rb
+++ b/app/classes/query/sequences.rb
@@ -1,32 +1,19 @@
 # frozen_string_literal: true
 
 class Query::Sequences < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [Sequence],
-      by_users: [User],
-      observations: [Observation],
-      locus: [:string],
-      locus_has: :string,
-      archive: [:string],
-      accession: [:string],
-      accession_has: :string,
-      notes_has: :string,
-      pattern: :string,
-      observation_query: { subquery: :Observation }
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= Sequence
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [Sequence])
+  query_attr(:by_users, [User])
+  query_attr(:observations, [Observation])
+  query_attr(:locus, [:string])
+  query_attr(:locus_has, :string)
+  query_attr(:archive, [:string])
+  query_attr(:accession, [:string])
+  query_attr(:accession_has, :string)
+  query_attr(:notes_has, :string)
+  query_attr(:pattern, :string)
+  query_attr(:observation_query, { subquery: :Observation })
 
   def alphabetical_by
     @alphabetical_by ||= Sequence[:locus]

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -22,9 +22,8 @@ class Query::SpeciesLists < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -1,34 +1,21 @@
 # frozen_string_literal: true
 
 class Query::SpeciesLists < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      date: [:date],
-      id_in_set: [SpeciesList],
-      by_users: [User],
-      title_has: :string,
-      has_notes: :boolean,
-      notes_has: :string,
-      has_comments: { boolean: [true] },
-      comments_has: :string,
-      search_where: :string,
-      locations: [Location],
-      projects: [Project],
-      pattern: :string,
-      observation_query: { subquery: :Observation }
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= SpeciesList
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:date, [:date])
+  query_attr(:id_in_set, [SpeciesList])
+  query_attr(:by_users, [User])
+  query_attr(:title_has, :string)
+  query_attr(:has_notes, :boolean)
+  query_attr(:notes_has, :string)
+  query_attr(:has_comments, { boolean: [true] })
+  query_attr(:comments_has, :string)
+  query_attr(:search_where, :string)
+  query_attr(:pattern, :string)
+  query_attr(:locations, [Location])
+  query_attr(:projects, [Project])
+  query_attr(:observation_query, { subquery: :Observation })
 
   def alphabetical_by
     @alphabetical_by ||= case params[:order_by].to_s

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -1,24 +1,11 @@
 # frozen_string_literal: true
 
 class Query::Users < Query::Base
-  def self.parameter_declarations
-    super.merge(
-      created_at: [:time],
-      updated_at: [:time],
-      id_in_set: [User],
-      has_contribution: :boolean,
-      pattern: :string
-    )
-  end
-
-  # Declare the parameters as model attributes, of custom type `query_param`
-  parameter_declarations.each do |param_name, accepts|
-    attribute param_name, :query_param, accepts: accepts
-  end
-
-  def model
-    @model ||= User
-  end
+  query_attr(:created_at, [:time])
+  query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [User])
+  query_attr(:has_contribution, :boolean)
+  query_attr(:pattern, :string)
 
   def alphabetical_by
     @alphabetical_by ||= case params[:order_by].to_s

--- a/app/classes/query/users.rb
+++ b/app/classes/query/users.rb
@@ -12,9 +12,8 @@ class Query::Users < Query::Base
   end
 
   # Declare the parameters as model attributes, of custom type `query_param`
-
-  parameter_declarations.each_key do |param_name|
-    attribute param_name, :query_param
+  parameter_declarations.each do |param_name, accepts|
+    attribute param_name, :query_param, accepts: accepts
   end
 
   def model

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -130,7 +130,7 @@ module ApplicationController::Queries
   def apply_one_content_filter(fltr, query_params, model, user_filter)
     query_class = "Query::#{model.to_s.pluralize}".constantize
     key = fltr.sym
-    return unless query_class.takes_parameter?(key)
+    return unless query_class.has_attribute?(key)
     return if query_params.key?(key)
     return unless fltr.on?(user_filter)
 

--- a/app/extensions/class.rb
+++ b/app/extensions/class.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#
+#  = Extensions to Class
+#
+class Class
+  # Convenience method for setting Query subclass attributes.
+  # These use a custom attribute type defined in app/types/query_param_type.rb
+  def query_attr(attr, accepts)
+    attribute(attr, :query_param, accepts:)
+  end
+end

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -1,8 +1,39 @@
 # frozen_string_literal: true
 
-# This is a custom attribute type for the Query class parameters.
-# https://stackoverflow.com/a/79417688/3357635
+# Custom attribute type for Query subclass attributes (parameters).
+# The arg `:accepts` describes valid or parseable attribute values,
+# according to the following syntax:
+#
+# = Simple values
+#   :string
+#   :date
+#   :time
+#   :float
+#   :boolean
+#   SpeciesList (any ActiveRecord model instance or id, parsed as an id)
+#
+# = Array values
+#   [:string]
+#   [:date]
+#   [:time]
+#   [Project] (array of ActiveRecord model instances or ids, parsed as ids)
+#
+# = Hash values
+#   { string: [:yes, :no] } (evaluated as an "enum", other values ignored)
+#   { boolean: [true] } (evaluated as an "enum", `false` ignored )
+#   { subquery: :Observation } (evaluated as a subquery, sub-params forwarded)
+#   { north:, south:, east:, west:} (forwarded as a hash of values)
+#
+# re: custom types - https://stackoverflow.com/a/79417688/3357635
+#
 class QueryParamType < ActiveModel::Type::Value
+  attr_reader :accepts
+
+  def initialize(**args)
+    @accepts = args[:accepts]
+    super
+  end
+
   # This is required and used if you register the type
   # instead of just passing the class
   def type = :query_param

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -1,41 +1,41 @@
 # frozen_string_literal: true
 
-# Custom attribute type for Query subclass attributes (parameters).
+# MO Custom attribute type for all Query subclass attributes (parameters).
 # The arg `:accepts` describes valid or parseable attribute values,
 # according to the following syntax:
 #
-# = Simple values
+# = Simple value types
 #   :string
 #   :date
 #   :time
 #   :float
 #   :boolean
-#   SpeciesList (any ActiveRecord model instance or id, parsed as an id)
+#   SpeciesList (ActiveRecord model instance or id, parsed as an id)
 #
-# = Array values
+# = Array value types
 #   [:string]
 #   [:date]
 #   [:time]
 #   [Project] (array of ActiveRecord model instances or ids, parsed as ids)
 #
-# = Hash values
+# = Hash value types
 #   { string: [:yes, :no] } (evaluated as an "enum", other values ignored)
 #   { boolean: [true] } (evaluated as an "enum", `false` ignored )
 #   { subquery: :Observation } (evaluated as a subquery, sub-params forwarded)
-#   { north:, south:, east:, west:} (forwarded as a hash of values)
+#   { north:, south:, east:, west: } (forwarded as a hash of values)
 #
-# re: custom types - https://stackoverflow.com/a/79417688/3357635
+# re: custom attribute types - https://stackoverflow.com/a/79417688/3357635
 #
 class QueryParamType < ActiveModel::Type::Value
   attr_reader :accepts
 
-  # We don't want to call `super` here, we want to overwrite it, because it
-  # will not accept our custom arg.
-  def initialize(**args) # rubocop:disable Lint/MissingSuper
-    @accepts = args[:accepts]
+  # Add our custom arg :accepts to the default args.
+  def initialize(precision: nil, limit: nil, scale: nil, accepts: nil)
+    super(precision:, limit:, scale:)
+    @accepts = accepts
   end
 
-  # This is required and used if you register the type
-  # instead of just passing the class
+  # This is required and used if registering the type instead of just passing
+  # the class (registered in config/initializers/active_model_types.rb)
   def type = :query_param
 end

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -29,9 +29,10 @@
 class QueryParamType < ActiveModel::Type::Value
   attr_reader :accepts
 
-  def initialize(**args)
+  # We don't want to call `super` here, we want to overwrite it, because it
+  # will not accept our custom arg.
+  def initialize(**args) # rubocop:disable Lint/MissingSuper
     @accepts = args[:accepts]
-    super
   end
 
   # This is required and used if you register the type

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -25,14 +25,15 @@
 #   { north:, south:, east:, west: } (forwarded as a hash of values)
 #
 # re: custom attribute types - https://stackoverflow.com/a/79417688/3357635
+#                              https://stackoverflow.com/a/78668203/3357635
 #
 class QueryParamType < ActiveModel::Type::Value
   attr_reader :accepts
 
   # Add our custom arg :accepts to the default args.
-  def initialize(precision: nil, limit: nil, scale: nil, accepts: nil)
-    super(precision:, limit:, scale:)
+  def initialize(accepts: nil)
     @accepts = accepts
+    super()
   end
 
   # This is required and used if registering the type instead of just passing

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -421,9 +421,9 @@ class QueryTest < UnitTestCase
     assert_equal(1, QueryRecord.count)
 
     # Trvial coercion: from a model to the same model.
-    q2 = q1.subquery_of(:Observation)
-    assert_equal(q1, q2)
-    assert_equal(1, QueryRecord.count)
+    # q2 = q1.subquery_of(:Observation)
+    # assert_equal(q1, q2)
+    # assert_equal(1, QueryRecord.count)
 
     # No search is coercable to RssLog (yet).
     q3 = q1.subquery_of(:RssLog)

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -421,9 +421,9 @@ class QueryTest < UnitTestCase
     assert_equal(1, QueryRecord.count)
 
     # Trvial coercion: from a model to the same model.
-    # q2 = q1.subquery_of(:Observation)
-    # assert_equal(q1, q2)
-    # assert_equal(1, QueryRecord.count)
+    q2 = q1.subquery_of(:Observation)
+    assert_equal(q1, q2)
+    assert_equal(1, QueryRecord.count)
 
     # No search is coercable to RssLog (yet).
     q3 = q1.subquery_of(:RssLog)


### PR DESCRIPTION
- Monkey patches `Class` to add a new attribute declaration method for `Query`, `:query_attr`. 
- Adds a new explicit option for the `:query_param` attribute type, `:accepts`, which our Query validator uses to figure out how to validate the attribute. (It's the same arg previously stored in the `parameter_declarations` hash.)
- Changes Query subclasses to declare attributes using `query_attr`, and changes callers of `parameter_declarations` to access Query `attribute_types` instead. `@params` are still used as the query's "active attributes" (i.e. non-nil).

Using ActiveModel attributes makes it possible for attribute declarations, and our validator, to use other inherited options: `precision`, `limit` and `scale`, that we don't declare on Query attributes yet, but could.