### PR TITLE
Fix missing review widgets on Help Identify page

### DIFF
--- a/app/components/matrix_table.rb
+++ b/app/components/matrix_table.rb
@@ -59,9 +59,9 @@ class Components::MatrixTable < Components::Base
 
   def render_cached_boxes
     @objects.each do |object|
-      if should_cache_object?(object)
+      if !@identify && should_cache_object?(object)
         cache([I18n.locale, object]) do
-          MatrixBox(user: @user, object: object, identify: @identify)
+          MatrixBox(user: @user, object: object)
         end
       else
         MatrixBox(user: @user, object: object, identify: @identify)

--- a/test/components/matrix_table_test.rb
+++ b/test/components/matrix_table_test.rb
@@ -212,6 +212,32 @@ class MatrixTableTest < ComponentTestCase
     end
   end
 
+  def test_does_not_cache_when_identify_is_true
+    obs = observations(:coprinus_comatus_obs)
+    obs.thumb_image.stub(:transferred, true) do
+      component = Components::MatrixTable.new(
+        objects: [obs],
+        user: @user,
+        cached: true,
+        identify: true
+      )
+
+      cache_called = false
+      component.stub(:cache, lambda { |_key, &block|
+        cache_called = true
+        block.call
+      }) do
+        html = render(component)
+        assert_includes(html, "box_#{obs.id}")
+      end
+
+      assert_not(
+        cache_called,
+        "Expected cache NOT to be called in identify mode"
+      )
+    end
+  end
+
   def test_different_locales_use_different_cache_keys
     obs = observations(:coprinus_comatus_obs)
     obs.thumb_image.stub(:transferred, true) do


### PR DESCRIPTION
## Summary
- The fragment cache in `MatrixTable` used key `[locale, object]` which didn't include the `identify` flag, so cached MatrixBox fragments from the regular Observation Index (rendered without identify UI) were served on the Help Identify page
- Skip caching entirely in identify mode since the content is user-specific (vote forms, mark-as-reviewed toggles) and must not be shared across users or page contexts

## Test plan
- [ ] Visit the Observation Index page to populate the fragment cache
- [ ] Visit Help Identify and confirm the vote widget, propose-naming link, and mark-as-reviewed toggle are visible
- [ ] Verify the regular Observation Index still renders correctly (no identify widgets leaking in)
- [ ] Run `bin/rails test test/components/matrix_table_test.rb test/components/matrix_box_test.rb`

Fixes #3961

🤖 Generated with [Claude Code](https://claude.com/claude-code)