### PR TITLE
Use bounding box matching for project location checklists

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -48,7 +48,7 @@ class Checklist
       @project = project
       @location = location
       @observations = if location.present?
-                        project.observations.where(location: location)
+                        project.observations.within_locations([location])
                       else
                         project.observations
                       end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -293,8 +293,9 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
         self.location_lng = nil
       end
     else
-      # Clear cached data when location is removed
-      self.where = nil
+      # Clear cached coordinates when location is removed
+      # Don't clear where if it was explicitly set by the user
+      self.where = nil unless where_changed?
       self.location_lat = nil
       self.location_lng = nil
     end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -280,11 +280,24 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       self.text_name = name.text_name
       self.classification = name.classification
     end
-    return unless location && location_id_changed?
+    return unless location_id_changed?
 
-    self.where = location.name
-    self.location_lat = location.center_lat
-    self.location_lng = location.center_lng
+    if location
+      self.where = location.name
+      # Only cache coordinates for locations within the box_area threshold
+      if location.box_area <= MO.obs_location_max_area
+        self.location_lat = location.center_lat
+        self.location_lng = location.center_lng
+      else
+        self.location_lat = nil
+        self.location_lng = nil
+      end
+    else
+      # Clear cached data when location is removed
+      self.where = nil
+      self.location_lat = nil
+      self.location_lng = nil
+    end
   end
 
   # This is meant to be run nightly to ensure that the cached name

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -280,7 +280,11 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       self.text_name = name.text_name
       self.classification = name.classification
     end
-    self.where = location.name if location && location_id_changed?
+    return unless location && location_id_changed?
+
+    self.where = location.name
+    self.location_lat = location.center_lat
+    self.location_lng = location.center_lng
   end
 
   # This is meant to be run nightly to ensure that the cached name

--- a/test/classes/pattern_search/observation_test.rb
+++ b/test/classes/pattern_search/observation_test.rb
@@ -195,7 +195,8 @@ class PatternSearch::ObservationTest < UnitTestCase
   end
 
   def test_observation_search_in_box
-    expect = Observation.where(lat: 34.1622, lng: -118.3521)
+    box = { west: -118.4, east: -118.3, north: 34.2, south: 34.1 }
+    expect = Observation.in_box(**box)
     assert(expect.any?)
     x = PatternSearch::Observation.new(
       "west:-118.4 east:-118.3 north:34.2 south:34.1"

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -105,6 +105,8 @@ agaricus_campestris_obs:
   log_updated_at: 2007-03-19 20:21:00
   when: 2007-03-19
   location: burbank
+  location_lat: 34.185
+  location_lng: -118.33
   where: Burbank, California, USA
   user: rolf
   name: agaricus_campestris

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3884,9 +3884,10 @@ class NameTest < UnitTestCase
                           lat: cal.north,
                           lng: cal.east,
                           user: rolf)
+    # Use a large location (box_area > threshold) so coordinates aren't cached
     obs_in_cal_without_lat_lng =
       Observation.create!(name: names_without_observations.second,
-                          location: locations(:burbank),
+                          location: locations(:california),
                           lat: nil,
                           lng: nil,
                           user: rolf)
@@ -3895,7 +3896,8 @@ class NameTest < UnitTestCase
     assert_not_includes(
       names_in_cal_box,
       obs_in_cal_without_lat_lng.name,
-      "Name.in_box should exclude Names whose only Observations lack lat/long"
+      "Name.in_box should exclude Names whose Observations have " \
+      "large locations (box_area > threshold) with no GPS coordinates"
     )
     e = MO.box_epsilon
     box = { north: e, south: 0, east: e, west: 0 }

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1753,4 +1753,29 @@ class ObservationTest < UnitTestCase
     @cc_obs.reload
     assert(@cc_obs.gps_hidden)
   end
+
+  # Test for issue #3770 - cache location center coordinates on observations
+  def test_cache_location_center_coordinates
+    create_new_objects
+
+    # Use albion location which has center coordinates
+    loc = locations(:albion)
+    assert_not_nil(loc.center_lat, "Fixture location should have center_lat")
+    assert_not_nil(loc.center_lng, "Fixture location should have center_lng")
+
+    # Assign location and save
+    @cc_obs.location = loc
+    @cc_obs.save!
+    @cc_obs.reload
+
+    # Verify location coordinates are cached on observation
+    assert_equal(
+      loc.center_lat, @cc_obs.location_lat,
+      "Observation should cache location center_lat as location_lat"
+    )
+    assert_equal(
+      loc.center_lng, @cc_obs.location_lng,
+      "Observation should cache location center_lng as location_lng"
+    )
+  end
 end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1758,24 +1758,61 @@ class ObservationTest < UnitTestCase
   def test_cache_location_center_coordinates
     create_new_objects
 
-    # Use albion location which has center coordinates
-    loc = locations(:albion)
-    assert_not_nil(loc.center_lat, "Fixture location should have center_lat")
-    assert_not_nil(loc.center_lng, "Fixture location should have center_lng")
+    # Test small location (box_area <= threshold): coordinates should be cached
+    small_loc = locations(:albion)
+    assert(small_loc.box_area <= MO.obs_location_max_area,
+           "Test location should be small (box_area <= threshold)")
+    assert_not_nil(small_loc.center_lat)
+    assert_not_nil(small_loc.center_lng)
 
-    # Assign location and save
+    @cc_obs.location = small_loc
+    @cc_obs.save!
+    @cc_obs.reload
+
+    assert_equal(small_loc.center_lat, @cc_obs.location_lat,
+                 "Small location: coordinates should be cached")
+    assert_equal(small_loc.center_lng, @cc_obs.location_lng,
+                 "Small location: coordinates should be cached")
+  end
+
+  def test_cache_location_coordinates_large_location
+    create_new_objects
+
+    # Test large location (box_area > threshold): coordinates should be nil
+    large_loc = locations(:unknown_location)
+    assert(large_loc.box_area > MO.obs_location_max_area,
+           "Test location should be large (box_area > threshold)")
+
+    @cc_obs.location = large_loc
+    @cc_obs.save!
+    @cc_obs.reload
+
+    assert_nil(@cc_obs.location_lat,
+               "Large location: coordinates should be nil")
+    assert_nil(@cc_obs.location_lng,
+               "Large location: coordinates should be nil")
+  end
+
+  def test_cache_location_coordinates_clears_when_removed
+    create_new_objects
+
+    # First assign a location
+    loc = locations(:albion)
     @cc_obs.location = loc
     @cc_obs.save!
     @cc_obs.reload
 
-    # Verify location coordinates are cached on observation
-    assert_equal(
-      loc.center_lat, @cc_obs.location_lat,
-      "Observation should cache location center_lat as location_lat"
-    )
-    assert_equal(
-      loc.center_lng, @cc_obs.location_lng,
-      "Observation should cache location center_lng as location_lng"
-    )
+    assert_equal(loc.center_lat, @cc_obs.location_lat)
+    assert_equal(loc.center_lng, @cc_obs.location_lng)
+
+    # Then remove the location
+    @cc_obs.location = nil
+    @cc_obs.save!
+    @cc_obs.reload
+
+    assert_nil(@cc_obs.location_lat,
+               "Removing location should clear cached coordinates")
+    assert_nil(@cc_obs.location_lng,
+               "Removing location should clear cached coordinates")
   end
 end


### PR DESCRIPTION
## Problem

Project checklists filtered by location showed inconsistent counts compared to the observation listing:

- **Checklist**: "Daedaleopsis confragosa (3)" 
- **Clicking the species**: Shows 4 observations

This occurred because:
1. **Checklist counting** used exact `location_id` matching (`where(location: location)`)
2. **Observation listing** used bounding box matching (`within_locations`)

## Example

For location "Connecticut Hill Wildlife Management Area" (ID 18469):
- 3 observations have `location_id = 18469` (exact match)
- 1 observation has `location_id = 30488` ("southeastern Finger Lakes") but GPS coordinates inside the bounding box

The checklist counted 3, but clicking showed 4.

## Solution

Changed `Checklist::ForProject` to use `within_locations([location])` instead of `where(location: location)`. This makes checklist counts consistent with observation listings.

```ruby
# Before
@observations = project.observations.where(location: location)

# After  
@observations = project.observations.within_locations([location])
```

## Testing

- Updated existing test to cache location coordinates (required for bounding box matching)
- Added new test `test_checklist_for_project_uses_bounding_box_matching` to verify the behavior
- All 6 checklist tests pass

## Dependencies

This PR is based on #3771 which adds the location coordinate caching feature. It should be merged after #3771.

## Impact

After this fix:
- Checklist counts will match observation listing counts
- Observations with GPS coordinates inside a location's bounding box will be counted, even if they have a different `location_id`
- No breaking changes to existing behavior

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>