### PR TITLE
Fix N+1 issue on ObservationsController#index page

### DIFF
--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -59,7 +59,8 @@ class Observation
     attr_accessor :observation, :namings, :votes, :consensus_changed
 
     def initialize(observation)
-      @observation = ::Observation.naming_includes.find(observation.id)
+      # @observation = ::Observation.naming_includes.find(observation.id)
+      @observation = observation
       @namings = observation.namings
       @votes = @namings.map(&:votes).flatten
       @consensus_changed = false


### PR DESCRIPTION
This line was introduced as part of the recent vote tally update PR #3049.  It's not clear to me yet why this change was made in this spot since all tests continue to pass without it.  For me (user nathan), the change in this PR drops loading the home page from 1873 database queries to 34.
