### PR TITLE
Add Claude Code testing documentation

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,59 @@
+---
+paths: test/**/*.rb
+---
+
+# Rails Testing Conventions
+
+## Test Execution Syntax
+
+**IMPORTANT: Rails uses MiniTest, not RSpec syntax**
+
+### Correct Syntax
+```bash
+# Run all tests
+bin/rails test
+
+# Run specific test file
+bin/rails test test/models/observation_test.rb
+
+# Run specific test by name (use -n flag, NOT ::ClassName#method)
+bin/rails test test/models/observation_test.rb -n test_scope_needs_naming
+
+# Run with verbose output
+bin/rails test test/models/observation_test.rb -v
+
+# Run controller tests
+bin/rails test:controllers
+
+# Run with coverage
+bin/rails test:coverage
+bundle exec rails test:coverage
+rake test:coverage
+```
+
+### Incorrect Syntax (DO NOT USE)
+```bash
+# ❌ WRONG - This is RSpec syntax, not Rails
+bin/rails test test/models/observation_test.rb::ObservationTest#test_name -v
+
+# ❌ This will cause LoadError: cannot load such file
+```
+
+## Test Structure
+- Framework: MiniTest (not RSpec)
+- Test files: `test/**/*_test.rb`
+- Fixtures: `test/fixtures/`
+- System tests: Capybara-based
+
+## Common Assertions
+- `assert(condition)`
+- `assert_equal(expected, actual)`
+- `assert_includes(collection, item)`
+- `assert_nil(value)`
+- `assert_response(:success)`
+
+## Running Specific Test Suites
+- All tests: `bin/rails test`
+- Controllers: `bin/rails test:controllers`
+- Models: `bin/rails test test/models/`
+- Coverage: `bin/rails test:coverage`

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,10 @@ coverage
 # Ignore VS Code config
 .vscode
 
-# Ignore Claude code config
-.claude/
+# Ignore Claude code local config (but allow shared docs)
+.claude/settings.local.json
+.claude/output-styles/
+CLAUDE.local.md
 
 # Ignore sensitive config stuff.
 /config/master.key


### PR DESCRIPTION
## Summary

Adds shared testing conventions documentation for Claude Code to help AI assistants use correct Rails test syntax across all sessions.

**Changes:**
- Created `.claude/rules/testing.md` with Rails MiniTest syntax guide
- Documents correct test execution patterns (use `-n` flag, not `::Class#method`)
- Includes common test commands and assertion reference
- Updated `.gitignore` to allow shared Claude docs while keeping local settings private

**Problem this solves:**
Claude Code was occasionally using RSpec-style test selectors (`test_file.rb::ClassName#method_name`) which fail with Rails MiniTest. This documentation ensures future sessions use the correct syntax (`-n test_name`).

**Example errors prevented:**
```bash
# ❌ WRONG (RSpec syntax)
bin/rails test test/models/observation_test.rb::ObservationTest#test_name
# LoadError: cannot load such file

# ✅ CORRECT (Rails MiniTest syntax)
bin/rails test test/models/observation_test.rb -n test_name
```

**Team benefit:**
The `.claude/rules/` directory is now tracked in git, so all team members using Claude Code will have consistent testing knowledge. Local settings (`.claude/settings.local.json`) remain private via `.gitignore`.

## Manual Test Plan

- [ ] Verify `.claude/rules/testing.md` is readable and accurate
- [ ] Confirm `.gitignore` still ignores local Claude settings
- [ ] Test that `git status` doesn't show `.claude/settings.local.json` as tracked
- [ ] Verify the testing syntax examples match current Rails conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)