### PR TITLE
Fix CI error when blocked_ips files don't exist

### DIFF
--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -158,6 +158,8 @@ class IpStats
     def blocked_ips_current?
       defined?(@blocked_ips_time) &&
         @blocked_ips_time.to_s != "" &&
+        File.exist?(MO.blocked_ips_file) &&
+        File.exist?(MO.okay_ips_file) &&
         @blocked_ips_time >= File.mtime(MO.blocked_ips_file) &&
         @blocked_ips_time >= File.mtime(MO.okay_ips_file)
     end


### PR DESCRIPTION
Add `File.exist?` checks before calling `File.mtime` on `blocked_ips` and `okay_ips` files in `IpStats.blocked_ips_current?`. These files are gitignored so they don't exist in CI environments.

When files don't exist, `blocked_ips_current?` returns false, triggering `populate_blocked_ips` which creates empty files via `FileUtils.touch`. Tests then run with empty IP lists, which is correct CI behavior.