### PR TITLE
Fix modal close button visibility in dark themes

### DIFF
--- a/app/assets/stylesheets/mo/_popups.scss
+++ b/app/assets/stylesheets/mo/_popups.scss
@@ -29,6 +29,21 @@
   // background-color: $modal-content-bg !important;
 }
 
+// Override Bootstrap 3's .close opacity (0.2) which makes the X nearly
+// invisible in dark themes like Amanita. Use the theme's danger color for a
+// clear dismiss button visible regardless of theme background.
+.modal-header .close {
+  opacity: 0.8;
+  color: $DANGER_COLOR;
+  text-shadow: none;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+    color: $DANGER_COLOR;
+  }
+}
+
 //
 // popup dialogs
 // --------------------------------------------------

--- a/app/assets/stylesheets/mo/_popups.scss
+++ b/app/assets/stylesheets/mo/_popups.scss
@@ -34,13 +34,13 @@
 // clear dismiss button visible regardless of theme background.
 .modal-header .close {
   opacity: 0.8;
-  color: $DANGER_COLOR;
+  color: $brand-danger;
   text-shadow: none;
 
   &:hover,
   &:focus {
     opacity: 1;
-    color: $DANGER_COLOR;
+    color: $brand-danger;
   }
 }
 


### PR DESCRIPTION
## Summary
- Override Bootstrap 3's `.close` button styling in modal headers to fix near-invisible dismiss button in dark themes
- Bootstrap 3 applies `opacity: 0.2` and a white `text-shadow` to `.close`, designed for light backgrounds — this makes the X effectively invisible on dark modal backgrounds (especially Amanita theme)
- Use theme's `$DANGER_COLOR` at `opacity: 0.8` (1.0 on hover) with no text-shadow, ensuring the close button is clearly visible and distinct across all themes

Fixes #3840

## Test plan
- [ ] Check the Community Vote popup (e.g., `/observations/104813/namings/125413/votes`) in Amanita theme — X should be clearly visible in red
- [ ] Check the same popup in other dark/mid-toned themes (Cantharellaceae, Hygrocybe)
- [ ] Check light themes (Agaricus, Black on White) to ensure the X is still visible and not garish
- [ ] Verify hover state increases opacity on the X button
- [ ] Check any other modals in the app to confirm they also benefit

🤖 Generated with [Claude Code](https://claude.com/claude-code)