### PR TITLE
Standardize calls to `pass_query_params`

### DIFF
--- a/app/controllers/concerns/descriptions/defaults.rb
+++ b/app/controllers/concerns/descriptions/defaults.rb
@@ -4,11 +4,14 @@
 module Descriptions::Defaults
   extend ActiveSupport::Concern
 
+  class_methods do
+    before_action :pass_query_params
+  end
+
   included do
     # PUT callback to make a description the default one.
     # Description must be publically readable and writable.
     def update
-      pass_query_params
       return unless (desc = find_description!)
 
       redirect_to(object_path_with_query(desc))

--- a/app/controllers/concerns/descriptions/defaults.rb
+++ b/app/controllers/concerns/descriptions/defaults.rb
@@ -4,11 +4,9 @@
 module Descriptions::Defaults
   extend ActiveSupport::Concern
 
-  class_methods do
-    before_action :pass_query_params
-  end
-
   included do
+    before_action :pass_query_params
+
     # PUT callback to make a description the default one.
     # Description must be publically readable and writable.
     def update

--- a/app/controllers/concerns/descriptions/publish.rb
+++ b/app/controllers/concerns/descriptions/publish.rb
@@ -4,11 +4,9 @@
 module Descriptions::Publish
   extend ActiveSupport::Concern
 
-  class_methods do
-    before_action :pass_query_params
-  end
-
   included do
+    before_action :pass_query_params
+
     # Publish a draft description.  If the name has no description, just turn
     # the draft into a public description and make it the default.  If the name
     # has a default description try to merge the draft into it.  If there is a

--- a/app/controllers/concerns/descriptions/publish.rb
+++ b/app/controllers/concerns/descriptions/publish.rb
@@ -4,13 +4,16 @@
 module Descriptions::Publish
   extend ActiveSupport::Concern
 
+  class_methods do
+    before_action :pass_query_params
+  end
+
   included do
     # Publish a draft description.  If the name has no description, just turn
     # the draft into a public description and make it the default.  If the name
     # has a default description try to merge the draft into it.  If there is a
     # conflict bring up the edit_description form to let the user do the merge.
     def update
-      pass_query_params
       return unless (draft = find_description!(params[:id].to_s))
 
       parent = draft.parent

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -6,6 +6,7 @@ class ExportController < ApplicationController
                        Name].freeze
 
   before_action :login_required
+  before_action :pass_query_params
 
   # Callback (no view) to let reviewers change the export status of an
   # Image, Name, Location or Description from the show pages.
@@ -48,7 +49,6 @@ class ExportController < ApplicationController
   end
 
   def parse_params
-    pass_query_params
     @type = params[:type].to_s
     @value = params[:value].to_s
     @model_class = EXPORTABLE_MODELS.find { |m| m.name.downcase == @type }

--- a/app/controllers/images/transformations_controller.rb
+++ b/app/controllers/images/transformations_controller.rb
@@ -3,10 +3,10 @@
 module Images
   class TransformationsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # Used by show_image to rotate and flip image. was GET. Currently a PUT
     def update
-      pass_query_params
       image = find_or_goto_index(Image, params[:id].to_s)
       return unless image
 

--- a/app/controllers/javascript_controller.rb
+++ b/app/controllers/javascript_controller.rb
@@ -7,6 +7,7 @@ class JavascriptController < ApplicationController
     :turn_javascript_off,
     :turn_javascript_on
   ]
+  before_action :pass_query_params, only: [:hide_thumbnail_map]
 
   # Force javascript on.
   def turn_javascript_on
@@ -36,7 +37,6 @@ class JavascriptController < ApplicationController
   end
 
   def hide_thumbnail_map
-    pass_query_params
     id = params[:id].to_s
     if @user
       @user.update_attribute(:thumbnail_maps, false)

--- a/app/controllers/locations/descriptions/versions_controller.rb
+++ b/app/controllers/locations/descriptions/versions_controller.rb
@@ -6,12 +6,12 @@ module Locations::Descriptions
     include ::Locations::Descriptions::SharedPrivateMethods
 
     before_action :login_required
+    before_action :pass_query_params
 
     # Show past version of LocationDescription.  Accessible only from
     # show_location_description page.
     def show
       store_location
-      pass_query_params
       return unless find_description!
 
       @location = @description.location

--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -144,7 +144,6 @@ module Locations
     end
 
     def destroy
-      pass_query_params
       return unless find_description!
 
       check_delete_permission_flash_and_redirect

--- a/app/controllers/locations/versions_controller.rb
+++ b/app/controllers/locations/versions_controller.rb
@@ -4,11 +4,11 @@
 module Locations
   class VersionsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # Show past version of Location.  Accessible only from show_location page.
     def show
       store_location
-      pass_query_params
       return unless find_location!
 
       if params[:version]
@@ -20,13 +20,15 @@ module Locations
       end
     end
 
+    def show_includes
+      [:user, :versions]
+    end
+
+    private
+
     def find_location!
       @location = Location.show_includes.safe_find(params[:id]) ||
                   flash_error_and_goto_index(Location, params[:id])
-    end
-
-    def show_includes
-      [:user, :versions]
     end
   end
 end

--- a/app/controllers/names/classification/inherit_controller.rb
+++ b/app/controllers/names/classification/inherit_controller.rb
@@ -4,11 +4,11 @@
 module Names::Classification
   class InheritController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # form
     def new
       store_location
-      pass_query_params
       return unless find_name!
 
       nil unless make_sure_name_is_at_or_above_genus!(@name)
@@ -17,8 +17,6 @@ module Names::Classification
     # POST callback
     def create
       store_location
-      pass_query_params
-
       return unless find_name!
       return unless make_sure_name_is_at_or_above_genus!(@name)
 

--- a/app/controllers/names/classification/propagate_controller.rb
+++ b/app/controllers/names/classification/propagate_controller.rb
@@ -4,10 +4,10 @@
 module Names::Classification
   class PropagateController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # PUT callback
     def update
-      pass_query_params
       return unless find_name!
       return unless make_sure_name_is_genus!(@name)
 

--- a/app/controllers/names/classification/refresh_controller.rb
+++ b/app/controllers/names/classification/refresh_controller.rb
@@ -4,10 +4,10 @@
 module Names::Classification
   class RefreshController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # PUT callback
     def update
-      pass_query_params
       return unless find_name!
       return unless make_sure_name_below_genus!(@name)
       return unless make_sure_genus_has_classification!(@name)

--- a/app/controllers/names/classification_controller.rb
+++ b/app/controllers/names/classification_controller.rb
@@ -4,18 +4,17 @@
 module Names
   class ClassificationController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # Form
     def edit
       store_location
-      pass_query_params
       nil unless find_name!
     end
 
     # PUT callback
     def update
       store_location
-      pass_query_params
       return unless find_name!
 
       @name.classification = params[:classification].to_s.strip_html.

--- a/app/controllers/names/descriptions/review_status_controller.rb
+++ b/app/controllers/names/descriptions/review_status_controller.rb
@@ -4,11 +4,11 @@
 module Names::Descriptions
   class ReviewStatusController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # PUT Callback to let reviewers change review_status of a NameDescription
     # from the show_name page.
     def update
-      pass_query_params
       desc = NameDescription.find(params[:id].to_s)
       desc.update_review_status(params[:value]) if reviewer?
       redirect_with_query(name_path(desc.name_id))

--- a/app/controllers/names/descriptions/versions_controller.rb
+++ b/app/controllers/names/descriptions/versions_controller.rb
@@ -6,11 +6,11 @@ module Names::Descriptions
     include ::Names::Descriptions::SharedPrivateMethods
 
     before_action :login_required
+    before_action :pass_query_params
 
     # Show past versions of NameDescription.  Accessible only from
     # show_name_description page.
     def show
-      pass_query_params
       store_location
       return unless find_description!
 

--- a/app/controllers/names/lifeforms/propagate_controller.rb
+++ b/app/controllers/names/lifeforms/propagate_controller.rb
@@ -4,14 +4,13 @@
 module Names::Lifeforms
   class PropagateController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     def edit
-      pass_query_params
       @name = find_or_goto_index(Name, params[:id])
     end
 
     def update
-      pass_query_params
       @name = find_or_goto_index(Name, params[:id])
 
       Name.all_lifeforms.each do |word|

--- a/app/controllers/names/lifeforms_controller.rb
+++ b/app/controllers/names/lifeforms_controller.rb
@@ -4,14 +4,13 @@
 module Names
   class LifeformsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     def edit
-      pass_query_params
       find_name!
     end
 
     def update
-      pass_query_params
       return unless find_name!
 
       words = Name.all_lifeforms.select do |word|

--- a/app/controllers/names/maps_controller.rb
+++ b/app/controllers/names/maps_controller.rb
@@ -4,6 +4,7 @@
 module Names
   class MapsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     def controller_model_name
       "Name"
@@ -11,7 +12,6 @@ module Names
 
     # Draw a map of all the locations where this name has been observed.
     def show
-      pass_query_params
       @name = find_or_goto_index(Name, params[:id].to_s)
       return unless @name
 

--- a/app/controllers/names/synonyms/approve_controller.rb
+++ b/app/controllers/names/synonyms/approve_controller.rb
@@ -4,11 +4,11 @@
 module Names::Synonyms
   class ApproveController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # Form accessible from show_name that lets a user make call this an accepted
     # name, possibly deprecating its synonyms at the same time.
     def new
-      pass_query_params
       return unless find_name!
       return if abort_if_name_locked!(@name)
 
@@ -16,7 +16,6 @@ module Names::Synonyms
     end
 
     def create
-      pass_query_params
       return unless find_name!
       return if abort_if_name_locked!(@name)
 

--- a/app/controllers/names/synonyms_controller.rb
+++ b/app/controllers/names/synonyms_controller.rb
@@ -6,6 +6,7 @@ module Names
     include Names::Synonyms::SharedPrivateMethods
 
     before_action :login_required
+    before_action :pass_query_params
 
     ############################################################################
     #
@@ -16,7 +17,6 @@ module Names
     # Form accessible from show_name that lets a user review all the synonyms
     # of a name, removing others, writing in new, etc.
     def edit
-      pass_query_params
       return unless find_name!
       return if abort_if_name_locked!(@name)
 
@@ -24,8 +24,6 @@ module Names
     end
 
     def update
-      pass_query_params
-
       return unless find_name!
       return if abort_if_name_locked!(@name)
 

--- a/app/controllers/names/versions_controller.rb
+++ b/app/controllers/names/versions_controller.rb
@@ -4,10 +4,10 @@
 module Names
   class VersionsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # Show past version of Name.  Accessible only from show_name page.
     def show
-      pass_query_params
       store_location
       return unless find_name!
 
@@ -22,15 +22,17 @@ module Names
                           pluck(:display_name)
     end
 
-    def find_name!
-      @name = Name.show_includes.safe_find(params[:id]) ||
-              flash_error_and_goto_index(Name, params[:id])
-    end
-
     def show_includes
       [:correct_spelling,
        { observations: :user },
        :user, :versions]
+    end
+
+    private
+
+    def find_name!
+      @name = Name.show_includes.safe_find(params[:id]) ||
+              flash_error_and_goto_index(Name, params[:id])
     end
   end
 end

--- a/app/controllers/observation_views_controller.rb
+++ b/app/controllers/observation_views_controller.rb
@@ -2,12 +2,12 @@
 
 class ObservationViewsController < ApplicationController
   before_action :login_required
+  before_action :pass_query_params
 
   # endpoint to mark an observation as 'reviewed' by the current user
   # Note that it doesn't take an ov.id param - it looks up or creates an ov
   # from an observation_id param (confusingly, :id!) and the current user
   def update
-    pass_query_params
     # basic sanitizing of the param. ivars needed in js response
     # checked is a string!
     @reviewed = params[:reviewed] == "1"

--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -3,6 +3,7 @@
 module Observations
   class MapsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params, only: :show
 
     def controller_model_name
       "Observation"
@@ -19,7 +20,6 @@ module Observations
 
     # Show map of one observation by id.
     def show
-      pass_query_params
       @observation = find_or_goto_index(Observation, params[:id].to_s)
       return unless @observation
 

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -3,6 +3,7 @@
 module Observations::Namings
   class VotesController < ApplicationController
     before_action :login_required # except: [:show]
+    before_action :pass_query_params
 
     # Index breakdown of votes for a given naming.
     # Linked from: observations/show
@@ -11,7 +12,6 @@ module Observations::Namings
     # Inputs: params[:naming_id], [:observation_id]
     # Outputs: @naming, @consensus
     def index
-      pass_query_params
       @naming = find_or_goto_index(Naming, params[:naming_id].to_s)
       obs = Observation.naming_includes.find(params[:observation_id])
       @consensus = Observation::NamingConsensus.new(obs)
@@ -64,8 +64,9 @@ module Observations::Namings
       create_or_update_vote
     end
 
+    private
+
     def create_or_update_vote
-      pass_query_params
       observation = load_observation_naming_includes # 1st load
       @naming = observation.namings.find(params[:naming_id])
       value_str = params.dig(:vote, :value).to_s

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -22,7 +22,6 @@ module ObservationsController::Show
   def show
     return if check_for_spider_block(request, params)
 
-    pass_query_params
     store_location
     if params[:flow].present?
       redirect_to_next_object(params[:flow].to_sym, Observation, params[:id])
@@ -45,6 +44,14 @@ module ObservationsController::Show
     @comments      = @observation.comments&.sort_by(&:created_at)&.reverse
     @images        = @observation.images_sorted
   end
+
+  # Tell search engines what the "correct" URL is for this page.
+  # Used in application/app/head
+  def canonical_url(obs)
+    observation_url(obs.id)
+  end
+
+  private
 
   def load_observation_for_show_observation_page
     includes = @user ? "show_includes" : "not_logged_in_show_includes" # scopes
@@ -70,12 +77,6 @@ module ObservationsController::Show
     return if params[:set_thumbnail_size].blank?
 
     default_thumbnail_size_set(params[:set_thumbnail_size])
-  end
-
-  # Tell search engines what the "correct" URL is for this page.
-  # Used in application/app/head
-  def canonical_url(obs)
-    observation_url(obs.id)
   end
 
   # Decide if the current query can be used to create a map.

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -6,6 +6,7 @@ class RssLogsController < ApplicationController
     :rss,
     :show
   ]
+  before_action :pass_query_params, only: [:show]
 
   # Default page.  Just displays latest happenings.  The actual action is
   # buried way down toward the end of this file.
@@ -85,7 +86,6 @@ class RssLogsController < ApplicationController
 
   # Show a single RssLog.
   def show
-    pass_query_params
     store_location
     case params[:flow]
     when "next"

--- a/app/controllers/species_lists/observations_controller.rb
+++ b/app/controllers/species_lists/observations_controller.rb
@@ -8,11 +8,11 @@
 module SpeciesLists
   class ObservationsController < ApplicationController
     before_action :login_required
+    before_action :pass_query_params
 
     # :add_remove_observations
     # Form to add or remove the current *query* of observations
     def edit
-      pass_query_params
       @id = params[:species_list].to_s
       @query = find_obs_query_or_redirect
     end
@@ -21,7 +21,6 @@ module SpeciesLists
     # PUT endpoint — via params[:commit], either add or remove a
     #                *query* of observations from a species_list
     def update
-      pass_query_params
       id = params[:species_list].to_s
       return unless (spl = find_list_or_reload_form!(id))
 

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -10,6 +10,7 @@
 class SpeciesListsController < ApplicationController
   before_action :login_required
   before_action :require_successful_user, only: [:new, :create]
+  before_action :pass_query_params, only: [:show]
   # Bullet wants us to eager load synonyms for @deprecated_names in
   # edit_species_list, and I thought it would be possible, but I can't
   # get it to work.  Seems toooo minor to waste any more time on.
@@ -98,7 +99,6 @@ class SpeciesListsController < ApplicationController
   def show
     store_location
     clear_query_in_session
-    pass_query_params
     return unless (@species_list = find_species_list!)
 
     set_project_ivar

--- a/app/controllers/visual_groups_controller.rb
+++ b/app/controllers/visual_groups_controller.rb
@@ -2,6 +2,7 @@
 
 class VisualGroupsController < ApplicationController
   before_action :login_required
+  before_action :pass_query_params, only: [:edit]
 
   # GET /visual_groups or /visual_groups.json
   def index
@@ -24,7 +25,6 @@ class VisualGroupsController < ApplicationController
 
   # GET /visual_groups/1/edit
   def edit
-    pass_query_params
     @visual_group = VisualGroup.find(params[:id])
     @filter = params[:filter]
     @filter = @visual_group.name unless @filter && @filter != ""


### PR DESCRIPTION
Preparation for `q` permalinks PR. Most controllers call this on the `before_action` callback, so i'm standardizing around that.

The fewer places this is called, the easier it will be to know where we deal with the param `q`, which will no longer be a string, but a stringified Object that Rails knows is an Object.

I cannot tell
- if this method is even necessary. We forward the `q` param all over the place and usually grab it from the page's incoming params. I don't know why we'd ever grab it from the query record.
- if it is necessary, why it isn't on every action, i.e. where it is that we DON'T want to pass `q`