### PR TITLE
Fix language switching in sidebar

### DIFF
--- a/app/components/sidebar/languages.rb
+++ b/app/components/sidebar/languages.rb
@@ -18,9 +18,7 @@ module Components
       register_value_helper :reload_with_args
 
       # Make request available to registered helpers
-      def request
-        @request
-      end
+      attr_reader :request
 
       def view_template
         div(class: "list-group-item pl-3 overflow-visible") do

--- a/app/components/sidebar/languages.rb
+++ b/app/components/sidebar/languages.rb
@@ -17,6 +17,11 @@ module Components
 
       register_value_helper :reload_with_args
 
+      # Make request available to registered helpers
+      def request
+        @request
+      end
+
       def view_template
         div(class: "list-group-item pl-3 overflow-visible") do
           div(class: "dropdown") do


### PR DESCRIPTION
## Summary
Fixes language dropdown not working after Languages component refactoring.

## Problem
The `reload_with_args` helper needs access to `request`, but it was stored as `@request` instance variable in the component. Registered helpers couldn't access it.

## Solution
Added a `request` method to expose `@request` so registered helpers can access it properly.

## Testing
- Ran Languages component tests - all passing
- Language dropdown links now generate correct URLs with `?user_locale=en` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)