### PR TITLE
Fix field slip ID losing underscores when editing other fields

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -210,7 +210,19 @@ class FieldSlipsController < ApplicationController
     id_str = params[:field_slip][:field_slip_name]
     return unless id_str
 
-    id_str.tr!("_", "")
+    # Handle textile formatted IDs defensively
+    # "_name Xxx yyy_" -> "Xxx yyy"
+    # "_Xxx yyy_" -> "Xxx yyy"
+    # "Xxx yyy" -> "Xxx yyy"
+    # "_Weird_name_" -> "Weird_name" (preserves internal underscores)
+    if id_str.match?(/\A_name\s+.*_\z/)
+      # Strip "_name " prefix and trailing "_"
+      id_str = id_str[6..-2]
+    elsif id_str.match?(/\A_.*_\z/)
+      # Strip leading and trailing underscores only
+      id_str = id_str[1..-2]
+    end
+
     names = Name.find_names(@user, id_str)
     return if names.blank?
 

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -210,31 +210,39 @@ class FieldSlipsController < ApplicationController
     id_str = params[:field_slip][:field_slip_name]
     return unless id_str
 
+    id_str = strip_textile_formatting(id_str)
+    names = Name.find_names(@user, id_str)
+    return if names.blank?
+
+    name = names[0]
+    create_naming_and_vote(name)
+  end
+
+  def strip_textile_formatting(id_str)
     # Handle textile formatted IDs defensively
     # "_name Xxx yyy_" -> "Xxx yyy"
     # "_Xxx yyy_" -> "Xxx yyy"
     # "Xxx yyy" -> "Xxx yyy"
     # "_Weird_name_" -> "Weird_name" (preserves internal underscores)
-    if id_str.match?(/\A_name\s+.*_\z/)
+    if id_str.start_with?("_name ") && id_str.end_with?("_")
       # Strip "_name " prefix and trailing "_"
-      id_str = id_str[6..-2]
-    elsif id_str.match?(/\A_.*_\z/)
+      id_str[6..-2]
+    elsif id_str.start_with?("_") && id_str.end_with?("_")
       # Strip leading and trailing underscores only
-      id_str = id_str[1..-2]
+      id_str[1..-2]
+    else
+      id_str
     end
+  end
 
-    names = Name.find_names(@user, id_str)
-    return if names.blank?
-
-    name = names[0]
+  def create_naming_and_vote(name)
     naming = @field_slip.observation.namings.find_by(name:)
     unless naming
       naming = Naming.user_construct({}, @field_slip.observation, @user)
       naming.name = name
       naming.save!
     end
-    vote = Vote.find_by(user: @user, naming:)
-    return if vote
+    return if Vote.find_by(user: @user, naming:)
 
     Vote.create!(favorite: true, value: Vote.maximum_vote, naming:, user: @user)
     Observation::NamingConsensus.new(@field_slip.observation).

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -595,8 +595,10 @@ class FieldSlipsControllerTest < FunctionalTestCase
           })
     assert_redirected_to(field_slip_url(fs1))
     # Check that a naming was created for this name
-    assert(fs1.observation.reload.namings.exists?(name: names(:coprinus_comatus)),
-           "Should create naming for '_name Xxx yyy_' format")
+    naming_exists = fs1.observation.reload.namings.exists?(
+      name: names(:coprinus_comatus)
+    )
+    assert(naming_exists, "Should create naming for '_name Xxx yyy_' format")
 
     # Test "_Xxx yyy_" format (without "name" prefix)
     fs2 = field_slips(:field_slip_two)
@@ -612,8 +614,10 @@ class FieldSlipsControllerTest < FunctionalTestCase
             }
           })
     assert_redirected_to(field_slip_url(fs2))
-    assert(fs2.observation.reload.namings.exists?(name: names(:agaricus_campestris)),
-           "Should create naming for '_Xxx yyy_' format")
+    naming_exists = fs2.observation.reload.namings.exists?(
+      name: names(:agaricus_campestris)
+    )
+    assert(naming_exists, "Should create naming for '_Xxx yyy_' format")
 
     # Test plain format (no underscores)
     fs3 = field_slips(:field_slip_previous)
@@ -629,8 +633,10 @@ class FieldSlipsControllerTest < FunctionalTestCase
             }
           })
     assert_redirected_to(field_slip_url(fs3))
-    assert(fs3.observation.reload.namings.exists?(name: names(:boletus_edulis)),
-           "Should create naming for plain 'Xxx yyy' format")
+    naming_exists = fs3.observation.reload.namings.exists?(
+      name: names(:boletus_edulis)
+    )
+    assert(naming_exists, "Should create naming for plain 'Xxx yyy' format")
   end
 
   def test_should_update_field_slip_and_merge_notes


### PR DESCRIPTION
## Summary

Fixes #3775 - Field slip ID field losing underscores when editing other fields

When editing a field slip with an ID containing underscores (e.g., `_name Xxx yyy_` or `_Xxx yyy_`), the underscores were being stripped when saving any field, even if the ID field itself wasn't changed.

## Root Cause

The "name " prefix comes from `Observation#field_slip_name` default value (added 2+ years ago) and should be preserved. The bug was in `FieldSlipsController#check_name`, which needs to defensively handle multiple textile formats when parsing the name to look up.

## Changes

Updated `check_name` to handle three textile ID formats:
- `_name Xxx yyy_` → extracts `Xxx yyy` (strips `_name ` prefix and trailing `_`)
- `_Xxx yyy_` → extracts `Xxx yyy` (strips leading/trailing `_` only)
- `Xxx yyy` → uses as-is (no stripping)

This preserves internal underscores (e.g., `_Weird_name_` → `Weird_name`).

## Testing

Added comprehensive tests:
- `test_should_preserve_underscores_in_id_when_editing_other_fields` - regression test for the original bug
- `test_check_name_handles_textile_formats` - verifies all three formats work correctly

All field slip controller tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)