### PR TITLE
Fix class names for InternalLink::Model

### DIFF
--- a/app/classes/internal_link/model.rb
+++ b/app/classes/internal_link/model.rb
@@ -12,7 +12,7 @@ class InternalLink
     def html_class
       result = if @alt_title
                  @alt_title
-               elsif @title.underscore.include?(model_name)
+               elsif @title.underscore.tr(" ", "_").include?(model_name)
                  @title
                else
                  "#{@title}_#{model_name}"
@@ -20,7 +20,7 @@ class InternalLink
       result += "_link"
       return result unless @model.respond_to?(:id)
 
-      "#{result}_#{@model.id}"
+      "#{result} #{result}_#{@model.id}"
     end
 
     def model_name


### PR DESCRIPTION
In `InternalLink::Model` currently, instead of producing an identifying HTML class for the link like 
`edit_field_slip_#{id}_link` 
it's producing 
`edit_field_slip_field_slip_#{id}_link`

This PR corrects what I believe was the intention of the class name builder. It also produces a generic class name, `edit_field_slip_link` in addition to the link with the ID, useful for tests.

The issue is that the class name builder for a link with a title like "Field Slip Index" is trying to match that with string for the `model_name`, e.g. "field_slip". It doesn't work because `"Field Slip Index".underscore` does not produce `field_slip_index`, i.e. it does not underscore the spaces, it produces `field slip index`.

Instead of 
```ruby
elsif @title.underscore.include?(model_name)
```
It needs to check
```ruby
elsif @title.underscore.tr(" ", "_").include?(model_name)
```