### PR TITLE
PublicationsController 100% coverage

### DIFF
--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -467,7 +467,9 @@ module ControllerExtensions
   def assert_response(arg, msg = "")
     return unless arg
 
-    if arg == :success || arg == :redirect || arg.is_a?(Integer)
+    # Is it a standard Rails HTTP status symbol or other pass-through value?
+    if (arg.is_a?(Symbol) && Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(arg)) ||
+       arg == :success || arg == :redirect || arg.is_a?(Integer)
       super
     else
       # Put together good error message telling us exactly what happened.

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -467,9 +467,13 @@ module ControllerExtensions
   def assert_response(arg, msg = "")
     return unless arg
 
-    # Is it a standard Rails HTTP status symbol or other pass-through value?
+    rails_response_predicates =
+      ActionDispatch::Assertions::ResponseAssertions::RESPONSE_PREDICATES
+    # Is it a standard Rails HTTP status symbol?
     if (arg.is_a?(Symbol) && Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(arg)) ||
-       arg == :success || arg == :redirect || arg.is_a?(Integer)
+       # or Rails response predicate (:success, :missing, :redirect, :error)?
+       (arg.is_a?(Symbol) && rails_response_predicates.key?(arg)) ||
+       arg.is_a?(Integer)
       super
     else
       # Put together good error message telling us exactly what happened.

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -123,7 +123,7 @@ class PublicationsControllerTest < FunctionalTestCase
     assert_difference("Publication.count", +1) do
       post(:create, params: { publication: { full: ref } }, format: :xml)
     end
-    assert_response(201) # created
+    assert_response(:created)
   end
 
   def test_should_not_create_publication_with_errors_xml
@@ -132,7 +132,7 @@ class PublicationsControllerTest < FunctionalTestCase
     assert_no_difference("Publication.count") do
       post(:create, params: { publication: { full: "" } }, format: :xml)
     end
-    assert_response(422) # unprocessable_content
+    assert_response(:unprocessable_content)
   end
 
   def test_should_not_update_publication_without_permission_xml
@@ -140,7 +140,7 @@ class PublicationsControllerTest < FunctionalTestCase
     login("mary")
     put(:update, params: { id: publications(:one_pub).id,
                            publication: { full: "New" } }, format: :xml)
-    assert_response(422) # unprocessable_content
+    assert_response(:unprocessable_content)
   end
 
   def test_should_not_update_publication_with_errors_xml
@@ -148,7 +148,7 @@ class PublicationsControllerTest < FunctionalTestCase
     login
     put(:update, params: { id: publications(:one_pub).id,
                            publication: { full: "" } }, format: :xml)
-    assert_response(422) # unprocessable_content
+    assert_response(:unprocessable_content)
   end
 
   def test_should_not_destroy_publication_without_permission_xml
@@ -157,6 +157,6 @@ class PublicationsControllerTest < FunctionalTestCase
     assert_no_difference("Publication.count") do
       delete(:destroy, params: { id: publications(:one_pub).id }, format: :xml)
     end
-    assert_response(422) # unprocessable_content
+    assert_response(:unprocessable_content)
   end
 end

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -90,4 +90,73 @@ class PublicationsControllerTest < FunctionalTestCase
 
     assert_redirected_to(publications_path)
   end
+
+  # HTML format tests for permission/validation failures
+  def test_should_not_update_publication_without_permission
+    login("mary")
+    put(:update, params: { id: publications(:one_pub).id,
+                           publication: { full: "New" } })
+    assert_redirected_to(publications_path)
+  end
+
+  def test_should_not_update_publication_with_errors
+    login
+    put(:update, params: { id: publications(:one_pub).id,
+                           publication: { full: "" } })
+    assert_response(:success)
+    assert_template(:edit)
+  end
+
+  def test_should_not_destroy_publication_without_permission
+    login("mary")
+    assert_no_difference("Publication.count") do
+      delete(:destroy, params: { id: publications(:one_pub).id })
+    end
+    assert_redirected_to(publications_path)
+  end
+
+  # XML format tests for coverage
+  def test_should_create_publication_xml
+    disable_unsafe_html_filter
+    login
+    ref = "Author, J.R. 2014. Test Publication."
+    assert_difference("Publication.count", +1) do
+      post(:create, params: { publication: { full: ref } }, format: :xml)
+    end
+    assert_response(201) # created
+  end
+
+  def test_should_not_create_publication_with_errors_xml
+    disable_unsafe_html_filter
+    login
+    assert_no_difference("Publication.count") do
+      post(:create, params: { publication: { full: "" } }, format: :xml)
+    end
+    assert_response(422) # unprocessable_content
+  end
+
+  def test_should_not_update_publication_without_permission_xml
+    disable_unsafe_html_filter
+    login("mary")
+    put(:update, params: { id: publications(:one_pub).id,
+                           publication: { full: "New" } }, format: :xml)
+    assert_response(422) # unprocessable_content
+  end
+
+  def test_should_not_update_publication_with_errors_xml
+    disable_unsafe_html_filter
+    login
+    put(:update, params: { id: publications(:one_pub).id,
+                           publication: { full: "" } }, format: :xml)
+    assert_response(422) # unprocessable_content
+  end
+
+  def test_should_not_destroy_publication_without_permission_xml
+    disable_unsafe_html_filter
+    login("mary")
+    assert_no_difference("Publication.count") do
+      delete(:destroy, params: { id: publications(:one_pub).id }, format: :xml)
+    end
+    assert_response(422) # unprocessable_content
+  end
 end


### PR DESCRIPTION
- Responds to https://coveralls.io/builds/76635221, which says there are 2 added or new uncovered lines ("21 of 23 new or added lines in 5 files covered"). 
- Covers all [previously uncovered lines of PublicationsController](https://coveralls.io/builds/76635221/source?filename=app%2Fcontrollers%2Fpublications_controller.rb).
- Allows test of response using any Rails RESPONSE_PREDICATE or standard HTTP status symbol. 