### PR TITLE
Fix include_subtaxa:false issue

### DIFF
--- a/app/classes/pattern_search/name.rb
+++ b/app/classes/pattern_search/name.rb
@@ -52,8 +52,8 @@ module PatternSearch
     # This converts any search that *looks like* a name search into
     # an actual name search. NOTE: This affects the index title.
     def hack_name_query
-      return unless args[:include_subtaxa].present? ||
-                    args[:include_synonyms].present?
+      return unless args.include?(:include_subtaxa) ||
+                    args.include?(:include_synonyms)
 
       args[:names] = args[:pattern]
       args.delete(:pattern)

--- a/test/classes/pattern_search/name_test.rb
+++ b/test/classes/pattern_search/name_test.rb
@@ -36,10 +36,25 @@ class PatternSearch::NameTest < UnitTestCase
     assert_name_arrays_equal(expect, x.query.results, :sort)
   end
 
+  def test_name_search_exclude_synonyms
+    expect = Name.names(lookup: names(:macrolepiota_rachodes),
+                        include_synonyms: false)
+    assert_not_empty(expect)
+    x = PatternSearch::Name.new("Macrolepiota rachodes include_synonyms:no")
+    assert_name_arrays_equal(expect, x.query.results, :sort)
+  end
+
   def test_name_search_include_subtaxa
     expect = Name.names(lookup: names(:agaricus), include_subtaxa: true)
     assert_not_empty(expect)
     x = PatternSearch::Name.new("Agaricus include_subtaxa:yes")
+    assert_name_arrays_equal(expect, x.query.results, :sort)
+  end
+
+  def test_name_search_exclude_subtaxa
+    expect = Name.names(lookup: names(:agaricus), include_subtaxa: false)
+    assert_not_empty(expect)
+    x = PatternSearch::Name.new("Agaricus include_subtaxa:no")
     assert_name_arrays_equal(expect, x.query.results, :sort)
   end
 


### PR DESCRIPTION
include_subtaxa:false or include_synonyms:false were failing, so URLs like:

https://mushroomobserver.org/names?pattern=Boletus+include_subtaxa%3Afalse

were throwing errors.  This was easily reproducible locally.  This branch allows these URLs to succeed without throwing any errors.