### PR TITLE
Fix flow destroying a new observation, should redirect to index (not next_obs)

### DIFF
--- a/app/controllers/observations_controller/destroy.rb
+++ b/app/controllers/observations_controller/destroy.rb
@@ -26,11 +26,17 @@ module ObservationsController::Destroy
       redirect_to({ action: :show, id: obs_id })
     else
       flash_notice(:runtime_destroy_observation_success.t(id: param_id))
-      if this_query
-        redirect_to({ action: :show, id: next_id })
-      else
-        redirect_to(action: :index)
-      end
+      redirect_after_destroy(this_query, next_id)
+    end
+  end
+
+  private
+
+  def redirect_after_destroy(query, next_id)
+    if query && next_id
+      redirect_to({ action: :show, id: next_id })
+    else
+      redirect_to(action: :index)
     end
   end
 end

--- a/test/controllers/observations_controller_destroy_test.rb
+++ b/test/controllers/observations_controller_destroy_test.rb
@@ -23,6 +23,26 @@ class ObservationsControllerDestroyTest < FunctionalTestCase
     end
   end
 
+  def test_destroy_observation_with_query_no_next
+    # Test that destroying an observation when query has no next_id
+    # redirects to index instead of crashing
+    obs = observations(:minimal_unknown_obs)
+    id = obs.id
+    login("mary")
+
+    # Create a query with just this one observation
+    query = Query.lookup_and_save(:Observation, ids: [id])
+    session[:checklist_source] = query.id.alphabetize
+
+    delete(:destroy, params: { id: id })
+
+    # Should redirect to index, not crash trying to show nil observation
+    assert_redirected_to(action: :index)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Observation.find(id)
+    end
+  end
+
   def test_original_filename_visibility
     login("mary")
     obs_id = observations(:agaricus_campestris_obs).id


### PR DESCRIPTION
Error thrown by the following sequence of operations. Couldn't replicate it main.

- click Create Observation, 
- click Create button (without filling in any fields)
- click Destroy Observation icon ❌ 
Result:
```ruby
ActionController::UrlGenerationError in ObservationsController#destroy
No route matches {:action=>"show", :controller=>"observations", :id=>nil}
Extracted source (around line #337):
              
      redirect_back(fallback_location: "/")
    else
      super
    end
  end

Rails.root: /Users/joe/mushroom-observer

Application Trace | Framework Trace | Full Trace
app/controllers/application_controller/queries.rb:337:in `redirect_to'
app/controllers/observations_controller/destroy.rb:30:in `destroy'
app/controllers/application_controller.rb:148:in `catch_errors_and_log_request_stats'
```