### PR TITLE
Fix count for all superimporter's iNat observations

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -238,11 +238,17 @@ class InatImportsController < ApplicationController
       only_id: true,
       without_field: "Mushroom Observer URL"
     }
-    unless InatImport.super_importer?(@user)
+    unless super_importing_anothers?
       args[:user_login] = params[:inat_username].strip
     end
     args[:id] = params[:inat_ids] if listing_ids?
     args
+  end
+
+  def super_importing_anothers?
+    InatImport.super_importer?(@user) &&
+      @user.inat_username.present? &&
+      params[:inat_username].strip != @user.inat_username
   end
 
   def clean_inat_ids

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -392,7 +392,7 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_select("#estimated_time", "00:00:24")
   end
 
-  def test_superimporter_estimate_excludes_user_login
+  def test_superimporter_import_listed_observations_estimate_excludes_user_login
     user = users(:dick) # Dick is a super_importer
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
@@ -419,7 +419,8 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_template(:confirm)
     assert_select(
       "#estimated_count", "1",
-      "Estimate should not filter by user_login if user is a super_importer"
+      "Estimate should not filter by user_login if a super_importer " \
+      "imports listed observations"
     )
   end
 
@@ -445,6 +446,37 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_redirected_to(INAT_AUTHORIZATION_URL)
     assert_equal(inat_username, inat_import.reload.inat_username,
                  "Should flatten inat_username from namespaced params")
+  end
+
+  def test_superimporter_import_all_own_observations_estimate_filters_by_user
+    user = users(:dick) # Dick is a super_importer with inat_username "dick"
+    assert(InatImport.super_importer?(user),
+           "Test requires user to be a super_importer")
+    assert_equal("dick", user.inat_username,
+                 "Test requires super_importer fixture with an inat_username")
+
+    # If user_login is excluded from the estimate query, then iNat returns
+    # all iNat fungal observations of all users(a huge number).
+    # Register generic stub first (lower priority).
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      to_return(status: 200, body: { total_results: 19_591_724 }.to_json)
+    # Register specific stub last (higher priority) to return a small count
+    # when user_login is correctly included in the estimate query.
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("user_login" => user.inat_username)).
+      to_return(status: 200, body: { total_results: 1 }.to_json)
+
+    login(user.login)
+    post(:create,
+         params: { inat_username: user.inat_username, all: 1, consent: 1 })
+
+    assert_response(:success)
+    assert_template(:confirm)
+    assert_select(
+      "#estimated_count", "1",
+      "Estimate for a super_importer's own import-all should filter " \
+      "by user_login, not return a global count"
+    )
   end
 
   def test_create_go_back_with_superform_params

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -456,7 +456,7 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Test requires super_importer fixture with an inat_username")
 
     # If user_login is excluded from the estimate query, then iNat returns
-    # all iNat fungal observations of all users(a huge number).
+    # all iNat fungal observations of all users (a huge number).
     # Register generic stub first (lower priority).
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 19_591_724 }.to_json)


### PR DESCRIPTION
Fixes #3971 

## Manual Tests

### Setup
These tests require a local account that is a member of the `SuperImporters Project` user group.

---

- [x] 1. Super_importer importing all own observations — estimate is reasonable ✅ (bug fix)

**Steps:**
1. Log in as a super_importer whose MO `inat_username` matches their actual iNat username
2. Go to **Import from iNaturalist**
3. Enter **your own** iNat username in the username field
4. Check **Import All**
5. Check the consent checkbox
6. Submit

**Expect:** The confirmation page shows an estimated import count that roughly matches your actual iNat observation count (e.g. a few dozen or hundred), **not** a global count in the tens of millions.

---

- [x] 2. Super_importer importing listed IDs from another user — no user_login filter ✅ (existing behavior)

**Steps:**
1. Log in as a super_importer
2. Go to **Import from iNaturalist**
3. Enter **another user's** iNat username in the username field
4. Enter one or more valid iNat observation IDs belonging to that user
5. Check the consent checkbox
6. Submit

**Expect:** The confirmation page shows an estimated count equal to the number of IDs listed (minus any previously imported), with no filtering by username.

---

- [x] 3. Super_importer whose stored `inat_username` is blank — estimate includes user_login ✅ (edge case)

**Steps:**
1. Log in as a super_importer whose MO account has no stored `inat_username` (never previously imported)
2. Go to **Import from iNaturalist**
3. Enter your iNat username in the username field
4. Check **Import All**
5. Check the consent checkbox
6. Submit

**Expect:** The confirmation page shows an estimated count filtered by the entered username (not a global count).

---

- [x] 4. Regular user importing all own observations — estimate unchanged ✅ (regression)

**Steps:**
1. Log in as a non-super_importer whose iNat username is set
2. Go to **Import from iNaturalist**
3. Enter your iNat username
4. Check **Import All**
5. Check the consent checkbox
6. Submit

**Expect:** The confirmation page shows an estimated count filtered by username, same as before.