### PR TITLE
Remove unneeded Create icon from indexes

### DIFF
--- a/app/helpers/header/rubric_helper.rb
+++ b/app/helpers/header/rubric_helper.rb
@@ -48,6 +48,7 @@ module Header
     ].freeze
 
     # Descriptions also don't get a create button
+    # Herbarium records are created via Observations, not from the index
     def nav_create(user, controller)
       unless user &&
              controller.methods.include?(:new) &&
@@ -66,7 +67,7 @@ module Header
 
     NAV_CREATABLES = %w[
       observations names species_lists projects locations images herbaria
-      herbarium_records collection_numbers glossary_terms field_slips
+      collection_numbers glossary_terms field_slips
       articles publications
     ].freeze
 

--- a/app/helpers/header/rubric_helper.rb
+++ b/app/helpers/header/rubric_helper.rb
@@ -67,8 +67,7 @@ module Header
 
     NAV_CREATABLES = %w[
       observations names species_lists projects locations images herbaria
-      collection_numbers glossary_terms field_slips
-      articles publications
+      glossary_terms field_slips articles publications
     ].freeze
 
     def nav_scan_qr_code(user, controller)

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -104,6 +104,8 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
 
     assert_template(:show)
     assert_template("shared/_matrix_box")
+    assert_select("a[href=?]", new_herbarium_record_path, false,
+                  "Fungarium Index should not have a `new` button")
   end
 
   def test_show_herbarium_record_has_notes


### PR DESCRIPTION
Remove New button (plus sign) from the herbarium_record index.
Records must be created from an Observation. Trying to create a record from the index throws an error.

- Resolves #3287

Similar for collection_numbers index, except displays flash error instead of throwing error.

### Manual Test

- Go to http://localhost:3000/herbarium_records/49651 (or any Fungarium Record)
Result: There should not be a New button (plus sign icon) next to Fungarium Records
- Go to http://localhost:3000/collection_numbers
Result: There should not be a New button (plus sign icon) next to Collection Numbers
