### PR TITLE
Convert admin/donations/edit to Phlex component

### DIFF
--- a/.claude/form_conversion_tracker.md
+++ b/.claude/form_conversion_tracker.md
@@ -8,7 +8,7 @@ Track progress converting ERB forms (`form_with`/`form_for`) to Phlex Superform 
 
 | File | Form | Status |
 | ---- | ---- | ------ |
-| `admin/donations/edit.html.erb` | Donations admin | |
+| `admin/donations/edit.html.erb` | Donations admin | Done |
 
 ### Observation Forms (4)
 
@@ -111,6 +111,7 @@ Track progress converting ERB forms (`form_with`/`form_for`) to Phlex Superform 
 | `Descriptions::PermissionsForm` | `descriptions/_form_permissions.html.erb` | 2026-02-08 |
 | `Descriptions::MoveForm` | `descriptions/_form_move.html.erb` | 2026-02-08 |
 | `Descriptions::MergeForm` | `descriptions/_form_merge.html.erb` | 2026-02-08 |
+| `DonationsReviewForm` | `admin/donations/edit.html.erb` | 2026-02-13 |
 | `NamingForm` | `observations/namings/_form.erb` | |
 | `ObservationForm` | `observations/_form.html.erb` | |
 

--- a/app/assets/stylesheets/mo/_tables.scss
+++ b/app/assets/stylesheets/mo/_tables.scss
@@ -161,7 +161,7 @@ thead tr {
 
   th:last-child,
   td:last-child {
-    border: 0;
+    border-right: 0;
   }
 }
 

--- a/app/classes/form_object/review_donations.rb
+++ b/app/classes/form_object/review_donations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Form object for the admin donations review form.
+# No attributes needed — checkboxes are rendered manually.
+class FormObject::ReviewDonations < FormObject::Base
+  # Force PATCH method for Superform (updates existing records)
+  def persisted?
+    true
+  end
+end

--- a/app/components/donations_review_form.rb
+++ b/app/components/donations_review_form.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Admin form for reviewing donations.
+# Renders a table of donations with checkboxes for marking
+# each donation as reviewed.
+class Components::DonationsReviewForm < Components::ApplicationForm
+  def initialize(form, donations:, **)
+    @donations = donations
+    super(form, **)
+  end
+
+  def view_template
+    submit(
+      :review_donations_update.l, center: true
+    )
+    render_donations_table
+    submit(
+      :review_donations_update.l, center: true
+    )
+  end
+
+  def form_action
+    admin_donations_path
+  end
+
+  private
+
+  def form_tag(&block)
+    form(
+      action: form_action, method: :post,
+      **form_attributes, &block
+    )
+  end
+
+  def form_attributes
+    {
+      id: "admin_review_donations_form",
+      style: "display: contents"
+    }
+  end
+
+  def render_donations_table
+    div(class: "text-center") do
+      render(
+        Components::Table.new(
+          @donations,
+          class: "table-striped " \
+                 "table-review-donations mb-3 mt-3"
+        )
+      ) do |t|
+        define_columns(t)
+      end
+    end
+  end
+
+  def define_columns(tbl)
+    tbl.column(:review_reviewed.t) do |donation|
+      render_checkbox(donation)
+    end
+    define_data_columns(tbl)
+  end
+
+  def define_data_columns(tbl)
+    tbl.column(:review_id.t) { |d| d.id.to_s }
+    tbl.column(:review_who.t, &:who)
+    tbl.column(:review_anon.t) { |d| d.anonymous.to_s }
+    tbl.column(:review_amount.t) { |d| d.amount.to_s }
+    tbl.column(:review_email.t, &:email)
+  end
+
+  def render_checkbox(donation)
+    input(
+      type: "hidden",
+      name: "reviewed[#{donation.id}]",
+      value: "0",
+      autocomplete: "off"
+    )
+    input(
+      type: "checkbox",
+      name: "reviewed[#{donation.id}]",
+      id: "reviewed_#{donation.id}",
+      value: "1",
+      checked: donation.reviewed,
+      class: "form-control"
+    )
+  end
+end

--- a/app/components/donations_review_form.rb
+++ b/app/components/donations_review_form.rb
@@ -64,7 +64,7 @@ class Components::DonationsReviewForm < Components::ApplicationForm
   def define_donor_columns(tbl)
     tbl.column(:review_id.t) { |d| d.id.to_s }
     tbl.column(:review_who.t, class: "text-left") do |d|
-      d.who.truncate(30)
+      d.who.to_s.truncate(30)
     end
     tbl.column(:review_anon.t) { |d| d.anonymous.to_s }
   end

--- a/app/components/donations_review_form.rb
+++ b/app/components/donations_review_form.rb
@@ -57,15 +57,26 @@ class Components::DonationsReviewForm < Components::ApplicationForm
     tbl.column(:review_reviewed.t) do |donation|
       render_checkbox(donation)
     end
-    define_data_columns(tbl)
+    define_donor_columns(tbl)
+    define_detail_columns(tbl)
   end
 
-  def define_data_columns(tbl)
+  def define_donor_columns(tbl)
     tbl.column(:review_id.t) { |d| d.id.to_s }
-    tbl.column(:review_who.t, &:who)
+    tbl.column(:review_who.t, class: "text-left") do |d|
+      d.who.truncate(30)
+    end
     tbl.column(:review_anon.t) { |d| d.anonymous.to_s }
+  end
+
+  def define_detail_columns(tbl)
     tbl.column(:review_amount.t) { |d| d.amount.to_s }
-    tbl.column(:review_email.t, &:email)
+    tbl.column(:review_email.t, class: "text-left") do |d|
+      d.email.to_s.truncate(50)
+    end
+    tbl.column(:review_date.t) do |d|
+      d.created_at.strftime("%Y-%m-%d")
+    end
   end
 
   def render_checkbox(donation)
@@ -80,8 +91,7 @@ class Components::DonationsReviewForm < Components::ApplicationForm
       name: "reviewed[#{donation.id}]",
       id: "reviewed_#{donation.id}",
       value: "1",
-      checked: donation.reviewed,
-      class: "form-control"
+      checked: donation.reviewed
     )
   end
 end

--- a/app/views/controllers/admin/donations/edit.html.erb
+++ b/app/views/controllers/admin/donations/edit.html.erb
@@ -4,36 +4,7 @@ add_page_title(:review_donations_title.l)
 add_context_nav(admin_donations_form_edit_tabs)
 %>
 
-<%= form_with(url: admin_donations_path,
-              id: "admin_review_donations_form", method: :patch) do |f| %>
-
-  <%= submit_button(form: f, button: :review_donations_update.l, center: true) %>
-
-  <div class="text-center">
-    <table class="table-striped table-review-donations mb-3 mt-3">
-      <thead>
-        <tr>
-          <% [:review_reviewed, :review_id, :review_who, :review_anon, :review_amount, :review_email].each do |label| %>
-            <th><%= label.t %></th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @donations.each do |d| %>
-          <tr>
-            <td><%= check_box(:reviewed, d.id, checked: d.reviewed,
-                              class: "form-control") %></td>
-            <td><%= d.id %></td>
-            <td><%= d.who %></td>
-            <td><%= d.anonymous %></td>
-            <td><%= d.amount %></td>
-            <td><%= d.email %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-  <!-- .text-center -->
-
-  <%= submit_button(form: f, button: :review_donations_update.l, center: true) %>
-<% end %>
+<%= render(Components::DonationsReviewForm.new(
+      FormObject::ReviewDonations.new,
+      donations: @donations
+    )) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3557,6 +3557,7 @@
   review_anon: Anon
   review_amount: Amount
   review_email: Email
+  review_date: Date
 
   user_add_tool: User Creation Tool
   user_add_email_prompt: Enter email


### PR DESCRIPTION
## Summary
- Replace inline ERB form/table in `admin/donations/edit` with a `DonationsReviewForm` Phlex component using Superform and `Components::Table`
- Add `FormObject::ReviewDonations` for Superform form initialization
- Fix `table-review-donations` CSS: change `border: 0` to `border-right: 0` on last column so horizontal row borders are consistent across all columns
- Add Date column (`created_at`) to the donations review table
- Left-justify and truncate Who (30 chars) and Email (50 chars) columns
- Use default checkbox style instead of `form-control`

## Test plan
- [x] Controller tests pass (`test/controllers/admin/donations_controller_test.rb`)
- [x] Integration tests pass (`test/integration/capybara/donations_integration_test.rb`)
- [x] RuboCop clean on all new/modified files
- [x] Manual verification: visit `/admin/donations/edit` in admin mode, verify table renders with all columns, checkboxes toggle reviewed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)