### PR TITLE
Fix issue with editing namings

### DIFF
--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -75,7 +75,7 @@ module Observations
       return redirect_to_obs(@observation) unless check_permission!(@naming)
 
       @consensus = Observation::NamingConsensus.new(@observation)
-      @vote = @consensus.owners_vote(@naming)
+      @vote = @consensus.users_vote(@naming, @user)
 
       if can_update?
         need_new_naming? ? create_new_naming : change_naming

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -59,7 +59,7 @@ module Observations
 
       init_edit_ivars
       @consensus = Observation::NamingConsensus.new(@observation)
-      @vote = @consensus.owners_vote(@naming)
+      @vote = @consensus.users_vote(@naming, @user)
 
       respond_to do |format|
         format.turbo_stream { render_modal_naming_form }

--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -24,7 +24,6 @@
 # db lookups have been moved here.
 #
 #  name_been_proposed?::    Has someone proposed this Name already?
-#  owners_votes::           Get all of the onwer's Vote's for this Observation.
 #  owner_preference::       owners's unique prefered Name (if any) for this Obs
 #  consensus_naming::       Guess which Naming is responsible for consensus.
 #  calc_consensus::         Calculate and cache the consensus naming/name.
@@ -35,7 +34,6 @@
 #  user_voted?::            Has a given User voted on this Naming?
 #  owner_voted?::           Has the owner voted on a given Naming?
 #  users_vote::             Get a given User's Vote on this Naming.
-#  owners_vote::            Owner's Vote on a given Naming.
 #  users_favorite?::        Is this Naming the given User's favorite?
 #  owners_favorite?::       Is a given Naming one of the owner's favorite(s)?
 #  change_vote::            Change a given User's Vote for a given Naming.
@@ -150,11 +148,6 @@ class Observation
       !users_vote(naming, user).nil?
     end
 
-    # Get the owner's Vote on a given Naming.
-    def owners_vote(naming)
-      users_vote(naming, @observation.user)
-    end
-
     # Get a given User's Vote on a given Naming.
     def users_vote(naming, user)
       votes.select do |v|
@@ -200,12 +193,6 @@ class Observation
       votes.any? do |v|
         v.user_id == user&.id && v.naming_id == naming.id && v.favorite
       end
-    end
-
-    # All of observation.user's votes on all Namings for this Observation
-    # Used in Observation and in tests
-    def owners_votes
-      user_votes(@observation.user)
     end
 
     # All of a given User's votes on all Namings for this Observation

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -39,6 +39,14 @@ module Observations
       )
     end
 
+    def test_edit_obs_owner_with_different_vote
+      nam = namings(:coprinus_comatus_other_naming)
+      params = { observation_id: nam.observation_id, id: nam.id.to_s }
+      login(nam.user.login)
+      get(:edit, params: params)
+      assert_select('option[selected="selected"][value="3.0"]', text: "I'd Call It That")
+    end
+
     def test_edit_naming_no_votes
       nam = namings(:minimal_unknown_naming)
       assert_empty(nam.votes)

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -75,6 +75,20 @@ module Observations
       assert_select("option[selected]", count: 2)
     end
 
+    def test_update_observation_new_name_different_user
+      login("mary")
+      nam = namings(:coprinus_comatus_other_naming)
+      new_name = "Easter bunny"
+      params = {
+        observation_id: nam.observation_id,
+        id: nam.id.to_s,
+        naming: { name: new_name }
+      }
+      put(:update, params: params)
+      assert_select('option[selected="selected"][value="3.0"]',
+                    text: "I'd Call It That")
+    end
+
     def test_update_observation_approved_new_name
       login("rolf")
       nam = namings(:coprinus_comatus_naming)

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -44,7 +44,8 @@ module Observations
       params = { observation_id: nam.observation_id, id: nam.id.to_s }
       login(nam.user.login)
       get(:edit, params: params)
-      assert_select('option[selected="selected"][value="3.0"]', text: "I'd Call It That")
+      assert_select('option[selected="selected"][value="3.0"]',
+                    text: "I'd Call It That")
     end
 
     def test_edit_naming_no_votes

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -594,7 +594,7 @@ class ObservationTest < UnitTestCase
     assert_not(consensus.user_voted?(namg1, rolf))
     assert_not(consensus.user_voted?(namg1, mary))
     assert_not(consensus.user_voted?(namg1, dick))
-    assert_nil(consensus.owners_vote(namg1))
+    assert_nil(consensus.users_vote(namg1, obs.user))
     assert_nil(consensus.users_vote(namg1, rolf))
     assert_nil(consensus.users_vote(namg1, mary))
     assert_nil(consensus.users_vote(namg1, dick))
@@ -622,7 +622,8 @@ class ObservationTest < UnitTestCase
     obs.reload
     assert(consensus.owner_voted?(namg1))
     assert(consensus.user_voted?(namg1, rolf))
-    assert(vote = consensus.owners_vote(namg1))
+
+    assert(vote = consensus.users_vote(namg1, obs.user))
     assert_equal(vote, consensus.users_vote(namg1, rolf))
     assert(consensus.owners_favorite?(namg1))
     assert(consensus.users_favorite?(namg1, rolf))

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -749,7 +749,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     new_obs = Observation.last
     consensus = Observation::NamingConsensus.new(new_obs)
     assert_names_equal(expected_values[:name], new_obs.name)
-    assert_equal(expected_values[:vote], consensus.owners_votes.first.value)
+    assert_equal(expected_values[:vote], consensus.user_votes(new_obs.user).first.value)
   end
 
   def assert_observation_has_correct_image(expected_values)

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -749,7 +749,8 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     new_obs = Observation.last
     consensus = Observation::NamingConsensus.new(new_obs)
     assert_names_equal(expected_values[:name], new_obs.name)
-    assert_equal(expected_values[:vote], consensus.user_votes(new_obs.user).first.value)
+    assert_equal(expected_values[:vote],
+                 consensus.user_votes(new_obs.user).first.value)
   end
 
   def assert_observation_has_correct_image(expected_values)


### PR DESCRIPTION
The problem scenario is when a user other than the owner of the observation creates a naming and then goes to edit that naming.  To reproduce:

1) Find an observation owned by another user.
2) Add a new name and vote for it with a value.
3) Edit the naming.

Currently, the vote field will say "No Opinion" rather than the vote value you just cast.
On the branch, the vote field should correctly show you the vote value you cast.

The issue is that it was only looking for votes owned by the owner of the observation.  Since the owner has necessarily not voted for the naming you just added, it gets "No Opinion".

Added a test for this scenario which fails on current main and succeeds on the branch.  I played around a bit with other circumstances and couldn't find any other edge cases that now misbehave, but it's worth poking at it more.  This issue may have been introduced as part of the modal refactor, but it also might be ancient bug that no one ever noticed/reported.

This issue was reported via email to webmaster@ by Igor at Jul 17, 2025, 11:20 PM.