### PR TITLE
Fix system tests to work with parallel testing

### DIFF
--- a/test/system/list_form_system_test.rb
+++ b/test/system/list_form_system_test.rb
@@ -12,13 +12,13 @@ class ListFormSystemTest < ApplicationSystemTestCase
     visit("/species_lists/#{species_list.id}/write_in/new")
     assert_selector("body.write_in__new")
     assert_field("list_members")
-    assert_field("list_name_id", type: :hidden)
+    assert_field("list_members_id", type: :hidden)
 
     name1 = names("coprinus_comatus")
     name2 = names("agaricus_campestris")
     name3 = names("stereum_hirsutum")
     fill_in("list_members", with: "Agaricus campestris")
-    assert_field("list_name_id", with: name2.id, type: :hidden)
+    assert_field("list_members_id", with: name2.id, type: :hidden)
     @browser.keyboard.type(:return)
     assert_field("list_members", with: /Agaricus campestris/)
     @browser.keyboard.type("Coprinus com")
@@ -26,7 +26,8 @@ class ListFormSystemTest < ApplicationSystemTestCase
     assert_selector(".auto_complete ul li a", text: "Coprinus comatus")
     @browser.keyboard.type(:down, :tab)
     assert_field("list_members", with: /Coprinus comatus/)
-    assert_field("list_name_id", with: "#{name2.id},#{name1.id}", type: :hidden)
+    assert_field("list_members_id", with: "#{name2.id},#{name1.id}",
+                                    type: :hidden)
     @browser.keyboard.type(:return)
     sleep(1)
     @browser.keyboard.type(:return)
@@ -35,8 +36,8 @@ class ListFormSystemTest < ApplicationSystemTestCase
     assert_selector(".auto_complete ul li a", text: "Stereum hirsutum")
     @browser.keyboard.type(:down, :tab)
     assert_field("list_members", with: /Stereum hirsutum/)
-    assert_field("list_name_id", with: "#{name2.id},#{name1.id},#{name3.id}",
-                                 type: :hidden)
+    assert_field("list_members_id", with: "#{name2.id},#{name1.id},#{name3.id}",
+                                    type: :hidden)
   end
 
   def test_multi_autocompleter_paste
@@ -48,7 +49,7 @@ class ListFormSystemTest < ApplicationSystemTestCase
     visit("/species_lists/#{species_list.id}/write_in/new")
     assert_selector("body.write_in__new")
     assert_field("list_members")
-    assert_field("list_name_id", type: :hidden)
+    assert_field("list_members_id", type: :hidden)
 
     name1 = names("coprinus_comatus")
     name2 = names("agaricus_campestris")
@@ -59,7 +60,7 @@ class ListFormSystemTest < ApplicationSystemTestCase
     )
     assert_field("list_members", with: /Agaricus campestris/)
     sleep(1)
-    assert_field("list_name_id", with: "#{name2.id},#{name1.id},#{name3.id}",
-                                 type: :hidden)
+    assert_field("list_members_id", with: "#{name2.id},#{name1.id},#{name3.id}",
+                                    type: :hidden)
   end
 end

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -80,7 +80,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # check new observation form defaults
     assert_date_is_now
     assert_geolocation_is_empty
-    last_obs = Observation.where(user_id: User.current.id).
+    last_obs = Observation.where(user_id: katrina.id).
                order(:created_at).last
     # This is currently "Falmouth, Massachusetts, USA"
     existing_loc = Location.find(last_obs.location_id)
@@ -136,7 +136,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # check new observation form defaults
     assert_date_is_now
     assert_geolocation_is_empty
-    last_obs = Observation.recent_by_user(User.current).last
+    last_obs = Observation.recent_by_user(katrina).last
     assert_selector("#observation_place_name", wait: 6)
     assert_selector("#observation_location_id", visible: :all)
     sleep(0.5)
@@ -169,7 +169,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # PART 2: Create matching location and test again
     # ---------------------------------------------------------
     # Make "University Park" available as a matching location.
-    university_park = Location.new(**UNIVERSITY_PARK)
+    university_park = Location.new(**UNIVERSITY_PARK, user: katrina)
     # Sanity check the lat/lng. `contains?(lat, lng)` is a Mappable::BoxMethod
     assert(university_park.contains?(GEOTAGGED_EXIF[:lat],
                                      GEOTAGGED_EXIF[:lng]))
@@ -183,7 +183,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # check new observation form defaults
     assert_date_is_now
     assert_geolocation_is_empty
-    last_obs = Observation.recent_by_user(User.current).last
+    last_obs = Observation.recent_by_user(katrina).last
     # This is currently "Falmouth, Massachusetts, USA"
     assert_field("observation_place_name", with: last_obs.where)
     assert_field("observation_location_id", with: last_obs.location_id,
@@ -318,7 +318,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_date_is_now
     assert_geolocation_is_empty
 
-    last_obs = Observation.recent_by_user(User.current).last
+    last_obs = Observation.recent_by_user(katrina).last
     assert_field("observation_place_name", with: last_obs.where)
 
     # Move to the next step, Identification


### PR DESCRIPTION
Also, fix all remaining broken system tests.

  1. `login!` - Check page content (`#user_nav_toggle`) instead of thread-local `User.current_id`
  2. `put_user_in_admin_mode` - Same fix for admin mode verification
  3. `list_form_system_test.rb` - Corrected hidden field ID
  4. `observation_form_system_test.rb` - Use local user variable instead of `User.current`