### PR TITLE
Add FieldSlip API calls

### DIFF
--- a/app/classes/api2/field_slip_api.rb
+++ b/app/classes/api2/field_slip_api.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+class API2
+  # API for FieldSlip
+  class FieldSlipAPI < ModelAPI
+    def model
+      FieldSlip
+    end
+
+    def high_detail_page_length
+      100
+    end
+
+    def low_detail_page_length
+      1000
+    end
+
+    def put_page_length
+      1000
+    end
+
+    def delete_page_length
+      1000
+    end
+
+    def high_detail_includes
+      [
+        :observation,
+        :project,
+        :user
+      ]
+    end
+
+    def query_params
+      {
+        id_in_set: parse_array(:field_slip, :id, as: :id),
+        created_at: parse_range(:time, :created_at),
+        updated_at: parse_range(:time, :updated_at),
+        by_users: parse_array(:user, :user, help: :creator),
+        code: parse(:string, :code, help: 1),
+        code_has: parse(:string, :code_has, help: 1),
+        observation: parse(:observation, :observation),
+        project: parse(:project, :project)
+      }
+    end
+
+    def create_params
+      {
+        code: parse(:string, :code, not_blank: true, help: 1),
+        observation: parse(:observation, :observation),
+        project: parse(:project, :project),
+        user: @user
+      }
+    end
+
+    def update_params
+      {
+        code: parse(:string, :set_code, not_blank: true, help: 1),
+        observation: parse(:observation, :set_observation),
+        project: parse(:project, :set_project)
+      }
+    end
+
+    def validate_create_params!(params)
+      raise(MissingParameter.new(:code)) if params[:code].blank?
+
+      validate_unique_code!(params[:code])
+    end
+
+    def validate_update_params!(params)
+      return if params.any?
+
+      raise(MissingSetParameters.new)
+    end
+
+    def before_create(params)
+      # Check if field slip with this code already exists
+      FieldSlip.find_by(code: params[:code])
+    end
+
+    def after_create(obj)
+      # Set current_user for permission checks in model
+      obj.current_user = @user if obj.respond_to?(:current_user=)
+    end
+
+    def build_setter(params)
+      lambda do |obj|
+        must_have_edit_permission!(obj)
+
+        # Validate code uniqueness if being changed
+        if params[:code] && params[:code] != obj.code
+          validate_unique_code!(params[:code], exclude: obj)
+        end
+
+        # Set current_user for permission checks in model
+        obj.current_user = @user if obj.respond_to?(:current_user=)
+
+        obj.attributes = params
+        obj.save
+        obj
+      end
+    end
+
+    def must_have_edit_permission!(obj)
+      return if obj.can_edit?(@user)
+
+      raise(MustHaveEditPermission.new(obj))
+    end
+
+    def validate_unique_code!(code, exclude: nil)
+      existing = FieldSlip.find_by(code: code)
+      return unless existing && existing != exclude
+
+      raise(CodeAlreadyUsed.new(code))
+    end
+
+    # Error class for duplicate code
+    class CodeAlreadyUsed < API2::Error
+      def initialize(code)
+        super()
+        @code = code
+      end
+
+      def to_s
+        "Field slip code '#{@code}' is already in use."
+      end
+    end
+  end
+end

--- a/app/classes/api2/field_slip_api.rb
+++ b/app/classes/api2/field_slip_api.rb
@@ -73,11 +73,6 @@ class API2
       raise(MissingSetParameters.new)
     end
 
-    def before_create(params)
-      # Check if field slip with this code already exists
-      FieldSlip.find_by(code: params[:code])
-    end
-
     def after_create(obj)
       # Set current_user for permission checks in model
       obj.current_user = @user if obj.respond_to?(:current_user=)

--- a/app/classes/api2/field_slip_api.rb
+++ b/app/classes/api2/field_slip_api.rb
@@ -7,22 +7,6 @@ class API2
       FieldSlip
     end
 
-    def high_detail_page_length
-      100
-    end
-
-    def low_detail_page_length
-      1000
-    end
-
-    def put_page_length
-      1000
-    end
-
-    def delete_page_length
-      1000
-    end
-
     def high_detail_includes
       [
         :observation,

--- a/app/classes/api2/parsers/field_slip_parser.rb
+++ b/app/classes/api2/parsers/field_slip_parser.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class API2
+  module Parsers
+    # Parse field_slips for API.
+    class FieldSlipParser < ObjectBase
+      def model
+        FieldSlip
+      end
+    end
+  end
+end

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -3,7 +3,12 @@
 class Query::FieldSlips < Query
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
+  query_attr(:id_in_set, [FieldSlip])
   query_attr(:by_users, [User])
+  query_attr(:code, [:string])
+  query_attr(:code_has, [:string])
+  query_attr(:observation, [Observation])
+  query_attr(:project, [Project])
   query_attr(:projects, [Project])
 
   def self.default_order

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -41,6 +41,10 @@ class API2Controller < ApplicationController
     rest_query(:external_site)
   end
 
+  def field_slips
+    rest_query(:field_slip)
+  end
+
   def herbaria
     rest_query(:herbarium)
   end

--- a/app/helpers/api2_inline_helper.rb
+++ b/app/helpers/api2_inline_helper.rb
@@ -76,6 +76,15 @@ module API2InlineHelper
     xml_string(xml, :name, external_site.name)
   end
 
+  def json_field_slip(field_slip)
+    strip_hash(id: field_slip.id,
+               code: field_slip.code.to_s)
+  end
+
+  def xml_field_slip(xml, field_slip)
+    xml_string(xml, :code, field_slip.code)
+  end
+
   def json_herbarium(herbarium)
     strip_hash(id: herbarium.id,
                code: herbarium.code.to_s,

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -32,9 +32,10 @@ class FieldSlip < AbstractModel
     sanitized = code_patterns.map do |pattern|
       sanitize_sql_like(pattern.upcase, "\\")
     end
-    conditions = sanitized.map { |pattern| "UPPER(code) LIKE '%#{pattern}%'" }.
-                 join(" OR ")
-    where(conditions)
+    arel = arel_table
+    upper_code = Arel::Nodes::NamedFunction.new("UPPER", [arel[:code]])
+    predicates = sanitized.map { |pattern| upper_code.matches("%#{pattern}%") }
+    where(predicates.reduce(:or))
   }
 
   scope :observation, lambda { |observation|

--- a/app/views/controllers/api2/_field_slip.json.jbuilder
+++ b/app/views/controllers/api2/_field_slip.json.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+json.id(object.id)
+json.type("field_slip")
+json.code(object.code.to_s)
+json.created_at(object.created_at.try(&:utc))
+json.updated_at(object.updated_at.try(&:utc))
+json.observation_id(object.observation_id)
+if detail
+  json.project(json_project(object.project)) if object.project
+  json.user(json_user(object.user)) if object.user
+else
+  json.project_id(object.project_id)
+  json.user_id(object.user_id)
+end

--- a/app/views/controllers/api2/_field_slip.xml.builder
+++ b/app/views/controllers/api2/_field_slip.xml.builder
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+xml.tag!(
+  tag,
+  id: object.id,
+  url: object.show_url,
+  type: "field_slip"
+) do
+  xml_string(xml, :code, object.code)
+  xml_datetime(xml, :created_at, object.created_at)
+  xml_datetime(xml, :updated_at, object.updated_at)
+  xml_minimal_object(xml, :observation, :observation, object.observation_id)
+  if detail
+    xml_detailed_object(xml, :project, object.project)
+    xml_detailed_object(xml, :user, object.user)
+  else
+    xml_minimal_object(xml, :project, :project, object.project_id)
+    xml_minimal_object(xml, :user, :user, object.user_id)
+  end
+end

--- a/test/classes/api2/field_slips_test.rb
+++ b/test/classes/api2/field_slips_test.rb
@@ -163,7 +163,7 @@ class API2::FieldSlipsTest < UnitTestCase
   def test_xml_field_slip_inline_helper
     slip = field_slips(:field_slip_one)
     helper = Object.new
-    helper.extend(API2InlineHelper)
+    helper.extend(API2Helper)
 
     xml = Builder::XmlMarkup.new(indent: 2)
     helper.xml_field_slip(xml, slip)
@@ -194,7 +194,7 @@ class API2::FieldSlipsTest < UnitTestCase
   def test_patching_someone_elses_field_slip
     slip = field_slips(:field_slip_one)
     other_user = users(:katrina)
-    other_key = ApiKey.create!(user: other_user)
+    other_key = APIKey.create!(user: other_user)
 
     params = {
       method: :patch,

--- a/test/classes/api2/field_slips_test.rb
+++ b/test/classes/api2/field_slips_test.rb
@@ -194,7 +194,10 @@ class API2::FieldSlipsTest < UnitTestCase
   def test_patching_someone_elses_field_slip
     slip = field_slips(:field_slip_one)
     other_user = users(:katrina)
-    other_key = APIKey.create!(user: other_user)
+    other_key = APIKey.create!(
+      user: other_user,
+      notes: "Test API key for permission check"
+    )
 
     params = {
       method: :patch,

--- a/test/classes/api2/field_slips_test.rb
+++ b/test/classes/api2/field_slips_test.rb
@@ -2,6 +2,7 @@
 
 require("test_helper")
 require("api2_extensions")
+require("builder")
 
 class API2::FieldSlipsTest < UnitTestCase
   include API2Extensions
@@ -157,5 +158,59 @@ class API2::FieldSlipsTest < UnitTestCase
     # Verify the API returns the slip without errors
     assert_equal(1, @api.results.length)
     assert_equal(slip.id, @api.results.first.id)
+  end
+
+  def test_xml_field_slip_inline_helper
+    slip = field_slips(:field_slip_one)
+    helper = Object.new
+    helper.extend(API2InlineHelper)
+
+    xml = Builder::XmlMarkup.new(indent: 2)
+    helper.xml_field_slip(xml, slip)
+
+    # Verify the XML contains the code
+    assert(xml.target!.include?(slip.code),
+           "XML output should contain field slip code")
+  end
+
+  def test_page_length_methods
+    api = API2::FieldSlipAPI.new
+    assert_equal(1000, api.put_page_length)
+    assert_equal(1000, api.delete_page_length)
+  end
+
+  def test_patching_field_slip_without_params
+    slip = field_slips(:field_slip_one)
+    params = {
+      method: :patch,
+      action: :field_slip,
+      api_key: @api_key.key,
+      id: slip.id
+    }
+    # Should fail because no set_* parameters provided
+    assert_api_fail(params)
+  end
+
+  def test_patching_someone_elses_field_slip
+    slip = field_slips(:field_slip_one)
+    other_user = users(:katrina)
+    other_key = ApiKey.create!(user: other_user)
+
+    params = {
+      method: :patch,
+      action: :field_slip,
+      api_key: other_key.key,
+      id: slip.id,
+      set_code: "NEW-CODE"
+    }
+    # Should fail because user doesn't have edit permission
+    assert_api_fail(params)
+  end
+
+  def test_code_already_used_error_message
+    slip = field_slips(:field_slip_one)
+    error = API2::FieldSlipAPI::CodeAlreadyUsed.new(slip.code)
+    assert_equal("Field slip code '#{slip.code}' is already in use.",
+                 error.to_s)
   end
 end

--- a/test/classes/api2/field_slips_test.rb
+++ b/test/classes/api2/field_slips_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require("test_helper")
+require("api2_extensions")
+
+class API2::FieldSlipsTest < UnitTestCase
+  include API2Extensions
+
+  def test_basic_field_slip_get
+    do_basic_get_test(FieldSlip)
+  end
+
+  # ---------------------------------------
+  #  :section: Field Slip Requests
+  # ---------------------------------------
+
+  def params_get(**)
+    { method: :get, action: :field_slip }.merge(**)
+  end
+
+  def test_getting_field_slips_by_code
+    slip = field_slips(:field_slip_one)
+    assert_api_pass(params_get(code: slip.code))
+    assert_api_results([slip])
+  end
+
+  def test_getting_field_slips_code_has
+    slips = FieldSlip.where(FieldSlip[:code].matches("%EOL%"))
+    assert_not_empty(slips)
+    assert_api_pass(params_get(code_has: "EOL"))
+    assert_api_results(slips)
+  end
+
+  def test_getting_field_slips_by_observation
+    obs = observations(:detailed_unknown_obs)
+    slip = FieldSlip.create!(
+      code: "TEST-#{rand(10_000)}",
+      observation: obs,
+      user: rolf
+    )
+    assert_api_pass(params_get(observation: obs.id))
+    assert_api_results([slip])
+  end
+
+  def test_getting_field_slips_by_project
+    project = projects(:eol_project)
+    slips = FieldSlip.where(project: project)
+    assert_not_empty(slips)
+    assert_api_pass(params_get(project: project.id))
+    assert_api_results(slips)
+  end
+
+  def test_getting_field_slips_by_user
+    slips = FieldSlip.where(user: mary)
+    assert_not_empty(slips)
+    assert_api_pass(params_get(user: "mary"))
+    assert_api_results(slips)
+  end
+
+  def test_posting_field_slip
+    obs = observations(:detailed_unknown_obs)
+    code = "NEMF-#{rand(100_000)}"
+    params = {
+      method: :post,
+      action: :field_slip,
+      api_key: @api_key.key,
+      code: code,
+      observation: obs.id
+    }
+    assert_api_fail(params.except(:api_key))
+    assert_api_fail(params.except(:code))
+    assert_api_pass(params)
+    slip = FieldSlip.find_by(code: code)
+    assert_not_nil(slip, "Field slip was not created")
+    assert_equal(code.upcase, slip.code)
+    assert_equal(obs.id, slip.observation_id)
+  end
+
+  def test_posting_field_slip_duplicate_code
+    slip = field_slips(:field_slip_one)
+    params = {
+      method: :post,
+      action: :field_slip,
+      api_key: @api_key.key,
+      code: slip.code
+    }
+    # Should fail because code already exists
+    assert_api_fail(params)
+  end
+
+  def test_patching_field_slip
+    slip = field_slips(:field_slip_one)
+    new_code = "UPDATED-#{rand(100_000)}"
+    params = {
+      method: :patch,
+      action: :field_slip,
+      api_key: @api_key.key,
+      id: slip.id,
+      set_code: new_code
+    }
+    assert_api_pass(params)
+    slip.reload
+    assert_equal(new_code.upcase, slip.code)
+  end
+
+  def test_patching_field_slip_observation
+    slip = field_slips(:field_slip_one)
+    obs = observations(:detailed_unknown_obs)
+    params = {
+      method: :patch,
+      action: :field_slip,
+      api_key: @api_key.key,
+      id: slip.id,
+      set_observation: obs.id
+    }
+    assert_api_pass(params)
+    slip.reload
+    assert_equal(obs.id, slip.observation_id)
+  end
+
+  def test_field_slip_json_inline_helper
+    slip = field_slips(:field_slip_one)
+    helper = Object.new
+    helper.extend(API2InlineHelper)
+
+    result = helper.json_field_slip(slip)
+
+    assert_equal(slip.id, result[:id])
+    assert_equal(slip.code, result[:code])
+  end
+
+  def test_field_slip_renders_json
+    slip = field_slips(:field_slip_one)
+    params = {
+      method: :get,
+      action: :field_slip,
+      id: slip.id,
+      detail: :high
+    }
+    assert_api_pass(params)
+
+    # Verify the API returns the slip without errors
+    assert_equal(1, @api.results.length)
+    assert_equal(slip.id, @api.results.first.id)
+  end
+
+  def test_field_slip_renders_xml
+    slip = field_slips(:field_slip_one)
+    params = {
+      method: :get,
+      action: :field_slip,
+      id: slip.id,
+      detail: :low
+    }
+    assert_api_pass(params)
+
+    # Verify the API returns the slip without errors
+    assert_equal(1, @api.results.length)
+    assert_equal(slip.id, @api.results.first.id)
+  end
+end

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -72,6 +72,10 @@ class API2ControllerTest < FunctionalTestCase
     do_basic_get_request_for_model(ExternalSite)
   end
 
+  def test_basic_field_slip_get_request
+    do_basic_get_request_for_model(FieldSlip)
+  end
+
   def test_basic_herbarium_get_request
     do_basic_get_request_for_model(Herbarium)
   end


### PR DESCRIPTION
# Summary

This pull request adds comprehensive API support for FieldSlip resources, enabling CRUD operations through the API2 endpoint. The implementation follows established patterns in the codebase for model-based API endpoints.

## Changes

Added API endpoint for querying, creating, and updating field slips with various filter parameters
Implemented JSON and XML view templates for field slip responses
Added scopes to the FieldSlip model for filtering by code, observation, and project
Created comprehensive test coverage for all API operations

## Manual Tests
```
# Some examples to riff on
curl -H "Accept: application/json" "http://localhost:3000/api2/field_slips?code_has=NEMF&detail=low"
curl -H "Accept: application/json" "http://localhost:3000/api2/field_slips?id=123&detail=high"
curl "http://localhost:3000/api2/field_slips?project=389"

# Create a new field slip
curl -X POST "http://localhost:3000/api2/field_slips" \
  -d "api_key=YOUR_API_KEY" \
  -d "code=NEMF-8642" \
  -d "observation=12345"

# Update field slip code
curl -X PATCH "http://localhost:3000/api2/field_slips" \
  -d "api_key=YOUR_API_KEY" \
  -d "id=456" \
  -d "set_code=UPDATED-0001"
```