### PR TITLE
Cancel tab for InatImport Form

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -40,7 +40,7 @@
 # 5. The InatImportJob:
 #      Uses the `code` to obtain an oauth access_token
 #      Trades the oauth token for a JWT api_token
-#      Checks if the MO user is trying to import someone else's obss
+#      Checks if the MO user is trying to import someone else's observations
 #      Makes an authenticated iNat API request for the desired observations
 #      For each iNat obs in the results,
 #         creates an Inat::Obs

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -11,8 +11,8 @@
 # 1. User calls `new`, fills out form
 #    Adds a InatImport instance if user lacks one
 # 2. create
-#      saves some user data in a InatImport instance
-#        attributes include: user, inat_ids, token, state
+#    saves some user data in a InatImport instance
+#      attributes include: user, inat_ids, token, state
 #    passes things off (redirects) to iNat at the INAT_AUTHORIZATION_URL
 # 3. iNat
 #    checks if MO is authorized to access iNat user's confidential data
@@ -40,7 +40,7 @@
 # 5. The InatImportJob:
 #      Uses the `code` to obtain an oauth access_token
 #      Trades the oauth token for a JWT api_token
-#      Checks if the MO user is trying to import some else's obss
+#      Checks if the MO user is trying to import someone else's obss
 #      Makes an authenticated iNat API request for the desired observations
 #      For each iNat obs in the results,
 #         creates an Inat::Obs

--- a/app/helpers/tabs/inat_imports_helper.rb
+++ b/app/helpers/tabs/inat_imports_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# html used in tabsets
+module Tabs
+  module InatImportsHelper
+    def inat_import_form_new_tabs
+      [cancel_to_observation_create_tab]
+    end
+
+    def cancel_to_observation_create_tab
+      InternalLink.new(:cancel_and_create.t(type: :OBSERVATION),
+                       new_observation_path).tab
+    end
+  end
+end

--- a/app/views/controllers/inat_imports/new.html.erb
+++ b/app/views/controllers/inat_imports/new.html.erb
@@ -1,5 +1,6 @@
 <%
   add_page_title(:inat_import_create_title.l)
+  add_context_nav(inat_import_form_new_tabs)
 %>
 
 <div>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -857,7 +857,7 @@
   add_object: Add [TYPE]
   add_objects: Add [TYPES]
   all_objects: All [TYPES]
-  cancel_and_create: Cancel (Create [TYPE])
+  cancel_and_create: "[:CANCEL] ([:CREATE] [TYPE])"
   cancel_and_show: Cancel (Show [TYPE])
   create_object: Create [TYPE]
   destroy_object: Destroy [TYPE]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -857,6 +857,7 @@
   add_object: Add [TYPE]
   add_objects: Add [TYPES]
   all_objects: All [TYPES]
+  cancel_and_create: Cancel (Create [TYPE])
   cancel_and_show: Cancel (Show [TYPE])
   create_object: Create [TYPE]
   destroy_object: Destroy [TYPE]

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -16,11 +16,7 @@ end
 # test importing iNaturalist Observations to Mushroom Observer
 class InatImportsControllerTest < FunctionalTestCase
   include ActiveJob::TestHelper
-
-  SITE = InatImportsController::SITE
-  REDIRECT_URI = InatImportsController::REDIRECT_URI
-  API_BASE = InatImportsController::API_BASE
-  MO_API_KEY_NOTES = InatImportsController::MO_API_KEY_NOTES
+  include Inat::Constants
 
   def test_show
     import = inat_imports(:rolf_inat_import)


### PR DESCRIPTION
Add a `Cancel` tab to the new InatImport view.

- Analog to the `Cancel` tabs added in #3076. See the [Slack conversation](https://mushroomobserver.slack.com/archives/C040TH9FV/p1752280354266689):

> Yeah, cancel buttons/links are unnecessary, but I expect many users don’t think that way.
Just added cancel wording/links to several create pages.  It’s a simple thing to do and if it reduces users friction seems worth it.

- Resolves #3079 

### Manual Test

- http://localhost:3000/inat_imports/new
Expected result: There should be a Cancel tab
- Click the tab
Expected result: Create Observation