### PR TITLE
Remove Redis dependency on production, add gem `solid_cable`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem("solid_queue")
 # https://github.com/rails/mission_control-jobs
 # Rails-based frontend to Active Job adapters for monitoring jobs
 gem("mission_control-jobs")
+# solid_cable for ActionCable without Redis
+gem("solid_cable")
 
 # sprockets for asset compilation and versioning
 gem("sprockets-rails")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,11 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    solid_cable (3.0.7)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_cache (1.0.7)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -605,6 +610,7 @@ DEPENDENCIES
   rubyzip (~> 2.3.0)
   simplecov
   simplecov-lcov
+  solid_cable
   solid_cache
   solid_queue
   sorted_set

--- a/README_DEVELOPMENT_INSTALL
+++ b/README_DEVELOPMENT_INSTALL
@@ -198,12 +198,14 @@ jason> mysql -u root -p
   CREATE DATABASE mo_development;
   CREATE DATABASE mo_test;
   CREATE DATABASE cache_development;
+  CREATE DATABASE cable_development;
   CREATE USER 'mo'@'localhost' IDENTIFIED BY 'xxx';
   # Command used to reset password if needed later:
   # SET PASSWORD FOR 'mo'@'localhost' = PASSWORD('xxx');
   GRANT ALL PRIVILEGES ON mo_development.* TO 'mo'@'localhost' WITH GRANT OPTION;
   GRANT ALL PRIVILEGES ON mo_test.* TO 'mo'@'localhost' WITH GRANT OPTION;
   GRANT ALL PRIVILEGES ON cache_development.* TO 'mo'@'localhost' WITH GRANT OPTION;
+  GRANT ALL PRIVILEGES ON cable_development.* TO 'mo'@'localhost' WITH GRANT OPTION;
 mo> cp config/database.yml-template config/database.yml
 mo> vi config/database.yml
   shared:
@@ -235,6 +237,12 @@ mo> vi config/database.yml
       password: mo
       host: localhost
       migrations_paths: "db/cache/migrate"
+    cable:
+      database: cable_development
+      username: mo
+      password: mo
+      host: 127.0.0.1
+      migrations_paths: db/cable_migrate
 
   test:
     database: mo_test
@@ -267,10 +275,13 @@ mo> rake lang:update
 
 
 # NOTE: 2024/02/09 The `create database` section above contains the steps to
-# create and use the new solid_cache db. If your development install is already
+# create and use the new solid_cache db.
+#
+# NOTE: 2025/04/18 The `create database` section above also contains steps to
+# create and use the new solid_cable db. If your development install is already
 # running however, do the following to set it up:
 #
-# 1. Check out <main> to get the `solid_cache` gem, new configs and migrations
+# 1. Check out <main> to get the `solid_cable` gem, new configs and migrations
 # 2. Run `bundle`
 # 3. You have to manually change your `config/database.yml`, since that file is
 #    not checked in to git. The relevant change regards _nesting_ db configs:
@@ -286,10 +297,16 @@ mo> rake lang:update
 #     password: mo
 #     host: 127.0.0.1
 #     migrations_paths: "db/cache/migrate"
+#   cable:
+#     database: cable_development
+#     username: mo
+#     password: mo
+#     host: 127.0.0.1
+#     migrations_paths: db/cable_migrate
 #
-# Your main db config should now be nested under `primary`, and the cache db
-# config under `cache`. Both can use the same mysql user/pw, there are no
-# further config changes necessary.
+# Your main db config should now be nested under `primary`, the cache db config
+# under `cache`, and the cable db config under `cable`. All can use the same
+# mysql user/pw, there are no further config changes necessary.
 #
 # 4. `sudo mysql`, create the new db and grant user 'mo' privileges in the new
 #    cache db. With a default setup, you should be able to sudo into mysql using

--- a/README_DEVELOPMENT_INSTALL
+++ b/README_DEVELOPMENT_INSTALL
@@ -308,7 +308,10 @@ mo> rake lang:update
 # under `cache`, and the cable db config under `cable`. All can use the same
 # mysql user/pw, there are no further config changes necessary.
 #
-# 4. `sudo mysql`, create the new db and grant user 'mo' privileges in the new
+# 4. Run `rails db:prepare`. That sets up the `cable` db. The next steps (5-8)
+#    should be unnecessary if you already have the `cache` db set up.
+#
+# 5. `sudo mysql`, create the new db and grant user 'mo' privileges in the new
 #    cache db. With a default setup, you should be able to sudo into mysql using
 #    your current user password - on a Mac, your user password - or get in with
 #    `mysql -u root` and no password.
@@ -339,11 +342,11 @@ mo> rake lang:update
 #    mysql> flush privileges;
 #    mysql> quit;
 #
-# 5. Run `rails db:create` locally. Don’t worry, this will NOT re-create any
+# 6. Run `rails db:create` locally. Don’t worry, this will NOT re-create any
 #    existing databases, only add the new `cache_development` db, using the
 #    new cache migrations that are on the main branch under `db/cache/migrate`.
-# 6. Run `rails db:migrate`, to set up the tables in the cache db properly
-# 7. run `rails s` and observe the log when loading the home page of the site.
+# 7. Run `rails db:migrate`, to set up the tables in the cache db properly
+# 8. run `rails s` and observe the log when loading the home page of the site.
 #    You should find log messages saying `solid_cache` is writing to the cache
 #    db and reading from it.
 #

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,15 +1,22 @@
-# ActionCable is a Rails feature that allows for
-# real-time communication between the server and the client.
-
+# Async adapter only works within the same process, so for manually triggering cable updates from a console,
+# and seeing results in the browser, you must do so from the web console (running inside the dev process),
+# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
+# to make the web console appear.
 development:
-  adapter: redis
-  url: redis://localhost:6379/4
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
 
 test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379" } %>
-  channel_prefix: mo_production
-  ssl_params: { ca_file: "/etc/ssl/certs/cs-certificates.crt" }
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,11 @@
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "channel_hash", limit: 8, null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end


### PR DESCRIPTION
See issue #2908. 
This aims to resolve an issue deleting comments that is currently throwing errors on production. The errors seem to be due to Redis not being booted, or not connecting for some other reason. 

The error is reproducible locally: just add and delete a comment from an obs. This PR resolves the error locally for me.

Having to install/deal with/reboot Redis, whether on production or locally, is proving to be a banana peel. The good news is that we don't have to use it anymore. There is a core Rails gem, installed by default in Rails 8, called [`solid_cable`](https://github.com/rails/solid_cable) that runs ActionCable off its own small MySQL database and gets rid of the Redis dependency for Turbo updates. Eliminating Redis was one of the goals of `solid_queue` and `solid_cache`, which we already use, and it seems to me to make sense to add this gem, now that we are having issues on production with comment updates/deletions.

I believe this is our last `redis` dependency, but i'm not sure. I believe removing Redis should be a separate PR in case it breaks anything.

NOTE: After deploy, we will need to 
- alter production's `database.yml`:
```
  cable:
    database: cable_production
    username: $
    password: $
    host: $
    migrations_paths: db/cable_migrate
```
- run `rails db:prepare`