### PR TITLE
Fix index pagination query param preservation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -229,10 +229,10 @@ module ApplicationHelper
       end
     end
 
-    # Put it back together using Rack to properly encode nested params
+    # Put it back together using Hash#to_query to properly encode nested params
     return addr if args.empty?
 
-    "#{addr}?#{Rack::Utils.build_nested_query(args)}"
+    "#{addr}?#{args.to_query}"
   end
 
   def form_submit_text(obj)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -200,21 +200,14 @@ module ApplicationHelper
   #
   def add_args_to_url(url, new_args)
     new_args = new_args.clone
-    args = {}
 
     # Garbage in, garbage out...
     return url unless url.valid_encoding?
 
-    # Parse parameters off of current URL.
+    # Parse parameters off of current URL using Rack to handle nested/array
+    # params like q[by_user][]=1&q[by_user][]=2
     addr, parms = url.split("?")
-    (parms ? parms.split("&") : []).each do |arg|
-      var, val = arg.split("=")
-      next unless var && var != ""
-
-      var = CGI.unescape(var)
-      # See note below about precedence in case of redundancy.
-      args[var] = val unless args.key?(var)
-    end
+    args = parms ? Rack::Utils.parse_nested_query(parms) : {}
 
     # Deal with the special "/xxx/id" case.
     if %r{/(\d+)$}.match?(addr)
@@ -232,16 +225,14 @@ module ApplicationHelper
       elsif val.is_a?(ActiveRecord::Base)
         args[var.to_s] = val.id.to_s
       else
-        args[var.to_s] = CGI.escape(val.to_s)
+        args[var.to_s] = val.to_s
       end
     end
 
-    # Put it back together.
-    return addr if args.keys.empty?
+    # Put it back together using Rack to properly encode nested params
+    return addr if args.empty?
 
-    addr + "?" + args.keys.sort.map do |k| # rubocop:disable Style/StringConcatenation
-      "#{CGI.escape(k)}=#{args[k] || ""}"
-    end.join("&")
+    "#{addr}?#{Rack::Utils.build_nested_query(args)}"
   end
 
   def form_submit_text(obj)

--- a/app/helpers/header/index_pagination_helper.rb
+++ b/app/helpers/header/index_pagination_helper.rb
@@ -278,13 +278,11 @@ module Header
     def q_param_to_hidden_fields(form)
       # This flattens the hash as it is in the permalink.
       # Seems safer than trying to parse the incoming URI's query_string.
-      query_string = Rack::Utils.build_nested_query(
-        { q: q_param(query_from_session) }
-      )
+      query_string = { q: q_param(query_from_session) }.to_query
       # Sets them up them the way a form would, i.e. fields_for(:q)
-      pairs = query_string.split(Rack::Utils::DEFAULT_SEP)
+      pairs = query_string.split("&")
       tags = pairs.map do |pair|
-        key, value = pair.split("=", 2).map { |str| Rack::Utils.unescape(str) }
+        key, value = pair.split("=", 2).map { |str| CGI.unescape(str) }
         form.hidden_field(key, value: value)
       end
       tags.safe_join("\n")

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -284,13 +284,47 @@ module ControllerExtensions
   end
 
   # Assert the existence of a given link in the response body, and check
-  # that it points to the right place.
+  # that it points to the right place. Uses order-agnostic URL matching
+  # since query parameter order can vary.
   def assert_link_in_html(label, url, _msg = nil)
     unless url.is_a?(String)
       revised_opts = raise_params(url)
       url = url_for(revised_opts)
     end
-    assert_select("a[href='#{url}']", text: label)
+    assert_link_with_params(label, url)
+  end
+
+  # Find a link matching the label and verify its href contains the same
+  # path and query parameters (in any order) as the expected URL.
+  def assert_link_with_params(label, expected_url)
+    expected_uri = URI.parse(expected_url)
+    expected_path = expected_uri.path
+    expected_params = Rack::Utils.parse_nested_query(expected_uri.query || "")
+    expected_fragment = expected_uri.fragment
+
+    links = css_select("a").select { |a| a.text.strip == label.to_s }
+    matching_link = links.find do |link|
+      href = link[:href]
+      next false unless href
+
+      actual_uri = URI.parse(href)
+      next false unless actual_uri.path == expected_path
+
+      actual_params = Rack::Utils.parse_nested_query(actual_uri.query || "")
+      next false unless actual_params == expected_params
+
+      # Check fragment if expected
+      if expected_fragment && actual_uri.fragment != expected_fragment
+        next false
+      end
+
+      true
+    end
+
+    found_hrefs = links.pluck(:href).inspect
+    assert(matching_link,
+           "Expected link '#{label}' with URL matching #{expected_url}, " \
+           "found #{found_hrefs}")
   end
 
   def assert_image_link_in_html(img_src, url, _msg = nil)

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -69,6 +69,32 @@ module Observations
       assert_equal(session[:search_type], :observations)
     end
 
+    # Test that multiple users in by_users are properly prefilled
+    def test_new_observations_search_form_prefilled_with_multiple_users
+      user1 = users(:rolf)
+      user2 = users(:mary)
+      user3 = users(:dick)
+
+      login
+      query = @controller.find_or_create_query(
+        :Observation,
+        by_users: [user1.id, user2.id, user3.id]
+      )
+      assert(query.id)
+      get(:new)
+      # Textarea should show newline-separated user names
+      assert_select(
+        "textarea#query_observations_by_users",
+        text: "#{user1.unique_text_name}\n#{user2.unique_text_name}\n" \
+              "#{user3.unique_text_name}"
+      )
+      # Hidden field should have space-separated ids
+      assert_select(
+        "input#query_observations_by_users_id",
+        value: "#{user1.id} #{user2.id} #{user3.id}"
+      )
+    end
+
     # query_observations is the form object.
     def test_create_observations_search
       login

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -622,10 +622,18 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     login
     # Test index links lose the id param on next/prev page and goto_page
     get(:index, params: { id: o_loc.third.id, q: })
-    next_href = observations_path(params: { page: 2, q: })
-    prev_href = observations_path(params: { q: })
-    assert_select("a.next_page_link[href='#{next_href}']")
-    assert_select("a.prev_page_link[href='#{prev_href}']", count: 0)
+
+    # Check that next page link exists with correct params (order-agnostic)
+    assert_select("a.next_page_link") do |links|
+      href = links.first["href"]
+      assert_includes(href, "page=2", "Next link should have page=2")
+      assert_includes(href, "q%5Bmodel%5D=Observation",
+                      "Next link should have q[model]=Observation")
+      assert_includes(href, "q%5Blocations%5D",
+                      "Next link should have q[locations]")
+    end
+    # On page 1, prev link should be disabled (has opacity-0 class)
+    assert_select("a.previous_page_link.disabled.opacity-0")
     assert_select("form.page_input[action='#{observations_url}']")
     assert_select("input[type='hidden'][name='q[model]'][value='Observation']")
   end

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -623,14 +623,17 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     # Test index links lose the id param on next/prev page and goto_page
     get(:index, params: { id: o_loc.third.id, q: })
 
+    # Build expected encoded strings using Hash#to_query for readability
+    q_model = { q: { model: "Observation" } }.to_query
+    q_locations = { q: { locations: nil } }.to_query.sub("=", "") # Just the key
+
     # Check that next page link exists with correct params (order-agnostic)
     assert_select("a.next_page_link") do |links|
       href = links.first["href"]
       assert_includes(href, "page=2", "Next link should have page=2")
-      assert_includes(href, "q%5Bmodel%5D=Observation",
+      assert_includes(href, q_model,
                       "Next link should have q[model]=Observation")
-      assert_includes(href, "q%5Blocations%5D",
-                      "Next link should have q[locations]")
+      assert_includes(href, q_locations, "Next link should have q[locations]")
     end
     # On page 1, prev link should be disabled (has opacity-0 class)
     assert_select("a.previous_page_link.disabled.opacity-0")
@@ -653,13 +656,10 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     login
     get(:index, params: { q: q })
 
-    # Build expected encoded strings using Rack::Utils for readability
-    # "q%5Bby_users%5D%5B%5D=#{user1.id}"
-    by_user_1 = Rack::Utils.build_nested_query(q: { by_users: [user1.id] })
-    # "q%5Bby_users%5D%5B%5D=#{user2.id}"
-    by_user_2 = Rack::Utils.build_nested_query(q: { by_users: [user2.id] })
-    # "q%5Bby_users%5D%5B%5D=#{user3.id}"
-    by_user_3 = Rack::Utils.build_nested_query(q: { by_users: [user3.id] })
+    # Build expected encoded strings using Hash#to_query for readability
+    by_user_1 = { q: { by_users: [user1.id] } }.to_query
+    by_user_2 = { q: { by_users: [user2.id] } }.to_query
+    by_user_3 = { q: { by_users: [user3.id] } }.to_query
 
     # Check that next page link preserves ALL array values
     assert_select("a.next_page_link") do |links|

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -15,9 +15,12 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   def test_add_args_to_url_append_args_to_url
-    assert_equal("/abcdef?a=2&foo=%22bar%22&this=that",
-                 add_args_to_url("/abcdef?foo=wrong&a=2",
-                                 foo: '"bar"', this: "that"))
+    result = add_args_to_url("/abcdef?foo=wrong&a=2", foo: '"bar"',
+                                                      this: "that")
+    assert(result.start_with?("/abcdef?"), "Should start with path")
+    assert_includes(result, "a=2", "Should preserve existing param")
+    assert_includes(result, "foo=%22bar%22", "Should replace foo param")
+    assert_includes(result, "this=that", "Should add new param")
   end
 
   def test_add_args_to_url_ending_with_id
@@ -38,5 +41,18 @@ class ApplicationHelperTest < ActionView::TestCase
   def test_add_args_to_url_invalid_utf_8_address_and_arg
     assert_equal("/blah\x80",
                  add_args_to_url("/blah\x80", x: "foo\xA0"))
+  end
+
+  # Test that array params (like q[by_user][]=1&q[by_user][]=2) are preserved
+  def test_add_args_to_url_preserves_array_params
+    url = "/observations?q%5Bby_user%5D%5B%5D=1&q%5Bby_user%5D%5B%5D=2"
+    result = add_args_to_url(url, page: 2)
+
+    # The result should contain both by_user values
+    assert_includes(result, "q%5Bby_user%5D%5B%5D=1",
+                    "Should preserve first array value")
+    assert_includes(result, "q%5Bby_user%5D%5B%5D=2",
+                    "Should preserve second array value")
+    assert_includes(result, "page=2", "Should add new page param")
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -45,14 +45,18 @@ class ApplicationHelperTest < ActionView::TestCase
 
   # Test that array params (like q[by_user][]=1&q[by_user][]=2) are preserved
   def test_add_args_to_url_preserves_array_params
-    url = "/observations?q%5Bby_user%5D%5B%5D=1&q%5Bby_user%5D%5B%5D=2"
+    # "q%5Bby_user%5D%5B%5D=1&q%5Bby_user%5D%5B%5D=2"
+    query_string = Rack::Utils.build_nested_query(q: { by_user: [1, 2] })
+    url = "/observations?#{query_string}"
     result = add_args_to_url(url, page: 2)
 
     # The result should contain both by_user values
-    assert_includes(result, "q%5Bby_user%5D%5B%5D=1",
-                    "Should preserve first array value")
-    assert_includes(result, "q%5Bby_user%5D%5B%5D=2",
-                    "Should preserve second array value")
+    # "q%5Bby_user%5D%5B%5D=1"
+    by_user_1 = Rack::Utils.build_nested_query(q: { by_user: [1] })
+    # "q%5Bby_user%5D%5B%5D=2"
+    by_user_2 = Rack::Utils.build_nested_query(q: { by_user: [2] })
+    assert_includes(result, by_user_1, "Should preserve first array value")
+    assert_includes(result, by_user_2, "Should preserve second array value")
     assert_includes(result, "page=2", "Should add new page param")
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -46,15 +46,15 @@ class ApplicationHelperTest < ActionView::TestCase
   # Test that array params (like q[by_user][]=1&q[by_user][]=2) are preserved
   def test_add_args_to_url_preserves_array_params
     # "q%5Bby_user%5D%5B%5D=1&q%5Bby_user%5D%5B%5D=2"
-    query_string = Rack::Utils.build_nested_query(q: { by_user: [1, 2] })
+    query_string = { q: { by_user: [1, 2] } }.to_query
     url = "/observations?#{query_string}"
     result = add_args_to_url(url, page: 2)
 
     # The result should contain both by_user values
     # "q%5Bby_user%5D%5B%5D=1"
-    by_user_1 = Rack::Utils.build_nested_query(q: { by_user: [1] })
+    by_user_1 = { q: { by_user: [1] } }.to_query
     # "q%5Bby_user%5D%5B%5D=2"
-    by_user_2 = Rack::Utils.build_nested_query(q: { by_user: [2] })
+    by_user_2 = { q: { by_user: [2] } }.to_query
     assert_includes(result, by_user_1, "Should preserve first array value")
     assert_includes(result, by_user_2, "Should preserve second array value")
     assert_includes(result, "page=2", "Should add new page param")


### PR DESCRIPTION
This addresses #3527. Regression tests added.

# To test this 

1. Go to the Observation search form.
2. Enter three users in Created By. @mo-nathan used:
Nathan Wilson (nathan)
Joseph D. Cohen (Joe Cohen)
Nimmo (barky)
3. Click search (currents 42 pages of 144 observations per page or approximately 6000 observations)
4. Note that the search criteria reflects all the listed users.
5. Click the right arrow to view the next page.
The number of pages **stays the same** and the search criteria keeps **all** of the users.

Also note that if you go back into the Observation search form, all three users are listed, and if you then do another search, then all three users show up.
___
Cause: in `app/helpers/application_helper.rb`, `add_args_to_url` (lines 201-245), line 210-216:

```ruby
  (parms ? parms.split("&") : []).each do |arg|
    var, val = arg.split("=")
    next unless var && var != ""

    var = CGI.unescape(var)
    # See note below about precedence in case of redundancy.
    args[var] = val unless args.key?(var)
  end
```
This is parsing query params by splitting on `&` and `=`, but it doesn't handle array params like `q[by_user][]=123&q[by_user][]=456`. Each `q[by_user][]` gets treated as the same key, and the unless `args.key?(var)` means only the first value is kept!

Adds tests that the query param array value is preserved.