### PR TITLE
Include locale in matrix box cache key

### DIFF
--- a/app/components/matrix_table.rb
+++ b/app/components/matrix_table.rb
@@ -60,7 +60,7 @@ class Components::MatrixTable < Components::Base
   def render_cached_boxes
     @objects.each do |object|
       if should_cache_object?(object)
-        cache(object) do
+        cache([I18n.locale, object]) do
           MatrixBox(user: @user, object: object, identify: @identify)
         end
       else

--- a/test/components/matrix_table_test.rb
+++ b/test/components/matrix_table_test.rb
@@ -188,4 +188,61 @@ class MatrixTableTest < UnitTestCase
     assert_includes(html, "block-test")
     assert_includes(html, "Custom content")
   end
+
+  def test_cache_key_includes_locale
+    obs = observations(:coprinus_comatus_obs)
+    obs.thumb_image.stub(:transferred, true) do
+      component = Components::MatrixTable.new(
+        objects: [obs],
+        user: @user,
+        cached: true
+      )
+
+      # Capture the cache key that gets passed to cache()
+      captured_key = nil
+      component.stub(:cache, lambda { |key, &block|
+        captured_key = key
+        block.call
+      }) do
+        render(component)
+      end
+
+      assert_equal([I18n.locale, obs], captured_key,
+                   "Cache key should include locale and object")
+    end
+  end
+
+  def test_different_locales_use_different_cache_keys
+    obs = observations(:coprinus_comatus_obs)
+    obs.thumb_image.stub(:transferred, true) do
+      keys = []
+
+      # Render with English locale
+      component_en = Components::MatrixTable.new(
+        objects: [obs], user: @user, cached: true
+      )
+      component_en.stub(:cache, lambda { |key, &block|
+        keys << key
+        block.call
+      }) do
+        I18n.with_locale(:en) { render(component_en) }
+      end
+
+      # Render with Spanish locale (new component instance)
+      component_es = Components::MatrixTable.new(
+        objects: [obs], user: @user, cached: true
+      )
+      component_es.stub(:cache, lambda { |key, &block|
+        keys << key
+        block.call
+      }) do
+        I18n.with_locale(:es) { render(component_es) }
+      end
+
+      assert_equal([:en, obs], keys[0], "First key should use :en locale")
+      assert_equal([:es, obs], keys[1], "Second key should use :es locale")
+      assert_not_equal(keys[0], keys[1], "Different locales should have " \
+                                         "different cache keys")
+    end
+  end
 end


### PR DESCRIPTION
The cache key now includes I18n.locale so each language gets its own cached version. Previously, the first user to view a matrix box would cache it in their language, and subsequent users would see that cached version regardless of their language setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)