### PR TITLE
Delete two almost-unused query param helpers, replace references

### DIFF
--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -4,7 +4,7 @@
 module ApplicationController::Queries
   def self.included(base)
     base.helper_method(
-      :query_from_session, :passed_query, :query_params, :add_query_param,
+      :query_from_session, :query_params, :add_query_param,
       :get_query_param, :query_params_set
     )
   end
@@ -184,18 +184,12 @@ module ApplicationController::Queries
   end
   # helper_method :query_from_session
 
-  # Get instance of Query which is being passed to subsequent pages.
-  def passed_query
-    Query.safe_find(query_params[:q].to_s.dealphabetize)
-  end
-  # helper_method :passed_query
-
   # NOTE: If we're going to cache user stuff that depends on their present q,
   # we'll need a helper to make the current QueryRecord (not just the id)
   # available to templates as an ApplicationController ivar. Something like:
   #
   # def current_query_record
-  #   current_query = passed_query || query_from_session # could both be nil!
+  #   current_query = query_from_session # could both be nil!
   #   current_query_record = current_query&.record || "no_query"
   # end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,6 @@
 #  add_header                   # add to html header from within view
 #  reload_with_args             # add args to url that got us to this page
 #  add_args_to_url              # change params of arbitrary url
-#  url_after_delete             # url to return to after deleting object
 #  get_next_id
 #
 module ApplicationHelper
@@ -242,32 +241,6 @@ module ApplicationHelper
     addr + "?" + args.keys.sort.map do |k| # rubocop:disable Style/StringConcatenation
       "#{CGI.escape(k)}=#{args[k] || ""}"
     end.join("&")
-  end
-
-  # Returns URL to return to after deleting an object.  Can't just return to
-  # the index, because we'd prefer to return to the correct page in the index,
-  # but to do that we need to know the id of next object.
-  def url_after_delete(object)
-    return nil unless object
-
-    id = get_next_id(object)
-    args = {
-      controller: object.show_controller,
-      action: object.index_action
-    }
-    args[:id] = id if id
-    url_for(add_query_param(args))
-  end
-
-  def get_next_id(object)
-    query = passed_query
-    return nil unless query
-    return nil unless query.model.to_s == object.class.name
-
-    idx = query.index(object)
-    return nil unless idx
-
-    query.result_ids[idx + 1] || query.result_ids[idx - 1]
   end
 
   def form_submit_text(obj)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -224,7 +224,8 @@ module LinkHelper # rubocop:disable Metrics/ModuleLength
   #                  target: term)
   #   destroy_button(
   #     name: :destroy_object.t(type: :herbarium),
-  #     target: herbarium_path(@herbarium, back: url_after_delete(@herbarium))
+  #     target: herbarium_path(@herbarium,
+  #     back: herbaria_path(@herbarium.try(&:id)))
   #   )
   #
   def destroy_button(target:, name: nil, **args)

--- a/app/helpers/tabs/sequences_helper.rb
+++ b/app/helpers/tabs/sequences_helper.rb
@@ -76,7 +76,8 @@ module Tabs
       InternalLink::Model.new(
         :destroy_object.t(type: :sequence),
         seq, seq,
-        html_options: { button: :destroy, back: url_after_delete(seq) }
+        html_options: { button: :destroy,
+                        back: observation_path(seq.observation) }
       ).tab
     end
 

--- a/app/views/controllers/observations/show/_sequences.erb
+++ b/app/views/controllers/observations/show/_sequences.erb
@@ -34,8 +34,7 @@ tag.div(
           )
           links << destroy_button(
             name: :destroy_object.t(type: :sequence),
-            target: sequence_path(id: sequence.id,
-                                  back: url_after_delete(sequence)),
+            target: sequence_path(id: sequence.id, back: observation_path(obs)),
             icon: :remove,
             class: "destroy_sequence_link_#{sequence.id}"
           )


### PR DESCRIPTION
- `url_after_delete` - only used on sequences, not needed 
- `passed_query` - only used by `url_after_delete`