### PR TITLE
Fix intermittent TranslatorsCreditTest failure from test isolation issue

### DIFF
--- a/test/components/translators_credit_test.rb
+++ b/test/components/translators_credit_test.rb
@@ -4,6 +4,11 @@ require "test_helper"
 
 # Tests for TranslatorsCredit component conditional rendering
 class TranslatorsCreditTest < ComponentTestCase
+  def setup
+    super
+    Language.ignore_usage
+  end
+
   def teardown
     Language.ignore_usage
     super


### PR DESCRIPTION
## Summary

Fixes an intermittent test failure in `TranslatorsCreditTest#test_renders_translators_credit_for_unofficial_language` caused by test isolation issues with the `Language.tracking_usage?` global state.

## Problem

The test was failing intermittently with:
```
Expected NOT to find element matching 'a#translations_for_page_link'.
```

Root cause: `Language.tracking_usage?` uses a class variable (`@@tags_used`) that's shared globally across all tests. Other test files (e.g., `translations_controller_test.rb`) call `Language.track_usage` without proper cleanup, causing state to leak into subsequent tests when they run in different orders.

## Solution

Added a `setup` method that calls `Language.ignore_usage` to ensure a clean state before each test runs. This provides defense-in-depth against test pollution from other test files, regardless of test execution order.

## Changes

- Added `setup` method to `TranslatorsCreditTest` that calls `Language.ignore_usage`
- Kept existing `teardown` method for cleanup after tests

## Test Plan

- [x] Verified `test_renders_translators_credit_for_unofficial_language` passes consistently
- [x] All tests in `translators_credit_test.rb` pass
- [x] No regressions in related component tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)