### PR TITLE
Search forms - automatically assign UI method from Query param definition

### DIFF
--- a/app/classes/search_field_ui.rb
+++ b/app/classes/search_field_ui.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Service object to determine which UI component to use for a search field.
+# Extracts UI selection logic from the Searchable concern.
+#
+# @example Usage in controller
+#   SearchFieldUI.for(controller: self, field: :names)
+#   # => :names_fields_for_obs
+#
+# @example With instance
+#   SearchFieldUI.new(controller: self, field: :has_images).ui_type
+#   # => :select_nil_boolean
+class SearchFieldUI
+  attr_reader :controller, :field
+
+  def initialize(controller:, field:)
+    @controller = controller
+    @field = field
+  end
+
+  # Class method for cleaner syntax
+  # @param controller [ApplicationController] the search controller instance
+  # @param field [Symbol] the field name to determine UI for
+  # @return [Symbol] the UI component type
+  def self.for(controller:, field:)
+    new(controller: controller, field: field).ui_type
+  end
+
+  # Determines the UI component type for the field
+  # @return [Symbol] the UI component type
+  # @raise [RuntimeError] if field is not defined in controller params
+  def ui_type
+    validate_field_defined!
+    determine_ui
+  end
+
+  private
+
+  def validate_field_defined!
+    defined = permitted_params + nested_params
+    return if defined.include?(field)
+
+    raise("Search field not permitted: #{field} " \
+          "in #{module_name}::SearchController")
+  end
+
+  def determine_ui
+    # Handle exceptions first
+    case field
+    when :names then names_field_ui
+    when :lookup then :multiple_value_autocompleter
+    when :include_synonyms, :include_subtaxa,
+         :include_immediate_subtaxa, :exclude_original_names,
+         :exclude_consensus, :include_all_name_proposals,
+         :misspellings, :rank, :confidence
+      custom_select_ui
+    when :region then region_field_ui
+    when :in_box then :in_box_fields
+    when :field_slips then :text_field_with_label
+    else
+      field_ui_from_query_attribute
+    end
+  end
+
+  def custom_select_ui
+    case field
+    when :include_synonyms, :include_subtaxa,
+         :include_immediate_subtaxa, :exclude_original_names,
+         :exclude_consensus, :include_all_name_proposals
+      :select_no_eq_nil_or_yes
+    when :misspellings then :select_misspellings
+    when :rank then :select_rank_range
+    when :confidence then :select_confidence_range
+    end
+  end
+
+  def field_ui_from_query_attribute
+    case definition
+    when :boolean then :select_nil_boolean
+    when :string then :text_field_with_label
+    when Array then ui_for_array_definition
+    when Class then :single_value_autocompleter
+    when Hash then ui_for_hash_definition
+    else
+      raise(
+        "Unhandled query attribute definition (SearchFieldUI) for " \
+        "#{field}: #{definition.inspect}"
+      )
+    end
+  end
+
+  # Determines UI for hash-based query attribute definitions
+  # @return [Symbol] the UI component type
+  def ui_for_hash_definition
+    case definition.keys.first.to_sym
+    when :boolean then :select_nil_yes
+    end
+  end
+
+  # Determines UI for array-based query attribute definitions
+  # @return [Symbol] the UI component type
+  def ui_for_array_definition
+    case definition.first
+    when :string, :time, :date then :text_field_with_label
+    when Class then :multiple_value_autocompleter
+    end
+  end
+
+  # Returns controller-specific names field UI
+  # @return [Symbol] the UI component type
+  def names_field_ui
+    case search_type
+    when :observations, :projects, :species_lists
+      :names_fields_for_obs
+    when :names
+      :names_fields_for_names
+    end
+  end
+
+  # Returns controller-specific region field UI
+  # @return [Symbol] the UI component type
+  def region_field_ui
+    case search_type
+    when :observations, :locations
+      :region_with_in_box_fields
+    else
+      :text_field_with_label
+    end
+  end
+
+  def module_name
+    @module_name ||= controller.class.name.deconstantize
+  end
+
+  def search_type
+    @search_type ||= module_name.underscore.to_sym
+  end
+
+  def query_subclass
+    @query_subclass ||= Query.const_get(module_name)
+  end
+
+  def permitted_params
+    controller.permitted_search_params
+  end
+
+  def nested_params
+    controller.nested_names_params
+  end
+
+  # Memoized query attribute definition for the field
+  def definition
+    @definition ||= query_subclass.attribute_types[field]&.accepts
+  end
+end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -19,7 +19,7 @@ module Searchable
         format.turbo_stream do
           render(turbo_stream: turbo_stream.update(
             :search_bar_help, # id of element to update contents of
-            partial: "#{parent_controller}/search/help"
+            partial: "#{search_type}/search/help"
           ))
         end
         format.html
@@ -56,7 +56,7 @@ module Searchable
       redirect_to(action: :new) and return unless validate_search_instance?
 
       save_search_query
-      redirect_to(controller: "/#{parent_controller}", action: :index,
+      redirect_to(controller: "/#{search_type}", action: :index,
                   q: @query.q_param)
     end
 
@@ -77,13 +77,15 @@ module Searchable
     # Default. Override in controllers
     def nested_names_params = []
 
-    # Used by search_form
-    def search_type = self.class.name.deconstantize.underscore.to_sym
+    # e.g. "SpeciesLists"
+    def module_name = self.class.name.deconstantize
 
-    def parent_controller = self.class.name.deconstantize.underscore
+    # e.g. :species_lists - Used by search_form
+    def search_type = module_name.underscore.to_sym
 
-    # Returns the capitalized :Symbol used by Query for the type of query.
-    def query_model = self.class.module_parent.name.singularize.to_sym
+    # e.g. :SpeciesList
+    # Returns the capitalized :ModelSymbol used by Query for the type of query.
+    def query_model = module_name.singularize.to_sym
 
     private
 
@@ -92,7 +94,7 @@ module Searchable
     # Gets the query class relevant to each controller, assuming the controller
     # is namespaced like Observations::SearchController
     def query_subclass
-      Query.const_get(self.class.module_parent.name)
+      Query.const_get(module_name)
     end
 
     def clear_form?

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -75,28 +75,24 @@ module Searchable
     end
 
     # Default. Override in controllers
-    def nested_names_params
-      []
-    end
+    def nested_names_params = []
 
     # Used by search_form
-    def search_type
-      self.class.name.deconstantize.underscore.to_sym
-    end
+    def search_type = self.class.name.deconstantize.underscore.to_sym
 
-    def parent_controller
-      self.class.name.deconstantize.underscore
-    end
+    def parent_controller = self.class.name.deconstantize.underscore
 
     # Returns the capitalized :Symbol used by Query for the type of query.
-    def query_model
-      self.class.module_parent.name.singularize.to_sym
-    end
+    def query_model = self.class.module_parent.name.singularize.to_sym
 
     private
 
-    def search_object_name
-      :"query_#{search_type}"
+    def search_object_name = :"query_#{search_type}"
+
+    # Gets the query class relevant to each controller, assuming the controller
+    # is namespaced like Observations::SearchController
+    def query_subclass
+      Query.const_get(self.class.module_parent.name)
     end
 
     def clear_form?
@@ -120,9 +116,7 @@ module Searchable
       perm
     end
 
-    def nested_in_box_params
-      [:north, :south, :east, :west].freeze
-    end
+    def nested_in_box_params = [:north, :south, :east, :west].freeze
 
     def split_names_lookup_strings
       # Nested blank values will make for null query results,
@@ -220,21 +214,15 @@ module Searchable
       @query = Query.lookup_and_save(query_model, **@search.params)
     end
 
-    def escape_location_string(location)
-      "\"#{location.tr(",", "\\,")}\""
-    end
+    def escape_location_string(location) = "\"#{location.tr(",", "\\,")}\""
 
     # def strings_with_commas
     #   [:location, :region].freeze
     # end
 
-    def fields_preferring_ids
-      []
-    end
+    def fields_preferring_ids = []
 
-    def fields_with_range
-      []
-    end
+    def fields_with_range = []
 
     # Passing some fields will raise an error if the required field is missing,
     # so just toss them. Not sure we have to do this, because Query will.
@@ -337,12 +325,6 @@ module Searchable
       when Class # e.g. [Project]
         :multiple_value_autocompleter
       end
-    end
-
-    # Gets the query class relevant to each controller, assuming the controller
-    # is namespaced like Observations::SearchController
-    def query_subclass
-      Query.const_get(self.class.module_parent.name)
     end
 
     def names_field_ui_for_this_controller

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -231,11 +231,5 @@ module Searchable
     #     fields.each { |field| @search.delete(field) }
     #   end
     # end
-
-    # Delegates to SearchFieldUI service object to determine UI component type
-    def search_field_type_from_controller(field:)
-      SearchFieldUI.for(controller: self, field: field)
-    end
-    helper_method :search_field_type_from_controller
   end
 end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -313,6 +313,11 @@ module Searchable
         :single_value_autocompleter
       when Hash
         field_ui_for_hash_definition(definition)
+      else
+        raise(
+          "Unhandled query attribute definition (search UI) for " \
+          "#{field}: #{definition.inspect}"
+        )
       end
     end
 

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -282,7 +282,7 @@ module Searchable
         :select_no_eq_nil_or_yes
       when :misspellings
         :select_misspellings
-      when :range
+      when :rank
         :select_rank_range
       when :confidence
         :select_confidence_range
@@ -299,7 +299,6 @@ module Searchable
 
     def field_ui_by_query_attr_definition(field)
       definition = query_subclass.attribute_types[field]&.accepts
-
       case definition
       when :boolean
         :select_nil_boolean
@@ -307,7 +306,7 @@ module Searchable
         :text_field_with_label
       when Array
         field_ui_for_array_definition(definition)
-      when AbstractModel
+      when Class
         :single_value_autocompleter
       when Hash
         field_ui_for_hash_definition(definition)
@@ -327,7 +326,7 @@ module Searchable
       case definition.first
       when :string, :time, :date
         :text_field_with_label
-      when Object
+      when Class
         :multiple_value_autocompleter
       end
     end
@@ -340,7 +339,7 @@ module Searchable
 
     def names_field_ui_for_this_controller
       case search_type
-      when :observations
+      when :observations, :projects, :species_lists
         :names_fields_for_obs
       when :names
         :names_fields_for_names

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -71,12 +71,12 @@ module Searchable
 
     # Used by search_helper to prefill nested params
     def nested_field_names
-      nested_names_param_names + nested_in_box_param_names
+      nested_names_params + nested_in_box_params
     end
 
     # Default. Override in controllers
     def nested_names_params
-      {}
+      []
     end
 
     # Used by search_form
@@ -112,22 +112,15 @@ module Searchable
     def permittables
       ranges = fields_with_range.map { |field| :"#{field}_range" }
       ids = fields_preferring_ids.map { |field| :"#{field}_id" }
-      names = { names: nested_names_param_names }
-      in_box = { in_box: nested_in_box_param_names }
-      perm = permitted_search_params.keys + ranges + ids
+      names = { names: nested_names_params }
+      in_box = { in_box: nested_in_box_params }
+      perm = permitted_search_params + ranges + ids
       perm << names
       perm << in_box
       perm
     end
 
-    def nested_names_param_names
-      keys = nested_names_params&.keys || []
-      return keys if keys.blank?
-
-      keys << :lookup
-    end
-
-    def nested_in_box_param_names
+    def nested_in_box_params
       [:north, :south, :east, :west].freeze
     end
 
@@ -255,13 +248,13 @@ module Searchable
     #   end
     # end
 
-    # The controllers define how they're going to parse their
+    # The query attributes define how they're going to parse their
     # fields, so we can use that to assign a field helper.
     def search_field_type_from_controller(field:)
       # return :pattern if field == :pattern
 
-      defined = permitted_search_params.merge(nested_names_params)
-      unless defined[field]
+      defined = permitted_search_params + nested_names_params
+      unless defined.include?(field)
         raise("No input defined for #{field} in #{controller_name}")
       end
 

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -279,7 +279,7 @@ module Searchable
       when :include_synonyms, :include_subtaxa,
         :include_immediate_subtaxa, :exclude_original_names,
         :exclude_consensus, :include_all_name_proposals
-        :select_nil_boolean
+        :select_no_eq_nil_or_yes
       when :misspellings
         :select_misspellings
       when :range
@@ -287,7 +287,7 @@ module Searchable
       when :confidence
         :select_confidence_range
       when :region
-        :region_with_in_box_fields
+        region_field_ui_for_this_controller
       when :in_box
         :in_box_fields
       when :field_slips
@@ -344,6 +344,15 @@ module Searchable
         :names_fields_for_obs
       when :names
         :names_fields_for_names
+      end
+    end
+
+    def region_field_ui_for_this_controller
+      case search_type
+      when :observations, :locations
+        :region_with_in_box_fields
+      else
+        :text_field_with_label
       end
     end
   end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -297,9 +297,9 @@ module Searchable
         :select_nil_boolean
       when :string
         :text_field_with_label
-      when Array
+      when Array # e.g. [Name]
         field_ui_for_array_definition(definition)
-      when Class
+      when Class # e.g. User
         :single_value_autocompleter
       when Hash
         field_ui_for_hash_definition(definition)
@@ -319,7 +319,7 @@ module Searchable
       case definition.first
       when :string, :time, :date
         :text_field_with_label
-      when Class
+      when Class # e.g. [Project]
         :multiple_value_autocompleter
       end
     end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -262,7 +262,7 @@ module Searchable
     end
     helper_method :search_field_type_from_controller
 
-    def search_field_ui(field) # rubocop:disable Metrics/CyclomaticComplexity
+    def search_field_ui(field)
       # handle exceptions first
       case field
       when :names
@@ -271,7 +271,25 @@ module Searchable
         :multiple_value_autocompleter
       when :include_synonyms, :include_subtaxa,
         :include_immediate_subtaxa, :exclude_original_names,
-        :exclude_consensus, :include_all_name_proposals
+        :exclude_consensus, :include_all_name_proposals,
+        :misspellings, :rank, :confidence
+        custom_select_ui(field)
+      when :region
+        region_field_ui_for_this_controller
+      when :in_box
+        :in_box_fields
+      when :field_slips # not an autocompleter
+        :text_field_with_label
+      else
+        field_ui_by_query_attr_definition(field)
+      end
+    end
+
+    def custom_select_ui(field)
+      case field
+      when :include_synonyms, :include_subtaxa,
+           :include_immediate_subtaxa, :exclude_original_names,
+           :exclude_consensus, :include_all_name_proposals
         :select_no_eq_nil_or_yes
       when :misspellings
         :select_misspellings
@@ -279,14 +297,6 @@ module Searchable
         :select_rank_range
       when :confidence
         :select_confidence_range
-      when :region
-        region_field_ui_for_this_controller
-      when :in_box
-        :in_box_fields
-      when :field_slips
-        :text_field_with_label
-      else
-        field_ui_by_query_attr_definition(field)
       end
     end
 

--- a/app/controllers/herbaria/search_controller.rb
+++ b/app/controllers/herbaria/search_controller.rb
@@ -11,18 +11,17 @@ module Herbaria
 
     before_action :login_required
 
-    # Also an index of helper methods to use for each field.
     def permitted_search_params
-      {
-        by_users: :multiple_value_autocompleter,
-        nonpersonal: :select_nil_yes,
-        code_has: :text_field_with_label,
-        name_has: :text_field_with_label,
-        description_has: :text_field_with_label,
-        mailing_address_has: :text_field_with_label,
-        created_at: :text_field_with_label,
-        updated_at: :text_field_with_label
-      }.freeze
+      [
+        :by_users,
+        :nonpersonal,
+        :code_has,
+        :name_has,
+        :description_has,
+        :mailing_address_has,
+        :created_at,
+        :updated_at
+      ].freeze
     end
 
     def fields_preferring_ids

--- a/app/controllers/locations/search_controller.rb
+++ b/app/controllers/locations/search_controller.rb
@@ -11,21 +11,20 @@ module Locations
 
     before_action :login_required
 
-    # Also an index of helper methods to use for each field.
     def permitted_search_params
-      {
-        created_at: :text_field_with_label,
-        updated_at: :text_field_with_label,
-        region: :region_with_in_box_fields,
-        in_box: :in_box_fields,
-        regexp: :text_field_with_label,
-        has_notes: :select_nil_boolean,
-        notes_has: :text_field_with_label,
-        by_users: :multiple_value_autocompleter,
-        by_editor: :single_value_autocompleter,
-        has_descriptions: :select_nil_yes, # ignores false
-        has_observations: :select_nil_yes # ignores false
-      }.freeze
+      [
+        :created_at,
+        :updated_at,
+        :region,
+        :in_box,
+        :regexp,
+        :has_notes,
+        :notes_has,
+        :by_users,
+        :by_editor,
+        :has_descriptions,
+        :has_observations
+      ].freeze
     end
 
     def fields_preferring_ids

--- a/app/controllers/names/search_controller.rb
+++ b/app/controllers/names/search_controller.rb
@@ -12,39 +12,39 @@ module Names
 
     before_action :login_required
 
-    # Also an index of helper methods to use for each field.
     def permitted_search_params
-      {
-        names: :names_fields_for_names,
-        has_observations: :select_nil_yes, # ignores false
-        deprecated: :select_nil_boolean,
-        has_author: :select_nil_boolean,
-        author_has: :text_field_with_label,
-        has_citation: :select_nil_boolean,
-        citation_has: :text_field_with_label,
-        has_classification: :select_nil_boolean,
-        classification_has: :text_field_with_label,
-        has_notes: :select_nil_boolean,
-        notes_has: :text_field_with_label,
-        has_comments: :select_nil_yes,
-        comments_has: :text_field_with_label,
-        has_default_description: :select_nil_boolean,
-        created_at: :text_field_with_label,
-        updated_at: :text_field_with_label,
-        has_synonyms: :select_nil_boolean,
-        misspellings: :select_misspellings,
-        rank: :select_rank_range,
-        lichen: :select_nil_boolean
-      }.freeze
+      [
+        :names,
+        :has_observations,
+        :deprecated,
+        :has_author,
+        :author_has,
+        :has_citation,
+        :citation_has,
+        :has_classification,
+        :classification_has,
+        :has_notes,
+        :notes_has,
+        :has_comments,
+        :comments_has,
+        :has_default_description,
+        :created_at,
+        :updated_at,
+        :has_synonyms,
+        :misspellings,
+        :rank,
+        :lichen
+      ].freeze
     end
 
     def nested_names_params
-      {
-        include_synonyms: :select_no_eq_nil_or_yes,
-        include_subtaxa: :select_no_eq_nil_or_yes,
-        include_immediate_subtaxa: :select_no_eq_nil_or_yes,
-        exclude_original_names: :select_no_eq_nil_or_yes
-      }.freeze
+      [
+        :lookup,
+        :include_synonyms,
+        :include_subtaxa,
+        :include_immediate_subtaxa,
+        :exclude_original_names
+      ].freeze
     end
 
     def fields_with_range

--- a/app/controllers/observations/search_controller.rb
+++ b/app/controllers/observations/search_controller.rb
@@ -11,47 +11,47 @@ module Observations
 
     before_action :login_required
 
-    # Also an index of helper methods to use for each field.
     def permitted_search_params
-      {
-        date: :text_field_with_label,
-        created_at: :text_field_with_label,
-        updated_at: :text_field_with_label,
-        names: :names_fields_for_obs,
-        confidence: :select_confidence_range,
-        has_name: :select_nil_boolean,
-        lichen: :select_nil_boolean,
-        within_locations: :multiple_value_autocompleter,
-        has_public_lat_lng: :select_nil_boolean,
-        is_collection_location: :select_nil_boolean,
-        region: :region_with_in_box_fields,
-        in_box: :in_box_fields,
-        has_specimen: :select_nil_boolean,
-        has_sequences: :select_nil_yes, # ignores false
-        has_images: :select_nil_boolean,
-        has_notes: :select_nil_boolean,
-        has_notes_fields: :text_field_with_label,
-        notes_has: :text_field_with_label,
-        has_comments: :select_nil_yes,
-        comments_has: :text_field_with_label,
-        by_users: :multiple_value_autocompleter,
-        projects: :multiple_value_autocompleter,
-        herbaria: :multiple_value_autocompleter,
-        species_lists: :multiple_value_autocompleter,
-        project_lists: :multiple_value_autocompleter,
-        field_slips: :text_field_with_label
-      }.freeze
+      [
+        :date,
+        :created_at,
+        :updated_at,
+        :names,
+        :confidence,
+        :has_name,
+        :lichen,
+        :within_locations,
+        :has_public_lat_lng,
+        :is_collection_location,
+        :region,
+        :in_box,
+        :has_specimen,
+        :has_sequences,
+        :has_images,
+        :has_notes,
+        :has_notes_fields,
+        :notes_has,
+        :has_comments,
+        :comments_has,
+        :by_users,
+        :projects,
+        :herbaria,
+        :species_lists,
+        :project_lists,
+        :field_slips
+      ].freeze
     end
 
     def nested_names_params
-      {
-        include_synonyms: :select_no_eq_nil_or_yes,
-        include_subtaxa: :select_no_eq_nil_or_yes,
-        include_immediate_subtaxa: :select_no_eq_nil_or_yes,
-        exclude_original_names: :select_no_eq_nil_or_yes,
-        include_all_name_proposals: :select_no_eq_nil_or_yes,
-        exclude_consensus: :select_no_eq_nil_or_yes
-      }.freeze
+      [
+        :lookup,
+        :include_synonyms,
+        :include_subtaxa,
+        :include_immediate_subtaxa,
+        :exclude_original_names,
+        :include_all_name_proposals,
+        :exclude_consensus
+      ].freeze
     end
 
     def fields_preferring_ids

--- a/app/controllers/projects/search_controller.rb
+++ b/app/controllers/projects/search_controller.rb
@@ -11,38 +11,38 @@ module Projects
 
     before_action :login_required
 
-    # Also an index of helper methods to use for each field.
     def permitted_search_params
-      {
-        members: :multiple_value_autocompleter,
-        names: :names_fields_for_obs,
-        region: :text_field_with_label,
-        field_slip_prefix_has: :text_field_with_label,
-        by_users: :multiple_value_autocompleter,
-        has_observations: :select_nil_yes, # ignores false
-        has_images: :select_nil_yes,
-        has_species_lists: :select_nil_yes,
-        title_has: :text_field_with_label,
-        has_summary: :select_nil_boolean,
-        summary_has: :text_field_with_label,
-        has_notes: :select_nil_boolean,
-        notes_has: :text_field_with_label,
-        has_comments: :select_nil_yes,
-        comments_has: :text_field_with_label,
-        created_at: :text_field_with_label,
-        updated_at: :text_field_with_label
-      }.freeze
+      [
+        :members,
+        :names,
+        :region,
+        :field_slip_prefix_has,
+        :by_users,
+        :has_observations,
+        :has_images,
+        :has_species_lists,
+        :title_has,
+        :has_summary,
+        :summary_has,
+        :has_notes,
+        :notes_has,
+        :has_comments,
+        :comments_has,
+        :created_at,
+        :updated_at
+      ].freeze
     end
 
     def nested_names_params
-      {
-        include_synonyms: :select_no_eq_nil_or_yes,
-        include_subtaxa: :select_no_eq_nil_or_yes,
-        include_immediate_subtaxa: :select_no_eq_nil_or_yes,
-        exclude_original_names: :select_no_eq_nil_or_yes,
-        include_all_name_proposals: :select_no_eq_nil_or_yes,
-        exclude_consensus: :select_no_eq_nil_or_yes
-      }.freeze
+      [
+        :lookup,
+        :include_synonyms,
+        :include_subtaxa,
+        :include_immediate_subtaxa,
+        :exclude_original_names,
+        :include_all_name_proposals,
+        :exclude_consensus
+      ].freeze
     end
 
     def fields_preferring_ids

--- a/app/controllers/species_lists/search_controller.rb
+++ b/app/controllers/species_lists/search_controller.rb
@@ -11,33 +11,33 @@ module SpeciesLists
 
     before_action :login_required
 
-    # Also an index of helper methods to use for each field.
     def permitted_search_params
-      {
-        by_users: :multiple_value_autocompleter,
-        projects: :multiple_value_autocompleter,
-        names: :names_fields_for_obs,
-        region: :text_field_with_label,
-        title_has: :text_field_with_label,
-        has_notes: :select_nil_boolean,
-        notes_has: :text_field_with_label,
-        has_comments: :select_nil_yes, # ignores false
-        comments_has: :text_field_with_label,
-        date: :text_field_with_label,
-        created_at: :text_field_with_label,
-        updated_at: :text_field_with_label
-      }.freeze
+      [
+        :by_users,
+        :projects,
+        :names,
+        :region,
+        :title_has,
+        :has_notes,
+        :notes_has,
+        :has_comments,
+        :comments_has,
+        :date,
+        :created_at,
+        :updated_at
+      ].freeze
     end
 
     def nested_names_params
-      {
-        include_synonyms: :select_no_eq_nil_or_yes,
-        include_subtaxa: :select_no_eq_nil_or_yes,
-        include_immediate_subtaxa: :select_no_eq_nil_or_yes,
-        exclude_original_names: :select_no_eq_nil_or_yes,
-        include_all_name_proposals: :select_no_eq_nil_or_yes,
-        exclude_consensus: :select_no_eq_nil_or_yes
-      }.freeze
+      [
+        :lookup,
+        :include_synonyms,
+        :include_subtaxa,
+        :include_immediate_subtaxa,
+        :exclude_original_names,
+        :include_all_name_proposals,
+        :exclude_consensus
+      ].freeze
     end
 
     def fields_preferring_ids

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -61,7 +61,7 @@ module SearchFormHelper
     args = { form:, search:, field: }
 
     args[:label] ||= search_label(field)
-    field_type = search_field_type_from_controller(field:)
+    field_type = SearchFieldUI.for(controller:, field:)
     return unless field_type
 
     # Prepare args for the field helper.

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -80,20 +80,6 @@ module SearchFormHelper
     end
   end
 
-  # The controllers define how they're going to parse their
-  # fields, so we can use that to assign a field helper.
-  def search_field_type_from_controller(field:)
-    # return :pattern if field == :pattern
-
-    defined = controller.permitted_search_params.
-              merge(controller.nested_names_params)
-    unless defined[field]
-      raise("No input defined for #{field} in #{controller.controller_name}")
-    end
-
-    defined[field]
-  end
-
   # Prepares HTML args for the field helper. This is where we can make
   # adjustments to the args hash before passing it to the field helper.
   # NOTE: Bootstrap 3 can't do full-width inline label/field.

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -27,6 +27,11 @@
 # re: custom attribute types - https://stackoverflow.com/a/79417688/3357635
 #                              https://stackoverflow.com/a/78668203/3357635
 #
+# NOTE: to retrieve the :accepts value for an attribute, you can call the
+#       Query method `attribute_types`. Rails `type_for_attribute` doesn't work.
+#
+#       Query::Observations.attribute_types[:has_sequences].accepts
+#
 class QueryParamType < ActiveModel::Type::Value
   attr_reader :accepts
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -29,6 +29,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym("CSV")
   inflect.acronym("TSV")
   inflect.acronym("QR")
+  inflect.acronym("UI")
   inflect.irregular("bonus", "bonuses")
   inflect.irregular("info", "info")
   inflect.irregular("google", "google")

--- a/test/classes/search_field_ui_test.rb
+++ b/test/classes/search_field_ui_test.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class SearchFieldUITest < UnitTestCase
+  # Mock controller for Observations search
+  class MockObservationsController
+    def self.name
+      "Observations::SearchController"
+    end
+
+    def permitted_search_params
+      [
+        :date,
+        :has_name,
+        :by_users,
+        :names,
+        :confidence,
+        :region,
+        :in_box,
+        :has_comments,
+        :include_synonyms,
+        :field_slips,
+        :undefined_field
+      ]
+    end
+
+    def nested_names_params
+      [:include_synonyms, :include_subtaxa]
+    end
+  end
+
+  # Mock controller for Names search
+  class MockNamesController
+    def self.name
+      "Names::SearchController"
+    end
+
+    def permitted_search_params
+      [:names, :region]
+    end
+
+    def nested_names_params
+      [:include_synonyms]
+    end
+  end
+
+  # Mock controller for Locations search
+  class MockLocationsController
+    def self.name
+      "Locations::SearchController"
+    end
+
+    def permitted_search_params
+      [:region, :in_box]
+    end
+
+    def nested_names_params
+      []
+    end
+  end
+
+  def setup
+    @obs_controller = MockObservationsController.new
+    @names_controller = MockNamesController.new
+    @locations_controller = MockLocationsController.new
+  end
+
+  # Test class method .for
+  def test_class_method_for
+    result = SearchFieldUI.for(
+      controller: @obs_controller,
+      field: :has_name
+    )
+    assert_equal(:select_nil_boolean, result)
+  end
+
+  # Test special case: names field for observations
+  def test_names_field_for_observations
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :names)
+    assert_equal(:names_fields_for_obs, ui.ui_type)
+  end
+
+  # Test special case: names field for names controller
+  def test_names_field_for_names
+    ui = SearchFieldUI.new(controller: @names_controller, field: :names)
+    assert_equal(:names_fields_for_names, ui.ui_type)
+  end
+
+  # Test special case: region field for observations (with in_box)
+  def test_region_field_for_observations
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :region)
+    assert_equal(:region_with_in_box_fields, ui.ui_type)
+  end
+
+  # Test special case: region field for locations (with in_box)
+  def test_region_field_for_locations
+    ui = SearchFieldUI.new(controller: @locations_controller, field: :region)
+    assert_equal(:region_with_in_box_fields, ui.ui_type)
+  end
+
+  # Test special case: region field for names (text field)
+  def test_region_field_for_names
+    ui = SearchFieldUI.new(controller: @names_controller, field: :region)
+    assert_equal(:text_field_with_label, ui.ui_type)
+  end
+
+  # Test special case: in_box field
+  def test_in_box_field
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :in_box)
+    assert_equal(:in_box_fields, ui.ui_type)
+  end
+
+  # Test special case: field_slips
+  def test_field_slips
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :field_slips)
+    assert_equal(:text_field_with_label, ui.ui_type)
+  end
+
+  # Test custom select UI: include_synonyms
+  def test_include_synonyms
+    ui = SearchFieldUI.new(
+      controller: @obs_controller,
+      field: :include_synonyms
+    )
+    assert_equal(:select_no_eq_nil_or_yes, ui.ui_type)
+  end
+
+  # Test custom select UI: confidence
+  def test_confidence_range
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :confidence)
+    assert_equal(:select_confidence_range, ui.ui_type)
+  end
+
+  # Test boolean field
+  def test_boolean_field
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :has_name)
+    assert_equal(:select_nil_boolean, ui.ui_type)
+  end
+
+  # Test array of User (Class) field
+  def test_array_of_class_field
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :by_users)
+    assert_equal(:multiple_value_autocompleter, ui.ui_type)
+  end
+
+  # Test array of date field
+  def test_array_of_date_field
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :date)
+    assert_equal(:text_field_with_label, ui.ui_type)
+  end
+
+  # Test hash with boolean field
+  def test_hash_with_boolean_field
+    ui = SearchFieldUI.new(controller: @obs_controller, field: :has_comments)
+    assert_equal(:select_nil_yes, ui.ui_type)
+  end
+
+  # Test error when field is not permitted
+  def test_raises_error_for_unpermitted_field
+    error = assert_raises(RuntimeError) do
+      SearchFieldUI.new(
+        controller: @obs_controller,
+        field: :invalid_field
+      ).ui_type
+    end
+    assert_match(/Search field not permitted: invalid_field/, error.message)
+    assert_match(/Observations::SearchController/, error.message)
+  end
+
+  # Test nested params are included in permitted fields
+  def test_nested_params_are_permitted
+    # include_synonyms is in nested_names_params, should not raise error
+    ui = SearchFieldUI.new(
+      controller: @obs_controller,
+      field: :include_synonyms
+    )
+    assert_equal(:select_no_eq_nil_or_yes, ui.ui_type)
+  end
+
+  # Test error for unhandled query attribute definition
+  def test_raises_error_for_unhandled_definition
+    # Create a mock attribute that returns :undefined type
+    mock_attribute = Minitest::Mock.new
+    mock_attribute.expect(:accepts, :undefined)
+
+    # Stub attribute_types to return our mock for :undefined_field
+    Query::Observations.stub(:attribute_types, {
+                               undefined_field: mock_attribute
+                             }) do
+      error = assert_raises(RuntimeError) do
+        SearchFieldUI.new(
+          controller: @obs_controller,
+          field: :undefined_field
+        ).ui_type
+      end
+      assert_match(
+        /Unhandled query attribute definition \(SearchFieldUI\)/,
+        error.message
+      )
+      assert_match(/undefined_field/, error.message)
+      assert_match(/:undefined/, error.message)
+    end
+
+    mock_attribute.verify
+  end
+end


### PR DESCRIPTION
This simplifies the Search controllers for faceted searches, by figuring out the UI field from the Query attribute definition, so the controllers do not have to manually assign each one.

There are quite a few exceptions, but it eliminates gotchas arising from mismatches between query attribute definitions and controller UI definitions, as currently when we're redefining `has_sequences` to accept a `no` value.

Completely reworked to use a PORO