### PR TITLE
Phlex Search Form Rank/Confidence fix

### DIFF
--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -176,10 +176,14 @@ module Searchable
 
     # Sort range values so min comes first. Works for both numeric values
     # (confidence) and string values (rank) that have a defined order.
+    # Filters out blank values before sorting to avoid validation errors.
     def sort_range_values(range)
-      return range if range.any?(&:blank?)
+      # Filter out blank values before sorting
+      non_blank = range.compact_blank
+      return [] if non_blank.empty?
+      return non_blank if non_blank.size == 1
 
-      sort_rank_range(range) || sort_numeric_range(range)
+      sort_rank_range(non_blank) || sort_numeric_range(non_blank)
     end
 
     def sort_rank_range(range)

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -363,6 +363,66 @@ module Observations
     end
 
     # ---------------------------------------------------------------
+    #  Single value confidence tests (blank + value scenarios)
+    #  Regression test for bug where selecting only the second dropdown
+    #  caused validation errors due to nil values
+    # ---------------------------------------------------------------
+
+    def test_create_with_only_confidence_range_value
+      # Submit with first dropdown blank, only second dropdown selected
+      # This previously caused validation errors with [nil, 2.0]
+      login
+      params = {
+        confidence: "", # blank/empty
+        confidence_range: 2.0 # only this one selected
+      }
+      post(:create, params: { query_observations: params })
+
+      assert_redirected_to(
+        controller: "/observations", action: :index,
+        params: {
+          q: { model: :Observation, confidence: [2.0] }
+        }
+      )
+    end
+
+    def test_create_with_only_first_confidence_value
+      # Submit with only first dropdown selected, second blank
+      login
+      params = {
+        confidence: 1.0,
+        confidence_range: "" # blank/empty
+      }
+      post(:create, params: { query_observations: params })
+
+      assert_redirected_to(
+        controller: "/observations", action: :index,
+        params: {
+          q: { model: :Observation, confidence: [1.0] }
+        }
+      )
+    end
+
+    def test_create_with_both_confidence_values_blank
+      # Submit with both dropdowns blank (no confidence filter)
+      login
+      params = {
+        confidence: "",
+        confidence_range: "",
+        has_images: true # add another param so query isn't completely empty
+      }
+      post(:create, params: { query_observations: params })
+
+      # Should create query without confidence parameter
+      assert_redirected_to(
+        controller: "/observations", action: :index,
+        params: {
+          q: { model: :Observation, has_images: true }
+        }
+      )
+    end
+
+    # ---------------------------------------------------------------
     #  Notes fields normalization tests
     # ---------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the issue with only specifying the second the value in both the Rank and Confidence range drop downs.

To test:
Go to the Observation search page
Set only the second Confidence value
Click search
On the nimmo-phlex-search-forms-superform branch you get an error and the + icon goes away.
On this branch you get search results and the UI doesn't get messed up.

Similar test on the Name search page for Rank.