### PR TITLE
Simplify iNat import source credit label

### DIFF
--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1406,7 +1406,7 @@
   source_credit_mo_android_app: Created via the "Mushroom Observer Android app":https://mushroomobserver.org/articles/34
   source_credit_mo_iphone_app: Created via the "Mushroom Observer iPhone app":https://mushroomobserver.org/articles/34
   source_credit_mo_api: Created via the "Mushroom Observer API":https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md.
-  source_credit_mo_inat_import: Imported from "iNaturalist":https://www.inaturalist.org via "Import from iNat":https://mushroomobserver.org/articles/39
+  source_credit_mo_inat_import: '"Imported from iNaturalist":https://mushroomobserver.org/articles/39'
 
   ##############################################################################
 


### PR DESCRIPTION
## Summary
- Change observation source credit from "Imported from iNaturalist via Import from iNat" to "Imported from iNaturalist"
- The entire phrase links to the MO article (articles/39) explaining the import process, rather than linking to iNaturalist.org
- Removes redundant "via Import from iNat" suffix

## Test plan
- [x] `bin/rails test test/models/observation_test.rb -n test_source_credit` passes
- [x] Verify on an imported observation that the label renders correctly with the article link

🤖 Generated with [Claude Code](https://claude.com/claude-code)