### PR TITLE
Add running job check to deploy script

### DIFF
--- a/script/check_running_jobs.rb
+++ b/script/check_running_jobs.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 # Called by deploy.sh to check for running background jobs.
-# Prints job details to stdout if any jobs are running; prints nothing
-# if no jobs are running.
+# Exit codes:
+#   0 - no jobs running
+#   2 - jobs are running (details printed to stdout)
+#   1 - error (rails runner default for unhandled exceptions)
 #
 # Usage: bundle exec rails runner script/check_running_jobs.rb
 
 claimed = SolidQueue::ClaimedExecution.includes(:job).all
-exit if claimed.empty?
+exit(0) if claimed.empty?
 
 def format_duration(total_seconds)
   hours, remainder = total_seconds.divmod(3600)
@@ -41,14 +43,10 @@ def inat_import_line(import, elapsed_str, remaining_str)
   remaining_str ? "#{base} remaining=~#{remaining_str}" : base
 end
 
-def inat_import_details(job, elapsed_str)
-  import_id = inat_import_id(job)
-  return nil unless import_id
-
+def inat_import_details(import_id, elapsed, elapsed_str)
   import = InatImport.find_by(id: import_id)
   return nil unless import
 
-  elapsed = (Time.zone.now - job.created_at).to_i
   remaining = inat_remaining_time(import, elapsed)
   remaining_str = format_duration(remaining) if remaining&.positive?
   inat_import_line(import, elapsed_str, remaining_str)
@@ -61,12 +59,17 @@ claimed.each do |ce|
   elapsed_str = format_duration(elapsed)
 
   if class_name == "InatImportJob"
-    details = inat_import_details(job, elapsed_str)
-    if details
-      puts(details)
-      next
+    import_id = inat_import_id(job)
+    if import_id
+      details = inat_import_details(import_id, elapsed, elapsed_str)
+      if details
+        puts(details)
+        next
+      end
     end
   end
 
   puts("#{class_name}: elapsed=#{elapsed_str}")
 end
+
+exit(2)

--- a/script/check_running_jobs.rb
+++ b/script/check_running_jobs.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Called by deploy.sh to check for running background jobs.
+# Prints job details to stdout if any jobs are running; prints nothing
+# if no jobs are running.
+#
+# Usage: bundle exec rails runner script/check_running_jobs.rb
+
+claimed = SolidQueue::ClaimedExecution.includes(:job).all
+exit if claimed.empty?
+
+def format_duration(total_seconds)
+  hours, remainder = total_seconds.divmod(3600)
+  minutes, seconds = remainder.divmod(60)
+  format("%dh %02dm %02ds", hours, minutes, seconds)
+end
+
+def inat_import_id(job)
+  args = job.arguments["arguments"]
+  gid = args&.first
+  return nil unless gid.is_a?(Hash)
+
+  global_id = gid["_aj_globalid"]
+  return nil unless global_id
+
+  global_id.split("/").last.to_i
+end
+
+def inat_remaining_time(import, elapsed)
+  remaining = import.total_expected_time - elapsed
+  [remaining.to_i, 0].max
+rescue StandardError
+  nil
+end
+
+def inat_import_line(import, elapsed_str, remaining_str)
+  base = "InatImportJob: user=#{import.user&.login} " \
+         "inat_user=#{import.inat_username} " \
+         "progress=#{import.imported_count}/#{import.importables} " \
+         "elapsed=#{elapsed_str}"
+  remaining_str ? "#{base} remaining=~#{remaining_str}" : base
+end
+
+def inat_import_details(job, elapsed_str)
+  import_id = inat_import_id(job)
+  return nil unless import_id
+
+  import = InatImport.find_by(id: import_id)
+  return nil unless import
+
+  elapsed = (Time.zone.now - job.created_at).to_i
+  remaining = inat_remaining_time(import, elapsed)
+  remaining_str = format_duration(remaining) if remaining&.positive?
+  inat_import_line(import, elapsed_str, remaining_str)
+end
+
+claimed.each do |ce|
+  job = ce.job
+  class_name = job.class_name
+  elapsed = (Time.zone.now - job.created_at).to_i
+  elapsed_str = format_duration(elapsed)
+
+  if class_name == "InatImportJob"
+    details = inat_import_details(job, elapsed_str)
+    if details
+      puts(details)
+      next
+    end
+  end
+
+  puts("#{class_name}: elapsed=#{elapsed_str}")
+end

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -38,15 +38,23 @@ if [ "$EXPECTED_RUBY" != "$CURRENT_RUBY" ]; then
 fi
 
 echo Checking for running background jobs...
-RUNNING_JOBS=$(bundle exec rails runner script/check_running_jobs.rb 2>&1)
+RUNNING_JOBS_OUTPUT=$(bundle exec rails runner script/check_running_jobs.rb 2>&1)
+RUNNING_JOBS_STATUS=$?
 
-if [ -n "$RUNNING_JOBS" ]; then
+if [ $RUNNING_JOBS_STATUS -eq 2 ]; then
     echo ""
     echo "Deploy aborted: background jobs are currently running."
     echo ""
-    echo "$RUNNING_JOBS"
+    echo "$RUNNING_JOBS_OUTPUT"
     echo ""
     echo "Wait for jobs to finish before deploying."
+    exit 1
+elif [ $RUNNING_JOBS_STATUS -ne 0 ]; then
+    echo ""
+    echo "Deploy aborted: failed to check for running background jobs."
+    echo ""
+    echo "$RUNNING_JOBS_OUTPUT"
+    echo ""
     exit 1
 fi
 

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -37,6 +37,19 @@ if [ "$EXPECTED_RUBY" != "$CURRENT_RUBY" ]; then
     exit 1
 fi
 
+echo Checking for running background jobs...
+RUNNING_JOBS=$(bundle exec rails runner script/check_running_jobs.rb 2>&1)
+
+if [ -n "$RUNNING_JOBS" ]; then
+    echo ""
+    echo "Deploy aborted: background jobs are currently running."
+    echo ""
+    echo "$RUNNING_JOBS"
+    echo ""
+    echo "Wait for jobs to finish before deploying."
+    exit 1
+fi
+
 tag=`date "+deploy-%Y-%m-%d-%H-%M"`
 echo Going for it\!
 

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -58,12 +58,20 @@ elif [ $RUNNING_JOBS_STATUS -ne 0 ]; then
     exit 1
 fi
 
+echo Stopping solidqueue to prevent new jobs during deploy...
+sudo service solidqueue stop
+if [ $? -ne 0 ]; then
+    echo Failed to stop solidqueue.
+    exit 1
+fi
+
 tag=`date "+deploy-%Y-%m-%d-%H-%M"`
 echo Going for it\!
 
 STASH_RESULT=`git stash`
 if [ $? -ne 0 ]; then
     echo git stash failed.
+    echo Restarting solidqueue... && sudo service solidqueue start
     exit 1
 fi
 
@@ -77,6 +85,7 @@ fi
 echo Getting latest code from github... && git pull
 if [ $? -ne 0 ]; then
     echo git pull failed.
+    echo Restarting solidqueue... && sudo service solidqueue start
     exit 1
 fi
 
@@ -84,6 +93,7 @@ if [ "$STASH_RESULT" != 'No local changes to save' ]; then
     echo Reapply local changes... && git stash pop
     if [ $? -ne 0 ]; then
 	echo Applying the stashed changes failed.
+	echo Restarting solidqueue... && sudo service solidqueue start
 	exit 1
     fi
 fi
@@ -93,7 +103,14 @@ echo Checking for migrations... && rake db:migrate && \
 echo Updating translations... && rake lang:update && \
 echo Precompiling assets... && rake assets:precompile && \
 echo Reloading puma... && sudo service puma restart && \
-echo Reloading solidqueue... && sudo service solidqueue restart && \
+echo Starting solidqueue... && sudo service solidqueue start && \
 echo Tagging repo with $tag... && git tag $tag && \
 echo Pushing new tag... && git push --tags && \
 echo SUCCESS\!
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "Deploy failed. Restarting solidqueue with existing code..."
+    sudo service solidqueue start
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #4117

- Adds a pre-deploy check for in-progress SolidQueue jobs before any git changes are made
- If a job is running, the deploy aborts with details: job class, elapsed time, and for iNat imports: user, progress, and estimated remaining time
- Extracted the job check into `script/check_running_jobs.rb` (Rails runner script) called from `script/deploy.sh`

## Background

Investigation confirmed that restarting SolidQueue during a deploy can permanently fail jobs (via SIGKILL after systemd's 90s timeout) or leave orphaned worker processes. A real case was found where a deploy on March 22 interrupted a 3,457-observation iNat import for user BDThomas mid-way through, forcing them to manually restart it 36 hours later. See issue comments for full analysis.

## Test plan

- [ ] Verify deploy proceeds normally when no jobs are running
- [ ] Verify deploy aborts with job details when a job is running (e.g., FieldSlipJob)
- [ ] Verify iNat import details (user, progress, remaining time) display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)