### PR TITLE
Fix NOT IN NULL bug in not_reviewed_by_user scope

### DIFF
--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -143,11 +143,9 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :not_reviewed_by_user, lambda { |user|
       user_id = user.is_a?(Integer) ? user : user&.id
       where.not(
-        id: ObservationView.where(
-          ObservationView.arel_table[:observation_id].eq(
-            Observation.arel_table[:id]
-          )
-        ).where(user_id: user_id, reviewed: 1).select(:observation_id)
+        id: ObservationView.where(user_id: user_id, reviewed: 1)
+          .where.not(observation_id: nil)
+          .select(:observation_id)
       )
     }
     # Higher taxa: returns narrowed-down group of id'd obs,

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -142,8 +142,13 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     scope :not_reviewed_by_user, lambda { |user|
       user_id = user.is_a?(Integer) ? user : user&.id
-      where.not(id: ObservationView.where(user_id: user_id, reviewed: 1).
-                    select(:observation_id))
+      where.not(
+        id: ObservationView.where(
+          ObservationView.arel_table[:observation_id].eq(
+            Observation.arel_table[:id]
+          )
+        ).where(user_id: user_id, reviewed: 1).select(:observation_id)
+      )
     }
     # Higher taxa: returns narrowed-down group of id'd obs,
     # in higher taxa under the given taxon

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -143,9 +143,9 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :not_reviewed_by_user, lambda { |user|
       user_id = user.is_a?(Integer) ? user : user&.id
       where.not(
-        id: ObservationView.where(user_id: user_id, reviewed: 1)
-          .where.not(observation_id: nil)
-          .select(:observation_id)
+        id: ObservationView.where(user_id: user_id, reviewed: 1).
+          where.not(observation_id: nil).
+          select(:observation_id)
       )
     }
     # Higher taxa: returns narrowed-down group of id'd obs,

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1239,7 +1239,7 @@ class ObservationTest < UnitTestCase
   # Regression test for NOT IN NULL bug
   # When observation_views contains a NULL observation_id, the NOT IN clause
   # in not_reviewed_by_user returns no results due to NULL semantics
-  def test_scope_needs_naming_with_null_observation_view
+  def test_scope_not_reviewed_by_user_with_null_observation_id
     # Create a NULL observation_id record in observation_views for rolf
     # This simulates data corruption or a bug that allowed NULL to be inserted
     ObservationView.create!(

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1236,6 +1236,30 @@ class ObservationTest < UnitTestCase
     )
   end
 
+  # Regression test for NOT IN NULL bug
+  # When observation_views contains a NULL observation_id, the NOT IN clause
+  # in not_reviewed_by_user returns no results due to NULL semantics
+  def test_scope_needs_naming_with_null_observation_view
+    # Create a NULL observation_id record in observation_views for rolf
+    # This simulates data corruption or a bug that allowed NULL to be inserted
+    ObservationView.create!(
+      observation_id: nil,
+      user_id: rolf.id,
+      reviewed: true,
+      last_view: Time.zone.now
+    )
+
+    # fungi_obs needs naming and rolf hasn't reviewed it
+    # This should still be included even with the NULL record
+    result = Observation.needs_naming(rolf)
+    assert_includes(
+      result,
+      observations(:fungi_obs),
+      "needs_naming scope should return observations even when " \
+      "observation_views contains NULL observation_id for the user"
+    )
+  end
+
   def test_scope_names
     assert_includes(Observation.names(lookup: names(:peltigera).id),
                     observations(:peltigera_obs))


### PR DESCRIPTION
## Summary

Fixes a SQL bug where the `not_reviewed_by_user` scope would return no results when the `observation_views` table contained NULL `observation_id` values. This occurred because SQL's NOT IN clause returns NULL (which is falsy) when the subquery contains any NULL values.

**Changes:**
- Added explicit NULL filtering to the subquery using `.where.not(observation_id: nil)`
- This generates `WHERE observation_id IS NOT NULL` in the SQL, preventing NULL values from entering the NOT IN subquery
- Added regression test to verify the fix handles NULL observation_ids correctly

**Root cause:**
When using `NOT IN` with a subquery that returns NULL values, SQL's three-valued logic causes the entire WHERE clause to evaluate as NULL/unknown for all rows, resulting in no results being returned.

**Why this approach:**
The fix directly addresses the root cause by filtering out NULL values before they enter the NOT IN subquery. This is simpler and more explicit than using correlated subqueries or NOT EXISTS patterns.

## Manual Test Plan

- [ ] Run the test suite to verify all tests pass: `bin/rails test`
- [ ] Specifically run the new regression test: `bin/rails test test/models/observation_test.rb -n test_scope_needs_naming_with_null_observation_view`
- [ ] Verify the test fails without the fix (revert changes, run test, should fail)
- [ ] Verify the test passes with the fix (apply changes, run test, should pass)
- [ ] Test the `needs_naming` scope in Rails console with a user who has reviewed observations
- [ ] Optionally: Check database for any existing NULL observation_ids: `rails runner "puts ObservationView.where(observation_id: nil).count"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)