### PR TITLE
Fix retransfer_images so it works better with the new rsync cronjob

### DIFF
--- a/config/etc/crontab
+++ b/config/etc/crontab
@@ -7,7 +7,7 @@ MAILTO=webmaster@mushroomobserver.org
 */6 * * * * /var/web/mo/bin/run script/retransfer_images
 # This runs staggered three minutes after retransfer_images:
 # 3-59/6 * * * * rsync -av --remove-source-files /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
-3-59/6 * * * * (cd /var/web/mo/public/images && find . -type f -mmin +1) | rsync -av --remove-source-files --files-from=- /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
+3-59/6 * * * * (cd /var/web/mo/public/images && find . -type f -mmin +3) | rsync -av --remove-source-files --files-from=- /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
 */4 * * * * /var/web/mo/bin/run script/parse_log
 1   * * * * /var/web/mo/bin/run script/check_for_orphaned_thumbnails
 13  3 * * * /var/web/mo/bin/run script/backup_blocked_ips.sh

--- a/config/etc/crontab
+++ b/config/etc/crontab
@@ -6,7 +6,8 @@ MAILTO=webmaster@mushroomobserver.org
 */5 * * * * /var/web/mo/bin/run rake email:send -f /var/web/mushroom-observer/Rakefile
 */6 * * * * /var/web/mo/bin/run script/retransfer_images
 # This runs staggered three minutes after retransfer_images:
-3-59/6 * * * * rsync -av --remove-source-files /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
+# 3-59/6 * * * * rsync -av --remove-source-files /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
+3-59/6 * * * * (cd /var/web/mo/public/images; find . -type f -mmin +1) | rsync -av --remove-source-files --files-from=- /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
 */4 * * * * /var/web/mo/bin/run script/parse_log
 1   * * * * /var/web/mo/bin/run script/check_for_orphaned_thumbnails
 13  3 * * * /var/web/mo/bin/run script/backup_blocked_ips.sh

--- a/config/etc/crontab
+++ b/config/etc/crontab
@@ -7,7 +7,7 @@ MAILTO=webmaster@mushroomobserver.org
 */6 * * * * /var/web/mo/bin/run script/retransfer_images
 # This runs staggered three minutes after retransfer_images:
 # 3-59/6 * * * * rsync -av --remove-source-files /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
-3-59/6 * * * * (cd /var/web/mo/public/images; find . -type f -mmin +1) | rsync -av --remove-source-files --files-from=- /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
+3-59/6 * * * * (cd /var/web/mo/public/images && find . -type f -mmin +1) | rsync -av --remove-source-files --files-from=- /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/
 */4 * * * * /var/web/mo/bin/run script/parse_log
 1   * * * * /var/web/mo/bin/run script/check_for_orphaned_thumbnails
 13  3 * * * /var/web/mo/bin/run script/backup_blocked_ips.sh

--- a/script/retransfer_images
+++ b/script/retransfer_images
@@ -21,7 +21,7 @@ DESCRIPTION
 
 END
 
-ids=$( run_mysql "SELECT id FROM images WHERE transferred=FALSE" )
+ids=$( run_mysql "SELECT id FROM images WHERE transferred=FALSE AND created_at <= NOW() - INTERVAL 10 MINUTE" )
 
 for id in $ids; do
   for subdir in thumb 320 640 960 1280 orig; do


### PR DESCRIPTION
Should allow `retransfer_images` to play better with the `rsync` command with a new time delay.

Add the time delay was necessary due to the rsync interacting badly with the iNat import which was causing the orig image to get deleted before the process_image script had successfully completed.