### PR TITLE
iNatImport External Link

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -140,7 +140,7 @@ module LinkHelper
     tag.span(text, **args)
   end
 
-  def external_link(obs, link)
+  def external_link(link)
     case link.external_site.name
     when "iNaturalist"
       concat(
@@ -148,11 +148,10 @@ module LinkHelper
           "iNat ##{link.url.sub(link.external_site.base_url, "")}", link.url
         )
       )
-      concat(" Imported ") if obs.source == "mo_inat_import"
     else
       concat(link_to(:on_site.t(site: link.external_site.name), link.url))
+      concat(tag.small(" #{link.created_at.web_date}"))
     end
-    concat(tag.small(" #{link.created_at.web_date}"))
   end
 
   # NOTE: Specific to glyphicons

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -140,6 +140,21 @@ module LinkHelper
     tag.span(text, **args)
   end
 
+  def external_link(obs, link)
+    case link.external_site.name
+    when "iNaturalist"
+      concat(
+        link_to(
+          "iNat ##{link.url.sub(link.external_site.base_url, "")}", link.url
+        )
+      )
+      concat(" Imported ") if obs.source == "mo_inat_import"
+    else
+      concat(link_to(:on_site.t(site: link.external_site.name), link.url))
+    end
+    concat(tag.small(" #{link.created_at.web_date}"))
+  end
+
   # NOTE: Specific to glyphicons
   LINK_ICON_INDEX = {
     edit: "edit",

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -42,7 +42,7 @@ class InatImportJob < ApplicationJob
     )
     @user = @inat_import.user
     @user_api_key = APIKey.find_by(user: @user, notes: MO_API_KEY_NOTES).key
-    @external_link_site = ExternalSite.find_by(name: "iNaturalist")
+    @external_site = ExternalSite.find_by(name: "iNaturalist")
   end
 
   # https://www.inaturalist.org/pages/api+reference#authorization_code_flow
@@ -249,8 +249,8 @@ class InatImportJob < ApplicationJob
     ExternalLink.create(
       user: @user,
       observation: @observation,
-      external_site: @external_link_site,
-      url: "#{@external_link_site.base_url}#{@inat_obs[:id]}"
+      external_site: @external_site,
+      url: "#{@external_site.base_url}#{@inat_obs[:id]}"
     )
   end
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -42,6 +42,7 @@ class InatImportJob < ApplicationJob
     )
     @user = @inat_import.user
     @user_api_key = APIKey.find_by(user: @user, notes: MO_API_KEY_NOTES).key
+    @external_link_site = ExternalSite.find_by(name: "iNaturalist")
   end
 
   # https://www.inaturalist.org/pages/api+reference#authorization_code_flow
@@ -180,6 +181,7 @@ class InatImportJob < ApplicationJob
     return unless @inat_obs.importable?
 
     create_observation
+    add_external_link
     add_inat_images(@inat_obs[:observation_photos])
     update_names_and_proposals
     add_inat_sequences
@@ -219,8 +221,7 @@ class InatImportJob < ApplicationJob
       specimen: @inat_obs.specimen?,
       text_name: Name.find(name_id).text_name,
       notes: @inat_obs.notes,
-      source: @inat_obs.source,
-      inat_id: @inat_obs[:id] }
+      source: @inat_obs.source }
   end
 
   # NOTE: 1. iNat users seem to add a prov name only if there's a sequence.
@@ -242,6 +243,15 @@ class InatImportJob < ApplicationJob
 
   def need_new_prov_name?(prov_name)
     prov_name.blank? || Name.where(text_name: prov_name).none?
+  end
+
+  def add_external_link
+    ExternalLink.create(
+      user: @user,
+      observation: @observation,
+      external_site: @external_link_site,
+      url: "#{@external_link_site.base_url}#{@inat_obs[:id]}"
+    )
   end
 
   def add_provisional_name(prov_name)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -395,9 +395,9 @@ class InatImportJob < ApplicationJob
   end
 
   def update_mushroom_observer_url_field
-    update_inat_observation_field(observation_id: @observation.inat_id,
+    update_inat_observation_field(observation_id: @inat_obs[:id],
                                   field_id: 5005,
-                                  value: "#{MO.http_domain}/#{@observation.id}")
+                                  value: "#{MO.http_domain}/#{@inat_obs[:id]}")
   end
 
   def update_inat_observation_field(observation_id:, field_id:, value:)

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -27,6 +27,7 @@ tag.div(
                   "iNat ##{link.url.sub(link.external_site.base_url, "")}", link.url
                 )
               )
+              concat("Imported ") if obs.source == "mo_inat_import"
             else
               concat(link_to(:on_site.t(site: link.external_site.name),
                              link.url))

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -21,7 +21,7 @@ tag.div(
       tag.ul(class: "tight-list") do
         obs.external_links.sort_by(&:site_name).map do |link|
           tag.li(id: "external_link_#{link.id}") do
-            (external_link(@observation, link))
+            (external_link(link))
             concat(
               [
                 " [",

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -21,8 +21,16 @@ tag.div(
       tag.ul(class: "tight-list") do
         obs.external_links.sort_by(&:site_name).map do |link|
           tag.li(id: "external_link_#{link.id}") do
-            concat(link_to(:on_site.t(site: link.external_site.name),
-                            link.url))
+            if link.external_site.name == "iNaturalist"
+              concat(
+                link_to(
+                  "iNat ##{link.url.sub(link.external_site.base_url, "")}", link.url
+                )
+              )
+            else
+              concat(link_to(:on_site.t(site: link.external_site.name),
+                             link.url))
+            end
             concat(tag.small(" #{link.created_at.web_date}"))
             concat(
               [

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -21,18 +21,7 @@ tag.div(
       tag.ul(class: "tight-list") do
         obs.external_links.sort_by(&:site_name).map do |link|
           tag.li(id: "external_link_#{link.id}") do
-            if link.external_site.name == "iNaturalist"
-              concat(
-                link_to(
-                  "iNat ##{link.url.sub(link.external_site.base_url, "")}", link.url
-                )
-              )
-              concat(" Imported ") if obs.source == "mo_inat_import"
-            else
-              concat(link_to(:on_site.t(site: link.external_site.name),
-                             link.url))
-            end
-            concat(tag.small(" #{link.created_at.web_date}"))
+            (external_link(@observation, link))
             concat(
               [
                 " [",

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -27,7 +27,7 @@ tag.div(
                   "iNat ##{link.url.sub(link.external_site.base_url, "")}", link.url
                 )
               )
-              concat("Imported ") if obs.source == "mo_inat_import"
+              concat(" Imported ") if obs.source == "mo_inat_import"
             else
               concat(link_to(:on_site.t(site: link.external_site.name),
                              link.url))

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -602,6 +602,13 @@ class InatImportJobTest < ActiveJob::TestCase
            find_by(observation_id: obs.id, user_id: user.id)
     assert(view.present?, "Failed to create ObservationView")
 
+    external_link = obs.external_links.first
+    assert_equal(
+      "https://inaturalist.org/observations/#{@parsed_results.first[:id]}",
+      external_link&.url,
+      "MO Observation should have ExternalLink to iNat observation"
+    )
+
     assert(obs.comments.any?, "Imported iNat should have >= 1 Comment")
     obs_comments =
       Comment.where(target_type: "Observation", target_id: obs.id)

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -5,12 +5,11 @@ require_relative "inat_import_job_test_doubles"
 
 class InatImportJobTest < ActiveJob::TestCase
   include InatImportJobTestDoubles
-  # Prevent stubs from persisting between test methods because
-  # the same request (/users/me) needs diffferent responses
   def setup
     @user = users(:inat_importer)
     directory_path = Rails.public_path.join("test_images/orig")
     FileUtils.mkdir_p(directory_path) unless Dir.exist?(directory_path)
+    @external_link_base_url = ExternalSite.find_by(name: "iNaturalist").base_url
   end
 
   # Had 1 identification, 0 photos, 0 observation_fields
@@ -604,7 +603,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     external_link = obs.external_links.first
     assert_equal(
-      "https://inaturalist.org/observations/#{@parsed_results.first[:id]}",
+      "#{@external_link_base_url}#{@parsed_results.first[:id]}",
       external_link&.url,
       "MO Observation should have ExternalLink to iNat observation"
     )


### PR DESCRIPTION
- For new iNat imports
  - Adds an  ExternalLink to the iNat observation
  - Leaves inat_id `nil`
- Changes display of iNat External Links (including existing links)
From: "[On iNaturalist](https://www.inaturalist.org/observations/279505513) 2025-05-08"
To: "[iNat #279505513](https://www.inaturalist.org/observations/279505513)".

### Note:

After this is deployed, I will perform these tasks
- #2984 
- #2985

## Suggested Manual Tests
- prior manually added external link
http://localhost:3000/obs/546201
Expected external link:  [iNat #279505513](https://www.inaturalist.org/observations/279505513)
- new import
  - create a throwaway iNat obs
  - import it
  Expected external link:  `iNat #nnnnnnnnn Imported yyyy-mm-dd`
  - (Delete the throwaway iNat obs).
