### PR TITLE
Make the login page the root without a redirect for non-logged in user

### DIFF
--- a/app/controllers/account/login_controller.rb
+++ b/app/controllers/account/login_controller.rb
@@ -12,8 +12,12 @@ module Account
 
     # the login form
     def new
-      @login = ""
-      @remember = true
+      if @user
+        redirect_to(observations_path)
+      else
+        @login = ""
+        @remember = true
+      end
     end
 
     # login post action
@@ -85,7 +89,7 @@ module Account
       User.current = @user
       session_user_set(@user)
       @remember ? autologin_cookie_set(@user) : clear_autologin_cookie
-      redirect_back_or_default("/account/welcome")
+      redirect_back_or_default(observations_path)
     end
 
     def login_unverified(user)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -373,6 +373,7 @@ class ApplicationController < ActionController::Base
 
   def calc_layout_params
     count = @user&.layout_count || MO.default_layout_count
+    count = 1 if count < 1
     { "count" => count }
   end
   helper_method :calc_layout_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,7 +265,9 @@ MushroomObserver::Application.routes.draw do
   #     resources :products
   #   end
 
-  # Default page "/" is /observations ordered order_by: :rss_log
+  # Default page "/" is the login page to push back on spiders.
+  # Visiting this page as a logged in user now redirects to the /observations
+  # index page.
   root "account/login#new"
 
   # Route /123 to /observations/123.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,7 +266,7 @@ MushroomObserver::Application.routes.draw do
   #   end
 
   # Default page "/" is /observations ordered order_by: :rss_log
-  root "observations#index"
+  root "account/login#new"
 
   # Route /123 to /observations/123.
   get "obs/:id" => "observations#show", id: /\d+/, as: "permanent_observation"

--- a/test/capybara_session_extensions.rb
+++ b/test/capybara_session_extensions.rb
@@ -60,7 +60,7 @@ module CapybaraSessionExtensions
   # Login the given user, testing to make sure it was successful.
   def login!(user, *, **kwargs)
     login(user, *, **kwargs)
-    session = kwargs[:session] || self
+    kwargs[:session] || self
     user = User.find_by(login: user) if user.is_a?(String)
     assert_equal(user.id, User.current_id, "Wrong user ended up logged in!")
   end

--- a/test/capybara_session_extensions.rb
+++ b/test/capybara_session_extensions.rb
@@ -61,7 +61,6 @@ module CapybaraSessionExtensions
   def login!(user, *, **kwargs)
     login(user, *, **kwargs)
     session = kwargs[:session] || self
-    assert_flash_success(session: session)
     user = User.find_by(login: user) if user.is_a?(String)
     assert_equal(user.id, User.current_id, "Wrong user ended up logged in!")
   end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -22,8 +22,7 @@ class SearchControllerTest < FunctionalTestCase
         }
       )
       assert_response(:redirect)
-      # Account for Observations being the home page
-      route = model == Observation ? "" : model.to_s.downcase.pluralize
+      route = model.to_s.downcase.pluralize
       assert_match(
         "http://test.host/#{route}?advanced_search=1",
         redirect_to_url
@@ -64,7 +63,7 @@ class SearchControllerTest < FunctionalTestCase
     get(:advanced, params: params)
     query = QueryRecord.last.query
     q = QueryRecord.last.id.alphabetize
-    assert_redirected_to(root_path(advanced_search: 1, q:))
+    assert_redirected_to(observations_path(advanced_search: 1, q:))
     assert_true(query.num_results.positive?)
     assert_equal("", query.params[:has_images])
     assert_true(query.params[:has_specimen])

--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -246,19 +246,6 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
   end
 
   def test_correct_invalid_preferences
-    flintstone = users("flintstone")
-    login!(flintstone)
-
-    visit(edit_account_preferences_path)
-    assert_selector("body.preferences__edit")
-    within("#account_preferences_form") do
-      fill_in("user_email", with: "valid@seemingly.com")
-      click_commit
-    end
-
-    assert_no_flash_errors
-    assert_selector("body.preferences__edit")
-
     # This user has an invalid region AND a bogus email
     nonregional = users("nonregional")
     login!(nonregional)

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -248,7 +248,6 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     proj.save
 
     # Prove that Project is not re-checked for the next Observation
-    login(:katrina)
     visit(new_observation_path)
     assert(
       has_unchecked_field?(proj_checkbox),


### PR DESCRIPTION
I think this might fix the Let's Encrypt issue.  Checkout the login process process and the root behavior both as a logged in and logged out user.