### PR TITLE
Validation on Herbarium object to ensure code field is unique

### DIFF
--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -63,11 +63,8 @@ class Herbarium < AbstractModel
   # personal_user_id is set to mark whose personal herbarium it is.
   belongs_to :personal_user, class_name: "User"
 
-  # Was unable to create an appropriate index that made Trilogy
-  # happy.
-  # rubocop:disable Rails/UniqueValidationWithoutIndex
-  validates :code, uniqueness: true, allow_blank: true
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
+  # Was unable to create an appropriate index that made Trilogy happy.
+  validates :code, uniqueness: true, allow_blank: true # rubocop:disable Rails/UniqueValidationWithoutIndex
 
   scope :order_by_default,
         -> { order_by(::Query::Herbaria.default_order) }


### PR DESCRIPTION
Related to #3082.  I attempted to create an appropriate index and kept running into issues.  Even tried switching from using '' as the defeault to nil which I got working from the MySQL side of things, but then it caused Query to fail due to an issue with CONCAT failing with `nil` values vs. blank strings.

This solution works, but is not ideal.  It is only doing the uniqueness constraint in Rails which can fail if multiple folks are trying to add an herbarium with the same code at the same time.  However, this seems extremely unlikely and in any case the consequences aren't that severe.