### PR TITLE
Exclude projects/ directory from RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ AllCops:
     - app/assets/javascripts/lightbox.js
     - "db/**/*"
     - "log/**/*"
+    - "projects/**/*"
     - public/design_test/jquery-1.5.2.min.js
     # We need not check these scripts, and some of them cause Rubocop errors
     - "script/old/**/*"


### PR DESCRIPTION
## Summary
- Adds `projects/**/*` to the RuboCop `AllCops.Exclude` list
- The `projects/` directory contains standalone scripts and data files that are not part of the Rails app

🤖 Generated with [Claude Code](https://claude.com/claude-code)