### PR TITLE
Fix intermittent test failures by adding super to setup methods

### DIFF
--- a/test/classes/ip_stats_test.rb
+++ b/test/classes/ip_stats_test.rb
@@ -5,6 +5,7 @@ require("fileutils")
 
 class IpStatsTest < UnitTestCase
   def setup
+    super
     fixture_path = Rails.root.join("test/fixtures")
     setup_file(MO.blocked_ips_file, "#{fixture_path}/blocked_ips.txt")
     setup_file(MO.okay_ips_file, "#{fixture_path}/okay_ips.txt")

--- a/test/classes/time_extensions_test.rb
+++ b/test/classes/time_extensions_test.rb
@@ -40,6 +40,7 @@ class TimeWithZoneExtensionsTest < ActiveSupport::TestCase
   include TimeExtensionsInterfaceTest
 
   def setup
+    super
     @object = Time.zone.now
   end
 end
@@ -49,6 +50,7 @@ class DateExtensionsTest < ActiveSupport::TestCase
   include DateExtensionsInterfaceTest
 
   def setup
+    super
     @object = Time.zone.today
   end
 end
@@ -59,6 +61,7 @@ class DateTimeExtensionsTest < ActiveSupport::TestCase
   include TimeExtensionsInterfaceTest
 
   def setup
+    super
     @object = DateTime.now
   end
 end

--- a/test/components/carousel_test.rb
+++ b/test/components/carousel_test.rb
@@ -6,6 +6,7 @@ class CarouselTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @obs = observations(:coprinus_comatus_obs)
     @images = @obs.images.to_a

--- a/test/components/form_carousel_item_test.rb
+++ b/test/components/form_carousel_item_test.rb
@@ -6,6 +6,7 @@ class FormCarouselItemTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @image = images(:connected_coprinus_comatus_image)
   end

--- a/test/components/form_carousel_test.rb
+++ b/test/components/form_carousel_test.rb
@@ -6,6 +6,7 @@ class FormCarouselTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @obs = observations(:coprinus_comatus_obs)
     @images = @obs.images.to_a

--- a/test/components/image_vote_interface_test.rb
+++ b/test/components/image_vote_interface_test.rb
@@ -6,6 +6,7 @@ class ImageCaptionVoteInterfaceTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @image = images(:connected_coprinus_comatus_image)
   end

--- a/test/components/interactive_image_test.rb
+++ b/test/components/interactive_image_test.rb
@@ -6,6 +6,7 @@ class InteractiveImageTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @image = images(:connected_coprinus_comatus_image)
   end

--- a/test/components/lightbox_caption_test.rb
+++ b/test/components/lightbox_caption_test.rb
@@ -6,6 +6,7 @@ class LightboxCaptionTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @obs = observations(:coprinus_comatus_obs)
     @image = @obs.images.first

--- a/test/components/lightbox_observation_title_test.rb
+++ b/test/components/lightbox_observation_title_test.rb
@@ -6,6 +6,7 @@ class LightboxObservationTitleTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
     @obs = observations(:coprinus_comatus_obs)
   end

--- a/test/components/matrix_box_test.rb
+++ b/test/components/matrix_box_test.rb
@@ -6,6 +6,7 @@ class MatrixBoxTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
   end
 

--- a/test/components/matrix_table_test.rb
+++ b/test/components/matrix_table_test.rb
@@ -6,6 +6,7 @@ class MatrixTableTest < UnitTestCase
   include ComponentTestHelper
 
   def setup
+    super
     @user = users(:rolf)
   end
 

--- a/test/controllers/add_dispatch_controller_test.rb
+++ b/test/controllers/add_dispatch_controller_test.rb
@@ -4,6 +4,7 @@ require("test_helper")
 
 class AddDispatchControllerTest < FunctionalTestCase
   def setup
+    super
     @user = users(:rolf)
     @project = projects(:bolete_project)
     @species_list = species_lists(:first_species_list)

--- a/test/controllers/images/originals_controller_test.rb
+++ b/test/controllers/images/originals_controller_test.rb
@@ -37,6 +37,7 @@ module Images
     DIR = Rails.root.join("tmp/downloads")
 
     def setup
+      super
       @mock_storage = MockStorage.new
       @test_image = Image.reorder(created_at: :asc).first
       @test_file = "#{DIR}/#{@test_image.id}.jpg"

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -6,6 +6,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
   tests ObservationsController
 
   def setup
+    super
     # Must do this to get center lats saved on fixtures without lat/lng.
     Location.update_box_area_and_center_columns
   end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -4,6 +4,7 @@ require("test_helper")
 
 class CommentTest < UnitTestCase
   def setup
+    super
     QueuedEmail.queue = true
   end
 

--- a/test/models/queued_email_test.rb
+++ b/test/models/queued_email_test.rb
@@ -4,6 +4,7 @@ require("test_helper")
 
 class QueuedEmailTest < UnitTestCase
   def setup
+    super
     QueuedEmail.queue = true
   end
 


### PR DESCRIPTION
Root Cause:
Test setup methods that don't call super miss critical initialization:
1. Clearing Symbol.missing_tags = [] (prevents tag accumulation)
2. Setting I18n.locale = :en

This causes intermittent CI failures in parallel test environments where missing translation tags from other tests accumulate in the shared class variable.

The Fix:
Added super to the beginning of setup methods in 16 test files:
- 10 component tests
- 6 other tests (classes, controllers, models)

This ensures proper test isolation through the standard setup/teardown lifecycle and prevents "Language tags missing" errors in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)