### PR TITLE
Field slip user fix

### DIFF
--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -176,7 +176,7 @@ class API2
 
         field_slip.update!(observation:)
       else
-        field_slip = FieldSlip.create!(observation:, code: @code)
+        field_slip = FieldSlip.create!(observation:, code: @code, user: @user)
         field_slip.current_user = @user
         field_slip.update_project
         field_slip.save!

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -4,12 +4,13 @@
 # code:    string, unique code for field slip, starts with project prefix
 
 class FieldSlip < AbstractModel
-  attr_accessor :current_user
+  attr_reader :current_user
 
   belongs_to :observation
   belongs_to :project
   belongs_to :user
 
+  validates :user_id, presence: true
   validates :code, uniqueness: true
   validates :code, presence: true
   validate do |field_slip|
@@ -25,6 +26,13 @@ class FieldSlip < AbstractModel
     project_ids = Lookup::Projects.new(projects).ids
     where(project: project_ids).distinct
   }
+
+  def current_user=(a_user)
+    @current_user = a_user
+    return if user
+
+    self.user = a_user
+  end
 
   def code=(val)
     code = val.upcase

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -42,6 +42,13 @@ class FieldSlip < AbstractModel
     update_project
   end
 
+  def observation=(val)
+    # Adopt the observation's user if we don't already have one
+    self.user = val.user unless user
+
+    self[:observation_id] = val.id
+  end
+
   def update_project
     prefix_match = code.match(/(^.+)[ -]\d+$/)
     return unless prefix_match

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -147,7 +147,9 @@ class FieldSlipsControllerTest < FunctionalTestCase
            })
     end
 
-    obs = FieldSlip.find_by(code: code).observation
+    fs = FieldSlip.find_by(code: code)
+    assert(fs.user)
+    obs = fs.observation
     assert_redirected_to(observation_url(obs))
     assert(project.member?(user))
     assert(project.observations.member?(obs))

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -421,6 +421,10 @@ class FieldSlipsControllerTest < FunctionalTestCase
     login(mary.login)
     get(:edit, params: { id: fs.id })
     assert_response(:success)
+    obs = Observation.last
+    fs.observation = obs
+    fs.save!
+    assert_equal(obs.user, fs.user)
   end
 
   def test_admin_should_get_edit

--- a/test/fixtures/field_slips.yml
+++ b/test/fixtures/field_slips.yml
@@ -57,6 +57,8 @@ field_slip_project_orphan:
   observation: recorder_obs
   code: ORPH-0001
 
+# In general FieldSlips should always have a User, but given that it's
+# relying on a Rails validatation it could happen.
 field_slip_user_orphan:
   project: current_project
   code: ORPH-0002


### PR DESCRIPTION
@JoeCohen noticed that a bunch of FieldSlips have been created without a recorded user.  The issue was introduced as part of the `User.current` clean up.  This PR fixes the issue by adding a validation that requires FieldSlips to have a User and fixes the resulting failing tests.

There should also be a Rails runner script written to update the FieldSlips that currently have no recorded user with the owner of the observation.

Looking more deeply this is potentially an issue with the Name, Naming, and Observation models as well since they have also switched over to the `@current_user` pattern while getting rid of `User.current` and are potentially vulnerable to the same issue.  However, at the moment only Observations have cases where the User is NULL and those appear to be from before the `User.current` clean up started and may be intentional.  Taking a similar approach with this models seems reasonable.  I believe in the case of the Observations it might result in users in essence adopting Observations that don't have a User set.  It would be worth digging more into the Observations case.  I looked a bit at the most recent case, 569283.  It's not clear what happened here, but I do note that it was created using the MO API.  Interestingly the associated images do have an owner who I think would be reasonable to make the owner of the Observation.