### PR TITLE
Observation show page "Namings" — update vote tallies when a naming is voted on

### DIFF
--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -93,7 +93,6 @@ module Observations::Namings
             render(partial: "observations/show/section_update",
                    locals: { identifier: "namings", obs: @observation,
                              user: @user, consensus: @consensus })
-            # redirect_with_query(@observation.show_link_args)
           end
           return
         end

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -87,19 +87,30 @@ module Observations::Namings
         format.turbo_stream do
           case params[:context]
           when "matrix_box"
-            render(partial: "observations/namings/update_matrix_box",
-                   locals: { obs: @observation })
-          else
-            render(partial: "observations/show/section_update",
-                   locals: { identifier: "namings", obs: @observation,
-                             user: @user, consensus: @consensus })
+            render_matrix_box_naming_update
+          when "namings_table"
+            render_namings_section_update
           end
-          return
         end
         format.html do
           redirect_with_query(@observation.show_link_args)
         end
       end
+    end
+
+    def render_matrix_box_naming_update
+      render(
+        partial: "observations/namings/update_matrix_box",
+        locals: { obs: @observation }
+      ) and return
+    end
+
+    def render_namings_section_update
+      render(
+        partial: "observations/show/section_update",
+        locals: { identifier: "namings", obs: @observation,
+                  user: @user, consensus: @consensus }
+      ) and return
     end
   end
 end

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -86,10 +86,10 @@ module Observations::Namings
       respond_to do |format|
         format.turbo_stream do
           case params[:context]
-          when "matrix_box"
-            render_matrix_box_naming_update
           when "namings_table"
             render_namings_section_update
+          when "matrix_box"
+            render_matrix_box_naming_update
           end
         end
         format.html do
@@ -98,18 +98,22 @@ module Observations::Namings
       end
     end
 
-    def render_matrix_box_naming_update
-      render(
-        partial: "observations/namings/update_matrix_box",
-        locals: { obs: @observation }
-      ) and return
-    end
-
     def render_namings_section_update
+      if @consensus.consensus_changed
+        redirect_with_query(@observation.show_link_args) and return
+      end
+
       render(
         partial: "observations/show/section_update",
         locals: { identifier: "namings", obs: @observation,
                   user: @user, consensus: @consensus }
+      ) and return
+    end
+
+    def render_matrix_box_naming_update
+      render(
+        partial: "observations/namings/update_matrix_box",
+        locals: { obs: @observation }
       ) and return
     end
   end

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -98,6 +98,8 @@ module Observations::Namings
       end
     end
 
+    # Re-render the whole obs template if the consensus changed. This will
+    # update the title and the name info panel. Otherwise, just update namings.
     def render_namings_section_update
       if @consensus.consensus_changed
         redirect_with_query(@observation.show_link_args) and return

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -90,7 +90,10 @@ module Observations::Namings
             render(partial: "observations/namings/update_matrix_box",
                    locals: { obs: @observation })
           else
-            redirect_with_query(@observation.show_link_args)
+            render(partial: "observations/show/section_update",
+                   locals: { identifier: "namings", obs: @observation,
+                             user: @user, consensus: @consensus })
+            # redirect_with_query(@observation.show_link_args)
           end
           return
         end

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# helpers for namings view
-# These helpers generate HTML for the "cells" of the "table".
+# These helpers generate HTML for the "cells" of the namings "table".
 # The main sections of this table are partials under "observations/show/namings"
+#
 # NOTE: some of the assembling of data could be in a presenter or component.
 # NOTE: We don't even print this table unless @user is logged in.
 # rubocop:disable Metrics/ModuleLength

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -3,7 +3,7 @@
 # helpers for namings view
 # These helpers generate HTML for the "cells" of the "table".
 # The main sections of this table are partials under "observations/show/namings"
-# TODO: some of this could be in a presenter or component
+# NOTE: some of the assembling of data could be in a presenter or component.
 # NOTE: We don't even print this table unless @user is logged in.
 # rubocop:disable Metrics/ModuleLength
 module NamingsHelper

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -1,59 +1,12 @@
 # frozen_string_literal: true
 
 # helpers for namings view
-# TODO: some of this should be in a presenter or ViewComponents
+# These helpers generate HTML for the "cells" of the "table".
+# The main sections of this table are partials under "observations/show/namings"
+# TODO: some of this could be in a presenter or component
 # NOTE: We don't even print this table unless @user is logged in.
 # rubocop:disable Metrics/ModuleLength
 module NamingsHelper
-  ##### Observation Naming "table" content #########
-  def observation_namings_table(user, obs, consensus)
-    tag.div(class: "namings-table panel panel-default mb-4",
-            id: "namings_table") do
-      [
-        observation_namings_table_header(obs),
-        observation_namings_table_rows(user, consensus), # only rows get updated
-        observation_namings_table_footer(user, obs)
-      ].safe_join
-    end
-  end
-
-  private
-
-  # nested rows/columns parallel those in the row
-  def observation_namings_table_header(obs)
-    header = naming_header_row_content
-    behavior = "flex-column justify-content-end"
-    propose_icon = propose_naming_link(
-      obs.id, text: :show_namings_propose_new_name.t,
-              btn_class: "",
-              context: "namings_table", icon: true
-    )
-
-    tag.div(class: "panel-heading namings-table-header") do
-      tag.div(class: "row") do
-        concat(
-          tag.div(class: "col-xs-10 col-sm-11") do
-            tag.div(class: "row") do
-              [
-                tag.div(header[:heading],
-                        class: "col col-sm-4 d-block #{behavior}"),
-                tag.div(header[:user_name],
-                        class: "col col-sm-3 d-none d-sm-block #{behavior}"),
-                tag.div(header[:consensus_vote],
-                        class: "col col-sm-2 d-none d-sm-block #{behavior}"),
-                tag.div(header[:your_vote],
-                        class: "col col-sm-3 d-none d-sm-block #{behavior}")
-              ].safe_join
-            end
-          end
-        )
-        concat(tag.div(class: "col-xs-2 col-sm-1 #{behavior}") do
-          tag.span(propose_icon, class: "float-right d-sm-none")
-        end)
-      end
-    end
-  end
-
   def naming_header_row_content
     heading_html = tag.h4(:show_namings_proposed_names.t,
                           class: "panel-title")
@@ -67,27 +20,6 @@ module NamingsHelper
       consensus_vote: consensus_heading_html,
       your_vote: your_heading_html
     }
-  end
-
-  # NEW - needs a current consensus object
-  # n+1 should be ok
-  def observation_namings_table_rows(user, consensus)
-    namings = consensus.namings.sort_by(&:created_at)
-    any_names = consensus.namings&.length&.positive?
-
-    tag.div(
-      id: "namings_table_rows", class: "list-group list-group-flush",
-      data: { controller: "section-update" }
-    ) do
-      if any_names
-        namings.each do |naming|
-          row = naming_row_content(user, consensus, naming)
-          concat(namings_table_row(row))
-        end
-      else
-        tag.div(:show_namings_no_names_yet.t, class: "list-group-item")
-      end
-    end
   end
 
   # NEW - needs a current consensus object
@@ -105,36 +37,6 @@ module NamingsHelper
       eyes: vote_icons_html(naming, consensus_favorite, favorite),
       reasons: reasons_html(naming)
     }
-  end
-
-  # Shows one proposed naming for this observation, with a tiny vote form.
-  # Also naming edit and delete buttons if the current user owns the naming.
-  # @vote is used by observations/namings/votes/form
-  # Note the nested grid: the reasons are packed under the left 11 cols,
-  # with the "eyes" graphic in the right 1 col for vertical space
-  # @vote = votes[naming.id]
-  def namings_table_row(row)
-    tag.div(class: "list-group-item") do
-      tag.div(class: "row align-items-center naming-row",
-              id: "observation_naming_#{row[:id]}") do
-        [
-          tag.div(class: "col col-sm-11") do
-            [
-              tag.div(class: "row align-items-center") do
-                [
-                  tag.div(row[:name], class: "col col-sm-4"),
-                  tag.div(row[:proposer], class: "col col-sm-3"),
-                  tag.div(row[:vote_tally], class: "col col-sm-2"),
-                  tag.div(row[:your_vote], class: "col col-sm-3")
-                ].safe_join
-              end,
-              tag.div(row[:reasons], class: "naming-reasons small mt-1")
-            ].safe_join
-          end,
-          tag.div(row[:eyes], class: "col-sm-1 d-none d-sm-block px-sm-0")
-        ].safe_join
-      end
-    end
   end
 
   # N+1: should not be checking permission here
@@ -196,7 +98,7 @@ module NamingsHelper
      user_link].safe_join
   end
 
-  # N+1: naming includes votes
+  # N+1: naming includes votes. Should have been reloaded by VotesController.
   def vote_tally_html(naming)
     vote_tally =
       (if naming.votes&.length&.positive?
@@ -239,8 +141,6 @@ module NamingsHelper
                class: "visible-xs-inline-block"),
      naming_vote_form(naming, vote, context: "namings_table")].safe_join
   end
-
-  public
 
   # Naming Vote Form: a select that submits on change with Stimulus
   # a tiny form within a naming row for voting on this naming only
@@ -345,42 +245,7 @@ module NamingsHelper
     reasons.map { |reason| content_tag(:div, reason) }.safe_join
   end
 
-  # nested rows/columns parallel those in the row partial
-  def observation_namings_table_footer(user, obs)
-    suggest = obs.thumb_image_id.present? &&
-              (user.admin ||
-               MO.image_model_beta_testers.include?(user.id))
-    buttons = observation_naming_buttons(obs, suggest)
-    help_text = :show_namings_consensus_help.t
-    help = content_tag(:div, help_text, class: "card-text small")
-
-    [
-      tag.div(class: "panel-footer") do
-        tag.div(class: "row") do
-          tag.div(class: "col-sm-11") do
-            tag.div(class: "row") do
-              concat(tag.div(buttons, class: "col col-md-4"))
-              concat(tag.div(help, class: "col col-md-8"))
-            end
-          end
-        end
-      end,
-      tag.div(class: "panel-footer d-none d-sm-block py-2") do
-        tag.div(class: "row") do
-          tag.div(class: "col-sm-11") do
-            tag.div(class: "row") do
-              [
-                tag.div(vote_legend_yours, class: "col-xs-4 col-xs-offset-4"),
-                tag.div(vote_legend_consensus, class: "col-xs-4")
-              ].safe_join
-            end
-          end
-        end
-      end
-    ].safe_join
-  end
-
-  def observation_naming_buttons(obs, do_suggestions)
+  def observation_naming_buttons(user, obs)
     buttons = []
     buttons << propose_naming_link(
       obs.id,
@@ -388,7 +253,9 @@ module NamingsHelper
       btn_class: "btn btn-default btn-sm d-none d-sm-inline-block",
       context: "namings_table"
     )
-    buttons << suggest_namings_link(obs) if do_suggestions
+    suggest = obs.thumb_image_id.present? &&
+              (user.admin || MO.image_model_beta_testers.include?(user.id))
+    buttons << suggest_namings_link(obs) if suggest
     buttons.safe_join(tag.br)
   end
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -7,17 +7,30 @@ export default class extends Controller {
 
   connect() {
     // console.log("Hello Modal " + this.element.id);
-    this.element.dataset.stimulus = "modal-connected";
+    this.element.dataset.modal = "connected"
   }
 
-  // Modal is only removed in the event that the page section updates.
+  // Modal form is only removed in the event that the page section updates.
   // That event is broadcast from the section-update controller.
-  // We can't fire on form submit response, because unless something's wrong
-  // turbo-stream will send a 200 response.
-  // Must be in jQuery for Boostrap 3 and 4
+  // We can't fire based on submit response, because unless something's wrong
+  // with the request, turbo-stream will send a 200 OK even if it didn't save.
   remove() {
     console.log("Removing modal")
-    $(this.element).modal('hide')
+    this.hide()
     this.element.remove()
+  }
+
+  // The modal_ajax_progress for voting should only be hidden,
+  // since it is printed in the layout and should not be removed from the page.
+  // Must be in jQuery for Boostrap 3 and 4
+  hide() {
+    console.log("Hiding modal")
+    $(this.element).modal('hide')
+    this.resetProgress()
+  }
+
+  // Reset the text within the progress modal, if it exists.
+  resetProgress() {
+    document.getElementById('mo_ajax_progress_caption').innerHTML = ""
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
   // We can't fire based on submit response, because unless something's wrong
   // with the request, turbo-stream will send a 200 OK even if it didn't save.
   remove() {
-    console.log("Removing modal")
+    // console.log("Removing modal")
     this.hide()
     this.element.remove()
   }
@@ -24,7 +24,7 @@ export default class extends Controller {
   // since it is printed in the layout and should not be removed from the page.
   // Must be in jQuery for Boostrap 3 and 4
   hide() {
-    console.log("Hiding modal")
+    // console.log("Hiding modal")
     $(this.element).modal('hide')
     this.resetProgress()
   }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
   // That event is broadcast from the section-update controller.
   // We can't fire on form submit response, because unless something's wrong
   // turbo-stream will send a 200 response.
+  // Must be in jQuery for Boostrap 3 and 4
   remove() {
     console.log("Removing modal")
     $(this.element).modal('hide')

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -1,21 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Handles page sections that get updated by Turbo on successful form submit.
+// Dispatching an event here allows triggering other Stimulus controller actions
+// that "clean up", e.g. remove or hide a modal.
 // Connects to data-controller="section-update"
 export default class extends Controller {
-
-  // this is a handler for page elements that get updated
-  // on successful form submit, so it "cleans up"
   connect() {
     this.element.dataset.sectionUpdate = "connected"
 
-    // Simpler than adding a data-action attribute on every section
-    // replaced by Turbo?
+    // Currently we're just using this to trigger modal:remove or modal:hide
     this.element.addEventListener("turbo:frame-render", this.updated())
   }
 
+  // Dispatch a custom event to the window element
   updated() {
     // console.log(this.element.id + " turbo:frame-render section updated")
-    // broadcast change
     this.dispatch("updated")
   }
 }

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -6,19 +6,15 @@ export default class extends Controller {
   // this is a handler for page elements that get updated
   // on successful form submit, so it "cleans up"
   connect() {
-    this.element.dataset.stimulus = "section-update-connected"
+    this.element.dataset.sectionUpdate = "connected"
 
-    // Note: this is simpler than adding a data-action attribute on every
-    // section replaced by Turbo
+    // Simpler than adding a data-action attribute on every section
+    // replaced by Turbo?
     this.element.addEventListener("turbo:frame-render", this.updated())
   }
 
   updated() {
-    console.log(this.element.id + " turbo:frame-render section updated")
-    // Remove modal which is present for certain updates (but not all)
-    // Must be in jQuery for Boostrap 3 and 4
-    $("#mo_ajax_progress").modal('hide')
-    document.getElementById('mo_ajax_progress_caption').innerHTML = ""
+    // console.log(this.element.id + " turbo:frame-render section updated")
     // broadcast change
     this.dispatch("updated")
   }

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -6,22 +6,25 @@ export default class extends Controller {
   // this is a handler for page elements that get updated
   // on successful form submit, so it "cleans up"
   connect() {
-    this.element.dataset.stimulus = "section-update-connected";
+    this.element.dataset.stimulus = "section-update-connected"
 
     // Note: this is simpler than adding an action on every frame. hides modal
-    this.element.addEventListener("turbo:frame-render", this.updated());
-    // this.element.addEventListener("turbo:before-stream-render", this.updated());
-    // this.element.addEventListener("turbo:submit-end", this.updated());
+    this.element.addEventListener("turbo:frame-render", this.updated())
+    // this.element.addEventListener("turbo:before-stream-render", this.sayHi())
+    // this.element.addEventListener("turbo:submit-end", this.sayHi())
   }
 
   updated() {
+    console.log(this.element.id + " turbo:frame-render section updated")
     // Remove modal which is present for certain updates (but not all)
     // Must be in jQuery for Boostrap 3 and 4
-    $("#mo_ajax_progress").modal('hide');
-    document.getElementById('mo_ajax_progress_caption').innerHTML = "";
-    console.log("Section updated");
+    $("#mo_ajax_progress").modal('hide')
+    document.getElementById('mo_ajax_progress_caption').innerHTML = ""
     // broadcast change
-    this.dispatch("updated");
+    this.dispatch("updated")
   }
 
+  sayHi() {
+    console.log(this.element.id + " turbo:before-stream-render")
+  }
 }

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -8,10 +8,9 @@ export default class extends Controller {
   connect() {
     this.element.dataset.stimulus = "section-update-connected"
 
-    // Note: this is simpler than adding an action on every frame. hides modal
+    // Note: this is simpler than adding a data-action attribute on every
+    // section replaced by Turbo
     this.element.addEventListener("turbo:frame-render", this.updated())
-    // this.element.addEventListener("turbo:before-stream-render", this.sayHi())
-    // this.element.addEventListener("turbo:submit-end", this.sayHi())
   }
 
   updated() {
@@ -22,9 +21,5 @@ export default class extends Controller {
     document.getElementById('mo_ajax_progress_caption').innerHTML = ""
     // broadcast change
     this.dispatch("updated")
-  }
-
-  sayHi() {
-    console.log(this.element.id + " turbo:before-stream-render")
   }
 }

--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -61,7 +61,7 @@ class Observation
     attr_accessor :observation, :namings, :votes
 
     def initialize(observation)
-      @observation = observation
+      @observation = ::Observation.naming_includes.find(observation.id)
       @namings = observation.namings
       @votes = @namings.map(&:votes).flatten
     end

--- a/app/views/controllers/observations/namings/index.erb
+++ b/app/views/controllers/observations/namings/index.erb
@@ -1,5 +1,6 @@
 <%=
 tag.div(id: "observation_namings") do
-  observation_namings_table(@user, @observation, @consensus)
+  render(partial: "observations/show/namings",
+         locals: { user: @user, obs: @observation, consensus: @consensus })
 end
 %>

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -16,10 +16,10 @@ end
 show_map   = @user ? @user.thumbnail_maps : !session[:hide_thumbnail_maps]
 show_lists = @user # && @observation.species_lists.any?
 
-obs_locals = { obs: @observation, consensus: @consensus, user: @user,
-               sites: @other_sites }
+obs_locals = { obs: @observation, consensus: @consensus, user: @user }
 carousel_locals = {
-  object: @observation, images: @images, html_id: "observation_images", user: @user,
+  object: @observation, images: @images,
+  html_id: "observation_images", user: @user,
   title: :IMAGES.t, links: observation_show_image_links(obs: @observation)
 }
 %>
@@ -33,7 +33,7 @@ carousel_locals = {
 
   <div class="col-xs-12 col-md-4 col-lg-5 float-sm-right">
     <%= render(partial: "observations/show/observation_details",
-               locals: obs_locals) %>
+               locals: obs_locals.merge(sites: @other_sites)) %>
     <% if @user %>
       <%= render(partial: "observations/show/name_info", locals: obs_locals) %>
 

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -2,18 +2,19 @@
 
 <!--OBSERVATION_NAMINGS / TABLE REFRESHED BY TURBO -->
 <%=
-tag.div(id: "observation_namings",
-        data: { controller: "section-update" }) do
-  tag.div(class: "namings-table panel panel-default mb-4",
-          id: "namings_table") do
-    [
-      render(partial: "observations/show/namings/header",
-             locals: { obs: }),
-      render(partial: "observations/show/namings/rows",
-             locals: { user:, consensus: }),
-      render(partial: "observations/show/namings/footer",
-             locals: { user:, obs: })
-    ].safe_join
-  end
-end %>
+tag.div(
+  id: "observation_namings",
+  class: "namings-table panel panel-default mb-4",
+  data: { controller: "section-update" }
+) do
+  [
+    render(partial: "observations/show/namings/header",
+            locals: { obs: }),
+    render(partial: "observations/show/namings/rows",
+            locals: { user:, consensus: }),
+    render(partial: "observations/show/namings/footer",
+            locals: { user:, obs: })
+  ].safe_join
+end
+%>
 <!--/OBSERVATION_NAMINGS -->

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -9,7 +9,7 @@ tag.div(
 ) do
   [
     render(partial: "observations/show/namings/header",
-            locals: { obs: }),
+            locals: { obs:, **naming_header_row_content }),
     render(partial: "observations/show/namings/rows",
             locals: { user:, obs:, consensus: }),
     render(partial: "observations/show/namings/footer",

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -11,7 +11,7 @@ tag.div(
     render(partial: "observations/show/namings/header",
             locals: { obs: }),
     render(partial: "observations/show/namings/rows",
-            locals: { user:, consensus: }),
+            locals: { user:, obs:, consensus: }),
     render(partial: "observations/show/namings/footer",
             locals: { user:, obs: })
   ].safe_join

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -8,13 +8,10 @@ tag.div(id: "observation_namings") do
     [
       render(partial: "observations/show/namings/header",
              locals: { obs: }),
-      # observation_namings_table_header(obs),
       render(partial: "observations/show/namings/rows",
              locals: { user:, consensus: }),
-      # observation_namings_table_rows(user, consensus), # only rows get updated
       render(partial: "observations/show/namings/footer",
              locals: { user:, obs: })
-      # observation_namings_table_footer(user, obs)
     ].safe_join
   end
 end %>

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -2,7 +2,8 @@
 
 <!--OBSERVATION_NAMINGS / TABLE REFRESHED BY TURBO -->
 <%=
-tag.div(id: "observation_namings") do
+tag.div(id: "observation_namings",
+        data: { controller: "section-update" }) do
   tag.div(class: "namings-table panel panel-default mb-4",
           id: "namings_table") do
     [

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -1,9 +1,21 @@
-<%
-@query ||= nil # tbd what this was ever used for in the table
-%>
+<%# locals: (obs: nil, user: nil, consensus: nil) %>
 
 <!--OBSERVATION_NAMINGS / TABLE REFRESHED BY TURBO -->
-<%= tag.div(id: "observation_namings") do
-  observation_namings_table(@user, obs, consensus)
+<%=
+tag.div(id: "observation_namings") do
+  tag.div(class: "namings-table panel panel-default mb-4",
+          id: "namings_table") do
+    [
+      render(partial: "observations/show/namings/header",
+             locals: { obs: }),
+      # observation_namings_table_header(obs),
+      render(partial: "observations/show/namings/rows",
+             locals: { user:, consensus: }),
+      # observation_namings_table_rows(user, consensus), # only rows get updated
+      render(partial: "observations/show/namings/footer",
+             locals: { user:, obs: })
+      # observation_namings_table_footer(user, obs)
+    ].safe_join
+  end
 end %>
 <!--/OBSERVATION_NAMINGS -->

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -30,13 +30,15 @@ partial = "observations/show/#{identifier}"
 <%=
 turbo_stream.replace(id) do
   render(
-    partial: partial,
-    locals: local_assigns.except(:identifier),
-    layout: false
+    partial: partial, layout: false,
+    locals: local_assigns.except(:identifier)
   )
 end
 
 turbo_stream.update("page_flash") do
   flash_notices_html
 end
+
+turbo_stream.close_modal("mo_ajax_progress")
+turbo_stream.remove("mo_ajax_progress")
 %>

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -1,18 +1,25 @@
 <%# locals: (identifier: "", obs: nil, user: nil, consensus: nil, sites: nil) %>
 
 <%#
-NOTE: This is a generalized Turbo-update template for the show obs page.
-It updates the observation view with results of an update or create action.
+Generalized template for Turbo live partial updates of the show obs page.
+This template is rendered by several controllers upon success of any action
+that creates or updates a resource associated with the Observation - for
+example a Naming, CollectionNumber, FungariumRecord, ExternalLink, or Sequence.
 
-It is intended to DRY the code for partial updates (although less direct),
-because these should have at least two consequences:
-  - updating a section of show obs
-  - updating the page flash to provide feedback that it's updated
-Otherwise, the create/update actions could render these explicitly.
+The reason this is a generalized template is because these updates should all
+do at least two things, via two separate `turbo_stream` actions below:
+  - Replace the relevant section of show obs
+  - Update the page flash to provide user feedback
+Each of the above controller responses could *explicitly* call both of these,
+but this partial is intended to be more DRY, at the cost of being indirect.
 
-The required local is `identifier`, which should match both
+Callers should pass the local_assign `identifier`, plus any locals needed by the section partial. The `identifier` is a string that should match both
   - the partial filename: views/controllers/observations/show/_#{identifier}.erb
-  - the last segment of the section's HTML ID as "observation_#{identifier}"
+  - the last segment of the section's HTML ID: "observation_#{identifier}"
+
+NOTE: The section partial should also have a `data-controller="status-update"`
+attribute on the outermost div. This calls the Stimulus controller to hide any
+modal forms when the div gets updated by Turbo.
 %>
 
 <%

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -34,11 +34,10 @@ turbo_stream.replace(id) do
     locals: local_assigns.except(:identifier)
   )
 end
+%>
 
+<%=
 turbo_stream.update("page_flash") do
   flash_notices_html
 end
-
-# turbo_stream.close_modal("mo_ajax_progress")
-# turbo_stream.remove("mo_ajax_progress")
 %>

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -39,6 +39,6 @@ turbo_stream.update("page_flash") do
   flash_notices_html
 end
 
-turbo_stream.close_modal("mo_ajax_progress")
-turbo_stream.remove("mo_ajax_progress")
+# turbo_stream.close_modal("mo_ajax_progress")
+# turbo_stream.remove("mo_ajax_progress")
 %>

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -1,20 +1,26 @@
 <%# locals: (identifier: "", obs: nil, user: nil, consensus: nil, sites: nil) %>
 
-<%=
-# Update observation view with results of update or create
-# if identifier == "namings"
-#   id = "namings_table_rows"
-#   turbo_stream.replace(id) do
-#     render(
-#       partial: "observations/show/namings/rows",
-#       locals: local_assigns.except(:identifier),
-#       layout: false
-#     )
-#     # observation_namings_table_rows(@user, @consensus)
-#   end
-# else
+<%#
+NOTE: This is a generalized Turbo-update template for the show obs page.
+It updates the observation view with results of an update or create action.
+
+It is intended to DRY the code for partial updates (although less direct),
+because these should have at least two consequences:
+  - updating a section of show obs
+  - updating the page flash to provide feedback that it's updated
+Otherwise, the create/update actions could render these explicitly.
+
+The required local is `identifier`, which should match both
+  - the partial filename: views/controllers/observations/show/_#{identifier}.erb
+  - the last segment of the section's HTML ID as "observation_#{identifier}"
+%>
+
+<%
 id = "observation_#{identifier}"
 partial = "observations/show/#{identifier}"
+%>
+
+<%=
 turbo_stream.replace(id) do
   render(
     partial: partial,
@@ -22,9 +28,8 @@ turbo_stream.replace(id) do
     layout: false
   )
 end
-# end
-%>
 
-<%= turbo_stream.update("page_flash") do
+turbo_stream.update("page_flash") do
   flash_notices_html
-end %>
+end
+%>

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -13,7 +13,8 @@ do at least two things, via two separate `turbo_stream` actions below:
 Each of the above controller responses could *explicitly* call both of these,
 but this partial is intended to be more DRY, at the cost of being indirect.
 
-Callers should pass the local_assign `identifier`, plus any locals needed by the section partial. The `identifier` is a string that should match both
+Callers should pass the local_assign `identifier`, plus any locals needed by
+the section partial. The `identifier` is a string that should match both
   - the partial filename: views/controllers/observations/show/_#{identifier}.erb
   - the last segment of the section's HTML ID: "observation_#{identifier}"
 

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -1,12 +1,16 @@
+<%# locals: (identifier: "") %>
+
 <%=
 # Update observation view with results of update or create
-# Needs locals: identifier
-# The namings table is a helper
-# N+1 - @observation.reload ?!
 if identifier == "namings"
   id = "namings_table_rows"
   turbo_stream.replace(id) do
-    observation_namings_table_rows(@user, @consensus)
+    render(
+      partial: "observations/show/namings/rows",
+      locals: local_assigns.except(:identifier),
+      layout: false
+    )
+    # observation_namings_table_rows(@user, @consensus)
   end
 else
   id = "observation_#{identifier}"

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -2,27 +2,27 @@
 
 <%=
 # Update observation view with results of update or create
-if identifier == "namings"
-  id = "namings_table_rows"
-  turbo_stream.replace(id) do
-    render(
-      partial: "observations/show/namings/rows",
-      locals: local_assigns.except(:identifier),
-      layout: false
-    )
-    # observation_namings_table_rows(@user, @consensus)
-  end
-else
-  id = "observation_#{identifier}"
-  partial = "observations/show/#{identifier}"
-  turbo_stream.replace(id) do
-    render(
-      partial: partial,
-      locals: local_assigns.except(:identifier),
-      layout: false
-    )
-  end
+# if identifier == "namings"
+#   id = "namings_table_rows"
+#   turbo_stream.replace(id) do
+#     render(
+#       partial: "observations/show/namings/rows",
+#       locals: local_assigns.except(:identifier),
+#       layout: false
+#     )
+#     # observation_namings_table_rows(@user, @consensus)
+#   end
+# else
+id = "observation_#{identifier}"
+partial = "observations/show/#{identifier}"
+turbo_stream.replace(id) do
+  render(
+    partial: partial,
+    locals: local_assigns.except(:identifier),
+    layout: false
+  )
 end
+# end
 %>
 
 <%= turbo_stream.update("page_flash") do

--- a/app/views/controllers/observations/show/_section_update.erb
+++ b/app/views/controllers/observations/show/_section_update.erb
@@ -1,4 +1,4 @@
-<%# locals: (identifier: "") %>
+<%# locals: (identifier: "", obs: nil, user: nil, consensus: nil, sites: nil) %>
 
 <%=
 # Update observation view with results of update or create

--- a/app/views/controllers/observations/show/namings/_footer.erb
+++ b/app/views/controllers/observations/show/namings/_footer.erb
@@ -1,0 +1,33 @@
+<%# locals: (user: nil, obs: nil) %>
+
+<%
+buttons = observation_naming_buttons(user, obs)
+help = tag.div(:show_namings_consensus_help.t, class: "card-text small")
+%>
+
+<%=
+[
+  tag.div(class: "panel-footer") do
+    tag.div(class: "row") do
+      tag.div(class: "col-sm-11") do
+        tag.div(class: "row") do
+          concat(tag.div(buttons, class: "col col-md-4"))
+          concat(tag.div(help, class: "col col-md-8"))
+        end
+      end
+    end
+  end,
+  tag.div(class: "panel-footer d-none d-sm-block py-2") do
+    tag.div(class: "row") do
+      tag.div(class: "col-sm-11") do
+        tag.div(class: "row") do
+          [
+            tag.div(vote_legend_yours, class: "col-xs-4 col-xs-offset-4"),
+            tag.div(vote_legend_consensus, class: "col-xs-4")
+          ].safe_join
+        end
+      end
+    end
+  end
+].safe_join
+%>

--- a/app/views/controllers/observations/show/namings/_header.erb
+++ b/app/views/controllers/observations/show/namings/_header.erb
@@ -1,7 +1,6 @@
-<%# locals: (obs: nil) %>
+<%# locals: (obs: nil, heading: "", user_name: "", consensus_vote: "", your_vote: "") %>
 
 <%
-header = naming_header_row_content
 behavior = "flex-column justify-content-end"
 propose_icon = propose_naming_link(
   obs.id, text: :show_namings_propose_new_name.t,
@@ -17,13 +16,13 @@ tag.div(class: "panel-heading namings-table-header") do
       tag.div(class: "col-xs-10 col-sm-11") do
         tag.div(class: "row") do
           [
-            tag.div(header[:heading],
+            tag.div(heading,
                     class: "col col-sm-4 d-block #{behavior}"),
-            tag.div(header[:user_name],
+            tag.div(user_name,
                     class: "col col-sm-3 d-none d-sm-block #{behavior}"),
-            tag.div(header[:consensus_vote],
+            tag.div(consensus_vote,
                     class: "col col-sm-2 d-none d-sm-block #{behavior}"),
-            tag.div(header[:your_vote],
+            tag.div(your_vote,
                     class: "col col-sm-3 d-none d-sm-block #{behavior}")
           ].safe_join
         end

--- a/app/views/controllers/observations/show/namings/_header.erb
+++ b/app/views/controllers/observations/show/namings/_header.erb
@@ -1,0 +1,37 @@
+<%# locals: (obs: nil) %>
+
+<%
+header = naming_header_row_content
+behavior = "flex-column justify-content-end"
+propose_icon = propose_naming_link(
+  obs.id, text: :show_namings_propose_new_name.t,
+          btn_class: "",
+          context: "namings_table", icon: true
+)
+%>
+
+<%=
+tag.div(class: "panel-heading namings-table-header") do
+  tag.div(class: "row") do
+    concat(
+      tag.div(class: "col-xs-10 col-sm-11") do
+        tag.div(class: "row") do
+          [
+            tag.div(header[:heading],
+                    class: "col col-sm-4 d-block #{behavior}"),
+            tag.div(header[:user_name],
+                    class: "col col-sm-3 d-none d-sm-block #{behavior}"),
+            tag.div(header[:consensus_vote],
+                    class: "col col-sm-2 d-none d-sm-block #{behavior}"),
+            tag.div(header[:your_vote],
+                    class: "col col-sm-3 d-none d-sm-block #{behavior}")
+          ].safe_join
+        end
+      end
+    )
+    concat(tag.div(class: "col-xs-2 col-sm-1 #{behavior}") do
+      tag.span(propose_icon, class: "float-right d-sm-none")
+    end)
+  end
+end
+%>

--- a/app/views/controllers/observations/show/namings/_row.erb
+++ b/app/views/controllers/observations/show/namings/_row.erb
@@ -1,0 +1,25 @@
+<%# locals: (id: nil, name: nil, proposer: nil, vote_tally: nil, your_vote: nil, reasons: nil, eyes: nil) %>
+
+<%=
+tag.div(class: "list-group-item") do
+  tag.div(class: "row align-items-center naming-row",
+          id: "observation_naming_#{id}") do
+    [
+      tag.div(class: "col col-sm-11") do
+        [
+          tag.div(class: "row align-items-center") do
+            [
+              tag.div(name, class: "col col-sm-4"),
+              tag.div(proposer, class: "col col-sm-3"),
+              tag.div(vote_tally, class: "col col-sm-2"),
+              tag.div(your_vote, class: "col col-sm-3")
+            ].safe_join
+          end,
+          tag.div(reasons, class: "naming-reasons small mt-1")
+        ].safe_join
+      end,
+      tag.div(eyes, class: "col-sm-1 d-none d-sm-block px-sm-0")
+    ].safe_join
+  end
+end
+%>

--- a/app/views/controllers/observations/show/namings/_rows.erb
+++ b/app/views/controllers/observations/show/namings/_rows.erb
@@ -1,8 +1,8 @@
-<%# locals: (user: nil, consensus: nil) %>
+<%# locals: (user: nil, obs: nil, consensus: nil) %>
 
 <%
-namings = consensus.namings&.reload&.sort_by(&:created_at)
-any_names = consensus.namings&.length&.positive?
+namings = obs.namings.sort_by(&:created_at)
+any_names = obs.namings&.length&.positive?
 %>
 
 <%=
@@ -12,10 +12,9 @@ tag.div(
 ) do
   if any_names
     namings.each do |naming|
-      row = naming_row_content(user, consensus, naming)
       concat(
         render(partial: "observations/show/namings/row",
-               locals: { **row })
+               locals: { **naming_row_content(user, consensus, naming) })
       )
     end
   else

--- a/app/views/controllers/observations/show/namings/_rows.erb
+++ b/app/views/controllers/observations/show/namings/_rows.erb
@@ -1,7 +1,7 @@
 <%# locals: (user: nil, consensus: nil) %>
 
 <%
-namings = consensus.namings.sort_by(&:created_at)
+namings = consensus.namings&.reload&.sort_by(&:created_at)
 any_names = consensus.namings&.length&.positive?
 %>
 

--- a/app/views/controllers/observations/show/namings/_rows.erb
+++ b/app/views/controllers/observations/show/namings/_rows.erb
@@ -8,8 +8,7 @@ any_names = consensus.namings&.length&.positive?
 <%=
 tag.div(
   id: "namings_table_rows",
-  class: "list-group list-group-flush",
-  data: { controller: "section-update" }
+  class: "list-group list-group-flush"
 ) do
   if any_names
     namings.each do |naming|

--- a/app/views/controllers/observations/show/namings/_rows.erb
+++ b/app/views/controllers/observations/show/namings/_rows.erb
@@ -1,0 +1,26 @@
+<%# locals: (user: nil, consensus: nil) %>
+
+<%
+namings = consensus.namings.sort_by(&:created_at)
+any_names = consensus.namings&.length&.positive?
+%>
+
+<%=
+tag.div(
+  id: "namings_table_rows",
+  class: "list-group list-group-flush",
+  data: { controller: "section-update" }
+) do
+  if any_names
+    namings.each do |naming|
+      row = naming_row_content(user, consensus, naming)
+      concat(
+        render(partial: "observations/show/namings/row",
+               locals: { **row })
+      )
+    end
+  else
+    tag.div(:show_namings_no_names_yet.t, class: "list-group-item")
+  end
+end
+%>

--- a/app/views/controllers/shared/_modal_ajax_progress.erb
+++ b/app/views/controllers/shared/_modal_ajax_progress.erb
@@ -9,7 +9,9 @@ message ||= ""
 tag.div(
   class: "modal", id: "mo_ajax_progress", role: "dialog",
   aria: { labelledby: "mo_ajax_progress_caption" },
-  data: { keyboard: false, backdrop: "static" }
+  data: { controller: "modal",
+          action: "section-update:updated@window->modal#remove",
+          keyboard: false, backdrop: "static" }
 ) do
   tag.div(class: "modal-dialog modal-sm", role: "document") do
     tag.div(class: "modal-content") do

--- a/app/views/controllers/shared/_modal_ajax_progress.erb
+++ b/app/views/controllers/shared/_modal_ajax_progress.erb
@@ -10,7 +10,7 @@ tag.div(
   class: "modal", id: "mo_ajax_progress", role: "dialog",
   aria: { labelledby: "mo_ajax_progress_caption" },
   data: { controller: "modal",
-          action: "section-update:updated@window->modal#remove",
+          action: "section-update:updated@window->modal#hide",
           keyboard: false, backdrop: "static" }
 ) do
   tag.div(class: "modal-dialog modal-sm", role: "document") do

--- a/test/controllers/observations/namings/votes_controller_test.rb
+++ b/test/controllers/observations/namings/votes_controller_test.rb
@@ -70,6 +70,41 @@ module Observations::Namings
       assert_equal(2, nam1.votes.length)
     end
 
+    # Just like the last test, but test Turbo response
+    def test_cast_vote_rolf_change_turbo
+      obs  = observations(:coprinus_comatus_obs)
+      nam1 = namings(:coprinus_comatus_naming)
+
+      login("rolf")
+      consensus = ::Observation::NamingConsensus.new(obs)
+      vote = consensus.users_vote(nam1, rolf)
+      put(:update, params: { vote: { value: "2" }, id: vote.id,
+                             naming_id: nam1.id, observation_id: obs.id },
+                   format: :turbo_stream)
+
+      # Check that turbo_stream updates the table with the new votes
+      assert_turbo_stream(action: :replace, target: "observation_namings") do
+        assert_select(
+          "observation_naming_#{nam1.id} a.vote-percent",
+          text: "#{nam1.reload.vote_percent.round}%"
+        )
+        assert_select(
+          "observation_naming_#{nam1.id} span.vote-number",
+          text: nam1.votes.length
+        )
+      end
+
+      # Now check that rolf's contribution is adjusted, as with the above test.
+      assert_equal(10, rolf.reload.contribution)
+
+      # Make sure observation was updated right.
+      assert_equal(names(:coprinus_comatus).id, obs.reload.name_id)
+
+      # Check vote.
+      assert_equal(3, nam1.vote_sum)
+      assert_equal(2, nam1.votes.length)
+    end
+
     # Now have Rolf increase his vote for Mary's. (changes consensus)
     # Votes: rolf=2/-3->3, mary=1/3, dick=x/x
     def test_cast_vote_rolf_second_greater

--- a/test/controllers/observations/namings/votes_controller_test.rb
+++ b/test/controllers/observations/namings/votes_controller_test.rb
@@ -82,9 +82,6 @@ module Observations::Namings
                              naming_id: nam1.id, observation_id: obs.id },
                    format: :turbo_stream)
 
-      # Check that turbo_stream updates the table with the new votes
-      assert_response("observations/show/_section_update")
-
       # Now check that rolf's contribution is adjusted, as with the above test.
       assert_equal(10, rolf.reload.contribution)
 

--- a/test/controllers/observations/namings/votes_controller_test.rb
+++ b/test/controllers/observations/namings/votes_controller_test.rb
@@ -83,16 +83,7 @@ module Observations::Namings
                    format: :turbo_stream)
 
       # Check that turbo_stream updates the table with the new votes
-      assert_turbo_stream(action: :replace, target: "observation_namings") do
-        assert_select(
-          "observation_naming_#{nam1.id} a.vote-percent",
-          text: "#{nam1.reload.vote_percent.round}%"
-        )
-        assert_select(
-          "observation_naming_#{nam1.id} span.vote-number",
-          text: nam1.votes.length
-        )
-      end
+      assert_response("observations/show/_section_update")
 
       # Now check that rolf's contribution is adjusted, as with the above test.
       assert_equal(10, rolf.reload.contribution)

--- a/test/controllers/observations_controller/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller/observations_controller_create_test.rb
@@ -819,26 +819,26 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     post(:create, params: params)
     # assert_template(action: expected_page)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
 
     params[:naming][:name] = "Agaricus sp"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
 
     params[:naming][:name] = "Agaricus sp."
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
 
     # Can we create observation with genus and add author?
     params[:naming][:name] = "Agaricus Author"
     params[:approved_name] = "Agaricus Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
     assert_equal("Agaricus Author", agaricus.reload.search_name)
     agaricus.author = nil
     agaricus.search_name = "Agaricus"
@@ -848,7 +848,7 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     params[:approved_name] = "Agaricus sp Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
     assert_equal("Agaricus Author", agaricus.reload.search_name)
     agaricus.author = nil
     agaricus.search_name = "Agaricus"
@@ -858,7 +858,7 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     params[:approved_name] = "Agaricus sp. Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
     assert_equal("Agaricus Author", agaricus.reload.search_name)
 
     # Can we create observation with genus specifying author?
@@ -866,19 +866,19 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
 
     params[:naming][:name] = "Agaricus sp Author"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
 
     params[:naming][:name] = "Agaricus sp. Author"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(agaricus.id, assigns(:observation).name_id)
+    assert_equal(agaricus.id, assigns(:observation).reload.name_id)
 
     # Can we create observation with deprecated genus?
     psalliota = names(:psalliota)
@@ -886,26 +886,26 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     params[:approved_name] = "Psalliota"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(psalliota.id, assigns(:observation).name_id)
+    assert_equal(psalliota.id, assigns(:observation).reload.name_id)
 
     params[:naming][:name] = "Psalliota sp"
     params[:approved_name] = "Psalliota sp"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(psalliota.id, assigns(:observation).name_id)
+    assert_equal(psalliota.id, assigns(:observation).reload.name_id)
 
     params[:naming][:name] = "Psalliota sp."
     params[:approved_name] = "Psalliota sp."
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(psalliota.id, assigns(:observation).name_id)
+    assert_equal(psalliota.id, assigns(:observation).reload.name_id)
 
     # Can we create observation with deprecated genus, adding author?
     params[:naming][:name] = "Psalliota Author"
     params[:approved_name] = "Psalliota Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(psalliota.id, assigns(:observation).name_id)
+    assert_equal(psalliota.id, assigns(:observation).reload.name_id)
     assert_equal("Psalliota Author", psalliota.reload.search_name)
     psalliota.author = nil
     psalliota.search_name = "Psalliota"
@@ -915,7 +915,7 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     params[:approved_name] = "Psalliota sp Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(psalliota.id, assigns(:observation).name_id)
+    assert_equal(psalliota.id, assigns(:observation).reload.name_id)
     assert_equal("Psalliota Author", psalliota.reload.search_name)
     psalliota.author = nil
     psalliota.search_name = "Psalliota"
@@ -925,7 +925,7 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     params[:approved_name] = "Psalliota sp. Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal(psalliota.id, assigns(:observation).name_id)
+    assert_equal(psalliota.id, assigns(:observation).reload.name_id)
     assert_equal("Psalliota Author", psalliota.reload.search_name)
 
     # Can we create new quoted genus?
@@ -934,73 +934,75 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     post(:create, params: params)
     # assert_template(controller: :observations, action: expected_page)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
     assert_equal("Gen. 'One'", assigns(:observation).name.search_name)
 
     params[:naming][:name] = "'Two' sp"
     params[:approved_name] = "'Two' sp"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'Two'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'Two'", assigns(:observation).reload.name.text_name)
     assert_equal("Gen. 'Two'", assigns(:observation).name.search_name)
 
     params[:naming][:name] = "Gen. 'Three' sp."
     params[:approved_name] = "Gen. 'Three' sp."
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'Three'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'Three'", assigns(:observation).reload.name.text_name)
     assert_equal("Gen. 'Three'", assigns(:observation).name.search_name)
 
     params[:naming][:name] = "'One'"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
 
     params[:naming][:name] = "'One' sp"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
 
     params[:naming][:name] = "'One' sp."
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
 
     # Can we create species under the quoted genus?
     params[:naming][:name] = "'One' foo"
     params[:approved_name] = "'One' foo"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One' foo", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One' foo",
+                 assigns(:observation).reload.name.text_name)
 
     params[:naming][:name] = "'One' 'bar'"
     params[:approved_name] = "'One' 'bar'"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One' sp. 'bar'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One' sp. 'bar'",
+                 assigns(:observation).reload.name.text_name)
 
     params[:naming][:name] = "'One' Author"
     params[:approved_name] = "'One' Author"
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
     assert_equal("Gen. 'One' Author", assigns(:observation).name.search_name)
 
     params[:naming][:name] = "'One' sp Author"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
     assert_equal("Gen. 'One' Author", assigns(:observation).name.search_name)
 
     params[:naming][:name] = "'One' sp. Author"
     params[:approved_name] = nil
     post(:create, params: params)
     assert_redirected_to(/#{expected_page}/)
-    assert_equal("Gen. 'One'", assigns(:observation).name.text_name)
+    assert_equal("Gen. 'One'", assigns(:observation).reload.name.text_name)
     assert_equal("Gen. 'One' Author", assigns(:observation).name.search_name)
   end
 

--- a/test/controllers/observations_controller/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller/observations_controller_create_test.rb
@@ -343,7 +343,7 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_equal(where, obs.where)
     assert_equal(names(:coprinus_comatus).id, nam.name_id)
     assert_equal("2.03659",
-                 format("%<vote_cache>.5f", vote_cache: obs.vote_cache))
+                 format("%<vote_cache>.5f", vote_cache: obs.reload.vote_cache))
     assert_not_nil(obs.rss_log)
     # This was getting set to zero instead of nil if no images were uploaded
     # when obs was created.

--- a/test/models/naming_test.rb
+++ b/test/models/naming_test.rb
@@ -34,13 +34,11 @@ class NamingTest < UnitTestCase
     assert(ncc.save)
 
     assert(ncc.errors.full_messages.join("; "))
-    ncc.reload
-    obs.reload
     User.current = rolf
     consensus = Observation::NamingConsensus.new(obs)
     consensus.calc_consensus
-    assert_equal(names(:agaricus_campestris), ncc.name)
-    assert_equal(names(:agaricus_campestris), obs.name)
+    assert_equal(names(:agaricus_campestris), ncc.reload.name)
+    assert_equal(names(:agaricus_campestris), obs.reload.name)
   end
 
   # Make sure it fails if we screw up.

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -149,6 +149,6 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_no_selector(".auto_complete")
     within("#obs_#{obs.id}_naming_form") { click_commit }
     assert_no_selector("#modal_obs_#{obs.id}_naming", wait: 9)
-    within("#namings_table") { assert_text("Peltigeraceae", wait: 6) }
+    within("#observation_namings") { assert_text("Peltigeraceae", wait: 6) }
   end
 end


### PR DESCRIPTION
- [x] Refactor the naming table to use partials with helpers, rather than only using helpers.
- [x] Use Turbo to render a partial update of the namings table _when the consensus has not changed_.
  - Use the same mechanism we do for other partial Turbo updates on the obs show page. In the `turbo_stream` response from `Observations::Namings::VotesController`, re-render the `namings` partial using `views/controllers/observations/show/_section_update.erb`, instead of re-rendering the full page `ObservationsController#show` and counting on Turbo's `idiomorph` to diff the page HTML
  - Easier to debug, can test the turbo response.
- [x] Call the stimulus `section-update_controller` on the `#observation_namings` div. This uses the same mechanism as other updates to hide the active modal after a section is updated. Update the persistent `mo_ajax_progress` modal that shows for vote updates so that it responds to the event dispatched by `section-update`.
- [x] If the consensus changed, keep the current behavior and refresh the whole page. This ensures that the obs title and name info panel are both refreshed with the new consensus name.
- [x] Test that the `turbo_stream` response works and updates records
 
Addresses #3034.