### PR TITLE
Try to fix intermittent blocked_ips test failure on CI

### DIFF
--- a/test/controllers/admin/blocked_ips_controller_test.rb
+++ b/test/controllers/admin/blocked_ips_controller_test.rb
@@ -4,6 +4,16 @@ require("test_helper")
 
 module Admin
   class BlockedIpsControllerTest < FunctionalTestCase
+    def setup
+      super
+      # Ensure blocked_ips.txt exists (may not exist on CI)
+      FileUtils.touch(MO.blocked_ips_file)
+      FileUtils.touch(MO.okay_ips_file)
+      # Reset IpStats to ensure clean state, especially when running
+      # in parallel with other tests that modify blocked_ips.txt
+      IpStats.reset!
+    end
+
     def test_blocked_ips
       ActiveSupport.to_time_preserves_timezone = true
       new_ip = "5.4.3.2"


### PR DESCRIPTION
The test was failing on CI with ENOENT because blocked_ips.txt doesn't exist in a fresh checkout. Added setup method that:
1. Creates blocked_ips.txt and okay_ips.txt if they don't exist
2. Calls IpStats.reset! to ensure clean state when running in parallel with other tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)