### PR TITLE
Fix rendering of login request new password and add integration test

### DIFF
--- a/app/components/login_form.rb
+++ b/app/components/login_form.rb
@@ -31,13 +31,13 @@ class Components::LoginForm < Components::ApplicationForm
 
   def render_forgot_login_text
     div(class: "form-group mt-3") do
-      :login_forgot_password.tp
+      raw(:login_forgot_password.tp) # rubocop:disable Rails/OutputSafety
     end
   end
 
   def render_help_text
     div(class: "form-group mt-3") do
-      :login_having_problems.tp
+      raw(:login_having_problems.tp) # rubocop:enable Rails/OutputSafety
     end
   end
 end

--- a/app/components/login_form.rb
+++ b/app/components/login_form.rb
@@ -37,7 +37,7 @@ class Components::LoginForm < Components::ApplicationForm
 
   def render_help_text
     div(class: "form-group mt-3") do
-      raw(:login_having_problems.tp) # rubocop:enable Rails/OutputSafety
+      raw(:login_having_problems.tp) # rubocop:disable Rails/OutputSafety
     end
   end
 end

--- a/test/integration/capybara/email_new_password_form_integration_test.rb
+++ b/test/integration/capybara/email_new_password_form_integration_test.rb
@@ -5,8 +5,12 @@ require("test_helper")
 # Simple smoke test for email new password form submission
 class EmailNewPasswordFormIntegrationTest < CapybaraIntegrationTestCase
   def test_request_new_password
-    # Visit the email new password page (no login required)
-    visit(account_email_new_password_path)
+    # Start at the login page
+    visit(new_account_login_path)
+    assert_selector("body.login__new")
+
+    # Click the "Email me a new one." link to go to password reset page
+    click_link("Email me a new one.")
     assert_selector("body.login__email_new_password")
 
     # Fill in the form with a valid login


### PR DESCRIPTION
Translation strings with unsafe embedded links have to be output like this in Phlex.

`raw(:login_forgot_password.tp) # rubocop:disable Rails/OutputSafety`

Phlex is pointing out a real issue with our code. These db translation strings are unsafe in the sense that it's easy for a user to mangle the link (or worse) when making a translation.

I'd ideally like to gradually get rid of these and just have simple links to avoid gotchas like this. To me it's preferable that an internal link be rendered in Rails as a `link_to` that's obvious in the code.

