### PR TITLE
Observation title adjustments

### DIFF
--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -99,6 +99,10 @@ ul.tight-list {
 .h3.page-title {
   font-size: 22px;
 
+  .badge-id {
+    font-size: 66% !important
+  }
+
   small {
     @extend .ml-3;
     color: $text-color;

--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -97,7 +97,7 @@ ul.tight-list {
 }
 
 .h3.page-title {
-  font-size: 20px;
+  font-size: 22px;
 
   small {
     @extend .ml-3;

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -16,19 +16,19 @@ module ObservationsHelper
   #
   # NOTE: Must pass owner naming, or it will be recalculated on every obs.
   # Only used for the page <title> element. #title is composed from parts.
-  def observation_show_title(obs:, owner_naming: nil, user: nil)
+  def observation_show_title(obs:, show_owner_naming: nil, user: nil)
     obs_title_consensus_name_link(
-      name: obs.name, owner_naming: owner_naming, user:
+      name: obs.name, show_owner_naming:, user:
     )
   end
 
-  # name portion of Observation title
-  def obs_title_consensus_name_link(name:, user:, owner_naming: nil)
+  # name portion of Observation title.
+  def obs_title_consensus_name_link(name:, user:, show_owner_naming: nil)
     if name.deprecated &&
        (prefer_name = name.best_preferred_synonym).present?
       obs_title_with_preferred_synonym_link(name, prefer_name, user)
     else
-      obs_title_name_link(name, owner_naming, user)
+      obs_title_name_link(name, show_owner_naming, user)
     end
   end
 
@@ -65,7 +65,7 @@ module ObservationsHelper
     end
   end
 
-  def obs_title_name_link(name, owner_naming, user)
+  def obs_title_name_link(name, show_owner_naming, user)
     text = [
       if user
         link_to_display_name_brief_authors(
@@ -75,20 +75,20 @@ module ObservationsHelper
         name.user_display_name_brief_authors(user).t.small_author
       end
     ]
-    # Differentiate this Name from Observer Preference
-    text << obs_consensus_id_flag if owner_naming
+    # Differentiate this Name from observer's preferred by printing "(Site ID)"
+    text << obs_consensus_id_flag if show_owner_naming
     text.safe_join(" ")
   end
 
   def obs_consensus_id_flag
-    tag.span("(#{:show_observation_site_id.t})", class: "small")
+    tag.span("(#{:show_observation_site_id.t})", class: "small text-nowrap")
   end
 
   ##### Portion of page title that includes user's naming preference #########
 
   # Observer Preference: Hydnum repandum
-  def owner_naming_line(owner_name, current_user = User.current)
-    return unless current_user&.view_owner_id
+  def owner_naming_line(name:, owner_name:, user:)
+    return unless user&.view_owner_id && owner_name.id != name.id
 
     [
       "#{:show_observation_owner_id.t}:",

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -86,27 +86,24 @@ module ObservationsHelper
 
   ##### Portion of page title that includes user's naming preference #########
 
-  # Observer Preference: Hydnum repandum
+  # Hydnum repandum (Observer Preference)
   def owner_naming_line(name:, owner_name:, user:)
-    return unless user&.view_owner_id && owner_name.id != name.id
+    return unless user&.view_owner_id && owner_name && owner_name.id != name.id
 
     [
-      "#{:show_observation_owner_id.t}:",
-      owner_favorite_or_explanation(current_user, owner_name).t
+      owner_preferred_naming(user, owner_name).t,
+      "(#{:show_observation_owner_id.l})"
     ].safe_join(" ")
   end
 
-  def owner_favorite_or_explanation(current_user, owner_name)
-    if owner_name
-      link_to_display_name_brief_authors(
-        current_user, owner_name,
-        class: "obs_owner_naming_link_#{owner_name.id}"
-      )
-    else
-      :show_observation_no_clear_preference
-    end
+  # Note that this is called with `.t` above
+  def owner_preferred_naming(user, owner_name)
+    link_to_display_name_brief_authors(
+      user, owner_name, class: "obs_owner_naming_link_#{owner_name.id}"
+    )
   end
 
+  # Called by more than one method
   def link_to_display_name_brief_authors(user, name, **)
     link_to(name.user_display_name_brief_authors(user).t.small_author,
             name_path(id: name.id), **)

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -81,7 +81,7 @@ module ObservationsHelper
   end
 
   def obs_consensus_id_flag
-    tag.span("(#{:show_observation_site_id.t})", class: "smaller")
+    tag.span("(#{:show_observation_site_id.t})", class: "small")
   end
 
   ##### Portion of page title that includes user's naming preference #########

--- a/app/views/controllers/observations/namings/suggestions/show.html.erb
+++ b/app/views/controllers/observations/namings/suggestions/show.html.erb
@@ -1,7 +1,10 @@
 <%
-@owner_naming = owner_naming_line(@owner_name) # before observation_show_title
+# before observation_show_title
+show_owner_naming = owner_naming_line(
+  name: @observation.name, owner_name: @owner_name, user: @user
+)
 show_title = observation_show_title(
-  obs: @observation, owner_naming: @owner_naming, user: @user
+  obs: @observation, show_owner_naming:, user: @user
 )
 add_page_title(show_title, [:OBSERVATION.l, show_title].safe_join(" "))
 num_images = @observation.images.length

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -1,8 +1,11 @@
 <%
-# owner_naming must be defined before show_obs_page_title
-@owner_naming = owner_naming_line(@owner_name, @user)
+# owner_naming must be defined before show_obs_page_title.
+# nil if not user's pref, or namings are identical.
+show_owner_naming = owner_naming_line(
+  name: @observation.name, owner_name: @owner_name, user: @user
+)
 show_title = observation_show_title(
-  obs: @observation, owner_naming: @owner_naming, user: @user
+  obs: @observation, show_owner_naming:, user: @user
 )
 add_show_title(show_title, @observation)
 add_owner_naming(@owner_naming)

--- a/app/views/controllers/observations/show.html.erb
+++ b/app/views/controllers/observations/show.html.erb
@@ -8,7 +8,7 @@ show_title = observation_show_title(
   obs: @observation, show_owner_naming:, user: @user
 )
 add_show_title(show_title, @observation)
-add_owner_naming(@owner_naming)
+add_owner_naming(show_owner_naming)
 if @user
   add_pager_for(@observation)
   add_interest_icons(@user, @observation)

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -358,6 +358,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     login(user_with_view_owner_id_true)
     obs = observations(:owner_only_favorite_ne_consensus)
     consensus = Observation::NamingConsensus.new(obs)
+    assert_not_equal(obs.name.id, consensus.owner_preference.id)
 
     get(:show, params: { id: obs.id })
     assert_select("#owner_naming",
@@ -368,10 +369,7 @@ class ObservationsControllerShowTest < FunctionalTestCase
     get(
       :show, params: { id: observations(:owner_multiple_favorites).id }
     )
-    assert_select("#owner_naming",
-                  { text: /#{:show_observation_no_clear_preference.t}/,
-                    count: 1 },
-                  "Observation should show lack of owner naming preference")
+    assert_equal(css_select("#owner_naming").length, 0)
   end
 
   def test_show_owner_naming_view_owner_id_false


### PR DESCRIPTION
- Bump up page title size, and ID badge size
- Only print "observer's preference" naming if present and different from the consensus naming