### PR TITLE
Create webmaster_question_integration_test.rb

### DIFF
--- a/test/integration/capybara/webmaster_question_integration_test.rb
+++ b/test/integration/capybara/webmaster_question_integration_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
+  def test_logged_in_user_submits_webmaster_question
+    rolf = users(:rolf)
+    login!(rolf)
+
+    email_count = ActionMailer::Base.deliveries.count
+
+    # Visit the webmaster question form
+    visit(new_admin_emails_webmaster_questions_path)
+
+    within("#webmaster_question_form") do
+      # Email field should be pre-filled with user's email
+      assert_field("webmaster_question_user_email", with: rolf.email)
+
+      # Fill in the question
+      fill_in("webmaster_question_question_content",
+              with: "I found a bug in the observation form")
+
+      # Submit the form
+      click_commit
+    end
+
+    # Should redirect with success message
+    assert_flash_text(:runtime_ask_webmaster_success.l)
+
+    # Verify email was sent
+    assert_equal(email_count + 1, ActionMailer::Base.deliveries.count)
+    email = ActionMailer::Base.deliveries.last
+    assert_match(/#{rolf.email}/, email.to_s)
+    assert_match(/bug in the observation form/, email.to_s)
+  end
+
+  def test_anonymous_user_submits_webmaster_question
+    email_count = ActionMailer::Base.deliveries.count
+
+    # Visit the webmaster question form without logging in
+    visit(new_admin_emails_webmaster_questions_path)
+
+    within("#webmaster_question_form") do
+      # Fill in both email and question
+      fill_in("webmaster_question_user_email",
+              with: "concerned_user@example.com")
+      fill_in("webmaster_question_question_content",
+              with: "I noticed something odd with the species page")
+
+      # Submit the form
+      click_commit
+    end
+
+    # Should redirect with success message
+    assert_flash_text(:runtime_ask_webmaster_success.l)
+
+    # Verify email was sent
+    assert_equal(email_count + 1, ActionMailer::Base.deliveries.count)
+    email = ActionMailer::Base.deliveries.last
+    assert_match(/concerned_user@example.com/, email.to_s)
+    assert_match(/odd with the species page/, email.to_s)
+  end
+
+  def test_validation_error_missing_email
+    visit(new_admin_emails_webmaster_questions_path)
+
+    within("#webmaster_question_form") do
+      # Leave email blank
+      fill_in("webmaster_question_user_email", with: "")
+      fill_in("webmaster_question_question_content",
+              with: "This is my question")
+
+      click_commit
+    end
+
+    # Should show error message
+    assert_flash_text(:runtime_ask_webmaster_need_address.l)
+  end
+
+  def test_validation_error_missing_content
+    visit(new_admin_emails_webmaster_questions_path)
+
+    within("#webmaster_question_form") do
+      fill_in("webmaster_question_user_email", with: "test@example.com")
+      fill_in("webmaster_question_question_content", with: "")
+
+      click_commit
+    end
+
+    # Should show error message
+    assert_flash_text(:runtime_ask_webmaster_need_content.l)
+  end
+
+  def test_spam_protection_for_anonymous_users
+    visit(new_admin_emails_webmaster_questions_path)
+
+    within("#webmaster_question_form") do
+      fill_in("webmaster_question_user_email", with: "spammer@example.com")
+      # Content with URL should trigger spam protection
+      fill_in("webmaster_question_question_content",
+              with: "Check out http://spam-site.com")
+
+      click_commit
+    end
+
+    # Should show antispam error
+    assert_flash_text(/robot spam/)
+  end
+
+  def test_logged_in_users_can_include_urls
+    rolf = users(:rolf)
+    login!(rolf)
+
+    email_count = ActionMailer::Base.deliveries.count
+
+    visit(new_admin_emails_webmaster_questions_path)
+
+    within("#webmaster_question_form") do
+      # Logged in users can include URLs in their questions
+      fill_in("webmaster_question_question_content",
+              with: "The page at https://mushroomobserver.org/123 has an error")
+
+      click_commit
+    end
+
+    # Should succeed for logged-in users
+    assert_flash_text(:runtime_ask_webmaster_success.l)
+
+    # Verify email was sent
+    assert_equal(email_count + 1, ActionMailer::Base.deliveries.count)
+  end
+end


### PR DESCRIPTION
Adds an integration to test what the controller test could not catch: that the form actually submits.

Controller tests send post requests, but if the form's params change but test and controller params don't, they won't catch the form not working in reality. 