### PR TITLE
Fix `Location.in_box` scope, using new `MO.box_epsilon` constant 

### DIFF
--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -168,8 +168,8 @@ module Mappable
       @south_east = [@south, @east]
       @edges = [@north, @south, @east, @west]
       if @north && @south
-        @is_point = @north ? (@north - @south) < 0.0001 : false
-        @is_box = @north ? (@north - @south) >= 0.0001 : false
+        @is_point = @north ? (@north - @south) < MO.box_epsilon : false
+        @is_box = @north ? (@north - @south) >= MO.box_epsilon : false
         @lat = ((@north + @south) / 2.0).round(4)
         @north_south_distance = @north ? @north - @south : nil
       end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -282,10 +282,10 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
 
     center_lat = (north + south) / 2
     center_lon = (east + west) / 2
-    self.north = center_lat + 0.0001
-    self.south = center_lat - 0.0001
-    self.east = center_lon + 0.0001
-    self.west = center_lon - 0.0001
+    self.north = center_lat + MO.box_epsilon
+    self.south = center_lat - MO.box_epsilon
+    self.east = center_lon + MO.box_epsilon
+    self.west = center_lon - MO.box_epsilon
   end
 
   def found_here?(obs)

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -4,10 +4,6 @@ module Location::Scopes
   # This is using Concern so we can define the scopes in this included module.
   extend ActiveSupport::Concern
 
-  # Small epsilon buffer (~11 meters at equator) to account for rounding
-  # in form inputs when comparing bounding box coordinates
-  IN_BOX_EPSILON = 0.0001
-
   # NOTE: To improve Coveralls display, avoid one-line stabby lambda scopes.
   # Two line stabby lambdas are OK, it's just the declaration line that will
   # always show as covered.
@@ -105,7 +101,7 @@ module Location::Scopes
       box = Mappable::Box.new(**args)
       return none unless box.valid?
 
-      e = IN_BOX_EPSILON
+      e = MO.box_epsilon
       where((Location[:south] >= box.south - e).
             and(Location[:north] <= box.north + e).
             # Location[:west] between w & 180 OR between 180 and e
@@ -119,7 +115,7 @@ module Location::Scopes
       box = Mappable::Box.new(**args)
       return none unless box.valid?
 
-      e = IN_BOX_EPSILON
+      e = MO.box_epsilon
       where((Location[:south] >= box.south - e).
             and(Location[:north] <= box.north + e).
             and(Location[:west] >= box.west - e).

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -102,6 +102,9 @@ MushroomObserver::Application.configure do
   config.location_bad_terms_file = "#{location_path}bad_terms.yml"
   config.unknown_location_name = "Earth"
   config.obs_location_max_area = 24_000
+  # Geographic epsilon for bounding box comparisons (~11 meters at equator).
+  # Used for: rounding tolerance, point vs box threshold, minimal box size.
+  config.box_epsilon = 0.0001
 
   # Limit the number of objects we draw on a google map.
   config.max_map_objects = 100

--- a/test/api2_extensions.rb
+++ b/test/api2_extensions.rb
@@ -171,13 +171,13 @@ module API2Extensions
     assert_in_delta(Time.zone.now, loc.updated_at, 1.minute)
     assert_users_equal(@user, loc.user)
     assert_equal(@name, loc.display_name)
-    assert_in_delta(@north, loc.north, 0.0001)
-    assert_in_delta(@south, loc.south, 0.0001)
-    assert_in_delta(@east, loc.east, 0.0001)
-    assert_in_delta(@west, loc.west, 0.0001)
-    assert_in_delta(@high, loc.high, 0.0001) if @high
+    assert_in_delta(@north, loc.north, MO.box_epsilon)
+    assert_in_delta(@south, loc.south, MO.box_epsilon)
+    assert_in_delta(@east, loc.east, MO.box_epsilon)
+    assert_in_delta(@west, loc.west, MO.box_epsilon)
+    assert_in_delta(@high, loc.high, MO.box_epsilon) if @high
     assert_nil(loc.high) unless @high
-    assert_in_delta(@low, loc.low, 0.0001) if @low
+    assert_in_delta(@low, loc.low, MO.box_epsilon) if @low
     assert_nil(loc.low) unless @low
     assert_equal(@notes, loc.notes) if @notes
     assert_nil(loc.notes) unless @notes

--- a/test/classes/api2/locations_test.rb
+++ b/test/classes/api2/locations_test.rb
@@ -204,12 +204,12 @@ class API2::LocationsTest < UnitTestCase
 
     albion.reload
     assert_equal("Reno, Nevada, USA", albion.display_name)
-    assert_in_delta(39.64, albion.north, 0.0001)
-    assert_in_delta(39.39, albion.south, 0.0001)
-    assert_in_delta(-119.70, albion.east, 0.0001)
-    assert_in_delta(-119.94, albion.west, 0.0001)
-    assert_in_delta(1700, albion.high, 0.0001)
-    assert_in_delta(1350, albion.low, 0.0001)
+    assert_in_delta(39.64, albion.north, MO.box_epsilon)
+    assert_in_delta(39.39, albion.south, MO.box_epsilon)
+    assert_in_delta(-119.70, albion.east, MO.box_epsilon)
+    assert_in_delta(-119.94, albion.west, MO.box_epsilon)
+    assert_in_delta(1700, albion.high, MO.box_epsilon)
+    assert_in_delta(1350, albion.low, MO.box_epsilon)
     assert_equal("Biggest Little City", albion.notes)
   end
 

--- a/test/classes/api2/observations_test.rb
+++ b/test/classes/api2/observations_test.rb
@@ -565,9 +565,9 @@ class API2::ObservationsTest < UnitTestCase
     assert_api_fail(params.except(:set_longitude))
     assert_api_pass(params)
     rolfs_obs.reload
-    assert_in_delta(12.34, rolfs_obs.lat, 0.0001)
-    assert_in_delta(-56.78, rolfs_obs.lng, 0.0001)
-    assert_in_delta(901, rolfs_obs.alt, 0.0001)
+    assert_in_delta(12.34, rolfs_obs.lat, MO.box_epsilon)
+    assert_in_delta(-56.78, rolfs_obs.lng, MO.box_epsilon)
+    assert_in_delta(901, rolfs_obs.alt, MO.box_epsilon)
 
     params = {
       method: :patch,

--- a/test/classes/box_test.rb
+++ b/test/classes/box_test.rb
@@ -46,7 +46,7 @@ class BoxTest < UnitTestCase
 
   def test_expand
     box = Mappable::Box.new(**valid_args)
-    expanded_box = box.expand(0.0001)
+    expanded_box = box.expand(MO.box_epsilon)
 
     assert_operator(expanded_box.north, :>, box.north)
     assert_operator(expanded_box.south, :<, box.south)

--- a/test/classes/collapsible_map_test.rb
+++ b/test/classes/collapsible_map_test.rb
@@ -35,21 +35,22 @@ class CollapsibleMapTest < UnitTestCase
   def assert_mapset(*args)
     mapset, lat, long, north, south, east, west, north_south, east_west = args
     assert_extents(mapset, north, south, east, west)
-    assert_in_delta(lat, mapset.lat, 0.0001,
+    e = MO.box_epsilon
+    assert_in_delta(lat, mapset.lat, e,
                     "expect <#{lat.round(4)}>, actual <#{mapset.lat.round(4)}>")
-    assert_in_delta(long, mapset.lng, 0.0001)
-    assert_in_delta(lat, mapset.center[0], 0.0001)
-    assert_in_delta(long, mapset.center[1], 0.0001)
-    assert_in_delta(north, mapset.north_west[0], 0.0001)
-    assert_in_delta(west, mapset.north_west[1], 0.0001)
-    assert_in_delta(north, mapset.north_east[0], 0.0001)
-    assert_in_delta(east, mapset.north_east[1], 0.0001)
-    assert_in_delta(south, mapset.south_west[0], 0.0001)
-    assert_in_delta(west, mapset.south_west[1], 0.0001)
-    assert_in_delta(south, mapset.south_east[0], 0.0001)
-    assert_in_delta(east, mapset.south_east[1], 0.0001)
-    assert_in_delta(north_south, mapset.north_south_distance, 0.0001)
-    assert_in_delta(east_west, mapset.east_west_distance, 0.0001)
+    assert_in_delta(long, mapset.lng, e)
+    assert_in_delta(lat, mapset.center[0], e)
+    assert_in_delta(long, mapset.center[1], e)
+    assert_in_delta(north, mapset.north_west[0], e)
+    assert_in_delta(west, mapset.north_west[1], e)
+    assert_in_delta(north, mapset.north_east[0], e)
+    assert_in_delta(east, mapset.north_east[1], e)
+    assert_in_delta(south, mapset.south_west[0], e)
+    assert_in_delta(west, mapset.south_west[1], e)
+    assert_in_delta(south, mapset.south_east[0], e)
+    assert_in_delta(east, mapset.south_east[1], e)
+    assert_in_delta(north_south, mapset.north_south_distance, e)
+    assert_in_delta(east_west, mapset.east_west_distance, e)
   end
 
   def assert_extents(mapset, north, south, east, west)
@@ -167,10 +168,10 @@ class CollapsibleMapTest < UnitTestCase
     assert_mapset_is_box(mapset, n, s, e, w)
 
     # Add box contained entirely inside.
-    loc.north -= 0.0001
-    loc.south += 0.0001
-    loc.east -= 0.0001
-    loc.west += 0.0001
+    loc.north -= MO.box_epsilon
+    loc.south += MO.box_epsilon
+    loc.east -= MO.box_epsilon
+    loc.west += MO.box_epsilon
     mapset.update_extents_with_box(loc)
     assert_mapset_is_box(mapset, n, s, e, w)
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -627,6 +627,25 @@ class LocationTest < UnitTestCase
     )
   end
 
+  # Regression test: searching with a location's own bounding box (rounded to
+  # 4 decimal places as in form inputs) should return that location.
+  def test_scope_in_box_finds_location_with_rounded_coordinates
+    salt_point = locations(:salt_point)
+
+    # Simulate form input rounding (4 decimal places)
+    rounded_box = {
+      north: salt_point.north.round(4),
+      south: salt_point.south.round(4),
+      east: salt_point.east.round(4),
+      west: salt_point.west.round(4)
+    }
+
+    results = Location.in_box(**rounded_box)
+    assert_includes(results, salt_point,
+                    "in_box should find location when searched with its own " \
+                    "rounded bounding box coordinates")
+  end
+
   def test_scope_contains_box
     # loc doesn't straddle 180
     #   potential br (bounding rectangle, external_loc) to "left" of loc

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3882,7 +3882,8 @@ class NameTest < UnitTestCase
       obs_in_cal_without_lat_lng.name,
       "Name.in_box should exclude Names whose only Observations lack lat/long"
     )
-    box = { north: 0.0001, south: 0, east: 0.0001, west: 0 }
+    e = MO.box_epsilon
+    box = { north: e, south: 0, east: e, west: 0 }
     assert_empty(Name.in_box(**box))
   end
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1379,7 +1379,8 @@ class ObservationTest < UnitTestCase
   end
 
   def tiny_box
-    @tiny_box ||= { north: 0.0001, south: 0.0001, east: 0.0001, west: 0 }
+    e = MO.box_epsilon
+    @tiny_box ||= { north: e, south: e, east: e, west: 0 }
   end
 
   def missing_west_box


### PR DESCRIPTION
###  Summary

  - Fix `in_box` scope not returning the location itself when searching with a location's own bounding box coordinates (due to form input rounding)
  - Add `MO.box_epsilon` constant (0.0001, ~11 meters) for geographic coordinate comparisons

###  Details

  `in_box` fix: Form inputs round coordinates to 4 decimal places, but the original `in_box` logic required exact containment. For example, a location with `south: 43.9145011902` would fail the check `loc.south >= box.south` when `box.south` was rounded to `43.9145`. Added an epsilon buffer to handle this rounding tolerance.

  New constant: Consolidated the magic number `0.0001` that was used in several places (scopes, `force_valid_lat_lngs!`, `MapSet` point/box threshold) into `MO.box_epsilon`.

### Test plan

  - `test/models/location_test.rb` - includes new regression test
  - `test/classes/collapsible_map_test.rb`
  - `test/controllers/locations/search_controller_test.rb`
  - Manual: Go to locations search at `localhost:3000/locations/search/new`, enter a location in Region field, verify search returns location itself in results
