### PR TITLE
Fix Observation with unknown user in Observation index

### DIFF
--- a/app/components/lightbox_caption.rb
+++ b/app/components/lightbox_caption.rb
@@ -154,7 +154,7 @@ class Components::LightboxCaption < Components::Base
 
   def render_obs_user(obs_user)
     if @user
-      user_link(@obs.user)
+      user_link(obs_user)
     else
       plain(obs_user.unique_text_name)
     end

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -190,7 +190,7 @@ module ObjectLinkHelper
   #
   def user_link(user, name = nil, args = {})
     if !user
-      return :unknown_user_name.t.html_safe # rubocop:disable Rails/OutputSafety
+      return :unknown_user_name.t
     elsif user.is_a?(Integer)
       name ||= "#{:USER.t} ##{user}"
       user_id = user

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -190,7 +190,7 @@ module ObjectLinkHelper
   #
   def user_link(user, name = nil, args = {})
     if !user
-      return "?"
+      return "?".html_safe
     elsif user.is_a?(Integer)
       name ||= "#{:USER.t} ##{user}"
       user_id = user

--- a/app/helpers/object_link_helper.rb
+++ b/app/helpers/object_link_helper.rb
@@ -190,7 +190,7 @@ module ObjectLinkHelper
   #
   def user_link(user, name = nil, args = {})
     if !user
-      return "?".html_safe
+      return :unknown_user_name.t.html_safe # rubocop:disable Rails/OutputSafety
     elsif user.is_a?(Integer)
       name ||= "#{:USER.t} ##{user}"
       user_id = user

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1564,6 +1564,9 @@
   create_naming_title: "Propose Name for Observation #[id]"
   create_new_naming_warn: Sorry, someone else has given this a positive vote, so we had to create a new Naming to accomodate your changes."
 
+  # observations/show
+  unknown_user_name: "?"
+
   # observations/identify
   obs_needing_id: Needing Identification
   obs_needing_id_intro: "Here you can quickly scan unidentified observations, propose a name, or vote on a current name. Use the search bar above to filter by location, taxon or user.\n\nIf you feel you can't improve on an identification, \"[:mark_as_reviewed]\" and it won't come up again. (It will still appear for others.)\n\n*\"Lightbox\" shortcuts:*\n&lsqb;&larr;&rsqb; &lsqb;&rarr;&rsqb; move between observations, &lsqb;return&rsqb; propose a name, &lsqb;/&rsqb; mark as reviewed."

--- a/test/controllers/application_controller_internationalization_test.rb
+++ b/test/controllers/application_controller_internationalization_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ApplicationControllerInternationalizationTest < FunctionalTestCase
+  # Use TestController for these tests because we need a concrete controller
+  # and ApplicationController is abstract and has no routes/actions to call
+  tests TestController
+
+  # Test that session_locale is used when no params or prefs locale exists
+  def test_session_locale_used_when_no_params_or_prefs
+    # Make a request without user_locale param and without logged-in user
+    # but with session locale set
+    get(:index, session: { locale: "pt" })
+
+    # The session locale should have been used (lines 68-69 should execute)
+    assert_equal("pt", I18n.locale.to_s)
+  end
+
+  # Test that session_locale is used when user has no locale preference
+  def test_session_locale_used_with_user_without_locale_pref
+    user = users(:rolf)
+    user.update(locale: nil)
+
+    login(user.login)
+
+    # Request without user_locale param, user has no locale pref
+    get(:index, session: { locale: "fr" })
+
+    # The session locale should have been used
+    assert_equal("fr", I18n.locale.to_s)
+  end
+
+  # Test that session_locale is used for ajax requests (prefs_locale skips ajax)
+  def test_session_locale_used_for_ajax_request
+    user = users(:rolf)
+    user.update(locale: "pt")
+    login(user.login)
+
+    # Ajax request should skip prefs_locale and use session_locale
+    get(:index, params: { controller: "ajax" }, session: { locale: "fr" })
+
+    # The session locale should have been used instead of user's preference
+    assert_equal("fr", I18n.locale.to_s)
+  end
+end

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -45,8 +45,7 @@ class ObjectLinkHelperTest < ActionView::TestCase
 
   def test_user_link_with_nil
     result = user_link(nil)
-    assert_equal("?", result)
-    assert(result.html_safe?, "user_link(nil) should return html_safe string")
+    assert_equal(:unknown_user_name.l, result)
   end
 
   def test_user_link_with_user

--- a/test/helpers/object_link_helper_test.rb
+++ b/test/helpers/object_link_helper_test.rb
@@ -43,6 +43,21 @@ class ObjectLinkHelperTest < ActionView::TestCase
                "Non-existent object should lack link.")
   end
 
+  def test_user_link_with_nil
+    result = user_link(nil)
+    assert_equal("?", result)
+    assert(result.html_safe?, "user_link(nil) should return html_safe string")
+  end
+
+  def test_user_link_with_user
+    user = users(:rolf)
+    result = user_link(user)
+    path = user_path(user.id)
+    html_class = "user_link_#{user.id}"
+    link_text = user.unique_text_name
+    assert_equal(expected_link(path, html_class, link_text), result)
+  end
+
   # - Helper Methods -----------------------------------------------------------
 
   def expected_link(path, html_class, link_text)


### PR DESCRIPTION
When an observation's user is nil, the lightbox caption would fail with "Phlex::ArgumentError: You passed an unsafe object to raw".

Changes:
- Fix user_link helper to return html_safe string when user is nil
- Fix render_obs_user to consistently use obs_user parameter
- Add tests for user_link with nil and valid user

The bug occurred because user_link(nil) returned plain "?" string instead of an html_safe string, which Phlex requires for safe rendering.

# Manual Test

-  Run any Observation search whose first page of results includes >= 1 Obsevation whose user is nil
Examples:
  - Observation pattern search for Geastrum velutinum
== http://localhost:3000/observations?q%5Bmodel%5D=Observation&q%5Bnames%5D%5Binclude_subtaxa%5D=true&q%5Bnames%5D%5Binclude_synonyms%5D=true&q%5Bnames%5D%5Blookup%5D%5B%5D=Geastrum+velutinum
  - This search which returns just two Observations, both of them bad
http://localhost:3000/observations?q%5Bdate%5D%5B%5D=2016-03-18&q%5Bdate%5D%5B%5D=2016-03-18&q%5Bmodel%5D=Observation&q%5Bnames%5D%5Bexclude_consensus%5D=false&q%5Bnames%5D%5Binclude_all_name_proposals%5D=false&q%5Bnames%5D%5Binclude_subtaxa%5D=true&q%5Bnames%5D%5Binclude_synonyms%5D=false&q%5Bnames%5D%5Blookup%5D%5B%5D=Agaricus&q%5Bwithin_locations%5D%5B%5D=13403&q%5Bwithin_locations%5D%5B%5D=13402
- Expected result: The index displays without error.

