### PR TITLE
Sync checkbox_field block handling and herbarium form

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -255,7 +255,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Wrapper options: :label, :prefs, :class_name
   # @yield [field_component] Optional block to set slots: `with_between`,
   #   `with_append`, `with_help`
-  def checkbox_field(field_name, **options)
+  def checkbox_field(field_name, **options, &block)
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
@@ -265,9 +265,8 @@ class Components::ApplicationForm < Superform::Rails::Form
     )
 
     set_help_slot(field_component, wrapper_opts[:help])
-    yield(field_component) if block_given?
 
-    render(field_component)
+    render(field_component, &block)
   end
 
   # Radio button group with Bootstrap radio wrapper per option

--- a/app/components/herbarium_form.rb
+++ b/app/components/herbarium_form.rb
@@ -99,12 +99,15 @@ class Components::HerbariumForm < Components::ApplicationForm
   def render_personal_checkbox
     checkbox_field(
       :personal,
-      label: :create_herbarium_personal.l
-    ) do |f|
-      f.with_help do
-        :create_herbarium_personal_help.t(name: @user&.personal_herbarium_name)
-      end
-    end
+      label: :create_herbarium_personal.l,
+      help: personal_checkbox_help
+    )
+  end
+
+  def personal_checkbox_help
+    :create_herbarium_personal_help.t(
+      name: @user&.personal_herbarium_name
+    )
   end
 
   def render_code_field


### PR DESCRIPTION
Commits missed in #3824

- checkbox_field now passes &block to render() instead of yielding before render, needed for array-mode checkboxes (cb.option)
- Herbarium form uses help: kwarg instead of block for slot config