### PR TITLE
Validate iNat ExternalLink entire URL

### DIFF
--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -56,10 +56,14 @@ class ExternalLink < AbstractModel
     return false unless (base_url = external_site&.base_url)
 
     # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
-    # causing FormatURL#url_exists? to fail. Skip the reachability check for
-    # iNat URLs constructed from base_url — format guaranteed by construction.
-    return url if external_site.name == "iNaturalist" &&
-                  url.to_s.start_with?(base_url)
+    # causing FormatURL#url_exists? to fail. Skip the reachability check,
+    # instead validating the URL format vs a regexp.
+    if external_site.name == "iNaturalist"
+      inat_url_re = /\A#{Regexp.escape(base_url)}\d+\z/
+      return url if url.to_s.match?(inat_url_re)
+
+      return false
+    end
 
     test_url = FormatURL.new(url, base_url)
     return false unless test_url.valid?

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -164,11 +164,8 @@ module Observations
     def test_update_external_link
       # obs owned by rolf, mary created link and is member of site's project
       link = external_links(:coprinus_comatus_obs_inaturalist_link)
-      new_url = "#{link.external_site.base_url}different_number"
-      params = {
-        id: link.id,
-        external_link: { url: new_url }
-      }
+      new_url = "#{link.external_site.base_url}999999"
+      params = { id: link.id, external_link: { url: new_url } }
 
       # not logged in
       put(:update, params:)

--- a/test/fixtures/external_links.yml
+++ b/test/fixtures/external_links.yml
@@ -17,7 +17,7 @@ coprinus_comatus_obs_inaturalist_link:
   updated_at:    2017-11-11 14:14:00
   observation:   coprinus_comatus_obs # owned by rolf
   external_site: inaturalist
-  url:           "https://inaturalist.org/observations/234723"
+  url:           "https://www.inaturalist.org/observations/234723"
 
 imported_inat_obs_inat_link:
   user:          dick

--- a/test/fixtures/external_links.yml
+++ b/test/fixtures/external_links.yml
@@ -9,7 +9,7 @@ coprinus_comatus_obs_mycoportal_link:
   updated_at:    2016-12-29 15:21:00
   observation:   coprinus_comatus_obs # owned by rolf
   external_site: mycoportal
-  url:           "http://mycoportal.org/portal/collections/individual/index.php?occid=1950183"
+  url:           "https://mycoportal.org/portal/collections/individual/index.php?occid=1950183"
 
 coprinus_comatus_obs_inaturalist_link:
   user:          mary
@@ -17,10 +17,10 @@ coprinus_comatus_obs_inaturalist_link:
   updated_at:    2017-11-11 14:14:00
   observation:   coprinus_comatus_obs # owned by rolf
   external_site: inaturalist
-  url:           "http://inaturalist.org/234723"
+  url:           "https://inaturalist.org/observations/234723"
 
 imported_inat_obs_inat_link:
   user:          dick
   observation:   imported_inat_obs
   external_site: inaturalist
-  url:           "https://www.inaturalist.org/12345"
+  url:           "https://www.inaturalist.org/observations/12345"

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -895,11 +895,11 @@ class InatImportJobTest < ActiveJob::TestCase
     stub_inat_interactions
 
     warnings = []
-    stubbed_error = ->(*) {
+    stubbed_error = lambda do |*|
       link = ExternalLink.new
       link.errors.add(:base, "stubbed failure")
       raise(ActiveRecord::RecordInvalid.new(link))
-    }
+    end
     Rails.logger.stub(:warn, ->(msg) { warnings << msg }) do
       ExternalLink.stub(:create!, stubbed_error) do
         assert_difference("Observation.count", 1,
@@ -916,10 +916,10 @@ class InatImportJobTest < ActiveJob::TestCase
     assert(obs.external_links.none?,
            "Observation should have no ExternalLink when creation fails")
     assert(
-      warnings.any? { |w|
+      warnings.any? do |w|
         w.include?("InatImport: failed to create ExternalLink") &&
           w.include?(inat_id.to_s)
-      },
+      end,
       "Should log a warning including the iNat obs ID when ExternalLink fails"
     )
   end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -883,6 +883,47 @@ class InatImportJobTest < ActiveJob::TestCase
                     "Should not log import success when error occurs")
   end
 
+  # Prove that the import continues (observation created, warning logged)
+  # when ExternalLink creation fails with RecordInvalid.
+  # Covers MoObservationBuilder#add_external_link rescue block.
+  def test_import_job_external_link_creation_failure
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    Location.create(user: @user, name: "Sevier Co., Tennessee, USA",
+                    north: 36.043571, south: 35.561849,
+                    east: -83.253046, west: -83.794123)
+    stub_inat_interactions
+
+    warnings = []
+    stubbed_error = ->(*) {
+      link = ExternalLink.new
+      link.errors.add(:base, "stubbed failure")
+      raise(ActiveRecord::RecordInvalid.new(link))
+    }
+    Rails.logger.stub(:warn, ->(msg) { warnings << msg }) do
+      ExternalLink.stub(:create!, stubbed_error) do
+        assert_difference("Observation.count", 1,
+                          "Observation should be created even if " \
+                          "ExternalLink.create! fails") do
+          InatImportJob.perform_now(@inat_import)
+        end
+      end
+    end
+
+    inat_id = @parsed_results.first[:id]
+    obs = Observation.find_by(inat_id: inat_id)
+    assert_not_nil(obs, "Cannot find imported Observation")
+    assert(obs.external_links.none?,
+           "Observation should have no ExternalLink when creation fails")
+    assert(
+      warnings.any? { |w|
+        w.include?("InatImport: failed to create ExternalLink") &&
+          w.include?(inat_id.to_s)
+      },
+      "Should log a warning including the iNat obs ID when ExternalLink fails"
+    )
+  end
+
   ########## Utilities
 
   ########## Utilities

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -62,7 +62,7 @@ class ExternalLinkTest < UnitTestCase
     end
   end
 
-  # iNat URLs must be only the basse url plus an observation numberic id,
+  # iNat URLs must be only the base url plus an observation numberic id,
   # e.g. /observations/12345.
   # A URL like /observations/abc should be invalid.
   def test_inaturalist_link_requires_numeric_id

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -13,16 +13,18 @@ class ExternalLinkTest < UnitTestCase
       external_site: site,
       url: "#{base_url}plus_id"
     )
-    assert_not_nil(link)
-    assert_empty(link.errors)
+    assert_not_nil(link, "ExternalLink should be created")
+    assert_empty(link.errors, "ExternalLink should have no errors")
   end
 
   def test_create_missing_attributes
     link = ExternalLink.create
-    assert_not_empty(link.errors[:user])
-    assert_not_empty(link.errors[:observation])
-    assert_not_empty(link.errors[:external_site])
-    assert_not_empty(link.errors[:url])
+    assert_not_empty(link.errors[:user], "ExternalLink should require a user")
+    assert_not_empty(link.errors[:observation],
+                     "ExternalLink should require an observation")
+    assert_not_empty(link.errors[:external_site],
+                     "ExternalLink should require an external_site")
+    assert_not_empty(link.errors[:url], "ExternalLink should require a url")
   end
 
   def test_create_validate_url
@@ -31,14 +33,16 @@ class ExternalLinkTest < UnitTestCase
 
     link = ExternalLink.create(url: "#{base_url}#{"toolong" * 100}",
                                external_site: site)
-    assert_not_empty(link.errors[:url])
+    assert_not_empty(link.errors[:url],
+                     "URL that is too long should be invalid")
 
     link = ExternalLink.create(url: "#{base_url}invalid url",
                                external_site: site)
-    assert_not_empty(link.errors[:url])
+    assert_not_empty(link.errors[:url],
+                     "URL with spaces should be invalid")
 
     link = ExternalLink.create(url: "#{base_url}url", external_site: site)
-    assert_empty(link.errors[:url])
+    assert_empty(link.errors[:url], "Valid URL should have no url errors")
   end
 
   # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
@@ -53,9 +57,27 @@ class ExternalLinkTest < UnitTestCase
       link = ExternalLink.create!(
         user: dick, observation: obs, external_site: site, url: url
       )
-      assert_empty(link.errors)
-      assert_equal(url, link.url)
+      assert_empty(link.errors, "iNat link should be created without errors")
+      assert_equal(url, link.url, "iNat link URL should be saved unchanged")
     end
+  end
+
+  # iNat URLs must be only the basse url plus an observation numberic id,
+  # e.g. /observations/12345.
+  # A URL like /observations/abc should be invalid.
+  def test_inaturalist_link_requires_numeric_id
+    site = external_sites(:inaturalist)
+    obs = observations(:minimal_unknown_obs)
+    url = "#{site.base_url}notanumber"
+
+    link = ExternalLink.create(
+      user: dick, observation: obs, external_site: site, url: url
+    )
+    assert_not_empty(
+      link.errors[:url],
+      "#{url} is not a valid iNat external link URL. " \
+      "It should be just #{site.base_url} + a numeric ID"
+    )
   end
 
   def test_uniqueness
@@ -64,7 +86,8 @@ class ExternalLinkTest < UnitTestCase
     base_url = site.base_url
 
     another_obs = observations(:minimal_unknown_obs)
-    assert_not_equal(link1.observation.id, another_obs.id)
+    assert_not_equal(link1.observation.id, another_obs.id,
+                     "Fixture observations should be different")
 
     # same observation
     link2 = ExternalLink.create(
@@ -73,7 +96,8 @@ class ExternalLinkTest < UnitTestCase
       external_site: site,
       url: "#{base_url}and_an_id"
     )
-    assert_not_empty(link2.errors)
+    assert_not_empty(link2.errors,
+                     "Duplicate link for same observation should be invalid")
 
     # different observation
     link3 = ExternalLink.create(
@@ -82,6 +106,7 @@ class ExternalLinkTest < UnitTestCase
       external_site: site,
       url: "#{base_url}and_an_id"
     )
-    assert_empty(link3.errors)
+    assert_empty(link3.errors,
+                 "Link for different observation should be valid")
   end
 end

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -81,7 +81,7 @@ class ExternalLinkTest < UnitTestCase
   end
 
   def test_uniqueness
-    link1 = ExternalLink.first
+    link1 = external_links(:coprinus_comatus_obs_mycoportal_link)
     site = link1.external_site
     base_url = site.base_url
 

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -62,7 +62,7 @@ class ExternalLinkTest < UnitTestCase
     end
   end
 
-  # iNat URLs must be only the base url plus an observation numberic id,
+  # iNat URLs must be only the base url plus an observation numeric id,
   # e.g. /observations/12345.
   # A URL like /observations/abc should be invalid.
   def test_inaturalist_link_requires_numeric_id


### PR DESCRIPTION
Follows up on yesterdays hotfix by validating the format of iNat external links.