### PR TITLE
Fix date range parser and expand validation for date query param

### DIFF
--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -14,7 +14,7 @@ class DateRangeParser
   attr_reader :range
 
   def initialize(string)
-    @string = string.dup
+    @string = string.to_s
     @range = parse_date_range
   end
 
@@ -71,7 +71,7 @@ class DateRangeParser
 
   # rubocop:disable Metrics/AbcSize
   def parse_date_words
-    val = +@string
+    val = @string.dup
     val = val.tr!("_", " ") if val.include?("_")
     parse_date_word!(val, "today", :today, :day, 0)
     parse_date_word!(val, "yesterday", :yesterday, :day, 1)

--- a/app/classes/date_range_parser/error.rb
+++ b/app/classes/date_range_parser/error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module DateRangeParser
+  class Error < ::StandardError
+    attr_accessor :args
+
+    def initialize(args = {})
+      super
+      self.args = args
+    end
+
+    def to_s
+      :date_range_parser_error.t(value: args[:val].inspect)
+    end
+  end
+end

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -245,9 +245,11 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
       nil
     elsif val.acts_like?(:date)
       format_date(val)
-    elsif /^\d\d\d\d(-\d\d?){0,2}$/i.match?(val.to_s) ||
-          /^\d\d?(-\d\d?)?$/i.match?(val.to_s)
-      val
+    # elsif /^\d\d\d\d(-\d\d?){0,2}$/i.match?(val.to_s) ||
+    #       /^\d\d?(-\d\d?)?$/i.match?(val.to_s)
+    #   val
+    elsif (val2 = parse_date_range(val))
+      val2
     elsif (val2 = parse_date(val)).acts_like?(:date)
       format_date(val2)
     else
@@ -259,6 +261,12 @@ module Query::Modules::Validation # rubocop:disable Metrics/ModuleLength
   def parse_date(val)
     Date.parse(val)
   rescue Date::Error
+    nil
+  end
+
+  def parse_date_range(val)
+    ::DateRangeParser.new(val.to_s).range
+  rescue ::DateRangeParser::Error.new(val:)
     nil
   end
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4352,6 +4352,9 @@
   # Advanced search error messages
   advanced_search_bad_q_error: Search expired or cannot be found. Please re-enter search criteria.
 
+  # Date Range Parser errors
+  date_range_parser_error: Invalid value for [value], expected date or date range of form YYYY, YYYY-YYYY, YYYY-MM, YYYY-MM-YYYY-MM, YYYY-MM-DD, YYYY-MM-DD-YYYY-MM-DD, MM, MM-MM or MM-DD-MM-DD.
+
   ##############################################################################
 
   # LESS IMPORTANT ENUMERATED SETS OF VALUES

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -83,11 +83,50 @@ class QueryTest < UnitTestCase
     assert_validation_errors(Query.lookup(:Name, has_synonyms: "bogus"))
   end
 
-  def test_validate_params_date
+  def test_validate_params_date_with_spaces
     assert_equal(
       ["2021-01-06"],
       Query.lookup(:Observation, date: "Jan 06, 2021").params[:date]
     )
+  end
+
+  def test_validate_params_date_month_range
+    assert_equal(
+      %w[06-01 12-31],
+      Query.lookup(:Observation, date: "06-12").params[:date]
+    )
+  end
+
+  def test_validate_params_date_year_range
+    assert_equal(
+      %w[2009-01-01 2023-12-31],
+      Query.lookup(:Observation, date: "2009-2023").params[:date]
+    )
+  end
+
+  def test_validate_params_date_year_month_range
+    assert_equal(
+      %w[2009-02-01 2023-05-31],
+      Query.lookup(:Observation, date: "2009-02-2023-05").params[:date]
+    )
+  end
+
+  def test_validate_params_date_with_words
+    date = "2021-01-06"
+    today = Time.zone.today
+    todate = format("%04d-%02d-%02d", today.year, today.mon, today.day)
+    assert_equal(
+      [todate, todate],
+      Query.lookup(:Observation, date: "today").params[:date]
+    )
+    # Check mix of date and word
+    assert_equal(
+      [date, todate],
+      Query.lookup(:Observation, date: "2021-01-06-today").params[:date]
+    )
+  end
+
+  def test_validate_params_date_nil
     assert_equal(
       [nil],
       Query.lookup(:Observation, date: "0").params[:date]


### PR DESCRIPTION
Fixes a bug discovered in `DateRangeParser`.

Expands `Query::Validation#validate_date`. Can instantiate a `DateRangeParser`, so it can validate a wider range of acceptable values, e.g. "2006-today"