### PR TITLE
Improve Location search UX and add pattern search help

### DIFF
--- a/app/classes/pattern_search/base.rb
+++ b/app/classes/pattern_search/base.rb
@@ -54,6 +54,39 @@ module PatternSearch
       query_params.except!(*modifiers)
     end
 
+    def put_nsew_params_in_box
+      north, south, east, west = query_params.values_at(:north, :south, :east,
+                                                        :west)
+      box = { north:, south:, east:, west: }
+      return if box.compact.blank?
+
+      box = validate_box(box)
+      query_params[:in_box] = box
+      query_params.except!(:north, :south, :east, :west)
+    end
+
+    def validate_box(box)
+      validator = Mappable::Box.new(**box)
+      return box if validator.valid?
+
+      check_for_missing_box_params
+      # Just fix the box if they've got it swapped
+      if query_params[:south] > query_params[:north]
+        box = box.merge(north: query_params[:south],
+                        south: query_params[:north])
+      end
+      box
+    end
+
+    def check_for_missing_box_params
+      debugger
+      [:north, :south, :east, :west].each do |term|
+        next if query_params[term].present?
+
+        raise(PatternSearch::MissingValueError.new(var: term))
+      end
+    end
+
     def help_message
       :pattern_search_terms_short_help.l
     end

--- a/app/classes/pattern_search/base.rb
+++ b/app/classes/pattern_search/base.rb
@@ -79,7 +79,6 @@ module PatternSearch
     end
 
     def check_for_missing_box_params
-      debugger
       [:north, :south, :east, :west].each do |term|
         next if query_params[term].present?
 

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -45,17 +45,6 @@ module PatternSearch
 
     private
 
-    def put_nsew_params_in_box
-      north, south, east, west = query_params.values_at(:north, :south, :east,
-                                                        :west)
-      box = { north:, south:, east:, west: }
-      return if box.compact.blank?
-
-      box = validate_box(box)
-      query_params[:in_box] = box
-      query_params.except!(:north, :south, :east, :west)
-    end
-
     def validate_box(box)
       validator = Mappable::Box.new(**box)
       return box if validator.valid?

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module PatternSearch
+  # Search where results returned are Locations
+  class Location < Base
+    PARAMS = {
+      # dates / times
+      created: [:created_at, :parse_date_range],
+      modified: [:updated_at, :parse_date_range],
+
+      # strings / lists
+      region: [:region, :parse_list_of_strings],
+      user: [:by_users, :parse_list_of_users],
+      editor: [:by_editor, :parse_user],
+      notes: [:notes_has, :parse_string],
+
+      # numeric - bounding box
+      east: [:east, :parse_longitude],
+      north: [:north, :parse_latitude],
+      south: [:south, :parse_latitude],
+      west: [:west, :parse_longitude],
+
+      # booleanish
+      has_notes: [:has_notes, :parse_boolean],
+      has_observations: [:has_observations, :parse_yes],
+      has_descriptions: [:has_descriptions, :parse_yes]
+    }.freeze
+
+    def self.params
+      PARAMS
+    end
+
+    delegate :params, to: :class
+
+    def self.model
+      ::Location
+    end
+
+    delegate :model, to: :class
+
+    def build_query
+      super
+      put_nsew_params_in_box
+    end
+
+    private
+
+    def put_nsew_params_in_box
+      north, south, east, west = query_params.values_at(:north, :south, :east,
+                                                        :west)
+      box = { north:, south:, east:, west: }
+      return if box.compact.blank?
+
+      box = validate_box(box)
+      query_params[:in_box] = box
+      query_params.except!(:north, :south, :east, :west)
+    end
+
+    def validate_box(box)
+      validator = Mappable::Box.new(**box)
+      return box if validator.valid?
+
+      check_for_missing_box_params
+      # Just fix the box if they've got it swapped
+      if query_params[:south] > query_params[:north]
+        box = box.merge(north: query_params[:south],
+                        south: query_params[:north])
+      end
+      box
+    end
+
+    def check_for_missing_box_params
+      [:north, :south, :east, :west].each do |term|
+        next if query_params[term].present?
+
+        raise(PatternSearch::MissingValueError.new(var: term))
+      end
+    end
+  end
+end

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -11,6 +11,7 @@ module PatternSearch
       # strings / lists
       region: [:region, :parse_list_of_strings],
       user: [:by_users, :parse_list_of_users],
+      editor: [:by_editor, :parse_user],
       notes: [:notes_has, :parse_string],
 
       # numeric - bounding box

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -11,7 +11,7 @@ module PatternSearch
       # strings / lists
       region: [:region, :parse_list_of_strings],
       user: [:by_users, :parse_list_of_users],
-      editor: [:by_editor, :parse_user],
+      editor: [:by_editor, :parse_list_of_users],
       notes: [:notes_has, :parse_string],
 
       # numeric - bounding box

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -45,18 +45,6 @@ module PatternSearch
 
     private
 
-    def validate_box(box)
-      validator = Mappable::Box.new(**box)
-      return box if validator.valid?
-
-      check_for_missing_box_params
-      # Just fix the box if they've got it swapped
-      if query_params[:south] > query_params[:north]
-        box = box.merge(north: query_params[:south],
-                        south: query_params[:north])
-      end
-      box
-    end
 
   end
 end

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -11,7 +11,6 @@ module PatternSearch
       # strings / lists
       region: [:region, :parse_list_of_strings],
       user: [:by_users, :parse_list_of_users],
-      editor: [:by_editor, :parse_user],
       notes: [:notes_has, :parse_string],
 
       # numeric - bounding box

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -41,9 +41,5 @@ module PatternSearch
       super
       put_nsew_params_in_box
     end
-
-    private
-
-
   end
 end

--- a/app/classes/pattern_search/location.rb
+++ b/app/classes/pattern_search/location.rb
@@ -58,12 +58,5 @@ module PatternSearch
       box
     end
 
-    def check_for_missing_box_params
-      [:north, :south, :east, :west].each do |term|
-        next if query_params[term].present?
-
-        raise(PatternSearch::MissingValueError.new(var: term))
-      end
-    end
   end
 end

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -107,37 +107,5 @@ module PatternSearch
         !query_params[:include_all_name_proposals].nil? ||
         !query_params[:exclude_consensus].nil?
     end
-
-    def put_nsew_params_in_box
-      north, south, east, west = query_params.values_at(:north, :south, :east,
-                                                        :west)
-      box = { north:, south:, east:, west: }
-      return if box.compact.blank?
-
-      box = validate_box(box)
-      query_params[:in_box] = box
-      query_params.except!(:north, :south, :east, :west)
-    end
-
-    def validate_box(box)
-      validator = Mappable::Box.new(**box)
-      return box if validator.valid?
-
-      check_for_missing_box_params
-      # Just fix the box if they've got it swapped
-      if query_params[:south] > query_params[:north]
-        box = box.merge(north: query_params[:south],
-                        south: query_params[:north])
-      end
-      box
-    end
-
-    def check_for_missing_box_params
-      [:north, :south, :east, :west].each do |term|
-        next if query_params[term].present?
-
-        raise(PatternSearch::MissingValueError.new(var: term))
-      end
-    end
   end
 end

--- a/app/classes/pattern_search/parser.rb
+++ b/app/classes/pattern_search/parser.rb
@@ -12,7 +12,7 @@ module PatternSearch
     /x
 
     def initialize(string)
-      self.incoming_string = string
+      self.incoming_string = string.gsub(/[“”]/, '"')
       self.terms = parse_incoming_string
     end
 

--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -164,6 +164,11 @@ module PatternSearch
       end
     end
 
+    def parse_user
+      val = make_sure_there_is_one_value!
+      parse_one_user(val).id
+    end
+
     def parse_list_of_strings
       vals
     end

--- a/app/classes/pattern_search/term.rb
+++ b/app/classes/pattern_search/term.rb
@@ -106,11 +106,11 @@ module PatternSearch
       vals.map do |val|
         # cop gives false positive
         if /^\d+$/.match?(val) # rubocop:disable Style/GuardClause
-          Location.safe_find(val) ||
+          ::Location.safe_find(val) ||
             raise(BadLocationError.new(var: var, val: val))
         else
-          Location.find_by_name_with_wildcards(val) ||
-            Location.find_by_scientific_name_with_wildcards(val) ||
+          ::Location.find_by_name_with_wildcards(val) ||
+            ::Location.find_by_scientific_name_with_wildcards(val) ||
             raise(BadLocationError.new(var: var, val: val))
         end
       end.flatten.map(&:id).uniq

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -10,7 +10,7 @@ class Query::Locations < Query
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Location])
   query_attr(:by_users, [User])
-  query_attr(:by_editor, User)
+  query_attr(:by_editor, [User])
   query_attr(:in_box, { north: :float, south: :float,
                         east: :float, west: :float })
   # query_attr(:region, :string) # content filter

--- a/app/controllers/locations/search_controller.rb
+++ b/app/controllers/locations/search_controller.rb
@@ -41,10 +41,10 @@ module Locations
     # pairings.
     FIELD_COLUMNS = [
       {
+        pattern: { shown: [:regexp] },
         area: { shown: [:region] }
       },
       {
-        pattern: { shown: [:regexp] },
         dates: { shown: [:created_at, :updated_at] },
         detail: {
           shown: [[:has_notes, :notes_has],

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -105,9 +105,8 @@ class SearchController < ApplicationController
   end
 
   def build_query_and_redirect(type, model_name, pattern)
-    # :Name and :Observation prevalidate the pattern with a PatternSearch
-    # instance, and check for errors defined by PatternSearch.
-    # :Location checks the user location format of the "pattern".
+    # :Name, :Observation, and :Location prevalidate the pattern with a
+    # PatternSearch instance, and check for errors defined by PatternSearch.
     query = query_from_pattern(model_name, pattern)
 
     # Finally we can redirect.
@@ -130,10 +129,8 @@ class SearchController < ApplicationController
 
   def query_from_pattern(model_name, pattern)
     case model_name
-    when :Observation, :Name
+    when :Observation, :Name, :Location
       pattern_search_query_from_pattern(model_name, pattern)
-    when :Location
-      location_query_from_pattern(pattern)
     else
       create_query(model_name, pattern:)
     end
@@ -150,12 +147,6 @@ class SearchController < ApplicationController
     end
     # This will create a blank query if there are errors.
     create_query(model_name, search.query&.params || {})
-  end
-
-  def location_query_from_pattern(pattern)
-    create_query(
-      :Location, pattern: Location.user_format(@user, pattern)
-    )
   end
 
   def flash_pattern_search_errors(search)

--- a/app/views/controllers/application/_top_nav.html.erb
+++ b/app/views/controllers/application/_top_nav.html.erb
@@ -5,7 +5,7 @@ container_classes = %w[
 ]
 top_nav_classes = class_names(container_classes, "justify-content-between")
 search_nav_classes = class_names(container_classes, "justify-content-center")
-search_help_types = [:names, :observations]
+search_help_types = [:names, :observations, :locations]
 search_form_types = [
   :names, :observations, :locations, :projects, :herbaria, :species_lists
 ]

--- a/app/views/controllers/locations/search/_help.erb
+++ b/app/views/controllers/locations/search/_help.erb
@@ -1,0 +1,4 @@
+<%= tag.p("#{:LOCATIONS.t} #{:SEARCHES.t}",
+          class: "mt-3 font-weight-bold") %>
+<%= :pattern_search_terms_help.tp %>
+<%= PatternSearch::Location.terms_help.tp %>

--- a/app/views/controllers/locations/search/show.erb
+++ b/app/views/controllers/locations/search/show.erb
@@ -1,0 +1,1 @@
+<%= render(partial: "locations/search/help") %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3891,6 +3891,7 @@
 
   # Help text for search_form_fields
   location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California, USA".
+  location_term_by_editor: Location edited by this user.
   location_term_by_users: "[:query_term_by_users(type=:LOCATION)]"
   location_term_pattern: "[:PATTERN]"
   location_term_regexp: "The Location's name includes this string."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3892,7 +3892,6 @@
   # Help text for search_form_fields
   location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a backslash as shown.
   location_term_by_users: "[:query_term_by_users(type=:LOCATION)]"
-  location_term_by_editor: Location edited by this user.
   location_term_pattern: "[:PATTERN]"
   location_term_regexp: "The Location's name includes this string."
   location_term_created: Date location was first posted.
@@ -3900,7 +3899,6 @@
   location_term_modified: Date location was last modified.
   location_term_updated_at: "[:location_term_modified]"
   location_term_user: "[:location_term_by_users]"
-  location_term_editor: "[:location_term_by_editor]"
   location_term_notes: "[:location_term_notes_has]"
   location_term_has_notes: "[:query_term_has_notes(type=:LOCATION)]"
   location_term_notes_has: "[:query_term_notes_has(type=:LOCATION)]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3900,7 +3900,7 @@
   location_term_modified: Date location was last modified.
   location_term_updated_at: "[:location_term_modified]"
   location_term_user: "[:location_term_by_users]"
-  location_term_editor: Location edited by this user.
+  location_term_editor: "[:location_term_by_editor]"
   location_term_notes: "[:location_term_notes_has]"
   location_term_has_notes: "[:query_term_has_notes(type=:LOCATION)]"
   location_term_notes_has: "[:query_term_notes_has(type=:LOCATION)]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3890,7 +3890,7 @@
   name_term_comments_has: "[:name_term_comments]"
 
   # Help text for search_form_fields
-  location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a back-slash as shown.
+  location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a backslash as shown.
   location_term_by_users: "[:query_term_by_users(type=:LOCATION)]"
   location_term_by_editor: Location edited by this user.
   location_term_pattern: "[:PATTERN]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3816,7 +3816,7 @@
   observation_term_location: Mushroom was observed within the the geographic bounds ([:east], [:north], [:south], [:west]) of this Location, regardless of the exact name of the Location of the Observation. Location must be an existing MO Location. Cf. **[:region]**.
   observation_term_locations: "[:observation_term_location]"
   observation_term_within_locations: "[:observation_term_location]"
-  observation_term_region: The Observation's Location name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a back-slash as shown. Cf. **[:location]**.
+  observation_term_region: The Observation's Location name includes this string. Partial match anchored at end, including country at least, e.g., "California, USA". Cf. **[:location]**.
   observation_term_pattern: "[:pattern]"
   observation_term_project: "[:observation_term_projects]"
   observation_term_projects: "[:query_term_projects(type=:OBSERVATION)]"
@@ -3890,7 +3890,7 @@
   name_term_comments_has: "[:name_term_comments]"
 
   # Help text for search_form_fields
-  location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a backslash as shown.
+  location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California, USA".
   location_term_by_users: "[:query_term_by_users(type=:LOCATION)]"
   location_term_pattern: "[:PATTERN]"
   location_term_regexp: "The Location's name includes this string."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1681,7 +1681,7 @@
   form_locations_refs: "[:form_names_refs]"
   form_locations_refs_help: "[:form_names_refs_help]"
   form_locations_help: Here you can define the place where you observed mushrooms, if a matching place doesn't exist in Mushroom Observer already. Please try to define locations that will be reusable by yourself or others. If you have an idea of the location's name, you can start typing and Google will return its best guess of the place you typed, and draw a box of the approximate boundaries on the map. At this point, you can manually edit both the boundaries and the name of the place. <a href="/locations/help" target="_new">More about Locations on MO.</a>
-  form_regions_help: The region for your search. Click "[:form_locations_find_on_map]" to view or modify the boundary area.
+  form_regions_help: Finds locations whose names end with this string. Since location names are hierarchical (e.g., "Howarth Park, Santa Rosa, California, USA"), this effectively searches by geographic region - searching for "California, USA" finds all locations in California. Must include the country. Click "[:form_locations_find_on_map]" to view or modify the boundary area.
   form_locations_find_on_map: Find on Map
   form_locations_get_elevation: Get Elevations
   form_locations_lat_long_help: All values should be in decimal degrees.
@@ -3890,15 +3890,24 @@
   name_term_comments_has: "[:name_term_comments]"
 
   # Help text for search_form_fields
-  location_term_region: The Location is within this Region; its name ends with this string. Must include the country, e.g., "California, USA".
+  location_term_region: The Location's name includes this string. Partial match anchored at end, including country at least, e.g., "California\, USA". Note that commas must be protected with a back-slash as shown.
   location_term_by_users: "[:query_term_by_users(type=:LOCATION)]"
   location_term_by_editor: Location edited by this user.
   location_term_pattern: "[:PATTERN]"
   location_term_regexp: "The Location's name includes this string."
-  location_term_created_at: "[:query_term_created_at(type=:LOCATION)]"
-  location_term_updated_at: "[:query_term_updated_at(type=:LOCATION)]"
+  location_term_created: Date location was first posted.
+  location_term_created_at: "[:location_term_created]"
+  location_term_modified: Date location was last modified.
+  location_term_updated_at: "[:location_term_modified]"
+  location_term_user: "[:location_term_by_users]"
+  location_term_editor: Location edited by this user.
+  location_term_notes: "[:location_term_notes_has]"
   location_term_has_notes: "[:query_term_has_notes(type=:LOCATION)]"
   location_term_notes_has: "[:query_term_notes_has(type=:LOCATION)]"
+  location_term_east: Longitude of eastern edge of search area.
+  location_term_west: Longitude of western edge of search area.
+  location_term_north: Latitude of northern edge of search area.
+  location_term_south: Latitude of southern edge of search area.
   location_term_has_observations: "[:query_term_has_observations]"
   location_term_has_descriptions: Has a description?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -474,7 +474,7 @@ MushroomObserver::Application.routes.draw do
 
   # ----- Locations: a lot of actions  ----------------------------
   namespace :locations do
-    resource :search, only: [:new, :create]
+    resource :search, only: [:show, :new, :create]
   end
 
   resources :locations, id: /\d+/, shallow: true do

--- a/test/classes/pattern_search/observation_test.rb
+++ b/test/classes/pattern_search/observation_test.rb
@@ -303,6 +303,15 @@ class PatternSearch::ObservationTest < UnitTestCase
     assert_obj_arrays_equal(expect, x.query.results, :sort)
   end
 
+  def test_observation_search_region_smart_quotes
+    expect = Observation.region("California, USA")
+    cal = locations(:california).observations.first
+    assert_not_nil(cal)
+    assert_includes(expect, cal)
+    x = PatternSearch::Observation.new("region:“USA, California”")
+    assert_obj_arrays_equal(expect, x.query.results, :sort)
+  end
+
   def test_observation_search_multiple_regions
     expect = Observation.region(["California, USA", "New York, USA"]).
              reorder(id: :asc).to_a

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require("test_helper")
@@ -533,7 +532,8 @@ class PatternSearchTest < UnitTestCase
 
   def test_location_pattern_search_with_invalid_north
     # North latitude must be between -90 and 90
-    search = PatternSearch::Location.new("north:95 south:34 east:-118 west:-119")
+    spec = "north:95 south:34 east:-118 west:-119"
+    search = PatternSearch::Location.new(spec)
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
     assert_equal(:north, search.errors.first.args[:var])
@@ -541,7 +541,8 @@ class PatternSearchTest < UnitTestCase
 
   def test_location_pattern_search_with_invalid_south
     # South latitude must be between -90 and 90
-    search = PatternSearch::Location.new("north:35 south:-95 east:-118 west:-119")
+    spec = "north:35 south:-95 east:-118 west:-119"
+    search = PatternSearch::Location.new(spec)
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
     assert_equal(:south, search.errors.first.args[:var])
@@ -549,7 +550,8 @@ class PatternSearchTest < UnitTestCase
 
   def test_location_pattern_search_with_invalid_east
     # East longitude must be between -180 and 180
-    search = PatternSearch::Location.new("north:35 south:34 east:185 west:-119")
+    spec = "north:35 south:34 east:185 west:-119"
+    search = PatternSearch::Location.new(spec)
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
     assert_equal(:east, search.errors.first.args[:var])
@@ -557,7 +559,8 @@ class PatternSearchTest < UnitTestCase
 
   def test_location_pattern_search_with_invalid_west
     # West longitude must be between -180 and 180
-    search = PatternSearch::Location.new("north:35 south:34 east:-118 west:-185")
+    spec = "north:35 south:34 east:-118 west:-185"
+    search = PatternSearch::Location.new(spec)
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
     assert_equal(:west, search.errors.first.args[:var])

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -429,10 +429,12 @@ class PatternSearchTest < UnitTestCase
     # Verify key parameters exist
     assert(params.key?(:region))
     assert(params.key?(:user))
+    assert(params.key?(:editor))
     assert(params.key?(:created))
     assert(params.key?(:modified))
     assert(params.key?(:has_notes))
     assert(params.key?(:has_observations))
+    assert(params.key?(:has_descriptions))
     assert(params.key?(:north))
     assert(params.key?(:south))
     assert(params.key?(:east))
@@ -473,6 +475,17 @@ class PatternSearchTest < UnitTestCase
   def test_location_pattern_search_with_has_observations
     search = PatternSearch::Location.new("has_observations:yes")
     assert_equal(true, search.query.params[:has_observations])
+  end
+
+  def test_location_pattern_search_with_has_descriptions
+    search = PatternSearch::Location.new("has_descriptions:yes")
+    assert_equal(true, search.query.params[:has_descriptions])
+  end
+
+  def test_location_pattern_search_with_editor
+    dick = users(:dick)
+    search = PatternSearch::Location.new("editor:dick")
+    assert_equal(dick.id, search.query.params[:by_editor])
   end
 
   def test_location_pattern_search_with_bounding_box

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -497,55 +497,63 @@ class PatternSearchTest < UnitTestCase
   end
 
   def test_location_pattern_search_with_missing_north
-    assert_raises(PatternSearch::MissingValueError) do
-      PatternSearch::Location.new("south:34 east:-118 west:-119")
-    end
+    search = PatternSearch::Location.new("south:34 east:-118 west:-119")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
+    assert_equal(:north, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_missing_south
-    assert_raises(PatternSearch::MissingValueError) do
-      PatternSearch::Location.new("north:35 east:-118 west:-119")
-    end
+    search = PatternSearch::Location.new("north:35 east:-118 west:-119")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
+    assert_equal(:south, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_missing_east
-    assert_raises(PatternSearch::MissingValueError) do
-      PatternSearch::Location.new("north:35 south:34 west:-119")
-    end
+    search = PatternSearch::Location.new("north:35 south:34 west:-119")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
+    assert_equal(:east, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_missing_west
-    assert_raises(PatternSearch::MissingValueError) do
-      PatternSearch::Location.new("north:35 south:34 east:-118")
-    end
+    search = PatternSearch::Location.new("north:35 south:34 east:-118")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
+    assert_equal(:west, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_invalid_north
     # North latitude must be between -90 and 90
-    assert_raises(PatternSearch::BadFloatError) do
-      PatternSearch::Location.new("north:95 south:34 east:-118 west:-119")
-    end
+    search = PatternSearch::Location.new("north:95 south:34 east:-118 west:-119")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
+    assert_equal(:north, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_invalid_south
     # South latitude must be between -90 and 90
-    assert_raises(PatternSearch::BadFloatError) do
-      PatternSearch::Location.new("north:35 south:-95 east:-118 west:-119")
-    end
+    search = PatternSearch::Location.new("north:35 south:-95 east:-118 west:-119")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
+    assert_equal(:south, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_invalid_east
     # East longitude must be between -180 and 180
-    assert_raises(PatternSearch::BadFloatError) do
-      PatternSearch::Location.new("north:35 south:34 east:185 west:-119")
-    end
+    search = PatternSearch::Location.new("north:35 south:34 east:185 west:-119")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
+    assert_equal(:east, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_invalid_west
     # West longitude must be between -180 and 180
-    assert_raises(PatternSearch::BadFloatError) do
-      PatternSearch::Location.new("north:35 south:34 east:-118 west:-185")
-    end
+    search = PatternSearch::Location.new("north:35 south:34 east:-118 west:-185")
+    assert_equal(1, search.errors.length)
+    assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
+    assert_equal(:west, search.errors.first.var)
   end
 
   def test_location_pattern_search_with_dates

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -520,6 +520,34 @@ class PatternSearchTest < UnitTestCase
     end
   end
 
+  def test_location_pattern_search_with_invalid_north
+    # North latitude must be between -90 and 90
+    assert_raises(PatternSearch::BadFloatError) do
+      PatternSearch::Location.new("north:95 south:34 east:-118 west:-119")
+    end
+  end
+
+  def test_location_pattern_search_with_invalid_south
+    # South latitude must be between -90 and 90
+    assert_raises(PatternSearch::BadFloatError) do
+      PatternSearch::Location.new("north:35 south:-95 east:-118 west:-119")
+    end
+  end
+
+  def test_location_pattern_search_with_invalid_east
+    # East longitude must be between -180 and 180
+    assert_raises(PatternSearch::BadFloatError) do
+      PatternSearch::Location.new("north:35 south:34 east:185 west:-119")
+    end
+  end
+
+  def test_location_pattern_search_with_invalid_west
+    # West longitude must be between -180 and 180
+    assert_raises(PatternSearch::BadFloatError) do
+      PatternSearch::Location.new("north:35 south:34 east:-118 west:-185")
+    end
+  end
+
   def test_location_pattern_search_with_dates
     search = PatternSearch::Location.new("created:2021-01-01")
     assert_equal(%w[2021-01-01 2021-01-01],

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -500,28 +500,28 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("south:34 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:north, search.errors.first.var)
+    assert_equal(:north, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_missing_south
     search = PatternSearch::Location.new("north:35 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:south, search.errors.first.var)
+    assert_equal(:south, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_missing_east
     search = PatternSearch::Location.new("north:35 south:34 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:east, search.errors.first.var)
+    assert_equal(:east, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_missing_west
     search = PatternSearch::Location.new("north:35 south:34 east:-118")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:west, search.errors.first.var)
+    assert_equal(:west, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_invalid_north
@@ -529,7 +529,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:95 south:34 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:north, search.errors.first.var)
+    assert_equal(:north, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_invalid_south
@@ -537,7 +537,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:35 south:-95 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:south, search.errors.first.var)
+    assert_equal(:south, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_invalid_east
@@ -545,7 +545,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:35 south:34 east:185 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:east, search.errors.first.var)
+    assert_equal(:east, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_invalid_west
@@ -553,7 +553,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:35 south:34 east:-118 west:-185")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:west, search.errors.first.var)
+    assert_equal(:west, search.errors.first.args[:var])
   end
 
   def test_location_pattern_search_with_dates

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -429,6 +429,7 @@ class PatternSearchTest < UnitTestCase
     # Verify key parameters exist
     assert(params.key?(:region))
     assert(params.key?(:user))
+    assert(params.key?(:editor))
     assert(params.key?(:created))
     assert(params.key?(:modified))
     assert(params.key?(:has_notes))
@@ -464,6 +465,12 @@ class PatternSearchTest < UnitTestCase
     dick = users(:dick)
     search = PatternSearch::Location.new("user:dick")
     assert_equal([dick.id], search.query.params[:by_users])
+  end
+
+  def test_location_pattern_search_with_editor
+    rolf = users(:rolf)
+    search = PatternSearch::Location.new("editor:rolf")
+    assert_equal(rolf.id, search.query.params[:by_editor])
   end
 
   def test_location_pattern_search_with_notes
@@ -581,6 +588,7 @@ class PatternSearchTest < UnitTestCase
     help_text = PatternSearch::Location.terms_help
     assert(help_text.include?("region"))
     assert(help_text.include?("user"))
+    assert(help_text.include?("editor"))
     assert(help_text.include?("created"))
     assert(help_text.include?("modified"))
     assert(help_text.include?("has_notes"))

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 require("test_helper")
@@ -429,7 +430,6 @@ class PatternSearchTest < UnitTestCase
     # Verify key parameters exist
     assert(params.key?(:region))
     assert(params.key?(:user))
-    assert(params.key?(:editor))
     assert(params.key?(:created))
     assert(params.key?(:modified))
     assert(params.key?(:has_notes))
@@ -482,12 +482,6 @@ class PatternSearchTest < UnitTestCase
     assert_equal(true, search.query.params[:has_descriptions])
   end
 
-  def test_location_pattern_search_with_editor
-    dick = users(:dick)
-    search = PatternSearch::Location.new("editor:dick")
-    assert_equal(dick.id, search.query.params[:by_editor])
-  end
-
   def test_location_pattern_search_with_bounding_box
     search = PatternSearch::Location.new(
       "north:35 south:34 east:-118 west:-119"
@@ -513,28 +507,28 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("south:34 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:north, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":north"))
   end
 
   def test_location_pattern_search_with_missing_south
     search = PatternSearch::Location.new("north:35 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:south, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":south"))
   end
 
   def test_location_pattern_search_with_missing_east
     search = PatternSearch::Location.new("north:35 south:34 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:east, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":east"))
   end
 
   def test_location_pattern_search_with_missing_west
     search = PatternSearch::Location.new("north:35 south:34 east:-118")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::MissingValueError, search.errors.first)
-    assert_equal(:west, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":west"))
   end
 
   def test_location_pattern_search_with_invalid_north
@@ -542,7 +536,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:95 south:34 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:north, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":north"))
   end
 
   def test_location_pattern_search_with_invalid_south
@@ -550,7 +544,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:35 south:-95 east:-118 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:south, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":south"))
   end
 
   def test_location_pattern_search_with_invalid_east
@@ -558,7 +552,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:35 south:34 east:185 west:-119")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:east, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":east"))
   end
 
   def test_location_pattern_search_with_invalid_west
@@ -566,7 +560,7 @@ class PatternSearchTest < UnitTestCase
     search = PatternSearch::Location.new("north:35 south:34 east:-118 west:-185")
     assert_equal(1, search.errors.length)
     assert_instance_of(PatternSearch::BadFloatError, search.errors.first)
-    assert_equal(:west, search.errors.first.var)
+    assert(search.errors.first.to_s.include?(":west"))
   end
 
   def test_location_pattern_search_with_dates

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -485,6 +485,41 @@ class PatternSearchTest < UnitTestCase
     )
   end
 
+  def test_location_pattern_search_with_swapped_north_south
+    # Should auto-correct swapped north/south values
+    search = PatternSearch::Location.new(
+      "north:34 south:35 east:-118 west:-119"
+    )
+    assert_equal(
+      { north: 35.0, south: 34.0, east: -118.0, west: -119.0 },
+      search.query.params[:in_box]
+    )
+  end
+
+  def test_location_pattern_search_with_missing_north
+    assert_raises(PatternSearch::MissingValueError) do
+      PatternSearch::Location.new("south:34 east:-118 west:-119")
+    end
+  end
+
+  def test_location_pattern_search_with_missing_south
+    assert_raises(PatternSearch::MissingValueError) do
+      PatternSearch::Location.new("north:35 east:-118 west:-119")
+    end
+  end
+
+  def test_location_pattern_search_with_missing_east
+    assert_raises(PatternSearch::MissingValueError) do
+      PatternSearch::Location.new("north:35 south:34 west:-119")
+    end
+  end
+
+  def test_location_pattern_search_with_missing_west
+    assert_raises(PatternSearch::MissingValueError) do
+      PatternSearch::Location.new("north:35 south:34 east:-118")
+    end
+  end
+
   def test_location_pattern_search_with_dates
     search = PatternSearch::Location.new("created:2021-01-01")
     assert_equal(%w[2021-01-01 2021-01-01],

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -419,4 +419,95 @@ class PatternSearchTest < UnitTestCase
                    x.lookup_param(:utilisateur))
     end
   end
+
+  # ----- PatternSearch::Location tests -----
+
+  def test_location_pattern_search_params
+    search = PatternSearch::Location.new("")
+    params = search.params
+
+    # Verify key parameters exist
+    assert(params.key?(:region))
+    assert(params.key?(:user))
+    assert(params.key?(:created))
+    assert(params.key?(:modified))
+    assert(params.key?(:has_notes))
+    assert(params.key?(:has_observations))
+    assert(params.key?(:north))
+    assert(params.key?(:south))
+    assert(params.key?(:east))
+    assert(params.key?(:west))
+  end
+
+  def test_location_pattern_search_model
+    search = PatternSearch::Location.new("")
+    assert_equal(::Location, search.model)
+  end
+
+  def test_location_pattern_search_simple
+    search = PatternSearch::Location.new("burbank")
+    assert_equal("burbank", search.query.params[:pattern])
+  end
+
+  def test_location_pattern_search_with_region
+    search = PatternSearch::Location.new('region:"California, USA"')
+    assert_equal(["California, USA"], search.query.params[:region])
+  end
+
+  def test_location_pattern_search_with_user
+    dick = users(:dick)
+    search = PatternSearch::Location.new("user:dick")
+    assert_equal([dick.id], search.query.params[:by_users])
+  end
+
+  def test_location_pattern_search_with_notes
+    search = PatternSearch::Location.new("notes:test")
+    assert_equal("test", search.query.params[:notes_has])
+  end
+
+  def test_location_pattern_search_with_has_notes
+    search = PatternSearch::Location.new("has_notes:yes")
+    assert_equal(true, search.query.params[:has_notes])
+  end
+
+  def test_location_pattern_search_with_has_observations
+    search = PatternSearch::Location.new("has_observations:yes")
+    assert_equal(true, search.query.params[:has_observations])
+  end
+
+  def test_location_pattern_search_with_bounding_box
+    search = PatternSearch::Location.new(
+      "north:35 south:34 east:-118 west:-119"
+    )
+    assert_equal(
+      { north: 35.0, south: 34.0, east: -118.0, west: -119.0 },
+      search.query.params[:in_box]
+    )
+  end
+
+  def test_location_pattern_search_with_dates
+    search = PatternSearch::Location.new("created:2021-01-01")
+    assert_equal(%w[2021-01-01 2021-01-01],
+                 search.query.params[:created_at])
+  end
+
+  def test_location_pattern_search_terms_help
+    help_text = PatternSearch::Location.terms_help
+    assert(help_text.include?("region"))
+    assert(help_text.include?("user"))
+    assert(help_text.include?("created"))
+    assert(help_text.include?("modified"))
+    assert(help_text.include?("has_notes"))
+  end
+
+  def test_location_pattern_search_combined_params
+    dick = users(:dick)
+    search = PatternSearch::Location.new(
+      'park region:"California, USA" user:dick has_notes:yes'
+    )
+    assert_equal("park", search.query.params[:pattern])
+    assert_equal(["California, USA"], search.query.params[:region])
+    assert_equal([dick.id], search.query.params[:by_users])
+    assert_equal(true, search.query.params[:has_notes])
+  end
 end

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -470,7 +470,7 @@ class PatternSearchTest < UnitTestCase
   def test_location_pattern_search_with_editor
     rolf = users(:rolf)
     search = PatternSearch::Location.new("editor:rolf")
-    assert_equal(rolf.id, search.query.params[:by_editor])
+    assert_equal([rolf.id], search.query.params[:by_editor])
   end
 
   def test_location_pattern_search_with_notes

--- a/test/classes/pattern_search_test.rb
+++ b/test/classes/pattern_search_test.rb
@@ -455,6 +455,11 @@ class PatternSearchTest < UnitTestCase
     assert_equal(["California, USA"], search.query.params[:region])
   end
 
+  def test_location_pattern_search_with_region_smart_quotes
+    search = PatternSearch::Location.new("region:“California, USA”")
+    assert_equal(["California, USA"], search.query.params[:region])
+  end
+
   def test_location_pattern_search_with_user
     dick = users(:dick)
     search = PatternSearch::Location.new("user:dick")

--- a/test/controllers/locations/search_controller_test.rb
+++ b/test/controllers/locations/search_controller_test.rb
@@ -40,7 +40,7 @@ module Locations
         has_notes: true,
         notes_has: "Symbiota",
         regexp: "Target",
-        by_editor: users(:rolf).id,
+        by_editor: [users(:rolf).id],
         has_observations: true
       )
       assert(query.id)
@@ -50,7 +50,8 @@ module Locations
       assert_select("select#query_locations_has_notes", selected: "yes")
       assert_select("input#query_locations_notes_has", value: "Symbiota")
       assert_select("input#query_locations_regexp", value: "Target")
-      assert_select("input#query_locations_by_editor", value: "Rolf Singer")
+      assert_select("textarea#query_locations_by_editor",
+                    text: "Rolf Singer (rolf)")
       assert_select("select#query_locations_has_observations",
                     selected: "yes")
       assert_equal(session[:search_type], :locations)

--- a/test/controllers/locations/search_controller_test.rb
+++ b/test/controllers/locations/search_controller_test.rb
@@ -7,6 +7,18 @@ require("test_helper")
 # ------------------------------------------------------------
 module Locations
   class SearchControllerTest < FunctionalTestCase
+    def test_show_help
+      login
+      get(:show)
+      assert_template("locations/search/_help")
+    end
+
+    def test_show_help_turbo
+      login
+      get(:show, format: :turbo_stream)
+      assert_template("locations/search/_help")
+    end
+
     def test_new_locations_search
       login
       get(:new)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -291,8 +291,8 @@ class SearchControllerTest < FunctionalTestCase
            "Location pattern search should extract user: keyword into by_users parameter")
     assert_equal([user.id.to_s], query_params["q[by_users][]"],
                  "by_users parameter should contain the user ID")
-    assert(query_params["q[pattern]"].blank?,
-           "Location pattern search should not include raw pattern with keywords")
+    assert_predicate(query_params["q[pattern]"], :blank?,
+                     "Location pattern search should not include raw pattern with keywords")
 
     # Test with editor: keyword as well
     params = { pattern_search: { pattern: "editor:#{user.login}",
@@ -307,7 +307,7 @@ class SearchControllerTest < FunctionalTestCase
            "Location pattern search should extract editor: keyword into by_editor parameter")
     assert_equal([user.id.to_s], query_params["q[by_editor]"],
                  "by_editor parameter should contain the user ID")
-    assert(query_params["q[pattern]"].blank?,
-           "Location pattern search should not include raw pattern with keywords")
+    assert_predicate(query_params["q[pattern]"], :blank?,
+                     "Location pattern search should not include raw pattern with keywords")
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -305,10 +305,10 @@ class SearchControllerTest < FunctionalTestCase
     redirect_url = URI.parse(redirect_to_url)
     query_params = CGI.parse(redirect_url.query)
 
-    assert(query_params.key?("q[by_editor]"),
+    assert(query_params.key?("q[by_editor][]"),
            "Location pattern search should extract editor: keyword into " \
            "by_editor parameter")
-    assert_equal([user.id.to_s], query_params["q[by_editor]"],
+    assert_equal([user.id.to_s], query_params["q[by_editor][]"],
                  "by_editor parameter should contain the user ID")
     assert_predicate(query_params["q[pattern]"], :blank?,
                      "Location pattern search should not include raw " \

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -280,11 +280,11 @@ class SearchControllerTest < FunctionalTestCase
 
     # Should redirect to locations index with proper query params
     assert_redirected_to(/locations/)
-    
+
     # Parse the redirect URL to extract query parameters
     redirect_url = URI.parse(redirect_to_url)
     query_params = CGI.parse(redirect_url.query)
-    
+
     # Verify that by_users parameter is present (indicating PatternSearch worked)
     # and pattern parameter is NOT present (would indicate raw pattern was used)
     assert(query_params.key?("q[by_users][]"),
@@ -293,16 +293,16 @@ class SearchControllerTest < FunctionalTestCase
                  "by_users parameter should contain the user ID")
     assert_nil(query_params["q[pattern]"],
                "Location pattern search should not include raw pattern with keywords")
-    
+
     # Test with editor: keyword as well
     params = { pattern_search: { pattern: "editor:#{user.login}",
                                  type: :locations } }
     get(:pattern, params:)
-    
+
     assert_redirected_to(/locations/)
     redirect_url = URI.parse(redirect_to_url)
     query_params = CGI.parse(redirect_url.query)
-    
+
     assert(query_params.key?("q[by_editor]"),
            "Location pattern search should extract editor: keyword into by_editor parameter")
     assert_equal([user.id.to_s], query_params["q[by_editor]"],

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -285,14 +285,16 @@ class SearchControllerTest < FunctionalTestCase
     redirect_url = URI.parse(redirect_to_url)
     query_params = CGI.parse(redirect_url.query)
 
-    # Verify that by_users parameter is present (indicating PatternSearch worked)
-    # and pattern parameter is NOT present (would indicate raw pattern was used)
+    # Verify that by_users parameter is present (PatternSearch worked)
+    # and pattern parameter is NOT present (raw pattern was used)
     assert(query_params.key?("q[by_users][]"),
-           "Location pattern search should extract user: keyword into by_users parameter")
+           "Location pattern search should extract user: keyword into " \
+           "by_users parameter")
     assert_equal([user.id.to_s], query_params["q[by_users][]"],
                  "by_users parameter should contain the user ID")
     assert_predicate(query_params["q[pattern]"], :blank?,
-                     "Location pattern search should not include raw pattern with keywords")
+                     "Location pattern search should not include raw " \
+                     "pattern with keywords")
 
     # Test with editor: keyword as well
     params = { pattern_search: { pattern: "editor:#{user.login}",
@@ -304,10 +306,12 @@ class SearchControllerTest < FunctionalTestCase
     query_params = CGI.parse(redirect_url.query)
 
     assert(query_params.key?("q[by_editor]"),
-           "Location pattern search should extract editor: keyword into by_editor parameter")
+           "Location pattern search should extract editor: keyword into " \
+           "by_editor parameter")
     assert_equal([user.id.to_s], query_params["q[by_editor]"],
                  "by_editor parameter should contain the user ID")
     assert_predicate(query_params["q[pattern]"], :blank?,
-                     "Location pattern search should not include raw pattern with keywords")
+                     "Location pattern search should not include raw " \
+                     "pattern with keywords")
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -291,8 +291,8 @@ class SearchControllerTest < FunctionalTestCase
            "Location pattern search should extract user: keyword into by_users parameter")
     assert_equal([user.id.to_s], query_params["q[by_users][]"],
                  "by_users parameter should contain the user ID")
-    assert_nil(query_params["q[pattern]"],
-               "Location pattern search should not include raw pattern with keywords")
+    assert(query_params["q[pattern]"].blank?,
+           "Location pattern search should not include raw pattern with keywords")
 
     # Test with editor: keyword as well
     params = { pattern_search: { pattern: "editor:#{user.login}",
@@ -307,7 +307,7 @@ class SearchControllerTest < FunctionalTestCase
            "Location pattern search should extract editor: keyword into by_editor parameter")
     assert_equal([user.id.to_s], query_params["q[by_editor]"],
                  "by_editor parameter should contain the user ID")
-    assert_nil(query_params["q[pattern]"],
-               "Location pattern search should not include raw pattern with keywords")
+    assert(query_params["q[pattern]"].blank?,
+           "Location pattern search should not include raw pattern with keywords")
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -266,4 +266,48 @@ class SearchControllerTest < FunctionalTestCase
     get(:pattern, params:)
     assert_redirected_to(user_path(user.id))
   end
+
+  def test_location_pattern_search_with_keywords
+    login
+    user = users(:rolf)
+
+    # Test that location pattern search with user: keyword uses PatternSearch
+    # and extracts the keyword into query parameters instead of treating it
+    # as a location name pattern
+    params = { pattern_search: { pattern: "user:#{user.login}",
+                                 type: :locations } }
+    get(:pattern, params:)
+
+    # Should redirect to locations index with proper query params
+    assert_redirected_to(/locations/)
+    
+    # Parse the redirect URL to extract query parameters
+    redirect_url = URI.parse(redirect_to_url)
+    query_params = CGI.parse(redirect_url.query)
+    
+    # Verify that by_users parameter is present (indicating PatternSearch worked)
+    # and pattern parameter is NOT present (would indicate raw pattern was used)
+    assert(query_params.key?("q[by_users][]"),
+           "Location pattern search should extract user: keyword into by_users parameter")
+    assert_equal([user.id.to_s], query_params["q[by_users][]"],
+                 "by_users parameter should contain the user ID")
+    assert_nil(query_params["q[pattern]"],
+               "Location pattern search should not include raw pattern with keywords")
+    
+    # Test with editor: keyword as well
+    params = { pattern_search: { pattern: "editor:#{user.login}",
+                                 type: :locations } }
+    get(:pattern, params:)
+    
+    assert_redirected_to(/locations/)
+    redirect_url = URI.parse(redirect_to_url)
+    query_params = CGI.parse(redirect_url.query)
+    
+    assert(query_params.key?("q[by_editor]"),
+           "Location pattern search should extract editor: keyword into by_editor parameter")
+    assert_equal([user.id.to_s], query_params["q[by_editor]"],
+                 "by_editor parameter should contain the user ID")
+    assert_nil(query_params["q[pattern]"],
+               "Location pattern search should not include raw pattern with keywords")
+  end
 end

--- a/test/integration/capybara/search_integration_test.rb
+++ b/test/integration/capybara/search_integration_test.rb
@@ -252,6 +252,25 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
     end
   end
 
+  # Test that locations pattern search help is displayed
+  def test_locations_pattern_search_help
+    login
+    visit("/locations/search")
+
+    # Verify the help partial is rendered
+    assert_selector("p", text: "Locations Searches")
+    # Verify that pattern search help intro is shown
+    assert_text("Your search string may contain terms")
+    assert_text("Recognized variables include:")
+    # Verify that pattern search terms are shown
+    assert_text("region")
+    assert_text("user")
+    assert_text("created")
+    assert_text("modified")
+    assert_text("has_notes")
+    assert_text("has_observations")
+  end
+
   # TODO: Test that selecting an MO location from region autocompleter
   # fills box inputs. Needs manual verification first.
   # def test_region_autocompleter_fills_box_inputs; end


### PR DESCRIPTION
Reordered search form panels to prioritize pattern search over region search for better usability. Updated region field help text to better explain hierarchical location name matching. Fixed bug preventing Location pattern search help from displaying by adding PatternSearch::Location class, help partials, and show route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Addresses issue #3576 