### PR TITLE
Naming/VariableNumber

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,6 +118,12 @@ Naming/BlockForwarding:
   # Default is `anonymous`
   # Keeping it `explicit` until we're ready to switch.
   EnforcedStyle: explicit
+Naming/VariableNumber:
+  # We have a mix of snake_case and normal case.
+  # Standardizing plus creating exceptions, would take some effort,
+  # is low priority, and the devs are good with disabling the cop.
+  # 2025-05-08 jdc
+  Enabled: false
 
 Performance/Casecmp:
   # This cop does not work with Unicode in Ruby 2.4

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -503,32 +503,6 @@ Naming/PredicateName:
     - 'app/models/observation.rb'
     - 'app/models/project.rb'
 
-# Offense count: 124
-# Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
-# SupportedStyles: snake_case, normalcase, non_integer
-# AllowedIdentifiers: TLS1_1, TLS1_2, capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339, x86_64
-Naming/VariableNumber:
-  Exclude:
-    - 'app/controllers/info_controller.rb'
-    - 'app/controllers/support_controller.rb'
-    - 'app/models/naming.rb'
-    - 'app/models/vote.rb'
-    - 'test/classes/api2/collection_numbers_test.rb'
-    - 'test/classes/api2/comments_test.rb'
-    - 'test/classes/api2/herbarium_records_test.rb'
-    - 'test/classes/api2/observations_test.rb'
-    - 'test/classes/query/comments_test.rb'
-    - 'test/controllers/comments_controller_test.rb'
-    - 'test/controllers/lookups_controller_test.rb'
-    - 'test/controllers/names/synonyms_controller_test.rb'
-    - 'test/controllers/support_controller_test.rb'
-    - 'test/mailers/application_mailer_test.rb'
-    - 'test/mailers/queued_email_test.rb'
-    - 'test/models/name_sorter_test.rb'
-    - 'test/models/name_test.rb'
-    - 'test/models/observation_test.rb'
-    - 'test/system/observation_naming_system_test.rb'
-
 # Offense count: 45
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ ACTIONS = {
     thanks: {},
     # Disable cop for legacy routes.
     # The routes are two very old pages that we might get rid of.
-    # rubocop:disable Naming/VariableNumber
+
     wrapup_2011: {},
     wrapup_2012: {}
     # rubocop:enable Naming/VariableNumber

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -66,7 +66,7 @@ class InatImportJobTest < ActiveJob::TestCase
     used_references = 2
     assert(
       proposed_name.reasons.key?(used_references),
-      "Proposed consensus Name reason should be #{:naming_reason_label_2.l}" # rubocop:disable Naming/VariableNumber
+      "Proposed consensus Name reason should be #{:naming_reason_label_2.l}"
     )
     proposed_name_notes = proposed_name[:reasons][used_references]
     suggesting_inat_user = JSON.parse(mock_inat_response)["results"].
@@ -135,7 +135,7 @@ class InatImportJobTest < ActiveJob::TestCase
     used_references = 2
     assert(
       proposed_name.reasons.key?(used_references),
-      "Proposed Name reason should be #{:naming_reason_label_2.l}" # rubocop:disable Naming/VariableNumber
+      "Proposed Name reason should be #{:naming_reason_label_2.l}"
     )
     proposed_name_notes = proposed_name[:reasons][used_references]
     suggesting_inat_user = JSON.parse(mock_inat_response)["results"].
@@ -386,7 +386,7 @@ class InatImportJobTest < ActiveJob::TestCase
     used_references = 2
     assert(
       proposed_name.reasons.key?(used_references),
-      "Proposed Name reason should be #{:naming_reason_label_2.l}" # rubocop:disable Naming/VariableNumber
+      "Proposed Name reason should be #{:naming_reason_label_2.l}"
     )
     proposed_name_notes = proposed_name[:reasons][used_references]
     provisional_field =


### PR DESCRIPTION
Disables Naming/VariableNumber cop

We have a mix of snake_case and normal case.
Standardizing plus creating exceptions, would take some effort, is low priority, and the devs are good with disabling the cop.