### PR TITLE
Add "Actions" to the mobile sidebar menu

### DIFF
--- a/app/helpers/header/context_nav_helper.rb
+++ b/app/helpers/header/context_nav_helper.rb
@@ -9,15 +9,44 @@
 #
 module Header
   module ContextNavHelper
-    # Short-hand to render shared context_nav partial for a given set of links.
+    # Shorthand to render shared context_nav partial for a given set of links.
     # Called in the view, defines `:context_nav` which is rendered in layout.
     def add_context_nav(links)
       return unless links.compact.length.positive?
 
+      add_context_nav_to_top_bar(links)
+      add_context_nav_to_sidebar(links)
+    end
+
+    def add_context_nav_to_top_bar(links)
       nav_links = context_nav_links(links)
       content_for(:context_nav) do
-        context_nav_dropdown(title: "Actions", id: "context_nav",
-                             links: nav_links)
+        context_nav_dropdown(title: :app_context_actions.l,
+                             id: "context_nav", links: nav_links)
+      end
+    end
+
+    def add_context_nav_to_sidebar(links)
+      classes = sidebar_css_classes
+      content_for(:context_nav_mobile) do
+        concat(
+          tag.div(
+            "#{:app_context_actions.t}:",
+            class: class_names(classes[:heading], classes[:mobile_only])
+          )
+        )
+        context_nav_sidebar_links(links, classes)
+      end
+    end
+
+    def context_nav_sidebar_links(links, classes)
+      links.each do |link|
+        concat(
+          sidebar_nav_link(
+            link,
+            class: class_names(classes[:indent], classes[:mobile_only])
+          )
+        )
       end
     end
 

--- a/app/helpers/header/toggles_helper.rb
+++ b/app/helpers/header/toggles_helper.rb
@@ -6,7 +6,7 @@
 module Header
   module TogglesHelper
     def search_nav_toggle
-      tag.div(class: "navbar-form px-sm-3") do
+      tag.div(class: "navbar-form px-2 px-sm-3") do
         tag.button(
           link_icon(:search, title: :SEARCH.l),
           class: "btn btn-sm btn-outline-default top_nav_button",

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SidebarHelper
+  # All helpers are autoloaded under Zeitwerk
+  def sidebar_css_classes
+    {
+      wrapper: "navbar navbar-inverse sidebar-nav list-group",
+      heading: "list-group-item disabled font-weight-bold",
+      item: "list-group-item",
+      admin: "list-group-item list-group-item-danger indent",
+      indent: "list-group-item indent",
+      mobile_only: "visible-xs",
+      desktop_only: "hidden-xs"
+    }.freeze
+  end
+end

--- a/app/views/controllers/application/_sidebar.html.erb
+++ b/app/views/controllers/application/_sidebar.html.erb
@@ -1,13 +1,5 @@
 <%
-classes = {
-  wrapper: "navbar navbar-inverse sidebar-nav list-group",
-  heading: "list-group-item disabled font-weight-bold",
-  item: "list-group-item",
-  admin: "list-group-item list-group-item-danger indent",
-  indent: "list-group-item indent",
-  mobile_only: "visible-xs",
-  desktop_only: "hidden-xs"
-}
+classes = sidebar_css_classes
 %>
 
 <nav id="sidebar" class="sidebar-offcanvas col-xs-8 col-sm-2 hidden-print">
@@ -30,6 +22,8 @@ classes = {
                       locals: { classes: classes }) %>
         <% end %>
       <% end %>
+
+      <%= yield(:context_nav_mobile) if @user %>
 
       <%# If caching obs/spl, this should be keyed for both User and QueryRecord
           (i.e. cache invalidated if query record updated, or new ID). %>

--- a/app/views/controllers/application/sidebar/_user.html.erb
+++ b/app/views/controllers/application/sidebar/_user.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div("", class: class_names(classes[:item], classes[:mobile_only])) do
+<%= tag.div("", class: class_names(classes[:heading], classes[:mobile_only])) do
   [
     tag.i("", class: "glyphicon glyphicon-user"),
     tag.span(h(@user.login), class: "ml-2")

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1479,6 +1479,7 @@
   app_advanced_search: Advanced Search
   app_timer: "time: [seconds] sec"
   app_index_timer: "[num] results in [seconds] sec"
+  app_context_actions: Actions
 
   # This shows up at the bottom of every page. We recommend something like: \n
   # "Translated into <Language> by _user your-login_"

--- a/test/integration/capybara/field_slips_integration_test.rb
+++ b/test/integration/capybara/field_slips_integration_test.rb
@@ -31,15 +31,15 @@ class FieldSlipsIntegrationTest < CapybaraIntegrationTestCase
     select(@field_slip.project.title, from: :PROJECT.t)
     click_on(:field_slip_keep_obs.t)
 
-    assert_text(:field_slip_updated.t)
+    assert_selector(class: "alert", text: :field_slip_updated.t)
   end
 
   def test_destroying_a_field_slip
     login!(mary)
     visit(field_slip_url(@field_slip))
-    click_on(:DESTROY.t, match: :first)
+    click_on(:DESTROY_OBJECT.t(type: :field_slip), match: :first)
 
-    assert_text(:field_slip_destroyed.t)
+    assert_selector(class: "alert", text: :field_slip_destroyed.t)
   end
 
   def test_new_observation_violates_project_constraints

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -110,7 +110,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     )
     first(class: "herbarium_records_for_herbarium_link").click
 
-    assert_selector("body.herbarium_records__index")
+    assert_selector("body", class: "herbarium_records__index")
     assert_selector("a[href*='#{edit_herbarium_record_path(id: rec.id)}']")
     click_on(class: "edit_herbarium_record_link_#{rec.id}")
 
@@ -121,22 +121,23 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
       click_commit
     end
 
-    assert_selector("body.herbarium_records__edit")
+    assert_selector("body", class: "herbarium_records__edit")
     back = current_fullpath
     first(class: "nonpersonal_herbaria_index_link").click
 
-    assert_selector("body.herbarium_records__index")
+    assert_selector("body", class: "herbaria__index")
     visit(back)
 
+    assert_selector("body", class: "herbarium_records__edit")
     within("#herbarium_record_form") do
       fill_in("herbarium_record_herbarium_name", with: rec.herbarium.name)
       click_commit
     end
 
-    assert_selector("body.herbarium_records__index")
+    assert_selector("body", class: "herbarium_records__index")
     click_on(class: "destroy_herbarium_record_link_#{rec.id}")
 
-    assert_selector("body.herbarium_records__index")
+    assert_selector("body", class: "herbarium_records__index")
     assert_not(obs.reload.herbarium_records.include?(rec))
   end
 

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -48,7 +48,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("a[href*='#{edit_observation_path(id: obs.id)}']")
 
     visit(back) # back to edit herbarium record
-    first(text: "Cancel (Show Observation)").click
+    click_on("Cancel (Show Observation)", match: :first)
     assert_selector("body.observations__show")
     assert_selector("a[href*='#{edit_observation_path(id: obs.id)}']")
 

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -123,9 +123,9 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
 
     assert_selector("body", class: "herbarium_records__edit")
     back = current_fullpath
-    first(class: "nonpersonal_herbaria_index_link").click
+    click_on(text: "Back to Fungarium Record Index", match: :first)
 
-    assert_selector("body", class: "herbaria__index")
+    assert_selector("body", class: "herbarium_records__index")
     visit(back)
 
     assert_selector("body", class: "herbarium_records__edit")

--- a/test/integration/capybara/herbarium_curator_integration_test.rb
+++ b/test/integration/capybara/herbarium_curator_integration_test.rb
@@ -48,7 +48,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("a[href*='#{edit_observation_path(id: obs.id)}']")
 
     visit(back) # back to edit herbarium record
-    click_on(text: "Cancel (Show Observation)")
+    first(text: "Cancel (Show Observation)").click
     assert_selector("body.observations__show")
     assert_selector("a[href*='#{edit_observation_path(id: obs.id)}']")
 
@@ -82,7 +82,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("body.herbarium_records__edit")
     assert_selector("#herbarium_record_form")
     back = current_fullpath
-    click_on(text: "Cancel (Show Fungarium Record)")
+    first(class: "herbarium_record_return_link").click
 
     assert_selector("body.herbarium_records__show")
     visit(back)
@@ -123,7 +123,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
 
     assert_selector("body.herbarium_records__edit")
     back = current_fullpath
-    click_on(text: "Back to Fungarium Record Index")
+    first(class: "nonpersonal_herbaria_index_link").click
 
     assert_selector("body.herbarium_records__index")
     visit(back)
@@ -169,7 +169,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     obs = observations(:minimal_unknown_obs)
     login!("mary")
     visit(new_herbarium_record_path(observation_id: obs.id))
-    click_link(class: "nonpersonal_herbaria_index_link")
+    first(class: "nonpersonal_herbaria_index_link").click
 
     assert_match(:HERBARIA.l, page.title)
   end
@@ -236,7 +236,7 @@ class HerbariumCuratorIntegrationTest < CapybaraIntegrationTestCase
     assert_equal([], user.curated_herbaria)
     login!(user.login)
     visit(herbaria_path)
-    click_link(class: "new_herbarium_link")
+    first(class: "new_herbarium_link").click
 
     within("#herbarium_form") do
       assert_field("herbarium_name")

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -138,7 +138,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
       assert_true(form.has_unchecked_field?("naming_reasons_3_check"))
       assert_true(form.has_field?("naming_reasons_3_notes", text: ""))
     end
-    namer_session.click_link(text: "Cancel (Show Observation)")
+    namer_session.first(class: "observation_return_link").click
 
     login(voter, session: voter_session)
     assert_not_equal(namer_session.driver.request.cookies["mo_user"],

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -19,15 +19,15 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     login
     name = names(:boletus_edulis)
     visit("/names/#{name.id}/map")
-    click_link("Show Observations")
+    click_on("Show Observations", match: :first)
     assert_match("Observations", page.title)
     filters = page.find_by_id("filters")
     filters.assert_text(name.text_name)
 
-    click_link("Show Map")
+    click_on("Show Map", match: :first)
     assert_match("Map of Observations", page.title)
-    # filters = page.find_by_id("filters")
-    # filters.assert_text(name.text_name)
+    filters = page.find_by_id("filters")
+    filters.assert_text(name.text_name)
   end
 
   # Prove that if a user clicks an Observation in Observation search results

--- a/test/integration/capybara/projects_integration_test.rb
+++ b/test/integration/capybara/projects_integration_test.rb
@@ -10,7 +10,7 @@ class ProjectsIntegrationTest < CapybaraIntegrationTestCase
 
     # ----- Add project, default dates
     visit(projects_path)
-    click_on(:list_projects_add_project.l)
+    click_on(:list_projects_add_project.l, match: :first)
     fill_in("project_title", with: title)
     fill_in(:WHERE.l, with: locations(:unknown_location).name)
     assert_selector(
@@ -30,7 +30,7 @@ class ProjectsIntegrationTest < CapybaraIntegrationTestCase
     # ----- Add project, specified date range
     title = "Super International Fungal Foray"
     visit(projects_path)
-    click_on(:list_projects_add_project.l)
+    click_on(:list_projects_add_project.l, match: :first)
     fill_in("project_title", with: title)
     fill_in(:WHERE.l, with: locations(:unknown_location).name)
     choose("project_dates_any_false")

--- a/test/integration/capybara/query_filters_integration_test.rb
+++ b/test/integration/capybara/query_filters_integration_test.rb
@@ -17,8 +17,8 @@ class QueryFiltersIntegrationTest < CapybaraIntegrationTestCase
     fill_in("pattern_search_pattern", with: obs.name.text_name)
     page.select("Observations", from: :pattern_search_type)
     within("#pattern_search_form") { click_button("Search") }
-    click_link("Show Locations")
-    click_link("Map Locations")
+    click_on("Show Locations", match: :first)
+    click_on("Map Locations", match: :first)
 
     filters = page.find("#filters")
     filters.assert_text(obs.name.text_name)
@@ -51,12 +51,12 @@ class QueryFiltersIntegrationTest < CapybaraIntegrationTestCase
     results.assert_no_text(obs.id.to_s)
 
     # Show Locations (from obs index) should be filtered
-    click_link("Show Locations")
+    click_on("Show Locations", match: :first)
     # page.find("#index_bar").assert_text(:filtered.t)
     page.find("#filters").assert_text(:query_has_images.l)
 
     # And mapping them (from locations index) should also be filtered.
-    click_link("Map Locations")
+    click_on("Map Locations", match: :first)
     # page.find("#index_bar").assert_text(:filtered.t)
     # page.find("#filters").assert_text(:query_has_images.l)
 

--- a/test/integration/capybara/related_records_integration_test.rb
+++ b/test/integration/capybara/related_records_integration_test.rb
@@ -8,7 +8,7 @@ class RelatedRecordsIntegrationTest < CapybaraIntegrationTestCase
     login
 
     visit(observations_path(pattern: "user:#{rolf.id}"))
-    click_link("a", class: "related_locations_link", text: "Show Locations")
+    click_on("Show Locations", match: :first)
     location = locations(:burbank)
     assert_selector("a", text: location.display_name)
     click_link(location.display_name)
@@ -25,7 +25,7 @@ class RelatedRecordsIntegrationTest < CapybaraIntegrationTestCase
     results = find_all("#results .matrix-box")
     assert_equal(Observation.locations(location).size, results.size)
     assert_selector("a", text: :show_objects.t(type: :location))
-    click_link(text: :show_objects.t(type: :location))
+    click_on(:show_objects.t(type: :location), match: :first)
 
     assert_match("Location", page.title, "Wrong page")
     assert_selector("a[href*='/locations/#{location.id}']")

--- a/test/integration/capybara/species_lists_integration_test.rb
+++ b/test/integration/capybara/species_lists_integration_test.rb
@@ -114,7 +114,7 @@ class SpeciesListsIntegrationTest < CapybaraIntegrationTestCase
 
     login
     visit(species_list_path(spl))
-    click_on(:species_list_show_add_remove_from_another_list.l)
+    first("a", text: :species_list_show_add_remove_from_another_list.l).click
 
     assert_match(
       edit_species_list_observations_path, current_path,


### PR DESCRIPTION
On mobile, back when "Actions" was rendered as a plain list of links in the "tabset", it simply took up a big chunk of the screen at the top of every page. On a phone, this could cover most of the screen.

Moving it to a dropdown menu from the top_bar cleaned up the page but made it inaccessible on mobile. This PR adds the "Actions" menu items to the top of the sidebar on mobile.

More work could be done to simplify the UI of the sidebar menu, which is now quite long on mobile, but this at least restores functionality.