### PR TITLE
Convert `object` Component props to `_Nilable(AbstractModel)`

### DIFF
--- a/app/components/carousel.rb
+++ b/app/components/carousel.rb
@@ -24,7 +24,7 @@ class Components::Carousel < Components::Base
     value.respond_to?(:to_a) ? value.to_a : value
   end
   prop :user, _Nilable(User)
-  prop :object, _Nilable(Object), default: nil
+  prop :object, _Nilable(AbstractModel), default: nil
   prop :size, Components::BaseImage::Size, default: :large
   prop :title, String, default: -> { :IMAGES.t }
   prop :links, String, default: ""

--- a/app/components/carousel_item.rb
+++ b/app/components/carousel_item.rb
@@ -18,7 +18,7 @@
 class Components::CarouselItem < Components::BaseImage
   # Additional carousel-specific properties
   prop :index, Integer, default: 0
-  prop :object, _Nilable(Object), default: nil
+  prop :object, _Nilable(AbstractModel), default: nil
 
   def initialize(index: 0, object: nil, **props)
     # Set carousel-specific defaults

--- a/app/components/image_copyright.rb
+++ b/app/components/image_copyright.rb
@@ -19,7 +19,7 @@ class Components::ImageCopyright < Components::Base
 
   prop :user, _Nilable(User)
   prop :image, _Nilable(::Image)
-  prop :object, _Nilable(Object), default: nil
+  prop :object, _Nilable(AbstractModel), default: nil
 
   def view_template
     return "" unless @image && show_copyright?

--- a/app/components/matrix_box.rb
+++ b/app/components/matrix_box.rb
@@ -30,7 +30,7 @@ class Components::MatrixBox < Components::Base
 
   # Properties
   prop :user, _Nilable(User), default: nil
-  prop :object, _Nilable(Object), default: nil
+  prop :object, _Nilable(AbstractModel), default: nil
   prop :id, _Nilable(_Union(Integer, String)), default: nil
   prop :columns, String, default: "col-xs-12 col-sm-6 col-md-4 col-lg-3"
   prop :extra_class, String, default: ""


### PR DESCRIPTION
In existing components that pass an MO `object` it's typed as `_Nilable(Object)`. It makes more sense for this to be `_Nilable(AbstractModel)`.

Housekeeping PR to establish a better pattern for typing in component props.