### PR TITLE
Revert "Add `log` param to Name API, fix silent save failures in `save_parents`"

### DIFF
--- a/app/classes/api2/name_api.rb
+++ b/app/classes/api2/name_api.rb
@@ -71,13 +71,11 @@ class API2
     def build_object
       params = create_params
       parse_name_author_rank_deprecated
-      @log = parse(:boolean, :log, default: true)
       done_parsing_parameters!
       validate_create_parameters!(params)
       parse = make_sure_name_parses!
       make_sure_name_doesnt_exist!(parse)
       name = create_name(parse, params)
-      name.user_log(@user, :log_name_created) if @log
       save_parents(parse)
       name
     end
@@ -192,12 +190,7 @@ class API2
       return unless parse.parent_name
 
       parents = Name.find_or_create_name_and_parents(@user, parse.parent_name)
-      parents.each do |n|
-        next unless n&.new_record?
-
-        n.save || raise(CreateFailed.new(n))
-        n.user_log(@user, :log_name_created) if @log
-      end
+      parents.each { |n| n.save if n&.new_record? }
     end
 
     # ----------------------------------------

--- a/test/classes/api2/names_test.rb
+++ b/test/classes/api2/names_test.rb
@@ -324,43 +324,6 @@ class API2::NamesTest < UnitTestCase
     assert_not_empty(Name.where(text_name: "Anzia"))
   end
 
-  def test_post_name_logs_creation
-    params = {
-      method: :post,
-      action: :name,
-      api_key: @api_key.key,
-      name: "Anzia ornata",
-      author: "(Zahlbr.) Asahina",
-      rank: "Species"
-    }
-    assert_api_pass(params)
-    name = Name.find_by(text_name: "Anzia ornata")
-    assert_not_nil(name, "Name 'Anzia ornata' was not created")
-    assert_not_nil(name.rss_log_id,
-                   "Name 'Anzia ornata' was created but not logged")
-    parent = Name.find_by(text_name: "Anzia")
-    assert_not_nil(parent, "Parent name 'Anzia' was not created")
-    assert_not_nil(parent.rss_log_id,
-                   "Parent name 'Anzia' was created but not logged")
-  end
-
-  def test_post_name_with_no_log
-    params = {
-      method: :post,
-      action: :name,
-      api_key: @api_key.key,
-      name: "Anzia ornata",
-      author: "(Zahlbr.) Asahina",
-      rank: "Species",
-      log: "no"
-    }
-    assert_api_pass(params)
-    name = Name.find_by(text_name: "Anzia ornata")
-    assert_not_nil(name, "Name 'Anzia ornata' was not created")
-    assert_nil(name.rss_log_id,
-               "Name 'Anzia ornata' was created with a log despite log: no")
-  end
-
   def test_patching_name_attributes
     agaricus = names(:agaricus)
     lepiota  = names(:lepiota)


### PR DESCRIPTION
Reverts MushroomObserver/mushroom-observer#4008