### PR TITLE
List missing locals and given them default values based on the code

### DIFF
--- a/app/views/controllers/observations/namings/_form.erb
+++ b/app/views/controllers/observations/namings/_form.erb
@@ -1,4 +1,4 @@
-<%# locals: (local: false, form_locals: {}) -%>
+<%# locals: (local: false, form_locals: {}, show_reasons: true, context: "blank") -%>
 
 <%
 # Fields must be separate because they're included in the obs form too.
@@ -35,7 +35,7 @@ end
 # `naming_locals`: modal forms can accept a `form_locals` local. The controller
 # may send `context` (i.e. where the form appears), which defaults to "blank".
 # `show_reasons` is false on the obs form, true on the naming form.
-naming_locals = { create:, button_name:, show_reasons: true, context: "blank" }.merge(form_locals)
+naming_locals = { create:, button_name:, show_reasons:, context: }.merge(form_locals)
 %>
 
 <%= form_with(**form_args) do |f| %>


### PR DESCRIPTION
This allows name proposals from the observation page again.  All tests appear to be passing as well.