### PR TITLE
Project list search filter refactor

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,22 +19,6 @@
 #
 module ApplicationHelper
   # All helpers are autoloaded under Zeitwerk
-  def object_search_field(object:, form:)
-    type = object.type_tag
-    messages = {
-      off: :search_status_all_names.l(type:),
-      red: :search_status_has_no_name.l(type:),
-      green: :search_status_has_name.l(type:)
-    }
-    render(partial: "shared/search_status_autocompleter",
-           locals: { form:, matches: object_names(object), messages: })
-  end
-
-  def object_names(object)
-    object.observations.joins(:name).select("names.text_name", "names.id").
-      distinct.order("names.text_name")
-  end
-
   def css_theme
     if in_admin_mode?
       "Admin"

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -453,6 +453,23 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     end
   end
 
+  # For project_list_search, add dispatch controller
+  def object_search_field(object:, form:)
+    type = object.type_tag
+    messages = {
+      off: :search_status_all_names.l(type:),
+      red: :search_status_has_no_name.l(type:),
+      green: :search_status_has_name.l(type:)
+    }
+    render(partial: "shared/search_status_autocompleter",
+           locals: { form:, matches: object_names(object), messages: })
+  end
+
+  def object_names(object)
+    object.observations.joins(:name).select("names.text_name", "names.id").
+      distinct.order("names.text_name")
+  end
+
   # Unused
   # def search_field_with_submit(args)
   #   opts = separate_field_options_from_args(args)

--- a/app/helpers/species_lists_helper.rb
+++ b/app/helpers/species_lists_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# View Helpers for Projects, Project Violations
+# View Helpers for Observation Lists
 module SpeciesListsHelper
   def species_list_title_panel(list)
     tag.div(class: "species_list_title") do

--- a/app/views/controllers/projects/show.html.erb
+++ b/app/views/controllers/projects/show.html.erb
@@ -6,7 +6,7 @@ add_project_banner(@project)
 <br />
 
 <%= panel_block(id: "project_search") do %>
-  <%= render(partial: "shared/search",
+  <%= render(partial: "shared/project_list_search",
              locals: { object: @project }) %>
 <% end %>
 <%= panel_block(id: "project_summary") do %>

--- a/app/views/controllers/shared/_project_list_search.html.erb
+++ b/app/views/controllers/shared/_project_list_search.html.erb
@@ -1,0 +1,11 @@
+<%#
+Project list search form
+for objects associated with a project or observation list
+%>
+
+<%= form_with(url: add_dispatch_path, method: :post) do |form| %>
+  <%= form.hidden_field(:object_id, value: object.id) %>
+  <%= form.hidden_field(:object_type, value: object.class.name) %>
+  <%= form.hidden_field(:project, value: @project&.id) %>
+  <%= object_search_field(object:, form:) %>
+<% end %>

--- a/app/views/controllers/shared/_search.html.erb
+++ b/app/views/controllers/shared/_search.html.erb
@@ -1,6 +1,0 @@
-<%= form_with url: add_dispatch_path, method: :post do |form| %>
-  <%= form.hidden_field :object_id, value: object.id %>
-  <%= form.hidden_field :object_type, value: object.class.name %>
-  <%= form.hidden_field :project, value: @project&.id %>
-  <%= object_search_field(object:, form:) %>
-<% end %>

--- a/app/views/controllers/shared/_search_status_autocompleter.erb
+++ b/app/views/controllers/shared/_search_status_autocompleter.erb
@@ -13,24 +13,29 @@ tag.div(
           search_status_matches_value: matches }
 ) do
   [
-    tag.div(class: "status-light-container") do
+    tag.div(class: "d-flex flex-row align-items-center form-inline mb-2") do
       [
-        tag.div(class: "status-indicator",
-                data: { search_status_target: "light" }),
-        tag.span(:search_status_all_names.l(type:),
-                 class: "status-text",
-                 data: { search_status_target: "message" }),
-        tag.div(class: "field-slip-container vcenter") do
+        tag.div(class: "status-light-container mb-1 mr-5") do
           [
-            tag.span("Field Slip:", for: "field_slip", class: "mx-3"),
-            tag.input(type: "text", id: "field_slip", name: "field_slip"),
-            tag.button("Add", type: "submit", class: "btn btn-default mx-3")
+            tag.div(class: "status-indicator",
+                    data: { search_status_target: "light" }),
+            tag.span(:search_status_all_names.l(type:),
+                    class: "status-text",
+                    data: { search_status_target: "message" })
+          ].safe_join
+        end,
+        tag.div(class: "field-slip-container field-group") do
+          [
+            form.label("Field Slip:", for: "field_slip",
+                       class: "font-weight-normal"),
+            form.text_field(:field_slip, class: "form-control mx-3", size: 9),
+            submit_button(form:, button: "Add")
           ].safe_join
         end
       ].safe_join
     end,
     autocompleter_field(
-      form:, field:, type:, label: "#{:SEARCH.l}:",
+      form:, field:, type:, label: "#{:SEARCH.l}:", class: "mb-2",
       data: {
         search_status_target: "input",
         action: [

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -16,34 +16,32 @@
 <%= species_list_title_panel(@species_list) if @project %>
 
 <%= panel_block(id: "list_search") do %>
-  <%= render(partial: "shared/search",
+  <%= render(partial: "shared/project_list_search",
              locals: { object: @species_list }) %>
 <% end %>
 
-<div class="container-text">
-  <%= panel_block do %>
-    <div style="display: flex; justify-content: space-between; align-items: center;">
-      <div><b><%= :WHEN.t %>:</b> <%= @species_list.when.web_date %></div>
-      <div>
-        <%= obs_change_links(@species_list) %> |
-        <%= download_button(target: @species_list, icon: :download) %>
-      </div>
+<%= panel_block do %>
+  <div class="d-flex justify-content-between align-items-center">
+    <div><b><%= :WHEN.t %>:</b> <%= @species_list.when.web_date %></div>
+    <div>
+      <%= obs_change_links(@species_list) %> |
+      <%= download_button(target: @species_list, icon: :download) %>
     </div>
-    <div><b><%= :OBSERVATIONS.t %>:</b> <%= @query.num_results %></div>
-    <div><b><%= :WHERE.t %>:</b>
-      <%= location_link(@species_list.where, @species_list.location, nil, true) rescue :UNKNOWN.t %>
+  </div>
+  <div><b><%= :OBSERVATIONS.t %>:</b> <%= @query.num_results %></div>
+  <div><b><%= :WHERE.t %>:</b>
+    <%= location_link(@species_list.where, @species_list.location, nil, true) rescue :UNKNOWN.t %>
+  </div>
+  <div><b><%= :WHO.t %>:</b> <%= user_link(@species_list.user) %></div>
+  <% if @species_list.projects.any? %>
+    <div><b><%= :PROJECTS.t %>:</b>
+      <%= @species_list.projects.map {|p| link_to_object(p)}.safe_join(" | ") %>
     </div>
-    <div><b><%= :WHO.t %>:</b> <%= user_link(@species_list.user) %></div>
-    <% if @species_list.projects.any? %>
-      <div><b><%= :PROJECTS.t %>:</b>
-        <%= @species_list.projects.map {|p| link_to_object(p)}.safe_join(" | ") %>
-      </div>
-    <% end %>
-    <% if @species_list.notes.present? %>
-      <div><%= ("*" + :NOTES.t + ":* " + @species_list.notes.to_s).tpl %></div>
-    <% end %>
   <% end %>
-</div>
+  <% if @species_list.notes.present? %>
+    <div><%= ("*" + :NOTES.t + ":* " + @species_list.notes.to_s).tpl %></div>
+  <% end %>
+<% end %>
 
 <% if @pagination_data.any?
   query_params_set(@query) %>


### PR DESCRIPTION
Small refactor to style and DRY the "Field Slip" input on this form, using existing form helpers.

PR also tries to clear up some naming confusion:
- renames form partial from "shared/search" to "shared/project_list_search"
- moves form helpers into "helpers/form_helpers"

Other details:
- makes second panel on species_lists/show same width as other elements