### PR TITLE
Simplify modals_helper.rb by passing locals directly

### DIFF
--- a/app/components/name_change_request_form.rb
+++ b/app/components/name_change_request_form.rb
@@ -3,9 +3,8 @@
 # Form for submitting a name change request email to admins.
 # Allows users to request changing a taxonomic name.
 class Components::NameChangeRequestForm < Components::ApplicationForm
-  def initialize(model, name:, new_name:, new_name_with_icn_id:, **)
+  def initialize(model, name:, new_name_with_icn_id:, **)
     @name = name
-    @new_name = new_name
     @new_name_with_icn_id = new_name_with_icn_id
     super(model, **)
   end

--- a/app/controllers/admin/emails/merge_requests_controller.rb
+++ b/app/controllers/admin/emails/merge_requests_controller.rb
@@ -23,7 +23,14 @@ module Admin
               locals: {
                 title: :email_merge_request_title.t(type: @model.type_tag),
                 identifier: "merge_request_email",
-                user: @user, form: "admin/emails/merge_requests/form"
+                user: @user,
+                form: "admin/emails/merge_requests/form",
+                form_locals: {
+                  model: FormObject::MergeRequest.new,
+                  old_obj: @old_obj,
+                  new_obj: @new_obj,
+                  model_class: @model
+                }
               }
             ) and return
           end

--- a/app/controllers/admin/emails/name_change_requests_controller.rb
+++ b/app/controllers/admin/emails/name_change_requests_controller.rb
@@ -26,7 +26,13 @@ module Admin
               locals: {
                 title: :email_name_change_request_title.l,
                 identifier: "name_change_request_email",
-                user: @user, form: "admin/emails/name_change_requests/form"
+                user: @user,
+                form: "admin/emails/name_change_requests/form",
+                form_locals: {
+                  model: FormObject::NameChangeRequest.new,
+                  name: @name,
+                  new_name_with_icn_id: @new_name_with_icn_id
+                }
               }
             ) and return
           end

--- a/app/views/controllers/admin/emails/merge_requests/_form.erb
+++ b/app/views/controllers/admin/emails/merge_requests/_form.erb
@@ -1,8 +1,0 @@
-<%# locals: (local: false) %>
-<%= render(Components::MergeRequestEmailForm.new(
-  FormObject::MergeRequest.new,
-  old_obj: @old_obj,
-  new_obj: @new_obj,
-  model_class: @model,
-  local: local
-)) %>

--- a/app/views/controllers/admin/emails/merge_requests/new.erb
+++ b/app/views/controllers/admin/emails/merge_requests/new.erb
@@ -3,5 +3,10 @@ add_page_title(:email_merge_request_title.t(type: @model.type_tag))
 add_context_nav(email_merge_request_tabs(old_obj: @old_obj))
 %>
 
-<%= render(partial: "admin/emails/merge_requests/form",
-           locals: { local: true }) %>
+<%= render(Components::MergeRequestEmailForm.new(
+      FormObject::MergeRequest.new,
+      old_obj: @old_obj,
+      new_obj: @new_obj,
+      model_class: @model,
+      local: true
+    )) %>

--- a/app/views/controllers/admin/emails/name_change_requests/_form.erb
+++ b/app/views/controllers/admin/emails/name_change_requests/_form.erb
@@ -1,6 +1,0 @@
-<%= render(Components::NameChangeRequestForm.new(
-  FormObject::NameChangeRequest.new,
-  name: @name,
-  new_name: @new_name,
-  new_name_with_icn_id: @new_name_with_icn_id
-)) %>

--- a/app/views/controllers/admin/emails/name_change_requests/new.erb
+++ b/app/views/controllers/admin/emails/name_change_requests/new.erb
@@ -3,5 +3,9 @@ add_page_title(:email_name_change_request_title.t)
 add_context_nav(email_name_change_request_tabs(name: @name))
 %>
 
-<%= render(partial: "admin/emails/name_change_requests/form",
-           locals: { local: true }) %>
+<%= render(Components::NameChangeRequestForm.new(
+      FormObject::NameChangeRequest.new,
+      name: @name,
+      new_name_with_icn_id: @new_name_with_icn_id,
+      local: true
+    )) %>


### PR DESCRIPTION
- Remove over-engineered FORM_PARAM_HANDLERS pattern and add_*_params methods
- Simplified from 150 to 53 lines by just merging locals into component params
- Update merge_requests and name_change_requests to use component directly
- Delete obsolete _form.erb partials for both
- Remove unused new_name: param from NameChangeRequestForm component

🤖 Generated with [Claude Code](https://claude.com/claude-code)