### PR TITLE
Send letter param for pagination by letter with hidden field

### DIFF
--- a/app/helpers/header/index_pagination_helper.rb
+++ b/app/helpers/header/index_pagination_helper.rb
@@ -188,7 +188,8 @@ module Header
       ) do |f|
         [
           page_input_group_with_button(f, this_page, max_page),
-          q_param_to_hidden_fields(f) # (Just :q. :id not relevant on next page)
+          q_param_to_hidden_fields(f), # (Just :q. :id irrelevant on next page)
+          letter_param_hidden_field(f)
         ].safe_join
       end
     end
@@ -287,6 +288,18 @@ module Header
         form.hidden_field(key, value: value)
       end
       tags.safe_join("\n")
+    end
+
+    # Populated by params if present, to maintain context for goto page input.
+    # Value needs to get updated by Stimulus if user changes letter input.
+    # Needs to work on window action from other instance of same controller.
+    def letter_param_hidden_field(form)
+      form.hidden_field(
+        :letter,
+        value: params[:letter],
+        data: { page_input_target: "letterHiddenInput",
+                action: "letterUpdated@window->page-input#syncLetter" }
+      )
     end
   end
 end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -18,7 +18,6 @@ export default class extends Controller {
   // with the request, turbo-stream will send a 200 OK even if it didn't save.
   remove(event) {
     const initiatingUser = event?.detail?.user
-    debugger
     if (!initiatingUser || initiatingUser !== this.userValue) { return }
 
     // console.log("Removing modal")

--- a/app/javascript/controllers/page-input_controller.js
+++ b/app/javascript/controllers/page-input_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="page-input"
 // Sanitizes the page number to min/max values
 export default class extends Controller {
-  static targets = ["numberInput", "letterInput"]
+  static targets = ["numberInput", "letterInput", "letterHiddenInput"]
   static values = { max: Number, letters: String }
 
   connect() {
@@ -30,10 +30,23 @@ export default class extends Controller {
     this.letterInputTarget.value = letterInput
     // if (letterInput == "") {
     this.letterInputTarget.setAttribute("value", letterInput)
-    // }
+    // emit the letterUpdated event
+    const event = new CustomEvent("letterUpdated", {
+      detail: {
+        letter: letterInput
+      },
+      bubbles: true, // Optional: Determines if the event bubbles up the DOM
+      cancelable: true, // Optional: Determines if the event can be canceled
+    })
+    document.dispatchEvent(event)
   }
 
   isLetter(char) {
     return /^[a-zA-Z]$/.test(char)
+  }
+
+  syncLetter(event) {
+    const letterInput = event?.detail?.letter
+    this.letterHiddenInputTarget.setAttribute("value", letterInput)
   }
 }


### PR DESCRIPTION
This PR changes the pagination UI so that paginating within letter results, (e.g. "A" of the names index) maintains the letter context between pages. Currently on `main`, it does not.

It adds a new "letter" hidden field within the "page" UI, that sends the current letter being queried along with the number of the next page.

The hidden field is synced by Stimulus in case the user changes the letter.

Resolves #3326