### PR TITLE
Fix checklist column layout alignment issue

### DIFF
--- a/app/assets/stylesheets/mo/_name_lister.scss
+++ b/app/assets/stylesheets/mo/_name_lister.scss
@@ -55,6 +55,6 @@ div.scroller {
   }
 }
 
-.checklist {
+.checklist .panel-body {
   columns: 24rem auto;
 }


### PR DESCRIPTION
## Problem

The checklist page for project locations had a layout issue where:
- Extra whitespace appeared in the upper left corner of the taxa list
- The first taxon was misaligned compared to other items

This was visible on pages like `https://mushroomobserver.org//checklist?location_id=25743&project_id=389`.

## Root Cause

The CSS columns property was applied to the `.checklist` selector (the panel element) instead of the `.checklist .panel-body` selector. This caused the panel-body wrapper div to be split across columns rather than just the list items inside it.

## Solution

Changed the CSS selector from `.checklist` to `.checklist .panel-body` to apply the column layout directly to the element containing the list.

**Before:**
```scss
.checklist {
  columns: 24rem auto;
}
```

**After:**
```scss
.checklist .panel-body {
  columns: 24rem auto;
}
```

## Testing

Visual inspection of checklist pages should show:
- No extra whitespace in upper left corner
- First taxon properly aligned with other items
- Column layout still functioning correctly

## Impact

- CSS-only change, no functional impact
- Fixes visual layout issue on all checklist pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)