### PR TITLE
Fix for gps_in_box "or distinct" issue

### DIFF
--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -331,7 +331,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           or(Observation.associated_location_center_in_box(box))
       else
         gps_in_box(box).or(
-          Observation.cached_location_center_in_box(box).distinct
+          Observation.cached_location_center_in_box(box)
         )
       end
     }

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -341,7 +341,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         and(Observation[:lat] <= box.north).
         and(Observation[:lng] <= box.east).
         and(Observation[:lng] >= box.west)
-      )
+      ).distinct
     }
     scope :cached_location_center_in_box, lambda { |box|
       # odd! AR will toss entire condition if below order is west, east

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -298,7 +298,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         and(Observation[:lat] <= box.north).
         and(Observation[:lng] >= box.west).
         or(Observation[:lng] <= box.east)
-      )
+      ).distinct
     }
     scope :cached_location_center_in_box_over_dateline, lambda { |box|
       where(
@@ -307,7 +307,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         and(Observation[:location_lat] <= box.north).
         and(Observation[:location_lng] >= box.west).
         or(Observation[:location_lng] <= box.east)
-      )
+      ).distinct
     }
     scope :associated_location_center_in_box_over_dateline, lambda { |box|
       left_outer_joins(:location).
@@ -317,7 +317,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           and(Location[:center_lat] <= box.north).
           and(Location[:center_lng] >= box.west).
           or(Location[:center_lng] <= box.east)
-        )
+        ).distinct
     }
     # mostly a helper for in_box
     scope :in_box_regular, lambda { |**args|
@@ -351,7 +351,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         and(Observation[:location_lat] <= box.north).
         and(Observation[:location_lng] <= box.east).
         and(Observation[:location_lng] >= box.west)
-      )
+      ).distinct
     }
     scope :associated_location_center_in_box, lambda { |box|
       left_outer_joins(:location).
@@ -361,7 +361,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           and(Location[:center_lat] <= box.north).
           and(Location[:center_lng] <= box.east).
           and(Location[:center_lng] >= box.west)
-        )
+        ).distinct
     }
     # Pass kwargs (:north, :south, :east, :west), any order
     scope :not_in_box, lambda { |**args|

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -330,7 +330,9 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         left_outer_joins(:location).gps_in_box(box).
           or(Observation.associated_location_center_in_box(box))
       else
-        gps_in_box(box).or(Observation.cached_location_center_in_box(box))
+        gps_in_box(box).or(
+          Observation.cached_location_center_in_box(box).distinct
+        )
       end
     }
     scope :gps_in_box, lambda { |box|

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1438,12 +1438,41 @@ class ObservationTest < UnitTestCase
   end
 
   def test_scope_in_box_with_taxon
-    box = { north: "36.2718",
-            south: "29.852",
-            east: "-82.92729999999999",
-            west: "-96.3512" }
-    obs = Observation.names(lookup: names(:coprinus)).in_box(**box)
-    obs.count
+    args = { north: "36.2718",
+             south: "29.852",
+             east: "-82.92729999999999",
+             west: "-96.3512" }
+    obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
+    assert(!obs.count.negative?)
+  end
+
+  def test_scope_in_box_over_dateline_with_taxon
+    args = { north: "36.2718",
+             south: "29.852",
+             east: "-82.92729999999999",
+             west: "9.3512" }
+    obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
+    assert(!obs.count.negative?)
+  end
+
+  def test_scope_in_box_with_taxon_vague
+    args = { vague: 1,
+             north: "36.2718",
+             south: "29.852",
+             east: "-82.92729999999999",
+             west: "-96.3512" }
+    obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
+    assert(!obs.count.negative?)
+  end
+
+  def test_scope_in_box_over_dateline_with_taxon_vague
+    args = { vague: 1,
+             north: "36.2718",
+             south: "29.852",
+             east: "-82.92729999999999",
+             west: "9.3512" }
+    obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
+    assert(!obs.count.negative?)
   end
 
   def test_scope_not_in_box

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1437,6 +1437,15 @@ class ObservationTest < UnitTestCase
     )
   end
 
+  def test_scope_in_box_with_taxon
+    box = { north: "36.2718",
+            south: "29.852",
+            east: "-82.92729999999999",
+            west: "-96.3512" }
+    obs = Observation.names(lookup: names(:coprinus)).in_box(**box)
+    obs.count
+  end
+
   def test_scope_not_in_box
     obs_with_burbank_geoloc = observations(:unknown_with_lat_lng)
     obss_not_in_cal_box = Observation.not_in_box(**cal_box)

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1443,7 +1443,7 @@ class ObservationTest < UnitTestCase
              east: "-82.92729999999999",
              west: "-96.3512" }
     obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
-    assert(!obs.count.negative?)
+    assert_not(obs.count.negative?)
   end
 
   def test_scope_in_box_over_dateline_with_taxon
@@ -1452,7 +1452,7 @@ class ObservationTest < UnitTestCase
              east: "-82.92729999999999",
              west: "9.3512" }
     obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
-    assert(!obs.count.negative?)
+    assert_not(obs.count.negative?)
   end
 
   def test_scope_in_box_with_taxon_vague
@@ -1462,7 +1462,7 @@ class ObservationTest < UnitTestCase
              east: "-82.92729999999999",
              west: "-96.3512" }
     obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
-    assert(!obs.count.negative?)
+    assert_not(obs.count.negative?)
   end
 
   def test_scope_in_box_over_dateline_with_taxon_vague
@@ -1472,7 +1472,7 @@ class ObservationTest < UnitTestCase
              east: "-82.92729999999999",
              west: "9.3512" }
     obs = Observation.names(lookup: names(:coprinus)).in_box(**args)
-    assert(!obs.count.negative?)
+    assert_not(obs.count.negative?)
   end
 
   def test_scope_not_in_box


### PR DESCRIPTION
Live error from production:
```
INFO -- : Started GET "/observations?q=24gLf" for 168.18.168.113 at 2025-04-24 19:17:12 +0000
INFO -- : Processing by ObservationsController#index as HTML
INFO -- :   Parameters: {"q"=>"24gLf"}
WARN -- : user=13109 robot=N ip=168.18.168.113
INFO -- : Completed 500 Internal Server Error in 610ms (ActiveRecord: 586.7ms (13 queries, 2 cached) | GC: 0.5ms)
E, [2025-04-24T19:17:12.874893 #1208483] ERROR -- :   
ArgumentError (Relation passed to #or must be structurally compatible. Incompatible values: [:distinct]):

app/models/observation/scopes.rb:333:in `block (2 levels) in <module:Scopes>'
app/models/observation/scopes.rb:275:in `block (2 levels) in <module:Scopes>'
app/classes/query/modules/initialization.rb:105:in `block in initialize_parameter_set'
app/classes/query/modules/initialization.rb:100:in `each'
app/classes/query/modules/initialization.rb:100:in `initialize_parameter_set'
app/classes/query/modules/initialization.rb:93:in `initialize_scopes'
app/classes/query/modules/initialization.rb:75:in `initialize_query'
app/classes/query/modules/results.rb:48:in `num_results'
app/controllers/application_controller/indexes.rb:267:in `set_index_view_ivars'
app/controllers/application_controller/indexes.rb:246:in `show_index_setup'
app/controllers/application_controller/indexes.rb:230:in `show_index_of_objects'
app/controllers/application_controller/indexes.rb:158:in `filtered_index'
app/controllers/application_controller/indexes.rb:50:in `block in build_index_with_query'
app/controllers/application_controller/indexes.rb:39:in `each'
app/controllers/application_controller/indexes.rb:39:in `build_index_with_query'
app/controllers/observations_controller/index.rb:7:in `index'
app/controllers/application_controller.rb:215:in `catch_errors_and_log_request_stats'
```

Was able to reproduce locally with a fresh copy of the production database.  The description of the query causing the issue is:
`{"in_box":{"north":36.2718,"south":29.852,"east":-82.92729999999999,"west":-96.3512},"names":{"lookup":["Ramaria"],"include_synonyms":true,"include_subtaxa":true},"model":"Observation"}`