### PR TITLE
Fix sidebar cache to update when changing languages

### DIFF
--- a/app/components/application_sidebar.rb
+++ b/app/components/application_sidebar.rb
@@ -68,8 +68,8 @@ module Components
     end
 
     def render_top_section
-      # This cache depends only on user status (logged-in? admin?)
-      cache([user_status_string(@user), "login"]) do
+      # This cache depends on user status and locale
+      cache([user_status_string(@user), I18n.locale, "login"]) do
         if @in_admin_mode
           render(Components::Sidebar::Admin.new(
                    heading_key: :app_admin,
@@ -122,8 +122,8 @@ module Components
     end
 
     def render_info_sections
-      # This cache depends only on user status (logged-in? admin?)
-      cache([user_status_string(@user), "links"]) do
+      # This cache depends on user status and locale
+      cache([user_status_string(@user), I18n.locale, "links"]) do
         render(Components::Sidebar::Section.new(
                  heading_key: :app_latest,
                  tabs: sidebar_latest_tabs(@user),


### PR DESCRIPTION
## Summary
Fixes cached sidebar sections not updating when switching languages.

## Problem
After switching languages, only the Observations and Species Lists sections were updating. The Admin/Login, Latest, Indexes, More, and Languages sections remained in the original language because they were cached with keys that didn't include locale.

## Solution
Added `I18n.locale` to both sidebar cache keys:
- `render_top_section` (Admin/Login sections)
- `render_info_sections` (Latest/Indexes/More/Languages sections)

## Testing
- Ran ApplicationSidebar tests - all passing
- Cache keys now invalidate when locale changes

## Related
Follow-up to #3709 which fixed the language switching mechanism itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)