### PR TITLE
Bump rubocop to 1.85.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,9 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.18.1)
+    json-schema (6.1.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -278,6 +281,8 @@ GEM
       net-pop
       net-smtp
     matrix (0.4.3)
+    mcp (0.7.1)
+      json-schema (>= 4.1)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
@@ -346,7 +351,7 @@ GEM
       version_gem (~> 1.1, >= 1.1.9)
     os (1.1.4)
     parallel (1.27.0)
-    parser (3.3.10.1)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     pdf-core (0.10.0)
@@ -440,10 +445,11 @@ GEM
       rqrcode_core (~> 2.0)
     rqrcode_core (2.1.0)
     rtf (0.3.3)
-    rubocop (1.84.2)
+    rubocop (1.85.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
+      mcp (~> 0.6)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)

--- a/app/classes/api2/core/uploads.rb
+++ b/app/classes/api2/core/uploads.rb
@@ -105,10 +105,13 @@ module API2::Uploads
       raise(API2::FileMissing.new(file)) unless File.exist?(file)
 
       super()
-      # File handle stored in content attribute; caller manages lifecycle
       self.content = File.open(file, "rb") # rubocop:disable Style/FileOpen
       self.content_length = File.size(file)
       self.content_type = `file --mime -b #{file}`.sub(/[;\s].*/, "")
+    end
+
+    def clean_up
+      content&.close
     end
   end
 

--- a/app/classes/api2/core/uploads.rb
+++ b/app/classes/api2/core/uploads.rb
@@ -105,7 +105,8 @@ module API2::Uploads
       raise(API2::FileMissing.new(file)) unless File.exist?(file)
 
       super()
-      self.content = File.open(file, "rb")
+      # File handle stored in content attribute; caller manages lifecycle
+      self.content = File.open(file, "rb") # rubocop:disable Style/FileOpen
       self.content_length = File.size(file)
       self.content_type = `file --mime -b #{file}`.sub(/[;\s].*/, "")
     end

--- a/app/classes/api2/error/create_failed.rb
+++ b/app/classes/api2/error/create_failed.rb
@@ -5,7 +5,7 @@ class API2
   class CreateFailed < ObjectError
     def initialize(obj)
       super
-      args.merge!(error: obj.formatted_errors.map(&:to_s).join("; "))
+      args.merge!(error: obj.formatted_errors.join("; "))
     end
   end
 end

--- a/app/classes/api2/error/one_or_the_other.rb
+++ b/app/classes/api2/error/one_or_the_other.rb
@@ -3,9 +3,9 @@
 class API2
   # Tried to both clear synonyms and add synonyms at the same time.
   class OneOrTheOther < FatalError
-    def initialize(args)
+    def initialize(fields)
       super()
-      args.merge!(args: args.join(", "))
+      self.args.merge!(args: fields.join(", "))
     end
   end
 end

--- a/app/classes/api2/error/one_or_the_other.rb
+++ b/app/classes/api2/error/one_or_the_other.rb
@@ -5,7 +5,7 @@ class API2
   class OneOrTheOther < FatalError
     def initialize(fields)
       super()
-      self.args.merge!(args: fields.join(", "))
+      args.merge!(args: fields.join(", "))
     end
   end
 end

--- a/app/classes/api2/error/one_or_the_other.rb
+++ b/app/classes/api2/error/one_or_the_other.rb
@@ -5,7 +5,7 @@ class API2
   class OneOrTheOther < FatalError
     def initialize(args)
       super()
-      args.merge!(args: args.map(&:to_s).join(", "))
+      args.merge!(args: args.join(", "))
     end
   end
 end

--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -99,7 +99,7 @@ class DateRangeParser
       date  = Date.current - num2.send(:"#{unit}s")
       left  = format_date(date.send(:"beginning_of_#{unit}")) unless last
       right = format_date(date.send(:"end_of_#{unit}")) unless first
-      [left, right].map(&:to_s).join("-")
+      [left, right].join("-")
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -174,7 +174,7 @@ class IpStats
 
     def parse_ip_list(file)
       FileUtils.touch(file) unless File.exist?(file)
-      File.open(file).readlines.map do |line|
+      File.readlines(file).map do |line|
         line.chomp.split(",").first
       end
     end

--- a/app/classes/query/params/filters.rb
+++ b/app/classes/query/params/filters.rb
@@ -9,8 +9,8 @@ module Query::Params::Filters
     # Get all param keys with `Query::Filter.all.map(&:sym)`.
     # Current params [:has_images, :has_specimens, :lichen, :region, :clade]
     def content_filter_parameter_declarations(model)
-      Query::Filter.by_model(model).each_with_object({}) do |fltr, decs|
-        decs[fltr.sym] = fltr.type
+      Query::Filter.by_model(model).to_h do |fltr|
+        [fltr.sym, fltr.type]
       end.merge(preference_filter: { boolean: [true] })
     end
   end

--- a/app/classes/robots.rb
+++ b/app/classes/robots.rb
@@ -25,7 +25,7 @@ class Robots
       results = {}
       if File.exist?(file)
         pat = Regexp.new('Allow: /(\w+)/(\w+)')
-        File.open(file).readlines.each do |line|
+        File.foreach(file) do |line|
           match = line.match(pat)
           next unless match
 

--- a/app/classes/textile.rb
+++ b/app/classes/textile.rb
@@ -236,7 +236,7 @@ class Textile < String
   }.freeze
   # case-insenstive match any of the non-Name markup tags
   NON_NAME_LINK_PATTERN =
-    /#{(MARKUP_TO_TAG.keys - [:name]).map(&:to_s).join("|")}/i
+    /#{(MARKUP_TO_TAG.keys - [:name]).join("|")}/i
   NAME_LINK_PATTERN = %r{
     (?<prefix> ^|\W) # capture start of string or non-word character
     (?: \**_+) # any asterisks then at least one underscore

--- a/app/components/external_link_form.rb
+++ b/app/components/external_link_form.rb
@@ -62,8 +62,8 @@ class Components::ExternalLinkForm < Components::ApplicationForm
   end
 
   def base_urls
-    @base_urls ||= @sites.each_with_object({}) do |site, hash|
-      hash[site.name] = site.base_url
+    @base_urls ||= @sites.to_h do |site|
+      [site.name, site.base_url]
     end
   end
 

--- a/app/controllers/names/eol_data/preview_controller.rb
+++ b/app/controllers/names/eol_data/preview_controller.rb
@@ -41,7 +41,7 @@ module Names::EolData
       end
 
       # Get corresponding names.
-      name_ids = @descs.keys.map(&:to_s).join(",")
+      name_ids = @descs.keys.join(",")
       @names = Name.where(id: name_ids).order(:sort_name, :author).to_a
 
       # Get corresponding images.

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -25,8 +25,8 @@ module SpeciesLists
     def init_member_vars_for_create
       @member_vote = Vote.maximum_vote
       @member_notes_parts = @species_list.form_notes_parts(@user)
-      @member_notes = @member_notes_parts.each_with_object({}) do |part, h|
-        h[part.to_sym] = ""
+      @member_notes = @member_notes_parts.to_h do |part|
+        [part.to_sym, ""]
       end
       @member_lat = nil
       @member_lng = nil

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -211,7 +211,8 @@ class TranslationsController < ApplicationController
     @index = []
     @tags = tags
     @tags_used = {}
-    file_handle ||= File.open(lang.export_file, "r:utf-8")
+    # Caller may pass an existing handle; method closes it at line 223
+    file_handle ||= File.open(lang.export_file, "r:utf-8") # rubocop:disable Style/FileOpen
     reset_everything
     file_handle.each_line do |line|
       line.force_encoding("utf-8")

--- a/app/extensions/time.rb
+++ b/app/extensions/time.rb
@@ -56,7 +56,7 @@ class ActiveSupport::TimeWithZone
 end
 
 # Make MO date and time formats available to Time, just in case.
-class Time
+class Time # rubocop:disable Style/OneClassPerFile
   delegate :web_date, to: :in_time_zone
 
   delegate :web_time, to: :in_time_zone
@@ -76,7 +76,7 @@ class Time
 end
 
 # Make MO date formats available to Date, just in case.
-class Date
+class Date # rubocop:disable Style/OneClassPerFile
   def web_date
     strftime(MO.web_date_format)
   end
@@ -92,7 +92,7 @@ end
 
 # Make MO Time formats available to DateTime, just in case.
 # DateTime inherits MO Date formats from Date, its superclass.
-class DateTime
+class DateTime # rubocop:disable Style/OneClassPerFile
   delegate :web_time, to: :in_time_zone
 
   delegate :api_time, to: :in_time_zone

--- a/app/helpers/user_stats_helper.rb
+++ b/app/helpers/user_stats_helper.rb
@@ -43,8 +43,8 @@ module UserStatsHelper
 
   # NOTE: This just helps create a keyed hash to access the paths.
   def user_stats_link_paths(user)
-    user_stats_links_table(user).each_with_object({}) do |row, links|
-      links[row[0]] = row[1]
+    user_stats_links_table(user).to_h do |row|
+      [row[0], row[1]]
     end
   end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -632,8 +632,7 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     if save_to_temp_file
       # Override whatever user gave us with result of "file --mime".
       self.upload_type =
-        # Handle passed directly to MimeMagic; block form not applicable here
-        MimeMagic.by_magic(File.open(upload_temp_file)).try(&:type) # rubocop:disable Style/FileOpen
+        File.open(upload_temp_file) { |file| MimeMagic.by_magic(file) }.try(&:type)
       if upload_type&.start_with?("image")
         result = true
       else

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -632,7 +632,8 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     if save_to_temp_file
       # Override whatever user gave us with result of "file --mime".
       self.upload_type =
-        File.open(upload_temp_file) { |file| MimeMagic.by_magic(file) }.try(&:type)
+        File.open(upload_temp_file) { |file| MimeMagic.by_magic(file) }.
+        try(&:type)
       if upload_type&.start_with?("image")
         result = true
       else

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -632,7 +632,8 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     if save_to_temp_file
       # Override whatever user gave us with result of "file --mime".
       self.upload_type =
-        MimeMagic.by_magic(File.open(upload_temp_file)).try(&:type)
+        # Handle passed directly to MimeMagic; block form not applicable here
+        MimeMagic.by_magic(File.open(upload_temp_file)).try(&:type) # rubocop:disable Style/FileOpen
       if upload_type&.start_with?("image")
         result = true
       else

--- a/app/models/language_exporter.rb
+++ b/app/models/language_exporter.rb
@@ -41,7 +41,7 @@ module LanguageExporter
     def locales_path=(path)
       @locales_path = path
       FileUtils.mkdir_p(locales_dir) unless File.directory?(locales_dir)
-      File.open("#{locales_dir}/en.txt", "a").close
+      FileUtils.touch("#{locales_dir}/en.txt")
     end
 
     def alt_locales_path(path, &block)
@@ -190,7 +190,7 @@ module LanguageExporter
   end
 
   def read_export_file_lines
-    File.open(export_file, "r:utf-8").readlines
+    File.readlines(export_file, encoding: "utf-8")
   end
 
   def write_export_file_lines(output_lines)

--- a/app/models/name/spelling.rb
+++ b/app/models/name/spelling.rb
@@ -166,7 +166,7 @@ module Name::Spelling
     # String words together replacing the one at +index+ with +sub+.
     def guess_pattern(words, index, sub) # :nodoc:
       result = (0..(words.length - 1)).map do |j|
-        (index == j ? sub : words[j])
+        index == j ? sub : words[j]
       end
       result.join(" ")
     end

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -60,8 +60,7 @@ module Name::Synonymy
   #
   def sort_synonyms
     all = synonyms - [self]
-    accepted_synonyms = all.reject(&:deprecated)
-    deprecated_synonyms = all.select(&:deprecated)
+    deprecated_synonyms, accepted_synonyms = all.partition(&:deprecated)
     [accepted_synonyms, deprecated_synonyms]
   end
 

--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -3,7 +3,8 @@
 module Views
 end
 
-module Components
+# Views and Components namespaces bootstrapped together in this initializer
+module Components # rubocop:disable Style/OneClassPerFile
   extend Phlex::Kit
 end
 

--- a/script/analyze_consensus_change.rb
+++ b/script/analyze_consensus_change.rb
@@ -34,7 +34,7 @@ class ReadOnlyCalculator < Observation::ConsensusCalculator
 end
 
 # Old algorithm: effective_weight always returns full weight.
-class OldCalculator < ReadOnlyCalculator
+class OldCalculator < ReadOnlyCalculator # rubocop:disable Style/OneClassPerFile
   private
 
   def effective_weight(_user_id, _val, wgt, _naming_id)

--- a/script/extract_log
+++ b/script/extract_log
@@ -50,7 +50,7 @@ unless File.exist?(file)
   exit(1)
 end
 
-File.open(file).readlines.each do |line|
+File.foreach(file) do |line|
   line.scrub! # remove non-utf8 characters
   match = line.match(/#(\d+)/)
   pid = match[1] if match

--- a/script/refresh_sitemap
+++ b/script/refresh_sitemap
@@ -248,7 +248,7 @@ def read_old_files(table)
   pat = Regexp.new("<loc>.*/(\\d+)</loc><lastmod>(.*)</lastmod>")
   wildcard = SITEMAP_FILE.sub("NAME", "#{table}-*")
   Dir.glob(wildcard).each do |file|
-    File.open(file).readlines.each do |line|
+    File.foreach(file) do |line|
       if (match = pat.match(line))
         result[match[1].to_i] = match[2]
       end

--- a/script/slowest_pages
+++ b/script/slowest_pages
@@ -23,7 +23,7 @@ FILE = ARGV[0] || File.expand_path("../log/production.log", __dir__)
 NUM  = ARGV[1].to_i
 
 data = {}
-File.open(FILE).readlines.each do |line|
+File.foreach(FILE) do |line|
   next unless line.start_with?("TIME:")
 
   _, time, status, controller, action, robot = line.split

--- a/script/update_googlebots.rb
+++ b/script/update_googlebots.rb
@@ -20,7 +20,7 @@ def config
   MO
 end
 
-module MushroomObserver
+module MushroomObserver # rubocop:disable Style/OneClassPerFile
   class Application
     def self.configure
       yield if block_given?
@@ -56,7 +56,7 @@ HELP
 
 def check_file(file)
   ips = {}
-  File.open(file).readlines.each do |line|
+  File.foreach(file) do |line|
     match = line.match(/^W.*TIME:.*\srobot\s(\d+\.\d+\.\d+\.\d+).*Googlebot/)
     ips[match[1]] = 1 if match
   end

--- a/script/update_ip_stats.rb
+++ b/script/update_ip_stats.rb
@@ -20,7 +20,7 @@ def config
   MO
 end
 
-module MushroomObserver
+module MushroomObserver # rubocop:disable Style/OneClassPerFile
   class Application
     def self.configure
       yield if block_given?

--- a/test/api2_extensions.rb
+++ b/test/api2_extensions.rb
@@ -28,7 +28,7 @@ module API2Extensions
   end
 
   def assert_no_errors(api, msg = "API2 errors")
-    msg = "#{msg}: <\n#{api.errors.map(&:to_s).join("\n")}\n>"
+    msg = "#{msg}: <\n#{api.errors.join("\n")}\n>"
     assert(api.errors.empty?, msg)
   end
 

--- a/test/classes/api2/names_test.rb
+++ b/test/classes/api2/names_test.rb
@@ -104,8 +104,7 @@ class API2::NamesTest < UnitTestCase
 
   def test_getting_names_misspellings
     names = Name.updated_on("2009-10-12")
-    goods = names.reject(&:correct_spelling_id)
-    bads  = names.select(&:correct_spelling_id)
+    bads, goods = names.partition(&:correct_spelling_id)
     assert_not_empty(names)
     assert_not_empty(goods)
     assert_not_empty(bads)

--- a/test/classes/autocomplete_test.rb
+++ b/test/classes/autocomplete_test.rb
@@ -18,7 +18,7 @@ class AutocompleteMock < Autocomplete::ByString
   end
 end
 
-class Autocomplete::ForMock < Autocomplete::ByWord
+class Autocomplete::ForMock < Autocomplete::ByWord # rubocop:disable Style/OneClassPerFile
   attr_accessor :rough_matches, :limit
 
   def truncate_matches
@@ -31,7 +31,7 @@ class Autocomplete::ForMock < Autocomplete::ByWord
 end
 # rubocop:enable Lint/UselessMethodDefinition
 
-class AutocompleteTest < UnitTestCase
+class AutocompleteTest < UnitTestCase # rubocop:disable Style/OneClassPerFile
   def test_subclass
     assert_equal("Autocomplete::ForName", Autocomplete.subclass("name").name)
     assert_equal("Autocomplete::ForMock",

--- a/test/classes/collapsible_map_test.rb
+++ b/test/classes/collapsible_map_test.rb
@@ -11,7 +11,7 @@ class BigDecimal
   end
 end
 
-class CollapsibleMapTest < UnitTestCase
+class CollapsibleMapTest < UnitTestCase # rubocop:disable Style/OneClassPerFile
   def assert_mapset_is_point(mapset, lat, long)
     assert_true(mapset.is_point)
     assert_false(mapset.is_box)

--- a/test/classes/language_exporter_test.rb
+++ b/test/classes/language_exporter_test.rb
@@ -185,7 +185,7 @@ class LanguageExporterTest < UnitTestCase
     use_test_locales do
       file = @official.export_file
       FileUtils.copy(template, file)
-      @official.write_export_file_lines(File.open(file, "r:utf-8").readlines)
+      @official.write_export_file_lines(File.readlines(file, encoding: "utf-8"))
       data = File.open(file, "r:utf-8") { |fh| YAML.safe_load(fh) }
       assert(data, "File read failed for #{file}")
 

--- a/test/classes/parallel_test_config_service_test.rb
+++ b/test/classes/parallel_test_config_service_test.rb
@@ -275,7 +275,7 @@ class ParallelTestConfigServiceTest < UnitTestCase
 end
 
 # Mock output handler for testing
-class MockOutputHandler
+class MockOutputHandler # rubocop:disable Style/OneClassPerFile
   delegate :puts, :print, to: :@output
 
   def initialize(output)

--- a/test/classes/textile_test.rb
+++ b/test/classes/textile_test.rb
@@ -9,7 +9,7 @@ class Textile
   end
 end
 
-class TextileTest < UnitTestCase
+class TextileTest < UnitTestCase # rubocop:disable Style/OneClassPerFile
   EXPLICIT_OBJECT_MARKUP = [
     "_observation 123_", # lower case explicit tag
     "_term bar code_",

--- a/test/classes/time_extensions_test.rb
+++ b/test/classes/time_extensions_test.rb
@@ -20,7 +20,7 @@ module DateExtensionsInterfaceTest
 end
 
 # test public interface of class which includes time
-module TimeExtensionsInterfaceTest
+module TimeExtensionsInterfaceTest # rubocop:disable Style/OneClassPerFile
   def test_responds_to_api_time
     assert_respond_to(@object, :api_time)
   end
@@ -35,7 +35,7 @@ module TimeExtensionsInterfaceTest
 end
 
 # test MO extensions to Rails' TimeWithZone class
-class TimeWithZoneExtensionsTest < ActiveSupport::TestCase
+class TimeWithZoneExtensionsTest < ActiveSupport::TestCase # rubocop:disable Style/OneClassPerFile
   include DateExtensionsInterfaceTest
   include TimeExtensionsInterfaceTest
 
@@ -46,7 +46,7 @@ class TimeWithZoneExtensionsTest < ActiveSupport::TestCase
 end
 
 # test MO extensions to Ruby's Date class
-class DateExtensionsTest < ActiveSupport::TestCase
+class DateExtensionsTest < ActiveSupport::TestCase # rubocop:disable Style/OneClassPerFile
   include DateExtensionsInterfaceTest
 
   def setup
@@ -56,7 +56,7 @@ class DateExtensionsTest < ActiveSupport::TestCase
 end
 
 # test MO extensions to Ruby's DateTime class
-class DateTimeExtensionsTest < ActiveSupport::TestCase
+class DateTimeExtensionsTest < ActiveSupport::TestCase # rubocop:disable Style/OneClassPerFile
   include DateExtensionsInterfaceTest
   include TimeExtensionsInterfaceTest
 

--- a/test/components/autocompleter_field_test.rb
+++ b/test/components/autocompleter_field_test.rb
@@ -255,7 +255,7 @@ class AutocompleterFieldTest < ComponentTestCase
 end
 
 # Test form class to demonstrate textarea autocompleter
-class TestTextareaAutocompleterForm < Components::ApplicationForm
+class TestTextareaAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     super do
       render(
@@ -270,7 +270,7 @@ class TestTextareaAutocompleterForm < Components::ApplicationForm
 end
 
 # Test form class for unknown autocompleter type
-class TestUnknownTypeAutocompleterForm < Components::ApplicationForm
+class TestUnknownTypeAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     super do
       render(
@@ -284,7 +284,7 @@ class TestUnknownTypeAutocompleterForm < Components::ApplicationForm
 end
 
 # Test form class for find_text option
-class TestFindTextAutocompleterForm < Components::ApplicationForm
+class TestFindTextAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     super do
       render(
@@ -299,7 +299,7 @@ class TestFindTextAutocompleterForm < Components::ApplicationForm
 end
 
 # Test form class for keep_text option (includes edit button)
-class TestKeepTextAutocompleterForm < Components::ApplicationForm
+class TestKeepTextAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     super do
       render(
@@ -315,7 +315,7 @@ class TestKeepTextAutocompleterForm < Components::ApplicationForm
 end
 
 # Test form class for create_text option (without create param)
-class TestCreateTextAutocompleterForm < Components::ApplicationForm
+class TestCreateTextAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     super do
       render(
@@ -330,7 +330,7 @@ class TestCreateTextAutocompleterForm < Components::ApplicationForm
 end
 
 # Test form class for modal create link (with create and create_path)
-class TestModalCreateAutocompleterForm < Components::ApplicationForm
+class TestModalCreateAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     super do
       render(
@@ -347,7 +347,7 @@ class TestModalCreateAutocompleterForm < Components::ApplicationForm
 end
 
 # Test form class for between slot
-class TestBetweenSlotAutocompleterForm < Components::ApplicationForm
+class TestBetweenSlotAutocompleterForm < Components::ApplicationForm # rubocop:disable Style/OneClassPerFile
   def view_template
     autocompleter_field(:notes, type: :user, label: "User:") do |f|
       f.with_between { "(Login Name)" }

--- a/test/components/crud_action_button_test.rb
+++ b/test/components/crud_action_button_test.rb
@@ -101,7 +101,7 @@ class CrudActionButtonTest < ComponentTestCase
   end
 end
 
-class LinkHelperButtonTest < ComponentTestCase
+class LinkHelperButtonTest < ComponentTestCase # rubocop:disable Style/OneClassPerFile
   # Test the helper wrappers that delegate to the component
 
   def test_destroy_button_helper

--- a/test/components/external_link_form_test.rb
+++ b/test/components/external_link_form_test.rb
@@ -10,8 +10,8 @@ class ExternalLinkFormTest < ComponentTestCase
     @user = users(:rolf)
     @sites = ExternalSite.all
     @site = @sites.first
-    @base_urls = @sites.each_with_object({}) do |site, hash|
-      hash[site.name] = site.base_url
+    @base_urls = @sites.to_h do |site|
+      [site.name, site.base_url]
     end
     @html = render_form
   end

--- a/test/components/table_test.rb
+++ b/test/components/table_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class TableTest < ComponentTestCase
   # Simple test struct for table rows
-  TestRow = Struct.new(:name, :age, :url, keyword_init: true)
+  TestRow = Struct.new(:name, :age, :url)
 
   def test_renders_table_with_columns
     rows = [

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -648,7 +648,8 @@ module ControllerExtensions
       if elements.length > 1
         message = "Found more than one input '#{id}'."
       elsif elements.length == 1
-        actual_val = CGI.unescapeHTML(elements.first.children.map(&:to_s).
+        # NodeSet has no #join; map(&:to_s) converts to String array first
+        actual_val = CGI.unescapeHTML(elements.first.children.map(&:to_s). # rubocop:disable Style/MapJoin
                          join).strip
         message = if actual_val != expect_val.to_s
                     "Input '#{id}' has wrong value, " \

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -538,6 +538,6 @@ class API2ControllerTest < FunctionalTestCase
   end
 end
 
-class UploadedFileWithChecksum < Rack::Test::UploadedFile
+class UploadedFileWithChecksum < Rack::Test::UploadedFile # rubocop:disable Style/OneClassPerFile
   attr_accessor :checksum
 end

--- a/test/controllers/images/originals_controller_test.rb
+++ b/test/controllers/images/originals_controller_test.rb
@@ -13,7 +13,7 @@ class MockStorage
   end
 end
 
-class MockBucket
+class MockBucket # rubocop:disable Style/OneClassPerFile
   def initialize
     @files = {}
   end
@@ -23,7 +23,7 @@ class MockBucket
   end
 end
 
-class MockFile
+class MockFile # rubocop:disable Style/OneClassPerFile
   def download(path)
     # Simulate file download by creating a test file
     FileUtils.mkdir_p(File.dirname(path))
@@ -32,7 +32,7 @@ class MockFile
 end
 
 # tests of Images controller
-module Images
+module Images # rubocop:disable Style/OneClassPerFile
   class OriginalsControllerTest < FunctionalTestCase
     include GeneralExtensions
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -14,7 +14,7 @@ class MockImageAPI
 end
 
 # test importing iNaturalist Observations to Mushroom Observer
-class InatImportsControllerTest < FunctionalTestCase
+class InatImportsControllerTest < FunctionalTestCase # rubocop:disable Style/OneClassPerFile
   include ActiveJob::TestHelper
   include Inat::Constants
 

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -196,7 +196,7 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
         notes: obs.notes.to_h,
         specimen: obs.specimen,
         thumb_image_id: "0",
-        good_image_ids: img_ids.map(&:to_s).join(" "),
+        good_image_ids: img_ids.join(" "),
         good_image: {
           img2.id => { notes: "new notes for two" },
           img3.id => { notes: "new notes for three" }

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -464,9 +464,9 @@ class SpeciesListsControllerTest < FunctionalTestCase
         "when(2i)" => "3",
         "when(3i)" => "14"
       },
-      project: rolf.projects_member.each_with_object({}) do |obj, result|
-        result["id_#{obj.id}"] = "1"
-      end
+      project: rolf.projects_member.to_h do |obj|
+                 ["id_#{obj.id}", "1"]
+               end
     }
     login("rolf")
     post(:create, params: params)
@@ -493,9 +493,9 @@ class SpeciesListsControllerTest < FunctionalTestCase
     count = spl.projects.count
     login(spl.user.login)
     params = { id: spl.id,
-               project: spl.projects.each_with_object({}) do |obj, result|
-                 result["id_#{obj.id}"] = "0"
-               end,
+               project: spl.projects.to_h do |obj|
+                          ["id_#{obj.id}", "0"]
+                        end,
                species_list: { title: spl.title } }
     put(:update, params:)
     spl.reload

--- a/test/controllers/translations_controller_test.rb
+++ b/test/controllers/translations_controller_test.rb
@@ -433,20 +433,12 @@ class TranslationsControllerTest < FunctionalTestCase
     # "unknown_tag" is not in the template file
     tags = hashify("unknown_tag")
     form = @controller.build_index(lang, tags, file)
-    major_headers = form.select do |item|
-      item.is_a?(
-        TranslationsController::TranslationsUIMajorHeader
-      )
-    end
+    major_headers = form.grep(TranslationsController::TranslationsUIMajorHeader)
     unlisted_header = major_headers.find do |h|
       h.string.include?("UNLISTED")
     end
     assert_not_nil(unlisted_header)
-    tag_fields = form.select do |item|
-      item.is_a?(
-        TranslationsController::TranslationsUITagField
-      )
-    end
+    tag_fields = form.grep(TranslationsController::TranslationsUITagField)
     assert(tag_fields.any? { |tf| tf.ttag == "unknown_tag" })
   end
 

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -576,7 +576,7 @@ module GeneralExtensions
     files.each do |file|
       filename = Array(file).first
       format = file.is_a?(Array) ? "r:#{file[1]}" : "r"
-      template = File.open(filename, format).read
+      template = File.open(filename, format, &:read)
       template = enforce_encoding(encoding, template)
       template = ERB.new(template).result # interpolate variables
       template = yield(template) if block_given?

--- a/test/jobs/image_loader_job_test.rb
+++ b/test/jobs/image_loader_job_test.rb
@@ -13,7 +13,7 @@ class MockStorage
   end
 end
 
-class MockBucket
+class MockBucket # rubocop:disable Style/OneClassPerFile
   def initialize
     @files = {}
   end
@@ -23,7 +23,7 @@ class MockBucket
   end
 end
 
-class MockFile
+class MockFile # rubocop:disable Style/OneClassPerFile
   def download(path)
     # Simulate file download by creating a test file
     FileUtils.mkdir_p(File.dirname(path))
@@ -31,7 +31,7 @@ class MockFile
   end
 end
 
-class ImageLoaderJobTest < ActiveJob::TestCase
+class ImageLoaderJobTest < ActiveJob::TestCase # rubocop:disable Style/OneClassPerFile
   include GeneralExtensions
 
   def setup

--- a/test/session_form_extensions.rb
+++ b/test/session_form_extensions.rb
@@ -148,7 +148,7 @@ module SessionExtensions
             inputs << field
 
           when "textarea"
-            field.value = CGI.unescapeHTML(elem.children.map(&:to_s).join)
+            field.value = CGI.unescapeHTML(elem.children.join)
             inputs << field
 
           when "file"
@@ -167,7 +167,7 @@ module SessionExtensions
               elements.each do |e|
                 opt = Field::Option.new
                 opt.value = CGI.unescapeHTML(e["value"])
-                opt.label = CGI.unescapeHTML(e.children.map(&:to_s).join)
+                opt.label = CGI.unescapeHTML(e.children.join)
                 opts << opt
                 val = opt.value \
                   if e["selected"] == "selected"

--- a/test/session_form_extensions.rb
+++ b/test/session_form_extensions.rb
@@ -148,7 +148,7 @@ module SessionExtensions
             inputs << field
 
           when "textarea"
-            field.value = CGI.unescapeHTML(elem.children.join)
+            field.value = CGI.unescapeHTML(elem.children.to_s)
             inputs << field
 
           when "file"
@@ -167,7 +167,7 @@ module SessionExtensions
               elements.each do |e|
                 opt = Field::Option.new
                 opt.value = CGI.unescapeHTML(e["value"])
-                opt.label = CGI.unescapeHTML(e.children.join)
+                opt.label = CGI.unescapeHTML(e.children.to_s)
                 opts << opt
                 val = opt.value \
                   if e["selected"] == "selected"

--- a/test/session_form_extensions.rb
+++ b/test/session_form_extensions.rb
@@ -148,7 +148,7 @@ module SessionExtensions
             inputs << field
 
           when "textarea"
-            field.value = CGI.unescapeHTML(elem.children.join)
+            field.value = CGI.unescapeHTML(elem.children.map(&:to_s).join) # rubocop:disable Style/MapJoin
             inputs << field
 
           when "file"
@@ -167,7 +167,7 @@ module SessionExtensions
               elements.each do |e|
                 opt = Field::Option.new
                 opt.value = CGI.unescapeHTML(e["value"])
-                opt.label = CGI.unescapeHTML(e.children.join)
+                opt.label = CGI.unescapeHTML(e.children.map(&:to_s).join) # rubocop:disable Style/MapJoin
                 opts << opt
                 val = opt.value \
                   if e["selected"] == "selected"

--- a/test/session_upload.rb
+++ b/test/session_upload.rb
@@ -9,7 +9,7 @@ class FileUpload
   end
 end
 
-class JpegUpload < FileUpload
+class JpegUpload < FileUpload # rubocop:disable Style/OneClassPerFile
   def initialize(filename)
     super(filename, "image/jpeg")
   end


### PR DESCRIPTION
- Bumps RuboCop to 1.85.0
- Deals with the 69 new violations caused by the update, either:
  - Fixes the violation, or
  - Inline disables the cop.