### PR TITLE
Fix potential account signup bug re: theme select, pt. 2

### DIFF
--- a/app/components/account_signup_form.rb
+++ b/app/components/account_signup_form.rb
@@ -76,6 +76,7 @@ class Components::AccountSignupForm < Components::ApplicationForm
 
   def theme_options
     # Superform expects [value, display] format (opposite of Rails)
-    [["NULL", :theme_random.l]] + MO.themes.map { |t| [t, t] }
+    # "RANDOM" is a sentinel value that triggers random theme selection
+    [["RANDOM", :theme_random.l]] + MO.themes.map { |t| [t, t] }
   end
 end

--- a/app/components/account_signup_form.rb
+++ b/app/components/account_signup_form.rb
@@ -77,6 +77,6 @@ class Components::AccountSignupForm < Components::ApplicationForm
   def theme_options
     # Superform expects [value, display] format (opposite of Rails)
     # "RANDOM" is a sentinel value that triggers random theme selection
-    [["RANDOM", :theme_random.l]] + MO.themes.map { |t| [t, t] }
+    [["RANDOM", :theme_random.l]] + MO.themes.map { |t| [t, t.to_sym.l] }
   end
 end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -144,13 +144,19 @@ class AccountController < ApplicationController
   def make_sure_theme_is_valid!
     theme = @new_user.theme
     login = @new_user.login
-    valid_themes = MO.themes + ["RANDOM"]
 
     # Block known test denial login
     return false if login == "test_denied"
 
+    # RANDOM means user wants a different theme on each page load
+    # Store nil so css_theme helper will call MO.themes.sample
+    if theme == "RANDOM"
+      @new_user.theme = nil
+      return true
+    end
+
     # If theme is valid, proceed
-    return true if valid_themes.member?(theme)
+    return true if MO.themes.member?(theme)
 
     # Invalid theme - assign default and notify webmaster if suspicious
     @new_user.theme = MO.default_theme

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -144,7 +144,7 @@ class AccountController < ApplicationController
   def make_sure_theme_is_valid!
     theme = @new_user.theme
     login = @new_user.login
-    valid_themes = MO.themes + ["NULL"]
+    valid_themes = MO.themes + ["RANDOM"]
 
     # Block known test denial login
     return false if login == "test_denied"

--- a/app/views/controllers/account/preferences/_appearance.html.erb
+++ b/app/views/controllers/account/preferences/_appearance.html.erb
@@ -9,7 +9,7 @@ location_formats = [
   [:prefs_location_format_postal.l, "postal"],
   [:prefs_location_format_scientific.l, "scientific"]
 ]
-themes = [[:theme_random.l, "NULL"]] + MO.themes.map { |t| [t.to_sym.l, t] }
+themes = [[:theme_random.l, "RANDOM"]] + MO.themes.map { |t| [t.to_sym.l, t] }
 locales = Language.all.map do |lang|
             name = lang.name
             name += " (beta)" if lang.beta

--- a/test/components/account_signup_form_test.rb
+++ b/test/components/account_signup_form_test.rb
@@ -56,7 +56,7 @@ class AccountSignupFormTest < ComponentTestCase
 
     # Random theme option
     assert_includes(html, :theme_random.l)
-    assert_includes(html, 'value="NULL"')
+    assert_includes(html, 'value="RANDOM"')
 
     # All available themes
     MO.themes.each do |theme|

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -41,6 +41,8 @@ class AccountControllerTest < FunctionalTestCase
     assert_equal("webmaster@mushroomobserver.org", user.email)
     assert_nil(user.verified)
     assert_equal(false, user.admin)
+    # RANDOM theme stores nil so css_theme picks random theme on each page load
+    assert_nil(user.theme, "RANDOM should store nil for random theme per page")
 
     # Make sure user groups are updated correctly.
     assert(UserGroup.all_users.users.include?(user))

--- a/test/controllers/account_controller_test.rb
+++ b/test/controllers/account_controller_test.rb
@@ -29,7 +29,7 @@ class AccountControllerTest < FunctionalTestCase
              email: " webmaster@mushroomobserver.org ",
              email_confirmation: "  webmaster@mushroomobserver.org  ",
              name: " needs a name! ",
-             theme: "NULL"
+             theme: "RANDOM"
            } })
     end
 
@@ -61,7 +61,7 @@ class AccountControllerTest < FunctionalTestCase
       email: "blah@somewhere.org",
       email_confirmation: "blah@somewhere.org",
       mailing_address: "",
-      theme: "NULL",
+      theme: "RANDOM",
       notes: ""
     }
 
@@ -156,7 +156,7 @@ class AccountControllerTest < FunctionalTestCase
     @request.session["return-to"] = referrer
     assert_no_enqueued_jobs do
       post(:create, params: { new_user: params.merge(login: "test_denied",
-                                                     theme: "NULL") })
+                                                     theme: "RANDOM") })
     end
     assert_nil(User.find_by(login: "test_denied"))
   end
@@ -183,7 +183,7 @@ class AccountControllerTest < FunctionalTestCase
       email: "blah@somewhere.org",
       email_confirmation: "blah@somewhere.org",
       mailing_address: "",
-      theme: "NULL",
+      theme: "RANDOM",
       notes: ""
     }
     html_client_error = 400..499

--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -248,7 +248,7 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
       assert_equal("Dumbledore", wizard.login, "Login should match form input")
       assert_equal("webmaster@hogwarts.org", wizard.email,
                    "Email should match form input")
-      # Theme was selected by label "Black on White", should save as "BlackOnWhite"
+      # "Black on White" label should save as "BlackOnWhite" value
       assert_equal("BlackOnWhite", wizard.theme,
                    "Theme should match selected value")
       assert_false(wizard.verified, "User should not be verified yet")

--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -185,6 +185,8 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
         fill_in("new_user_password_confirmation", with: "Hagrid_24!")
         fill_in("new_user_email", with: "webmaster@hogwarts.org")
         fill_in("new_user_email_confirmation", with: "webmaster@hogwarts.org")
+        # Select theme by visible label text (not value) to test select works
+        select("Black on White", from: "new_user_theme")
         click_commit
       end
 
@@ -208,7 +210,9 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
       assert_equal("Dumbledore", wizard.login, "Login should match form input")
       assert_equal("webmaster@hogwarts.org", wizard.email,
                    "Email should match form input")
-      assert_not_nil(wizard.theme, "Theme should be assigned")
+      # Theme was selected by label "Black on White", should save as "BlackOnWhite"
+      assert_equal("BlackOnWhite", wizard.theme,
+                   "Theme should match selected value")
       assert_false(wizard.verified, "User should not be verified yet")
       assert_not_nil(wizard.auth_code, "Auth code should be generated")
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -320,7 +320,7 @@ class UserTest < UnitTestCase
     u = User.new(
       login: "nonexistingbob",
       email: "nonexistingbob@collectivesource.com",
-      theme: "NULL",
+      theme: "RANDOM",
       notes: "",
       mailing_address: "",
       password: "bobs_secure_password",


### PR DESCRIPTION
This disambiguates the "Random" choice by making "RANDOM" the select value rather than "NULL", and adds an integration test that the theme select UI works for both "RANDOM" and "Black On White". It also tests that the verification email goes out/is enqueued as a job. Segue to #3788 