### PR TITLE
Resume adding external links to imports.

### DIFF
--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -91,27 +91,15 @@ class Inat
 
     def add_external_link
       external_site = ExternalSite.find_by(name: "iNaturalist")
-      link = ExternalLink.new(
+      ExternalLink.create!(
         user: user,
         observation: @observation,
         external_site: external_site,
         url: "#{external_site.base_url}#{inat_obs[:id]}"
       )
-      # FIXME: 2026-03-27 jdc: We cannot validate the external link because
-      # inat is blocking our request to validate the URL because
-      # Cloudflare returns 403 for HEAD and GET requests
-      # to www.inaturalist.org (but not api.inaturalist.org)
-      # from both the webserver (64.225.31.18) and http://localhost:3000/
-      # Therefore skip validation. We know the URL is valid because
-      # it's based on the iNat observation ID, and we can confirm that it
-      # works when we visit it in a browser.
-      # The reasons for the block are unclear. Could be one or more of:
-      # No browser headers Net::HTTP doesn't send User-Agent, Accept, or
-      #  the Sec-CH-UA-* Client Hints headers Cloudflare demandsvia critical-ch
-      # IP reputation — the server's IP may have been flagged
-      # Rate limiting — the MO server may be making enough requests to iNat
-      # (during imports) that Cloudflare started treating it as a bot
-      link.save!(validate: false)
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("InatImport: failed to create ExternalLink " \
+                        "for iNat obs #{inat_obs[:id]}: #{e.message}")
     end
 
     def create_missing_identification_names

--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -91,12 +91,27 @@ class Inat
 
     def add_external_link
       external_site = ExternalSite.find_by(name: "iNaturalist")
-      ExternalLink.create(
+      link = ExternalLink.new(
         user: user,
         observation: @observation,
         external_site: external_site,
         url: "#{external_site.base_url}#{inat_obs[:id]}"
       )
+      # FIXME: 2026-03-27 jdc: We cannot validate the external link because
+      # inat is blocking our request to validate the URL because
+      # Cloudflare returns 403 for HEAD and GET requests
+      # to www.inaturalist.org (but not api.inaturalist.org)
+      # from both the webserver (64.225.31.18) and http://localhost:3000/
+      # Therefore skip validation. We know the URL is valid because
+      # it's based on the iNat observation ID, and we can confirm that it
+      # works when we visit it in a browser.
+      # The reasons for the block are unclear. Could be one or more of:
+      # No browser headers Net::HTTP doesn't send User-Agent, Accept, or
+      #  the Sec-CH-UA-* Client Hints headers Cloudflare demandsvia critical-ch
+      # IP reputation — the server's IP may have been flagged
+      # Rate limiting — the MO server may be making enough requests to iNat
+      # (during imports) that Cloudflare started treating it as a bot
+      link.save!(validate: false)
     end
 
     def create_missing_identification_names

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -55,6 +55,12 @@ class ExternalLink < AbstractModel
   def format_url_for_external_site
     return false unless (base_url = external_site&.base_url)
 
+    # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
+    # causing FormatURL#url_exists? to fail. Skip the reachability check for
+    # iNat URLs constructed from base_url — format is guaranteed by construction.
+    return url if external_site.name == "iNaturalist" &&
+                  url.to_s.start_with?(base_url)
+
     test_url = FormatURL.new(url, base_url)
     return false unless test_url.valid?
 

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -57,7 +57,7 @@ class ExternalLink < AbstractModel
 
     # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
     # causing FormatURL#url_exists? to fail. Skip the reachability check for
-    # iNat URLs constructed from base_url — format is guaranteed by construction.
+    # iNat URLs constructed from base_url — format guaranteed by construction.
     return url if external_site.name == "iNaturalist" &&
                   url.to_s.start_with?(base_url)
 

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -41,6 +41,23 @@ class ExternalLinkTest < UnitTestCase
     assert_empty(link.errors[:url])
   end
 
+  # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
+  # causing FormatURL#url_exists? to return false and silently drop the link.
+  # For iNat URLs constructed from base_url, skip FormatURL entirely.
+  def test_inaturalist_link_skips_format_url
+    site = external_sites(:inaturalist)
+    obs = observations(:minimal_unknown_obs)
+    url = "#{site.base_url}253297232"
+
+    FormatURL.stub(:new, ->(*) { raise("FormatURL should not be called") }) do
+      link = ExternalLink.create!(
+        user: dick, observation: obs, external_site: site, url: url
+      )
+      assert_empty(link.errors)
+      assert_equal(url, link.url)
+    end
+  end
+
   def test_uniqueness
     link1 = ExternalLink.first
     site = link1.external_site


### PR DESCRIPTION
Hotfix for iNat/Cloudflare blocking HEAD/GET requests to www.inaturalist.org (but not to the api) from both the webserver and local server