### PR TITLE
Field slips show UI - add edit/remove buttons, remove redundant "Actions", and adjust tests

### DIFF
--- a/app/helpers/tabs/field_slips_helper.rb
+++ b/app/helpers/tabs/field_slips_helper.rb
@@ -2,14 +2,6 @@
 
 module Tabs
   module FieldSlipsHelper
-    def field_slip_show_tabs(field_slip, user)
-      links = [field_slips_index_tab, new_field_slip_tab]
-      return links unless field_slip.can_edit?(user)
-
-      links.push(edit_field_slip_tab(field_slip),
-                 destroy_field_slip_tab(field_slip))
-    end
-
     def field_slip_edit_tabs(field_slip)
       [field_slips_index_tab, show_field_slip_tab(field_slip)]
     end
@@ -20,7 +12,7 @@ module Tabs
 
     def field_slips_index_tab
       InternalLink::Model.new(
-        :field_slip_index.t, FieldSlip, field_slips_path
+        :INDEX_OBJECT.t(type: :field_slips), FieldSlip, field_slips_path
       ).tab
     end
 
@@ -32,7 +24,8 @@ module Tabs
 
     def show_field_slip_tab(field_slip)
       InternalLink::Model.new(
-        :field_slip_show.t, field_slip, field_slip_path(field_slip)
+        :SHOW_OBJECT.t(type: :field_slip), field_slip,
+        field_slip_path(field_slip)
       ).tab
     end
 

--- a/app/views/controllers/field_slips/show.html.erb
+++ b/app/views/controllers/field_slips/show.html.erb
@@ -1,11 +1,11 @@
 <%
 add_page_title("#{:FIELD_SLIP.t}: #{@field_slip.code}")
-add_context_nav(field_slip_show_tabs(@field_slip, @user))
+add_edit_icons(@field_slip)
 container_class(:wide)
 %>
 
 <%= alert_block(notice, level: :success) if notice %>
 
-<%= render(@field_slip) %>
+<%= content_padded { render(@field_slip) } %>
 
 <%= show_object_footer(@user, @field_slip) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2895,11 +2895,11 @@
   field_slip_creator: Creator
   field_slip_destroy: Destroy this field slip
   field_slip_destroyed: Field slip was successfully destroyed.
-  field_slip_edit: Edit [:FIELD_SLIP]
+  field_slip_edit: "[:edit_object(type=:FIELD_SLIP)]"
   field_slip_editing: Editing Field Slip
   field_slip_errors: prohibited this field_slip from being saved
   field_slip_filter_by: Filter by [:PROJECT]
-  field_slip_index: "[:FIELD_SLIP] Index"
+  field_slip_index: "[:index_object(type=:FIELD_SLIPS)]"
   field_slip_job_no_project: No Project with id=[ID]
   field_slip_job_no_tracker: No Field Slip Tracker found
   field_slip_keep_obs: Save with Current Observation

--- a/test/integration/capybara/field_slips_integration_test.rb
+++ b/test/integration/capybara/field_slips_integration_test.rb
@@ -18,7 +18,8 @@ class FieldSlipsIntegrationTest < CapybaraIntegrationTestCase
     login!(mary)
     visit(field_slips_url)
     first(class: /field_slip_link_/).click
-    assert_text(:INDEX_OBJECT.t(type: :field_slips))
+    assert_selector("body.field_slips__show")
+    assert_selector("a", class: "field_slips_index_link")
   end
 
   def test_updating_a_field_slip

--- a/test/integration/capybara/field_slips_integration_test.rb
+++ b/test/integration/capybara/field_slips_integration_test.rb
@@ -18,7 +18,7 @@ class FieldSlipsIntegrationTest < CapybaraIntegrationTestCase
     login!(mary)
     visit(field_slips_url)
     first(class: /field_slip_link_/).click
-    assert_text(:field_slip_index.t)
+    assert_text(:INDEX_OBJECT.t(type: :field_slips))
   end
 
   def test_updating_a_field_slip


### PR DESCRIPTION
- Adds the edit/remove buttons used elsewhere on show pages
- Removes redundant actions from the "Actions" menu
- Adjusts tests