### PR TITLE
Enable raise_delivery_errors and log email failures

### DIFF
--- a/config/initializers/mail_delivery_error_logging.rb
+++ b/config/initializers/mail_delivery_error_logging.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Log email delivery failures to email-debug.log, then re-raise
+# so Solid Queue can track the failure. This ensures we notice
+# delivery errors instead of silently swallowing them.
+Rails.application.config.after_initialize do
+  ActionMailer::MailDeliveryJob.rescue_from(
+    StandardError
+  ) do |exception|
+    mailer, action = arguments[0..1]
+    args = arguments[3..] || []
+    msg = "DELIVERY FAILED #{mailer}##{action}"
+    msg << " args=#{args.inspect}" if args.any?
+    msg << " error=#{exception.class}: " \
+           "#{exception.message}"
+    Rails.root.join("log/email-debug.log").
+      open("a:utf-8") do |fh|
+        fh.puts("#{Time.zone.now} #{msg}")
+      end
+    raise(exception)
+  end
+end

--- a/config/initializers/mail_delivery_error_logging.rb
+++ b/config/initializers/mail_delivery_error_logging.rb
@@ -8,9 +8,9 @@ Rails.application.config.after_initialize do
     StandardError
   ) do |exception|
     mailer, action = arguments[0..1]
-    args = arguments[3..] || []
+    params = arguments[3] || {}
     msg = "DELIVERY FAILED #{mailer}##{action}"
-    msg << " args=#{args.inspect}" if args.any?
+    msg << " params=#{params.inspect}" if params.present?
     msg << " error=#{exception.class}: " \
            "#{exception.message}"
     Rails.root.join("log/email-debug.log").

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require("test_helper")
+require("net/smtp")
+
+class ApplicationJobTest < ActiveJob::TestCase
+  def setup
+    super
+    @log_path = Rails.root.join("log/email-debug.log")
+    @original_content =
+      File.exist?(@log_path) ? File.read(@log_path) : ""
+  end
+
+  def teardown
+    File.write(@log_path, @original_content)
+    super
+  end
+
+  def test_mail_delivery_failure_logged_to_email_debug_log
+    error = Net::SMTPAuthenticationError.new(
+      "535 Authentication failed"
+    )
+
+    UserQuestionMailer.stub(
+      :deliver_mail, ->(_mail) { raise(error) }
+    ) do
+      UserQuestionMailer.build(
+        sender: users(:rolf),
+        receiver: users(:mary),
+        subject: "test",
+        message: "body"
+      ).deliver_later
+
+      assert_raises(Net::SMTPAuthenticationError) do
+        perform_enqueued_jobs
+      end
+    end
+
+    log_entries = File.read(@log_path)
+    new_entries = log_entries.sub(@original_content, "")
+    assert_match(/DELIVERY FAILED/, new_entries)
+    assert_match(/UserQuestionMailer/, new_entries)
+    assert_match(/Net::SMTPAuthenticationError/, new_entries)
+    assert_match(/Authentication failed/, new_entries)
+  end
+
+  def test_non_mail_job_failure_not_logged
+    job = Class.new(ApplicationJob) do
+      self.queue_adapter = :test
+
+      def perform
+        raise(StandardError.new("test error"))
+      end
+    end
+
+    assert_raises(StandardError) do
+      job.perform_now
+    end
+
+    log_entries = File.read(@log_path)
+    new_entries = log_entries.sub(@original_content, "")
+    assert_empty(
+      new_entries,
+      "Non-mail job errors should not be logged " \
+      "to email-debug.log"
+    )
+  end
+
+  def test_mail_delivery_failure_re_raises_exception
+    error = Net::SMTPServerBusy.new(
+      "450 Too many connections"
+    )
+
+    UserQuestionMailer.stub(
+      :deliver_mail, ->(_mail) { raise(error) }
+    ) do
+      UserQuestionMailer.build(
+        sender: users(:rolf),
+        receiver: users(:mary),
+        subject: "test",
+        message: "body"
+      ).deliver_later
+
+      raised = assert_raises(Net::SMTPServerBusy) do
+        perform_enqueued_jobs
+      end
+      assert_equal(
+        "450 Too many connections", raised.message
+      )
+    end
+  end
+end

--- a/test/jobs/mail_delivery_error_logging_test.rb
+++ b/test/jobs/mail_delivery_error_logging_test.rb
@@ -3,16 +3,21 @@
 require("test_helper")
 require("net/smtp")
 
-class ApplicationJobTest < ActiveJob::TestCase
+class MailDeliveryErrorLoggingTest < ActiveJob::TestCase
   def setup
     super
     @log_path = Rails.root.join("log/email-debug.log")
+    @log_existed = File.exist?(@log_path)
     @original_content =
-      File.exist?(@log_path) ? File.read(@log_path) : ""
+      @log_existed ? File.read(@log_path) : ""
   end
 
   def teardown
-    File.write(@log_path, @original_content)
+    if @log_existed
+      File.write(@log_path, @original_content)
+    elsif File.exist?(@log_path)
+      File.delete(@log_path)
+    end
     super
   end
 


### PR DESCRIPTION
This is a followup to the issue where verification emails were failing silently.  @pellaea left a comment about why the errors were disabled, but at this point that approach doesn't seem like the right approach to me.  I would first like to see how commonly issues arise.  If there are common patterns, then I think it is better to address those patterns directly rather than turning off alerts for any errors.

## Summary
- Remove `ActionMailer::Base.raise_delivery_errors = false` from `ApplicationMailer`, allowing the production config's `raise_delivery_errors = true` to take effect so email delivery problems are detected promptly
- Add `config/initializers/mail_delivery_error_logging.rb` that patches `ActionMailer::MailDeliveryJob` with a `rescue_from` handler to log delivery failures to `email-debug.log` before re-raising (so Solid Queue also tracks the failure)
- Guard `after_action` delivery callbacks (`webmaster_delivery`, `news_delivery`) with `message.to.blank?` to prevent errors when `mo_mail` returns early for invalid addresses or opted-out users
- Remove dead `noreply_delivery` method (never referenced as an `after_action` by any mailer)

## Test plan
- [x] All 25 existing mailer tests pass, including `test_undeliverable_email` and `test_opt_out`
- [x] 3 new tests in `test/jobs/application_job_test.rb`:
  - Mail delivery failure is logged to `email-debug.log` with mailer name and error details
  - Non-mail job failures are NOT logged to `email-debug.log`
  - Mail delivery failure re-raises the original exception
- [ ] Deploy and monitor `email-debug.log` for any unexpected delivery errors

Fixes #3942

🤖 Generated with [Claude Code](https://claude.com/claude-code)