### PR TITLE
iNat Notes blank lines

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -110,8 +110,10 @@ class Inat
           # strip p tags to avoid messing up textile and keep notes source clean
           gsub(%r{</?p>}, "")&.
           # compress newlines/returns to single newline, leaving an html comment
-          # because our textiling won't render text after consecutive newlines
-          gsub(/[\n\r]+/, "<!--- blank line(s) removed --->\n").
+          # because our textiling won't render text after consecutive newlines:
+          #   manually typed blank lines appear as `\r\n\r\n` in iNat notes
+          #   Pulk's mirror script inserts `\n\n` in iNat notes
+          gsub(/(\r?\n){2,}/, "<!--- blank line(s) removed --->\n").
           to_s }
     end
 

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -109,9 +109,9 @@ class Inat
         Other: self[:description]&.
           # strip p tags to avoid messing up textile and keep notes source clean
           gsub(%r{</?p>}, "")&.
-          # compress newlines/returns to single newline because
-          # our textiling won't render anything after consecutive newlines
-          gsub(/[\n\r]+/, "\n").
+          # compress newlines/returns to single newline, leaving an html comment
+          # because our textiling won't render text after consecutive newlines
+          gsub(/[\n\r]+/, "<!--- blank line(s) removed --->\n").
           to_s }
     end
 

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -106,8 +106,13 @@ class Inat
 
       { Collector: collector,
         snapshot_key => snapshot,
-        # strip p tags and ensure it's a string
-        Other: self[:description]&.gsub(%r{</?p>}, "").to_s }
+        Other: self[:description]&.
+          # strip p tags to avoid messing up textile and keep notes source clean
+          gsub(%r{</?p>}, "")&.
+          # compress newlines/returns to single newline because
+          # our textiling won't render anything after consecutive newlines
+          gsub(/[\n\r]+/, "\n").
+          to_s }
     end
 
     # min bounding rectangle of iNat location blurred by public accuracy

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -384,9 +384,18 @@ class InatObsTest < UnitTestCase
       mock_observation("trametes").notes[:Other],
       "iNat Description should be mapped to MO Notes Other"
     )
+
+    mock_obs = mock_observation("tremella_mesenterica")
     assert_equal(
-      "", mock_observation("tremella_mesenterica").notes[:Other],
+      "", mock_obs.notes[:Other],
       "Notes Other should be a blank String if iNat Description is empty"
+    )
+
+    mock_obs = mock_observation("tremella_mesenterica")
+    mock_obs[:description] = "before blank line\r\n\r\nafter blank line"
+    assert_equal(
+      "before blank line\nafter blank line", mock_obs.notes[:Other],
+      "Failed to compress consecutive newlines/returns in Notes[:Other]"
     )
   end
 

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -72,14 +72,14 @@ class InatObsTest < UnitTestCase
 
     # Observation form needs the Notes "parts keys to be normalized
     snapshot_key = Observation.notes_normalized_key(:inat_snapshot_caption.l)
-    expected_notes =
-      { Collector: "jdcohenesq",
-        snapshot_key => expected_snapshot,
-        Other: "on Quercus\n\n&#8212;\n\nOriginally posted " \
-               "to Mushroom Observer on Mar. 7, 2024." }
+    other = "on Quercus\n&#8212;\nOriginally posted " \
+            "to Mushroom Observer on Mar. 7, 2024."
+    expected_notes = { Collector: "jdcohenesq",
+                       snapshot_key => expected_snapshot,
+                       Other: other }
     assert_equal(
       expected_notes, mock_inat_obs.notes,
-      "MO notes should include: iNat Collector || login, iNat Description"
+      "MO notes should include: (iNat Collector || login) && iNat Description"
     )
 
     expect = License.where(License[:url] =~ "/by-nc/").

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -223,7 +223,9 @@ class InatImportJobTest < ActiveJob::TestCase
 
     obs = Observation.last
     assert_equal(
-      "before blank line\nafter blank line", obs.notes[:Other],
+      "before blank line<!--- blank line(s) removed --->\n" \
+      "after blank line",
+      obs.notes[:Other],
       "Failed to compress consecutive newlines/returns in Notes[:Other]"
     )
   end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -205,6 +205,29 @@ class InatImportJobTest < ActiveJob::TestCase
     assert(obs.sequences.none?)
   end
 
+  def test_import_job_blank_line_in_description
+    create_ivars_from_filename("tremella_mesenterica")
+
+    # modify iNat observation description to include blank line
+    parsed_response = JSON.parse(@mock_inat_response, symbolize_names: true)
+    description = "before blank line\r\n\r\nafter blank line"
+    parsed_response[:results].first[:description] = description
+    @mock_inat_response = parsed_response.to_json
+
+    stub_inat_interactions
+
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(@inat_import)
+    end
+
+    obs = Observation.last
+    assert_equal(
+      "before blank line\nafter blank line", obs.notes[:Other],
+      "Failed to compress consecutive newlines/returns in Notes[:Other]"
+    )
+  end
+
   # Had 2 photos, 6 identifications of 3 taxa, a different taxon,
   # 9 obs fields, including "DNA Barcode ITS", "Collection number", "Collector"
   def test_import_job_obs_with_sequence_and_multiple_ids


### PR DESCRIPTION
Display (in MO iNat imports) text which followed blank lines in iNat Notes. 

- Resolves #3180 (user-reported bug): 
Some iNat observations have Note sections with blank lines in the middle.
When those observations are imported to MO, the text which was after the blank lines disappears in show Observation
- Replaces consecutive LFs, CRs from iNat Notes with an html comment (invisible in show Observation).
- Technical details in CoPilot Pull Request Overview.

###  Suggested Manual Test

- Import an iNat observation whose Notes contain a blank line plus additional text.
Expected Result:
In MO the imported Observation Notes show the additional text.
- Delete the iNat observation or clean it up by deleting the "Mushroom Observer URL" Observation Field.
