### PR TITLE
Fix radio_field value attribute

### DIFF
--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -56,7 +56,7 @@ class Components::ApplicationForm < Superform::Rails::Form
         type: :radio,
         name: field.dom.name,
         id: radio_id(value),
-        value: value,
+        value: value.to_s,
         checked: option_checked?(value)
       }.merge(@attributes)
     end

--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -52,13 +52,13 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def radio_attributes(value)
-      {
+      @attributes.merge(
         type: :radio,
         name: field.dom.name,
         id: radio_id(value),
         value: value.to_s,
         checked: option_checked?(value)
-      }.merge(@attributes)
+      )
     end
 
     def radio_id(value)

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -623,6 +623,23 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(html, "input[value='20'][checked]")
   end
 
+  # Regression test: Symbol option values should be converted to strings
+  def test_radio_field_with_symbol_values
+    proxy = Components::ApplicationForm::FieldProxy.new(
+      "chosen_name", :status, :active
+    )
+    html = render(Components::ApplicationForm::RadioField.new(
+                    proxy, [:active, "Active"], [:inactive, "Inactive"]
+                  ))
+
+    # Symbol values should be rendered as strings
+    assert_html(html, "input[value='active']")
+    assert_html(html, "input[value='inactive']")
+    # The active option should be checked (matching Symbol :active)
+    assert_html(html, "input[value='active'][checked]")
+    assert_html(html, "input[value='inactive']:not([checked])")
+  end
+
   # Autocompleter field tests
   def test_autocompleter_field_renders_structure
     form = render_form do


### PR DESCRIPTION
Radio button value attributes must be strings in HTML. When a non-string value (e.g., symbol or integer) was passed, it could cause comparison mismatches or unexpected form submission values.