### PR TITLE
Set an upper limit to the length of the `session["return-to"]` 

### DIFF
--- a/app/classes/login_system.rb
+++ b/app/classes/login_system.rb
@@ -78,7 +78,7 @@ module LoginSystem
   # we can return to this location by calling redirect_back_or_default
   def store_location
     # guard against overlong query strings
-    session["return-to"] = if request.fullpath.length > 256
+    session["return-to"] = if request.fullpath.length > 512
                              nil
                            else
                              request.fullpath

--- a/app/classes/login_system.rb
+++ b/app/classes/login_system.rb
@@ -78,9 +78,11 @@ module LoginSystem
   # we can return to this location by calling redirect_back_or_default
   def store_location
     # guard against overlong query strings
-    return request.path unless request.fullpath.length < 256
-
-    session["return-to"] = request.fullpath
+    session["return-to"] = if request.fullpath.length > 256
+                             nil
+                           else
+                             request.fullpath
+                           end
   end
 
   # move to the last store_location call or to the passed default one

--- a/app/classes/login_system.rb
+++ b/app/classes/login_system.rb
@@ -77,6 +77,9 @@ module LoginSystem
   # store current uri in the session.
   # we can return to this location by calling redirect_back_or_default
   def store_location
+    # guard against overlong query strings
+    return request.path unless request.fullpath.length < 256
+
     session["return-to"] = request.fullpath
   end
 

--- a/test/capybara_session_extensions.rb
+++ b/test/capybara_session_extensions.rb
@@ -43,7 +43,7 @@ module CapybaraSessionExtensions
 
   # Login the given user in the current session.
   def login(login = users(:zero_user).login, password = "testpassword",
-            remember_me = true, session: self)
+            remember_me: true, session: self)
     login = login.login if login.is_a?(User) # get the right user field
     session.visit("/account/login/new")
     session.assert_selector("body.login__new")

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -667,8 +667,8 @@ module ControllerExtensions
   end
 
   # Get the query_params encoded as a query string. Hard to reproduce otherwise
-  def query_string(query_string)
-    observations_path(q: query_string).split("?")[1]
+  def query_string(q_param)
+    observations_path(q: q_param).split("?")[1]
   end
 
   def assert_session_query_record_is_correct

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -713,4 +713,68 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     results = @controller.instance_variable_get(:@objects).sort_by(&:id)
     assert_obj_arrays_equal(observations_in_region, results)
   end
+
+  def test_index_return_to_cookie_is_under_limit
+    query = @controller.create_query(:Observation, **PARAMS_UNDER_LIMIT)
+    get(:index, params: { q: query.q_param })
+    assert_not_nil(session["return-to"])
+    assert_match(query_string(query.q_param), session["return-to"])
+
+    query = @controller.create_query(:Observation, **NERFC_QUERY_PARAMS)
+    get(:index, params: { q: query.q_param })
+    assert_nil(session["return-to"])
+  end
+
+  PARAMS_UNDER_LIMIT =
+    { names: {
+        lookup: ["Agaricus campestris"],
+        include_synonyms: true,
+        include_subtaxa: true
+      },
+      region: "Massachusetts, USA",
+      has_images: true }.freeze
+
+  NERFC_QUERY_PARAMS =
+    { names: {
+        lookup:
+          ["Amanita ristichii",
+           "Boletus purpureorubellus",
+           "Butyriboletus billieae",
+           "Entoloma indigoferum",
+           "Caloboletus peckii",
+           "Clavulinopsis appalachiensis",
+           "Dendrocollybia racemosa",
+           "Echinodontium ballouii",
+           "Entoloma flavoviride",
+           "Helvella palustris",
+           "Hodophilus peckianus",
+           "Hypocreopsis rhododendri",
+           "Psathyrella epimyces",
+           "Pseudofistulina radicata",
+           "Squamanita imbachii",
+           "Squamanita umbonata",
+           "Tricholoma apium",
+           "Tricholoma grave",
+           "Underwoodia columnaris",
+           "Volvariella surrecta",
+           "Wynnea sparassoides"]
+      },
+      region:
+      ["Connecticut, USA",
+       "Maine, USA",
+       "Massachusetts, USA",
+       "New Hampshire, USA",
+       "New Jersey, USA",
+       "New York, USA",
+       "Pennsylvania, USA",
+       "Rhode Island, USA",
+       "Vermont, USA",
+       "New Brunswick, Canada",
+       "Newfoundland and Labrador, Canada",
+       "Newfoundland, Canada",
+       "Labrador, Canada",
+       "Nova Scotia, Canada",
+       "Eastern Ontario, Canada",
+       "Prince Edward Island, Canada",
+       "Quebec, Canada"] }.freeze
 end


### PR DESCRIPTION
On production a long query string causes cookie overflow when `store_location` is called.

This stores `nil` in case it's a long one, so `redirect_back_or_default` will go to the default.