### PR TITLE
Remove `lookup_xxx_by_name(vals)` methods

### DIFF
--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -50,7 +50,7 @@ module AbstractModel::Scopes
     }
 
     scope :by_users, lambda { |users|
-      ids = lookup_users_by_name(users)
+      ids = Lookup::Users.new(users).ids
       where(user: ids)
     }
     scope :by_editor, lambda { |user|
@@ -478,50 +478,6 @@ module AbstractModel::Scopes
       fields.reduce(starting) do |result, field|
         result + arel_table[field].coalesce("")
       end
-    end
-
-    def lookup_external_sites_by_name(vals)
-      Lookup::ExternalSites.new(vals).ids
-    end
-
-    def lookup_field_slips_by_name(vals)
-      Lookup::FieldSlips.new(vals).ids
-    end
-
-    def lookup_herbaria_by_name(vals)
-      Lookup::Herbaria.new(vals).ids
-    end
-
-    def lookup_herbarium_records_by_name(vals)
-      Lookup::HerbariumRecords.new(vals).ids
-    end
-
-    def lookup_locations_by_name(vals)
-      Lookup::Locations.new(vals).ids
-    end
-
-    def lookup_names_by_name(vals, params = {})
-      Lookup::Names.new(vals, **params).ids
-    end
-
-    def lookup_projects_by_name(vals)
-      Lookup::Projects.new(vals).ids
-    end
-
-    def lookup_lists_for_projects_by_name(vals)
-      Lookup::ProjectSpeciesLists.new(vals).ids
-    end
-
-    def lookup_species_lists_by_name(vals)
-      Lookup::SpeciesLists.new(vals).ids
-    end
-
-    def lookup_regions_by_name(vals)
-      Lookup::Regions.new(vals).ids
-    end
-
-    def lookup_users_by_name(vals)
-      Lookup::Users.new(vals).ids
     end
 
     def exact_match_condition(table_column, vals)

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -40,7 +40,7 @@ class ExternalLink < AbstractModel
   scope :url_has,
         ->(phrase) { search_columns(ExternalLink[:url], phrase) }
   scope :external_sites, lambda { |sites|
-    ids = lookup_external_sites_by_name(sites)
+    ids = Lookup::ExternalSites.new(sites).ids
     where(external_site_id: ids)
   }
   scope :observations,

--- a/app/models/image/scopes.rb
+++ b/app/models/image/scopes.rb
@@ -87,12 +87,12 @@ module Image::Scopes
       joins(observation_images: :observation).
         where(observation: { location_id: ids })
     }
-    scope :projects, lambda { |proj|
-      ids = lookup_projects_by_name(proj)
+    scope :projects, lambda { |projects|
+      ids = Lookup::Projects.new(projects).ids
       joins(:project_images).where(project_images: { project_id: ids })
     }
-    scope :species_lists, lambda { |spl|
-      ids = lookup_species_lists_by_name(spl)
+    scope :species_lists, lambda { |species_lists|
+      ids = Lookup::SpeciesLists.new(species_lists).ids
       joins(observation_images: { observation: :species_list_observations }).
         where(species_list_observations: { species_list_id: ids })
     }

--- a/app/models/image/scopes.rb
+++ b/app/models/image/scopes.rb
@@ -82,8 +82,8 @@ module Image::Scopes
       joins(:observation_images).
         where(observation_images: { observation: obs })
     }
-    scope :locations, lambda { |loc|
-      ids = lookup_locations_by_name(loc)
+    scope :locations, lambda { |locations|
+      ids = Lookup::Locations.new(locations).ids
       joins(observation_images: :observation).
         where(observation: { location_id: ids })
     }

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -39,7 +39,7 @@ module Location::Scopes
 
     # This is a convenience for lookup by text name. Used by `observation_query`
     scope :locations, lambda { |locations|
-      location_ids = lookup_locations_by_name(locations)
+      location_ids = Lookup::Locations.new(locations).ids
       where(id: location_ids).distinct
     }
 

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -92,17 +92,17 @@ class LocationDescription < Description
     where(public: bool)
   }
   scope :by_author, lambda { |user|
-    ids = lookup_users_by_name(user)
+    ids = Lookup::Users.new(user).ids
     joins(:location_description_authors).distinct.
       where(location_description_authors: { user_id: ids })
   }
   scope :by_editor, lambda { |user|
-    ids = lookup_users_by_name(user)
+    ids = Lookup::Users.new(user).ids
     joins(:location_description_editors).distinct.
       where(location_description_editors: { user_id: ids })
   }
-  scope :locations, lambda { |loc|
-    ids = lookup_locations_by_name(loc)
+  scope :locations, lambda { |locations|
+    ids = Lookup::Locations.new(locations).ids
     where(location: ids)
   }
 

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -268,7 +268,7 @@ module Name::Scopes
     }
     # Accepts region string, location_id, or Location instance
     scope :locations, lambda { |locations|
-      location_ids = lookup_regions_by_name(locations)
+      location_ids = Lookup::Regions.new(locations).ids
       joins(:observations).
         where(observations: { location: location_ids }).distinct
     }

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -49,7 +49,7 @@ module Name::Scopes
           -> { order_by(::Query::Names.default_order) }
 
     scope :names, lambda { |lookup:, **related_name_args|
-      ids = lookup_names_by_name(lookup, related_name_args.compact)
+      ids = Lookup::Names.new(lookup, related_name_args.compact).ids
       return none unless ids
 
       where(id: ids).with_correct_spelling.distinct
@@ -261,7 +261,7 @@ module Name::Scopes
       joins(:observations).distinct
     }
     scope :species_lists, lambda { |species_lists|
-      species_list_ids = lookup_species_lists_by_name(species_lists)
+      species_list_ids = Lookup::SpeciesLists.new(species_lists).ids
       joins(observations: :species_list_observations).
         merge(SpeciesListObservation.where(species_list: species_list_ids)).
         distinct

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -106,12 +106,12 @@ class NameDescription < Description
         -> { order_by(::Query::NameDescriptions.default_order) }
 
   scope :by_author, lambda { |user|
-    ids = lookup_users_by_name(user)
+    ids = Lookup::Users.new(user).ids
     joins(:name_description_authors).distinct.
       where(name_description_authors: { user_id: ids })
   }
   scope :by_editor, lambda { |user|
-    ids = lookup_users_by_name(user)
+    ids = Lookup::Users.new(user).ids
     joins(:name_description_editors).distinct.
       where(name_description_editors: { user_id: ids })
   }
@@ -124,14 +124,14 @@ class NameDescription < Description
         ->(bool = true) { where(ok_for_export: bool) }
 
   scope :names, lambda { |lookup:, **related_name_args|
-    ids = lookup_names_by_name(lookup, related_name_args.compact)
+    ids = Lookup::Names.new(lookup, related_name_args.compact).ids
     return none unless ids
 
     where(name_id: ids).distinct
   }
 
   scope :projects, lambda { |projects|
-    ids = lookup_projects_by_name(projects)
+    ids = Lookup::Projects.new(projects).ids
     where(project: ids)
   }
 

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -257,7 +257,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       end
     }
     scope :locations, lambda { |locations|
-      location_ids = lookup_locations_by_name(locations)
+      location_ids = Lookup::Locations.new(locations).ids
       where(location: location_ids).distinct
     }
     # Pass Box kwargs (:north, :south, :east, :west), any order.

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -111,12 +111,12 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :search_where,
         ->(phrase) { search_columns(SpeciesList[:where], phrase) }
 
-  scope :locations, lambda { |loc|
-    ids = lookup_locations_by_name(loc)
+  scope :locations, lambda { |locations|
+    ids = Lookup::Locations.new(locations).ids
     where(location_id: ids).distinct
   }
   scope :projects, lambda { |projects|
-    ids = lookup_projects_by_name(projects)
+    ids = Lookup::Projects.new(projects).ids
     joins(:project_species_lists).
       where(project_species_lists: { project_id: ids }).distinct
   }


### PR DESCRIPTION
These largely uncovered "convenience methods" are barely used, less versatile, and not any more concise than the code they conceal.

For example, these are equivalent:
```ruby
lookup_external_sites_by_name(vals)
```
```ruby
Lookup::ExternalSites.new(vals).ids
```

I'm not crazy about the fact that they don't return records, as their name would imply — they only return ids. Using the `Lookup` classes directly can return records, ids, or other useful things. This PR converts the few callers of these methods to use `Lookup::XXX` directly and deletes the methods.