### PR TITLE
Matrix box footer - use Stimulus to sync to local time zones

### DIFF
--- a/app/components/matrix_box.rb
+++ b/app/components/matrix_box.rb
@@ -201,7 +201,15 @@ class Components::MatrixBox < Components::Base
   end
 
   def render_footer_time(time)
-    div(class: "rss-what small") { time.display_time } if time
+    return unless time
+
+    div(
+      class: "rss-what rss-updated-at small",
+      data: { controller: "local-time", local_time_utc_value: time.utc.iso8601 }
+    ) do
+      # Server-rendered fallback for no-JS clients; replaced by Stimulus
+      time.display_time
+    end
   end
 
   def render_user_detail(user)

--- a/app/javascript/controllers/local-time_controller.js
+++ b/app/javascript/controllers/local-time_controller.js
@@ -23,7 +23,12 @@ export default class extends Controller {
     const minutes = String(date.getMinutes()).padStart(2, "0")
     const seconds = String(date.getSeconds()).padStart(2, "0")
 
+    // Get timezone abbreviation (e.g., "PST", "EST")
+    const timezone = new Intl.DateTimeFormat('en-US', {
+      timeZoneName: 'short'
+    }).formatToParts(date).find(part => part.type === 'timeZoneName')?.value || ''
+
     this.element.textContent =
-      `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+      `${year}-${month}-${day} ${hours}:${minutes}:${seconds} ${timezone}`
   }
 }

--- a/app/javascript/controllers/local-time_controller.js
+++ b/app/javascript/controllers/local-time_controller.js
@@ -23,6 +23,7 @@ export default class extends Controller {
     const minutes = String(date.getMinutes()).padStart(2, "0")
     const seconds = String(date.getSeconds()).padStart(2, "0")
 
-    this.element.textContent = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+    this.element.textContent =
+      `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
   }
 }

--- a/app/javascript/controllers/local-time_controller.js
+++ b/app/javascript/controllers/local-time_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="local-time"
+// Converts a UTC ISO timestamp to local time display
+export default class extends Controller {
+  static values = { utc: String }
+
+  connect() {
+    this.formatLocalTime()
+  }
+
+  formatLocalTime() {
+    if (!this.utcValue) return
+
+    const date = new Date(this.utcValue)
+    if (isNaN(date.getTime())) return
+
+    // Format as YYYY-MM-DD HH:MM:SS in local time
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, "0")
+    const day = String(date.getDate()).padStart(2, "0")
+    const hours = String(date.getHours()).padStart(2, "0")
+    const minutes = String(date.getMinutes()).padStart(2, "0")
+    const seconds = String(date.getSeconds()).padStart(2, "0")
+
+    this.element.textContent = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+  }
+}

--- a/test/system/local_time_system_test.rb
+++ b/test/system/local_time_system_test.rb
@@ -20,11 +20,11 @@ class LocalTimeSystemTest < ApplicationSystemTestCase
                  utc_value,
                  "Expected ISO8601 UTC format")
 
-    # Verify the displayed time format is YYYY-MM-DD HH:MM:SS
+    # Verify the displayed time format is YYYY-MM-DD HH:MM:SS TZ
     displayed_time = time_element.text
-    assert_match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+    assert_match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+$/,
                  displayed_time,
-                 "Expected local time format YYYY-MM-DD HH:MM:SS")
+                 "Expected local time format YYYY-MM-DD HH:MM:SS TZ")
 
     # Verify the controller connected by checking the time was converted
     # (The UTC and displayed times should differ unless in UTC timezone)
@@ -57,7 +57,10 @@ class LocalTimeSystemTest < ApplicationSystemTestCase
         const hours = String(date.getHours()).padStart(2, '0');
         const minutes = String(date.getMinutes()).padStart(2, '0');
         const seconds = String(date.getSeconds()).padStart(2, '0');
-        const expectedLocal = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+        const timezone = new Intl.DateTimeFormat('en-US', {
+          timeZoneName: 'short'
+        }).formatToParts(date).find(part => part.type === 'timeZoneName')?.value || '';
+        const expectedLocal = `${year}-${month}-${day} ${hours}:${minutes}:${seconds} ${timezone}`;
 
         return {
           utcValue: utcValue,

--- a/test/system/local_time_system_test.rb
+++ b/test/system/local_time_system_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+class LocalTimeSystemTest < ApplicationSystemTestCase
+  def test_matrix_box_footer_time_converted_to_local
+    login!(users("rolf"))
+
+    # Visit observations index which has matrix boxes with timestamps
+    visit("/")
+    assert_selector("body.observations__index")
+
+    # Find a matrix box with a time footer
+    time_element = find(".rss-updated-at", match: :first, wait: 5)
+
+    # Verify the Stimulus controller data attribute is present
+    utc_value = time_element["data-local-time-utc-value"]
+    assert(utc_value.present?, "Expected UTC value data attribute")
+    assert_match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+                 utc_value,
+                 "Expected ISO8601 UTC format")
+
+    # Verify the displayed time format is YYYY-MM-DD HH:MM:SS
+    displayed_time = time_element.text
+    assert_match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+                 displayed_time,
+                 "Expected local time format YYYY-MM-DD HH:MM:SS")
+
+    # Verify the controller connected by checking the time was converted
+    # (The UTC and displayed times should differ unless in UTC timezone)
+    # We can at least verify the JS ran by checking the format changed
+    # from whatever the server rendered to our expected format
+  end
+
+  def test_local_time_controller_converts_utc_correctly
+    login!(users("rolf"))
+
+    visit("/")
+    assert_selector("body.observations__index")
+    assert_selector(".rss-updated-at", wait: 5)
+
+    # Use JavaScript to verify the conversion is correct
+    # We'll create a test element and verify the controller works
+    result = evaluate_script(<<~JS)
+      (function() {
+        const el = document.querySelector('.rss-updated-at');
+        if (!el) return { error: 'No element found' };
+
+        const utcValue = el.dataset.localTimeUtcValue;
+        if (!utcValue) return { error: 'No UTC value' };
+
+        // Parse the UTC time and format in local time
+        const date = new Date(utcValue);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        const seconds = String(date.getSeconds()).padStart(2, '0');
+        const expectedLocal = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+
+        return {
+          utcValue: utcValue,
+          displayedTime: el.textContent.trim(),
+          expectedLocal: expectedLocal,
+          match: el.textContent.trim() === expectedLocal
+        };
+      })()
+    JS
+
+    assert_nil(result["error"], result["error"])
+    assert(result["match"],
+           "Displayed time '#{result["displayedTime"]}' should match " \
+           "expected local time '#{result["expectedLocal"]}' " \
+           "(from UTC: #{result["utcValue"]})")
+  end
+end

--- a/test/system/local_time_system_test.rb
+++ b/test/system/local_time_system_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+class LocalTimeSystemTest < ApplicationSystemTestCase
+  def test_matrix_box_footer_time_converted_to_local
+    login!(users("rolf"))
+
+    # Visit observations index which has matrix boxes with timestamps
+    visit("/")
+    assert_selector("body.observations__index")
+
+    # Find a matrix box with a time footer
+    time_element = find(".rss-updated-at", match: :first, wait: 5)
+
+    # Verify the Stimulus controller data attribute is present
+    utc_value = time_element["data-local-time-utc-value"]
+    assert(utc_value.present?, "Expected UTC value data attribute")
+    assert_match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+                 utc_value,
+                 "Expected ISO8601 UTC format")
+
+    # Verify the displayed time format is YYYY-MM-DD HH:MM:SS
+    displayed_time = time_element.text
+    assert_match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+                 displayed_time,
+                 "Expected local time format YYYY-MM-DD HH:MM:SS")
+
+    # Verify the controller connected by checking the time was converted
+    # (The UTC and displayed times should differ unless in UTC timezone)
+    # We can at least verify the JS ran by checking the format changed
+    # from whatever the server rendered to our expected format
+  end
+
+  def test_local_time_controller_converts_utc_correctly
+    login!(users("rolf"))
+
+    visit("/")
+    assert_selector("body.observations__index")
+    assert_selector(".rss-updated-at", wait: 5)
+
+    # Use JavaScript to verify the conversion is correct
+    # We'll create a test element and verify the controller works
+    result = evaluate_script(<<~JS)
+      (function() {
+        const el = document.querySelector('.rss-updated-at');
+        if (!el) return { error: 'No element found' };
+
+        const utcValue = el.dataset.localTimeUtcValue;
+        if (!utcValue) return { error: 'No UTC value' };
+
+        // Parse the UTC time and format in local time
+        const date = new Date(utcValue);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        const seconds = String(date.getSeconds()).padStart(2, '0');
+        const expectedLocal = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+
+        return {
+          utcValue: utcValue,
+          displayedTime: el.textContent.trim(),
+          expectedLocal: expectedLocal,
+          match: el.textContent.trim() === expectedLocal
+        };
+      })()
+    JS
+
+    assert_nil(result["error"], result["error"])
+    assert(result["match"],
+           "Displayed time '#{result['displayedTime']}' should match " \
+           "expected local time '#{result['expectedLocal']}' " \
+           "(from UTC: #{result['utcValue']})")
+  end
+end


### PR DESCRIPTION
This took all of 15 minutes, using the following prompt in Claude Code:
> OK our matrix boxes on the obs index and rss_logs index have a ".log-footer" section that prints information about the most recent modifications to the record. The matrix box HTML is cached, though, so local clients will see the "rss-updated-at" time as the updating user's time zone, not their own. I'd like to  1. store the updated time in UTC as a data value "time-updated-value", formatted `toISOString()` for a Stimulus controller `static values`  2. write a new stimulus controller to update that span on the client, formatted in local time as "YYYY-MM-DD hh:mm::ss" 