### PR TITLE
Email outage recovery plan and scripts

### DIFF
--- a/app/mailers/account_recovery_mailer.rb
+++ b/app/mailers/account_recovery_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Custom mailer for sending recovery emails to users whose accounts
+# were affected by the verification email outage (Jan 14 - Feb 17, 2026).
+#
+# Uses news_delivery (gmail_smtp_settings_news) since the webmaster
+# credentials were broken during this period.
+class AccountRecoveryMailer < ApplicationMailer
+  after_action :news_delivery, only: [:build]
+
+  def build(receiver:, subject:, body:)
+    setup_user(receiver)
+    @title = subject
+    @body = body
+    debug_log(:account_recovery, nil, receiver, email: receiver.email)
+    mo_mail(@title, to: receiver, from: MO.accounts_email_address)
+  end
+end

--- a/app/views/mailers/account_recovery_mailer/build.html.erb
+++ b/app/views/mailers/account_recovery_mailer/build.html.erb
@@ -1,0 +1,13 @@
+<%
+if @user.email_html %>
+<html>
+<head>
+<title><%= "#{:app_title.t}: #{@title}" %></title>
+</head>
+<body topmargin=0 leftmargin=0 rightmargin=0 bottommargin=0><br/>
+<%= @body.html_safe %>
+<br/>
+</body>
+</html>
+<% else %><%= @body.html_to_ascii %>
+<% end %>

--- a/doc/email_outage_2026_feb.md
+++ b/doc/email_outage_2026_feb.md
@@ -1,0 +1,215 @@
+# Email Outage: January 14 - February 17, 2026
+
+## Summary
+
+Verification emails (and other emails using `webmaster_delivery` SMTP
+credentials) stopped sending on approximately January 14, 2026 UTC. The
+root cause was expired/invalidated Gmail SMTP App Password credentials
+for the `gmail_smtp_settings_webmaster` account. The issue went
+undetected for over a month because `ApplicationMailer` (line 14) sets
+`ActionMailer::Base.raise_delivery_errors = false` globally, silently
+swallowing all SMTP authentication errors.
+
+## Timeline (all times UTC)
+
+- **~Jan 14**: `gmail_smtp_settings_webmaster` SMTP credentials stop
+  working. All mailers using `webmaster_delivery` begin silently failing:
+  - `VerifyAccountMailer` (account verification)
+  - `PasswordMailer` (password resets)
+  - `WebmasterMailer` (webmaster question form)
+  - `VerifyApiKeyMailer` (API key verification)
+
+- **Jan 14 - Feb 17**: New users sign up but never receive verification
+  emails. Password resets also fail silently. Webmaster question form
+  submissions are lost (WebmasterMailer has no `debug_log`). Some users
+  create multiple accounts with the same email trying to get verified.
+
+- **Feb 17**: Root cause identified. Confirmed by setting
+  `ActionMailer::Base.raise_delivery_errors = true` in Rails console
+  and calling `VerifyAccountMailer.build(...).deliver_now`, which
+  produces:
+  ```
+  Net::SMTPAuthenticationError: 535-5.7.8 Username and Password not accepted
+  ```
+
+- **Feb 17**: New Gmail App Password generated and
+  `gmail_smtp_settings_webmaster` credentials updated.
+
+- **Feb 17** (after credential fix): Nathan verifies email is working
+  by sending a test verification email to himself. Confirmed working.
+  Then sends `VerifyAccountMailer` to unverified users. These emails
+  are delivered successfully.
+
+- **Feb 17 05:13 UTC**: `script/refresh_caches` cron job runs. Its
+  `User.cull_unverified_users` method deletes ~20 users where
+  `verified IS NULL AND created_at <= 1.month.ago`. These are users
+  created between Jan 16 05:13 and Jan 17 05:13 UTC — exactly 1 month
+  old. These users had just received working verification emails, but
+  deleting their accounts makes those verification links point to
+  nonexistent users.
+
+- **Feb 17** (after 05:13 UTC): `script/refresh_caches` cron job
+  disabled.
+
+## What Was NOT Affected
+
+- **`gmail_smtp_settings_news`**: Working fine throughout. All mailers
+  using `news_delivery` continued sending normally. This includes most
+  notification emails: comments, naming proposals, observation changes,
+  user questions, consensus changes, etc.
+
+- **`gmail_smtp_settings_noreply`**: Not currently used by any mailer.
+
+## Affected Mailers (use `webmaster_delivery`)
+
+| Mailer | Impact |
+|---|---|
+| `VerifyAccountMailer` | New users never received verification emails |
+| `PasswordMailer` | Password reset emails silently failed |
+| `WebmasterMailer` | Webmaster form submissions lost (no debug_log) |
+| `VerifyApiKeyMailer` | API key verification emails silently failed |
+
+## Data Loss
+
+### Recoverable from Production Logs
+- **WebmasterMailer submissions**: Although WebmasterMailer does not
+  call `debug_log`, the Rails production logs record the full
+  `Parameters` hash for each POST to
+  `/admin/emails/webmaster_questions`, including the sender's email
+  and full message text. Gzipped daily log archives are available at
+  `log/old/production.log-YYYYMMDD.gz`. Use
+  `script/extract_webmaster_emails.rb` to extract them.
+
+### Recoverable from Database Backups
+- **~20 deleted user accounts**: Users deleted by `cull_unverified_users`
+  on Feb 17 05:13 UTC. These can be restored from database backups.
+  The condition for affected users:
+  ```sql
+  verified IS NULL
+  AND created_at >= '2026-01-16 05:13:00'
+  AND created_at < '2026-01-17 05:13:00'
+  ```
+
+### Still in Production Database
+- **Other unverified users**: Users created after Jan 17 05:13 UTC who
+  haven't been culled yet. These users exist in production but never
+  received working verification emails.
+
+## Recovery Plan
+
+### Step 1: Update SMTP Credentials (DONE)
+New Gmail App Password generated and applied to
+`gmail_smtp_settings_webmaster`.
+
+### Step 2: Disable refresh_caches (DONE)
+Cron job disabled to prevent further deletion of unverified users during
+recovery.
+
+### Step 3: Restore Deleted Users from Backup
+
+Load the most recent backup before Feb 17 05:13 UTC into a temporary
+database, then run the recovery script:
+
+```bash
+# Load backup into temporary database
+mysql -u root -p -e "CREATE DATABASE mo_backup"
+mysql -u root -p mo_backup < /path/to/backup_before_feb17.sql
+
+# Dry run first
+BACKUP_DB=mo_backup bin/rails runner script/recover_deleted_users.rb
+
+# If dry run looks correct, run for real
+BACKUP_DB=mo_backup RECOVER_FOR_REAL=1 bin/rails runner script/recover_deleted_users.rb
+```
+
+The script:
+1. Queries backup DB for users matching the deletion window
+2. Re-inserts User records with original IDs and all column data
+3. Re-creates `UserGroup` ("user {id}") for each restored user
+4. Re-creates `UserGroupUser` associations (per-user group + "all users")
+5. Reports multi-account users (same email, different logins)
+
+### Step 4: Send Recovery Emails
+
+Two groups of restored users receive customized emails via
+`AccountRecoveryMailer` (which uses `news_delivery` — the working
+credentials):
+
+**Group A — Restored users with unique email**:
+- Explains their account was temporarily removed by maintenance
+- Notes the verification link from the earlier email should work again
+- Provides a fresh verification link as a fallback
+
+**Group B — Restored users with shared email** (same email appears on
+another unverified account — either another restored user, or a later
+account the person created after their original was deleted):
+- Thanks them for their persistence
+- Lists ALL unverified accounts for that email (restored + non-deleted)
+- Provides individual verification links for each account
+- Explains they only need to verify one
+
+Note: Multi-account detection spans both restored users and existing
+production users, since some people created new accounts after their
+original was deleted by `refresh_caches`.
+
+```bash
+# Dry run first
+bin/rails runner script/send_recovery_emails.rb
+
+# If dry run looks correct, send for real
+SEND_FOR_REAL=1 bin/rails runner script/send_recovery_emails.rb
+```
+
+### Step 5: Re-enable refresh_caches
+
+After all recovery emails have been sent and users have had reasonable
+time to verify (~1 week), re-enable the `script/refresh_caches` cron
+job.
+
+## Root Cause Analysis
+
+### Primary cause
+Gmail SMTP App Password for `gmail_smtp_settings_webmaster` was
+invalidated/expired around January 14, 2026.
+
+### Contributing factors
+
+1. **`raise_delivery_errors = false` in ApplicationMailer** (line 14):
+   This global override silently swallows ALL delivery errors, including
+   SMTP authentication failures. The production config sets
+   `raise_delivery_errors = true`, but ApplicationMailer overrides it
+   back to `false` on load.
+
+2. **No delivery monitoring/alerting**: No mechanism to detect when
+   emails stop being delivered successfully.
+
+3. **WebmasterMailer lacks `debug_log`**: Unlike most other mailers,
+   WebmasterMailer doesn't call `debug_log`, making it impossible to
+   trace lost submissions.
+
+## Recommended Follow-up Actions
+
+1. **Remove or conditionally apply `raise_delivery_errors = false`**:
+   At minimum, log delivery errors even if we don't raise them.
+   Consider adding error handling that logs failures to
+   `email-debug.log`.
+
+2. **Add `debug_log` to WebmasterMailer**: Ensures a record exists of
+   all webmaster form submissions regardless of delivery success.
+
+3. **Add email delivery monitoring**: Alert when SMTP errors occur or
+   when the email-debug.log shows no activity for an extended period.
+
+4. **Consider credential rotation alerts**: Set calendar reminders for
+   Gmail App Password expiration/rotation.
+
+## Scripts Created
+
+- `script/recover_deleted_users.rb` — Restores users from backup DB
+- `script/send_recovery_emails.rb` — Sends customized recovery emails
+- `script/extract_webmaster_emails.rb` — Extracts missed webmaster
+  question submissions from production log archives
+- `app/mailers/account_recovery_mailer.rb` — Custom mailer using
+  `news_delivery`
+- `app/views/mailers/account_recovery_mailer/build.html.erb` — Email
+  template

--- a/script/extract_webmaster_emails.rb
+++ b/script/extract_webmaster_emails.rb
@@ -1,0 +1,135 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Extract webmaster question submissions from production logs during
+# the email outage period (Jan 14 - Feb 17, 2026).
+#
+# These submissions were enqueued via SolidQueue but delivery failed
+# silently due to broken gmail_smtp_settings_webmaster credentials.
+# The log Parameters lines contain the full message content.
+#
+# USAGE (run on production server):
+#   ruby script/extract_webmaster_emails.rb > /tmp/missed_webmaster_emails.txt
+#
+#   # Or specify custom log dir and output file:
+#   ruby script/extract_webmaster_emails.rb /var/web/mo/log /tmp/output.txt
+
+require "zlib"
+
+LOG_DIR = ARGV[0] || "/var/web/mo/log"
+OUTPUT = ARGV[1] ? File.open(ARGV[1], "w") : $stdout
+
+# Outage period: Jan 14 00:00 UTC through Feb 17 (when creds were fixed)
+START_DATE = "20260114"
+END_DATE = "20260217"
+
+count = 0
+
+def process_log_lines(lines, source)
+  entries = []
+  i = 0
+  while i < lines.size
+    line = lines[i]
+
+    # Look for the POST to webmaster_questions
+    if line.include?('POST "/admin/emails/webmaster_questions"')
+      # Extract timestamp from this line
+      timestamp = line[/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/]
+
+      # Scan ahead for the Parameters line (usually 2 lines later)
+      search_end = [i + 5, lines.size].min
+      (i + 1...search_end).each do |j|
+        next unless lines[j].include?("Parameters:")
+
+        params_line = lines[j]
+
+        reply_to = params_line[/"reply_to"=>"([^"]*)"/, 1]
+        # Message sits between "message"=>" and the closing ", "commit"
+        # or "}} at end of params
+        message = params_line[/"message"=>"(.*?)",\s*"commit"/, 1] ||
+                  params_line[/"message"=>"(.*?)"\}\}/, 1] ||
+                  params_line[/"message"=>"(.*?)"/, 1]
+
+        next unless reply_to
+
+        # Unescape \r\n to actual newlines for readability
+        message = message.to_s
+                         .gsub('\r\n', "\n")
+                         .gsub('\n', "\n")
+                         .gsub('\r', "")
+
+        entries << {
+          timestamp: timestamp || "unknown",
+          source: source,
+          reply_to: reply_to,
+          message: message
+        }
+        break
+      end
+    end
+
+    i += 1
+  end
+  entries
+end
+
+# Collect relevant gzipped log files
+gz_files = Dir.glob("#{LOG_DIR}/old/production.log-*.gz").select do |f|
+  date = f[/(\d{8})\.gz$/, 1]
+  date && date >= START_DATE && date <= END_DATE
+end.sort
+
+OUTPUT.puts("=" * 60)
+OUTPUT.puts("Webmaster Questions During Email Outage")
+OUTPUT.puts("Period: #{START_DATE} - #{END_DATE}")
+OUTPUT.puts("Extracted: #{Time.now.utc.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+OUTPUT.puts("=" * 60)
+OUTPUT.puts
+
+# Process gzipped log files
+gz_files.each do |gz_file|
+  date = gz_file[/(\d{8})\.gz$/, 1]
+  $stderr.puts("Scanning #{File.basename(gz_file)}...")
+
+  lines = []
+  Zlib::GzipReader.open(gz_file) do |gz|
+    gz.each_line { |line| lines << line }
+  end
+
+  entries = process_log_lines(lines, date)
+  entries.each do |entry|
+    count += 1
+    OUTPUT.puts("--- ##{count} ---")
+    OUTPUT.puts("Date:  #{entry[:timestamp]} UTC")
+    OUTPUT.puts("From:  #{entry[:reply_to]}")
+    OUTPUT.puts("Log:   production.log-#{entry[:source]}.gz")
+    OUTPUT.puts
+    OUTPUT.puts(entry[:message])
+    OUTPUT.puts
+  end
+end
+
+# Also check current production.log
+current_log = "#{LOG_DIR}/production.log"
+if File.exist?(current_log)
+  $stderr.puts("Scanning production.log (current)...")
+  lines = File.readlines(current_log)
+  entries = process_log_lines(lines, "current")
+  entries.each do |entry|
+    count += 1
+    OUTPUT.puts("--- ##{count} ---")
+    OUTPUT.puts("Date:  #{entry[:timestamp]} UTC")
+    OUTPUT.puts("From:  #{entry[:reply_to]}")
+    OUTPUT.puts("Log:   production.log (current)")
+    OUTPUT.puts
+    OUTPUT.puts(entry[:message])
+    OUTPUT.puts
+  end
+end
+
+OUTPUT.puts("=" * 60)
+OUTPUT.puts("Total: #{count} webmaster question(s) found")
+OUTPUT.puts("=" * 60)
+
+OUTPUT.close if ARGV[1]
+$stderr.puts("Done. Found #{count} webmaster question(s).")

--- a/script/recover_deleted_users.rb
+++ b/script/recover_deleted_users.rb
@@ -1,0 +1,229 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Recovery script for users deleted by refresh_caches on Feb 17, 2026
+# at 05:13 UTC.
+#
+# These users were unverified and created between Jan 16 05:13 UTC and
+# Jan 17 05:13 UTC (i.e., exactly 1 month old at deletion time).
+#
+# The cull_unverified_users method deleted:
+#   1. UserGroup named "user {id}" for each user
+#   2. All UserGroupUser records for those user IDs
+#   3. The User records themselves
+#
+# This script restores users from a database backup dump, re-creates
+# their UserGroup and UserGroupUser associations, and generates a
+# report of affected users.
+#
+# PREREQUISITES:
+#   1. Load the backup into a separate database, e.g.:
+#        mysql -u root -p -e "CREATE DATABASE mo_backup"
+#        mysql -u root -p mo_backup < /path/to/backup.sql
+#
+#   2. Set BACKUP_DB env var to the name of the backup database.
+#
+# USAGE:
+#   # Dry run (default) - shows what would be restored
+#   BACKUP_DB=mo_backup bin/rails runner script/recover_deleted_users.rb
+#
+#   # Actually restore users
+#   BACKUP_DB=mo_backup RECOVER_FOR_REAL=1 \
+#     bin/rails runner script/recover_deleted_users.rb
+
+BACKUP_DB = ENV.fetch("BACKUP_DB", "mo_backup")
+DRY_RUN = ENV["RECOVER_FOR_REAL"] != "1"
+CONN = ActiveRecord::Base.connection
+
+# Time window: users created between these times were deleted by
+# cull_unverified_users at 05:13 UTC on Feb 17, 2026
+CREATED_AFTER = "2026-01-16 05:13:00"
+CREATED_BEFORE = "2026-01-17 05:13:00"
+
+def print_header
+  puts("=" * 60)
+  if DRY_RUN
+    puts("DRY RUN - No changes will be made")
+  else
+    puts("LIVE RUN - Restoring users")
+  end
+  puts("=" * 60)
+  puts
+end
+
+def fetch_backup_users
+  puts("Querying backup database '#{BACKUP_DB}' for deleted users...")
+
+  quoted_db = CONN.quote_table_name(BACKUP_DB)
+  rows = CONN.select_all(
+    "SELECT * FROM #{quoted_db}.users " \
+    "WHERE verified IS NULL " \
+    "AND created_at >= '#{CREATED_AFTER}' " \
+    "AND created_at < '#{CREATED_BEFORE}' " \
+    "ORDER BY id"
+  )
+
+  if rows.empty?
+    puts("No users found in backup matching criteria. Exiting.")
+    exit(0)
+  end
+
+  puts("Found #{rows.count} user(s) to restore:")
+  puts
+  rows.each do |u|
+    puts("  ID: #{u['id']}, Login: #{u['login']}, " \
+         "Email: #{u['email']}, Created: #{u['created_at']}")
+  end
+  puts
+  rows
+end
+
+def remove_already_existing(backup_users)
+  existing_ids = User.where(
+    id: backup_users.map { |u| u["id"] }
+  ).pluck(:id)
+
+  if existing_ids.any?
+    puts("WARNING: Users #{existing_ids.join(', ')} already exist " \
+         "in production. Skipping those.")
+    backup_users = backup_users.reject do |u|
+      existing_ids.include?(u["id"])
+    end
+  end
+
+  if backup_users.empty?
+    puts("All users already exist. Nothing to restore.")
+    exit(0)
+  end
+
+  backup_users
+end
+
+def find_multi_account_emails(backup_users)
+  emails = backup_users.map { |u| u["email"] }
+  email_counts = emails.tally.select { |_email, count| count > 1 }
+  multi = email_counts.keys
+
+  if multi.any?
+    puts("Users with multiple accounts (same email):")
+    multi.each do |email|
+      logins = backup_users.select { |u| u["email"] == email }
+                           .map { |u| u["login"] }
+      puts("  #{email}: #{logins.join(', ')}")
+    end
+    puts
+  end
+
+  multi
+end
+
+def restore_user(attrs, all_users_group)
+  # Use INSERT INTO ... SELECT FROM backup to preserve exact data
+  # including the original ID
+  user_columns = CONN.columns("users").map(&:name)
+  filtered = attrs.to_h.slice(*user_columns)
+
+  cols = filtered.keys.map { |c| "`#{c}`" }.join(", ")
+  vals = filtered.values.map { |v| CONN.quote(v) }.join(", ")
+
+  CONN.execute(
+    "INSERT INTO users (#{cols}) VALUES (#{vals})"
+  )
+  puts("  Restored User ##{attrs['id']} (#{attrs['login']})")
+
+  # Re-create single-user meta-group
+  one_user_group = UserGroup.create!(
+    name: "user #{attrs['id']}",
+    meta: true
+  )
+  puts("    Created UserGroup '#{one_user_group.name}' " \
+       "(ID: #{one_user_group.id})")
+
+  # Create UserGroupUser associations
+  UserGroupUser.create!(
+    user_id: attrs["id"],
+    user_group_id: one_user_group.id
+  )
+  UserGroupUser.create!(
+    user_id: attrs["id"],
+    user_group_id: all_users_group.id
+  )
+  puts("    Added to 'all users' group")
+end
+
+def print_report(backup_users, multi_account_emails, dry_run:)
+  puts("=" * 60)
+  puts("RECOVERY REPORT")
+  puts("=" * 60)
+  puts
+  puts("Total users: #{backup_users.count}")
+  puts("Multi-account emails: #{multi_account_emails.size}")
+  puts
+
+  puts("--- All Users ---")
+  backup_users.each do |u|
+    flag = multi_account_emails.include?(u["email"]) ? " [MULTI]" : ""
+    puts("  ID=#{u['id']} login=#{u['login']} " \
+         "email=#{u['email']} created=#{u['created_at']}#{flag}")
+  end
+  puts
+
+  if multi_account_emails.any?
+    puts("--- Multi-Account Users ---")
+    multi_account_emails.each do |email|
+      users = backup_users.select { |u| u["email"] == email }
+      puts("  #{email}:")
+      users.each do |u|
+        puts("    - #{u['login']} (ID: #{u['id']})")
+      end
+    end
+    puts
+  end
+
+  if dry_run
+    puts("(Dry run - no changes were made)")
+  else
+    puts("Recovery complete. Next steps:")
+    puts("  1. Run script/send_recovery_emails.rb to email users")
+    puts("  2. Monitor log/email-debug.log for delivery confirmation")
+  end
+end
+
+# Main execution
+print_header
+
+backup_users = fetch_backup_users
+backup_users = remove_already_existing(backup_users)
+multi_account_emails = find_multi_account_emails(backup_users)
+
+all_users_group = UserGroup.find_by(name: "all users")
+unless all_users_group
+  puts("ERROR: 'all users' group not found. Aborting.")
+  exit(1)
+end
+puts("'all users' group ID: #{all_users_group.id}")
+puts
+
+if DRY_RUN
+  puts("DRY RUN: Would restore #{backup_users.count} user(s).")
+  puts("DRY RUN: Would create #{backup_users.count} UserGroup(s).")
+  puts("DRY RUN: Would create #{backup_users.count * 2} " \
+       "UserGroupUser(s).")
+  puts
+  puts("Re-run with RECOVER_FOR_REAL=1 to perform restoration.")
+  puts
+  print_report(backup_users, multi_account_emails, dry_run: true)
+  exit(0)
+end
+
+puts("Restoring users...")
+ActiveRecord::Base.transaction do
+  backup_users.each do |u|
+    restore_user(u, all_users_group)
+  end
+end
+
+puts
+puts("Successfully restored #{backup_users.count} user(s).")
+puts
+print_report(backup_users, multi_account_emails, dry_run: false)

--- a/script/recover_deleted_users.rb
+++ b/script/recover_deleted_users.rb
@@ -64,15 +64,7 @@ end
 
 def fetch_backup_users
   puts("Querying backup database '#{BACKUP_DB}' for deleted users...")
-
-  quoted_db = CONN.quote_table_name(BACKUP_DB)
-  rows = CONN.select_all(
-    "SELECT * FROM #{quoted_db}.users " \
-    "WHERE verified IS NULL " \
-    "AND created_at >= '#{CREATED_AFTER}' " \
-    "AND created_at < '#{CREATED_BEFORE}' " \
-    "ORDER BY id"
-  )
+  rows = query_backup_users
 
   if rows.empty?
     puts("No users found in backup matching criteria. Exiting.")
@@ -87,6 +79,19 @@ def fetch_backup_users
   end
   puts
   rows
+end
+
+def query_backup_users
+  quoted_db = CONN.quote_table_name(BACKUP_DB)
+  quoted_after = CONN.quote(CREATED_AFTER)
+  quoted_before = CONN.quote(CREATED_BEFORE)
+  CONN.select_all(
+    "SELECT * FROM #{quoted_db}.users " \
+    "WHERE verified IS NULL " \
+    "AND created_at >= #{quoted_after} " \
+    "AND created_at < #{quoted_before} " \
+    "ORDER BY id"
+  )
 end
 
 def remove_already_existing(backup_users)

--- a/script/send_recovery_emails.rb
+++ b/script/send_recovery_emails.rb
@@ -142,7 +142,7 @@ def send_multi_account_email(email, users, opts)
   receiver = users.last
   account_list = build_account_list(users, opts)
   body = multi_account_body(email, account_list)
-  subject = "Mushroom Observer - Your Accounts Are Ready to Verify"
+  subject = "Mushroom Observer - Account Verification Followup"
 
   logins = users.map(&:login).join(", ")
   puts("  #{email} (logins: #{logins})")
@@ -163,9 +163,9 @@ def build_account_list(users, opts)
       opts[:restored_start], opts[:restored_end]
     )
     status = restored ? " (restored)" : ""
-    "<li>Login: <strong>#{ERB::Util.html_escape(u.login)}</strong> " \
-      "(Account ##{u.id})#{status} &mdash; " \
-      "<a href=\"#{verify_url}\">Verify this account</a></li>"
+    "<li>Login: <strong>#{ERB::Util.html_escape(u.login)}</strong>" \
+      "#{status}<br/>" \
+      "<a href=\"#{verify_url}\">#{verify_url}</a></li>"
   end.join("\n")
 end
 
@@ -195,7 +195,12 @@ def multi_account_body(email, account_list)
     in ways that are difficult to fix later. Any accounts you leave
     unverified will be automatically removed after 30 days.</p>
 
-    <p>If you have any questions, please contact us at
+    <p>If you have already verified more than one of these accounts,
+    please contact us at webmaster@mushroomobserver.org and let us
+    know which account you would like to keep. We can help merge or
+    remove the extra account(s).</p>
+
+    <p>If you have any other questions, please contact us at
     webmaster@mushroomobserver.org.</p>
 
     <p>Thank you for your patience,<br/>

--- a/script/send_recovery_emails.rb
+++ b/script/send_recovery_emails.rb
@@ -157,9 +157,13 @@ group_b_emails.each do |email, users|
     #{account_list}
     </ul>
 
-    <p>Please click the verification link for the account you would
-    like to use. You only need to verify one account. Any unverified
-    accounts will be automatically removed after 30 days.</p>
+    <p><strong>Important: Please verify only one of these
+    accounts.</strong> Choose the login name you prefer and click its
+    verification link. Do not verify more than one &mdash; having
+    multiple active accounts with the same email can cause confusion,
+    such as observations and other data being split across accounts
+    in ways that are difficult to fix later. Any accounts you leave
+    unverified will be automatically removed after 30 days.</p>
 
     <p>If you have any questions, please contact us at
     webmaster@mushroomobserver.org.</p>

--- a/script/send_recovery_emails.rb
+++ b/script/send_recovery_emails.rb
@@ -164,7 +164,7 @@ def build_account_list(users, opts)
     )
     status = restored ? " (restored)" : ""
     "<li>Login: <strong>#{ERB::Util.html_escape(u.login)}</strong>" \
-      "#{status}<br/>" \
+      "#{status}<br/> " \
       "<a href=\"#{verify_url}\">#{verify_url}</a></li>"
   end.join("\n")
 end

--- a/script/send_recovery_emails.rb
+++ b/script/send_recovery_emails.rb
@@ -1,0 +1,183 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Send custom recovery/verification emails to users whose accounts
+# were deleted by refresh_caches on Feb 17, 2026 at 05:13 UTC and
+# then restored from backup.
+#
+# Two groups:
+#   Group A: Restored users with a unique email (no other unverified
+#            account shares their email). They get a straightforward
+#            "your account was restored, please verify" email.
+#
+#   Group B: Restored users whose email is shared with one or more
+#            other unverified accounts (either other restored users,
+#            or later accounts the person created that weren't deleted).
+#            They get an email listing ALL accounts for that email
+#            with individual verification links.
+#
+# Multi-account detection spans both restored users AND existing
+# unverified users in production — because some people created a new
+# account after their original was deleted.
+#
+# PREREQUISITES:
+#   1. script/recover_deleted_users.rb has already been run
+#   2. AccountRecoveryMailer exists with news_delivery
+#
+# USAGE:
+#   # Dry run (default) - shows what emails would be sent
+#   bin/rails runner script/send_recovery_emails.rb
+#
+#   # Actually send emails
+#   SEND_FOR_REAL=1 bin/rails runner script/send_recovery_emails.rb
+
+DRY_RUN = ENV["SEND_FOR_REAL"] != "1"
+
+puts("=" * 60)
+puts(DRY_RUN ? "DRY RUN - No emails will be sent" :
+               "LIVE RUN - Sending emails")
+puts("=" * 60)
+puts
+
+# Restored users: unverified, created in the deletion window
+restored_start = Time.zone.parse("2026-01-16 05:13:00 UTC")
+restored_end = Time.zone.parse("2026-01-17 05:13:00 UTC")
+
+restored_users = User.where(verified: nil)
+                     .where(created_at: restored_start..restored_end)
+                     .order(:created_at)
+
+puts("Found #{restored_users.count} restored user(s).")
+puts
+
+# Collect emails from restored users
+restored_emails = restored_users.map(&:email).uniq
+
+# For each restored email, find ALL unverified accounts with that email
+# (includes both restored users and later accounts that weren't deleted)
+multi_account_emails = {}
+restored_emails.each do |email|
+  all_accounts = User.where(verified: nil, email: email).order(:created_at)
+  multi_account_emails[email] = all_accounts if all_accounts.size > 1
+end
+
+# Split restored users into Group A (unique email) and Group B (shared)
+multi_emails_set = multi_account_emails.keys.to_set
+group_a = restored_users.select { |u| !multi_emails_set.include?(u.email) }
+group_b_emails = multi_account_emails
+
+puts("Group A (restored, unique email): #{group_a.size}")
+puts("Group B (shared email, one email per): #{group_b_emails.size}")
+puts
+
+domain = MO.http_domain
+
+def send_email(user, subject, body)
+  AccountRecoveryMailer.build(
+    receiver: user,
+    subject: subject,
+    body: body
+  ).deliver_now
+end
+
+# --- Group A: Restored users with unique email ---
+puts("--- Group A: Restored Users (unique email) ---")
+group_a.each do |user|
+  verify_url = "#{domain}/account/verify/#{user.id}" \
+               "?auth_code=#{user.auth_code}"
+
+  body = <<~HTML
+    <p>Dear #{ERB::Util.html_escape(user.login)},</p>
+
+    <p>You recently received a verification email from Mushroom
+    Observer. Unfortunately, a routine maintenance process
+    temporarily removed your account before you had a chance to
+    verify it, which caused that verification link to stop
+    working. We apologize for the confusion.</p>
+
+    <p>Your account has been restored. The verification link from
+    the earlier email should now work again. If you no longer have
+    that email, you can use the link below:</p>
+
+    <p><a href="#{verify_url}">#{verify_url}</a></p>
+
+    <p>If you have any questions, please contact us at
+    webmaster@mushroomobserver.org.</p>
+
+    <p>Thank you for your patience,<br/>
+    The Mushroom Observer Team</p>
+  HTML
+
+  subject = "Mushroom Observer - Account Restored, Please Verify"
+
+  puts("  #{user.email} (#{user.login}, ID: #{user.id})")
+  unless DRY_RUN
+    send_email(user, subject, body)
+    puts("    SENT")
+  end
+end
+puts
+
+# --- Group B: Shared-email users ---
+puts("--- Group B: Multi-Account Users ---")
+group_b_emails.each do |email, users|
+  # Use the most recently created account as the receiver
+  # (for email_html preference), since that's likely the one
+  # they intended to use
+  receiver = users.last
+
+  account_list = users.map do |u|
+    verify_url = "#{domain}/account/verify/#{u.id}" \
+                 "?auth_code=#{u.auth_code}"
+    status = u.created_at.between?(restored_start, restored_end) ?
+               " (restored)" : ""
+    "<li>Login: <strong>#{ERB::Util.html_escape(u.login)}</strong>" \
+      " (Account ##{u.id})#{status} &mdash; " \
+      "<a href=\"#{verify_url}\">Verify this account</a></li>"
+  end.join("\n")
+
+  body = <<~HTML
+    <p>Dear Mushroom Observer user,</p>
+
+    <p>We recently experienced a technical issue with our email system
+    that prevented verification emails from being delivered between
+    January 14 and February 17, 2026. We apologize for the
+    inconvenience.</p>
+
+    <p>We noticed that you created multiple accounts with this email
+    address. Thank you for your persistence! Here are the accounts
+    associated with #{ERB::Util.html_escape(email)}:</p>
+
+    <ul>
+    #{account_list}
+    </ul>
+
+    <p>Please click the verification link for the account you would
+    like to use. You only need to verify one account. Any unverified
+    accounts will be automatically removed after 30 days.</p>
+
+    <p>If you have any questions, please contact us at
+    webmaster@mushroomobserver.org.</p>
+
+    <p>Thank you for your patience,<br/>
+    The Mushroom Observer Team</p>
+  HTML
+
+  subject = "Mushroom Observer - Your Accounts Are Ready to Verify"
+
+  logins = users.map(&:login).join(", ")
+  puts("  #{email} (logins: #{logins})")
+  unless DRY_RUN
+    send_email(receiver, subject, body)
+    puts("    SENT")
+  end
+end
+puts
+
+puts("=" * 60)
+if DRY_RUN
+  puts("DRY RUN complete. Re-run with SEND_FOR_REAL=1 to send.")
+else
+  puts("All emails sent. Check log/email-debug.log for delivery log.")
+end
+puts("=" * 60)


### PR DESCRIPTION
## Summary

- Documents the Jan 14 – Feb 17, 2026 email outage caused by expired `gmail_smtp_settings_webmaster` credentials
- Provides scripts to recover affected users and extract missed webmaster questions from production logs
- Adds a custom mailer (`AccountRecoveryMailer`) using working `news_delivery` credentials to send tailored recovery emails

## Details

**Root cause**: Gmail App Password for `gmail_smtp_settings_webmaster` expired ~Jan 14. `ApplicationMailer` line 14 sets `raise_delivery_errors = false` globally, silently swallowing all SMTP errors for 34 days.

**Affected mailers**: `VerifyAccountMailer`, `PasswordMailer`, `WebmasterMailer`, `VerifyApiKeyMailer` — all use `webmaster_delivery`.

**User impact**: Users who signed up between Jan 14 and Jan 17 05:13 UTC never received verification emails and were deleted by nightly `refresh_caches` runs (Feb 14–17 at 05:13 UTC). Some created multiple accounts with the same email.

### Files added

| File | Purpose |
|---|---|
| `doc/email_outage_2026_feb.md` | Full developer summary with timeline, root cause analysis, and recovery plan |
| `script/recover_deleted_users.rb` | Restores users from backup DB, re-creates UserGroup/UserGroupUser associations |
| `script/send_recovery_emails.rb` | Sends customized emails to restored users (unique-email vs multi-account) |
| `script/extract_webmaster_emails.rb` | Extracts missed webmaster questions from gzipped production log archives |
| `app/mailers/account_recovery_mailer.rb` | Custom mailer using `news_delivery` (working credentials) |
| `app/views/mailers/account_recovery_mailer/build.html.erb` | Email template respecting user HTML preference |

### Recovery steps (documented in `doc/email_outage_2026_feb.md`)

1. ✅ Update SMTP credentials (done)
2. ✅ Disable `refresh_caches` cron (done)
3. Load `database-20260213.gz` into temp DB, run `recover_deleted_users.rb`
4. Run `send_recovery_emails.rb` to email restored users
5. Run `extract_webmaster_emails.rb` to recover missed webmaster questions
6. Re-enable `refresh_caches` after ~1 week

## Test plan

- [x] Review `doc/email_outage_2026_feb.md` for accuracy and completeness
- [x] Dry-run `recover_deleted_users.rb` against backup to verify correct user set
- [x] Dry-run `send_recovery_emails.rb` to verify email grouping (unique vs multi-account)
- [x] Dry-run `extract_webmaster_emails.rb` against a sample log file
- [x] Live-run each script on production in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)