### PR TITLE
One InatImport at a time

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -85,6 +85,7 @@ class InatImportsController < ApplicationController
     return unless @inat_import.pending?
 
     tracker = InatImportJobTracker.where(inat_import: @inat_import).last
+    flash_error(:inat_import_tracker_pending.t)
     redirect_to(
       inat_import_path(@inat_import, params: { tracker_id: tracker.id })
     )

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -80,7 +80,15 @@ class InatImportsController < ApplicationController
     @inat_import = InatImport.find(params[:id])
   end
 
-  def new; end
+  def new
+    @inat_import = InatImport.find_by(user: @user)
+    return unless @inat_import.pending?
+
+    tracker = InatImportJobTracker.where(inat_import: @inat_import).last
+    redirect_to(
+      inat_import_path(@inat_import, params: { tracker_id: tracker.id })
+    )
+  end
 
   def create
     return reload_form unless params_valid?

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -28,8 +28,13 @@ class InatImport < ApplicationRecord
   }
 
   belongs_to :user
+  has_many :inat_import_job_trackers, dependent: :delete_all
 
   serialize :log, type: Array, coder: YAML
+
+  def pending?
+    %w[Authorizing Authenticating Importing].include?(state)
+  end
 
   def add_response_error(error)
     response_errors << "#{error.class.name}: #{error.message}\n"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3104,6 +3104,7 @@
   inat_import_tracker_results: Results
   inat_import_tracker_importable_count: Number of Importable Observations
   inat_import_tracker_imported_count: Number Imported
+  inat_import_tracker_pending: Please wait until your pending iNat Import is Done before starting a new one.
   inat_importables_explanation: "An ??importable?? observation is an iNaturalist observation: which you created, which does not exist in MO, and whose iNat identity is a fungus or slime mold."
 
   # observer/list_notifications

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -61,6 +61,19 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_new_inat_import_pending_import
+    user = users(:katrina)
+    import = inat_imports(:katrina_inat_import)
+    tracker = inat_import_job_trackers(:katrina_tracker)
+
+    login(user.login)
+    get(:new)
+
+    assert_redirected_to(
+      inat_import_path(import, params: { tracker_id: tracker.id })
+    )
+  end
+
   def test_create_missing_username
     user = users(:rolf)
     id = "123"

--- a/test/fixtures/inat_import_job_trackers.yml
+++ b/test/fixtures/inat_import_job_trackers.yml
@@ -1,1 +1,4 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+katrina_tracker:
+  inat_import: <%= ActiveRecord::FixtureSet.identify(:katrina_inat_import) %>

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -30,3 +30,9 @@ inat_importer_inat_import:
   <<: *DEFAULTS
   user: inat_importer
   inat_username: inat_importer_inat_username
+
+# katrina is in the middle of an import
+katrina_inat_import:
+  <<: *DEFAULTS
+  user: katrina
+  state: <%= InatImport.states[:Importing] %>


### PR DESCRIPTION
- Prevents user from starting a second InatImportJob if an Import is in progress.
- Redirects user to the JobTracker page for the pending job.
- Delivers #3000 

### Suggested Manual Test
- Sign out of iNat
- In MO, import an iNat observation http://localhost:3000/inat_imports/new (any iNat observation number will do).
- When redirected to iNat, simply leave the tab open, _without signing in_.
- Open a 2nd tab; import an iNat observation http://localhost:3000/inat_imports/new (any number).
Expected result: 
Redirected to iNat Import Tracker with Flash Error `Please wait until your pending iNat Import is Done before starting a new one.`
- IMPORTANT: Clean up:
- In the iNat tab, Sign In to iNat
Expected result, both tabs:
iNat Import Tracker; Status: Done
