### PR TITLE
Glossary Term mulitiple images fix

### DIFF
--- a/app/views/controllers/glossary_terms/show.html.erb
+++ b/app/views/controllers/glossary_terms/show.html.erb
@@ -34,7 +34,8 @@ add_context_nav(glossary_term_show_tabs(term: @glossary_term, user: @user))
   <% @other_images.each do |image|  %>
     <div class="col-sm-4">
       <%= panel_block do
-        interactive_image(image, votes: true, id_prefix: "glossary_term_image")
+        interactive_image(@user, image, votes: true,
+                          id_prefix: "glossary_term_image")
       end %>
     </div>
   <% end %>

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -79,6 +79,18 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_show_with_multiple_images
+    term = glossary_terms(:plane_glossary_term)
+    assert(term.images.size > 1, "Test needs term with multiple images")
+
+    get(:show, params: { id: term.id })
+
+    assert_response(
+      :success,
+      "Glossary Terms with >1 image should be viewable without logging in"
+    )
+  end
+
   def test_show_logged_in
     term = glossary_terms(:square_glossary_term)
     assert_operator(term.version, :>, 1,


### PR DESCRIPTION
Fixes Error showing glossary_term with multiple images

Bug was:
```
INFO -- :   Rendered layout controllers/layouts/application.html.erb (Duration: 9.7ms | GC: 0.4ms)
INFO -- : Completed 500 Internal Server Error in 3139ms (ActiveRecord: 3101.8ms (22 queries, 1 cached) | GC: 9.0ms)
E, [2025-05-03T12:54:32.009121 #3708937] ERROR -- :
ActionView::Template::Error (wrong number of arguments (given 1, expected 2))
```