### PR TITLE
PatternSearch form: commit with q permalink

### DIFF
--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -224,24 +224,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     pattern = params[:pattern].to_s
     type = controller_model_name.pluralize.underscore.to_sym
     redirect_to(search_pattern_path(pattern_search: { pattern:, type: }))
-    # pattern = params[:pattern].to_s
-    # if (obj = maybe_pattern_is_an_id(pattern))
-    #   redirect_to(send(:"#{controller_model_name.underscore}_path", obj.id))
-    #   [nil, {}]
-    # else
-    #   query = create_query(controller_model_name.to_sym, pattern:)
-    #   [query, {}]
-    # end
   end
-
-  # If so, redirect to the show page for that object.
-  # def maybe_pattern_is_an_id(pattern)
-  #   if /^\d+$/.match?(pattern)
-  #     return controller_model_name.constantize.safe_find(pattern)
-  #   end
-
-  #   false
-  # end
 
   # Render an index or set of search results as a list or matrix. Arguments:
   # query::         Query instance describing search/index.

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -217,26 +217,31 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     { id: params[:id].to_s, always_index: true }
   end
 
-  # Most pattern searches follow this, um, pattern.
+  # Pattern searches should now hit each controller with a :q param,
+  # after the search is parsed in `SearchController#pattern`.
+  # This is for backwards compatibility with old bookmarks.
   def pattern
     pattern = params[:pattern].to_s
-    if (obj = maybe_pattern_is_an_id(pattern))
-      redirect_to(send(:"#{controller_model_name.underscore}_path", obj.id))
-      [nil, {}]
-    else
-      query = create_query(controller_model_name.to_sym, pattern:)
-      [query, {}]
-    end
+    type = controller_model_name.pluralize.underscore.to_sym
+    redirect_to(search_pattern_path(pattern_search: { pattern:, type: }))
+    # pattern = params[:pattern].to_s
+    # if (obj = maybe_pattern_is_an_id(pattern))
+    #   redirect_to(send(:"#{controller_model_name.underscore}_path", obj.id))
+    #   [nil, {}]
+    # else
+    #   query = create_query(controller_model_name.to_sym, pattern:)
+    #   [query, {}]
+    # end
   end
 
   # If so, redirect to the show page for that object.
-  def maybe_pattern_is_an_id(pattern)
-    if /^\d+$/.match?(pattern)
-      return controller_model_name.constantize.safe_find(pattern)
-    end
+  # def maybe_pattern_is_an_id(pattern)
+  #   if /^\d+$/.match?(pattern)
+  #     return controller_model_name.constantize.safe_find(pattern)
+  #   end
 
-    false
-  end
+  #   false
+  # end
 
   # Render an index or set of search results as a list or matrix. Arguments:
   # query::         Query instance describing search/index.

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,7 +32,7 @@ class CommentsController < ApplicationController
 
   # ApplicationController uses this table to dispatch #index to a private method
   def index_active_params
-    [:target, :pattern, :by_user, :for_user, :by].freeze
+    [:target, :pattern, :by_user, :for_user, :by, :q].freeze
   end
 
   # Shows comments by a given user, most recent first. (Linked from show_user.)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -59,21 +59,6 @@ class LocationsController < ApplicationController
     [nil, {}]
   end
 
-  # Displays a list of locations matching a given string.
-  def pattern
-    pattern = params[:pattern].to_s
-    loc = Location.safe_find(pattern) if /^\d+$/.match?(pattern)
-    if loc
-      redirect_to(location_path(loc.id))
-      [nil, {}]
-    else
-      query = create_query(
-        :Location, pattern: Location.user_format(@user, pattern)
-      )
-      [query, { link_all_sorts: true }]
-    end
-  end
-
   # Displays a list of all locations whose country matches the param.
   def country
     query = create_query(:Location, regexp: "#{params[:country]}$")

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -40,29 +40,6 @@ class NamesController < ApplicationController
     [nil, {}]
   end
 
-  # Display list of names that match a string.
-  # def pattern
-  #   if pattern.match?(/^\d+$/) &&
-  #      (name = Name.safe_find(pattern))
-  #     redirect_to(name_path(name.id))
-  #     [nil, {}]
-  #   else
-  #     return_pattern_search_results(pattern)
-  #   end
-  # end
-
-  # def return_pattern_search_results(pattern)
-  #   # Have to use PatternSearch here to catch invalid PatternSearch terms.
-  #   # Can't just send pattern to Query as create_query(:Observation, pattern:)
-  #   search = PatternSearch::Name.new(pattern)
-  #   return render_pattern_search_error(search) if search.errors.any?
-
-  #   # Call create_query to apply user content filters
-  #   query = create_query(:Name, search.query.params)
-  #   make_name_suggestions(search)
-  #   [query, {}]
-  # end
-
   def make_name_suggestions
     return unless @objects.empty? &&
                   params[:q].is_a?(ActionController::Parameters) &&
@@ -72,20 +49,6 @@ class NamesController < ApplicationController
 
     @name_suggestions = Name.suggest_alternate_spellings(original_spelling)
   end
-
-  # def make_name_suggestions(search)
-  #   alternate_spellings = search.query.params[:pattern]
-  #   return unless alternate_spellings && @objects.empty?
-
-  #   @name_suggestions =
-  #     Name.suggest_alternate_spellings(alternate_spellings)
-  # end
-
-  # def render_pattern_search_error(search)
-  #   search.errors.each { |error| flash_error(error.to_s) }
-  #   render("names/index")
-  #   [nil, {}]
-  # end
 
   # Disabling the cop because subaction methods are going away soon
   # rubocop:disable Naming/PredicatePrefix

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -9,6 +9,7 @@ class NamesController < ApplicationController
   # INDEX
   #
   def index
+    make_name_suggestions
     build_index_with_query
   end
 
@@ -40,42 +41,51 @@ class NamesController < ApplicationController
   end
 
   # Display list of names that match a string.
-  def pattern
-    pattern = params[:pattern].to_s
-    if pattern.match?(/^\d+$/) &&
-       (name = Name.safe_find(pattern))
-      redirect_to(name_path(name.id))
-      [nil, {}]
-    else
-      return_pattern_search_results(pattern)
-    end
+  # def pattern
+  #   if pattern.match?(/^\d+$/) &&
+  #      (name = Name.safe_find(pattern))
+  #     redirect_to(name_path(name.id))
+  #     [nil, {}]
+  #   else
+  #     return_pattern_search_results(pattern)
+  #   end
+  # end
+
+  # def return_pattern_search_results(pattern)
+  #   # Have to use PatternSearch here to catch invalid PatternSearch terms.
+  #   # Can't just send pattern to Query as create_query(:Observation, pattern:)
+  #   search = PatternSearch::Name.new(pattern)
+  #   return render_pattern_search_error(search) if search.errors.any?
+
+  #   # Call create_query to apply user content filters
+  #   query = create_query(:Name, search.query.params)
+  #   make_name_suggestions(search)
+  #   [query, {}]
+  # end
+
+  def make_name_suggestions
+    return unless @objects.empty? &&
+                  params[:q].is_a?(ActionController::Parameters) &&
+                  (original_spelling = params.dig(:q, :pattern))
+
+    return unless original_spelling
+
+    @name_suggestions = Name.suggest_alternate_spellings(original_spelling)
   end
 
-  def return_pattern_search_results(pattern)
-    # Have to use PatternSearch here to catch invalid PatternSearch terms.
-    # Can't just send pattern to Query as create_query(:Observation, pattern:)
-    search = PatternSearch::Name.new(pattern)
-    return render_pattern_search_error(search) if search.errors.any?
+  # def make_name_suggestions(search)
+  #   alternate_spellings = search.query.params[:pattern]
+  #   return unless alternate_spellings && @objects.empty?
 
-    # Call create_query to apply user content filters
-    query = create_query(:Name, search.query.params)
-    make_name_suggestions(search)
-    [query, {}]
-  end
+  #   @name_suggestions =
+  #     Name.suggest_alternate_spellings(alternate_spellings)
+  # end
 
-  def make_name_suggestions(search)
-    alternate_spellings = search.query.params[:pattern]
-    return unless alternate_spellings && @objects.empty?
-
-    @name_suggestions =
-      Name.suggest_alternate_spellings(alternate_spellings)
-  end
-
-  def render_pattern_search_error(search)
-    search.errors.each { |error| flash_error(error.to_s) }
-    render("names/index")
-    [nil, {}]
-  end
+  # def render_pattern_search_error(search)
+  #   search.errors.each { |error| flash_error(error.to_s) }
+  #   render("names/index")
+  #   [nil, {}]
+  # end
 
   # Disabling the cop because subaction methods are going away soon
   # rubocop:disable Naming/PredicatePrefix

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -65,37 +65,6 @@ class ObservationsController
       raise("Query::Observations.advanced_search_params is undefined.")
     end
 
-    # Display matrix of Observations whose notes, etc. match a string pattern.
-    # def pattern
-    #   pattern = params[:pattern].to_s
-    #   if pattern.match?(/^\d+$/) &&
-    #      (observation = Observation.safe_find(pattern))
-    #     redirect_to(permanent_observation_path(observation.id))
-    #   else
-    #     return_pattern_search_results(pattern)
-    #   end
-    # end
-
-    # def return_pattern_search_results(pattern)
-    #   # Have to use PatternSearch here to catch invalid PatternSearch terms.
-    #   # Can't just send pattern to Query as create_query(:Observation, pattern:)
-    #   search = PatternSearch::Observation.new(pattern)
-    #   return render_pattern_search_error(search) if search.errors.any?
-
-    #   # Call create_query to apply user content filters
-    #   query = create_query(:Observation, search.query.params)
-    #   make_name_suggestions(search)
-
-    #   if params[:needs_naming]
-    #     redirect_to(
-    #       identify_observations_path(q: q_param(query))
-    #     )
-    #     [nil, {}]
-    #   else
-    #     [query, {}]
-    #   end
-    # end
-
     # Different from NamesController. Returns arrays of [name, count]
     def make_name_suggestions
       return unless @objects.empty? &&
@@ -109,26 +78,6 @@ class ObservationsController
         [name, count]
       end
     end
-
-    # def make_name_suggestions(search)
-    #   alternate_spellings = search.query.params[:pattern]
-    #   return unless alternate_spellings && @objects.empty?
-
-    #   names = Name.suggest_alternate_spellings(alternate_spellings)
-    #   @name_suggestions = names.sort_by(&:sort_name).map do |name|
-    #     query = Query.create_query(:Observation, pattern: name.text_name)
-    #     count = query.num_results
-    #     [name, count]
-    #   end
-    # end
-
-    # def render_pattern_search_error(search)
-    #   search.errors.each { |error| flash_error(error.to_s) }
-    #   if params[:needs_naming]
-    #     redirect_to(identify_observations_path(q: q_param))
-    #   end
-    #   [nil, {}]
-    # end
 
     # Displays matrix of Observations with the given name proposed but not
     # actually that name.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,7 +21,7 @@ class ProjectsController < ApplicationController
 
   # ApplicationController uses this to dispatch #index to a private method
   def index_active_params
-    [:pattern, :member, :by].freeze
+    [:pattern, :member, :by, :q].freeze
   end
 
   # Display list of projects with a given member, sorted by date.

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -27,15 +27,7 @@ class SearchController < ApplicationController
       flash_and_redirect_invalid_search(type) and return
     end
 
-    # Save it so that we can keep it in the search bar in subsequent pages.
-    session[:pattern] = pattern
-    session[:search_type] = type
-
-    if type == :google
-      site_google_search(pattern)
-    else
-      forward_pattern_search(type, pattern)
-    end
+    save_pattern_and_proceed(type, pattern)
   end
 
   PATTERN_SEARCHABLE_MODELS = [
@@ -55,6 +47,18 @@ class SearchController < ApplicationController
   # controller, which will send it back as a :q.
   #
   private
+
+  def save_pattern_and_proceed(type, pattern)
+    # Save it so that we can keep it in the search bar in subsequent pages.
+    session[:pattern] = pattern
+    session[:search_type] = type
+
+    if type == :google
+      site_google_search(pattern)
+    else
+      forward_pattern_search(type, pattern)
+    end
+  end
 
   def site_google_search(pattern)
     if pattern.blank?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -109,20 +109,27 @@ class SearchController < ApplicationController
   end
 
   def build_query_and_redirect(type, model_name, pattern)
-    # name and obs prevalidate the pattern with PatternSearch instance,
-    # and check for errors defined by PatternSearch.
-    # location alters format of pattern
-    # Finally we can build search and redirect.
+    # :Name and :Observation prevalidate the pattern with a PatternSearch
+    # instance, and check for errors defined by PatternSearch.
+    # :Location checks the user location format of the "pattern".
     query = query_from_pattern(model_name, pattern)
-    if model_name == :Observation && params[:needs_naming]
+
+    # Finally we can redirect.
+    if coming_from_obs_needing_ids?(model_name)
       redirect_to(identify_observations_path(q: query.q_param))
-    elsif query.result_ids.length == 1
+    elsif single_result?(query)
       redirect_to(send(:"#{type.to_s.singularize}_path", query.first_id))
     else
       redirect_to(send(:"#{type}_path", params: { q: query.q_param }))
     end
-    # Name and obs Controllers must dig :q, :pattern to check name suggestions
-    # on main index action.
+  end
+
+  def coming_from_obs_needing_ids?(model_name)
+    model_name == :Observation && params[:needs_naming]
+  end
+
+  def single_result?(query)
+    query.result_ids.length == 1
   end
 
   def query_from_pattern(model_name, pattern)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -41,8 +41,11 @@ class SearchController < ApplicationController
 
   def save_pattern_and_proceed(type, pattern)
     # Save it so that we can keep it in the search bar in subsequent pages.
-    session[:pattern] = pattern
-    session[:search_type] = type
+    # But don't save encoded incoming patterns that are too large.
+    unless pattern.bytesize > 4096
+      session[:pattern] = pattern
+      session[:search_type] = type
+    end
 
     if type == :google
       site_google_search(pattern)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -26,17 +26,6 @@ class SearchController < ApplicationController
     save_pattern_and_proceed(type, pattern)
   end
 
-  # Bring indexes #pattern and #maybe_pattern_is_an_id here
-  # Harmonize methods in Locations, names, obs, users that create query, opts
-  # Figure out what the special cases are, name and make methods
-  #
-  # forward_pattern_search with :q q_param, not :pattern param.
-  # Pattern is already saved in session, so that rehydrates pattern form.
-  # :q will rehydrate search form.
-  #
-  # Make controllers forward :pattern param from existing bookmarks to this
-  # controller, which will send it back as a :q.
-  #
   private
 
   def save_pattern_and_proceed(type, pattern)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,15 @@
 
 # searches defined by the url query string
 class SearchController < ApplicationController
+  # These are plural symbols because the search bar sends them this way.
+  PATTERN_SEARCHABLE_MODELS = [
+    :comments, :glossary_terms, :herbaria, :herbarium_records, :images,
+    :locations, :names, :observations, :projects, :species_lists, :users
+  ].freeze
+
+  # Image advanced search retired in 2021
+  ADVANCED_SEARCHABLE_MODELS = [Location, Name, Observation].freeze
+
   # This is the action the search bar commits to.  It just redirects to one of
   # several "foreign" search actions:
   #   /comments/index (params[:pattern])
@@ -29,11 +38,6 @@ class SearchController < ApplicationController
 
     save_pattern_and_proceed(type, pattern)
   end
-
-  PATTERN_SEARCHABLE_MODELS = [
-    :comments, :glossary_terms, :herbaria, :herbarium_records, :images,
-    :locations, :names, :observations, :projects, :species_lists, :users
-  ].freeze
 
   # Bring indexes #pattern and #maybe_pattern_is_an_id here
   # Harmonize methods in Locations, names, obs, users that create query, opts
@@ -170,9 +174,6 @@ class SearchController < ApplicationController
   end
 
   public
-
-  # Image advanced search retired in 2021
-  ADVANCED_SEARCHABLE_MODELS = [Location, Name, Observation].freeze
 
   # Advanced search form.  When it posts it just redirects to one of several
   # "foreign" search actions:

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,21 +11,8 @@ class SearchController < ApplicationController
   # Image advanced search retired in 2021
   ADVANCED_SEARCHABLE_MODELS = [Location, Name, Observation].freeze
 
-  # This is the action the search bar commits to.  It just redirects to one of
-  # several "foreign" search actions:
-  #   /comments/index (params[:pattern])
-  #   /glossary_terms/index (params[:pattern])
-  #   /herbaria/index (params[:pattern])
-  #   /herbarium_records/index (params[:pattern])
-  #   /images/index (params[:pattern])
-  #   /locations/index (params[:pattern])
-  #   /names/index (params[:pattern])
-  #   /observations/index (params[:pattern])
-  #   /projects/index (params[:pattern])
-  #   /species_lists/index (params[:pattern])
-  #   /users/index (params[:pattern])
-  #   /project/project_search
-  #   /species_lists/index
+  # This is the action the search bar commits to.
+  # It creates a query and forwards that to the appropriate index as :q.
   def pattern
     pattern = params.dig(:pattern_search, :pattern).to_s.strip_squeeze
     type = params.dig(:pattern_search, :type)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -69,8 +69,8 @@ class SearchController < ApplicationController
     end
   end
 
-  # Convert pattern into :q here, so we hit the index with a standard permalink.
-  # In the case of "needs_naming", this is added to the search path params?
+  # Convert pattern into :q here, so we hit the index with a standard permalink
+  # and have a saved query that we can refine in a search form.
   def forward_pattern_search(type, pattern)
     model_name = type.to_s.singularize.camelize.to_sym
 
@@ -141,7 +141,7 @@ class SearchController < ApplicationController
     when :Observation, :Name
       pattern_search_query_from_pattern(model_name, pattern)
     when :Location
-      send(:"#{model_name.to_s.underscore}_query_from_pattern", pattern)
+      location_query_from_pattern(pattern)
     else
       create_query(model_name, pattern:)
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -68,12 +68,12 @@ class SearchController < ApplicationController
   # Convert pattern into :q here, so we hit the index with a standard permalink.
   # In the case of "needs_naming", this is added to the search path params?
   def forward_pattern_search(type, pattern)
-    model_name = type.to_s.singularize.titleize.to_sym
+    model_name = type.to_s.singularize.camelize.to_sym
 
     if pattern.blank?
       redirect_to(send(:"#{type}_path"))
     elsif (obj = exact_match(model_name, pattern))
-      redirect_to(send(:"#{model_name.underscore}_path", obj.id))
+      redirect_to(send(:"#{type.to_s.singularize}_path", obj.id))
     else
       build_query_and_redirect(type, model_name, pattern)
     end
@@ -102,7 +102,7 @@ class SearchController < ApplicationController
 
   def maybe_pattern_is_an_id(model_name, pattern)
     if /^\d+$/.match?(pattern)
-      return model_name.constantize.safe_find(pattern)
+      return model_name.to_s.constantize.safe_find(pattern)
     end
 
     false
@@ -128,9 +128,9 @@ class SearchController < ApplicationController
     when :Observation, :Name
       pattern_search_query_from_pattern(model_name, pattern)
     when :Location
-      send(:"#{model_name.underscore}_query_from_pattern", pattern)
+      send(:"#{model_name.to_s.underscore}_query_from_pattern", pattern)
     else
-      create_query(model_name.to_sym, pattern:)
+      create_query(model_name, pattern:)
     end
   end
 

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -76,18 +76,6 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_flash_text(/no matching collection numbers found/i)
   end
 
-  def test_index_pattern_str_matching_one_collection_number
-    numbers = CollectionNumber.where("name like '%neighbor%'")
-    assert_equal(1, numbers.count)
-
-    login
-    get(:index, params: { pattern: "neighbor" })
-
-    assert_redirected_to(collection_number_path(id: numbers.first.id))
-    assert_no_flash
-    assert_session_query_record_is_correct
-  end
-
   def test_index_pattern_str_matching_multiple_collection_numbers
     pattern = "Singer"
     numbers = CollectionNumber.where(CollectionNumber[:name] =~ pattern)
@@ -95,7 +83,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
            "Test needs a pattern matching many collection numbers")
 
     login
-    get(:index, params: { pattern: pattern })
+    get(:index, params: { q: { model: :CollectionNumber, pattern: pattern } })
 
     assert_response(:success)
     assert_page_title(:COLLECTION_NUMBERS.l)
@@ -104,15 +92,6 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     # a show link, and (because logged in user created the numbers)
     # an edit link
     assert_equal(numbers.count * 2, collection_number_links.count)
-  end
-
-  def test_index_pattern_number_matching_one_collection_number
-    number = collection_numbers(:minimal_unknown_coll_num).id
-
-    login
-    get(:index, params: { pattern: number })
-
-    assert_redirected_to(collection_number_path(number))
   end
 
   def collection_number_links

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -62,15 +62,6 @@ class CommentsControllerTest < FunctionalTestCase
                                          value: params[:type].to_s))
   end
 
-  def test_index_pattern_id
-    id = comments(:fungi_comment).id
-
-    login
-    get(:index, params: { pattern: id })
-
-    assert_redirected_to(comment_path(id))
-  end
-
   def test_index_pattern_search_str
     search_str = "Let's"
     assert(comments(:minimal_unknown_obs_comment_2).summary.

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -63,16 +63,16 @@ class CommentsControllerTest < FunctionalTestCase
   end
 
   def test_index_pattern_search_str
-    search_str = "Let's"
+    pattern = "Let's"
     assert(comments(:minimal_unknown_obs_comment_2).summary.
-           start_with?(search_str),
+           start_with?(pattern),
            "Search string must have a hit in Comment fixtures")
 
     login
-    get(:index, params: { pattern: search_str })
+    get(:index, params: { q: { model: :Comment, pattern: } })
 
     assert_page_title(:COMMENTS.l)
-    assert_displayed_filters("#{:query_pattern.l}: #{search_str}")
+    assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
   end
 
   def test_index_by_user_who_created_one_comment

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -45,19 +45,17 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     )
   end
 
+  def q_pattern(pattern)
+    { q: { model: :GlossaryTerm, pattern: } }
+  end
+
   def test_glossary_term_search
     conic = glossary_terms(:conic_glossary_term)
     convex = glossary_terms(:convex_glossary_term)
 
-    get(:index, params: { pattern: "conic" })
-    assert_redirected_to(glossary_term_path(conic.id))
-    assert_session_query_record_is_correct
-
-    get(:index, params: { pattern: conic.id })
-    assert_redirected_to(glossary_term_path(conic.id))
-
     login
-    get(:index, params: { pattern: "con" })
+    get(:index, params: q_pattern("con"))
+    assert_session_query_record_is_correct
     assert_template("index")
     assert_select(
       "a[href*='glossary_terms/#{conic.id}']", text: conic.name

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -296,7 +296,7 @@ class HerbariaControllerTest < FunctionalTestCase
     pattern = "Personal Herbarium"
 
     login
-    get(:index, params: { pattern: pattern })
+    get(:index, params: { q: { model: Herbarium, pattern: pattern } })
 
     assert_page_title(:HERBARIA.l)
     assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
@@ -314,16 +314,6 @@ class HerbariaControllerTest < FunctionalTestCase
         "#{herbarium.format_name})"
       )
     end
-  end
-
-  def test_index_pattern_integer
-    login
-    get(:index, params: { pattern: nybg.id })
-
-    assert_redirected_to(
-      herbarium_path(nybg),
-      "Herbarium search for ##{nybg.id} should show #{nybg.name} herbarium"
-    )
   end
 
   def test_index_reverse_records

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -38,23 +38,13 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     pattern = "Coprinus comatus"
 
     login
-    get(:index, params: { pattern: pattern })
+    get(:index, params: { q: { model: :HerbariumRecord, pattern: pattern } })
 
     assert_response(:success)
     assert_page_title(:HERBARIUM_RECORDS.l)
     assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
     # In results, expect 1 row per herbarium_record
     assert_select("#results tr", 2)
-  end
-
-  def test_index_pattern_with_one_matching_record
-    record = herbarium_records(:interesting_unknown)
-
-    login
-    get(:index, params: { pattern: record.id })
-
-    assert_redirected_to(herbarium_record_path(record.id))
-    assert_no_flash
   end
 
   def test_index_herbarium_id_with_multiple_records

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -84,11 +84,15 @@ class ImagesControllerTest < FunctionalTestCase
     )
   end
 
+  def q_pattern(pattern)
+    { model: :Image, pattern: }
+  end
+
   def test_index_pattern_text_multiple_hits
     pattern = "USA"
 
     login
-    get(:index, params: { pattern: pattern })
+    get(:index, params: { q: q_pattern(pattern) })
 
     assert_template("index", partial: "_image")
     assert_page_title(:IMAGES.l)
@@ -99,19 +103,10 @@ class ImagesControllerTest < FunctionalTestCase
     pattern = "nothingMatchesAxotl"
 
     login
-    get(:index, params: { pattern: pattern })
+    get(:index, params: { q: q_pattern(pattern) })
 
     assert_flash_text(:runtime_no_matches.l(type: :images.l))
     assert_template("index")
-  end
-
-  def test_index_pattern_image_id
-    image = images(:commercial_inquiry_image)
-
-    login
-    get(:index, params: { pattern: image.id })
-
-    assert_redirected_to(image_path(image))
   end
 
   def test_show_image

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -85,14 +85,15 @@ class ImagesControllerTest < FunctionalTestCase
   end
 
   def q_pattern(pattern)
-    { model: :Image, pattern: }
+    { q: { model: :Image, pattern: } }
   end
 
   def test_index_pattern_text_multiple_hits
     pattern = "USA"
+    params = q_pattern(pattern)
 
     login
-    get(:index, params: { q: q_pattern(pattern) })
+    get(:index, params:)
 
     assert_template("index", partial: "_image")
     assert_page_title(:IMAGES.l)
@@ -101,9 +102,10 @@ class ImagesControllerTest < FunctionalTestCase
 
   def test_index_pattern_text_no_hits
     pattern = "nothingMatchesAxotl"
+    params = q_pattern(pattern)
 
     login
-    get(:index, params: { q: q_pattern(pattern) })
+    get(:index, params:)
 
     assert_flash_text(:runtime_no_matches.l(type: :images.l))
     assert_template("index")

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -72,6 +72,18 @@ class ImagesControllerTest < FunctionalTestCase
     assert_redirected_to(search_advanced_path)
   end
 
+  # The pattern param is maintained only for backwards compatibility.
+  # Should redirect to SearchController#pattern
+  def test_index_pattern_param_redirected_to_search
+    pattern = "USA"
+
+    login
+    get(:index, params: { pattern: pattern })
+    assert_redirected_to(
+      search_pattern_path(pattern_search: { pattern:, type: :images })
+    )
+  end
+
   def test_index_pattern_text_multiple_hits
     pattern = "USA"
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -250,12 +250,12 @@ class LocationsControllerTest < FunctionalTestCase
     assert_redirected_to(search_advanced_path)
   end
 
-  def test_index_pattern
+  def test_index_pattern_multiple_hits
     search_str = "California"
     matches = Location.where(Location[:name].matches("%#{search_str}%"))
 
     login
-    get(:index, params: { pattern: search_str })
+    get(:index, params: { q: { model: :Location, pattern: search_str } })
 
     assert_select(
       "#content a:match('href', ?)", %r{#{locations_path}/\d+},
@@ -263,14 +263,6 @@ class LocationsControllerTest < FunctionalTestCase
     )
     assert_page_title(:LOCATIONS.l)
     assert_displayed_filters("#{:query_pattern.l}: #{search_str}")
-  end
-
-  def test_index_pattern_id
-    loc = locations(:salt_point)
-
-    login
-    get(:index, params: { pattern: loc.id.to_s })
-    assert_redirected_to(location_path(loc.id))
   end
 
   def test_index_country

--- a/test/controllers/names_controller_index_test.rb
+++ b/test/controllers/names_controller_index_test.rb
@@ -171,41 +171,6 @@ class NamesControllerIndexTest < FunctionalTestCase
     )
   end
 
-  # def test_index_pattern_id
-  #   id = names(:agaricus).id
-
-  #   login
-  #   get(:index, params: { pattern: id })
-
-  #   assert_redirected_to(name_path(id))
-  # end
-
-  # def test_index_pattern_help
-  #   pattern = "help:me"
-  #   login
-  #   get(:index, params: { q: q_pattern(pattern) })
-
-  #   assert_match(/unexpected term/i, css_select("#flash_notices").text)
-  # end
-
-  # # It's not getting near_misses
-  # def test_index_pattern_near_miss
-  #   near_miss_pattern = "agaricis campestrus"
-  #   assert_empty(
-  #     Name.with_correct_spelling.where(search_name: near_miss_pattern),
-  #     "Test needs a pattern without a correctly spelled exact match"
-  #   )
-  #   near_misses = Name.with_correct_spelling.
-  #                 where(Name[:search_name] =~ /agaric.s campestr.s/)
-
-  #   login
-  #   get(:index, params: { pattern: near_miss_pattern })
-  #   near_misses.each do |near_miss|
-  #     assert_select("#results a[href*='names/#{near_miss.id}'] .display-name",
-  #                   text: near_miss.search_name)
-  #   end
-  # end
-
   def test_index_has_observations
     login
     get(:index, params: { has_observations: true })

--- a/test/controllers/names_controller_index_test.rb
+++ b/test/controllers/names_controller_index_test.rb
@@ -141,7 +141,7 @@ class NamesControllerIndexTest < FunctionalTestCase
   end
 
   def q_pattern(pattern)
-    { model: :Name, pattern: }
+    { q: { model: :Name, pattern: } }
   end
 
   # The pattern param is maintained only for backwards compatibility.
@@ -158,9 +158,10 @@ class NamesControllerIndexTest < FunctionalTestCase
 
   def test_index_pattern_multiple_hits
     pattern = "Agaricus"
+    params = q_pattern(pattern)
 
     login
-    get(:index, params: { q: q_pattern(pattern) })
+    get(:index, params:)
     assert_page_title(:NAMES.l)
     assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
     assert_select(

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -296,21 +296,26 @@ class ObservationsControllerIndexTest < FunctionalTestCase
   end
 
   def q_pattern(pattern)
-    { model: :Observation, pattern: }
+    { q: { model: :Observation, pattern: } }
   end
 
-  def test_index_pattern_multiple_hits
-    pattern = "Agaricus"
-
-    setup_rolfs_index
-    get(:index, params: {
+  def q_name_params(pattern)
+    {
       q: {
         model: :Observation,
         names: {
           lookup: pattern, include_synonyms: true, include_subtaxa: true
         }
       }
-    })
+    }
+  end
+
+  def test_index_pattern_multiple_hits
+    pattern = "Agaricus"
+    params = q_name_params(pattern)
+
+    setup_rolfs_index
+    get(:index, params:)
 
     # Pattern search guesses this is a name query
     assert_page_title(:OBSERVATIONS.l)
@@ -322,16 +327,10 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
   def test_index_pattern1
     pattern = "Boletus edulis"
+    params = q_name_params(pattern)
 
     setup_rolfs_index
-    get(:index, params: {
-      q: {
-        model: :Observation,
-        names: {
-          lookup: pattern, include_synonyms: true, include_subtaxa: true
-        }
-      }
-    })
+    get(:index, params:)
 
     # Pattern search guesses this is a name query
     assert_page_title(:OBSERVATIONS.l)
@@ -344,17 +343,10 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
   def test_index_pattern_page2
     pattern = "Boletus edulis"
+    params = q_name_params(pattern).merge(page: 2)
 
     login
-    get(:index, params: {
-      q: {
-        model: :Observation,
-        names: {
-          lookup: pattern, include_synonyms: true, include_subtaxa: true
-        }
-      },
-      page: 2
-    })
+    get(:index, params:)
 
     # Pattern search guesses this is a name query
     assert_page_title(:OBSERVATIONS.l)
@@ -367,17 +359,11 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
   def test_index_filter_display_is_concise
     pattern = "Agrocybe arvalis" # There are two
+    params = q_name_params(pattern)
 
     setup_rolfs_index
     # This is what search_controller sends for that pattern:
-    get(:index, params: {
-      q: {
-        model: :Observation,
-        names: {
-          lookup: pattern, include_synonyms: true, include_subtaxa: true
-        }
-      }
-    })
+    get(:index, params:)
     assert_page_title(:OBSERVATIONS.l)
     assert_displayed_filters("#{:query_names.l}: #{pattern}")
 
@@ -396,9 +382,10 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
   def test_index_pattern_no_hits
     pattern = "no hits"
+    params = q_pattern(pattern)
 
     login
-    get(:index, params: { q: q_pattern(pattern) })
+    get(:index, params:)
 
     assert_empty(css_select('[id="context_nav"]').text,
                  "RH tabset should be empty when search has no hits")

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -208,28 +208,10 @@ class ProjectsControllerTest < FunctionalTestCase
     pattern = "Project"
 
     login
-    get(:index, params: { pattern: "Project" })
+    get(:index, params: { q: { model: :Project, pattern: } })
 
     assert_page_title(:PROJECTS.l)
     assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
-  end
-
-  def test_index_pattern_search_by_name_one_hit
-    project = projects(:bolete_project)
-
-    login
-    get(:index, params: { pattern: "Bolete Project" })
-
-    assert_redirected_to(project_path(project.id))
-    assert_session_query_record_is_correct
-  end
-
-  def test_index_pattern_search_by_id
-    project = projects(:bolete_project)
-
-    login
-    get(:index, params: { pattern: project.id.to_s })
-    assert_redirected_to(project_path(project.id))
   end
 
   def test_add_project

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -192,12 +192,11 @@ class SearchControllerTest < FunctionalTestCase
 
   def test_pattern_search_from_needs_naming
     pattern = "Briceland"
+    params = { pattern_search: { pattern:, type: :observations },
+               needs_naming: rolf }
 
     login
-    get(:pattern, params: {
-      pattern_search: { pattern:, type: :observations },
-      needs_naming: rolf
-    })
+    get(:pattern, params:)
 
     assert_redirected_to(
       identify_observations_path(q: { model: :Observation, pattern: }),
@@ -208,12 +207,11 @@ class SearchControllerTest < FunctionalTestCase
 
   def test_pattern_search_from_needs_naming_bad_pattern
     pattern = { error: "" }
+    params = { pattern_search: { pattern:, type: :observations },
+               needs_naming: rolf }
 
     login
-    get(:pattern, params: {
-      pattern_search: { pattern:, type: :observations },
-      needs_naming: rolf
-    })
+    get(:pattern, params:)
 
     assert_redirected_to(
       identify_observations_path(q: { model: :Observation }),

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -96,47 +96,65 @@ class SearchControllerTest < FunctionalTestCase
     login
     params = { pattern_search: { pattern: "12", type: :observations } }
     get(:pattern, params: params)
-    assert_redirected_to(observations_path(pattern: "12"))
+    assert_redirected_to(
+      observations_path(q: { model: :Observation, pattern: "12" })
+    )
     assert_equal(:observations, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "34", type: :images } }
     get(:pattern, params: params)
-    assert_redirected_to(images_path(pattern: "34"))
+    assert_redirected_to(
+      images_path(q: { model: :Image, pattern: "34" })
+    )
     assert_equal(:images, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "56", type: :names } }
     get(:pattern, params: params)
-    assert_redirected_to(names_path(pattern: "56"))
+    assert_redirected_to(
+      names_path(q: { model: :Name, pattern: "56" })
+    )
     assert_equal(:names, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "78", type: :locations } }
     get(:pattern, params: params)
-    assert_redirected_to(locations_path(pattern: "78"))
+    assert_redirected_to(
+      locations_path(q: { model: :Location, pattern: "78" })
+    )
     assert_equal(:locations, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "90", type: :comments } }
     get(:pattern, params: params)
-    assert_redirected_to(comments_path(pattern: "90"))
+    assert_redirected_to(
+      comments_path(q: { model: :Comment, pattern: "90" })
+    )
     assert_equal(:comments, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "21", type: :projects } }
     get(:pattern, params: params)
-    assert_redirected_to(projects_path(pattern: "21"))
+    assert_redirected_to(
+      projects_path(q: { model: :Project, pattern: "21" })
+    )
     assert_equal(:projects, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "12", type: :species_lists } }
     get(:pattern, params: params)
-    assert_redirected_to(species_lists_path(pattern: "12"))
+    assert_redirected_to(
+      species_lists_path(q: { model: :SpeciesList, pattern: "12" })
+    )
     assert_equal(:species_lists, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "34", type: :users } }
     get(:pattern, params: params)
-    assert_redirected_to(users_path(pattern: "34"))
+    assert_redirected_to(
+      users_path(q: { model: :User, pattern: "34" })
+    )
     assert_equal(:users, @request.session[:search_type])
 
     params = { pattern_search: { pattern: "34", type: :glossary_terms } }
     get(:pattern, params: params)
-    assert_redirected_to(glossary_terms_path(pattern: "34"))
+    assert_redirected_to(
+      glossary_terms_path(q: { model: :GlossaryTerm, pattern: "34" })
+    )
     assert_equal(:glossary_terms, @request.session[:search_type])
 
     stub_request(:any, /google.com/)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -92,6 +92,17 @@ class SearchControllerTest < FunctionalTestCase
     assert_equal("", query.params[:clade])
   end
 
+  # This permalink caused a server error when setting session[:pattern] without
+  # checking bytesize.
+  def test_pattern_search_long_permalink_pattern
+    pattern = "created%3A2006-2024+has_observations%3A1+" \
+              "has_classification%3A1+has_notes%3A%22yes%22+has_comments%3A1"
+    params = { pattern_search: { pattern:, type: :names } }
+
+    get(:pattern, params:)
+    assert_redirected_to(names_path(q: { model: :Name, pattern: }))
+  end
+
   def test_pattern_search_redirects_to_controllers_with_q
     login
 

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -132,7 +132,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     pattern = "query"
 
     login
-    get(:index, params: { pattern: pattern })
+    get(:index, params: { q: { model: :SpeciesList, pattern: } })
 
     assert_response(:success)
     assert_page_title(:SPECIES_LISTS.l)
@@ -141,29 +141,6 @@ class SpeciesListsControllerTest < FunctionalTestCase
       "#content a:match('href', ?)", %r{^#{species_lists_path}/\d+},
       { count: SpeciesList.where(SpeciesList[:title] =~ pattern).count },
       "Wrong number of results"
-    )
-  end
-
-  def test_index_pattern_id
-    spl = species_lists(:unknown_species_list)
-
-    login
-    get(:index, params: { pattern: spl.id })
-
-    assert_redirected_to(species_list_path(spl.id))
-  end
-
-  def test_index_pattern_one_hit
-    pattern = "mysteries"
-
-    login
-    get(:index, params: { pattern: pattern })
-
-    assert_response(:redirect)
-    assert_match(
-      species_list_path(species_lists(:unknown_species_list)),
-      redirect_to_url,
-      "Wrong page"
     )
   end
 

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -174,7 +174,7 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
            "expected 2 Images in Observation, got #{image_count}")
   end
 
-  def test_search
+  def test_search_names
     login
 
     # Search for a name.  (Only one.)
@@ -183,24 +183,38 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     within("#pattern_search_form") { click_button("Search") }
     assert_match(names(:coprinus_comatus).text_name,
                  page.title, "Wrong page")
+  end
+
+  def test_search_observations
+    login
 
     # Search for observations of that name.  (Only one.)
+    fill_in("pattern_search_pattern", with: "Coprinus comatus")
     select("Observations", from: "pattern_search_type")
     within("#pattern_search_form") { click_button("Search") }
     assert_match(/#{observations(:coprinus_comatus_obs).id}/,
                  page.title, "Wrong page")
+  end
 
-    # Image pattern searches temporarily disabled for performamce
-    # 2021-09-12 JDC
-    # Search for images of the same thing.  (Still only one.)
-    # select("Images", from: "pattern_search_type")
-    # within("#pattern_search_form") { click_button("Search") }
-    # assert_match(
-    #   %r{^/image/show_image/#{images(:connected_coprinus_comatus_image).id}},
-    #   current_fullpath
-    # )
+  # Image pattern searches temporarily disabled for performamce
+  # 2021-09-12 JDC
+  # def test_search_images
+  #   login
+
+  #   # Search for images of the same thing.  (Still only one.)
+  #   select("Images", from: "pattern_search_type")
+  #   within("#pattern_search_form") { click_button("Search") }
+  #   assert_match(
+  #     %r{^/image/show_image/#{images(:connected_coprinus_comatus_image).id}},
+  #     current_fullpath
+  #   )
+  # end
+
+  def test_search_locations
+    login
 
     # There should be no locations of that name, though.
+    fill_in("pattern_search_pattern", with: "Coprinus comatus")
     select("Locations", from: "pattern_search_type")
     within("#pattern_search_form") { click_button("Search") }
     assert_match("Locations", page.title, "Wrong page")
@@ -221,7 +235,7 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
            "Found these: #{labels.inspect}")
   end
 
-  def test_search_from_obs_needing_ids
+  def test_search_observations_from_obs_needing_ids
     login
 
     visit("/observations/identify")

--- a/test/integration/capybara/names_integration_test.rb
+++ b/test/integration/capybara/names_integration_test.rb
@@ -84,12 +84,12 @@ class NamesIntegrationTest < CapybaraIntegrationTestCase
     assert_nil(good_name.synonym_id)
   end
 
-  def test_name_pattern_search_with_near_miss_corrected
-    near_miss_pattern = "agaricis campestrus"
+  def test_name_pattern_search_with_correctable_pattern
+    correctable_pattern = "agaricis campestrus"
 
     login
     visit("/")
-    fill_in("pattern_search_pattern", with: near_miss_pattern)
+    fill_in("pattern_search_pattern", with: correctable_pattern)
     page.select("Names", from: :pattern_search_type)
     within("#pattern_search_form") { click_button("Search") }
 
@@ -97,6 +97,10 @@ class NamesIntegrationTest < CapybaraIntegrationTestCase
                     text: "Maybe you meant one of the following names?")
 
     corrected_pattern = "Agaricus"
+    name = names(:agaricus_campestris)
+    assert_selector("#content a[href *= 'names/#{name.id}']",
+                    text: name.search_name)
+    assert_selector("#content div.alert-warning", text: corrected_pattern)
 
     fill_in("pattern_search_pattern", with: corrected_pattern)
     page.select("Names", from: :pattern_search_type)

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -187,20 +187,6 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("#title", text: "#{obs.id} #{obs.name.search_name}")
   end
 
-  # I don't understand this test. There's no way to enter a hash in the form.
-  # def test_observation_pattern_search_with_bad_pattern
-  #   pattern = { error: "" }
-
-  #   login
-  #   visit("/")
-  #   fill_in("pattern_search_pattern", with: pattern)
-  #   page.select("Observations", from: :pattern_search_type)
-  #   within("#pattern_search_form") { click_button("Search") }
-
-  #   assert_selector("#flash_notices div.alert-warning")
-  #   assert_selector("#results", { text: "" }, "There should be no results")
-  # end
-
   # Tests of show_name_helper module
   # Prove that all these links appear under "Observations of"
   def test_links_to_observations_of

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -170,12 +170,13 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
                     text: :runtime_no_matches.l(type: :observations.l))
     assert_match("Observations", page.title)
     assert_selector("#results", text: "")
+
+    corrected_pattern = "Agaricus campestris"
     assert_selector(
       "#content a[href *= 'observations?pattern=Agaricus+campestris']",
       text: names(:agaricus_campestris).search_name
     )
-
-    corrected_pattern = "Agaricus campestris"
+    assert_selector("#content div.alert-warning", text: corrected_pattern)
     obs = observations(:agaricus_campestris_obs)
 
     fill_in("pattern_search_pattern", with: corrected_pattern)
@@ -185,6 +186,20 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     assert_no_selector("#content div.alert-warning")
     assert_selector("#title", text: "#{obs.id} #{obs.name.search_name}")
   end
+
+  # I don't understand this test. There's no way to enter a hash in the form.
+  # def test_observation_pattern_search_with_bad_pattern
+  #   pattern = { error: "" }
+
+  #   login
+  #   visit("/")
+  #   fill_in("pattern_search_pattern", with: pattern)
+  #   page.select("Observations", from: :pattern_search_type)
+  #   within("#pattern_search_form") { click_button("Search") }
+
+  #   assert_selector("#flash_notices div.alert-warning")
+  #   assert_selector("#results", { text: "" }, "There should be no results")
+  # end
 
   # Tests of show_name_helper module
   # Prove that all these links appear under "Observations of"


### PR DESCRIPTION
This changes the `SearchController#pattern` action so that instead of forwarding the `:pattern` param to the appropriate controller index, it builds the query for the pattern (converting keywords to query params, for Name and Observation) and forwards the resulting `:q` param to the index. 

To do this, it moves all the logic for the `pattern` index param handler into `SearchController` and DRY's it quite a bit. To maintain backwards compatibility with existing `?pattern=foo` permalinks, `ApplicationController::Indexes` now forwards all incoming `:pattern` params to `SearchController`, which turns them into queries and sends them back to the appropriate controller. 

(Note: this makes it necessary to move some pattern search tests into integration tests, because while you can test a `:q` param with a `pattern` sub-param in a controller test, you can't test the `pattern` param, because it redirects to another controller.)

The idea here is to have search-bar pattern searches produce and save a query that can populate a faceted search form, if opened, and be further refined. For example, if somebody went to the trouble to search for a name at a location in a project, escaping their commas and everything, in the search bar, and then suddenly discovers the new search forms, they will find all their (valid) search params are already filled in the form. :)

A side-effect is this standardizes the format of search permalinks around the `:q` param. `?pattern=bar` permalinks will no longer be produced by the search bar, although they will still be parsed and processed.

Because the pattern is saved in the session, the search bar separately remembers the last search pattern entered there.