### PR TITLE
Use regex-matching scopes in `Lookup` subclass `lookup_method` and similar

### DIFF
--- a/app/classes/lookup/herbaria.rb
+++ b/app/classes/lookup/herbaria.rb
@@ -9,6 +9,6 @@ class Lookup::Herbaria < Lookup
   end
 
   def lookup_method(name)
-    Herbarium.where(name: name)
+    Herbarium.name_has(name)
   end
 end

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -88,12 +88,28 @@ class Lookup::Names < Lookup
                else
                  Name.clean_incoming_string(val)
                end
-    if parse&.author.present?
-      matches = Name.search_name_has(srch_str).select(*minimal_name_columns)
-    end
+    matches = author_search(parse, srch_str)
     return matches unless matches.empty?
 
-    Name.text_name_has(srch_str).select(*minimal_name_columns)
+    text_name_search(srch_str)
+  end
+
+  def author_search(parse, srch_str)
+    return if parse&.author.blank?
+
+    if @params[:include_subtaxa]
+      Name.search_name_has(srch_str).select(*minimal_name_columns)
+    else
+      Name.where(search_name: srch_str).select(*minimal_name_columns)
+    end
+  end
+
+  def text_name_search(srch_str)
+    if @params[:include_subtaxa]
+      return Name.text_name_has(srch_str).select(*minimal_name_columns)
+    end
+
+    Name.where(text_name: srch_str).select(*minimal_name_columns)
   end
 
   def add_synonyms_if_necessary(names)

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -89,11 +89,11 @@ class Lookup::Names < Lookup
                  Name.clean_incoming_string(val)
                end
     if parse&.author.present?
-      matches = Name.where(search_name: srch_str).select(*minimal_name_columns)
+      matches = Name.search_name_has(srch_str).select(*minimal_name_columns)
     end
     return matches unless matches.empty?
 
-    Name.where(text_name: srch_str).select(*minimal_name_columns)
+    Name.text_name_has(srch_str).select(*minimal_name_columns)
   end
 
   def add_synonyms_if_necessary(names)

--- a/app/classes/lookup/projects.rb
+++ b/app/classes/lookup/projects.rb
@@ -9,6 +9,6 @@ class Lookup::Projects < Lookup
   end
 
   def lookup_method(name)
-    Project.where(title: name)
+    Project.title_has(name.to_s.clean_pattern)
   end
 end

--- a/app/classes/lookup/species_lists.rb
+++ b/app/classes/lookup/species_lists.rb
@@ -9,6 +9,6 @@ class Lookup::SpeciesLists < Lookup
   end
 
   def lookup_method(name)
-    SpeciesList.where(title: name)
+    SpeciesList.title_has(name)
   end
 end

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -18,6 +18,7 @@ class Query::Names < Query
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean })
   query_attr(:text_name_has, :string)
+  query_attr(:search_name_has, :string)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
   query_attr(:misspellings, { string: [:no, :either, :only] })

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -56,8 +56,8 @@ module Name::Scopes
     }
     scope :text_name_has,
           ->(phrase) { search_columns(Name[:text_name], phrase) }
-    # scope :search_name_has,
-    #       ->(phrase) { search_columns(Name[:search_name], phrase) }
+    scope :search_name_has,
+          ->(phrase) { search_columns(Name[:search_name], phrase) }
 
     # NOTE: with_correct_spelling is tacked on to most Name queries.
     scope :misspellings, lambda { |boolish = :no|

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -93,15 +93,15 @@ class LookupTest < UnitTestCase
     assert_lookup_names([name1, name2, name3],
                         ["Macrolepiota"],
                         include_immediate_subtaxa: true)
-    assert_lookup_names([name1, name2, name3, name4, name5],
-                        ["Macrolepiota"],
-                        include_synonyms: 1, # test boolean
-                        include_subtaxa: 1)
-    assert_lookup_names([name2, name3, name4, name5],
+    assert_lookup_names([name4, name5],
                         ["Macrolepiota"],
                         include_synonyms: true,
                         include_subtaxa: true,
                         exclude_original_names: true)
+    assert_lookup_names([name1, name2, name3, name4, name5],
+                        ["Macrolepiota"],
+                        include_synonyms: 1, # test boolean
+                        include_subtaxa: 1)
 
     name5.update(synonym_id: nil)
     name5 = Name.where(text_name: "Pseudolepiota rachodes").
@@ -149,7 +149,7 @@ class LookupTest < UnitTestCase
     assert_lookup_names([name1, name2],
                         ["Peltigeraceae"],
                         include_immediate_subtaxa: true)
-    assert_lookup_names([name2, name4, name5, name6, name7],
+    assert_lookup_names([name1, name2, name4, name5, name6, name7],
                         ["Peltigera"],
                         include_subtaxa: true)
     assert_lookup_names([name2, name4, name6],

--- a/test/classes/query/names_test.rb
+++ b/test/classes/query/names_test.rb
@@ -260,6 +260,12 @@ class Query::NamesTest < UnitTestCase
     assert_query(expects, :Name, text_name_has: "Agaricus")
   end
 
+  def test_name_search_name_has
+    expects = Name.with_correct_spelling.
+              search_name_has("Agaricus").order_by_default
+    assert_query(expects, :Name, search_name_has: "Agaricus")
+  end
+
   def test_name_has_author
     expects = Name.with_correct_spelling.has_author.order_by_default
     assert_query(expects, :Name, has_author: true)

--- a/test/integration/capybara/search_integration_test.rb
+++ b/test/integration/capybara/search_integration_test.rb
@@ -42,7 +42,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
       form.fill_in("query_names_names_lookup", with: lookup)
       form.select("yes", from: "query_names_names_include_synonyms")
       form.select("yes", from: "query_names_names_include_subtaxa")
-      form.select("yes", from: "query_names_names_exclude_original_names")
+      form.select("no", from: "query_names_names_exclude_original_names")
       form.select("yes", from: "query_names_has_author")
       form.select("either", from: "query_names_misspellings")
 

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3630,18 +3630,21 @@ class NameTest < UnitTestCase
       user: users(:rolf)
     )
 
-    # This is somewhat counter-intuitive, but
-    #  is a rarely occuring edge case;
-    #  is consistent with the current behavior of pattern_search;
-    #  improves the performance of the scope; and
-    #  greatly simplifies the code.
-    # https://github.com/MushroomObserver/mushroom-observer/pull/1082/files#r928148711
-    # https://github.com/MushroomObserver/mushroom-observer/pull/1082#issuecomment-1193235924
+    # Since lookup now does pattern matching when include_subtaxa is
+    # true rather than precise name matching, "Amanita group" is now
+    # included when you select "include_subtaxa".
     assert_includes(
+      Name.names(lookup: "Amanita", include_subtaxa: true), amanita_group,
+      "`include_subtaxa` at or below genus <X> should include `<X> group`"
+    )
+    # However, the semantics of exclude_original_names has now changed
+    # to exclude the any of the pattern matching names.
+    assert_not_includes(
       Name.names(
         lookup: "Amanita", include_subtaxa: true, exclude_original_names: true
       ), amanita_group,
-      "`include_subtaxa` at or below genus <X> should include `<X> group`"
+      "`include_subtaxa` and `exclude_original_names` should not include " \
+      "`<X> group`"
     )
 
     assert_not_includes(


### PR DESCRIPTION
The idea here is to expand the results of `Lookup` classes, so that they more resemble the results of pattern searches. `Lookup::Locations` already does this: it uses the scope `name_has` to match substrings, e.g. "New York". The biggest change here is to `Lookup::Names`.

These changes will affect the results returned by queries sent by autocompleters for association fields, but possibly other results on the site, since Lookup is used elsewhere.

- Herbaria
- Locations
- Names
- Projects
- SpeciesLists
- Users