### PR TITLE
Fix create Location bug with user.id

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -389,7 +389,7 @@ class LocationsController < ApplicationController
       if (user = User.safe_find(@set_user))
         user.location = @location
         user.save
-        redirect_to(user_path(@set_user.id))
+        redirect_to(user_path(user))
       end
     else
       redirect_to(location_path(@location.id))

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -556,6 +556,23 @@ class LocationsControllerTest < FunctionalTestCase
     construct_location_error(params)
   end
 
+  # Regression test for bug where @set_user.id was called on a String,
+  # causing NoMethodError: undefined method `id' for an instance of String
+  def test_create_location_with_set_user
+    user = users(:mary)
+    login(user.login)
+    params = barton_flats_params
+    params[:set_user] = user.id.to_s
+
+    assert_nil(user.location)
+    post(:create, params: params)
+
+    loc = assigns(:location)
+    assert_redirected_to(user_path(user))
+    user.reload
+    assert_equal(loc, user.location)
+  end
+
   ##############################################################################
   #
   #    EDIT


### PR DESCRIPTION
Bug reported by @JoeCohen, sleuthed by Claude in like 6 seconds.

```
app/controllers/locations_controller.rb:392:in `return_to_caller'
app/controllers/locations_controller.rb:255:in `create'
app/controllers/application_controller.rb:148:in `catch_errors_and_log_request_stats'
INFO -- : Started POST "/locations?approved_where=Northern+San+Diego+County%2C+California%2C+USA&set_user=2138&where=Northern+San+Diego+County%2C+California%2C+USA" for 68.6.147.63 at 2025-12-08 00:31:35 +0000
INFO -- : Processing by LocationsController#create as HTML
INFO -- :   Parameters: {"utf8"=>"✓", "authenticity_token"=>"[FILTERED]", "location"=>{"display_name"=>"Northern San Diego Co., California, USA", "north"=>"45.0", "west"=>"-90.0", "east"=>"90.0", "south"=>"-45.0", "high"=>"", "low"=>"", "notes"=>"", "hidden"=>"0"}, "commit"=>"Create", "approved_where"=>"Northern San Diego County, California, USA", "set_user"=>"2138", "where"=>"Northern San Diego County, California, USA"}
WARN -- : user=2138 robot=N ip=68.6.147.63
INFO -- : Completed 500 Internal Server Error in 1995ms (ActiveRecord: 1981.2ms (11 queries, 2 cached) | GC: 1.8ms)
E, [2025-12-08T00:31:36.999859 #1249004] ERROR -- :   
NoMethodError (undefined method `id' for an instance of String):
```

⏺ Let me look at the `return_to_caller` method in the locations controller:

⏺ Read(app/controllers/locations_controller.rb)
  ⎿  Read 50 lines

⏺ Found it. On line 392:

  `redirect_to(user_path(@set_user.id))`

  The problem is `@set_user` is a String (the value "2138" from `params[:set_user]`), not a User object. So calling `.id` on it fails with `NoMethodError: undefined` method 'id' for an instance of String.

  Compare this to line 386 where `@set_herbarium` is used directly without .id:
  `redirect_to(herbarium_path(@set_herbarium))`

  The fix should be to just use `@set_user` directly (Rails will accept the string ID):

  `redirect_to(user_path(@set_user))`

  Or for consistency with the pattern above where `user` was already looked up:
  `redirect_to(user_path(user))`

  Would you like me to fix this?

Yes please, and let's write a regression test too