### PR TITLE
Fix advanced search for provisional names

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -91,9 +91,19 @@ class SearchController < ApplicationController
 
       # Treat User field differently; remove angle-bracketed user name,
       # since it was included by the auto-completer only as a hint.
-      val = user_login(params[:search]) if field == :search_user
+      if field == :search_user
+        val = user_login(params[:search])
+      elsif field == :search_name
+        val = parse_search_name(params[:search][:search_name])
+      end
       query_params[field] = val
     end
+  end
+
+  def parse_search_name(search_name)
+    return nil unless search_name
+
+    Name.parse_name(search_name)&.search_name || search_name
   end
 
   def user_login(params)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -30,6 +30,25 @@ class SearchControllerTest < FunctionalTestCase
     end
   end
 
+  def test_advanced_provisional_name
+    login
+    get(:advanced,
+        params: {
+          search: {
+            search_name: 'Cortinarius "sp-IN34"',
+            search_user: "",
+            model: "name",
+            search_content: "",
+            search_where: ""
+          },
+          commit: "Search"
+        }
+       )
+    assert_response(:redirect)
+    query = QueryRecord.find(redirect_to_url.split("=")[-1].dealphabetize)
+    assert_match(names(:provisional_name).text_name, query.description)
+  end
+
   def test_advanced_search_content_filters
     login
     # Make sure all the right buttons and fields are present.


### PR DESCRIPTION
Advanced search should now work with older style provisional names, e.g.: Cortinarius "sp-IN34"