### PR TITLE
Fix query param called by Observation index param `where`

### DIFF
--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -161,19 +161,12 @@ class ObservationsController
     end
 
     # Display matrix of Observations whose "where" matches a string.
-    # NOTE: To consolidate flavors in Query, we're passing the possible
-    # `search_where` param from the advanced search form straight through to
-    # Query's obs advanced search class, which searches two tables (obs and
-    # loc) for the fuzzy match.
-    # Here we are passing the front end's `where` to the similar Query
-    # `locations` string handling param of Query::Observations. If the param
-    # names in Observations were the same, with ObservationAdvancedSearch,
-    # because of inheritance, query would use it first for AdvancedSearch's
-    # table-join search, but then Base would add an extra AND clause to search
-    # observations, that will preclude getting results.
+    # NOTE: We're passing the `search_where` param from advanced search to
+    # AbstractModel's scope `search_where`, which searches two tables
+    # (obs and loc) for the fuzzy match.
     def where
       where = params[:where].to_s
-      query = create_query(:Observation, locations: where)
+      query = create_query(:Observation, search_where: where)
       [query, { always_index: true }]
     end
 

--- a/test/controllers/observations_controller/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller/observations_controller_index_test.rb
@@ -550,7 +550,9 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     login
     get(:index, params: { where: location.name })
     assert_displayed_title(:OBSERVATIONS.l)
-    assert_displayed_filters("#{:query_locations.l}: #{location.display_name}")
+    assert_displayed_filters(
+      "#{:query_search_where.l}: #{location.display_name}"
+    )
     assert_match(new_location_path(where: location.name), @response.body)
   end
 
@@ -562,7 +564,9 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_select("#results a", { text: "« Prev" },
                   "Wrong page or display is missing a link to Prev page")
     assert_displayed_title(:OBSERVATIONS.l)
-    assert_displayed_filters("#{:query_locations.l}: #{location.display_name}")
+    assert_displayed_filters(
+      "#{:query_search_where.l}: #{location.display_name}"
+    )
     assert_not_empty(css_select('[id="context_nav"]').text, "Tabset is empty")
   end
 


### PR DESCRIPTION
The scope called by this index param was incorrectly set by me to `locations`, which only searches the location table. 

`search_where` is the correct Query param name and scope for a text fuzzy search of observations by location name. This gets undefined "locations", which are not locations at all, but basically orphaned strings in the obs table. (NOTE: no scope can be named `where`, that refers to the AR method.)

This kind of stuff is now much easier to debug if you're clear about three things and what they do.
- `index` params
- Query params
- scopes

In this case, the **index param** from issue #2930 is `where` — `observations?where=%22Mangalore,%20India%22`.

The `index` param is dispatched directly to an action in `ObservationsController::Index` called `where`. 
Before this PR, that was:
```ruby
    def where
      where = params[:where].to_s
      query = create_query(:Observation, locations: where)
      [query, { always_index: true }]
    end
```

What does that do? Query now passes all of its params directly to the Observation scopes. In this case, `locations`. Let's look at that:
```ruby
    scope :locations, lambda { |locations|
      location_ids = lookup_locations_by_name(locations)
      where(location: location_ids).distinct
    }
```

This scope does not search the column `observations.where`, it's purely a location table search. That's the issue.

I happen to remember that the scope we want is the one used by Advanced Search: `search_where`. That's defined in `AbstractModel::Scopes` because it's available on three different models, Observation, Name and Location. Note that it searches the column `Observation[:where]` while left_outer_joining to `:location`, meaning that it grabs observations with or without a Location.

```ruby
    scope :search_where, lambda { |phrase|
      scope = all
      scope = case klass.name
              when "Observation"
                scope.left_outer_joins(:location)
              when "Name"
                scope.joins(
                  :observations,
                  Observation.left_outer_joins(:location).arel.join_sources
                )
              when "Location"
                scope
              end
      field = if klass.name == "Location"
                Location[:name]
              else
                Observation[:where]
              end
      scope.search_columns(field, phrase)
    }
```

I realize this could be a gotcha, so I feel like it's worth taking a minute to read through `AbstractModel::Scopes` so you're not wondering.

This PR changes the `index` param to call the `search_where` scope instead.
```ruby
    def where
      where = params[:where].to_s
      query = create_query(:Observation, search_where: where)
      [query, { always_index: true }]
    end
```