### PR TITLE
Fix prawn-svg deprecation warning

### DIFF
--- a/app/classes/prawn/field_slip_card.rb
+++ b/app/classes/prawn/field_slip_card.rb
@@ -118,7 +118,8 @@ module Prawn
       title_width = 5.cm
       svg(qr_svg("https://mushroomobserver.org/qr/#{code}"),
           at: [QR_LEFT, QR_TOP],
-          width: QR_SIZE)
+          width: QR_SIZE,
+          enable_web_requests: false)
       font("#{Prawn::ManualBuilder::DATADIR}/fonts/DejaVuSans.ttf") do
         text_box("#{@tracker.title} Field Slip:",
                  at: [QR_RIGHT + QR_MARGIN, QR_TOP],

--- a/test/jobs/field_slip_job_test.rb
+++ b/test/jobs/field_slip_job_test.rb
@@ -49,6 +49,17 @@ class FieldSlipJobTest < ActiveJob::TestCase
     end
   end
 
+  def test_no_prawn_svg_warnings
+    job = FieldSlipJob.new
+    tracker = field_slip_job_trackers(:fsjt_page_two)
+    FieldSlipJobTracker.stub(:pdf_directory, @pdf_dir) do
+      warnings = capture_io { job.perform(tracker.id) }[1]
+      File.delete(tracker.filepath)
+      assert_empty(warnings.scan(/prawn-svg.*WARNING/),
+                   "Expected no prawn-svg warnings, got: #{warnings}")
+    end
+  end
+
   def test_deletes_old_tracker_files
     job = FieldSlipJob.new
     tracker = field_slip_job_trackers(:fsjt_page_two)


### PR DESCRIPTION
## Summary
- Pass `enable_web_requests: false` to the `svg()` call in `Prawn::FieldSlipCard#qr_code` to suppress the prawn-svg deprecation warning about `enable_web_requests` defaulting to `true`
- The SVG content is a locally-generated QR code with no external resource references, so web requests are not needed
- Add test asserting no prawn-svg warnings are emitted during field slip PDF generation

Fixes #4051

## Test plan
- [x] New test `test_no_prawn_svg_warnings` fails before fix, passes after
- [x] Existing field slip job tests continue to pass
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)