### PR TITLE
Switch search bar "search type" select to use plural type values

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -19,7 +19,13 @@ class SearchController < ApplicationController
   #   /species_lists/index
   def pattern
     pattern = params.dig(:pattern_search, :pattern) { |p| p.to_s.strip_squeeze }
-    type = params.dig(:pattern_search, :type)&.to_sym
+    unless (type = params.dig(:pattern_search, :type))
+      flash_and_redirect_invalid_search(type) and return
+    end
+
+    # Temporary 2025-08-14: safe-pluralize the type (will not double-pluralize)
+    # When reverting, also remove the `unless` block above.
+    type = type.to_s.pluralize.to_sym
 
     # Save it so that we can keep it in the search bar in subsequent pages.
     session[:pattern] = pattern
@@ -68,18 +74,22 @@ class SearchController < ApplicationController
     case type
     when :google
       site_google_search(pattern)
-    when :comment, :glossary_term, :herbarium, :herbarium_record, :image,
-         :location, :name, :observation, :project, :species_list, :user
+
+    when :comments, :glossary_terms, :herbaria, :herbarium_records, :images,
+         :locations, :names, :observations, :projects, :species_lists, :users
       redirect_to_search_or_index(
         pattern: pattern,
-        search_path: send(:"#{type.to_s.pluralize}_path",
-                          params: { pattern: pattern }),
-        index_path: send(:"#{type.to_s.pluralize}_path")
+        search_path: send(:"#{type}_path", params: { pattern: pattern }),
+        index_path: send(:"#{type}_path")
       )
     else
-      flash_error(:runtime_invalid.t(type: :search, value: type.inspect))
-      redirect_back_or_default("/")
+      flash_and_redirect_invalid_search(type) and return
     end
+  end
+
+  def flash_and_redirect_invalid_search(type)
+    flash_error(:runtime_invalid.t(type: :search, value: type.inspect))
+    redirect_back_or_default("/")
   end
 
   # NOTE: The autocompleters for name, location, and user all make the ids

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -19,13 +19,7 @@ class SearchController < ApplicationController
   #   /species_lists/index
   def pattern
     pattern = params.dig(:pattern_search, :pattern) { |p| p.to_s.strip_squeeze }
-    unless (type = params.dig(:pattern_search, :type))
-      flash_and_redirect_invalid_search(type) and return
-    end
-
-    # Temporary 2025-08-14: safe-pluralize the type (will not double-pluralize)
-    # When reverting, also remove the `unless` block above.
-    type = type.to_s.pluralize.to_sym
+    type = params.dig(:pattern_search, :type)
 
     # Save it so that we can keep it in the search bar in subsequent pages.
     session[:pattern] = pattern

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -19,7 +19,7 @@ class SearchController < ApplicationController
   #   /species_lists/index
   def pattern
     pattern = params.dig(:pattern_search, :pattern) { |p| p.to_s.strip_squeeze }
-    type = params.dig(:pattern_search, :type)
+    type = params.dig(:pattern_search, :type)&.to_sym
 
     # Save it so that we can keep it in the search bar in subsequent pages.
     session[:pattern] = pattern

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# helpers for search forms.
+module SearchHelper
+  def search_type_options
+    [
+      [:COMMENTS.l, :comments],
+      [:GLOSSARY.l, :glossary_terms],
+      [:HERBARIA.l, :herbaria],
+      # Temporarily disabled for performance reasons. 2021-09-12 JDC
+      # [:IMAGES.l, :images],
+      [:LOCATIONS.l, :locations],
+      [:NAMES.l, :names],
+      [:OBSERVATIONS.l, :observations],
+      [:PROJECTS.l, :projects],
+      [:SPECIES_LISTS.l, :species_lists],
+      [:HERBARIUM_RECORDS.l, :herbarium_records],
+      [:USERS.l, :users],
+      [:app_search_google.l, :google]
+    ].sort
+  end
+end

--- a/app/views/controllers/application/top_nav/_search_bar.html.erb
+++ b/app/views/controllers/application/top_nav/_search_bar.html.erb
@@ -1,23 +1,9 @@
 <%
-options = [
-  [:COMMENTS.l, :comments],
-  [:GLOSSARY.l, :glossary_terms],
-  [:HERBARIA.l, :herbaria],
-  # Temporarily disabled for performance reasons. 2021-09-12 JDC
-  # [:IMAGES.l, :images],
-  [:LOCATIONS.l, :locations],
-  [:NAMES.l, :names],
-  [:OBSERVATIONS.l, :observations],
-  [:PROJECTS.l, :projects],
-  [:SPECIES_LISTS.l, :species_lists],
-  [:HERBARIUM_RECORDS.l, :herbarium_records],
-  [:USERS.l, :users],
-  [:app_search_google.l, :google],
-].sort
 # Temporary 2025-08-14: safe-pluralize the type (will not double-pluralize)
 # When removing just revert to `session[:search_type]`
 default = session[:search_type]&.to_s&.pluralize&.to_sym
-search_options = options_for_select(options, default || :observations)
+search_options = options_for_select(search_type_options,
+                                    default || :observations)
 identify_page = controller.controller_name == "identify"
 icon_class = class_names(%w[btn navbar-link px-0])
 form_group_class = class_names(

--- a/app/views/controllers/application/top_nav/_search_bar.html.erb
+++ b/app/views/controllers/application/top_nav/_search_bar.html.erb
@@ -1,22 +1,23 @@
 <%
 options = [
-  [:COMMENTS.l, :comment],
-  [:GLOSSARY.l, :glossary_term],
-  [:HERBARIA.l, :herbarium],
+  [:COMMENTS.l, :comments],
+  [:GLOSSARY.l, :glossary_terms],
+  [:HERBARIA.l, :herbaria],
   # Temporarily disabled for performance reasons. 2021-09-12 JDC
-  # [:IMAGES.l, :image],
-  [:LOCATIONS.l, :location],
-  [:NAMES.l, :name],
-  [:OBSERVATIONS.l, :observation],
-  [:PROJECTS.l, :project],
-  [:SPECIES_LISTS.l, :species_list],
-  [:HERBARIUM_RECORDS.l, :herbarium_record],
-  [:USERS.l, :user],
+  # [:IMAGES.l, :images],
+  [:LOCATIONS.l, :locations],
+  [:NAMES.l, :names],
+  [:OBSERVATIONS.l, :observations],
+  [:PROJECTS.l, :projects],
+  [:SPECIES_LISTS.l, :species_lists],
+  [:HERBARIUM_RECORDS.l, :herbarium_records],
+  [:USERS.l, :users],
   [:app_search_google.l, :google],
 ].sort
-search_options = options_for_select(
-                   options, session[:search_type] || :observation
-                 )
+# Temporary 2025-08-14: safe-pluralize the type (will not double-pluralize)
+# When removing just revert to `session[:search_type]`
+default = session[:search_type]&.to_s&.pluralize&.to_sym
+search_options = options_for_select(options, default || :observations)
 identify_page = controller.controller_name == "identify"
 icon_class = class_names(%w[btn navbar-link px-0])
 form_group_class = class_names(

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -31,5 +31,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym("QR")
   inflect.irregular("bonus", "bonuses")
   inflect.irregular("info", "info")
+  inflect.irregular("google", "google")
   inflect.irregular("user_stats", "user_stats")
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -92,39 +92,39 @@ class SearchControllerTest < FunctionalTestCase
 
   def test_pattern_search
     login
-    params = { pattern_search: { pattern: "12", type: :observation } }
+    params = { pattern_search: { pattern: "12", type: :observations } }
     get(:pattern, params: params)
     assert_redirected_to(observations_path(pattern: "12"))
 
-    params = { pattern_search: { pattern: "34", type: :image } }
+    params = { pattern_search: { pattern: "34", type: :images } }
     get(:pattern, params: params)
     assert_redirected_to(images_path(pattern: "34"))
 
-    params = { pattern_search: { pattern: "56", type: :name } }
+    params = { pattern_search: { pattern: "56", type: :names } }
     get(:pattern, params: params)
     assert_redirected_to(names_path(pattern: "56"))
 
-    params = { pattern_search: { pattern: "78", type: :location } }
+    params = { pattern_search: { pattern: "78", type: :locations } }
     get(:pattern, params: params)
     assert_redirected_to(locations_path(pattern: "78"))
 
-    params = { pattern_search: { pattern: "90", type: :comment } }
+    params = { pattern_search: { pattern: "90", type: :comments } }
     get(:pattern, params: params)
     assert_redirected_to(comments_path(pattern: "90"))
 
-    params = { pattern_search: { pattern: "21", type: :project } }
+    params = { pattern_search: { pattern: "21", type: :projects } }
     get(:pattern, params: params)
     assert_redirected_to(projects_path(pattern: "21"))
 
-    params = { pattern_search: { pattern: "12", type: :species_list } }
+    params = { pattern_search: { pattern: "12", type: :species_lists } }
     get(:pattern, params: params)
     assert_redirected_to(species_lists_path(pattern: "12"))
 
-    params = { pattern_search: { pattern: "34", type: :user } }
+    params = { pattern_search: { pattern: "34", type: :users } }
     get(:pattern, params: params)
     assert_redirected_to(users_path(pattern: "34"))
 
-    params = { pattern_search: { pattern: "34", type: :glossary_term } }
+    params = { pattern_search: { pattern: "34", type: :glossary_terms } }
     get(:pattern, params: params)
     assert_redirected_to(glossary_terms_path(pattern: "34"))
 
@@ -144,13 +144,13 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern, params: params)
     assert_redirected_to("/")
 
-    params = { pattern_search: { pattern: "", type: :observation } }
+    params = { pattern_search: { pattern: "", type: :observations } }
     get(:pattern, params: params)
     assert_redirected_to(observations_path)
 
     # Make sure this redirects to the index that lists all herbaria,
     # rather than the index that lists query results.
-    params = { pattern_search: { pattern: "", type: :herbarium } }
+    params = { pattern_search: { pattern: "", type: :herbaria } }
     get(:pattern, params: params)
     assert_redirected_to(herbaria_path)
   end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -153,6 +153,10 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern, params: params)
     assert_redirected_to("/")
 
+    params = { pattern_search: { pattern: "x", type: nil } }
+    get(:pattern, params: params)
+    assert_redirected_to("/")
+
     params = { pattern_search: { pattern: "", type: :observations } }
     get(:pattern, params: params)
     assert_redirected_to(observations_path)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -95,38 +95,47 @@ class SearchControllerTest < FunctionalTestCase
     params = { pattern_search: { pattern: "12", type: :observations } }
     get(:pattern, params: params)
     assert_redirected_to(observations_path(pattern: "12"))
+    assert_equal(:observations, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "34", type: :images } }
     get(:pattern, params: params)
     assert_redirected_to(images_path(pattern: "34"))
+    assert_equal(:images, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "56", type: :names } }
     get(:pattern, params: params)
     assert_redirected_to(names_path(pattern: "56"))
+    assert_equal(:names, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "78", type: :locations } }
     get(:pattern, params: params)
     assert_redirected_to(locations_path(pattern: "78"))
+    assert_equal(:locations, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "90", type: :comments } }
     get(:pattern, params: params)
     assert_redirected_to(comments_path(pattern: "90"))
+    assert_equal(:comments, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "21", type: :projects } }
     get(:pattern, params: params)
     assert_redirected_to(projects_path(pattern: "21"))
+    assert_equal(:projects, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "12", type: :species_lists } }
     get(:pattern, params: params)
     assert_redirected_to(species_lists_path(pattern: "12"))
+    assert_equal(:species_lists, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "34", type: :users } }
     get(:pattern, params: params)
     assert_redirected_to(users_path(pattern: "34"))
+    assert_equal(:users, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "34", type: :glossary_terms } }
     get(:pattern, params: params)
     assert_redirected_to(glossary_terms_path(pattern: "34"))
+    assert_equal(:glossary_terms, @request.session[:search_type])
 
     stub_request(:any, /google.com/)
     pattern =  "hexiexiva"


### PR DESCRIPTION
This PR is pretty minor. It changes the select options in the search bar to provide plural symbols as values, e.g. `:observations` instead of `:observation`. The only receiver of these form values is `SearchController`. By the time this param hits the `SearchController`, it needs to be pluralized anyway. 

More importantly, this PR makes the faceted search Stimulus controller easier to write, for when this `select` also controls the appearance of faceted forms.

The PR includes a graceful fallback that will handle and update the user's `session[:search_type]` if it is currently stored as a singular symbol. I don't know how long it will take to update all user cookies, but I plan to leave the fallback in place for awhile.

Adds new tests that `session[:search_type]` is updated. Cannot test the old style singular values because sessions do not persist in integration tests.