### PR TITLE
Fix intermittent deadlock in FieldSlipsControllerTest

### DIFF
--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -464,7 +464,14 @@ class FieldSlipsControllerTest < FunctionalTestCase
     login(mary.login)
     get(:edit, params: { id: fs.id })
     assert_response(:success)
-    obs = Observation.last
+    # Create a new observation for this test instead of using Observation.last
+    # to avoid deadlocks with other tests in the suite
+    obs = Observation.create!(
+      user: mary,
+      when: Time.zone.now,
+      where: "Test Location",
+      name: names(:fungi)
+    )
     fs.observation = obs
     fs.save!
     assert_equal(obs.user, fs.user)


### PR DESCRIPTION
Replace Observation.last with creating a new observation to avoid database deadlocks when tests run in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)