### PR TITLE
Enable import_all

### DIFF
--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -38,8 +38,7 @@ class Inat
 
     def update_inat_observation
       update_mushroom_observer_url_field
-      sleep(1)
-      update_description
+      sleep(1) # Avoid hitting iNat API rate limits
     end
 
     def update_mushroom_observer_url_field
@@ -58,25 +57,6 @@ class Inat
         request(method: :post,
                 path: "observation_field_values",
                 payload: payload)
-    end
-
-    def update_description
-      return if super_importer? && importing_someone_elses_obs?
-
-      description = @inat_obs[:description]
-      updated_description =
-        "#{IMPORTED_BY_MO} #{Time.zone.today.strftime(MO.web_date_format)}"
-      updated_description.prepend("#{description}\n\n") if description.present?
-
-      payload = { observation: { description: updated_description,
-                                 ignore_photos: 1 } }
-      path = "observations/#{@inat_obs[:id]}?ignore_photos=1"
-      Inat::APIRequest.new(@inat_import.token).
-        request(method: :put, path: path, payload: payload)
-    end
-
-    def importing_someone_elses_obs?
-      @inat_obs[:user][:login] != @inat_import.inat_username
     end
 
     def increment_imported_counts

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -3,6 +3,7 @@
 class Inat
   class ObservationImporter
     include Inat::Constants
+    attr_reader :inat_import, :user
 
     def initialize(inat_import, user)
       @inat_import = inat_import
@@ -11,6 +12,8 @@ class Inat
 
     def import_page(page)
       page["results"].each do |result|
+        return false if inat_import.canceled?
+
         import_one_result(JSON.generate(result))
       end
     end

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -16,7 +16,7 @@ class Inat
 
     def import_page(page)
       page["results"].each do |result|
-        return false if inat_import.canceled?
+        return false if inat_import.reload.canceled?
 
         import_one_result(JSON.generate(result))
       end

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -3,6 +3,7 @@
 class Inat
   class ObservationImporter
     include Inat::Constants
+
     attr_reader :inat_import, :user
 
     def initialize(inat_import, user)

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Inat
+  # Import a page of parsed iNat API observation search results,
+  # using Inat::Obs to parse each result and
+  # Inat::MoObservationBuilder to create an MO Observation.
   class ObservationImporter
     include Inat::Constants
 

--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -13,6 +13,18 @@ class Inat
       @import = import
       @last_import_id = 0
       @ids = ids
+      return if @import.inat_username.present?
+
+      # A belt-and-suspenders safety measure.
+      # See also InatImportsController::Validators#username_present?
+      # Always require inat_username as a safety measure.
+      # Else we risk importing iNat observations of all users
+      # or even worse, importing all observations of all users
+      raise(
+        ArgumentError.new(
+          "PageParser called with InatImport which lacks inat_username"
+        )
+      )
     end
 
     # Get next page of iNat API results, using per_page & id_above params.

--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -55,7 +55,7 @@ class Inat
         id: nil, id_above: nil, only_id: false, per_page: 200,
         order: "asc", order_by: "id",
         # obss of only the iNat user with iNat login @inat_import.inat_username
-        # This prevents accidentally importing observations of multiple
+        # Prevents accidentally importing observations of multiple users
         user_login: @import.inat_username,
         # only fungi and slime molds
         iconic_taxa: ICONIC_TAXA,

--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Inat
+  # Get one page of observations results (up to 200) from the iNat API,
+  # https://api.inaturalist.org/v1/docs/#!/Observations/get_observations
+  # returning a parsed JSON object.
   class PageParser
     include Inat::Constants
 
@@ -13,14 +16,11 @@ class Inat
       @restricted_user_login = restricted_user_login
     end
 
-    # Get one page of observations (up to 200)
-    # This is where we actually hit the iNat API
-    # https://api.inaturalist.org/v1/docs/#!/Observations/get_observations
-    # https://stackoverflow.com/a/11251654/3357635
     # NOTE: The `ids` parameter may be a comma-separated list of iNat obs
     # ids - that needs to be URL encoded to a string when passed as an arg here
     # because URI.encode_www_form deals with arrays by passing the same key
     # multiple times.
+    # https://stackoverflow.com/a/11251654/3357635
     def next_page
       result = next_request(id: @ids, id_above: @last_import_id,
                             user_login: @restricted_user_login)

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -127,6 +127,8 @@ class InatImportsController < ApplicationController
   # When implementing import_all, we should instead use the iNat API
   # to get the number of observations to be imported.
   def importables_count
+    return nil if importing_all?
+
     params[:inat_ids].split(",").length
   end
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -181,11 +181,10 @@ class InatImportsController < ApplicationController
   public
 
   def cancel
-    inat_import = InatImport.find(params[:id])
-    inat_import.update(cancel: true)
-    tracker = InatImportJobTracker.where(inat_import: inat_import).
-              order(:created_at).last
-    redirect_to(inat_import_path(inat_import,
-                                 params: { tracker_id: tracker.id }))
+    @inat_import = InatImport.find(params[:id])
+    @inat_import.update(cancel: true)
+    @tracker = InatImportJobTracker.where(inat_import: @inat_import).
+               order(:created_at).last
+    render(:show)
   end
 end

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -185,7 +185,6 @@ class InatImportsController < ApplicationController
     inat_import.update(cancel: true)
     tracker = InatImportJobTracker.where(inat_import: inat_import).
               order(:created_at).last
-    # flash_warning(:inat_import_tracker_canceled.l)
     redirect_to(inat_import_path(inat_import,
                                  params: { tracker_id: tracker.id }))
   end

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -117,7 +117,8 @@ class InatImportsController < ApplicationController
       response_errors: "",
       token: "",
       log: [],
-      ended_at: nil
+      ended_at: nil,
+      cancel: false
     )
   end
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -6,6 +6,7 @@
 # new (get)
 # create (post)
 # authorization_response (get)
+# cancel (post):: cancels the InatImportJob
 #
 # Work flow:
 # 1. User calls `new`, fills out form
@@ -174,5 +175,17 @@ class InatImportsController < ApplicationController
     # clean out this user's old tracker(s)
     InatImportJobTracker.where(inat_import: inat_import.id).destroy_all
     InatImportJobTracker.create(inat_import: inat_import.id)
+  end
+
+  public
+
+  def cancel
+    inat_import = InatImport.find(params[:id])
+    inat_import.update(cancel: true)
+    tracker = InatImportJobTracker.where(inat_import: inat_import).
+              order(:created_at).last
+    # flash_warning(:inat_import_tracker_canceled.l)
+    redirect_to(inat_import_path(inat_import,
+                                 params: { tracker_id: tracker.id }))
   end
 end

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -15,6 +15,10 @@ module InatImportsController::Validators
       consented?
   end
 
+  # Always require inat_username as a safety measure.
+  # Else we risk importing iNat observations of all users
+  # or even worse, importing all observations of all users
+  # See also Inat::PageParser#initialize
   def username_present?
     return true if params[:inat_username].present?
 

--- a/app/helpers/inat_import_job_trackers_helper.rb
+++ b/app/helpers/inat_import_job_trackers_helper.rb
@@ -9,6 +9,17 @@ module InatImportJobTrackersHelper
     inat_import.state != "Done"
   end
 
+  def remaining_time_in_hours_minutes_seconds(tracker)
+    # force remaining time to be 0 if the Job is done
+    # prevents displaying :inat_import_tracker_calculating_time.l
+    time = if tracker.status == "Done"
+             0
+           else
+             tracker.estimated_remaining_time
+           end
+    time_in_hours_minutes_seconds(time)
+  end
+
   def time_in_hours_minutes_seconds(seconds)
     return :inat_import_tracker_calculating_time.l if seconds.nil?
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -108,7 +108,7 @@ class InatImportJob < ApplicationJob
     return false if page_empty?(parsed_page)
 
     observation_importer.import_page(parsed_page)
-    return false if canceled?
+    return false if inat_import.reload.canceled?
 
     parser.last_import_id = parsed_page["results"].last["id"]
     more_pages?(parsed_page)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -86,15 +86,6 @@ class InatImportJob < ApplicationJob
     inat_import.inat_ids.delete(" ")
   end
 
-  # limit iNat API search to observations by iNat user with this login
-  def restricted_user_login
-    if super_importer?
-      nil # Super importers can import anyone's iNat observations
-    else
-      inat_username
-    end
-  end
-
   # Import the next page of iNat API results,
   # returning true if there are more pages of results, false if done.
   def parsing?(parser)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -9,6 +9,7 @@ class InatImportJob < ApplicationJob
 
   delegate :token, to: :inat_import
   delegate :user, to: :inat_import
+  delegate :canceled?, to: :inat_import
 
   def perform(inat_import)
     create_ivars(inat_import)
@@ -92,6 +93,7 @@ class InatImportJob < ApplicationJob
     return false if page_empty?(parsed_page)
 
     import_page(parsed_page)
+    return import_canceled if canceled?
 
     parser.last_import_id = parsed_page["results"].last["id"]
     return true unless last_page?(parsed_page)
@@ -102,6 +104,11 @@ class InatImportJob < ApplicationJob
 
   def page_empty?(page)
     page["total_results"].zero?
+  end
+
+  def import_canceled # rubocop:disable Naming/PredicateMethod
+    log("Import canceled by user")
+    false
   end
 
   def last_page?(parsed_page)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -78,9 +78,7 @@ class InatImportJob < ApplicationJob
 
     # Request a page of iNat observations at a time, until done with all pages
     # (or canceled).
-    # To get one page, use iNats `per_page` & `id_above` params.
-    # https://api.inaturalist.org/v1/docs/#!/Observations/get_observations
-    parser = Inat::PageParser.new(inat_import, inat_ids, restricted_user_login)
+    parser = Inat::PageParser.new(inat_import, inat_ids)
     while parsing?(parser); end
   end
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -84,6 +84,15 @@ class InatImportJob < ApplicationJob
     inat_import.inat_ids.delete(" ")
   end
 
+  # limit iNat API search to observations by iNat user with this login
+  def restricted_user_login
+    if super_importer?
+      nil # Super importers can import anyone's iNat observations
+    else
+      inat_import.inat_username
+    end
+  end
+
   # Import the next page of iNat API results,
   # returning true if there are more pages of results, false if done.
   def parsing?(parser)
@@ -107,15 +116,6 @@ class InatImportJob < ApplicationJob
 
   def more_pages?(parsed_page)
     parsed_page["total_results"] > parsed_page["page"] * parsed_page["per_page"]
-  end
-
-  # limit iNat API search to observations by iNat user with this login
-  def restricted_user_login
-    if super_importer?
-      nil
-    else
-      inat_import.inat_username
-    end
   end
 
   def import_page(page)

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -122,10 +122,6 @@ class InatImportJob < ApplicationJob
     parsed_page["total_results"] > parsed_page["page"] * parsed_page["per_page"]
   end
 
-  def import_page(page)
-    observation_importer.import_page(page)
-  end
-
   def observation_importer
     @observation_importer ||=
       ::Inat::ObservationImporter.new(inat_import, user)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -23,12 +23,15 @@
 #  last_obs_start          when started importing a single iNat obs
 #                          reset in InatImportsController#authorization_response
 #                          and in Job after each observation import
+#  cancel/canceled::       Did the user requested canceling the Job
 #
 # == Methods
 #  total_expected_time     total expected time for associated Job
 #  last_obs_elapsed_time   time spent importing a single iNat obs
 #
 class InatImport < ApplicationRecord
+  alias_attribute :canceled, :cancel # for readability, e.g., job.canceled?
+
   enum :state, {
     Unstarted: 0,
     # waiting for User to authorize MO to access iNat data

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -12,7 +12,9 @@
 #                          depending on the state of the import
 #                          https://www.inaturalist.org/pages/api+reference#authorization_code_flow
 #  inat_ids::              string of id's of iNat obss to be imported
-#  inat_username::         this user's iNat login
+#  inat_username::         iNat login of user whose obss are being imported
+#                          Appended to iNat API query in order to generally
+#                          an MO user from importing someone else's iNat obss
 #  import_all:             whether to import all of user's relevant iNat obss
 #  importables::           number of importable observations in job
 #  imported_count::        running count of iNat obss imported in associated job

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -7,7 +7,7 @@
         [
           # Status: <status>
           tag.span(class: "font-weight-bold") do
-            "#{:STATUS.}: "
+            "#{:STATUS}: "
           end,
           tag.span(tracker.status),
           tag.br,

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -39,9 +39,7 @@
       tag.span(class: "font-weight-bold") do
         "#{:inat_import_tracker_estimated_remaining_time.l}: "
       end,
-      tag.span(
-        time_in_hours_minutes_seconds(tracker.estimated_remaining_time)
-      ),
+      tag.span(remaining_time_in_hours_minutes_seconds(tracker)),
       tag.br,
 
       tag.span(class: "font-weight-bold") do

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -7,7 +7,7 @@
         [
           # Status: <status>
           tag.span(class: "font-weight-bold") do
-            "#{:inat_import_tracker_status.t}: "
+            "#{:STATUS.}: "
           end,
           tag.span(tracker.status),
           tag.br,

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -7,7 +7,7 @@
         [
           # Status: <status>
           tag.span(class: "font-weight-bold") do
-            "#{:STATUS}: "
+            "#{:STATUS.l}: "
           end,
           tag.span(tracker.status),
           tag.br,

--- a/app/views/controllers/inat_imports/new.html.erb
+++ b/app/views/controllers/inat_imports/new.html.erb
@@ -23,7 +23,7 @@
     <%= check_box_with_label(form: f, field: :consent,
                              class: "mt-3", label: :inat_import_consent.l) %>
     <%= panel_block do %>
-      <p><b><%= :inat_details_heading.t %></b></p>
+      <p><b><%= :inat_details_heading.l %></b></p>
       <%= :inat_details_list.t %>
     <% end %>
     <%= f.submit(:SUBMIT.l, { class: "btn btn-default" }) %>

--- a/app/views/controllers/inat_imports/new.html.erb
+++ b/app/views/controllers/inat_imports/new.html.erb
@@ -17,7 +17,6 @@
           class: "form-control") %>
       <%= check_box_with_label(form: f, field: :all,
                                class: "mt-3", label: :inat_import_all.l) %>
-
     <% end %>
 
     <%= check_box_with_label(form: f, field: :consent,

--- a/app/views/controllers/inat_imports/new.html.erb
+++ b/app/views/controllers/inat_imports/new.html.erb
@@ -15,12 +15,13 @@
       <%= f.label(:inat_id, "#{:inat_import_list.l}: ") %>
       <%= f.text_field(:inat_ids, size: 10, value: @inat_ids,
           class: "form-control") %>
-      <%#= check_box_with_label(form: f, field: :all,
-                               class: "mt-3", label: :inat_import_all.t) %>
+      <%= check_box_with_label(form: f, field: :all,
+                               class: "mt-3", label: :inat_import_all.l) %>
+
     <% end %>
 
     <%= check_box_with_label(form: f, field: :consent,
-                             class: "mt-3", label: :inat_import_consent.t) %>
+                             class: "mt-3", label: :inat_import_consent.l) %>
     <%= panel_block do %>
       <p><b><%= :inat_details_heading.t %></b></p>
       <%= :inat_details_list.t %>

--- a/app/views/controllers/inat_imports/show.html.erb
+++ b/app/views/controllers/inat_imports/show.html.erb
@@ -31,3 +31,10 @@
     { class: "mt-3 btn btn-default" }
   )
 %>
+<%=
+  link_to(
+    :inat_import_tracker_cancel.l,
+    inat_import_cancel_path(id: @tracker.inat_import),
+    { class: "mt-3 btn btn-default" }
+  )
+%>

--- a/app/views/controllers/inat_imports/show.html.erb
+++ b/app/views/controllers/inat_imports/show.html.erb
@@ -33,7 +33,7 @@
 %>
 <%=
   link_to(
-    :inat_import_tracker_cancel.l,
+    :CANCEL.l,
     inat_import_cancel_path(id: @tracker.inat_import),
     { class: "mt-3 btn btn-default" }
   )

--- a/app/views/controllers/inat_imports/show.html.erb
+++ b/app/views/controllers/inat_imports/show.html.erb
@@ -17,24 +17,26 @@
   end
 %>
 
-<%=
-  # NOTE: jdc 2025-02-08 When available, replace the target with a link to
-  # the Observations imported by this InatImport. I.e. Observations:
-  # - created by @user
-  # - from @tracker.started_at -- @tracker.ended_at || time.now
-  # - ideally with source: InatImport)
-  # - ordered by created_at desc
-  link_to(
-    :inat_import_tracker_results.l,
-    observations_path(
-      pattern: "user:#{@user.id} created:#{Date.today.strftime}-#{Date.tomorrow.strftime}"),
-    { class: "mt-3 btn btn-default" }
-  )
-%>
-<%=
-  link_to(
-    :CANCEL.l,
-    inat_import_cancel_path(id: @tracker.inat_import),
-    { class: "mt-3 btn btn-default" }
-  )
-%>
+<%= tag.div(class: "mt-3") do %>
+  <%=
+    # NOTE: jdc 2025-02-08 When available, replace the target with a link to
+    # the Observations imported by this InatImport. I.e. Observations:
+    # - created by @user
+    # - from @tracker.started_at -- @tracker.ended_at || time.now
+    # - ideally with source: InatImport)
+    # - ordered by created_at desc
+    link_to(
+      :inat_import_tracker_results.l,
+      observations_path(
+        pattern: "user:#{@user.id} created:#{Date.today.strftime}-#{Date.tomorrow.strftime}"),
+      { class: "btn btn-default" }
+    )
+  %>
+  <%=
+    put_button(
+      name: :CANCEL.l,
+      path: inat_import_cancel_path(id: @tracker.inat_import),
+      class: "btn btn-default"
+    )
+  %>
+<% end %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3079,7 +3079,7 @@
   inat_import_all: Import all my iNat observations instead of a list
   inat_import_consent: "(Required) I consent to creating MushroomObserver Observation(s) based on my iNaturalist observations, including their photos."
   inat_consent_required: Your consent is required to import Inat observations. Please check the checkbox to give your consent.
-  inat_username: Your iNat Username (mandatory)
+  inat_username: iNat Username (mandatory)
   runtime_illegal_inat_id: iNat observation number can contain only numbers, commas, and spaces
   inat_missing_username: Missing your iNat Username
   inat_no_imports_designated: You must list the iNat observation(s) to be imported

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3099,7 +3099,7 @@
   inat_not_imported: Not Imported
 
   inat_details_heading: Details/Caveats
-  inat_details_list: "* MO imports only fungal observations.\n* MO lists most iNat data and/or maps it to analogous MO fields.\n* MO hides coordinates from the public if iNat obscured them.\n* The MO Location is a rectangle with an MO-style name, rather than the iNat Place name."
+  inat_details_list: "* Excludes Observations previously imported from/exported to iNat.\n* MO imports only fungal observations.\n* MO lists most iNat data and/or maps it to analogous MO fields.\n* MO hides coordinates from the public if iNat obscured them.\n* The MO Location is a rectangle with an MO-style name, rather than the iNat Place name."
 
   # /inat_import_job_tracker
   INAT_IMPORTS: iNat Imports

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3114,6 +3114,7 @@
   inat_import_imported: Imported
   inat_import_tracker_done: "Click [:inat_import_tracker_results] to see imported Observations."
   inat_import_tracker_results: Results
+  inat_import_tracker_cancel: "[:CANCEL]"
   inat_import_tracker_importable_count: Number of Importable Observations
   inat_import_tracker_imported_count: Number Imported
   inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3105,7 +3105,6 @@
   INAT_IMPORTS: iNat Imports
   INAT_IMPORT_JOB_TRACKERS: iNat Import Trackers
   inat_import_tracker: iNat Import Tracker
-  inat_import_tracker_status: "[:STATUS]"
   inat_import_tracker_started: Started
   inat_import_tracker_elapsed_time: Elapsed Time
   inat_import_tracker_estimated_remaining_time: Estimated Remaining Time
@@ -3114,7 +3113,6 @@
   inat_import_imported: Imported
   inat_import_tracker_done: "Click [:inat_import_tracker_results] to see imported Observations."
   inat_import_tracker_results: Results
-  inat_import_tracker_cancel: "[:CANCEL]"
   inat_import_tracker_importable_count: Number of Importable Observations
   inat_import_tracker_imported_count: Number Imported
   inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3086,8 +3086,9 @@
   inat_previous_import: iNat [inat_id] previously imported as MO Observation [mo_obs_id]
   inat_previous_mirror: iNat [inat_id] is a "mirror" of existing MO Observation [mo_obs_id]
   inat_too_many_ids_listed: Too many ids listed
-  inat_import_started: Your import has started. Refresh page to update results.
+  inat_importing_all_anothers: You cannot import all observations of another person
 
+  inat_import_started: Your import has started. Refresh page to update results.
   inat_no_authorization: iNat import aborted; MO did not received authorization to access iNat user data
   inat_wrong_user: You cannot import an iNat observation created by someone else. To import your own observation, make sure that noone else is logged into iNat on your device and that you entered the correct iNat username.
   inat_page_of_obs_failed: Failed to get page of observations from iNat API

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3099,7 +3099,7 @@
   inat_not_imported: Not Imported
 
   inat_details_heading: Details/Caveats
-  inat_details_list: "- MO will list most iNat data and/or map it to analogous MO fields.\n- Coordinates are hidden from the public if iNat obscured them.\n- Location is a rectangle with an MO-style name, rather than the iNat Place name."
+  inat_details_list: "* MO imports only fungal observations.\n* MO lists most iNat data and/or maps it to analogous MO fields.\n* MO hides coordinates from the public if iNat obscured them.\n* The MO Location is a rectangle with an MO-style name, rather than the iNat Place name."
 
   # /inat_import_job_tracker
   INAT_IMPORTS: iNat Imports

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,6 +446,8 @@ MushroomObserver::Application.routes.draw do
   get("inat_imports/authorization_response",
       to: "inat_imports#authorization_response",
       as: "inat_import_authorization_response")
+  get("inat_imports/cancel/:id", to: "inat_imports#cancel",
+                                 as: "inat_import_cancel")
   resources :inat_imports, only: [:show, :new, :create] do
     resources :job_trackers, only: [:show], module: :inat_imports
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,7 +446,7 @@ MushroomObserver::Application.routes.draw do
   get("inat_imports/authorization_response",
       to: "inat_imports#authorization_response",
       as: "inat_import_authorization_response")
-  get("inat_imports/cancel/:id", to: "inat_imports#cancel",
+  put("inat_imports/cancel/:id", to: "inat_imports#cancel",
                                  as: "inat_import_cancel")
   resources :inat_imports, only: [:show, :new, :create] do
     resources :job_trackers, only: [:show], module: :inat_imports

--- a/db/migrate/20250725173255_add_cancel_to_inat_imports.rb
+++ b/db/migrate/20250725173255_add_cancel_to_inat_imports.rb
@@ -1,0 +1,5 @@
+class AddCancelToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column :inat_imports, :cancel, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_142904) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_25_173255) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -223,6 +223,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_142904) do
     t.integer "total_seconds"
     t.float "avg_import_time"
     t.datetime "last_obs_start"
+    t.boolean "cancel"
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -2,7 +2,6 @@
 
 require("test_helper")
 
-# test mapping of iNat observation photo key/values to MO Image attributes
 class InatObservationImporterTest < UnitTestCase
   def test_canceled
     import = inat_imports(:ollie_inat_import)
@@ -14,7 +13,8 @@ class InatObservationImporterTest < UnitTestCase
     importer = ::Inat::ObservationImporter.new(import, user)
     assert_no_difference(
       "Observation.count",
-      "ObservationImporter should stop importing if the Import is canceled"
+      "ObservationImporter should stop importing observations after " \
+      "user cancels the Import"
     ) do
       importer.import_page(page)
     end

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# test mapping of iNat observation photo key/values to MO Image attributes
+class InatObservationImporterTest < UnitTestCase
+  def test_canceled
+    import = inat_imports(:ollie_inat_import)
+    assert(import.canceled?, "Test needs a canceled InatImport fixture")
+    user = import.user
+    mock_inat_response = File.read("test/inat/calostoma_lutescens.txt")
+    page = JSON.parse(mock_inat_response)
+
+    importer = ::Inat::ObservationImporter.new(import, user)
+    assert_no_difference(
+      "Observation.count",
+      "ObservationImporter should stop importing if the Import is canceled"
+    ) do
+      importer.import_page(page)
+    end
+  end
+end

--- a/test/classes/inat_page_parser_test.rb
+++ b/test/classes/inat_page_parser_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class InatPageParserTest < UnitTestCase
+  def test_inat_username_required
+    import = inat_imports(:ollie_inat_import)
+    assert_raises(ArgumentError) do
+      Inat::PageParser.new(import, "12345")
+    end
+  end
+end

--- a/test/controllers/inat_imports/job_trackers_controller_test.rb
+++ b/test/controllers/inat_imports/job_trackers_controller_test.rb
@@ -20,7 +20,7 @@ module InatImports
       # remove HTML tags for easier testing of displayed text
       body = strip_tags(@response.body)
 
-      assert(body.include?("#{:inat_import_tracker_status.l}: Unstarted"))
+      assert(body.include?("#{:STATUS.l}: Unstarted"))
       importables_line =
         "#{:inat_import_imported.l}: 0 of#{tracker.importables}"
       assert(body.include?(importables_line))
@@ -42,7 +42,7 @@ module InatImports
       assert_response(:success)
       body = strip_tags(@response.body)
 
-      assert(body.include?("#{:inat_import_tracker_status.l}: Done"))
+      assert(body.include?("#{:STATUS.l}: Done"))
       assert(body.include?(
                "#{:inat_import_tracker_estimated_remaining_time.l}: 00:00:00"
              ))

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -318,6 +318,16 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_import_all
+    user = users(:mary)
+    params = { inat_username: user.inat_username, all: 1, consent: 1 }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+  end
+
   def test_inat_username_unchanged_if_authorization_denied
     user = users(:rolf)
     assert_blank(user.inat_username,

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -285,6 +285,21 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_flash_error
   end
 
+  def test_import_all_anothers_observations
+    user = users(:dick) # Dick is a iNat superimporter
+    params = { inat_username: "anything", inat_ids: nil,
+               consent: 1, all: 1 }
+
+    login(user.login)
+    assert_no_difference("Observation.count",
+                         "iNat obss imported without consent") do
+      post(:create, params: params)
+    end
+
+    assert_flash_text(:inat_importing_all_anothers.t)
+    assert_form_action(action: :create)
+  end
+
   def test_import_authorized
     user = users(:rolf)
     assert_blank(user.inat_username,

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -343,16 +343,14 @@ class InatImportsControllerTest < FunctionalTestCase
     import = inat_imports(:katrina_inat_import)
     assert(import.job_pending? && !import.canceled?,
            "Test needs a Import fixture with a uncancelled, pending Job")
-    tracker = inat_import_job_trackers(:katrina_tracker)
 
     login
     get(:cancel, params: { id: import.id })
 
+    assert_response(:success)
+    assert_template(:show)
     assert(import.reload.canceled?,
            "Clicking cancel button should make InatImport.canceled? == true")
-    assert_redirected_to(
-      inat_import_path(import, params: { tracker_id: tracker.id })
-    )
   end
 
   ########## Utilities

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -73,6 +73,20 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_create_cancel_reset
+    user = users(:ollie)
+    import = inat_imports(:ollie_inat_import)
+    assert(import.canceled?, "Test needs a canceled InatImport fixture")
+    id = "123"
+    params = { inat_ids: id, inat_username: user.inat_username, consent: 1 }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_not(import.reload.canceled?,
+               "`cancel` should be false when starting an import")
+  end
+
   def test_create_missing_username
     user = users(:rolf)
     id = "123"

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -325,6 +325,22 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_cancel
+    import = inat_imports(:katrina_inat_import)
+    assert(import.job_pending? && !import.canceled?,
+           "Test needs a Import fixture with a uncancelled, pending Job")
+    tracker = inat_import_job_trackers(:katrina_tracker)
+
+    login
+    get(:cancel, params: { id: import.id })
+
+    assert(import.reload.canceled?,
+           "Clicking cancel button should make InatImport.canceled? == true")
+    assert_redirected_to(
+      inat_import_path(import, params: { tracker_id: tracker.id })
+    )
+  end
+
   ########## Utilities
 
   # iNat url where user is sent in order to authorize MO access

--- a/test/fixtures/inat_import_job_trackers.yml
+++ b/test/fixtures/inat_import_job_trackers.yml
@@ -5,3 +5,6 @@ katrina_tracker:
 
 lone_wolf_tracker:
   inat_import: <%= ActiveRecord::FixtureSet.identify(:lone_wolf_import) %>
+
+ollie_tracker:
+  inat_import: <%= ActiveRecord::FixtureSet.identify(:ollie_inat_import) %>

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -60,3 +60,10 @@ lone_wolf_import:
   state: <%= InatImport.states[:Done] %>
   ended_at: <%= Time.zone.now + 15.seconds %>
   response_errors: "Random error msg"
+
+# ollie canceled an import
+ollie_inat_import:
+  <<: *DEFAULTS
+  user: ollie
+  state: <%= InatImport.states[:Done] %>
+  cancel: true

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -13,6 +13,7 @@ DEFAULTS: &DEFAULTS
   total_imported_count: nil
   total_seconds: nil
   avg_import_time: nil
+  cancel: false
 
 rolf_inat_import:
   <<: *DEFAULTS
@@ -39,6 +40,7 @@ katrina_inat_import:
   user: katrina
   state: <%= InatImport.states[:Importing] %>
   inat_username: katrina_inat_username
+  cancel: false
 
 inat_importer_inat_import:
   <<: *DEFAULTS

--- a/test/fixtures/inat_imports.yml
+++ b/test/fixtures/inat_imports.yml
@@ -66,4 +66,5 @@ ollie_inat_import:
   <<: *DEFAULTS
   user: ollie
   state: <%= InatImport.states[:Done] %>
+  inat_username: null # used in InatPageParserTest
   cancel: true

--- a/test/fixtures/user_groups.yml
+++ b/test/fixtures/user_groups.yml
@@ -81,6 +81,7 @@ thorsten_only:
 webmaster_only:
   name: user <%= ActiveRecord::FixtureSet.identify(:webmaster) %>
 
+# can import other users' iNat observations
 super_importers_users:
   name: SuperImporters Project
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -53,6 +53,7 @@ junk:
 
 # Need third for testing votes
 # Also is the default user for Observation fixture set.
+# And Dick is a iNat superimporter
 dick:
   <<: *DEFAULTS
   name: Tricky Dick

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -84,6 +84,7 @@ roy:
 ollie:
   <<: *DEFAULTS
   name: Ollie
+  inat_username: ollie_inat_username
   user_groups: all_users, burbank_users, ollie_only
 
 spammer:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -59,6 +59,7 @@ dick:
   email_general_question: false
   verified: 2006-03-02 21:14:00
   user_groups: all_users, bolete_users, bolete_admins, albion_users, albion_admins, dick_only, falmouth_2023_09_users, super_importers_users
+  inat_username: null
 
 lone_wolf:
   <<: *DEFAULTS

--- a/test/helpers/inat_import_job_trackers_helper_test.rb
+++ b/test/helpers/inat_import_job_trackers_helper_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# test the helpers for InatImportJobTracker
+class InatImportJobTrackersHelperTest < ActionView::TestCase
+  def test_time_in_hours_minutes_seconds
+    tracker = inat_import_job_trackers(:ollie_tracker)
+    assert_equal("Done", tracker.status, "Test needs fixture that's Done")
+
+    assert_equal("00:00:00", remaining_time_in_hours_minutes_seconds(tracker))
+  end
+end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -520,7 +520,6 @@ class InatImportJobTest < ActiveJob::TestCase
     @user = users(:dick)
     assert(InatImport.super_importers.include?(@user),
            "Test needs User fixture that's SuperImporter")
-    old_inat_username = @user.inat_username
 
     create_ivars_from_filename("calostoma_lutescens")
     stub_inat_interactions

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -533,10 +533,8 @@ class InatImportJobTest < ActiveJob::TestCase
     end
 
     assert_empty(@inat_import.response_errors, "There should be no errors")
-    assert_equal(
-      old_inat_username, @user.reload.inat_username,
-      "SuperImporter's inat_username should not change"
-    )
+    assert_nil(@user.reload.inat_username,
+               "SuperImporter's inat_username should not change")
   end
 
   def test_import_canceled

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -520,6 +520,7 @@ class InatImportJobTest < ActiveJob::TestCase
     @user = users(:dick)
     assert(InatImport.super_importers.include?(@user),
            "Test needs User fixture that's SuperImporter")
+    old_inat_username = @user.inat_username
 
     create_ivars_from_filename("calostoma_lutescens")
     stub_inat_interactions(superimporter: true)
@@ -532,6 +533,10 @@ class InatImportJobTest < ActiveJob::TestCase
     end
 
     assert_empty(@inat_import.response_errors, "There should be no errors")
+    assert_equal(
+      old_inat_username, @user.reload.inat_username,
+      "SuperImporter's inat_username should not change"
+    )
   end
 
   def test_import_canceled

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -523,7 +523,7 @@ class InatImportJobTest < ActiveJob::TestCase
     old_inat_username = @user.inat_username
 
     create_ivars_from_filename("calostoma_lutescens")
-    stub_inat_interactions(superimporter: true)
+    stub_inat_interactions
 
     assert_difference(
       "Observation.count", 1,

--- a/test/jobs/inat_import_job_test_doubles.rb
+++ b/test/jobs/inat_import_job_test_doubles.rb
@@ -5,13 +5,11 @@ module InatImportJobTestDoubles
 
   def stub_inat_interactions(
     id_above: 0,
-    login: @inat_import.inat_username,
-    superimporter: false
+    login: @inat_import.inat_username
   )
     stub_token_requests
     stub_check_username_match(login)
-    stub_inat_observation_request(id_above: id_above,
-                                  superimporter: superimporter)
+    stub_inat_observation_request(id_above: id_above)
     stub_inat_photo_requests
     stub_modify_inat_observations
   end
@@ -69,7 +67,7 @@ module InatImportJobTestDoubles
                 headers: {})
   end
 
-  def stub_inat_observation_request(id_above: 0, superimporter: false)
+  def stub_inat_observation_request(id_above: 0)
     query_args = {
       iconic_taxa: ICONIC_TAXA,
       id: @inat_import.inat_ids,
@@ -79,7 +77,7 @@ module InatImportJobTestDoubles
       order: "asc",
       order_by: "id",
       without_field: "Mushroom Observer URL",
-      user_login: (@inat_import.inat_username unless superimporter)
+      user_login: @inat_import.inat_username
     }
 
     stub_request(:get, "#{API_BASE}/observations?#{query_args.to_query}").


### PR DESCRIPTION
Let an MO user import all their iNat observations.
(Limited to observations which are fungal and which weren't already imported from iNat or mirrored to iNat.)

- Adds `Import all my iNat observations ...` checklist to the InatImport form.
- If checked, imports all of the user's iNat observations except those:
  - previously imported from iNat, or 
  - copied to iNat via Pulk's (currently broken) `mirror` script or iNat's defunct import from MO function.

## Manual Test

### **WARNING!!!**

> - Testing the import_all feature potentially imports many more iNat obs than you except.
> - Be prepared to cancel the import and to repair -- in iNat -- any surpise imports.
> - In my case, I thought I had only 3 non-imported iNat observations. 
> But import_all correctly tried to import 72 observations. 
> - By the time I realized what was happening and canceled the import, 
> it had imported 5 observations which I then had to clean up in iNat.
>> <img width="279" height="290" alt="Screenshot 2025-08-03 at 11 45 51 AM" src="https://github.com/user-attachments/assets/aff00e8b-e71a-4e45-af79-e7d6ca18e01c" />

### Suggested test procedure

- Create a sacrificial iNat observation
- Go to http://localhost:3000/inat_imports/new
- Click the `Import all my iNat observations` and the consent checkboxes
- Submit
- **Watch the **`Imported:`** line on the `iNat Import Tracker` page
- ASAP click Cancel If it wants to import more than 1 observation. 
Expected result:
It imports at least one iNat observation
- Click Results
- Clean up iNat if there are surprise imports.  
  For each surprise import, 
  - click the Inat `External Link` to get to the iNat observation.
  - Delete the `Mushroom Observer URL` Observation Field in the iNat observation:
    - scroll to the `Mushroom Observer URL` Observation Field
    - click on `Mushroom Observer URL` (not on the URL)
    - click Delete in the resulting pop-up.
