### PR TITLE
Enable `simplecov` to run parallel tests with merged coverage results

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    env:
+      PARALLEL_WORKERS: 4
     steps:
       # check-out repo under $GITHUB_WORKSPACE, so that workflow can access it.
       # https://github.com/actions/checkout
@@ -43,6 +45,12 @@ jobs:
           mysql -u root -proot < db/initialize.sql
           cp db/vagrant/database.yml config
 
+      - name: Create parallel test databases
+        run: |
+          for i in $(seq 0 $((PARALLEL_WORKERS - 1))); do
+            mysql -u root -proot -e "DROP DATABASE IF EXISTS \`mo_test-$i\`; CREATE DATABASE \`mo_test-$i\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
+          done
+
       - name: Create test image directories
         run: |
           for dir in images test_images;
@@ -63,6 +71,13 @@ jobs:
           bundle exec rake db:schema:load
           bundle exec rake db:fixtures:load
 
+      - name: Load fixtures into parallel test databases
+        run: |
+          for i in $(seq 0 $((PARALLEL_WORKERS - 1))); do
+            MO_TEST_DATABASE=mo_test-$i bundle exec rake db:schema:load
+            MO_TEST_DATABASE=mo_test-$i bundle exec rake db:fixtures:load
+          done
+
       - name: Update translation files
         run: bundle exec rake lang:update
 
@@ -70,6 +85,9 @@ jobs:
         run: |
           touch log/test.log
           touch log/production.log
+
+      - name: Set up parallel test config files
+        run: bundle exec rake parallel:test:setup
 
       # And finally we can run the test suite
       - name: Run tests

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           for i in $(seq 0 $((PARALLEL_WORKERS - 1))); do
             mysql -u root -proot -e "DROP DATABASE IF EXISTS \`mo_test-$i\`; CREATE DATABASE \`mo_test-$i\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
-            TEST_ENV_NUMBER=$i bundle exec rake db:schema:load db:fixtures:load
+            TEST_ENV_NUMBER=$i bundle exec rake db:schema_load_no_fk db:fixtures:load
           done
 
       - name: Update translation files

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -45,12 +45,6 @@ jobs:
           mysql -u root -proot < db/initialize.sql
           cp db/vagrant/database.yml config
 
-      - name: Create parallel test databases
-        run: |
-          for i in $(seq 0 $((PARALLEL_WORKERS - 1))); do
-            mysql -u root -proot -e "DROP DATABASE IF EXISTS \`mo_test-$i\`; CREATE DATABASE \`mo_test-$i\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
-          done
-
       - name: Create test image directories
         run: |
           for dir in images test_images;
@@ -71,11 +65,11 @@ jobs:
           bundle exec rake db:schema:load
           bundle exec rake db:fixtures:load
 
-      - name: Load fixtures into parallel test databases
+      - name: Create and load parallel test databases
         run: |
           for i in $(seq 0 $((PARALLEL_WORKERS - 1))); do
-            MO_TEST_DATABASE=mo_test-$i bundle exec rake db:schema:load
-            MO_TEST_DATABASE=mo_test-$i bundle exec rake db:fixtures:load
+            mysql -u root -proot -e "DROP DATABASE IF EXISTS \`mo_test-$i\`; CREATE DATABASE \`mo_test-$i\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
+            TEST_ENV_NUMBER=$i bundle exec rake db:schema:load db:fixtures:load
           done
 
       - name: Update translation files

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -65,11 +65,12 @@ jobs:
           bundle exec rake db:schema:load
           bundle exec rake db:fixtures:load
 
-      - name: Create and load parallel test databases
+      - name: Create parallel test databases from main
         run: |
+          mysqldump -u root -proot mo_test > /tmp/mo_test.sql
           for i in $(seq 0 $((PARALLEL_WORKERS - 1))); do
             mysql -u root -proot -e "DROP DATABASE IF EXISTS \`mo_test-$i\`; CREATE DATABASE \`mo_test-$i\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
-            TEST_ENV_NUMBER=$i bundle exec rake db:schema_load_no_fk db:fixtures:load
+            mysql -u root -proot "mo_test-$i" < /tmp/mo_test.sql
           done
 
       - name: Update translation files

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,8 @@ MushroomObserver::Application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Enable eager loading in CI for accurate SimpleCov coverage with parallel tests.
+  config.eager_load = ENV["CI"].present?
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,7 @@ MushroomObserver::Application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  # Enable eager loading in CI for accurate SimpleCov coverage with parallel tests.
+  # Eager load in CI so SimpleCov sees all code before workers fork.
   config.eager_load = ENV["CI"].present?
 
   # Configure static asset server for tests with Cache-Control for performance.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,8 +50,7 @@ MushroomObserver::Application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  # Eager load in CI so SimpleCov sees all code before workers fork.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
@@ -65,6 +64,9 @@ MushroomObserver::Application.configure do
 
   # Use a different cache store in test.
   config.cache_store = :null_store
+
+  # Use primary database for SolidCache (avoids needing separate cache db)
+  config.solid_cache.connects_to = { database: { writing: :primary } }
 
   # Render exception templates for rescuable exceptions and raise for other
   # exceptions.

--- a/db/initialize.sql
+++ b/db/initialize.sql
@@ -37,3 +37,4 @@ grant all privileges on mo_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on cache_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on mo_test.* to 'mo'@'localhost' with grant option;
 grant all privileges on `mo_test-%`.* to 'mo'@'localhost';
+grant create on *.* to 'mo'@'localhost';

--- a/db/initialize.sql
+++ b/db/initialize.sql
@@ -10,6 +10,10 @@ drop database if exists mo_test;
 create database mo_test
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
+drop database if exists cache_test;
+create database cache_test
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
 drop database if exists mo_tmp;
 create database mo_tmp;
 use mo_tmp;
@@ -36,4 +40,5 @@ drop database mo_tmp;
 grant all privileges on mo_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on cache_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on mo_test.* to 'mo'@'localhost' with grant option;
+grant all privileges on cache_test.* to 'mo'@'localhost' with grant option;
 grant all privileges on `mo_test-%`.* to 'mo'@'localhost';

--- a/db/initialize.sql
+++ b/db/initialize.sql
@@ -10,10 +10,6 @@ drop database if exists mo_test;
 create database mo_test
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
-drop database if exists cache_test;
-create database cache_test
-  DEFAULT CHARACTER SET utf8
-  DEFAULT COLLATE utf8_general_ci;
 drop database if exists mo_tmp;
 create database mo_tmp;
 use mo_tmp;
@@ -40,5 +36,4 @@ drop database mo_tmp;
 grant all privileges on mo_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on cache_development.* to 'mo'@'localhost' with grant option;
 grant all privileges on mo_test.* to 'mo'@'localhost' with grant option;
-grant all privileges on cache_test.* to 'mo'@'localhost' with grant option;
 grant all privileges on `mo_test-%`.* to 'mo'@'localhost';

--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -42,19 +42,11 @@ development:
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
 test:
-  primary:
-    # Support worker-specific databases in parallel testing
-    # Set MO_TEST_DATABASE env var to override (e.g., mo_test-0, mo_test-1, etc.)
-    database: <%= ENV.fetch("MO_TEST_DATABASE", "mo_test") %>
-    username: mo
-    password: mo
-  # Required for eager loading in CI (SolidCache models need this connection)
-  # Enables accurate SimpleCov coverage with parallel test workers
-  cache:
-    database: cache_test
-    username: mo
-    password: mo
-    migrations_paths: "db/cache/migrate"
+  # Support worker-specific databases in parallel testing
+  # Set MO_TEST_DATABASE env var to override (e.g., mo_test-0, mo_test-1, etc.)
+  database: <%= ENV.fetch("MO_TEST_DATABASE", "mo_test") %>
+  username: mo
+  password: mo
 
 production:
   database: mo_development

--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -42,11 +42,19 @@ development:
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
 test:
-  # Support worker-specific databases in parallel testing
-  # Set MO_TEST_DATABASE env var to override (e.g., mo_test-0, mo_test-1, etc.)
-  database: <%= ENV.fetch("MO_TEST_DATABASE", "mo_test") %>
-  username: mo
-  password: mo
+  primary:
+    # Support worker-specific databases in parallel testing
+    # Set MO_TEST_DATABASE env var to override (e.g., mo_test-0, mo_test-1, etc.)
+    database: <%= ENV.fetch("MO_TEST_DATABASE", "mo_test") %>
+    username: mo
+    password: mo
+  # Required for eager loading in CI (SolidCache models need this connection)
+  # Enables accurate SimpleCov coverage with parallel test workers
+  cache:
+    database: cache_test
+    username: mo
+    password: mo
+    migrations_paths: "db/cache/migrate"
 
 production:
   database: mo_development

--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -42,12 +42,10 @@ development:
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
 #
-# Support worker-specific databases in parallel testing:
-# - TEST_ENV_NUMBER is set by Rails for each parallel worker (0, 1, 2, etc.)
-# - MO_TEST_DATABASE can override for manual testing
-<% test_db = ENV["MO_TEST_DATABASE"] || (ENV["TEST_ENV_NUMBER"].to_s.empty? ? "mo_test" : "mo_test-#{ENV['TEST_ENV_NUMBER']}") %>
+# Parallel testing: TEST_ENV_NUMBER selects mo_test-0, mo_test-1, etc.
+# MO_TEST_DATABASE can override for manual testing.
 test:
-  database: <%= test_db %>
+  database: <%= ENV.fetch("MO_TEST_DATABASE") { ENV["TEST_ENV_NUMBER"].to_s.empty? ? "mo_test" : "mo_test-#{ENV['TEST_ENV_NUMBER']}" } %>
   username: mo
   password: mo
 

--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -43,8 +43,19 @@ development:
 # Do not set this db to the same as development or production.
 test:
   # Support worker-specific databases in parallel testing
-  # Set MO_TEST_DATABASE env var to override (e.g., mo_test-0, mo_test-1, etc.)
-  database: <%= ENV.fetch("MO_TEST_DATABASE", "mo_test") %>
+  # Rails sets TEST_ENV_NUMBER for each parallel worker (0, 1, 2, etc.)
+  # MO_TEST_DATABASE can override for manual testing
+  <%
+    test_env_num = ENV["TEST_ENV_NUMBER"]
+    db_name = if ENV["MO_TEST_DATABASE"]
+                ENV["MO_TEST_DATABASE"]
+              elsif test_env_num && !test_env_num.empty?
+                "mo_test-#{test_env_num}"
+              else
+                "mo_test"
+              end
+  %>
+  database: <%= db_name %>
   username: mo
   password: mo
 

--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -41,21 +41,13 @@ development:
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
+#
+# Support worker-specific databases in parallel testing:
+# - TEST_ENV_NUMBER is set by Rails for each parallel worker (0, 1, 2, etc.)
+# - MO_TEST_DATABASE can override for manual testing
+<% test_db = ENV["MO_TEST_DATABASE"] || (ENV["TEST_ENV_NUMBER"].to_s.empty? ? "mo_test" : "mo_test-#{ENV['TEST_ENV_NUMBER']}") %>
 test:
-  # Support worker-specific databases in parallel testing
-  # Rails sets TEST_ENV_NUMBER for each parallel worker (0, 1, 2, etc.)
-  # MO_TEST_DATABASE can override for manual testing
-  <%
-    test_env_num = ENV["TEST_ENV_NUMBER"]
-    db_name = if ENV["MO_TEST_DATABASE"]
-                ENV["MO_TEST_DATABASE"]
-              elsif test_env_num && !test_env_num.empty?
-                "mo_test-#{test_env_num}"
-              else
-                "mo_test"
-              end
-  %>
-  database: <%= db_name %>
+  database: <%= test_db %>
   username: mo
   password: mo
 

--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -45,7 +45,7 @@ development:
 # Parallel testing: TEST_ENV_NUMBER selects mo_test-0, mo_test-1, etc.
 # MO_TEST_DATABASE can override for manual testing.
 test:
-  database: <%= ENV.fetch("MO_TEST_DATABASE") { ENV["TEST_ENV_NUMBER"].to_s.empty? ? "mo_test" : "mo_test-#{ENV['TEST_ENV_NUMBER']}" } %>
+  database: "<%= ENV['MO_TEST_DATABASE'] || (ENV['TEST_ENV_NUMBER'].to_s.empty? && 'mo_test') || 'mo_test-' + ENV['TEST_ENV_NUMBER'] %>"
   username: mo
   password: mo
 

--- a/lib/tasks/parallel_test.rake
+++ b/lib/tasks/parallel_test.rake
@@ -17,3 +17,12 @@ namespace :parallel do
     end
   end
 end
+
+namespace :db do
+  desc "Load schema with FK checks disabled (for SolidQueue compatibility)"
+  task schema_load_no_fk: :environment do
+    ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS=0")
+    Rake::Task["db:schema:load"].invoke
+    ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS=1")
+  end
+end

--- a/lib/tasks/parallel_test.rake
+++ b/lib/tasks/parallel_test.rake
@@ -17,12 +17,3 @@ namespace :parallel do
     end
   end
 end
-
-namespace :db do
-  desc "Load schema with FK checks disabled (for SolidQueue compatibility)"
-  task schema_load_no_fk: :environment do
-    ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS=0")
-    Rake::Task["db:schema:load"].invoke
-    ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS=1")
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,6 @@
 require("rails")
 
 # Only load SimpleCov when explicitly requested or in CI
-# Parallel testing has issues with SimpleCov, so disable it by default
 if ENV["COVERAGE"] == "true" || ENV["CI"] == "true"
   require("simplecov")
   require("simplecov-lcov")
@@ -111,12 +110,21 @@ module ActiveSupport
     # Run tests in parallel with specified workers
     # Threshold can be set via PARALLEL_TEST_THRESHOLD environment variable
     # Default is 50 (Rails default) if not set
-    # Note: Disable parallel testing when collecting coverage because
-    # SimpleCov doesn't fully support Rails 7's built-in parallel testing
     threshold = ENV["PARALLEL_TEST_THRESHOLD"]&.to_i || 50
+    parallelize(workers: :number_of_processors, threshold: threshold)
+
+    # Configure SimpleCov to work with parallel test workers
+    # Each worker gets a unique command_name to prevent result clobbering
     coverage_mode = ENV["COVERAGE"] == "true" || ENV["CI"] == "true"
-    workers = coverage_mode ? 1 : :number_of_processors
-    parallelize(workers: workers, threshold: threshold)
+    if coverage_mode
+      parallelize_setup do |worker|
+        SimpleCov.command_name("#{SimpleCov.command_name}-#{worker}")
+      end
+
+      parallelize_teardown do |_worker|
+        SimpleCov.result
+      end
+    end
 
     ##########################################################################
     #  Transactional fixtures


### PR DESCRIPTION
  test/test_helper.rb:
  - Removed the restriction that disabled parallelization when coverage was enabled
  - Added `parallelize_setup` to give each worker a unique `SimpleCov.command_name`
  - Added `parallelize_teardown` to call `SimpleCov.result` for proper merging of coverage results into a single report

  config/environments/test.rb:
  - Changed `eager_load` from `false` to `ENV["CI"].present?` for accurate coverage in CI

Result: Tests now run in parallel (4 processes on my machine) while still collecting accurate, merged coverage data. CI should see a nice speedup.