### PR TITLE
Improve test coverage on `CollectionNumber` and `HerbariumRecord` forms

### DIFF
--- a/app/helpers/panel_helper.rb
+++ b/app/helpers/panel_helper.rb
@@ -114,8 +114,11 @@ module PanelHelper
     end
   end
 
-  def alert_block(level = :warning, string = "")
-    content_tag(:div, string, class: "alert alert-#{level}")
+  # Create a div for alert messages.
+  def alert_block(msg = nil, level: :warning, **args, &block)
+    msg = capture(&block) if block
+    args[:class] = class_names("alert", "alert-#{level}", args[:class])
+    tag.div(msg, **args)
   end
 
   # Create a div for notes.

--- a/app/views/controllers/application/app/_banners.html.erb
+++ b/app/views/controllers/application/app/_banners.html.erb
@@ -1,35 +1,50 @@
 <!--CALLOUT_BANNERS-->
-<div id="banners" class="hidden-print">
+<%
+admin_banner_classes = "h3 text-center font-weight-bold p-2"
+%>
+
+<%= tag.div(id: "banners", class: "hidden-print") do %>
 
   <% if in_admin_mode? %>
-    <div id="admin_banner" class="h3 text-center font-weight-bold p-2">
-      DANGER: You are in administrator mode. Proceed with caution.
-    </div>
+    <%= tag.div(
+      "DANGER: You are in administrator mode. Proceed with caution.",
+      id: "admin_banner", class: admin_banner_classes
+    ) %>
   <% elsif session[:real_user_id].present? %>
-    <div id="admin_banner" class="h3 text-center font-weight-bold p-2">
-      DANGER: You are currently logged in as <%= User.current.login %>.
-    </div>
+    <%= tag.div(
+      "DANGER: You are currently logged in as #{User.current.login}.",
+      id: "admin_banner", class: admin_banner_classes
+    ) %>
   <% end %>
 
-  <% if Banner.current %>
-    <div data-controller="banner">
-      <div id="banner" class="alert alert-success message-banner" data-banner-target="banner">
-        <button
-        class="close"
-        id="dismiss-banner"
-        data-banner-target="dismissButton"
-        aria-label="Close"
-        data-version="<%= Banner.current.version %>">
-          <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
-        </button>
-        <p><%= Banner.current.message.t %></p>
-      </div>
-      <div class="show_banner_container position-relative d-block w-100 py-2 text-right" data-banner-target="container">
-        <div data-banner-target="showButton" class="show_banner_icon text-green d-block">
-          <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
-        </div>
-      </div>
-    </div>
-  <% end %>
-</div>
+  <%= tag.div(data: { controller: "banner" }) do
+    [
+      alert_block(level: :success, class: "message-banner",
+                  data: { banner_target: "banner" }) do
+        [
+          tag.button(
+            link_icon(:chevron_up, title: :CLOSE.l),
+            type: :button, class: "close",
+            id: "dismiss-banner",
+            data: { banner_target: "dismissButton",
+                    version: Banner.current.version },
+            aria: { label: :CLOSE.l }
+          ),
+          tag.p(Banner.current.message.t)
+        ].safe_join
+      end,
+      tag.div(
+        class: "position-relative w-100 py-2 text-right",
+        data: { banner_target: "container" }
+      ) do
+        tag.div(
+          link_icon(:chevron_down, title: :SHOW.l),
+          class: "show_banner_icon text-green d-block",
+          data: { banner_target: "showButton" }
+        )
+      end
+    ].safe_join
+  end if Banner.current %>
+
+<% end %>
 <!--/CALLOUT_BANNERS-->

--- a/app/views/controllers/collection_numbers/_form.erb
+++ b/app/views/controllers/collection_numbers/_form.erb
@@ -24,7 +24,8 @@ end
 
   <% if @collection_number.observations.size > 1 %>
     <%= alert_block(
-      :warning, :edit_affects_multiple_observations.t(type: :collection_number)
+      :warning, :edit_affects_multiple_observations.t(type: :collection_number),
+      class: "multiple-observations-warning"
     ) %>
   <% end %>
 

--- a/app/views/controllers/collection_numbers/_form.erb
+++ b/app/views/controllers/collection_numbers/_form.erb
@@ -24,8 +24,8 @@ end
 
   <% if @collection_number.observations.size > 1 %>
     <%= alert_block(
-      :warning, :edit_affects_multiple_observations.t(type: :collection_number),
-      class: "multiple-observations-warning"
+      :edit_affects_multiple_observations.t(type: :collection_number),
+      level: :warning, class: "multiple-observations-warning"
     ) %>
   <% end %>
 

--- a/app/views/controllers/field_slips/_form.html.erb
+++ b/app/views/controllers/field_slips/_form.html.erb
@@ -1,17 +1,19 @@
 <%
-  action = controller.action_name
+action = controller.action_name
 %>
 
 <% if field_slip.errors.any? %>
-  <div class="alert alert-danger">
-    <%= "#{pluralize(field_slip.errors.count,
-      :error.t, plural: :errors.t)} #{:field_slip_errors.t}" %>:
-    <ul>
-      <% field_slip.errors.each do |error| %>
-        <li><%= error.full_message %></li>
-      <% end %>
-    </ul>
-  </div>
+  <% count = pluralize(field_slip.errors.count, :error.t, plural: :errors.t) %>
+  <%= alert_block(level: :danger) do
+    [
+      tag.p("#{count} #{:field_slip_errors.t}:"),
+      tag.ul do
+        field_slip.errors.each do |error|
+          concat(tag.li(error.full_message))
+        end
+      end
+    ].safe_join
+  end %>
 <% end %>
 
 <% if field_slip.code %>
@@ -46,30 +48,31 @@
     <%= check_box_with_label(form:, field: :inat,
                              label: :field_slip_other_inat.t ) %>
 
-    <%= submit_button(form:, button: :field_slip_quick_create_obs.t, class: "mb-5") if action == "new" %>
+    <%= submit_button(form:, button: :field_slip_quick_create_obs.t,
+                      class: "mb-5") if action == "new" %>
 
     <%= render(partial: "shared/notes_fields",
                locals: { form:, fields: field_slip.notes_fields }) %>
 
-    <%= submit_button(form:, button: :field_slip_add_images.t, class: "mt-5") if action == "new" %>
+    <%= submit_button(form:, button: :field_slip_add_images.t,
+                      class: "mt-5") if action == "new" %>
 
-    <div class="row mt-5">
+    <%= tag.div(class: "row mt-5") do %>
       <% if field_slip.observation %>
-        <div class="col-sm-6">
-          <%= render(partial: "field_slips/obs_thumbnail",
-                     locals: { obs: field_slip.observation, form:,
-                               button: :field_slip_keep_obs.t }) %>
-        </div>
+        <%= tag.div(class: "col-sm-6") do
+          render(partial: "field_slips/obs_thumbnail",
+                 locals: { obs: field_slip.observation, form:,
+                           button: :field_slip_keep_obs.t })
+        end %>
       <% end %>
       <% obs = previous_observation(field_slip.observation, @user)
          if obs %>
-        <div class="col-sm-6">
-          <%= render(partial: "field_slips/obs_thumbnail",
-                     locals: { obs:, form:,
-                               button: :field_slip_last_obs.t }) %>
-        </div>
+        <%= tag.div(class: "col-sm-6") do
+          render(partial: "field_slips/obs_thumbnail",
+                 locals: { obs:, form:, button: :field_slip_last_obs.t })
+        end %>
       <% end %>
-    </div>
+    <% end %>
 
     <%= submit_button(form:, button: :field_slip_create_obs.t,
                       class: "my-5") if action == "edit" %>
@@ -77,7 +80,8 @@
   <% end %>
 <% else %>
   <%= form_with(url: new_field_slip_url, method: :get) do |form| %>
-    <%= text_field_with_label(form:, field: :code, label: "#{:field_slip_code.t}:") %>
+    <%= text_field_with_label(form:, field: :code,
+                              label: "#{:field_slip_code.t}:") %>
     <%= submit_button(form:, button: :field_slip_create_obs.t,
                       class: "mt-5") %>
   <% end %>

--- a/app/views/controllers/field_slips/index.html.erb
+++ b/app/views/controllers/field_slips/index.html.erb
@@ -7,9 +7,7 @@ container_class(:wide)
 project_title = @query&.params_cache&.dig(:project)&.title || ""
 %>
 
-<% if notice %>
-  <%= tag.p(notice, class: "alert alert-success") %>
-<% end %>
+<%= alert_block(notice, level: :success) if notice %>
 
 <%= tag.div(class: "content-block") do %>
   <% if @project %>

--- a/app/views/controllers/field_slips/show.html.erb
+++ b/app/views/controllers/field_slips/show.html.erb
@@ -4,9 +4,7 @@ add_context_nav(field_slip_show_tabs(@field_slip, @user))
 container_class(:wide)
 %>
 
-<% if notice %>
-  <p class="alert alert-success"><%= notice %></p>
-<% end %>
+<%= alert_block(notice, level: :success) if notice %>
 
 <%= render(@field_slip) %>
 

--- a/app/views/controllers/herbaria/index.html.erb
+++ b/app/views/controllers/herbaria/index.html.erb
@@ -9,13 +9,10 @@ flash_error(@error) if @error && @objects.empty?
 nonpersonal = (@query&.params&.dig(:nonpersonal))
 %>
 
-<% if @merge %>
-  <div class="alert alert-warning container-text mt-3">
-    <%= :herbarium_index_merge_help.tp(name: @merge.format_name,
-                                     url: reload_with_args(merge: nil)) %>
-  </div>
-  <!--.container-text-->
-<% end %>
+<%= alert_block(level: :warning, class: "container-text mt-3") do
+  :herbarium_index_merge_help.tp(name: @merge.format_name,
+                                  url: reload_with_args(merge: nil))
+end if @merge %>
 
 <%= paginated_results do %>
   <% if @objects.any? %>

--- a/app/views/controllers/herbarium_records/_form.erb
+++ b/app/views/controllers/herbarium_records/_form.erb
@@ -24,8 +24,8 @@ end
 
   <% if @herbarium_record.observations.size > 1 %>
     <%= alert_block(
-      :warning, :edit_affects_multiple_observations.t(type: :herbarium_record),
-      class: "multiple-observations-warning"
+      :edit_affects_multiple_observations.t(type: :herbarium_record),
+      level: :warning, class: "multiple-observations-warning"
     ) %>
   <% end %>
 

--- a/app/views/controllers/herbarium_records/_form.erb
+++ b/app/views/controllers/herbarium_records/_form.erb
@@ -24,7 +24,8 @@ end
 
   <% if @herbarium_record.observations.size > 1 %>
     <%= alert_block(
-      :warning, :edit_affects_multiple_observations.t(type: :herbarium_record)
+      :warning, :edit_affects_multiple_observations.t(type: :herbarium_record),
+      class: "multiple-observations-warning"
     ) %>
   <% end %>
 

--- a/app/views/controllers/inat_imports/job_trackers/_current.erb
+++ b/app/views/controllers/inat_imports/job_trackers/_current.erb
@@ -52,7 +52,7 @@
       tag.span(tracker.response_errors, class: "violation-highlight"),
       tag.br,
 
-      tag.p(tracker.help, class: "alert alert-warning mt-3"),
+      alert_block(tracker.help, level: :warning, class: "mt-3"),
       tag.br
     ].safe_join
   end

--- a/app/views/controllers/names/classification/inherit/new.html.erb
+++ b/app/views/controllers/names/classification/inherit/new.html.erb
@@ -10,21 +10,20 @@ container_class(:text)
 
 <%= form_with(url: action) do |f| %>
 
-  <% if @options %>
-    <div class="alert alert-warning">
-      <%= @message.tp %>
-      <% @options.each do |name| %>
-        <%= radio_with_label(form: f, field: :options, value: name.id,
-                              label: name.display_name.t) %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= alert_block(level: :warning) do
+    concat(@message.tp)
+    @options.each do |name|
+      concat(radio_with_label(
+        form: f, field: :options, value: name.id, label: name.display_name.t
+      ))
+    end
+  end if @options %>
 
   <%= text_field_with_label(
-        form: f, field: :parent, value: @parent_text_name,
-        label: "#{:inherit_classification_parent_name.t}:",
-        data: { autofocus: true }, inline: true
-      ) %>
+    form: f, field: :parent, value: @parent_text_name,
+    label: "#{:inherit_classification_parent_name.t}:",
+    data: { autofocus: true }, inline: true
+  ) %>
 
   <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
 

--- a/app/views/controllers/names/synonyms/_fields_members.html.erb
+++ b/app/views/controllers/names/synonyms/_fields_members.html.erb
@@ -1,27 +1,32 @@
 <%# alerts plus list of members and option to deprecate all %>
 
-<% if @new_names && (@new_names != []) %>
-  <div class="alert alert-danger">
-    <%= :form_synonyms_missing_names.t %><br/>
-    <span class="pl-3">
-      <% @new_names.each do |n| %>
-        <%= h(n) %><br/>
-      <% end %>
-    </span>
-    <%= help_note(:span, :form_synonyms_missing_names_help.t) %>
-  </div>
-<% end %>
+<% alert_block(level: :danger) do
+  [
+    tag.div(:form_synonyms_missing_names.t),
+    tag.div(class: "pl-3") do
+      @new_names.each do |n|
+        concat(tag.div(h(n)))
+      end
+    end,
+    help_note(:span, :form_synonyms_missing_names_help.t)
+  ].safe_join
+end if @new_names.present? %>
 
-<div class="form-group">
-  <%= check_box_with_label(form: f, field: :deprecate_all, value: "1",
-                           checked: @deprecate_all && "checked",
-                           label: :form_synonyms_deprecate_synonyms.t) %>
-  <%= help_block(:p, :form_synonyms_deprecate_synonyms_help.t) %>
-</div>
+<%= tag.div(class: "form-group") do
+  [
+    check_box_with_label(
+      form: f, field: :deprecate_all, value: "1",
+      checked: @deprecate_all && "checked",
+      label: :form_synonyms_deprecate_synonyms.t
+    ),
+    help_block(:p, :form_synonyms_deprecate_synonyms_help.t)
+  ].safe_join
+end %>
 
 <%= text_area_with_label(
-      form: f, field: :synonym_members, value: @list_members,
-      label: :form_synonyms_names.t + ":", data: { autofocus: true },
-      between: help_block(:p, :form_synonyms_names_help.t(
-                                name: @name.display_name))
-    ) %>
+  form: f, field: :synonym_members, value: @list_members,
+  label: :form_synonyms_names.t + ":", data: { autofocus: true },
+  between: help_block(
+    :p, :form_synonyms_names_help.t(name: @name.display_name)
+  )
+) %>

--- a/app/views/controllers/observations/form/_projects.html.erb
+++ b/app/views/controllers/observations/form/_projects.html.erb
@@ -24,9 +24,9 @@ end
   <%= fields_for(:project) do |f_p| %>
 
     <% if error_messages.present? || suspect_messages.present? %>
-      <%= tag.div(id: "project_messages") do %>
-        <% [error_messages, suspect_messages].compact.each do |messages| %>
-          <%= tag.div(class: "alert alert-#{messages[:level]}") do
+      <%= tag.div(id: "project_messages") do
+        [error_messages, suspect_messages].compact.each do |messages|
+          concat(alert_block(level: messages[:level]) do
             [
               tag.div(
                 "#{:form_observations_projects_out_of_range.t(
@@ -41,9 +41,9 @@ end
               end,
               tag.p(messages[:help])
             ].safe_join
-          end %>
-        <% end %>
-      <% end %>
+          end)
+        end
+      end %>
       <%= check_box_with_label(
         form: f_p, field: :ignore_proj_conflicts,
         label: :form_observations_projects_ignore_project_constraints.t
@@ -52,15 +52,15 @@ end
 
     <%= tag.p(:form_observations_project_help.t) %>
 
-    <%= tag.div(class: "overflow-scroll-checklist") do %>
-      <% @projects.each do |project| %>
-        <%= check_box_with_label(
+    <%= tag.div(class: "overflow-scroll-checklist") do
+      @projects.each do |project|
+        concat(check_box_with_label(
           form: f_p, field: :"id_#{project.id}", label: project.title,
           checked: @project_checks[project.id],
           disabled: !project.user_can_add_observation?(@observation, @user)
-        ) %>
-      <% end %>
-    <% end %>
+        ))
+      end
+    end %>
 
   <% end %>
 <%# end %>

--- a/app/views/controllers/projects/aliases/_form.erb
+++ b/app/views/controllers/projects/aliases/_form.erb
@@ -13,19 +13,26 @@
     form_args = form_args.deep_merge({ data: { turbo: true } })
   end
 %>
+
 <%= form_with(**form_args) do |form| %>
+
   <% if project_alias.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <h2><%= pluralize(project_alias.errors.count, "error") %> prohibited this project alias from being saved:</h2>
-      <ul>
-        <% project_alias.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <% count = pluralize(project_alias.errors.count, "error") %>
+    <%= alert_block(level: :danger, id: "error_explanation") do
+      [
+        tag.h2("#{count} prohibited this project alias from being saved:"),
+        tag.ul do
+          project_alias.errors.full_messages.each do |message|
+            concat(tag.li(message))
+          end
+        end
+      ].safe_join
+    end %>
   <% end %>
 
-  <%= text_field_with_label(form:, field: :name, label: "#{:Name.t}:", inline: true) %>
+  <%= text_field_with_label(
+    form:, field: :name, label: "#{:Name.t}:", inline: true
+  ) %>
   <%= form.hidden_field(:project_id, value: project_alias.project_id) %>
 
   <%= tag.div(class: "form-group dropdown",

--- a/app/views/controllers/shared/_form_list_feedback.erb
+++ b/app/views/controllers/shared/_form_list_feedback.erb
@@ -1,6 +1,6 @@
 <%=
 if !@new_names.blank?
-  tag.div(class: "alert alert-danger", id: "missing_names") do
+  alert_block(level: :danger, id: "missing_names") do
     concat(tag.div(:form_list_feedback_missing_names.t,
                    class: "font-weight-bold"))
     concat(help_note(:div, :form_list_feedback_missing_names_help.t))
@@ -15,7 +15,7 @@ end
 
 <%=
 if !@deprecated_names.blank?
-  tag.div(class: "alert alert-warning", id: "deprecated_names") do
+  alert_block(level: :warning, id: "deprecated_names") do
     concat(tag.div(:form_species_lists_deprecated.t, class: "font-weight-bold"))
     concat(help_note(:div, :form_species_lists_deprecated_help.t))
     concat(tag.p do
@@ -40,7 +40,7 @@ end
 
 <%=
 if !@multiple_names.blank?
-  tag.div(class: "alert alert-warning", id: "ambiguous_names") do
+  alert_block(level: :warning, id: "ambiguous_names") do
     concat(tag.div(:form_species_lists_multiple_names.t,
                    class: "font-weight-bold"))
     concat(help_note(:div, :form_species_lists_multiple_names_help.t))

--- a/app/views/controllers/shared/_form_location_feedback.erb
+++ b/app/views/controllers/shared/_form_location_feedback.erb
@@ -1,7 +1,8 @@
 <%# feedback about @dubious_where_reasons %>
 
 <%= if @dubious_where_reasons&.any?
-  tag.div(class: "alert alert-warning my-3", id: "dubious_location_messages") do
+  alert_block(level: :warning, class: "my-3",
+              id: "dubious_location_messages") do
     concat(tag.div(@dubious_where_reasons.safe_join(safe_br)))
     concat(tag.span(:form_observations_dubious_help.t(button: button),
                     class: "help-note"))

--- a/app/views/controllers/shared/_form_name_feedback.erb
+++ b/app/views/controllers/shared/_form_name_feedback.erb
@@ -19,7 +19,8 @@ parent_deprecated - t/f
 <%=
 ##### Warnings #####
 if valid_names
-  tag.div(class: "alert alert-warning", id: "name_messages") do
+
+  alert_block(level: :warning, id: "name_messages") do
     concat(tag.div do
       if suggest_corrections || names.blank?
         :form_naming_not_recognized.t(name: given_name)
@@ -50,8 +51,10 @@ if valid_names
         end
         concat(fields_for(:chosen_name) do |f_c|
           valid_names.each do |n|
-            concat(radio_with_label(form: f_c, field: :name_id, value: n.id,
-                                    label: n.display_name.t, class: "ml-4"))
+            concat(radio_with_label(
+              form: f_c, field: :name_id, value: n.id,
+              label: n.display_name.t, class: "ml-4"
+            ))
           end
         end)
       end)
@@ -65,7 +68,7 @@ if valid_names
 ##### Errors #####
 elsif names&.length == 0
 
-  tag.div(class: "alert alert-danger", id: "name_messages") do
+  alert_block(level: :danger, id: "name_messages") do
     concat(tag.div(:form_naming_not_recognized.t(name: given_name)))
     concat(help_note(
       :div, :form_naming_not_recognized_help.t(button: button_name)
@@ -74,15 +77,17 @@ elsif names&.length == 0
 
 elsif names&.length &.> 1
 
-  tag.div(class: "alert alert-danger", id: "name_messages") do
+  alert_block(level: :danger, id: "name_messages") do
     concat(tag.div(
       [:form_naming_multiple_names.t(name: given_name), ":"].safe_join
     ))
     concat(fields_for(:chosen_name) do |f_c|
       names.each do |n|
-        concat(radio_with_label(form: f_c, field: :name_id, value: n.id,
-                                label: n.display_name.t, class: "ml-4 name-radio",
-                                append: tag.span(" (#{n.observations.size})")))
+        concat(radio_with_label(
+          form: f_c, field: :name_id, value: n.id,
+          label: n.display_name.t, class: "ml-4 name-radio",
+          append: tag.span(" (#{n.observations.size})")
+        ))
       end
     end)
     concat(help_note(:div, :form_naming_multiple_names_help.t))

--- a/app/views/controllers/visual_groups/_form.html.erb
+++ b/app/views/controllers/visual_groups/_form.html.erb
@@ -2,18 +2,19 @@
               id: "visual_group_form") do |f| %>
 
   <% if visual_group.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <h2>
-	<%= pluralize(visual_group.errors.count, "error") %>
-	prohibited this visual_group from being saved:
-      </h2>
-
-      <ul>
-        <% visual_group.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <% count = pluralize(
+      visual_group.errors.count, :error.t, plural: :errors.t
+    ) %>
+    <%= alert_block(level: :danger, id: "error_explanation") do
+      [
+        tag.h2("#{count} prohibited this visual_group from being saved:"),
+        tag.ul do
+          visual_group.errors.each do |error|
+            concat(tag.li(error.full_message))
+          end
+        end
+      ].safe_join
+    end %>
   <% end %>
 
   <div>

--- a/app/views/controllers/visual_models/_form.html.erb
+++ b/app/views/controllers/visual_models/_form.html.erb
@@ -1,23 +1,27 @@
 <%= form_with(model: visual_model) do |f| %>
   <% if visual_model.errors.any? %>
-    <div id="error_explanation" class="alert alert-danger">
-      <%= "#{pluralize(visual_model.errors.count,
-        :error.t, plural: :errors.t)} #{:visual_model_errors.t}" %>:
-      <ul>
-        <% visual_model.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <% count = pluralize(
+      visual_model.errors.count, :error.t, plural: :errors.t
+    ) %>
+    <%= alert_block(level: :danger, id: "error_explanation") do
+      [
+        tag.h2("#{count} #{:visual_model_errors.t}:"),
+        tag.ul do
+          visual_model.errors.each do |error|
+            concat(tag.li(error.full_message))
+          end
+        end
+      ].safe_join
+    end %>
   <% end %>
 
-  <div class="form-group field">
+  <%= tag.div(class: "form-group field") do %>
     <%= f.label(:name) %>
     <%= f.text_field(:name, class: "form-control") %>
     <%= :VISUAL_MODEL.t %>
-  </div>
+  <% end %>
 
-  <div class="actions">
+  <%= tag.div(class: "actions") do %>
     <%= submit_button(form: f, button: :SUBMIT.t, center: true) %>
-  </div>
+  <% end %>
 <% end %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2722,7 +2722,7 @@
   edit_herbarium_record_back_to_index: Back to Fungarium Record Index
   edit_herbarium_record_cant_add_or_remove: Only curators or the observer can add or remove an observation to or from a fungarium record.
   edit_herbarium_record_already_used: This fungarium record already exists. If you want to merge records, move the observations from this record to the other, then delete this record.
-  edit_affects_multiple_observations: The changes you make here will affect all of the observations shown.  If you wish to change a single observation, go to that observation, remove the incorrect [type] from it, then add the correct one.  That will leave the [type] unchanged for any other observations associated with it.
+  edit_affects_multiple_observations: The changes you make here will affect all of the observations shown. If you wish to change a single observation, go to that observation, remove the incorrect [type] from it, then add the correct one. That will leave the [type] unchanged for any other observations associated with it.
 
   # herbarium_record/destroy_herbarium_record
   delete_herbarium_record: Destroy Fungarium Record

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -344,6 +344,21 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_template("collection_numbers/_form")
   end
 
+  def test_edit_collection_number_multiple_obs
+    # obs1 = observations(:agaricus_campestris_obs)
+    obs2 = observations(:coprinus_comatus_obs)
+    num1 = collection_numbers(:agaricus_campestris_coll_num)
+    num1.add_observation(obs2)
+    assert(num1.observations.size > 1)
+
+    login
+    get(:edit, params: { id: num1.id })
+    assert_select(
+      ".multiple-observations-warning",
+      text: :edit_affects_multiple_observations.t(type: :collection_number)
+    )
+  end
+
   def test_update_collection_number
     obs = observations(:coprinus_comatus_obs)
     number = collection_numbers(:coprinus_comatus_coll_num)

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -359,6 +359,21 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_template("herbarium_records/_form")
   end
 
+  def test_edit_herbarium_record_multiple_obs
+    # obs1 = observations(:coprinus_comatus_obs)
+    obs2 = observations(:agaricus_campestris_obs)
+    hr1 = herbarium_records(:coprinus_comatus_nybg_spec)
+    hr1.add_observation(obs2)
+    assert(hr1.observations.size > 1)
+
+    login
+    get(:edit, params: { id: hr1.id })
+    assert_select(
+      ".multiple-observations-warning",
+      text: :edit_affects_multiple_observations.t(type: :herbarium_record)
+    )
+  end
+
   def test_update_herbarium_record
     herbarium_record_setup => { params:, nybg_rec:, nybg_user:, rolf_herb: }
 


### PR DESCRIPTION
For some reason other PRs are complaining about reduced coverage on these forms. I don't think those PRs have anything to do with the lack of coverage, but this should improve coverage and shut Coveralls up.

Working on the two forms reminded me they were the starting point for a shelved plan to dry-up our "alerts" so they use a common helper method `alert_block`. Shared components make upgrading Bootstrap easier. 

This PR completes the refactor of all templates that render alerts to use the helper.