### PR TITLE
Remove duplicate text/html from nginx gzip_types

### DIFF
--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -54,7 +54,7 @@ http {
   gzip_proxied any;
   gzip_min_length 500;
   gzip_disable "MSIE [1-6]\.";
-  gzip_types text/plain text/html text/xml text/css
+  gzip_types text/plain text/xml text/css
              text/comma-separated-values
              text/javascript application/x-javascript
              application/atom+xml;


### PR DESCRIPTION
## Summary
- Remove explicit `text/html` from `gzip_types` in nginx.conf — nginx always gzips `text/html` implicitly, so listing it triggers a `duplicate MIME type` warning on `nginx -t`

## Test plan
- [ ] Run `sudo nginx -t` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)