### PR TITLE
Remove calls to `clear_query_in_session`

### DIFF
--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -268,7 +268,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
 
   def show_index_setup(query, display_opts)
     store_location
-    clear_query_in_session if session[:query_record] != query.id
+    # clear_query_in_session if session[:query_record] != query.id
     update_stored_query(query)
     query.need_letters = display_opts[:letters] if display_opts[:letters]
     set_index_view_ivars(query, display_opts)

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -180,11 +180,10 @@ module ApplicationController::Queries
   #
   ##############################################################################
 
-  # Change the query that +query_param+ passes along to the next request,
-  # and update session[:query_record].
+  # Change the query stored in session[:query_record].
   # NOTE: ApplicationController::Indexes#show_index_setup calls this.
   def update_stored_query(query = nil)
-    clear_query_in_session
+    # clear_query_in_session
     return if browser.bot? || !query
 
     store_query_in_session(query)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -178,7 +178,6 @@ class LocationsController < ApplicationController
 
   # Show a Location and one of its LocationDescription's, including a map.
   def show
-    clear_query_in_session
     case params[:flow]
     when "next"
       redirect_to_next_object(:next, Location, params[:id].to_s)

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -137,8 +137,6 @@ class NamesController < ApplicationController
   # Show a Name, one of its NameDescription's, associated taxa, and a bunch of
   # relevant Observations.
   def show
-    clear_query_in_session
-
     case params[:flow]
     when "next"
       redirect_to_next_object(:next, Name, params[:id].to_s)

--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -34,9 +34,6 @@ module ObservationsController::New
     init_license_var
     init_new_image_var(Time.zone.now)
 
-    # Clear search list. [Huh? -JPH 20120513]
-    clear_query_in_session
-
     @observation = Observation.new
     if params[:notes]
       @observation.notes = params[:notes].to_unsafe_h.symbolize_keys

--- a/app/controllers/species_lists/name_lists_controller.rb
+++ b/app/controllers/species_lists/name_lists_controller.rb
@@ -56,7 +56,6 @@ module SpeciesLists
       return unless @user
 
       @species_list = SpeciesList.new
-      clear_query_in_session
       init_project_vars_for_create
       @list_members = params[:results].tr("|", " ").delete("*")
       render("species_lists/new")

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -89,7 +89,6 @@ class SpeciesListsController < ApplicationController
   ##############################################################################
 
   def show
-    clear_query_in_session
     return unless (@species_list = find_species_list!)
 
     set_project_ivar


### PR DESCRIPTION
These were leftover from a different use of the session query as a checklist query.

`clear_query_in_session` should not be necessary now. Calling it on `:show` actions creates issues like #3272. Calling it in `:index` actions seems equally unnecessary, as a new query will simply replace the `session[:query_record]`.