### PR TITLE
Consolidate and rename permission helpers

### DIFF
--- a/app/controllers/account/preferences_controller.rb
+++ b/app/controllers/account/preferences_controller.rb
@@ -169,7 +169,7 @@ module Account
     end
 
     def permitted_user_with_valid_email_type?(user)
-      user && check_permission!(user) && EMAIL_TYPES.include?(email_type)
+      user && permission!(user) && EMAIL_TYPES.include?(email_type)
     end
 
     def email_type_setter

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -331,20 +331,6 @@ class ApplicationController < ActionController::Base
     @project = Project.safe_find(project_id)
   end
 
-  def permission?(obj, error_message)
-    result = (in_admin_mode? || obj.can_edit?(@user)) # rubocop:disable Style/RedundantParentheses
-    flash_error(error_message) unless result
-    result
-  end
-
-  def can_delete?(obj)
-    permission?(obj, :runtime_no_destroy.l(type: obj.type_tag))
-  end
-
-  def can_edit?(obj)
-    permission?(obj, :runtime_no_update.l(type: obj.type_tag))
-  end
-
   def render_xml(args)
     request.format = "xml"
     respond_to do |format|

--- a/app/controllers/application_controller/authentication.rb
+++ b/app/controllers/application_controller/authentication.rb
@@ -148,7 +148,21 @@ module ApplicationController::Authentication
 
   # Is the current User the correct User (or is admin mode on)?  Returns true
   # or false.  (*NOTE*: this is available to views.)
-  #
+
+  def permission?(obj, error_message)
+    result = (in_admin_mode? || obj.can_edit?(@user)) # rubocop:disable Style/RedundantParentheses
+    flash_error(error_message) unless result
+    result
+  end
+
+  def can_delete?(obj)
+    permission?(obj, :runtime_no_destroy.l(type: obj.type_tag))
+  end
+
+  def can_edit?(obj)
+    permission?(obj, :runtime_no_update.l(type: obj.type_tag))
+  end
+
   #   <% if check_permission(@object)
   #     link_to('Destroy', :action => :destroy_object)
   #   end %>

--- a/app/controllers/application_controller/authentication.rb
+++ b/app/controllers/application_controller/authentication.rb
@@ -149,18 +149,18 @@ module ApplicationController::Authentication
   # Is the current User the correct User (or is admin mode on)?  Returns true
   # or false.  (*NOTE*: this is available to views.)
 
-  def permission?(obj, error_message)
-    result = (in_admin_mode? || obj.can_edit?(@user)) # rubocop:disable Style/RedundantParentheses
-    flash_error(error_message) unless result
-    result
+  def permission?(obj, error_message: nil)
+    permission = in_admin_mode? || correct_user_for_object?(obj)
+    flash_error(error_message) unless permission
+    permission
   end
 
   def can_delete?(obj)
-    permission?(obj, :runtime_no_destroy.l(type: obj.type_tag))
+    permission?(obj, error_message: :runtime_no_destroy.l(type: obj.type_tag))
   end
 
   def can_edit?(obj)
-    permission?(obj, :runtime_no_update.l(type: obj.type_tag))
+    permission?(obj, error_message: :runtime_no_update.l(type: obj.type_tag))
   end
 
   #   <% if check_permission(@object)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -235,7 +235,7 @@ class CommentsController < ApplicationController
     return unless (@comment = find_comment!)
 
     @target = @comment.target
-    if !check_permission!(@comment)
+    if !permission!(@comment)
       # all html requests redirect to object show page
     elsif !@comment.destroy
       flash_error(:runtime_form_comments_destroy_failed.t(id: params[:id]))
@@ -319,7 +319,7 @@ class CommentsController < ApplicationController
   end
 
   def check_permission_or_redirect!(comment, target)
-    return true if check_permission!(comment)
+    return true if permission!(comment)
 
     show_flash_and_send_back(target)
     false

--- a/app/controllers/glossary_terms/images_controller.rb
+++ b/app/controllers/glossary_terms/images_controller.rb
@@ -66,7 +66,7 @@ module GlossaryTerms
       @object = find_or_goto_index(GlossaryTerm, params[:id].to_s)
       return unless @object
 
-      return if check_permission!(@object)
+      return if permission!(@object)
 
       redirect_to(glossary_term_path(@object.id))
     end
@@ -76,7 +76,7 @@ module GlossaryTerms
       @object = find_or_goto_index(GlossaryTerm, params[:id].to_s)
       return unless @object
 
-      unless check_permission!(@object)
+      unless permission!(@object)
         return redirect_to(glossary_term_path(@object.id))
       end
 

--- a/app/controllers/images/transformations_controller.rb
+++ b/app/controllers/images/transformations_controller.rb
@@ -9,7 +9,7 @@ module Images
       image = find_or_goto_index(Image, params[:id].to_s)
       return unless image
 
-      transform_image_and_flash_notices(image) if check_permission!(image)
+      transform_image_and_flash_notices(image) if permission!(image)
 
       # NOTE: 2022/12 params[:size] is unused in show_image
       redirect_to(image_path(image))

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -249,7 +249,7 @@ class ImagesController < ApplicationController
 
   def delete_and_redirect(next_state = nil)
     return redirect_to(action: :show, id: @image.id) unless
-      check_permission!(@image)
+      permission!(@image)
 
     @image.log_destroy
     @image.destroy

--- a/app/controllers/observations/images_controller.rb
+++ b/app/controllers/observations/images_controller.rb
@@ -63,7 +63,7 @@ module Observations
     end
 
     def check_image_permission!
-      return if check_permission!(@image)
+      return if permission!(@image)
 
       redirect_to(image_path(@image))
     end
@@ -204,7 +204,7 @@ module Observations
     end
 
     def check_observation_permission!
-      return true if check_permission!(@observation)
+      return true if permission!(@observation)
 
       redirect_to(permanent_observation_path(id: @observation.id))
       false

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -53,8 +53,8 @@ module Observations
       init_ivars
       @observation = Observation.show_includes.find(params[:observation_id])
       @naming = naming_from_params
-      # N+1: What is this doing? Watch out for check_permission!
-      return redirect_to_obs(@observation) unless check_permission!(@naming)
+      # N+1: What is this doing? Watch out for permission!
+      return redirect_to_obs(@observation) unless permission!(@naming)
 
       init_edit_ivars
       @consensus = Observation::NamingConsensus.new(@observation)
@@ -70,8 +70,8 @@ module Observations
       init_ivars
       @observation = Observation.show_includes.find(params[:observation_id])
       @naming = naming_from_params
-      # N+1: What is this doing? Watch out for check_permission!
-      return redirect_to_obs(@observation) unless check_permission!(@naming)
+      # N+1: What is this doing? Watch out for permission!
+      return redirect_to_obs(@observation) unless permission!(@naming)
 
       @consensus = Observation::NamingConsensus.new(@observation)
       @vote = @consensus.users_vote(@naming, @user)
@@ -346,7 +346,7 @@ module Observations
     end
 
     def destroy_if_we_can(naming)
-      if !check_permission!(naming)
+      if !permission!(naming)
         flash_error(:runtime_destroy_naming_denied.t(id: naming.id))
       elsif !in_admin_mode? && !@consensus.deletable?(naming)
         flash_warning(:runtime_destroy_naming_someone_else.t)

--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -26,7 +26,7 @@ module Observations
       return unless (@species_list = find_species_list!) &&
                     (@observation = find_observation!)
 
-      unless check_permission!(@species_list)
+      unless permission!(@species_list)
         return redirect_to(species_list_path(@species_list.id))
       end
 

--- a/app/controllers/observations_controller/destroy.rb
+++ b/app/controllers/observations_controller/destroy.rb
@@ -18,7 +18,7 @@ module ObservationsController::Destroy
       next_id = this_query.next_id
     end
 
-    if !check_permission!(@observation)
+    if !permission!(@observation)
       flash_error(:runtime_destroy_observation_denied.t(id: obs_id))
       redirect_to({ action: :show, id: obs_id })
     elsif !@observation.destroy

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -28,7 +28,7 @@ module ObservationsController::EditAndUpdate
     return unless find_observation!
 
     # Make sure user owns this observation!
-    unless check_permission!(@observation)
+    unless permission!(@observation)
       redirect_to(action: :show, id: @observation.id) and return
     end
 
@@ -75,7 +75,7 @@ module ObservationsController::EditAndUpdate
     return unless find_observation!
 
     # Make sure user owns this observation!
-    unless check_permission!(@observation)
+    unless permission!(@observation)
       redirect_to(action: :show, id: @observation.id) and return
     end
 

--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -105,7 +105,7 @@ module ObservationsController::New
   end
 
   def add_list(list)
-    return unless list && check_permission(list)
+    return unless list && permission?(list)
 
     @lists << list unless @lists.include?(list)
     @list_checks[list.id] = true

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -200,7 +200,7 @@ module ObservationsController::SharedFormMethods
 
     # Now check for edits.
     @good_images.map do |image|
-      next unless check_permission(image)
+      next unless permission?(image)
 
       args = params.dig(:good_image, image.id.to_s)
       next unless args

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -93,7 +93,7 @@ class ProjectsController < ApplicationController
     @start_date_fixed = @project.start_date.present?
     @end_date_fixed = @project.end_date.present?
     @project_dates_any = !@start_date_fixed && !@end_date_fixed
-    return if check_permission!(@project)
+    return if permission!(@project)
 
     redirect_to(project_path(@project.id))
   end
@@ -126,9 +126,7 @@ class ProjectsController < ApplicationController
   def update
     return unless find_project_and_where!
 
-    unless check_permission!(@project)
-      return redirect_to(project_path(@project.id))
-    end
+    return redirect_to(project_path(@project.id)) unless permission!(@project)
 
     upload_image_if_present
     @summary = params[:project][:summary]
@@ -157,7 +155,7 @@ class ProjectsController < ApplicationController
   def destroy
     return unless find_project_and_where!
 
-    if !check_permission!(@project)
+    if !permission!(@project)
       redirect_to(project_path(@project.id))
     elsif !@project.destroy
       flash_error(:destroy_project_failed.t)

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -178,7 +178,7 @@ class SequencesController < ApplicationController
   # ---------- Create, Edit ----------------------------------------------------
 
   def make_sure_can_edit!(obj)
-    return true if check_permission(obj)
+    return true if permission?(obj)
 
     flash_warning(:permission_denied.t)
     show_flash_and_send_back
@@ -186,7 +186,7 @@ class SequencesController < ApplicationController
   end
 
   def make_sure_can_delete!(sequence)
-    return true if check_permission(sequence)
+    return true if permission?(sequence)
 
     flash_error(:permission_denied.t)
     show_flash_and_send_to_back_object

--- a/app/controllers/species_lists/observations_controller.rb
+++ b/app/controllers/species_lists/observations_controller.rb
@@ -64,7 +64,7 @@ module SpeciesLists
     end
 
     def do_add_remove_observations_by_query(spl, query)
-      return unless check_permission!(spl)
+      return unless permission!(spl)
 
       if params[:commit] == :ADD.l
         do_add_observations_by_query(spl, query)

--- a/app/controllers/species_lists/projects_controller.rb
+++ b/app/controllers/species_lists/projects_controller.rb
@@ -11,7 +11,7 @@ module SpeciesLists
     def edit
       return unless (@list = find_species_list!)
 
-      if check_permission!(@list)
+      if permission!(@list)
         @projects = projects_to_manage
         @object_states = manage_object_states
         @project_states = manage_project_states
@@ -23,7 +23,7 @@ module SpeciesLists
     def update
       return unless (@list = find_species_list!)
 
-      if check_permission!(@list)
+      if permission!(@list)
         @projects = projects_to_manage
         @object_states = manage_object_states
         @project_states = manage_project_states
@@ -130,7 +130,7 @@ module SpeciesLists
     end
 
     def attach_observations_to_project(proj)
-      obs = @list.observations.select { |o| check_permission(o) }
+      obs = @list.observations.select { |o| permission?(o) }
       obs -= proj.observations
       return unless obs.any?
 
@@ -142,7 +142,7 @@ module SpeciesLists
     end
 
     def remove_observations_from_project(proj)
-      obs = @list.observations.select { |o| check_permission(o) }
+      obs = @list.observations.select { |o| permission?(o) }
       unless @user.projects_member.include?(proj)
         obs.select! { |o| o.user == @user }
       end
@@ -158,7 +158,7 @@ module SpeciesLists
 
     def attach_images_to_project(proj)
       imgs = @list.observations.map(&:images).flatten.uniq.
-             select { |i| check_permission(i) }
+             select { |i| permission?(i) }
       imgs -= proj.images
       return unless imgs.any?
 
@@ -171,7 +171,7 @@ module SpeciesLists
 
     def remove_images_from_project(proj)
       imgs = @list.observations.map(&:images).flatten.uniq.
-             select { |i| check_permission(i) }
+             select { |i| permission?(i) }
       unless @user.projects_member.include?(proj)
         imgs.select! { |i| i.user == @user }
       end

--- a/app/controllers/species_lists/uploads_controller.rb
+++ b/app/controllers/species_lists/uploads_controller.rb
@@ -8,7 +8,7 @@ module SpeciesLists
     def new
       return unless (@species_list = find_species_list!)
 
-      if check_permission!(@species_list)
+      if permission!(@species_list)
         query = create_query(:Observation, species_lists: @species_list,
                                            order_by: :name)
         @observation_list = query.results
@@ -21,7 +21,7 @@ module SpeciesLists
     def create
       return unless (@species_list = find_species_list!)
 
-      if check_permission!(@species_list)
+      if permission!(@species_list)
         sorter = NameSorter.new
         @species_list.file = params[:species_list][:file]
         @species_list.process_file_data(@user, sorter)

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -11,7 +11,7 @@ module SpeciesLists
 
     def create
       @species_list = SpeciesList.find(params[:id])
-      if check_permission!(@species_list)
+      if permission!(@species_list)
         process_write_in_list
       else
         redirect_to(species_list_path(@species_list))

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -111,7 +111,7 @@ class SpeciesListsController < ApplicationController
   def edit
     return unless (@species_list = find_species_list!)
 
-    if check_permission!(@species_list)
+    if permission!(@species_list)
       @place_name = @species_list.place_name
       init_project_vars_for_edit(@species_list)
     else
@@ -127,7 +127,7 @@ class SpeciesListsController < ApplicationController
   def update
     return unless (@species_list = find_species_list!)
 
-    if check_permission!(@species_list)
+    if permission!(@species_list)
       process_species_list(:update)
     else
       redirect_to(species_list_path(@species_list))
@@ -138,7 +138,7 @@ class SpeciesListsController < ApplicationController
   def clear
     return unless (@species_list = find_species_list!)
 
-    if check_permission!(@species_list)
+    if permission!(@species_list)
       @species_list.clear
       flash_notice(:runtime_species_list_clear_success.t)
     end
@@ -148,7 +148,7 @@ class SpeciesListsController < ApplicationController
   def destroy
     return unless (@species_list = find_species_list!)
 
-    if check_permission!(@species_list)
+    if permission!(@species_list)
       @species_list.destroy
       id = params[:id].to_s
       flash_notice(:runtime_species_list_destroy_success.t(id: id))

--- a/app/helpers/header/interest_and_edit_icons_helper.rb
+++ b/app/helpers/header/interest_and_edit_icons_helper.rb
@@ -14,7 +14,7 @@ module Header
   module InterestAndEditIconsHelper
     # Edit and destroy icons for the show page title bar.
     def add_edit_icons(object)
-      return unless check_permission(object)
+      return unless permission?(object)
 
       content_for(:edit_icons) do
         [

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -79,7 +79,7 @@ module ImagesHelper
   def show_original_name?(image, original)
     original && image &&
       image.original_name.present? &&
-      (check_permission(image) ||
+      (permission?(image) ||
        image.user &&
        image.user.keep_filenames == "keep_and_show")
   end

--- a/app/helpers/namings_helper.rb
+++ b/app/helpers/namings_helper.rb
@@ -41,7 +41,7 @@ module NamingsHelper
 
   # N+1: should not be checking permission here
   def naming_name_html(user, naming)
-    if check_permission(naming)
+    if permission?(naming)
       edit_link = modal_link_to(
         "obs_#{naming.observation_id}_naming_#{naming.id}",
         *edit_naming_tab(naming)
@@ -151,7 +151,7 @@ module NamingsHelper
   def naming_vote_form(naming, vote, context: "blank")
     vote_id = vote&.id
     method = vote_id ? :patch : :post
-    can_vote = check_permission(naming)
+    can_vote = permission?(naming)
     menu = if !can_vote || !vote || vote&.value&.zero?
              Vote.opinion_menu
            else

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -137,7 +137,7 @@ module ObservationsHelper
   end
 
   def observation_show_image_links(obs:)
-    return "" unless check_permission(obs)
+    return "" unless permission?(obs)
 
     icon_link_to(*reuse_images_for_observation_tab(obs))
   end

--- a/app/helpers/tabs/checklists_helper.rb
+++ b/app/helpers/tabs/checklists_helper.rb
@@ -34,7 +34,7 @@ module Tabs
       links = [
         show_object_tab(list)
       ]
-      if check_permission(list)
+      if permission?(list)
         links += [
           edit_species_list_tab(list)
         ]

--- a/app/helpers/tabs/comments_helper.rb
+++ b/app/helpers/tabs/comments_helper.rb
@@ -9,7 +9,7 @@ module Tabs
           :comment_show_show.t(type: comment.target_type_localized)
         )
       ]
-      return unless check_permission(comment)
+      return unless permission?(comment)
 
       links += comment_mod_tabs(comment)
       links

--- a/app/helpers/tabs/images_helper.rb
+++ b/app/helpers/tabs/images_helper.rb
@@ -68,7 +68,7 @@ module Tabs
     end
 
     def image_mod_tabs(image)
-      return unless check_permission(image)
+      return unless permission?(image)
 
       [
         edit_image_tab(image),

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -11,7 +11,7 @@ module Tabs
         projects_index_tab,
         object_return_tab(project)
       ]
-      links << destroy_project_tab(project) if check_permission(project)
+      links << destroy_project_tab(project) if permission?(project)
       links
     end
 
@@ -28,7 +28,7 @@ module Tabs
         projects_index_tab,
         object_return_tab(project)
       ]
-      return unless check_permission(project)
+      return unless permission?(project)
 
       # Note this is just an edit_project_tab with different wording
       links << change_member_status_tab(project)

--- a/app/helpers/tabs/species_lists_helper.rb
+++ b/app/helpers/tabs/species_lists_helper.rb
@@ -7,7 +7,7 @@ module Tabs
     # Can't access this page unless logged in as of 2023
     def species_list_show_tabs(list:, query: nil)
       tabs = species_list_logged_in_show_tabs(list, query)
-      return tabs unless check_permission(list)
+      return tabs unless permission?(list)
 
       tabs += species_list_user_show_tabs(list)
       tabs

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -32,7 +32,7 @@ class ImagePresenter < BasePresenter
     # if image.is_a?(Image) && args[:original] == true
     #   notes = !image.notes || image.notes.blank? ? "" : image.notes
     #   show_name = image.original_name.present? &&
-    #               (check_permission(image) ||
+    #               (permission?(image) ||
     #                image.user && image.user.keep_filenames == :keep_and_show)
     #   notes += "\n#{image.original_name}" if show_name
     # end

--- a/app/views/controllers/api2/_image.json.jbuilder
+++ b/app/views/controllers/api2/_image.json.jbuilder
@@ -9,7 +9,7 @@ json.quality(object.vote_cache) if object.vote_cache.present?
 json.created_at(object.created_at.try(&:utc))
 json.updated_at(object.updated_at.try(&:utc))
 json.original_name(object.original_name.to_s) \
-  if check_permission(object) && object.original_name.present?
+  if permission?(object) && object.original_name.present?
 json.number_of_views(object.num_views) if object.num_views.present?
 json.last_viewed(object.last_view.try(&:utc)) if object.last_view.present?
 json.ok_for_export(object.ok_for_export ? true : false)

--- a/app/views/controllers/api2/_image.xml.builder
+++ b/app/views/controllers/api2/_image.xml.builder
@@ -13,7 +13,7 @@ xml.tag!(
   xml_datetime(xml, :created_at, object.created_at)
   xml_datetime(xml, :updated_at, object.updated_at)
   xml_string(xml, :original_name, object.original_name) \
-    if check_permission(object)
+    if permission?(object)
   xml_integer(xml, :number_of_views, object.num_views)
   xml_datetime(xml, :last_viewed, object.last_view)
   xml_boolean(xml, :ok_for_export, true) if object.ok_for_export

--- a/app/views/controllers/images/show/_image_panel.html.erb
+++ b/app/views/controllers/images/show/_image_panel.html.erb
@@ -2,7 +2,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <div class="text-center small image-controls">
-      <% if check_permission(@image) %>
+      <% if permission?(@image) %>
         <%= put_button(name: :image_show_rotate_left.t,
                        path: transform_image_path(id: @image.id,
                                                   op: :rotate_left,
@@ -30,7 +30,7 @@
         <%= image_vote_links(@user, @image) %>
       <% end %>
       <% if !@image.original_name.blank? &&
-            (check_permission(@image) ||
+            (permission?(@image) ||
               @image.user && @image.user.keep_filenames == "keep_and_show") %>
         <%= @image.original_name %>
       <% end %>

--- a/app/views/controllers/observations/form/_species_lists.html.erb
+++ b/app/views/controllers/observations/form/_species_lists.html.erb
@@ -9,7 +9,7 @@
       <% @lists.each do |list| %>
         <%= check_box_with_label(
           form: f_l, field: :"id_#{list.id}", label: list.title,
-          checked: @list_checks[list.id], disabled: !check_permission(list)
+          checked: @list_checks[list.id], disabled: !permission?(list)
         ) %>
       <% end %>
     <% end %>

--- a/app/views/controllers/observations/show/_species_lists.erb
+++ b/app/views/controllers/observations/show/_species_lists.erb
@@ -9,7 +9,7 @@ panel_block(heading: :show_lists_header.t,
       obs.species_lists.map do |spl|
         tag.li(id: "species_list_#{spl.id}") do
           concat(link_to(spl.format_name.t, species_list_path(spl.id)))
-          if check_permission(spl)
+          if permission?(spl)
             concat(put_button(name: "[#{:REMOVE.t}]",
                               path: observation_species_list_path(
                                 id: obs.id, species_list_id: spl.id,

--- a/app/views/controllers/observations/species_lists/edit.html.erb
+++ b/app/views/controllers/observations/species_lists/edit.html.erb
@@ -21,7 +21,7 @@ end %>
         <%= render(
           partial: "species_lists/species_list",
           locals: { species_list: species_list, observation: @observation,
-                    remove: check_permission(species_list) }
+                    remove: permission?(species_list) }
         ) %>
       <% end %>
     <% end %>
@@ -34,7 +34,7 @@ end %>
         <%= render(
           partial: "species_lists/species_list",
           locals: { species_list: species_list, observation: @observation,
-                    add: check_permission(species_list) }
+                    add: permission?(species_list) }
         ) %>
       <% end %>
     <% end %>

--- a/app/views/controllers/projects/show.html.erb
+++ b/app/views/controllers/projects/show.html.erb
@@ -82,7 +82,7 @@ container_class(:wide)
         ) %>
   <% end %>
 
-  <% if check_permission(@project) %>
+  <% if permission?(@project) %>
     <div class="mt-3">
       <%= link_to("#{@project.user_group.users.count} #{:MEMBERS.l}",
                   project_members_path(@project.id),

--- a/app/views/controllers/species_lists/show.html.erb
+++ b/app/views/controllers/species_lists/show.html.erb
@@ -31,7 +31,7 @@ column_classes(:nine_three)
               locals: { observation:, user: @user,
                         species_list: @species_list,
                         image: observation.thumb_image_id,
-                        remove: check_permission(@species_list) }) %>
+                        remove: permission?(@species_list) }) %>
           <% end %>
         <% else %>
           <%= tag.div(:species_list_show_no_members.tp) %>


### PR DESCRIPTION
We currently have overlapping helper methods for checking user permission to edit or delete an object.

- `check_permission(obj)` - the most commonly used. Returns boolean, does not flash if denied. Rubocop doesn't like this method name, because it returns boolean so it should be something like `permission?`. Checks:
  - `in_admin_mode?`
  - `(obj.is_a?(String) || obj.is_a?(Integer)) && obj.to_i == @user.id`
  - `obj.user_id == @user.id`
  - `obj.can_edit?(@user)`, configurable per model, can involve being an editor or member of a group
- `check_permission!(obj)` - also commonly used, calls `check_permission` but flashes "denied" message if denied

- `permission?(obj, message)` - Sort of a private method. Checks `in_admin_mode? || obj.can_edit?(@user)`. Near-duplicate of `check_permission!(obj)` but does fewer checks and requires an `error_message` arg. Returns boolean, flashes message if denied. Not currently called anywhere, except by the below methods:
- `can_edit?(obj)` -  Calls `permission?`. Used in controllers but not views. Flashes specific "cannot update" message if denied
- `can_delete?(obj)` - Calls `permission?`. Used in controllers but not views. Flashes specific "cannot delete" message if denied

This PR consolidates the first three methods around the Rubocop-approved names `permission?` and `permission!`. 

- Checks for all possible permissions in `permission?`, as in the old `check_permission`. Returns boolean.
- Gives `permission!` a default `error_message` arg, the "denied" message from `check_permission!`
- `can_edit?` and `can_delete?` now call `permission!` passing their own error messages