### PR TITLE
Fix TypeError when params[:q] is a String in set_project_ivar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -322,8 +322,9 @@ class ApplicationController < ActionController::Base
   # NOTE: SpeciesList show pages cannot nav prev/next within a project without
   # having the project param stored inside the query record, q.
   def set_project_ivar
+    query = query_from_q_param # includes fallback for old q
     # NOTE: Query param projects is always an array of ids.
-    query_projects = extract_query_projects
+    query_projects = query&.params&.dig(:projects) || []
     # If more than one project, it's none.
     # Only want single-project associations
     query_project = query_projects.size > 1 ? nil : query_projects.first
@@ -331,12 +332,6 @@ class ApplicationController < ActionController::Base
     # At this point, we still might not have one. That's fine - just return nil.
     @project = Project.safe_find(project_id)
   end
-
-  def extract_query_projects
-    query = query_from_q_param # includes fallback for old q
-    query&.params&.dig(:projects) || []
-  end
-  private :extract_query_projects
 
   def render_xml(args)
     request.format = "xml"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -333,13 +333,8 @@ class ApplicationController < ActionController::Base
   end
 
   def extract_query_projects
-    if params[:q].is_a?(String)
-      # Load the saved query to get its project associations
-      query = Query.safe_find(params[:q])
-      query&.params&.dig(:projects) || []
-    else
-      params.dig(:q, :projects) || []
-    end
+    query = query_from_q_param # includes fallback for old q
+    query&.params&.dig(:projects) || []
   end
   private :extract_query_projects
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -323,13 +323,25 @@ class ApplicationController < ActionController::Base
   # having the project param stored inside the query record, q.
   def set_project_ivar
     # NOTE: Query param projects is always an array of ids.
-    query_projects = params.dig(:q, :projects) || []
-    # If more than one project, it's none. Only want single-project associations
+    query_projects = extract_query_projects
+    # If more than one project, it's none.
+    # Only want single-project associations
     query_project = query_projects.size > 1 ? nil : query_projects.first
     project_id = params[:project] || query_project
     # At this point, we still might not have one. That's fine - just return nil.
     @project = Project.safe_find(project_id)
   end
+
+  def extract_query_projects
+    if params[:q].is_a?(String)
+      # Load the saved query to get its project associations
+      query = Query.safe_find(params[:q])
+      query&.params&.dig(:projects) || []
+    else
+      params.dig(:q, :projects) || []
+    end
+  end
+  private :extract_query_projects
 
   def render_xml(args)
     request.format = "xml"

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -265,6 +265,28 @@ class SpeciesListsControllerTest < FunctionalTestCase
                   "H1 title element should exist and contain content")
   end
 
+  # Regression test for bug where params[:q] as a String (saved query ID)
+  # caused TypeError: String does not have #dig method in set_project_ivar
+  def test_show_species_list_with_saved_query_string
+    login
+    spl = species_lists(:reused_list)
+    project = spl.projects[0]
+
+    # Create a saved query with project associations
+    query = Query.lookup(:SpeciesList, projects: [project.id])
+    query.save
+    query_id = query.record.id.to_s
+
+    # This should not raise TypeError when params[:q] is a String
+    assert_nothing_raised do
+      get(:show, params: { id: spl.id, q: query_id })
+    end
+
+    assert_response(:success)
+    assert_select("h1#title", /#{spl.title}/,
+                  "H1 title element should exist and contain content")
+  end
+
   def test_show_species_lists_attached_to_projects
     login
     proj1 = projects(:eol_project)

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -274,8 +274,8 @@ class SpeciesListsControllerTest < FunctionalTestCase
 
     # Create a saved query with project associations
     query = Query.lookup(:SpeciesList, projects: [project.id])
-    query.save
-    query_id = query.record.id.to_s
+    assert(query.save)
+    query_id = query.record.id.alphabetize
 
     # This should not raise TypeError when params[:q] is a String
     assert_nothing_raised do


### PR DESCRIPTION
Previously, when params[:q] was a saved query ID (String) instead of a Hash of query parameters, calling params.dig(:q, :projects) raised: "TypeError: String does not have #dig method"

This occurred when navigating species lists with a saved query parameter, such as /species_lists/1417?q=1mvpX

Changes:
- Extract query project logic into private extract_query_projects method
- Handle both String (saved query ID) and Hash (inline params) cases
- When params[:q] is a String, load the Query record and extract projects from its stored parameters
- Add regression test to prevent future occurrences
- Refactor to resolve RuboCop complexity metrics violations

The fix properly retrieves project associations from saved queries, allowing species list navigation within project contexts to work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)