### PR TITLE
nimmo alterations to project banner

### DIFF
--- a/app/components/project_banner.rb
+++ b/app/components/project_banner.rb
@@ -14,10 +14,10 @@ module Components
   #
   class ProjectBanner < Base
     include Phlex::Rails::Helpers::ContentFor
-    include Rails.application.routes.url_helpers
 
     prop :project, _Nilable(Project)
     prop :on_project_page, _Boolean, default: false
+    prop :current_tab, _Nilable(String), default: nil
 
     def view_template
       return unless @project
@@ -203,22 +203,19 @@ module Components
       )
     end
 
-    def tab_item(text, path, controller_name)
+    def tab_item(text, path, tab_name)
       li(class: "nav-item") do
-        a(href: path, class: tab_classes(controller_name)) { text }
+        a(href: path, class: tab_classes(tab_name)) { text }
       end
     end
 
-    def tab_classes(controller_name)
+    def tab_classes(tab_name)
       base = "mt-3 nav-link"
-      "#{base} #{"active" if active_tab?(controller_name)}"
+      "#{base} #{"active" if active_tab?(tab_name)}"
     end
 
     def active_tab?(tab_name)
-      current = controller_name
-      current = "locations" if current == "checklists" &&
-                               params.include?("location_id")
-      current == tab_name
+      @current_tab == tab_name
     end
 
     def project_has_content?

--- a/app/components/project_banner.rb
+++ b/app/components/project_banner.rb
@@ -63,26 +63,6 @@ module Components
     end
 
     def render_banner_title_with_icons(with_overlay_styling:)
-      if @on_project_page
-        nav_classes = if with_overlay_styling
-                        "show_title_nav d-flex justify-content-between"
-                      else
-                        "show_title_nav d-flex justify-content-between pl-3"
-                      end
-        nav(class: nav_classes) do
-          render_banner_title(with_overlay_styling: with_overlay_styling)
-          trusted_html(show_page_edit_icons)
-        end
-      else
-        render_banner_title(with_overlay_styling: with_overlay_styling)
-      end
-    end
-
-    def project_subtitle?
-      @project.location || (@project.start_date && @project.end_date)
-    end
-
-    def render_banner_title(with_overlay_styling:)
       title_classes = if with_overlay_styling
                         "h3 banner-image-text"
                       else
@@ -91,11 +71,20 @@ module Components
 
       h1(class: title_classes, id: title_id) do
         if @on_project_page
-          trusted_html(show_title_id_badge(@project))
-          plain(" ")
+          div(class: "d-flex align-items-center") do
+            trusted_html(show_title_id_badge(@project))
+            plain(" ")
+            trusted_html(link_to_object(@project))
+            trusted_html(show_page_edit_icons)
+          end
+        else
+          trusted_html(link_to_object(@project))
         end
-        trusted_html(link_to_object(@project))
       end
+    end
+
+    def project_subtitle?
+      @project.location || (@project.start_date && @project.end_date)
     end
 
     def title_id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -334,6 +334,16 @@ class ApplicationController < ActionController::Base
     @project = Project.safe_find(project_id)
   end
 
+  # Determines the active project tab based on current controller/params.
+  # Used by ProjectBanner component to highlight the active navigation tab.
+  def active_project_tab
+    tab = controller_name
+    # Checklist page with location_id is really a locations tab
+    tab = "locations" if tab == "checklists" && params.include?("location_id")
+    tab
+  end
+  helper_method :active_project_tab
+
   def render_xml(args)
     request.format = "xml"
     respond_to do |format|

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -74,7 +74,8 @@ module Tabs
         render(Components::ProjectBanner.new(
                  project: project,
                  on_project_page: controller.controller_name == "projects" &&
-                                  action_name == "show"
+                                  action_name == "show",
+                 current_tab: active_project_tab
                ))
       end
     end

--- a/app/views/controllers/projects/show.html.erb
+++ b/app/views/controllers/projects/show.html.erb
@@ -31,7 +31,7 @@ container_class(:wide)
   <% end %>
 <% end %>
 
-<p id="project_join_trust_edit">
+<div id="project_join_trust_edit" class="mb-4">
   <% if @project.can_join?(@user) %>
     <%= post_button(name: :show_project_join.t,
                     class: "btn btn-default btn-lg",
@@ -102,7 +102,7 @@ container_class(:wide)
                 new_project_admin_request_path(project_id: @project.id),
                 { class: "btn btn-default btn-lg" }) %>
   <% end %>
-</p>
+</div>
 
 <%= render(partial: "comments/comments_for_object",
            locals: { object: @project, comments: @comments,

--- a/test/components/project_banner_test.rb
+++ b/test/components/project_banner_test.rb
@@ -129,10 +129,28 @@ class ProjectBannerTest < ComponentTestCase
     assert_no_html(html, "#project_tabs")
   end
 
+  def test_active_tab_highlights_current_tab
+    project = projects(:eol_project)
+    html = render_banner(project: project, current_tab: "observations")
+
+    # Observations tab should have active class
+    assert_match(/observations.*active/i, html)
+  end
+
+  def test_summary_tab_active_for_projects_controller
+    project = projects(:eol_project)
+    html = render_banner(project: project, current_tab: "projects")
+
+    # Projects tab (summary) should have active class
+    assert_html(html, "a.nav-link.active[href='/projects/#{project.id}']")
+  end
+
   private
 
-  def render_banner(on_project_page: false, project: projects(:eol_project))
+  def render_banner(on_project_page: false, project: projects(:eol_project),
+                    current_tab: nil)
     render(Components::ProjectBanner.new(on_project_page: on_project_page,
-                                         project: project))
+                                         project: project,
+                                         current_tab: current_tab))
   end
 end


### PR DESCRIPTION
#### Remove controller methods from component
  1. ApplicationController (app/controllers/application_controller.rb:337-345): Added active_project_tab helper method that determines the current tab based on controller_name and params (the location_id check for checklists).
  2. ProjectBanner (app/components/project_banner.rb):
    - Added current_tab prop (line 21)
    - Simplified active_tab?(tab_name) to just @current_tab == tab_name (lines 218-220)
    - Renamed parameter from controller_name to tab_name in tab_item and tab_classes for clarity
  3. ProjectsHelper (app/helpers/tabs/projects_helper.rb:78): Updated add_project_banner to pass current_tab: active_project_tab
  4. Tests (test/components/project_banner_test.rb): Added tests for active tab highlighting and updated the render helper to accept current_tab

  The component no longer accesses params or controller_name directly - all context comes via props from the caller.