### PR TITLE
Remove search of NameDescriptions when searching for Names

### DIFF
--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -215,8 +215,7 @@ module Name::Scopes
     # }
     # This is what's called by pattern_search
     scope :pattern, lambda { |phrase|
-      cols = Name.searchable_columns + NameDescription.searchable_columns
-      joins_default_descriptions.search_columns(cols, phrase)
+      search_columns(Name.searchable_columns, phrase)
     }
     # https://stackoverflow.com/a/77064711/3357635
     # AR's assumed join condition is `Name[:id].eq(NameDescription[:name_id])`

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -349,7 +349,9 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_pattern_search_description_notes
-    expects = [names(:agaricus_campestras).id]
+    # NameDescription matches, but searching that
+    # by default leads to surprising results.
+    expects = [] # [names(:agaricus_campestras).id]
     scope = Name.pattern("prevent me")
     assert_query_scope(
       expects, scope, :Name, pattern: "prevent me"
@@ -357,7 +359,9 @@ class Query::NamesTest < UnitTestCase
   end
 
   def test_name_pattern_search_description_gen_desc
-    expects = [names(:suillus).id]
+    # NameDescription matches, but searching that
+    # by default leads to surprising results.
+    expects = [] # [names(:suillus).id]
     scope = Name.pattern("smell as sweet")
     assert_query_scope(
       expects, scope, :Name, pattern: "smell as sweet"
@@ -366,7 +370,9 @@ class Query::NamesTest < UnitTestCase
 
   # Prove pattern search gets hits for description look_alikes
   def test_name_pattern_search_description_look_alikes
-    expects = [names(:peltigera).id]
+    # NameDescription matches, but searching that
+    # by default leads to surprising results.
+    expects = [] # [names(:peltigera).id]
     scope = Name.pattern("superficially similar")
     assert_query_scope(
       expects, scope, :Name, pattern: "superficially similar"


### PR DESCRIPTION
Note that the changes to the tests make them a bit odd.  There are three tests that check different aspects of the NameDescription.  I changed it so it expects no results.  Not sure if I should leave it that way, delete all of the tests, or just leave one.