### PR TITLE
Refactor pagination a bit

### DIFF
--- a/app/helpers/header/index_pagination_helper.rb
+++ b/app/helpers/header/index_pagination_helper.rb
@@ -6,14 +6,13 @@ module Header
     LETTERS = ("A".."Z")
 
     def add_pagination(pagination_data, args = {})
-      content_for(:index_pagination) do
-        concat(tag.div do
-          concat(content_for(:sorter)) if content_for?(:sorter)
-        end)
-        concat(tag.div(class: "d-flex") do
-          concat(letter_pagination_nav(pagination_data, args))
-          concat(number_pagination_nav(pagination_data, args))
-        end)
+      content_for(:index_pagination_top) do
+        index_pagination(pagination_data, args, position: :top)
+      end
+      return unless pagination_data.num_pages > 1
+
+      content_for(:index_pagination_bottom) do
+        index_pagination(pagination_data, args, position: :bottom)
       end
     end
 
@@ -30,17 +29,21 @@ module Header
       results = capture(&block).to_s
 
       tag.div(id: html_id, data: { q: get_query_param }) do
-        concat(bottom_pagination)
+        concat(content_for(:index_pagination_top))
         concat(results)
-        concat(bottom_pagination)
+        concat(content_for(:index_pagination_bottom))
       end
     end
 
-    def bottom_pagination
-      return "" unless content_for?(:index_pagination)
-
-      tag.div(class: "pagination-bottom navbar-flex") do
-        content_for(:index_pagination)
+    def index_pagination(pagination_data, args = {}, position: :top)
+      tag.div(class: "pagination-#{position} navbar-flex mb-2") do
+        concat(tag.div(class: "d-flex") do
+          concat(content_for(:sorter)) if content_for?(:sorter)
+        end)
+        concat(tag.div(class: "d-flex") do
+          concat(letter_pagination_nav(pagination_data, args))
+          concat(number_pagination_nav(pagination_data, args))
+        end)
       end
     end
 

--- a/app/helpers/header/index_pagination_helper.rb
+++ b/app/helpers/header/index_pagination_helper.rb
@@ -9,7 +9,7 @@ module Header
       content_for(:index_pagination_top) do
         index_pagination(pagination_data, args, position: :top)
       end
-      return unless pagination_data.num_pages > 1
+      return unless pagination_data && pagination_data.num_pages > 1
 
       content_for(:index_pagination_bottom) do
         index_pagination(pagination_data, args, position: :bottom)

--- a/app/helpers/header/sorter_helper.rb
+++ b/app/helpers/header/sorter_helper.rb
@@ -15,11 +15,27 @@ module Header
       title = sort_nav_order_by(query, sorts)
 
       content_for(:sorter) do
-        tag.div(class: "d-inline-block pl-3 sorter") do
-          concat(tag.label("#{:sort_by_header.l}:",
-                           class: "font-weight-normal mr-2 hidden-xs"))
+        tag.div(class: "navbar-flex pl-3 sorter") do
+          concat(tag.div("#{:sort_by_header.l}:",
+                         class: "navbar-text mx-0 hidden-xs"))
           concat(sort_nav_dropdown(title:, links:))
         end
+      end
+    end
+
+    def sort_nav_dropdown(title: "", links: [])
+      tag.div(class: "dropdown d-inline-block navbar-form px-2") do
+        [
+          sort_nav_toggle(title),
+          tag.ul(
+            class: "sorts dropdown-menu",
+            aria: { labelledby: "sort_nav_toggle" }
+          ) do
+            links.compact.each do |link|
+              concat(tag.li(link))
+            end
+          end
+        ].safe_join
       end
     end
 
@@ -92,22 +108,6 @@ module Header
       return ctlr unless model && ctlr != "contributors"
 
       model.underscore.pluralize
-    end
-
-    def sort_nav_dropdown(title: "", links: [])
-      tag.div(class: "dropdown d-inline-block") do
-        [
-          sort_nav_toggle(title),
-          tag.ul(
-            class: "sorts dropdown-menu",
-            aria: { labelledby: "sort_nav_toggle" }
-          ) do
-            links.compact.each do |link|
-              concat(tag.li(link))
-            end
-          end
-        ].safe_join
-      end
     end
 
     def sort_nav_toggle(title)

--- a/app/views/controllers/application/content/_index_bar.erb
+++ b/app/views/controllers/application/content/_index_bar.erb
@@ -1,24 +1,18 @@
 <%
 filters = content_for?(:filters) || content_for?(:filter_help)
-pagination = content_for?(:index_pagination)
 %>
 
-<% if filters || pagination %>
+<% if filters %>
   <%= tag.div(class: "row") do %>
     <%= tag.div(class: "col-xs-12") do %>
-      <%# Indexes: Query filter subtitle and pagination %>
-      <%= tag.div(id: "index_bar", class: "mb-3") do %>
+      <%# Indexes: Query filter subtitle %>
+      <%= tag.div(id: "index_bar", class: "mb-2") do %>
         <%= tag.div(class: "px-3 mt-2 mb-3") do
           if filters
             concat(yield(:filters)) if !content_for?(:banner_image)
             concat(yield(:filter_help))
           end
         end %>
-        <%# if pagination %>
-          <%# tag.div(class: "pagination-top navbar-flex px-3") do
-            concat(yield(:index_pagination))
-          end %>
-        <%# end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/controllers/names/index.html.erb
+++ b/app/views/controllers/names/index.html.erb
@@ -21,7 +21,7 @@ flash_error(@error) if @error && @objects.empty?
   <% if @objects.any? %>
     <% counts = Name.count_observations(@objects) %>
 
-    <%= tag.div(class: "list-group name-index") do %>
+    <%= tag.div(class: "list-group name-index mb-3") do %>
       <%= render(partial: "name", collection: @objects, as: :name,
                  locals: { counts: }) %>
     <% end %>


### PR DESCRIPTION
This should merge ahead of #3188.

Doesn't repeat sorter if there are no paged results. We only need a sorter at the top in that case. Also cleans up commented-out code in index bar, and makes pagination/sorter spacing more consistent.