### PR TITLE
Leave iNat obs description unchanged

### DIFF
--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -38,8 +38,7 @@ class Inat
 
     def update_inat_observation
       update_mushroom_observer_url_field
-      sleep(1)
-      update_description
+      sleep(1) # Avoid hitting iNat API rate limits
     end
 
     def update_mushroom_observer_url_field
@@ -58,25 +57,6 @@ class Inat
         request(method: :post,
                 path: "observation_field_values",
                 payload: payload)
-    end
-
-    def update_description
-      return if super_importer? && importing_someone_elses_obs?
-
-      description = @inat_obs[:description]
-      updated_description =
-        "#{IMPORTED_BY_MO} #{Time.zone.today.strftime(MO.web_date_format)}"
-      updated_description.prepend("#{description}\n\n") if description.present?
-
-      payload = { observation: { description: updated_description,
-                                 ignore_photos: 1 } }
-      path = "observations/#{@inat_obs[:id]}?ignore_photos=1"
-      Inat::APIRequest.new(@inat_import.token).
-        request(method: :put, path: path, payload: payload)
-    end
-
-    def importing_someone_elses_obs?
-      @inat_obs[:user][:login] != @inat_import.inat_username
     end
 
     def increment_imported_counts


### PR DESCRIPTION
Do not modify iNat observation Description when importing an iNat observation.

- Resolves #2531 iNat superimporter another's obs. That caused a 401 because iNat (generally?) won't let one user (e.g. superimporter) modfify the Description of another's observation. 
Therefore don't try to update the Description.
(It's possible to update the Description when importing one's own observation.  But there's little point in doing that if we can't do it for all imports.)
- Resolves #2733 Inat Notes Imported By