### PR TITLE
Clear connection after fork

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,14 +35,13 @@ activate_control_app
 
 if rails_env == "production"
   on_worker_boot do
-    require("active_record")
-    begin
-      ActiveRecord::Base.connection.disconnect!
-    rescue StandardError
-      ActiveRecord::ConnectionNotEstablished
-    end
-    ActiveRecord::Base.establish_connection(
-      YAML.load_file("#{app_path}/config/database.yml")[rails_env]["primary"]
-    )
+    # Clear ALL connection pools (primary, cache, etc.) after fork.
+    # Without this, forked workers inherit connections whose Trilogy
+    # @owner thread no longer matches Thread.current, causing
+    # Trilogy::SynchronizationError when SolidCache's background
+    # expiry thread tries to use the inherited cache connection.
+    # Surfaced by Trilogy 2.11.0 which now raises explicitly on
+    # concurrent connection use (previously silent/undefined behavior).
+    ActiveRecord::Base.clear_all_connections!
   end
 end


### PR DESCRIPTION
Fixes Trilogy::SynchronizationError (exposed by Trilogy update) after Puma fork. See [Slack Discussion](https://mushroomobserver.slack.com/archives/C040TH9FV/p1774311327838369).

Replace the manual disconnect/establish_connection in on_worker_boot with ActiveRecord::Base.clear_all_connections!, which clears all connection pools (primary, cache, etc.) after fork.

The old code only disconnected the primary database connection, leaving the SolidCache :cache role connection inherited from the parent process with a stale Trilogy @owner thread reference. When SolidCache's background expiry thread (expiry_method: :thread) ran in a Puma worker, Trilogy detected the thread mismatch and raised SynchronizationError.

This was always broken but became visible with Trilogy 2.11.0, which now raises an explicit error on concurrent connection use rather than proceeding with undefined behavior.