### PR TITLE
Fix superimporter preview estimate

### DIFF
--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -392,6 +392,37 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_select("#estimated_time", "00:00:24")
   end
 
+  def test_superimporter_estimate_excludes_user_login
+    user = users(:dick) # Dick is a super_importer
+    assert(InatImport.super_importer?(user),
+           "Test requires user to be a super_importer")
+    other_inat_username = "some_other_inat_user"
+    # Any id will work if it hasn't already be imported
+    inat_ids = "339315928"
+    assert_nil(Observation.find_by(inat_id: inat_ids.to_i))
+
+    # If the bug is present, the request includes user_login, which returns
+    # 0 results.
+    # Register this stub last so it takes priority when user_login is present.
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      to_return(status: 200, body: { total_results: 1 }.to_json)
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("user_login" => other_inat_username)).
+      to_return(status: 200, body: { total_results: 0 }.to_json)
+
+    login(user.login)
+    post(:create,
+         params: { inat_ids: inat_ids, inat_username: other_inat_username,
+                   consent: 1 })
+
+    assert_response(:success)
+    assert_template(:confirm)
+    assert_select(
+      "#estimated_count", "1",
+      "Estimate should not filter by user_login if user is a super_importer"
+    )
+  end
+
   def test_create_confirmed_with_superform_params
     user = users(:rolf)
     inat_import = inat_imports(:rolf_inat_import)

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -397,7 +397,7 @@ class InatImportsControllerTest < FunctionalTestCase
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
     other_inat_username = "some_other_inat_user"
-    # Any id will work if it hasn't already be imported
+    # Any id will work if it hasn't already been imported
     inat_ids = "339315928"
     assert_nil(Observation.find_by(inat_id: inat_ids.to_i))
 


### PR DESCRIPTION
Resolves #3945.

## Manual Tests
- [x] login as a superimporter
  - navigate to Import from iNat (`localhost:3000/inat_imports/new`)
  - fill in iNat Username with the supermiporter's iNat username
  - fill in `Comma separated list ... `with the iNat observation id of an iNat obs of an iNat user who isn't an MO users, and which observation has not been imported. (Example: `339315928` (which is https://www.inaturalist.org/observations/339315928)
  - Consent
  - Submit
Expected result: 
Estimated number of imports: 1
Estimated time: <non-zero>
(current main says "Estimated number of imports: 0 / Estimated time: 00:00:00"

- [x] Do the same thing, but logged in as a non-superimporter
Expected result:
Estimated number of imports: 0
Estimated time: 00:00:00