### PR TITLE
Make all user fixtures accessible via helper methods

### DIFF
--- a/test/integration/capybara/user_fixture_helpers_test.rb
+++ b/test/integration/capybara/user_fixture_helpers_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Test that user fixture helper methods work in integration tests
+class UserFixtureHelpersTest < CapybaraIntegrationTestCase
+  def test_existing_user_helpers_still_work
+    # These had explicit method definitions before
+    assert_equal(users(:rolf), rolf)
+    assert_equal(users(:mary), mary)
+    assert_equal(users(:dick), dick)
+    assert_equal(users(:katrina), katrina)
+  end
+
+  def test_new_dynamic_user_helpers_work
+    # These never had explicit methods - now they work via method_missing
+    assert_equal(users(:admin), admin)
+    assert_equal(users(:ollie), ollie)
+    assert_equal(users(:thorsten), thorsten)
+    assert_equal(users(:webmaster), webmaster)
+  end
+
+  def test_all_user_fixtures_accessible_as_methods
+    # Get all user fixture names from the loaded fixtures
+    # @loaded_fixtures is set by ActiveSupport::TestCase
+    user_fixture_names = @loaded_fixtures["users"].fixtures.keys
+
+    # Verify we can access each one as a method
+    user_fixture_names.each do |fixture_name|
+      expected_user = users(fixture_name.to_sym)
+      actual_user = send(fixture_name.to_sym)
+      assert_equal(expected_user, actual_user,
+                   "Helper method '#{fixture_name}' should return " \
+                   "users(:#{fixture_name})")
+    end
+  end
+
+  def test_nonexistent_user_raises_error
+    assert_raises(StandardError) do
+      nonexistent_user_xyz
+    end
+  end
+end

--- a/test/models/user_fixture_accessibility_test.rb
+++ b/test/models/user_fixture_accessibility_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Test that all user fixtures are accessible via helper methods.
+# This validates that fixture names follow Ruby method naming conventions.
+class UserFixtureAccessibilityTest < UnitTestCase
+  def test_all_user_fixtures_are_accessible_as_methods
+    # Get all user fixture names
+    user_fixture_names = @loaded_fixtures["users"].fixtures.keys
+    inaccessible_fixtures = []
+
+    # Check each fixture
+    user_fixture_names.each do |fixture_name|
+      # Try to access it as a method
+      unless valid_ruby_method_name?(fixture_name)
+        inaccessible_fixtures << fixture_name
+      end
+    end
+
+    # If any fixtures are inaccessible, fail with a helpful message
+    if inaccessible_fixtures.any?
+      fixture_list = inaccessible_fixtures.map do |name|
+        "  - #{name}"
+      end.join("\n")
+      flunk(
+        "Some user fixtures cannot be accessed as helper methods:\n" \
+        "#{fixture_list}\n\n" \
+        "Fixture names must be valid Ruby method names (lowercase letters, " \
+        "digits, and underscores only, starting with a lowercase letter or " \
+        "underscore).\n\n" \
+        "To fix this, rename these fixtures to use only lowercase letters, " \
+        "digits, and underscores.\n\n" \
+        "Example: Instead of 'My-User', use 'my_user'"
+      )
+    end
+
+    # Also verify we can actually call each one
+    user_fixture_names.each do |fixture_name|
+      expected_user = users(fixture_name.to_sym)
+      actual_user = send(fixture_name.to_sym)
+      assert_equal(expected_user, actual_user,
+                   "Helper method '#{fixture_name}' should return " \
+                   "users(:#{fixture_name})")
+    end
+  end
+
+  private
+
+  # Check if a string is a valid Ruby method name
+  def valid_ruby_method_name?(name)
+    # Ruby method names must:
+    # - Start with lowercase letter or underscore
+    # - Contain only lowercase letters, digits, and underscores
+    # - Optionally end with ? or ! (not applicable for our use case)
+    name.to_s.match?(/\A[a-z_][a-z0-9_]*\z/)
+  end
+end

--- a/test/system/user_fixture_helpers_system_test.rb
+++ b/test/system/user_fixture_helpers_system_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+# Test that user fixture helper methods work in system tests
+class UserFixtureHelpersSystemTest < ApplicationSystemTestCase
+  def test_existing_user_helpers_still_work
+    # These had explicit method definitions before
+    assert_equal(users(:rolf), rolf)
+    assert_equal(users(:mary), mary)
+    assert_equal(users(:dick), dick)
+    assert_equal(users(:katrina), katrina)
+  end
+
+  def test_new_dynamic_user_helpers_work
+    # These never had explicit methods - now they work via method_missing
+    assert_equal(users(:admin), admin)
+    assert_equal(users(:ollie), ollie)
+    assert_equal(users(:thorsten), thorsten)
+    assert_equal(users(:webmaster), webmaster)
+  end
+
+  def test_nonexistent_user_raises_error
+    assert_raises(StandardError) do
+      nonexistent_user_xyz
+    end
+  end
+end


### PR DESCRIPTION
Housekeeping PR to help me with these Claude PRs. 

In our tests currently, you can write `login(rolf)` but not `login(admin)`. The user fixture accessor methods only exist for the most frequently used users. This keeps tripping Claude up, and it's gotten me too. 

This PR dynamically creates accessor methods for all user fixtures, and also adds a test to be sure nobody makes a new user fixture that won't work this way, i.e. whose name conflicts with an existing test method name. 

So with this, now you can just write `login(lone_wolf)` in any test, instead of `login(users(:lone_wolf))`.
