### PR TITLE
Change faceted Observations search form to use "within_locations" scope as expected

### DIFF
--- a/app/controllers/observations/search_controller.rb
+++ b/app/controllers/observations/search_controller.rb
@@ -21,7 +21,7 @@ module Observations
         confidence: :select_confidence_range,
         has_name: :select_nil_boolean,
         lichen: :select_nil_boolean,
-        locations: :multiple_value_autocompleter,
+        within_locations: :multiple_value_autocompleter,
         has_public_lat_lng: :select_nil_boolean,
         is_collection_location: :select_nil_boolean,
         region: :region_with_in_box_fields,
@@ -83,7 +83,7 @@ module Observations
           collapsed: [:confidence, [:has_name, :lichen]]
         },
         location: {
-          shown: [:locations],
+          shown: [:within_locations],
           collapsed: [[:has_public_lat_lng, :is_collection_location], :region]
         }
       },

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -194,6 +194,8 @@ module SearchFormHelper
       :name
     when :by_users, :by_editor, :members
       :user
+    when :within_locations
+      :location
     else
       field.to_s.singularize.to_sym
     end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3813,6 +3813,7 @@
   observation_term_herbaria: "[:observation_term_herbarium]"
   observation_term_location: Mushroom was observed within the the geographic bounds ([:east], [:north], [:south], [:west]) of this Location, regardless of the exact name of the Location of the Observation. Location must be an existing MO Location. Cf. **[:region]**.
   observation_term_locations: "[:observation_term_location]"
+  observation_term_within_locations: "[:observation_term_location]"
   observation_term_region: The Observation's Location name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a back-slash as shown. Cf. **[:location]**.
   observation_term_pattern: "[:pattern]"
   observation_term_project: "[:observation_term_projects]"

--- a/test/integration/capybara/search_integration_test.rb
+++ b/test/integration/capybara/search_integration_test.rb
@@ -98,6 +98,27 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
     assert_selector("#results", text: projects(:empty_project).title)
   end
 
+  def test_observations_search_form_within_locations
+    california = "California, USA"
+
+    login
+    visit("/observations/search/new")
+    within("#observations_search_form") do |form|
+      assert_selector("#query_observations_within_locations")
+      form.fill_in("query_observations_within_locations", with: california)
+
+      first(:button, type: "submit").click
+    end
+
+    assert_no_selector("#flash_notices")
+    assert_selector("#filters", text: "within locations: #{california}")
+    # Verify observations from California localities appear in results
+    # Spot-check for observations from Burbank, Point Reyes, and Pasadena
+    assert_selector("#results", text: "Burbank, California, USA")
+    assert_selector("#results", text: "Point Reyes National Seashore")
+    assert_selector("#results", text: "Pasadena, California, USA")
+  end
+
   # def test_species_lists_search_form; end
 
   # def test_herbaria_search_form; end


### PR DESCRIPTION
Pattern search already uses this scope, but i forgot to switch the faceted form to use it.

Adds a test that it works.

Resolves #3454 