### PR TITLE
Use `superform` fork with `radio_field` support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem("literal")
 # Enable Slot API for Phlex
 gem("phlex-slotable")
 # Superform for type-safe forms with Phlex
-gem("superform")
+gem("superform", github: "nimmolo/superform", branch: "nimmo-add-radio-fields")
 # Strict ivars: raises a NameError if an ivar is nil (undefined). Must be
 # required in config/boot.rb to work: https://github.com/yippee-fun/strict_ivars
 # gem("strict_ivars", require: false)
@@ -202,7 +202,8 @@ group :test do
   gem("database_cleaner-active_record")
 
   # allows test results to be reported back to test runner IDE's
-  gem("minitest")
+  # Pin to 5.x - minitest 6.0 is incompatible with Rails 7.2
+  gem("minitest", "~> 5.27")
   gem("minitest-reporters")
 
   # restore `assigns` and `assert_template` to tests

--- a/Gemfile
+++ b/Gemfile
@@ -202,8 +202,8 @@ group :test do
   gem("database_cleaner-active_record")
 
   # allows test results to be reported back to test runner IDE's
-  # Pin to 5.x - minitest 6.0 is incompatible with Rails 7.2
-  gem("minitest", "~> 5.27")
+  # minitest 6.0 is incompatible with Rails 7.2
+  gem("minitest", "< 6")
   gem("minitest-reporters")
 
   # restore `assigns` and `assert_template` to tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,7 +629,7 @@ DEPENDENCIES
   literal
   mimemagic
   mini_racer (~> 0.18.1)
-  minitest (~> 5.27)
+  minitest (< 6)
   minitest-reporters
   mission_control-jobs
   mo_acts_as_versioned (>= 0.6.6)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,15 @@ GIT
     mo_acts_as_versioned (0.6.6)
       activerecord (>= 3.0.9)
 
+GIT
+  remote: https://github.com/nimmolo/superform.git
+  revision: 25449f8adf9febad3531ba3e3e3038629c031fbb
+  branch: nimmo-add-radio-fields
+  specs:
+    superform (0.6.1)
+      phlex-rails (~> 2.0)
+      zeitwerk (~> 2.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -527,9 +536,6 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
-    superform (0.6.1)
-      phlex-rails (~> 2.0)
-      zeitwerk (~> 2.6)
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.5.0)
@@ -623,7 +629,7 @@ DEPENDENCIES
   literal
   mimemagic
   mini_racer (~> 0.18.1)
-  minitest
+  minitest (~> 5.27)
   minitest-reporters
   mission_control-jobs
   mo_acts_as_versioned (>= 0.6.6)!
@@ -654,7 +660,7 @@ DEPENDENCIES
   sprockets (~> 4.2.1)
   sprockets-rails
   stimulus-rails
-  superform
+  superform!
   terser
   trilogy
   turbo-rails


### PR DESCRIPTION
- Point `superform` to `nimmolo/superform` branch `nimmo-add-radio-fields` which adds `RadioField` and `RadioGroupField` components
- Pin `minitest` to `~> 5.27` (`6.0` is incompatible with Rails 7.2)