### PR TITLE
Fix name "edit misspelling" flash message "no changes made" bug

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -445,25 +445,36 @@ class NamesController < ApplicationController
   end
 
   def perform_change_existing_name
-    update_correct_spelling
+    spelling_changed = update_correct_spelling
     set_name_author_and_rank
     set_unparsed_attrs
-    if !@name.changed?
-      any_changes = false
-    elsif !@name.save_with_log(@user, :log_name_updated)
-      raise(:runtime_unable_to_save_changes.t)
-    else
-      flash_notice(:runtime_edit_name_success.t(
-                     name: @name.user_real_search_name(@user)
-                   ))
-      any_changes = true
-    end
+    any_changes = if @name.changed?
+                    save_name_and_flash_success
+                  else
+                    # Name may have been saved by mark_misspelled/merge_synonyms
+                    flash_success if spelling_changed
+                    spelling_changed
+                  end
     # Update ancestors regardless whether name changed; maybe this will add
     # missing ancestors in case database is messed up. But don't update
     # ancestors if non-admin is changing locked namge because that would create
     # bogus name and ancestors if @parse.search_name differs from @name
     update_ancestors if editable_in_session?
     any_changes
+  end
+
+  def save_name_and_flash_success # rubocop:disable Naming/PredicateMethod
+    raise(:runtime_unable_to_save_changes.t) unless
+      @name.save_with_log(@user, :log_name_updated)
+
+    flash_success
+    true
+  end
+
+  def flash_success
+    flash_notice(:runtime_edit_name_success.t(
+                   name: @name.user_real_search_name(@user)
+                 ))
   end
 
   # Update the misspelling status.
@@ -477,19 +488,24 @@ class NamesController < ApplicationController
   # 2) Otherwise, if the text field is filled in it looks up the name and
   #    sets correct_spelling_id.
   #
-  # All changes are made (but not saved) to +@name+.  It returns true if
-  # everything went well.  If it couldn't recognize the correct name, it
-  # changes nothing and raises a RuntimeError.
+  # All changes are made (but not saved) to +@name+.  If it couldn't recognize
+  # the correct name, it changes nothing and raises a RuntimeError.
   #
-  def update_correct_spelling
-    return unless editable_in_session?
+  # Returns true if changes were made and saved (via mark_misspelled).
+  #
+  def update_correct_spelling # rubocop:disable Naming/PredicateMethod
+    return false unless editable_in_session?
 
     if @name.is_misspelling? && (!@misspelling || @correct_spelling.blank?)
       @name.correct_spelling = nil
       @parse = parse_name # update boldness in @parse.params
+      false # Change tracked via @name.changed?, not saved yet
     elsif @correct_spelling.present?
-      set_correct_spelling
+      set_correct_spelling # This saves the name via mark_misspelled
       @parse = parse_name # update boldness in @parse.params
+      true # Changes were saved, dirty tracking cleared
+    else
+      false
     end
   end
 

--- a/test/integration/capybara/names_integration_test.rb
+++ b/test/integration/capybara/names_integration_test.rb
@@ -210,6 +210,56 @@ class NamesIntegrationTest < CapybaraIntegrationTestCase
                  "Failed to update lifeform")
   end
 
+  # REGRESSION TEST for bug: When marking a name as misspelt via the edit form,
+  # the flash incorrectly says "No changes made" even though changes were made.
+  # Root cause: merge_synonyms (in Name::Synonymy) calls self.save, which clears
+  # the dirty tracking. Then perform_change_existing_name sees @name.changed?
+  # is false and sets any_changes = false, triggering the incorrect flash.
+  # This test FAILS until the bug is fixed.
+  def test_mark_name_as_misspelt_via_edit_form
+    bad_name = names(:agaricus_campestros)
+    good_name = names(:agaricus_campestris)
+
+    # Verify initial state
+    assert_not(bad_name.deprecated, "bad_name should not be deprecated")
+    assert_not(bad_name.is_misspelling?, "bad_name should not be misspelling")
+    assert_nil(bad_name.correct_spelling_id, "bad_name should have no spelling")
+
+    login(rolf)
+    visit(edit_name_path(bad_name))
+
+    # Check the misspelling checkbox
+    check("name_misspelling")
+
+    # Fill in the correct spelling (autocompleter field)
+    fill_in("name_correct_spelling", with: good_name.search_name)
+
+    # Submit the form (click first submit button)
+    first("input[type='submit']").click
+
+    # Reload to get current state
+    bad_name.reload
+    good_name.reload
+
+    # Verify the name was correctly marked as misspelt
+    assert(bad_name.deprecated,
+           "Name should be deprecated after marking as misspelt")
+    assert(bad_name.is_misspelling?,
+           "Name should be marked as misspelling")
+    assert_equal(good_name.id, bad_name.correct_spelling_id,
+                 "Correct spelling should be set to good_name")
+
+    # Verify synonymy was created
+    assert_not_nil(bad_name.synonym_id, "Synonym should be created")
+    assert_equal(bad_name.synonym_id, good_name.synonym_id,
+                 "Both names should share the same synonym")
+
+    # BUG: This assertion currently fails because the flash incorrectly shows
+    # "No changes made" even though the name was changed and saved.
+    # When the bug is fixed, this should pass.
+    page.assert_no_text("No changes made")
+  end
+
   def test_lifeform_propagate
     genus = names(:tremella)
     species = names(:tremella_celata)

--- a/test/integration/capybara/names_integration_test.rb
+++ b/test/integration/capybara/names_integration_test.rb
@@ -211,11 +211,12 @@ class NamesIntegrationTest < CapybaraIntegrationTestCase
   end
 
   # REGRESSION TEST for bug: When marking a name as misspelt via the edit form,
-  # the flash incorrectly says "No changes made" even though changes were made.
+  # the flash incorrectly said "No changes made" even though changes were made.
   # Root cause: merge_synonyms (in Name::Synonymy) calls self.save, which clears
-  # the dirty tracking. Then perform_change_existing_name sees @name.changed?
-  # is false and sets any_changes = false, triggering the incorrect flash.
-  # This test FAILS until the bug is fixed.
+  # the dirty tracking. Then perform_change_existing_name saw @name.changed?
+  # is false and set any_changes = false, triggering the incorrect flash.
+  # Fix: update_correct_spelling now returns true when changes were saved via
+  # mark_misspelled, and perform_change_existing_name uses this return value.
   def test_mark_name_as_misspelt_via_edit_form
     bad_name = names(:agaricus_campestros)
     good_name = names(:agaricus_campestris)
@@ -254,9 +255,7 @@ class NamesIntegrationTest < CapybaraIntegrationTestCase
     assert_equal(bad_name.synonym_id, good_name.synonym_id,
                  "Both names should share the same synonym")
 
-    # BUG: This assertion currently fails because the flash incorrectly shows
-    # "No changes made" even though the name was changed and saved.
-    # When the bug is fixed, this should pass.
+    # Verify flash does NOT show "No changes made"
     page.assert_no_text("No changes made")
   end
 


### PR DESCRIPTION
**The new integration test here confirms this bug exists on `main`.**

### Incorrect flash when editing Name to be misspelt.
To replicate
- Edit a Name (I used the newly created `Xanthoperenniporia`.)
- Check `This name is misspelt`
- Fill in `It should be` with an existing, approved name. (I used `Perenniporia`.)
- click `Save Edits`
Result:
- correctly deprecates the Name as misspelt, shows correct spelling and preferred synonym
- Incorrectly flashes `No changes made.`
<img width="880" height="778" alt="Screenshot 2025-11-25 at 4 13 50 PM" src="https://github.com/user-attachments/assets/a83bb4e8-79dd-404e-8356-8034bc4fe40c" />
