### PR TITLE
Fix contributors image display

### DIFF
--- a/app/views/controllers/contributors/_contributor.erb
+++ b/app/views/controllers/contributors/_contributor.erb
@@ -8,7 +8,7 @@ columns ||= "col-xs-12 col-sm-6 col-md-4 col-lg-3"
 <%= matrix_box(columns: columns, id: "user_#{user.id}") do %>
   <%= tag.div(class: "panel panel-default") do %>
     <%= tag.div(class: "panel-sizing") do %>
-      <%= if user.image
+      <%= if user.image_id
         tag.div(class: "thumbnail-container") do
           interactive_image(user, user.image, image_link: user_path(user.id),
                             votes: false, full_width: true)

--- a/app/views/controllers/contributors/_contributor.erb
+++ b/app/views/controllers/contributors/_contributor.erb
@@ -8,9 +8,9 @@ columns ||= "col-xs-12 col-sm-6 col-md-4 col-lg-3"
 <%= matrix_box(columns: columns, id: "user_#{user.id}") do %>
   <%= tag.div(class: "panel panel-default") do %>
     <%= tag.div(class: "panel-sizing") do %>
-      <%= if user.image_id
+      <%= if user.image
         tag.div(class: "thumbnail-container") do
-          interactive_image(user, user.image_id, image_link: user_path(user.id),
+          interactive_image(user, user.image, image_link: user_path(user.id),
                             votes: false, full_width: true)
         end
       end %>


### PR DESCRIPTION
Reported by @JoeCohen.

`interactive_image` prefers an `Image` object, not an id.