### PR TITLE
Remove references to `current_user` helper in components

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -110,7 +110,6 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Register view helpers that forms might need
   # Use register_value_helper for helpers that return values (not HTML)
   register_value_helper :in_admin_mode?
-  register_value_helper :current_user
   register_value_helper :url_for
   register_value_helper :rank_as_string
 

--- a/app/components/carousel.rb
+++ b/app/components/carousel.rb
@@ -10,7 +10,7 @@
 #
 # @example
 #   render Components::Carousel.new(
-#     user: current_user,
+#     user: @user,
 #     images: @images,
 #     object: @observation,
 #     title: "Observation Images",

--- a/app/components/carousel_item.rb
+++ b/app/components/carousel_item.rb
@@ -10,7 +10,7 @@
 #
 # @example
 #   render Components::CarouselItem.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image,
 #     object: @observation,
 #     index: 0

--- a/app/components/carousel_thumbnail.rb
+++ b/app/components/carousel_thumbnail.rb
@@ -7,7 +7,7 @@
 #
 # @example
 #   render Components::CarouselThumbnail.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image,
 #     index: 0,
 #     carousel_id: "observation_123_carousel"

--- a/app/components/form_carousel.rb
+++ b/app/components/form_carousel.rb
@@ -7,7 +7,7 @@
 #
 # @example
 #   render Components::FormCarousel.new(
-#     user: current_user,
+#     user: @user,
 #     images: @good_images,
 #     obs_thumb_id: @observation.thumb_image_id,
 #     exif_data: @exif_data

--- a/app/components/form_carousel_item.rb
+++ b/app/components/form_carousel_item.rb
@@ -13,7 +13,7 @@
 #
 # @example
 #   render Components::FormCarouselItem.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image,
 #     index: 0,
 #     upload: false,

--- a/app/components/form_image_fields.rb
+++ b/app/components/form_image_fields.rb
@@ -13,7 +13,7 @@
 #
 # @example
 #   render Components::FormImageFields.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image,
 #     img_id: 123,
 #     upload: false

--- a/app/components/image_copyright.rb
+++ b/app/components/image_copyright.rb
@@ -4,13 +4,13 @@
 #
 # @example Basic usage
 #   render Components::ImageCopyright.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image
 #   )
 #
 # @example With context object
 #   render Components::ImageCopyright.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image,
 #     object: @observation
 #   )

--- a/app/components/interactive_image.rb
+++ b/app/components/interactive_image.rb
@@ -8,7 +8,7 @@
 #
 # @example
 #   render Components::InteractiveImage.new(
-#     user: current_user,
+#     user: @user,
 #     image: @image,
 #     size: :thumbnail,
 #     votes: true

--- a/app/components/sidebar/user.rb
+++ b/app/components/sidebar/user.rb
@@ -6,7 +6,7 @@ module Components
     #
     # @example Basic usage
     #   render(Components::Sidebar::User.new(
-    #     user: current_user,
+    #     user: @user,
     #     classes: sidebar_css_classes,
     #     in_admin_mode: in_admin_mode?
     #   ))


### PR DESCRIPTION
The helper is not used in components at this point, unnecessary include.

Other references are just code examples in comments.