### PR TITLE
Move some comments to appropriate module and move Query::Validator out of Query::Modules

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -1,131 +1,15 @@
 # frozen_string_literal: true
 
+#  == Query (Factory)
 #
-#  = Query Model
-#
-#  This class encapsulates a hash of params that can produce an ActiveRecord
-#  statement for a database query, that looks up one or more objects of a
-#  given type, matching certain conditions in a certain order.
-#
-#  Queries are specified by a model.  The model specifies which kind
-#  of objects are being requested, e.g. :Name or :Observation. They are
-#  dyamically joined with any number of additional tables, as required by
-#  sorting and selection conditions.
-#
-#  To filter query results, you can send additional parameters.  For example,
-#  create_query(:Comment, for_user: user.id) retrieves comments posted on a
-#  given user's observations.  Query saves the parameters alongside the model,
-#  and together these fully specify a query that may be recreated and
-#  executed at a later time, even potentially by another user (e.g., if users
-#  share links that have query specs embedded in them). They can be serialized
-#  and printed as a permalink, or carried along in the session while the user
-#  is navigating around related records.
-#
-#  `initialize_query` is the internal method that translates the params and
-#  their values to ActiveRecord scopes with the same names, without executing
-#  the query. (Scopes are independent of Query, and need to be defined on each
-#  model.) Only the public accessors like `results` actually load the database
-#  records for the current page of results.
-#
-#  Query also keeps track of "where you are in the query".  Browsing through
-#  filtered results, if you visit a "show" page, you can continue navigating
-#  through the same results via the "next" and "prev" links on the show page,
-#  within the same query — as if you were paging through results in the index.
-#
-#  Each model has a default search order (:default), which is used by the prev
-#  and next actions when the specified query no longer exists.  For example, if
-#  you click on an observation from the main index, prev and next travserse the
-#  results of an :Observation order_by: :rss_log query.  If the user comes back
-#  a day later, this query will have been culled by the garbage collector (see
-#  below), so prev and next need to be able to create a default query on the
-#  fly.
-#
-#  == Example Usage
-#
-#  Get observations created by @user:
-#
-#    query = Query.lookup(:Observation, by_users: [@user])
-#
-#  You may further tweak a query after it's been created:
-#
-#    query = Query.lookup(:Observation)
-#    query.add_join(:names)
-#    query.where << 'names.correct_spelling_id IS NULL'
-#    query.order = 'names.sort_name ASC'
-#
-#  Now you may execute it in various ways:
-#
-#    num_results = query.num_results
-#    ids         = query.result_ids
-#    instances   = query.results
-#
-#  Sequence operators let you use the query as a pseudo-iterator:  (Note, these
-#  are somewhat more subtle than shown here, as nested queries may require the
-#  creation of new query instances.  See the section on nested queries below.)
-#
-#    query = Query.lookup(:Observation)
-#    query.current = @observation
-#    next  = query.current if query.next
-#    this  = query.current if query.prev
-#    prev  = query.current if query.prev
-#    first = query.current if query.first
-#    last  = query.current if query.last
-#
-#  Finally, Query's know how to work with PaginationData:
-#
-#    # In controller:
-#    query = create_query(:Name)
-#    @pagination_data = number_pagination_data
-#    @names = query.paginate(@pagination_data)
-#
-#    # Or if you want to paginate by letter first, then page number:
-#    query = create_query(:Name)
-#    query.need_letters = 'names.sort_name'
-#    @pagination_data = letter_pagination_data
-#    @names = query.paginate(@pagination_data)
-#
-#  == Sequence Operators
-#
-#  The "correct" usage of the sequence operators is subtle and inflexible due
-#  to the complexities of the query potentially being nested.  This is how it
-#  is designed to work:
-#
-#    query = Query.lookup(:Image)
-#
-#    # Note that query.next *MAY* return a clone.
-#    if new_query = query.next
-#      puts "Next image is: " + new_query.current_id
-#    else
-#      puts "No more images."
-#    end
-#
-#    # Must reset otherwise query.prev just goes back to original place.
-#    query.reset
-#    if new_query = query.prev
-#      puts "Previous image is: " + new_query.current_id
-#    else
-#      puts "No more images."
-#    end
-#
-#    # Note: query.last works the same.
-#    if new_query = query.first
-#      puts "First image is: " + new_query.current_id
-#    else
-#      puts "There are no matching images!"
-#    end
-#
-#  == Attributes of all Query instances:
-#
-#  model::              Class of model results belong to.
-#  params::             Hash of parameters used to create query.
-#  current::            Current location in query (for sequence operators).
-#  subqueries::         Cache of subquery Query instances, used for filtering.
-#
+#  This class is simply a factory for Query instances. It could maybe be better
+#  named QueryFactory, with class methods like `create_query`, but as it is,
+#  `Query.new` and `Query.lookup` are a lot more concise.
 #
 #  NOTE: The `Query::#{Model}` classes do not inherit from this class. They
 #        inherit from `Query::Base`, which does not inherit from this either.
-#        `Query` is simply a convenience delegator/accessor for class methods
-#        that may be called from outside Query, like `Query.lookup`
+#        `Query` acts also as a convenience delegator/accessor for class methods
+#        that may be called from outside Query, like `Query.lookup`.
 #
 class Query
   include Query::Modules::QueryRecords

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -217,13 +217,24 @@
 #
 #  ## DEFAULT ORDER
 #
-#  Each model has a default search order (:default), which is used by the prev
-#  and next actions when the specified query no longer exists.  For example, if
-#  you click on an observation from the main index, prev and next travserse the
-#  results of an :Observation order_by: :rss_log query.  If the user comes back
-#  a day later, this query will have been culled by the garbage collector (see
-#  below), so prev and next need to be able to create a default query on the
-#  fly.
+#  Each model should define a default search order (:default_order), which is a
+#  keyword parsed by the `order_by` scope, and should map to a scope or class
+#  method named `order_by_#{:default_order}` in `AbstractModel::Scopes`.
+#
+#  This order is also used by the prev and next actions when the specified query
+#  no longer exists. For example, if you click on an observation from the main
+#  index, prev and next travserse the results of an order_by: :rss_log query.
+#  If the user comes back a day later, this query will have been culled by the
+#  garbage collector (see Query::Modules::QueryRecords), so prev and next need
+#  to be able to create a default query on the fly.
+#
+#  ## ALPHABETICAL BY
+#
+#  For indexes where we want users to be able to paginate the results by letter,
+#  the Query class should specify which column to use for sorting. This should
+#  be given as `Model[:column]`, in case it is being sorted on the column of a
+#  joined table. Check existing examples.
+#
 #
 #  ############################################################################
 #

--- a/app/classes/query/base.rb
+++ b/app/classes/query/base.rb
@@ -1,5 +1,52 @@
 # frozen_string_literal: true
 
+#  == Query Base Model
+#
+#  This class encapsulates a hash of params that can produce an ActiveRecord
+#  statement for a database query, that looks up one or more objects of a
+#  given type, matching certain conditions in a certain order.
+#
+#  Queries are specified by a model.  The model specifies which kind
+#  of objects are being requested, e.g. :Name or :Observation. They are
+#  dyamically joined with any number of additional tables, as required by
+#  sorting and selection conditions.
+#
+#  To filter query results, you can send additional parameters.  For example,
+#  create_query(:Comment, for_user: user.id) retrieves comments posted on a
+#  given user's observations.  Query saves the parameters alongside the model,
+#  and together these fully specify a query that may be recreated and
+#  executed at a later time, even potentially by another user (e.g., if users
+#  share links that have query specs embedded in them). They can be serialized
+#  and printed as a permalink, or carried along in the session while the user
+#  is navigating around related records.
+#
+#  == Example Usage
+#
+#  Get observations created by @user:
+#
+#    query = Query.lookup(:Observation, by_users: [@user])
+#
+#  You may further tweak a query after it's been created:
+#
+#    query = Query.lookup(:Observation)
+#    query.add_join(:names)
+#    query.where << 'names.correct_spelling_id IS NULL'
+#    query.order = 'names.sort_name ASC'
+#
+#  Now you may execute it in various ways:
+#
+#    num_results = query.num_results
+#    ids         = query.result_ids
+#    instances   = query.results
+#
+#  == Attributes of all Query instances:
+#
+#  model::              Class of model results belong to.
+#  params::             Hash of parameters used to create query.
+#  current::            Current location in query (for sequence operators).
+#  subqueries::         Cache of subquery Query instances, used for filtering.
+#
+#
 #  CREATING A NEW QUERY SUBCLASS
 #
 #  To make an ActiveRecord model queryable, create a new class that inherits
@@ -44,8 +91,8 @@
 #  In our case, we define our own validator and data type. That data type is
 #  `query_param`, and the attribute values are checked and sanitized by
 #  Query::Modules::Validation on initialization. Calling `valid?` uses
-#  Query::Modules::Validator to check for any validation errors that may
-#  have been stored in the Query instance by `clean_and_validate_params`.
+#  Query::Validator to check for any validation errors that may have been
+#  stored in the Query instance by `clean_and_validate_params`.
 #
 #  `valid?` should mean the parameter values are usable by the corresponding
 #  ActiveRecord scope in each model. The scopes are what actually execute the
@@ -168,6 +215,16 @@
 #
 #  Each sub-param is validated as a :float.
 #
+#  ## DEFAULT ORDER
+#
+#  Each model has a default search order (:default), which is used by the prev
+#  and next actions when the specified query no longer exists.  For example, if
+#  you click on an observation from the main index, prev and next travserse the
+#  results of an :Observation order_by: :rss_log query.  If the user comes back
+#  a day later, this query will have been culled by the garbage collector (see
+#  below), so prev and next need to be able to create a default query on the
+#  fly.
+#
 #  ############################################################################
 #
 #  == Class and Instance Methods
@@ -201,7 +258,7 @@ class Query::Base
   # Declare query attributes with method defined in app/extensions/class.rb
   query_attr(:order_by, :string)
 
-  validates_with Query::Modules::Validator
+  validates_with Query::Validator
 
   # "clean up" and reassign attributes before validation
   before_validation :clean_and_validate_params
@@ -264,10 +321,6 @@ class Query::Base
     self.class.default_order || :id
   end
 
-  def ==(other)
-    serialize == other.try(&:serialize)
-  end
-
   # Serialize the query params, adding the model, for saving to a QueryRecord.
   # We use this column of QueryRecord to identify an existing query record that
   # matches current params, and sometimes to recompose a query from the string.
@@ -281,6 +334,10 @@ class Query::Base
   # you can't use SQL on the column value, you have to compare parsed instances.
   def serialize
     attributes.compact.sort.to_h.merge(model: model.name).to_json
+  end
+
+  def ==(other)
+    serialize == other.try(&:serialize)
   end
 
   def record

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-#  :section: Initialization
+#  :module: Initialization
 #
 #  Helper methods for turning Query parameters into AR conditions.
 #
@@ -13,6 +13,12 @@
 #  To get the results for an :index page or for pagination, the methods in
 #  `Query::Modules::Results` need to call `initialize_query`, which makes the
 #  scope chain of the Query instance accessible via `#query`.
+#
+#  `initialize_query` is the internal method that translates the params and
+#  their values to ActiveRecord scopes with the same names, without executing
+#  the query. (Scopes are independent of Query, and need to be defined on each
+#  model.) Only the public accessors like `results` actually load the database
+#  records for the current page of results.
 #
 #  Example:
 #

--- a/app/classes/query/modules/query_records.rb
+++ b/app/classes/query/modules/query_records.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-# Methods that are available to instances as class methods, and to ::Query.
-# ::Query is a convenience delegator class so callers can access these methods.
+##############################################################################
+#
+#  :module: QueryRecords
+#
+#  Methods that are available to instances as class methods, and to ::Query.
+#  ::Query is a convenience delegator class so callers can access these methods.
 #
 #  QueryRecords:
 #  find::               Find a QueryRecord id and reinstantiate a Query from it.

--- a/app/classes/query/modules/results.rb
+++ b/app/classes/query/modules/results.rb
@@ -2,7 +2,7 @@
 
 ##############################################################################
 #
-#  :section: Results
+#  :module: Results
 #
 #  Caching note:
 #  Query caches results, and result_ids.  Any of results, result_ids,

--- a/app/classes/query/modules/sequence.rb
+++ b/app/classes/query/modules/sequence.rb
@@ -2,10 +2,12 @@
 
 ##############################################################################
 #
-#  :section: Sequence
+#  :module: Sequence
 #
-#  Methods for moving forward/back up/down within Query results.
-#  Used on show pages of individual records.
+#  Query keeps track of "where you are in the query".  Browsing through
+#  filtered results, if you visit a "show" page, you can continue navigating
+#  through the same results via the "next" and "prev" links on the show page,
+#  within the same query — as if you were paging through results in the index.
 #
 #  NOTE: The next and prev sequence operators always grab the entire set of
 #  result_ids.  No attempt is made to reduce the query.  NOTE: we might be
@@ -16,6 +18,9 @@
 #
 #  Methods:
 #
+#  Methods for moving forward/back up/down within Query results.
+#  Used on show pages of individual records.
+#
 #  current_id=::  Set current place in results by id.
 #  current=::     Same as above, but accepts record instances.
 #  current(*)     Current place in results, with record instantiated.
@@ -25,6 +30,62 @@
 #  previous::
 #  next::
 #  last::
+#
+#  Sequence operators let you use the query as a pseudo-iterator:  (Note, these
+#  are somewhat more subtle than shown here, as nested queries may require the
+#  creation of new query instances.  See the section on nested queries below.)
+#
+#    query = Query.lookup(:Observation)
+#    query.current = @observation
+#    next  = query.current if query.next
+#    this  = query.current if query.prev
+#    prev  = query.current if query.prev
+#    first = query.current if query.first
+#    last  = query.current if query.last
+#
+#  Query knows how to work with PaginationData:
+#
+#    # In controller:
+#    query = create_query(:Name)
+#    @pagination_data = number_pagination_data
+#    @names = query.paginate(@pagination_data)
+#
+#    # Or if you want to paginate by letter first, then page number:
+#    query = create_query(:Name)
+#    query.need_letters = 'names.sort_name'
+#    @pagination_data = letter_pagination_data
+#    @names = query.paginate(@pagination_data)
+#
+#  == Sequence Operators
+#
+#  The "correct" usage of the sequence operators is subtle and inflexible due
+#  to the complexities of the query potentially being nested.  This is how it
+#  is designed to work:
+#
+#    query = Query.lookup(:Image)
+#
+#    # Note that query.next *MAY* return a clone.
+#    if new_query = query.next
+#      puts "Next image is: " + new_query.current_id
+#    else
+#      puts "No more images."
+#    end
+#
+#    # Must reset otherwise query.prev just goes back to original place.
+#    query.reset
+#    if new_query = query.prev
+#      puts "Previous image is: " + new_query.current_id
+#    else
+#      puts "No more images."
+#    end
+#
+#    # Note: query.last works the same.
+#    if new_query = query.first
+#      puts "First image is: " + new_query.current_id
+#    else
+#      puts "There are no matching images!"
+#    end
+#
 #
 ###############################################################################
 

--- a/app/classes/query/modules/subqueries.rb
+++ b/app/classes/query/modules/subqueries.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-# Methods that are available to instances as class methods, and to ::Query.
-# ::Query is a convenience delegator class so callers can access these methods.
+##############################################################################
+#
+#  :module: Sequence
+#
+#  Methods that are available to instances as class methods, and to ::Query.
+#  ::Query is a convenience delegator class so callers can access these methods.
 #
 #  Subqueries:
 #  current_or_related_query:: Convert queries from one model to another; can be

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
-# Validation of Query parameters, plus substitution of ids for instances.
+##############################################################################
+#
+#  :module: Validation
+#
+#  Validation of Query parameters, plus substitution of ids for instances.
+#
 module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   attr_accessor :params, :params_cache, :subqueries, :valid, :validation_errors
 

--- a/app/classes/query/validator.rb
+++ b/app/classes/query/validator.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-# Validation of Query parameters.
-class Query::Modules::Validator < ActiveModel::Validator
+##############################################################################
+#
+#  :class: Validator
+#
+#  Validation of Query parameters.
+#
+class Query::Validator < ActiveModel::Validator
   def initialize(options = {})
     super
     options[:class].attr_accessor(:validation_errors)


### PR DESCRIPTION
Mostly finishes moving comment blocks around to the module where they're appropriate and helpful. 

Also: `Query::Validator` is a class and not a module, so it seems like it should be in the main `classes/query` directory.