### PR TITLE
Compare users when updating a page section, before deleting modal

### DIFF
--- a/app/controllers/admin/emails/merge_requests_controller.rb
+++ b/app/controllers/admin/emails/merge_requests_controller.rb
@@ -20,11 +20,11 @@ module Admin
           format.turbo_stream do
             render(
               partial: "shared/modal_form",
-              locals: { identifier: "merge_request_email",
-                        title: :email_merge_request_title.t(
-                          type: @model.type_tag
-                        ),
-                        user: @user, form: "admin/email/merge_requests/form" }
+              locals: {
+                title: :email_merge_request_title.t(type: @model.type_tag),
+                identifier: "merge_request_email",
+                user: @user, form: "admin/email/merge_requests/form"
+              }
             ) and return
           end
         end

--- a/app/controllers/admin/emails/merge_requests_controller.rb
+++ b/app/controllers/admin/emails/merge_requests_controller.rb
@@ -24,7 +24,7 @@ module Admin
                         title: :email_merge_request_title.t(
                           type: @model.type_tag
                         ),
-                        form: "admin/email/merge_requests/form" }
+                        user: @user, form: "admin/email/merge_requests/form" }
             ) and return
           end
         end

--- a/app/controllers/admin/emails/name_change_requests_controller.rb
+++ b/app/controllers/admin/emails/name_change_requests_controller.rb
@@ -20,10 +20,11 @@ module Admin
           format.turbo_stream do
             render(
               partial: "shared/modal_form",
-              locals: { identifier: "name_change_request_email",
-                        title: :email_name_change_request_title.l,
-                        user: @user,
-                        form: "admin/email/name_change_requests/form" }
+              locals: {
+                title: :email_name_change_request_title.l,
+                identifier: "name_change_request_email",
+                user: @user, form: "admin/email/name_change_requests/form"
+              }
             ) and return
           end
         end

--- a/app/controllers/admin/emails/name_change_requests_controller.rb
+++ b/app/controllers/admin/emails/name_change_requests_controller.rb
@@ -22,6 +22,7 @@ module Admin
               partial: "shared/modal_form",
               locals: { identifier: "name_change_request_email",
                         title: :email_name_change_request_title.l,
+                        user: @user,
                         form: "admin/email/name_change_requests/form" }
             ) and return
           end

--- a/app/controllers/admin/emails/webmaster_questions_controller.rb
+++ b/app/controllers/admin/emails/webmaster_questions_controller.rb
@@ -14,10 +14,11 @@ module Admin
           format.turbo_stream do
             render(
               partial: "shared/modal_form",
-              locals: { identifier: "webmaster_question_email",
-                        title: :ask_webmaster_title.l,
-                        user: @user,
-                        form: "admin/email/webmaster_questions/form" }
+              locals: {
+                title: :ask_webmaster_title.l,
+                identifier: "webmaster_question_email",
+                user: @user, form: "admin/email/webmaster_questions/form"
+              }
             ) and return
           end
         end

--- a/app/controllers/admin/emails/webmaster_questions_controller.rb
+++ b/app/controllers/admin/emails/webmaster_questions_controller.rb
@@ -16,6 +16,7 @@ module Admin
               partial: "shared/modal_form",
               locals: { identifier: "webmaster_question_email",
                         title: :ask_webmaster_title.l,
+                        user: @user,
                         form: "admin/email/webmaster_questions/form" }
             ) and return
           end

--- a/app/controllers/collection_numbers/remove_observations_controller.rb
+++ b/app/controllers/collection_numbers/remove_observations_controller.rb
@@ -25,8 +25,7 @@ module CollectionNumbers
           render(
             partial: "shared/modal_form",
             locals: {
-              title: @title,
-              identifier: "collection_number_observation",
+              title: @title, identifier: "collection_number_observation",
               user: @user, form: "collection_numbers/remove_observations/form"
             }
           ) and return

--- a/app/controllers/collection_numbers/remove_observations_controller.rb
+++ b/app/controllers/collection_numbers/remove_observations_controller.rb
@@ -27,7 +27,7 @@ module CollectionNumbers
             locals: {
               title: @title,
               identifier: "collection_number_observation",
-              form: "collection_numbers/remove_observations/form"
+              user: @user, form: "collection_numbers/remove_observations/form"
             }
           ) and return
         end

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -359,8 +359,7 @@ class CollectionNumbersController < ApplicationController
   def reload_collection_number_modal_form_and_flash
     render(
       partial: "shared/modal_form_reload",
-      locals: { identifier: modal_identifier,
-                user: @user, form: "collection_numbers/form" }
+      locals: { identifier: modal_identifier, form: "collection_numbers/form" }
     ) and return true
   end
 end

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -322,7 +322,7 @@ class CollectionNumbersController < ApplicationController
     render(
       partial: "shared/modal_form",
       locals: { title: modal_title, identifier: modal_identifier,
-                form: "collection_numbers/form" }
+                user: @user, form: "collection_numbers/form" }
     ) and return
   end
 
@@ -360,7 +360,7 @@ class CollectionNumbersController < ApplicationController
     render(
       partial: "shared/modal_form_reload",
       locals: { identifier: modal_identifier,
-                form: "collection_numbers/form" }
+                user: @user, form: "collection_numbers/form" }
     ) and return true
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -266,13 +266,13 @@ class CommentsController < ApplicationController
   def render_modal_comment_form
     render(partial: "shared/modal_form",
            locals: { title: modal_title, identifier: modal_identifier,
-                     form: "comments/form" }) and return
+                     user: @user, form: "comments/form" }) and return
   end
 
   def reload_modal_form
     render(partial: "shared/modal_form_reload",
            locals: { identifier: modal_identifier,
-                     form: "comments/form" })
+                     user: @user, form: "comments/form" })
   end
 
   def modal_identifier

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -271,8 +271,7 @@ class CommentsController < ApplicationController
 
   def reload_modal_form
     render(partial: "shared/modal_form_reload",
-           locals: { identifier: modal_identifier,
-                     user: @user, form: "comments/form" })
+           locals: { identifier: modal_identifier, form: "comments/form" })
   end
 
   def modal_identifier

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -398,8 +398,7 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   def reload_herbarium_modal_form_and_flash
     render(
       partial: "shared/modal_form_reload",
-      locals: { identifier: modal_identifier,
-                user: @user, form: "herbaria/form" }
+      locals: { identifier: modal_identifier, form: "herbaria/form" }
     ) and return true
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -158,7 +158,7 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
     render(partial: "shared/modal_form",
            locals: { title: modal_title, action: modal_form_action,
                      identifier: modal_identifier, local: false,
-                     form: "herbaria/form" }) and return
+                     user: @user, form: "herbaria/form" }) and return
   end
 
   def modal_identifier
@@ -396,7 +396,8 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   def reload_herbarium_modal_form_and_flash
     render(
       partial: "shared/modal_form_reload",
-      locals: { identifier: modal_identifier, form: "herbaria/form" }
+      locals: { identifier: modal_identifier,
+                user: @user, form: "herbaria/form" }
     ) and return true
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -155,10 +155,12 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   end
 
   def render_modal_herbarium_form
-    render(partial: "shared/modal_form",
-           locals: { title: modal_title, action: modal_form_action,
-                     identifier: modal_identifier, local: false,
-                     user: @user, form: "herbaria/form" }) and return
+    render(
+      partial: "shared/modal_form",
+      locals: { title: modal_title, identifier: modal_identifier,
+                user: @user, form: "herbaria/form",
+                form_locals: { local: false, action: modal_form_action } }
+    ) and return
   end
 
   def modal_identifier

--- a/app/controllers/herbarium_records/remove_observations_controller.rb
+++ b/app/controllers/herbarium_records/remove_observations_controller.rb
@@ -27,7 +27,7 @@ module HerbariumRecords
             locals: {
               title: @title,
               identifier: "herbarium_record_observation",
-              form: "herbarium_records/remove_observations/form"
+              user: @user, form: "herbarium_records/remove_observations/form"
             }
           ) and return
         end

--- a/app/controllers/herbarium_records/remove_observations_controller.rb
+++ b/app/controllers/herbarium_records/remove_observations_controller.rb
@@ -25,8 +25,7 @@ module HerbariumRecords
           render(
             partial: "shared/modal_form",
             locals: {
-              title: @title,
-              identifier: "herbarium_record_observation",
+              title: @title, identifier: "herbarium_record_observation",
               user: @user, form: "herbarium_records/remove_observations/form"
             }
           ) and return

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -424,8 +424,7 @@ class HerbariumRecordsController < ApplicationController
   def reload_herbarium_record_modal_form_and_flash
     render(
       partial: "shared/modal_form_reload",
-      locals: { identifier: modal_identifier,
-                user: @user, form: "herbarium_records/form" }
+      locals: { identifier: modal_identifier, form: "herbarium_records/form" }
     ) and return true
   end
 end

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -387,7 +387,7 @@ class HerbariumRecordsController < ApplicationController
   def render_modal_herbarium_record_form
     render(partial: "shared/modal_form",
            locals: { title: modal_title, identifier: modal_identifier,
-                     form: "herbarium_records/form" }) and return
+                     user: @user, form: "herbarium_records/form" }) and return
   end
 
   def modal_identifier
@@ -424,7 +424,8 @@ class HerbariumRecordsController < ApplicationController
   def reload_herbarium_record_modal_form_and_flash
     render(
       partial: "shared/modal_form_reload",
-      locals: { identifier: modal_identifier, form: "herbarium_records/form" }
+      locals: { identifier: modal_identifier,
+                user: @user, form: "herbarium_records/form" }
     ) and return true
   end
 end

--- a/app/controllers/images/emails_controller.rb
+++ b/app/controllers/images/emails_controller.rb
@@ -15,12 +15,16 @@ module Images
       respond_to do |format|
         format.html
         format.turbo_stream do
-          render(partial: "shared/modal_form",
-                 locals: { identifier: "commercial_inquiry_email",
-                           title: :commercial_inquiry_title.t(
-                             name: @image.unique_format_name
-                           ),
-                           user: @user, form: "images/emails/form" }) and return
+          render(
+            partial: "shared/modal_form",
+            locals: {
+              title: :commercial_inquiry_title.t(
+                name: @image.unique_format_name
+              ),
+              identifier: "commercial_inquiry_email",
+              user: @user, form: "images/emails/form"
+            }
+          ) and return
         end
       end
     end

--- a/app/controllers/images/emails_controller.rb
+++ b/app/controllers/images/emails_controller.rb
@@ -20,7 +20,7 @@ module Images
                            title: :commercial_inquiry_title.t(
                              name: @image.unique_format_name
                            ),
-                           form: "images/emails/form" }) and return
+                           user: @user, form: "images/emails/form" }) and return
         end
       end
     end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -502,7 +502,7 @@ class LocationsController < ApplicationController
   def render_modal_location_form
     render(partial: "shared/modal_form",
            locals: { title: modal_title, identifier: modal_identifier,
-                     form: "locations/form" }) and return
+                     user: @user, form: "locations/form" }) and return
   end
 
   def modal_identifier

--- a/app/controllers/observations/emails_controller.rb
+++ b/app/controllers/observations/emails_controller.rb
@@ -19,6 +19,7 @@ module Observations
                            title: :ask_observation_question_title.t(
                              name: @observation.unique_format_name
                            ),
+                           user: @user,
                            form: "observations/emails/form" }) and return
         end
       end

--- a/app/controllers/observations/emails_controller.rb
+++ b/app/controllers/observations/emails_controller.rb
@@ -14,13 +14,16 @@ module Observations
       respond_to do |format|
         format.html
         format.turbo_stream do
-          render(partial: "shared/modal_form",
-                 locals: { identifier: "observation_email",
-                           title: :ask_observation_question_title.t(
-                             name: @observation.unique_format_name
-                           ),
-                           user: @user,
-                           form: "observations/emails/form" }) and return
+          render(
+            partial: "shared/modal_form",
+            locals: {
+              title: :ask_observation_question_title.t(
+                name: @observation.unique_format_name
+              ),
+              identifier: "observation_email",
+              user: @user, form: "observations/emails/form"
+            }
+          ) and return
         end
       end
     end

--- a/app/controllers/observations/external_links_controller.rb
+++ b/app/controllers/observations/external_links_controller.rb
@@ -197,7 +197,7 @@ module Observations
       render(
         partial: "observations/show/section_update",
         locals: { identifier: "external_links",
-                  obs: @observation, sites: @other_sites }
+                  obs: @observation, user: @user, sites: @other_sites }
       ) and return
     end
 

--- a/app/controllers/observations/external_links_controller.rb
+++ b/app/controllers/observations/external_links_controller.rb
@@ -206,7 +206,7 @@ module Observations
       render(
         partial: "shared/modal_form_reload",
         locals: { identifier: modal_identifier,
-                  user: @user, form: "observations/external_links/form" }
+                  form: "observations/external_links/form" }
       ) and return true
     end
   end

--- a/app/controllers/observations/external_links_controller.rb
+++ b/app/controllers/observations/external_links_controller.rb
@@ -166,7 +166,7 @@ module Observations
       render(
         partial: "shared/modal_form",
         locals: { title: modal_title, identifier: modal_identifier,
-                  form: "observations/external_links/form" }
+                  user: @user, form: "observations/external_links/form" }
       ) and return
     end
 
@@ -206,7 +206,7 @@ module Observations
       render(
         partial: "shared/modal_form_reload",
         locals: { identifier: modal_identifier,
-                  form: "observations/external_links/form" }
+                  user: @user, form: "observations/external_links/form" }
       ) and return true
     end
   end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -135,6 +135,7 @@ module Observations
                title: modal_title, local: false,
                identifier: modal_identifier,
                form: "observations/namings/form",
+               user: @user,
                form_locals: { show_reasons: true,
                               context: params[:context] }
              }) and return
@@ -256,6 +257,7 @@ module Observations
                  locals: {
                    identifier: modal_identifier,
                    form: "observations/namings/form",
+                   user: @user,
                    form_locals: { show_reasons: true,
                                   context: params[:context] }
                  }) and return true

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -130,15 +130,16 @@ module Observations
     end
 
     def render_modal_naming_form
-      render(partial: "shared/modal_form",
-             locals: {
-               title: modal_title, local: false,
-               identifier: modal_identifier,
-               form: "observations/namings/form",
-               user: @user,
-               form_locals: { show_reasons: true,
-                              context: params[:context] }
-             }) and return
+      render(
+        partial: "shared/modal_form",
+        locals: {
+          title: modal_title, identifier: modal_identifier,
+          user: @user, form: "observations/namings/form",
+          form_locals: {
+            local: false, show_reasons: true, context: params[:context]
+          }
+        }
+      ) and return
     end
 
     def modal_identifier
@@ -253,14 +254,16 @@ module Observations
       respond_to do |format|
         format.html { render(action: redo_action) and return }
         format.turbo_stream do
-          render(partial: "shared/modal_form_reload",
-                 locals: {
-                   identifier: modal_identifier,
-                   form: "observations/namings/form",
-                   user: @user,
-                   form_locals: { show_reasons: true,
-                                  context: params[:context] }
-                 }) and return true
+          render(
+            partial: "shared/modal_form_reload",
+            locals: {
+              identifier: modal_identifier,
+              user: @user, form: "observations/namings/form",
+              form_locals: {
+                show_reasons: true, context: params[:context]
+              }
+            }
+          ) and return true
         end
       end
     end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -257,11 +257,8 @@ module Observations
           render(
             partial: "shared/modal_form_reload",
             locals: {
-              identifier: modal_identifier,
-              user: @user, form: "observations/namings/form",
-              form_locals: {
-                show_reasons: true, context: params[:context]
-              }
+              identifier: modal_identifier, form: "observations/namings/form",
+              form_locals: { show_reasons: true, context: params[:context] }
             }
           ) and return true
         end

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -112,7 +112,8 @@ module Projects
       render(
         partial: "shared/modal_form",
         locals: { title: modal_title, identifier: modal_identifier,
-                  form: "projects/aliases/form", project_alias: @project_alias }
+                  user: @user, form: "projects/aliases/form",
+                  project_alias: @project_alias }
       ) and return
     end
 
@@ -120,7 +121,7 @@ module Projects
       render(
         partial: "shared/modal_form_reload",
         locals: { identifier: modal_identifier,
-                  form: "projects/aliases/form",
+                  user: @user, form: "projects/aliases/form",
                   form_locals: { project_alias: @project_alias } }
       ) and return true
     end

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -113,7 +113,7 @@ module Projects
         partial: "shared/modal_form",
         locals: { title: modal_title, identifier: modal_identifier,
                   user: @user, form: "projects/aliases/form",
-                  project_alias: @project_alias }
+                  form_locals: { project_alias: @project_alias } }
       ) and return
     end
 

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -120,8 +120,7 @@ module Projects
     def reload_modal_project_alias_form
       render(
         partial: "shared/modal_form_reload",
-        locals: { identifier: modal_identifier,
-                  user: @user, form: "projects/aliases/form",
+        locals: { identifier: modal_identifier, form: "projects/aliases/form",
                   form_locals: { project_alias: @project_alias } }
       ) and return true
     end

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -277,7 +277,7 @@ class SequencesController < ApplicationController
   def render_modal_sequence_form
     render(partial: "shared/modal_form",
            locals: { title: modal_title, identifier: modal_identifier,
-                     form: "sequences/form" }) and return
+                     user: @user, form: "sequences/form" }) and return
   end
 
   def modal_identifier

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -19,7 +19,7 @@ module Users
                            title: :ask_user_question_title.t(
                              user: @target.legal_name
                            ),
-                           form: "users/emails/form" }) and return
+                           user: @user, form: "users/emails/form" }) and return
         end
       end
     end

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -14,12 +14,14 @@ module Users
       respond_to do |format|
         format.html
         format.turbo_stream do
-          render(partial: "shared/modal_form",
-                 locals: { identifier: "user_question_email",
-                           title: :ask_user_question_title.t(
-                             user: @target.legal_name
-                           ),
-                           user: @user, form: "users/emails/form" }) and return
+          render(
+            partial: "shared/modal_form",
+            locals: {
+              title: :ask_user_question_title.t(user: @target.legal_name),
+              identifier: "user_question_email",
+              user: @user, form: "users/emails/form"
+            }
+          ) and return
         end
       end
     end

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -67,11 +67,7 @@ module LightboxHelper
   # This is different from observation_show_title, more like matrix_box title
   def caption_obs_title(user:, obs:, identify:)
     btn_style = identify ? "text-bold" : "btn btn-primary"
-    text = if identify
-             tag.span("#{:OBSERVATION.l}: ", class: "font-weight-normal")
-           else
-             ""
-           end
+    text = caption_obs_title_text(identify)
     tag.h4(
       id: "observation_what_#{obs.id}", class: "obs-what",
       data: { controller: "section-update", section_update_user_value: user.id }
@@ -83,6 +79,14 @@ module LightboxHelper
                 id: "caption_obs_link_#{obs.id}"),
         obs.user_format_name(user).t.small_author
       ].compact_blank!.safe_join(" ")
+    end
+  end
+
+  def caption_obs_title_text(identify)
+    if identify
+      tag.span("#{:OBSERVATION.l}: ", class: "font-weight-normal")
+    else
+      ""
     end
   end
 

--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -74,7 +74,7 @@ module LightboxHelper
            end
     tag.h4(
       id: "observation_what_#{obs.id}", class: "obs-what",
-      data: { controller: "section-update" }
+      data: { controller: "section-update", section_update_user_value: user.id }
     ) do
       [
         text,

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -4,6 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 // get updated on successful form submit, so it "cleans up"
 export default class extends Controller {
   // static targets = ["form"] // unused rn
+  static values = { user: Number }
 
   connect() {
     // console.log("Hello Modal " + this.element.id);
@@ -11,10 +12,15 @@ export default class extends Controller {
   }
 
   // Modal form is only removed in the event that the page section updates.
-  // That event is broadcast from the section-update controller.
+  // That event is broadcast from the section-update controller with a user id.
+  // Only remove the modal if the updating user is the same who has modal open.
   // We can't fire based on submit response, because unless something's wrong
   // with the request, turbo-stream will send a 200 OK even if it didn't save.
-  remove() {
+  remove(event) {
+    const initiatingUser = event?.detail?.user
+    debugger
+    if (!initiatingUser || initiatingUser !== this.userValue) { return }
+
     // console.log("Removing modal")
     this.hide()
     this.element.remove()

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -5,6 +5,8 @@ import { Controller } from "@hotwired/stimulus"
 // that "clean up", e.g. remove or hide a modal.
 // Connects to data-controller="section-update"
 export default class extends Controller {
+  static values = { user: Number }
+
   connect() {
     this.element.dataset.sectionUpdate = "connected"
 
@@ -15,6 +17,6 @@ export default class extends Controller {
   // Dispatch a custom event to the window element
   updated() {
     // console.log(this.element.id + " turbo:frame-render section updated")
-    this.dispatch("updated")
+    this.dispatch("updated", { detail: { user: this.userValue } })
   }
 }

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -10,6 +10,9 @@ export default class extends Controller {
   connect() {
     this.element.dataset.sectionUpdate = "connected"
 
+    if (this.userValue == undefined) {
+      alert("Sections monitored by section-update require a userValue.")
+    }
     // Currently we're just using this to trigger modal:remove or modal:hide
     this.element.addEventListener("turbo:frame-render", this.updated())
   }

--- a/app/javascript/controllers/section-update_controller.js
+++ b/app/javascript/controllers/section-update_controller.js
@@ -14,7 +14,10 @@ export default class extends Controller {
     this.element.addEventListener("turbo:frame-render", this.updated())
   }
 
-  // Dispatch a custom event to the window element
+  // Dispatch a custom event to the window element, containing a user_id
+  // of the user initiating the update (modifying the record updated).
+  // This is compared with the modal controller's userValue -- if they are the
+  // same, a turbo_frame-render dispatching this event should hide the modal.
   updated() {
     // console.log(this.element.id + " turbo:frame-render section updated")
     this.dispatch("updated", { detail: { user: this.userValue } })

--- a/app/views/controllers/comments/_comment.erb
+++ b/app/views/controllers/comments/_comment.erb
@@ -14,7 +14,7 @@ target_type = tag.span(target.class.name.to_sym.t, class: "small") \
 tag.div(
   class: "list-group-item comment",
   id: dom_id(comment),
-  data: { controller: "section-update" }
+  data: { controller: "section-update", section_update_user_value: user.id }
 ) do
   concat(tag.div(class: "row") do
     [

--- a/app/views/controllers/observations/show/_collection_numbers.erb
+++ b/app/views/controllers/observations/show/_collection_numbers.erb
@@ -1,12 +1,14 @@
+<%# locals: (obs: nil, user: nil) %>
+
 <%
 numbers  = obs.collection_numbers
-can_edit = in_admin_mode? || obs.can_edit?(@user)
+can_edit = in_admin_mode? || obs.can_edit?(user)
 %>
 
 <%=
   tag.div(
     id: "observation_collection_numbers", class: "obs-collection",
-    data: { controller: "section-update", section_update_user_value: @user.id }
+    data: { controller: "section-update", section_update_user_value: user.id }
   ) do
 
     if numbers.any? && can_edit

--- a/app/views/controllers/observations/show/_collection_numbers.erb
+++ b/app/views/controllers/observations/show/_collection_numbers.erb
@@ -6,7 +6,7 @@ can_edit = in_admin_mode? || obs.can_edit?(@user)
 <%=
   tag.div(
     id: "observation_collection_numbers", class: "obs-collection",
-    data: { controller: "section-update" }
+    data: { controller: "section-update", section_update_user_value: @user.id }
   ) do
 
     if numbers.any? && can_edit

--- a/app/views/controllers/observations/show/_external_links.erb
+++ b/app/views/controllers/observations/show/_external_links.erb
@@ -3,7 +3,7 @@
 <%=
 tag.div(
   id: "observation_external_links", class: "obs-links",
-  data: { controller: "section-update", section_update_user_value: user&.id }
+  data: { controller: "section-update", section_update_user_value: user.id }
 ) do
 
   [

--- a/app/views/controllers/observations/show/_external_links.erb
+++ b/app/views/controllers/observations/show/_external_links.erb
@@ -3,7 +3,7 @@
 <%=
 tag.div(
   id: "observation_external_links", class: "obs-links",
-  data: { controller: "section-update", section_update_user_value: user.id }
+  data: { controller: "section-update", section_update_user_value: user&.id }
 ) do
 
   [
@@ -35,7 +35,7 @@ tag.div(
                 ),
                 "]"
               ].safe_join(" ")
-            ) if link.can_edit?(@user) || in_admin_mode?
+            ) if link.can_edit?(user) || in_admin_mode?
           end
         end.safe_join
       end

--- a/app/views/controllers/observations/show/_external_links.html.erb
+++ b/app/views/controllers/observations/show/_external_links.html.erb
@@ -3,7 +3,7 @@
 <%=
 tag.div(
   id: "observation_external_links", class: "obs-links",
-  data: { controller: "section-update" }
+  data: { controller: "section-update", section_update_user_value: user.id }
 ) do
 
   [

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -1,12 +1,14 @@
+<%# locals: (obs: nil, user: nil) %>
+
 <%
 records = obs.herbarium_records
-can_add = in_admin_mode? || obs.can_edit?(@user) ||
-          @user && @user.curated_herbaria.any?
+can_add = in_admin_mode? || obs.can_edit?(user) ||
+          user && user.curated_herbaria.any?
 %>
 <%=
   tag.div(
     id: "observation_herbarium_records", class: "obs-herbarium",
-    data: { controller: "section-update", section_update_user_value: @user.id }
+    data: { controller: "section-update", section_update_user_value: user.id }
   ) do
 
     if records.any? && can_add
@@ -26,7 +28,7 @@ can_add = in_admin_mode? || obs.can_edit?(@user) ||
           records.map do |record|
             tag.li(id: "herbarium_record_#{record.id}") do
               concat(link_to(*herbarium_record_tab(record, obs)))
-              if record.can_edit?(@user) || in_admin_mode?
+              if record.can_edit?(user) || in_admin_mode?
                 concat(
                   [
                     " [",

--- a/app/views/controllers/observations/show/_herbarium_records.erb
+++ b/app/views/controllers/observations/show/_herbarium_records.erb
@@ -6,7 +6,7 @@ can_add = in_admin_mode? || obs.can_edit?(@user) ||
 <%=
   tag.div(
     id: "observation_herbarium_records", class: "obs-herbarium",
-    data: { controller: "section-update" }
+    data: { controller: "section-update", section_update_user_value: @user.id }
   ) do
 
     if records.any? && can_add

--- a/app/views/controllers/observations/show/_namings.erb
+++ b/app/views/controllers/observations/show/_namings.erb
@@ -5,7 +5,7 @@
 tag.div(
   id: "observation_namings",
   class: "namings-table panel panel-default mb-4",
-  data: { controller: "section-update" }
+  data: { controller: "section-update", section_update_user_value: user.id }
 ) do
   [
     render(partial: "observations/show/namings/header",

--- a/app/views/controllers/observations/show/_observation_details.erb
+++ b/app/views/controllers/observations/show/_observation_details.erb
@@ -7,7 +7,7 @@ show_links = user && (obs.external_links.any? || sites.any?)
 
 <%= panel_block(id: "observation_details",
                 heading: :show_observation_details.l,
-                heading_links: @user && obs_details_links(obs),
+                heading_links: user && obs_details_links(obs),
                 class: "name-section") do %>
 
   <%= observation_details_when_where_who(obs:, user:) %>

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -8,7 +8,7 @@ can_edit  = in_admin_mode? || obs.can_edit?(user)
 <%=
 tag.div(
   id: "observation_sequences", class: "obs-sequence",
-  data: { controller: "section-update" }
+  data: { controller: "section-update", section_update_user_value: user.id }
 ) do
 
   concat(tag.div do

--- a/app/views/controllers/projects/aliases/_form.erb
+++ b/app/views/controllers/projects/aliases/_form.erb
@@ -15,7 +15,7 @@
 %>
 <%= form_with(**form_args) do |form| %>
   <% if project_alias.errors.any? %>
-    <div id="error_explanation">
+    <div id="error_explanation" class="alert alert-danger">
       <h2><%= pluralize(project_alias.errors.count, "error") %> prohibited this project alias from being saved:</h2>
       <ul>
         <% project_alias.errors.full_messages.each do |message| %>

--- a/app/views/controllers/shared/_modal_form.erb
+++ b/app/views/controllers/shared/_modal_form.erb
@@ -8,6 +8,7 @@ Requires these locals:
   identifier, used to build html ids for parts of the modal
   title, the text in the modal-header h4
   form, full path (after /views/) of the partial building the form
+  user, the @user opening this form, to know if a section update should close it
   (locals) anything else you want to send to the body partial.
      { turbo: true } gets merged so that form sends via js
 
@@ -26,14 +27,14 @@ note: MUST REMOVE **.html**.erb file extension from form partials!
 %>
 
 <%
-form_locals = local_assigns.except(:identifier, :title, :form)
+form_locals = local_assigns.except(:identifier, :title, :form, :user)
 %>
 
 <%=
 tag.div(
   class: "modal", id: "modal_#{identifier}", role: "dialog",
   aria: { labelledby: "modal_#{identifier}_header" },
-  data: { controller: "modal",
+  data: { controller: "modal", modal_user_value: user.id,
           action: "section-update:updated@window->modal#remove",
           identifier: identifier } # not sure
 ) do

--- a/app/views/controllers/shared/_modal_form.erb
+++ b/app/views/controllers/shared/_modal_form.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:, identifier:, title:, user:, form_locals: {}) %>
+
 <%#
 Entire template for a Bootstrap modal with a form.
 Called in turbo_stream responses from `new` and `edit` form actions.
@@ -9,7 +11,7 @@ Requires these locals:
   title, the text in the modal-header h4
   form, full path (after /views/) of the partial building the form
   user, the @user opening this form, to know if a section update should close it
-  (locals) anything else you want to send to the body partial.
+  form_locals, anything else you want to send to the body partial.
      { turbo: true } gets merged so that form sends via js
 
 In order to keep form progress if the modal is closed and opened again,
@@ -17,17 +19,15 @@ it's not destroyed when closed. Successful submit updates the page.
 When page section with data-controller: section_update is updated,
 that controller dispatches the updated event, and this line below:
   data-action: "section-update:updated@window->modal#remove"
-calls the action `remove` in the modal controller.
+calls the action `remove` in the modal controller. That controller compares
+the user_id of the section_update event with the user of this modal, so
+that broadcasts don't unintentionally close other peoples' modals.
 
 Sounds circuitous, but we don't want the modal getting removed on submit,
 in case there are form problems. The consequence of form success is the page
 being updated. Note that all actions are called by data tags on html elements.
 
 note: MUST REMOVE **.html**.erb file extension from form partials!
-%>
-
-<%
-form_locals = local_assigns.except(:identifier, :title, :form, :user)
 %>
 
 <%=

--- a/app/views/controllers/shared/_modal_form_reload.erb
+++ b/app/views/controllers/shared/_modal_form_reload.erb
@@ -1,4 +1,4 @@
-<%# locals: (identifier:, form:, user:, form_locals: {}) -%>
+<%# locals: (identifier:, form:, form_locals: {}) -%>
 <%
 # What to do if a form submit doesn't succeed
 %>

--- a/app/views/controllers/shared/_modal_form_reload.erb
+++ b/app/views/controllers/shared/_modal_form_reload.erb
@@ -1,7 +1,7 @@
-<%# locals: (identifier:, form:, form_locals: {}) -%>
+<%# locals: (identifier:, form:, user:, form_locals: {}) -%>
 <%
 # What to do if a form submit doesn't succeed
-# Takes locals: { identifier:, form:, form_locals: {} }
+# Takes locals: { identifier:, form:, user:, form_locals: {} }
 # form_locals ||= {}
 %>
 
@@ -10,5 +10,5 @@
 end %>
 
 <%= turbo_stream.replace("#{identifier}_form") do
-  render(partial: form, locals: { local: false, form_locals: })
+  render(partial: form, locals: { local: false, user:, form_locals: })
 end %>

--- a/app/views/controllers/shared/_modal_form_reload.erb
+++ b/app/views/controllers/shared/_modal_form_reload.erb
@@ -8,5 +8,5 @@
 end %>
 
 <%= turbo_stream.replace("#{identifier}_form") do
-  render(partial: form, locals: { local: false, user:, form_locals: })
+  render(partial: form, locals: { local: false, form_locals: })
 end %>

--- a/app/views/controllers/shared/_modal_form_reload.erb
+++ b/app/views/controllers/shared/_modal_form_reload.erb
@@ -1,8 +1,6 @@
 <%# locals: (identifier:, form:, user:, form_locals: {}) -%>
 <%
 # What to do if a form submit doesn't succeed
-# Takes locals: { identifier:, form:, user:, form_locals: {} }
-# form_locals ||= {}
 %>
 
 <%= turbo_stream.update("modal_#{identifier}_flash") do

--- a/app/views/controllers/visual_groups/_form.html.erb
+++ b/app/views/controllers/visual_groups/_form.html.erb
@@ -2,7 +2,7 @@
               id: "visual_group_form") do |f| %>
 
   <% if visual_group.errors.any? %>
-    <div id="error_explanation">
+    <div id="error_explanation" class="alert alert-danger">
       <h2>
 	<%= pluralize(visual_group.errors.count, "error") %>
 	prohibited this visual_group from being saved:

--- a/app/views/controllers/visual_models/_form.html.erb
+++ b/app/views/controllers/visual_models/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: visual_model) do |f| %>
   <% if visual_model.errors.any? %>
-    <div id="error_explanation">
+    <div id="error_explanation" class="alert alert-danger">
       <%= "#{pluralize(visual_model.errors.count,
         :error.t, plural: :errors.t)} #{:visual_model_errors.t}" %>:
       <ul>


### PR DESCRIPTION
Addresses #3200. I won't even describe it because CoPilot is writing better descriptions these days.

Requires the manual test described in #3200. For good measure, manual testers should also test comment updates against another browser window with a CollectionNumber, HerbariumRecord, Sequence, or ExternalLink form modal open. No comment update should close anyone else's modal at this point.

#### Durability against regression:
The PR changes the `modal_form` partial to require a `user`, using the newish Rails `locals` template variables, declared in a magic comment at the top of the template. All partials monitored by `data: { controller: "section-update" }` Stimulus (not only comments) are now also required to supply a `section_update_user_value` as a data attribute — in the case of comment updates, it's the `comment.user`.  If it's not supplied the Stimulus controller will send an alert to the page.

The modal Stimulus controller checks that the users match before closing any modal. In the event of a broadcast update from a comment or any other future broadcast,  the `section-update` Stimulus controller notices the updated div, emits an `updated` event, and sends the `userValue` as a data value in the JS `event.detail`. This is checked by the `modal` Stimulus controller against the modal's `userValue`.