### PR TITLE
Clean up bad code examples in Phlex components

### DIFF
--- a/app/components/api_key_form.rb
+++ b/app/components/api_key_form.rb
@@ -24,11 +24,7 @@ class Components::APIKeyForm < Components::ApplicationForm
     div(class: "input-group") do
       render_cancel_button if @cancel_target
 
-      render(field(:notes).text(
-               wrapper_options: { label: false },
-               size: 40,
-               class: "form-control border-none"
-             ))
+      text_field(:notes, label: false, size: 40, class: "form-control border-none")
 
       span(class: "input-group-btn") do
         submit(:CREATE.l, submits_with: submits_text)

--- a/app/components/api_key_form.rb
+++ b/app/components/api_key_form.rb
@@ -24,7 +24,8 @@ class Components::APIKeyForm < Components::ApplicationForm
     div(class: "input-group") do
       render_cancel_button if @cancel_target
 
-      text_field(:notes, label: false, size: 40, class: "form-control border-none")
+      text_field(:notes, label: false, size: 40,
+                         class: "form-control border-none")
 
       span(class: "input-group-btn") do
         submit(:CREATE.l, submits_with: submits_text)

--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -357,6 +357,44 @@ class Components::ApplicationForm < Superform::Rails::Form
     render(field_component)
   end
 
+  # Static field - displays a value as plain text (not editable)
+  # @param field_name [Symbol] the field name
+  # @param options [Hash] all field and wrapper options
+  # All wrapper options same as text_field
+  # @yield [field_component] Optional block to set slots
+  def static_field(field_name, **options)
+    wrapper_opts = options.slice(*WRAPPER_OPTIONS)
+    field_opts = options.except(*WRAPPER_OPTIONS)
+
+    field_component = field(field_name).static(
+      wrapper_options: wrapper_opts,
+      **field_opts
+    )
+
+    yield(field_component) if block_given?
+
+    render(field_component)
+  end
+
+  # Read-only field - displays value with hidden input for form submission
+  # @param field_name [Symbol] the field name
+  # @param options [Hash] all field and wrapper options
+  # All wrapper options same as text_field
+  # @yield [field_component] Optional block to set slots
+  def read_only_field(field_name, **options)
+    wrapper_opts = options.slice(*WRAPPER_OPTIONS)
+    field_opts = options.except(*WRAPPER_OPTIONS)
+
+    field_component = field(field_name).read_only(
+      wrapper_options: wrapper_opts,
+      **field_opts
+    )
+
+    yield(field_component) if block_given?
+
+    render(field_component)
+  end
+
   # File field with label and Bootstrap form-group wrapper
   # @param field_name [Symbol] the field name
   # @param options [Hash] all field and wrapper options

--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -360,11 +360,14 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Static field - displays a value as plain text (not editable)
   # @param field_name [Symbol] the field name
   # @param options [Hash] all field and wrapper options
+  # @option options [String] :value the text to display
   # All wrapper options same as text_field
   # @yield [field_component] Optional block to set slots
   def static_field(field_name, **options)
-    wrapper_opts = options.slice(*WRAPPER_OPTIONS)
-    field_opts = options.except(*WRAPPER_OPTIONS)
+    # For static fields, :value is a wrapper option (displayed text)
+    static_wrapper_opts = WRAPPER_OPTIONS + [:value]
+    wrapper_opts = options.slice(*static_wrapper_opts)
+    field_opts = options.except(*static_wrapper_opts)
 
     field_component = field(field_name).static(
       wrapper_options: wrapper_opts,
@@ -379,11 +382,14 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Read-only field - displays value with hidden input for form submission
   # @param field_name [Symbol] the field name
   # @param options [Hash] all field and wrapper options
+  # @option options [String] :value the text to display (also submitted)
   # All wrapper options same as text_field
   # @yield [field_component] Optional block to set slots
   def read_only_field(field_name, **options)
-    wrapper_opts = options.slice(*WRAPPER_OPTIONS)
-    field_opts = options.except(*WRAPPER_OPTIONS)
+    # For read_only fields, :value is a wrapper option (displayed text)
+    read_only_wrapper_opts = WRAPPER_OPTIONS + [:value]
+    wrapper_opts = options.slice(*read_only_wrapper_opts)
+    field_opts = options.except(*read_only_wrapper_opts)
 
     field_component = field(field_name).read_only(
       wrapper_options: wrapper_opts,

--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -107,6 +107,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Register view helpers that forms might need
   # Use register_value_helper for helpers that return values (not HTML)
   register_value_helper :in_admin_mode?
+  register_value_helper :pluralize
   register_value_helper :url_for
   register_value_helper :rank_as_string
 

--- a/app/components/commercial_inquiry_form.rb
+++ b/app/components/commercial_inquiry_form.rb
@@ -38,12 +38,8 @@ class Components::CommercialInquiryForm < Components::ApplicationForm
   end
 
   def render_message_field
-    label = "#{:ask_user_question_message.t}:"
-    render(field(:message).textarea(
-             wrapper_options: { label: label },
-             value: @message,
-             rows: 10
-           ))
+    textarea_field(:message, label: "#{:ask_user_question_message.t}:",
+                             value: @message, rows: 10)
   end
 
   def form_action

--- a/app/components/donation_form.rb
+++ b/app/components/donation_form.rb
@@ -15,6 +15,6 @@ class Components::DonationForm < Components::ApplicationForm
   end
 
   def form_action
-    view_context.admin_donations_path
+    admin_donations_path
   end
 end

--- a/app/components/glossary_term_form.rb
+++ b/app/components/glossary_term_form.rb
@@ -20,9 +20,9 @@ class Components::GlossaryTermForm < Components::ApplicationForm
 
   # Automatically determine action URL based on whether record is persisted
   def form_action
-    return view_context.glossary_terms_path if model.nil? || !model.persisted?
+    return glossary_terms_path if model.nil? || !model.persisted?
 
-    view_context.glossary_term_path(model)
+    glossary_term_path(model)
   end
 
   def render_locked_checkbox

--- a/app/components/license_form.rb
+++ b/app/components/license_form.rb
@@ -13,9 +13,9 @@ class Components::LicenseForm < Components::ApplicationForm
 
   # Automatically determine action URL based on whether record is persisted
   def form_action
-    return view_context.licenses_path if model.nil? || !model.persisted?
+    return licenses_path if model.nil? || !model.persisted?
 
-    view_context.license_path(model)
+    license_path(model)
   end
 
   def render_display_name_field

--- a/app/components/merge_request_form.rb
+++ b/app/components/merge_request_form.rb
@@ -22,32 +22,15 @@ class Components::MergeRequestForm < Components::ApplicationForm
   private
 
   def render_object_fields
-    render(field(:old_obj).static(
-             wrapper_options: {
-               label: "#{type_label}:",
-               value: @old_obj.unique_format_name.t,
-               inline: true
-             }
-           ))
-
-    render(field(:new_obj).static(
-             wrapper_options: {
-               label: "#{type_label}:",
-               value: @new_obj.unique_format_name.t,
-               inline: true
-             }
-           ))
+    static_field(:old_obj, label: "#{type_label}:",
+                           value: @old_obj.unique_format_name.t, inline: true)
+    static_field(:new_obj, label: "#{type_label}:",
+                           value: @new_obj.unique_format_name.t, inline: true)
   end
 
   def render_notes_field
-    render(field(:notes).textarea(
-             wrapper_options: {
-               label: "#{:Notes.t}:"
-             },
-             rows: 10,
-             value: "",
-             data: { autofocus: true }
-           ))
+    textarea_field(:notes, label: "#{:Notes.t}:", rows: 10,
+                           value: "", data: { autofocus: true })
   end
 
   def type_label

--- a/app/components/name_change_request_form.rb
+++ b/app/components/name_change_request_form.rb
@@ -22,34 +22,20 @@ class Components::NameChangeRequestForm < Components::ApplicationForm
   private
 
   def render_name_field
-    render(field(:name).static(
-             wrapper_options: {
-               label: "#{:NAME.t}:",
-               value: "#{@name.unique_search_name}[##{@name.icn_id}]",
-               inline: true
-             }
-           ))
+    static_field(:name, label: "#{:NAME.t}:",
+                        value: "#{@name.unique_search_name}[##{@name.icn_id}]",
+                        inline: true)
   end
 
   def render_new_name_field
-    render(field(:new_name_with_icn_id).read_only(
-             wrapper_options: {
-               label: "#{:new_name.t}:",
-               value: @new_name_with_icn_id,
-               inline: true
-             }
-           ))
+    read_only_field(:new_name_with_icn_id, label: "#{:new_name.t}:",
+                                           value: @new_name_with_icn_id,
+                                           inline: true)
   end
 
   def render_notes_field
-    render(field(:notes).textarea(
-             wrapper_options: {
-               label: "#{:Notes.t}:"
-             },
-             rows: 10,
-             value: "",
-             data: { autofocus: true }
-           ))
+    textarea_field(:notes, label: "#{:Notes.t}:", rows: 10,
+                           value: "", data: { autofocus: true })
   end
 
   def form_action

--- a/app/components/name_form.rb
+++ b/app/components/name_form.rb
@@ -248,9 +248,9 @@ class Components::NameForm < Components::ApplicationForm
 
   def form_action
     if @model.new_record?
-      view_context.names_path
+      names_path
     else
-      view_context.name_path(@model)
+      name_path(@model)
     end
   end
 end

--- a/app/components/observer_question_form.rb
+++ b/app/components/observer_question_form.rb
@@ -24,13 +24,9 @@ class Components::ObserverQuestionForm < Components::ApplicationForm
   end
 
   def render_message_field
-    label = "#{:ask_user_question_message.t}:"
-    render(field(:message).textarea(
-             wrapper_options: { label: label },
-             value: @message,
-             rows: 6,
-             data: { autofocus: true }
-           ))
+    textarea_field(:message, label: "#{:ask_user_question_message.t}:",
+                             value: @message, rows: 6,
+                             data: { autofocus: true })
   end
 
   def form_action

--- a/app/components/publication_form.rb
+++ b/app/components/publication_form.rb
@@ -15,9 +15,9 @@ class Components::PublicationForm < Components::ApplicationForm
 
   # Automatically determine action URL based on whether record is persisted
   def form_action
-    return view_context.publications_path if model.nil? || !model.persisted?
+    return publications_path if model.nil? || !model.persisted?
 
-    view_context.publication_path(model)
+    publication_path(model)
   end
 
   def render_full_field

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -61,7 +61,7 @@ class Components::SearchForm < Components::ApplicationForm
   end
 
   def form_action
-    @form_action_url || view_context.url_for(action: :create)
+    @form_action_url || url_for(action: :create)
   end
 
   def form_attributes
@@ -463,7 +463,7 @@ class Components::SearchForm < Components::ApplicationForm
       # Derive clear URL from action URL (replace /search with /search/new)
       "#{@form_action_url.sub(%r{/search$}, "/search/new")}?clear=true"
     else
-      view_context.url_for(action: :new, clear: true)
+      url_for(action: :new, clear: true)
     end
   end
 end

--- a/app/components/user_question_form.rb
+++ b/app/components/user_question_form.rb
@@ -23,24 +23,14 @@ class Components::UserQuestionForm < Components::ApplicationForm
   private
 
   def render_subject_field
-    render(field(:subject).text(
-             wrapper_options: {
-               label: "#{:ask_user_question_subject.t}:"
-             },
-             value: @subject,
-             size: 70,
-             data: { autofocus: true }
-           ))
+    text_field(:subject, label: "#{:ask_user_question_subject.t}:",
+                         value: @subject, size: 70,
+                         data: { autofocus: true })
   end
 
   def render_message_field
-    render(field(:message).textarea(
-             wrapper_options: {
-               label: "#{:ask_user_question_message.t}:"
-             },
-             value: @message,
-             rows: 10
-           ))
+    textarea_field(:message, label: "#{:ask_user_question_message.t}:",
+                             value: @message, rows: 10)
   end
 
   def form_action

--- a/app/components/visual_group_form.rb
+++ b/app/components/visual_group_form.rb
@@ -38,7 +38,7 @@ class Components::VisualGroupForm < Components::ApplicationForm
   def render_name_field
     div(class: "form-group") do
       div(class: "form-inline") do
-        render(field(:name).text(size: 40, class: "form-control"))
+        text_field(:name, size: 40, class: "form-control", label: false)
         span(class: "ml-3") { :VISUAL_GROUP.t }
       end
     end

--- a/app/components/visual_group_form.rb
+++ b/app/components/visual_group_form.rb
@@ -23,24 +23,14 @@ class Components::VisualGroupForm < Components::ApplicationForm
   private
 
   def render_errors
-    count = view_context.pluralize(model.errors.count, :error.t,
-                                   plural: :errors.t)
+    count = pluralize(model.errors.count, :error.l, plural: :errors.l)
 
     Alert(level: :danger, id: "error_explanation") do
-      [error_header(count), error_list].join.html_safe # rubocop:disable Rails/OutputSafety
-    end
-  end
-
-  def error_header(count)
-    view_context.tag.h2(
-      "#{count} prohibited this visual_group from being saved:"
-    )
-  end
-
-  def error_list
-    view_context.tag.ul do
-      model.errors.each do |error|
-        view_context.concat(view_context.tag.li(error.full_message))
+      h2 { "#{count} prohibited this visual_group from being saved:" }
+      ul do
+        model.errors.each do |error|
+          li { error.full_message }
+        end
       end
     end
   end
@@ -56,9 +46,9 @@ class Components::VisualGroupForm < Components::ApplicationForm
 
   def form_action
     if model.persisted?
-      view_context.visual_group_path(model)
+      visual_group_path(model)
     else
-      view_context.visual_model_visual_groups_path(@visual_model)
+      visual_model_visual_groups_path(@visual_model)
     end
   end
 end

--- a/app/components/visual_model_form.rb
+++ b/app/components/visual_model_form.rb
@@ -14,21 +14,14 @@ class Components::VisualModelForm < Components::ApplicationForm
   private
 
   def render_errors
+    count = pluralize(model.errors.count, :error.l, plural: :errors.l)
+
     Alert(level: :danger, id: "error_explanation") do
-      [error_header, error_list].join.html_safe # rubocop:disable Rails/OutputSafety
-    end
-  end
-
-  def error_header
-    count = view_context.pluralize(model.errors.count, :error.t,
-                                   plural: :errors.t)
-    view_context.tag.h2("#{count} #{:visual_model_errors.t}:")
-  end
-
-  def error_list
-    view_context.tag.ul do
-      model.errors.each do |error|
-        view_context.concat(view_context.tag.li(error.full_message))
+      h2 { "#{count} #{:visual_model_errors.l}:" }
+      ul do
+        model.errors.each do |error|
+          li { error.full_message }
+        end
       end
     end
   end

--- a/app/components/visual_model_form.rb
+++ b/app/components/visual_model_form.rb
@@ -28,7 +28,7 @@ class Components::VisualModelForm < Components::ApplicationForm
 
   def render_name_field
     div(class: "form-group field") do
-      render(field(:name).text(class: "form-control"))
+      text_field(:name, class: "form-control", label: false)
       whitespace
       plain(:VISUAL_MODEL.t)
     end

--- a/app/components/webmaster_question_form.rb
+++ b/app/components/webmaster_question_form.rb
@@ -23,29 +23,15 @@ class Components::WebmasterQuestionForm < Components::ApplicationForm
   private
 
   def render_email_field
-    render(field(:email).text(
-             wrapper_options: {
-               label: "#{:ask_webmaster_your_email.t}:"
-             },
-             value: @email,
-             size: 60,
-             data: {
-               autofocus: @email.blank? || @email_error
-             }
-           ))
+    text_field(:email, label: "#{:ask_webmaster_your_email.t}:",
+                       value: @email, size: 60,
+                       data: { autofocus: @email.blank? || @email_error })
   end
 
   def render_question_field
-    render(field(:message).textarea(
-             wrapper_options: {
-               label: "#{:ask_webmaster_question.t}:"
-             },
-             value: @message,
-             rows: 10,
-             data: {
-               autofocus: @email.present? && !@email_error
-             }
-           ))
+    textarea_field(:message, label: "#{:ask_webmaster_question.t}:",
+                             value: @message, rows: 10,
+                             data: { autofocus: @email.present? && !@email_error })
   end
 
   def form_action

--- a/app/components/webmaster_question_form.rb
+++ b/app/components/webmaster_question_form.rb
@@ -31,7 +31,8 @@ class Components::WebmasterQuestionForm < Components::ApplicationForm
   def render_question_field
     textarea_field(:message, label: "#{:ask_webmaster_question.t}:",
                              value: @message, rows: 10,
-                             data: { autofocus: @email.present? && !@email_error })
+                             data: { autofocus: @email.present? &&
+                                                !@email_error })
   end
 
   def form_action


### PR DESCRIPTION
Quite a few of my forms had sloppy examples of Phlex code. Claude is more likely to use existing code for reference, rather than "claude rules", so it's more efficient in the long run to correct code than to give it instructions.

### Corrected patterns
#### Never any need to call `view_context.whatever_path`. 
Phlex knows about `glossary_term_path`.                                                                                                     
  - `glossary_term_form.rb, license_form.rb, name_form.rb, publication_form.rb, donation_form.rb, visual_group_form.rb, search_form.rb`                

#### Never any need to call `view_context.tag(:h2)`
Phlex has all its own tag helpers.
  Refactored a couple forms to use Phlex native elements:
  - Replaced `view_context.tag.*` with `h2 {}`, `ul {}`, `li {}`

#### Added to ApplicationForm:
  - `register_value_helper :pluralize`
  - `static_field` helper method
  - `read_only_field` helper method

#### We have superform helpers for every field type, so no need to call `render(field(:name).type(args))`
  Converted to our superform helper methods:
  - visual_group_form.rb, visual_model_form.rb - `text_field`
  - api_key_form.rb - `text_field`
  - commercial_inquiry_form.rb, observer_question_form.rb - `textarea_field`
  - webmaster_question_form.rb - `text_field, textarea_field`
  - merge_request_form.rb - `static_field, textarea_field`
  - name_change_request_form.rb - `static_field, read_only_field, textarea_field`
  - user_question_form.rb - `text_field, textarea_field`

 #### Fixed localization:
  - Changed .t to .l for :error, :errors, :visual_model_errors