### PR TITLE
Make form field columns a controller constant

### DIFF
--- a/app/controllers/locations/search_controller.rb
+++ b/app/controllers/locations/search_controller.rb
@@ -37,27 +37,29 @@ module Locations
     #   [{ in_box: [:north, :south, :east, :west]
     # end
 
-    private
-
     # This is the list of fields that are displayed in the search form. In the
     # template, each hash is interpreted as a column, and each key is a
     # panel_body (either shown or hidden) with an array of fields or field
     # pairings.
-    def set_up_form_field_groupings
-      @field_columns = [
-        {
-          area: { shown: [:region] }
+    FIELD_COLUMNS = [
+      {
+        area: { shown: [:region] }
+      },
+      {
+        pattern: { shown: [:pattern], collapsed: [:regexp] },
+        dates: { shown: [:created_at, :updated_at] },
+        detail: {
+          shown: [[:has_notes, :notes_has],
+                  [:has_observations, :has_descriptions]]
         },
-        {
-          pattern: { shown: [:pattern], collapsed: [:regexp] },
-          dates: { shown: [:created_at, :updated_at] },
-          detail: {
-            shown: [[:has_notes, :notes_has],
-                    [:has_observations, :has_descriptions]]
-          },
-          connected: { shown: [:by_users, :by_editor] }
-        }
-      ].freeze
+        connected: { shown: [:by_users, :by_editor] }
+      }
+    ].freeze
+
+    private
+
+    def set_up_form_field_groupings
+      @field_columns = FIELD_COLUMNS
     end
   end
 end

--- a/app/controllers/names/search_controller.rb
+++ b/app/controllers/names/search_controller.rb
@@ -52,37 +52,39 @@ module Names
       [:rank]
     end
 
-    private
-
     # This is the list of fields that are displayed in the search form. In the
     # template, each hash is interpreted as a column, and each key is a panel
     # with an array of fields or field pairings.
+    FIELD_COLUMNS = [
+      { name: {
+          shown: [:names],
+          # NOTE: These appear via js if names[:lookup] input has any value.
+          # See SearchHelper#autocompleter_with_conditional_fields
+          # conditional: [
+          #   [:include_subtaxa, :include_synonyms],
+          #   [:include_immediate_subtaxa, :exclude_original_names]
+          # ],
+          collapsed: [:pattern, :rank, :lichen]
+        },
+        quality: {
+          shown: [[:misspellings, :deprecated]],
+          collapsed: [[:has_author, :author_has],
+                      [:has_citation, :citation_has],
+                      [:has_default_description]]
+        } },
+      { detail: {
+          shown: [[:has_classification, :classification_has]],
+          collapsed: [[:has_notes, :notes_has],
+                      [:has_comments, :comments_has],
+                      [:has_observations]]
+        },
+        dates: { shown: [[:created_at, :updated_at]], collapsed: [] } }
+    ].freeze
+
+    private
+
     def set_up_form_field_groupings
-      @field_columns = [
-        { name: {
-            shown: [:names],
-            # NOTE: These appear via js if names[:lookup] input has any value.
-            # See SearchHelper#autocompleter_with_conditional_fields
-            # conditional: [
-            #   [:include_subtaxa, :include_synonyms],
-            #   [:include_immediate_subtaxa, :exclude_original_names]
-            # ],
-            collapsed: [:pattern, :rank, :lichen]
-          },
-          quality: {
-            shown: [[:misspellings, :deprecated]],
-            collapsed: [[:has_author, :author_has],
-                        [:has_citation, :citation_has],
-                        [:has_default_description]]
-          } },
-        { detail: {
-            shown: [[:has_classification, :classification_has]],
-            collapsed: [[:has_notes, :notes_has],
-                        [:has_comments, :comments_has],
-                        [:has_observations]]
-          },
-          dates: { shown: [[:created_at, :updated_at]], collapsed: [] } }
-      ].freeze
+      @field_columns = FIELD_COLUMNS
     end
   end
 end

--- a/app/controllers/observations/search_controller.rb
+++ b/app/controllers/observations/search_controller.rb
@@ -69,6 +69,42 @@ module Observations
     #              :include_all_name_proposals, :exclude_consensus] }]
     # end
 
+    # This is the list of fields that are displayed in the search form. In the
+    # template, each hash is interpreted as a column, and each key is a
+    # panel_body (either shown or hidden) with an array of fields or field
+    # pairings.
+    FIELD_COLUMNS = [
+      {
+        dates: { shown: [:date], collapsed: [:created_at, :updated_at] },
+        name: {
+          shown: [:names],
+          # NOTE: These appear via js if names[:lookup] input has any value.
+          # See SearchHelper#autocompleter_with_conditional_fields
+          # conditional: [[:include_subtaxa, :include_synonyms],
+          #               [:include_all_name_proposals, :exclude_consensus]],
+          collapsed: [:confidence, [:has_name, :lichen]]
+        },
+        location: {
+          shown: [:locations],
+          collapsed: [[:has_public_lat_lng, :is_collection_location],
+                      :region]
+        }
+      },
+      {
+        pattern: { shown: [:pattern], collapsed: [] },
+        detail: {
+          shown: [[:has_specimen, :has_sequences]],
+          collapsed: [[:has_images, :has_notes],
+                      [:has_notes_fields, :notes_has],
+                      [:has_comments, :comments_has]]
+        },
+        connected: {
+          shown: [:by_users, :projects],
+          collapsed: [:herbaria, :species_lists, :project_lists, :field_slips]
+        }
+      }
+    ].freeze
+
     private
 
     # This is the list of fields that are displayed in the search form. In the
@@ -76,37 +112,7 @@ module Observations
     # panel_body (either shown or hidden) with an array of fields or field
     # pairings.
     def set_up_form_field_groupings
-      @field_columns = [
-        {
-          dates: { shown: [:date], collapsed: [:created_at, :updated_at] },
-          name: {
-            shown: [:names],
-            # NOTE: These appear via js if names[:lookup] input has any value.
-            # See SearchHelper#autocompleter_with_conditional_fields
-            # conditional: [[:include_subtaxa, :include_synonyms],
-            #               [:include_all_name_proposals, :exclude_consensus]],
-            collapsed: [:confidence, [:has_name, :lichen]]
-          },
-          location: {
-            shown: [:locations],
-            collapsed: [[:has_public_lat_lng, :is_collection_location],
-                        :region]
-          }
-        },
-        {
-          pattern: { shown: [:pattern], collapsed: [] },
-          detail: {
-            shown: [[:has_specimen, :has_sequences]],
-            collapsed: [[:has_images, :has_notes],
-                        [:has_notes_fields, :notes_has],
-                        [:has_comments, :comments_has]]
-          },
-          connected: {
-            shown: [:by_users, :projects],
-            collapsed: [:herbaria, :species_lists, :project_lists, :field_slips]
-          }
-        }
-      ].freeze
+      @field_columns = FIELD_COLUMNS
     end
   end
 end

--- a/app/controllers/projects/search_controller.rb
+++ b/app/controllers/projects/search_controller.rb
@@ -41,30 +41,32 @@ module Projects
     #   [{ in_box: [:north, :south, :east, :west]
     # end
 
-    private
-
     # This is the list of fields that are displayed in the search form. In the
     # template, each hash is interpreted as a column, and each key is a
     # panel_body (either shown or hidden) with an array of fields or field
     # pairings.
-    def set_up_form_field_groupings
-      @field_columns = [
-        {
-          connected: {
-            shown: [:members, :field_slip_prefix_has],
-            collapsed: [:by_users, [:has_observations, :has_species_lists],
-                        [:has_images]]
-          }
-        },
-        {
-          detail: {
-            shown: [:pattern, :title_has],
-            collapsed: [[:has_summary, :summary_has],
-                        [:has_comments, :comments_has]]
-          },
-          dates: { shown: [:created_at, :updated_at] }
+    FIELD_COLUMNS = [
+      {
+        connected: {
+          shown: [:members, :field_slip_prefix_has],
+          collapsed: [:by_users, [:has_observations, :has_species_lists],
+                      [:has_images]]
         }
-      ].freeze
+      },
+      {
+        detail: {
+          shown: [:pattern, :title_has],
+          collapsed: [[:has_summary, :summary_has],
+                      [:has_comments, :comments_has]]
+        },
+        dates: { shown: [:created_at, :updated_at] }
+      }
+    ].freeze
+
+    private
+
+    def set_up_form_field_groupings
+      @field_columns = FIELD_COLUMNS
     end
   end
 end


### PR DESCRIPTION
This is a refactor so the form can be called from the search bar, without the local controller setting up the form. 