### PR TITLE
Show map pin instead of Location box to creator of Observation with hidden gps

### DIFF
--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -22,10 +22,18 @@ module Observations
       @observation = find_or_goto_index(Observation, params[:id].to_s)
       return unless @observation
 
+      if permission?(@observation)
+        lat = @observation.lat
+        lng = @observation.lng
+      else
+        lat = @observation.public_lat
+        lng = @observation.public_lng
+      end
+
       @observations = [
         Mappable::MinimalObservation.new(id: @observation.id,
-                                         lat: @observation.public_lat,
-                                         lng: @observation.public_lng,
+                                         lat: lat,
+                                         lng: lng,
                                          location: @observation.location,
                                          location_id: @observation.location_id)
       ]


### PR DESCRIPTION
Resolves #3358 

### Manual Test

- go to one of your Observations which has hidden gps
- click the "nnn°N nnn°W nnn m [Click for map]" link
Result: Map with a pin at the hidden lat/lng. (In main, the map instead shows a Location box.)
- go to someone else's Observations which had hidden gps (Ex http://localhost:3000/obs/593737)
Result: (sam as main) There is not a "nnn°N nnn°W nnn m [Click for map]" link
