### PR TITLE
Name suggestions partial (Obs pattern searches) — move Query to controller

### DIFF
--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -8,14 +8,14 @@
 #  values. Each value is ultimately validated separately, via methods below
 #  that are specific to a data type. In the case of subqueries, the whole
 #  package of values is sent to a new Query instantiation which returns its own
-#  validation_messages. These are added to this query's messages.
+#  validation_errors. These are added to this query's messages.
 #
 #  Each validation method here may first "clean" the value, e.g. substituting
 #  ids for instances. Generally validators do not change data, but we do here
 #  to offer callers the convenience of passing instances rather than ids.
 #
 #  In the event it gets data that it cannot parse, it stores a message in the
-#  array of `@validation_messages`, and saves that to the Query. Callers can
+#  array of `@validation_errors`, and saves that to the Query. Callers can
 #  access these messages to return them via flash to users, for example when
 #  the query comes from a form.
 #

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -52,12 +52,12 @@ class NamesController < ApplicationController
     end
   end
 
+  # NamesIntegrationTest#test_name_pattern_search_with_near_miss_corrected
   def show_non_id_pattern_results(pattern)
     query = create_query(:Name, pattern:)
-    if query.validation_messages.any?
-      query.validation_messages.each do |error|
-        flash_error(error.to_s)
-      end
+    errors = query.validation_errors
+    if errors.any?
+      errors.each { |error| flash_error(error.to_s) }
       render("names/index")
       [nil, {}]
     else

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -53,23 +53,21 @@ class NamesController < ApplicationController
   end
 
   def show_non_id_pattern_results(pattern)
-    search = PatternSearch::Name.new(pattern)
-    if search.errors.any?
-      search.errors.each do |error|
+    query = create_query(:Name, pattern:)
+    if query.validation_messages.any?
+      query.validation_messages.each do |error|
         flash_error(error.to_s)
       end
       render("names/index")
       [nil, {}]
     else
-      # Call create_query to apply user content filters
-      query = create_query(:Name, search.query.params)
-      make_name_suggestions(search)
+      make_name_suggestions(query)
       [query, {}]
     end
   end
 
-  def make_name_suggestions(search)
-    alternate_spellings = search.query.params[:pattern]
+  def make_name_suggestions(query)
+    alternate_spellings = query.params[:pattern]
     return unless alternate_spellings && @objects.empty?
 
     @name_suggestions =
@@ -77,7 +75,6 @@ class NamesController < ApplicationController
   end
 
   # Disabling the cop because subaction methods are going away soon
-  # rubocop:disable Naming/PredicatePrefix
   # Display list of names that have observations.
   def has_observations
     query = create_query(:Name, has_observations: 1)
@@ -90,7 +87,6 @@ class NamesController < ApplicationController
     query = create_query(:Name, has_descriptions: 1)
     [query, {}]
   end
-  # rubocop:enable Naming/PredicatePrefix
 
   # Display list of the most popular 100 names that don't have descriptions.
   # NOTE: all this extra info and help will be lost if user re-sorts.

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -54,6 +54,7 @@ class NamesController < ApplicationController
 
   # NamesIntegrationTest#test_name_pattern_search_with_near_miss_corrected
   def show_non_id_pattern_results(pattern)
+    # NOTE: the **controller** method `create_query` applies user filters
     query = create_query(:Name, pattern:)
     errors = query.validation_errors
     if errors.any?

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -79,6 +79,7 @@ class NamesController < ApplicationController
   end
 
   # Disabling the cop because subaction methods are going away soon
+  # rubocop:disable Naming/PredicatePrefix
   # Display list of names that have observations.
   def has_observations
     query = create_query(:Name, has_observations: 1)
@@ -91,6 +92,7 @@ class NamesController < ApplicationController
     query = create_query(:Name, has_descriptions: 1)
     [query, {}]
   end
+  # rubocop:enable Naming/PredicatePrefix
 
   # Display list of the most popular 100 names that don't have descriptions.
   # NOTE: all this extra info and help will be lost if user re-sorts.

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -77,6 +77,7 @@ class NamesController < ApplicationController
 
   # Disabling the cop because subaction methods are going away soon
   # Display list of names that have observations.
+  # rubocop:disable Naming/PredicatePrefix
   def has_observations
     query = create_query(:Name, has_observations: 1)
     [query, {}]
@@ -88,6 +89,7 @@ class NamesController < ApplicationController
     query = create_query(:Name, has_descriptions: 1)
     [query, {}]
   end
+  # rubocop:enable Naming/PredicatePrefix
 
   # Display list of the most popular 100 names that don't have descriptions.
   # NOTE: all this extra info and help will be lost if user re-sorts.

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -75,9 +75,12 @@ class ObservationsController
       end
     end
 
+    # ObservationsIntegrationTest#
+    # test_observation_pattern_search_with_correctable_pattern/
     def return_pattern_search_results(pattern)
       query = create_query(:Observation, pattern:)
-      return render_pattern_search_error(query) if search.errors.any?
+      errors = query.validation_errors
+      return render_pattern_search_error(errors) if errors.any?
 
       make_name_suggestions(query)
 
@@ -99,8 +102,8 @@ class ObservationsController
         Name.suggest_alternate_spellings(alternate_spellings)
     end
 
-    def render_pattern_search_error(query)
-      query.validation_messages.each { |error| flash_error(error.to_s) }
+    def render_pattern_search_error(errors)
+      errors.each { |error| flash_error(error.to_s) }
       if params[:needs_naming]
         redirect_to(identify_observations_path(q: get_query_param))
       end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -78,6 +78,7 @@ class ObservationsController
     # ObservationsIntegrationTest#
     # test_observation_pattern_search_with_correctable_pattern/
     def return_pattern_search_results(pattern)
+      # NOTE: the **controller** method `create_query` applies user filters
       query = create_query(:Observation, pattern:)
       errors = query.validation_errors
       return render_pattern_search_error(errors) if errors.any?

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -76,12 +76,10 @@ class ObservationsController
     end
 
     def return_pattern_search_results(pattern)
-      search = PatternSearch::Observation.new(pattern)
-      return render_pattern_search_error(search) if search.errors.any?
+      query = create_query(:Observation, pattern:)
+      return render_pattern_search_error(query) if search.errors.any?
 
-      # Call create_query to apply user content filters
-      query = create_query(:Observation, search.query.params)
-      make_name_suggestions(search)
+      make_name_suggestions(query)
 
       if params[:needs_naming]
         redirect_to(
@@ -93,16 +91,16 @@ class ObservationsController
       end
     end
 
-    def make_name_suggestions(search)
-      alternate_spellings = search.query.params[:pattern]
+    def make_name_suggestions(query)
+      alternate_spellings = query.params[:pattern]
       return unless alternate_spellings && @objects.empty?
 
       @name_suggestions =
         Name.suggest_alternate_spellings(alternate_spellings)
     end
 
-    def render_pattern_search_error(search)
-      search.errors.each { |error| flash_error(error.to_s) }
+    def render_pattern_search_error(query)
+      query.validation_messages.each { |error| flash_error(error.to_s) }
       if params[:needs_naming]
         redirect_to(identify_observations_path(q: get_query_param))
       end

--- a/app/views/controllers/observations/show/_name_suggestions.erb
+++ b/app/views/controllers/observations/show/_name_suggestions.erb
@@ -1,10 +1,8 @@
 <%= tag.div(class: "alert-warning") do %>
   <%= tag.p("#{:list_observations_suggestions.t}:") %>
-  <% names.sort_by(&:sort_name).each do |name| %>
+  <% names.each do |name, count| %>
     <%= tag.div(class: "pl-3") do %>
       <%=
-        query = Query.create_query(:Observation, pattern: name.text_name)
-        count = query.num_results
         if count.zero?
           # link to Name because a pattern search would be circular
           :list_observation_name.t + ": " +

--- a/app/views/controllers/observations/show/_name_suggestions.erb
+++ b/app/views/controllers/observations/show/_name_suggestions.erb
@@ -3,8 +3,8 @@
   <% names.sort_by(&:sort_name).each do |name| %>
     <%= tag.div(class: "pl-3") do %>
       <%=
-        search = PatternSearch::Observation.new(name.text_name)
-        count = search.query.num_results
+        query = Query.create_query(:Observation, pattern: name.text_name)
+        count = query.num_results
         if count.zero?
           # link to Name because a pattern search would be circular
           :list_observation_name.t + ": " +


### PR DESCRIPTION
Removes a query from a partial. Views should not execute queries.

Controller now packs the `count` info into the `@name_suggestions`.