### PR TITLE
Fix species list link on project tab

### DIFF
--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -168,6 +168,11 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
     UserStats.update_contribution(:del, :species_list_entries, user_id)
   end
 
+  def show_link_with_project(project)
+    trace_tests if project
+    show_link_args.tap { |result| result[:project] = project.id if project }
+  end
+
   def self.find_by_title_with_wildcards(str)
     find_using_wildcards("title", str)
   end

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -169,7 +169,6 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def show_link_with_project(project)
-    trace_tests if project
     show_link_args.tap { |result| result[:project] = project.id if project }
   end
 

--- a/app/views/controllers/species_lists/_species_list.erb
+++ b/app/views/controllers/species_lists/_species_list.erb
@@ -1,4 +1,4 @@
-<%# locals: (species_list:, observation: nil, remove: false, add: false) %>
+<%# locals: (species_list:, observation: nil, remove: false, add: false, project: nil) %>
 
 <%#
 Each listing in the index, or
@@ -18,7 +18,7 @@ place = species_list.place_name.t rescue :UNKNOWN.l
     <%= tag.div do %>
       <%= tag.div do
         [
-          link_to(species_list.show_link_args) do
+          link_to(species_list.show_link_with_project(@project)) do
             tag.span(species_list.text_name.t, class: "list_what h4")
           end,
           tag.span("(#{species_list.when.to_s})", class: "list_when ml-4")

--- a/app/views/controllers/species_lists/index.html.erb
+++ b/app/views/controllers/species_lists/index.html.erb
@@ -12,7 +12,8 @@ flash_error(@error) if @error && @objects.empty?
   <% if @objects.any? %>
     <%= tag.div(class: "list-group") do %>
       <%= render(partial: "species_list",
-                 collection: @objects, as: :species_list) %>
+          collection: @objects, as: :species_list,
+	  project: @project) %>
     <% end %>
   <% end %>
 <% end %>

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -186,7 +186,9 @@ class SpeciesListsControllerTest < FunctionalTestCase
 
     # there's no banner for this project
     assert_page_title(:SPECIES_LISTS.l)
-    assert_match(project.species_lists.first.title, @response.body)
+    spl = project.species_lists.first
+    assert_match(spl.title, @response.body)
+    assert_select("a[href*='species_lists/#{spl.id}?project=#{project.id}']")
   end
 
   def test_index_for_project_with_no_lists


### PR DESCRIPTION
Add the project parameter to the species list show link on the project observation list tab.