### PR TITLE
Fix observations download when not logged in

### DIFF
--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -59,8 +59,13 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
 
   def check_for_spider_block(request, params)
     return false if @user
-    if request.url.include?(permanent_observation_path(id: params[:id]))
-      return false
+
+    begin
+      if request.url.include?(permanent_observation_path(id: params[:id]))
+        return false
+      end
+    rescue ActionController::UrlGenerationError
+      # Still a spider...
     end
 
     Rails.logger.warn(:runtime_spiders_begone.t)

--- a/app/views/controllers/comments/_comment.erb
+++ b/app/views/controllers/comments/_comment.erb
@@ -23,7 +23,7 @@ target_type = tag.span(target.class.name.to_sym.t, class: "small") \
         concat(tag.div(class: "comment-info") do
           concat(tag.span(class: "comment-author text-nowrap") do
             ["#{:BY.t}: ",
-             if controls
+             if defined?(controls) && controls
                user_link(user)
              else
                user.unique_text_name

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -129,6 +129,11 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     end
   end
 
+  def test_observation_label_download_not_logged_in
+    visit(observations_downloads_path)
+    assert_equal(403, page.status_code) # forbidden
+  end
+
   def test_old_observation_path_not_logged_in
     visit(observation_path(Observation.first.id))
     assert_equal(403, page.status_code) # forbidden


### PR DESCRIPTION
Fixes bug in `/observations/downloads?commit=Print+Labels&q=1vKTa`.