### PR TITLE
Source credit in ActivityLog

### DIFF
--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -84,7 +84,8 @@ module MatrixBoxHelper
       [
         matrix_box_what(presenter, object_id, identify),
         matrix_box_where(presenter),
-        matrix_box_when_who(presenter)
+        matrix_box_when_who(presenter),
+        matrix_box_source_credit(presenter)
       ].safe_join
     end
   end
@@ -161,6 +162,28 @@ module MatrixBoxHelper
         concat(tag.span(presenter.when, class: "rss-when"))
         concat(": ")
         concat(user_link(presenter.who, nil, class: "rss-who"))
+      end
+    end
+  end
+
+  def matrix_box_source_credit(presenter)
+    return unless presenter.respond_to?(:source_credit) ||
+                  presenter.respond_to?(:target) # e.g. rss_log presenter
+
+    target = if presenter.respond_to?(:source_credit)
+               presenter
+             elsif presenter.respond_to?(:target) # rss_log presenter
+               presenter.target
+             else
+               return nil
+             end
+
+    return unless target.respond_to?(:source_credit) &&
+                  target.source_noteworthy?
+
+    tag.div(class: "textile") do
+      tag.small do
+        target.source_credit.tpl
       end
     end
   end

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -167,15 +167,10 @@ module MatrixBoxHelper
   end
 
   def matrix_box_source_credit(presenter)
-    return unless presenter.respond_to?(:source_credit) ||
-                  presenter.respond_to?(:target) # e.g. rss_log presenter
-
     target = if presenter.respond_to?(:source_credit)
                presenter
              elsif presenter.respond_to?(:target) # rss_log presenter
                presenter.target
-             else
-               return nil
              end
 
     return unless target.respond_to?(:source_credit) &&

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -85,7 +85,7 @@ module MatrixBoxHelper
         matrix_box_what(presenter, object_id, identify),
         matrix_box_where(presenter),
         matrix_box_when_who(presenter),
-        matrix_box_source_credit(presenter)
+        tag.small(matrix_box_source_credit(presenter))
       ].safe_join
     end
   end
@@ -176,7 +176,7 @@ module MatrixBoxHelper
     return unless target.respond_to?(:source_credit) &&
                   target.source_noteworthy?
 
-    tag.div do
+    tag.div(class: "source-credit") do
       tag.small do
         target.source_credit.tpl
       end

--- a/app/helpers/matrix_box_helper.rb
+++ b/app/helpers/matrix_box_helper.rb
@@ -176,7 +176,7 @@ module MatrixBoxHelper
     return unless target.respond_to?(:source_credit) &&
                   target.source_noteworthy?
 
-    tag.div(class: "textile") do
+    tag.div do
       tag.small do
         target.source_credit.tpl
       end

--- a/app/presenters/matrix_box_presenter.rb
+++ b/app/presenters/matrix_box_presenter.rb
@@ -51,15 +51,8 @@ class MatrixBoxPresenter < BasePresenter
       self.location = target.location
     end
     self.time = rss_log.updated_at
-
     figure_out_rss_log_target_images(target)
-    return unless (temp = rss_log.detail)
-
-    temp = target.source_credit.tpl if target.respond_to?(:source_credit) &&
-                                       target.source_noteworthy?
-
-    # To avoid calling rss_log.detail twice
-    self.detail = temp
+    self.detail = rss_log.detail
   end
 
   # Grabs all the information needed for view from Image instance.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1361,11 +1361,11 @@
   log_object_updated: "[:log_object_updated_by_user]"
   log_object_updated_at: "[:log_object_updated_by_user]"
 
-  source_credit_mo_website: Created using the "Mushroom Observer website":https://mushroomobserver.org.
-  source_credit_mo_android_app: Created using the "Mushroom Observer Android app":https://mushroomobserver.org/articles/34.
-  source_credit_mo_iphone_app: Created using the "Mushroom Observer iPhone app":https://mushroomobserver.org/articles/34.
-  source_credit_mo_api: Created using the "Mushroom Observer API":https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md.
-  source_credit_mo_inat_import: Imported from "iNaturalist":https://www.inaturalist.org using the "Mushroom Observer website":https://mushroomobserver.org
+  source_credit_mo_website: Created via the Mushroom Observer website
+  source_credit_mo_android_app: Created via the "Mushroom Observer Android app":https://mushroomobserver.org/articles/34
+  source_credit_mo_iphone_app: Created via the "Mushroom Observer iPhone app":https://mushroomobserver.org/articles/34
+  source_credit_mo_api: Created via the "Mushroom Observer API":https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md.
+  source_credit_mo_inat_import: Imported from "iNaturalist":https://www.inaturalist.org via "Import from iNat":https://mushroomobserver.org/articles/39
 
   ##############################################################################
 

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -150,4 +150,14 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_match(activity_logs_path,
                  @response.header["Location"], "Redirected to wrong page")
   end
+
+  def test_rss_log_display_source_credit
+    obs = observations(:imported_inat_obs)
+
+    login
+    get(:index, params: { type: :observation })
+
+    assert_includes(@response.body, obs.source_credit.tpl,
+                    "RssLog is missing Source credit")
+  end
 end

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -160,4 +160,20 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_includes(@response.body, obs.source_credit.tpl,
                     "RssLog is missing Source credit")
   end
+
+  def test_rss_log_display_source_credit_updated_observation
+    obs = observations(:imported_inat_obs)
+    time = Time.now.utc
+    obs.update(updated_at: time, log_updated_at: time)
+    log = rss_logs(:imported_inat_obs_rss_log)
+    log.update(updated_at: time,
+               notes: "log_observation_updated user dick\n" \
+                      "log_observation_created user dick\n")
+
+    login
+    get(:index, params: { type: :observation })
+
+    assert_includes(@response.body, obs.source_credit.tpl,
+                    "RssLog is missing Source credit")
+  end
 end

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -35,6 +35,7 @@ DEFAULTS: &DEFAULTS
   classification: ""
   rss_log: $LABEL_rss_log
   needs_naming: 1
+  source: nil
 
 minimal_unknown_obs:
   <<: *DEFAULTS
@@ -813,7 +814,11 @@ recorder_obs:
 imported_inat_obs:
   <<: *DEFAULTS
   user: dick
+  created_at: <%= Time.now.utc %>
+  updated_at: <%= Time.now.utc %>
+  log_updated_at: <%= Time.now.utc %>
   inat_id: 12345
+  source: <%= Observation.sources[:mo_inat_import] %>
 
 provisional_obs:
   <<: *DEFAULTS

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -815,7 +815,7 @@ imported_inat_obs:
   <<: *DEFAULTS
   user: dick
   created_at: 2025-08-01 04:05:03
-  updated_at: 2023-08-01 04:05:03
+  updated_at: 2025-08-01 04:05:03
   log_updated_at: 2025-08-01 04:05:03
   inat_id: 12345
   source: <%= Observation.sources[:mo_inat_import] %>

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -814,9 +814,9 @@ recorder_obs:
 imported_inat_obs:
   <<: *DEFAULTS
   user: dick
-  created_at: <%= Time.now.utc %>
-  updated_at: <%= Time.now.utc %>
-  log_updated_at: <%= Time.now.utc %>
+  created_at: 2025-08-01 04:05:03
+  updated_at: 2023-08-01 04:05:03
+  log_updated_at: 2025-08-01 04:05:03
   inat_id: 12345
   source: <%= Observation.sources[:mo_inat_import] %>
 

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -472,7 +472,10 @@ recorder_obs_rss_log:
 
 imported_inat_obs_rss_log:
   <<: *DEFAULTS
+  created_at: <%= Time.now.utc %>
+  updated_at: <%= Time.now.utc %>
   observation: imported_inat_obs
+  notes: "log_observation_created user dick\n"
 
 species_list_rss_log:
   species_list: first_species_list

--- a/test/fixtures/rss_logs.yml
+++ b/test/fixtures/rss_logs.yml
@@ -472,8 +472,8 @@ recorder_obs_rss_log:
 
 imported_inat_obs_rss_log:
   <<: *DEFAULTS
-  created_at: <%= Time.now.utc %>
-  updated_at: <%= Time.now.utc %>
+  created_at: 2025-08-01 04:05:03
+  updated_at: 2025-08-01 04:05:03
   observation: imported_inat_obs
   notes: "log_observation_created user dick\n"
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1622,6 +1622,10 @@ class ObservationTest < UnitTestCase
     obs = observations(:amateur_obs)
     assert_equal("mo_iphone_app", obs.source)
     assert_equal(:source_credit_mo_iphone_app, obs.source_credit)
+
+    obs = observations(:imported_inat_obs)
+    assert_equal("mo_inat_import", obs.source)
+    assert_equal(:source_credit_mo_inat_import, obs.source_credit)
   end
 
   def test_hidden_location


### PR DESCRIPTION
Always displays source_credit in ActivityLogs (affects iNat imports and Observations created via the MO API)

- Resolves #3146
- Harmonizes index and ActivityLogs MatrixBoxes
- Moves ActivityLogs source_credit from MatrixBox footer to MatrixBox details.
- Adds source_credit to indexes, always displaying it there.

## Suggested Manual test
- Find the id of the newest iNat import or Observation created via the API. Example:
```
Observation.where(source: "mo_inat_import").order(created_at: :desc).first.id
  Observation Load (542.4ms)  SELECT `observations`.* FROM `observations` WHERE `observations`.`source` = 5 ORDER BY `observations`.`created_at` DESC LIMIT 1
=> 581599
```
- Propose a new Name for (or otherwise modify) that Observation (to move it to the top of the Activity Log for easier viewing).
- Go to the [ActivityLogs](http://localhost:3000/activity_logs).  Expected Result -- The Box for that Observation (see screenshot) should:
  - Display your update in the Box footer. (`main` does not display the update.)
  - Display the source in the Box details, directly under the Observation.user. (`main` displays the source in the Box footer.)
- Go to the [Observation index](url).
Expected result:
- The Box should look the same as in the ActivityLogs. (`main` does not display the source.)
<img width="380" height="476" alt="Screenshot 2025-08-11 at 8 47 04 AM" src="https://github.com/user-attachments/assets/de644865-d372-4898-a6d4-b9f6cf7d9fb6" />
