### PR TITLE
Fix 500 error when viewing observations from location with box_area order

### DIFF
--- a/app/views/controllers/locations/show/_coordinates.erb
+++ b/app/views/controllers/locations/show/_coordinates.erb
@@ -5,7 +5,7 @@ if in_admin_mode?
   heading_links << destroy_button(target: @location, icon: :delete)
   heading_links << icon_link_with_query(*location_reverse_order_tab(@location))
 end
-footer = icon_link_with_query(*observations_at_location_tab(@location))
+footer = icon_link_to(*observations_at_location_tab(@location))
 %>
 <%= render(Components::Panel.new(
       panel_id: "location_coordinates"


### PR DESCRIPTION
## Summary
  - Fixes #3585: 500 error when clicking \"Observations at this Location\" link from a location search with \"Area\" sort order
  - Changed \`icon_link_with_query\` to \`icon_link_to\` to prevent incorrect query parameter propagation
  - Added integration test to prevent regression

  ## Problem
  When users performed a location search, sorted by \"Area\" (box_area), clicked on a location, and then clicked \"Observations at this Location\", the application returned a 500 error.

  The issue occurred because \`icon_link_with_query\` was automatically appending the current Location query (with \`order_by=box_area\`) to the observations link. This overwrote the correctly-crafted Observation query, causing the Observations controller to receive an invalid \`box_area\` order parameter.

  ## Solution
  Changed line 8 in \`app/views/controllers/locations/show/_coordinates.erb\` from \`icon_link_with_query\` to \`icon_link_to\`. This preserves the Observation query that was already created in \`observations_at_location_tab\` without adding the current Location query parameters.

  ## Test Plan
  - [x] Added integration test \`test_observations_link_from_location_with_box_area_order\` that reproduces the bug scenario
  - [x] Test passes with the fix
  - [x] All existing location controller tests pass (45 tests)
  - [x] All related records integration tests pass (2 tests)
  - [x] Manually tested the fix as confirmed by @mo-nathan"
