### PR TITLE
New `ComponentTestCase`

### DIFF
--- a/test/component_test_case.rb
+++ b/test/component_test_case.rb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
-# Helper module for testing Phlex components
+# Base class for component tests that provides common setup and helpers.
 # Based on https://www.phlex.fun/components/testing.html
-module ComponentTestHelper
+#
+# @example Usage
+#   class MyComponentTest < ComponentTestCase
+#     def test_renders_content
+#       html = render(Components::MyComponent.new(title: "Test"))
+#       assert_html(html, "h1", text: "Test")
+#     end
+#   end
+#
+class ComponentTestCase < UnitTestCase
   # Render a Phlex component with proper Rails view context
   delegate :render, to: :view_context
 
   # Get the Rails view context needed for components to access helpers
   delegate :view_context, to: :controller
+
+  def setup
+    super
+    controller.request = ActionDispatch::TestRequest.create
+  end
 
   # Create a test controller instance with auth methods
   def controller
@@ -92,6 +106,17 @@ module ComponentTestHelper
         "got #{attr_name}='#{actual_value}'"
       )
     end
+  end
+
+  # Assert HTML does NOT contain a specific CSS selector
+  # @param html [String] The HTML to search
+  # @param selector [String] CSS selector that should NOT be found
+  # @param message [String] Optional custom failure message
+  def assert_no_html(html, selector, message = nil)
+    doc = Nokogiri::HTML(html)
+    element = doc.at_css(selector)
+    message ||= "Expected NOT to find element matching '#{selector}'"
+    assert_nil(element, message)
   end
 
   # Assert that a child selector is nested within a parent selector.

--- a/test/components/activity_log_type_filters_test.rb
+++ b/test/components/activity_log_type_filters_test.rb
@@ -61,26 +61,19 @@ class ActivityLogTypeFiltersTest < ComponentTestCase
     # observation should be checked
     assert_html(html, "input[type='checkbox'][value='observation'][checked]")
 
-    # name should NOT be checked (no checked attribute)
-    doc = Nokogiri::HTML(html)
-    name_checkbox = doc.at_css("input[type='checkbox'][value='name']")
-    assert(name_checkbox, "Expected to find name checkbox")
-    assert_not(name_checkbox["checked"], "Name checkbox should not be checked")
+    # name should exist but NOT be checked
+    assert_html(html, "input[type='checkbox'][value='name']")
+    assert_no_html(html, "input[type='checkbox'][value='name'][checked]")
   end
 
   def test_active_class_on_single_selected_type
     html = render_component(nil, ["observation"])
 
     # The observation label should have active class
-    doc = Nokogiri::HTML(html)
-    obs_label = doc.at_css("label:has(input[value='observation'])")
-    assert(obs_label, "Expected to find observation label")
-    assert_includes(obs_label["class"], "active")
+    assert_html(html, "label.active:has(input[value='observation'])")
 
     # The name label should NOT have active class
-    name_label = doc.at_css("label:has(input[value='name'])")
-    assert(name_label, "Expected to find name label")
-    assert_not_includes(name_label["class"], "active")
+    assert_html(html, "label:not(.active):has(input[value='name'])")
   end
 
   def test_type_filter_link_present_when_not_selected
@@ -105,10 +98,7 @@ class ActivityLogTypeFiltersTest < ComponentTestCase
   def test_no_hidden_fields_without_query
     html = render_component(nil, ["all"])
 
-    doc = Nokogiri::HTML(html)
-    hidden_inputs = doc.css("input[type='hidden']")
-    assert_equal(0, hidden_inputs.size,
-                 "Should have no hidden fields without query")
+    assert_html(html, "input[type='hidden']", count: 0)
   end
 
   private

--- a/test/components/activity_log_type_filters_test.rb
+++ b/test/components/activity_log_type_filters_test.rb
@@ -2,13 +2,7 @@
 
 require "test_helper"
 
-class ActivityLogTypeFiltersTest < UnitTestCase
-  include ComponentTestHelper
-
-  def setup
-    controller.request = ActionDispatch::TestRequest.create
-  end
-
+class ActivityLogTypeFiltersTest < ComponentTestCase
   def test_renders_form_with_get_method
     html = render_component(nil, ["all"])
 

--- a/test/components/alert_test.rb
+++ b/test/components/alert_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class AlertTest < UnitTestCase
-  include ComponentTestHelper
+class AlertTest < ComponentTestCase
 
   def test_renders_basic_alert_with_message
     html = render_component(
@@ -75,11 +74,9 @@ class AlertTest < UnitTestCase
       )
     )
 
-    doc = Nokogiri::HTML(html)
-    div = doc.at_css("div.alert")
-
-    assert_equal("alert", div["data-controller"])
-    assert_equal("message", div["data-target"])
+    assert_html(html, "div.alert",
+                attribute: { "data-controller" => "alert",
+                             "data-target" => "message" })
   end
 
   def test_renders_alert_with_multiple_custom_attributes
@@ -93,14 +90,8 @@ class AlertTest < UnitTestCase
       )
     )
 
-    doc = Nokogiri::HTML(html)
-    div = doc.at_css("div.alert")
-
-    assert_equal("test-alert", div["id"])
-    assert(div["class"].include?("alert"))
-    assert(div["class"].include?("alert-info"))
-    assert(div["class"].include?("custom-class"))
-    assert_equal("123", div["data-value"])
+    assert_html(html, "div#test-alert.alert.alert-info.custom-class",
+                attribute: { "data-value" => "123" })
   end
 
   def test_default_level_is_warning

--- a/test/components/alert_test.rb
+++ b/test/components/alert_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class AlertTest < ComponentTestCase
-
   def test_renders_basic_alert_with_message
     html = render_component(
       Components::Alert.new(message: "Test message")

--- a/test/components/api_key_form_test.rb
+++ b/test/components/api_key_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class APIKeyFormTest < ComponentTestCase
-
   def setup
     @api_key = APIKey.new
 

--- a/test/components/api_key_form_test.rb
+++ b/test/components/api_key_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class APIKeyFormTest < UnitTestCase
-  include ComponentTestHelper
+class APIKeyFormTest < ComponentTestCase
 
   def setup
     @api_key = APIKey.new
 
     # Set up controller request context for form URL generation
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_standalone_layout_without_cancel_button

--- a/test/components/application_form/autocompleter_prefill_test.rb
+++ b/test/components/application_form/autocompleter_prefill_test.rb
@@ -3,9 +3,7 @@
 require "test_helper"
 require "ostruct"
 
-class ApplicationFormAutocompleterPrefillTest < UnitTestCase
-  include ComponentTestHelper
-
+class ApplicationFormAutocompleterPrefillTest < ComponentTestCase
   # Test form that includes the AutocompleterPrefill module
   class TestForm < Components::ApplicationForm
     include Components::ApplicationForm::AutocompleterPrefill

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ApplicationFormTest < ComponentTestCase
-
   def setup
     @user = users(:rolf)
     @collection_number = collection_numbers(:coprinus_comatus_coll_num)

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -2,15 +2,13 @@
 
 require "test_helper"
 
-class ApplicationFormTest < UnitTestCase
-  include ComponentTestHelper
+class ApplicationFormTest < ComponentTestCase
 
   def setup
     @user = users(:rolf)
     @collection_number = collection_numbers(:coprinus_comatus_coll_num)
 
     # Set up controller request context for form URL generation
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   # Text field tests

--- a/test/components/article_form_test.rb
+++ b/test/components/article_form_test.rb
@@ -2,13 +2,11 @@
 
 require "test_helper"
 
-class ArticleFormTest < UnitTestCase
-  include ComponentTestHelper
+class ArticleFormTest < ComponentTestCase
 
   def setup
     super
     @article = Article.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/article_form_test.rb
+++ b/test/components/article_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ArticleFormTest < ComponentTestCase
-
   def setup
     super
     @article = Article.new

--- a/test/components/authors_and_editors_test.rb
+++ b/test/components/authors_and_editors_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class AuthorsAndEditorsTest < ComponentTestCase
-
   # Test double for description objects
   class TestDescription
     attr_reader :authors, :editors, :id, :type_tag

--- a/test/components/authors_and_editors_test.rb
+++ b/test/components/authors_and_editors_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class AuthorsAndEditorsTest < UnitTestCase
-  include ComponentTestHelper
+class AuthorsAndEditorsTest < ComponentTestCase
 
   # Test double for description objects
   class TestDescription

--- a/test/components/autocompleter_field_test.rb
+++ b/test/components/autocompleter_field_test.rb
@@ -2,13 +2,11 @@
 
 require "test_helper"
 
-class AutocompleterFieldTest < UnitTestCase
-  include ComponentTestHelper
+class AutocompleterFieldTest < ComponentTestCase
 
   def setup
     super
     @herbarium_record = HerbariumRecord.new
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_component_has_correct_html_structure
@@ -123,10 +121,8 @@ class AutocompleterFieldTest < UnitTestCase
     html = render_with_component
 
     # Text input autocompleters should NOT have separator (single value only)
-    doc = Nokogiri::HTML(html)
-    autocompleter = doc.at_css(".autocompleter")
-    assert_nil(autocompleter["data-separator"],
-               "Text input autocompleter should not have separator attribute")
+    assert_no_html(html, ".autocompleter[data-separator]",
+                   "Text input autocompleter should not have separator attribute")
   end
 
   def test_hidden_field_derives_id_field_name
@@ -157,17 +153,9 @@ class AutocompleterFieldTest < UnitTestCase
     )
 
     # Dropdown items should have click action with namespaced controller
-    doc = Nokogiri::HTML(html)
-    links = doc.css("li.dropdown-item a[data-action]")
-    assert(links.size == 10, "Should have 10 links with click actions")
-    links.each do |link|
-      action = link["data-action"]
-      assert_includes(
-        action,
-        "click->autocompleter--herbarium#selectRow:prevent",
-        "Link should have selectRow action"
-      )
-    end
+    selector = "li.dropdown-item " \
+               "a[data-action*='click->autocompleter--herbarium#selectRow']"
+    assert_html(html, selector, count: 10)
   end
 
   def test_unknown_autocompleter_type_logs_warning

--- a/test/components/autocompleter_field_test.rb
+++ b/test/components/autocompleter_field_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class AutocompleterFieldTest < ComponentTestCase
-
   def setup
     super
     @herbarium_record = HerbariumRecord.new
@@ -121,8 +120,10 @@ class AutocompleterFieldTest < ComponentTestCase
     html = render_with_component
 
     # Text input autocompleters should NOT have separator (single value only)
-    assert_no_html(html, ".autocompleter[data-separator]",
-                   "Text input autocompleter should not have separator attribute")
+    assert_no_html(
+      html, ".autocompleter[data-separator]",
+      "Text input autocompleter should not have separator attribute"
+    )
   end
 
   def test_hidden_field_derives_id_field_name

--- a/test/components/base_test.rb
+++ b/test/components/base_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class BaseTest < ComponentTestCase
-
   # Simple test component to test trusted_html method
   class TestComponent < Components::Base
     def view_template

--- a/test/components/base_test.rb
+++ b/test/components/base_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class BaseTest < UnitTestCase
-  include ComponentTestHelper
+class BaseTest < ComponentTestCase
 
   # Simple test component to test trusted_html method
   class TestComponent < Components::Base

--- a/test/components/bounds_hidden_fields_test.rb
+++ b/test/components/bounds_hidden_fields_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class BoundsHiddenFieldsTest < ComponentTestCase
-
   def test_renders_all_six_bound_fields
     html = render_component(Components::BoundsHiddenFields.new)
 

--- a/test/components/bounds_hidden_fields_test.rb
+++ b/test/components/bounds_hidden_fields_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class BoundsHiddenFieldsTest < UnitTestCase
-  include ComponentTestHelper
+class BoundsHiddenFieldsTest < ComponentTestCase
 
   def test_renders_all_six_bound_fields
     html = render_component(Components::BoundsHiddenFields.new)
@@ -39,26 +38,20 @@ class BoundsHiddenFieldsTest < UnitTestCase
       Components::BoundsHiddenFields.new(location: location)
     )
 
-    doc = Nokogiri::HTML(html)
-
-    north_input = doc.at_css("input[name='location[north]']")
-    assert_equal(location.north.to_s, north_input["value"])
-
-    south_input = doc.at_css("input[name='location[south]']")
-    assert_equal(location.south.to_s, south_input["value"])
-
-    east_input = doc.at_css("input[name='location[east]']")
-    assert_equal(location.east.to_s, east_input["value"])
-
-    west_input = doc.at_css("input[name='location[west]']")
-    assert_equal(location.west.to_s, west_input["value"])
+    assert_html(html, "input[name='location[north]']",
+                attribute: { value: location.north.to_s })
+    assert_html(html, "input[name='location[south]']",
+                attribute: { value: location.south.to_s })
+    assert_html(html, "input[name='location[east]']",
+                attribute: { value: location.east.to_s })
+    assert_html(html, "input[name='location[west]']",
+                attribute: { value: location.west.to_s })
   end
 
   def test_renders_without_location_with_empty_values
     html = render_component(Components::BoundsHiddenFields.new)
-    doc = Nokogiri::HTML(html)
 
-    north_input = doc.at_css("input[name='location[north]']")
-    assert_nil(north_input["value"])
+    # Hidden fields should have no value attribute when location is nil
+    assert_no_html(html, "input[name='location[north]'][value]")
   end
 end

--- a/test/components/carousel_test.rb
+++ b/test/components/carousel_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class CarouselTest < UnitTestCase
-  include ComponentTestHelper
+class CarouselTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/carousel_test.rb
+++ b/test/components/carousel_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class CarouselTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/collapse_help_block_test.rb
+++ b/test/components/collapse_help_block_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class CollapseHelpBlockTest < UnitTestCase
-  include ComponentTestHelper
+class CollapseHelpBlockTest < ComponentTestCase
 
   def test_renders_basic_collapse_block_with_content
     html = render_component(

--- a/test/components/collapse_help_block_test.rb
+++ b/test/components/collapse_help_block_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class CollapseHelpBlockTest < ComponentTestCase
-
   def test_renders_basic_collapse_block_with_content
     html = render_component(
       Components::CollapseHelpBlock.new(target_id: "help_1")

--- a/test/components/collection_number_form_test.rb
+++ b/test/components/collection_number_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class CollectionNumberFormTest < UnitTestCase
-  include ComponentTestHelper
+class CollectionNumberFormTest < ComponentTestCase
 
   def setup
     super
     @collection_number = CollectionNumber.new
     @observation = observations(:coprinus_comatus_obs)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 
@@ -53,9 +51,8 @@ class CollectionNumberFormTest < UnitTestCase
 
   def test_omits_turbo_when_local_true
     html = render_form_local
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("form[data-turbo]"))
+    assert_no_html(html, "form[data-turbo]")
   end
 
   def test_auto_determines_url_for_existing_collection_number

--- a/test/components/collection_number_form_test.rb
+++ b/test/components/collection_number_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class CollectionNumberFormTest < ComponentTestCase
-
   def setup
     super
     @collection_number = CollectionNumber.new

--- a/test/components/comment_form_test.rb
+++ b/test/components/comment_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class CommentFormTest < ComponentTestCase
-
   def setup
     @comment = Comment.new
     @html = render_form

--- a/test/components/comment_form_test.rb
+++ b/test/components/comment_form_test.rb
@@ -2,12 +2,10 @@
 
 require "test_helper"
 
-class CommentFormTest < UnitTestCase
-  include ComponentTestHelper
+class CommentFormTest < ComponentTestCase
 
   def setup
     @comment = Comment.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 
@@ -39,9 +37,8 @@ class CommentFormTest < UnitTestCase
 
   def test_omits_turbo_when_local_true
     html = render_form_local
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("form[data-turbo]"))
+    assert_no_html(html, "form[data-turbo]")
   end
 
   def test_auto_determines_url_for_new_comment

--- a/test/components/commercial_inquiry_form_test.rb
+++ b/test/components/commercial_inquiry_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class CommercialInquiryFormTest < ComponentTestCase
-
   def setup
     super
     @model = FormObject::CommercialInquiry.new

--- a/test/components/commercial_inquiry_form_test.rb
+++ b/test/components/commercial_inquiry_form_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class CommercialInquiryFormTest < UnitTestCase
-  include ComponentTestHelper
+class CommercialInquiryFormTest < ComponentTestCase
 
   def setup
     super
@@ -11,7 +10,6 @@ class CommercialInquiryFormTest < UnitTestCase
     @image = images(:commercial_inquiry_image)
     @user = users(:rolf)
     @message = "Test message"
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/donation_form_test.rb
+++ b/test/components/donation_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class DonationFormTest < ComponentTestCase
-
   def setup
     super
     @donation = Donation.new

--- a/test/components/donation_form_test.rb
+++ b/test/components/donation_form_test.rb
@@ -2,13 +2,11 @@
 
 require "test_helper"
 
-class DonationFormTest < UnitTestCase
-  include ComponentTestHelper
+class DonationFormTest < ComponentTestCase
 
   def setup
     super
     @donation = Donation.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/email_new_password_form_test.rb
+++ b/test/components/email_new_password_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class EmailNewPasswordFormTest < UnitTestCase
-  include ComponentTestHelper
+class EmailNewPasswordFormTest < ComponentTestCase
 
   def setup
     @user = User.new
 
     # Set up controller request context for form URL generation
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/email_new_password_form_test.rb
+++ b/test/components/email_new_password_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class EmailNewPasswordFormTest < ComponentTestCase
-
   def setup
     @user = User.new
 

--- a/test/components/external_link_form_test.rb
+++ b/test/components/external_link_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ExternalLinkFormTest < ComponentTestCase
-
   def setup
     super
     @external_link = ExternalLink.new

--- a/test/components/external_link_form_test.rb
+++ b/test/components/external_link_form_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class ExternalLinkFormTest < UnitTestCase
-  include ComponentTestHelper
+class ExternalLinkFormTest < ComponentTestCase
 
   def setup
     super
@@ -15,7 +14,6 @@ class ExternalLinkFormTest < UnitTestCase
     @base_urls = @sites.each_with_object({}) do |site, hash|
       hash[site.name] = site.base_url
     end
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 
@@ -61,9 +59,8 @@ class ExternalLinkFormTest < UnitTestCase
 
   def test_omits_turbo_when_local_true
     html = render_form_local
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("form[data-turbo]"))
+    assert_no_html(html, "form[data-turbo]")
   end
 
   def test_auto_determines_url_for_existing_external_link

--- a/test/components/form_camera_info_test.rb
+++ b/test/components/form_camera_info_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class FormCameraInfoTest < ComponentTestCase
-
   def test_renders_gps_info_with_all_values
     component = Components::FormCameraInfo.new(
       img_id: 123,

--- a/test/components/form_camera_info_test.rb
+++ b/test/components/form_camera_info_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class FormCameraInfoTest < UnitTestCase
-  include ComponentTestHelper
+class FormCameraInfoTest < ComponentTestCase
 
   def test_renders_gps_info_with_all_values
     component = Components::FormCameraInfo.new(

--- a/test/components/form_carousel_item_test.rb
+++ b/test/components/form_carousel_item_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class FormCarouselItemTest < UnitTestCase
-  include ComponentTestHelper
+class FormCarouselItemTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/form_carousel_item_test.rb
+++ b/test/components/form_carousel_item_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class FormCarouselItemTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/form_carousel_test.rb
+++ b/test/components/form_carousel_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class FormCarouselTest < UnitTestCase
-  include ComponentTestHelper
+class FormCarouselTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/form_carousel_test.rb
+++ b/test/components/form_carousel_test.rb
@@ -209,10 +209,12 @@ class FormCarouselTest < ComponentTestCase
     )
 
     # Thumbnails at same level as carousel-inner
-    doc = Nokogiri::HTML(html)
-    carousel = doc.at_css(".carousel.image-form-carousel")
-    assert(carousel, "Should have carousel")
-    assert(carousel.at_css(".carousel-inner"), "Should have carousel-inner")
-    assert(carousel.at_css(".carousel-indicators"), "Should have indicators")
+    assert_html(html, ".carousel.image-form-carousel")
+    assert_nested(html,
+                  parent_selector: ".carousel.image-form-carousel",
+                  child_selector: ".carousel-inner")
+    assert_nested(html,
+                  parent_selector: ".carousel.image-form-carousel",
+                  child_selector: ".carousel-indicators")
   end
 end

--- a/test/components/form_carousel_test.rb
+++ b/test/components/form_carousel_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class FormCarouselTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/form_location_map_test.rb
+++ b/test/components/form_location_map_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class FormLocationMapTest < UnitTestCase
-  include ComponentTestHelper
+class FormLocationMapTest < ComponentTestCase
 
   def test_renders_map_div_with_default_id
     html = render_component(Components::FormLocationMap.new)
@@ -23,30 +22,26 @@ class FormLocationMapTest < UnitTestCase
     html = render_component(
       Components::FormLocationMap.new(id: "test_map")
     )
-    doc = Nokogiri::HTML(html)
-    map_div = doc.at_css("div#test_map")
 
-    # Boolean true renders as empty string in Phlex data attributes
-    assert(map_div.key?("data-editable"))
-    assert_equal("mapDiv", map_div["data-map-target"])
+    # Check editable attribute exists and map-target is set
+    assert_html(html, "div#test_map[data-editable]",
+                attribute: { "data-map-target" => "mapDiv" })
   end
 
   def test_renders_map_with_default_location_type
     html = render_component(Components::FormLocationMap.new)
-    doc = Nokogiri::HTML(html)
-    map_div = doc.at_css("div.form-map")
 
-    assert_equal("location", map_div["data-map-type"])
+    assert_html(html, "div.form-map",
+                attribute: { "data-map-type" => "location" })
   end
 
   def test_renders_map_with_custom_map_type
     html = render_component(
       Components::FormLocationMap.new(map_type: "observation")
     )
-    doc = Nokogiri::HTML(html)
-    map_div = doc.at_css("div.form-map")
 
-    assert_equal("observation", map_div["data-map-type"])
+    assert_html(html, "div.form-map",
+                attribute: { "data-map-type" => "observation" })
   end
 
   def test_renders_button_group
@@ -57,14 +52,11 @@ class FormLocationMapTest < UnitTestCase
 
   def test_renders_toggle_button
     html = render_component(Components::FormLocationMap.new(id: "test_map"))
-    doc = Nokogiri::HTML(html)
 
-    toggle_btn = doc.at_css("button.map-toggle")
-    assert(toggle_btn)
-    assert_equal("button", toggle_btn["type"])
-    assert_equal("toggleMapBtn", toggle_btn["data-map-target"])
-    assert_equal("false", toggle_btn["aria-expanded"])
-    assert_equal("test_map", toggle_btn["aria-controls"])
+    assert_html(html, "button.map-toggle[type='button']",
+                attribute: { "data-map-target" => "toggleMapBtn",
+                             "aria-expanded" => "false",
+                             "aria-controls" => "test_map" })
   end
 
   def test_renders_toggle_button_with_show_and_hide_labels
@@ -76,20 +68,16 @@ class FormLocationMapTest < UnitTestCase
 
   def test_renders_clear_button
     html = render_component(Components::FormLocationMap.new)
-    doc = Nokogiri::HTML(html)
 
-    clear_btn = doc.at_css("button.map-clear")
-    assert(clear_btn)
-    assert_equal("button", clear_btn["type"])
-    assert_equal("mapClearBtn", clear_btn["data-map-target"])
+    assert_html(html, "button.map-clear[type='button']",
+                attribute: { "data-map-target" => "mapClearBtn" })
   end
 
   def test_uses_default_location_format_without_user
     html = render_component(Components::FormLocationMap.new)
-    doc = Nokogiri::HTML(html)
-    map_div = doc.at_css("div.form-map")
 
-    assert_equal("postal", map_div["data-location-format"])
+    assert_html(html, "div.form-map",
+                attribute: { "data-location-format" => "postal" })
   end
 
   def test_uses_user_location_format_when_provided
@@ -99,9 +87,8 @@ class FormLocationMapTest < UnitTestCase
     html = render_component(
       Components::FormLocationMap.new(user: user)
     )
-    doc = Nokogiri::HTML(html)
-    map_div = doc.at_css("div.form-map")
 
-    assert_equal("scientific", map_div["data-location-format"])
+    assert_html(html, "div.form-map",
+                attribute: { "data-location-format" => "scientific" })
   end
 end

--- a/test/components/form_location_map_test.rb
+++ b/test/components/form_location_map_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class FormLocationMapTest < ComponentTestCase
-
   def test_renders_map_div_with_default_id
     html = render_component(Components::FormLocationMap.new)
 

--- a/test/components/form_name_feedback_test.rb
+++ b/test/components/form_name_feedback_test.rb
@@ -3,11 +3,6 @@
 require "test_helper"
 
 class FormNameFeedbackTest < ComponentTestCase
-
-  def setup
-    super
-  end
-
   def test_renders_parent_deprecated_warning
     parent = names(:lactarius)
     html = render_feedback(

--- a/test/components/form_name_feedback_test.rb
+++ b/test/components/form_name_feedback_test.rb
@@ -2,12 +2,10 @@
 
 require "test_helper"
 
-class FormNameFeedbackTest < UnitTestCase
-  include ComponentTestHelper
+class FormNameFeedbackTest < ComponentTestCase
 
   def setup
     super
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_parent_deprecated_warning

--- a/test/components/glossary_term_form_test.rb
+++ b/test/components/glossary_term_form_test.rb
@@ -2,12 +2,10 @@
 
 require "test_helper"
 
-class GlossaryTermFormTest < UnitTestCase
-  include ComponentTestHelper
+class GlossaryTermFormTest < ComponentTestCase
 
   def setup
     @glossary_term = GlossaryTerm.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/glossary_term_form_test.rb
+++ b/test/components/glossary_term_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class GlossaryTermFormTest < ComponentTestCase
-
   def setup
     @glossary_term = GlossaryTerm.new
     @html = render_form

--- a/test/components/herbarium_curator_request_form_test.rb
+++ b/test/components/herbarium_curator_request_form_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class HerbariumCuratorRequestFormTest < UnitTestCase
-  include ComponentTestHelper
+class HerbariumCuratorRequestFormTest < ComponentTestCase
 
   # Test model that includes necessary ActiveModel modules
   class TestRequest
@@ -21,7 +20,6 @@ class HerbariumCuratorRequestFormTest < UnitTestCase
     super
     @model = TestRequest.new
     @herbarium = herbaria(:nybg_herbarium)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/herbarium_curator_request_form_test.rb
+++ b/test/components/herbarium_curator_request_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class HerbariumCuratorRequestFormTest < ComponentTestCase
-
   # Test model that includes necessary ActiveModel modules
   class TestRequest
     include ActiveModel::Model

--- a/test/components/herbarium_form_test.rb
+++ b/test/components/herbarium_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class HerbariumFormTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/herbarium_form_test.rb
+++ b/test/components/herbarium_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class HerbariumFormTest < UnitTestCase
-  include ComponentTestHelper
+class HerbariumFormTest < ComponentTestCase
 
   def setup
     super
     @user = users(:rolf)
     @herbarium = Herbarium.new
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_form_with_name_field
@@ -90,9 +88,8 @@ class HerbariumFormTest < UnitTestCase
                     user: @user,
                     local: true
                   ))
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("input[name='herbarium[code]']"))
+    assert_no_html(html, "input[name='herbarium[code]']")
   end
 
   def test_renders_code_field_for_institutional_herbarium
@@ -132,9 +129,8 @@ class HerbariumFormTest < UnitTestCase
 
   def test_omits_back_field_when_not_provided
     html = render_form
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("input[name='herbarium[back]']"))
+    assert_no_html(html, "input[name='herbarium[back]']")
   end
 
   def test_enables_turbo_for_modal_rendering
@@ -149,49 +145,34 @@ class HerbariumFormTest < UnitTestCase
 
   def test_disables_turbo_for_local_form
     html = render_form
-    doc = Nokogiri::HTML(html)
 
     # local: true should not have data-turbo attribute
-    form = doc.at_css("form")
-    assert_nil(form["data-turbo"])
+    assert_no_html(html, "form[data-turbo]")
   end
 
   def test_renders_map_controller_data_attributes
     html = render_form
-    doc = Nokogiri::HTML(html)
-    form = doc.at_css("form#herbarium_form")
 
-    assert_equal("map", form["data-controller"])
-    # Boolean false in Phlex doesn't render the attribute or renders empty
-    # Check that the form has map controller - the map-open state is optional
-    assert(form["data-controller"].include?("map"))
+    assert_html(html, "form#herbarium_form",
+                attribute: { "data-controller" => "map" })
   end
 
   def test_autocompleter_hidden_field_attributes
-    phlex_html = render_form
-    phlex_doc = Nokogiri::HTML(phlex_html)
+    html = render_form
 
-    # Find autocompleter wrapper
-    phlex_ac = phlex_doc.at_css("#herbarium_location_autocompleter")
-    assert(phlex_ac, "Phlex should have autocompleter wrapper")
-
-    # Find hidden field
-    phlex_hidden = phlex_doc.at_css(
-      "#herbarium_location_autocompleter input[type='hidden']"
-    )
-    assert(phlex_hidden, "Phlex should have hidden field in autocompleter")
-
-    # Verify correct data attributes on wrapper
-    assert_equal("autocompleter--location", phlex_ac["data-controller"])
-    assert_equal("location", phlex_ac["data-type"])
-    assert_equal("#herbarium_form",
-                 phlex_ac["data-autocompleter--location-map-outlet"])
+    # Verify autocompleter wrapper with correct data attributes
+    assert_html(html, "#herbarium_location_autocompleter",
+                attribute: { "data-controller" => "autocompleter--location",
+                             "data-type" => "location",
+                             "data-autocompleter--location-map-outlet" =>
+                               "#herbarium_form" })
 
     # Verify hidden field attributes use custom hidden_name with model prefix
-    assert_equal("herbarium_location_id", phlex_hidden["id"],
-                 "Hidden field id should be herbarium_location_id")
-    assert_equal("herbarium[location_id]", phlex_hidden["name"],
-                 "Hidden field name should be herbarium[location_id]")
+    assert_html(
+      html,
+      "#herbarium_location_autocompleter input[type='hidden']" \
+      "#herbarium_location_id[name='herbarium[location_id]']"
+    )
   end
 
   private

--- a/test/components/herbarium_record_form_test.rb
+++ b/test/components/herbarium_record_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class HerbariumRecordFormTest < ComponentTestCase
-
   def setup
     super
     @herbarium_record = HerbariumRecord.new

--- a/test/components/herbarium_record_form_test.rb
+++ b/test/components/herbarium_record_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class HerbariumRecordFormTest < UnitTestCase
-  include ComponentTestHelper
+class HerbariumRecordFormTest < ComponentTestCase
 
   def setup
     super
     @herbarium_record = HerbariumRecord.new
     @observation = observations(:coprinus_comatus_obs)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 
@@ -63,9 +61,8 @@ class HerbariumRecordFormTest < UnitTestCase
 
   def test_omits_turbo_when_local_true
     html = render_form_local
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("form[data-turbo]"))
+    assert_no_html(html, "form[data-turbo]")
   end
 
   def test_auto_determines_url_for_existing_herbarium_record

--- a/test/components/image_vote_anonymity_form_test.rb
+++ b/test/components/image_vote_anonymity_form_test.rb
@@ -3,9 +3,7 @@
 require "test_helper"
 
 class ImageVoteAnonymityFormTest < ComponentTestCase
-
-  def setup
-  end
+  def setup; end
 
   def test_renders_vote_counts
     html = render_form(num_anonymous: 5, num_public: 10)

--- a/test/components/image_vote_anonymity_form_test.rb
+++ b/test/components/image_vote_anonymity_form_test.rb
@@ -2,11 +2,9 @@
 
 require "test_helper"
 
-class ImageVoteAnonymityFormTest < UnitTestCase
-  include ComponentTestHelper
+class ImageVoteAnonymityFormTest < ComponentTestCase
 
   def setup
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_vote_counts

--- a/test/components/image_vote_interface_test.rb
+++ b/test/components/image_vote_interface_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ImageCaptionVoteInterfaceTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/image_vote_interface_test.rb
+++ b/test/components/image_vote_interface_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class ImageCaptionVoteInterfaceTest < UnitTestCase
-  include ComponentTestHelper
+class ImageCaptionVoteInterfaceTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/index_pagination_nav_test.rb
+++ b/test/components/index_pagination_nav_test.rb
@@ -3,7 +3,6 @@
 require("test_helper")
 
 class IndexPaginationNavTest < ComponentTestCase
-
   def setup
     super
     @request_url = "/observations?q%5Bmodel%5D=Observation"
@@ -164,17 +163,11 @@ class IndexPaginationNavTest < ComponentTestCase
                     q_params: @q_params
                   ))
 
-    doc = Nokogiri::HTML(html)
-
     # Prev link should NOT have disabled class
-    prev_link = doc.at_css("a.prev_page_link")
-    assert(prev_link, "Expected prev link")
-    assert_not_includes(prev_link["class"], "disabled")
+    assert_html(html, "a.prev_page_link:not(.disabled)")
 
     # Next link should NOT have disabled class
-    next_link = doc.at_css("a.next_page_link")
-    assert(next_link, "Expected next link")
-    assert_not_includes(next_link["class"], "disabled")
+    assert_html(html, "a.next_page_link:not(.disabled)")
   end
 
   def test_page_input_form_has_correct_structure
@@ -363,13 +356,11 @@ class IndexPaginationNavTest < ComponentTestCase
                   ))
 
     # The page input form should have a hidden letter field
-    doc = Nokogiri::HTML(html)
-    page_form = doc.at_css("nav.pagination_numbers form.page_input")
-    assert(page_form, "Expected page input form")
-
-    letter_hidden = page_form.at_css("input[type='hidden'][name='letter']")
-    assert(letter_hidden, "Expected hidden letter field in page form")
-    assert_equal("B", letter_hidden["value"])
+    assert_nested(
+      html,
+      parent_selector: "nav.pagination_numbers form.page_input",
+      child_selector: "input[type='hidden'][name='letter'][value='B']"
+    )
   end
 
   def test_renders_nothing_when_pagination_data_nil
@@ -452,22 +443,17 @@ class IndexPaginationNavTest < ComponentTestCase
                     args: { anchor: "results" }
                   ))
 
-    doc = Nokogiri::HTML(html)
-
-    # Prev link should have anchor
-    prev_link = doc.at_css("a.prev_page_link")
-    assert(prev_link, "Expected prev link")
-    assert_includes(prev_link["href"], "#results")
+    # Prev link should have anchor (use attribute substring match)
+    assert_html(html, "a.prev_page_link[href*='#results']")
 
     # Next link should have anchor
-    next_link = doc.at_css("a.next_page_link")
-    assert(next_link, "Expected next link")
-    assert_includes(next_link["href"], "#results")
+    assert_html(html, "a.next_page_link[href*='#results']")
 
     # Max page link should have anchor
-    max_link = doc.at_css("nav.pagination_numbers a:not(.prev_page_link)" \
-                          ":not(.next_page_link)")
-    assert(max_link, "Expected max page link")
-    assert_includes(max_link["href"], "#results")
+    assert_html(
+      html,
+      "nav.pagination_numbers " \
+      "a:not(.prev_page_link):not(.next_page_link)[href*='#results']"
+    )
   end
 end

--- a/test/components/index_pagination_nav_test.rb
+++ b/test/components/index_pagination_nav_test.rb
@@ -2,8 +2,7 @@
 
 require("test_helper")
 
-class IndexPaginationNavTest < UnitTestCase
-  include ComponentTestHelper
+class IndexPaginationNavTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/interactive_image_test.rb
+++ b/test/components/interactive_image_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class InteractiveImageTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/interactive_image_test.rb
+++ b/test/components/interactive_image_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class InteractiveImageTest < UnitTestCase
-  include ComponentTestHelper
+class InteractiveImageTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/license_form_test.rb
+++ b/test/components/license_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class LicenseFormTest < ComponentTestCase
-
   def setup
     @license = License.new
     @html = render_form

--- a/test/components/license_form_test.rb
+++ b/test/components/license_form_test.rb
@@ -2,12 +2,10 @@
 
 require "test_helper"
 
-class LicenseFormTest < UnitTestCase
-  include ComponentTestHelper
+class LicenseFormTest < ComponentTestCase
 
   def setup
     @license = License.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/lightbox_caption_test.rb
+++ b/test/components/lightbox_caption_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class LightboxCaptionTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/lightbox_caption_test.rb
+++ b/test/components/lightbox_caption_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class LightboxCaptionTest < UnitTestCase
-  include ComponentTestHelper
+class LightboxCaptionTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/lightbox_observation_title_test.rb
+++ b/test/components/lightbox_observation_title_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class LightboxObservationTitleTest < UnitTestCase
-  include ComponentTestHelper
+class LightboxObservationTitleTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/lightbox_observation_title_test.rb
+++ b/test/components/lightbox_observation_title_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class LightboxObservationTitleTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/login_form_test.rb
+++ b/test/components/login_form_test.rb
@@ -2,12 +2,10 @@
 
 require "test_helper"
 
-class LoginFormTest < UnitTestCase
-  include ComponentTestHelper
+class LoginFormTest < ComponentTestCase
 
   def setup
     @model = FormObject::Login.new(login: "testuser", remember_me: true)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/login_form_test.rb
+++ b/test/components/login_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class LoginFormTest < ComponentTestCase
-
   def setup
     @model = FormObject::Login.new(login: "testuser", remember_me: true)
     @html = render_form

--- a/test/components/mark_as_reviewed_toggle_test.rb
+++ b/test/components/mark_as_reviewed_toggle_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class MarkAsReviewedToggleTest < UnitTestCase
-  include ComponentTestHelper
+class MarkAsReviewedToggleTest < ComponentTestCase
 
   def test_renders_with_default_parameters
     html = render_component(Components::MarkAsReviewedToggle.new(

--- a/test/components/mark_as_reviewed_toggle_test.rb
+++ b/test/components/mark_as_reviewed_toggle_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class MarkAsReviewedToggleTest < ComponentTestCase
-
   def test_renders_with_default_parameters
     html = render_component(Components::MarkAsReviewedToggle.new(
                               observation_view: build_obs_view(123)

--- a/test/components/matrix_box_test.rb
+++ b/test/components/matrix_box_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class MatrixBoxTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/matrix_box_test.rb
+++ b/test/components/matrix_box_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class MatrixBoxTest < UnitTestCase
-  include ComponentTestHelper
+class MatrixBoxTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/matrix_table_test.rb
+++ b/test/components/matrix_table_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class MatrixTableTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/matrix_table_test.rb
+++ b/test/components/matrix_table_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class MatrixTableTest < UnitTestCase
-  include ComponentTestHelper
+class MatrixTableTest < ComponentTestCase
 
   def setup
     super

--- a/test/components/merge_request_email_form_test.rb
+++ b/test/components/merge_request_email_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class MergeRequestEmailFormTest < ComponentTestCase
-
   def setup
     super
     @email = FormObject::MergeRequest.new

--- a/test/components/merge_request_email_form_test.rb
+++ b/test/components/merge_request_email_form_test.rb
@@ -2,15 +2,13 @@
 
 require "test_helper"
 
-class MergeRequestEmailFormTest < UnitTestCase
-  include ComponentTestHelper
+class MergeRequestEmailFormTest < ComponentTestCase
 
   def setup
     super
     @email = FormObject::MergeRequest.new
     @old_name = names(:coprinus_comatus)
     @new_name = names(:agaricus_campestris)
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_form_with_help_text

--- a/test/components/name_change_request_form_test.rb
+++ b/test/components/name_change_request_form_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class NameChangeRequestFormTest < UnitTestCase
-  include ComponentTestHelper
+class NameChangeRequestFormTest < ComponentTestCase
 
   def setup
     super
@@ -11,7 +10,6 @@ class NameChangeRequestFormTest < UnitTestCase
     @name = names(:coprinus_comatus)
     @new_name = "Agaricus foo"
     @new_name_with_icn_id = "#{@new_name}[#123456]"
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_form_with_help_text

--- a/test/components/name_change_request_form_test.rb
+++ b/test/components/name_change_request_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class NameChangeRequestFormTest < ComponentTestCase
-
   def setup
     super
     @email = FormObject::NameChangeRequest.new

--- a/test/components/name_form_test.rb
+++ b/test/components/name_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class NameFormTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/name_form_test.rb
+++ b/test/components/name_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class NameFormTest < UnitTestCase
-  include ComponentTestHelper
+class NameFormTest < ComponentTestCase
 
   def setup
     super
     @user = users(:rolf)
     @name = names(:coprinus_comatus)
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   # --- New record (create mode) ---

--- a/test/components/name_tracker_form_test.rb
+++ b/test/components/name_tracker_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class NameTrackerFormTest < ComponentTestCase
-
   def setup
     super
     @name = names(:coprinus_comatus)

--- a/test/components/name_tracker_form_test.rb
+++ b/test/components/name_tracker_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class NameTrackerFormTest < UnitTestCase
-  include ComponentTestHelper
+class NameTrackerFormTest < ComponentTestCase
 
   def setup
     super
     @name = names(:coprinus_comatus)
     @note_template = "Test template"
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_enable_button_for_new_tracker

--- a/test/components/names_lookup_field_group_test.rb
+++ b/test/components/names_lookup_field_group_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class NamesLookupFieldGroupTest < ComponentTestCase
-
   def setup
     super
     @name = names(:coprinus_comatus)

--- a/test/components/names_lookup_field_group_test.rb
+++ b/test/components/names_lookup_field_group_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class NamesLookupFieldGroupTest < UnitTestCase
-  include ComponentTestHelper
+class NamesLookupFieldGroupTest < ComponentTestCase
 
   def setup
     super
     @name = names(:coprinus_comatus)
     @query = Query.lookup(:Observation)
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   # Indirectly covers line 80 by asserting autocompleter value uses display_name

--- a/test/components/naming_fields_test.rb
+++ b/test/components/naming_fields_test.rb
@@ -4,15 +4,13 @@ require "test_helper"
 
 # Tests for NamingFields component (Superform mode only).
 # For ERB form tests, see the system tests for observation form.
-class NamingFieldsTest < UnitTestCase
-  include ComponentTestHelper
+class NamingFieldsTest < ComponentTestCase
 
   def setup
     super
     @naming = Naming.new
     @vote = Vote.new
     @reasons = @naming.init_reasons
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   # Test for bug: edit naming form missing vote/confidence and reasons fields

--- a/test/components/naming_fields_test.rb
+++ b/test/components/naming_fields_test.rb
@@ -5,7 +5,6 @@ require "test_helper"
 # Tests for NamingFields component (Superform mode only).
 # For ERB form tests, see the system tests for observation form.
 class NamingFieldsTest < ComponentTestCase
-
   def setup
     super
     @naming = Naming.new

--- a/test/components/naming_form_test.rb
+++ b/test/components/naming_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class NamingFormTest < ComponentTestCase
-
   def setup
     super
     @naming = Naming.new
@@ -74,11 +73,11 @@ class NamingFormTest < ComponentTestCase
   def test_no_collapse_class_for_lightbox_context
     html = render_form_with_context("lightbox")
 
-    doc = Nokogiri::HTML(html)
-    collapse_div = doc.at_css(
-      "div[data-autocompleter--name-target='collapseFields']"
+    # Collapse div should exist but NOT have collapse class
+    assert_html(
+      html,
+      "div:not(.collapse)[data-autocompleter--name-target='collapseFields']"
     )
-    assert_not_includes(collapse_div["class"].to_s, "collapse")
   end
 
   def test_includes_blank_option_for_new_naming
@@ -90,10 +89,7 @@ class NamingFormTest < ComponentTestCase
     @vote = votes(:coprinus_comatus_owner_vote)
     html = render_edit_form
 
-    doc = Nokogiri::HTML(html)
-    selector = "select[name='naming[vote][value]'] option[value='']"
-    blank_option = doc.at_css(selector)
-    assert_nil(blank_option)
+    assert_no_html(html, "select[name='naming[vote][value]'] option[value='']")
   end
 
   def test_selects_vote_value_for_existing_naming
@@ -151,9 +147,8 @@ class NamingFormTest < ComponentTestCase
 
   def test_omits_turbo_when_local_true
     html = render_form_with_local(true)
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("form[data-turbo]"))
+    assert_no_html(html, "form[data-turbo]")
   end
 
   private

--- a/test/components/naming_form_test.rb
+++ b/test/components/naming_form_test.rb
@@ -2,15 +2,13 @@
 
 require "test_helper"
 
-class NamingFormTest < UnitTestCase
-  include ComponentTestHelper
+class NamingFormTest < ComponentTestCase
 
   def setup
     super
     @naming = Naming.new
     @observation = observations(:coprinus_comatus_obs)
     @vote = Vote.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_new_form
   end
 

--- a/test/components/naming_reasons_fields_test.rb
+++ b/test/components/naming_reasons_fields_test.rb
@@ -5,14 +5,12 @@ require "test_helper"
 # NamingReasonsFields is tested through NamingForm since it requires a Superform
 # namespace. See test/components/naming_form_test.rb for tests that cover the
 # reasons fields functionality.
-class NamingReasonsFieldsTest < UnitTestCase
-  include ComponentTestHelper
+class NamingReasonsFieldsTest < ComponentTestCase
 
   def setup
     super
     @naming = Naming.new
     @observation = observations(:coprinus_comatus_obs)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form_with_reasons
   end
 

--- a/test/components/naming_reasons_fields_test.rb
+++ b/test/components/naming_reasons_fields_test.rb
@@ -6,7 +6,6 @@ require "test_helper"
 # namespace. See test/components/naming_form_test.rb for tests that cover the
 # reasons fields functionality.
 class NamingReasonsFieldsTest < ComponentTestCase
-
   def setup
     super
     @naming = Naming.new
@@ -52,20 +51,18 @@ class NamingReasonsFieldsTest < ComponentTestCase
     reasons[1].notes = "Test notes"
     html = render_form_with_reasons(reasons: reasons)
 
-    doc = Nokogiri::HTML(html)
-    selector = "input[type='checkbox'][name='naming[reasons][1][check]']"
-    checkbox = doc.at_css(selector)
-    container = doc.at_css("div[id='reasons_1_notes']")
-
-    assert(checkbox["checked"], "checkbox should be checked")
-    assert_includes(container["class"], "show")
+    # Checkbox should be checked
+    assert_html(
+      html,
+      "input[type='checkbox'][name='naming[reasons][1][check]'][checked]"
+    )
+    # Container should have "show" class (expanded)
+    assert_html(html, "div#reasons_1_notes.show")
   end
 
   def test_unchecked_reason_has_collapsed_textarea
-    doc = Nokogiri::HTML(@html)
-    container = doc.at_css("div[id='reasons_1_notes']")
-
-    assert_not_includes(container["class"], "show")
+    # Container should NOT have "show" class (collapsed)
+    assert_html(@html, "div#reasons_1_notes:not(.show)")
   end
 
   private

--- a/test/components/object_footer_test.rb
+++ b/test/components/object_footer_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class ObjectFooterTest < UnitTestCase
-  include ComponentTestHelper
+class ObjectFooterTest < ComponentTestCase
 
   # Test double for objects with footer metadata
   class TestObject

--- a/test/components/object_footer_test.rb
+++ b/test/components/object_footer_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ObjectFooterTest < ComponentTestCase
-
   # Test double for objects with footer metadata
   class TestObject
     attr_reader :created_at, :updated_at, :user, :user_id, :version,

--- a/test/components/observer_question_form_test.rb
+++ b/test/components/observer_question_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ObserverQuestionFormTest < ComponentTestCase
-
   def setup
     super
     @model = FormObject::ObserverQuestion.new

--- a/test/components/observer_question_form_test.rb
+++ b/test/components/observer_question_form_test.rb
@@ -2,15 +2,13 @@
 
 require "test_helper"
 
-class ObserverQuestionFormTest < UnitTestCase
-  include ComponentTestHelper
+class ObserverQuestionFormTest < ComponentTestCase
 
   def setup
     super
     @model = FormObject::ObserverQuestion.new
     @observation = observations(:minimal_unknown_obs)
     @message = "Where did you find this?"
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/panel_test.rb
+++ b/test/components/panel_test.rb
@@ -2,8 +2,7 @@
 
 require("test_helper")
 
-class PanelTest < UnitTestCase
-  include ComponentTestHelper
+class PanelTest < ComponentTestCase
 
   def test_panel_with_heading_and_collapsible_content
     edit_link = view_context.link_to("Edit", "/edit", class: "btn btn-sm")

--- a/test/components/panel_test.rb
+++ b/test/components/panel_test.rb
@@ -3,7 +3,6 @@
 require("test_helper")
 
 class PanelTest < ComponentTestCase
-
   def test_panel_with_heading_and_collapsible_content
     edit_link = view_context.link_to("Edit", "/edit", class: "btn btn-sm")
     html = render(Components::Panel.new(

--- a/test/components/project_admin_request_form_test.rb
+++ b/test/components/project_admin_request_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class ProjectAdminRequestFormTest < UnitTestCase
-  include ComponentTestHelper
+class ProjectAdminRequestFormTest < ComponentTestCase
 
   def setup
     super
     @model = FormObject::ProjectAdminRequest.new
     @project = projects(:eol_project)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/project_admin_request_form_test.rb
+++ b/test/components/project_admin_request_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class ProjectAdminRequestFormTest < ComponentTestCase
-
   def setup
     super
     @model = FormObject::ProjectAdminRequest.new

--- a/test/components/publication_form_test.rb
+++ b/test/components/publication_form_test.rb
@@ -2,15 +2,13 @@
 
 require "test_helper"
 
-class PublicationFormTest < UnitTestCase
-  include ComponentTestHelper
+class PublicationFormTest < ComponentTestCase
 
   def setup
     @user = users(:rolf)
     @publication = Publication.new # New publication for create form
 
     # Set up controller request context for form URL generation
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   def test_renders_form_with_all_fields

--- a/test/components/publication_form_test.rb
+++ b/test/components/publication_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class PublicationFormTest < ComponentTestCase
-
   def setup
     @user = users(:rolf)
     @publication = Publication.new # New publication for create form

--- a/test/components/qr_reader_form_test.rb
+++ b/test/components/qr_reader_form_test.rb
@@ -2,12 +2,10 @@
 
 require "test_helper"
 
-class QRReaderFormTest < UnitTestCase
-  include ComponentTestHelper
+class QRReaderFormTest < ComponentTestCase
 
   def setup
     @model = FieldSlip.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/qr_reader_form_test.rb
+++ b/test/components/qr_reader_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class QRReaderFormTest < ComponentTestCase
-
   def setup
     @model = FieldSlip.new
     @html = render_form

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class SearchFormTest < ComponentTestCase
-
   def setup
     super
     @query = Query::Observations.new
@@ -27,24 +26,17 @@ class SearchFormTest < ComponentTestCase
   # When local (on a search page), form should NOT use turbo_stream
   def test_form_no_turbo_stream_when_local
     html = render_form(local: true)
-    doc = Nokogiri::HTML(html)
 
-    form = doc.at_css("form#observations_search_form")
-    assert(form, "Should have form")
-    assert_nil(form["data-turbo-stream"],
-               "Form should NOT have data-turbo-stream when local")
+    assert_html(html, "form#observations_search_form")
+    assert_no_html(html, "form#observations_search_form[data-turbo-stream]")
   end
 
   # When not local (in nav dropdown), form SHOULD use turbo_stream
   # for future in-place result updates
   def test_form_uses_turbo_stream_when_not_local
     html = render_form(local: false)
-    doc = Nokogiri::HTML(html)
 
-    form = doc.at_css("form#observations_search_form")
-    assert(form, "Should have form")
-    assert_equal("true", form["data-turbo-stream"],
-                 "Form should have data-turbo-stream='true' when not local")
+    assert_html(html, "form#observations_search_form[data-turbo-stream='true']")
   end
 
   def test_renders_panels_for_field_columns
@@ -71,26 +63,19 @@ class SearchFormTest < ComponentTestCase
   # because #search_nav_form doesn't exist on search pages
   def test_clear_button_no_turbo_stream_when_local
     html = render_form(local: true)
-    doc = Nokogiri::HTML(html)
 
-    clear_btn = doc.at_css("a.clear-button")
-    assert(clear_btn, "Should have clear button")
-    assert_nil(clear_btn["data-turbo-stream"],
-               "Clear button should NOT have data-turbo-stream when local")
-    assert_match(%r{/search/new\?clear=true}, clear_btn["href"],
-                 "Clear button should link to search/new with clear param")
+    assert_html(html, "a.clear-button")
+    assert_no_html(html, "a.clear-button[data-turbo-stream]")
+    # Clear button should link to search/new with clear param
+    assert_html(html, "a.clear-button[href*='/search/new?clear=true']")
   end
 
   # When not local (in nav dropdown), clear button SHOULD use turbo_stream
   # to update #search_nav_form without full page reload
   def test_clear_button_uses_turbo_stream_when_not_local
     html = render_form(local: false)
-    doc = Nokogiri::HTML(html)
 
-    clear_btn = doc.at_css("a.clear-button")
-    assert(clear_btn, "Should have clear button")
-    assert_equal("true", clear_btn["data-turbo-stream"],
-                 "Clear button needs data-turbo-stream when not local")
+    assert_html(html, "a.clear-button[data-turbo-stream='true']")
   end
 
   def test_renders_header_when_not_local
@@ -103,10 +88,8 @@ class SearchFormTest < ComponentTestCase
 
   def test_does_not_render_header_when_local
     html = render_form(local: true)
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css(".navbar-flex"),
-               "Expected NOT to find element matching '.navbar-flex'")
+    assert_no_html(html, ".navbar-flex")
   end
 
   def test_names_search_form_has_correct_field_ids
@@ -198,15 +181,12 @@ class SearchFormTest < ComponentTestCase
     }
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # The collapse div should have class "in" to be expanded
-    selector = "[data-autocompleter--name-target='collapseFields']"
-    collapse_div = doc.at_css(selector)
-    assert(collapse_div, "Should have collapse div for modifier fields")
-    assert_includes(collapse_div["class"], "in",
-                    "Collapse div should have 'in' class when modifiers " \
-                    "have values")
+    assert_html(
+      html,
+      "[data-autocompleter--name-target='collapseFields'].in"
+    )
   end
 
   # TDD test: Panel collapse should be expanded when collapsed field has value
@@ -216,14 +196,9 @@ class SearchFormTest < ComponentTestCase
     query.created_at = "2024-01-01"
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # The dates panel's collapse div should have class "in"
-    collapse_div = doc.at_css("#observations_dates.panel-collapse")
-    assert(collapse_div, "Should have dates panel collapse div")
-    assert_includes(collapse_div["class"], "in",
-                    "Panel collapse should have 'in' class when collapsed " \
-                    "field has value")
+    assert_html(html, "#observations_dates.panel-collapse.in")
   end
 
   # TDD test: Panel collapse should NOT be expanded when no collapsed fields
@@ -234,14 +209,9 @@ class SearchFormTest < ComponentTestCase
     query.date = "2024-01-01"
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # The dates panel's collapse div should NOT have class "in"
-    collapse_div = doc.at_css("#observations_dates.panel-collapse")
-    assert(collapse_div, "Should have dates panel collapse div")
-    assert_not_includes(collapse_div["class"].to_s, "in",
-                        "Panel collapse should NOT have 'in' class when only " \
-                        "shown fields are set")
+    assert_html(html, "#observations_dates.panel-collapse:not(.in)")
   end
 
   # TDD test: Modifier collapse should be expanded when lookup has value
@@ -255,15 +225,12 @@ class SearchFormTest < ComponentTestCase
     }
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # The collapse div SHOULD have class "in" because lookup has a value
-    selector = "[data-autocompleter--name-target='collapseFields']"
-    collapse_div = doc.at_css(selector)
-    assert(collapse_div, "Should have collapse div for modifier fields")
-    assert_includes(collapse_div["class"], "in",
-                    "Collapse div should have 'in' class when lookup " \
-                    "has a value")
+    assert_html(
+      html,
+      "[data-autocompleter--name-target='collapseFields'].in"
+    )
   end
 
   # TDD test: Modifier collapse NOT expanded when names hash is empty
@@ -272,15 +239,12 @@ class SearchFormTest < ComponentTestCase
     # Don't set any names at all
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # The collapse div should NOT have class "in"
-    selector = "[data-autocompleter--name-target='collapseFields']"
-    collapse_div = doc.at_css(selector)
-    assert(collapse_div, "Should have collapse div for modifier fields")
-    assert_not_includes(collapse_div["class"].to_s, "in",
-                        "Collapse div should NOT have 'in' class when " \
-                        "names is empty")
+    assert_html(
+      html,
+      "[data-autocompleter--name-target='collapseFields']:not(.in)"
+    )
   end
 
   # TDD test: by_users hidden field should have correct name for controller
@@ -288,12 +252,7 @@ class SearchFormTest < ComponentTestCase
   def test_by_users_hidden_field_has_correct_name
     html = render_form
 
-    doc = Nokogiri::HTML(html)
-    hidden_field = doc.at_css("input[type='hidden'][name*='by_users_id']")
-
-    assert(hidden_field,
-           "by_users autocompleter should have hidden field " \
-           "query_observations[by_users_id], not [user_id]")
+    assert_html(html, "input[type='hidden'][name*='by_users_id']")
   end
 
   # NOTE: render_select_no_eq_nil_or_yes was removed as dead code.
@@ -306,20 +265,22 @@ class SearchFormTest < ComponentTestCase
     html = render_form
 
     # Should use :"query_#{field_name}".l.humanize for labels
-    doc = Nokogiri::HTML(html)
-    label = doc.at_css("label[for='query_observations_date']")
-    assert(label, "Should have date label")
-    assert_equal(:query_date.l.humanize, label.text.strip)
+    assert_html(
+      html,
+      "label[for='query_observations_date']",
+      text: :query_date.l.humanize
+    )
   end
 
   def test_date_field_prefills_string_value
     query = Query::Observations.new(date: "2024-01-15")
     html = render_form_with_query(query)
 
-    doc = Nokogiri::HTML(html)
-    input = doc.at_css("#query_observations_date")
-    assert(input, "Should have date input")
-    assert_equal("2024-01-15", input["value"])
+    assert_html(
+      html,
+      "#query_observations_date",
+      attribute: { value: "2024-01-15" }
+    )
   end
 
   def test_date_field_joins_array_for_range
@@ -328,10 +289,11 @@ class SearchFormTest < ComponentTestCase
     query.date = %w[2021-01-06 2021-01-15]
     html = render_form_with_query(query)
 
-    doc = Nokogiri::HTML(html)
-    input = doc.at_css("#query_observations_date")
-    assert(input, "Should have date input")
-    assert_equal("2021-01-06-2021-01-15", input["value"])
+    assert_html(
+      html,
+      "#query_observations_date",
+      attribute: { value: "2021-01-06-2021-01-15" }
+    )
   end
 
   # Cover NamesLookupFieldGroup bool_to_string false branch (line 160)
@@ -362,12 +324,13 @@ class SearchFormTest < ComponentTestCase
     query.names = { lookup: [unknown_id] }
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
-    lookup_input = doc.at_css("#query_observations_names_lookup")
-    assert(lookup_input, "Should have names lookup input")
     # Unknown ID should pass through as-is
-    assert_equal(unknown_id.to_s, lookup_input["value"])
+    assert_html(
+      html,
+      "#query_observations_names_lookup",
+      attribute: { value: unknown_id.to_s }
+    )
   end
 
   # Cover NamesLookupFieldGroup modifiers_have_values? (lines 106-107)
@@ -378,14 +341,12 @@ class SearchFormTest < ComponentTestCase
     query.names = { include_synonyms: true }
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # Collapse should be expanded because modifier has value
-    selector = "[data-autocompleter--name-target='collapseFields']"
-    collapse_div = doc.at_css(selector)
-    assert(collapse_div, "Should have collapse div")
-    assert_includes(collapse_div["class"], "in",
-                    "Collapse should be expanded when modifier has value")
+    assert_html(
+      html,
+      "[data-autocompleter--name-target='collapseFields'].in"
+    )
   end
 
   # Rank range with only the second value set should use minimum as first value
@@ -585,16 +546,10 @@ class SearchFormTest < ComponentTestCase
     query.in_box = { north: 45.0, south: 40.0, east: -70.0, west: -80.0 }
 
     html = render_form_with_query(query)
-    doc = Nokogiri::HTML(html)
 
     # Check that box inputs have prefilled values
-    north_input = doc.at_css("input[name*='north']")
-    assert(north_input, "Should have north input")
-    assert_equal("45.0", north_input["value"])
-
-    south_input = doc.at_css("input[name*='south']")
-    assert(south_input, "Should have south input")
-    assert_equal("40.0", south_input["value"])
+    assert_html(html, "input[name*='north']", attribute: { value: "45.0" })
+    assert_html(html, "input[name*='south']", attribute: { value: "40.0" })
   end
 
   # Test array_to_newlines with array value (line 422)
@@ -640,26 +595,22 @@ class SearchFormTest < ComponentTestCase
 
   def test_form_has_max_length_value_attribute
     html = render_form
-    doc = Nokogiri::HTML(html)
 
-    form = doc.at_css("form#observations_search_form")
-    assert_equal(
-      Searchable::MAX_SEARCH_INPUT_LENGTH.to_s,
-      form["data-search-length-validator-max-length-value"],
-      "Form should have max length value set to " \
-      "#{Searchable::MAX_SEARCH_INPUT_LENGTH}"
+    assert_html(
+      html,
+      "form#observations_search_form" \
+      "[data-search-length-validator-max-length-value=" \
+      "'#{Searchable::MAX_SEARCH_INPUT_LENGTH}']"
     )
   end
 
   def test_form_has_search_type_value_attribute
     html = render_form
-    doc = Nokogiri::HTML(html)
 
-    form = doc.at_css("form#observations_search_form")
-    assert_equal(
-      "observations",
-      form["data-search-length-validator-search-type-value"],
-      "Form should have search type value set"
+    assert_html(
+      html,
+      "form#observations_search_form" \
+      "[data-search-length-validator-search-type-value='observations']"
     )
   end
 
@@ -672,10 +623,7 @@ class SearchFormTest < ComponentTestCase
 
   def test_form_uses_post_method
     html = render_form
-    doc = Nokogiri::HTML(html)
 
-    form = doc.at_css("form#observations_search_form")
-    assert_equal("post", form["method"],
-                 "Form should use POST method to avoid URL length limits")
+    assert_html(html, "form#observations_search_form[method='post']")
   end
 end

--- a/test/components/search_form_test.rb
+++ b/test/components/search_form_test.rb
@@ -2,13 +2,11 @@
 
 require "test_helper"
 
-class SearchFormTest < UnitTestCase
-  include ComponentTestHelper
+class SearchFormTest < ComponentTestCase
 
   def setup
     super
     @query = Query::Observations.new
-    controller.request = ActionDispatch::TestRequest.create
     # Use real search controller from the app
     @search_controller = ::Observations::SearchController.new
   end

--- a/test/components/sequence_form_test.rb
+++ b/test/components/sequence_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class SequenceFormTest < ComponentTestCase
-
   def setup
     super
     @observation = observations(:coprinus_comatus_obs)

--- a/test/components/sequence_form_test.rb
+++ b/test/components/sequence_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class SequenceFormTest < UnitTestCase
-  include ComponentTestHelper
+class SequenceFormTest < ComponentTestCase
 
   def setup
     super
     @observation = observations(:coprinus_comatus_obs)
     @sequence = Sequence.new(observation: @observation)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 
@@ -56,9 +54,8 @@ class SequenceFormTest < UnitTestCase
 
   def test_omits_turbo_when_local_true
     html = render_form_local
-    doc = Nokogiri::HTML(html)
 
-    assert_nil(doc.at_css("form[data-turbo]"))
+    assert_no_html(html, "form[data-turbo]")
   end
 
   def test_auto_determines_url_for_existing_sequence

--- a/test/components/show_prev_next_nav_test.rb
+++ b/test/components/show_prev_next_nav_test.rb
@@ -2,8 +2,7 @@
 
 require("test_helper")
 
-class ShowPrevNextNavTest < UnitTestCase
-  include ComponentTestHelper
+class ShowPrevNextNavTest < ComponentTestCase
 
   def setup
     super
@@ -70,10 +69,7 @@ class ShowPrevNextNavTest < UnitTestCase
     assert_html(html, "a.prev_object_link.disabled")
 
     # Next link should NOT have disabled class
-    doc = Nokogiri::HTML(html)
-    next_link = doc.at_css("a.next_object_link")
-    assert(next_link, "Expected next link")
-    assert_not_includes(next_link["class"], "disabled")
+    assert_html(html, "a.next_object_link:not(.disabled)")
   end
 
   def test_next_link_disabled_when_last_item
@@ -88,10 +84,7 @@ class ShowPrevNextNavTest < UnitTestCase
     assert_html(html, "a.next_object_link.disabled")
 
     # Prev link should NOT have disabled class
-    doc = Nokogiri::HTML(html)
-    prev_link = doc.at_css("a.prev_object_link")
-    assert(prev_link, "Expected prev link")
-    assert_not_includes(prev_link["class"], "disabled")
+    assert_html(html, "a.prev_object_link:not(.disabled)")
   end
 
   def test_both_links_enabled_when_middle_item
@@ -102,15 +95,8 @@ class ShowPrevNextNavTest < UnitTestCase
                     query: @query
                   ))
 
-    doc = Nokogiri::HTML(html)
-
-    prev_link = doc.at_css("a.prev_object_link")
-    assert(prev_link, "Expected prev link")
-    assert_not_includes(prev_link["class"], "disabled")
-
-    next_link = doc.at_css("a.next_object_link")
-    assert(next_link, "Expected next link")
-    assert_not_includes(next_link["class"], "disabled")
+    assert_html(html, "a.prev_object_link:not(.disabled)")
+    assert_html(html, "a.next_object_link:not(.disabled)")
   end
 
   def test_prev_link_has_correct_href

--- a/test/components/show_prev_next_nav_test.rb
+++ b/test/components/show_prev_next_nav_test.rb
@@ -3,7 +3,6 @@
 require("test_helper")
 
 class ShowPrevNextNavTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/textile_sandbox_form_test.rb
+++ b/test/components/textile_sandbox_form_test.rb
@@ -2,11 +2,9 @@
 
 require "test_helper"
 
-class TextileSandboxFormTest < UnitTestCase
-  include ComponentTestHelper
+class TextileSandboxFormTest < ComponentTestCase
 
   def setup
-    controller.request = ActionDispatch::TestRequest.create
   end
 
   # NOTE: Page title and help block are now rendered by the view
@@ -32,14 +30,14 @@ class TextileSandboxFormTest < UnitTestCase
 
   def test_does_not_render_up_arrows_when_no_result
     html = render_initial_form
-    doc = Nokogiri::HTML(html)
-    assert_nil(doc.at_css(".sandbox-up-ptr"))
+
+    assert_no_html(html, ".sandbox-up-ptr")
   end
 
   def test_does_not_render_result_section_when_no_result
     html = render_initial_form
-    doc = Nokogiri::HTML(html)
-    assert_nil(doc.at_css(".sandbox"))
+
+    assert_no_html(html, ".sandbox")
   end
 
   def test_renders_result_section_when_showing_result
@@ -68,13 +66,12 @@ class TextileSandboxFormTest < UnitTestCase
     assert_html(html, ".sandbox li", count: 3)
 
     # Verify individual list items contain correct text
-    doc = Nokogiri::HTML(html)
-    list_items = doc.css(".sandbox li").map(&:text)
-    assert_equal(%w[Woof Bark Meow], list_items)
+    assert_html(html, ".sandbox li", text: "Woof")
+    assert_html(html, ".sandbox li", text: "Bark")
+    assert_html(html, ".sandbox li", text: "Meow")
 
     # Should NOT contain escaped HTML in the rendered output
-    sandbox_content = doc.at_css(".sandbox").inner_html
-    assert_no_match(/&lt;/, sandbox_content)
+    assert_no_match(/&lt;/, html)
   end
 
   def test_renders_escaped_html_when_test_codes_button_clicked
@@ -120,9 +117,9 @@ class TextileSandboxFormTest < UnitTestCase
 
   def test_does_not_render_submit_button_below_textarea_when_showing_result
     html = render_form_with_result(:sandbox_test.l)
-    doc = Nokogiri::HTML(html)
+
     # Count submit buttons - should be 2 (in up arrows section only)
-    assert_equal(2, doc.css("input[type='submit']").count)
+    assert_html(html, "input[type='submit']", count: 2)
   end
 
   def test_renders_quick_reference_section

--- a/test/components/textile_sandbox_form_test.rb
+++ b/test/components/textile_sandbox_form_test.rb
@@ -3,9 +3,7 @@
 require "test_helper"
 
 class TextileSandboxFormTest < ComponentTestCase
-
-  def setup
-  end
+  def setup; end
 
   # NOTE: Page title and help block are now rendered by the view
   # template (Views::Controllers::Info::TextileSandbox), not the

--- a/test/components/textile_sandbox_form_test.rb
+++ b/test/components/textile_sandbox_form_test.rb
@@ -3,8 +3,6 @@
 require "test_helper"
 
 class TextileSandboxFormTest < ComponentTestCase
-  def setup; end
-
   # NOTE: Page title and help block are now rendered by the view
   # template (Views::Controllers::Info::TextileSandbox), not the
   # component. Those should be tested in controller/integration tests.

--- a/test/components/textile_sandbox_form_test.rb
+++ b/test/components/textile_sandbox_form_test.rb
@@ -65,10 +65,10 @@ class TextileSandboxFormTest < ComponentTestCase
     assert_html(html, ".sandbox ol")
     assert_html(html, ".sandbox li", count: 3)
 
-    # Verify individual list items contain correct text
-    assert_html(html, ".sandbox li", text: "Woof")
-    assert_html(html, ".sandbox li", text: "Bark")
-    assert_html(html, ".sandbox li", text: "Meow")
+    # Verify individual list items contain correct text in order
+    assert_html(html, ".sandbox li:nth-child(1)", text: "Woof")
+    assert_html(html, ".sandbox li:nth-child(2)", text: "Bark")
+    assert_html(html, ".sandbox li:nth-child(3)", text: "Meow")
 
     # Should NOT contain escaped HTML in the rendered output
     assert_no_match(/&lt;/, html)

--- a/test/components/user_bonuses_form_test.rb
+++ b/test/components/user_bonuses_form_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class UserBonusesFormTest < UnitTestCase
-  include ComponentTestHelper
+class UserBonusesFormTest < ComponentTestCase
 
   def setup
     super
@@ -11,7 +10,6 @@ class UserBonusesFormTest < UnitTestCase
     @user_stats = UserStats.find_or_create_by(user_id: @user.id)
     @user_stats.bonuses = [[10, "Test reason 1"], [20, "Test reason 2"],
                            [30, "Test reason 3"]]
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/user_bonuses_form_test.rb
+++ b/test/components/user_bonuses_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class UserBonusesFormTest < ComponentTestCase
-
   def setup
     super
     @user = users(:rolf)

--- a/test/components/user_question_form_test.rb
+++ b/test/components/user_question_form_test.rb
@@ -2,8 +2,7 @@
 
 require "test_helper"
 
-class UserQuestionFormTest < UnitTestCase
-  include ComponentTestHelper
+class UserQuestionFormTest < ComponentTestCase
 
   def setup
     super
@@ -11,7 +10,6 @@ class UserQuestionFormTest < UnitTestCase
     @target = users(:mary)
     @subject = "Test subject"
     @message = "Test message"
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/user_question_form_test.rb
+++ b/test/components/user_question_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class UserQuestionFormTest < ComponentTestCase
-
   def setup
     super
     @model = FormObject::UserQuestion.new

--- a/test/components/visual_group_form_test.rb
+++ b/test/components/visual_group_form_test.rb
@@ -2,14 +2,12 @@
 
 require "test_helper"
 
-class VisualGroupFormTest < UnitTestCase
-  include ComponentTestHelper
+class VisualGroupFormTest < ComponentTestCase
 
   def setup
     super
     @visual_model = visual_models(:visual_model_one)
     @visual_group = VisualGroup.new(visual_model: @visual_model)
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/visual_group_form_test.rb
+++ b/test/components/visual_group_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class VisualGroupFormTest < ComponentTestCase
-
   def setup
     super
     @visual_model = visual_models(:visual_model_one)

--- a/test/components/visual_model_form_test.rb
+++ b/test/components/visual_model_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class VisualModelFormTest < ComponentTestCase
-
   def setup
     super
     @visual_model = VisualModel.new

--- a/test/components/visual_model_form_test.rb
+++ b/test/components/visual_model_form_test.rb
@@ -2,13 +2,11 @@
 
 require "test_helper"
 
-class VisualModelFormTest < UnitTestCase
-  include ComponentTestHelper
+class VisualModelFormTest < ComponentTestCase
 
   def setup
     super
     @visual_model = VisualModel.new
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/webmaster_question_form_test.rb
+++ b/test/components/webmaster_question_form_test.rb
@@ -2,15 +2,13 @@
 
 require "test_helper"
 
-class WebmasterQuestionFormTest < UnitTestCase
-  include ComponentTestHelper
+class WebmasterQuestionFormTest < ComponentTestCase
 
   def setup
     super
     @email = FormObject::WebmasterQuestion.new
     @user_email = "test@example.com"
     @message = "My question"
-    controller.request = ActionDispatch::TestRequest.create
     @html = render_form
   end
 

--- a/test/components/webmaster_question_form_test.rb
+++ b/test/components/webmaster_question_form_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 
 class WebmasterQuestionFormTest < ComponentTestCase
-
   def setup
     super
     @email = FormObject::WebmasterQuestion.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,8 +78,8 @@ require("rails/test_help")
   check_for_unsafe_html
   uploaded_string
 
-  component_test_helper
   unit_test_case
+  component_test_case
   functional_test_case
   integration_test_case
   capybara_integration_test_case


### PR DESCRIPTION
`ComponentTestCase` is the name that Claude keeps looking for when writing new component tests, so I decided to lean into it. 

It's a good idea, because it DRY’s up the component tests even more than the existing `ComponentTestHelper` by providing a base class that has a `setup` method, etc.

It requires all pending Phlex component PRs to:
- Change their new component tests to inherit from new `ComponentTestCase`, not `UnitTestCase`. They should no longer include `ComponentTestHelper`, which has been deleted; those methods have been incorporated into `ComponentTestCase`. Be sure to check calls to `super` if the test class duplicates the base class `setup`
- Refactor everywhere that new tests directly call `Nokogiri::HTML` to use `ComponentTestCase` helpers `assert_html`/`assert_no_html`. This cuts a ton of verbosity out of tests and is important to provide examples that keep Claude writing DRY tests for future components.

Another benefit of `assert_html` vs `assert_includes` is that `assert_html` is:
  - More precise - CSS selectors verify structure, not just string presence
  - Fewer lines - combine related checks
  - Better errors - tells you which selector failed

Claude can easily handle these two refactors, with explicit instructions like the above. I’m happy to do the conversion for any PRs other than my own. I think you guys will prefer this setup.