### PR TITLE
Fix silent loss of VerifyAccount emails on SMTP failure

### DIFF
--- a/app/models/queued_email/verify_account.rb
+++ b/app/models/queued_email/verify_account.rb
@@ -10,8 +10,17 @@ class QueuedEmail
       result
     end
 
+    # Override to enable raise_delivery_errors so we can detect SMTP failures.
+    # If delivery fails, return false so the email stays in queue for retry.
     def deliver_email
+      old_setting = ActionMailer::Base.raise_delivery_errors
+      ActionMailer::Base.raise_delivery_errors = true
       VerifyAccountMailer.build(to_user).deliver_now
+    rescue StandardError => e
+      Rails.logger.error("VerifyAccount email failed: #{e.message}")
+      false
+    ensure
+      ActionMailer::Base.raise_delivery_errors = old_setting
     end
 
     # In this case we want current_user for

--- a/config/etc/crontab
+++ b/config/etc/crontab
@@ -3,7 +3,7 @@ RAILS_ENV=production
 MAILTO=webmaster@mushroomobserver.org
 
 *   * * * * /var/web/mo/bin/run script/update_ip_stats.rb
-*/5 * * * * /var/web/mo/bin/run rake email:send -f /var/web/mushroom-observer/Rakefile
+*   * * * * /var/web/mo/bin/run rake email:send -f /var/web/mushroom-observer/Rakefile
 */6 * * * * /var/web/mo/bin/run script/retransfer_images
 # This runs staggered three minutes after retransfer_images:
 # 3-59/6 * * * * rsync -av --remove-source-files /var/web/mo/public/images/ mo@images.mushroomobserver.org:/data/images/mo/


### PR DESCRIPTION
##  Summary

  - Fix bug where transient SMTP failures silently destroyed `VerifyAccount` emails
  - `VerifyAccount` emails now retry via the queue if immediate delivery fails

##  Problem

  When a user signs up, `VerifyAccount` emails are sent immediately via `send_email`, and destroyed if the return value is truthy. However, `deliver_now` returns a `Mail::Message` even when SMTP silently fails (because `ApplicationMailer` sets `raise_delivery_errors = false`).

  This meant transient SMTP failures (network hiccup, Gmail timeout, rate limiting) would cause the email to be destroyed without actually being delivered - losing the verification email forever.

##  The Fix

  For `VerifyAccount` emails specifically, temporarily enable `raise_delivery_errors` during delivery. If an exception is raised, catch it, log it, and return `false`. This leaves the email in the queue for the cron job to retry with its normal retry logic.

This PR also reduces the cron interval for sending email from 5 minutes to 1 minute. 
## Test plan

  - Existing mailer and controller tests pass
  - Manual test: Sign up flow still sends verification email
  - If SMTP fails, email should remain in queue for retry

  🤖 Generated with https://claude.com/claude-code
