### PR TITLE
Restore inat_id

### DIFF
--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -123,27 +123,6 @@ module ObservationsHelper
             name_path(id: name.id), **)
   end
 
-  def observation_details_inat(obs:)
-    return nil if obs.inat_id.blank?
-
-    inat_link_desc =
-      if obs.source == "mo_inat_import"
-        :show_observation_details_inat_import.t(
-          date: obs.created_at.strftime("%Y-%m-%d")
-        )
-      else
-        :show_observation_details_inat_export.t
-      end
-
-    tag.p(id: "inat_id") do
-      [
-        "#{inat_link_desc} ",
-        link_to("#{:inat.t} ##{obs.inat_id}",
-                "https://inaturalist.org/observations/#{obs.inat_id}")
-      ].safe_join(" ")
-    end
-  end
-
   def observation_map_coordinates(obs:)
     if obs.location
       loc = obs.location

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -221,7 +221,8 @@ class InatImportJob < ApplicationJob
       specimen: @inat_obs.specimen?,
       text_name: Name.find(name_id).text_name,
       notes: @inat_obs.notes,
-      source: @inat_obs.source }
+      source: @inat_obs.source,
+      inat_id: @inat_obs[:id] }
   end
 
   # NOTE: 1. iNat users seem to add a prov name only if there's a sequence.

--- a/app/views/controllers/observations/show/_observation_details.erb
+++ b/app/views/controllers/observations/show/_observation_details.erb
@@ -10,8 +10,6 @@ show_links = user && (obs.external_links.any? || sites.any?)
                 heading_links: @user && obs_details_links(obs),
                 class: "name-section") do %>
 
-  <%= observation_details_inat(obs: obs) %>
-
   <%= observation_details_when_where_who(obs:, user:) %>
 
   <% if user %>


### PR DESCRIPTION
- Restores adding `inat_id` when importing an iNat obs.
- Removes now-redundant display of link to iNat in observation view details

We need to keep the `inat_id` data in order to prevent importing the same iNat obs muitiple times.
