### PR TITLE
Fix image upload file type validation

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -430,6 +430,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     max_size_in_mb = (max_size.to_f / 1024 / 1024).round
     max_upload_msg = :validate_image_file_too_big.l(max: max_size_in_mb)
     opts = opts.merge(
+      accept: "image/*",
       data: {
         action: "change->file-input#validate", file_input_target: "input",
         max_upload_size: max_size, max_upload_msg: max_upload_msg

--- a/app/javascript/controllers/file-input_controller.js
+++ b/app/javascript/controllers/file-input_controller.js
@@ -11,22 +11,34 @@ export default class extends Controller {
     this.old_callback = this.inputTarget.onchange;
   }
 
-  // Override onchange callback with one which checks file size.
-  // If exceeded, it gives an alert and clears the field.
+  // Override onchange callback with one which checks file type and size.
+  // If invalid, it gives an alert and clears the field.
   // If not, it passes execution to the original callback (if any).
   validate(event) {
     if (!this.max_size) alert("Missing max_upload_size attribute for #" + id);
     if (!this.error_msg) alert("Missing max_upload_msg attribute for #" + id);
 
-    // alert("Applying validation to " + field.id);
-    if (this.inputTarget.files[0].size > this.max_size) {
-      alert(this.error_msg);
-      // clear_file_input_field(this);
+    const file = this.inputTarget.files[0];
+    if (!file) return;
+
+    // Check file type - folders have empty type, reject non-images
+    if (!file.type || !file.type.startsWith('image/')) {
+      alert("Please select an image file (JPG, PNG, GIF, etc.)");
       this.inputTarget.value = "";
-    } else if (this.old_callback) {
+      return;
+    }
+
+    // Check file size
+    if (file.size > this.max_size) {
+      alert(this.error_msg);
+      this.inputTarget.value = "";
+      return;
+    }
+
+    if (this.old_callback) {
       this.old_callback.bind(event.target).call();
     } else {
-      this.nameTarget.innerHTML = this.inputTarget.files[0].name
+      this.nameTarget.innerHTML = file.name
     }
   }
 }

--- a/test/helpers/forms_helper_test.rb
+++ b/test/helpers/forms_helper_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Test form helpers
+class FormsHelperTest < ActionView::TestCase
+  def test_file_field_with_label_has_accept_attribute
+    # Create a minimal form builder for testing
+    form = ActionView::Helpers::FormBuilder.new(
+      :upload, nil, self, {}
+    )
+
+    html = file_field_with_label(
+      form: form,
+      field: :image,
+      label: "Upload Image"
+    )
+
+    # Should have accept="image/*" attribute to restrict file picker to images
+    assert_includes(html, 'accept="image/*"',
+                    "File input should have accept attribute for images")
+  end
+
+  def test_file_field_with_label_has_file_input_controller
+    form = ActionView::Helpers::FormBuilder.new(
+      :upload, nil, self, {}
+    )
+
+    html = file_field_with_label(
+      form: form,
+      field: :image,
+      label: "Upload Image"
+    )
+
+    # Should have Stimulus controller for client-side validation
+    assert_includes(html, 'data-controller="file-input"',
+                    "Should have file-input Stimulus controller")
+    # HTML escapes > to &gt; in attributes
+    assert_includes(html, "change-&gt;file-input#validate",
+                    "Should trigger validation on change")
+  end
+end

--- a/test/system/image_upload_system_test.rb
+++ b/test/system/image_upload_system_test.rb
@@ -49,4 +49,31 @@ class ImageUploadSystemTest < ApplicationSystemTestCase
     assert_equal(1, glossary_term.images.count,
                  "Glossary term should have one image")
   end
+
+  # Test that the file input rejects non-image files with an alert
+  def test_file_input_rejects_non_image_files
+    user = users("rolf")
+    login!(user)
+
+    # Use the projects form which has file_field_with_label
+    visit(new_project_path)
+    assert_selector("body.projects__new")
+
+    # Create a temporary text file (non-image)
+    text_file = Tempfile.new(["test", ".txt"])
+    text_file.write("This is not an image")
+    text_file.close
+
+    begin
+      # Attach the non-image file and expect an alert
+      alert_text = accept_alert do
+        attach_file("upload_image", text_file.path, visible: false)
+      end
+
+      assert_equal("Please select an image file (JPG, PNG, GIF, etc.)",
+                   alert_text)
+    ensure
+      text_file.unlink
+    end
+  end
 end


### PR DESCRIPTION
### Project forms, Glossary Term forms, User profiles:
Fixes issue #3713 where people drag a folder to the upload button
Obs form uses a different interface. This is OK on the obs form PR branch.

1. JS validation (file-input_controller.js):
  - Checks file.type exists and starts with image/
  - Folders have empty type, so they're rejected with a friendly message
  - Refactored to use early returns for cleaner flow

2. HTML attribute (forms_helper.rb):
  - Added accept: "image/*" to file input
  - Browser file picker will default to showing only images