### PR TITLE
Fix map autozoom for locations

### DIFF
--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -196,8 +196,8 @@ export default class extends Controller {
     const center = results[0].geometry.location.toJSON()
 
     if (this.map) {
-      if (viewport) this.map.fitBounds(viewport)
-      this.placeClosestRectangle(viewport, extents) // viewport is optional
+      // placeClosestRectangle will handle fitBounds after zoom completes
+      this.placeClosestRectangle(viewport, extents)
     }
     this.updateFields(viewport, extents, center)
     // For non-autocompleted place input in the location form

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -116,23 +116,21 @@ export default class extends GeocodeController {
     }
   }
 
-  // We don't draw the map for the create obs form on load, to save on API
-  // If we only have one marker, don't use fitBounds - it's too zoomed in.
-  // Call setCenter, setZoom with marker position and desired zoom level.
+  // We don't draw the map for the create obs form on load, to save on API.
+  // Always use fitBounds to properly display the location bounds, with a
+  // maxZoom to prevent zooming in too close for small/point locations.
   drawMap() {
     this.verbose("map:drawMap")
     this.map = new google.maps.Map(this.mapDivTarget, this.mapOptions)
     if (this.mapBounds) {
-      if (Object.keys(this.collection.sets).length == 1) {
-        const pt = new google.maps.LatLng(
-          this.collection.extents.lat,
-          this.collection.extents.lng
-        )
-        this.map.setCenter(pt)
-        this.map.setZoom(12)
-      } else {
-        this.map.fitBounds(this.mapBounds)
-      }
+      this.map.fitBounds(this.mapBounds)
+      // Prevent excessive zoom for small locations (points or tiny areas)
+      const maxZoom = 15
+      google.maps.event.addListenerOnce(this.map, 'bounds_changed', () => {
+        if (this.map.getZoom() > maxZoom) {
+          this.map.setZoom(maxZoom)
+        }
+      })
     }
   }
 


### PR DESCRIPTION
 Fixes #3694: Map controller overrides Google Maps auto-zoom for rectangles

  Root Cause: In drawMap(), for single-location collections, the code used a fixed zoom: 12 and centered on the location point. For large locations (like Lake George, NY), zoom 12 is too zoomed in to show the entire bounds.

  Fix: Changed drawMap() to always use fitBounds() which lets Google Maps automatically calculate the correct zoom level to show the entire location. Added a maxZoom limit of 15 to prevent excessive zoom-in for small/point locations.

  Before:
  - Single locations: fixed zoom: 12, centered on point
  - Multiple locations: fitBounds()

  After:
  - All locations: fitBounds() with maxZoom=15 cap
