### PR TITLE
`DateRangeParser` to handle user input date ranges

### DIFF
--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Parses user-input date ranges (or strings) into a range of Ruby dates that
+# MO's date AR scopes can handle.
+#
+# Can parse ranges like "2008-01-05-2008-03-14", "2009-2011",
+# "02-08" (month range), "09-03" (month range wrapping new year),
+# and underscored Ruby-style phrases like "last_year", "1_day_ago", etc.
+#
+# Accessor
+#     :range        returns an array or simple string representing a start date.
+#
+class DateRangeParser
+  attr_reader :range
+
+  def initialize(string)
+    @string = string.dup
+    @range = parse_date_range
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def parse_date_range
+    val = parse_date_words
+    a, b, c, d, e, f = val.split("-")
+    case val
+    when /^\d{4}$/
+      yyyymmdd([a, 1, 1], [a, 12, 31])
+    when /^\d{4}-\d\d?$/
+      yyyymmdd([a, b, 1], [a, b, 31])
+    when /^\d{4}-\d\d?-\d\d?$/
+      yyyymmdd([a, b, c], [a, b, c])
+    when /^\d{4}-\d{4}$/
+      yyyymmdd([a, 1, 1], [b, 12, 31])
+    when /^\d{4}-\d\d?-\d{4}-\d\d?$/
+      yyyymmdd([a, b, 1], [c, d, 31])
+    when /^\d{4}-\d\d?-\d\d?-\d{4}-\d\d?-\d\d?$/
+      yyyymmdd([a, b, c], [d, e, f])
+    when /^\d\d?$/
+      mmdd([a, 1], [a, 31])
+    when /^\d\d?-\d\d?$/
+      mmdd([a, 1], [b, 31])
+    when /^\d\d?-\d\d?-\d\d?-\d\d?$/
+      mmdd([a, b], [c, d])
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  ##########################################################################
+
+  private
+
+  def yyyymmdd(from, to)
+    [format("%04<year>d-%02<month>d-%02<day>d",
+            year: from.first, month: from.second.to_i,
+            day: from.third.to_i),
+     format("%04<year>d-%02<month>d-%02<day>d",
+            year: to.first, month: to.second.to_i,
+            day: [to.third.to_i, eom(to.first, to.second).to_i].min)]
+  end
+
+  def mmdd(from, to)
+    [format("%02<year>d-%02<month>d",
+            year: from.first.to_i, month: from.second.to_i),
+     format("%02<year>d-%02<month>d",
+            year: to.first.to_i, month: to.second.to_i)]
+  end
+
+  def eom(year, month)
+    Date.new(year.to_i, month.to_i).end_of_month.strftime("%d")
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def parse_date_words
+    val = +@string
+    val = val.tr!("_", " ") if val.include?("_")
+    parse_date_word!(val, "today", :today, :day, 0)
+    parse_date_word!(val, "yesterday", :yesterday, :day, 1)
+    parse_date_word!(val, "\d+ days ago", :days_ago, :day, "N")
+    parse_date_word!(val, "this week", :this_week, :week, 0)
+    parse_date_word!(val, "last week", :last_week, :week, 1)
+    parse_date_word!(val, "\d+ weeks ago", :weeks_ago, :week, "N")
+    parse_date_word!(val, "this month", :this_month, :month, 0)
+    parse_date_word!(val, "last month", :last_month, :month, 1)
+    parse_date_word!(val, "\d+ months ago", :months_ago, :month, "N")
+    parse_date_word!(val, "this year", :this_year, :year, 0)
+    parse_date_word!(val, "last year", :last_year, :year, 1)
+    parse_date_word!(val, "\d+ years ago", :years_ago, :year, "N")
+    val
+  end
+
+  def parse_date_word!(val, english, tag, unit, num)
+    translation = Regexp.escape(:"search_value_#{tag}".l).
+                  sub(/\bN\b/, '\d+')
+    # This bit of cleverness runs until there's nothing in line 1 to `sub!`
+    1 while val.to_s.sub!(/(^|-)(#{english}|#{translation})(-|$)/) do |word|
+      first = word.sub!(/-$/, "")
+      last  = word.sub!(/^-/, "")
+      num2  = num == "N" ? word.to_i : num
+      date  = Date.current - num2.send(:"#{unit}s")
+      left  = format_date(date.send(:"beginning_of_#{unit}")) unless last
+      right = format_date(date.send(:"end_of_#{unit}")) unless first
+      [left, right].map(&:to_s).join("-")
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def format_date(date)
+    date.strftime("%Y-%m-%d")
+  end
+end

--- a/app/classes/pattern_search/term/dates.rb
+++ b/app/classes/pattern_search/term/dates.rb
@@ -5,91 +5,11 @@ module PatternSearch
     # parse the date variable in pattern searches
     module Dates
       def parse_date_range
-        val = parse_date_words
-        a, b, c, d, e, f = val.split("-")
-        case val
-        when /^\d{4}$/
-          yyyymmdd([a, 1, 1], [a, 12, 31])
-        when /^\d{4}-\d\d?$/
-          yyyymmdd([a, b, 1], [a, b, 31])
-        when /^\d{4}-\d\d?-\d\d?$/
-          yyyymmdd([a, b, c], [a, b, c])
-        when /^\d{4}-\d{4}$/
-          yyyymmdd([a, 1, 1], [b, 12, 31])
-        when /^\d{4}-\d\d?-\d{4}-\d\d?$/
-          yyyymmdd([a, b, 1], [c, d, 31])
-        when /^\d{4}-\d\d?-\d\d?-\d{4}-\d\d?-\d\d?$/
-          yyyymmdd([a, b, c], [d, e, f])
-        when /^\d\d?$/
-          mmdd([a, 1], [a, 31])
-        when /^\d\d?-\d\d?$/
-          mmdd([a, 1], [b, 31])
-        when /^\d\d?-\d\d?-\d\d?-\d\d?$/
-          mmdd([a, b], [c, d])
-        else
-          raise(BadDateRangeError.new(var: var, val: first_val))
-        end
-      end
-
-      ##########################################################################
-
-      private
-
-      def yyyymmdd(from, to)
-        [format("%04<year>d-%02<month>d-%02<day>d",
-                year: from.first, month: from.second.to_i,
-                day: from.third.to_i),
-         format("%04<year>d-%02<month>d-%02<day>d",
-                year: to.first, month: to.second.to_i,
-                day: [to.third.to_i, eom(to.first, to.second).to_i].min)]
-      end
-
-      def mmdd(from, to)
-        [format("%02<year>d-%02<month>d",
-                year: from.first.to_i, month: from.second.to_i),
-         format("%02<year>d-%02<month>d",
-                year: to.first.to_i, month: to.second.to_i)]
-      end
-
-      def eom(year, month)
-        Date.new(year.to_i, month.to_i).end_of_month.strftime("%d")
-      end
-
-      def parse_date_words
         val = make_sure_there_is_one_value!.dup
-        val.tr!("_", " ")
-        parse_date_word!(val, "today", :today, :day, 0)
-        parse_date_word!(val, "yesterday", :yesterday, :day, 1)
-        parse_date_word!(val, "\d+ days ago", :days_ago, :day, "N")
-        parse_date_word!(val, "this week", :this_week, :week, 0)
-        parse_date_word!(val, "last week", :last_week, :week, 1)
-        parse_date_word!(val, "\d+ weeks ago", :weeks_ago, :week, "N")
-        parse_date_word!(val, "this month", :this_month, :month, 0)
-        parse_date_word!(val, "last month", :last_month, :month, 1)
-        parse_date_word!(val, "\d+ months ago", :months_ago, :month, "N")
-        parse_date_word!(val, "this year", :this_year, :year, 0)
-        parse_date_word!(val, "last year", :last_year, :year, 1)
-        parse_date_word!(val, "\d+ years ago", :years_ago, :year, "N")
+        val = ::DateRangeParser.new(val).range
+        raise(BadDateRangeError.new(var: var, val: first_val)) if val.nil?
+
         val
-      end
-
-      def parse_date_word!(val, english, tag, unit, num)
-        translation = Regexp.escape(:"search_value_#{tag}".l).
-                      sub(/\bN\b/, '\d+')
-        # This bit of cleverness runs until there's nothing in line 1 to `sub!`
-        1 while val.to_s.sub!(/(^|-)(#{english}|#{translation})(-|$)/) do |word|
-          first = word.sub!(/-$/, "")
-          last  = word.sub!(/^-/, "")
-          num2  = num == "N" ? word.to_i : num
-          date  = Date.current - num2.send(:"#{unit}s")
-          left  = format_date(date.send(:"beginning_of_#{unit}")) unless last
-          right = format_date(date.send(:"end_of_#{unit}")) unless first
-          [left, right].map(&:to_s).join("-")
-        end
-      end
-
-      def format_date(date)
-        date.strftime("%Y-%m-%d")
       end
     end
   end

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -144,6 +144,7 @@ module AbstractModel::Scopes
     # NOTE: On MO so far, all date columns are named :when.
     scope :date, lambda { |early, late = nil, col: :when|
       early, late = early if early.is_a?(Array)
+      early, late = ::DateRangeParser.new(early).range if late.blank?
       if late.blank?
         date_after(early, col:)
       else

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -21,7 +21,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       on_date(ymd_string)
     }
     scope :found_after, lambda { |ymd_string|
-      date(ymd_string)
+      date_after(ymd_string)
     }
     scope :found_before, lambda { |ymd_string|
       date_before(ymd_string)

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -533,7 +533,7 @@ class Query::NamesTest < UnitTestCase
   def test_name_with_observation_subquery_date
     date = observations(:california_obs).when.as_json
     expects = Name.with_correct_spelling.joins(:observations).distinct.
-              where(Observation[:when] >= date).order_by_default
+              where(Observation[:when].eq(date)).order_by_default
     scope = Name.with_correct_spelling.joins(:observations).distinct.
             merge(Observation.date(date)).order_by_default
     assert_query_scope(expects, scope,

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -654,8 +654,11 @@ class Query::ObservationsTest < UnitTestCase
     # years should return between
     assert_query(Observation.date("2005", "2009").order_by_default,
                  :Observation, date: %w[2005 2009])
-    # test scope accepts array values
+    # test scope accepts array values for year
     assert_query(Observation.date(%w[2005 2009]).order_by_default,
+                 :Observation, date: %w[2005 2009])
+    # test scope accepts string values for year
+    assert_query(Observation.date("2005-2009").order_by_default,
                  :Observation, date: %w[2005 2009])
     # in a month range, any year
     assert_query(Observation.date("05", "12").order_by_default,
@@ -663,11 +666,17 @@ class Query::ObservationsTest < UnitTestCase
     # in a month range, any year, within array
     assert_query(Observation.date(%w[05 12]).order_by_default,
                  :Observation, date: %w[05 12])
-    # in a date range, any year
-    assert_query(Observation.date("02-22", "08-22").order_by_default,
+    # in a month range, any year, within array
+    assert_query(Observation.date(%w[05 12]).order_by_default,
+                 :Observation, date: %w[05 12])
+    # in a date range, any year, via string
+    assert_query(Observation.date("02-22-08-22").order_by_default,
                  :Observation, date: %w[02-22 08-22])
     # period wraps around the new year
     assert_query(Observation.date("08-22", "02-22").order_by_default,
+                 :Observation, date: %w[08-22 02-22])
+    # period wraps around the new year, via string
+    assert_query(Observation.date("08-22-02-22").order_by_default,
                  :Observation, date: %w[08-22 02-22])
     # full dates
     assert_query(Observation.date("2009-08-22", "2009-10-20").order_by_default,
@@ -677,6 +686,9 @@ class Query::ObservationsTest < UnitTestCase
                  :Observation, date: %w[2015-08-22 2016-02-22])
     # as array
     assert_query(Observation.date(%w[2015-08-22 2016-02-22]).order_by_default,
+                 :Observation, date: %w[2015-08-22 2016-02-22])
+    # as string
+    assert_query(Observation.date("2015-08-22-2016-02-22").order_by_default,
                  :Observation, date: %w[2015-08-22 2016-02-22])
   end
 


### PR DESCRIPTION
This PR moves the date range string parser from `PatternSearch` into a PORO, so it can be used to parse user-input date ranges in the new faceted forms.

Responds to an issue discovered by @mo-nathan testing the Observation search form. The `date` field should accept the same values as the `PatternSearch` keyword `date:val`, e.g. `"2008-2009"`, `"last_year"`, `"08-03"`, etc.