### PR TITLE
Replace deprecated .length with .char_length in Arel queries

### DIFF
--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -36,7 +36,7 @@ module Location::Scopes
     scope :shortest_names_with, lambda { |pattern|
       return none if pattern.blank?
 
-      name_has(pattern).order(Location[:name].length)
+      name_has(pattern).order(Location[:name].char_length)
     }
 
     scope :has_notes,

--- a/app/models/name/propagate_generic_classifications.rb
+++ b/app/models/name/propagate_generic_classifications.rb
@@ -58,7 +58,7 @@ module Name::PropagateGenericClassifications
     def accepted_generic_classification_strings
       geni = Name.not_deprecated.rank("Genus").
              where(Name[:author].does_not_match("sensu lato%")).
-             where(Name[:classification].length > 2).
+             where(Name[:classification].char_length > 2).
              pluck(:text_name, :classification)
       geni.each_with_object({}) do |vals, classifications|
         text_name, classification = vals

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -157,7 +157,7 @@ module Name::Spelling
 
       # Create SQL query out of these patterns.
       Name.with_correct_spelling.
-        where(Name[:text_name].length.between(min_len..max_len)).
+        where(Name[:text_name].char_length.between(min_len..max_len)).
         where(Name[:text_name].matches_any(patterns)).limit(10).to_a
     end
 


### PR DESCRIPTION
# Replace deprecated Arel .length with .char_length

## Summary
- Replace deprecated Arel `.length` with `.char_length` in database queries
- Fixes deprecation warnings appearing during test runs

## Background
The MySQL database adapter for Rails is deprecating the Arel `.length` method with the following warning:

> `length` is now deprecated. Use `byte_size` or `char_length` instead. `length` relies on the vendor's `LEN/LENGTH` implementation and it's not portable

This deprecation ensures developers explicitly choose between:
- `.char_length` for character count (what most text operations need)
- `.byte_size` for byte count (for binary data or size limits)

Different databases handle `LENGTH()` SQL functions differently, making the generic `.length` method ambiguous and not portable across database backends.

## Changes
- **app/models/name/spelling.rb:160**: Use `char_length` for text_name field length filtering
- **app/models/location/scopes.rb:39**: Use `char_length` for name field length ordering
- **app/models/name/propagate_generic_classifications.rb:61**: Use `char_length` for classification field length filtering

All replacements use `char_length` (character count) as this is the appropriate measure for text field comparisons in these SQL query contexts.

## Test Plan
- [x] Verified deprecation warnings no longer appear during test runs
- [x] Ran test suite to confirm existing tests pass without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
