### PR TITLE
Avoid namings without names

### DIFF
--- a/app/models/name/resolve.rb
+++ b/app/models/name/resolve.rb
@@ -34,16 +34,19 @@ module Name::Resolve
       names = []
       if output_what.nil? || input_what == output_what
         names = find_or_create_name_and_parents(user, input_what)
-        if names.last
-          names.each do |n|
-            next unless n&.new_record?
-
-            n.inherit_stuff
-            return nil unless n.save_with_log(user, :log_updated_by)
-          end
-        end
+        return nil if names.last && !update_and_save_names(user, names)
       end
       names.last
+    end
+
+    def update_and_save_names(user, names)
+      names.each do |n|
+        next unless n&.new_record?
+
+        n.inherit_stuff
+        return false unless n.save_with_log(user, :log_updated_by)
+      end
+      true
     end
 
     def save_names(user, names, deprecate)

--- a/app/models/name/resolve.rb
+++ b/app/models/name/resolve.rb
@@ -39,7 +39,7 @@ module Name::Resolve
             next unless n&.new_record?
 
             n.inherit_stuff
-            n.save_with_log(user, :log_updated_by)
+            return nil unless n.save_with_log(user, :log_updated_by)
           end
         end
       end

--- a/app/models/naming/name_resolver.rb
+++ b/app/models/naming/name_resolver.rb
@@ -85,7 +85,7 @@ class Naming
       # has no author.)
       if @names.empty? &&
          (@name = Name.create_needed_names(user, approved_name2, corrected))
-        @names << name
+        @names << name if @name
       end
 
       # No matches -- suggest some correct names to make Debbie happy.

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -557,6 +557,19 @@ module Observations
       assert_equal("Foo sp. 'bar' Author", new_name.search_name)
     end
 
+    def test_create_bad_prov_name
+      # Must be a genus where all genus fixtures have an author
+      name = "Suillus sp. 'A*G'"
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: { name: name },
+        approved_name: name
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_equal(0, Naming.where(name_id: nil).count)
+    end
+
     # Rolf can destroy his naming if Mary deletes her vote on it.
     def test_rolf_destroy_rolfs_naming
       obs  = observations(:coprinus_comatus_obs)


### PR DESCRIPTION
Currently you can test this by adding the name "Agaricus sp. 'A.G.'" to any existing observation.  On main this should cause a hard error.  On the branch this should essentially put you into a loop of the naming dialog until you change the name to something acceptable.  The conditions for this problem are a bit tricky since if there is a genus that does not currently have an author then it will take a different code path that will be more successful than this bug.