### PR TITLE
Fix a bunch of little vouchering related stuff

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -243,8 +243,8 @@ class FieldSlipsController < ApplicationController
     flash_notice(:field_slip_welcome.t(title: project.title))
     return if project_member
 
-    ProjectMember.create(project:, user:, trust_level: "hidden_gps")
-    flash_notice(:add_members_with_gps_trust.l)
+    ProjectMember.create(project:, user:, trust_level: "editing")
+    flash_notice(:add_members_with_editing.l)
   end
 
   def disconnect_observation(obs)

--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -56,6 +56,7 @@ module ObservationsController::New
     add_list(SpeciesList.safe_find(params[:species_list]))
     @observation.when = params[:date] if params[:date]
     add_field_slip_project(@field_code)
+    check_location
   end
 
   ##############################################################################
@@ -123,6 +124,17 @@ module ObservationsController::New
       @project_checks[proj.id] = (proj == project) ||
                                  (@project_checks[proj.id] &&
                                   proj.field_slip_prefix.nil?)
+    end
+  end
+
+  def check_location
+    if params[:place_name]
+      # Cannot use @place_name since that's being used for approved_where
+      @default_place_name = params[:place_name]
+      loc = Location.place_name_to_location(@default_place_name)
+      @location = loc if loc
+    else
+      @default_place_name = @observation.place_name
     end
   end
 end

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -106,7 +106,7 @@ module Projects
     def find_member(str)
       return User.safe_find(str) if str.to_s.match?(/^\d+$/)
 
-      User.find_by(login: str.to_s.sub(/ <.*>$/, ""))
+      User.lookup_unique_text_name(str)
     end
 
     def update_membership(project, candidate)

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -209,8 +209,8 @@ module Projects
       project_member = ProjectMember.find_by(project:, user:)
       unless project_member
         project_member = ProjectMember.create(project:, user:,
-                                              trust_level: "hidden_gps")
-        flash_notice(:add_members_with_gps_trust.l)
+                                              trust_level: "editing")
+        flash_notice(:add_members_with_editing.l)
       end
       return unless project_member
       return if type == :admin || add

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -118,7 +118,8 @@ class ProjectsController < ApplicationController
     else
       return create_project(title, admin_name, params[:project][:place_name])
     end
-    @project = Project.new
+    @project = Project.new(project_params)
+    @project_dates_any = params[:project][:dates_any].downcase == "true"
     image_ivars
     render(:new, location: new_project_path(q: get_query_param))
   end
@@ -170,6 +171,15 @@ class ProjectsController < ApplicationController
   end
 
   private ############################################################
+
+  def project_params
+    params.require(:project).permit(
+      :open_membership, :title, :summary, :field_slip_prefix, :place_name,
+      :location_id,
+      :"start_date(1i)", :"start_date(2i)", :"start_date(3i)",
+      :"end_date(1i)", :"end_date(2i)", :"end_date(3i)"
+    )
+  end
 
   def image_ivars
     @licenses = License.available_names_and_ids(@user.license)

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -231,8 +231,7 @@ module Tabs
     # FORMS
 
     def observation_form_new_tabs
-      # [new_inat_import_tab, new_herbarium_tab]
-      [new_inat_import_tab]
+      [new_inat_import_tab, observations_index_tab]
     end
 
     def observation_form_edit_tabs(obs:)
@@ -284,24 +283,12 @@ module Tabs
        edit_observation_tab(obs)]
     end
 
-    # This appears to be dead code
-    # def observation_download_tabs
-    #   [observations_index_tab]
-    # end
-
-    # def observations_index_tab
-    #   InternalLink.new(
-    #     :download_observations_back.l,
-    #     add_query_param(observations_path)
-    #   ).tab
-    # end
-
-    # def obs_change_tabs(obs)
-    #   return unless check_permission(obs)
-
-    #   [edit_observation_tab(obs),
-    #    destroy_observation_tab(obs)]
-    # end
+    def observations_index_tab
+      InternalLink.new(
+        :cancel_to_index.t(type: :OBSERVATION),
+        add_query_param(observations_path)
+      ).tab
+    end
 
     def obs_details_links(obs)
       print_labels_button(obs)

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -35,7 +35,7 @@ module Tabs
     end
 
     def projects_index_tab
-      InternalLink.new(:app_list_projects.t, projects_path).tab
+      InternalLink.new(:cancel_to_index.t(type: :PROJECT), projects_path).tab
     end
 
     def new_project_tab

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -95,7 +95,7 @@ module Tabs
     end
 
     def species_list_form_new_tabs
-      [name_lister_tab]
+      [name_lister_tab, species_list_index_tab]
     end
 
     def species_list_form_edit_tabs(list:)
@@ -133,6 +133,12 @@ module Tabs
     def name_lister_tab
       InternalLink.new(
         :name_lister_title.t, new_species_list_name_lister_path
+      ).tab
+    end
+
+    def species_list_index_tab
+      InternalLink.new(
+        :cancel_to_index.t(type: :SPECIES_LIST), species_lists_path
       ).tab
     end
 

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -138,7 +138,8 @@ module Tabs
 
     def species_list_index_tab
       InternalLink.new(
-        :cancel_to_index.t(type: :SPECIES_LIST), species_lists_path
+        :cancel_to_index.t(type: :SPECIES_LIST),
+        add_query_param(species_lists_path)
       ).tab
     end
 

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -33,6 +33,7 @@ t_s = {
                            class: "constrained-label"),
                   tag.span("#{:form_observations_create_locality.l}:",
                            class: "create-label")].safe_join(" "),
+          value: @default_place_name,
           help: observation_location_help,
           hidden_value: location&.id,
           hidden_data: { map_target: "locationId",

--- a/app/views/controllers/projects/_form.html.erb
+++ b/app/views/controllers/projects/_form.html.erb
@@ -18,7 +18,7 @@
                             label: :FIELD_SLIP_PREFIX.t + ":") %>
 
   <%= autocompleter_field(form: f, field: :place_name, type: :location,
-                          label: "#{:WHERE.t}:", between: :required) %>
+                          label: "#{:WHERE.t}:") %>
 
   <%= tag.div(
     tag.p("*#{:form_projects_date_range.t}*".t) +

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -45,7 +45,7 @@
              locals: { button: button } ) %>
 
   <%= autocompleter_field(form: f, field: :place_name, type: :location,
-                          label: "#{:WHERE.l}:", between: :required) %>
+                          label: "#{:WHERE.l}:") %>
 
   <%= render(partial: "species_lists/form/fields_for_member",
              locals: { f: f }) %>

--- a/app/views/controllers/species_lists/_form.html.erb
+++ b/app/views/controllers/species_lists/_form.html.erb
@@ -31,7 +31,7 @@
     end %>
   </div>
 
-  <%= text_field_with_label(form: f, field: :title, between: :required,
+  <%= text_field_with_label(form: f, field: :title,
                             label: "#{:form_species_lists_title.l}:") %>
 
   <%= text_area_with_label(form: f, field: :notes, rows: 12,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -858,6 +858,7 @@
   add_objects: Add [TYPES]
   all_objects: All [TYPES]
   cancel_and_show: Cancel (Show [TYPE])
+  cancel_to_index: Cancel ([TYPE] Index)
   create_object: Create [TYPE]
   destroy_object: Destroy [TYPE]
   edit_object: Edit [TYPE]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3331,7 +3331,7 @@
   # ADMIN-TYPE PAGES
 
   # project/<id>/members/new
-  add_members_with_gps_trust: Hidden GPS data shared with project admins.
+  add_members_with_editing: Project admins can edit your associated observations.
   add_members_change_status: Change Status
   add_members_denied: "Permission denied: only admins for a project can add new members."
   add_members_title: Add [:users] to [title]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -858,7 +858,7 @@
   add_objects: Add [TYPES]
   all_objects: All [TYPES]
   cancel_and_show: Cancel (Show [TYPE])
-  cancel_to_index: Cancel ([TYPE] Index)
+  cancel_to_index: "[:CANCEL] ([TYPE] [:INDEX])"
   create_object: Create [TYPE]
   destroy_object: Destroy [TYPE]
   edit_object: Edit [TYPE]

--- a/config/location/bad_terms.yml
+++ b/config/location/bad_terms.yml
@@ -85,7 +85,6 @@
 "Near ": "near "
 "Rd ": "Rd. "
 "Rd,": "Rd.,"
-"Road,": "Rd.,"
 "St ": "St. "
 "St,": "St.,"
 "Street,": "St.,"

--- a/test/controllers/projects/members_controller_test.rb
+++ b/test/controllers/projects/members_controller_test.rb
@@ -321,7 +321,7 @@ module Projects
       assert_not(target_user.in_group?(eol_project.user_group.name))
       params = {
         project_id: eol_project.id,
-        candidate: "#{target_user.login} <Should Ignore This>"
+        candidate: target_user.unique_text_name
       }
       post_requires_login(:create, params, mary.login)
       assert_redirected_to(project_members_path(eol_project.id))


### PR DESCRIPTION
Items:
- [x] Allow "Road" in location names since that's what Google likes.
- [x] Remove "(required)" from place where it isn't true.
- [x] Add "Cancel" links to Create Observation, Create Observation List, and Create Project pages.
- [x] Correctly pass the place name from the field slip to the create observation form.
- [x] Fix user autocomplete on project member add page
- [x] Flip default on user trust for open projects
- [x] When Create Project encounters error the page is losing the form data
