### PR TITLE
Silence most SolidQueue and Turbo in development log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem("turbo-rails")
 # redis for combining actioncable broadcasts with turbo_stream
 gem("redis", "~> 4.0")
 # minimal two way bridge between the V8 JavaScript engine and Ruby
+# Locked here because "0.19.0" will not compile for nimmolo
 gem("mini_racer", "~> 0.18.1")
 
 # Add Arel helpers for more concise query syntax in Arel

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem("turbo-rails")
 # redis for combining actioncable broadcasts with turbo_stream
 gem("redis", "~> 4.0")
 # minimal two way bridge between the V8 JavaScript engine and Ruby
-gem("mini_racer")
+gem("mini_racer", "~> 0.18.1")
 
 # Add Arel helpers for more concise query syntax in Arel
 # https://github.com/camertron/arel-helpers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,12 +248,12 @@ GEM
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)
-    libv8-node (24.1.0.0)
-    libv8-node (24.1.0.0-aarch64-linux)
-    libv8-node (24.1.0.0-arm64-darwin)
-    libv8-node (24.1.0.0-x86_64-darwin)
-    libv8-node (24.1.0.0-x86_64-linux)
-    libv8-node (24.1.0.0-x86_64-linux-musl)
+    libv8-node (23.6.1.0)
+    libv8-node (23.6.1.0-aarch64-linux)
+    libv8-node (23.6.1.0-arm64-darwin)
+    libv8-node (23.6.1.0-x86_64-darwin)
+    libv8-node (23.6.1.0-x86_64-linux)
+    libv8-node (23.6.1.0-x86_64-linux-musl)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -273,8 +273,8 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.5)
-    mini_racer (0.19.0)
-      libv8-node (~> 24.1.0.0)
+    mini_racer (0.18.1)
+      libv8-node (~> 23.6.1.0)
     minitest (5.25.5)
     minitest-reporters (1.7.1)
       ansi
@@ -602,7 +602,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mimemagic
-  mini_racer
+  mini_racer (~> 0.18.1)
   minitest
   minitest-reporters
   mission_control-jobs

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -135,7 +135,7 @@ MushroomObserver::Application.configure do
   #   # .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
   # end
   # config.logger = ActiveSupport::BroadcastLogger.new(*loggers)
-  config.logger = ActiveSupport::Logger.new($stdout)
+  # config.logger = ActiveSupport::Logger.new($stdout)
 
   # Silence Solid Queue polling in the logs
   ENV["SOLID_QUEUE_LOG_ON"] = "false" # used by a temporary hack below

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -135,6 +135,12 @@ MushroomObserver::Application.configure do
   #   # .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
   # end
   # config.logger = ActiveSupport::BroadcastLogger.new(*loggers)
+  config.logger = ActiveSupport::Logger.new($stdout)
+
+  # Silence Solid Queue polling in the logs
+  ENV["SOLID_QUEUE_LOG_ON"] = "false" # used by a temporary hack below
+  config.solid_queue.logger = false
+  config.solid_queue.silence_polling = true
 
   # Serve assets in rails.
   config.public_file_server.enabled = true
@@ -176,6 +182,27 @@ MushroomObserver::Application.configure do
   # Set up ActionCable to use a standalone server at port 28080
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "ws://localhost:28080" # use :wss in production
+end
+
+# Temporary hack until config.solid_queue.silence_queries is available
+# https://github.com/rails/solid_queue/issues/210
+module SilenceSolidQueue
+  def heartbeat
+    # only silence if explicitly set to not log (default to logging)
+    # true or not set (or anything else) means log, "false" means silence
+    silence_heartbeat = ENV["SOLID_QUEUE_LOG_ON"] == "false"
+
+    # if ActiveRecord::Base.logger
+    if silence_heartbeat && ActiveRecord::Base.logger
+      ActiveRecord::Base.logger.silence { super }
+    else
+      super
+    end
+  end
+end
+
+Rails.application.config.after_initialize do
+  SolidQueue::Process.prepend(SilenceSolidQueue)
 end
 
 file = File.expand_path("../consts-site.rb", __dir__)


### PR DESCRIPTION
Note: Also downgrades gem `mini_racer` to 0.18.1, because current 0.19.1 doesn't compile for me locally.