### PR TITLE
Create 20250420000000_solid_cable_initial_migration.solid_cable.rb

### DIFF
--- a/db/cable_migrate/20250420000000_solid_cable_initial_migration.solid_cable.rb
+++ b/db/cable_migrate/20250420000000_solid_cable_initial_migration.solid_cable.rb
@@ -1,0 +1,11 @@
+class SolidCableInitialMigration < ActiveRecord::Migration[7.1]
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "channel_hash", limit: 8, null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end


### PR DESCRIPTION
Puts the schema in an initial migration, as suggested by https://github.com/rails/solid_cable/issues/45