### PR TITLE
Move sorter towards pagination and refactor some indexes

### DIFF
--- a/app/assets/stylesheets/mo/_tables.scss
+++ b/app/assets/stylesheets/mo/_tables.scss
@@ -58,17 +58,26 @@ thead tr {
 }
 
 .table-herbarium {
+  table-layout: fixed;
+
+  th:nth-child(1),
+  td:nth-child(1),
+  th:nth-child(2),
+  td:nth-child(2) {
+    width: 7.5rem;
+    text-align: center;
+  }
+
   th:nth-child(1),
   td:nth-child(1) {
     text-align: center;
   }
 
-  td:nth-child(2),
-  td:nth-child(3) {
+  td:nth-child(3),
+  td:nth-child(4) {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 10em;
   }
 }
 

--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -95,6 +95,15 @@
   }
 }
 
+@media screen and (min-width: $screen-sm-min) {
+  .sorter {
+    .dropdown-menu {
+      right: 0;
+      left: auto;
+    }
+  }
+}
+
 @media screen and (max-width: $screen-sm-max) {
   #top_nav {
     h4 {

--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -95,14 +95,15 @@
   }
 }
 
-@media screen and (min-width: $screen-sm-min) {
-  .sorter {
-    .dropdown-menu {
-      right: 0;
-      left: auto;
-    }
-  }
-}
+// If sorter is on the right:
+// @media screen and (min-width: $screen-sm-min) {
+//   .sorter {
+//     .dropdown-menu {
+//       right: 0;
+//       left: auto;
+//     }
+//   }
+// }
 
 @media screen and (max-width: $screen-sm-max) {
   #top_nav {

--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -140,3 +140,8 @@
     }
   }
 }
+
+#index_bar {
+  @extend .d-flex, .justify-content-between, .flex-wrap, .border-bottom;
+  border-bottom-color: $navbar-default-border;
+}

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -44,6 +44,10 @@
   flex-shrink: 0 !important;
 }
 
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
 .align-items-center {
   align-items: center !important;
 }
@@ -118,6 +122,10 @@
 
 .float-left {
   float: left !important;
+}
+
+.float-none {
+  float: none !important;
 }
 
 .align-middle {

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -190,6 +190,10 @@
   font-size: 80% !important;
 }
 
+.link-normal {
+  color: inherit !important;
+}
+
 .border-none {
   border: none !important;
 }
@@ -754,6 +758,10 @@
 
 .opacity-0 {
   opacity: 0 !important;
+}
+
+.opacity-75 {
+  opacity: 75% !important;
 }
 
 .gap-2 {

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -552,6 +552,10 @@
   padding-right: 1.5rem !important;
 }
 
+.pr-5 {
+  padding-right: 3rem !important;
+}
+
 .text-nowrap {
   white-space: nowrap !important;
 }

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -16,6 +16,6 @@ class Query::Herbaria < Query
   end
 
   def self.default_order
-    :name
+    :records
   end
 end

--- a/app/helpers/header/filters_helper.rb
+++ b/app/helpers/header/filters_helper.rb
@@ -18,7 +18,7 @@ module Header
     end
 
     def query_filters(query)
-      tag.div(id: "filters",
+      tag.div(id: "filters", class: "position-relative pr-5",
               data: { controller: "filter-caption",
                       query_params: query.params.to_json,
                       query_record: query.record.id,
@@ -41,7 +41,7 @@ module Header
     end
 
     def filter_caption_truncated(query)
-      tag.div(class: "position-relative pr-3 collapse in",
+      tag.div(class: "collapse in",
               id: "caption-truncated",
               data: { filter_caption_target: "truncated" }) do
         concat(filter_caption_toggle_button(true))
@@ -50,7 +50,7 @@ module Header
     end
 
     def filter_caption_full(query)
-      tag.div(class: "position-relative pr-3 collapse", id: "caption-full",
+      tag.div(class: "collapse", id: "caption-full",
               data: { filter_caption_target: "full" }) do
         concat(filter_caption_toggle_button(false))
         concat(filter_caption_params(query, false))
@@ -81,11 +81,24 @@ module Header
 
     def filter_caption_param_text(query, truncate)
       if query.params.except(:order_by).present?
-        query.params.except(:order_by).compact_blank.each do |key, val|
-          filter_caption_one_param(query, key, val, truncate:)
-        end
+        tag = truncate ? :span : :div
+        filter_caption_params_joined(query, query.params, truncate:, tag:)
       else
         :ALL.l
+      end
+    end
+
+    def filter_caption_params_joined(query, params_hash, truncate:, tag:)
+      array = params_hash.except(:order_by).compact_blank.map do |key, val|
+        capture { filter_caption_one_param(query, key, val, truncate:, tag:) }
+      end
+
+      if truncate
+        concat(array.first(CAPTION_TRUNCATE).safe_join(", "))
+        concat("…") if array.length > CAPTION_TRUNCATE
+      else
+        joiner = tag == :span ? ", " : ""
+        concat(array.safe_join(joiner))
       end
     end
 
@@ -94,6 +107,7 @@ module Header
     def filter_caption_one_param(query, key, val, truncate: false, tag: :div)
       concat(content_tag(tag) do
         if key.to_s.include?("_query")
+          # val in this case is a params hash
           filter_caption_subquery(query, key, val, truncate)
         elsif val.is_a?(Hash)
           filter_caption_grouped_params(query, key, val, truncate)
@@ -108,9 +122,7 @@ module Header
     # inside the brackets and indented.
     def filter_caption_subquery(query, label, hash, truncate)
       concat(tag.span("#{:"query_#{label}".l}: [ "))
-      hash.except(:order_by).each do |key, val|
-        filter_caption_one_param(query, key, val, truncate:, tag: :span)
-      end
+      filter_caption_params_joined(query, hash, truncate:, tag: :span)
       concat(tag.span(" ] "))
     end
 
@@ -198,13 +210,13 @@ module Header
     # For values that aren't ids, just join and maybe truncate
     def param_val_itself(key, val, truncate)
       if key == :type # lowercase strings joined by spaces
-        val = val.titleize.split.join(", ")
+        string = val.titleize.split.join(", ")
       elsif val.is_a?(Array)
         val = val.first(CAPTION_TRUNCATE) if truncate
-        val = val.join(", ")
-        val += ", ..." if truncate && val.length > CAPTION_TRUNCATE
+        string = val.join(", ")
+        string += ", …" if truncate && val.length > CAPTION_TRUNCATE
       end
-      val
+      string
     end
 
     # The max number of named items is hardcoded here to 3.

--- a/app/helpers/header/filters_helper.rb
+++ b/app/helpers/header/filters_helper.rb
@@ -213,9 +213,9 @@ module Header
       if key == :type # lowercase strings joined by spaces
         string = val.titleize.split.join(", ")
       elsif val.is_a?(Array)
-        val = val.first(CAPTION_TRUNCATE) if truncate
-        string = val.join(", ")
-        string += ", …" if truncate && val.length > CAPTION_TRUNCATE
+        string = truncate ? val.first(CAPTION_TRUNCATE) : val
+        string = string.join(", ")
+        string += ", ..." if truncate && val.length > CAPTION_TRUNCATE
       else
         string = val
       end

--- a/app/helpers/header/filters_helper.rb
+++ b/app/helpers/header/filters_helper.rb
@@ -88,6 +88,7 @@ module Header
       end
     end
 
+    # params_hash is separate from query to enable reusability in subqueries
     def filter_caption_params_joined(query, params_hash, truncate:, tag:)
       array = params_hash.except(:order_by).compact_blank.map do |key, val|
         capture { filter_caption_one_param(query, key, val, truncate:, tag:) }
@@ -215,6 +216,8 @@ module Header
         val = val.first(CAPTION_TRUNCATE) if truncate
         string = val.join(", ")
         string += ", …" if truncate && val.length > CAPTION_TRUNCATE
+      else
+        string = val
       end
       string
     end

--- a/app/helpers/header/index_pagination_helper.rb
+++ b/app/helpers/header/index_pagination_helper.rb
@@ -7,9 +7,13 @@ module Header
 
     def add_pagination(pagination_data, args = {})
       content_for(:index_pagination) do
-        concat(letter_pagination_nav(pagination_data, args))
-        concat(number_pagination_nav(pagination_data, args))
-        concat(content_for(:sorter)) if content_for?(:sorter)
+        concat(tag.div do
+          concat(content_for(:sorter)) if content_for?(:sorter)
+        end)
+        concat(tag.div(class: "d-flex") do
+          concat(letter_pagination_nav(pagination_data, args))
+          concat(number_pagination_nav(pagination_data, args))
+        end)
       end
     end
 
@@ -26,6 +30,7 @@ module Header
       results = capture(&block).to_s
 
       tag.div(id: html_id, data: { q: get_query_param }) do
+        concat(bottom_pagination)
         concat(results)
         concat(bottom_pagination)
       end
@@ -34,7 +39,7 @@ module Header
     def bottom_pagination
       return "" unless content_for?(:index_pagination)
 
-      tag.div(class: "pagination-bottom d-flex justify-content-end") do
+      tag.div(class: "pagination-bottom navbar-flex") do
         content_for(:index_pagination)
       end
     end

--- a/app/helpers/header/index_pagination_helper.rb
+++ b/app/helpers/header/index_pagination_helper.rb
@@ -9,6 +9,7 @@ module Header
       content_for(:index_pagination) do
         concat(letter_pagination_nav(pagination_data, args))
         concat(number_pagination_nav(pagination_data, args))
+        concat(content_for(:sorter)) if content_for?(:sorter)
       end
     end
 

--- a/app/helpers/header/sorter_helper.rb
+++ b/app/helpers/header/sorter_helper.rb
@@ -15,7 +15,7 @@ module Header
       title = sort_nav_order_by(query, sorts)
 
       content_for(:sorter) do
-        tag.div(class: "d-inline-block", id: "sorter") do
+        tag.div(class: "d-inline-block pl-4", id: "sorter") do
           concat(tag.label("#{:sort_by_header.l}:",
                            class: "font-weight-normal mr-2 hidden-xs"))
           concat(sort_nav_dropdown(title:, id: "sorts", links:))

--- a/app/helpers/header/sorter_helper.rb
+++ b/app/helpers/header/sorter_helper.rb
@@ -15,7 +15,7 @@ module Header
       title = sort_nav_order_by(query, sorts)
 
       content_for(:sorter) do
-        tag.div(class: "d-inline-block pl-4 sorter") do
+        tag.div(class: "d-inline-block pl-3 sorter") do
           concat(tag.label("#{:sort_by_header.l}:",
                            class: "font-weight-normal mr-2 hidden-xs"))
           concat(sort_nav_dropdown(title:, links:))

--- a/app/helpers/header/sorter_helper.rb
+++ b/app/helpers/header/sorter_helper.rb
@@ -18,7 +18,7 @@ module Header
         tag.div(class: "d-inline-block pl-4 sorter") do
           concat(tag.label("#{:sort_by_header.l}:",
                            class: "font-weight-normal mr-2 hidden-xs"))
-          concat(sort_nav_dropdown(title:, id: "sorts", links:))
+          concat(sort_nav_dropdown(title:, links:))
         end
       end
     end
@@ -94,12 +94,12 @@ module Header
       model.underscore.pluralize
     end
 
-    def sort_nav_dropdown(title: "", id: "", links: [])
+    def sort_nav_dropdown(title: "", links: [])
       tag.div(class: "dropdown d-inline-block") do
         [
           sort_nav_toggle(title),
           tag.ul(
-            id:, class: "dropdown-menu",
+            class: "sorts dropdown-menu",
             aria: { labelledby: "sort_nav_toggle" }
           ) do
             links.compact.each do |link|

--- a/app/helpers/header/sorter_helper.rb
+++ b/app/helpers/header/sorter_helper.rb
@@ -15,7 +15,7 @@ module Header
       title = sort_nav_order_by(query, sorts)
 
       content_for(:sorter) do
-        tag.div(class: "d-inline-block pl-4", id: "sorter") do
+        tag.div(class: "d-inline-block pl-4 sorter") do
           concat(tag.label("#{:sort_by_header.l}:",
                            class: "font-weight-normal mr-2 hidden-xs"))
           concat(sort_nav_dropdown(title:, id: "sorts", links:))

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -181,6 +181,7 @@ module LinkHelper # rubocop:disable Metrics/ModuleLength
     question: "question-sign",
     alert: "alert",
     list: "list",
+    copy: "copy",
     clone: "duplicate",
     merge: "transfer",
     move: "random",

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
     navigator.clipboard.writeText(this.sourceTarget.innerText)
     // this.sourceTarget.dataset.title = "Copied"
     const tooltipInner =
-      this.sourceTarget.nextElementSibling.querySelector(".tooltip-inner")
+      this.element.querySelector(".tooltip-inner")
     if (tooltipInner) { tooltipInner.innerText = this.copiedValue }
   }
 }

--- a/app/javascript/controllers/filter-caption_controller.js
+++ b/app/javascript/controllers/filter-caption_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
     // if not, hide the buttons
     this.fullLength = this.fullTarget.lastChild.innerText.length
     this.truncLength = this.truncatedTarget.lastChild.innerText.length
-    if (Math.abs(this.fullLength - this.truncLength) <= 9) {
+    if (Math.abs(this.fullLength - this.truncLength) <= 3) {
       this.hideButtons()
     }
   }

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Gather details for items in matrix-style ndex pages.
+# Gather details for items in matrix-style index pages.
 class MatrixBoxPresenter < BasePresenter
   attr_accessor \
     :id,         # id of the target or log object

--- a/app/views/controllers/application/_top_nav.html.erb
+++ b/app/views/controllers/application/_top_nav.html.erb
@@ -26,8 +26,7 @@ identify_page = controller.controller_name == "identify"
                  class: "font-weight-bold mr-2", id: "rubric") %>
       <%= tag.div(class: "mr-3 mr-sm-4 mr-lg-5") do
         [
-          nav_create(@user, controller),
-          nav_scan_qr_code(@user, controller)
+          nav_create(@user, controller)
         ].safe_join(" ")
       end %>
     <% end %>
@@ -35,6 +34,7 @@ identify_page = controller.controller_name == "identify"
     <%# right side %>
     <%= tag.div(class: right_classes) do %>
       <%= search_nav_toggle %>
+      <%= nav_scan_qr_code(@user, controller) %>
       <%= tag.ul(class: "nav navbar-nav navbar-right hidden-xs mr-0") do %>
         <%= yield(:context_nav) if content_for?(:context_nav) %>
         <%= render(partial: "application/top_nav/user_nav") if !@user.nil? %>

--- a/app/views/controllers/application/_top_nav.html.erb
+++ b/app/views/controllers/application/_top_nav.html.erb
@@ -30,7 +30,6 @@ identify_page = controller.controller_name == "identify"
           nav_scan_qr_code(@user, controller)
         ].safe_join(" ")
       end %>
-      <%= yield(:sorter) if(content_for?(:sorter)) %>
     <% end %>
 
     <%# right side %>

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -16,7 +16,7 @@ pagination = content_for?(:index_pagination)
         end %>
         <% if pagination %>
           <%= tag.div(class: "pagination-top navbar-flex") do
-            yield(:index_pagination)
+            concat(yield(:index_pagination))
           end %>
         <% end %>
       <% end %>

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -5,20 +5,20 @@ pagination = content_for?(:index_pagination)
 
 <% if filters || pagination %>
   <%= tag.div(class: "row") do %>
-    <%= tag.div(class: "col-xs-12", id: "index_bar") do %>
+    <%= tag.div(class: "col-xs-12") do %>
       <%# Indexes: Query filter subtitle and pagination %>
-      <%= tag.div(class: "d-flex justify-content-between flex-wrap") do %>
-        <%= tag.div(class: "px-3 mb-3") do
+      <%= tag.div(id: "index_bar", class: "mb-3") do %>
+        <%= tag.div(class: "px-3 mt-2 mb-3") do
           if filters
             concat(yield(:filters)) if !content_for?(:banner_image)
             concat(yield(:filter_help))
           end
         end %>
-        <% if pagination %>
-          <%= tag.div(class: "pagination-top navbar-flex px-3") do
+        <%# if pagination %>
+          <%# tag.div(class: "pagination-top navbar-flex px-3") do
             concat(yield(:index_pagination))
           end %>
-        <% end %>
+        <%# end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -7,7 +7,7 @@ pagination = content_for?(:index_pagination)
   <%= tag.div(class: "row") do %>
     <%= tag.div(class: "col-xs-12", id: "index_bar") do %>
       <%# Indexes: Query filter subtitle and pagination %>
-      <%= tag.div(class: "d-flex justify-content-between") do %>
+      <%= tag.div(class: "d-flex justify-content-between flex-wrap") do %>
         <%= tag.div(class: "px-3 mb-3") do
           if filters
             concat(yield(:filters)) if !content_for?(:banner_image)
@@ -15,7 +15,7 @@ pagination = content_for?(:index_pagination)
           end
         end %>
         <% if pagination %>
-          <%= tag.div(class: "pagination-top navbar-flex") do
+          <%= tag.div(class: "pagination-top navbar-flex px-3") do
             concat(yield(:index_pagination))
           end %>
         <% end %>

--- a/app/views/controllers/herbaria/index.html.erb
+++ b/app/views/controllers/herbaria/index.html.erb
@@ -1,5 +1,5 @@
 <%
-container_class(:wide)
+container_class(:full)
 add_index_title(@query)
 add_context_nav(herbaria_index_tabs(query: @query))
 add_sorter(@query, herbaria_index_sorts(query: @query))
@@ -19,29 +19,23 @@ nonpersonal = (@query&.params&.dig(:nonpersonal))
 
 <%= paginated_results do %>
   <% if @objects.any? %>
-    <table class="table-striped table-herbarium mt-3">
+    <table class="table table-striped table-herbarium w-100 mt-3">
       <thead>
         <tr>
-          <th><%= :herbarium_index_records.t %></th>
-          <th><%= :USER.t unless nonpersonal %></th>
           <th><%= :herbarium_code.t %></th>
-          <th><%= :NAME.t %></th>
+          <th><%= :herbarium_index_records.t %></th>
+          <th><%= :HERBARIUM.t %></th>
+          <th><%= :USER.t unless nonpersonal %></th>
         </tr>
       </thead>
       <tbody>
         <% @objects.each do |herbarium| %>
           <tr>
             <td>
-              <%= herbarium.herbarium_records.length %>
-            </td>
-            <td>
-              <%= if !nonpersonal && herbarium.personal_user.present?
-                    tag.span(user_link(herbarium.personal_user),
-                            title: herbarium.personal_user.unique_text_name)
-              end %>
-            </td>
-            <td>
               <%= herbarium.code %>
+            </td>
+            <td>
+              <%= herbarium.herbarium_records.length %>
             </td>
             <td>
               <% if !@merge || !@user %>
@@ -63,12 +57,18 @@ nonpersonal = (@query&.params&.dig(:nonpersonal))
               <% end %>
               <% if @user && !@merge &&
                       (herbarium.can_edit? || in_admin_mode?) %>
-              [<%= link_with_query(:EDIT.t, edit_herbarium_path(herbarium),
-                    class: "edit_herbarium_link_#{herbarium.id}") %> |
-              <%= link_to(:MERGE.t, herbaria_path(merge: herbarium.id),
-                    class: "merge_herbarium_link_#{herbarium.id}") %>]
-            <% end %>
-          </td>
+                [<%= link_with_query(:EDIT.t, edit_herbarium_path(herbarium),
+                      class: "edit_herbarium_link_#{herbarium.id}") %> |
+                <%= link_to(:MERGE.t, herbaria_path(merge: herbarium.id),
+                      class: "merge_herbarium_link_#{herbarium.id}") %>]
+              <% end %>
+            </td>
+            <td>
+              <%= if !nonpersonal && herbarium.personal_user.present?
+                    tag.span(user_link(herbarium.personal_user),
+                            title: herbarium.personal_user.unique_text_name)
+              end %>
+            </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/controllers/locations/index.html.erb
+++ b/app/views/controllers/locations/index.html.erb
@@ -18,8 +18,7 @@ observation_counts = calc_counts(@objects, @query)
 flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
 %>
 
-<%= content_for(:filters) do %>
-  <%= :list_place_names_popularity.t if @objects.count > 1 %>
+<%= tag.div(class: "content-block") do %>
   <%= :list_place_names_parenthetical.t %>
 <% end %>
 

--- a/app/views/controllers/locations/index.html.erb
+++ b/app/views/controllers/locations/index.html.erb
@@ -18,17 +18,17 @@ observation_counts = calc_counts(@objects, @query)
 flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
 %>
 
-<%= tag.div(class: "content-block") do %>
-  <%= :list_place_names_parenthetical.t %>
-<% end %>
 
 <div class="row mt-3">
-  <div class="col-md-6">
+  <div class="col-md-7">
     <% if @known_pages.any? && @known_data.any? %>
-      <div class="h4 px-3">
+      <div class="h4 px-3 mb-0">
         <%= :list_place_names_known.t %>
         <%= :list_place_names_known_order.t if @default_orders %>
       </div>
+      <%= tag.div(class: "content-block") do %>
+        <%= tag.small(:list_place_names_parenthetical.t) %>
+      <% end %>
       <%= paginated_results do %>
         <div class="list-group">
           <% @known_data.each do |location| %>
@@ -42,7 +42,7 @@ flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
     <% end %>
   </div>
 
-  <div class="col-md-6">
+  <div class="col-md-5">
     <% if @undef_pages.any? && @undef_data.any? %>
       <div class="h4 px-3">
         <%= :list_place_names_undef.t %>
@@ -55,12 +55,13 @@ flash_error(@error) if @error && @known_pages.empty? && @undef_pages.empty?
             location_name = obs[:where] %>
           <div class="list-group-item">
             <%= location_link(location_name, nil, count) %>
-            <%=
-              link_to(
-                :list_place_names_merge.t,
-                matching_locations_for_observations_path(where: location_name)
-              )
-              %>
+            <%= icon_link_to(
+                  :list_place_names_merge.t,
+                  matching_locations_for_observations_path(
+                    where: location_name
+                  ),
+                  icon: :merge, show_text: false
+                ) %>
           </div>
         <% end %>
       </div>

--- a/app/views/controllers/names/_name.erb
+++ b/app/views/controllers/names/_name.erb
@@ -1,0 +1,31 @@
+<%= tag.div(class: "list-group-item") do %>
+  <%= tag.span(show_title_id_badge(name, "rss-id mr-4")) %>
+  <%= tag.span(
+    data: { controller: "clipboard", clipboard_copied_value: :COPIED.l }
+  ) do %>
+    <%= link_with_query(name.show_link_args) do
+      tag.span(name.user_display_name(@user).html_safe.t,
+              class: "display-name",
+              data: { clipboard_target: "source" })
+    end %>
+    <%= tag.button(
+          link_icon(:copy, text: :COPY_THIS_NAME.l),
+          role: "button",
+          class: "btn btn-link py-0 link-normal opacity-75",
+          data: {
+            toggle: "tooltip", placement: "bottom", title: :COPY_THIS_NAME.l,
+            action: "clipboard#copy"
+          }
+        ) %>
+  <% end %>
+  <%= tag.span(counts[name.id], class: "badge") if counts[name.id] %>
+<% end %>
+<% if @has_descriptions %>
+  <% if (desc = name.description)%>
+    <%= tag.span(desc.authors.map(&:login).join(", ")) %>
+    <%= tag.span(desc.note_status.map(&:to_s).join("/")) %>
+    <%= tag.span(:"review_#{desc.review_status}".l) %>
+  <% else %>
+    <%= tag.span("--- not the default ---") %>
+  <% end %>
+<% end %>

--- a/app/views/controllers/names/index.html.erb
+++ b/app/views/controllers/names/index.html.erb
@@ -32,10 +32,14 @@ flash_error(@error) if @error && @objects.empty?
 
     <div class="list-group name-index">
       <% @objects.each do |name| %>
-        <%= link_with_query(name.show_link_args, class: "list-group-item") do
-          concat(tag.span(name.user_display_name(@user).html_safe.t, class: "display-name"))
-          concat(tag.span(counts[name.id], class: "badge")) if counts[name.id]
-        end %>
+        <%= tag.div(class: "list-group-item") do %>
+          <%= tag.span(show_title_id_badge(name, "rss-id mr-4")) %>
+          <%= link_with_query(name.show_link_args) do
+            tag.span(name.user_display_name(@user).html_safe.t,
+                    class: "display-name")
+          end %>
+          <%= tag.span(counts[name.id], class: "badge") if counts[name.id] %>
+        <% end %>
         <% if @has_descriptions %>
           <% if (desc = name.description)%>
             <span><%= desc.authors.map(&:login).join(", ") %></span>

--- a/app/views/controllers/names/index.html.erb
+++ b/app/views/controllers/names/index.html.erb
@@ -30,7 +30,7 @@ flash_error(@error) if @error && @objects.empty?
   <% if @objects.any? %>
     <% counts = Name.count_observations(@objects) %>
 
-    <%= tag.div(class: "list-group") do %>
+    <%= tag.div(class: "list-group name-index") do %>
       <%= render(partial: "name", collection: @objects, as: :name,
                  locals: { counts: }) %>
     <% end %>

--- a/app/views/controllers/names/index.html.erb
+++ b/app/views/controllers/names/index.html.erb
@@ -30,27 +30,10 @@ flash_error(@error) if @error && @objects.empty?
   <% if @objects.any? %>
     <% counts = Name.count_observations(@objects) %>
 
-    <div class="list-group name-index">
-      <% @objects.each do |name| %>
-        <%= tag.div(class: "list-group-item") do %>
-          <%= tag.span(show_title_id_badge(name, "rss-id mr-4")) %>
-          <%= link_with_query(name.show_link_args) do
-            tag.span(name.user_display_name(@user).html_safe.t,
-                    class: "display-name")
-          end %>
-          <%= tag.span(counts[name.id], class: "badge") if counts[name.id] %>
-        <% end %>
-        <% if @has_descriptions %>
-          <% if (desc = name.description)%>
-            <span><%= desc.authors.map(&:login).join(", ") %></span>
-            <span><%= desc.note_status.map(&:to_s).join("/") %></span>
-            <span><%= :"review_#{desc.review_status}".l %></span>
-          <% else %>
-            <span>--- not the default ---</span>
-          <% end %>
-        <% end %>
-      <% end %>
-    </div>
+    <%= tag.div(class: "list-group") do %>
+      <%= render(partial: "name", collection: @objects, as: :name,
+                 locals: { counts: }) %>
+    <% end %>
 
   <% end %>
 <% end %>

--- a/app/views/controllers/projects/_object.html.erb
+++ b/app/views/controllers/projects/_object.html.erb
@@ -1,8 +1,0 @@
-<div class="list-group-item">
-  <%= content_tag(:big, link_with_query(object.title.t,
-                  object.show_link_args)) %>
-  <%= object.open_membership ? "(#{:OPEN.t})" : "" %>
-  <br/>
-  <%= content_tag(:small, object.created_at.web_time) %>:
-  <%= user_link(object.user) %>
-</div>

--- a/app/views/controllers/projects/_project.html.erb
+++ b/app/views/controllers/projects/_project.html.erb
@@ -1,0 +1,18 @@
+<%= tag.div(class: "list-group-item d-flex align-items-start") do %>
+  <%= tag.div(show_title_id_badge(project, "rss-id mr-4"),
+              class: "text-larger") %>
+  <%= tag.div do %>
+    <%= tag.div do
+      [
+        link_with_query(project.show_link_args) do
+          tag.span(project.title.t, class: "h4")
+        end,
+        tag.span(project.open_membership ? "(#{:OPEN.t})" : "", class: "ml-4")
+      ].safe_join(" ")
+    end %>
+    <%= tag.div do
+      [tag.small("#{project.created_at.web_time}:"),
+       user_link(project.user)].safe_join(" ")
+    end %>
+  <% end %>
+<% end %>

--- a/app/views/controllers/projects/index.html.erb
+++ b/app/views/controllers/projects/index.html.erb
@@ -3,13 +3,14 @@ add_index_title(@query)
 add_context_nav(projects_index_tabs)
 add_sorter(@query, projects_index_sorts)
 add_pagination(@pagination_data)
+container_class(:text_image)
 
 flash_error(@error) if @error && @objects.empty?
 %>
 
 <!-- list the projects -->
 <%= paginated_results do %>
-  <div class="list-group">
-    <%= render(partial: "projects/object", collection: @objects) %>
-  </div>
+  <%= tag.div(class: "list-group") do %>
+    <%= render(partial: "project", collection: @objects, as: :project) %>
+  <% end %>
 <% end %>

--- a/app/views/controllers/species_lists/_species_list.erb
+++ b/app/views/controllers/species_lists/_species_list.erb
@@ -1,0 +1,23 @@
+<%# locals: (species_list:) %>
+
+<%# Each listing in the index %>
+<%
+place = species_list.place_name.t rescue :UNKNOWN.l
+%>
+
+<%= tag.div(class: "list-group-item d-flex align-items-start") do %>
+  <%= tag.div(show_title_id_badge(species_list), class: "h3 my-0") %>
+  <%= tag.div do %>
+    <%= tag.div do
+      [
+        link_with_query(species_list.show_link_args) do
+          tag.span(species_list.text_name.t, class: "list_what h4")
+        end,
+        tag.span("(#{species_list.when.to_s})", class: "list_when ml-4")
+      ].safe_join(" ")
+    end %>
+    <%= tag.div do
+      [tag.span(place), "|", user_link(species_list.user)].safe_join(" ")
+    end %>
+  <% end %>
+<% end %>

--- a/app/views/controllers/species_lists/_species_list.erb
+++ b/app/views/controllers/species_lists/_species_list.erb
@@ -6,7 +6,8 @@ place = species_list.place_name.t rescue :UNKNOWN.l
 %>
 
 <%= tag.div(class: "list-group-item d-flex align-items-start") do %>
-  <%= tag.div(show_title_id_badge(species_list), class: "h3 my-0") %>
+  <%= tag.div(show_title_id_badge(species_list, "rss-id mr-4"),
+              class: "text-larger") %>
   <%= tag.div do %>
     <%= tag.div do
       [

--- a/app/views/controllers/species_lists/index.html.erb
+++ b/app/views/controllers/species_lists/index.html.erb
@@ -12,19 +12,7 @@ flash_error(@error) if @error && @objects.empty?
   <% if @objects.any? %>
     <div class="list-group">
       <% @objects.each do |species_list| %>
-        <div class="list-group-item">
-          <div class="text-larger">
-            <%=
-              when_span = tag.span(species_list.when.to_s, class: "list_when")
-              what_span = tag.span(species_list.unique_text_name.t,
-                                   class: "list_what")
-              args = add_query_param(species_list.show_link_args)
-              link_with_query(when_span + ": " + what_span, args)
-            %>
-          </div><!-- .text-larger -->
-          <span><%= species_list.place_name.t rescue :UNKNOWN.t %></span> |
-          <span><%= user_link(species_list.user) %></span>
-        </div>
+        <%= render(partial: "species_list", locals: { species_list: }) %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/controllers/species_lists/index.html.erb
+++ b/app/views/controllers/species_lists/index.html.erb
@@ -10,11 +10,10 @@ flash_error(@error) if @error && @objects.empty?
 
 <%= paginated_results do %>
   <% if @objects.any? %>
-    <div class="list-group">
-      <% @objects.each do |species_list| %>
-        <%= render(partial: "species_list", locals: { species_list: }) %>
-      <% end %>
-    </div>
+    <%= tag.div(class: "list-group") do %>
+      <%= render(partial: "species_list",
+                 collection: @objects, as: :species_list) %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -23,15 +23,6 @@ column_classes(:nine_three)
     <%= render(partial: "shared/list_search",
                locals: { object: @species_list }) %>
 
-    <%# Put pagination down where it feels right %>
-    <% if content_for?(:index_pagination) %>
-      <%= tag.div(
-        class: "pagination-top d-flex justify-content-end align-items-center"
-      ) do
-        yield(:index_pagination)
-      end %>
-    <% end %>
-
     <%= paginated_results do %>
       <%= tag.div(class: "list-group") do %>
         <% if @objects.any? %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -726,7 +726,8 @@
   # close a popup window
   CLOSE: Close
   close: close
-  COPY_THIS_ID: Copy this ID
+  COPY_THIS_ID: "Copy this [:ID]"
+  COPY_THIS_NAME: "Copy this [:NAME]"
   COPIED: Copied
   CREATE: Create
   create: create

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -55,8 +55,8 @@ class Query::HerbariaTest < UnitTestCase
   end
 
   def test_herbarium_name_has
-    expects = [herbaria(:curatorless_herbarium), herbaria(:dick_herbarium),
-               herbaria(:rolf_herbarium)]
+    expects = [herbaria(:rolf_herbarium), herbaria(:curatorless_herbarium),
+               herbaria(:dick_herbarium)]
     scope = Herbarium.name_has("Herbarium").order_by_default
     assert_query_scope(expects, scope, :Herbarium, name_has: "Herbarium")
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -64,7 +64,7 @@ class UsersControllerTest < FunctionalTestCase
     assert_template("users/index")
 
     assert_page_title(:USERS.l)
-    assert_empty(css_select("#sorts"), "There should be no sort links")
+    assert_empty(css_select(".sorts"), "There should be no sort links")
 
     flash_text = :runtime_no_matches.l.sub("[types]", "users")
     assert_flash_text(flash_text)
@@ -144,7 +144,7 @@ class UsersControllerTest < FunctionalTestCase
   # can be shown via the same action.
   # Prove that sorting links include "Contribution" (when not in admin mode)
   def prove_sorting_links_include_contribution
-    sorting_links = css_select("#sorts")
+    sorting_links = css_select(".sorts")
     assert_match(/Contribution/, sorting_links.text)
   end
 

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -517,10 +517,10 @@ module GeneralExtensions
     order_by = by.dup
     reverse = order_by.sub!(/^reverse_/, "") # changes by and returns boolean
     class_name = "#{adjusted_controller_class_name}_by_#{order_by}_link"
-    assert_select("#sorts a.#{class_name}[disabled=disabled]", text, msg)
+    assert_select(".sorts a.#{class_name}[disabled=disabled]", text, msg)
     return unless reverse
 
-    assert_select("#sorts a.#{class_name}[disabled=disabled]",
+    assert_select(".sorts a.#{class_name}[disabled=disabled]",
                   :sort_by_reverse.l, msg)
   end
 

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -154,7 +154,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     )
     # strip query string
     first_herbarium_path = herbaria_show_links.first["href"].sub(/\?.*/, "")
-    first("#sorts a", text: "Reverse Order").click
+    first(".sorts a", text: "Reverse Order").click
 
     reverse_herbaria_show_links = page.all("td > a[class^='herbarium_link']")
 

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -291,17 +291,17 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     end
 
     # Try sorting differently.
-    within("#sorts") { click_link(text: "User") }
+    within("#header .sorts") { click_link(text: "User") }
     check_results_length(save_results)
 
     # Date is ambiguous, there's also 'Date Posted'
-    within("#sorts") { click_link(exact_text: "Date") }
+    within("#header .sorts") { click_link(exact_text: "Date") }
     check_results_length(save_results)
 
-    within("#sorts") { click_link(text: "Reverse Order") }
+    within("#header .sorts") { click_link(text: "Reverse Order") }
     check_results_length(save_results)
 
-    within("#sorts") { click_link(text: "Name") }
+    within("#header .sorts") { click_link(text: "Name") }
     # Last time through - reset `save_results` with current results
     save_results = check_results_length(save_results)
     # Must set `save_hrefs` here to avoid variable going stale...

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -291,17 +291,17 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     end
 
     # Try sorting differently.
-    within("#header .sorts") { click_link(text: "User") }
+    within(first("#results .sorts")) { click_link(text: "User") }
     check_results_length(save_results)
 
     # Date is ambiguous, there's also 'Date Posted'
-    within("#header .sorts") { click_link(exact_text: "Date") }
+    within(first("#results .sorts")) { click_link(exact_text: "Date") }
     check_results_length(save_results)
 
-    within("#header .sorts") { click_link(text: "Reverse Order") }
+    within(first("#results .sorts")) { click_link(text: "Reverse Order") }
     check_results_length(save_results)
 
-    within("#header .sorts") { click_link(text: "Name") }
+    within(first("#results .sorts")) { click_link(text: "Name") }
     # Last time through - reset `save_results` with current results
     save_results = check_results_length(save_results)
     # Must set `save_hrefs` here to avoid variable going stale...

--- a/test/session_extensions.rb
+++ b/test/session_extensions.rb
@@ -381,7 +381,7 @@ module SessionExtensions
     when :context_nav
       "#context_nav"
     when :sorts
-      "#sorts"
+      "#header .sorts"
     when :site_nav
       "#navigation"
     when :results


### PR DESCRIPTION
Moves the sorter to the pagination row, on the left. Pagination row width is now conditional on # results, i think it makes more sense.

Moves the QR scan icon to the right side, away from the rubric.

Makes a number of adjustments in how the Query filters caption is composed, on indexes.

Also spiffs up a number of indexes.

<img width="1774" height="818" alt="image" src="https://github.com/user-attachments/assets/d5ebaec9-def2-4455-bc51-3eed6ad500c2" />

<img width="2084" height="1086" alt="image" src="https://github.com/user-attachments/assets/90709ef6-4203-4212-8dfb-84c89d451710" />

![Screen Shot 2025-08-08 at 2 05 56 PM](https://github.com/user-attachments/assets/5efce4e4-7e85-415c-8baf-cfdc24fd23af)

<img width="1900" height="776" alt="image" src="https://github.com/user-attachments/assets/0c04cabf-a1aa-4ec0-9450-946a9ce0e22d" />

Doesn't change Observations much, since it's already full width:
![Screen Shot 2025-08-08 at 2 08 17 PM](https://github.com/user-attachments/assets/76a779db-94cb-495d-895f-25a6a3f69732)
