### PR TITLE
Return to Tracker if InatJob pending

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -72,7 +72,7 @@ class InatImportsController < ApplicationController
     return unless @inat_import.pending?
 
     tracker = InatImportJobTracker.where(inat_import: @inat_import).last
-    flash_error(:inat_import_tracker_pending.t)
+    flash_warning(:inat_import_tracker_pending.l)
     redirect_to(
       inat_import_path(@inat_import, params: { tracker_id: tracker.id })
     )

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -71,7 +71,8 @@ class InatImportsController < ApplicationController
     @inat_import = InatImport.find_or_create_by(user: @user)
     return unless @inat_import.job_pending?
 
-    tracker = InatImportJobTracker.where(inat_import: @inat_import).last
+    tracker = InatImportJobTracker.where(inat_import: @inat_import).
+              order(:created_at).last
     flash_warning(:inat_import_tracker_pending.l)
     redirect_to(
       inat_import_path(@inat_import, params: { tracker_id: tracker.id })

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -69,7 +69,7 @@ class InatImportsController < ApplicationController
 
   def new
     @inat_import = InatImport.find_or_create_by(user: @user)
-    return unless @inat_import.pending?
+    return unless @inat_import.job_pending?
 
     tracker = InatImportJobTracker.where(inat_import: @inat_import).last
     flash_warning(:inat_import_tracker_pending.l)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -48,8 +48,8 @@ class InatImport < ApplicationRecord
   # (Only gets used once.)
   BASE_AVG_IMPORT_SECONDS = 15
 
-  def pending?
-    %w[Authorizing Authenticating Importing].include?(state)
+  def job_pending?
+    %w[Authenticating Importing].include?(state)
   end
 
   def add_response_error(error)

--- a/app/models/inat_import_job_tracker.rb
+++ b/app/models/inat_import_job_tracker.rb
@@ -3,11 +3,12 @@
 # For display of status of an InatImportJob
 #
 # == Attributes
-#  inat_import::  id of the iNatImport for the job
+#  inat_import::   id of the iNatImport for the job
 #
 # == Methods
-#  status::           state of the iNat import of this tracker
+#  status::        state of the iNat import of this tracker
 #  elapsed_time::  time since the tracker was created
+#  help::          help message displayed at the bottom of the page
 #
 class InatImportJobTracker < ApplicationRecord
   delegate :ended_at, to: :import
@@ -43,6 +44,14 @@ class InatImportJobTracker < ApplicationRecord
       ""
     else
       "#{:ERRORS.t}: "
+    end
+  end
+
+  def help
+    if status == "Done"
+      :inat_import_tracker_done.l
+    else
+      :inat_import_tracker_leave_page.l
     end
   end
 

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -52,6 +52,9 @@
 
       tag.span(tracker.error_caption, class: "font-weight-bold"),
       tag.span(tracker.response_errors, class: "violation-highlight"),
+      tag.br,
+
+      tag.p(tracker.help, class: "alert alert-warning mt-3"),
       tag.br
     ].safe_join
   end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3110,9 +3110,11 @@
   inat_import_tracker_calculating_time: "Calculating ..."
   inat_import_tracker_ended: Ended
   inat_import_imported: Imported
+  inat_import_tracker_done: "Click [:inat_import_tracker_results] to see imported Observations."
   inat_import_tracker_results: Results
   inat_import_tracker_importable_count: Number of Importable Observations
   inat_import_tracker_imported_count: Number Imported
+  inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.
   inat_import_tracker_pending: Please wait until your pending iNat Import is Done before starting a new one.
   inat_importables_explanation: "An ??importable?? observation is an iNaturalist observation: which you created, which does not exist in MO, and whose iNat identity is a fungus or slime mold."
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -55,9 +55,8 @@ class InatImportsControllerTest < FunctionalTestCase
     login(user.login)
     get(:new)
 
-    assert_flash_error(
-      "Should flash error when user tries to start a new iNat import " \
-      "while another is already in progress"
+    assert_flash_warning(
+      "Should flash warning if user starts iNat import while another is running"
     )
     assert_redirected_to(
       inat_import_path(import, params: { tracker_id: tracker.id })


### PR DESCRIPTION
- Fixes an issue in InatImport#new:
   Prevents it from going to the Tracker page (which displays the Job status) before the Job is created.
- Tracker page (which displays the Job status) has different text depending on whether the Job is complete:
  - If incomplete, tells user they can leave the page, and how to return.
  - If complete, tells user to view the results of the Job (i.e., the newly imported Observations). 
