### PR TITLE
Vertical space between term definition and external searches

### DIFF
--- a/app/views/controllers/glossary_terms/show.html.erb
+++ b/app/views/controllers/glossary_terms/show.html.erb
@@ -13,7 +13,7 @@ column_classes(:eight_four)
         <%= tag.p(@glossary_term.description.tpl) %>
       <% end %>
 
-      <%= tag.div(class: "external_searches") do %>
+      <%= tag.div(id: "external_searches") do %>
         <%= tag.p(link_to(*search_tab_for(:Wikipedia, @glossary_term.name))) %>
       <% end %>
     <% end %>

--- a/app/views/controllers/glossary_terms/show.html.erb
+++ b/app/views/controllers/glossary_terms/show.html.erb
@@ -10,7 +10,11 @@ column_classes(:eight_four)
 
     <%= tag.div(class: "content-block") do %>
       <%= @glossary_term.description.tpl %>
-      <%= tag.p(link_to(*search_tab_for(:Wikipedia, @glossary_term.name))) %>
+      <%= tag.br %>
+      <%= tag.div(class: "external_searches") do %>
+        <%= tag.p(link_to(*search_tab_for(:Wikipedia, @glossary_term.name))) %>
+      <% end %>
+
     <% end %>
 
   <% end %>

--- a/app/views/controllers/glossary_terms/show.html.erb
+++ b/app/views/controllers/glossary_terms/show.html.erb
@@ -9,12 +9,13 @@ column_classes(:eight_four)
   <%= tag.div(class: yield(:left_columns)) do %>
 
     <%= tag.div(class: "content-block") do %>
-      <%= @glossary_term.description.tpl %>
-      <%= tag.br %>
+      <%= tag.div(class: "description") do %>
+        <%= tag.p(@glossary_term.description.tpl) %>
+      <% end %>
+
       <%= tag.div(class: "external_searches") do %>
         <%= tag.p(link_to(*search_tab_for(:Wikipedia, @glossary_term.name))) %>
       <% end %>
-
     <% end %>
 
   <% end %>

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -91,8 +91,10 @@ class GlossaryTermsControllerTest < FunctionalTestCase
 
   def test_show_logged_in
     term = glossary_terms(:square_glossary_term)
-    assert_operator(term.version, :>, 1,
-                    "Test needs a GlossaryTerm fixture with multiple versions")
+    assert_operator(
+      term.version, :>, 1,
+      "Test needs a GlossaryTerm fixture with multiple versions"
+    )
     prior_version_path =
       version_of_glossary_term_path(term.id, version: term.version - 1)
 
@@ -113,11 +115,13 @@ class GlossaryTermsControllerTest < FunctionalTestCase
       { count: 1,
         text: /Creator.*: #{rolf.name}Editors: #{mary.name}, #{katrina.name}/ }
     )
-    assert_select(
-      "a[href='https://en.wikipedia.org/w/index.php?search=#{term.name}']",
-      true,
-      "Glossary Term page should have link to Wikipedia search for the Term"
-    )
+    assert_select("#external_searches") do
+      assert_select(
+        "a[href='https://en.wikipedia.org/w/index.php?search=#{term.name}']",
+        true,
+        "Glossary Term missing an external search for Wikipedia"
+      )
+    end
   end
 
   def test_show_admin_delete


### PR DESCRIPTION
Adds vertical space between Glossary Term definition and external searches.

This gets rid of a minor, repetitive annoyance: the automatically generated link to Wikipedia, like this
<img width="407" height="91" alt="Screenshot 2026-01-22 at 04 51 17" src="https://github.com/user-attachments/assets/5efec8d8-53c1-4548-8f1f-3b76372386de" />

is jammed up against the definition, which looks ugly and makes it appear that the link was part of, or the source of, the definition.
