### PR TITLE
Phlex: use new `mark_safe` for `register_output_helper`

### DIFF
--- a/.claude/style_guide.md
+++ b/.claude/style_guide.md
@@ -93,6 +93,26 @@ end
 
 ## Phlex Component Style
 
+### Form Components (Superform)
+
+Form components extend `Components::ApplicationForm` which provides helper methods
+for rendering fields. **Always use these helpers** instead of the verbose
+`render(field(...).xxx(...))` pattern.
+
+```ruby
+# Good - Use helper methods
+text_field(:name, label: "Name:", size: 40)
+textarea_field(:notes, label: "Notes:", rows: 6)
+checkbox_field(:approved, label: "Approved")
+select_field(:rank, rank_options, label: "Rank:")
+static_field(:display_name, label: "Name:", value: @model.name, inline: true)
+read_only_field(:locked_field, label: "Value:", value: @value)
+
+# Bad - Verbose render(field(...)) pattern
+render(field(:name).text(wrapper_options: { label: "Name:" }, size: 40))
+render(field(:notes).textarea(wrapper_options: { label: "Notes:" }, rows: 6))
+```
+
 ### HTML Helpers
 
 **Use Phlex's native HTML helpers** instead of Rails `tag` helpers wrapped in `unsafe_raw`.

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -13,23 +13,20 @@ class Components::Base < Phlex::HTML
   include Components::TrustedHtml
 
   # Register custom output helpers (return HTML)
-  register_output_helper :show_title_id_badge
-  register_output_helper :link_to_object
-  register_output_helper :show_page_edit_icons
-  register_output_helper :naming_vote_form
-  register_output_helper :propose_naming_link
-  register_output_helper :location_link
-  register_output_helper :user_link
-  register_output_helper :modal_link_to
-  register_output_helper :put_button
-  register_output_helper :text_area_with_label
-  register_output_helper :date_select_with_label
-  register_output_helper :text_field_with_label
-  register_output_helper :select_with_label
-  register_output_helper :link_icon
-  register_output_helper :make_table
-  register_output_helper :help_block_with_arrow
-  register_output_helper :observation_location_help
+  # mark_safe: true tells Phlex to trust the output without checking SafeBuffer
+  register_output_helper :show_title_id_badge, mark_safe: true
+  register_output_helper :link_to_object, mark_safe: true
+  register_output_helper :show_page_edit_icons, mark_safe: true
+  register_output_helper :naming_vote_form, mark_safe: true
+  register_output_helper :propose_naming_link, mark_safe: true
+  register_output_helper :location_link, mark_safe: true
+  register_output_helper :user_link, mark_safe: true
+  register_output_helper :modal_link_to, mark_safe: true
+  register_output_helper :put_button, mark_safe: true
+  register_output_helper :link_icon, mark_safe: true
+  register_output_helper :make_table, mark_safe: true
+  register_output_helper :help_block_with_arrow, mark_safe: true
+  register_output_helper :observation_location_help, mark_safe: true
 
   # Register custom value helpers (return values)
   register_value_helper :permission?

--- a/app/components/crud_action_button.rb
+++ b/app/components/crud_action_button.rb
@@ -52,7 +52,7 @@ class Components::CrudActionButton < Components::Base
     capture do
       if @args[:icon]
         span(class: "sr-only") { trusted_html(@name) }
-        trusted_html(link_icon(@args[:icon]))
+        link_icon(@args[:icon])
       else
         trusted_html(@name)
       end

--- a/app/components/object_footer.rb
+++ b/app/components/object_footer.rb
@@ -38,6 +38,11 @@ module Components
 
     private
 
+    # NOTE: We use view_context.user_link() instead of the registered output
+    # helper user_link() because we need the return value for interpolation
+    # into translation strings. Registered output helpers write directly to the
+    # Phlex buffer rather than returning a value.
+
     # Renders metadata for old versions of versioned objects
     def render_old_version_metadata(num_versions)
       trusted_html(:footer_version_out_of.t(num: @obj.version,
@@ -48,7 +53,7 @@ module Components
       user = User.safe_find(@obj.user_id)
       br
       trusted_html(:footer_updated_by.t(
-                     user: user_link(user),
+                     user: view_context.user_link(user),
                      date: @obj.updated_at.web_time
                    ))
     end
@@ -83,7 +88,7 @@ module Components
       latest_user = User.safe_find(@versions.last.user_id)
       br
       trusted_html(:footer_last_updated_by.t(
-                     user: user_link(latest_user),
+                     user: view_context.user_link(latest_user),
                      date: @obj.updated_at.web_time
                    ))
     end
@@ -98,7 +103,7 @@ module Components
       return unless @obj.created_at
 
       trusted_html(:footer_created_by.t(
-                     user: user_link(@obj.user),
+                     user: view_context.user_link(@obj.user),
                      date: @obj.created_at.web_time
                    ))
     end

--- a/app/components/object_footer.rb
+++ b/app/components/object_footer.rb
@@ -48,7 +48,7 @@ module Components
       user = User.safe_find(@obj.user_id)
       br
       trusted_html(:footer_updated_by.t(
-                     user: view_context.user_link(user),
+                     user: user_link(user),
                      date: @obj.updated_at.web_time
                    ))
     end
@@ -83,7 +83,7 @@ module Components
       latest_user = User.safe_find(@versions.last.user_id)
       br
       trusted_html(:footer_last_updated_by.t(
-                     user: view_context.user_link(latest_user),
+                     user: user_link(latest_user),
                      date: @obj.updated_at.web_time
                    ))
     end
@@ -98,7 +98,7 @@ module Components
       return unless @obj.created_at
 
       trusted_html(:footer_created_by.t(
-                     user: view_context.user_link(@obj.user),
+                     user: user_link(@obj.user),
                      date: @obj.created_at.web_time
                    ))
     end

--- a/app/components/project_banner.rb
+++ b/app/components/project_banner.rb
@@ -72,13 +72,13 @@ module Components
       h1(class: title_classes, id: title_id) do
         if @on_project_page
           div(class: "d-flex align-items-center") do
-            trusted_html(show_title_id_badge(@project))
+            show_title_id_badge(@project)
             plain(" ")
-            trusted_html(link_to_object(@project))
-            trusted_html(show_page_edit_icons)
+            link_to_object(@project)
+            show_page_edit_icons
           end
         else
-          trusted_html(link_to_object(@project))
+          link_to_object(@project)
         end
       end
     end


### PR DESCRIPTION
Per [this pull request on Phlex](https://github.com/yippee-fun/phlex-rails/pull/303), we don't have to use `trusted_html` as much. Available now since @JoeCohen bumped our version of Phlex.

We can basically now tell Phlex that a registered output helper already returns safe HTML.

This updates `Components::Base` to use this, and updates callers.