### PR TITLE
3427 relax import list limit

### DIFF
--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -58,7 +58,7 @@ class Inat
         user_login: @import.inat_username,
         # only fungi and slime molds
         iconic_taxa: ICONIC_TAXA,
-        # and which haven't been exported from or inported to MO
+        # and which haven't been exported from or imported to MO
         # This field was written by iNat's defunct Import from MO feature
         # is written by Pulk's mirror script, and by
         # ObservationImporter#update_mushroom_observer_url_field

--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -59,6 +59,9 @@ class Inat
         # only fungi and slime molds
         iconic_taxa: ICONIC_TAXA,
         # and which haven't been exported from or inported to MO
+        # This field was written by iNat's defunct Import from MO feature
+        # is written by Pulk's mirror script, and by
+        # ObservationImporter#update_mushroom_observer_url_field
         without_field: "Mushroom Observer URL"
       }.merge(args)
       # super_importers can import observations of other users.

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -93,7 +93,8 @@ class InatImportsController < ApplicationController
   private
 
   def reload_form
-    @inat_ids = params[:inat_ids]
+    # clean trailing commas and whitespace
+    @inat_ids = params[:inat_ids].sub(/[,\s]+\z/, "")
     @inat_username = params[:inat_username]
     render(:new)
   end
@@ -125,8 +126,9 @@ class InatImportsController < ApplicationController
       importables: importables_count,
       imported_count: 0,
       avg_import_time: @inat_import.initial_avg_import_seconds,
-      inat_ids: params[:inat_ids],
       inat_username: params[:inat_username].strip,
+      # clean trailing commas and whitespace
+      inat_ids: params[:inat_ids].sub(/[,\s]+\z/, ""),
       response_errors: "",
       token: "",
       log: [],

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -128,7 +128,7 @@ class InatImportsController < ApplicationController
       avg_import_time: @inat_import.initial_avg_import_seconds,
       inat_username: params[:inat_username].strip,
       # clean trailing commas and whitespace
-      inat_ids: params[:inat_ids].sub(/[,\s]+\z/, ""),
+      inat_ids: params[:inat_ids]&.sub(/[,\s]+\z/, ""),
       response_errors: "",
       token: "",
       log: [],

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -7,7 +7,6 @@ module InatImportsController::Validators
   #  Puma max query string size (1024 * 10)
   #  MAX_COOKIE_SIZE
   #  - ~256 to allow for other stuff
-  # divide by 10
   MAX_ID_LIST_SIZE =
     [1024 * 10, ActionDispatch::Cookies::MAX_COOKIE_SIZE].min - 256
 

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -71,6 +71,8 @@ module InatImportsController::Validators
   end
 
   def inat_id_list
+    return [] unless listing_ids?
+
     params[:inat_ids].delete(" ").split(",").map(&:to_i)
   end
 

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -3,7 +3,6 @@
 module InatImportsController::Validators
   SITE = "https://www.inaturalist.org"
 
-
   # Maximum size of id list param, based on
   #  Puma max query string size (1024 * 10)
   #  MAX_COOKIE_SIZE

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -3,6 +3,15 @@
 module InatImportsController::Validators
   SITE = "https://www.inaturalist.org"
 
+
+  # Maximum size of id list param, based on
+  #  Puma max query string size (1024 * 10)
+  #  MAX_COOKIE_SIZE
+  #  - ~256 to allow for other stuff
+  # divide by 10
+  MAX_ID_LIST_SIZE =
+    [1024 * 10, ActionDispatch::Cookies::MAX_COOKIE_SIZE].min - 256
+
   private
 
   def params_valid?
@@ -55,11 +64,8 @@ module InatImportsController::Validators
   end
 
   def list_within_size_limits?
-    # Limit based on Puma max query string (10,240 chars)
-    # Subtract ~256 for other params = 9,984 chars available
-    # This allows ~900 iNat IDs (9 digits + separator = 10 chars each)
     return true if importing_all? || # ignore list size if importing all
-                   params[:inat_ids].length <= 9984
+                   params[:inat_ids].length <= MAX_ID_LIST_SIZE
 
     flash_warning(:inat_too_many_ids_listed.t)
     false

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -23,7 +23,6 @@ module InatImportsController::Validators
     imports_unambiguously_designated? &&
       valid_inat_ids_param? &&
       list_within_size_limits? &&
-      fresh_import? &&
       not_importing_all_anothers?
   end
 
@@ -63,20 +62,6 @@ module InatImportsController::Validators
                    params[:inat_ids].length <= 9984
 
     flash_warning(:inat_too_many_ids_listed.t)
-    false
-  end
-
-  # Are the listed iNat IDs fresh (i.e., not already imported)?
-  def fresh_import?
-    return true if importing_all?
-
-    previous_imports = Observation.where(inat_id: inat_id_list)
-    return true if previous_imports.none?
-
-    previous_imports.each do |import|
-      flash_warning(:inat_previous_import.t(inat_id: import.inat_id,
-                                            mo_obs_id: import.id))
-    end
     false
   end
 

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -57,8 +57,11 @@ module InatImportsController::Validators
   end
 
   def list_within_size_limits?
+    # Limit based on Puma max query string (10,240 chars)
+    # Subtract ~256 for other params = 9,984 chars available
+    # This allows ~900 iNat IDs (9 digits + separator = 10 chars each)
     return true if importing_all? || # ignore list size if importing all
-                   params[:inat_ids].length <= 255
+                   params[:inat_ids].length <= 9984
 
     flash_warning(:inat_too_many_ids_listed.t)
     false

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -110,12 +110,7 @@ class InatImportJob < ApplicationJob
 
   def import_parsed_page_of_observations(parsed_page)
     log_new_page(parsed_page)
-    # NOTE: for reasons I don't understand, this fixes a bug where
-    # the tracker used the number of observations on the current page
-    # as the total number of observations. jdc20260115
-    if parsed_page["page"].to_i == 1
-      inat_import.update(importables: parsed_page["total_results"])
-    end
+    inat_import.update(importables: parsed_page["total_results"])
     observation_importer.import_page(parsed_page)
     log("Finished importing observations on parsed page")
   end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -112,7 +112,7 @@ class InatImportJob < ApplicationJob
     log_new_page(parsed_page)
     # NOTE: for reasons I don't understand, this fixes a bug where
     # the tracker used the number of observations on the current page
-    # as the total number of obervations. jdc20260115
+    # as the total number of observations. jdc20260115
     if parsed_page["page"].to_i == 1
       inat_import.update(importables: parsed_page["total_results"])
     end

--- a/app/views/controllers/inat_imports/new.html.erb
+++ b/app/views/controllers/inat_imports/new.html.erb
@@ -14,8 +14,8 @@
       <%= panel.with_heading { :inat_choose_observations.l } %>
       <%= panel.with_body do %>
         <%= f.label(:inat_id, "#{:inat_import_list.l}: ") %>
-        <%= f.text_field(:inat_ids, size: 10, value: @inat_ids,
-                         class: "form-control") %>
+        <%= f.text_area(:inat_ids, value: @inat_ids,
+                        class: "form-control") %>
         <%= check_box_with_label(form: f, field: :all,
                                  class: "mt-3", label: :inat_import_all.l) %>
       <% end %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3107,7 +3107,7 @@
   inat_missing_username: Missing your iNat Username
   inat_no_imports_designated: You must list the iNat observation(s) to be imported
   inat_list_xor_all: "Either (a) list the iNat observation(s), or (b) check \"Import all ...\" (not both)"
-  inat_previous_import: iNat [inat_id] previously imported as MO Observation [mo_obs_id]
+  inat_previous_import: "[count] listed ids previously imported and will not be re-imported"
   inat_too_many_ids_listed: Too many ids listed
   inat_importing_all_anothers: You cannot import all observations of another person
   inat_observed_missing_date: Observed Missing Date

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3098,7 +3098,7 @@
   # observation/inat_imports
   inat_import_create_title: Import from iNat
   inat_choose_observations: "Inat Observations to Import:"
-  inat_import_list: "Comma separated list of up to 10 observation #s"
+  inat_import_list: "Comma separated list of up to 900 observation #s"
   inat_import_all: Import all my iNat observations instead of a list
   inat_import_consent: "(Required) I consent to creating MushroomObserver Observation(s) based on my iNaturalist observations, including their photos."
   inat_consent_required: Your consent is required to import Inat observations. Please check the checkbox to give your consent.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3098,7 +3098,7 @@
   # observation/inat_imports
   inat_import_create_title: Import from iNat
   inat_choose_observations: "Inat Observations to Import:"
-  inat_import_list: "Comma separated list of up to 900 observation #s"
+  inat_import_list: "Comma separated list of up to about 384 observation #s"
   inat_import_all: Import all my iNat observations instead of a list
   inat_import_consent: "(Required) I consent to creating MushroomObserver Observation(s) based on my iNaturalist observations, including their photos."
   inat_consent_required: Your consent is required to import Inat observations. Please check the checkbox to give your consent.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3108,7 +3108,6 @@
   inat_no_imports_designated: You must list the iNat observation(s) to be imported
   inat_list_xor_all: "Either (a) list the iNat observation(s), or (b) check \"Import all ...\" (not both)"
   inat_previous_import: iNat [inat_id] previously imported as MO Observation [mo_obs_id]
-  inat_previous_mirror: iNat [inat_id] is a "mirror" of existing MO Observation [mo_obs_id]
   inat_too_many_ids_listed: Too many ids listed
   inat_importing_all_anothers: You cannot import all observations of another person
   inat_observed_missing_date: Observed Missing Date

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2024_02_03_041048) do
-  create_table "solid_cache_entries", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_cache_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
     t.binary "value", size: :long, null: false
     t.datetime "created_at", null: false

--- a/db/migrate/20260114002432_change_inat_ids_to_text.rb
+++ b/db/migrate/20260114002432_change_inat_ids_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeInatIdsToText < ActiveRecord::Migration[7.2]
+  def up
+    change_column(:inat_imports, :inat_ids, :text)
+  end
+
+  def down
+    change_column(:inat_imports, :inat_ids, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_01_095531) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_14_002432) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -209,7 +209,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_01_095531) do
   create_table "inat_imports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "state", default: 0
-    t.string "inat_ids"
+    t.text "inat_ids"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token"

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -179,7 +179,7 @@ class InatImportsControllerTest < FunctionalTestCase
 
     assert_response(:redirect)
     assert_equal(id_list, inat_import.reload.inat_ids,
-                 "Failed to save inat_ids at maximum length1")
+                 "Failed to save inat_ids at maximum length")
   end
 
   def test_strips_trailing_commas_and_space_chars_from_id_list

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -35,8 +35,8 @@ class InatImportsControllerTest < FunctionalTestCase
 
     assert_response(:success)
     assert_form_action(action: :create)
-    assert_select("input#inat_ids", true,
-                  "Form needs a field for inputting iNat ids")
+    assert_select("textarea#inat_ids", true,
+                  "Form needs a textarea for inputting iNat ids")
     assert_select("input#inat_username", true,
                   "Form needs a field for inputting iNat username")
     assert_select("input[type=checkbox][id=consent]", true,

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -240,13 +240,10 @@ class InatImportsControllerTest < FunctionalTestCase
       post(:create, params: params)
     end
 
-    # NOTE: 2024-09-04 jdc
-    # I'd prefer to assert that the flash include links to both obss,
-    # At the moment, it's taking too long to figure out how.
-    assert_flash_text(/iNat #{inat_id} previously imported/)
+    assert_flash_text(/#{:inat_previous_import.l(count: 1)}/)
     # It should continue even if some ids were previously imported
     # The job will exclude privious imports via the iNat API
-    # without_field: "Mushroom Observer URL" param.
+    # `without_field: "Mushroom Observer URL"` param.
     assert_redirected_to(INAT_AUTHORIZATION_URL)
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -192,39 +192,6 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_flash_text(/iNat #{inat_id} previously imported/)
   end
 
-  def test_create_previously_mirrored
-    user = users(:rolf)
-    inat_id = "1234567"
-    mirrored_obs = Observation.create(
-      where: "North Falmouth, Massachusetts, USA",
-      user: user,
-      when: "2023-09-08",
-      inat_id: nil,
-      # When Pulk's `mirror`Python script copies an MO Obs to iNat,
-      # it adds a text in this form to the MO Obs notes
-      # See https://github.com/JacobPulk/mirror
-      notes: { Other: "Mirrored on iNaturalist as <a href=\"https://www.inaturalist.org/observations/#{inat_id}\">observation #{inat_id}</a> on December 18, 2023" }
-    )
-    params = { inat_username: "anything", inat_ids: inat_id, consent: 1 }
-
-    login
-    assert_no_difference(
-      "Observation.count",
-      "Imported an iNat obs which had been 'mirrored' from MO"
-    ) do
-      post(:create, params: params)
-    end
-
-    # NOTE: 2024-09-04 jdc
-    # I'd prefer that the flash include links to both obss,
-    # and that this (or another) assertion check for that.
-    # At the moment, it's taking too long to figure out how.
-    assert_flash_text(
-      "iNat #{inat_id} is a &#8220;mirror&#8221; of " \
-      "existing MO Observation #{mirrored_obs.id}"
-    )
-  end
-
   def test_create_strip_inat_username
     user = users(:mary)
     assert(APIKey.where(user: user, notes: MO_API_KEY_NOTES).none?,

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -194,7 +194,7 @@ class InatImportsControllerTest < FunctionalTestCase
 
     post(:create,
          params: { inat_ids: id_list,
-                   inat_username: "", # omit this to force form reloadd
+                   inat_username: "", # omit this to force form reload
                    consent: 1 })
 
     assert_form_action(action: :create)

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -152,6 +152,36 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_flash_text(:inat_consent_required.l)
   end
 
+  def test_allows_maximum_ids
+    user = users(:rolf)
+    inat_username = "rolf" # use different inat_username to test if it's updated
+    inat_import = inat_imports(:rolf_inat_import)
+    assert_equal("Unstarted", inat_import.state,
+                 "Need a Unstarted inat_import fixture")
+    assert_equal(0, inat_import.total_imported_count.to_i,
+                 "Test needs InatImport fixture without prior imports")
+
+    id = 1_234_567_890
+    reps = InatImportsController::Validators::MAX_ID_LIST_SIZE / id.to_s.length
+    id_list = (id.to_s * reps).chop
+
+    stub_request(:any, authorization_url)
+    login(user.login)
+
+    assert_no_difference(
+      "Observation.count",
+      "Authorization request to iNat shouldn't create MO Observation(s)"
+    ) do
+      post(:create,
+           params: { inat_ids: id_list, inat_username: inat_username,
+                     consent: 1 })
+    end
+
+    assert_response(:redirect)
+    assert_equal(id_list, inat_import.reload.inat_ids,
+                 "Failed to save inat_ids at maximum length1")
+  end
+
   def test_create_too_many_ids_listed
     # generate an id list that's barely too long
     id_list = ""
@@ -288,38 +318,6 @@ class InatImportsControllerTest < FunctionalTestCase
 
     assert_flash_text(:inat_importing_all_anothers.t)
     assert_form_action(action: :create)
-  end
-
-  def test_allows_maximum_ids_listed
-    user = users(:rolf)
-    inat_username = "rolf" # use different inat_username to test if it's updated
-    inat_import = inat_imports(:rolf_inat_import)
-    assert_equal("Unstarted", inat_import.state,
-                 "Need a Unstarted inat_import fixture")
-    assert_equal(0, inat_import.total_imported_count.to_i,
-                 "Test needs InatImport fixture without prior imports")
-
-    id = 1_234_567_890
-    # default max characters in a Puma query, minus some for other params
-    limit = 9984
-    reps = limit / id.to_s.length
-    id_list = (id.to_s * reps).chop
-
-    stub_request(:any, authorization_url)
-    login(user.login)
-
-    assert_no_difference(
-      "Observation.count",
-      "Authorization request to iNat shouldn't create MO Observation(s)"
-    ) do
-      post(:create,
-           params: { inat_ids: id_list, inat_username: inat_username,
-                     consent: 1 })
-    end
-
-    assert_response(:redirect)
-    assert_equal(id_list, inat_import.reload.inat_ids,
-                 "Failed to save inat_ids at maximum length1")
   end
 
   def test_import_authorized

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -242,7 +242,7 @@ class InatImportsControllerTest < FunctionalTestCase
 
     assert_flash_text(/#{:inat_previous_import.l(count: 1)}/)
     # It should continue even if some ids were previously imported
-    # The job will exclude privious imports via the iNat API
+    # The job will exclude previous imports via the iNat API
     # `without_field: "Mushroom Observer URL"` param.
     assert_redirected_to(INAT_AUTHORIZATION_URL)
   end

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -186,10 +186,13 @@ class InatImportsControllerTest < FunctionalTestCase
     end
 
     # NOTE: 2024-09-04 jdc
-    # I'd prefer that the flash include links to both obss,
-    # and that this (or another) assertion check for that.
+    # I'd prefer to assert that the flash include links to both obss,
     # At the moment, it's taking too long to figure out how.
     assert_flash_text(/iNat #{inat_id} previously imported/)
+    # It should continue even if some ids were previously imported
+    # The job will exclude privious imports via the iNat API
+    # without_field: "Mushroom Observer URL" param.
+    assert_redirected_to(INAT_AUTHORIZATION_URL)
   end
 
   def test_create_strip_inat_username
@@ -247,7 +250,7 @@ class InatImportsControllerTest < FunctionalTestCase
                      consent: 1 })
     end
 
-    assert_response(:redirect)
+    assert_redirected_to(INAT_AUTHORIZATION_URL)
     assert_equal(inat_ids.split(",").length, inat_import.reload.importables,
                  "Failed to save InatImport.importables")
     assert_equal("Authorizing", inat_import.reload.state,

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -156,7 +156,10 @@ class InatImportsControllerTest < FunctionalTestCase
     # generate an id list that's barely too long
     id_list = ""
     id = 1_234_567_890
-    id_list += "#{id += 1}," until id_list.length > 9984
+    until id_list.length > InatImportsController::Validators::MAX_ID_LIST_SIZE
+      id_list += "#{id += 1},"
+    end
+
     params = { inat_username: "anything", inat_ids: id_list, consent: 1 }
 
     login

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -156,7 +156,7 @@ class InatImportsControllerTest < FunctionalTestCase
     # generate an id list that's barely too long
     id_list = ""
     id = 1_234_567_890
-    id_list += "#{id += 1}," until id_list.length > 255
+    id_list += "#{id += 1}," until id_list.length > 9984
     params = { inat_username: "anything", inat_ids: id_list, consent: 1 }
 
     login

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -182,6 +182,28 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Failed to save inat_ids at maximum length1")
   end
 
+  def test_strips_trailing_commas_and_space_chars_from_id_list
+    inat_import = inat_imports(:rolf_inat_import)
+    user = inat_import.user
+    assert_equal("Unstarted", inat_import.state,
+                 "Need a Unstarted inat_import fixture")
+    id_list = "123,456,789, \n"
+    expected_saved_id_list = "123,456,789"
+    stub_request(:any, authorization_url)
+    login(user.login)
+
+    post(:create,
+         params: { inat_ids: id_list,
+                   inat_username: "", # omit this to force form reloadd
+                   consent: 1 })
+
+    assert_form_action(action: :create)
+    assert_select(
+      "textarea#inat_ids", { text: expected_saved_id_list, count: 1 },
+      "inat_ids textarea should have trailing commas and whitespace stripped"
+    )
+  end
+
   def test_create_too_many_ids_listed
     # generate an id list that's barely too long
     id_list = ""

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -946,7 +946,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     # The observation should have been destroyed after the error
     assert_equal(obs_count_before, Observation.count,
-                 "Observation should be destroyed after error")
+                 "MO Observation should be destroyed after iNat API error")
 
     errors = JSON.parse(@inat_import.response_errors, symbolize_names: true)
     assert_equal(status, errors[:error], "Incorrect error status")


### PR DESCRIPTION
Allow user to enter up to 384 iNat ids to import at the same time.

- The immediate goal is to facilitate importing NEMF 2025 iNat Observations to MO. This PR is sufficient to do that.
- The PR does not address other existing issues relating to iNat imports, including:
  - Display of remaining time and observations is incorrect after importing 200 observations
  - MO does not support the rank `series` and secondary ranks above genus. The importer currently treats names at those ranks as _Fungi_.
  - For and Observation's Location, the importer uses the smallest existing MO Location encompassing the iNat error-expanded lat/lng.

### :small_red_triangle: Optional Manual Testing :small_red_triangle:
:small_red_triangle: ***DANGER*** :small_red_triangle:
Before manual testing, comment out `app/classes/inat/observation_importer.rb` line 82 
```ruby
      # update_mushroom_observer_url_field
```
If you fail to do this, you will modify the iNat Observations (by adding an `Mushroom Observer URL` observation_field).
I'm unaware of any way to repair that automatically. 

The optional manual test is simply inputting many iNat id's into the appropriate field in the iNat Import form, then clicking Submit. 
NOTE: It typically 6 seconds to import an observation locally. If you enter 384 id's you're looking at almost 40 minutes for the job to comple.
