### PR TITLE
Fix some NAMA related issues

### DIFF
--- a/app/controllers/add_dispatch_controller.rb
+++ b/app/controllers/add_dispatch_controller.rb
@@ -37,7 +37,6 @@ class AddDispatchController < ApplicationController
   end
 
   def find_code(project, code)
-    trace_tests
     return nil if code.blank?
     return code unless code[0].match?(/\d/)
     return "#{project.field_slip_prefix}-#{code}" if project

--- a/app/controllers/add_dispatch_controller.rb
+++ b/app/controllers/add_dispatch_controller.rb
@@ -32,8 +32,10 @@ class AddDispatchController < ApplicationController
     project = Project.safe_find(params[:project])
     return project if project
 
-    species_list = find_species_list
-    species_list&.projects&.first
+    projects = find_species_list&.projects
+    return nil unless projects
+
+    projects.where.not(field_slip_prefix: nil).first
   end
 
   def find_code(project, code)

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -117,7 +117,7 @@ class FieldSlip < AbstractModel
   def collector
     return observation.collector if observation&.collector
 
-    (user || @current_user).textile_name
+    (user || @current_user).unique_text_name
   end
 
   def date

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -257,7 +257,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def is_collector?(user)
-    user && notes[:Collector] == user.textile_name
+    user && notes[:Collector]&.include?("_user #{user.login}_")
   end
 
   def project_admin?(user = User.current)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -441,7 +441,11 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def textile_name
-    "_user #{login}_"
+    if name.blank?
+      "_user #{login}_"
+    else
+      "#{name} (_user #{login}_)"
+    end
   end
 
   def self.lookup_unique_text_name(str)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2902,6 +2902,8 @@
   field_slips_too_many_field_slips: You have requested more than [MAX] slips.
   field_slips_one_per_page: One field slip per page. Print shops prefer this. Otherwise 6/page which works best on US letter page.
 
+  bad_dispatch_code: Unable to interpret code, [code]
+
   # Project Aliases
   project_alias_created: Field slip was successfully created.
   project_alias_destroyed: Field slip was successfully destroyed.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2902,7 +2902,7 @@
   field_slips_too_many_field_slips: You have requested more than [MAX] slips.
   field_slips_one_per_page: One field slip per page. Print shops prefer this. Otherwise 6/page which works best on US letter page.
 
-  bad_dispatch_code: Unable to interpret code, [code]
+  bad_dispatch_code: Unable to interpret Field Slip code, [code]
 
   # Project Aliases
   project_alias_created: Field slip was successfully created.

--- a/test/controllers/add_dispatch_controller_test.rb
+++ b/test/controllers/add_dispatch_controller_test.rb
@@ -204,4 +204,41 @@ class AddDispatchControllerTest < FunctionalTestCase
     get(:new, params: { project: 999_999 })
     assert_redirected_to(new_observation_path)
   end
+
+  # Test project implied by species_list
+  def test_species_list_with_project
+    spl = species_lists(:unknown_species_list)
+    prefix = spl.projects.first.field_slip_prefix
+    field_slip = "123"
+    get(:new, params: {
+          object_type: "SpeciesList",
+          object_id: spl,
+          field_slip:
+        })
+
+    expected_url = "#{MO.http_domain}/qr/#{prefix}-#{field_slip}"
+    expected_params = "project=#{@project.id}&species_list=#{spl.id}"
+    expected_full_url = "#{expected_url}?#{expected_params}"
+
+    assert_redirected_to(expected_full_url)
+  end
+
+  # Test species_list without project
+  def test_species_list_without_project
+    spl = species_lists(:first_species_list)
+    field_slip = "123"
+    get(:new, params: {
+          object_type: "SpeciesList",
+          object_id: spl,
+          field_slip:
+        })
+
+    expected_url = new_observation_path
+    expected_params = "species_list=#{spl.id}"
+    expected_full_url = "#{expected_url}?#{expected_params}"
+
+    assert_redirected_to(expected_full_url)
+
+    assert_flash_warning(:bad_dispatch_code.t(code: field_slip))
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -219,3 +219,8 @@ ann_user:
 inat_importer:
   <<: *DEFAULTS
   keep_filenames: <%= User.keep_filenames[:keep_and_show] %>
+
+nihilist_user:
+  <<: *DEFAULTS
+  login: Nil
+  name: <%= nil %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -223,4 +223,4 @@ inat_importer:
 nihilist_user:
   <<: *DEFAULTS
   login: Nil
-  name: <%= nil %>
+  name: ""

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -599,4 +599,9 @@ class UserTest < UnitTestCase
       assert_equal(user, User.lookup_unique_text_name(user.unique_text_name))
     end
   end
+
+  def test_nihilist
+    user = users(:nihilist_user)
+    assert(user.textile_name.include?(user.login))
+  end
 end


### PR DESCRIPTION
- Fix bug with using only field slip numbers in a species list.

To test, go to a species lists and enter just a number in the Field Slip edit text.  Click Add.
If the species list has one (or more) Projects with a field slip prefix, then it should go ahead and do the usual Field Slip thing using one of those prefixes.  The cases where there would be more than one should be rare, so the code just picks the first one.
If the species list doesn't have a Project with a field slip, then it generates a flash message and goes to the create observation workflow.

- Include User.name in the textile version of a User.
Setting the name in a field slip should now include User.name in any relevant fields (when there is a name exists).