### PR TITLE
Fix obs form naming fields

### DIFF
--- a/app/views/controllers/observations/_form.html.erb
+++ b/app/views/controllers/observations/_form.html.erb
@@ -119,15 +119,10 @@ form_element_data = {
       <% end %>
       <%= tag.div(class: "row") do
         concat(tag.div(class: "col-xs-12 col-md-6") do
-          render(Components::NamingFields.new(
-                   create:,
-                   show_reasons: false,
-                   unfocused: true,
-                   name_help: :form_naming_name_help_leave_blank.t,
-                   vote: @vote,
-                   given_name: @given_name || "",
-                   reasons: @reasons
-                 ))
+          render(partial: "observations/namings/fields",
+                 locals: { create:, button_name:, show_reasons: false,
+                           unfocused: true,
+                           name_help: :form_naming_name_help_leave_blank.t })
         end) if create
         concat(tag.div(class: "col-xs-12 col-md-6") do
           render(partial: "observations/form/specimen_section",

--- a/app/views/controllers/observations/form/_details.html.erb
+++ b/app/views/controllers/observations/form/_details.html.erb
@@ -14,7 +14,7 @@ t_s = {
   <%= tag.div(class: "col-xs-12 col-md-6") do %>
     <!-- WHEN -->
     <%= date_select_with_label(
-      form: f, field: :when, label: :WHEN.t + ":",
+      form: f, field: :when, label: :WHEN.t + ":", class: "mb-3"
     ) %>
     <!-- /WHEN -->
 

--- a/test/components/naming_fields_test.rb
+++ b/test/components/naming_fields_test.rb
@@ -2,6 +2,8 @@
 
 require "test_helper"
 
+# Tests for NamingFields component (Superform mode only).
+# For ERB form tests, see the system tests for observation form.
 class NamingFieldsTest < UnitTestCase
   include ComponentTestHelper
 
@@ -17,33 +19,50 @@ class NamingFieldsTest < UnitTestCase
   def test_renders_vote_field_for_existing_naming
     @naming = namings(:coprinus_comatus_naming)
     @vote = votes(:coprinus_comatus_owner_vote)
-    html = render_fields(create: false)
+    html = render_naming_form(create: false)
 
     assert_html(html, "select[name='naming[vote][value]']")
   end
 
   def test_renders_vote_field_for_new_naming
-    html = render_fields(create: true)
+    html = render_naming_form(create: true)
 
     assert_html(html, "select[name='naming[vote][value]']")
   end
 
   def test_renders_reasons_fields_when_show_reasons_true
-    html = render_fields(create: true, show_reasons: true)
+    html = render_naming_form(create: true, show_reasons: true)
 
     assert_html(html, "input[name*='reasons']")
   end
 
   def test_renders_name_autocompleter
-    html = render_fields(create: true)
+    html = render_naming_form(create: true)
 
     assert_html(html, "input[name='naming[name]']")
   end
 
+  # Test for bug: collapseFields target must use namespaced controller format
+  # The autocompleter--name controller requires data-autocompleter--name-target
+  # not data-autocompleter-target
+  def test_collapse_fields_uses_correct_stimulus_target
+    html = render_naming_form(create: true)
+
+    # Should use the namespaced target format for autocompleter--name controller
+    assert_match(/data-autocompleter--name-target=.collapseFields/, html,
+                 "collapseFields should use autocompleter--name-target")
+    # Should NOT use the old non-namespaced format
+    assert_no_match(/data-autocompleter-target=.collapseFields/, html,
+                    "Should not use non-namespaced autocompleter-target")
+  end
+
   private
 
-  def render_fields(create: true, show_reasons: true, context: "lightbox")
-    component = Components::NamingFields.new(
+  # Render NamingFields via NamingForm which provides the form_namespace
+  def render_naming_form(create: true, show_reasons: true, context: "lightbox")
+    component = Components::NamingForm.new(
+      @naming,
+      observation: observations(:minimal_unknown_obs),
       vote: @vote,
       given_name: "",
       reasons: @reasons,

--- a/test/components/naming_form_test.rb
+++ b/test/components/naming_form_test.rb
@@ -67,8 +67,10 @@ class NamingFormTest < UnitTestCase
   end
 
   def test_collapse_class_for_blank_context
-    assert_html(@html,
-                "div.collapse[data-autocompleter--name-target='collapseFields']")
+    assert_html(
+      @html,
+      "div.collapse[data-autocompleter--name-target='collapseFields']"
+    )
   end
 
   def test_no_collapse_class_for_lightbox_context

--- a/test/components/naming_form_test.rb
+++ b/test/components/naming_form_test.rb
@@ -68,14 +68,16 @@ class NamingFormTest < UnitTestCase
 
   def test_collapse_class_for_blank_context
     assert_html(@html,
-                "div.collapse[data-autocompleter-target='collapseFields']")
+                "div.collapse[data-autocompleter--name-target='collapseFields']")
   end
 
   def test_no_collapse_class_for_lightbox_context
     html = render_form_with_context("lightbox")
 
     doc = Nokogiri::HTML(html)
-    collapse_div = doc.at_css("div[data-autocompleter-target='collapseFields']")
+    collapse_div = doc.at_css(
+      "div[data-autocompleter--name-target='collapseFields']"
+    )
     assert_not_includes(collapse_div["class"].to_s, "collapse")
   end
 


### PR DESCRIPTION
Revert to `naming/_fields.erb` partial for the obs form.

The `NamingFields` component with the "ERB" pathway wasn't working.