### PR TITLE
Switch map elevations to OpenElevationAPI

### DIFF
--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -15,6 +15,8 @@ class API2Controller < ApplicationController
   require("xmlrpc/client")
   require("api2")
 
+  include CorsHeaders
+
   disable_filters
 
   # wrapped parameters break JSON requests in the unit tests.
@@ -173,12 +175,14 @@ class API2Controller < ApplicationController
     render(layout: false, template: "/api2/results")
   end
 
+  # Only set CORS headers for GET requests, allowing only GET
   def set_cors_headers
     return unless request.method == "GET"
 
-    response.set_header("Access-Control-Allow-Origin", "*")
-    response.set_header("Access-Control-Allow-Headers",
-                        "Origin, X-Requested-With, Content-Type, Accept")
-    response.set_header("Access-Control-Allow-Methods", "GET")
+    super
+  end
+
+  def cors_allowed_methods
+    %w[GET].freeze
   end
 end

--- a/app/controllers/concerns/cors_headers.rb
+++ b/app/controllers/concerns/cors_headers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Adds CORS headers for API endpoints.
+#
+# Usage:
+#   include CorsHeaders
+#   before_action :set_cors_headers
+#
+# By default, allows GET, POST, OPTIONS methods. Override `cors_allowed_methods`
+# to customize.
+module CorsHeaders
+  extend ActiveSupport::Concern
+
+  ALLOWED_HEADERS = "Origin, X-Requested-With, Content-Type, Accept"
+  DEFAULT_METHODS = %w[GET POST OPTIONS].freeze
+
+  private
+
+  def set_cors_headers
+    response.set_header("Access-Control-Allow-Origin", "*")
+    response.set_header("Access-Control-Allow-Headers", ALLOWED_HEADERS)
+    response.set_header("Access-Control-Allow-Methods",
+                        cors_allowed_methods.join(", "))
+  end
+
+  # Override in controller to restrict allowed methods
+  def cors_allowed_methods
+    DEFAULT_METHODS
+  end
+end

--- a/app/controllers/geo/base_controller.rb
+++ b/app/controllers/geo/base_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Geo
+  # Base controller for geographic services (elevation, geocoding, etc.)
+  # These endpoints proxy external APIs to avoid exposing API keys
+  # and to provide a stable interface.
+  class BaseController < ApplicationController
+    include CorsHeaders
+
+    disable_filters
+    before_action :set_cors_headers
+    layout false
+
+    private
+
+    def render_error(message, status: :bad_request)
+      render(json: { error: message }, status: status)
+    end
+  end
+end

--- a/app/controllers/geo/elevations_controller.rb
+++ b/app/controllers/geo/elevations_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Geo
+  # Proxies elevation requests to Open-Elevation API.
+  # This provides a stable interface and avoids exposing external API details.
+  #
+  # Usage:
+  #   GET /geo/elevation?locations=39.7391,-104.9847|40.0,-105.0
+  #   POST /geo/elevation with JSON body: { "locations": [...] }
+  #
+  class ElevationsController < BaseController
+    OPEN_ELEVATION_URL = "https://api.open-elevation.com/api/v1/lookup"
+
+    # GET /geo/elevation?locations=lat1,lng1|lat2,lng2
+    # POST /geo/elevation with JSON body
+    def show
+      locations = parse_locations
+      return render_error("No locations provided") if locations.blank?
+
+      result = fetch_elevations(locations)
+      render(json: result)
+    rescue StandardError => e
+      Rails.logger.error("Elevation API error: #{e.message}")
+      render_error("Failed to fetch elevations", status: :service_unavailable)
+    end
+
+    private
+
+    def parse_locations
+      if request.post? && request.content_type&.include?("application/json")
+        parse_json_locations
+      else
+        parse_query_locations
+      end
+    end
+
+    # Parse locations from query string: "lat1,lng1|lat2,lng2"
+    def parse_query_locations
+      return [] if params[:locations].blank?
+
+      params[:locations].split("|").map do |pair|
+        lat, lng = pair.split(",").map(&:to_f)
+        { "latitude" => lat, "longitude" => lng }
+      end
+    end
+
+    # Parse locations from JSON body: [{"lat": 1, "lng": 2}, ...]
+    def parse_json_locations
+      body = JSON.parse(request.body.read)
+      locations = body["locations"] || []
+      locations.map do |loc|
+        {
+          "latitude" => loc["lat"] || loc["latitude"],
+          "longitude" => loc["lng"] || loc["longitude"]
+        }
+      end
+    rescue JSON::ParserError
+      []
+    end
+
+    def fetch_elevations(locations)
+      response = elevation_http_client.request(elevation_request(locations))
+      parse_elevation_response(response)
+    end
+
+    def elevation_http_client
+      uri = URI(OPEN_ELEVATION_URL)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 5
+      http.read_timeout = 10
+      http
+    end
+
+    def elevation_request(locations)
+      req = Net::HTTP::Post.new(URI(OPEN_ELEVATION_URL))
+      req["Content-Type"] = "application/json"
+      req.body = { locations: locations }.to_json
+      req
+    end
+
+    def parse_elevation_response(response)
+      if response.is_a?(Net::HTTPSuccess)
+        JSON.parse(response.body)
+      else
+        { "error" => "Upstream API error", "status" => response.code }
+      end
+    end
+  end
+end

--- a/app/helpers/form_locations_helper.rb
+++ b/app/helpers/form_locations_helper.rb
@@ -111,7 +111,7 @@ module FormLocationsHelper
   def elevation_request_button
     tag.button(
       :form_locations_get_elevation.l,
-      type: :button, class: "btn btn-default",
+      id: "get_elevation_btn", type: :button, class: "btn btn-default",
       data: { map_target: "getElevation", action: "map#getElevations",
               map_points_param: "input", map_type_param: "rectangle" }
     )

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -335,7 +335,7 @@ export default class extends Controller {
         this.roundOff(parseFloat(results[0].elevation))
     }
     if (this.hasGetElevationTarget)
-      this.getElevationTarget.disabled = true
+      this.getElevationTarget.classList.add("d-none")
   }
 
   // Using a regular expression

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -286,18 +286,29 @@ export default class extends Controller {
   placeClosestRectangle(viewport, extents) {
   }
 
-  // Computes an array of arrays of [lat, lng] from a set of bounds on the fly
-  // Returns array of Google Map points {lat:, lng:} LatLngLiteral objects
-  // Does not actually get elevations from the API.
-  // Only lat/lng points that can be sent for elevations.
+  // Generates a 9x9 grid of sample points (81 total) within the bounds.
+  // Returns array of Google Map points {lat:, lng:} LatLngLiteral objects.
+  // More points = better min/max elevation estimates for large/mountainous areas.
   sampleElevationPointsOf(bounds) {
-    return [
-      { lat: bounds?.south, lng: bounds?.west },
-      { lat: bounds?.north, lng: bounds?.west },
-      { lat: bounds?.north, lng: bounds?.east },
-      { lat: bounds?.south, lng: bounds?.east },
-      this.centerFromBounds(bounds)
-    ]
+    if (!bounds?.north || !bounds?.south || !bounds?.east || !bounds?.west) {
+      return []
+    }
+
+    const points = []
+    const gridSize = 9
+    const latStep = (bounds.north - bounds.south) / (gridSize - 1)
+    const lngStep = (bounds.east - bounds.west) / (gridSize - 1)
+
+    for (let i = 0; i < gridSize; i++) {
+      for (let j = 0; j < gridSize; j++) {
+        points.push({
+          lat: bounds.south + (i * latStep),
+          lng: bounds.west + (j * lngStep)
+        })
+      }
+    }
+
+    return points
   }
 
   // Computes the center of a Google Maps Rectangle's LatLngBoundsLiteral object

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -49,8 +49,6 @@ export default class extends GeocodeController {
     this.lastGeolocatedAddress = ""
 
     this.libraries = ["maps", "geocoding", "marker"]
-    if (this.needElevationsValue == true)
-      this.libraries.push("elevation")
 
     const loader = new Loader({
       apiKey: "AIzaSyCxT5WScc3b99_2h2Qfy5SX6sTnE1CX3FA",
@@ -84,8 +82,6 @@ export default class extends GeocodeController {
     loader
       .load()
       .then((google) => {
-        if (this.needElevationsValue == true)
-          this.elevationService = new google.maps.ElevationService()
         this.geocoder = new google.maps.Geocoder()
         // Everything except the obs form map: draw the map.
         if (!(this.map_type === "observation" && this.editable)) {
@@ -652,10 +648,22 @@ export default class extends GeocodeController {
     let points
     if (this.marker) {
       const position = this.marker.getPosition().toJSON()
-      points = [position] // this.sampleElevationCenterOf(position)
+      points = [position]
     } else if (this.rectangle) {
       const bounds = this.rectangle.getBounds().toJSON()
       points = this.sampleElevationPointsOf(bounds)
+    } else if (this.hasNorthInputTarget) {
+      // Fallback: read from input fields if no map objects exist
+      const bounds = {
+        north: parseFloat(this.northInputTarget.value),
+        south: parseFloat(this.southInputTarget.value),
+        east: parseFloat(this.eastInputTarget.value),
+        west: parseFloat(this.westInputTarget.value)
+      }
+      if (!isNaN(bounds.north) && !isNaN(bounds.south) &&
+          !isNaN(bounds.east) && !isNaN(bounds.west)) {
+        points = this.sampleElevationPointsOf(bounds)
+      }
     }
     return points
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,11 @@ MushroomObserver::Application.routes.draw do
   get "obs/:id" => "observations#show", id: /\d+/, as: "permanent_observation"
   get ":id" => "observations#show", id: /\d+/ # , as: "permanent_observation"
 
+  # ----- Geo: internal geographic services (elevation, geocoding) -----------
+  namespace :geo do
+    match "elevation", to: "elevations#show", via: [:get, :post]
+  end
+
   # NOTE: The nesting below is necessary to get nice path helpers
   resource :account, only: [:new, :create], controller: "account"
 

--- a/test/controllers/geo/elevations_controller_test.rb
+++ b/test/controllers/geo/elevations_controller_test.rb
@@ -53,7 +53,77 @@ module Geo
       assert_equal("Upstream API error", json["error"])
     end
 
+    # Live API test - skipped by default, run manually to verify grid sampling.
+    # Tests the Mt. Hood area bounding box with grids of increasing density.
+    # Run with: bin/rails test test/controllers/geo/elevations_controller_test.rb \
+    #           -n test_grid_sampling_density_live_api
+    def test_grid_sampling_density_live_api
+      skip("Live API test - run with LIVE_API=1") unless ENV["LIVE_API"]
+
+      # Mt. Hood area - good test case for mountainous terrain
+      box = { north: 45.5203, south: 44.8101, east: -121.3586, west: -122.2301 }
+
+      [9, 12, 15, 18, 21].each do |size|
+        points = generate_grid(box, size)
+        elevations = fetch_live_elevations(points)
+
+        if elevations.any?
+          high = elevations.max
+          low = elevations.min
+          puts "#{size}x#{size} (#{points.size} pts): " \
+               "High=#{high}m, Low=#{low}m, Range=#{high - low}m"
+        else
+          puts "#{size}x#{size} (#{points.size} pts): API error or empty response"
+        end
+
+        sleep(2) # Be nice to the API
+      end
+
+      assert(true, "Grid sampling experiment complete")
+    end
+
     private
+
+    def generate_grid(box, size)
+      points = []
+      lat_step = (box[:north] - box[:south]) / (size - 1).to_f
+      lng_step = (box[:east] - box[:west]) / (size - 1).to_f
+
+      size.times do |i|
+        size.times do |j|
+          points << {
+            lat: box[:south] + (i * lat_step),
+            lng: box[:west] + (j * lng_step)
+          }
+        end
+      end
+      points
+    end
+
+    def fetch_live_elevations(points)
+      uri = URI(Geo::ElevationsController::OPEN_ELEVATION_URL)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = 10
+      http.read_timeout = 60
+
+      # Open-Elevation expects { locations: [{latitude:, longitude:}, ...] }
+      formatted = points.map { |p| { latitude: p[:lat], longitude: p[:lng] } }
+
+      req = Net::HTTP::Post.new(uri)
+      req["Content-Type"] = "application/json"
+      req.body = { locations: formatted }.to_json
+
+      response = http.request(req)
+      result = JSON.parse(response.body)
+
+      unless result["results"]
+        puts "API Error: #{result}"
+        return []
+      end
+
+      result["results"].map { |r| r["elevation"] }
+    end
 
     def stub_open_elevation_api
       stub_request(:post, Geo::ElevationsController::OPEN_ELEVATION_URL).

--- a/test/controllers/geo/elevations_controller_test.rb
+++ b/test/controllers/geo/elevations_controller_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Geo
+  class ElevationsControllerTest < IntegrationTestCase
+    def test_get_elevation_with_query_string
+      stub_open_elevation_api
+      login
+
+      get(geo_elevation_path, params: { locations: "39.7391,-104.9847" })
+
+      assert_response(:success)
+      json = response.parsed_body
+      assert_equal(1, json["results"].length)
+      assert_equal(1617.0, json["results"][0]["elevation"])
+    end
+
+    def test_post_elevation_with_json_body
+      stub_open_elevation_api
+      login
+
+      post(
+        geo_elevation_path,
+        params: { locations: [{ lat: 39.7391, lng: -104.9847 }] }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+      assert_response(:success)
+      json = response.parsed_body
+      assert_equal(1, json["results"].length)
+    end
+
+    def test_returns_error_when_no_locations
+      login
+
+      get(geo_elevation_path)
+
+      assert_response(:bad_request)
+      json = response.parsed_body
+      assert_equal("No locations provided", json["error"])
+    end
+
+    def test_handles_upstream_api_error
+      stub_request(:post, Geo::ElevationsController::OPEN_ELEVATION_URL).
+        to_return(status: 500, body: "Internal Server Error")
+      login
+
+      get(geo_elevation_path, params: { locations: "39.7391,-104.9847" })
+
+      assert_response(:success) # We still return 200 with error in body
+      json = response.parsed_body
+      assert_equal("Upstream API error", json["error"])
+    end
+
+    private
+
+    def stub_open_elevation_api
+      stub_request(:post, Geo::ElevationsController::OPEN_ELEVATION_URL).
+        to_return(
+          status: 200,
+          body: {
+            results: [
+              { latitude: 39.7391, longitude: -104.9847, elevation: 1617.0 }
+            ]
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+  end
+end

--- a/test/system/location_form_system_test.rb
+++ b/test/system/location_form_system_test.rb
@@ -30,4 +30,35 @@ class LocationFormSystemTest < ApplicationSystemTestCase
     # assert_field("location_high", with: "1388.2098")
     # assert_field("location_low", with: "287.8201")
   end
+
+  # TODO: Investigate why Open-Elevation API calls fail in Capybara test
+  # environment but work in real browser. The functionality is verified
+  # manually - elevations auto-populate after geocoding a location.
+  def skip_test_elevations_auto_populate_after_geocoding
+    rolf = users("rolf")
+    login!(rolf)
+
+    visit("/locations/new")
+    assert_selector("body.locations__new")
+    assert_selector("#map_div div div") # map loaded
+
+    fill_in("location_display_name", with: "genolhac gard france")
+    click_button(:form_locations_find_on_map.l)
+
+    # Wait for geocoding to complete
+    assert_selector("#location_display_name.geocoded", wait: 10)
+
+    # Wait for elevations to populate (async call after geocoding)
+    # The button gets disabled once elevations are fetched
+    assert_selector("#location_get_elevation[disabled]", wait: 15)
+
+    # Elevations should be populated
+    high_value = find("#location_high").value
+    low_value = find("#location_low").value
+
+    assert_not_empty(high_value, "High elevation should be populated")
+    assert_not_empty(low_value, "Low elevation should be populated")
+    assert(high_value.to_f > low_value.to_f,
+           "High elevation should be greater than low")
+  end
 end

--- a/test/system/location_form_system_test.rb
+++ b/test/system/location_form_system_test.rb
@@ -31,10 +31,7 @@ class LocationFormSystemTest < ApplicationSystemTestCase
     # assert_field("location_low", with: "287.8201")
   end
 
-  # TODO: Investigate why Open-Elevation API calls fail in Capybara test
-  # environment but work in real browser. The functionality is verified
-  # manually - elevations auto-populate after geocoding a location.
-  def skip_test_elevations_auto_populate_after_geocoding
+  def test_elevations_auto_populate_after_geocoding
     rolf = users("rolf")
     login!(rolf)
 
@@ -49,8 +46,8 @@ class LocationFormSystemTest < ApplicationSystemTestCase
     assert_selector("#location_display_name.geocoded", wait: 10)
 
     # Wait for elevations to populate (async call after geocoding)
-    # The button gets disabled once elevations are fetched
-    assert_selector("#location_get_elevation[disabled]", wait: 15)
+    # The button gets hidden once elevations are fetched
+    assert_selector("#get_elevation_btn.d-none", visible: false, wait: 15)
 
     # Elevations should be populated
     high_value = find("#location_high").value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,7 +55,9 @@ WebMock.disable_net_connect!(
   allow: [
     "chromedriver.storage.googleapis.com", # in case we install Chrome
     "github.com", # for Firefox
-    "objects.githubusercontent.com" # for Firefox
+    "objects.githubusercontent.com", # for Firefox
+    "api.open-elevation.com", # for elevation lookups in system tests
+    /googleapis\.com/ # for Google Maps in system tests
   ]
 )
 


### PR DESCRIPTION
Fixes the broken "Get Elevations" button on the Location form - switches from Google Elevation API (which has referrer restrictions) to Open-Elevation API. Elevations auto-populate after geocoding a location. Fixes #3690.

Takes GoogleElevationAPI off our bill completely. Pretty nifty coding from Claude, too. Very minimal changes to Stimulus; the call comes from Ruby.

## Manual Test
There's a new system test for the elevation fields getting populated from OpenElevation, but manual test welcome. Pick a place to geocode in the /locations/new form, and it should get its bounds and elevation min/max populated.

### Changes
- Calls Open-Elevation API via a backend proxy, instead of directly from JS. This may guard against referrer restrictions in the future.
- Creates /geo namespace - new internal API for geographic services
- Adds CorsHeaders concern - consolidated duplicate CORS code between API2 and Geo controllers

### New files:
  - app/controllers/concerns/cors_headers.rb - CORS concern
  - app/controllers/geo/base_controller.rb - Base geo controller
  - app/controllers/geo/elevations_controller.rb - Elevation proxy
  - test/controllers/geo/elevations_controller_test.rb - Tests

###  Modified files:
  - app/controllers/api2_controller.rb - Uses CORS concern
  - app/javascript/controllers/geocode_controller.js - Uses /geo/elevation
  - app/javascript/controllers/map_controller.js - Input fallback for sampleElevationPoints
  - config/routes.rb - Added /geo/elevation route
  - test/system/location_form_system_test.rb - Added (skipped) elevation test
  - test/test_helper.rb - Allow Open-Elevation & Google APIs