### PR TITLE
Projects faceted search form

### DIFF
--- a/app/controllers/projects/search_controller.rb
+++ b/app/controllers/projects/search_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Projects search form and help.
+#
+# Route: `project_search_path`, `new_project_search_path`
+# Only one action here. Call namespaced controller actions with a hash like
+# `{ controller: "/projects/search", action: :create }`
+module Projects
+  class SearchController < ApplicationController
+    include ::Searchable
+
+    before_action :login_required
+
+    # Also an index of helper methods to use for each field.
+    def permitted_search_params
+      {
+        members: :multiple_value_autocompleter,
+        field_slip_prefix_has: :text_field_with_label,
+        by_users: :multiple_value_autocompleter,
+        has_observations: :select_boolean,
+        has_images: :select_boolean,
+        has_species_lists: :select_boolean,
+        pattern: :text_field_with_label,
+        title_has: :text_field_with_label,
+        has_summary: :select_boolean,
+        summary_has: :text_field_with_label,
+        has_notes: :select_boolean,
+        notes_has: :text_field_with_label,
+        has_comments: :select_boolean,
+        comments_has: :text_field_with_label,
+        created_at: :text_field_with_label,
+        updated_at: :text_field_with_label
+      }.freeze
+    end
+
+    def fields_preferring_ids
+      [:by_users, :members]
+    end
+
+    # def fields_with_requirements
+    #   [{ in_box: [:north, :south, :east, :west]
+    # end
+
+    private
+
+    # This is the list of fields that are displayed in the search form. In the
+    # template, each hash is interpreted as a column, and each key is a
+    # panel_body (either shown or hidden) with an array of fields or field
+    # pairings.
+    def set_up_form_field_groupings
+      @field_columns = [
+        {
+          connected: {
+            shown: [:members, :field_slip_prefix_has],
+            collapsed: [:by_users, [:has_observations, :has_species_lists],
+                        [:has_images]]
+          }
+        },
+        {
+          detail: {
+            shown: [:pattern, :title_has],
+            collapsed: [[:has_summary, :summary_has],
+                        [:has_comments, :comments_has]]
+          },
+          dates: { shown: [:created_at, :updated_at] }
+        }
+      ].freeze
+    end
+  end
+end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -193,12 +193,12 @@ module SearchHelper
 
     # rightward destructuring assignment, Ruby 3 feature
     args => { field:, search: }
-    args[:type] = search_autocompleter_type(field)
+    type = args[:type] = search_autocompleter_type(field)
     args[:separator] = SEARCH_SEPARATOR
     args[:textarea] = true
     args[:hidden_name] = :"#{field}_id"
     args[:hidden_value] = search_attribute_possibly_nested_value(search, field)
-    args[:value] = search_autocompleter_prefillable_values(search, field)
+    args[:value] = search_autocompleter_prefillable_values(search, field, type)
     autocompleter_field(**args.except(:search))
   end
 
@@ -208,38 +208,37 @@ module SearchHelper
       :project
     when :lookup
       :name
-    when :by_users, :by_editor
+    when :by_users, :by_editor, :members
       :user
     else
       field.to_s.singularize.to_sym
     end
   end
 
-  def search_autocompleter_prefillable_values(search, field)
+  def search_autocompleter_prefillable_values(search, field, type)
     values = search_attribute_possibly_nested_value(search, field)
     return values unless values.is_a?(Array)
 
-    search_string_values(values, field)
+    search_string_values(values, type)
   end
 
   # For autocompleters, if the value(s) is/are ids, we need to lookup the
   # strings that should be prefilled in the text field — ids go in the
   # "hidden_field" for ids.
-  def search_string_values(values, field)
+  def search_string_values(values, type)
     values.map do |val|
       if val.is_a?(Numeric) ||
          (val.is_a?(String) && val.match(/^-?(\d+(\.\d+)?|\.\d+)$/))
-        search_string_via_lookup_id(val, field)
+        search_string_via_lookup_id(val, type)
       else
         val
       end
     end.join(SEARCH_SEPARATOR)
   end
 
-  def search_string_via_lookup_id(val, field)
-    lookup_name = field.to_s.camelize # already plural
-    lookup_name = "Names" if lookup_name == "Lookup"
-    lookup_name = "Users" if lookup_name == "ByUsers"
+  # The autocompleter type is a model.type_tag
+  def search_string_via_lookup_id(val, type)
+    lookup_name = type.to_s.camelize.pluralize
     lookup = "Lookup::#{lookup_name}".constantize
     title_method = lookup::TITLE_METHOD # this is the attribute we want
     model = lookup_name.singularize.constantize

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -181,10 +181,10 @@ module SearchHelper
     raise("Autocompleter field needs a search object.") if args[:search].blank?
 
     args => { field:, search: }
-    args[:type] = search_autocompleter_type(field)
+    type = args[:type] = search_autocompleter_type(field)
     args[:hidden_name] = :"#{field}_id"
     args[:hidden_value] = search_attribute_possibly_nested_value(search, field)
-    args[:value] = search_autocompleter_prefillable_values(search, field)
+    args[:value] = search_autocompleter_prefillable_values(search, field, type)
     autocompleter_field(**args.except(:search))
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -94,8 +94,9 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
         -> { order_by(::Query::Projects.default_order) }
 
   scope :members, lambda { |members|
+    ids = Lookup::Users.new(members).ids # User lookup only takes logins or ids
     joins(user_group: :user_group_users).
-      merge(UserGroupUser.where(user: members))
+      merge(UserGroupUser.where(user: ids))
   }
   scope :title_has,
         ->(phrase) { search_columns(Project[:title], phrase) }

--- a/app/views/controllers/projects/search/new.erb
+++ b/app/views/controllers/projects/search/new.erb
@@ -1,0 +1,8 @@
+<%
+add_new_title(:search_object, :PROJECTS)
+container_class(:wide)
+%>
+
+<%= render(partial: "shared/search_form",
+           locals: { local: true, search: @search,
+                     field_columns: @field_columns } ) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3842,6 +3842,21 @@
   location_term_has_observations: Has observations?
   location_term_has_descriptions: Has a description?
 
+  project_term_members: Project has one of these members.
+  project_term_field_slip_prefix_has: Project field slips have this prefix.
+  project_term_by_users: Project created by one of these users.
+  project_term_has_observations: "[:location_term_has_observations]"
+  project_term_has_species_lists: Has observation lists?
+  project_term_has_images: Has images?
+  project_term_pattern: "[:PATTERN]"
+  project_term_title_has: Project title contains these words.
+  project_term_has_summary: Project has summary.
+  project_term_summary_has: Project summary has these words.
+  project_term_has_comments: Project has comments.
+  project_term_comments_has: Project comments have these words.
+  project_term_created_at: Date project was first used.
+  project_term_updated_at: Date project was last modified.
+
   # link to search bar help
   search_bar_help: Search Help
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -665,6 +665,10 @@ MushroomObserver::Application.routes.draw do
   # ----- Policy: one route  --------------------------------------------------
   get("/policy/privacy")
 
+  namespace :projects do
+    resource :search, only: [:new, :create]
+  end
+
   resources :projects do
     resources :admin_requests, only: [:new, :create],
                                controller: "projects/admin_requests"

--- a/test/controllers/projects/search_controller_test.rb
+++ b/test/controllers/projects/search_controller_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# ------------------------------------------------------------
+#  Locations search
+# ------------------------------------------------------------
+module Projects
+  class SearchControllerTest < FunctionalTestCase
+    def test_new_projects_search
+      login
+      get(:new)
+    end
+
+    def test_new_projects_search_form_prefilled_from_existing_query
+      login
+      query = @controller.find_or_create_query(
+        :Project,
+        members: [users(:mary).id, users(:katrina).id],
+        title_has: "Symbiota",
+        has_summary: true,
+        pattern: "anything",
+        has_observations: true
+      )
+      assert(query.id)
+      assert_equal(query.id, session[:query_record])
+      get(:new)
+      assert_select("textarea#query_projects_members",
+                    text: "Mary Newbie\nKatrina")
+      assert_select("input#query_projects_title_has", value: "Symbiota")
+      assert_select("select#query_projects_has_summary", selected: "yes")
+      assert_select("input#query_projects_pattern", value: "anything")
+      assert_select("select#query_projects_has_observations", selected: "yes")
+    end
+
+    def test_create_projects_search
+      login
+      params = {
+        title_has: "Symbiota",
+        has_observations: true
+      }
+      post(:create, params: { query_projects: params })
+
+      assert_redirected_to(controller: "/projects", action: :index,
+                           params: { q: { model: :Project, **params } })
+    end
+  end
+end

--- a/test/integration/capybara/search_integration_test.rb
+++ b/test/integration/capybara/search_integration_test.rb
@@ -50,4 +50,22 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("#filters", text: location.bounding_box[:south])
     assert_selector("#results", text: locations(:burbank).text_name)
   end
+
+  def test_projects_search_form
+    members = users(:mary).login
+
+    login
+    visit("/projects/search/new")
+    within("#projects_search_form") do |form|
+      assert_selector("#query_projects_members")
+      form.fill_in("query_projects_members", with: members)
+
+      first(:button, type: "submit").click
+    end
+
+    assert_no_selector("#flash_notices")
+    assert_selector("#filters", text: users(:mary).name)
+    assert_selector("#results", text: projects(:two_list_project).title)
+    assert_selector("#results", text: projects(:empty_project).title)
+  end
 end


### PR DESCRIPTION
Note: this PR alters the `Project.members` scope to lookup users by `login` or `id` — currently it only accepts ID. Most other User scopes use this lookup, and it's more convenient for search forms.

![Screen Shot 2025-09-11 at 2 40 56 AM](https://github.com/user-attachments/assets/17ce68a0-ad37-4df7-8eec-fdbb36882bc1)
