### PR TITLE
Fix `in_box` scopes `or` chaining, resolve `vague?` vs `MO.obs_location_max_area`

### DIFF
--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -130,7 +130,7 @@ module Mappable
     # Arbitrary test for whether a box covers too large an area to be useful on
     # a map with other boxes. Large boxes can obscure more precise locations.
     def vague?
-      calculate_area > 24_000 # kmˆ2   or use MO.obs_location_max_area
+      calculate_area > MO.obs_location_max_area
     end
 
     # NOTE: DELTA = 0.20 is way too strict a limit for remote locations.

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -192,7 +192,7 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   # end
 
   def validate_float(param, val)
-    if val.is_a?(Integer) || val.is_a?(Float) ||
+    if val.is_a?(BigDecimal) || val.is_a?(Integer) || val.is_a?(Float) ||
        (val.is_a?(String) && val.match(/^-?(\d+(\.\d+)?|\.\d+)$/))
       val.to_f
     else

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -192,7 +192,7 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   # end
 
   def validate_float(param, val)
-    if val.is_a?(BigDecimal) || val.is_a?(Integer) || val.is_a?(Float) ||
+    if val.is_a?(Numeric) ||
        (val.is_a?(String) && val.match(/^-?(\d+(\.\d+)?|\.\d+)$/))
       val.to_f
     else

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -144,10 +144,12 @@ module MapHelper
   def mapset_associated_links_for_type(set, type)
     query_type = type.to_s.camelize.to_sym
     path_helper = :"#{type.to_s.pluralize}_path"
-    # probably already have a query, from the index that got us here.
-    # this will correctly merge the in_box param into the query.
+    # We probably already have a query, from the index that got us here.
+    # This will correctly merge the in_box param into the query.
     query = controller.
             find_or_create_query(query_type, in_box: mapset_box_params(set))
+    # Add the query params to the link data for debugging.
+    # Can remove when we start splatting query params in the URL.
     [link_to(:show_all.t, add_query_param(send(path_helper), query),
              data: query.params),
      link_to(:map_all.t, add_query_param(send(:"map_#{path_helper}"), query),

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -144,11 +144,14 @@ module MapHelper
   def mapset_associated_links_for_type(set, type)
     query_type = type.to_s.camelize.to_sym
     path_helper = :"#{type.to_s.pluralize}_path"
-    # probably already have a query, from the index that got us here. add box
-    query = controller.find_or_create_query(query_type)
-    query.in_box = mapset_box_params(set)
-    [link_to(:show_all.t, add_query_param(send(path_helper), query)),
-     link_to(:map_all.t, add_query_param(send(:"map_#{path_helper}"), query))]
+    # probably already have a query, from the index that got us here.
+    # this will correctly merge the in_box param into the query.
+    query = controller.
+            find_or_create_query(query_type, in_box: mapset_box_params(set))
+    [link_to(:show_all.t, add_query_param(send(path_helper), query),
+             data: query.params),
+     link_to(:map_all.t, add_query_param(send(:"map_#{path_helper}"), query),
+             data: query.params)]
   end
 
   def mapset_observation_link(obs, args)

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -145,8 +145,8 @@ module MapHelper
     query_type = type.to_s.camelize.to_sym
     path_helper = :"#{type.to_s.pluralize}_path"
     # probably already have a query, from the index that got us here. add box
-    query = controller.
-            find_or_create_query(query_type, in_box: mapset_box_params(set))
+    query = controller.find_or_create_query(query_type)
+    query.in_box = mapset_box_params(set)
     [link_to(:show_all.t, add_query_param(send(path_helper), query)),
      link_to(:map_all.t, add_query_param(send(:"map_#{path_helper}"), query))]
   end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -281,13 +281,14 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       box = Mappable::Box.new(**args.except(:vague))
       return none unless box.valid?
 
+      scope = all
       if include_vague_locations
         # this join is necessary for the `or` condition, which requires it
-        left_outer_joins(:location).gps_in_box_over_dateline(box).
-          or(Observation.associated_location_center_in_box_over_dateline(box))
+        scope.left_outer_joins(:location).gps_in_box_over_dateline(box).
+          or(scope.associated_location_center_in_box_over_dateline(box))
       else
-        gps_in_box_over_dateline(box).
-          or(Observation.cached_location_center_in_box_over_dateline(box))
+        scope.gps_in_box_over_dateline(box).
+          or(scope.cached_location_center_in_box_over_dateline(box))
       end
     }
     # In these the box.east edge is in the w hemisphere, -180..
@@ -325,13 +326,14 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       box = Mappable::Box.new(**args.except(:vague))
       return none unless box.valid?
 
+      scope = all
       if include_vague_locations
         # this join is necessary for the `or` condition, which requires it
-        left_outer_joins(:location).gps_in_box(box).
-          or(Observation.associated_location_center_in_box(box))
+        scope.left_outer_joins(:location).gps_in_box(box).
+          or(scope.associated_location_center_in_box(box))
       else
-        gps_in_box(box).or(
-          Observation.cached_location_center_in_box(box)
+        scope.gps_in_box(box).or(
+          scope.cached_location_center_in_box(box)
         )
       end
     }

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -101,7 +101,7 @@ MushroomObserver::Application.configure do
   config.location_prefixes_file  = "#{location_path}prefixes.yml"
   config.location_bad_terms_file = "#{location_path}bad_terms.yml"
   config.unknown_location_name = "Earth"
-  config.obs_location_max_area = 4_000
+  config.obs_location_max_area = 24_000
 
   # Limit the number of objects we draw on a google map.
   config.max_map_objects = 100

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -304,6 +304,33 @@ class Query::ObservationsTest < UnitTestCase
                  :Observation, in_box: box)
   end
 
+  # `in_box` originally had a badly-formed `or` that did not preserve the
+  # original scope on both branches of the `or` condition. The result was
+  # that a chained `in_box` query returned (seemingly) everything `in_box`.
+  def test_observation_in_box_with_other_scopes
+    # Have to do this, otherwise columns not populated
+    Location.update_box_area_and_center_columns
+    box = { north: 35, south: 34, east: -118, west: -119 }
+    in_box_expects = Observation.in_box(**box).order_by_default
+    # be sure we have more than one user's obs in this box
+    box_users = in_box_expects.pluck(:user_id).uniq
+    assert(box_users.size > 1)
+    assert(box_users.include?(mary.id))
+    chained_expects = Observation.by_users(mary.id).
+                      in_box(**box).order_by_default
+    assert_not_equal(in_box_expects, chained_expects)
+
+    box = locations(:california).bounding_box
+    in_box_expects = Observation.in_box(**box).order_by_default
+    chained_expects = Observation.by_users(mary.id).
+                      in_box(**box).order_by_default
+    # be sure we have more than one user's obs in this box
+    box_users = in_box_expects.pluck(:user_id).uniq
+    assert(box_users.size > 1)
+    assert(box_users.include?(mary.id))
+    assert_not_equal(in_box_expects, chained_expects)
+  end
+
   def test_observation_of_children
     name = names(:agaricus)
     params = { lookup: name.id, include_subtaxa: true }

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -324,11 +324,15 @@ class Query::ObservationsTest < UnitTestCase
     box = locations(:california).bounding_box
     in_box_expects = Query.lookup(:Observation, in_box: box)
     # be sure we have more than one value in this box
-    box_icl = in_box_expects.results.pluck(:is_collection_location).uniq
-    assert(box_icl.size > 1)
+    box_names = in_box_expects.results.pluck(:name_id).uniq
+    assert(box_names.size > 1)
 
     chained_expects = Query.lookup(
-      :Observation, in_box: box, is_collection_location: 1
+      :Observation, in_box: box,
+                    names: {
+                      lookup: "Agaricus campestris",
+                      include_synonyms: true
+                    }
     )
     assert_not_equal(in_box_expects.result_ids, chained_expects.result_ids)
   end


### PR DESCRIPTION
Resolves #3198

For queries like this
```ruby
Query.lookup(:Observation, in_box: locations(:massachusetts).bounding_box, by_users: 1)
```
the Observation scopes were producing unexpected results if `in_box` was chained with another scope. The results appeared to be ignoring the `by_users` scope, or at least returning inappropriate results.

Solution: the `or` clause in `in_box` scope was not formed correctly, so it was producing the wrong SQL.

Before this PR, note that the user query only applies to the first branch of the `WHERE`:
```sql
SELECT DISTINCT `observations`.* 
FROM `observations` 
WHERE (
  (
    (`observations`.`user_id` = 1) AND 
    (`observations`.`lat` >= 41.1870994568) AND 
    (`observations`.`lat` <= 42.8867988586) AND 
    (`observations`.`lng` <= -69.8589019775) AND 
    (`observations`.`lng` >= -73.508102417)
  ) OR (
    (`observations`.`lat` IS NULL) AND 
    (`observations`.`location_lat` >= 41.1870994568) AND 
    (`observations`.`location_lat` <= 42.8867988586) AND 
    (`observations`.`location_lng` <= -69.8589019775) AND 
    (`observations`.`location_lng` >= -73.508102417)
  )
) ORDER BY `observations`.`when` DESC, `observations`.`id` DESC
```

After this PR, note that the user query applies to both branches:
```sql
SELECT DISTINCT `observations`.* 
FROM `observations` 
WHERE (`observations`.`user_id` = 1) AND (
  (
    (
      (`observations`.`lat` >= 41.1870994568) AND 
      (`observations`.`lat` <= 42.8867988586) AND 
      (`observations`.`lng` <= -69.8589019775) AND 
      (`observations`.`lng` >= -73.508102417)
    ) OR (
      (`observations`.`lat` IS NULL) AND 
      (`observations`.`location_lat` >= 41.1870994568) AND 
      (`observations`.`location_lat` <= 42.8867988586) AND 
      (`observations`.`location_lng` <= -69.8589019775) AND 
      (`observations`.`location_lng` >= -73.508102417)
    )
  )
) ORDER BY `observations`.`when` DESC, `observations`.`id` DESC
```