### PR TITLE
Cancel button for InatImportJob

### DIFF
--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -3,6 +3,7 @@
 class Inat
   class ObservationImporter
     include Inat::Constants
+    attr_reader :inat_import, :user
 
     def initialize(inat_import, user)
       @inat_import = inat_import
@@ -11,6 +12,8 @@ class Inat
 
     def import_page(page)
       page["results"].each do |result|
+        return false if inat_import.canceled?
+
         import_one_result(JSON.generate(result))
       end
     end

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -16,7 +16,7 @@ class Inat
 
     def import_page(page)
       page["results"].each do |result|
-        return false if inat_import.canceled?
+        return false if inat_import.reload.canceled?
 
         import_one_result(JSON.generate(result))
       end

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -3,6 +3,7 @@
 class Inat
   class ObservationImporter
     include Inat::Constants
+
     attr_reader :inat_import, :user
 
     def initialize(inat_import, user)

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Inat
+  # Import a page of parsed iNat API observation search results,
+  # using Inat::Obs to parse each result and
+  # Inat::MoObservationBuilder to create an MO Observation.
   class ObservationImporter
     include Inat::Constants
 

--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Inat
+  # Get one page of observations results (up to 200) from the iNat API,
+  # https://api.inaturalist.org/v1/docs/#!/Observations/get_observations
+  # returning a parsed JSON object.
   class PageParser
     include Inat::Constants
 
@@ -13,14 +16,11 @@ class Inat
       @restricted_user_login = restricted_user_login
     end
 
-    # Get one page of observations (up to 200)
-    # This is where we actually hit the iNat API
-    # https://api.inaturalist.org/v1/docs/#!/Observations/get_observations
-    # https://stackoverflow.com/a/11251654/3357635
     # NOTE: The `ids` parameter may be a comma-separated list of iNat obs
     # ids - that needs to be URL encoded to a string when passed as an arg here
     # because URI.encode_www_form deals with arrays by passing the same key
     # multiple times.
+    # https://stackoverflow.com/a/11251654/3357635
     def next_page
       result = next_request(id: @ids, id_above: @last_import_id,
                             user_login: @restricted_user_login)

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -181,11 +181,10 @@ class InatImportsController < ApplicationController
   public
 
   def cancel
-    inat_import = InatImport.find(params[:id])
-    inat_import.update(cancel: true)
-    tracker = InatImportJobTracker.where(inat_import: inat_import).
-              order(:created_at).last
-    redirect_to(inat_import_path(inat_import,
-                                 params: { tracker_id: tracker.id }))
+    @inat_import = InatImport.find(params[:id])
+    @inat_import.update(cancel: true)
+    @tracker = InatImportJobTracker.where(inat_import: @inat_import).
+               order(:created_at).last
+    render(:show)
   end
 end

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -185,7 +185,6 @@ class InatImportsController < ApplicationController
     inat_import.update(cancel: true)
     tracker = InatImportJobTracker.where(inat_import: inat_import).
               order(:created_at).last
-    # flash_warning(:inat_import_tracker_canceled.l)
     redirect_to(inat_import_path(inat_import,
                                  params: { tracker_id: tracker.id }))
   end

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -117,7 +117,8 @@ class InatImportsController < ApplicationController
       response_errors: "",
       token: "",
       log: [],
-      ended_at: nil
+      ended_at: nil,
+      cancel: false
     )
   end
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -6,6 +6,7 @@
 # new (get)
 # create (post)
 # authorization_response (get)
+# cancel (post):: cancels the InatImportJob
 #
 # Work flow:
 # 1. User calls `new`, fills out form
@@ -174,5 +175,17 @@ class InatImportsController < ApplicationController
     # clean out this user's old tracker(s)
     InatImportJobTracker.where(inat_import: inat_import.id).destroy_all
     InatImportJobTracker.create(inat_import: inat_import.id)
+  end
+
+  public
+
+  def cancel
+    inat_import = InatImport.find(params[:id])
+    inat_import.update(cancel: true)
+    tracker = InatImportJobTracker.where(inat_import: inat_import).
+              order(:created_at).last
+    # flash_warning(:inat_import_tracker_canceled.l)
+    redirect_to(inat_import_path(inat_import,
+                                 params: { tracker_id: tracker.id }))
   end
 end

--- a/app/helpers/inat_import_job_trackers_helper.rb
+++ b/app/helpers/inat_import_job_trackers_helper.rb
@@ -9,6 +9,17 @@ module InatImportJobTrackersHelper
     inat_import.state != "Done"
   end
 
+  def remaining_time_in_hours_minutes_seconds(tracker)
+    # force remaining time to be 0 if the Job is done
+    # prevents displaying :inat_import_tracker_calculating_time.l
+    time = if tracker.status == "Done"
+             0
+           else
+             tracker.estimated_remaining_time
+           end
+    time_in_hours_minutes_seconds(time)
+  end
+
   def time_in_hours_minutes_seconds(seconds)
     return :inat_import_tracker_calculating_time.l if seconds.nil?
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -108,7 +108,7 @@ class InatImportJob < ApplicationJob
     return false if page_empty?(parsed_page)
 
     observation_importer.import_page(parsed_page)
-    return false if canceled?
+    return false if inat_import.reload.canceled?
 
     parser.last_import_id = parsed_page["results"].last["id"]
     more_pages?(parsed_page)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -9,6 +9,7 @@ class InatImportJob < ApplicationJob
 
   delegate :token, to: :inat_import
   delegate :user, to: :inat_import
+  delegate :canceled?, to: :inat_import
 
   def perform(inat_import)
     create_ivars(inat_import)
@@ -92,6 +93,7 @@ class InatImportJob < ApplicationJob
     return false if page_empty?(parsed_page)
 
     import_page(parsed_page)
+    return import_canceled if canceled?
 
     parser.last_import_id = parsed_page["results"].last["id"]
     return true unless last_page?(parsed_page)
@@ -102,6 +104,11 @@ class InatImportJob < ApplicationJob
 
   def page_empty?(page)
     page["total_results"].zero?
+  end
+
+  def import_canceled # rubocop:disable Naming/PredicateMethod
+    log("Import canceled by user")
+    false
   end
 
   def last_page?(parsed_page)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -84,6 +84,15 @@ class InatImportJob < ApplicationJob
     inat_import.inat_ids.delete(" ")
   end
 
+  # limit iNat API search to observations by iNat user with this login
+  def restricted_user_login
+    if super_importer?
+      nil # Super importers can import anyone's iNat observations
+    else
+      inat_import.inat_username
+    end
+  end
+
   # Import the next page of iNat API results,
   # returning true if there are more pages of results, false if done.
   def parsing?(parser)
@@ -107,15 +116,6 @@ class InatImportJob < ApplicationJob
 
   def more_pages?(parsed_page)
     parsed_page["total_results"] > parsed_page["page"] * parsed_page["per_page"]
-  end
-
-  # limit iNat API search to observations by iNat user with this login
-  def restricted_user_login
-    if super_importer?
-      nil
-    else
-      inat_import.inat_username
-    end
   end
 
   def import_page(page)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -122,10 +122,6 @@ class InatImportJob < ApplicationJob
     parsed_page["total_results"] > parsed_page["page"] * parsed_page["per_page"]
   end
 
-  def import_page(page)
-    observation_importer.import_page(page)
-  end
-
   def observation_importer
     @observation_importer ||=
       ::Inat::ObservationImporter.new(inat_import, user)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -23,12 +23,15 @@
 #  last_obs_start          when started importing a single iNat obs
 #                          reset in InatImportsController#authorization_response
 #                          and in Job after each observation import
+#  cancel/canceled::       Did the user requested canceling the Job
 #
 # == Methods
 #  total_expected_time     total expected time for associated Job
 #  last_obs_elapsed_time   time spent importing a single iNat obs
 #
 class InatImport < ApplicationRecord
+  alias_attribute :canceled, :cancel # for readability, e.g., job.canceled?
+
   enum :state, {
     Unstarted: 0,
     # waiting for User to authorize MO to access iNat data

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -7,7 +7,7 @@
         [
           # Status: <status>
           tag.span(class: "font-weight-bold") do
-            "#{:STATUS.}: "
+            "#{:STATUS}: "
           end,
           tag.span(tracker.status),
           tag.br,

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -39,9 +39,7 @@
       tag.span(class: "font-weight-bold") do
         "#{:inat_import_tracker_estimated_remaining_time.l}: "
       end,
-      tag.span(
-        time_in_hours_minutes_seconds(tracker.estimated_remaining_time)
-      ),
+      tag.span(remaining_time_in_hours_minutes_seconds(tracker)),
       tag.br,
 
       tag.span(class: "font-weight-bold") do

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -7,7 +7,7 @@
         [
           # Status: <status>
           tag.span(class: "font-weight-bold") do
-            "#{:inat_import_tracker_status.t}: "
+            "#{:STATUS.}: "
           end,
           tag.span(tracker.status),
           tag.br,

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -7,7 +7,7 @@
         [
           # Status: <status>
           tag.span(class: "font-weight-bold") do
-            "#{:STATUS}: "
+            "#{:STATUS.l}: "
           end,
           tag.span(tracker.status),
           tag.br,

--- a/app/views/controllers/inat_imports/show.html.erb
+++ b/app/views/controllers/inat_imports/show.html.erb
@@ -31,3 +31,10 @@
     { class: "mt-3 btn btn-default" }
   )
 %>
+<%=
+  link_to(
+    :inat_import_tracker_cancel.l,
+    inat_import_cancel_path(id: @tracker.inat_import),
+    { class: "mt-3 btn btn-default" }
+  )
+%>

--- a/app/views/controllers/inat_imports/show.html.erb
+++ b/app/views/controllers/inat_imports/show.html.erb
@@ -33,7 +33,7 @@
 %>
 <%=
   link_to(
-    :inat_import_tracker_cancel.l,
+    :CANCEL.l,
     inat_import_cancel_path(id: @tracker.inat_import),
     { class: "mt-3 btn btn-default" }
   )

--- a/app/views/controllers/inat_imports/show.html.erb
+++ b/app/views/controllers/inat_imports/show.html.erb
@@ -17,24 +17,26 @@
   end
 %>
 
-<%=
-  # NOTE: jdc 2025-02-08 When available, replace the target with a link to
-  # the Observations imported by this InatImport. I.e. Observations:
-  # - created by @user
-  # - from @tracker.started_at -- @tracker.ended_at || time.now
-  # - ideally with source: InatImport)
-  # - ordered by created_at desc
-  link_to(
-    :inat_import_tracker_results.l,
-    observations_path(
-      pattern: "user:#{@user.id} created:#{Date.today.strftime}-#{Date.tomorrow.strftime}"),
-    { class: "mt-3 btn btn-default" }
-  )
-%>
-<%=
-  link_to(
-    :CANCEL.l,
-    inat_import_cancel_path(id: @tracker.inat_import),
-    { class: "mt-3 btn btn-default" }
-  )
-%>
+<%= tag.div(class: "mt-3") do %>
+  <%=
+    # NOTE: jdc 2025-02-08 When available, replace the target with a link to
+    # the Observations imported by this InatImport. I.e. Observations:
+    # - created by @user
+    # - from @tracker.started_at -- @tracker.ended_at || time.now
+    # - ideally with source: InatImport)
+    # - ordered by created_at desc
+    link_to(
+      :inat_import_tracker_results.l,
+      observations_path(
+        pattern: "user:#{@user.id} created:#{Date.today.strftime}-#{Date.tomorrow.strftime}"),
+      { class: "btn btn-default" }
+    )
+  %>
+  <%=
+    put_button(
+      name: :CANCEL.l,
+      path: inat_import_cancel_path(id: @tracker.inat_import),
+      class: "btn btn-default"
+    )
+  %>
+<% end %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3114,6 +3114,7 @@
   inat_import_imported: Imported
   inat_import_tracker_done: "Click [:inat_import_tracker_results] to see imported Observations."
   inat_import_tracker_results: Results
+  inat_import_tracker_cancel: "[:CANCEL]"
   inat_import_tracker_importable_count: Number of Importable Observations
   inat_import_tracker_imported_count: Number Imported
   inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3105,7 +3105,6 @@
   INAT_IMPORTS: iNat Imports
   INAT_IMPORT_JOB_TRACKERS: iNat Import Trackers
   inat_import_tracker: iNat Import Tracker
-  inat_import_tracker_status: "[:STATUS]"
   inat_import_tracker_started: Started
   inat_import_tracker_elapsed_time: Elapsed Time
   inat_import_tracker_estimated_remaining_time: Estimated Remaining Time
@@ -3114,7 +3113,6 @@
   inat_import_imported: Imported
   inat_import_tracker_done: "Click [:inat_import_tracker_results] to see imported Observations."
   inat_import_tracker_results: Results
-  inat_import_tracker_cancel: "[:CANCEL]"
   inat_import_tracker_importable_count: Number of Importable Observations
   inat_import_tracker_imported_count: Number Imported
   inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,6 +446,8 @@ MushroomObserver::Application.routes.draw do
   get("inat_imports/authorization_response",
       to: "inat_imports#authorization_response",
       as: "inat_import_authorization_response")
+  get("inat_imports/cancel/:id", to: "inat_imports#cancel",
+                                 as: "inat_import_cancel")
   resources :inat_imports, only: [:show, :new, :create] do
     resources :job_trackers, only: [:show], module: :inat_imports
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,7 +446,7 @@ MushroomObserver::Application.routes.draw do
   get("inat_imports/authorization_response",
       to: "inat_imports#authorization_response",
       as: "inat_import_authorization_response")
-  get("inat_imports/cancel/:id", to: "inat_imports#cancel",
+  put("inat_imports/cancel/:id", to: "inat_imports#cancel",
                                  as: "inat_import_cancel")
   resources :inat_imports, only: [:show, :new, :create] do
     resources :job_trackers, only: [:show], module: :inat_imports

--- a/db/migrate/20250725173255_add_cancel_to_inat_imports.rb
+++ b/db/migrate/20250725173255_add_cancel_to_inat_imports.rb
@@ -1,0 +1,5 @@
+class AddCancelToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column :inat_imports, :cancel, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_142904) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_25_173255) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -223,6 +223,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_142904) do
     t.integer "total_seconds"
     t.float "avg_import_time"
     t.datetime "last_obs_start"
+    t.boolean "cancel"
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -2,7 +2,6 @@
 
 require("test_helper")
 
-# test mapping of iNat observation photo key/values to MO Image attributes
 class InatObservationImporterTest < UnitTestCase
   def test_canceled
     import = inat_imports(:ollie_inat_import)
@@ -14,7 +13,8 @@ class InatObservationImporterTest < UnitTestCase
     importer = ::Inat::ObservationImporter.new(import, user)
     assert_no_difference(
       "Observation.count",
-      "ObservationImporter should stop importing if the Import is canceled"
+      "ObservationImporter should stop importing observations after " \
+      "user cancels the Import"
     ) do
       importer.import_page(page)
     end

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# test mapping of iNat observation photo key/values to MO Image attributes
+class InatObservationImporterTest < UnitTestCase
+  def test_canceled
+    import = inat_imports(:ollie_inat_import)
+    assert(import.canceled?, "Test needs a canceled InatImport fixture")
+    user = import.user
+    mock_inat_response = File.read("test/inat/calostoma_lutescens.txt")
+    page = JSON.parse(mock_inat_response)
+
+    importer = ::Inat::ObservationImporter.new(import, user)
+    assert_no_difference(
+      "Observation.count",
+      "ObservationImporter should stop importing if the Import is canceled"
+    ) do
+      importer.import_page(page)
+    end
+  end
+end

--- a/test/controllers/inat_imports/job_trackers_controller_test.rb
+++ b/test/controllers/inat_imports/job_trackers_controller_test.rb
@@ -20,7 +20,7 @@ module InatImports
       # remove HTML tags for easier testing of displayed text
       body = strip_tags(@response.body)
 
-      assert(body.include?("#{:inat_import_tracker_status.l}: Unstarted"))
+      assert(body.include?("#{:STATUS.l}: Unstarted"))
       importables_line =
         "#{:inat_import_imported.l}: 0 of#{tracker.importables}"
       assert(body.include?(importables_line))
@@ -42,7 +42,7 @@ module InatImports
       assert_response(:success)
       body = strip_tags(@response.body)
 
-      assert(body.include?("#{:inat_import_tracker_status.l}: Done"))
+      assert(body.include?("#{:STATUS.l}: Done"))
       assert(body.include?(
                "#{:inat_import_tracker_estimated_remaining_time.l}: 00:00:00"
              ))

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -343,16 +343,14 @@ class InatImportsControllerTest < FunctionalTestCase
     import = inat_imports(:katrina_inat_import)
     assert(import.job_pending? && !import.canceled?,
            "Test needs a Import fixture with a uncancelled, pending Job")
-    tracker = inat_import_job_trackers(:katrina_tracker)
 
     login
     get(:cancel, params: { id: import.id })
 
+    assert_response(:success)
+    assert_template(:show)
     assert(import.reload.canceled?,
            "Clicking cancel button should make InatImport.canceled? == true")
-    assert_redirected_to(
-      inat_import_path(import, params: { tracker_id: tracker.id })
-    )
   end
 
   ########## Utilities

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -73,6 +73,20 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_create_cancel_reset
+    user = users(:ollie)
+    import = inat_imports(:ollie_inat_import)
+    assert(import.canceled?, "Test needs a canceled InatImport fixture")
+    id = "123"
+    params = { inat_ids: id, inat_username: user.inat_username, consent: 1 }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_not(import.reload.canceled?,
+               "`cancel` should be false when starting an import")
+  end
+
   def test_create_missing_username
     user = users(:rolf)
     id = "123"

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -325,6 +325,22 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_cancel
+    import = inat_imports(:katrina_inat_import)
+    assert(import.job_pending? && !import.canceled?,
+           "Test needs a Import fixture with a uncancelled, pending Job")
+    tracker = inat_import_job_trackers(:katrina_tracker)
+
+    login
+    get(:cancel, params: { id: import.id })
+
+    assert(import.reload.canceled?,
+           "Clicking cancel button should make InatImport.canceled? == true")
+    assert_redirected_to(
+      inat_import_path(import, params: { tracker_id: tracker.id })
+    )
+  end
+
   ########## Utilities
 
   # iNat url where user is sent in order to authorize MO access

--- a/test/fixtures/inat_import_job_trackers.yml
+++ b/test/fixtures/inat_import_job_trackers.yml
@@ -5,3 +5,6 @@ katrina_tracker:
 
 lone_wolf_tracker:
   inat_import: <%= ActiveRecord::FixtureSet.identify(:lone_wolf_import) %>
+
+ollie_tracker:
+  inat_import: <%= ActiveRecord::FixtureSet.identify(:ollie_inat_import) %>

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -60,3 +60,10 @@ lone_wolf_import:
   state: <%= InatImport.states[:Done] %>
   ended_at: <%= Time.zone.now + 15.seconds %>
   response_errors: "Random error msg"
+
+# ollie canceled an import
+ollie_inat_import:
+  <<: *DEFAULTS
+  user: ollie
+  state: <%= InatImport.states[:Done] %>
+  cancel: true

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -13,6 +13,7 @@ DEFAULTS: &DEFAULTS
   total_imported_count: nil
   total_seconds: nil
   avg_import_time: nil
+  cancel: false
 
 rolf_inat_import:
   <<: *DEFAULTS
@@ -39,6 +40,7 @@ katrina_inat_import:
   user: katrina
   state: <%= InatImport.states[:Importing] %>
   inat_username: katrina_inat_username
+  cancel: false
 
 inat_importer_inat_import:
   <<: *DEFAULTS

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -84,6 +84,7 @@ roy:
 ollie:
   <<: *DEFAULTS
   name: Ollie
+  inat_username: ollie_inat_username
   user_groups: all_users, burbank_users, ollie_only
 
 spammer:

--- a/test/helpers/inat_import_job_trackers_helper_test.rb
+++ b/test/helpers/inat_import_job_trackers_helper_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# test the helpers for InatImportJobTracker
+class InatImportJobTrackersHelperTest < ActionView::TestCase
+  def test_time_in_hours_minutes_seconds
+    tracker = inat_import_job_trackers(:ollie_tracker)
+    assert_equal("Done", tracker.status, "Test needs fixture that's Done")
+
+    assert_equal("00:00:00", remaining_time_in_hours_minutes_seconds(tracker))
+  end
+end


### PR DESCRIPTION
Add a functioning Cancel button to InatImport#show view

- Adds a binary `InatImport#cancel` attribute
- Clicking the Cancel button sets `cancel == true`
- ImportJob checks that attribute deep inside the `parsing?` loop, and even deeper in `ObservationImporter`, terminating the Job if `canceling?`
- Resolves #3080

### Suggested Manual Test

- Create several sacrificial iNat observations
- Read the rest of this test, then import those observations.
- Wait until the `iNat Import Tracker` `Status` changes to `Importing`, then _immediately_ click the Cancel button.
Expected result:
  - The Job terminates, with `Status: Done`
  - It imports fewer than all of your sacrificial iNat observations. (See screenshot below.)
  - `Estimated Remaining Time: 00:00:00`
  - It displays `Ended` time
  
<img width="309" height="286" alt="Screenshot 2025-07-31 at 5 06 33 PM" src="https://github.com/user-attachments/assets/3bad7a78-770e-4088-bdfd-66823cdbdf99" />

- I suggest deleting the sacrificial iNat observations when you're done.


 