### PR TITLE
Add herbarium code index

### DIFF
--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -88,7 +88,7 @@ class Herbarium < AbstractModel
         ->(str) { search_columns(Herbarium[:mailing_address], str) }
 
   scope :pattern, lambda { |phrase|
-    cols = (Herbarium[:code] + Herbarium[:name] +
+    cols = (Herbarium[:code].coalesce("") + Herbarium[:name] +
             Herbarium[:description].coalesce("") +
             Herbarium[:mailing_address].coalesce(""))
     search_columns(cols, phrase).distinct

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -64,7 +64,7 @@ class Herbarium < AbstractModel
   belongs_to :personal_user, class_name: "User"
 
   # Was unable to create an appropriate index that made Trilogy happy.
-  validates :code, uniqueness: true, allow_blank: true # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :code, uniqueness: true, allow_blank: true
 
   scope :order_by_default,
         -> { order_by(::Query::Herbaria.default_order) }

--- a/db/migrate/20250714142904_add_unique_index_to_herbaria_code.rb
+++ b/db/migrate/20250714142904_add_unique_index_to_herbaria_code.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToHerbariaCode < ActiveRecord::Migration[7.2]
+  def up
+    change_column(:herbaria, :code, :string, limit: 8, null: true, default: nil)
+    execute("UPDATE herbaria SET code = NULL WHERE code = ''")
+    add_index(:herbaria, :code, unique: true, where: "code IS NOT NULL")
+  end
+
+  def down
+    remove_index(:herbaria, :code)
+    execute("UPDATE herbaria SET code = '' WHERE code is NULL")
+    change_column(:herbaria, :code, :string, limit: 8, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_22_170532) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_14_142904) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -150,8 +150,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_22_170532) do
     t.text "description"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.string "code", limit: 8, default: "", null: false
+    t.string "code", limit: 8
     t.integer "personal_user_id"
+    t.index ["code"], name: "index_herbaria_on_code", unique: true
   end
 
   create_table "herbarium_curators", charset: "utf8mb3", force: :cascade do |t|

--- a/test/fixtures/herbaria.yml
+++ b/test/fixtures/herbaria.yml
@@ -20,16 +20,19 @@ nybg_herbarium:
 rolf_herbarium:
   name: "Uncle Rolf's Personal Herbarium"
   personal_user: rolf
+  code: null
   curators: rolf
 
 # Empty herbarium
 dick_herbarium:
   name: "Dick's Personal Herbarium"
   personal_user: dick
+  code: null
   curators: dick
 
 fundis_herbarium:
   name: "Fungal Diversity Survey"
+  code: null
 
 field_museum:
   name: The Field Museum
@@ -39,3 +42,4 @@ field_museum:
 
 curatorless_herbarium:
   name: $LABEL
+  code: null


### PR DESCRIPTION
Adds an SQL index to the herbaria table.  This now works correct since the pattern scope for herbaria now does a coalesce to address null values in the code field.