### PR TITLE
Fix uninitialized constant FileMissing in API2::Uploads

### DIFF
--- a/app/classes/api2/core/uploads.rb
+++ b/app/classes/api2/core/uploads.rb
@@ -52,7 +52,7 @@ module API2::Uploads
       super()
       fetch(url)
     rescue StandardError => e
-      raise(CouldntDownloadURL.new(url, e))
+      raise(API2::CouldntDownloadURL.new(url, e))
     end
 
     def fetch(url, limit = 10)

--- a/app/classes/api2/core/uploads.rb
+++ b/app/classes/api2/core/uploads.rb
@@ -102,7 +102,7 @@ module API2::Uploads
   # Class encapsulating an upload from a file stored locally on the server
   class UploadFromFile < Upload
     def initialize(file)
-      raise(FileMissing.new(file)) unless File.exist?(file)
+      raise(API2::FileMissing.new(file)) unless File.exist?(file)
 
       super()
       self.content = File.open(file, "rb")


### PR DESCRIPTION
## Summary
- Fixed `uninitialized constant FileMissing` error in `API2::Uploads::UploadFromFile`
- Changed `FileMissing.new` to `API2::FileMissing.new` to use the correct namespace

## Background
When using the `upload_file` parameter for server-side file uploads (as opposed to HTTP multipart uploads via the `upload` parameter), the code raised an error due to missing namespace qualification.

## Changes
- Updated `app/classes/api2/core/uploads.rb` line 105 to use `API2::FileMissing.new(file)` instead of `FileMissing.new(file)`

## Test plan
- [x] RuboCop passes
- [ ] Manual testing: Test API2 image upload with `upload_file` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)