### PR TITLE
Generalize `button_link` helper

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -39,9 +39,9 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   def js_button(**args, &block)
     button = block ? capture(&block) : args[:button]
     opts = args.except(:form, :button, :class, :center)
-    opts[:class] = "btn btn-default"
-    opts[:class] += " center-block my-3" if args[:center] == true
-    opts[:class] += " #{args[:class]}" if args[:class].present?
+    classes = %w[btn btn-default]
+    classes += %w[center-block my-3] if args[:center] == true
+    opts[:class] = class_names(classes, args[:class])
 
     button_tag(button, type: :button, **opts)
   end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -394,4 +394,11 @@ module LinkHelper # rubocop:disable Metrics/ModuleLength
 
     button_to(path, html_options) { [content, icon].safe_join }
   end
+
+  def button_link(title, path, **args)
+    classes = %w[btn btn-default]
+    args[:class] = class_names(classes, args[:class])
+
+    link_to(title, path, **args)
+  end
 end

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -224,7 +224,8 @@ module Tabs
                     **project_button_args),
         button_link(:IMAGES.l, img_link, **project_button_args),
         button_link(:DOWNLOAD.l,
-                    add_q_param(new_observations_download_path, query), **project_button_args)
+                    add_q_param(new_observations_download_path, query),
+                    **project_button_args)
       ]
       if project.field_slip_prefix
         buttons << button_link(:FIELD_SLIPS.t, field_slips_path(project:),

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -177,38 +177,42 @@ module Tabs
        project_species_list_images_button(query)]
     end
 
-    def button_link(title, path)
-      styling = { class: "btn btn-default btn-lg my-3 mr-3" }
-      link_to(title, path, styling)
+    def project_button_args
+      { class: "btn-lg my-3 mr-3" }
     end
 
     def project_species_list_map_button(query)
-      button_link(:MAP.t, add_q_param(map_observations_path, query))
+      button_link(:MAP.l, add_q_param(map_observations_path, query),
+                  **project_button_args)
     end
 
     def project_species_list_observations_button(query)
-      button_link(:OBSERVATIONS.t, add_q_param(observations_path, query))
+      button_link(:OBSERVATIONS.l, add_q_param(observations_path, query),
+                  **project_button_args)
     end
 
     def project_species_list_names_button(list)
-      button_link(:NAMES.t,
-                  checklist_path(species_list_id: list.id))
+      button_link(:NAMES.l,
+                  checklist_path(species_list_id: list.id),
+                  **project_button_args)
     end
 
     def project_species_list_locations_button(query)
       return unless query && Query.related?(:Location, :Observation)
 
-      button_link(:LOCATIONS.t,
-                  InternalLink::RelatedQuery.new(Location, :Observation,
-                                                 query, controller).url)
+      locations_url = InternalLink::RelatedQuery.new(
+        Location, :Observation, query, controller
+      ).url
+      button_link(:LOCATIONS.l, locations_url, **project_button_args)
     end
 
     def project_species_list_images_button(query)
       return unless query && Query.related?(:Location, :Observation)
 
-      button_link(:IMAGES.t,
-                  InternalLink::RelatedQuery.new(Image, :Observation,
-                                                 query, controller).url)
+      images_url = InternalLink::RelatedQuery.new(
+        Image, :Observation, query, controller
+      ).url
+      button_link(:IMAGES.l, images_url, **project_button_args)
     end
 
     def project_observation_buttons(project, query)
@@ -216,14 +220,15 @@ module Tabs
 
       _img_name, img_link, = related_images_tab(:Observation, query)
       buttons = [
-        button_link(:MAP.t, add_q_param(map_observations_path, query)),
-        button_link(:IMAGES.l, img_link),
+        button_link(:MAP.t, add_q_param(map_observations_path, query),
+                    **project_button_args),
+        button_link(:IMAGES.l, img_link, **project_button_args),
         button_link(:DOWNLOAD.l,
-                    add_q_param(new_observations_download_path, query))
+                    add_q_param(new_observations_download_path, query), **project_button_args)
       ]
       if project.field_slip_prefix
-        buttons << button_link(:FIELD_SLIPS.t,
-                               field_slips_path(project:))
+        buttons << button_link(:FIELD_SLIPS.t, field_slips_path(project:),
+                               **project_button_args)
       end
 
       # Download Observations


### PR DESCRIPTION
@mo-nathan This is your `button_link` helper from the project show page. 

I'm just generalizing it so it can take args and has defaults, because I need it for the search form "clear" button. Also moving it to `links_helper`.