### PR TITLE
`WebmasterQuestionForm` component, use in modal and standardize `:message` param

### DIFF
--- a/app/classes/form_object/webmaster_question.rb
+++ b/app/classes/form_object/webmaster_question.rb
@@ -7,7 +7,7 @@ class FormObject::WebmasterQuestion
   include ActiveModel::Attributes
 
   attribute :email, :string
-  attribute :content, :string
+  attribute :message, :string
 
   # Override model_name to control form field namespacing
   # This makes field names match controller expectations

--- a/app/components/webmaster_question_form.rb
+++ b/app/components/webmaster_question_form.rb
@@ -3,10 +3,10 @@
 # Form for submitting a question to the webmaster.
 # Allows users to ask questions about the site.
 class Components::WebmasterQuestionForm < Components::ApplicationForm
-  def initialize(model, email: nil, email_error: false, content: nil, **)
+  def initialize(model, email: nil, email_error: false, message: nil, **)
     @email = email
     @email_error = email_error
-    @content = content
+    @message = message
     super(model, **)
   end
 
@@ -39,11 +39,11 @@ class Components::WebmasterQuestionForm < Components::ApplicationForm
 
   def render_question_field
     namespace(:question) do |builder|
-      render(builder.field(:content).textarea(
+      render(builder.field(:message).textarea(
                wrapper_options: {
                  label: "#{:ask_webmaster_question.t}:"
                },
-               value: @content,
+               value: @message,
                rows: 10,
                data: {
                  autofocus: @email.present? && !@email_error

--- a/app/components/webmaster_question_form.rb
+++ b/app/components/webmaster_question_form.rb
@@ -23,33 +23,29 @@ class Components::WebmasterQuestionForm < Components::ApplicationForm
   private
 
   def render_email_field
-    namespace(:user) do |builder|
-      render(builder.field(:email).text(
-               wrapper_options: {
-                 label: "#{:ask_webmaster_your_email.t}:"
-               },
-               value: @email,
-               size: 60,
-               data: {
-                 autofocus: @email.blank? || @email_error
-               }
-             ))
-    end
+    render(field(:email).text(
+             wrapper_options: {
+               label: "#{:ask_webmaster_your_email.t}:"
+             },
+             value: @email,
+             size: 60,
+             data: {
+               autofocus: @email.blank? || @email_error
+             }
+           ))
   end
 
   def render_question_field
-    namespace(:question) do |builder|
-      render(builder.field(:message).textarea(
-               wrapper_options: {
-                 label: "#{:ask_webmaster_question.t}:"
-               },
-               value: @message,
-               rows: 10,
-               data: {
-                 autofocus: @email.present? && !@email_error
-               }
-             ))
-    end
+    render(field(:message).textarea(
+             wrapper_options: {
+               label: "#{:ask_webmaster_question.t}:"
+             },
+             value: @message,
+             rows: 10,
+             data: {
+               autofocus: @email.present? && !@email_error
+             }
+           ))
   end
 
   def form_action

--- a/app/controllers/account/verifications_controller.rb
+++ b/app/controllers/account/verifications_controller.rb
@@ -81,11 +81,11 @@ module Account
       url = "#{MO.http_domain}/account/verify/#{user.id}?" \
             "auth_code=#{user.auth_code}"
       body = :email_verify_intro.tp(user: user.login, link: url)
-      content = "email: #{user.email}\n\n #{body.html_to_ascii}"
+      message = "email: #{user.email}\n\n #{body.html_to_ascii}"
       WebmasterMailer.build(
         sender_email: user.email,
         subject: :email_subject_verify.l,
-        content: content
+        message:
       ).deliver_later
     end
 

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -152,11 +152,11 @@ class AccountController < ApplicationController
       # to automate creation of accounts?
 
       # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-      content = WebmasterMailer.prepend_user(@user, denied_message(@new_user))
+      message = WebmasterMailer.prepend_user(@user, denied_message(@new_user))
       WebmasterMailer.build(
         sender_email: MO.accounts_email_address,
         subject: "Account Denied",
-        content: content
+        message:
       ).deliver_later
     end
     false

--- a/app/controllers/admin/emails/merge_requests_controller.rb
+++ b/app/controllers/admin/emails/merge_requests_controller.rb
@@ -69,11 +69,11 @@ module Admin
       def send_merge_request
         # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
         temporarily_set_locale(MO.default_locale) do
-          content = WebmasterMailer.prepend_user(@user, merge_request_content)
+          message = WebmasterMailer.prepend_user(@user, merge_request_content)
           WebmasterMailer.build(
             sender_email: @user.email,
             subject: "#{@model.name} Merge Request",
-            content: content
+            message:
           ).deliver_later
         end
         flash_notice(:email_merge_request_success.t)

--- a/app/controllers/admin/emails/name_change_requests_controller.rb
+++ b/app/controllers/admin/emails/name_change_requests_controller.rb
@@ -64,13 +64,13 @@ module Admin
       def send_name_change_request(name_with_icn_id, new_name_with_icn_id)
         # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
         temporarily_set_locale(MO.default_locale) do
-          content = WebmasterMailer.prepend_user(
+          message = WebmasterMailer.prepend_user(
             @user, change_request_content(name_with_icn_id,
                                           new_name_with_icn_id)
           )
           WebmasterMailer.build(
             sender_email: @user.email,
-            content: content,
+            message:,
             subject: "Request to change Name having dependents"
           ).deliver_later
         end

--- a/app/controllers/admin/emails/webmaster_questions_controller.rb
+++ b/app/controllers/admin/emails/webmaster_questions_controller.rb
@@ -34,8 +34,8 @@ module Admin
       end
 
       def create
-        @email = params.dig(:webmaster_question, :user, :email)
-        @message = params.dig(:webmaster_question, :question, :message)
+        @email = params.dig(:webmaster_question, :email)
+        @message = params.dig(:webmaster_question, :message)
         @email_error = false
         create_webmaster_question
       end

--- a/app/controllers/admin/emails/webmaster_questions_controller.rb
+++ b/app/controllers/admin/emails/webmaster_questions_controller.rb
@@ -6,7 +6,7 @@ module Admin
     class WebmasterQuestionsController < ApplicationController
       def new
         @email = params.dig(:user, :email)
-        @content = params.dig(:question, :content)
+        @message = params.dig(:question, :message)
         @email = @user.email if @user
 
         respond_to do |format|
@@ -17,7 +17,16 @@ module Admin
               locals: {
                 title: :ask_webmaster_title.l,
                 identifier: "webmaster_question_email",
-                user: @user, form: "admin/emails/webmaster_questions/form"
+                user: @user,
+                form: "admin/emails/webmaster_questions/form",
+                form_locals: {
+                  model: FormObject::WebmasterQuestion.new(
+                    email: @email, message: @message
+                  ),
+                  email: @email,
+                  email_error: false,
+                  message: @message
+                }
               }
             ) and return
           end
@@ -26,7 +35,7 @@ module Admin
 
       def create
         @email = params.dig(:webmaster_question, :user, :email)
-        @content = params.dig(:webmaster_question, :question, :content)
+        @message = params.dig(:webmaster_question, :question, :message)
         @email_error = false
         create_webmaster_question
       end
@@ -36,7 +45,7 @@ module Admin
       def create_webmaster_question
         if invalid_email?
           handle_invalid_email
-        elsif @content.blank?
+        elsif @message.blank?
           handle_missing_content
         elsif non_user_potential_spam?
           handle_spam
@@ -67,8 +76,8 @@ module Admin
 
       def send_email_and_redirect
         # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-        content = WebmasterMailer.prepend_user(@user, @content)
-        WebmasterMailer.build(sender_email: @email, content: content).
+        message = WebmasterMailer.prepend_user(@user, @message)
+        WebmasterMailer.build(sender_email: @email, message:).
           deliver_later
         flash_notice(:runtime_ask_webmaster_success.t)
         redirect_to("/")
@@ -76,9 +85,9 @@ module Admin
 
       def non_user_potential_spam?
         !@user && (
-          /https?:/.match?(@content) ||
-          %r{<[/a-zA-Z]+>}.match?(@content) ||
-          @content.exclude?(" ")
+          /https?:/.match?(@message) ||
+          %r{<[/a-zA-Z]+>}.match?(@message) ||
+          @message.exclude?(" ")
         )
       end
     end

--- a/app/controllers/herbaria/curator_requests_controller.rb
+++ b/app/controllers/herbaria/curator_requests_controller.rb
@@ -37,11 +37,11 @@ module Herbaria
 
     def send_curator_request_email
       # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-      content = WebmasterMailer.prepend_user(@user, curator_request_content)
+      message = WebmasterMailer.prepend_user(@user, curator_request_content)
       WebmasterMailer.build(
         sender_email: @user.email,
         subject: "Herbarium Curator Request",
-        content: content
+        message:
       ).deliver_later
     end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -361,11 +361,11 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
            "Name: #{@herbarium.name} (#{@herbarium.code})\n" \
            "User: #{@user.id}, #{@user.login}, #{@user.name}\n" \
            "Obj: #{@herbarium.show_url}\n"
-    content = WebmasterMailer.prepend_user(@user, body)
+    message = WebmasterMailer.prepend_user(@user, body)
     WebmasterMailer.build(
       sender_email: @user.email,
       subject: "New Herbarium",
-      content: content
+      message:
     ).deliver_later
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -464,13 +464,13 @@ class LocationsController < ApplicationController
 
   def email_admin_location_change
     # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-    content = WebmasterMailer.prepend_user(@user, email_location_change_content)
+    message = WebmasterMailer.prepend_user(@user, email_location_change_content)
     WebmasterMailer.build(
       sender_email: @user.email,
       subject: "Nontrivial Location Change",
-      content: content
+      message:
     ).deliver_later
-    LocationsControllerTest.report_email(content) if Rails.env.test?
+    LocationsControllerTest.report_email(message) if Rails.env.test?
   end
 
   def email_location_change_content

--- a/app/controllers/names/trackers_controller.rb
+++ b/app/controllers/names/trackers_controller.rb
@@ -135,11 +135,11 @@ module Names
              "Name: ##{name.id} / #{name.search_name}\n" \
              "Note: [[#{name_tracker.note_template}]]\n\n" \
              "#{MO.http_domain}/names/trackers/#{name_tracker.id}/approve"
-      content = WebmasterMailer.prepend_user(@user, body)
+      message = WebmasterMailer.prepend_user(@user, body)
       WebmasterMailer.build(
         sender_email: user.email,
         subject: "New Name Tracker with Template",
-        content: content
+        message:
       ).deliver_later
 
       # Let the user know that the note_template feature requires approval.

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -575,13 +575,13 @@ class NamesController < ApplicationController
 
   def email_admin_name_change
     # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-    content = WebmasterMailer.prepend_user(@user, email_name_change_content)
+    message = WebmasterMailer.prepend_user(@user, email_name_change_content)
     WebmasterMailer.build(
       sender_email: @user.email,
       subject: "Nontrivial Name Change",
-      content: content
+      message:
     ).deliver_later
-    NamesControllerUpdateTest.report_email(content) if Rails.env.test?
+    NamesControllerUpdateTest.report_email(message) if Rails.env.test?
   end
 
   def email_name_change_content
@@ -673,7 +673,7 @@ class NamesController < ApplicationController
   end
 
   def email_admin_icn_id_conflict(survivor)
-    content = :email_merger_icn_id_conflict.l(
+    message = :email_merger_icn_id_conflict.l(
       name: survivor.user_real_search_name(@user),
       surviving_icn_id: survivor.icn_id,
       deleted_icn_id: @name.icn_id,
@@ -682,13 +682,13 @@ class NamesController < ApplicationController
       edit_url: "#{MO.http_domain}/names/#{@name.id}/edit"
     )
     # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-    content = WebmasterMailer.prepend_user(@user, content)
+    message = WebmasterMailer.prepend_user(@user, message)
     WebmasterMailer.build(
       sender_email: @user.email,
       subject: "Merger identifier conflict",
-      content: content
+      message:
     ).deliver_later
-    NamesControllerUpdateMergeTest.report_email(content) if Rails.env.test?
+    NamesControllerUpdateMergeTest.report_email(message) if Rails.env.test?
   end
 
   # ----------------------------------------------------------------------------

--- a/app/helpers/modals_helper.rb
+++ b/app/helpers/modals_helper.rb
@@ -23,7 +23,9 @@ module ModalsHelper
       WebmasterQuestion: Components::WebmasterQuestionForm
     }
 
-    component_class = model ? component_map[model.class.name.to_sym] : nil
+    # Use demodulized name to handle both ActiveRecord and FormObject classes
+    model_key = model&.class&.name&.demodulize&.to_sym
+    component_class = model_key ? component_map[model_key] : nil
 
     if component_class
       render_modal_component(

--- a/app/helpers/modals_helper.rb
+++ b/app/helpers/modals_helper.rb
@@ -19,7 +19,8 @@ module ModalsHelper
       ExternalLink: Components::ExternalLinkForm,
       HerbariumRecord: Components::HerbariumRecordForm,
       CollectionNumber: Components::CollectionNumberForm,
-      Sequence: Components::SequenceForm
+      Sequence: Components::SequenceForm,
+      WebmasterQuestion: Components::WebmasterQuestionForm
     }
 
     component_class = model ? component_map[model.class.name.to_sym] : nil
@@ -68,10 +69,15 @@ module ModalsHelper
   end
 
   def add_form_specific_params(params, component_class, locals)
-    return unless component_class == Components::ExternalLinkForm
-
-    params[:user] = locals[:user] if locals[:user]
-    params[:sites] = locals[:sites] if locals[:sites]
-    params[:site] = locals[:site] if locals[:site]
+    case component_class.name
+    when "Components::ExternalLinkForm"
+      params[:user] = locals[:user] if locals[:user]
+      params[:sites] = locals[:sites] if locals[:sites]
+      params[:site] = locals[:site] if locals[:site]
+    when "Components::WebmasterQuestionForm"
+      params[:email] = locals[:email] if locals[:email]
+      params[:email_error] = locals[:email_error] if locals.key?(:email_error)
+      params[:message] = locals[:message] if locals[:message]
+    end
   end
 end

--- a/app/helpers/modals_helper.rb
+++ b/app/helpers/modals_helper.rb
@@ -24,7 +24,7 @@ module ModalsHelper
     }
 
     # Use demodulized name to handle both ActiveRecord and FormObject classes
-    model_key = model&.class&.name&.demodulize&.to_sym
+    model_key = demodulized_class_name(model)
     component_class = model_key ? component_map[model_key] : nil
 
     if component_class
@@ -73,13 +73,27 @@ module ModalsHelper
   def add_form_specific_params(params, component_class, locals)
     case component_class.name
     when "Components::ExternalLinkForm"
-      params[:user] = locals[:user] if locals[:user]
-      params[:sites] = locals[:sites] if locals[:sites]
-      params[:site] = locals[:site] if locals[:site]
+      add_external_link_params(params, locals)
     when "Components::WebmasterQuestionForm"
-      params[:email] = locals[:email] if locals[:email]
-      params[:email_error] = locals[:email_error] if locals.key?(:email_error)
-      params[:message] = locals[:message] if locals[:message]
+      add_webmaster_question_params(params, locals)
     end
+  end
+
+  def add_external_link_params(params, locals)
+    params[:user] = locals[:user] if locals[:user]
+    params[:sites] = locals[:sites] if locals[:sites]
+    params[:site] = locals[:site] if locals[:site]
+  end
+
+  def add_webmaster_question_params(params, locals)
+    params[:email] = locals[:email] if locals[:email]
+    params[:email_error] = locals[:email_error] if locals.key?(:email_error)
+    params[:message] = locals[:message] if locals[:message]
+  end
+
+  def demodulized_class_name(model)
+    return nil unless model
+
+    model.class.name.demodulize.to_sym
   end
 end

--- a/app/mailers/webmaster_mailer.rb
+++ b/app/mailers/webmaster_mailer.rb
@@ -4,10 +4,10 @@
 class WebmasterMailer < ApplicationMailer
   after_action :webmaster_delivery, only: [:build]
 
-  def build(sender_email:, content:, subject: nil)
+  def build(sender_email:, message:, subject: nil)
     I18n.locale = MO.default_locale
     @title = subject || :email_subject_webmaster_question.l(user: sender_email)
-    @question = content
+    @question = message
     mo_mail(@title,
             to: MO.webmaster_email_address,
             from: MO.webmaster_email_address,

--- a/app/models/comment/callbacks.rb
+++ b/app/models/comment/callbacks.rb
@@ -34,13 +34,13 @@ module Comment::Callbacks
     return unless user_ids.intersect?(::MO.oil_users)
 
     # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-    content = WebmasterMailer.prepend_user(
+    message = WebmasterMailer.prepend_user(
       User.admin, oil_and_water_content(user_ids)
     )
     WebmasterMailer.build(
       sender_email: MO.noreply_email_address,
       subject: oil_and_water_subject,
-      content: content
+      message:
     ).deliver_later
   end
 

--- a/app/models/name/notify.rb
+++ b/app/models/name/notify.rb
@@ -12,12 +12,12 @@ module Name::Notify
   def notify_webmaster
     return if skip_notify
 
-    content = WebmasterMailer.prepend_user(user,
+    message = WebmasterMailer.prepend_user(user,
                                            "#{MO.http_domain}/names/#{id}")
     WebmasterMailer.build(
       sender_email: user.email,
       subject: "#{user.login} created #{user_real_text_name(user)}",
-      content: content
+      message:
     ).deliver_later
   end
 

--- a/app/views/controllers/admin/emails/webmaster_questions/_form.erb
+++ b/app/views/controllers/admin/emails/webmaster_questions/_form.erb
@@ -1,6 +1,0 @@
-<%= render(Components::WebmasterQuestionForm.new(
-  FormObject::WebmasterQuestion.new(email: @email, message: @message),
-  email: @email,
-  email_error: @email_error,
-  message: @message
-)) %>

--- a/app/views/controllers/admin/emails/webmaster_questions/_form.erb
+++ b/app/views/controllers/admin/emails/webmaster_questions/_form.erb
@@ -1,6 +1,6 @@
 <%= render(Components::WebmasterQuestionForm.new(
-  FormObject::WebmasterQuestion.new(email: @email, content: @content),
+  FormObject::WebmasterQuestion.new(email: @email, message: @message),
   email: @email,
   email_error: @email_error,
-  content: @content
+  message: @message
 )) %>

--- a/app/views/controllers/admin/emails/webmaster_questions/new.erb
+++ b/app/views/controllers/admin/emails/webmaster_questions/new.erb
@@ -2,5 +2,10 @@
 add_page_title(:ask_webmaster_title.t)
 %>
 
-<%= render(partial: "admin/emails/webmaster_questions/form",
-           locals: { local: true }) %>
+<%= render(Components::WebmasterQuestionForm.new(
+      FormObject::WebmasterQuestion.new(email: @email, message: @message),
+      email: @email,
+      email_error: @email_error,
+      message: @message,
+      local: true
+    )) %>

--- a/test/components/webmaster_question_form_test.rb
+++ b/test/components/webmaster_question_form_test.rb
@@ -9,7 +9,7 @@ class WebmasterQuestionFormTest < UnitTestCase
     super
     @email = FormObject::WebmasterQuestion.new
     @user_email = "test@example.com"
-    @content = "My question"
+    @message = "My question"
     controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
@@ -27,9 +27,9 @@ class WebmasterQuestionFormTest < UnitTestCase
 
   def test_renders_form_with_question_field
     assert_html(@html, "body", text: :ask_webmaster_question.l)
-    assert_html(@html, "textarea[name='webmaster_question[question][content]']")
+    assert_html(@html, "textarea[name='webmaster_question[question][message]']")
     assert_html(@html, "textarea[rows='10']")
-    assert_includes(@html, @content)
+    assert_includes(@html, @message)
   end
 
   def test_renders_submit_button
@@ -43,7 +43,7 @@ class WebmasterQuestionFormTest < UnitTestCase
     form = Components::WebmasterQuestionForm.new(
       @email,
       email: @user_email,
-      content: @content
+      message: @message
     )
     # Stub url_for to avoid routing errors in test environment
     form.stub(:url_for, "/test_action") do

--- a/test/components/webmaster_question_form_test.rb
+++ b/test/components/webmaster_question_form_test.rb
@@ -20,14 +20,14 @@ class WebmasterQuestionFormTest < UnitTestCase
 
   def test_renders_form_with_email_field
     assert_html(@html, "body", text: :ask_webmaster_your_email.l)
-    assert_html(@html, "input[name='webmaster_question[user][email]']")
+    assert_html(@html, "input[name='webmaster_question[email]']")
     assert_html(@html, "input[size='60']")
     assert_includes(@html, @user_email)
   end
 
   def test_renders_form_with_question_field
     assert_html(@html, "body", text: :ask_webmaster_question.l)
-    assert_html(@html, "textarea[name='webmaster_question[question][message]']")
+    assert_html(@html, "textarea[name='webmaster_question[message]']")
     assert_html(@html, "textarea[rows='10']")
     assert_includes(@html, @message)
   end

--- a/test/controllers/account/verifications_controller_test.rb
+++ b/test/controllers/account/verifications_controller_test.rb
@@ -113,12 +113,21 @@ module Account
         login: "micky",
         email: "mm@disney.com"
       )
+      # Should enqueue VerifyAccountMailer to user
       assert_enqueued_with(
         job: ActionMailer::MailDeliveryJob,
         args: ["VerifyAccountMailer", "build", "deliver_now",
                { args: [{ receiver: user }] }]
       ) do
-        post(:resend_email, params: { id: user.id })
+        # Should also enqueue WebmasterMailer to notify root
+        assert_enqueued_with(
+          job: ActionMailer::MailDeliveryJob,
+          args: lambda { |args|
+            args[0] == "WebmasterMailer" && args[1] == "build"
+          }
+        ) do
+          post(:resend_email, params: { id: user.id })
+        end
       end
       assert_flash_success
     end

--- a/test/controllers/admin/emails/webmaster_questions_controller_test.rb
+++ b/test/controllers/admin/emails/webmaster_questions_controller_test.rb
@@ -106,8 +106,8 @@ module Admin
         post(:create,
              params: {
                webmaster_question: {
-                 user: { email: email },
-                 question: { message: args[:message] || "Some message" }
+                 email: email,
+                 message: args[:message] || "Some message"
                }
              })
         assert_response(response)

--- a/test/controllers/admin/emails/webmaster_questions_controller_test.rb
+++ b/test/controllers/admin/emails/webmaster_questions_controller_test.rb
@@ -40,7 +40,7 @@ module Admin
         perform_enqueued_jobs do
           ask_webmaster_test(
             "anonymous@example.com",
-            content: "I noticed something odd",
+            message: "I noticed something odd",
             response: :redirect,
             flash: :runtime_ask_webmaster_success.t
           )
@@ -63,17 +63,17 @@ module Admin
 
       def test_send_webmaster_question_need_content
         ask_webmaster_test("bogus@email.com",
-                           content: "",
+                           message: "",
                            flash: :runtime_ask_webmaster_need_content.t)
       end
 
       def test_send_webmaster_question_antispam
         disable_unsafe_html_filter
         ask_webmaster_test("bogus@email.com",
-                           content: "Buy <a href='http://junk'>Me!</a>",
+                           message: "Buy <a href='http://junk'>Me!</a>",
                            flash: :runtime_ask_webmaster_antispam.t)
         ask_webmaster_test("okay_user@email.com",
-                           content: "iwxobjUzvkhmaCt",
+                           message: "iwxobjUzvkhmaCt",
                            flash: :runtime_ask_webmaster_antispam.t)
       end
 
@@ -85,7 +85,7 @@ module Admin
         perform_enqueued_jobs do
           ask_webmaster_test(
             user.email,
-            content: "https://mushroomobserver.org/123 has an error",
+            message: "https://mushroomobserver.org/123 has an error",
             response: :redirect,
             flash: :runtime_ask_webmaster_success.t
           )
@@ -107,7 +107,7 @@ module Admin
              params: {
                webmaster_question: {
                  user: { email: email },
-                 question: { content: args[:content] || "Some content" }
+                 question: { message: args[:message] || "Some message" }
                }
              })
         assert_response(response)

--- a/test/integration/capybara/webmaster_question_integration_test.rb
+++ b/test/integration/capybara/webmaster_question_integration_test.rb
@@ -17,10 +17,10 @@ class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
     perform_enqueued_jobs do
       within("#webmaster_question_form") do
         # Email field should be pre-filled with user's email
-        assert_field("webmaster_question_user_email", with: rolf.email)
+        assert_field("webmaster_question_email", with: rolf.email)
 
         # Fill in the question
-        fill_in("webmaster_question_question_content",
+        fill_in("webmaster_question_message",
                 with: "I found a bug in the observation form")
 
         # Submit the form
@@ -47,9 +47,9 @@ class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
     perform_enqueued_jobs do
       within("#webmaster_question_form") do
         # Fill in both email and question
-        fill_in("webmaster_question_user_email",
+        fill_in("webmaster_question_email",
                 with: "concerned_user@example.com")
-        fill_in("webmaster_question_question_content",
+        fill_in("webmaster_question_message",
                 with: "I noticed something odd with the species page")
 
         # Submit the form
@@ -72,8 +72,8 @@ class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
 
     within("#webmaster_question_form") do
       # Leave email blank
-      fill_in("webmaster_question_user_email", with: "")
-      fill_in("webmaster_question_question_content",
+      fill_in("webmaster_question_email", with: "")
+      fill_in("webmaster_question_message",
               with: "This is my question")
 
       click_commit
@@ -87,8 +87,8 @@ class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
     visit(new_admin_emails_webmaster_questions_path)
 
     within("#webmaster_question_form") do
-      fill_in("webmaster_question_user_email", with: "test@example.com")
-      fill_in("webmaster_question_question_content", with: "")
+      fill_in("webmaster_question_email", with: "test@example.com")
+      fill_in("webmaster_question_message", with: "")
 
       click_commit
     end
@@ -101,9 +101,9 @@ class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
     visit(new_admin_emails_webmaster_questions_path)
 
     within("#webmaster_question_form") do
-      fill_in("webmaster_question_user_email", with: "spammer@example.com")
+      fill_in("webmaster_question_email", with: "spammer@example.com")
       # Content with URL should trigger spam protection
-      fill_in("webmaster_question_question_content",
+      fill_in("webmaster_question_message",
               with: "Check out http://spam-site.com")
 
       click_commit
@@ -124,7 +124,7 @@ class WebmasterQuestionIntegrationTest < CapybaraIntegrationTestCase
     perform_enqueued_jobs do
       within("#webmaster_question_form") do
         # Logged in users can include URLs in their questions
-        fill_in("webmaster_question_question_content",
+        fill_in("webmaster_question_message",
                 with: "Page https://mushroomobserver.org/123 has an error")
 
         click_commit

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -286,7 +286,7 @@ class ApplicationMailerTest < UnitTestCase
     run_mail_test("webmaster_question") do
       WebmasterMailer.build(
         sender_email: mary.email,
-        content: "A question"
+        message: "A question"
       ).deliver_now
     end
   end


### PR DESCRIPTION
Housekeeping PR for existing WebmasterEmail component and existing WebmasterMail solid queue functionality.

This PR updates the Webmaster Mail form to use the new component, and updates `WebmasterMailer` and all its callers to use `:message` instead of `:content` for consistency with other mailers like `ObserverQuestionMailer`, `UserQuestionMailer`, `AuthorMailer`, and `ProjectAdminRequestMailer`.

- Delete redundant `_form.erb` partial, render component directly in `new.erb`
- Add email assertion to `test_email_tracking_enable_with_note`

### Changes

Mailer:
- `WebmasterMailer#build`: Changed `content:` parameter to `message:`
Form components and objects:
- Flatten `WebmasterQuestionForm` `params: [:user][:email] → [:email]`, `[:question][:message] → [:message]`
- Add `WebmasterQuestion` to `modal_form` `component_map` (with `.demodulize` fix for `FormObject` classes)
- `FormObject::WebmasterQuestion`: Renamed `content` attribute to `message`
- `Components::WebmasterQuestionForm`: Updated to use `@message`
- `_form.erb` partial: Deleted
  
Controller:
- `WebmasterQuestionsController`: Changed `@content` to `@message` throughout

All `WebmasterMailer.build` callers updated (13 locations):
- `Name::Notify#notify_webmaster`
- `Comment::Callbacks#oil_and_water`
- `AccountController#create_new_account`
- `Account::VerificationsController.notify_root_of_verification_email`
- `Admin::Emails::NameChangeRequestsController#send_name_change_request`
- `Admin::Emails::MergeRequestsController#send_merge_request`
- `Admin::Emails::WebmasterQuestionsController#send_email_and_redirect`
- `NamesController#email_admin_name_change`
- `NamesController#email_admin_icn_id_conflict`
- `LocationsController#email_admin_location_change`
- `Names::TrackersController#notify_webmaster_of_template`
- `HerbariaController#notify_admins_of_new_herbarium`
- `Herbaria::CuratorRequestsController#send_curator_request_email`

Modal form component support:
- Added `WebmasterQuestion` to `ModalsHelper#component_map` so the modal can render the component directly
- Updated `add_form_specific_params` to handle `WebmasterQuestionForm`'s parameters
