### PR TITLE
MyCoPortal report unedited

### DIFF
--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+module Report
+  # Report for exporting Observations to MyCoPortal
+  # https://mycoportal.org/
+  # https://www.mycoportal.org/portal/api/v2/documentation
+  # MyCoPortal is a Symbiota-based portal for Mycology
+  # https://symbiota.org/
+  # https://biokic.github.io/symbiota-docs/
+  # https://github.com/Symbiota/Symbiota
+  class Mycoportal < TSV
+    # These plus Column labels comprising
+    # Symbiota Standard Field names which are useful for our purposes
+    # https://biokic.github.io/symbiota-docs/editor/edit/fields/#standard-fields
+    # plus MO-specific fields that are useful for uploads to Symbiota portals
+    def labels
+      %w[
+        scientificName
+        scientificNameAuthorship
+        taxonRank
+        genus
+        specificEpithet
+        infraspecificEpithet
+        recordedBy
+        recordNumber
+        disposition
+        eventDate
+        year
+        month
+        day
+        country
+        stateProvince
+        county
+        locality
+        decimalLatitude
+        decimalLongitude
+        minimumElevationInMeters
+        maximumElevationInMeters
+        dateLastModified
+        substrate
+        host
+        fieldNotes
+        mushroomObserverId
+        observationUrl
+        imageUrls
+      ]
+    end
+
+    def format_row(row) # rubocop:disable Metrics/AbcSize
+      [
+        row.name_text_name,
+        row.name_author,
+        row.name_rank,
+        row.genus,
+        row.species,
+        row.form_or_variety_or_subspecies,
+        collector(row),
+        number(row), # collectors number || "MUOB #{observation.id}", Cf. obs_id
+        disposition(row),
+        row.obs_when,
+        row.year,
+        row.month,
+        row.day,
+        row.country,
+        row.state,
+        row.county,
+        row.locality,
+        row.best_lat,
+        row.best_lng,
+        row.best_low,
+        row.best_high,
+        row.obs_updated_at,
+        substrate(row),
+        host(row), # MyCoPortal `host` == Sybiota/DWC associatedTaxa
+        field_notes(row), # occurrenceRemarks
+        row.obs_id, # MCP `dpk`; catalogNumber = "MUOB #{observation.id}"
+        row.obs_url, # MO-specific; used in MCP Desciption / verbatimAttributes
+        image_urls(row) # MO-specific
+      ]
+    end
+
+    def collector(row)
+      collector_and_number(row).first
+    end
+
+    def number(row)
+      collector_and_number(row).second
+    end
+
+    def collector_and_number(row)
+      if row.val(2).blank?
+        [row.user_name_or_login, "MUOB #{row.obs_id}"]
+      else
+        row.val(2).split("\n").min_by(&:to_i).split("\t")[1..2]
+      end
+    end
+
+    def substrate(row)
+      explode_notes(row).first
+    end
+
+    def host(row)
+      explode_notes(row).second
+    end
+
+    def field_notes(row)
+      explode_notes(row).third
+    end
+
+    def explode_notes(row)
+      notes = row.obs_notes_as_hash || {}
+      [
+        extract_notes_field(notes, :Substrate),
+        extract_notes_field(notes, :Host),
+        export_other_notes(notes)
+      ]
+    end
+
+    def extract_notes_field(notes, field)
+      clean_notes(notes.delete(field).to_s)
+    end
+
+    def export_other_notes(notes)
+      clean_notes(Observation.export_formatted(notes))
+    end
+
+    def clean_notes(str)
+      str.strip.
+        # Compress consecutive whitespaces before (not after) Textilizing
+        # because some whitespace combinations can confuse Textile
+        # Example: `\r\n \r\n`
+        gsub(/\s+/, " ").
+        t.html_to_ascii
+    end
+
+    def image_urls(row)
+      row.val(1).to_s.split(", ").sort_by(&:to_i).
+        map { |id| image_url(id) }.join(" ")
+    end
+
+    def image_url(id)
+      # Image.url(:full_size, id, transferred: true)
+      # The following URL is the permanent one, should always be correct,
+      # no matter how much we change the underlying image server(s) around.
+      "#{MO.http_domain}/images/orig/#{id}.jpg"
+    end
+
+    def disposition(row)
+      return nil unless row.obs_specimen
+
+      str = row.val(3).to_s.split("\n").map do |val|
+        # ignore accession number because our data is garbage
+        val.split("\t").first
+      end.join("; ")
+      return str if str.present?
+
+      "vouchered"
+    end
+
+    def sort_before(rows)
+      rows.sort_by(&:obs_id)
+    end
+
+    def extend_data!(rows)
+      add_image_ids!(rows, 1)
+      add_collector_ids!(rows, 2)
+      add_herbarium_accession_numbers!(rows, 3)
+    end
+  end
+end

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -4,7 +4,8 @@ module Report
   # Report for exporting Observations to MyCoPortal
   # https://mycoportal.org/
   # https://www.mycoportal.org/portal/api/v2/documentation
-  # MyCoPortal is a Symbiota-based portal for Mycology
+  #
+  # MyCoPortal is built on Symbiota
   # https://symbiota.org/
   # https://biokic.github.io/symbiota-docs/
   # https://github.com/Symbiota/Symbiota
@@ -14,63 +15,66 @@ module Report
     # https://biokic.github.io/symbiota-docs/editor/edit/fields/#standard-fields
     # plus MO-specific fields that are useful for uploads to Symbiota portals
     def labels
-      %w[
-        scientificName
-        scientificNameAuthorship
-        taxonRank
-        genus
-        specificEpithet
-        infraspecificEpithet
-        recordedBy
-        recordNumber
-        disposition
-        eventDate
-        year
-        month
-        day
-        country
-        stateProvince
-        county
-        locality
-        decimalLatitude
-        decimalLongitude
-        minimumElevationInMeters
-        maximumElevationInMeters
-        dateLastModified
-        substrate
-        host
-        fieldNotes
-        mushroomObserverId
-        observationUrl
-        imageUrls
+      [
+        # "occid", # MCP's internal id of the record : 7962944,
+        # "collid", # id of MCP's MO collection :  36
+        # "basisOfRecord", # : "HumanObservation",
+        "scientificName",
+        "scientificNameAuthorship",
+        "taxonRank",
+        "genus",
+        "specificEpithet",
+        "infraspecificEpithet",
+        "recordedBy",
+        "recordNumber", # collection no. assigned to specimen by the collector
+        "disposition", # controlled vocab: "vouchered" or nil
+        "eventDate",
+        "year",
+        "month",
+        "day",
+        "country",
+        "stateProvince",
+        "county",
+        "locality",
+        "decimalLatitude",
+        "decimalLongitude",
+        "minimumElevationInMeters",
+        "maximumElevationInMeters",
+        "dateLastModified",
+        "substrate",
+        "host",
+        "fieldNotes",
+        "mushroomObserverId", # probably should be dbpk, : "514",
+        "observationUrl",
+        "imageUrls"
       ]
     end
 
     def format_row(row) # rubocop:disable Metrics/AbcSize
       [
-        row.name_text_name,
-        row.name_author,
-        row.name_rank,
-        row.genus,
-        row.species,
-        row.form_or_variety_or_subspecies,
-        collector(row),
+        row.name_text_name, # scientificName
+        row.name_author, # scientificNameAuthorship
+        row.name_rank, # taxonRank
+        row.genus, # genus
+        row.species, # specificEpithet
+        row.form_or_variety_or_subspecies, # infraspecificEpithet
+        collector(row), # recordedBy
         number(row), # collectors number || "MUOB #{observation.id}", Cf. obs_id
-        disposition(row),
-        row.obs_when,
-        row.year,
-        row.month,
-        row.day,
-        row.country,
-        row.state,
-        row.county,
-        row.locality,
-        row.best_lat,
-        row.best_lng,
-        row.best_low,
-        row.best_high,
-        row.obs_updated_at,
-        substrate(row),
+        disposition(row), # disposition
+        row.obs_when, # eventDate
+        row.year, # year
+        row.month, # month
+        row.day, # day
+        row.country, # country
+        row.state, # stateProvince
+        row.county, # county
+        row.locality, # locality
+        row.best_lat, # decimalLatitude
+        row.best_lng, # decimalLongitude
+        row.best_low, # minimumElevationInMeters
+        row.best_high, # maximumElevationInMeters
+        row.obs_updated_at, # dateLastModified
+        substrate(row), # MyCoPortal `substrate` == Sybiota/DWC substrate
         host(row), # MyCoPortal `host` == Sybiota/DWC associatedTaxa
         field_notes(row), # occurrenceRemarks
         row.obs_id, # MCP `dpk`; catalogNumber = "MUOB #{observation.id}"

--- a/app/controllers/observations/downloads_controller.rb
+++ b/app/controllers/observations/downloads_controller.rb
@@ -72,6 +72,8 @@ module Observations
         Report::Symbiota.new(args)
       when "fundis"
         Report::Fundis.new(args)
+      when "mycoportal"
+        Report::Mycoportal.new(args)
       else
         raise("Invalid download type: #{format.inspect}")
       end

--- a/app/views/controllers/observations/downloads/_form.html.erb
+++ b/app/views/controllers/observations/downloads/_form.html.erb
@@ -26,7 +26,10 @@
     <%= radio_with_label(form: f, field: :format, value: :fundis,
                           checked: (@format == "fundis") && "checked",
                           label: :download_observations_fundis.t) %>
-  </div>
+    <%= radio_with_label(form: f, field: :format, value: :mycoportal,
+                          checked: (@format == "mycoportal") && "checked",
+                          label: :download_observations_mycoportal.t) %>
+</div>
 
   <p><%= :download_observations_encoding.t %>:</p>
   <div class="form-group">

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1535,8 +1535,9 @@
   download_observations_raw: CSV spreadsheet
   download_observations_adolf: The Adolf Special™
   download_observations_darwin: Darwin Core
-  download_observations_symbiota: Symbiota
   download_observations_fundis: FunDiS
+  download_observations_mycoportal: MyCoPortal
+  download_observations_symbiota: Symbiota
   download_observations_what_is_this: what is this?
   download_observations_encoding: Choose character encoding
   download_observations_ascii: ASCII (no accents)

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -393,6 +393,132 @@ class ReportTest < UnitTestCase
     do_tsv_test(Report::Symbiota, obs, expect, &:id)
   end
 
+  def test_mycoportal1
+    obs = observations(:detailed_unknown_obs)
+    obs.notes = {
+      Substrate: "wood\tchips",
+      Habitat: "lawn",
+      Host: "_Agaricus_",
+      Other: "First\tline.\nSecond\tline."
+    }
+    obs.save!
+
+    img1 = images(:in_situ_image)
+    img2 = images(:turned_over_image)
+    expect = [
+      "Fungi",
+      "",
+      "Kingdom",
+      "Fungi",
+      "",
+      "",
+      "Mary Newbie",
+      "174",
+      "NY",
+      "2006-05-11",
+      "2006",
+      "5",
+      "11",
+      "USA",
+      "California",
+      "",
+      "Burbank",
+      "34.185",
+      "-118.33",
+      "148",
+      "294",
+      "#{obs.updated_at.api_time} UTC",
+      "wood chips",
+      "Agaricus",
+      "Habitat: lawn Other: First line. Second line.",
+      obs.id.to_s,
+      "https://mushroomobserver.org/#{obs.id}",
+      "https://mushroomobserver.org/images/orig/#{img1.id}.jpg " \
+        "https://mushroomobserver.org/images/orig/#{img2.id}.jpg"
+    ]
+    do_tsv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  def test_mycoportal2
+    obs = observations(:agaricus_campestrus_obs)
+    expect = [
+      "Agaricus campestrus",
+      "L.",
+      "Species",
+      "Agaricus",
+      "campestrus",
+      "",
+      "Rolf Singer",
+      "MUOB #{obs.id}",
+      "",
+      "2007-06-23",
+      "2007",
+      "6",
+      "23",
+      "USA",
+      "California",
+      "",
+      "Burbank",
+      "34.185",
+      "-118.33",
+      "148",
+      "294",
+      "#{obs.updated_at.api_time} UTC",
+      "",
+      "",
+      "From somewhere else",
+      obs.id.to_s,
+      "https://mushroomobserver.org/#{obs.id}"
+    ]
+    do_tsv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  def test_mycoportal_compress_consecutive_whitespace
+    obs = observations(:detailed_unknown_obs)
+    obs.notes = {
+      Substrate: "wood\tchips",
+      Habitat: "lawn",
+      Host: "_Agaricus_",
+      Other: "1st line.\r\n\r\n2nd line.\r\n \r\n3rd line."
+    }
+    obs.save!
+
+    img1 = images(:in_situ_image)
+    img2 = images(:turned_over_image)
+    expect = [
+      "Fungi",
+      "",
+      "Kingdom",
+      "Fungi",
+      "",
+      "",
+      "Mary Newbie",
+      "174",
+      "NY",
+      "2006-05-11",
+      "2006",
+      "5",
+      "11",
+      "USA",
+      "California",
+      "",
+      "Burbank",
+      "34.185",
+      "-118.33",
+      "148",
+      "294",
+      "#{obs.updated_at.api_time} UTC",
+      "wood chips",
+      "Agaricus",
+      "Habitat: lawn Other: 1st line. 2nd line. 3rd line.",
+      obs.id.to_s,
+      "https://mushroomobserver.org/#{obs.id}",
+      "https://mushroomobserver.org/images/orig/#{img1.id}.jpg " \
+        "https://mushroomobserver.org/images/orig/#{img2.id}.jpg"
+    ]
+    do_tsv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
   def test_rounding_of_latitudes_etc
     row = Report::Row.new(vals = [])
     vals[2] = 1.20456

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -405,34 +405,35 @@ class ReportTest < UnitTestCase
 
     img1 = images(:in_situ_image)
     img2 = images(:turned_over_image)
+
     expect = [
-      "Fungi",
-      "",
-      "Kingdom",
-      "Fungi",
-      "",
-      "",
-      "Mary Newbie",
-      "174",
-      "NY",
-      "2006-05-11",
-      "2006",
-      "5",
-      "11",
-      "USA",
-      "California",
-      "",
-      "Burbank",
-      "34.185",
-      "-118.33",
-      "148",
+      "Fungi", # scientificName
+      "", # scientificNameAuthorship
+      "Kingdom", # taxonRank
+      "Fungi", # genus
+      "", # specificEpithet
+      "", # infraspecificEpithet
+      "Mary Newbie", # recordedBy
+      "174", # recordNumber
+      "NY", # disposition
+      "2006-05-11", # eventDate
+      "2006", # year
+      "5", # month
+      "11", # day
+      "USA", # country
+      "California", # stateProvince
+      "", # county
+      "Burbank", # locality
+      "34.185", # decimalLatitude
+      "-118.33", # decimalLongitude
+      "148", # minimumElevationInMeters
       "294",
-      "#{obs.updated_at.api_time} UTC",
-      "wood chips",
-      "Agaricus",
-      "Habitat: lawn Other: First line. Second line.",
-      obs.id.to_s,
-      "https://mushroomobserver.org/#{obs.id}",
+      "#{obs.updated_at.api_time} UTC", # dateLastModified
+      "wood chips", # substrate
+      "Agaricus", # host
+      "Habitat: lawn Other: First line. Second line.", # fieldNotes
+      obs.id.to_s, # mushroomObserverId
+      "https://mushroomobserver.org/#{obs.id}", # observationUrl
       "https://mushroomobserver.org/images/orig/#{img1.id}.jpg " \
         "https://mushroomobserver.org/images/orig/#{img2.id}.jpg"
     ]
@@ -442,33 +443,33 @@ class ReportTest < UnitTestCase
   def test_mycoportal2
     obs = observations(:agaricus_campestrus_obs)
     expect = [
-      "Agaricus campestrus",
-      "L.",
-      "Species",
-      "Agaricus",
-      "campestrus",
-      "",
-      "Rolf Singer",
-      "MUOB #{obs.id}",
-      "",
-      "2007-06-23",
-      "2007",
-      "6",
-      "23",
-      "USA",
-      "California",
-      "",
-      "Burbank",
-      "34.185",
-      "-118.33",
-      "148",
-      "294",
-      "#{obs.updated_at.api_time} UTC",
-      "",
-      "",
-      "From somewhere else",
-      obs.id.to_s,
-      "https://mushroomobserver.org/#{obs.id}"
+      "Agaricus campestrus", # scientificName
+      "L.", # scientificNameAuthorship
+      "Species", # taxonRank
+      "Agaricus", # genus
+      "campestrus", # specificEpithet
+      "", # infraspecificEpithet
+      "Rolf Singer", # recordedBy
+      "MUOB #{obs.id}", # recordNumber
+      "", # disposition
+      "2007-06-23", # eventDate
+      "2007", # year
+      "6", # month
+      "23", # day
+      "USA", # country
+      "California", # stateProvince
+      "", # county
+      "Burbank", # locality
+      "34.185", # decimalLatitude
+      "-118.33", # decimalLongitude
+      "148", # minimumElevationInMeters
+      "294", # maximumElevationInMeters
+      "#{obs.updated_at.api_time} UTC", # dateLastModified
+      "", # substrate
+      "", # host
+      "From somewhere else", # fieldNotes
+      obs.id.to_s, # mushroomObserverId
+      "https://mushroomobserver.org/#{obs.id}" # observationUrl
     ]
     do_tsv_test(Report::Mycoportal, obs, expect, &:id)
   end
@@ -486,35 +487,35 @@ class ReportTest < UnitTestCase
     img1 = images(:in_situ_image)
     img2 = images(:turned_over_image)
     expect = [
-      "Fungi",
-      "",
-      "Kingdom",
-      "Fungi",
-      "",
-      "",
-      "Mary Newbie",
-      "174",
-      "NY",
-      "2006-05-11",
-      "2006",
-      "5",
-      "11",
-      "USA",
-      "California",
-      "",
-      "Burbank",
-      "34.185",
-      "-118.33",
-      "148",
-      "294",
-      "#{obs.updated_at.api_time} UTC",
-      "wood chips",
-      "Agaricus",
-      "Habitat: lawn Other: 1st line. 2nd line. 3rd line.",
-      obs.id.to_s,
-      "https://mushroomobserver.org/#{obs.id}",
+      "Fungi", # scientificName
+      "", # scientificNameAuthorship
+      "Kingdom", # taxonRank
+      "Fungi", # genus
+      "", # specificEpithet
+      "", # infraspecificEpithet
+      "Mary Newbie", # recordedBy
+      "174", # recordNumber
+      "NY", # disposition
+      "2006-05-11", # eventDate
+      "2006", # year
+      "5", # month
+      "11", # day
+      "USA", # country
+      "California", # stateProvince
+      "", # county
+      "Burbank", # locality
+      "34.185", # decimalLatitude
+      "-118.33", # decimalLongitude
+      "148", # minimumElevationInMeters
+      "294", # maximumElevationInMeters
+      "#{obs.updated_at.api_time} UTC", # dateLastModified
+      "wood chips", # substrate
+      "Agaricus", # host
+      "Habitat: lawn Other: 1st line. 2nd line. 3rd line.", # fieldNotes
+      obs.id.to_s, # mushroomObserverId
+      "https://mushroomobserver.org/#{obs.id}", # observationUrl
       "https://mushroomobserver.org/images/orig/#{img1.id}.jpg " \
-        "https://mushroomobserver.org/images/orig/#{img2.id}.jpg"
+        "https://mushroomobserver.org/images/orig/#{img2.id}.jpg" # imageUrls
     ]
     do_tsv_test(Report::Mycoportal, obs, expect, &:id)
   end

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -17,50 +17,9 @@ module Observations
                     "Missing a MyCoPortal radio button")
     end
 
-    def test_create_with_invalid_format
-      query = Query.lookup_and_save(:Observation, by_users: mary.id)
-      login(:mary)
-
-      post(
-      :create,
-      params: {
-        q: query.id.alphabetize,
-        format: "invalid_format",
-        encoding: "UTF-8",
-        commit: "Download"
-      }
-      )
-
-      assert_flash_error
-      assert_redirected_to(species_list_path(query.id.to_s))
-    end
-
-    def test_create_with_valid_format
-      query = Query.lookup_and_save(:Observation, by_users: mary.id)
-      login(:mary)
-
-      post(
-      :create,
-      params: {
-        q: query.id.alphabetize,
-        format: "csv",
-        encoding: "UTF-8",
-        commit: "Download"
-      }
-      )
-
-      assert_no_flash
-      assert_response(:success)
-      assert_match(/observation_id/, @response.body, "CSV header not found in response")
-    end
-
-    def test_print_labels_with_no_query
-      login(:mary)
-
-      get(:print_labels, params: { q: nil })
-
-      assert_flash_error
-      assert_redirected_to(observations_path)
+    def test_download_observation_index
+      obs = Observation.reorder(id: :asc).where(user: mary)
+      assert(obs.length >= 4)
       query = Query.lookup_and_save(:Observation, by_users: mary.id)
 
       # Add herbarium_record to fourth obs for testing purposes.

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -165,6 +165,18 @@ module Observations
       )
       assert_no_flash
       assert_response(:success)
+
+      post(
+        :create,
+        params: {
+          q: query.id.alphabetize,
+          format: "mycoportal",
+          encoding: "UTF-8",
+          commit: "Download"
+        }
+      )
+      assert_no_flash
+      assert_response(:success)
     end
 
     def test_download_too_many_observations

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -4,9 +4,63 @@ require("test_helper")
 
 module Observations
   class DownloadsControllerTest < FunctionalTestCase
-    def test_download_observation_index
-      obs = Observation.reorder(id: :asc).where(user: mary)
-      assert(obs.length >= 4)
+    def test_new
+      query = Query.lookup_and_save(:Observation, by_users: mary.id)
+      assert(query.num_results > 1, "Test needs query with multiple results")
+
+      login(:rolf)
+      get(:new, params: { q: query.id.alphabetize })
+
+      assert_no_flash
+      assert_response(:success)
+      assert_select("input[type=radio][id=format_mycoportal]", true,
+                    "Missing a MyCoPortal radio button")
+    end
+
+    def test_create_with_invalid_format
+      query = Query.lookup_and_save(:Observation, by_users: mary.id)
+      login(:mary)
+
+      post(
+      :create,
+      params: {
+        q: query.id.alphabetize,
+        format: "invalid_format",
+        encoding: "UTF-8",
+        commit: "Download"
+      }
+      )
+
+      assert_flash_error
+      assert_redirected_to(species_list_path(query.id.to_s))
+    end
+
+    def test_create_with_valid_format
+      query = Query.lookup_and_save(:Observation, by_users: mary.id)
+      login(:mary)
+
+      post(
+      :create,
+      params: {
+        q: query.id.alphabetize,
+        format: "csv",
+        encoding: "UTF-8",
+        commit: "Download"
+      }
+      )
+
+      assert_no_flash
+      assert_response(:success)
+      assert_match(/observation_id/, @response.body, "CSV header not found in response")
+    end
+
+    def test_print_labels_with_no_query
+      login(:mary)
+
+      get(:print_labels, params: { q: nil })
+
+      assert_flash_error
+      assert_redirected_to(observations_path)
       query = Query.lookup_and_save(:Observation, by_users: mary.id)
 
       # Add herbarium_record to fourth obs for testing purposes.


### PR DESCRIPTION
Creates a `Mycoportal` report and UI.

The report basically duplicates the existing Symbiota report.
It is only the first PR in reviving exports to MyCoPortal, and is not yet suitable for actual exports.
Follow-on PRs will make corrections and revisions based on communications with MCP. 
This PR incurs technical debt (duplication) due to time constrains in getting the exports working.

