### PR TITLE
Fix confidence in the Observation search form

### DIFF
--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -321,18 +321,20 @@ class Components::SearchForm < Components::ApplicationForm
   end
 
   # If first is blank, fill with min (range from min to value).
-  # If second is blank, fill with max (scope treats nil as ≥ first).
-  # Special case: "No Opinion" (0) doesn't fill with max, stays as single value.
+  # If second is blank, keep as single value - scope handles the appropriate range.
+  # Single value behavior:
+  # - 0.0: Exact match
+  # - Positive: Range from (next_lower, value]
+  # - Negative: Range from [value, next_higher)
   def fill_confidence_range(original, sorted)
     return [sorted.first, sorted.last] if sorted.size > 1
 
     if original.first.nil? || original.first.to_s.blank?
+      # First dropdown blank, second has value - range from min to that value
       [Vote::MINIMUM_VOTE.to_f, sorted.first]
-    elsif sorted.first.zero?
-      # "No Opinion" (0) should not be filled with maximum - exact match only
-      [sorted.first, nil]
     else
-      [sorted.first, Vote::MAXIMUM_VOTE.to_f]
+      # Single value selection - don't fill with max, let scope handle the range
+      [sorted.first, nil]
     end
   end
 

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -334,7 +334,9 @@ class Components::SearchForm < Components::ApplicationForm
       [Vote::MINIMUM_VOTE.to_f, sorted.first]
     else
       # Single value selection - don't fill with max, let scope handle the range
-      [sorted.first, nil]
+      # Return integer 0 for "No Opinion" to match Vote.opinion_menu
+      first_value = sorted.first.zero? ? 0 : sorted.first
+      [first_value, nil]
     end
   end
 

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -321,8 +321,8 @@ class Components::SearchForm < Components::ApplicationForm
   end
 
   # If first is blank, fill with min (range from min to value).
-  # If second is blank, keep as single value - scope handles the appropriate range.
-  # Single value behavior:
+  # If second is blank, keep as single value - scope handles the
+  # appropriate range. Single value behavior:
   # - 0.0: Exact match
   # - Positive: Range from (next_lower, value]
   # - Negative: Range from [value, next_higher)

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -322,11 +322,15 @@ class Components::SearchForm < Components::ApplicationForm
 
   # If first is blank, fill with min (range from min to value).
   # If second is blank, fill with max (scope treats nil as ≥ first).
+  # Special case: "No Opinion" (0) doesn't fill with max, stays as single value.
   def fill_confidence_range(original, sorted)
     return [sorted.first, sorted.last] if sorted.size > 1
 
     if original.first.nil? || original.first.to_s.blank?
       [Vote::MINIMUM_VOTE.to_f, sorted.first]
+    elsif sorted.first.zero?
+      # "No Opinion" (0) should not be filled with maximum - exact match only
+      [sorted.first, nil]
     else
       [sorted.first, Vote::MAXIMUM_VOTE.to_f]
     end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -90,9 +90,13 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
 
     # Filters for confidence on vote_cache scale -3.0..3.0
     # To translate percentage to vote_cache: (val.to_f / (100 / 3))
+    # Special case: "No Opinion" (0) searches for exactly 0.0
     scope :confidence, lambda { |min, max = nil|
       min, max = min if min.is_a?(Array)
-      if max.nil? || max == min # max may be 0
+      # Special case: 0 (No Opinion) should match exactly, not >= 0
+      if (max.nil? || max == min) && min.to_f.zero?
+        where(Observation[:vote_cache].eq(0))
+      elsif max.nil? || max == min # max may be 0
         where(Observation[:vote_cache].gteq(min))
       else
         where(Observation[:vote_cache].in(min..max))

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -4,6 +4,9 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
   # This is using Concern so we can define the scopes in this included module.
   extend ActiveSupport::Concern
 
+  # Confidence levels for vote_cache filtering
+  CONFIDENCE_LEVELS = [3.0, 2.0, 1.0, 0.0, -1.0, -2.0, -3.0].freeze
+
   # NOTE: To improve Coveralls display, avoid one-line stabby lambda scopes.
   # Two line stabby lambdas are OK, it's just the declaration line that will
   # always show as covered.
@@ -97,37 +100,74 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     #   searches for vote_cache > 1.0 AND <= 2.0
     # - Negative values: Range from [value, next_higher) - e.g., "Not Likely"
     #   searches for vote_cache >= -2.0 AND < -1.0
+    #
+    # Range behavior combines the lower bound from min with upper bound
+    # from max:
+    # - "Promising" to "I'd Call It That": vote_cache > 1.0 AND <= 3.0
+    # - "Not Likely" to "Promising": vote_cache >= -2.0 AND <= 2.0
     scope :confidence, lambda { |min, max = nil|
       min, max = min if min.is_a?(Array)
-      confidence_levels = [3.0, 2.0, 1.0, 0.0, -1.0, -2.0, -3.0].freeze
 
       if max.nil? || max == min
-        # Single value search
-        value = min.to_f
-
-        if value.zero?
-          # No Opinion: exact match
-          where(Observation[:vote_cache].eq(0))
-        elsif value.positive?
-          # Positive confidence: range from (next_lower, value]
-          next_lower = confidence_levels.select do |v|
-            v < value
-          end.max || (value - 1.0)
-          where(Observation[:vote_cache].gt(next_lower).
-                and(Observation[:vote_cache].lteq(value)))
-        else
-          # Negative confidence: range from [value, next_higher)
-          next_higher = confidence_levels.select do |v|
-            v > value
-          end.min || (value + 1.0)
-          where(Observation[:vote_cache].gteq(value).
-                and(Observation[:vote_cache].lt(next_higher)))
-        end
+        confidence_single_value(min.to_f)
       else
-        # Range search: use as-is
-        where(Observation[:vote_cache].in(min..max))
+        confidence_range(min.to_f, max.to_f)
       end
     }
+
+    def self.confidence_single_value(value)
+      if value.zero?
+        where(Observation[:vote_cache].eq(0))
+      elsif value.positive?
+        confidence_positive_single(value)
+      else
+        confidence_negative_single(value)
+      end
+    end
+
+    def self.confidence_positive_single(value)
+      next_lower = CONFIDENCE_LEVELS.select { |v| v < value }.max ||
+                   (value - 1.0)
+      where(Observation[:vote_cache].gt(next_lower).
+            and(Observation[:vote_cache].lteq(value)))
+    end
+
+    def self.confidence_negative_single(value)
+      next_higher = CONFIDENCE_LEVELS.select { |v| v > value }.min ||
+                    (value + 1.0)
+      where(Observation[:vote_cache].gteq(value).
+            and(Observation[:vote_cache].lt(next_higher)))
+    end
+
+    def self.confidence_range(min_val, max_val)
+      lower = confidence_lower_bound(min_val)
+      upper = confidence_upper_bound(max_val)
+      where(lower.and(upper))
+    end
+
+    def self.confidence_lower_bound(value)
+      if value.zero?
+        Observation[:vote_cache].gteq(0)
+      elsif value.positive?
+        next_lower = CONFIDENCE_LEVELS.select { |v| v < value }.max ||
+                     (value - 1.0)
+        Observation[:vote_cache].gt(next_lower)
+      else
+        Observation[:vote_cache].gteq(value)
+      end
+    end
+
+    def self.confidence_upper_bound(value)
+      if value.zero?
+        Observation[:vote_cache].lteq(0)
+      elsif value.positive?
+        Observation[:vote_cache].lteq(value)
+      else
+        next_higher = CONFIDENCE_LEVELS.select { |v| v > value }.min ||
+                      (value + 1.0)
+        Observation[:vote_cache].lt(next_higher)
+      end
+    end
     scope :needs_naming, lambda { |user|
       needs_naming_generally.not_reviewed_by_user(user).distinct
     }

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -153,7 +153,7 @@ class Vote < AbstractModel
     [:vote_confidence_0,   -3.0]
   ].freeze
 
-  NO_OPINION_VAL = [:vote_no_opinion, 0].freeze
+  NO_OPINION_VAL = [:vote_no_opinion, 0.0].freeze
 
   # List of options interpreted as "confidence".
   #
@@ -174,7 +174,10 @@ class Vote < AbstractModel
   end
 
   # Find label of closest value in the "confidence" menu.
+  # Special case: 0 returns "No Opinion"
   def self.confidence(val)
+    return no_opinion if val.to_f.zero?
+
     lookup_value(val, confidence_menu)
   end
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -153,7 +153,7 @@ class Vote < AbstractModel
     [:vote_confidence_0,   -3.0]
   ].freeze
 
-  NO_OPINION_VAL = [:vote_no_opinion, 0.0].freeze
+  NO_OPINION_VAL = [:vote_no_opinion, 0].freeze
 
   # List of options interpreted as "confidence".
   #

--- a/test/classes/query/sequences_test.rb
+++ b/test/classes/query/sequences_test.rb
@@ -139,10 +139,12 @@ class Query::SequencesTest < UnitTestCase
       [seq1, seq2], scope,
       :Sequence, observation_query: { species_lists: "List of mysteries" }
     )
-    scope = Sequence.observation_query(confidence: "2").order_by(:id)
+    # seq4's observation (peltigera_obs) has vote_cache ~2.4, which falls
+    # in "I'd Call It That" (3.0) range: vote_cache > 2.0 AND <= 3.0
+    scope = Sequence.observation_query(confidence: "3").order_by(:id)
     assert_query_scope(
       [seq4], scope,
-      :Sequence, observation_query: { confidence: "2" }
+      :Sequence, observation_query: { confidence: "3" }
     )
   end
 

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -559,8 +559,8 @@ class SearchFormTest < UnitTestCase
     end
 
     assert(selected, "First confidence select should have selected option")
-    assert_equal("0.0", selected["value"],
-                 "First confidence should be 0.0 (No Opinion)")
+    assert_equal("0", selected["value"],
+                 "First confidence should be 0 (No Opinion)")
 
     # Second select should have blank/nil option selected (exact match,
     # not a range)

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -503,6 +503,41 @@ class SearchFormTest < UnitTestCase
     assert_equal("3.0", selected_range["value"])
   end
 
+  # "No Opinion" (0) should not be filled with maximum - exact match only
+  def test_confidence_no_opinion_stays_single_value
+    query = Query::Observations.new
+    query.confidence = [0.0]
+
+    html = render_form_with_query(query)
+    doc = Nokogiri::HTML(html)
+
+    # First select should have 0 (No Opinion) selected
+    confidence_select = doc.at_css("#query_observations_confidence")
+    assert(confidence_select, "Should have confidence select")
+    selected = confidence_select.at_css("option[selected]")
+
+    # Debug: print all options if test fails
+    unless selected
+      puts "\n=== DEBUG: First dropdown options ==="
+      confidence_select.css("option").each do |opt|
+        puts "  value=#{opt['value'].inspect}, selected=#{opt['selected'].inspect}, text=#{opt.text}"
+      end
+    end
+
+    assert(selected, "First confidence select should have selected option")
+    assert_equal("0.0", selected["value"],
+                 "First confidence should be 0.0 (No Opinion)")
+
+    # Second select should have blank/nil option selected (exact match, not a range)
+    confidence_range_select = doc.at_css("#query_observations_confidence_range")
+    assert(confidence_range_select, "Should have confidence_range select")
+    # The blank option should be selected
+    selected_range = confidence_range_select.at_css("option[selected]")
+    assert(selected_range, "Second confidence select should have an option selected")
+    assert_equal("", selected_range["value"].to_s,
+                 "Second confidence should have blank value for No Opinion (exact match)")
+  end
+
   # Cover RegionWithBoxFields box_value and build_minimal_location
   # when in_box has values (lines 114, 130, 132)
   def test_region_fields_prefilled_with_box_values

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -479,7 +479,8 @@ class SearchFormTest < UnitTestCase
                  "Second rank should be blank for exact match")
   end
 
-  # Confidence with first value set, second blank = single value (scope handles range)
+  # Confidence with first value set, second blank = single value
+  # (scope handles range)
   def test_confidence_single_positive_value_stays_single
     query = Query::Observations.new
     query.confidence = [2.0]
@@ -494,14 +495,17 @@ class SearchFormTest < UnitTestCase
     assert(selected, "First confidence select should have selected option")
     assert_equal("2.0", selected["value"])
 
-    # Second select should have blank option selected (single value, not a range)
+    # Second select should have blank option selected (single value,
+    # not a range)
     confidence_range_select = doc.at_css("#query_observations_confidence_range")
     assert(confidence_range_select, "Should have confidence_range select")
     selected_range = confidence_range_select.at_css("option[selected]")
     assert(selected_range,
            "Second confidence select should have an option selected")
-    assert_equal("", selected_range["value"].to_s,
-                 "Second confidence should have blank value for single value search")
+    assert_equal(
+      "", selected_range["value"].to_s,
+      "Second confidence should have blank value for single value search"
+    )
   end
 
   # Negative confidence single value stays single
@@ -519,14 +523,17 @@ class SearchFormTest < UnitTestCase
     assert(selected, "First confidence select should have selected option")
     assert_equal("-1.0", selected["value"])
 
-    # Second select should have blank option selected (single value, not a range)
+    # Second select should have blank option selected (single value,
+    # not a range)
     confidence_range_select = doc.at_css("#query_observations_confidence_range")
     assert(confidence_range_select, "Should have confidence_range select")
     selected_range = confidence_range_select.at_css("option[selected]")
     assert(selected_range,
            "Second confidence select should have an option selected")
-    assert_equal("", selected_range["value"].to_s,
-                 "Second confidence should have blank value for single value search")
+    assert_equal(
+      "", selected_range["value"].to_s,
+      "Second confidence should have blank value for single value search"
+    )
   end
 
   # "No Opinion" (0) should not be filled with maximum - exact match only
@@ -546,7 +553,8 @@ class SearchFormTest < UnitTestCase
     unless selected
       puts("\n=== DEBUG: First dropdown options ===")
       confidence_select.css("option").each do |opt|
-        puts("  value=#{opt["value"].inspect}, selected=#{opt["selected"].inspect}, text=#{opt.text}")
+        puts("  value=#{opt["value"].inspect}, " \
+             "selected=#{opt["selected"].inspect}, text=#{opt.text}")
       end
     end
 
@@ -554,15 +562,18 @@ class SearchFormTest < UnitTestCase
     assert_equal("0.0", selected["value"],
                  "First confidence should be 0.0 (No Opinion)")
 
-    # Second select should have blank/nil option selected (exact match, not a range)
+    # Second select should have blank/nil option selected (exact match,
+    # not a range)
     confidence_range_select = doc.at_css("#query_observations_confidence_range")
     assert(confidence_range_select, "Should have confidence_range select")
     # The blank option should be selected
     selected_range = confidence_range_select.at_css("option[selected]")
     assert(selected_range,
            "Second confidence select should have an option selected")
-    assert_equal("", selected_range["value"].to_s,
-                 "Second confidence should have blank value for No Opinion (exact match)")
+    assert_equal(
+      "", selected_range["value"].to_s,
+      "Second confidence should have blank value for No Opinion (exact match)"
+    )
   end
 
   # Cover RegionWithBoxFields box_value and build_minimal_location

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -454,17 +454,20 @@ module Observations
       assert(query.id)
       get(:new)
 
-      # First select should have "No Opinion" (0.0) selected
+      # First select should have "No Opinion" (0) selected
       assert_select("select#query_observations_confidence") do
-        assert_select("option[selected][value='0.0']")
+        assert_select("option[selected][value='0']")
       end
-      # Second select should have blank option selected (exact match, not a range)
+      # Second select should have blank option selected (exact match,
+      # not a range)
       assert_select("select#query_observations_confidence_range") do
         assert_select("option[selected]") do |options|
           assert_equal(1, options.length)
           # The blank option has an empty or nil value attribute
-          assert(options.first["value"].blank?,
-                 "Second confidence dropdown should have blank value for No Opinion")
+          assert(
+            options.first["value"].blank?,
+            "Second confidence dropdown should have blank value for No Opinion"
+          )
         end
       end
     end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -423,6 +423,53 @@ module Observations
     end
 
     # ---------------------------------------------------------------
+    #  "No Opinion" (0) special case tests
+    # ---------------------------------------------------------------
+
+    def test_create_with_no_opinion_searches_for_exact_zero
+      # User selects "No Opinion" (0) in first dropdown, second blank
+      # Should search for exactly vote_cache = 0, not >= 0
+      login
+      params = {
+        confidence: 0,
+        confidence_range: ""
+      }
+      post(:create, params: { query_observations: params })
+
+      assert_redirected_to(
+        controller: "/observations", action: :index,
+        params: {
+          q: { model: :Observation, confidence: [0.0] }
+        }
+      )
+    end
+
+    def test_prefill_no_opinion_confidence
+      # Bug: "No Opinion" (0) should display correctly, not be filled with max
+      login
+      query = @controller.find_or_create_query(
+        :Observation,
+        confidence: [0]
+      )
+      assert(query.id)
+      get(:new)
+
+      # First select should have "No Opinion" (0.0) selected
+      assert_select("select#query_observations_confidence") do
+        assert_select("option[selected][value='0.0']")
+      end
+      # Second select should have blank option selected (exact match, not a range)
+      assert_select("select#query_observations_confidence_range") do
+        assert_select("option[selected]") do |options|
+          assert_equal(1, options.length)
+          # The blank option has an empty or nil value attribute
+          assert(options.first["value"].blank?,
+                 "Second confidence dropdown should have blank value for No Opinion")
+        end
+      end
+    end
+
+    # ---------------------------------------------------------------
     #  Notes fields normalization tests
     # ---------------------------------------------------------------
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1602,6 +1602,52 @@ class ObservationTest < UnitTestCase
     assert_empty(Observation.confidence(3.1, 3.2))
   end
 
+  def test_scope_confidence_single_value_ranges
+    # Single positive values should search for range (next_lower, value]
+    # "Promising" (2.0) should match vote_cache > 1.0 AND <= 2.0
+    promising_results = Observation.confidence(2.0)
+    promising_results.each do |obs|
+      assert(obs.vote_cache > 1.0,
+             "vote_cache should be > 1.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache <= 2.0,
+             "vote_cache should be <= 2.0, got #{obs.vote_cache}")
+    end
+
+    # Single negative values should search for range [value, next_higher)
+    # "Doubtful" (-1.0) should match vote_cache >= -1.0 AND < 0.0
+    doubtful_results = Observation.confidence(-1.0)
+    doubtful_results.each do |obs|
+      assert(obs.vote_cache >= -1.0,
+             "vote_cache should be >= -1.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache < 0.0,
+             "vote_cache should be < 0.0, got #{obs.vote_cache}")
+    end
+
+    # "No Opinion" (0.0) should match exactly 0.0
+    no_opinion_results = Observation.confidence(0.0)
+    no_opinion_results.each do |obs|
+      assert_equal(0.0, obs.vote_cache, "vote_cache should be exactly 0.0")
+    end
+
+    # "I'd Call It That" (3.0) should match vote_cache > 2.0 AND <= 3.0
+    max_results = Observation.confidence(3.0)
+    max_results.each do |obs|
+      assert(obs.vote_cache > 2.0,
+             "vote_cache should be > 2.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache <= 3.0,
+             "vote_cache should be <= 3.0, got #{obs.vote_cache}")
+    end
+
+    # "As If!" (-3.0) should match vote_cache >= -3.0 AND < -2.0
+    min_results = Observation.confidence(-3.0)
+    min_results.each do |obs|
+      assert(obs.vote_cache >= -3.0,
+             "vote_cache should be >= -3.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache < -2.0,
+             "vote_cache should be < -2.0, got #{obs.vote_cache}")
+    end
+  end
+
   # Currently Query ignores false, so scope does too.
   # def test_scope_has_comments_false
   #   assert_includes(Observation.has_comments(false),

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1648,6 +1648,51 @@ class ObservationTest < UnitTestCase
     end
   end
 
+  def test_scope_confidence_range_searches
+    # Range searches should combine lower bound from min with upper bound
+    # from max
+
+    # "Promising" (2.0) to "I'd Call It That" (3.0)
+    # Should search for vote_cache > 1.0 AND <= 3.0
+    promising_to_max = Observation.confidence(2.0, 3.0)
+    promising_to_max.each do |obs|
+      assert(obs.vote_cache > 1.0,
+             "vote_cache should be > 1.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache <= 3.0,
+             "vote_cache should be <= 3.0, got #{obs.vote_cache}")
+    end
+
+    # "Could Be" (1.0) to "Promising" (2.0)
+    # Should search for vote_cache > 0.0 AND <= 2.0
+    could_be_to_promising = Observation.confidence(1.0, 2.0)
+    could_be_to_promising.each do |obs|
+      assert(obs.vote_cache > 0.0,
+             "vote_cache should be > 0.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache <= 2.0,
+             "vote_cache should be <= 2.0, got #{obs.vote_cache}")
+    end
+
+    # "Not Likely" (-2.0) to "Promising" (2.0)
+    # Should search for vote_cache >= -2.0 AND <= 2.0
+    not_likely_to_promising = Observation.confidence(-2.0, 2.0)
+    not_likely_to_promising.each do |obs|
+      assert(obs.vote_cache >= -2.0,
+             "vote_cache should be >= -2.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache <= 2.0,
+             "vote_cache should be <= 2.0, got #{obs.vote_cache}")
+    end
+
+    # "Not Likely" (-2.0) to "Doubtful" (-1.0)
+    # Should search for vote_cache >= -2.0 AND < 0.0
+    not_likely_to_doubtful = Observation.confidence(-2.0, -1.0)
+    not_likely_to_doubtful.each do |obs|
+      assert(obs.vote_cache >= -2.0,
+             "vote_cache should be >= -2.0, got #{obs.vote_cache}")
+      assert(obs.vote_cache < 0.0,
+             "vote_cache should be < 0.0, got #{obs.vote_cache}")
+    end
+  end
+
   # Currently Query ignores false, so scope does too.
   # def test_scope_has_comments_false
   #   assert_includes(Observation.has_comments(false),

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -85,4 +85,16 @@ class VoteTest < UnitTestCase
       assert_equal(true, ov.reviewed)
     end
   end
+
+  def test_confidence_returns_no_opinion_for_zero
+    # Bug: Vote.confidence(0) was returning "Doubtful" instead of "No Opinion"
+    assert_equal("No Opinion", Vote.confidence(0))
+    assert_equal("No Opinion", Vote.confidence(0.0))
+  end
+
+  def test_confidence_returns_labels_for_nonzero_values
+    assert_equal("I'd Call It That", Vote.confidence(3.0))
+    assert_equal("Doubtful", Vote.confidence(-1.0))
+    assert_equal("As If!", Vote.confidence(-3.0))
+  end
 end


### PR DESCRIPTION
What I think makes sense is to think of each named value as being a range from that value to the next value that is closer to 0.  So "I'd Call It That" is everything above "Promising" and "Not Likely" is everything below "Doubtful" up to "Not Likely".  When two values are given then it's the full range between those values inclusive.

Try it out and see if it the results make sense to you.
