### PR TITLE
Fix a CSS error caused by a hasty PR

### DIFF
--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -2,8 +2,17 @@
 // top nav bar
 // --------------------------------------------------
 
-.navbar-nav,
-.nav {
+.navbar-nav {
+  li {
+    form.button_to {
+      display: block;
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+  }
+}
+
+#title_bar .nav {
   li {
     a,
     form.button_to {

--- a/app/views/controllers/application/content/_page_title.erb
+++ b/app/views/controllers/application/content/_page_title.erb
@@ -12,10 +12,10 @@ show_title_classes = %w[
 ]
 %>
 
-<%= tag.div(class: "row") do %>
+<%= tag.div(class: "row", id: "title_bar") do %>
   <%# Page title. Indexes have none — `rubric` in top_nav has model name. %>
   <% if action_name != "index" %>
-    <%= tag.div(class: yield(:left_columns), id: "title_bar") do %>
+    <%= tag.div(class: yield(:left_columns)) do %>
       <%= tag.nav(class: class_names(show_title_classes)) do
         concat(tag.h1(title, class: "h3 page-title mt-3 mb-4", id: "title"))
         concat(show_page_edit_icons)


### PR DESCRIPTION
My PR #3234 messed up the top_nav dropdown layout.

![Screen Shot 2025-09-07 at 1 50 40 PM](https://github.com/user-attachments/assets/c94639bf-cb6b-40c1-b6a6-6eeead386a0a)

Corrected:
![Screen Shot 2025-09-07 at 1 50 55 PM](https://github.com/user-attachments/assets/e436d2ee-7d1a-4d8a-bf3c-99ce95ee1fbd)
