### PR TITLE
Search form: disable Google elevation API calls

### DIFF
--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -17,6 +17,7 @@ module MapHelper
       controller: "map",
       map_target: "mapDiv",
       map_type: "info",
+      need_elevations_value: true,
       map_open: true,
       editable: false,
       controls: [:large_map, :map_type].to_json,

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -393,7 +393,9 @@ module SearchFormHelper
   end
 
   def region_with_in_box_fields(**args)
-    tag.div(data: { controller: "map", map_open: true }) do
+    tag.div(
+      data: { controller: "map", map_open: true, need_elevations_value: false }
+    ) do
       [
         form_location_input_find_on_map(
           form: args[:form], field: :region, value: args[:search]&.region,
@@ -422,10 +424,8 @@ module SearchFormHelper
   end
 
   def search_editable_map(minimal_loc)
-    # capture do
     make_map(objects: [minimal_loc], editable: true, map_type: "location",
              map_open: true, controller: nil)
-    # end
   end
 
   # To be mappable, we need to instantiate a minimal location from the search.

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -240,6 +240,7 @@ export default class extends Controller {
   // Action can be attached to the "Get Elevation" button.
   // `points` is then the event
   getElevations(points, type = "") {
+    // Return if controller property needElevations is false
     this.verbose("geocode:getElevations")
     // "Get Elevation" button on a form sends this param
     if (this.hasGetElevationTarget &&

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -82,7 +82,6 @@ export default class extends Controller {
   }
 
   tryToGeolocate() {
-    debugger
     this.verbose("geocode:tryToGeolocate")
     const address = this.placeInputTarget.value
 
@@ -250,7 +249,6 @@ export default class extends Controller {
     // Return if controller property needElevations is false
     if (!this.needElevationsValue) return false
 
-    debugger
     this.verbose("geocode:getElevations")
     // "Get Elevation" button on a form sends this param
     if (this.hasGetElevationTarget &&

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -48,10 +48,14 @@ export default class extends GeocodeController {
     this.lastGeocodedLatLng = { lat: null, lng: null }
     this.lastGeolocatedAddress = ""
 
+    this.libraries = ["maps", "geocoding", "marker"]
+    if (this.needElevationsValue == true)
+      this.libraries.push("elevation")
+
     const loader = new Loader({
       apiKey: "AIzaSyCxT5WScc3b99_2h2Qfy5SX6sTnE1CX3FA",
       version: "quarterly",
-      libraries: ["maps", "geocoding", "marker", "elevation"]
+      libraries: this.libraries
     })
 
     if (this.collection) {
@@ -80,7 +84,8 @@ export default class extends GeocodeController {
     loader
       .load()
       .then((google) => {
-        this.elevationService = new google.maps.ElevationService()
+        if (this.needElevationsValue == true)
+          this.elevationService = new google.maps.ElevationService()
         this.geocoder = new google.maps.Geocoder()
         // Everything except the obs form map: draw the map.
         if (!(this.map_type === "observation" && this.editable)) {


### PR DESCRIPTION
Should reduce our calls to the Google Elevation API back to former levels, or lower.

This adds a new [Stimulus "value"](https://stimulus.hotwired.dev/reference/values) `needElevationsValue` to the Geocode and Map controllers — a "value" is basically a property that you can set when instantiating the controller. The controller will only check elevations if this value is "true", which is now the default. The search from instantiates it with "false".