### PR TITLE
Fix handling of users with underscores in their login names

### DIFF
--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -351,7 +351,7 @@ class Textile < String
       (?: _[a-zA-Z]+)? # optionally including underscores
     )
     \s+
-    (?<id> [^_\s](?:[^_\n]+[^_\s])?) # id -- integer or string
+    (?<id> [^_\s](?:[^\n]+?[^_\s])?) # id -- integer or string
     (?: _+)
 
     (?! (?: \w|</[a-z]+>)) # discard if trailed by word char or html close tag

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -62,7 +62,7 @@ class LookupsController < ApplicationController
   # controller/action after looking up the object.
   # inputs: model Class, true/false
   def lookup_general(model, accepted: false)
-    id = params[:id].to_s.gsub(/[+_]/, " ").strip_squeeze
+    id = params[:id].to_s.strip_squeeze
 
     matches, suggestions = find_matches_and_suggestions(model, id, accepted)
     return if /^\d+$/.match?(id) && !matches

--- a/test/controllers/lookups_controller_test.rb
+++ b/test/controllers/lookups_controller_test.rb
@@ -193,6 +193,13 @@ class LookupsControllerTest < FunctionalTestCase
                       "/lookups/lookup_user/I.+G.+Saponov")
   end
 
+  def test_underscore_user_lookup
+    login
+    user = users(:underscore_user)
+    get(:lookup_user, params: { id: user.login })
+    assert_redirected_to(user_path(user.id))
+  end
+
   def test_lookup_glossary_term_by_number
     term = glossary_terms(:conic_glossary_term)
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -232,3 +232,8 @@ nihilist_user:
   <<: *DEFAULTS
   login: Nil
   name: ""
+
+underscore_user:
+  <<: *DEFAULTS
+  login: I_am_crazy_about_underscores
+  name: Underscore Crazy

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -604,4 +604,9 @@ class UserTest < UnitTestCase
     user = users(:nihilist_user)
     assert(user.textile_name.include?(user.login))
   end
+
+  def test_user_with_underscore
+    user = users(:lone_wolf)
+    assert_match(/lookup_user/, user.textile_name.tl)
+  end
 end


### PR DESCRIPTION
Addresses #3364.  Note that this changes the lookup mechanism to stop ignoring pluses and underscores.  It's not clear why this was the case.  I'm guessing it has to do with translating params in URL encoding which I think is handled better now.  The entire test suite passes so hopefully we're cool.

To test go to http://localhost:3000/589094.  On `main` you will see the text `Collector: Sam Bucciarelli (user That_hippie_chick)`.  This should be a link instead.  On this branch, you will instead see `Sam Bucciarelli ([That_hippie_chick](http://localhost:3000/lookups/lookup_user/That_hippie_chick))` which contains an link to the appropriate user.  In addition to changing how this gets render, the PR also fixes the lookup controller so it handles these cases correctly.