### PR TITLE
Refactor `flash_notices_html` to use the `flash_notices.erb` partial

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,25 +57,23 @@ module ApplicationHelper
   end
 
   # This can be called to display flash notices either in the page or a modal.
-  # Send it an html `id` to be able to find the notices via JS later.
   def flash_notices_html
     return "" unless flash_notices?
 
+    notices = flash_get_notices
     alert_class = case flash_notice_level
                   when 0 then "alert-success"
                   when 1 then "alert-warning"
                   when 2 then "alert-danger"
                   end
-
-    notices = flash_get_notices
     flash_clear
 
-    tag.div(notices, id: "flash_notices",
-                     class: class_names("alert mt-3", alert_class))
+    render(partial: "application/app/flash_notices",
+           locals: { notices:, alert_class: })
   end
 
   def render_turbo_stream_flash_messages
-    turbo_stream.replace("flash", partial: "application/app/flash_notices")
+    turbo_stream.update("page_flash") { flash_notices_html }
   end
 
   # Returns a string that indicates the current user/logged_in/admin status.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,6 +57,8 @@ module ApplicationHelper
   end
 
   # This can be called to display flash notices either in the page or a modal.
+  # `flash_notices?` `flash_get_notices` `flash_notice_level` and `flash_clear`
+  # are defined in ApplicationController::FlashNotices.
   def flash_notices_html
     return "" unless flash_notices?
 

--- a/app/views/controllers/application/app/_flash_notices.html.erb
+++ b/app/views/controllers/application/app/_flash_notices.html.erb
@@ -1,13 +1,9 @@
+<%# locals: (notices: "", alert_class: nil) %>
+
 <!--FLASH NOTICES-->
 <%=
 # This can be called to display flash notices either in the page or in a modal.
-# Send it an html `id` local to be able to find the notices later
-klass = case flash_notice_level
-  when 0; "alert-success"
-  when 1; "alert-warning"
-  when 2; "alert-danger"
-end
-
-tag.div(flash_get_notices, id: id, class: "alert mt-3 #{klass}")
+tag.div(notices, id: "flash_notices",
+                 class: class_names("alert mt-3", alert_class))
 %>
 <!--/FLASH NOTICES-->


### PR DESCRIPTION
The partial was previously unused. DRYing the code allows a turbo_stream update method to call the same helper without duplicating.