### PR TITLE
Phlex `NameForm` — show `locked` field (admin only)

### DIFF
--- a/app/components/name_form.rb
+++ b/app/components/name_form.rb
@@ -37,12 +37,7 @@ class Components::NameForm < Components::ApplicationForm
   end
 
   def render_admin_locked_checkbox
-    field(:locked).checkbox(
-      wrapper_options: {
-        label: :form_names_locked.l,
-        wrap_class: "mt-3"
-      }
-    )
+    checkbox_field(:locked, label: :form_names_locked.l, wrap_class: "mt-3")
   end
 
   def render_editable_fields

--- a/test/controllers/names_controller_update_test.rb
+++ b/test/controllers/names_controller_update_test.rb
@@ -719,6 +719,7 @@ class NamesControllerUpdateTest < FunctionalTestCase
 
     make_admin(rolf.login)
     get(:edit, params: { id: name.id })
+    assert_select("input[type=checkbox]#name_locked", count: 1)
     assert_select("input[type=text]#name_icn_id", count: 1)
     assert_select("select#name_rank", count: 1)
     assert_select("select#name_deprecated", count: 1)


### PR DESCRIPTION
Fixes #3757, reported by @JoeCohen 

Adds controller test that the field renders

Please merge if OK.