### PR TITLE
Fix autocomplete

### DIFF
--- a/app/classes/autocomplete.rb
+++ b/app/classes/autocomplete.rb
@@ -32,9 +32,7 @@ class Autocomplete
 
   # returns an array of { name:, id: } objects
   def matching_records
-    # unless 'whole', use the first letter of the string to define the matches
-    token = string # whole ? string : string[0]
-    self.matches = rough_matches(token) || [] # defined in type-subclass
+    self.matches = rough_matches(string) || [] # defined in type-subclass
     clean_matches
 
     unless all

--- a/app/classes/autocomplete.rb
+++ b/app/classes/autocomplete.rb
@@ -15,7 +15,7 @@ class Autocomplete
   PUNCTUATION = '[ -\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]'
 
   def limit
-    1000
+    5000
   end
 
   def self.subclass(type)
@@ -33,7 +33,7 @@ class Autocomplete
   # returns an array of { name:, id: } objects
   def matching_records
     # unless 'whole', use the first letter of the string to define the matches
-    token = whole ? string : string[0]
+    token = string # whole ? string : string[0]
     self.matches = rough_matches(token) || [] # defined in type-subclass
     clean_matches
 

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -1816,36 +1816,27 @@ export default class extends Controller {
   }
 
   // Process response from server:
-  // 1. first line is string actually used to match;
+  // 1. first line is first character of string actually used to match; [Unused]
   // 2. the last string is "..." if the set of results is incomplete;
   // 3. the rest are matching results.
   //
-  // `this.primer` is a huge array of records usually matching only the first
-  // letter typed, which is assumed not to change too often. `this.matches` is
-  // the smaller array of records "refined" from the primer, matching the search
-  // token as it is typed out. The pulldown menu is populated with the matches.
+  // `this.primer` is a huge array of records matching the letters
+  // typed to get the set down to a manageable size which is assumed
+  // not to change too often.  `this.matches` is the smaller array of
+  // records "refined" from the primer, matching the search token as
+  // it is typed out. The pulldown menu is populated with the matches.
   //
   processFetchResponse(new_primer) {
     this.verbose("autocompleter:processFetchResponse()");
 
     // Clear flag telling us request is pending.
     this.fetch_request = null;
-    // Record string actually used to do matching: might be less strict
-    // than one sent in request.
-
-    // Why the following code?  The last_fetch_request is already correct.
-    // if (new_primer.length > 0)
-    //   this.last_fetch_request = new_primer[0]['name'];
 
     // Check for trailing "..." signaling incomplete set of results.
     if (new_primer.length > 1 &&
       new_primer[new_primer.length - 1]['name'] == "...") {
       this.last_fetch_incomplete = true;
       new_primer = new_primer.slice(0, new_primer.length - 1);
-      // if (this.focused)
-      //   just in case we need to refine the request due to
-      //   activity while waiting for this response
-      //   this.scheduleRefresh();
     } else {
       this.last_fetch_incomplete = false;
     }

--- a/app/javascript/controllers/autocompleter_controller.js
+++ b/app/javascript/controllers/autocompleter_controller.js
@@ -1832,8 +1832,10 @@ export default class extends Controller {
     this.fetch_request = null;
     // Record string actually used to do matching: might be less strict
     // than one sent in request.
-    if (new_primer.length > 0)
-      this.last_fetch_request = new_primer[0]['name'];
+
+    // Why the following code?  The last_fetch_request is already correct.
+    // if (new_primer.length > 0)
+    //   this.last_fetch_request = new_primer[0]['name'];
 
     // Check for trailing "..." signaling incomplete set of results.
     if (new_primer.length > 1 &&

--- a/test/controllers/autocompleters_controller_test.rb
+++ b/test/controllers/autocompleters_controller_test.rb
@@ -59,7 +59,7 @@ class AutocompletersControllerTest < FunctionalTestCase
     expect.unshift({ name: "M", id: 0 })
     expect.sort_by! { |loc| [loc[:name], -loc[:id]] }
     expect.uniq! { |loc| loc[:name] }
-    good_autocompleter_request(type: :location, string: "Modesto")
+    good_autocompleter_request(type: :location, string: "M")
     assert_equivalent(expect, JSON.parse(@response.body))
 
     login("roy") # prefers location_format: :scientific
@@ -73,7 +73,7 @@ class AutocompletersControllerTest < FunctionalTestCase
     expect.unshift({ name: "M", id: 0 })
     expect.sort_by! { |loc| [loc[:name], -loc[:id]] }
     expect.uniq! { |loc| loc[:name] }
-    good_autocompleter_request(type: :location, string: "Modesto")
+    good_autocompleter_request(type: :location, string: "M")
     assert_equivalent(expect, JSON.parse(@response.body))
     login("mary") # prefers location_format: :postal
     good_autocompleter_request(type: :location, string: "Xystus")
@@ -104,7 +104,7 @@ class AutocompletersControllerTest < FunctionalTestCase
     expect.unshift({ name: "D", id: 0 })
     expect.sort_by! { |hrb| hrb[:name] }
     expect.uniq! { |hrb| hrb[:name] }
-    good_autocompleter_request(type: :herbarium, string: "Dick")
+    good_autocompleter_request(type: :herbarium, string: "D")
     assert_equivalent(expect, JSON.parse(@response.body))
   end
 
@@ -122,11 +122,16 @@ class AutocompletersControllerTest < FunctionalTestCase
     assert_equivalent(expect, JSON.parse(@response.body))
   end
 
-  def test_autocomplete_name
+  def test_autocomplete_name_a
     login("rolf")
+    good_autocompleter_request(type: :name, string: "A")
+    assert_equivalent(expected_name_matches("A"), JSON.parse(@response.body))
+  end
+
+  def expected_name_matches(substring)
     names = Name.with_correct_spelling.
             select(:text_name, :id, :deprecated).distinct.
-            where(Name[:text_name].matches("A%"))
+            where(Name[:text_name].matches("#{substring}%"))
 
     expect = names.map do |name|
       name = name.attributes.symbolize_keys
@@ -139,11 +144,18 @@ class AutocompletersControllerTest < FunctionalTestCase
       [(name[:name].match?(" ") ? "b" : "a") + name[:name], name[:deprecated]]
     end
     expect.uniq! { |name| name[:name] }
-    expect.unshift({ name: "A", id: 0 })
+    expect.unshift({ name: substring[0], id: 0 })
+  end
 
+  def test_autocomplete_name_agaricus
+    login("rolf")
     good_autocompleter_request(type: :name, string: "Agaricus")
-    assert_equivalent(expect, JSON.parse(@response.body))
+    assert_equivalent(expected_name_matches("Agaricus"),
+                      JSON.parse(@response.body))
+  end
 
+  def test_autocomplete_name_no_match
+    login("rolf")
     good_autocompleter_request(type: :name, string: "Umbilicaria")
     assert_equivalent([{ name: "U", id: 0 }],
                       JSON.parse(@response.body))
@@ -156,7 +168,7 @@ class AutocompletersControllerTest < FunctionalTestCase
                pluck(:title, :id).uniq.map do |name, id|
       { name:, id: }
     end
-    good_autocompleter_request(type: :project, string: "Babushka")
+    good_autocompleter_request(type: :project, string: "B")
     assert_equivalent([{ name: "B", id: 0 }] + b_titles,
                       JSON.parse(@response.body))
 
@@ -164,11 +176,11 @@ class AutocompletersControllerTest < FunctionalTestCase
                pluck(:title, :id).uniq.map do |name, id|
       { name:, id: }
     end
-    good_autocompleter_request(type: :project, string: "Perfidy")
+    good_autocompleter_request(type: :project, string: "P")
     assert_equivalent([{ name: "P", id: 0 }] + p_titles,
                       JSON.parse(@response.body))
 
-    good_autocompleter_request(type: :project, string: "Xystus")
+    good_autocompleter_request(type: :project, string: "X")
     assert_equivalent([{ name: "X", id: 0 }],
                       JSON.parse(@response.body))
   end
@@ -186,22 +198,22 @@ class AutocompletersControllerTest < FunctionalTestCase
     assert_equal("List of mysteries", list3[:name])
     assert_equal("lone_wolf_list", list4[:name])
 
-    good_autocompleter_request(type: :species_list, string: "List")
+    good_autocompleter_request(type: :species_list, string: "L")
     assert_equivalent([{ name: "L", id: 0 }, list1, list2, list3, list4],
                       JSON.parse(@response.body))
 
-    good_autocompleter_request(type: :species_list, string: "Mojo")
+    good_autocompleter_request(type: :species_list, string: "M")
     assert_equivalent([{ name: "M", id: 0 }, list3],
                       JSON.parse(@response.body))
 
-    good_autocompleter_request(type: :species_list, string: "Xystus")
+    good_autocompleter_request(type: :species_list, string: "X")
     assert_equivalent([{ name: "X", id: 0 }],
                       JSON.parse(@response.body))
   end
 
   def test_autocomplete_user
     login("rolf")
-    good_autocompleter_request(type: :user, string: "Rover")
+    good_autocompleter_request(type: :user, string: "R")
     assert_equivalent(
       [{ name: "R", id: 0 },
        { name: "Rolf Singer (rolf)", id: rolf.id },
@@ -210,19 +222,19 @@ class AutocompletersControllerTest < FunctionalTestCase
       JSON.parse(@response.body)
     )
 
-    good_autocompleter_request(type: :user, string: "Dodo")
+    good_autocompleter_request(type: :user, string: "D")
     assert_equivalent([{ name: "D", id: 0 },
                        { name: "#{dick.name} (#{dick.login})",
                          id: dick.id }],
                       JSON.parse(@response.body))
 
-    good_autocompleter_request(type: :user, string: "Komodo")
+    good_autocompleter_request(type: :user, string: "K")
     assert_equivalent([{ name: "K", id: 0 },
                        { name: "#{katrina.name} (#{katrina.login})",
                          id: katrina.id }],
                       JSON.parse(@response.body))
 
-    good_autocompleter_request(type: :user, string: "Xystus")
+    good_autocompleter_request(type: :user, string: "X")
     assert_equivalent([{ name: "X", id: 0 }],
                       JSON.parse(@response.body))
   end


### PR DESCRIPTION
The current bad behavior is that if you try to autocomplete a name like "Phylloscypha phyllogena" the JS currently keeps re-asking for a huge list of all the names that start with "p".  The issue as far as I've been able to diagnose has at least three layers.

1. We have a *lot* of names that start with "phyl" and there is a limit of 1000 names.  I bumped this up to 5000 which is higher than the maximum number of names we currently have for each 2-letter combo.
2. The current code is using a parameter "whole" that it's not clear if it is intended to mean "whole words" or use the "whole string".  It appears in the JS to be intended to mean the first, but in Rails as the second.  I updated the Rails so it ignores this value for getting the search token.
3. The JS code is resetting a variable called `this.last_fetch_request` when responses come back based on the first result of the AJAX response.  This part of the response is always a single letter.  I don't see the reason for this logic since the value in `this.last_fetch_request` is already correct when the response comes in.  So I commented out this code.

Now things work seem to work correctly at least in the autocomplete for Field Slip names.  I am pretty uncomfortable with some of these changes given the number of things that rely on this autocomplete code and would like some through review and testing.