### PR TITLE
Enable import all

### DIFF
--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -42,11 +42,9 @@ class Inat
       query_args = {
         id: nil, id_above: nil, only_id: false, per_page: 200,
         order: "asc", order_by: "id",
-        # obss of only the iNat user with iNat login @inat_import.inat_username
-        user_login: nil,
-        # only fungi and slime molds
-        iconic_taxa: ICONIC_TAXA,
-        # and which haven't been exported from or inported to MO
+        user_login: nil, # only observations of by InatImport.inat_username
+        iconic_taxa: ICONIC_TAXA, # of only fungi and slime molds
+        # which weren't exported from/imported to MO
         without_field: "Mushroom Observer URL"
       }.merge(args)
       headers = { authorization: "Bearer #{@importer.token}", accept: :json }

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -34,10 +34,14 @@ module InatImportsController::Validators
   end
 
   def imports_designated?
-    return true if params[:all] == "1" || params[:inat_ids].present?
+    return true if importing_all_observations? || params[:inat_ids].present?
 
     flash_warning(:inat_no_imports_designated.t)
     false
+  end
+
+  def importing_all_observations?
+    params[:all] == "1"
   end
 
   def list_within_size_limits?
@@ -62,7 +66,10 @@ module InatImportsController::Validators
     params[:inat_ids].delete(" ").split(",").map(&:to_i)
   end
 
+  # Was Obseervation previously "mirrored" to iNat by Pulk's `mirror` script?
   def unmirrored?
+    return true if importing_all_observations?
+
     conditions = inat_id_list.map do |inat_id|
       Observation[:notes].matches("%Mirrored on iNaturalist as <a href=\"https://www.inaturalist.org/observations/#{inat_id}\">%")
     end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -112,11 +112,7 @@ class InatImportJob < ApplicationJob
 
   # limit iNat API search to observations by iNat user with this login
   def restricted_user_login
-    if super_importer?
-      nil
-    else
-      inat_import.inat_username
-    end
+    inat_import.inat_username
   end
 
   def import_page(page)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -12,7 +12,7 @@
 #                          depending on the state of the import
 #                          https://www.inaturalist.org/pages/api+reference#authorization_code_flow
 #  inat_ids::              string of id's of iNat obss to be imported
-#  inat_username::         this user's iNat login
+#  inat_username::         iNat login of user whose obss are being imported
 #  import_all:             whether to import all of user's relevant iNat obss
 #  importables::           number of importable observations in job
 #  imported_count::        running count of iNat obss imported in associated job

--- a/app/views/controllers/inat_imports/new.html.erb
+++ b/app/views/controllers/inat_imports/new.html.erb
@@ -15,7 +15,7 @@
       <%= f.label(:inat_id, "#{:inat_import_list.l}: ") %>
       <%= f.text_field(:inat_ids, size: 10, value: @inat_ids,
           class: "form-control") %>
-      <%#= check_box_with_label(form: f, field: :all,
+      <%= check_box_with_label(form: f, field: :all,
                                class: "mt-3", label: :inat_import_all.t) %>
     <% end %>
 


### PR DESCRIPTION
Allow an MO user to import all their iNat observations by checking the Import All box.


