### PR TITLE
When blanking autocompleter, clear hidden ids

### DIFF
--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -53,6 +53,35 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_field("query_observations_by_users", with: "Roy Halling (roy)")
   end
 
+  # https://github.com/MushroomObserver/mushroom-observer/issues/3374
+  def test_clearing_autocompleter_clears_hidden_id
+    login!(@roy)
+
+    visit("/observations/search/new")
+    assert_selector("body.search__new")
+
+    # Select a user via autocomplete
+    find_field("query_observations_by_users").click
+    @browser.keyboard.type("rolf")
+    assert_selector(".auto_complete") # wait for autocomplete
+    assert_selector(".auto_complete ul li a", text: "Rolf Singer")
+    @browser.keyboard.type(:down, :tab)
+    sleep(0.5)
+    assert_field("query_observations_by_users", with: "Rolf Singer (rolf)")
+
+    # Hidden ID should be set
+    hidden_field = find("#query_observations_by_users_id", visible: false)
+    assert_not_empty(hidden_field.value, "Hidden ID should be set after selection")
+
+    # Clear the field with select-all and delete
+    find_field("query_observations_by_users").click
+    @browser.keyboard.type([:meta, "a"], :backspace)
+    sleep(0.5)
+
+    # Hidden ID should now be empty
+    assert_empty(hidden_field.value, "Hidden ID should be cleared when text is cleared")
+  end
+
   # def test_observation_search_location_autocompleter
   #   login!(@roy)
 

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -66,24 +66,19 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_selector(".auto_complete") # wait for autocomplete
     assert_selector(".auto_complete ul li a", text: "Rolf Singer")
     @browser.keyboard.type(:down, :tab)
-    sleep(0.5)
+    # Capybara's assert_field waits for the value to appear
     assert_field("query_observations_by_users", with: "Rolf Singer (rolf)")
 
-    # Hidden ID should be set
+    # Hidden ID should be set - wait for it to have a non-empty value
     hidden_field = find("#query_observations_by_users_id", visible: false)
-    assert_not_empty(
-      hidden_field.value, "Hidden ID should be set after selection"
-    )
+    assert(hidden_field.value.present?,
+           "Hidden ID should be set after selection")
 
-    # Clear the field with select-all and delete
-    find_field("query_observations_by_users").click
-    @browser.keyboard.type([:meta, "a"], :backspace)
-    sleep(0.5)
+    # Clear the field - use Capybara's cross-platform method
+    fill_in("query_observations_by_users", with: "")
 
-    # Hidden ID should now be empty
-    assert_empty(
-      hidden_field.value, "Hidden ID should be cleared when text is cleared"
-    )
+    # Hidden ID should now be empty (use waiting matcher)
+    assert_field("query_observations_by_users_id", type: :hidden, with: "")
   end
 
   # def test_observation_search_location_autocompleter

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -71,7 +71,9 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
 
     # Hidden ID should be set
     hidden_field = find("#query_observations_by_users_id", visible: false)
-    assert_not_empty(hidden_field.value, "Hidden ID should be set after selection")
+    assert_not_empty(
+      hidden_field.value, "Hidden ID should be set after selection"
+    )
 
     # Clear the field with select-all and delete
     find_field("query_observations_by_users").click
@@ -79,7 +81,9 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     sleep(0.5)
 
     # Hidden ID should now be empty
-    assert_empty(hidden_field.value, "Hidden ID should be cleared when text is cleared")
+    assert_empty(
+      hidden_field.value, "Hidden ID should be cleared when text is cleared"
+    )
   end
 
   # def test_observation_search_location_autocompleter


### PR DESCRIPTION
Addresses #3374 

  Bug: Clearing the "Created By" autocompleter field didn't clear the hidden ID, so searches still filtered by the old user.

  Root causes:
  1. `clearLastHiddenIdAndKeeper()` used index-based removal, but `getSearchTokenIndex()` returns -1 when input is empty
  2. `slice()` was used instead of `splice()` (doesn't modify array)
  3. No `input` event listener (only `keyup`/`change`)

  Fixes in `autocompleter_controller.js`:
  1. Added `input` event listener for reliable value change detection
  2. `clearLastHiddenTargetValue() `- now clears everything when input is completely empty
  3. `clearLastHiddenIdAndKeeper()` - fixed `slice` → `splice`
  4. `clearHiddenIdAndData()` - also updates DOM attribute
  5. `updateHiddenId()` - don't clear hidden ID if matches haven't loaded yet (prevents regression)

Added system test to `autocompleter_system_test.rb`
- `test_clearing_autocompleter_clears_hidden_id`