### PR TITLE
Fix and test `in_box` search form params

### DIFF
--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -95,7 +95,12 @@ module Searchable
     end
 
     def split_names_lookup_strings
-      return if (vals = @query_params.dig(:names, :lookup)).blank?
+      # Nested blank values will make for null query results,
+      # so eliminate the whole :names param if it doesn't have a lookup.
+      if (vals = @query_params.dig(:names, :lookup)).blank?
+        @query_params[:names] = nil
+        return
+      end
 
       @query_params[:names][:lookup] = vals.split("\r\n")
     end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -375,7 +375,7 @@ module SearchHelper
 
   # currently combined with region for observations form
   def in_box_fields(**args)
-    fields_for(:in_box) do |fib|
+    args[:form].fields_for(:in_box) do |fib|
       search_compass_input_and_map(form: fib, search: args[:search])
     end
   end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -101,5 +101,23 @@ module Observations
         params: { q: { model: :Observation, **validated_params } }
       )
     end
+
+    # Check that empty nested-names-params do not interfere with the query.
+    def test_create_observations_search_in_box
+      login
+      location = locations(:burbank)
+      params = {
+        names: {
+          lookup: "",
+          include_synonyms: ""
+        },
+        in_box: location.bounding_box
+      }
+      post(:create, params: { query_observations: params })
+      assert_redirected_to(
+        controller: "/observations", action: :index,
+        params: { q: { model: :Observation, **params.except(:names) } }
+      )
+    end
   end
 end

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -206,6 +206,7 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
 
   def test_observation_search_form
     lookup = "Agaricus campestris"
+    location = locations(:burbank)
 
     login
     visit("/observations/search/new")
@@ -214,12 +215,17 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
       form.fill_in("query_observations_names_lookup", with: lookup)
       # assert_selector("#query_observations_names_lookup", text: lookup)
       form.select("yes", from: "query_observations_names_include_synonyms")
+      location.bounding_box.each do |key, val|
+        form.fill_in("query_observations_in_box_#{key}", with: val)
+      end
+
       first(:button, type: "submit").click
     end
 
     assert_no_selector("#flash_notices")
     assert_selector("#filters", text: lookup)
     assert_selector("#results", text: lookup)
+    assert_selector("#results", text: observations(:agaricus_campestris_obs).id)
   end
 
   # Tests of show_name_helper module


### PR DESCRIPTION
From a bug reported by @JoeCohen. The issue was tricky to spot at first. 

I didn’t nest the `in_box` fields, and only those, under the form object. 
In other words in the form template, or helper, it has to be `form.fields_for(:in_box) do |fields|`  not just `fields_for(:in_box) do |fields|`

The other issue was the nested `names` params force zero results if they have blank values, so i need to check for a blank and null out the whole param if so.