### PR TITLE
Edit External Link

### DIFF
--- a/app/views/controllers/observations/external_links/_form.erb
+++ b/app/views/controllers/observations/external_links/_form.erb
@@ -5,14 +5,16 @@ case action_name
 when "new", "create"
   url_params = { action: :create, id: @observation.id }
   button = :ADD.t
+  sites = @sites.sort_by(&:name)
+  options = sites.map { |site| [site.name, site.id] }
+  selected = @site || @sites&.first
 when "edit", "update"
   url_params = { action: :update, id: @external_link.id }
   url_params = url_params.merge({ back: @back }) if @back.present?
   button = :UPDATE.t
+  options = [@site.name]
+  selected = @site
 end
-sites = @sites.sort_by(&:name)
-options = sites.map { |site| [site.name, site.id] }
-selected = @site || @sites&.first
 
 form_args = {
   model: @external_link, url: url_params, id: "external_link_form",

--- a/test/classes/query/external_links_test.rb
+++ b/test/classes/query/external_links_test.rb
@@ -25,7 +25,9 @@ class Query::ExternalLinksTest < UnitTestCase
   def test_external_link_by_users
     scope = ExternalLink.by_users(users(:mary)).order_by_default
     assert_query(scope, :ExternalLink, by_users: users(:mary))
-    assert_query([], :ExternalLink, by_users: users(:dick))
+    assert_query(ExternalLink.by_users(users(:dick)).order_by_default,
+                 :ExternalLink, by_users: users(:dick))
+    assert_query([], :ExternalLink, by_users: users(:zero_user))
   end
 
   def test_external_link_observations

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -114,8 +114,13 @@ module Observations
     end
 
     def test_edit_external_link
+      skip
+      # {"controller"=>"observations/external_links", "action"=>"edit", "id"=>"3800"}
+    end
+
+    def test_update_external_link
       # obs owned by rolf, mary created link and is member of site's project
-      link    = ExternalLink.first
+      link = external_links(:coprinus_comatus_obs_inaturalist_link)
       new_url = "#{link.external_site.base_url}different_number"
       params = {
         id: link.id,
@@ -150,7 +155,7 @@ module Observations
 
     def test_remove_external_link_not_logged_in
       # obs owned by rolf, mary created link and is member of site's project
-      link = ExternalLink.first
+      link = external_links(:coprinus_comatus_obs_inaturalist_link)
       params = { id: link.id }
 
       # not logged in
@@ -160,7 +165,7 @@ module Observations
 
     # dick doesn't have permission
     def test_remove_external_link_no_permission
-      link = ExternalLink.first
+      link = external_links(:coprinus_comatus_obs_inaturalist_link)
       params = { id: link.id }
       login("dick")
       delete(:destroy, params:)
@@ -169,7 +174,7 @@ module Observations
 
     # mary can
     def test_remove_external_link_project_member
-      link = ExternalLink.first
+      link = external_links(:coprinus_comatus_obs_inaturalist_link)
       params = { id: link.id }
       login("mary")
       delete(:destroy, params:)

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -114,8 +114,12 @@ module Observations
     end
 
     def test_edit_external_link
-      skip
-      # {"controller"=>"observations/external_links", "action"=>"edit", "id"=>"3800"}
+      link = external_links(:imported_inat_obs_inat_link)
+
+      login(link.user.login)
+      post(:edit, params: { id: link.id })
+
+      assert_response(:success)
     end
 
     def test_update_external_link

--- a/test/fixtures/external_links.yml
+++ b/test/fixtures/external_links.yml
@@ -19,3 +19,8 @@ coprinus_comatus_obs_inaturalist_link:
   external_site: inaturalist
   url:           "http://inaturalist.org/234723"
 
+imported_inat_obs_inat_link:
+  user:          dick
+  observation:   imported_inat_obs
+  external_site: inaturalist
+  url:           "https://www.inaturalist.org/12345"

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -811,6 +811,7 @@ recorder_obs:
 
 imported_inat_obs:
   <<: *DEFAULTS
+  user: dick
   inat_id: 12345
 #
 #


### PR DESCRIPTION
Fixes #2995 (Error thrown when clicking External Link edit icon)

### Manual Test
- Create an External Link for one of your Observations. 
E.g. create an iNaturalist link to `https://www.inaturalist.org/observations/12345`
- Click the edit icon for that link
Expected result: Displays the edit modal

