### PR TITLE
Limit total user search string input

### DIFF
--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -48,6 +48,7 @@ class Components::SearchForm < Components::ApplicationForm
 
   def view_template
     render_header unless @local
+    div(id: "search_#{search_type}_flash") # turbo_stream update target
     render_form_columns
     render_form_buttons
   end
@@ -57,7 +58,7 @@ class Components::SearchForm < Components::ApplicationForm
   # Form configuration
 
   def form_tag(&block)
-    form(action: form_action, method: form_method, **form_attributes, &block)
+    form(action: form_action, method: :post, **form_attributes, &block)
   end
 
   def form_action
@@ -67,9 +68,14 @@ class Components::SearchForm < Components::ApplicationForm
   def form_attributes
     attrs = {
       id: "#{search_type}_search_form",
-      class: "faceted-search-form pb-4"
+      class: "faceted-search-form pb-4",
+      data: {
+        controller: "search-length-validator",
+        search_length_validator_max_length_value: 9500,
+        search_length_validator_search_type_value: search_type
+      }
     }
-    attrs[:data] = turbo_stream_data unless @local
+    attrs[:data].merge!(turbo_stream_data) unless @local
     attrs
   end
 

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -69,7 +69,12 @@ class Components::SearchForm < Components::ApplicationForm
     attrs = {
       id: "#{search_type}_search_form",
       class: "faceted-search-form pb-4",
-      data: {}
+      data: {
+        controller: "search-length-validator",
+        search_length_validator_max_length_value:
+          Searchable::MAX_SEARCH_INPUT_LENGTH,
+        search_length_validator_search_type_value: search_type
+      }
     }
     attrs[:data].merge!(turbo_stream_data) unless @local
     attrs

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -71,7 +71,8 @@ class Components::SearchForm < Components::ApplicationForm
       class: "faceted-search-form pb-4",
       data: {
         controller: "search-length-validator",
-        search_length_validator_max_length_value: 9500,
+        search_length_validator_max_length_value:
+          Searchable::MAX_SEARCH_INPUT_LENGTH,
         search_length_validator_search_type_value: search_type
       }
     }

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -69,12 +69,7 @@ class Components::SearchForm < Components::ApplicationForm
     attrs = {
       id: "#{search_type}_search_form",
       class: "faceted-search-form pb-4",
-      data: {
-        controller: "search-length-validator",
-        search_length_validator_max_length_value:
-          Searchable::MAX_SEARCH_INPUT_LENGTH,
-        search_length_validator_search_type_value: search_type
-      }
+      data: {}
     }
     attrs[:data].merge!(turbo_stream_data) unless @local
     attrs

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -15,9 +15,6 @@ module Searchable
   # Maximum allowed total length of all search input fields
   MAX_SEARCH_INPUT_LENGTH = 9500
 
-  # Default values to exclude from length calculation
-  DEFAULT_EXCLUDED_VALUES = ["true", "false", "0.0", "", "no", "yes"].freeze
-
   included do
     # Render help for the pattern search bar (if available), for current model
     def show
@@ -47,9 +44,6 @@ module Searchable
 
       set_up_form_field_groupings # in case we need to re-render the form
       @query_params = params.require(search_object_name).permit(permittables)
-
-      # Validate total input length before processing
-      return if search_input_too_long?
 
       prepare_raw_params
       redirect_to(action: :new) and return unless validate_search_instance?
@@ -272,52 +266,6 @@ module Searchable
 
       @query_params[:has_notes_fields] =
         val.split("\n").map { |f| f.strip.tr(" ", "_") }.compact_blank
-    end
-
-    # Validate total length of search input to prevent Puma URL errors
-    def search_input_too_long?
-      total_length = calculate_search_input_length(@query_params)
-      return false if total_length <= MAX_SEARCH_INPUT_LENGTH
-
-      respond_to do |format|
-        format.turbo_stream do
-          render(turbo_stream: turbo_stream.update(
-            "search_#{search_type}_flash",
-            partial: "search/length_error",
-            locals: { length: total_length, max: MAX_SEARCH_INPUT_LENGTH }
-          ))
-        end
-        format.html do
-          flash_error(
-            :runtime_search_string_too_long.t(
-              max: MAX_SEARCH_INPUT_LENGTH,
-              length: total_length
-            )
-          )
-          redirect_to(action: :new)
-        end
-      end
-      true
-    end
-
-    # Default values to exclude from length calculation
-    DEFAULT_EXCLUDED_VALUES = ["true", "false", "0.0", "", "no", "yes"].freeze
-
-    # Calculate total length excluding metadata and default values
-    def calculate_search_input_length(params_hash)
-      total = 0
-      params_hash.each do |key, value|
-        next unless value.is_a?(String)
-        # Exclude default values
-        next if DEFAULT_EXCLUDED_VALUES.include?(value)
-        # Exclude rank fields (Names search)
-        next if key.to_s.include?("rank")
-        # Exclude bounding box coordinates
-        next if key.to_s.include?("in_box")
-
-        total += value.length
-      end
-      total
     end
 
     # Passing some fields will raise an error if the required field is missing,

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -12,6 +12,9 @@
 module Searchable
   extend ActiveSupport::Concern
 
+  # Maximum allowed total length of all search input fields
+  MAX_SEARCH_INPUT_LENGTH = 9500
+
   included do
     # Render help for the pattern search bar (if available), for current model
     def show
@@ -264,9 +267,6 @@ module Searchable
       @query_params[:has_notes_fields] =
         val.split("\n").map { |f| f.strip.tr(" ", "_") }.compact_blank
     end
-
-    # Maximum allowed total length of all search input fields
-    MAX_SEARCH_INPUT_LENGTH = 9500
 
     # Validate that the cumulative length of all search inputs doesn't exceed
     # the maximum to prevent Puma URL length errors (10,240 char limit).

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -13,7 +13,7 @@ module Searchable
   extend ActiveSupport::Concern
 
   # Maximum allowed total length of all search input fields
-  MAX_SEARCH_INPUT_LENGTH = 9500
+  MAX_SEARCH_INPUT_LENGTH = 8000
 
   included do
     # Render help for the pattern search bar (if available), for current model

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -23,6 +23,11 @@ class SearchController < ApplicationController
       flash_and_redirect_invalid_search(type) and return
     end
 
+    if pattern.length > 9500
+      flash_error(:runtime_search_string_too_long.t(max: 9500, length: pattern.length))
+      redirect_back(fallback_location: root_path) and return
+    end
+
     save_pattern_and_proceed(type, pattern)
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -23,15 +23,22 @@ class SearchController < ApplicationController
       flash_and_redirect_invalid_search(type) and return
     end
 
-    if pattern.length > 9500
-      flash_error(:runtime_search_string_too_long.t(max: 9500, length: pattern.length))
-      redirect_back(fallback_location: root_path) and return
-    end
+    return if pattern_too_long?(pattern)
 
     save_pattern_and_proceed(type, pattern)
   end
 
   private
+
+  def pattern_too_long?(pattern)
+    return false if pattern.length <= 9500
+
+    flash_error(
+      :runtime_search_string_too_long.t(max: 9500, length: pattern.length)
+    )
+    redirect_back_or_to(root_path)
+    true
+  end
 
   def save_pattern_and_proceed(type, pattern)
     # Save it so that we can keep it in the search bar in subsequent pages.

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,10 +31,13 @@ class SearchController < ApplicationController
   private
 
   def pattern_too_long?(pattern)
-    return false if pattern.length <= 9500
+    return false if pattern.length <= Searchable::MAX_SEARCH_INPUT_LENGTH
 
     flash_error(
-      :runtime_search_string_too_long.t(max: 9500, length: pattern.length)
+      :runtime_search_string_too_long.t(
+        max: Searchable::MAX_SEARCH_INPUT_LENGTH,
+        length: pattern.length
+      )
     )
     redirect_back_or_to(root_path)
     true

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["flash"]
+  static values = {
+    maxLength: { type: Number, default: 9500 },
+    searchType: String
+  }
+
+  connect() {
+    // Listen for form submission
+    this.element.addEventListener("submit", this.validateLength.bind(this))
+  }
+
+  validateLength(event) {
+    const totalLength = this.calculateTotalLength()
+
+    if (totalLength > this.maxLengthValue) {
+      // Prevent form submission
+      event.preventDefault()
+      event.stopPropagation()
+
+      // Display error message
+      this.showError(totalLength)
+
+      return false
+    }
+
+    // Clear any previous error if validation passes
+    this.clearError()
+    return true
+  }
+
+  calculateTotalLength() {
+    const formData = new FormData(this.element)
+    let totalLength = 0
+
+    for (const [key, value] of formData.entries()) {
+      if (typeof value === 'string') {
+        totalLength += value.length
+      }
+    }
+
+    return totalLength
+  }
+
+  showError(actualLength) {
+    const errorHtml = `
+      <div class="alert alert-danger">
+        <a class="close" data-dismiss="alert">×</a>
+        Search input is too long (${actualLength} characters).
+        Maximum allowed is ${this.maxLengthValue} characters.
+        Please shorten your search criteria.
+      </div>
+    `
+
+    const flashDiv = document.getElementById(`search_${this.searchTypeValue}_flash`)
+    if (flashDiv) {
+      flashDiv.innerHTML = errorHtml
+      flashDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }
+
+  clearError() {
+    const flashDiv = document.getElementById(`search_${this.searchTypeValue}_flash`)
+    if (flashDiv) {
+      flashDiv.innerHTML = ''
+    }
+  }
+}

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -52,8 +52,10 @@ export default class extends Controller {
       if (typeof value === 'string') {
         const fieldExcluded = excludedFields.includes(key)
         const defaultExcluded = defaultValues.includes(value)
-        const excluded = fieldExcluded || defaultExcluded
-        console.log(`Field: ${key}, Length: ${value.length}, Excluded: ${excluded} (field: ${fieldExcluded}, default: ${defaultExcluded}), Value: ${value.substring(0, 50)}...`)
+        // Exclude rank fields (Names search only)
+        const isRankField = key.includes('[rank]') || key.includes('[rank_range]')
+        const excluded = fieldExcluded || defaultExcluded || isRankField
+        console.log(`Field: ${key}, Length: ${value.length}, Excluded: ${excluded} (field: ${fieldExcluded}, default: ${defaultExcluded}, rank: ${isRankField}), Value: ${value.substring(0, 50)}...`)
         if (!excluded) {
           totalLength += value.length
         }

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -35,11 +35,31 @@ export default class extends Controller {
     const formData = new FormData(this.element)
     let totalLength = 0
 
+    // Fields to exclude from length calculation
+    const excludedFields = [
+      'authenticity_token',
+      'commit',
+      'utf8',
+      '_method',
+      'button'
+    ]
+
+    // Default values to exclude from length calculation
+    const defaultValues = ['true', 'false', '0.0', '']
+
+    console.log('=== Form Field Analysis ===')
     for (const [key, value] of formData.entries()) {
       if (typeof value === 'string') {
-        totalLength += value.length
+        const fieldExcluded = excludedFields.includes(key)
+        const defaultExcluded = defaultValues.includes(value)
+        const excluded = fieldExcluded || defaultExcluded
+        console.log(`Field: ${key}, Length: ${value.length}, Excluded: ${excluded} (field: ${fieldExcluded}, default: ${defaultExcluded}), Value: ${value.substring(0, 50)}...`)
+        if (!excluded) {
+          totalLength += value.length
+        }
       }
     }
+    console.log(`Total Length: ${totalLength}`)
 
     return totalLength
   }

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -54,8 +54,10 @@ export default class extends Controller {
         const defaultExcluded = defaultValues.includes(value)
         // Exclude rank fields (Names search only)
         const isRankField = key.includes('[rank]') || key.includes('[rank_range]')
-        const excluded = fieldExcluded || defaultExcluded || isRankField
-        console.log(`Field: ${key}, Length: ${value.length}, Excluded: ${excluded} (field: ${fieldExcluded}, default: ${defaultExcluded}, rank: ${isRankField}), Value: ${value.substring(0, 50)}...`)
+        // Exclude bounding box coordinates (in_box fields)
+        const isCoordinateField = key.includes('[in_box]')
+        const excluded = fieldExcluded || defaultExcluded || isRankField || isCoordinateField
+        console.log(`Field: ${key}, Length: ${value.length}, Excluded: ${excluded} (field: ${fieldExcluded}, default: ${defaultExcluded}, rank: ${isRankField}, coords: ${isCoordinateField}), Value: ${value.substring(0, 50)}...`)
         if (!excluded) {
           totalLength += value.length
         }

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -65,6 +65,7 @@ export default class extends Controller {
   }
 
   showError(actualLength) {
+    console.log(`showError called with ${actualLength}, searchType: ${this.searchTypeValue}`)
     const errorHtml = `
       <div class="alert alert-danger">
         <a class="close" data-dismiss="alert">×</a>
@@ -74,7 +75,9 @@ export default class extends Controller {
       </div>
     `
 
-    const flashDiv = document.getElementById(`search_${this.searchTypeValue}_flash`)
+    const searchType = this.searchTypeValue.replace(/-/g, '_')
+    const flashDiv = document.getElementById(`search_${searchType}_flash`)
+    console.log(`flashDiv found:`, flashDiv)
     if (flashDiv) {
       flashDiv.innerHTML = errorHtml
       flashDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
@@ -82,7 +85,8 @@ export default class extends Controller {
   }
 
   clearError() {
-    const flashDiv = document.getElementById(`search_${this.searchTypeValue}_flash`)
+    const searchType = this.searchTypeValue.replace(/-/g, '_')
+    const flashDiv = document.getElementById(`search_${searchType}_flash`)
     if (flashDiv) {
       flashDiv.innerHTML = ''
     }

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -45,7 +45,7 @@ export default class extends Controller {
     ]
 
     // Default values to exclude from length calculation
-    const defaultValues = ['true', 'false', '0.0', '']
+    const defaultValues = ['true', 'false', '0.0', '', 'no', 'yes']
 
     console.log('=== Form Field Analysis ===')
     for (const [key, value] of formData.entries()) {

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["flash"]
   static values = {
-    maxLength: { type: Number, default: 9500 },
+    maxLength: { type: Number, default: 8000 },
     searchType: String
   }
 

--- a/app/javascript/controllers/search_length_validator_controller.js
+++ b/app/javascript/controllers/search_length_validator_controller.js
@@ -47,7 +47,6 @@ export default class extends Controller {
     // Default values to exclude from length calculation
     const defaultValues = ['true', 'false', '0.0', '', 'no', 'yes']
 
-    console.log('=== Form Field Analysis ===')
     for (const [key, value] of formData.entries()) {
       if (typeof value === 'string') {
         const fieldExcluded = excludedFields.includes(key)
@@ -57,19 +56,16 @@ export default class extends Controller {
         // Exclude bounding box coordinates (in_box fields)
         const isCoordinateField = key.includes('[in_box]')
         const excluded = fieldExcluded || defaultExcluded || isRankField || isCoordinateField
-        console.log(`Field: ${key}, Length: ${value.length}, Excluded: ${excluded} (field: ${fieldExcluded}, default: ${defaultExcluded}, rank: ${isRankField}, coords: ${isCoordinateField}), Value: ${value.substring(0, 50)}...`)
         if (!excluded) {
           totalLength += value.length
         }
       }
     }
-    console.log(`Total Length: ${totalLength}`)
 
     return totalLength
   }
 
   showError(actualLength) {
-    console.log(`showError called with ${actualLength}, searchType: ${this.searchTypeValue}`)
     const errorHtml = `
       <div class="alert alert-danger">
         <a class="close" data-dismiss="alert">×</a>
@@ -81,7 +77,6 @@ export default class extends Controller {
 
     const searchType = this.searchTypeValue.replace(/-/g, '_')
     const flashDiv = document.getElementById(`search_${searchType}_flash`)
-    console.log(`flashDiv found:`, flashDiv)
     if (flashDiv) {
       flashDiv.innerHTML = errorHtml
       flashDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' })

--- a/app/views/controllers/herbaria/search/new.erb
+++ b/app/views/controllers/herbaria/search/new.erb
@@ -3,8 +3,10 @@ add_new_title(:search_object, :HERBARIA)
 container_class(:wide)
 %>
 
-<%= render(Components::SearchForm.new(
-      @search,
-      search_controller: controller,
-      local: true
-    )) %>
+<div id="herbaria_search_container">
+  <%= render(Components::SearchForm.new(
+        @search,
+        search_controller: controller,
+        local: @local.nil? ? true : @local
+      )) %>
+</div>

--- a/app/views/controllers/locations/search/new.erb
+++ b/app/views/controllers/locations/search/new.erb
@@ -3,8 +3,10 @@ add_new_title(:search_object, :LOCATIONS)
 container_class(:wide)
 %>
 
-<%= render(Components::SearchForm.new(
-      @search,
-      search_controller: controller,
-      local: true
-    )) %>
+<div id="locations_search_container">
+  <%= render(Components::SearchForm.new(
+        @search,
+        search_controller: controller,
+        local: @local.nil? ? true : @local
+      )) %>
+</div>

--- a/app/views/controllers/names/search/new.erb
+++ b/app/views/controllers/names/search/new.erb
@@ -3,8 +3,10 @@ add_new_title(:search_object, :NAMES)
 container_class(:wide)
 %>
 
-<%= render(Components::SearchForm.new(
-      @search,
-      search_controller: controller,
-      local: true
-    )) %>
+<div id="names_search_container">
+  <%= render(Components::SearchForm.new(
+        @search,
+        search_controller: controller,
+        local: @local.nil? ? true : @local
+      )) %>
+</div>

--- a/app/views/controllers/observations/search/new.erb
+++ b/app/views/controllers/observations/search/new.erb
@@ -3,8 +3,10 @@ add_new_title(:search_object, :OBSERVATIONS)
 container_class(:wide)
 %>
 
-<%= render(Components::SearchForm.new(
-      @search,
-      search_controller: controller,
-      local: true
-    )) %>
+<div id="observations_search_container">
+  <%= render(Components::SearchForm.new(
+        @search,
+        search_controller: controller,
+        local: @local.nil? ? true : @local
+      )) %>
+</div>

--- a/app/views/controllers/projects/search/new.erb
+++ b/app/views/controllers/projects/search/new.erb
@@ -3,8 +3,10 @@ add_new_title(:search_object, :PROJECTS)
 container_class(:wide)
 %>
 
-<%= render(Components::SearchForm.new(
-      @search,
-      search_controller: controller,
-      local: true
-    )) %>
+<div id="projects_search_container">
+  <%= render(Components::SearchForm.new(
+        @search,
+        search_controller: controller,
+        local: @local.nil? ? true : @local
+      )) %>
+</div>

--- a/app/views/controllers/species_lists/search/new.erb
+++ b/app/views/controllers/species_lists/search/new.erb
@@ -3,8 +3,10 @@ add_new_title(:search_object, :SPECIES_LISTS)
 container_class(:wide)
 %>
 
-<%= render(Components::SearchForm.new(
-      @search,
-      search_controller: controller,
-      local: true
-    )) %>
+<div id="species_lists_search_container">
+  <%= render(Components::SearchForm.new(
+        @search,
+        search_controller: controller,
+        local: @local.nil? ? true : @local
+      )) %>
+</div>

--- a/app/views/search/_length_error.html.erb
+++ b/app/views/search/_length_error.html.erb
@@ -1,0 +1,4 @@
+<div class="alert alert-danger">
+  <a class="close" data-dismiss="alert">×</a>
+  <%= :runtime_search_string_too_long.t(max: max, length: length) %>
+</div>

--- a/app/views/search/_length_error.html.erb
+++ b/app/views/search/_length_error.html.erb
@@ -1,4 +1,0 @@
-<div class="alert alert-danger">
-  <a class="close" data-dismiss="alert">×</a>
-  <%= :runtime_search_string_too_long.t(max: max, length: length) %>
-</div>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2977,6 +2977,7 @@
 
   # search/advanced
   advanced_search_at_least_one: Please provide at least one search parameter
+  search_input_too_long: "Search input is too long ([length] characters). Maximum allowed is [max] characters. Please shorten your search criteria."
   advanced_search_caveat: "Advanced search has somewhat limited options because of performance issues that result in timeouts. Please \"email the webmaster\":/admin/emails/webmaster_questions/new if you experience timeouts or if there are particular types of searches you would like to have added.\n\nHints : It's okay to leave some of the fields blank, e.g., if you leave 'Observer' blank, it will return results by all [:users]. It matches the exact string given. Use \"OR\" (all caps) to tell it to match one of several possible strings, e.g. \"Xanthoria OR Xanthomendoza\". Use a star as a wildcard, e.g. \"Wells Gray*Canada\" will match \"Wells Gray, Canada\", \"Wells Gray Park, Canada\", and \"Wells Gray Provincial Park, Canada\". (See notes under 'Content', too.)"
   advanced_search_content: Content
   advanced_search_content_help: Text contained in [:observation] notes or [:comments]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4178,6 +4178,7 @@
   runtime_no_matches_pattern: No [types] matching '[value]' found.
   runtime_no_matches_regexp: No [types] matching '[value]' found.
   runtime_no_more: There are no more [types].
+  runtime_search_string_too_long: "Search string too long ([length] characters). Maximum is [max] characters."
   runtime_no_objects: There are no [types].
   runtime_no_parse: "Unable to parse: '[value]'"
   runtime_no_save: Unable to save [type].

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -646,9 +646,10 @@ class SearchFormTest < UnitTestCase
 
     form = doc.at_css("form#observations_search_form")
     assert_equal(
-      "9500",
+      Searchable::MAX_SEARCH_INPUT_LENGTH.to_s,
       form["data-search-length-validator-max-length-value"],
-      "Form should have max length value set to 9500"
+      "Form should have max length value set to " \
+      "#{Searchable::MAX_SEARCH_INPUT_LENGTH}"
     )
   end
 

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -631,4 +631,52 @@ class SearchFormTest < UnitTestCase
     )
     render(form)
   end
+
+  # ------- Length Validation Infrastructure Tests -------
+
+  def test_form_has_length_validator_stimulus_controller
+    html = render_form
+
+    assert_html(html, "form[data-controller='search-length-validator']")
+  end
+
+  def test_form_has_max_length_value_attribute
+    html = render_form
+    doc = Nokogiri::HTML(html)
+
+    form = doc.at_css("form#observations_search_form")
+    assert_equal(
+      "9500",
+      form["data-search-length-validator-max-length-value"],
+      "Form should have max length value set to 9500"
+    )
+  end
+
+  def test_form_has_search_type_value_attribute
+    html = render_form
+    doc = Nokogiri::HTML(html)
+
+    form = doc.at_css("form#observations_search_form")
+    assert_equal(
+      "observations",
+      form["data-search-length-validator-search-type-value"],
+      "Form should have search type value set"
+    )
+  end
+
+  def test_form_has_flash_container_div
+    html = render_form
+
+    assert_html(html, "#search_observations_flash",
+                "Form should have flash container for error messages")
+  end
+
+  def test_form_uses_post_method
+    html = render_form
+    doc = Nokogiri::HTML(html)
+
+    form = doc.at_css("form#observations_search_form")
+    assert_equal("post", form["method"],
+                 "Form should use POST method to avoid URL length limits")
+  end
 end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -679,7 +679,8 @@ module Observations
     def test_server_handles_very_long_input_without_error
       login
       # Create input that would exceed URL limits but is fine in POST body
-      long_text = "x" * 15_000 # Well over 9500 limit
+      # Well over MAX_SEARCH_INPUT_LENGTH limit
+      long_text = "x" * 15_000
       params = {
         notes_has: long_text,
         has_specimen: true

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -276,7 +276,7 @@ class SearchControllerTest < FunctionalTestCase
 
     # Test with pattern over the limit (should fail)
     # Use a pattern that won't be reduced by strip_squeeze
-    pattern = "abcd" * 2376  # 9504 characters
+    pattern = "abcd" * 2376 # 9504 characters
     params = { pattern_search: { pattern:, type: :locations } }
     get(:pattern, params:)
     assert_response(:redirect)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -266,4 +266,20 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern, params:)
     assert_redirected_to(user_path(user.id))
   end
+
+  def test_pattern_search_rejects_overlong_pattern
+    # Test with pattern exactly at the limit (should work)
+    pattern = "a" * 9500
+    params = { pattern_search: { pattern:, type: :locations } }
+    get(:pattern, params:)
+    assert_redirected_to(locations_path(q: { model: :Location, pattern: }))
+
+    # Test with pattern over the limit (should fail)
+    # Use a pattern that won't be reduced by strip_squeeze
+    pattern = "abcd" * 2376  # 9504 characters
+    params = { pattern_search: { pattern:, type: :locations } }
+    get(:pattern, params:)
+    assert_response(:redirect)
+    assert_flash_error
+  end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -269,7 +269,7 @@ class SearchControllerTest < FunctionalTestCase
 
   def test_pattern_search_rejects_overlong_pattern
     # Test with pattern exactly at the limit (should work)
-    pattern = "a" * 9500
+    pattern = "a" * Searchable::MAX_SEARCH_INPUT_LENGTH
     params = { pattern_search: { pattern:, type: :locations } }
     get(:pattern, params:)
     assert_redirected_to(locations_path(q: { model: :Location, pattern: }))


### PR DESCRIPTION
Add client-side length validation to search forms to prevent Puma::HttpParserError

# Manual Testing Plan: Search Input Length Validation

## Overview
This plan tests the client-side validation that prevents Puma errors when search form inputs exceed 9,500 characters.

## Test 1: Client-Side Validation (Normal Flow)

### Steps:
1. Navigate to any search page (e.g., `/observations/search/new`)
2. Fill in one field with exactly 9,500 characters
3. Click submit

### Expected Result:
- Form submits successfully
- No error message appears

### Steps (Continued):
4. Fill in one field with 9,501 characters
5. Click submit

### Expected Result:
- Form submission is prevented
- Error message appears: "Search input is too long (9501 characters). Maximum allowed is 9500 characters. Please shorten your search criteria."
- Form data is preserved

### Steps (Continued):
6. Reduce input to 9,500 characters or less
7. Click submit

### Expected Result:
- Error message disappears
- Form submits successfully

---

## Test 2: All Search Types

### Steps:
Test validation on all 6 search forms:
- `/observations/search/new`
- `/names/search/new`
- `/locations/search/new`
- `/projects/search/new`
- `/species_lists/search/new`
- `/herbaria/search/new`

For each form:
1. Enter 9,501 characters in any text field
2. Click submit

### Expected Result:
- Error appears in the correct flash container for each search type
- Error message shows correct character count (9501)
- Validation works consistently across all forms

---

## Test 3: Multiple Fields

### Steps:
1. Fill multiple fields with long text:
   - Field 1: 3,200 characters
   - Field 2: 3,200 characters
   - Field 3: 3,200 characters
   - Total: 9,600 characters
2. Click submit

### Expected Result:
- Form submission is prevented
- Error shows total: "Search input is too long (9600 characters)..."

### Steps (Continued):
3. Reduce one field to 3,100 characters (new total: 9,500)
4. Click submit

### Expected Result:
- Error disappears
- Form submits successfully

---

## Test 4: Edge Cases

### Test 4.1: Empty Form
**Steps:** Submit empty form  
**Expected:** Form submits normally (default values like "true"/"false"/"0.0" are excluded from count)

### Test 4.2: Special Characters
**Steps:** Enter 9,501 characters including emojis and unicode (e.g., "🍄" × 4751)  
**Expected:** Validation counts characters correctly, shows error with 9502

### Test 4.3: Whitespace
**Steps:** Enter 9,501 spaces or newlines  
**Expected:** Validation counts whitespace, shows error with 9501

### Test 4.4: Mixed Inputs
**Steps:** Fill form with various fields including checkboxes and one long text field (9,501 chars)  
**Expected:** Only user-entered text is counted (excluding default "true"/"false"/"0.0"), shows error with 9501

#### Test 4.4.1: Mixed Inputs - Rank range
**Steps:** Fill Name search form with one long text field (9,501 chars)  and Rank: Species to Genus
**Expected:** Only user-entered text is counted (excluding default "true"/"false"/"0.0", excluding Rank drop-down selections), shows error with 9501

#### Test 4.4.2: Mixed Inputs - Coordinates
**Steps:** Fill Location search form with one long text field (9,501 chars) and Coordinates N, S, E, W with multiple digits
**Expected:** Only user-entered text, excluding Rank drop-down selections, is counted (excluding default "true"/"false"/"0.0"), shows error with 9501

---

## Test 5: JavaScript Disabled (Fallback)

### Steps:
1. Disable JavaScript in browser (Chrome: DevTools → Settings → Debugger → Disable JavaScript)
2. Navigate to `/observations/search/new`
3. Fill form with > 10,240 characters
4. Click submit

### Expected Result:
- Form submits via POST
- Data sent in request body (not URL)
- No Puma errors occur
- Server processes request normally

---

## Test 6: Pattern Search
### Steps:
1. Click the search icon/link in the top navigation bar
2. Paste > 9,500 characters in the Pattern Search window
3 Click Search
 
### Expected Result:
- Error message: Search string too long (9501 characters). Maximum is 9500 characters.

---

## Test 7: Verify Accurate Counting

### Steps:
1. Open browser console (F12 → Console)
4. Navigate to `/observations/search/new`
5. Paste exactly 9,501 characters into "Notes has" field
6. Click submit
7. Check console output

### Expected Result:
- Console shows field breakdown with excluded fields marked
- Default values (true, false, 0.0) are excluded from count
- Form metadata (authenticity_token, _method, commit) is excluded
- Total shows exactly 9,501 characters
- Error message displays "9501 characters" (not 9532 or other incorrect value)

---

## Test Data Generators

### Browser Console
```javascript
// Exactly at limit
'x'.repeat(9500)

// Just over limit
'x'.repeat(9501)

// Way over limit
'x'.repeat(15000)

// Multiple fields test (paste in each field)
'a'.repeat(3200)
'b'.repeat(3200)
'c'.repeat(3200)
```

### Character Counts
- 9,500 characters = limit (should pass)
- 9,501 characters = 1 over (should fail)
- 15,000 characters = extreme case (should fail with correct count)

---

## Success Criteria

✅ All search forms prevent submission when user input > 9,500 characters  
✅ Error messages display with accurate character count (excluding defaults/metadata)  
✅ Error messages disappear when input is reduced  
✅ Form data is preserved when validation fails  
✅ POST method prevents Puma errors even when JavaScript is disabled  
✅ All 6 search types work consistently  
✅ Navigation bar search validation works correctly  
✅ Console logging shows correct field exclusions
