### PR TITLE
Avoid providing default for Collector for new field flips

### DIFF
--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -115,9 +115,7 @@ class FieldSlip < AbstractModel
   end
 
   def collector
-    return observation.collector if observation&.collector
-
-    (user || @current_user)&.unique_text_name
+    observation&.collector
   end
 
   def date

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -58,6 +58,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     get(:new, params: { code: code })
     assert_response(:success)
     assert(response.body.include?(project.title))
+    assert_select('input[name="field_slip[collector]"]:not([value])')
   end
 
   def test_should_create_field_slip_with_last_viewed_obs


### PR DESCRIPTION
We found that the current user is usually the wrong thing during foray events with recorders.