### PR TITLE
Bump github actions/checkout from v4 to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,23 @@
-# Use Dependabot to regularly update dependencies
+# Use Dependabot to update packages in ecosystems
+# https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file
+
+# Update gem dependencies
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
-
 version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
+      interval: "weekly"
+
+# Update GitHub Actions
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
       interval: "weekly"

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -19,7 +19,7 @@ jobs:
       # check-out repo under $GITHUB_WORKSPACE, so that workflow can access it.
       # https://github.com/actions/checkout
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # https://github.com/ruby/setup-ruby
       - name: Set up Ruby
@@ -103,7 +103,7 @@ jobs:
       # check-out repo under $GITHUB_WORKSPACE, so that workflow can access it.
       # https://github.com/actions/checkout
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # https://github.com/ruby/setup-ruby
       - name: Set up Ruby


### PR DESCRIPTION
Resolves #4088.
Hopefully gets rid of `Node.js 20 actions are deprecated` warnings.