### PR TITLE
Namings and Votes: Turbo response tests, including for matrix_box and lightgallery, plus other forms

### DIFF
--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -320,8 +320,7 @@ class CollectionNumbersController < ApplicationController
         redirect_to_back_object_or_object(@back_object, @collection_number) and
           return
       end
-      # renders the flash in the modal, but not sure it's necessary
-      # to have a response here. are they getting sent back?
+      # renders the flash in the modal
       format.turbo_stream do
         render(partial: "shared/modal_flash_update",
                locals: { identifier: modal_identifier }) and return

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -144,9 +144,7 @@ class CommentsController < ApplicationController
                        !in_admin_mode?
 
     flash_error(:runtime_show_description_denied.t)
-    parent = object.parent
-    redirect_to(controller: parent.show_controller,
-                action: parent.show_action, id: parent.id)
+    show_flash_and_send_back(object.parent)
     false
   end
 
@@ -333,8 +331,7 @@ class CommentsController < ApplicationController
   def check_permission_or_redirect!(comment, target)
     return true if check_permission!(comment)
 
-    redirect_with_query(controller: target.show_controller,
-                        action: target.show_action, id: target.id)
+    show_flash_and_send_back(target)
     false
   end
 
@@ -351,6 +348,19 @@ class CommentsController < ApplicationController
       @comment.log_update
       flash_notice(:runtime_form_comments_edit_success.t(id: @comment.id))
       true
+    end
+  end
+
+  def show_flash_and_send_back(target)
+    respond_to do |format|
+      format.html do
+        redirect_with_query(target.show_link_args) and return
+      end
+      # renders the flash in the modal
+      format.turbo_stream do
+        render(partial: "shared/modal_flash_update",
+               locals: { identifier: modal_identifier }) and return
+      end
     end
   end
 end

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -299,7 +299,7 @@ class HerbariumRecordsController < ApplicationController
     return true if @herbarium_record.herbarium.curator?(@user)
 
     flash_error(:permission_denied.t)
-    redirect_to_back_object_or_object(@back_object, @herbarium_record)
+    show_flash_and_send_back
     false
   end
 

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -174,7 +174,7 @@ class HerbariumRecordsController < ApplicationController
     @herbarium_record =
       HerbariumRecord.new(permitted_herbarium_record_params)
     normalize_parameters
-    return if flash_error_and_reload_if_form_has_errors
+    return if form_has_errors?
 
     if herbarium_label_free?
       save_herbarium_record_and_update_associations
@@ -225,7 +225,7 @@ class HerbariumRecordsController < ApplicationController
     old_herbarium = @herbarium_record.herbarium
     @herbarium_record.attributes = permitted_herbarium_record_params
     normalize_parameters
-    return if flash_error_and_reload_if_form_has_errors
+    return if form_has_errors?
 
     if herbarium_label_free?
       update_herbarium_record_and_notify_curators(old_herbarium)
@@ -254,24 +254,10 @@ class HerbariumRecordsController < ApplicationController
   end
 
   # create, update
-  def flash_error_and_reload_if_form_has_errors
-    redirect_params = case action_name # this is a rails var
-                      when "create"
-                        { action: :new }
-                      when "update"
-                        { action: :edit }
-                      end
-    redirect_params = redirect_params.merge({ back: @back }) if @back.present?
-
+  def form_has_errors?
     unless validate_herbarium_name! # may add flashes
-      respond_to do |format|
-        format.html do
-          redirect_to(redirect_params) and return true
-        end
-        format.turbo_stream do
-          reload_herbarium_record_modal_form_and_flash
-        end
-      end
+      flash_and_reload_form
+      return true
     end
 
     unless can_add_record_to_herbarium?
@@ -280,6 +266,25 @@ class HerbariumRecordsController < ApplicationController
     end
 
     false
+  end
+
+  def flash_and_reload_form
+    redirect_params = case action_name # this is a rails var
+                      when "create"
+                        { action: :new }
+                      when "update"
+                        { action: :edit }
+                      end
+    redirect_params[:back] = @back if @back.present?
+
+    respond_to do |format|
+      format.html do
+        redirect_to(redirect_params)
+      end
+      format.turbo_stream do
+        reload_herbarium_record_modal_form_and_flash
+      end
+    end
   end
 
   def permitted_herbarium_record_params

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -115,7 +115,7 @@ module Observations::Namings
     def render_matrix_box_naming_update
       render(
         partial: "observations/namings/update_matrix_box",
-        locals: { obs: @observation }
+        locals: { obs: @observation, user: @user }
       ) and return
     end
   end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -218,7 +218,7 @@ module Observations
           case params[:context]
           when "lightgallery", "matrix_box"
             render(partial: "observations/namings/update_matrix_box",
-                   locals: { obs: @observation })
+                   locals: { obs: @observation, user: @user })
           else
             redirect_to_obs(@observation)
           end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -299,18 +299,6 @@ module Observations
       @reasons = @naming.init_reasons(reasons)
     end
 
-    # Define local_assigns for the update_observation partial
-    # @observation.reload doesn't do the includes
-    # This is a reload of all the naming table associations, after update
-    # The destroy action already preloads the obs, however.
-    def locals_for_update_observation(preloaded_obs = nil)
-      obs = preloaded_obs || Observation.naming_includes.find(@observation.id)
-      consensus = Observation::NamingConsensus.new(obs)
-      owner_name = consensus.owner_preference
-
-      [obs, consensus, owner_name]
-    end
-
     # Use case: user changes their mind on a name they've proposed, but it's
     # already been upvoted by others. We don't let them change this naming,
     # because that would bring the other people's votes along with it.

--- a/app/views/controllers/observations/namings/_update_matrix_box.erb
+++ b/app/views/controllers/observations/namings/_update_matrix_box.erb
@@ -1,12 +1,14 @@
+<%# locals: (obs:, user:) %>
+
 <%# Replace the title in the lightbox caption %>
 <%= turbo_stream.replace("observation_what_#{obs.id}") do
-  caption_obs_title(user: @user, obs: obs, identify: true)
+  caption_obs_title(user: user, obs: obs, identify: true)
 end %>
 
 <%# Replace the title in the matrix_box %>
 <%= turbo_stream.replace("box_title_#{obs.id}") do
   matrix_box_title(name: obs.format_name.t.break_name.small_author,
-                   id: obs.id)
+                   id: obs.id, type: :observation)
 end %>
 
 <%# are not removed via data-controller="section-update" because replaced %>

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -191,8 +191,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     }
     login(user.login)
     assert_difference("CollectionNumber.count", 1) do
-      post(:create, params: params,
-                    format: :turbo_stream)
+      post(:create, params: params, format: :turbo_stream)
     end
   end
 
@@ -375,7 +374,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     patch(:update, params:)
     assert_flash_text(/permission denied/i)
 
-    # test turbo
+    # Test turbo shows flash warning
     patch(:update, params:, format: :turbo_stream)
     assert_flash_text(/permission denied/i)
     assert_template("shared/_modal_flash_update")

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -170,6 +170,15 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  def test_new_collection_number_turbo
+    obs_id = observations(:coprinus_comatus_obs).id
+
+    login("rolf")
+    get(:new, params: { observation_id: obs_id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("collection_numbers/_form")
+  end
+
   def test_create_collection_number_with_turbo
     obs = observations(:strobilurus_diminutivus_obs)
     user = obs.user
@@ -325,6 +334,15 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     make_admin("mary")
     get(:edit, params: { id: number.id })
     assert_response(:success)
+  end
+
+  def test_edit_collection_number_turbo
+    number = collection_numbers(:coprinus_comatus_coll_num)
+
+    login("rolf")
+    get(:edit, params: { id: number.id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("collection_numbers/_form")
   end
 
   def test_update_collection_number

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -234,7 +234,7 @@ class CommentsControllerTest < FunctionalTestCase
 
     # Test turbo shows flash error
     get(:new, params:, format: :turbo_stream)
-    assert_template("shared/_modal_form_reload")
+    assert_template("shared/_modal_flash_update")
     assert_flash_error
   end
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -232,6 +232,7 @@ class CommentsControllerTest < FunctionalTestCase
     assert_flash_error("MO should flash if trying to comment on object" \
                        "for which user lacks read privileges")
 
+    # Test turbo shows flash error
     get(:new, params:, format: :turbo_stream)
     assert_template("shared/_modal_form_reload")
     assert_flash_error

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -189,31 +189,40 @@ class CommentsControllerTest < FunctionalTestCase
     assert_template("show")
   end
 
-  def test_add_comment
+  def test_new_comment
     obs_id = observations(:minimal_unknown_obs).id
     requires_login(:new, target: obs_id, type: :Observation)
     assert_form_action(action: :create, target: obs_id, type: :Observation)
   end
 
-  def test_add_comment_to_project
+  def test_new_comment_turbo
+    obs_id = observations(:minimal_unknown_obs).id
+    get(:new, params: { target: obs_id, type: :Observation },
+              format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("comments/_form")
+    assert_form_action(action: :create, target: obs_id, type: :Observation)
+  end
+
+  def test_new_comment_for_project
     project_id = projects(:eol_project).id
     requires_login(:new, target: project_id, type: :Project)
     assert_form_action(action: :create, target: project_id, type: :Project)
   end
 
-  def test_add_comment_no_id
+  def test_new_comment_no_id
     login("dick")
     get(:new)
     assert_response(:redirect)
   end
 
-  def test_add_comment_to_name_with_synonyms
+  def test_new_comment_for_name_with_synonyms
     name_id = names(:chlorophyllum_rachodes).id
     requires_login(:new, target: name_id, type: :Name)
     assert_form_action(action: :create, target: name_id, type: :Name)
   end
 
-  def test_add_comment_to_unreadable_object
+  def test_new_comment_to_unreadable_object
     katrina_is_not_reader = name_descriptions(:peltigera_user_desc)
     login(:katrina)
     get(:new,
@@ -231,6 +240,16 @@ class CommentsControllerTest < FunctionalTestCase
     requires_user(:edit,
                   [{ controller: "/observations", action: :show,
                      id: obs.id }], params)
+    assert_form_action(action: :update, id: comment.id.to_s)
+  end
+
+  def test_edit_comment_turbo
+    comment = comments(:minimal_unknown_obs_comment_1)
+    login
+
+    get(:edit, params: { id: comment.id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("comments/_form")
     assert_form_action(action: :update, id: comment.id.to_s)
   end
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -197,6 +197,7 @@ class CommentsControllerTest < FunctionalTestCase
 
   def test_new_comment_turbo
     obs_id = observations(:minimal_unknown_obs).id
+    login
     get(:new, params: { target: obs_id, type: :Observation },
               format: :turbo_stream)
     assert_template("shared/_modal_form")

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -225,12 +225,16 @@ class CommentsControllerTest < FunctionalTestCase
 
   def test_new_comment_to_unreadable_object
     katrina_is_not_reader = name_descriptions(:peltigera_user_desc)
+    params = { type: :NameDescription, target: katrina_is_not_reader.id }
     login(:katrina)
-    get(:new,
-        params: { type: :NameDescription, target: katrina_is_not_reader.id })
 
+    get(:new, params:)
     assert_flash_error("MO should flash if trying to comment on object" \
                        "for which user lacks read privileges")
+
+    get(:new, params:, format: :turbo_stream)
+    assert_template("shared/_modal_form_reload")
+    assert_flash_error
   end
 
   def test_edit_comment
@@ -268,7 +272,7 @@ class CommentsControllerTest < FunctionalTestCase
     assert_not(obs.comments.member?(comment))
   end
 
-  def test_save_comment
+  def test_create_comment
     assert_equal(10, rolf.contribution)
     obs = observations(:minimal_unknown_obs)
     comment_count = obs.comments.size

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -246,8 +246,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
   def test_create_herbarium_record_with_turbo
     login
     assert_difference("HerbariumRecord.count", 1) do
-      post(:create, params: herbarium_record_params,
-                    format: :turbo_stream)
+      post(:create, params: herbarium_record_params, format: :turbo_stream)
     end
   end
 
@@ -381,7 +380,9 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     post(:update, params: { id: nybg.id })
     assert_redirected_to(action: :edit)
 
+    # Test turbo shows flash
     post(:update, params: { id: nybg.id }, format: :turbo_stream)
+    assert_flash_text(/missing/i)
     assert_template("shared/_modal_form_reload")
   end
 

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -380,6 +380,9 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     nybg = herbarium_records(:coprinus_comatus_nybg_spec)
     post(:update, params: { id: nybg.id })
     assert_redirected_to(action: :edit)
+
+    post(:update, params: { id: nybg.id }, format: :turbo_stream)
+    assert_template("shared/_modal_form_reload")
   end
 
   def test_update_herbarium_record_redirect

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -184,6 +184,16 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_equal(assigns(:herbarium_record).accession_number, "MO #{obs_id}")
   end
 
+  def test_new_herbarium_record_turbo
+    obs_id = observations(:unknown_with_no_naming).id
+
+    login("rolf")
+    get(:new, params: { observation_id: obs_id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("herbarium_records/_form")
+    assert_equal(assigns(:herbarium_record).accession_number, "MO #{obs_id}")
+  end
+
   def test_new_herbarium_record_with_collection_number
     obs = observations(:coprinus_comatus_obs)
     get(:new, params: { observation_id: obs.id })
@@ -333,6 +343,15 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     make_admin("mary") # Non-curator, but an admin
     get(:edit, params: { id: nybg.id })
     assert_template(:edit)
+  end
+
+  def test_edit_herbarium_record_turbo
+    nybg = herbarium_records(:coprinus_comatus_nybg_spec)
+
+    login("rolf")
+    get(:edit, params: { id: nybg.id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("herbarium_records/_form")
   end
 
   def test_update_herbarium_record

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -29,8 +29,16 @@ module Observations
       obs, _obs2, _site, _url, params = setup_create_test
       login("dick")
       post(:create, params:)
-      assert_flash_error
+      assert_flash_warning
       assert_redirected_to(permanent_observation_path(obs.id))
+    end
+
+    def test_add_external_link_not_permitted_turbo
+      _obs, _obs2, _site, _url, params = setup_create_test
+      login("dick")
+      post(:create, params:, format: :turbo_stream)
+      assert_flash_warning
+      assert_template("shared/_modal_flash_update")
     end
 
     # rolf can because he owns it
@@ -138,7 +146,7 @@ module Observations
       # dick doesn't have permission
       login("dick")
       put(:update, params:)
-      assert_flash_error
+      assert_flash_warning
 
       # mary can
       login("mary")
@@ -173,7 +181,7 @@ module Observations
       params = { id: link.id }
       login("dick")
       delete(:destroy, params:)
-      assert_flash_error
+      assert_flash_warning
     end
 
     # mary can
@@ -192,26 +200,26 @@ module Observations
       obs  = observations(:coprinus_comatus_obs)
       link = external_links(:coprinus_comatus_obs_mycoportal_link)
       @controller.instance_variable_set(:@user, rolf)
-      assert_link_allowed(link)
-      assert_link_allowed(obs, site)
+      assert_link_allowed(link:)
+      assert_link_allowed(obs:, site:)
       @controller.instance_variable_set(:@user, mary)
-      assert_link_allowed(link)
-      assert_link_allowed(obs, site)
+      assert_link_allowed(link:)
+      assert_link_allowed(obs:, site:)
       @controller.instance_variable_set(:@user, dick)
-      assert_link_forbidden(link)
-      assert_link_forbidden(obs, site)
+      assert_link_forbidden(link:)
+      assert_link_forbidden(obs:, site:)
 
       dick.update(admin: true)
-      assert_link_allowed(link)
-      assert_link_allowed(obs, site)
+      assert_link_allowed(link:)
+      assert_link_allowed(obs:, site:)
     end
 
-    def assert_link_allowed(*)
-      assert_true(@controller.send(:check_external_link_permission!, *))
+    def assert_link_allowed(**)
+      assert_true(@controller.send(:check_external_link_permission!, **))
     end
 
-    def assert_link_forbidden(*)
-      assert_false(@controller.send(:check_external_link_permission!, *))
+    def assert_link_forbidden(**)
+      assert_false(@controller.send(:check_external_link_permission!, **))
     end
   end
 end

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -5,6 +5,26 @@ require("test_helper")
 # This has to be a system test
 module Observations
   class ExternalLinksControllerTest < FunctionalTestCase
+    def test_new_external_link_form
+      obs = observations(:imported_inat_obs)
+
+      login(obs.user.login)
+      get(:new, params: { id: obs.id })
+
+      assert_response(:success)
+    end
+
+    def test_new_external_link_form_turbo
+      obs = observations(:imported_inat_obs)
+
+      login(obs.user.login)
+      get(:new, params: { id: obs.id }, format: :turbo_stream)
+
+      assert_response(:success)
+      assert_template("shared/_modal_form")
+      assert_template("observations/external_links/_form")
+    end
+
     def setup_create_test
       obs  = observations(:agaricus_campestris_obs) # owned by rolf
       obs2 = observations(:agaricus_campestrus_obs) # owned by rolf
@@ -18,14 +38,14 @@ module Observations
     end
 
     # not logged in
-    def test_add_external_link_not_logged_in
+    def test_create_external_link_not_logged_in
       _obs, _obs2, _site, _url, params = setup_create_test
       post(:create, params:)
       assert_redirected_to(new_account_login_path)
     end
 
     # dick can't do it
-    def test_add_external_link_not_permitted
+    def test_create_external_link_not_permitted
       obs, _obs2, _site, _url, params = setup_create_test
       login("dick")
       post(:create, params:)
@@ -33,7 +53,7 @@ module Observations
       assert_redirected_to(permanent_observation_path(obs.id))
     end
 
-    def test_add_external_link_not_permitted_turbo
+    def test_create_external_link_not_permitted_turbo
       _obs, _obs2, _site, _url, params = setup_create_test
       login("dick")
       post(:create, params:, format: :turbo_stream)
@@ -42,7 +62,7 @@ module Observations
     end
 
     # rolf can because he owns it
-    def test_add_external_link_owner
+    def test_create_external_link_owner
       obs, _obs2, site, url, params = setup_create_test
       login("rolf")
       post(:create, params:)
@@ -55,7 +75,7 @@ module Observations
     end
 
     # And now with Turbo...
-    def test_add_external_link_turbo
+    def test_create_external_link_turbo
       _, _obs2, _, _, params = setup_create_test
       login("rolf")
       assert_difference("ExternalLink.count", 1) do
@@ -65,7 +85,7 @@ module Observations
     end
 
     # bad url
-    def test_add_external_link_bad_url
+    def test_create_external_link_bad_url
       _obs, _obs2, _site, _url, params = setup_create_test
       login("mary")
       params2 = params.dup
@@ -75,7 +95,7 @@ module Observations
     end
 
     # bad url
-    def test_add_external_link_404_response
+    def test_create_external_link_404_response
       _obs, _obs2, _site, _url, params = setup_create_test
       login("mary")
       params2 = params.dup
@@ -86,7 +106,7 @@ module Observations
       assert_flash_error
     end
 
-    def test_add_external_link_good_url_no_scheme
+    def test_create_external_link_good_url_no_scheme
       _obs, _obs2, _site, url, params = setup_create_test
       login("mary")
       params2 = params.dup
@@ -96,7 +116,7 @@ module Observations
       assert_equal(url, ExternalLink.last.url)
     end
 
-    def test_add_external_link_good_url_no_www
+    def test_create_external_link_good_url_no_www
       _obs, _obs2, _site, url, params = setup_create_test
       login("mary")
       params2 = params.dup
@@ -107,7 +127,7 @@ module Observations
     end
 
     # mary can because she's a member of the external site's project
-    def test_add_external_link_project_member
+    def test_create_external_link_project_member
       _obs, obs2, site, url, params = setup_create_test
       login("mary")
       params2 = params.dup
@@ -121,13 +141,24 @@ module Observations
       assert_equal(url, ExternalLink.last.url)
     end
 
-    def test_edit_external_link
+    def test_edit_external_link_form
       link = external_links(:imported_inat_obs_inat_link)
 
       login(link.user.login)
-      post(:edit, params: { id: link.id })
+      get(:edit, params: { id: link.id })
 
       assert_response(:success)
+    end
+
+    def test_edit_external_link_form_turbo
+      link = external_links(:imported_inat_obs_inat_link)
+
+      login(link.user.login)
+      get(:edit, params: { id: link.id }, format: :turbo_stream)
+
+      assert_response(:success)
+      assert_template("shared/_modal_form")
+      assert_template("observations/external_links/_form")
     end
 
     def test_update_external_link

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -43,9 +43,10 @@ module Observations
     # This is the standard case, nothing unusual or stressful here.
     def test_propose_naming
       args = propose_naming_setup
+      args => { params: }
 
       login("rolf")
-      post(:create, params: args[:params])
+      post(:create, params:)
       assert_response(:redirect)
 
       post_propose_naming_assertions(args)
@@ -53,10 +54,33 @@ module Observations
 
     def test_propose_naming_turbo
       args = propose_naming_setup
+      args => { params: } # ruby 3 rightward assignment from hash
 
       login("rolf")
-      post(:create, params: args[:params], format: :turbo_stream)
+      post(:create, params:, format: :turbo_stream)
       assert_response(:redirect)
+
+      post_propose_naming_assertions(args)
+    end
+
+    def test_propose_naming_turbo_from_identify_ui
+      args = propose_naming_setup
+      params = args[:params].merge(context: "matrix_box")
+
+      login("rolf")
+      post(:create, params:, format: :turbo_stream)
+      assert_template("observations/namings/_update_matrix_box")
+
+      post_propose_naming_assertions(args)
+    end
+
+    def test_propose_naming_turbo_from_lightgallery_ui
+      args = propose_naming_setup
+      params = args[:params].merge(context: "lightgallery")
+
+      login("rolf")
+      post(:create, params:, format: :turbo_stream)
+      assert_template("observations/namings/_update_matrix_box")
 
       post_propose_naming_assertions(args)
     end

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -43,12 +43,19 @@ module Observations
     # This is the standard case, nothing unusual or stressful here.
     def test_propose_naming
       args = propose_naming_setup
-      debugger
-      args =>
-        { obs:, consensus:, o_count:, g_count:, n_count:, v_count:, params: }
 
       login("rolf")
-      post(:create, params: params)
+      post(:create, params: args[:params])
+      assert_response(:redirect)
+
+      post_propose_naming_assertions(args)
+    end
+
+    def test_propose_naming_turbo
+      args = propose_naming_setup
+
+      login("rolf")
+      post(:create, params: args[:params], format: :turbo_stream)
       assert_response(:redirect)
 
       post_propose_naming_assertions(args)
@@ -97,7 +104,7 @@ module Observations
     end
 
     def post_propose_naming_assertions(args)
-      { obs:, consensus:, o_count:, g_count:, n_count:, v_count: } => args
+      args => { obs:, consensus:, o_count:, g_count:, n_count:, v_count: }
       # Make sure the right number of objects were created.
       assert_equal(o_count, Observation.count)
       assert_equal(g_count + 1, Naming.count)

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -15,6 +15,10 @@ module Observations
       )
     end
 
+    # ------------------------------------------------------------
+    #  Test propose naming form.
+    # ------------------------------------------------------------
+
     def test_new_form
       obs = observations(:coprinus_comatus_obs)
       params = { observation_id: obs.id.to_s }
@@ -31,6 +35,312 @@ module Observations
       assert_form_action(action: "create", approved_name: "",
                          observation_id: obs.id.to_s)
     end
+
+    # ------------------------------------------------------------
+    #  Test proposing new namings.
+    # ------------------------------------------------------------
+
+    # This is the standard case, nothing unusual or stressful here.
+    def test_propose_naming
+      args = propose_naming_setup
+
+      { obs:, consensus:, o_count:, g_count:,
+        n_count:, v_count:, params: } => args
+      debugger
+      login("rolf")
+      post(:create, params: params)
+      assert_response(:redirect)
+
+      post_propose_naming_assertions(args)
+    end
+
+    def propose_naming_setup
+      o_count = Observation.count
+      g_count = Naming.count
+      n_count = Name.count
+      v_count = Vote.count
+
+      nam = names(:coprinus_comatus)
+      obs = observations(:coprinus_comatus_obs)
+      nmg1 = namings(:coprinus_comatus_naming)
+      nmg2 = namings(:coprinus_comatus_other_naming)
+      consensus = Observation::NamingConsensus.new(obs)
+
+      # Make a few assertions up front to make sure fixtures are as expected.
+      assert_equal(nam.id, obs.name_id)
+      assert(consensus.user_voted?(nmg1, rolf))
+      assert(consensus.user_voted?(nmg1, mary))
+      assert_not(consensus.user_voted?(nmg1, dick))
+      assert(consensus.user_voted?(nmg2, rolf))
+      assert(consensus.user_voted?(nmg2, mary))
+      assert_not(consensus.user_voted?(nmg2, dick))
+
+      # Rolf, the owner of observations(:coprinus_comatus_obs),
+      # already has a naming, which he's 80% sure of.
+      # Create a new one (the genus Agaricus) that he's 100%
+      # sure of.  (Mary also has a naming with two votes.)
+      params = {
+        observation_id: obs.id,
+        naming: {
+          name: "Agaricus",
+          vote: { value: "3" },
+          reasons: {
+            "1" => { check: "1", notes: "Looks good to me." },
+            "2" => { check: "1", notes: "" },
+            "3" => { check: "0", notes: "Spore texture." },
+            "4" => { check: "0", notes: "" }
+          }
+        }
+      }
+
+      { obs:, consensus:, o_count:, g_count:, n_count:, v_count:, params: }
+    end
+
+    def post_propose_naming_assertions(args)
+      { obs:, consensus:, o_count:, g_count:, n_count:, v_count: } => args
+      # Make sure the right number of objects were created.
+      assert_equal(o_count, Observation.count)
+      assert_equal(g_count + 1, Naming.count)
+      assert_equal(n_count, Name.count)
+      assert_equal(v_count + 1, Vote.count)
+
+      # Make sure contribution is updated correctly.
+      assert_equal(12, rolf.reload.contribution)
+
+      # Make sure everything I need is reloaded.
+      obs.reload
+
+      # Get new objects.
+      naming = Naming.last
+      vote = Vote.last
+
+      # Make sure observation was updated and referenced correctly.
+      assert_equal(3, obs.namings.length)
+      assert_equal(names(:agaricus).id, obs.name_id)
+
+      # Make sure naming was created correctly and referenced.
+      assert_equal(obs, naming.observation)
+      assert_equal(names(:agaricus).id, naming.name_id)
+      assert_equal(rolf, naming.user)
+      assert_equal(3, naming.reasons_array.count(&:used?))
+      assert_equal(1, naming.votes.length)
+
+      # Make sure vote was created correctly.
+      assert_equal(naming, vote.naming)
+      assert_equal(rolf, vote.user)
+      assert_equal(3, vote.value)
+
+      # Make sure reasons were created correctly.
+      nr1, nr2, nr3, nr4 = naming.reasons_array
+      assert_equal(1, nr1.num)
+      assert_equal(2, nr2.num)
+      assert_equal(3, nr3.num)
+      assert_equal(4, nr4.num)
+      assert_equal("Looks good to me.", nr1.notes)
+      assert_equal("", nr2.notes)
+      assert_equal("Spore texture.", nr3.notes)
+      assert_nil(nr4.notes)
+      assert(nr1.used?)
+      assert(nr2.used?)
+      assert(nr3.used?)
+      assert_not(nr4.used?)
+
+      # Make sure a few random methods work right, too. Must re-calc_consensus
+      consensus.calc_consensus
+      assert_equal(3, naming.vote_sum)
+      assert_equal(vote, consensus.users_vote(naming, rolf))
+      assert(consensus.user_voted?(naming, rolf))
+      assert_not(consensus.user_voted?(naming, mary))
+    end
+
+    # Now see what happens when rolf's new naming is less confident than old.
+    def test_propose_uncertain_naming
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: {
+          name: "Agaricus",
+          vote: { value: "-1" }
+        }
+      }
+      login("rolf")
+      post(:create, params: params)
+      assert_response(:redirect)
+      assert_equal(12, rolf.reload.contribution)
+
+      # Make sure everything I need is reloaded.
+      observations(:coprinus_comatus_obs).reload
+      namings(:coprinus_comatus_naming).reload
+
+      # Make sure observation was updated right.
+      assert_equal(names(:coprinus_comatus).id,
+                   observations(:coprinus_comatus_obs).name_id)
+
+      # Sure, check the votes, too, while we're at it.
+      assert_equal(3, namings(:coprinus_comatus_naming).vote_sum) # 2+1 = 3
+    end
+
+    # Now see what happens when a third party proposes a name, and it wins.
+    def test_propose_dicks_naming
+      o_count = Observation.count
+      g_count = Naming.count
+      n_count = Name.count
+      v_count = Vote.count
+
+      # Dick proposes "Conocybe filaris" out of the blue.
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: {
+          name: "Conocybe filaris",
+          vote: { value: "3" }
+        }
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_response(:redirect)
+      assert_equal(12, dick.reload.contribution)
+      naming = Naming.last
+
+      # Make sure the right number of objects were created.
+      assert_equal(o_count + 0, Observation.count)
+      assert_equal(g_count + 1, Naming.count)
+      assert_equal(n_count + 0, Name.count)
+      assert_equal(v_count + 1, Vote.count)
+
+      # Make sure everything I need is reloaded.
+      observations(:coprinus_comatus_obs).reload
+      namings(:coprinus_comatus_naming).reload
+      namings(:coprinus_comatus_other_naming).reload
+
+      # Check votes.
+      assert_equal(3, namings(:coprinus_comatus_naming).vote_sum)
+      assert_equal(0, namings(:coprinus_comatus_other_naming).vote_sum)
+      assert_equal(3, naming.vote_sum)
+      assert_equal(2, namings(:coprinus_comatus_naming).votes.length)
+      assert_equal(2, namings(:coprinus_comatus_other_naming).votes.length)
+      assert_equal(1, naming.votes.length)
+
+      # Make sure observation was updated right.
+      assert_equal(names(:conocybe_filaris).id,
+                   observations(:coprinus_comatus_obs).name_id)
+    end
+
+    # Test a bug in name resolution: was failing to recognize that
+    # "Genus species (With) Author" was recognized even if "Genus species"
+    # was already in the database.
+    def test_propose_naming_with_author_when_name_without_author_already_exists
+      login("dick")
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: {
+          name: "Conocybe filaris (With) Author",
+          vote: { value: "3" }
+        }
+      }
+      post(:create, params: params)
+      obs = observations(:coprinus_comatus_obs)
+      assert_redirected_to(permanent_observation_path(obs.id))
+      # Dick is getting points for the naming, vote, and name change.
+      assert_equal(12 + 10, dick.reload.contribution)
+      naming = Naming.last
+      assert_equal("Conocybe filaris", naming.name.text_name)
+      assert_equal("(With) Author", naming.name.author)
+      assert_equal(names(:conocybe_filaris).id, naming.name_id)
+    end
+
+    # Test a bug in name resolution: was failing to recognize that
+    # "Genus species (With) Author" was recognized even if "Genus species"
+    # was already in the database.
+    def test_propose_naming_fill_in_author
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: { name: "Agaricus campestris" }
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_response(:success) # really means failed
+      what = @controller.instance_variable_get(:@given_name)
+      assert_equal("Agaricus campestris L.", what)
+    end
+
+    # Test a bug in name resolution: was failing to recognize that
+    # "Genus species (With) Author" was recognized even if "Genus species"
+    # was already in the database.
+    def test_propose_naming_name_with_quotes
+      name = "Foo 'bar' Author"
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: { name: name },
+        approved_name: name
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_response(:redirect)
+      assert(new_name = Name.find_by(text_name: "Foo sp. 'bar'"))
+      assert_equal("Foo sp. 'bar' Author", new_name.search_name)
+    end
+
+    def test_propose_naming_bad_prov_name
+      # Must be a genus where all genus fixtures have an author
+      name = "Suillus sp. 'A*G'"
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: { name: name },
+        approved_name: name
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_equal(0, Naming.where(name_id: nil).count)
+    end
+
+    def test_propose_naming_enforce_imageless_rules
+      params = {
+        observation_id: observations(:coprinus_comatus_obs).id,
+        naming: { name: "Imageless" }
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_response(:success) # really means failed
+    end
+
+    def test_propose_naming_automatic_author_bug
+      obs = observations(:minimal_unknown_obs)
+      name = names(:peltigera)
+      assert_equal("Genus", name.rank)
+      assert_not_empty(name.author)
+      old_author = name.author
+
+      params = {
+        observation_id: obs.id,
+        naming: { name: "#{name.text_name} Seneca #{name.author}" },
+        approved_name: "#{name.text_name} #{name.author}"
+      }
+      login("dick")
+      post(:create, params: params)
+
+      name.reload
+      assert_equal(old_author, name.author)
+      assert_flash_error
+      assert_response(:success, "Was expecting it to re-serve the form " \
+                                "because the name wasn't recognized.")
+    end
+
+    def test_propose_naming_automatic_case_correction
+      obs = observations(:minimal_unknown_obs)
+      name = names(:coprinus_comatus)
+      params = {
+        observation_id: obs.id,
+        naming: { name: "Coprinus Comatus" }
+      }
+      login("dick")
+      post(:create, params: params)
+      assert_flash_success
+      naming = obs.namings.where(user: dick).first
+      assert_names_equal(name, naming.name)
+    end
+
+    # ------------------------------------------------------------
+    #  Test edit naming form.
+    # ------------------------------------------------------------
 
     def test_edit_form
       nam = namings(:coprinus_comatus_naming)
@@ -65,7 +375,12 @@ module Observations
       assert_select("#naming_vote_value", text: /#{:vote_no_opinion.l}/)
     end
 
-    def test_update_observation_new_name
+    # ------------------------------------------------------------
+    #  Test updating namings, and
+    #  setting and changing preferred_namings.
+    # ------------------------------------------------------------
+
+    def test_update_naming_new_name
       login("rolf")
       nam = namings(:coprinus_comatus_naming)
       old_name = nam.text_name
@@ -84,7 +399,7 @@ module Observations
       assert_select("option[selected]", count: 2)
     end
 
-    def test_update_observation_new_name_different_user
+    def test_update_naming_new_name_different_user
       login("mary")
       nam = namings(:coprinus_comatus_other_naming)
       new_name = "Easter bunny"
@@ -98,7 +413,7 @@ module Observations
                     text: "I'd Call It That")
     end
 
-    def test_update_observation_approved_new_name
+    def test_update_naming_approved_new_name
       login("rolf")
       nam = namings(:coprinus_comatus_naming)
       old_name = nam.text_name
@@ -128,7 +443,7 @@ module Observations
       )
     end
 
-    def test_update_observation_multiple_match
+    def test_update_naming_multiple_match
       login("rolf")
       nam = namings(:coprinus_comatus_naming)
       old_name = nam.text_name
@@ -147,7 +462,7 @@ module Observations
       assert_select("option[selected]", count: 2)
     end
 
-    def test_update_observation_chosen_multiple_match
+    def test_update_naming_chosen_multiple_match
       login("rolf")
       nmg = namings(:coprinus_comatus_naming)
       old_name = nmg.text_name
@@ -171,7 +486,7 @@ module Observations
       assert_not_equal(old_name, nam.text_name)
     end
 
-    def test_update_observation_deprecated
+    def test_update_naming_deprecated
       login("rolf")
       nam = namings(:coprinus_comatus_naming)
       old_name = nam.text_name
@@ -190,7 +505,7 @@ module Observations
       assert_select("option[selected]", count: 2)
     end
 
-    def test_update_observation_chosen_deprecated
+    def test_update_naming_chosen_deprecated
       login("rolf")
       nmg = namings(:coprinus_comatus_naming)
       start_name = nmg.name
@@ -215,7 +530,7 @@ module Observations
       assert_equal(chosen_name.id, nam.name_id)
     end
 
-    def test_update_observation_accepted_deprecated
+    def test_update_naming_accepted_deprecated
       login("rolf")
       nmg = namings(:coprinus_comatus_naming)
       start_name = nmg.name
@@ -360,246 +675,13 @@ module Observations
       assert_equal(rolf, vote.user)
     end
 
-    # ------------------------------------------------------------
-    #  Test proposing new names, casting and changing votes, and
-    #  setting and changing preferred_namings.
-    # ------------------------------------------------------------
-
-    # This is the standard case, nothing unusual or stressful here.
-    def test_propose_naming
-      o_count = Observation.count
-      g_count = Naming.count
-      n_count = Name.count
-      v_count = Vote.count
-
-      nam = names(:coprinus_comatus)
-      obs = observations(:coprinus_comatus_obs)
-      nmg1 = namings(:coprinus_comatus_naming)
-      nmg2 = namings(:coprinus_comatus_other_naming)
-      consensus = Observation::NamingConsensus.new(obs)
-
-      # Make a few assertions up front to make sure fixtures are as expected.
-      assert_equal(nam.id, obs.name_id)
-      assert(consensus.user_voted?(nmg1, rolf))
-      assert(consensus.user_voted?(nmg1, mary))
-      assert_not(consensus.user_voted?(nmg1, dick))
-      assert(consensus.user_voted?(nmg2, rolf))
-      assert(consensus.user_voted?(nmg2, mary))
-      assert_not(consensus.user_voted?(nmg2, dick))
-
-      # Rolf, the owner of observations(:coprinus_comatus_obs),
-      # already has a naming, which he's 80% sure of.
-      # Create a new one (the genus Agaricus) that he's 100%
-      # sure of.  (Mary also has a naming with two votes.)
-      params = {
-        observation_id: obs.id,
-        naming: {
-          name: "Agaricus",
-          vote: { value: "3" },
-          reasons: {
-            "1" => { check: "1", notes: "Looks good to me." },
-            "2" => { check: "1", notes: "" },
-            "3" => { check: "0", notes: "Spore texture." },
-            "4" => { check: "0", notes: "" }
-          }
-        }
-      }
-      login("rolf")
-      post(:create, params: params)
-      assert_response(:redirect)
-
-      # Make sure the right number of objects were created.
-      assert_equal(o_count + 0, Observation.count)
-      assert_equal(g_count + 1, Naming.count)
-      assert_equal(n_count + 0, Name.count)
-      assert_equal(v_count + 1, Vote.count)
-
-      # Make sure contribution is updated correctly.
-      assert_equal(12, rolf.reload.contribution)
-
-      # Make sure everything I need is reloaded.
-      obs.reload
-
-      # Get new objects.
-      naming = Naming.last
-      vote = Vote.last
-
-      # Make sure observation was updated and referenced correctly.
-      assert_equal(3, obs.namings.length)
-      assert_equal(names(:agaricus).id, obs.name_id)
-
-      # Make sure naming was created correctly and referenced.
-      assert_equal(obs, naming.observation)
-      assert_equal(names(:agaricus).id, naming.name_id)
-      assert_equal(rolf, naming.user)
-      assert_equal(3, naming.reasons_array.count(&:used?))
-      assert_equal(1, naming.votes.length)
-
-      # Make sure vote was created correctly.
-      assert_equal(naming, vote.naming)
-      assert_equal(rolf, vote.user)
-      assert_equal(3, vote.value)
-
-      # Make sure reasons were created correctly.
-      nr1, nr2, nr3, nr4 = naming.reasons_array
-      assert_equal(1, nr1.num)
-      assert_equal(2, nr2.num)
-      assert_equal(3, nr3.num)
-      assert_equal(4, nr4.num)
-      assert_equal("Looks good to me.", nr1.notes)
-      assert_equal("", nr2.notes)
-      assert_equal("Spore texture.", nr3.notes)
-      assert_nil(nr4.notes)
-      assert(nr1.used?)
-      assert(nr2.used?)
-      assert(nr3.used?)
-      assert_not(nr4.used?)
-
-      # Make sure a few random methods work right, too. Must re-calc_consensus
-      consensus.calc_consensus
-      assert_equal(3, naming.vote_sum)
-      assert_equal(vote, consensus.users_vote(naming, rolf))
-      assert(consensus.user_voted?(naming, rolf))
-      assert_not(consensus.user_voted?(naming, mary))
-    end
-
-    # Now see what happens when rolf's new naming is less confident than old.
-    def test_propose_uncertain_naming
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: {
-          name: "Agaricus",
-          vote: { value: "-1" }
-        }
-      }
-      login("rolf")
-      post(:create, params: params)
-      assert_response(:redirect)
-      assert_equal(12, rolf.reload.contribution)
-
-      # Make sure everything I need is reloaded.
-      observations(:coprinus_comatus_obs).reload
-      namings(:coprinus_comatus_naming).reload
-
-      # Make sure observation was updated right.
-      assert_equal(names(:coprinus_comatus).id,
-                   observations(:coprinus_comatus_obs).name_id)
-
-      # Sure, check the votes, too, while we're at it.
-      assert_equal(3, namings(:coprinus_comatus_naming).vote_sum) # 2+1 = 3
-    end
-
-    # Now see what happens when a third party proposes a name, and it wins.
-    def test_propose_dicks_naming
-      o_count = Observation.count
-      g_count = Naming.count
-      n_count = Name.count
-      v_count = Vote.count
-
-      # Dick proposes "Conocybe filaris" out of the blue.
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: {
-          name: "Conocybe filaris",
-          vote: { value: "3" }
-        }
-      }
-      login("dick")
-      post(:create, params: params)
-      assert_response(:redirect)
-      assert_equal(12, dick.reload.contribution)
-      naming = Naming.last
-
-      # Make sure the right number of objects were created.
-      assert_equal(o_count + 0, Observation.count)
-      assert_equal(g_count + 1, Naming.count)
-      assert_equal(n_count + 0, Name.count)
-      assert_equal(v_count + 1, Vote.count)
-
-      # Make sure everything I need is reloaded.
-      observations(:coprinus_comatus_obs).reload
-      namings(:coprinus_comatus_naming).reload
-      namings(:coprinus_comatus_other_naming).reload
-
-      # Check votes.
-      assert_equal(3, namings(:coprinus_comatus_naming).vote_sum)
-      assert_equal(0, namings(:coprinus_comatus_other_naming).vote_sum)
-      assert_equal(3, naming.vote_sum)
-      assert_equal(2, namings(:coprinus_comatus_naming).votes.length)
-      assert_equal(2, namings(:coprinus_comatus_other_naming).votes.length)
-      assert_equal(1, naming.votes.length)
-
-      # Make sure observation was updated right.
-      assert_equal(names(:conocybe_filaris).id,
-                   observations(:coprinus_comatus_obs).name_id)
-    end
-
-    # Test a bug in name resolution: was failing to recognize that
-    # "Genus species (With) Author" was recognized even if "Genus species"
-    # was already in the database.
-    def test_create_with_author_when_name_without_author_already_exists
-      login("dick")
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: {
-          name: "Conocybe filaris (With) Author",
-          vote: { value: "3" }
-        }
-      }
-      post(:create, params: params)
-      obs = observations(:coprinus_comatus_obs)
-      assert_redirected_to(permanent_observation_path(obs.id))
-      # Dick is getting points for the naming, vote, and name change.
-      assert_equal(12 + 10, dick.reload.contribution)
-      naming = Naming.last
-      assert_equal("Conocybe filaris", naming.name.text_name)
-      assert_equal("(With) Author", naming.name.author)
-      assert_equal(names(:conocybe_filaris).id, naming.name_id)
-    end
-
-    # Test a bug in name resolution: was failing to recognize that
-    # "Genus species (With) Author" was recognized even if "Genus species"
-    # was already in the database.
-    def test_create_fill_in_author
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: { name: "Agaricus campestris" }
-      }
-      login("dick")
-      post(:create, params: params)
-      assert_response(:success) # really means failed
-      what = @controller.instance_variable_get(:@given_name)
-      assert_equal("Agaricus campestris L.", what)
-    end
-
-    # Test a bug in name resolution: was failing to recognize that
-    # "Genus species (With) Author" was recognized even if "Genus species"
-    # was already in the database.
-    def test_create_name_with_quotes
-      name = "Foo 'bar' Author"
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: { name: name },
-        approved_name: name
-      }
-      login("dick")
-      post(:create, params: params)
-      assert_response(:redirect)
-      assert(new_name = Name.find_by(text_name: "Foo sp. 'bar'"))
-      assert_equal("Foo sp. 'bar' Author", new_name.search_name)
-    end
-
-    def test_create_bad_prov_name
-      # Must be a genus where all genus fixtures have an author
-      name = "Suillus sp. 'A*G'"
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: { name: name },
-        approved_name: name
-      }
-      login("dick")
-      post(:create, params: params)
-      assert_equal(0, Naming.where(name_id: nil).count)
+    def assert_edit
+      assert_template("observations/namings/edit")
+      assert_template("observations/show/_observation_details")
+      assert_template("shared/_form_name_feedback")
+      assert_template("observations/namings/_form")
+      assert_template("observations/namings/_fields")
+      assert_template("observations/show/_images")
     end
 
     # Rolf can destroy his naming if Mary deletes her vote on it.
@@ -679,61 +761,6 @@ module Observations
       assert_equal(3, nam1.votes.length)
       assert_equal(0, nam2.reload.vote_sum)
       assert_equal(2, nam2.votes.length)
-    end
-
-    def test_enforce_imageless_rules
-      params = {
-        observation_id: observations(:coprinus_comatus_obs).id,
-        naming: { name: "Imageless" }
-      }
-      login("dick")
-      post(:create, params: params)
-      assert_response(:success) # really means failed
-    end
-
-    def assert_edit
-      assert_template("observations/namings/edit")
-      assert_template("observations/show/_observation_details")
-      assert_template("shared/_form_name_feedback")
-      assert_template("observations/namings/_form")
-      assert_template("observations/namings/_fields")
-      assert_template("observations/show/_images")
-    end
-
-    def test_automatic_author_bug
-      obs = observations(:minimal_unknown_obs)
-      name = names(:peltigera)
-      assert_equal("Genus", name.rank)
-      assert_not_empty(name.author)
-      old_author = name.author
-
-      params = {
-        observation_id: obs.id,
-        naming: { name: "#{name.text_name} Seneca #{name.author}" },
-        approved_name: "#{name.text_name} #{name.author}"
-      }
-      login("dick")
-      post(:create, params: params)
-
-      name.reload
-      assert_equal(old_author, name.author)
-      assert_flash_error
-      assert_response(:success, "Was expecting it to re-serve the form " \
-                                "because the name wasn't recognized.")
-    end
-
-    def test_automatic_case_correction
-      obs = observations(:minimal_unknown_obs)
-      name = names(:coprinus_comatus)
-      params = {
-        observation_id: obs.id,
-        naming: { name: "Coprinus Comatus" }
-      }
-      login("dick")
-      post(:create, params: params)
-      assert_flash_success
-      naming = obs.namings.where(user: dick).first
-      assert_names_equal(name, naming.name)
     end
   end
 end

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -23,6 +23,15 @@ module Observations
                          observation_id: obs.id.to_s)
     end
 
+    def test_new_form_turbo
+      obs = observations(:coprinus_comatus_obs)
+      params = { observation_id: obs.id.to_s }
+      login
+      get(:new, params:, format: :turbo_stream)
+      assert_form_action(action: "create", approved_name: "",
+                         observation_id: obs.id.to_s)
+    end
+
     def test_edit_form
       nam = namings(:coprinus_comatus_naming)
       params = { observation_id: nam.observation_id, id: nam.id.to_s }

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -43,10 +43,10 @@ module Observations
     # This is the standard case, nothing unusual or stressful here.
     def test_propose_naming
       args = propose_naming_setup
-
-      { obs:, consensus:, o_count:, g_count:,
-        n_count:, v_count:, params: } => args
       debugger
+      args =>
+        { obs:, consensus:, o_count:, g_count:, n_count:, v_count:, params: }
+
       login("rolf")
       post(:create, params: params)
       assert_response(:redirect)

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -32,6 +32,8 @@ module Observations
       params = { observation_id: obs.id.to_s }
       login
       get(:new, params:, format: :turbo_stream)
+      assert_template("shared/_modal_form")
+      assert_template("observations/namings/_form")
       assert_form_action(action: "create", approved_name: "",
                          observation_id: obs.id.to_s)
     end
@@ -374,19 +376,34 @@ module Observations
     # ------------------------------------------------------------
 
     def test_edit_form
-      nam = namings(:coprinus_comatus_naming)
-      params = { observation_id: nam.observation_id, id: nam.id.to_s }
-      requires_user(:edit, { controller: "/observations", action: :show,
-                             id: nam.observation_id }, params)
-      assert_form_action(action: "update", approved_name: nam.text_name,
-                         id: nam.id.to_s)
-      assert_select("option[selected]", count: 2)
-
-      login(nam.user.login)
-      get(:edit, params: params)
+      params = edit_form_test_setup
+      get(:edit, params:)
       assert_no_flash(
         "User should be able to edit his own Naming without warning or error"
       )
+    end
+
+    def test_edit_form_turbo
+      params = edit_form_test_setup
+      get(:edit, params:, format: :turbo_stream)
+      assert_template("shared/_modal_form")
+      assert_template("observations/namings/_form")
+      assert_no_flash(
+        "User should be able to edit his own Naming without warning or error"
+      )
+    end
+
+    def edit_form_test_setup
+      nam = namings(:coprinus_comatus_naming)
+      params = { observation_id: nam.observation_id, id: nam.id }
+      requires_user(:edit, { controller: "/observations", action: :show,
+                             id: nam.observation_id }, params)
+      assert_form_action(action: "update", approved_name: nam.text_name,
+                         id: nam.id)
+      assert_select("option[selected]", count: 2)
+
+      login(nam.user.login)
+      params
     end
 
     def test_edit_obs_owner_with_different_vote

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -117,7 +117,7 @@ class SequencesControllerTest < FunctionalTestCase
     params = { observation_id: obs.id, q: q }
 
     login("zero") # This user has no Observations
-    get(:new, params: params)
+    get(:new, params:)
 
     assert_response(:success,
                     "A user should be able to get form to add Sequence " \
@@ -131,6 +131,15 @@ class SequencesControllerTest < FunctionalTestCase
       "form[action*='q=#{q}']", true,
       "Sequence form submit action missing/incorrect 'q' query param"
     )
+  end
+
+  def test_new_turbo
+    obs = observations(:minimal_unknown_obs)
+
+    login("zero") # This user has no Observations
+    get(:new, params: { observation_id: obs.id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("sequences/_form")
   end
 
   def test_new_login_required
@@ -343,6 +352,18 @@ class SequencesControllerTest < FunctionalTestCase
     login(observer.login)
     get(:edit, params: { id: sequence.id })
     assert_response(:success)
+  end
+
+  def test_edit_turbo
+    sequence = sequences(:local_sequence)
+    obs      = sequence.observation
+    observer = obs.user
+
+    # Prove Observation's creator can edit Sequence
+    login(observer.login)
+    get(:edit, params: { id: sequence.id }, format: :turbo_stream)
+    assert_template("shared/_modal_form")
+    assert_template("sequences/_form")
   end
 
   def test_edit_deposited_sequence

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -410,6 +410,11 @@ class SequencesControllerTest < FunctionalTestCase
     # Prove user cannot edit Sequence he didn't create for Obs he didn't create
     get(:edit, params: { id: sequence.id })
     assert_redirected_to(obs.show_link_args)
+
+    # Test turbo shows flash warning
+    get(:edit, params: { id: sequence.id }, format: :turbo_stream)
+    assert_flash_warning
+    assert_template("shared/_modal_flash_update")
   end
 
   def test_edit_redirect


### PR DESCRIPTION
This tests that both the naming form, and the casting of naming votes, works via Turbo and in fact sends updated `erb` partials out. These partials were not tested before.

Also improves testing of Comment, CollectionNumber, HerbariumRecord, Sequence and ExternalLink turbo responses (spotted inspecting coveralls results).

Fixes an uncaught error handling bug in CollectionNumber and HerbariumRecord turbo responses.