### PR TITLE
Observation show sections updated by Stimulus: remove unnecessary data attributes

### DIFF
--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -77,10 +77,7 @@ module NamingsHelper
 
     tag.div(class: "list-group list-group-flush",
             id: "namings_table_rows",
-            data: {
-              controller: "section-update",
-              updated_by: "modal_naming_#{consensus.observation.id}"
-            }) do
+            data: { controller: "section-update" }) do
       if any_names
         namings.each do |naming|
           row = naming_row_content(consensus, naming)

--- a/app/views/controllers/comments/_comments_for_object.erb
+++ b/app/views/controllers/comments/_comments_for_object.erb
@@ -23,8 +23,7 @@ tag.div(
     end,
     tag.div(id: "comments",
             class: "list-group list-group-flush comments",
-            data: { controller: "section-update",
-                    updated_by: "modal_comment" }) do
+            data: { controller: "section-update" }) do
       unless comments.empty?
         comments.each do |comment|
           concat(render(partial: "comments/comment", object: comment,

--- a/app/views/controllers/observations/show/_collection_numbers.erb
+++ b/app/views/controllers/observations/show/_collection_numbers.erb
@@ -7,8 +7,7 @@ can_edit = in_admin_mode? || obs.can_edit?
   tag.div(
     id: "observation_collection_numbers",
     class: "obs-collection",
-    data: { controller: "section-update",
-            updated_by: "modal_collection_number" }
+    data: { controller: "section-update" }
   ) do
 
     if numbers.any? && can_edit

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -3,7 +3,7 @@
 <%=
 tag.div(
   class: "obs-links", id: "observation_external_links",
-  data: { controller: "section-update", updated_by: "modal_external_link" }
+  data: { controller: "section-update" }
 ) do
 
   [

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -7,8 +7,7 @@ can_add = in_admin_mode? || obs.can_edit? ||
   tag.div(
     id: "observation_herbarium_records",
     class: "obs-herbarium",
-    data: { controller: "section-update",
-            updated_by: "modal_herbarium_record" }
+    data: { controller: "section-update" }
   ) do
 
     if records.any? && can_add

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -15,9 +15,7 @@ tag.div(
     concat(sequences.any? ? "#{:Sequences.l}: " :
             "#{:show_observation_no_sequences.l} ")
     concat(
-      ["[",
-        modal_link_to("sequence", *new_sequence_tab(obs)),
-        "]"].safe_join
+      ["[", modal_link_to("sequence", *new_sequence_tab(obs)), "]"].safe_join
     ) if user
   end) if user || sequences.any?
 

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -8,7 +8,7 @@ can_edit  = in_admin_mode? || obs.can_edit?
 <%=
 tag.div(
   class: "obs-sequence", id: "observation_sequences",
-  data: { controller: "section-update", updated_by: "modal_sequence" }
+  data: { controller: "section-update" }
 ) do
 
   concat(tag.div do


### PR DESCRIPTION
This removes dead code from templates that was confusing me.