### PR TITLE
Allow import_all as a user's first import

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -94,7 +94,7 @@ class InatImportsController < ApplicationController
 
   def reload_form
     # clean trailing commas and whitespace
-    @inat_ids = params[:inat_ids].sub(/[,\s]+\z/, "")
+    @inat_ids = params[:inat_ids]&.sub(/[,\s]+\z/, "")
     @inat_username = params[:inat_username]
     render(:new)
   end

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -75,10 +75,14 @@ module InatImportsController::Validators
     params[:inat_ids].delete(" ").split(",").map(&:to_i)
   end
 
-  # Block importing **all** of another user's iNat observations
+  # Block superimporter from importing **all** another user's iNat observations
   # Seems so hard to reverse if done accidentally that we should prevent it,
   # at least for now.
   def not_importing_all_anothers?
+    # At this stage we care only about superimporters because
+    # other users are limited to importing their own observations
+    # by InatImportJob#ensure_importing_own_observations
+    return true unless InatImport.super_importer?(@user)
     unless importing_all? &&
            (params[:inat_username] != @user.inat_username)
       return true

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -27,10 +27,15 @@
 #                          and in Job after each observation import
 #  cancel/canceled::       Did the user requested canceling the Job
 #
+# == Class Methods
+#  super_importers         users who can import other users' iNat obss
+#  super_importer?         is a given user a super_importer?
+
 # == Methods
 #  total_expected_time     total expected time for associated Job
 #  last_obs_elapsed_time   time spent importing a single iNat obs
 #  adequate_constraints?   enough constraints on which observations to import?
+#
 #
 class InatImport < ApplicationRecord
   alias_attribute :canceled, :cancel # for readability, e.g., job.canceled?

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -324,6 +324,27 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_flash_error
   end
 
+  def test_import_all
+    user = users(:mary)
+    params = { inat_username: user.inat_username, all: 1, consent: 1 }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+  end
+
+  def test_allow_first_time_import_all
+    user = users(:rolf)
+    assert_nil(user.inat_username, "Test needs fixture without inat_username")
+    params = { inat_username: "anything", all: 1, consent: 1 }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+  end
+
   def test_import_all_anothers_observations
     user = users(:dick) # Dick is a iNat superimporter
     params = { inat_username: "anything", inat_ids: nil,
@@ -370,16 +391,6 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_redirected_to(
       inat_import_path(inat_import, params: { tracker_id: tracker.id })
     )
-  end
-
-  def test_import_all
-    user = users(:mary)
-    params = { inat_username: user.inat_username, all: 1, consent: 1 }
-
-    login(user.login)
-    post(:create, params: params)
-
-    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
   end
 
   def test_inat_username_unchanged_if_authorization_denied

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -360,6 +360,20 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_form_action(action: :create)
   end
 
+  def test_super_importer_can_import_specific_ids_from_another_user
+    user = users(:dick) # Dick is a super_importer
+    assert(InatImport.super_importer?(user),
+           "Test requires user to be a super_importer")
+    params = { inat_username: "other_inat_user", inat_ids: "12345",
+               consent: 1 }
+
+    stub_request(:any, authorization_url)
+    login(user.login)
+    post(:create, params: params)
+
+    assert_redirected_to(INAT_AUTHORIZATION_URL)
+  end
+
   def test_import_authorized
     user = users(:rolf)
     assert_blank(user.inat_username,


### PR DESCRIPTION
See [CoPilot Pull request overview](https://github.com/MushroomObserver/mushroom-observer/pull/3817#pullrequestreview-3753487614) below.

This fixes the bug exposed yesterday by [Dawn Wehman (dawnwehman)](https://mushroomobserver.org/users/166069).

### Manual Test
- Log out of iNat
- Find an MO user who lacks a `inat_username`.  (Example: `User 3: "Jeffrey Kramer (chef jeff)"`.)
- Login to MO as that user.
- http://localhost:3000/inat_imports/new
- Fill in something as the inat_username, check `Import all ...`, check the consent
<img width="586" height="283" alt="Screenshot 2026-02-04 at 2 16 32 PM" src="https://github.com/user-attachments/assets/b191d8e7-6afb-41f3-a868-972525d6a86c" />

- Submit
- Expected result
Redirected to the iNat signing page (https://www.inaturalist.org/users/sign_in)