### PR TITLE
Fix remaining `user`less calls to interactive_image

### DIFF
--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -103,15 +103,6 @@ module ImagesHelper
        image.copyright_holder != object.user&.legal_name)
   end
 
-  def show_best_image(obs)
-    return unless obs&.thumb_image
-
-    interactive_image(obs.thumb_image,
-                      link: observation_path(id: obs.id),
-                      size: :small,
-                      votes: true) + image_copyright(obs.thumb_image, obs)
-  end
-
   # pass an image instance if possible, to ensure access to fallback image.url
   def original_image_link(image_or_image_id, classes)
     id = if image_or_image_id.is_a?(Image)

--- a/app/views/controllers/info/site_stats.html.erb
+++ b/app/views/controllers/info/site_stats.html.erb
@@ -40,8 +40,9 @@ add_context_nav(info_site_stats_tabs)
   <% if obs_length > 3 %>
     <% @observations[3,3].each do |obs| %>
       <%= interactive_image(
-          obs.thumb_image, image_link: observation_path(obs.id), votes: true
-        ) %><br/>
+            @user, obs.thumb_image, image_link: observation_path(obs.id),
+            votes: true
+          ) %><br/>
       <br/>
     <% end %>
   <% end %>


### PR DESCRIPTION
`interactive_image` now needs user as its first argument, else it throws a "wrong number of arguments" Error.
- Adds `user` argument to one call.
- Deletes unused method which had the other userless call.