### PR TITLE
Fix stuck InatImport when worker crashes

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -22,8 +22,17 @@ class InatImportJob < ApplicationJob
   rescue StandardError => e
     log("Error occurred: #{e.message}")
     inat_import.add_response_error(e)
+  # Intentional: catch non-StandardError exceptions so they are logged
+  # and recorded on the import record rather than silently lost.
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    # Re-raise shutdown signals so the worker shuts down cleanly.
+    # The ensure block has already run at that point.
+    raise if e.is_a?(SignalException) || e.is_a?(SystemExit)
+
+    log("Unexpected error: #{e.message}")
+    inat_import&.add_response_error(e.message)
   ensure
-    done
+    safe_done
   end
 
   private
@@ -153,6 +162,14 @@ class InatImportJob < ApplicationJob
 
     inat_import.add_response_error(
       :inat_unlicensed_obs_summary.t(count: unlicensed_obs)
+    )
+  end
+
+  def safe_done
+    done
+  rescue StandardError => e
+    Rails.logger.error(
+      "InatImportJob: done failed for import #{inat_import&.id}: #{e.message}"
     )
   end
 

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -30,7 +30,7 @@ class InatImportJob < ApplicationJob
     # Re-raise shutdown signals so the worker shuts down cleanly.
     # ensure still runs during unwinding; the $ERROR_INFO check below skips
     # safe_done so the record stays Importing and the recovery job cleans it up.
-    raise if shutdown_signal?(e)
+    raise if non_rescuable?(e)
 
     log("Unexpected error: #{e.message}")
     inat_import&.add_response_error(e.message)
@@ -38,7 +38,7 @@ class InatImportJob < ApplicationJob
     # Skip safe_done on shutdown signals: leave the record in Importing state
     # so SolidQueue can requeue the job. The recovery job will finalize it
     # if the worker is killed before the job can be retried.
-    safe_done unless shutdown_signal?($ERROR_INFO)
+    safe_done unless non_rescuable?($ERROR_INFO)
   end
 
   private
@@ -171,8 +171,12 @@ class InatImportJob < ApplicationJob
     )
   end
 
-  def shutdown_signal?(error)
-    error.is_a?(SignalException) || error.is_a?(SystemExit)
+  def non_rescuable?(error)
+    error.is_a?(SignalException) ||
+      error.is_a?(SystemExit) ||
+      error.is_a?(NoMemoryError) ||
+      error.is_a?(SystemStackError) ||
+      error.is_a?(ScriptError)
   end
 
   def safe_done

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -180,11 +180,16 @@ class InatImportJob < ApplicationJob
   end
 
   def safe_done
+    original_exception = $ERROR_INFO
     done
   rescue StandardError => e
     Rails.logger.error(
       "InatImportJob: done failed for import #{inat_import&.id}: #{e.message}"
     )
+    # Re-raise if done failed on the happy path so the job fails visibly
+    # and SolidQueue can retry. Swallow only when already handling an error,
+    # so the original exception is not masked.
+    raise unless original_exception
   end
 
   def done

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "English"
+
 class InatImportJob < ApplicationJob
   attr_accessor :inat_import
 
@@ -26,13 +28,17 @@ class InatImportJob < ApplicationJob
   # and recorded on the import record rather than silently lost.
   rescue Exception => e # rubocop:disable Lint/RescueException
     # Re-raise shutdown signals so the worker shuts down cleanly.
-    # The ensure block has already run at that point.
-    raise if e.is_a?(SignalException) || e.is_a?(SystemExit)
+    # ensure still runs during unwinding; the $ERROR_INFO check below skips
+    # safe_done so the record stays Importing and the recovery job cleans it up.
+    raise if shutdown_signal?(e)
 
     log("Unexpected error: #{e.message}")
     inat_import&.add_response_error(e.message)
   ensure
-    safe_done
+    # Skip safe_done on shutdown signals: leave the record in Importing state
+    # so SolidQueue can requeue the job. The recovery job will finalize it
+    # if the worker is killed before the job can be retried.
+    safe_done unless shutdown_signal?($ERROR_INFO)
   end
 
   private
@@ -163,6 +169,10 @@ class InatImportJob < ApplicationJob
     inat_import.add_response_error(
       :inat_unlicensed_obs_summary.t(count: unlicensed_obs)
     )
+  end
+
+  def shutdown_signal?(error)
+    error.is_a?(SignalException) || error.is_a?(SystemExit)
   end
 
   def safe_done

--- a/app/jobs/inat_import_recovery_job.rb
+++ b/app/jobs/inat_import_recovery_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Finds InatImport records stuck in the Importing state and marks them Done.
+# Scheduled in config/recurring.yml to run every STUCK_THRESHOLD minutes.
+# This recovers from worker process crashes (e.g., SIGKILL, OOM) where the
+# job's ensure block never ran.
+class InatImportRecoveryJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    InatImport.where(state: "Importing", ended_at: nil).
+      where(updated_at: ..InatImport::STUCK_THRESHOLD.ago).
+      find_each do |import|
+        import.update(state: "Done", ended_at: Time.zone.now)
+        import.add_response_error(
+          "Import did not complete — the import may have crashed. " \
+          "You can restart the import."
+        )
+        Rails.logger.warn(
+          "InatImportRecoveryJob: marked stuck import #{import.id} as Done"
+        )
+      end
+  end
+end

--- a/app/jobs/inat_import_recovery_job.rb
+++ b/app/jobs/inat_import_recovery_job.rb
@@ -8,17 +8,15 @@ class InatImportRecoveryJob < ApplicationJob
   queue_as :default
 
   def perform
-    InatImport.where(state: "Importing", ended_at: nil).
-      where(updated_at: ..InatImport::STUCK_THRESHOLD.ago).
-      find_each do |import|
-        import.update(state: "Done", ended_at: Time.zone.now)
-        import.add_response_error(
-          "Import did not complete — the import may have crashed. " \
-          "You can restart the import."
-        )
-        Rails.logger.warn(
-          "InatImportRecoveryJob: marked stuck import #{import.id} as Done"
-        )
-      end
+    InatImport.stuck.find_each do |import|
+      import.update(state: "Done", ended_at: Time.zone.now)
+      import.add_response_error(
+        "Import did not complete — the import may have crashed. " \
+        "You can restart the import."
+      )
+      Rails.logger.warn(
+        "InatImportRecoveryJob: marked stuck import #{import.id} as Done"
+      )
+    end
   end
 end

--- a/app/jobs/inat_import_recovery_job.rb
+++ b/app/jobs/inat_import_recovery_job.rb
@@ -9,10 +9,12 @@ class InatImportRecoveryJob < ApplicationJob
 
   def perform
     InatImport.stuck.find_each do |import|
-      import.update(state: "Done", ended_at: Time.zone.now)
-      import.add_response_error(
-        "Import did not complete — the import may have crashed. " \
-        "You can restart the import."
+      crashed_msg = "Import did not complete — the import may have crashed. " \
+                    "You can restart the import."
+      import.update!(
+        state: "Done",
+        ended_at: Time.zone.now,
+        response_errors: "#{import.response_errors}#{crashed_msg}\n"
       )
       Rails.logger.warn(
         "InatImportRecoveryJob: marked stuck import #{import.id} as Done"

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -65,6 +65,11 @@ class InatImport < ApplicationRecord
   # crashed. Must match the schedule in config/recurring.yml.
   STUCK_THRESHOLD = 3.minutes
 
+  scope :stuck, lambda {
+    where(state: "Importing", ended_at: nil).
+      where(updated_at: ...STUCK_THRESHOLD.ago)
+  }
+
   # Are there enough constraints on which observations to import?
   # See also InatImportsController::Validators#adequately_constrained?
   # Need to make sure that the iNat API query has enough constrains so

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -61,6 +61,10 @@ class InatImport < ApplicationRecord
   # (Only gets used once.)
   BASE_AVG_IMPORT_SECONDS = 15
 
+  # An import stuck in Importing state longer than this is assumed to have
+  # crashed. Must match the schedule in config/recurring.yml.
+  STUCK_THRESHOLD = 3.minutes
+
   # Are there enough constraints on which observations to import?
   # See also InatImportsController::Validators#adequately_constrained?
   # Need to make sure that the iNat API query has enough constrains so
@@ -77,6 +81,13 @@ class InatImport < ApplicationRecord
 
   def job_pending?
     %w[Authenticating Importing].include?(state)
+  end
+
+  # True if stuck in Importing state with no recent activity.
+  # updated_at is touched after every observation import, so
+  # no update in longer than STUCK_THRESHOLD indicates a crashed worker.
+  def stuck?
+    Importing? && ended_at.nil? && updated_at < STUCK_THRESHOLD.ago
   end
 
   def add_response_error(error)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -12,6 +12,10 @@
 #     command: "DeletedStuff.clear_all"
 #     schedule: every day at 9am
 production:
+  recover_stuck_inat_imports:
+    class: InatImportRecoveryJob
+    # schedule must match InatImport::STUCK_THRESHOLD
+    schedule: every 3 minutes
   repopulate_location_and_observation_center_lat_lng:
     class: UpdateBoxAreaAndCenterColumnsJob
     schedule: every day at midnight

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1121,11 +1121,7 @@ class InatImportJobTest < ActiveJob::TestCase
                    "ended_at should be set after successful job")
   end
 
-  def test_safe_done_marks_import_done_when_done_raises
-    create_ivars_from_filename("calostoma_lutescens")
-    @user.update(inat_username: @inat_import.inat_username)
-    stub_inat_interactions
-
+  def test_safe_done_reraises_when_done_fails_on_happy_path
     job = InatImportJob.new
     job.instance_variable_set(:@inat_import, @inat_import)
     job.define_singleton_method(:done) do
@@ -1138,8 +1134,31 @@ class InatImportJobTest < ActiveJob::TestCase
     rescue StandardError => e
       exception = e
     end
-    assert_nil(exception,
-               "safe_done should swallow done's exception, got: #{exception}")
+    assert_not_nil(exception,
+                   "safe_done should re-raise when done fails with no " \
+                   "original exception in flight")
+  end
+
+  def test_safe_done_swallows_done_failure_when_handling_error
+    job = InatImportJob.new
+    job.instance_variable_set(:@inat_import, @inat_import)
+    job.define_singleton_method(:done) do
+      raise(StandardError.new("done failed"))
+    end
+
+    swallowed = true
+    begin
+      raise(StandardError.new("original error"))
+    rescue StandardError
+      begin
+        job.send(:safe_done)
+      rescue StandardError
+        swallowed = false
+      end
+    end
+    assert(swallowed,
+           "safe_done should swallow done's exception when an error " \
+           "is already in flight")
   end
 
   # -------- Other Utilities

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1106,6 +1106,37 @@ class InatImportJobTest < ActiveJob::TestCase
     end
   end
 
+  # -------- safe_done tests
+
+  def test_safe_done_marks_import_done_normally
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    stub_inat_interactions
+
+    InatImportJob.perform_now(@inat_import)
+
+    assert_equal("Done", @inat_import.reload.state,
+                 "Import should be Done after successful job")
+    assert_not_nil(@inat_import.ended_at,
+                   "ended_at should be set after successful job")
+  end
+
+  def test_safe_done_marks_import_done_when_done_raises
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    stub_inat_interactions
+
+    job = InatImportJob.new
+    job.instance_variable_set(:@inat_import, @inat_import)
+    job.define_singleton_method(:done) do
+      raise(StandardError.new("done failed"))
+    end
+
+    assert_nothing_raised("safe_done should swallow done's exception") do
+      job.send(:safe_done)
+    end
+  end
+
   # -------- Other Utilities
 
   # Hack to turn results with many pages into results with one page

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1129,7 +1129,7 @@ class InatImportJobTest < ActiveJob::TestCase
     end
 
     exception = nil
-    begin
+    Rails.logger.stub(:error, nil) do
       job.send(:safe_done)
     rescue StandardError => e
       exception = e

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1132,9 +1132,14 @@ class InatImportJobTest < ActiveJob::TestCase
       raise(StandardError.new("done failed"))
     end
 
-    assert_nothing_raised("safe_done should swallow done's exception") do
+    exception = nil
+    begin
       job.send(:safe_done)
+    rescue StandardError => e
+      exception = e
     end
+    assert_nil(exception,
+               "safe_done should swallow done's exception, got: #{exception}")
   end
 
   # -------- Other Utilities

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1106,6 +1106,36 @@ class InatImportJobTest < ActiveJob::TestCase
     end
   end
 
+  # -------- rescue Exception / non_rescuable? tests
+
+  def test_perform_records_unexpected_non_standard_exception
+    create_ivars_from_filename("calostoma_lutescens")
+    stub_token_requests
+    stub_check_username_match(@inat_import.inat_username)
+
+    job = InatImportJob.new
+    job.define_singleton_method(:import_requested_observations) do
+      raise(Exception.new("unexpected bare exception")) # rubocop:disable Lint/RaiseException
+    end
+
+    job.perform(@inat_import)
+
+    @inat_import.reload
+    assert_match(/unexpected bare exception/, @inat_import.response_errors,
+                 "Non-fatal Exception should be recorded in response_errors")
+    assert_equal("Done", @inat_import.state,
+                 "Import should be marked Done after unexpected exception")
+  end
+
+  def test_non_rescuable_true_for_remaining_fatal_types
+    job = InatImportJob.new
+
+    [NoMemoryError.new, SystemStackError.new, LoadError.new].each do |error|
+      assert(job.send(:non_rescuable?, error),
+             "#{error.class} should be non_rescuable")
+    end
+  end
+
   # -------- safe_done tests
 
   def test_safe_done_marks_import_done_normally

--- a/test/jobs/inat_import_recovery_job_test.rb
+++ b/test/jobs/inat_import_recovery_job_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class InatImportRecoveryJobTest < ActiveJob::TestCase
+  def test_marks_stuck_import_as_done
+    import = inat_imports(:katrina_inat_import)
+    import.update_column(:updated_at,
+                         InatImport::STUCK_THRESHOLD.ago - 1.second)
+
+    InatImportRecoveryJob.perform_now
+
+    import.reload
+    assert_equal("Done", import.state,
+                 "Stuck import should be marked Done")
+    assert_not_nil(import.ended_at,
+                   "Stuck import should have ended_at set")
+    assert_match(/the import may have crashed/, import.response_errors,
+                 "Stuck import should have crash error in response_errors")
+  end
+
+  def test_does_not_touch_recently_active_import
+    import = inat_imports(:katrina_inat_import)
+    import.update_column(:updated_at, Time.zone.now)
+
+    InatImportRecoveryJob.perform_now
+
+    import.reload
+    assert_equal("Importing", import.state,
+                 "Recently active import should not be touched")
+  end
+
+  def test_does_not_touch_done_import
+    import = inat_imports(:lone_wolf_import)
+    original_errors = import.response_errors
+
+    InatImportRecoveryJob.perform_now
+
+    import.reload
+    assert_equal(original_errors, import.response_errors,
+                 "Done import should not be modified")
+  end
+end

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -122,6 +122,29 @@ class InatImportTest < ActiveSupport::TestCase
                  "response_errors should be initialized to empty string")
   end
 
+  def test_stuck_when_importing_and_stale
+    import = inat_imports(:katrina_inat_import)
+    import.update_column(:updated_at,
+                         InatImport::STUCK_THRESHOLD.ago - 1.second)
+
+    assert(import.stuck?,
+           "Import in Importing state with stale updated_at should be stuck")
+  end
+
+  def test_not_stuck_when_importing_but_recent
+    import = inat_imports(:katrina_inat_import)
+    import.update_column(:updated_at, Time.zone.now)
+
+    assert_not(import.stuck?,
+               "Import with recent updated_at should not be stuck")
+  end
+
+  def test_not_stuck_when_done
+    import = inat_imports(:lone_wolf_import)
+
+    assert_not(import.stuck?, "Done import should not be stuck")
+  end
+
   def test_add_response_error_without_prior_errors
     import = InatImport.new(user: users(:rolf))
     import.save!


### PR DESCRIPTION
Addresses the "The one failed job" case described in a [comment to Issue 4117](https://github.com/MushroomObserver/mushroom-observer/issues/4117#issuecomment-4232753832)

Add InatImportRecoveryJob, scheduled every 3 minutes, to find InatImport records stuck in Importing state (updated_at older than STUCK_THRESHOLD) and mark them Done with an error message. Addresses the case where a worker process is SIGKILL'd or OOM-killed and the job's ensure block never runs.

Also bulletproof InatImportJob#perform: add a rescue Exception clause (re-raising shutdown signals) to log unexpected errors to response_errors, and wrap the ensure's done call in safe_done so a DB failure there doesn't suppress the original exception.

Resolves #4119 