### PR TITLE
Add the Actions menu to Observation Lists when seen in a Project context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -391,7 +391,8 @@ class ApplicationController < ActionController::Base
   # having the project param stored inside the query record, q.
   def set_project_ivar
     # NOTE: Query param projects is always an array of ids.
-    query_projects = QueryRecord.check_param(:projects, params[:q])
+    query_projects = QueryRecord.check_param(:projects, params[:q]) || []
+    # If more than one project, it's none. Only want single-project associations
     query_project = query_projects.size > 1 ? nil : query_projects.first
     project_id = params[:project] || query_project
     # At this point, we still might not have one. That's fine - just return nil.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -387,6 +387,17 @@ class ApplicationController < ActionController::Base
   end
   helper_method :calc_layout_params
 
+  # NOTE: SpeciesList show pages cannot nav prev/next within a project without
+  # having the project param stored inside the query record, q.
+  def set_project_ivar
+    # NOTE: Query param projects is always an array of ids.
+    query_projects = QueryRecord.check_param(:projects, params[:q])
+    query_project = query_projects.size > 1 ? nil : query_projects.first
+    project_id = params[:project] || query_project
+    # At this point, we still might not have one. That's fine - just return nil.
+    @project = Project.safe_find(project_id)
+  end
+
   def permission?(obj, error_message)
     result = (in_admin_mode? || obj.can_edit?(@user)) # rubocop:disable Style/RedundantParentheses
     flash_error(error_message) unless result

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -100,7 +100,7 @@ class SpeciesListsController < ApplicationController
     pass_query_params
     return unless (@species_list = find_species_list!)
 
-    @project = Project.safe_find(params[:project])
+    set_project_ivar
     case params[:flow]
     when "next"
       redirect_to_next_object(:next, SpeciesList, params[:id]) and return

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -25,6 +25,7 @@ class SpeciesListsController < ApplicationController
   # INDEX
   #
   def index
+    set_project_ivar
     build_index_with_query
   end
 

--- a/app/helpers/species_lists_helper.rb
+++ b/app/helpers/species_lists_helper.rb
@@ -2,12 +2,12 @@
 
 # View Helpers for Observation Lists
 module SpeciesListsHelper
-  def species_list_title_panel(list)
-    tag.div(class: "species_list_title") do
-      concat(tag.br)
-      concat(panel_block(id: "species_list_title") do
-               tag.span(list.unique_format_name, class: "h3")
-             end)
-    end
-  end
+  # def species_list_title_panel(list)
+  #   tag.div(class: "species_list_title") do
+  #     concat(tag.br)
+  #     concat(panel_block(id: "species_list_title") do
+  #              tag.span(list.unique_format_name, class: "h3")
+  #            end)
+  #   end
+  # end
 end

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -71,7 +71,7 @@ module Tabs
     end
 
     def add_project_banner(project)
-      add_page_title(link_to_object(project))
+      content_for(:banner_title) { link_to_object(project) }
 
       if project.location
         content_for(:project_location) do

--- a/app/helpers/title_interest_icons_helper.rb
+++ b/app/helpers/title_interest_icons_helper.rb
@@ -19,13 +19,15 @@ module TitleInterestIconsHelper
   def add_interest_icons(user, object)
     return unless user
 
-    img1, img2, img3 = img_link_array(user, object)
+    img1, img2, img3 = interest_links(user, object)
 
     content_for(:interest_icons) do
-      [
-        tag.li { img1 },
-        tag.li { img2 + img3 }
-      ].safe_join
+      tag.ul(class: "nav navbar-flex interest-eyes h4 my-0") do
+        [
+          tag.li { img1 },
+          tag.li { img2 + img3 }
+        ].safe_join
+      end
     end
   end
 
@@ -41,19 +43,19 @@ module TitleInterestIconsHelper
   end
 
   # Array of image links which user can click to control getting email re object
-  def img_link_array(user, object)
+  def interest_links(user, object)
     type = object.type_tag
     case user.interest_in(object)
     when :watching
-      img_links_when_watching(object, type)
+      interest_links_when_watching(object, type)
     when :ignoring
-      img_links_when_ignoring(object, type)
+      interest_links_when_ignoring(object, type)
     else
-      img_links_default(object, type)
+      interest_links_default(object, type)
     end
   end
 
-  def img_links_when_watching(object, type)
+  def interest_links_when_watching(object, type)
     alt1 = :interest_watching.l(object: type.l)
     alt2 = :interest_default_help.l(object: type.l)
     alt3 = :interest_ignore_help.l(object: type.l)
@@ -65,7 +67,7 @@ module TitleInterestIconsHelper
     [img1, img2, img3]
   end
 
-  def img_links_when_ignoring(object, type)
+  def interest_links_when_ignoring(object, type)
     alt1 = :interest_ignoring.l(object: type.l)
     alt2 = :interest_watch_help.l(object: type.l)
     alt3 = :interest_default_help.l(object: type.l)
@@ -77,7 +79,7 @@ module TitleInterestIconsHelper
     [img1, img2, img3]
   end
 
-  def img_links_default(object, type)
+  def interest_links_default(object, type)
     alt1 = :interest_watch_help.l(object: type.l)
     alt2 = :interest_ignore_help.l(object: type.l)
     img1 = interest_icon_small("watch", alt1)

--- a/app/helpers/title_prev_next_helper.rb
+++ b/app/helpers/title_prev_next_helper.rb
@@ -26,13 +26,13 @@ module TitlePrevNextHelper
       %w[navbar-link navbar-left btn btn-lg px-0 prev_object_link]
     )
     path = if object.type_tag == :rss_log
-             send(:activity_log_path, object.id, flow: "prev")
+             :activity_log_path
            else
-             send(:"#{object.type_tag}_path", object.id, flow: "prev")
+             :"#{object.type_tag}_path"
            end
 
     icon_link_to(
-      :PREV.t, add_query_param(path),
+      :PREV.t, add_query_param(send(path, object.id, flow: "prev")),
       class: classes, icon: :previous, show_text: false
     )
   end
@@ -60,13 +60,13 @@ module TitlePrevNextHelper
       %w[navbar-link navbar-left btn btn-lg px-0 next_object_link]
     )
     path = if object.type_tag == :rss_log
-             send(:activity_log_path, object.id, flow: "next")
+             :activity_log_path
            else
-             send(:"#{object.type_tag}_path", object.id, flow: "next")
+             :"#{object.type_tag}_path"
            end
 
     icon_link_to(
-      :NEXT.t, add_query_param(path),
+      :NEXT.t, add_query_param(send(path, object.id, flow: "next")),
       class: classes, icon: :next, show_text: false
     )
   end

--- a/app/models/query_record.rb
+++ b/app/models/query_record.rb
@@ -43,9 +43,17 @@ class QueryRecord < ApplicationRecord
   end
 
   # Checks and returns the value of a param in the saved QueryRecord
-  def self.check_param(param, q_value)
-    qr = QueryRecord.find(q_value.dealphabetize)
-    qr_query = qr.query
-    qr_query.params[param]
+  def self.check_param(param, q_param)
+    query_record = QueryRecord.safe_find(q_param&.dealphabetize)
+    return nil unless query_record
+
+    query_record.query.params[param]
+  end
+
+  # copied from abstract model, which this does not inherit from
+  def self.safe_find(id)
+    find(id)
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 end

--- a/app/models/query_record.rb
+++ b/app/models/query_record.rb
@@ -41,4 +41,11 @@ class QueryRecord < ApplicationRecord
 
     @last_cleanup = Time.zone.now
   end
+
+  # Checks and returns the value of a param in the saved QueryRecord
+  def self.check_param(param, q_value)
+    qr = QueryRecord.find(q_value.dealphabetize)
+    qr_query = qr.query
+    qr_query.params[param]
+  end
 end

--- a/app/views/controllers/application/content/_header.html.erb
+++ b/app/views/controllers/application/content/_header.html.erb
@@ -25,6 +25,16 @@ index_bar =
   <%# Immediately below the top nav: index filters or page title, plus page nav.
       Indexes have no "#title" — `rubric` in top_nav has the model name. %>
   <%= render(partial: "application/content/project_banner") if has_banner %>
+
+  <%= tag.div(class: "row") do %>
+    <%# Project tabs %>
+    <% if content_for?(:project_tabs) %>
+      <%= tag.div(class: title_cols, id: "project_tabs") do
+        yield(:project_tabs)
+      end %>
+    <% end %>
+  <% end %>
+
   <% if index_bar %>
     <%# Index filters and pagination, full width. %>
     <%= render(partial: "application/content/index_bar") %>
@@ -38,13 +48,6 @@ index_bar =
     <% if content_for?(:type_filters) %>
       <%= tag.div(class: "hidden-print col-xs-12") do
         yield(:type_filters)
-      end %>
-    <% end %>
-
-    <%# Project tabs %>
-    <% if content_for?(:project_tabs) %>
-      <%= tag.div(class: title_cols, id: "project_tabs") do
-        yield(:project_tabs)
       end %>
     <% end %>
 

--- a/app/views/controllers/application/content/_header.html.erb
+++ b/app/views/controllers/application/content/_header.html.erb
@@ -18,7 +18,8 @@ title_cols = content_for?(:interest_icons) ? title_cols : ""
 title_cols = class_names("col-xs-12", title_cols)
 index_bar =
   (action_name == "index" && controller.controller_name != "articles") ||
-  controller.controller_name == "maps"
+  controller.controller_name == "maps" ||
+  content_for?(:numbers) || content_for?(:letters)
 %>
 
 <%= tag.header(id: "header") do %>
@@ -35,12 +36,14 @@ index_bar =
     <% end %>
   <% end %>
 
-  <% if index_bar %>
-    <%# Index filters and pagination, full width. %>
-    <%= render(partial: "application/content/index_bar") %>
-  <% elsif action_name != "index" %>
+  <% if action_name != "index" %>
     <%# Page title, edit icons, interest icons and page nav. %>
     <%= render(partial: "application/content/page_title") %>
+  <% end %>
+
+  <% if index_bar %>
+    <%# Index filters and pagination, full width. Could be species list show %>
+    <%= render(partial: "application/content/index_bar") %>
   <% end %>
 
   <%= tag.div(class: "row") do %>

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -16,7 +16,7 @@ pagination = content_for?(:numbers) || content_for?(:letters)
           end
         end %>
         <% if pagination %>
-          <%= tag.div(class: "pagination-top navbar navbar-flex") do
+          <%= tag.div(class: "pagination-top navbar-flex") do
             concat(yield(:numbers))
             concat(yield(:letters))
           end %>

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -1,6 +1,6 @@
 <%
-filters = (content_for?(:filters) || content_for?(:filter_help)) &&
-          !content_for?(:banner_image)
+filters = content_for?(:filters) || content_for?(:filter_help)
+
 pagination = content_for?(:numbers) || content_for?(:letters)
 %>
 
@@ -9,12 +9,12 @@ pagination = content_for?(:numbers) || content_for?(:letters)
     <%= tag.div(class: "col-xs-12", id: "index_bar") do %>
       <%# Indexes: Query filter subtitle and pagination %>
       <%= tag.div(class: "d-flex justify-content-between") do %>
-        <% if filters %>
-          <%= tag.div(class: "px-3 mb-3") do
-            concat(yield(:filters))
+        <%= tag.div(class: "px-3 mb-3") do
+          if filters
+            concat(yield(:filters)) if !content_for?(:banner_image)
             concat(yield(:filter_help))
-          end %>
-        <% end %>
+          end
+        end %>
         <% if pagination %>
           <%= tag.div(class: "pagination-top navbar navbar-flex") do
             concat(yield(:numbers))

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -1,5 +1,6 @@
 <%
-filters = content_for?(:filters) || content_for?(:filter_help)
+filters = (content_for?(:filters) || content_for?(:filter_help)) &&
+          !content_for?(:banner_image)
 pagination = content_for?(:numbers) || content_for?(:letters)
 %>
 

--- a/app/views/controllers/application/content/_page_title.erb
+++ b/app/views/controllers/application/content/_page_title.erb
@@ -1,11 +1,13 @@
 <%
 has_banner = content_for?(:banner_image)
-needs_page_title = !(has_banner && controller.controller_name == "projects")
+is_projects = controller.controller_name == "projects"
+needs_page_title = !(has_banner && is_projects)
 add_interest_icons = (content_for?(:interest_icons))
 title_cols = "col-sm-8 col-lg-7"
 project_subtitle = content_for?(:project_location) ||
                    content_for?(:project_date_range)
 title_class = has_banner ? "h3" : "h4"
+title = is_projects ? "" : yield(:title)
 %>
 
 <%= tag.div(class: "row") do %>
@@ -16,7 +18,7 @@ title_class = has_banner ? "h3" : "h4"
         class: "show_title_nav d-flex justify-content-between pl-3"
       ) do
         [
-          tag.h1(yield(:title), class: title_class, id: "title"),
+          tag.h1(title, class: title_class, id: "title"),
           tag.ul(class: "nav navbar-nav object_edit h4") do
             concat(yield(:edit_icons))
           end
@@ -36,7 +38,7 @@ title_class = has_banner ? "h3" : "h4"
 
   <%# Show pages (except projects): %>
   <%# Interest and edit icons, prev/index/next links %>
-  <% if action_name == "show" && !has_banner %>
+  <% if action_name == "show" # && !has_banner %>
     <%= tag.div(
       class: class_names(yield(:right_columns), "hidden-print text-right")
     ) do

--- a/app/views/controllers/application/content/_page_title.erb
+++ b/app/views/controllers/application/content/_page_title.erb
@@ -1,19 +1,16 @@
 <%
 has_banner = content_for?(:banner_image)
-is_projects = controller.controller_name == "projects" &&
-              %w[index, show].include?(action_name)
-needs_page_title = !(has_banner && is_projects)
 add_interest_icons = (content_for?(:interest_icons))
 title_cols = "col-sm-8 col-lg-7"
 project_subtitle = content_for?(:project_location) ||
                    content_for?(:project_date_range)
 title_class = has_banner ? "h3" : "h4"
-title = is_projects ? "" : yield(:title)
+title = yield(:title) unless has_banner
 %>
 
 <%= tag.div(class: "row") do %>
   <%# Page title. Indexes have none — `rubric` in top_nav has model name. %>
-  <% if action_name != "index" && needs_page_title %>
+  <% if action_name != "index" && !has_banner %>
     <%= tag.div(class: yield(:left_columns), id: "title_bar") do %>
       <%= tag.nav(
         class: "show_title_nav d-flex justify-content-between pl-3"

--- a/app/views/controllers/application/content/_page_title.erb
+++ b/app/views/controllers/application/content/_page_title.erb
@@ -1,6 +1,7 @@
 <%
 has_banner = content_for?(:banner_image)
-is_projects = controller.controller_name == "projects"
+is_projects = controller.controller_name == "projects" &&
+              %w[index, show].include?(action_name)
 needs_page_title = !(has_banner && is_projects)
 add_interest_icons = (content_for?(:interest_icons))
 title_cols = "col-sm-8 col-lg-7"

--- a/app/views/controllers/application/content/_page_title.erb
+++ b/app/views/controllers/application/content/_page_title.erb
@@ -1,5 +1,6 @@
 <%
 has_banner = content_for?(:banner_image)
+needs_page_title = !(has_banner && controller.controller_name == "projects")
 add_interest_icons = (content_for?(:interest_icons))
 title_cols = "col-sm-8 col-lg-7"
 project_subtitle = content_for?(:project_location) ||
@@ -9,7 +10,7 @@ title_class = has_banner ? "h3" : "h4"
 
 <%= tag.div(class: "row") do %>
   <%# Page title. Indexes have none — `rubric` in top_nav has model name. %>
-  <% if action_name != "index" %>
+  <% if action_name != "index" && needs_page_title %>
     <%= tag.div(class: yield(:left_columns), id: "title_bar") do %>
       <%= tag.nav(
         class: "show_title_nav d-flex justify-content-between pl-3"

--- a/app/views/controllers/application/content/_page_title.erb
+++ b/app/views/controllers/application/content/_page_title.erb
@@ -4,31 +4,30 @@ add_interest_icons = (content_for?(:interest_icons))
 title_cols = "col-sm-8 col-lg-7"
 project_subtitle = content_for?(:project_location) ||
                    content_for?(:project_date_range)
+title_class = has_banner ? "h3" : "h4"
 %>
 
 <%= tag.div(class: "row") do %>
   <%# Page title. Indexes have none — `rubric` in top_nav has model name. %>
   <% if action_name != "index" %>
     <%= tag.div(class: yield(:left_columns), id: "title_bar") do %>
-      <% if !has_banner %>
-        <%= tag.nav(
-          class: "show_title_nav d-flex justify-content-between pl-3"
-        ) do
+      <%= tag.nav(
+        class: "show_title_nav d-flex justify-content-between pl-3"
+      ) do
+        [
+          tag.h1(yield(:title), class: title_class, id: "title"),
+          tag.ul(class: "nav navbar-nav object_edit h4") do
+            concat(yield(:edit_icons))
+          end
+        ].safe_join
+      end %>
+      <% if !has_banner && project_subtitle %>
+        <%= tag.div(class: "pl-3 mb-3") do
           [
-            tag.h1(yield(:title), class: "h4", id: "title"),
-            tag.ul(class: "nav navbar-nav object_edit h4") do
-              concat(yield(:edit_icons))
-            end
+            tag.div(yield(:project_location), class: "project_location"),
+            tag.div(yield(:project_date_range), class: "project_date_range")
           ].safe_join
         end %>
-        <% if project_subtitle %>
-          <%= tag.div(class: "pl-3 mb-3") do
-            [
-              tag.div(yield(:project_location), class: "project_location"),
-              tag.div(yield(:project_date_range), class: "project_date_range")
-            ].safe_join
-          end %>
-        <% end %>
       <% end %>
       <%= yield(:owner_naming) %>
     <% end %>

--- a/app/views/controllers/application/content/_project_banner.erb
+++ b/app/views/controllers/application/content/_project_banner.erb
@@ -4,8 +4,8 @@
   <%= tag.div(class: "col-xs-12", id: "project_banner") do %>
     <%= yield(:banner_image) %>
     <%= tag.div(class: "bottom-left ml-3 mb-3 p-2") do %>
-      <%= tag.h1(yield(:title),
-                  class: "h3 banner-image-text", id: "title") -%>
+      <%= tag.h1(yield(:banner_title),
+                 class: "h3 banner-image-text", id: "title") -%>
       <% if content_for?(:project_location) %>
         <%= tag.div(yield(:project_location),
                     class: "project_location banner-image-text") %>

--- a/app/views/controllers/application/content/_project_banner.erb
+++ b/app/views/controllers/application/content/_project_banner.erb
@@ -1,11 +1,14 @@
 <%# Project banner with title, location, date_range %>
+<%
+title_id = controller.controller_name == "projects" ? "title" : "banner_title"
+%>
 
 <%= tag.div(class: "row") do %>
   <%= tag.div(class: "col-xs-12", id: "project_banner") do %>
     <%= yield(:banner_image) %>
     <%= tag.div(class: "bottom-left ml-3 mb-3 p-2") do %>
       <%= tag.h1(yield(:banner_title),
-                 class: "h3 banner-image-text", id: "banner_title") -%>
+                 class: "h3 banner-image-text", id: title_id) -%>
       <% if content_for?(:project_location) %>
         <%= tag.div(yield(:project_location),
                     class: "project_location banner-image-text") %>

--- a/app/views/controllers/application/content/_project_banner.erb
+++ b/app/views/controllers/application/content/_project_banner.erb
@@ -5,7 +5,7 @@
     <%= yield(:banner_image) %>
     <%= tag.div(class: "bottom-left ml-3 mb-3 p-2") do %>
       <%= tag.h1(yield(:banner_title),
-                 class: "h3 banner-image-text", id: "title") -%>
+                 class: "h3 banner-image-text", id: "banner_title") -%>
       <% if content_for?(:project_location) %>
         <%= tag.div(yield(:project_location),
                     class: "project_location banner-image-text") %>

--- a/app/views/controllers/checklists/show.html.erb
+++ b/app/views/controllers/checklists/show.html.erb
@@ -1,13 +1,8 @@
 <%
 container_class(:full)
-if @project
-  add_project_banner(@project)
-else
-  add_page_title(checklist_show_title(user: @show_user,
-                                      list: @species_list))
-  add_context_nav(checklist_show_tabs(user: @show_user,
-                                  list: @species_list))
-end
+add_project_banner(@project) if @project
+add_page_title(checklist_show_title(user: @show_user, list: @species_list))
+add_context_nav(checklist_show_tabs(user: @show_user, list: @species_list))
 %>
 
 <div class="my-4">

--- a/app/views/controllers/field_slips/index.html.erb
+++ b/app/views/controllers/field_slips/index.html.erb
@@ -1,13 +1,10 @@
 <%
-if @project
-  add_project_banner(@project)
-else
-  add_index_title(@query)
-  add_context_nav(field_slips_index_tabs)
-  project_title = @query&.params_cache&.dig(:project)&.title || ""
-end
+add_project_banner(@project) if @project
+add_index_title(@query)
+add_context_nav(field_slips_index_tabs)
 add_pagination(@pagination_data)
 container_class(:wide)
+project_title = @query&.params_cache&.dig(:project)&.title || ""
 %>
 
 <% if notice %>

--- a/app/views/controllers/observations/index.html.erb
+++ b/app/views/controllers/observations/index.html.erb
@@ -1,13 +1,9 @@
 <%
-if @project
-  add_project_banner(@project)
-  container_class(:wide)
-else
-  add_index_title(@query) # note default above is non-nil
-  container_class(:full)
-  add_context_nav(observations_index_tabs(query: @query)) if @objects.any?
-end
+add_project_banner(@project) if @project
 project_observation_buttons(@project, @query)
+container_class(:full)
+add_index_title(@query) # note default above is non-nil
+add_context_nav(observations_index_tabs(query: @query)) if @objects.any?
 add_sorter(@query, observations_index_sorts)
 add_pagination(@pagination_data)
 

--- a/app/views/controllers/projects/aliases/edit.html.erb
+++ b/app/views/controllers/projects/aliases/edit.html.erb
@@ -1,10 +1,9 @@
 <%
-  add_project_banner(@project_alias.project)
-  container_class(:text)
-  project_id = @project_alias.project_id
+add_project_banner(@project_alias.project)
+add_page_title(:project_alias_edit.l(name: @project_alias.name))
+container_class(:text)
+project_id = @project_alias.project_id
 %>
-
-<h1><%= :project_alias_edit.l(name: @project_alias.name) %></h1>
 
 <%= render("form", project_alias: @project_alias, local: true) %>
 

--- a/app/views/controllers/projects/aliases/index.html.erb
+++ b/app/views/controllers/projects/aliases/index.html.erb
@@ -1,10 +1,9 @@
 <%
-  add_project_banner(@project)
-  container_class(:wide)
-  project_id = @project.id
+add_project_banner(@project)
+add_page_title(:PROJECT_ALIASES.l)
+container_class(:wide)
+project_id = @project.id
 %>
-
-<h1>Project Aliases</h1>
 
 <%=
   make_table(headers: project_alias_headers,

--- a/app/views/controllers/projects/aliases/new.html.erb
+++ b/app/views/controllers/projects/aliases/new.html.erb
@@ -1,10 +1,9 @@
 <%
-  add_project_banner(@project_alias.project)
-  container_class(:text)
-  project_id = @project_alias.project_id
+add_project_banner(@project_alias.project)
+add_page_title(:project_alias_new.l)
+container_class(:text)
+project_id = @project_alias.project_id
 %>
-
-<h1><%= :project_alias_new.l %></h1>
 
 <%= render("form", project_alias: @project_alias, local: true) %>
 

--- a/app/views/controllers/projects/locations/index.html.erb
+++ b/app/views/controllers/projects/locations/index.html.erb
@@ -15,7 +15,10 @@ container_class(:wide)
     <% @locations.each do |loc| %>
       <tr>
         <td class="align-middle">
-          <%= link_to(loc.display_name, checklist_path(project_id: @project.id, location_id: loc.id)) %>
+          <%= link_to(
+            loc.display_name,
+            checklist_path(project_id: @project.id, location_id: loc.id)
+          ) %>
         </td>
         <td class="align-middle">
           <%= render(partial: "projects/aliases",

--- a/app/views/controllers/projects/show.html.erb
+++ b/app/views/controllers/projects/show.html.erb
@@ -1,5 +1,6 @@
 <%
 add_project_banner(@project)
+add_page_title(@project.title)
 container_class(:wide)
 %>
 

--- a/app/views/controllers/projects/show.html.erb
+++ b/app/views/controllers/projects/show.html.erb
@@ -3,8 +3,6 @@ add_project_banner(@project)
 container_class(:wide)
 %>
 
-<br />
-
 <%= render(partial: "shared/list_search", locals: { object: @project }) %>
 
 <%= panel_block(id: "project_summary") do %>

--- a/app/views/controllers/species_lists/index.html.erb
+++ b/app/views/controllers/species_lists/index.html.erb
@@ -1,13 +1,9 @@
 <%
-if @project
-  add_project_banner(@project)
-  container_class(:wide)
-else
-  add_index_title(@query)
-  container_class(:full)
-end
+add_project_banner(@project) if @project
+add_index_title(@query)
 add_sorter(@query, species_lists_index_sorts(query: @query))
 add_pagination(@pagination_data)
+container_class(:full)
 
 flash_error(@error) if @error && @objects.empty?
 %>

--- a/app/views/controllers/species_lists/index.html.erb
+++ b/app/views/controllers/species_lists/index.html.erb
@@ -12,20 +12,19 @@ flash_error(@error) if @error && @objects.empty?
   <% if @objects.any? %>
     <div class="list-group">
       <% @objects.each do |species_list| %>
-      <div class="list-group-item">
-        <div class="text-larger">
-          <%=
-            when_span = tag.span(species_list.when.to_s, class: "list_when")
-            what_span = tag.span(species_list.unique_text_name.t,
-                                class: "list_what")
-            args = species_list.show_link_args
-            args[:project] = @project if @project
-            link_to(when_span + ": " + what_span, args)
-          %>
-        </div><!-- .text-larger -->
-        <span><%= species_list.place_name.t rescue :UNKNOWN.t %></span> |
-        <span><%= user_link(species_list.user) %></span>
-      </div>
+        <div class="list-group-item">
+          <div class="text-larger">
+            <%=
+              when_span = tag.span(species_list.when.to_s, class: "list_when")
+              what_span = tag.span(species_list.unique_text_name.t,
+                                   class: "list_what")
+              args = add_query_param(species_list.show_link_args)
+              link_with_query(when_span + ": " + what_span, args)
+            %>
+          </div><!-- .text-larger -->
+          <span><%= species_list.place_name.t rescue :UNKNOWN.t %></span> |
+          <span><%= user_link(species_list.user) %></span>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -1,6 +1,4 @@
 <%
-container_class(:double)
-column_classes(:nine_three)
 add_project_banner(@project) if @project
 show_title = @species_list.unique_format_name
 add_page_title(show_title, ["#{:SPECIES_LIST.l}:", show_title].safe_join(" "))
@@ -9,6 +7,8 @@ add_edit_icons(@species_list)
 add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
 add_pager_for(@species_list)
 query_params_set(@query) if @pagination_data.any?
+container_class(:double)
+column_classes(:nine_three)
 %>
 
 <%= tag.div(class: "row") do %>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -5,7 +5,7 @@ add_page_title(show_title, ["#{:SPECIES_LIST.l}:", show_title].safe_join(" "))
 add_interest_icons(@user, @species_list)
 add_edit_icons(@species_list)
 add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
-add_pager_for(@species_list)
+add_pager_for(@species_list) # takes you to prev/next list, not page of obs
 add_pagination(@pagination_data)
 query_params_set(@query) if @pagination_data.any?
 container_class(:double)

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -1,7 +1,11 @@
 <%
 add_project_banner(@project) if @project
-show_title = @species_list.unique_format_name
-add_page_title(show_title, ["#{:SPECIES_LIST.l}:", show_title].safe_join(" "))
+page_title = "#{:SPECIES_LIST.l}: #{@species_list.unique_format_name}"
+show_title = [
+  @species_list.title,
+  tag.span(@species_list.id, class: "badge badge-outline ml-3")
+].safe_join(" ")
+add_page_title(show_title, page_title)
 add_interest_icons(@user, @species_list)
 add_edit_icons(@species_list)
 add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
@@ -14,9 +18,6 @@ column_classes(:nine_three)
 
 <%= tag.div(class: "row") do %>
   <%= tag.div(class: yield(:left_columns)) do %>
-
-    <%# this needs to be a regular page_title, but below the project tabs %>
-    <%# species_list_title_panel(@species_list) if @project %>
 
     <%= render(partial: "shared/list_search",
                locals: { object: @species_list }) %>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -1,22 +1,20 @@
 <%
 container_class(:double)
 column_classes(:nine_three)
+add_project_banner(@project) if @project
+show_title = @species_list.unique_format_name
+add_page_title(show_title, ["#{:SPECIES_LIST.l}:", show_title].safe_join(" "))
+add_interest_icons(@user, @species_list)
+add_edit_icons(@species_list)
 add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
-if @project
-  add_project_banner(@project)
-else
-  show_title = @species_list.unique_format_name
-  add_page_title(show_title, ["#{:SPECIES_LIST.l}:", show_title].safe_join(" "))
-  add_pager_for(@species_list)
-  add_interest_icons(@user, @species_list)
-  add_edit_icons(@species_list)
-end
+add_pager_for(@species_list)
 query_params_set(@query) if @pagination_data.any?
 %>
 
 <%= tag.div(class: "row") do %>
   <%= tag.div(class: yield(:left_columns)) do %>
 
+    <%# this needs to be a regular page_title, but below the project tabs %>
     <%= species_list_title_panel(@species_list) if @project %>
 
     <%= render(partial: "shared/list_search",

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -1,12 +1,12 @@
 <%
 container_class(:double)
 column_classes(:nine_three)
+add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
 if @project
   add_project_banner(@project)
 else
   show_title = @species_list.unique_format_name
   add_page_title(show_title, ["#{:SPECIES_LIST.l}:", show_title].safe_join(" "))
-  add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
   add_pager_for(@species_list)
   add_interest_icons(@user, @species_list)
   add_edit_icons(@species_list)

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -15,7 +15,7 @@ query_params_set(@query) if @pagination_data.any?
   <%= tag.div(class: yield(:left_columns)) do %>
 
     <%# this needs to be a regular page_title, but below the project tabs %>
-    <%= species_list_title_panel(@species_list) if @project %>
+    <%# species_list_title_panel(@species_list) if @project %>
 
     <%= render(partial: "shared/list_search",
                locals: { object: @species_list }) %>

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -6,6 +6,7 @@ add_interest_icons(@user, @species_list)
 add_edit_icons(@species_list)
 add_context_nav(species_list_show_tabs(list: @species_list, query: @query))
 add_pager_for(@species_list)
+add_pagination(@pagination_data)
 query_params_set(@query) if @pagination_data.any?
 container_class(:double)
 column_classes(:nine_three)

--- a/test/controllers/observations_controller/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller/observations_controller_index_test.rb
@@ -569,7 +569,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     get(:index, params: { project: project.id })
 
     assert_response(:success)
-    assert_page_title(project.title)
+    assert_page_title(:OBSERVATIONS.l)
   end
 
   def test_index_project_without_observations
@@ -579,7 +579,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     get(:index, params: { project: project.id })
 
     assert_response(:success)
-    assert_page_title(project.title)
+    assert_page_title(:OBSERVATIONS.l)
     assert_flash_text(:runtime_no_matches.l(type: :observation))
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -76,6 +76,20 @@ class ProjectsControllerTest < FunctionalTestCase
       "a[href*=?]", new_project_member_path(project_id: p_id), count: 0
     )
     assert_select("form[action=?]", add_dispatch_path, count: 1)
+    assert_select("h1#title", /\S/,
+                  "H1 title element should exist but be empty")
+    assert_select("div#project_banner", true,
+                  "Project banner div should be present")
+  end
+
+  def test_show_project_without_banner
+    login("zero") # Not the owner of eol_project
+    p_id = projects(:empty_project).id
+    get(:show, params: { id: p_id })
+    assert_select("h1#title", /\S/,
+                  "H1 title element should exist and contain content")
+    assert_select("div#project_banner", false,
+                  "Project banner div should be absent")
   end
 
   def test_show_project_nonexistent

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -230,7 +230,8 @@ class SpeciesListsControllerTest < FunctionalTestCase
     login
     get(:index, params: { project: project.id })
 
-    assert_page_title(project.title)
+    # there's no banner for this project
+    assert_page_title(:SPECIES_LISTS.l)
     assert_match(project.species_lists.first.title, @response.body)
   end
 
@@ -241,7 +242,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     get(:index, params: { project: project.id })
 
     assert_response(:success)
-    assert_page_title(project.title)
+    assert_page_title(:SPECIES_LISTS.l)
     assert_flash_text(:runtime_no_matches.l(types: :species_lists))
   end
 

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -454,6 +454,10 @@ module GeneralExtensions
     assert_match(expect, css_select("title").text, msg)
   end
 
+  def assert_banner_title(expect, msg = "Wrong banner title")
+    assert_match(expect, css_select("#banner_title").text, msg)
+  end
+
   def assert_displayed_filters(expect, msg = "Wrong filters")
     assert_match(expect, css_select("#filters").text, msg)
   end


### PR DESCRIPTION
I think it now makes sense to make these actions available in the Project context.  I removed them originally due to all the clutter.

However, I've also realized that the Project context version of this page now needs the species list pager that I apparently neglected back when I added the Project context, `add_pager_for(@species_list)`.  Just adding that code in `app/views/controllers/species_lists/show.html.erb` doesn't seem to work.