### PR TITLE
Create `FormObject::Base` to remove boilerplate

### DIFF
--- a/app/classes/form_object/base.rb
+++ b/app/classes/form_object/base.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Base class for form objects used with Superform.
+# Provides ActiveModel compatibility and sensible defaults.
+class FormObject::Base
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  # Use demodulized class name for field namespacing.
+  # FormObject::AdminSession → "AdminSession" → admin_session[field]
+  # Subclasses can override if different namespacing is needed.
+  def self.model_name
+    ActiveModel::Name.new(self, nil, name.demodulize)
+  end
+end

--- a/app/classes/form_object/commercial_inquiry.rb
+++ b/app/classes/form_object/commercial_inquiry.rb
@@ -2,14 +2,6 @@
 
 # Form object for commercial inquiry about an image
 # Handles form data for image licensing inquiries
-class FormObject::CommercialInquiry
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::CommercialInquiry < FormObject::Base
   attribute :message, :string
-
-  # Field names like commercial_inquiry[message]
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "CommercialInquiry")
-  end
 end

--- a/app/classes/form_object/feature_email.rb
+++ b/app/classes/form_object/feature_email.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-class FormObject::FeatureEmail
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+# Form object for feature announcement emails
+class FormObject::FeatureEmail < FormObject::Base
   attribute :content, :string
-
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "FeatureEmail")
-  end
 end

--- a/app/classes/form_object/herbarium_curator_request.rb
+++ b/app/classes/form_object/herbarium_curator_request.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
 # Form object for requesting herbarium curator access
-class FormObject::HerbariumCuratorRequest
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::HerbariumCuratorRequest < FormObject::Base
   attribute :notes, :string
 
   def persisted?
     false
-  end
-
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "herbarium_curator_request")
   end
 end

--- a/app/classes/form_object/image_vote_anonymity.rb
+++ b/app/classes/form_object/image_vote_anonymity.rb
@@ -2,18 +2,11 @@
 
 # Form object for image vote anonymity updates
 # This form has no fields - just displays counts and provides action buttons
-class FormObject::ImageVoteAnonymity
-  include ActiveModel::Model
-
+class FormObject::ImageVoteAnonymity < FormObject::Base
   attr_accessor :num_anonymous, :num_public
 
   # Not persisted - this form triggers an action, doesn't save data
   def persisted?
     true # Return true so form uses PATCH method
-  end
-
-  # Override model_name to avoid params namespacing since we don't need it
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "ImageVoteAnonymity")
   end
 end

--- a/app/classes/form_object/login.rb
+++ b/app/classes/form_object/login.rb
@@ -2,15 +2,12 @@
 
 # Form object for user login
 # Handles login form data with proper field namespacing
-class FormObject::Login
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::Login < FormObject::Base
   attribute :login, :string
   attribute :password, :string
   attribute :remember_me, :boolean, default: false
 
-  # Override model_name to use "user" for field namespacing
+  # Custom model_name to use "user" for field namespacing
   # This makes field names like user[login] instead of login[login]
   # to match existing controller expectations
   def self.model_name

--- a/app/classes/form_object/merge_request.rb
+++ b/app/classes/form_object/merge_request.rb
@@ -2,14 +2,6 @@
 
 # Form object for submitting a merge request email to admins
 # Allows users to request merging two objects (e.g., names or locations)
-class FormObject::MergeRequest
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::MergeRequest < FormObject::Base
   attribute :notes, :string
-
-  # Override model_name to control form field namespacing
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "MergeRequest")
-  end
 end

--- a/app/classes/form_object/name_change_request.rb
+++ b/app/classes/form_object/name_change_request.rb
@@ -2,14 +2,6 @@
 
 # Form object for requesting changes to taxonomic names
 # Handles form data for name change request emails to admins
-class FormObject::NameChangeRequest
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::NameChangeRequest < FormObject::Base
   attribute :notes, :string
-
-  # Override model_name to control form field namespacing
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "NameChangeRequest")
-  end
 end

--- a/app/classes/form_object/observer_question.rb
+++ b/app/classes/form_object/observer_question.rb
@@ -2,14 +2,6 @@
 
 # Form object for asking an observation owner a question
 # Handles form data for observation-related messages
-class FormObject::ObserverQuestion
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::ObserverQuestion < FormObject::Base
   attribute :message, :string
-
-  # Field names like observer_question[message]
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "ObserverQuestion")
-  end
 end

--- a/app/classes/form_object/project_admin_request.rb
+++ b/app/classes/form_object/project_admin_request.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 # Form object for requesting project admin access
-class FormObject::ProjectAdminRequest
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::ProjectAdminRequest < FormObject::Base
   attribute :subject, :string
   attribute :content, :string
 
@@ -12,6 +9,7 @@ class FormObject::ProjectAdminRequest
     false
   end
 
+  # Custom model_name to match controller expectations
   def self.model_name
     ActiveModel::Name.new(self, nil, "email")
   end

--- a/app/classes/form_object/textile_sandbox.rb
+++ b/app/classes/form_object/textile_sandbox.rb
@@ -2,14 +2,6 @@
 
 # Form object for the textile sandbox form.
 # This is not backed by a database, just a struct to hold form data.
-class FormObject::TextileSandbox
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::TextileSandbox < FormObject::Base
   attribute :code, :string
-
-  # Field names like textile_sandbox[code]
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "TextileSandbox")
-  end
 end

--- a/app/classes/form_object/user_question.rb
+++ b/app/classes/form_object/user_question.rb
@@ -2,15 +2,7 @@
 
 # Form object for asking another user a question
 # Handles form data for user-to-user messages
-class FormObject::UserQuestion
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::UserQuestion < FormObject::Base
   attribute :subject, :string
   attribute :message, :string
-
-  # Field names like user_question[subject], user_question[message]
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "UserQuestion")
-  end
 end

--- a/app/classes/form_object/webmaster_question.rb
+++ b/app/classes/form_object/webmaster_question.rb
@@ -2,16 +2,7 @@
 
 # Form object for asking the webmaster a question
 # Handles form data for anonymous or logged-in users
-class FormObject::WebmasterQuestion
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class FormObject::WebmasterQuestion < FormObject::Base
   attribute :email, :string
   attribute :message, :string
-
-  # Override model_name to control form field namespacing
-  # This makes field names match controller expectations
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "WebmasterQuestion")
-  end
 end


### PR DESCRIPTION
Base class for Superform form objects

  Created: `app/classes/form_object/base.rb`
  - Provides `ActiveModel::Model` and `ActiveModel::Attributes`
  - Auto-demodulizes class name for field namespacing, e.g. `FormObject::AdminSession` gets field name prefix `admin_session` -> `admin_session_user_id`

  Updated to inherit from Base (removed boilerplate):
  - CommercialInquiry
  - FeatureEmail
  - HerbariumCuratorRequest
  - ImageVoteAnonymity
  - MergeRequest
  - NameChangeRequest
  - ObserverQuestion
  - TextileSandbox
  - UserQuestion
  - WebmasterQuestion

  Updated with custom model_name retained:
  - Login → uses "User" for field names
  - ProjectAdminRequest → uses "email" for field names
