### PR TITLE
Revert dependabot change to MiniRacer version and add test to prevent repeat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,8 @@ gem("requestjs-rails")
 # turbo for partial page updates
 gem("turbo-rails")
 # minimal two way bridge between the V8 JavaScript engine and Ruby
-# Locked here because "0.19.0" will not compile for nimmolo
-gem("mini_racer", "~> 0.19.1")
+# Locked here at "0.18.1" because "0.19.0" will not compile for nimmolo
+gem("mini_racer", "~> 0.18.1")
 
 # Add Arel helpers for more concise query syntax in Arel
 # https://github.com/camertron/arel-helpers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,12 +248,12 @@ GEM
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)
-    libv8-node (24.1.0.0)
-    libv8-node (24.1.0.0-aarch64-linux)
-    libv8-node (24.1.0.0-arm64-darwin)
-    libv8-node (24.1.0.0-x86_64-darwin)
-    libv8-node (24.1.0.0-x86_64-linux)
-    libv8-node (24.1.0.0-x86_64-linux-musl)
+    libv8-node (23.6.1.0)
+    libv8-node (23.6.1.0-aarch64-linux)
+    libv8-node (23.6.1.0-arm64-darwin)
+    libv8-node (23.6.1.0-x86_64-darwin)
+    libv8-node (23.6.1.0-x86_64-linux)
+    libv8-node (23.6.1.0-x86_64-linux-musl)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -273,8 +273,8 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.5)
-    mini_racer (0.19.1)
-      libv8-node (~> 24.1.0.0)
+    mini_racer (0.18.1)
+      libv8-node (~> 23.6.1.0)
     minitest (5.26.0)
     minitest-reporters (1.7.1)
       ansi
@@ -602,7 +602,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mimemagic
-  mini_racer (~> 0.19.1)
+  mini_racer (~> 0.18.1)
   minitest
   minitest-reporters
   mission_control-jobs

--- a/test/gems/mini_racer_version_test.rb
+++ b/test/gems/mini_racer_version_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MiniRacerVersionTest < FunctionalTestCase
+  # test version "0.18.1" because ">= 0.19.0" will not compile for older Macs
+  # Issue documented here: https://github.com/rubyjs/mini_racer/issues/359
+  def test_mini_racer_version
+    assert_equal(MiniRacer::VERSION, "0.18.1")
+  end
+end


### PR DESCRIPTION
The issue is documented here: https://github.com/rubyjs/mini_racer/issues/359