### PR TITLE
Fix destroy buttons on show pages for observation associated records

### DIFF
--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -104,9 +104,19 @@ class CollectionNumbersController < ApplicationController
     return unless @collection_number
     return unless make_sure_can_delete!(@collection_number)
 
+    figure_out_where_to_go_back_to
+    @observation = @back_object if @back_object.is_a?(Observation)
     @collection_number.destroy
+
     respond_to do |format|
-      format.turbo_stream { render_collection_numbers_section_update }
+      # Only render turbo_stream if we have an observation to update
+      format.turbo_stream do
+        if @observation
+          render_collection_numbers_section_update
+        else
+          redirect_with_query(action: :index)
+        end
+      end
       format.html { redirect_with_query(action: :index) }
     end
   end

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -112,10 +112,18 @@ class HerbariumRecordsController < ApplicationController
     return unless make_sure_can_delete!(@herbarium_record)
 
     figure_out_where_to_go_back_to
+    @observation = @back_object if @back_object.is_a?(Observation)
     @herbarium_record.destroy
 
     respond_to do |format|
-      format.turbo_stream { render_herbarium_records_section_update }
+      # Only render turbo_stream if we have an observation to update
+      format.turbo_stream do
+        if @observation
+          render_herbarium_records_section_update
+        else
+          redirect_with_query(action: :index)
+        end
+      end
       format.html { redirect_with_query(action: :index) }
     end
   end

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -258,7 +258,16 @@ class SequencesController < ApplicationController
 
   def show_flash_and_send_to_back_object
     respond_to do |format|
-      format.turbo_stream { render_sequences_section_update }
+      # Only render turbo_stream if we came from an observation page
+      format.turbo_stream do
+        if @back_object.is_a?(Observation)
+          render_sequences_section_update
+        elsif @back == "index"
+          redirect_with_query(action: :index)
+        else
+          redirect_to(@observation.show_link_args)
+        end
+      end
       format.html do
         if @back == "index"
           redirect_with_query(action: :index)

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -523,4 +523,22 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     delete(:destroy, params: { id: nums[1].id, q: })
     assert_redirected_to(collection_numbers_path(params: { q: }))
   end
+
+  # Bug: Destroy button on show page uses turbo_stream format, causing error
+  # because @observation is nil. Should redirect with HTML format instead.
+  def test_destroy_collection_number_turbo_from_show_page
+    login("rolf")
+    collection_number = collection_numbers(:coprinus_comatus_coll_num)
+    collection_number_count = CollectionNumber.count
+
+    # Simulate clicking Destroy button on the show page (back: "show")
+    # The button incorrectly requests turbo_stream format
+    delete(:destroy, params: { id: collection_number.id, back: "show" },
+                     format: :turbo_stream)
+
+    # Should still successfully destroy and redirect (not error)
+    assert_equal(collection_number_count - 1, CollectionNumber.count)
+    # Should redirect to index since we can't do turbo_stream update
+    assert_redirected_to(collection_numbers_path)
+  end
 end

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -518,4 +518,22 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_redirected_to(herbarium_records_path(q:))
     assert_session_query_record_is_correct
   end
+
+  # Bug: Destroy button on show page uses turbo_stream format, causing error
+  # because @observation is nil. Should redirect with HTML format instead.
+  def test_destroy_herbarium_record_turbo_from_show_page
+    login("rolf")
+    herbarium_record = herbarium_records(:coprinus_comatus_rolf_spec)
+    herbarium_record_count = HerbariumRecord.count
+
+    # Simulate clicking Destroy button on the show page (back: "show")
+    # The button incorrectly requests turbo_stream format
+    delete(:destroy, params: { id: herbarium_record.id, back: "show" },
+                     format: :turbo_stream)
+
+    # Should still successfully destroy and redirect (not error)
+    assert_equal(herbarium_record_count - 1, HerbariumRecord.count)
+    # Should redirect to index since we can't do turbo_stream update
+    assert_redirected_to(herbarium_records_path)
+  end
 end

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -755,4 +755,23 @@ class SequencesControllerTest < FunctionalTestCase
     assert_redirected_to(action: :index, q:)
     assert_session_query_record_is_correct
   end
+
+  # Bug: Destroy button on show page uses turbo_stream format, causing error
+  # because we're not on an observation page. Should redirect instead.
+  def test_destroy_turbo_from_show_page
+    sequence = sequences(:local_sequence)
+    sequence_count = Sequence.count
+
+    login(sequence.user.login)
+    # Simulate clicking Destroy button on the show page (back: "show")
+    # The button incorrectly requests turbo_stream format
+    delete(:destroy, params: { id: sequence.id, back: "show" },
+                     format: :turbo_stream)
+
+    # Should still successfully destroy and redirect (not error)
+    assert_equal(sequence_count - 1, Sequence.count)
+    # Should redirect to observation since we can't do turbo_stream update
+    # on a non-observation page
+    assert_redirected_to(sequence.observation.show_link_args)
+  end
 end


### PR DESCRIPTION
The bug was that Destroy buttons on HerbariumRecords#show, CollectionNumbers#show, and Sequences#show pages were requesting TURBO_STREAM format (due to `data: { turbo: true }` on the button), but the controllers were trying to render turbo_stream responses that update an observation page section - which doesn't exist when you're on a show page.

Adds tests.

Fixes #3669