### PR TITLE
Remove duplicate text_names in filter captions

### DIFF
--- a/app/helpers/header/filters_helper.rb
+++ b/app/helpers/header/filters_helper.rb
@@ -232,8 +232,10 @@ module Header
                 end
       subclass = PARAM_LOOKUPS[param]
       lookup = "Lookup::#{subclass}".constantize
-      joined_vals = lookup.new(lookups, include_misspellings: false).
-                    titles.join(", ")
+      # Use Set in case there are doubles, as for many Genus names
+      joined_vals = Set.new(
+        lookup.new(lookups, include_misspellings: false).titles
+      ).join(", ")
       return joined_vals unless truncate
 
       filter_truncate_joined_string(joined_vals, ids)

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -330,6 +330,27 @@ class ObservationsControllerIndexTest < FunctionalTestCase
                   "Wrong page or display is missing a link to Previous page")
   end
 
+  def test_index_filter_display_is_concise
+    pattern = "Agrocybe arvalis" # There are two
+
+    setup_rolfs_index
+    get(:index, params: { pattern: pattern })
+    assert_page_title(:OBSERVATIONS.l)
+    assert_displayed_filters("#{:query_names.l}: #{pattern}")
+
+    filter_txt = "#{:query_names.l}: #{pattern}, with synonyms, with subtaxa"
+    assert_equal(filter_txt + filter_txt,
+                 css_select("#filters").text, "Filter text is wrong.")
+
+    filter_txt_dup =
+      "#{:query_names.l}: #{pattern}, #{pattern}, with synonyms, with subtaxa"
+    assert_not_equal(
+      filter_txt_dup + filter_txt_dup,
+      css_select("#filters").text,
+      "Filter caption for 'Names' is repeating a text_name."
+    )
+  end
+
   def test_index_pattern_no_hits
     pattern = "no hits"
 


### PR DESCRIPTION
Filter captions for indexes with name filters can contain duplicates, since they only show the `text_name`, and the `author` can differ.

![Screen Shot 2025-08-30 at 10 41 00 PM](https://github.com/user-attachments/assets/67777c49-f9d2-492f-a8e8-132f1d483318)

This eliminates duplicates by using a `Set` and adds a test that fails on `<main>`.