### PR TITLE
Exclude lib from coverage

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,10 @@ else
 end
 
 SimpleCov.start("rails") do
+  # filters
+  # https://github.com/simplecov-ruby/simplecov?tab=readme-ov-file#defining-custom-filters
+  # Exclude lib as we have so little there.
+  add_filter(%r{/lib/})
   # An always empty file which is always reported as a coverage decrease
   add_filter("/channels/application_cable/channel.rb")
 end


### PR DESCRIPTION
Exclude lib from coverage to avoid incorrect "Coverage decreased" reports by Coveralls.
See https://mushroomobserver.slack.com/archives/C09LDHTBXE1/p1761411666567649