### PR TITLE
List pattern_search NULL Location

### DIFF
--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -123,9 +123,7 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
 
   scope :pattern, lambda { |phrase|
     cols = SpeciesList[:title] + SpeciesList[:notes].coalesce("") +
-           Arel::Nodes::Case.new.
-           when(Location[:id].not_eq(nil)).then(Location[:name]).
-           else(SpeciesList[:where])
+           Location[:name].coalesce(SpeciesList[:where])
     left_outer_joins(:location).search_columns(cols, phrase)
   }
 

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -123,7 +123,8 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
 
   scope :pattern, lambda { |phrase|
     cols = SpeciesList[:title] + SpeciesList[:notes].coalesce("") +
-           Location[:id].when(present?).then(Location[:name]).
+           Arel::Nodes::Case.new.
+           when(Location[:id].not_eq(nil)).then(Location[:name]).
            else(SpeciesList[:where])
     left_outer_joins(:location).search_columns(cols, phrase)
   }

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -122,7 +122,7 @@ class Query::SpeciesListsTest < UnitTestCase
     list = species_lists(:no_where_list)
     ids = [list.id]
     scope = SpeciesList.pattern(list.title).order_by_default
-    assert_query_scope(ids, scope, :SpeciesList, search_where: list.title)
+    assert_query_scope(ids, scope, :SpeciesList, pattern: list.title)
 
     # in notes
     pattern = species_lists(:query_notes_list).notes

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -120,9 +120,8 @@ class Query::SpeciesListsTest < UnitTestCase
     assert_query(expects, :SpeciesList, pattern: "query_first_list")
     # in title, with NULL where
     list = species_lists(:no_where_list)
-    ids = [list.id]
-    scope = SpeciesList.pattern(list.title).order_by_default
-    assert_query_scope(ids, scope, :SpeciesList, pattern: list.title)
+    pattern = list.title
+    assert_pattern_search_query_scope(list, pattern)
 
     # in notes
     pattern = species_lists(:query_notes_list).notes
@@ -145,5 +144,11 @@ class Query::SpeciesListsTest < UnitTestCase
 
   def species_list_pattern_search(pattern)
     SpeciesList.pattern(pattern).order_by_default
+  end
+
+  def assert_pattern_search_query_scope(list, pattern)
+    ids = [list.id]
+    scope = SpeciesList.pattern(pattern).order_by_default
+    assert_query_scope(ids, scope, :SpeciesList, pattern: pattern)
   end
 end

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -140,7 +140,7 @@ class Query::SpeciesListsTest < UnitTestCase
     assert_query(expects, :SpeciesList, pattern: "")
   end
 
-  def assert_pattern_search_query_scope(list, pattern: search_pattern)
+  def assert_pattern_search_query_scope(list, pattern:)
     ids = [list.id]
     scope = species_list_pattern_search(pattern)
     assert_query_scope(ids, scope, :SpeciesList, pattern: pattern)

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -118,14 +118,22 @@ class Query::SpeciesListsTest < UnitTestCase
     pattern = "query_first_list"
     expects = species_list_pattern_search(pattern)
     assert_query(expects, :SpeciesList, pattern: "query_first_list")
+    # in title, with NULL where
+    list = species_lists(:no_where_list)
+    ids = [list.id]
+    scope = SpeciesList.pattern(list.title).order_by_default
+    assert_query_scope(ids, scope, :SpeciesList, search_where: list.title)
+
     # in notes
     pattern = species_lists(:query_notes_list).notes
     expects = species_list_pattern_search(pattern)
     assert_query(expects, :SpeciesList, pattern: pattern)
+
     # in location
     pattern = locations(:burbank).name
     expects = species_list_pattern_search(pattern)
     assert_query(expects, :SpeciesList, pattern: locations(:burbank).name)
+
     # in where
     pattern = species_lists(:where_list).where
     expects = species_list_pattern_search(pattern)

--- a/test/classes/query/species_lists_test.rb
+++ b/test/classes/query/species_lists_test.rb
@@ -114,19 +114,18 @@ class Query::SpeciesListsTest < UnitTestCase
 
   def test_species_list_pattern
     assert_query([], :SpeciesList, pattern: "nonexistent pattern")
+
     # in title
-    pattern = "query_first_list"
-    expects = species_list_pattern_search(pattern)
-    assert_query(expects, :SpeciesList, pattern: "query_first_list")
+    list = species_lists(:query_first_list)
+    assert_pattern_search_query_scope(list, pattern: list.title)
+
     # in title, with NULL where
     list = species_lists(:no_where_list)
-    pattern = list.title
-    assert_pattern_search_query_scope(list, pattern)
+    assert_pattern_search_query_scope(list, pattern: list.title)
 
     # in notes
-    pattern = species_lists(:query_notes_list).notes
-    expects = species_list_pattern_search(pattern)
-    assert_query(expects, :SpeciesList, pattern: pattern)
+    list = species_lists(:query_notes_list)
+    assert_pattern_search_query_scope(list, pattern: list.notes)
 
     # in location
     pattern = locations(:burbank).name
@@ -134,21 +133,20 @@ class Query::SpeciesListsTest < UnitTestCase
     assert_query(expects, :SpeciesList, pattern: locations(:burbank).name)
 
     # in where
-    pattern = species_lists(:where_list).where
-    expects = species_list_pattern_search(pattern)
-    assert_query(expects, :SpeciesList, pattern: pattern)
+    list = species_lists(:where_list)
+    assert_pattern_search_query_scope(list, pattern: list.where)
 
     expects = SpeciesList.order_by_default
     assert_query(expects, :SpeciesList, pattern: "")
   end
 
-  def species_list_pattern_search(pattern)
-    SpeciesList.pattern(pattern).order_by_default
+  def assert_pattern_search_query_scope(list, pattern: search_pattern)
+    ids = [list.id]
+    scope = species_list_pattern_search(pattern)
+    assert_query_scope(ids, scope, :SpeciesList, pattern: pattern)
   end
 
-  def assert_pattern_search_query_scope(list, pattern)
-    ids = [list.id]
-    scope = SpeciesList.pattern(pattern).order_by_default
-    assert_query_scope(ids, scope, :SpeciesList, pattern: pattern)
+  def species_list_pattern_search(pattern)
+    SpeciesList.pattern(pattern).order_by_default
   end
 end

--- a/test/fixtures/species_lists.yml
+++ b/test/fixtures/species_lists.yml
@@ -103,3 +103,9 @@ reused_list:
   <<: *DEFAULTS
   user: mary
   when: 2023-11-19
+
+no_where_list:
+  <<: *DEFAULTS
+  user: mary
+  when: 2023-11-19
+  where: NULL


### PR DESCRIPTION
Fixes a bug in `SpeciesList.pattern_search` scope

Resolves #3025
