### PR TITLE
Enhanced error message if user imports another user's iNat observation

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -59,17 +59,20 @@ class InatImportJob < ApplicationJob
       raise("iNat API user request failed: #{e.message}")
     end
 
-    me_user = JSON.parse(response.body)["results"].first["login"]
-    log("inat_logged_in_user: #{me_user}")
-    wrong_inat_user_error(me_user) unless me_user == inat_username
+    inat_logged_in_user = JSON.parse(response.body)["results"].first["login"]
+    log("inat_logged_in_user: #{inat_logged_in_user}")
+    return if inat_logged_in_user == inat_username
+
+    wrong_inat_user_error(inat_logged_in_user)
   end
 
   def super_importer?
     InatImport.super_importer?(user)
   end
 
-  def wrong_inat_user_error(me_user)
-    raise(:inat_wrong_user.t(inat_username: inat_username, me_user: me_user))
+  def wrong_inat_user_error(inat_logged_in_user)
+    raise(:inat_wrong_user.t(inat_username: inat_username,
+                             inat_logged_in_user: inat_logged_in_user))
   end
 
   def import_requested_observations

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3106,7 +3106,7 @@
 
   inat_import_started: Your import has started. Refresh page to update results.
   inat_no_authorization: iNat import aborted; MO did not received authorization to access iNat user data
-  inat_wrong_user: You cannot import an iNat observation created by someone else. To import your own observation, make sure that noone else is logged into iNat on your device and that you entered the correct iNat username.
+  inat_wrong_user: "\"[me_user]\" is logged into iNat. To import iNat observation(s) of \"[inat_username]\" make sure that \"[inat_username]\" is logged into iNat on your device."
   inat_page_of_obs_failed: Failed to get page of observations from iNat API
 
   inat_snapshot_caption: iNat imported data

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3106,7 +3106,7 @@
 
   inat_import_started: Your import has started. Refresh page to update results.
   inat_no_authorization: iNat import aborted; MO did not received authorization to access iNat user data
-  inat_wrong_user: "[me_user] is logged into iNat. To import iNat observations of [inat_username] make sure that [inat_username] is logged into iNat on your device"
+  inat_wrong_user: "[inat_logged_in_user] is logged into iNat. To import iNat observations of [inat_username] make sure that [inat_username] is logged into iNat on your device"
   inat_page_of_obs_failed: Failed to get page of observations from iNat API
 
   inat_snapshot_caption: iNat imported data

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3106,7 +3106,7 @@
 
   inat_import_started: Your import has started. Refresh page to update results.
   inat_no_authorization: iNat import aborted; MO did not received authorization to access iNat user data
-  inat_wrong_user: "\"[me_user]\" is logged into iNat. To import iNat observation(s) of \"[inat_username]\" make sure that \"[inat_username]\" is logged into iNat on your device."
+  inat_wrong_user: "[me_user] is logged into iNat. To import iNat observations of [inat_username] make sure that [inat_username] is logged into iNat on your device"
   inat_page_of_obs_failed: Failed to get page of observations from iNat API
 
   inat_snapshot_caption: iNat imported data

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -583,11 +583,10 @@ class InatImportJobTest < ActiveJob::TestCase
       InatImportJob.perform_now(@inat_import)
     end
 
-    assert_match(
-      :inat_wrong_user.l(
-        inat_username: @inat_import.inat_username, me_user: me_user
-      ),
-      @inat_import.response_errors,
+    expect = :inat_wrong_user.l(inat_username: @inat_import.inat_username,
+                                me_user: me_user)
+    assert_includes(
+      @inat_import.response_errors, expect,
       "It should warn if a user tries to import another's iNat obs"
     )
   end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -587,7 +587,7 @@ class InatImportJobTest < ActiveJob::TestCase
       :inat_wrong_user.l(
         inat_username: @inat_import.inat_username, me_user: me_user
       ),
-      @inat_import.response_errors.gsub("&#8220;", '"').gsub("&#8221;", '"'),
+      @inat_import.response_errors,
       "It should warn if a user tries to import another's iNat obs"
     )
   end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -575,8 +575,8 @@ class InatImportJobTest < ActiveJob::TestCase
   def test_import_anothers_observation
     create_ivars_from_filename("calostoma_lutescens")
 
-    me_user = "WrongUser"
-    stub_inat_interactions(login: me_user)
+    inat_logged_in_user = "WrongUser"
+    stub_inat_interactions(login: inat_logged_in_user)
 
     assert_difference("Observation.count", 0,
                       "It should not import another user's observation") do
@@ -584,7 +584,7 @@ class InatImportJobTest < ActiveJob::TestCase
     end
 
     expect = :inat_wrong_user.l(inat_username: @inat_import.inat_username,
-                                me_user: me_user)
+                                inat_logged_in_user: inat_logged_in_user)
     assert_includes(
       @inat_import.response_errors, expect,
       "It should warn if a user tries to import another's iNat obs"

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -575,7 +575,8 @@ class InatImportJobTest < ActiveJob::TestCase
   def test_import_anothers_observation
     create_ivars_from_filename("calostoma_lutescens")
 
-    stub_inat_interactions(login: "another user")
+    me_user = "WrongUser"
+    stub_inat_interactions(login: me_user)
 
     assert_difference("Observation.count", 0,
                       "It should not import another user's observation") do
@@ -583,7 +584,10 @@ class InatImportJobTest < ActiveJob::TestCase
     end
 
     assert_match(
-      :inat_wrong_user.l, @inat_import.response_errors,
+      :inat_wrong_user.l(
+        inat_username: @inat_import.inat_username, me_user: me_user
+      ),
+      @inat_import.response_errors.gsub("&#8220;", '"').gsub("&#8221;", '"'),
       "It should warn if a user tries to import another's iNat obs"
     )
   end


### PR DESCRIPTION
See [Pull Request Overview](https://github.com/MushroomObserver/mushroom-observer/pull/3371#pullrequestreview-3352092642) for details

The motivation for this PR is: one user says he cannot import an iNat observations because he always receives the error message "You cannot import an iNat observation created by someone else."
I cannot replicate the problem on my local (when logged in as that user) -- the import just works.
I hope that the enhanced message will help us to figure out what's going on. 

# Suggested Manual Test
## NOTE: requires knowing the iNat username of someone else who is not a superimporter

- Login to iNat as yourself
- Login to MO as someone else who is not a superimporter
- Import from iNat, filling in the form with:
  - that person's `inat_username` 
  - the iNat ID of someone else's observation
  - Submit
  
### Expected result:

> Status: Done
Imported: 0 of 1 observations
...
Errors: <your inat_username> is logged into iNat. To import iNat observations of <other person's inat_username> make sure that <other person's inat_username> is logged into iNat on your device
<img width="732" height="215" alt="Screenshot 2025-10-18 at 5 20 02 PM" src="https://github.com/user-attachments/assets/a85c7704-676d-458b-b17e-aca5f375027e" />
