### PR TITLE
Return forbidden status for observaiton#status is user not logged in

### DIFF
--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -57,6 +57,14 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     filtered_index(new_query, display_opts)
   end
 
+  def check_for_spider_block
+    return if @user
+
+    Rails.logger.warn(:runtime_spiders_begone)
+    render(json: :runtime_spiders_begone.t,
+           status: :forbidden)
+  end
+
   # It's not always the controller_name, e.g. ContributorsController -> User
   def controller_model_name
     controller_name.classify

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -10,7 +10,7 @@ class ObservationsController < ApplicationController
 
   # Disable cop: all these methods are defined in files included above.
   # rubocop:disable Rails/LexicallyScopedActionFilter
-  before_action :login_required
+  before_action :login_required, except: [:show]
   before_action :pass_query_params, only: [:show, :edit, :update]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -20,6 +20,8 @@ module ObservationsController::Show
   #   @other_sites
   #   @votes
   def show
+    return if check_for_spider_block
+
     pass_query_params
     store_location
     if params[:flow].present?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4005,6 +4005,7 @@
   runtime_removed_id_from: "Successfully removed [type] #[value] from [name]."
   runtime_removed_name: Successfully removed [type] '[value]'.
   runtime_removed_name_from: Successfully removed [type] '[value]' from [name].
+  runtime_spiders_begone: Spiders Begone!  Please login (mushroomobserver.org/account/login/new) to access this page.
   runtime_updated_at: Successfully updated [type].
   runtime_updated_id: "Successfully updated [type] #[value]."
   runtime_updated_name: Successfully updated [type] '[value]'.

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -22,8 +22,9 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
     original_name = obs.name
 
     namer_session.visit("/#{obs.id}")
-    namer_session.assert_selector("body.login__new")
+    assert_equal(403, namer_session.status_code)
     login(namer, session: namer_session)
+    namer_session.visit("/#{obs.id}")
     assert_false(namer_session.has_link?(class: /edit_naming/))
     assert_false(namer_session.has_selector?(class: /destroy_naming_link_/))
     namer_session.first(class: "propose-naming-link").click

--- a/test/integration/capybara/random_integration_test.rb
+++ b/test/integration/capybara/random_integration_test.rb
@@ -68,9 +68,10 @@ class RandomIntegrationTest < CapybaraIntegrationTestCase
 
   def test_thumbnail_maps
     visit("/#{observations(:minimal_unknown_obs).id}")
-    assert_selector("body.login__new")
+    assert_equal(403, status_code)
 
     login("dick")
+    visit("/#{observations(:minimal_unknown_obs).id}")
     assert_selector("body.observations__show")
     assert_selector("div.thumbnail-map")
     click_link(text: "Hide thumbnail map")


### PR DESCRIPTION
If you're not logged in, visiting any observation show page, e.g., /443107?q=2145h, should now return a JSON response that has a status of "forbidden) (403).