### PR TITLE
Double render spider fix

### DIFF
--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -61,7 +61,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     return false if @user
     return false if request.url.include?(permanent_observation_path(id: params[:id]))
 
-    Rails.logger.warn(:runtime_spiders_begone)
+    Rails.logger.warn(:runtime_spiders_begone.t)
     render(json: :runtime_spiders_begone.t,
            status: :forbidden)
   end

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -59,7 +59,9 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
 
   def check_for_spider_block(request, params)
     return false if @user
-    return false if request.url.include?(permanent_observation_path(id: params[:id]))
+    if request.url.include?(permanent_observation_path(id: params[:id]))
+      return false
+    end
 
     Rails.logger.warn(:runtime_spiders_begone.t)
     render(json: :runtime_spiders_begone.t,

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -58,8 +58,8 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   end
 
   def check_for_spider_block(request, params)
-    return if @user
-    return if request.url.include?(permanent_observation_path(id: params[:id]))
+    return false if @user
+    return false if request.url.include?(permanent_observation_path(id: params[:id]))
 
     Rails.logger.warn(:runtime_spiders_begone)
     render(json: :runtime_spiders_begone.t,

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -20,7 +20,7 @@ module ObservationsController::Show
   #   @other_sites
   #   @votes
   def show
-    check_for_spider_block(request, params)
+    return if check_for_spider_block(request, params)
     pass_query_params
     store_location
     if params[:flow].present?

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -21,6 +21,7 @@ module ObservationsController::Show
   #   @votes
   def show
     return if check_for_spider_block(request, params)
+
     pass_query_params
     store_location
     if params[:flow].present?


### PR DESCRIPTION
Fixes double render error for URLs like: `/observations/261523?flow=next`