### PR TITLE
Order project observations by thumbnail quality

### DIFF
--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -174,7 +174,8 @@ class ObservationsController
         project = find_or_goto_index(Project, params[:project].to_s)
       )
 
-      query = create_query(:Observation, projects: project)
+      query = create_query(:Observation, projects: project,
+                           order_by: "thumbnail_quality")
       @project = project
       [query, { always_index: true }]
     end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -175,7 +175,7 @@ class ObservationsController
       )
 
       query = create_query(:Observation, projects: project,
-                           order_by: "thumbnail_quality")
+                                         order_by: "thumbnail_quality")
       @project = project
       [query, { always_index: true }]
     end

--- a/app/models/abstract_model/ordering_scopes.rb
+++ b/app/models/abstract_model/ordering_scopes.rb
@@ -271,7 +271,7 @@ module AbstractModel::OrderingScopes
     def order_by_thumbnail_quality
       return all unless self == Observation
 
-      joins(:images).where(Observation[:thumb_image_id].eq(Image[:id])).
+      left_outer_joins(:images).where(Observation[:thumb_image_id].eq(Image[:id]).or(Image[:id].eq(nil))).
         distinct.order(Image[:vote_cache].desc, Observation[:vote_cache].desc)
     end
 

--- a/app/models/abstract_model/ordering_scopes.rb
+++ b/app/models/abstract_model/ordering_scopes.rb
@@ -271,8 +271,9 @@ module AbstractModel::OrderingScopes
     def order_by_thumbnail_quality
       return all unless self == Observation
 
-      left_outer_joins(:images).where(Observation[:thumb_image_id].eq(Image[:id]).or(Image[:id].eq(nil))).
-        distinct.order(Image[:vote_cache].desc, Observation[:vote_cache].desc)
+      left_outer_joins(:images).where(
+        Observation[:thumb_image_id].eq(Image[:id]).or(Image[:id].eq(nil))
+      ).distinct.order(Image[:vote_cache].desc, Observation[:vote_cache].desc)
     end
 
     def order_by_title

--- a/app/views/controllers/shared/_carousel.erb
+++ b/app/views/controllers/shared/_carousel.erb
@@ -19,6 +19,7 @@ if !images.nil? && images.any?
           data: { ride: "false", interval: "false" }) do
     concat(tag.div(class: "carousel-inner bg-light", role: "listbox") do
       images.each_with_index do |image, index|
+        next unless image
         concat(render(partial: "shared/carousel_item",
                       locals: { image:, size:, index:, object:, user: }))
       end
@@ -27,6 +28,7 @@ if !images.nil? && images.any?
     concat(
       tag.ol(class: "carousel-indicators panel-footer py-2 px-0 mb-0") do
         images.each_with_index do |image, index|
+          next unless image
           concat(render(partial: "shared/carousel_thumbnail",
                         locals: { image:, index:, html_id: }))
         end


### PR DESCRIPTION
This is a better default for the NEMF project, but I'm not sure it's the right ordering for all projects.  The current default ordering is "Date".  I could also see an argument for "Activity".  In some ways it doesn't matter a lot since changing the order is just a click, but there may be folks who don't what this cheese moved.  It could be an option for a project, but that's a lot more work.  Would love to some thoughts from others.

I do think the `left_outer_joins` change to app/models/abstract_model/ordering_scopes.rb is worth doing regardless of whether we actually change the default ordering.  As the code currently stands the "Thumbnail Quality" sort order causes observations that have no images or no image votes to silently disappear.