### PR TITLE
Increase SolidQueue job retention time.

### DIFF
--- a/app/jobs/discard_stale_jobs_job.rb
+++ b/app/jobs/discard_stale_jobs_job.rb
@@ -14,7 +14,7 @@ class DiscardStaleJobsJob < ApplicationJob
     # When a job fails SolidQueue adds an entry to the
     # SolidQueue::FailedExecution table.
     old_failed_executions =
-      # FaildedExecution.created_at is when the job failed.
+      # FailedExecution.created_at is when the job failed.
       SolidQueue::FailedExecution.where(created_at: ...discard_date)
     return if old_failed_executions.none?
 

--- a/app/jobs/discard_stale_jobs_job.rb
+++ b/app/jobs/discard_stale_jobs_job.rb
@@ -11,10 +11,10 @@ class DiscardStaleJobsJob < ApplicationJob
   end
 
   def discard_stale_failed_jobs(discard_date)
-    # Solid Queue does not have a failed or failed_at column.
-    # Instead it tracks failed jobs using the finished_at column
-    # and a related failed executions table
+    # When a job fails SolidQueue adds an entry to the
+    # SolidQueue::FailedExecution table.
     old_failed_executions =
+      # FaildedExecution.created_at is when the job failed.
       SolidQueue::FailedExecution.where(created_at: ...discard_date)
     return if old_failed_executions.none?
 
@@ -27,7 +27,9 @@ class DiscardStaleJobsJob < ApplicationJob
     end
 
     discarded = old_failed_count - SolidQueue::FailedExecution.count
-    log("Discarded #{discarded} jobs which failed before #{discard_date}")
+    log(
+      "Removed #{discarded} FailedExecutions failing before #{discard_date}"
+    )
   end
 
   def discard_stale_finished_jobs

--- a/config/application.rb
+++ b/config/application.rb
@@ -95,7 +95,7 @@ module MushroomObserver
 
     config.solid_cache.connects_to = { database: { writing: :cache } }
     # https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings
-    config.solid_queue.clear_finished_jobs_after = 1.day
+    config.solid_queue.clear_finished_jobs_after = 1.week
 
     # dartsass-sprockets - sssh! about the bootstrap deprectations
     config.sass.quiet_deps = true

--- a/test/jobs/discard_stale_jobs_job_test.rb
+++ b/test/jobs/discard_stale_jobs_job_test.rb
@@ -6,7 +6,7 @@ class DiscardStaleJobsJobTest < ActiveJob::TestCase
   def test_discarding_failed_jobs
     assert_difference(
       "SolidQueue::FailedExecution.count", -1,
-      "Should discard 1 stale failed Job"
+      "Should remove 1 entry from FailedExecutions"
     ) do
       DiscardStaleJobsJob.perform_now
     end


### PR DESCRIPTION
Retains finished and failed jobs for 1 week to allow more time to inspect them.
Resolves #3465