### PR TITLE
Add test for bug reported by Igor regarding broken naming interface

### DIFF
--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -23,6 +23,15 @@ module Observations
                          observation_id: obs.id.to_s)
     end
 
+    def test_new_form_turbo
+      obs = observations(:coprinus_comatus_obs)
+      params = { observation_id: obs.id.to_s }
+      login
+      get(:new, params:, format: :turbo_stream)
+      assert_form_action(action: "create", approved_name: "",
+                         observation_id: obs.id.to_s)
+    end
+
     def test_edit_form
       nam = namings(:coprinus_comatus_naming)
       params = { observation_id: nam.observation_id, id: nam.id.to_s }


### PR DESCRIPTION
This is just a quick test of loading the naming form via turbo.  It fails if you revert the change in #3207, but succeeds are current main.