### PR TITLE
Fix autocompleter JS - should clear matching id when string changes

### DIFF
--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -426,6 +426,13 @@ export default class BaseAutocompleterController extends Controller {
       this.cssUncollapseFields();
       if (new_value != old_value) {
         this.old_value = new_value;
+        // Clear hidden ID if value changed from what was selected.
+        // Compare trimmed values since selection may add trailing space.
+        const selectedName = this.hiddenTarget.dataset.name;
+        if (selectedName &&
+            new_value.trim() !== selectedName.trim()) {
+          this.clearHiddenId();
+        }
         if (do_refresh) {
           this.verbose("autocompleter:ourChange()");
           this.scheduleRefresh();

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -475,10 +475,10 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
       assert_selector(".auto_complete ul li a", text: /Burbank/i, wait: 5)
       @browser.keyboard.type(:down, :tab)
 
-      # Verify location was selected
+      # Verify location was selected (hidden field is place_name_id)
       assert_selector(".has-id", wait: 5)
-      assert_field("herbarium_location_id", with: burbank.id.to_s,
-                                            type: :hidden)
+      assert_field("herbarium_place_name_id", with: burbank.id.to_s,
+                                              type: :hidden)
 
       # Now edit the text by adding a street address at the beginning
       field = find_field("herbarium_place_name")
@@ -490,7 +490,7 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
       # has-id should be cleared since text no longer matches selected value
       assert_no_selector(".has-id", wait: 5)
       # Hidden field should be empty
-      assert_field("herbarium_location_id", with: "", type: :hidden)
+      assert_field("herbarium_place_name_id", with: "", type: :hidden)
     end
   end
 end

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -458,4 +458,39 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     # Should have selected a species list
     assert_field("species_list", with: /Query/i)
   end
+
+  # Verify editing selected value clears the has-id state
+  def test_autocompleter_clears_id_on_edit
+    rolf = users("rolf")
+    login!(rolf)
+    burbank = locations("burbank")
+
+    visit("/herbaria/new")
+
+    within("#herbarium_form") do
+      # Select an existing location
+      find_field("herbarium_place_name").click
+      @browser.keyboard.type("burbank")
+      assert_selector(".auto_complete", wait: 5)
+      assert_selector(".auto_complete ul li a", text: /Burbank/i, wait: 5)
+      @browser.keyboard.type(:down, :tab)
+
+      # Verify location was selected
+      assert_selector(".has-id", wait: 5)
+      assert_field("herbarium_location_id", with: burbank.id.to_s,
+                                            type: :hidden)
+
+      # Now edit the text by adding a street address at the beginning
+      field = find_field("herbarium_place_name")
+      field.click
+      # Move to beginning and type prefix
+      @browser.keyboard.type(:home)
+      @browser.keyboard.type("123 Main St, ")
+
+      # has-id should be cleared since text no longer matches selected value
+      assert_no_selector(".has-id", wait: 5)
+      # Hidden field should be empty
+      assert_field("herbarium_location_id", with: "", type: :hidden)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3673

Adds system test