### PR TITLE
Comment Broadcast - Note that turbo-rails gem update may restore default broadcasting

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -127,7 +127,9 @@ class Comment < AbstractModel
   end
 
   # Default broadcasting "later" (with solid_queue and ActiveJob)
-  # NOTE: create/update doesn't work locally after first job.
+  # NOTE: create/update doesn't work locally after first job, but
+  # turbo-rails gem v >= 2.0.14 should fix this.
+  # https://github.com/hotwired/turbo-rails/pull/710 -
   # broadcasts_to(->(comment) { [comment.target, :comments] },
   #               inserts_by: :prepend, partial: "comments/comment",
   #               locals: { controls: true },


### PR DESCRIPTION
I just found out from Alex on StackOverflow that what stumped me all week is an issue in the `turbo-rails` gem that was fixed this week. A future release may allow us to simplify the broadcast method in `comment.rb`