### PR TITLE
Fix pattern search keyword "cookie overflow" crashing bug

### DIFF
--- a/app/classes/pattern_search/base.rb
+++ b/app/classes/pattern_search/base.rb
@@ -3,30 +3,30 @@
 module PatternSearch
   # Base class for PatternSearch; handles everything plus build_query
   class Base
-    attr_accessor :errors, :parser, :args, :query
+    attr_accessor :errors, :parser, :query_params, :query
 
     def initialize(string)
       self.errors = []
       self.parser = PatternSearch::Parser.new(string)
       build_query
-      real_model = model.name.to_sym
-      if args.include?(:pattern) && real_model == :Name
-        pat = args[:pattern]
-        args[:pattern] = ::Name.parse_name(pat)&.search_name || pat
+      model_symbol = model.name.to_sym
+      if query_params.include?(:pattern) && model_symbol == :Name
+        pat = query_params[:pattern]
+        query_params[:pattern] = ::Name.parse_name(pat)&.search_name || pat
       end
-      self.query = Query.lookup(real_model, args)
+      self.query = Query.lookup(model_symbol, query_params)
     rescue Error => e
       errors << e
     end
 
     def build_query
-      self.args = {}
+      self.query_params = {}
       parser.terms.each do |term|
         if term.var == :pattern
-          args[:pattern] = term.parse_pattern
+          query_params[:pattern] = term.parse_pattern
         elsif (param = lookup_param(term.var))
           query_param, parse_method = param
-          args[query_param] = term.send(parse_method)
+          query_params[query_param] = term.send(parse_method)
         else
           raise(
             PatternSearch::BadTermError.new(term: term,
@@ -44,18 +44,21 @@ module PatternSearch
       lookup, include_subtaxa, include_synonyms,
       include_immediate_subtaxa, exclude_original_names,
       include_all_name_proposals, exclude_consensus =
-        args.values_at(:names, *modifiers)
+        query_params.values_at(:names, *modifiers)
       names = { lookup:, include_subtaxa:, include_synonyms:,
                 include_immediate_subtaxa:, exclude_original_names:,
                 include_all_name_proposals:, exclude_consensus: }
       return if names.compact.blank?
 
-      args[:names] = names.compact
-      args.except!(*modifiers)
+      query_params[:names] = names.compact
+      query_params.except!(*modifiers)
     end
 
+    # 2025-09-04 - The "terms_help" message makes the flash too long,
+    # causes cookie session overflow.
     def help_message
-      "#{:pattern_search_terms_help.l}\n#{self.class.terms_help}"
+      ""
+      # "#{:pattern_search_terms_help.l}\n#{self.class.terms_help}"
     end
 
     def self.terms_help

--- a/app/classes/pattern_search/base.rb
+++ b/app/classes/pattern_search/base.rb
@@ -55,7 +55,7 @@ module PatternSearch
     end
 
     def help_message
-      "#{:pattern_search_terms_help.l}\n#{self.class.terms_help}"
+      :pattern_search_terms_short_help.l
     end
 
     def self.terms_help

--- a/app/classes/pattern_search/error/bad_term_error.rb
+++ b/app/classes/pattern_search/error/bad_term_error.rb
@@ -3,24 +3,8 @@
 module PatternSearch
   class BadTermError < Error
     def to_s
-      param = args[:term].var.to_s
-      value = args[:term].vals.join(",")
-      # 2024-04-16: Add a message about us switching these three params.
-      # Feel free to delete this and the translation string
-      # :pattern_search_bad_term_error_suggestion, after a while.
-      if %w[images sequence specimen].include?(param)
-        new_term = "has_#{param}"
-        gen = "#{:pattern_search_bad_term_error_suggestion.tp(
-          term: param, new_term: new_term, vals: value
-        )}\n"
-      else
-        gen = ""
-      end
-      gen += :pattern_search_bad_term_error.tp(
-        type: args[:type], help: args[:help],
-        term: param.inspect
-      )
-      gen
+      :pattern_search_bad_term_error.tp(type: args[:type], help: args[:help],
+                                        term: args[:term].var.to_s.inspect)
     end
   end
 end

--- a/app/classes/pattern_search/name.rb
+++ b/app/classes/pattern_search/name.rb
@@ -52,11 +52,11 @@ module PatternSearch
     # This converts any search that *looks like* a name search into
     # an actual name search. NOTE: This affects the index title.
     def hack_name_query
-      return unless args.include?(:include_subtaxa) ||
-                    args.include?(:include_synonyms)
+      return unless query_params.include?(:include_subtaxa) ||
+                    query_params.include?(:include_synonyms)
 
-      args[:names] = args[:pattern]
-      args.delete(:pattern)
+      query_params[:names] = query_params[:pattern]
+      query_params.delete(:pattern)
     end
   end
 end

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -75,40 +75,47 @@ module PatternSearch
     # This converts any search that *looks like* a name search into
     # an actual name search. NOTE: This affects the index title.
     def hack_name_query
-      return unless args[:pattern].present? && args[:names].empty? &&
+      return unless query_params[:pattern].present? && query_params[:names].empty? &&
                     (is_pattern_a_name? || any_taxa_modifiers_present?)
 
-      args[:names] = args[:pattern]
-      args.delete(:pattern)
+      query_params[:names] = query_params[:pattern]
+      query_params.delete(:pattern)
     end
 
     def default_to_including_synonyms_and_subtaxa
-      return if args[:names].empty?
+      return if query_params[:names].empty?
 
-      args[:include_subtaxa] = true if args[:include_subtaxa].nil?
-      args[:include_synonyms] = true if args[:include_synonyms].nil?
+      if query_params[:include_subtaxa].nil?
+        query_params[:include_subtaxa] =
+          true
+      end
+      return unless query_params[:include_synonyms].nil?
+
+      query_params[:include_synonyms] =
+        true
     end
 
     def is_pattern_a_name?
-      pat = ::Name.parse_name(args[:pattern])&.search_name || args[:pattern]
+      pat = ::Name.parse_name(query_params[:pattern])&.search_name || query_params[:pattern]
       ::Name.where(text_name: pat).or(::Name.where(search_name: pat)).any?
     end
 
     def any_taxa_modifiers_present?
-      !args[:include_subtaxa].nil? ||
-        !args[:include_synonyms].nil? ||
-        !args[:include_all_name_proposals].nil? ||
-        !args[:exclude_consensus].nil?
+      !query_params[:include_subtaxa].nil? ||
+        !query_params[:include_synonyms].nil? ||
+        !query_params[:include_all_name_proposals].nil? ||
+        !query_params[:exclude_consensus].nil?
     end
 
     def put_nsew_params_in_box
-      north, south, east, west = args.values_at(:north, :south, :east, :west)
+      north, south, east, west = query_params.values_at(:north, :south, :east,
+                                                        :west)
       box = { north:, south:, east:, west: }
       return if box.compact.blank?
 
       box = validate_box(box)
-      args[:in_box] = box
-      args.except!(:north, :south, :east, :west)
+      query_params[:in_box] = box
+      query_params.except!(:north, :south, :east, :west)
     end
 
     def validate_box(box)
@@ -117,15 +124,16 @@ module PatternSearch
 
       check_for_missing_box_params
       # Just fix the box if they've got it swapped
-      if args[:south] > args[:north]
-        box = box.merge(north: args[:south], south: args[:north])
+      if query_params[:south] > query_params[:north]
+        box = box.merge(north: query_params[:south],
+                        south: query_params[:north])
       end
       box
     end
 
     def check_for_missing_box_params
       [:north, :south, :east, :west].each do |term|
-        next if args[term].present?
+        next if query_params[term].present?
 
         raise(PatternSearch::MissingValueError.new(var: term))
       end

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -75,7 +75,8 @@ module PatternSearch
     # This converts any search that *looks like* a name search into
     # an actual name search. NOTE: This affects the index title.
     def hack_name_query
-      return unless query_params[:pattern].present? && query_params[:names].empty? &&
+      return unless query_params[:pattern].present? &&
+                    query_params[:names].empty? &&
                     (is_pattern_a_name? || any_taxa_modifiers_present?)
 
       query_params[:names] = query_params[:pattern]
@@ -96,7 +97,8 @@ module PatternSearch
     end
 
     def is_pattern_a_name?
-      pat = ::Name.parse_name(query_params[:pattern])&.search_name || query_params[:pattern]
+      pat = ::Name.parse_name(query_params[:pattern])&.search_name ||
+            query_params[:pattern]
       ::Name.where(text_name: pat).or(::Name.where(search_name: pat)).any?
     end
 

--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -4,7 +4,7 @@ module PatternSearch
   # Parse PatternSearch parameter terms
   # Sample use:
   #   elsif term.var == :specimen
-  #     args[:has_specimen] = term.parse_boolean_string
+  #     query_params[:has_specimen] = term.parse_boolean_string
   class Term
     include Dates
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,10 +31,10 @@ class SearchController < ApplicationController
   def save_pattern_and_proceed(type, pattern)
     # Save it so that we can keep it in the search bar in subsequent pages.
     # But don't save encoded incoming patterns that are too large.
-    # unless pattern.bytesize > 4096
-    #   session[:pattern] = pattern
-    #   session[:search_type] = type
-    # end
+    unless pattern.bytesize > 2048
+      session[:pattern] = pattern
+      session[:search_type] = type
+    end
 
     if type == :google
       site_google_search(pattern)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -140,11 +140,11 @@ class SearchController < ApplicationController
       session[:pattern] = nil
     end
     # This will create a blank query if there are errors.
-    find_or_create_query(model_name, search.query&.params || {})
+    create_query(model_name, search.query&.params || {})
   end
 
   def location_query_from_pattern(pattern)
-    find_or_create_query(
+    create_query(
       :Location, pattern: Location.user_format(@user, pattern)
     )
   end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3709,6 +3709,7 @@
 
   # Search bar help
   pattern_search_terms_help: "Your search string may contain terms of the form \"variable:value\", where value can be quoted, and in some cases can contain more than one value separated by commas. Recognized variables include:"
+  pattern_search_terms_short_help: Click the ? next to the search bar for a list of expected terms.
 
   observation_term_when: Date mushroom was observed; YYYY-MM-DD, YYYY or MM; ranges okay.
   observation_term_created: Date observation was first posted.

--- a/test/classes/pattern_search/observation_test.rb
+++ b/test/classes/pattern_search/observation_test.rb
@@ -258,31 +258,6 @@ class PatternSearch::ObservationTest < UnitTestCase
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 
-  # 2024-04-16 temporary: test that we suggest new terms for retired terms.
-  def test_observation_search_bad_term_suggestions
-    x = PatternSearch::Observation.new("images:true")
-    assert_equal(
-      :pattern_search_bad_term_error_suggestion.tp(
-        term: "images", val: "true", new_term: "has_images"
-      ).to_s.as_displayed,
-      x.errors[0].to_s.t.as_displayed
-    )
-    y = PatternSearch::Observation.new("sequence:true")
-    assert_equal(
-      :pattern_search_bad_term_error_suggestion.tp(
-        term: "sequence", val: "true", new_term: "has_sequence"
-      ).to_s.as_displayed,
-      y.errors[0].to_s.t.as_displayed
-    )
-    z = PatternSearch::Observation.new("specimen:true")
-    assert_equal(
-      :pattern_search_bad_term_error_suggestion.tp(
-        term: "specimen", val: "true", new_term: "has_specimen"
-      ).to_s.as_displayed,
-      z.errors[0].to_s.t.as_displayed
-    )
-  end
-
   def test_observation_search_has_name_no
     expect = Observation.has_name(false)
     assert(expect.any?)

--- a/test/classes/pattern_search/observation_test.rb
+++ b/test/classes/pattern_search/observation_test.rb
@@ -7,27 +7,27 @@ class PatternSearch::ObservationTest < UnitTestCase
     # "Turkey" is not a name, and no taxa modifiers present, so no reason to
     # suspect that this is a name query.  Should leave it completely alone.
     x = PatternSearch::Observation.new("Turkey")
-    assert_equal({ pattern: "Turkey" }, x.args)
+    assert_equal({ pattern: "Turkey" }, x.query_params)
 
     # "Agaricus" is a name, so let's assume this is a name query.  Note that
     # it will include synonyms and subtaxa by default.
     x = PatternSearch::Observation.new("Agaricus")
     assert_equal({ names: { lookup: "Agaricus", include_subtaxa: true,
-                            include_synonyms: true } }, x.args)
+                            include_synonyms: true } }, x.query_params)
 
     # "Turkey" is not a name, true, but user asked for synonyms to be included,
     # so they must have expected "Turkey" to be a name.  Note that it will also
     # include subtaxa by default, because that behavior was not specified.
     x = PatternSearch::Observation.new("Turkey include_synonyms:yes")
     assert_equal({ names: { lookup: "Turkey", include_synonyms: true,
-                            include_subtaxa: true } }, x.args)
+                            include_subtaxa: true } }, x.query_params)
 
     # Just make sure the user is allowed to explicitly turn off synonyms and
     # subtaxa in any names query.
     x = PatternSearch::Observation.new("Foo bar include_synonyms:no " \
                                        "include_subtaxa:no")
     assert_equal({ names: { lookup: "Foo bar", include_synonyms: false,
-                            include_subtaxa: false } }, x.args)
+                            include_subtaxa: false } }, x.query_params)
   end
 
   def test_observation_search_for_old_provisional

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -157,6 +157,19 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     end
   end
 
+  def test_observation_pattern_search_with_bad_keyword
+    correctable_pattern = "foo:campestrus"
+
+    login
+    visit("/")
+    fill_in("pattern_search_pattern", with: correctable_pattern)
+    page.select("Observations", from: :pattern_search_type)
+    within("#pattern_search_form") { click_button("Search") }
+    assert_match("Observations", page.title)
+    assert_selector("#flash_notices",
+                    text: :runtime_no_matches.l(type: :observations.l))
+  end
+
   def test_observation_pattern_search_with_correctable_pattern
     correctable_pattern = "agaricis campestrus"
 

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -166,8 +166,12 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     page.select("Observations", from: :pattern_search_type)
     within("#pattern_search_form") { click_button("Search") }
     assert_match("Observations", page.title)
-    assert_selector("#flash_notices",
-                    text: :runtime_no_matches.l(type: :observations.l))
+    assert_selector(
+      "#flash_notices",
+      text: :pattern_search_bad_term_error.tp(
+        type: :observation, help: "", term: "\"foo\""
+      ).as_displayed
+    )
   end
 
   def test_observation_pattern_search_with_correctable_pattern


### PR DESCRIPTION
Pattern searches with an unrecognized keyword cause a cookie overflow. (#3252). This is a crashing bug on production.

It turns out it happens because it generates a flash error message explaining all possible `term:value` combinations that is too big for the cookie. 

I guess that wasn't an issue before, because before my refactor of the SearchController it flashed immediately. Now the message must be stored for one redirect.

In any case, the `term:value` combos are now available via Turbo by clicking the search help button in the search bar, so this PR slims down the flash error message to just say the term "foo" is unrecognized.

___

**Other change**: changes `PatternSearch` attribute `arg` to `query_param`, which is what it is. I kept getting confused by this attribute when debugging PatternSearch and I hope this makes it clearer for other devs.