### PR TITLE
Clear naming reasons notes field when reason unchecked

### DIFF
--- a/app/components/naming_reasons_fields.rb
+++ b/app/components/naming_reasons_fields.rb
@@ -31,7 +31,8 @@ class Components::NamingReasonsFields < Components::Base
   def container_data
     {
       controller: "naming-reason",
-      action: "$shown.bs.collapse->naming-reason#focusInput"
+      action: "$shown.bs.collapse->naming-reason#focusInput " \
+              "$hidden.bs.collapse->naming-reason#clearInput"
     }
   end
 
@@ -54,14 +55,14 @@ class Components::NamingReasonsFields < Components::Base
   def checkbox_label_data(reason)
     {
       toggle: "collapse",
-      target: "#reasons_#{reason.num}_notes"
+      target: "#naming_reasons_#{reason.num}_notes"
     }
   end
 
   def checkbox_label_aria(reason)
     {
       expanded: reason.used?.to_s,
-      controls: "reasons_#{reason.num}_notes"
+      controls: "naming_reasons_#{reason.num}_notes"
     }
   end
 
@@ -69,7 +70,7 @@ class Components::NamingReasonsFields < Components::Base
     # Bootstrap 3: "collapse" when hidden, "collapse in" when visible
     collapse_class = reason.used? ? "collapse in" : "collapse"
 
-    div(id: "reasons_#{reason.num}_notes",
+    div(id: "naming_reasons_#{reason.num}_notes",
         class: class_names("form-group mb-3", collapse_class),
         data: { naming_reason_target: "collapse" }) do
       render(reason_ns.field(:notes).textarea(

--- a/app/javascript/controllers/naming-reason_controller.js
+++ b/app/javascript/controllers/naming-reason_controller.js
@@ -15,16 +15,24 @@ export default class extends Controller {
 
   connect() {
     this.element.dataset.namingReason = "connected";
-    this.delegate = delegate('shown.bs.collapse')
+    this.delegateShown = delegate('shown.bs.collapse')
+    this.delegateHidden = delegate('hidden.bs.collapse')
   }
 
   disconnect() {
-    abnegate('shown.bs.collapse', this.delegate)
+    abnegate('shown.bs.collapse', this.delegateShown)
+    abnegate('hidden.bs.collapse', this.delegateHidden)
   }
 
   // Focuses the input within, when a collapsed reason panel is shown
   focusInput(event) {
     // console.log('Event fired on #' + event.currentTarget.id);
     this.inputTarget.focus()
+  }
+
+  // Clear the input within, when a reason panel is unchecked
+  clearInput(event) {
+    // console.log('Event fired on #' + event.currentTarget.id);
+    this.inputTarget.value = ""
   }
 }

--- a/test/components/naming_reasons_fields_test.rb
+++ b/test/components/naming_reasons_fields_test.rb
@@ -10,40 +10,31 @@ class NamingReasonsFieldsTest < ComponentTestCase
     super
     @naming = Naming.new
     @observation = observations(:coprinus_comatus_obs)
-    @html = render_form_with_reasons
   end
 
-  def test_renders_checkbox_for_each_reason
+  def test_new_naming_renders_all_reasons_collapsed
+    html = render_form_with_reasons
+
+    # Verify each reason has checkbox, textarea, and proper structure
     @naming.init_reasons.each_key do |num|
-      selector = "input[type='checkbox'][name='naming[reasons][#{num}][check]']"
-      assert_html(@html, selector)
+      # Checkbox for each reason
+      assert_html(
+        html,
+        "input[type='checkbox'][name='naming[reasons][#{num}][check]']"
+      )
+      # Textarea for each reason
+      assert_html(html, "textarea[name='naming[reasons][#{num}][notes]']")
+      # Label targets the corresponding textarea collapse
+      assert_html(html, "label[data-target='#naming_reasons_#{num}_notes']")
+      # Textarea container has matching ID
+      assert_html(html, "div[id='naming_reasons_#{num}_notes']")
     end
-  end
 
-  def test_renders_textarea_for_each_reason
-    @naming.init_reasons.each_key do |num|
-      assert_html(@html, "textarea[name='naming[reasons][#{num}][notes]']")
-    end
-  end
-
-  def test_textarea_has_collapse_class
-    assert_html(@html, "div.collapse textarea")
-  end
-
-  def test_checkbox_has_data_toggle_attribute
-    assert_html(@html, "label[data-toggle='collapse']")
-  end
-
-  def test_checkbox_targets_corresponding_textarea
-    @naming.init_reasons.each_key do |num|
-      assert_html(@html, "label[data-target='#reasons_#{num}_notes']")
-    end
-  end
-
-  def test_textarea_container_has_matching_id
-    @naming.init_reasons.each_key do |num|
-      assert_html(@html, "div[id='reasons_#{num}_notes']")
-    end
+    # Bootstrap collapse structure
+    assert_html(html, "div.collapse textarea")
+    assert_html(html, "label[data-toggle='collapse']")
+    # Unchecked reason should be collapsed (has "collapse" but NOT "in")
+    assert_html(html, "div#naming_reasons_1_notes.collapse:not(.in)")
   end
 
   def test_checked_reason_shows_expanded_textarea
@@ -57,12 +48,7 @@ class NamingReasonsFieldsTest < ComponentTestCase
       "input[type='checkbox'][name='naming[reasons][1][check]'][checked]"
     )
     # Container should have "collapse in" classes (Bootstrap 3 expanded)
-    assert_html(html, "div#reasons_1_notes.collapse.in")
-  end
-
-  def test_unchecked_reason_has_collapsed_textarea
-    # Container should have "collapse" but NOT "in" class (collapsed)
-    assert_html(@html, "div#reasons_1_notes.collapse:not(.in)")
+    assert_html(html, "div#naming_reasons_1_notes.collapse.in")
   end
 
   private


### PR DESCRIPTION
Fixes #3762. Can be tested manually according to the bug report.

  1. Adds new JS handler to naming reasons checkboxes that clears the input when unchecked, via existing `naming-reason_controller.js` Stimulus.
   
  2. Adds naming reason assertions to `test_create_minimal_observation` (`test/system/observation_form_system_test.rb`):
  - After filling in "Coprinus comatus", checks reason 2 ("Used references") checkbox
  - Fills the textarea with "Wikipedia"
  - Unchecks the checkbox and asserts the textarea collapses
  - Re-checks and asserts the textarea reappears but is empty (confirming `clearInput` works)
  - Unchecks again before submitting
  - After creation, verifies reason 2 is NOT stored in the database

  3. Consolidates `NamingReasonsFieldsTest` (`test/components/naming_reasons_fields_test.rb`):
  - Reduced from 8 separate test methods to 2 consolidated tests
  - `test_new_naming_renders_all_reasons_collapsed` - combines all default rendering assertions (checkboxes, textareas, collapse structure, data attributes)
  - `test_checked_reason_shows_expanded_textarea` - tests the expanded state for a checked reason
  - Both tests pass with the same coverage, fewer component instantiations