### PR TITLE
Remove Redis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,8 +71,6 @@ gem("stimulus-rails")
 gem("requestjs-rails")
 # turbo for partial page updates
 gem("turbo-rails")
-# redis for combining actioncable broadcasts with turbo_stream
-gem("redis", "~> 4.0")
 # minimal two way bridge between the V8 JavaScript engine and Ruby
 # Locked here because "0.19.0" will not compile for nimmolo
 gem("mini_racer", "~> 0.18.1")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,6 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
-    redis (4.8.1)
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -614,7 +613,6 @@ DEPENDENCIES
   puma
   rails-controller-testing
   railties (~> 7.2.2.1)
-  redis (~> 4.0)
   requestjs-rails
   rest-client
   rqrcode


### PR DESCRIPTION
Per @nimmolo "I dont think we need Redis at all. Solid Queue and Cable got rid of the uses for it."
(This PR catalyzed by Dependabot PR [Bump redis from 4.8.1 to 5.4.1 #3117](https://github.com/MushroomObserver/mushroom-observer/pull/3117))