### PR TITLE
Turn off non-logged in access to field_slips URLs

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -4,6 +4,7 @@ class FieldSlipsController < ApplicationController
   include Show
   include Index
 
+  before_action :login_required
   # Disable cop: all these methods are defined in files included above.
   # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :set_field_slip, only: [:edit, :update, :destroy]


### PR DESCRIPTION
`FieldSlipsController#show` throws a 500 without login because the template needs a `@user`.

Seems like it should be login-only.