### PR TITLE
Avoid setting the collector if the observation already exists

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -195,9 +195,13 @@ class FieldSlipsController < ApplicationController
     obs = @field_slip.observation
     return unless obs
 
+    # Don't update Collector
+    notes = field_slip_notes
+    notes.delete(:Collector)
+
     check_name
     # Don't override obs.when or obs.place_name
-    obs.notes.value_merge!(field_slip_notes)
+    obs.notes.value_merge!(notes)
     obs.notes.compact_blank!
     obs.save!
   end

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -197,7 +197,7 @@ class FieldSlipsController < ApplicationController
 
     # Don't update Collector
     notes = field_slip_notes
-    notes.delete(:Collector)
+    notes.delete(:Collector) unless @user == obs.user
 
     check_name
     # Don't override obs.when or obs.place_name

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -76,8 +76,28 @@ class FieldSlipsControllerTest < FunctionalTestCase
              }
            })
     end
+  end
+
+  def test_should_not_change_collector_of_last_viewed_obs
+    login(@field_slip.user.login)
+    ObservationView.update_view_stats(@field_slip.observation_id,
+                                      @field_slip.user_id)
+    collector = @field_slip.collector
+    code = "Y#{@field_slip.code}"
+    assert_difference("FieldSlip.count") do
+      post(:create,
+           params: {
+             commit: :field_slip_last_obs.t,
+             field_slip: {
+               code: code,
+               project_id: projects(:eol_project).id,
+               collector: rolf.login
+             }
+           })
+    end
 
     slip = FieldSlip.find_by(code: code)
+    assert_equal(collector, slip.collector)
     assert_redirected_to(observation_url(slip.observation))
     assert_equal(slip.observation, ObservationView.last(@field_slip.user))
   end


### PR DESCRIPTION
Currently on main if you create a new field slip with the collector specified and then you associate it with an existing observation that you don't own, that collector gets edit rights to the associated observation.  This can be used by any user to get edit rights to any observation.  This should only be allowed for observations that the user setting the collector owns.

To test:
1) Visit an observation you don't own.
2) Click the field slip icon in the upper right (looks like a little QR code)
3) Add yourself as the Collector
4) Save the field slip
On main, you should now be able to edit the observation
On the branch, you cannot

However, if it is an observation you own, then you can add another user as the collector to give them the ability to edit your observation.  One could debate that if you have can edit the observation, you should be able to change the collector from the field slip.  However, this seems like an edge case that you can work around by changing the collector of the observation rather changing it through the field slip.