### PR TITLE
Update test declaration format from block-style to method-based

### DIFF
--- a/test/classes/image_script_test.rb
+++ b/test/classes/image_script_test.rb
@@ -300,7 +300,7 @@ class ImageScriptTest < UnitTestCase
     cmd = "#{script} --verbose 2>&1 > #{tempfile}"
     status = system(cmd)
     errors = File.read(tempfile)
-    assert status, "Something went wrong with #{script}:\n#{errors}"
+    assert(status, "Something went wrong with #{script}:\n#{errors}")
     assert_equal(<<-ERROR_TEXT.unindent, errors)
       Listing local 1280
       Listing local 320

--- a/test/classes/image_script_test.rb
+++ b/test/classes/image_script_test.rb
@@ -86,7 +86,7 @@ class ImageScriptTest < UnitTestCase
 
   ##############################################################################
 
-  test "fixture_id_defs" do
+  def test_fixture_id_defs
     assert_equal(images(:in_situ_image).id, in_situ_id,
                  "in_situ_id defined incorrectly")
     assert_equal(images(:turned_over_image).id, turned_over_id,
@@ -98,7 +98,7 @@ class ImageScriptTest < UnitTestCase
                  "disconnected_id defined incorrectly")
   end
 
-  test "process_image" do
+  def test_process_image
     script = script_file("process_image")
     tempfile = Tempfile.new("test").path
     original_image = Rails.root.join("test/images/pleopsidium.tiff")
@@ -160,7 +160,7 @@ class ImageScriptTest < UnitTestCase
     end
   end
 
-  test "retransfer_images" do
+  def test_retransfer_images
     # In unit tests, ActiveRecord wraps all work on the database in a
     # transaction.  Soon as you look at the database it becomes immune to
     # external changes for the rest of the test.  In this test we want to check
@@ -241,7 +241,7 @@ class ImageScriptTest < UnitTestCase
                "960/#{turned_over_id}.jpg shouldnt be on server 2")
   end
 
-  test "rotate_image" do
+  def test_rotate_image
     script = script_file("rotate_image")
     tempfile = Tempfile.new("test").path
     test_image = Rails.root.join("test/images/sticky.jpg")
@@ -265,7 +265,7 @@ class ImageScriptTest < UnitTestCase
     assert_equal(true, img.transferred)
   end
 
-  test "verify_images" do
+  def test_verify_images
     script = script_file("verify_images")
     tempfile = Tempfile.new("test").path
     File.write("#{local_root}/orig/#{turned_over_id}.tiff", "A")

--- a/test/classes/script_test.rb
+++ b/test/classes/script_test.rb
@@ -19,7 +19,7 @@ class ScriptTest < UnitTestCase
     env = { "SENDER" => sender }
     cmd = "echo \"#{header}\n\n#{body}\" | #{script} \"#{subject}\" " \
           "> #{tempfile}"
-    assert system(env, cmd)
+    assert(system(env, cmd))
     expect = <<-EMAIL.unindent
       To: #{sender}
       Subject: #{subject}
@@ -51,7 +51,7 @@ class ScriptTest < UnitTestCase
     script = script_file("lookup_user")
     tempfile = Tempfile.new("test").path
     cmd = "#{script} dick > #{tempfile}"
-    assert system(cmd)
+    assert(system(cmd))
     expect =
       "id login name email verified last_use\n" \
       "#{users(:dick).id} dick Tricky Dick dick@collectivesource.com " \
@@ -64,21 +64,21 @@ class ScriptTest < UnitTestCase
     script = script_file("make_eol_xml")
     dest_file = Tempfile.new("test").path
     stdout_file = Tempfile.new("test").path
-    assert !File.exist?(dest_file) || File.empty?(dest_file)
+    assert(!File.exist?(dest_file) || File.empty?(dest_file))
     cmd = "#{script} #{dest_file} > #{stdout_file}"
 
     script_succeeded = system(cmd)
 
-    assert script_succeeded, "Script failed."
-    assert File.size(dest_file).positive?,
-           "#{dest_file} should have content but is empty."
+    assert(script_succeeded, "Script failed.")
+    assert(File.size(dest_file).positive?,
+           "#{dest_file} should have content but is empty.")
     assert_equal("", File.read(stdout_file),
                  "#{stdout_file} should be empty, but has content")
     # In test mode, the script just grabs first observation from api
     # (or mocks grabbing the first observation from api).
     # We don't care about testing name/eol, we just want to test that
     # the script can successfully wget any page from the server!
-    assert File.read(dest_file).include?('<results number="1">')
+    assert(File.read(dest_file).include?('<results number="1">'))
     # system("cp #{dest_file} x.xml")
   end
 
@@ -88,7 +88,7 @@ class ScriptTest < UnitTestCase
     cmd = "#{script} &>#{tempfile}"
     status = system(cmd)
     errors = File.read(tempfile)
-    assert status, "Something went wrong with #{script}:\n#{errors}"
+    assert(status, "Something went wrong with #{script}:\n#{errors}")
   end
 
   def test_refresh_name_lister_cache

--- a/test/classes/script_test.rb
+++ b/test/classes/script_test.rb
@@ -9,7 +9,7 @@ class ScriptTest < UnitTestCase
 
   ##############################################################################
 
-  test "autoreply" do
+  def test_autoreply
     sender = "test@email.com"
     subject = "RE: do not reply"
     header = "To: blah\nFrom: blah\nSubject: blah"
@@ -47,7 +47,7 @@ class ScriptTest < UnitTestCase
   #   end
   # end
 
-  test "lookup_user" do
+  def test_lookup_user
     script = script_file("lookup_user")
     tempfile = Tempfile.new("test").path
     cmd = "#{script} dick > #{tempfile}"
@@ -60,7 +60,7 @@ class ScriptTest < UnitTestCase
     assert_equal(expect, actual)
   end
 
-  test "make_eol_xml" do
+  def test_make_eol_xml
     script = script_file("make_eol_xml")
     dest_file = Tempfile.new("test").path
     stdout_file = Tempfile.new("test").path
@@ -82,7 +82,7 @@ class ScriptTest < UnitTestCase
     # system("cp #{dest_file} x.xml")
   end
 
-  test "parse_log" do
+  def test_parse_log
     script = script_file("parse_log")
     tempfile = Tempfile.new("test").path
     cmd = "#{script} &>#{tempfile}"
@@ -91,7 +91,7 @@ class ScriptTest < UnitTestCase
     assert status, "Something went wrong with #{script}:\n#{errors}"
   end
 
-  test "refresh_name_lister_cache" do
+  def test_refresh_name_lister_cache
     script = script_file("refresh_name_lister_cache")
     tempfile = Tempfile.new("test").path
     output_file = MO.name_lister_cache_file

--- a/test/controllers/admin/banners_controller_test.rb
+++ b/test/controllers/admin/banners_controller_test.rb
@@ -7,13 +7,13 @@ class Admin::BannersControllerTest < FunctionalTestCase
     make_admin("admin")
   end
 
-  test "should get index" do
+  def test_should_get_index
     get(:index)
     assert_response :success
     assert_select "textarea", banners(:one).message
   end
 
-  test "should create banner" do
+  def test_should_create_banner
     assert_difference("Banner.count", 1) do
       post(:create, params: { banner: { message: "New Banner" } })
     end
@@ -21,7 +21,7 @@ class Admin::BannersControllerTest < FunctionalTestCase
     assert_redirected_to admin_banners_path
   end
 
-  test "should not create banner with empty message" do
+  def test_should_not_create_banner_with_empty_message
     assert_no_difference("Banner.count") do
       post(:create, params: { banner: { message: "" } })
     end

--- a/test/controllers/admin/banners_controller_test.rb
+++ b/test/controllers/admin/banners_controller_test.rb
@@ -9,8 +9,8 @@ class Admin::BannersControllerTest < FunctionalTestCase
 
   def test_should_get_index
     get(:index)
-    assert_response :success
-    assert_select "textarea", banners(:one).message
+    assert_response(:success)
+    assert_select("textarea", banners(:one).message)
   end
 
   def test_should_create_banner
@@ -18,7 +18,7 @@ class Admin::BannersControllerTest < FunctionalTestCase
       post(:create, params: { banner: { message: "New Banner" } })
     end
 
-    assert_redirected_to admin_banners_path
+    assert_redirected_to(admin_banners_path)
   end
 
   def test_should_not_create_banner_with_empty_message
@@ -26,7 +26,7 @@ class Admin::BannersControllerTest < FunctionalTestCase
       post(:create, params: { banner: { message: "" } })
     end
 
-    assert_response :success
-    assert_select "div", "Failed to update banner."
+    assert_response(:success)
+    assert_select("div", "Failed to update banner.")
   end
 end

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -11,13 +11,13 @@ class VisualGroupsControllerTest < FunctionalTestCase
   def test_should_get_index
     login
     get(:index, params: { visual_model_id: @visual_model.id })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_get_new
     login
     get(:new, params: { visual_model_id: @visual_model.id })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_create_visual_group
@@ -31,9 +31,9 @@ class VisualGroupsControllerTest < FunctionalTestCase
              }
            })
     end
-    assert_redirected_to visual_model_visual_groups_url(
-      @visual_model, VisualGroup.last
-    )
+    assert_redirected_to(visual_model_visual_groups_url(
+                           @visual_model, VisualGroup.last
+                         ))
   end
 
   def test_should_not_create_visual_group
@@ -47,7 +47,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
              }
            })
     end
-    assert_redirected_to new_visual_model_visual_group_url(@visual_model)
+    assert_redirected_to(new_visual_model_visual_group_url(@visual_model))
   end
 
   def test_should_not_create_visual_group_due_to_tab
@@ -61,7 +61,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
              }
            })
     end
-    assert_redirected_to new_visual_model_visual_group_url(@visual_model)
+    assert_redirected_to(new_visual_model_visual_group_url(@visual_model))
   end
 
   def test_should_show_visual_group
@@ -70,7 +70,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
           id: @visual_group.id,
           visual_model_id: @visual_model.id
         })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_show_visual_group_with_filter
@@ -80,13 +80,13 @@ class VisualGroupsControllerTest < FunctionalTestCase
           filter: "Agaricus",
           visual_model_id: @visual_model.id
         })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_get_edit
     login
     get(:edit, params: { id: @visual_group.id })
-    assert_response :success
+    assert_response(:success)
     assert_match(image_path(observations(:peltigera_mary_obs).thumb_image.id),
                  response.body)
   end
@@ -94,7 +94,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
   def test_should_get_edit_page_with_excluded_images
     login
     get(:edit, params: { id: @visual_group.id, status: "excluded" })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_update_visual_group
@@ -106,8 +106,8 @@ class VisualGroupsControllerTest < FunctionalTestCase
               approved: @visual_group.approved
             }
           })
-    assert_redirected_to visual_model_visual_groups_url(@visual_model,
-                                                        @visual_group)
+    assert_redirected_to(visual_model_visual_groups_url(@visual_model,
+                                                        @visual_group))
   end
 
   def test_should_not_update_visual_group
@@ -119,7 +119,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
               approved: @visual_group.approved
             }
           })
-    assert_redirected_to edit_visual_group_url(@visual_group)
+    assert_redirected_to(edit_visual_group_url(@visual_group))
   end
 
   def test_should_destroy_visual_group
@@ -127,6 +127,6 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_difference("VisualGroup.count", -1) do
       delete(:destroy, params: { id: @visual_group.id })
     end
-    assert_redirected_to visual_model_visual_groups_url(@visual_model)
+    assert_redirected_to(visual_model_visual_groups_url(@visual_model))
   end
 end

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -8,19 +8,19 @@ class VisualGroupsControllerTest < FunctionalTestCase
     @visual_model = @visual_group.visual_model
   end
 
-  test "should get index" do
+  def test_should_get_index
     login
     get(:index, params: { visual_model_id: @visual_model.id })
     assert_response :success
   end
 
-  test "should get new" do
+  def test_should_get_new
     login
     get(:new, params: { visual_model_id: @visual_model.id })
     assert_response :success
   end
 
-  test "should create visual_group" do
+  def test_should_create_visual_group
     login
     assert_difference("VisualGroup.count") do
       post(:create, params: {
@@ -36,7 +36,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     )
   end
 
-  test "should not create visual_group" do
+  def test_should_not_create_visual_group
     login
     assert_no_difference("VisualGroup.count") do
       post(:create, params: {
@@ -50,7 +50,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_redirected_to new_visual_model_visual_group_url(@visual_model)
   end
 
-  test "should not create visual_group due to tab" do
+  def test_should_not_create_visual_group_due_to_tab
     login
     assert_no_difference("VisualGroup.count") do
       post(:create, params: {
@@ -64,7 +64,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_redirected_to new_visual_model_visual_group_url(@visual_model)
   end
 
-  test "should show visual_group" do
+  def test_should_show_visual_group
     login
     get(:show, params: {
           id: @visual_group.id,
@@ -73,7 +73,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_response :success
   end
 
-  test "should show visual_group with filter" do
+  def test_should_show_visual_group_with_filter
     login
     get(:show, params: {
           id: @visual_group.id,
@@ -83,7 +83,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_response :success
   end
 
-  test "should get edit" do
+  def test_should_get_edit
     login
     get(:edit, params: { id: @visual_group.id })
     assert_response :success
@@ -91,13 +91,13 @@ class VisualGroupsControllerTest < FunctionalTestCase
                  response.body)
   end
 
-  test "should get edit page with excluded images" do
+  def test_should_get_edit_page_with_excluded_images
     login
     get(:edit, params: { id: @visual_group.id, status: "excluded" })
     assert_response :success
   end
 
-  test "should update visual_group" do
+  def test_should_update_visual_group
     login
     patch(:update, params: {
             id: @visual_group.id,
@@ -110,7 +110,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
                                                         @visual_group)
   end
 
-  test "should not update visual_group" do
+  def test_should_not_update_visual_group
     login
     patch(:update, params: {
             id: @visual_group.id,
@@ -122,7 +122,7 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_redirected_to edit_visual_group_url(@visual_group)
   end
 
-  test "should destroy visual_group" do
+  def test_should_destroy_visual_group
     login
     assert_difference("VisualGroup.count", -1) do
       delete(:destroy, params: { id: @visual_group.id })

--- a/test/controllers/visual_models_controller_test.rb
+++ b/test/controllers/visual_models_controller_test.rb
@@ -7,19 +7,19 @@ class VisualModelsControllerTest < FunctionalTestCase
     @visual_model = visual_models(:visual_model_one)
   end
 
-  test "should get index" do
+  def test_should_get_index
     login
     get(:index)
     assert_response :success
   end
 
-  test "should get new" do
+  def test_should_get_new
     login
     get(:new)
     assert_response :success
   end
 
-  test "should create visual_model" do
+  def test_should_create_visual_model
     login
     assert_difference("VisualModel.count") do
       post(:create, params: { visual_model: {
@@ -30,7 +30,7 @@ class VisualModelsControllerTest < FunctionalTestCase
     assert_redirected_to visual_model_url(VisualModel.last)
   end
 
-  test "should not create visual_model" do
+  def test_should_not_create_visual_model
     login
     assert_no_difference("VisualModel.count") do
       post(:create, params: { visual_model: {
@@ -41,7 +41,7 @@ class VisualModelsControllerTest < FunctionalTestCase
     assert_redirected_to new_visual_model_url
   end
 
-  test "should not create visual_model due to tab" do
+  def test_should_not_create_visual_model_due_to_tab
     login
     assert_no_difference("VisualModel.count") do
       post(:create, params: { visual_model: {
@@ -52,26 +52,26 @@ class VisualModelsControllerTest < FunctionalTestCase
     assert_redirected_to new_visual_model_url
   end
 
-  test "should show visual_model" do
+  def test_should_show_visual_model
     login
     get(:show, params: { id: visual_models(:visual_model_one).id })
     assert_response :success
   end
 
-  test "should show visual_model as json" do
+  def test_should_show_visual_model_as_json
     login
     get(:show, params: { format: :json,
                          id: visual_models(:visual_model_one).id })
     assert_response :success
   end
 
-  test "should get edit" do
+  def test_should_get_edit
     login
     get(:edit, params: { id: @visual_model.id })
     assert_response :success
   end
 
-  test "should update visual_model" do
+  def test_should_update_visual_model
     login
     patch(:update, params: {
             id: @visual_model.id,
@@ -80,7 +80,7 @@ class VisualModelsControllerTest < FunctionalTestCase
     assert_redirected_to visual_model_url(@visual_model)
   end
 
-  test "should not update visual_model" do
+  def test_should_not_update_visual_model
     login
     patch(:update, params: {
             id: @visual_model.id,
@@ -89,7 +89,7 @@ class VisualModelsControllerTest < FunctionalTestCase
     assert_redirected_to edit_visual_model_url(@visual_model)
   end
 
-  test "should destroy visual_model" do
+  def test_should_destroy_visual_model
     login
     assert_difference("VisualModel.count", -1) do
       delete(:destroy, params: { id: @visual_model.id })

--- a/test/controllers/visual_models_controller_test.rb
+++ b/test/controllers/visual_models_controller_test.rb
@@ -10,13 +10,13 @@ class VisualModelsControllerTest < FunctionalTestCase
   def test_should_get_index
     login
     get(:index)
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_get_new
     login
     get(:new)
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_create_visual_model
@@ -27,7 +27,7 @@ class VisualModelsControllerTest < FunctionalTestCase
            } })
     end
 
-    assert_redirected_to visual_model_url(VisualModel.last)
+    assert_redirected_to(visual_model_url(VisualModel.last))
   end
 
   def test_should_not_create_visual_model
@@ -38,7 +38,7 @@ class VisualModelsControllerTest < FunctionalTestCase
            } })
     end
 
-    assert_redirected_to new_visual_model_url
+    assert_redirected_to(new_visual_model_url)
   end
 
   def test_should_not_create_visual_model_due_to_tab
@@ -49,26 +49,26 @@ class VisualModelsControllerTest < FunctionalTestCase
            } })
     end
 
-    assert_redirected_to new_visual_model_url
+    assert_redirected_to(new_visual_model_url)
   end
 
   def test_should_show_visual_model
     login
     get(:show, params: { id: visual_models(:visual_model_one).id })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_show_visual_model_as_json
     login
     get(:show, params: { format: :json,
                          id: visual_models(:visual_model_one).id })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_get_edit
     login
     get(:edit, params: { id: @visual_model.id })
-    assert_response :success
+    assert_response(:success)
   end
 
   def test_should_update_visual_model
@@ -77,7 +77,7 @@ class VisualModelsControllerTest < FunctionalTestCase
             id: @visual_model.id,
             visual_model: { name: @visual_model.name }
           })
-    assert_redirected_to visual_model_url(@visual_model)
+    assert_redirected_to(visual_model_url(@visual_model))
   end
 
   def test_should_not_update_visual_model
@@ -86,7 +86,7 @@ class VisualModelsControllerTest < FunctionalTestCase
             id: @visual_model.id,
             visual_model: { name: "" }
           })
-    assert_redirected_to edit_visual_model_url(@visual_model)
+    assert_redirected_to(edit_visual_model_url(@visual_model))
   end
 
   def test_should_destroy_visual_model
@@ -94,6 +94,6 @@ class VisualModelsControllerTest < FunctionalTestCase
     assert_difference("VisualModel.count", -1) do
       delete(:destroy, params: { id: @visual_model.id })
     end
-    assert_redirected_to visual_models_url
+    assert_redirected_to(visual_models_url)
   end
 end

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -11,7 +11,7 @@ class FieldSlipJobTest < ActiveJob::TestCase
     File.delete(tracker.filepath)
   end
 
-  def test_it_should_perform_with_one_per_page
+  def test_performs_with_one_per_page
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_one_per_page)
     job.perform(tracker.id)

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 class FieldSlipJobTest < ActiveJob::TestCase
-  def test_it_should_perform
+  def test_perform
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_page_two)
     job.perform(tracker.id)

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 class FieldSlipJobTest < ActiveJob::TestCase
-  test "it should perform" do
+  def test_it_should_perform
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_page_two)
     job.perform(tracker.id)
@@ -11,7 +11,7 @@ class FieldSlipJobTest < ActiveJob::TestCase
     File.delete(tracker.filepath)
   end
 
-  test "it should perform with one per page" do
+  def test_it_should_perform_with_one_per_page
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_one_per_page)
     job.perform(tracker.id)
@@ -19,7 +19,7 @@ class FieldSlipJobTest < ActiveJob::TestCase
     File.delete(tracker.filepath)
   end
 
-  test "it should delete old trackers" do
+  def test_it_should_delete_old_trackers
     old_tracker_id = field_slip_job_trackers(:fsjt_old).id
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_page_two)
@@ -28,7 +28,7 @@ class FieldSlipJobTest < ActiveJob::TestCase
     assert_nil(FieldSlipJobTracker.find_by(id: old_tracker_id))
   end
 
-  test "it should delete old tracker files" do
+  def test_it_should_delete_old_tracker_files
     old_filepath = field_slip_job_trackers(:fsjt_old).filepath
     FileUtils.touch(old_filepath)
     job = FieldSlipJob.new

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -28,7 +28,7 @@ class FieldSlipJobTest < ActiveJob::TestCase
     assert_nil(FieldSlipJobTracker.find_by(id: old_tracker_id))
   end
 
-  def test_it_should_delete_old_tracker_files
+  def test_deletes_old_tracker_files
     old_filepath = field_slip_job_trackers(:fsjt_old).filepath
     FileUtils.touch(old_filepath)
     job = FieldSlipJob.new

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -19,7 +19,7 @@ class FieldSlipJobTest < ActiveJob::TestCase
     File.delete(tracker.filepath)
   end
 
-  def test_it_should_delete_old_trackers
+  def test_deletes_old_trackers
     old_tracker_id = field_slip_job_trackers(:fsjt_old).id
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_page_two)

--- a/test/jobs/image_loader_job_test.rb
+++ b/test/jobs/image_loader_job_test.rb
@@ -52,7 +52,7 @@ class ImageLoaderJobTest < ActiveJob::TestCase
     FileUtils.rm_rf(DIR)
   end
 
-  test "image download works" do
+  def test_image_download_works
     rolf_count = users(:rolf).original_image_quota
     admin_count = User.admin.original_image_quota
     with_stubs do
@@ -63,7 +63,7 @@ class ImageLoaderJobTest < ActiveJob::TestCase
     end
   end
 
-  test "image already there" do
+  def test_image_already_there
     FileUtils.mkdir_p(File.dirname(@test_file))
     File.write(@test_file, "already cached")
     with_stubs do
@@ -72,7 +72,7 @@ class ImageLoaderJobTest < ActiveJob::TestCase
     end
   end
 
-  test "image download fails" do
+  def test_image_download_fails
     with_stubs do
       MockBucket.stub(:new, -> { raise("test") }) do
         ImageLoaderJob.perform_now(@test_image.id, users(:rolf).id)

--- a/test/models/banner_test.rb
+++ b/test/models/banner_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 class BannerTest < ActiveSupport::TestCase
-  test "current" do
+  def test_current
     assert_equal(Banner.current, Banner.order(version: :desc).first)
   end
 end


### PR DESCRIPTION
Refactor 8 test files to use the modern method-based test declaration format (def test_name) instead of the older block-style syntax (test "name" do).

Files updated:
- test/jobs/field_slip_job_test.rb (4 tests)
- test/jobs/image_loader_job_test.rb (3 tests)
- test/classes/script_test.rb (5 tests)
- test/classes/image_script_test.rb (5 tests)
- test/models/banner_test.rb (1 test)
- test/controllers/visual_groups_controller_test.rb (12 tests)
- test/controllers/visual_models_controller_test.rb (9 tests)
- test/controllers/admin/banners_controller_test.rb (3 tests)

All tests pass successfully with the new format.

Fixes #3588

🤖 Generated with [Claude Code](https://claude.com/claude-code)