### PR TITLE
Use the location.name if @default_place_name is not set

### DIFF
--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -33,7 +33,7 @@ t_s = {
                            class: "constrained-label"),
                   tag.span("#{:form_observations_create_locality.l}:",
                            class: "create-label")].safe_join(" "),
-          value: @default_place_name,
+          value: @default_place_name || location&.name,
           help: observation_location_help,
           hidden_value: location&.id,
           hidden_data: { map_target: "locationId",

--- a/test/controllers/observations_controller/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller/observations_controller_show_test.rb
@@ -424,6 +424,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_select("a[href=?]",
                   reuse_images_for_observation_path(obs.id), minimum: 1)
     get(:edit, params: { id: obs.id })
+    assert_match(obs.location.name, response.body)
     assert_response(:success)
 
     login("dick") # Project permission


### PR DESCRIPTION
To test:

Go to an observation you own.
Click Edit Observation.
Currently the "Locality" field is shown as empty.
On the branch, the correct location name should be shown.