### PR TITLE
Project excluded_observations list and Exclude buttons

### DIFF
--- a/app/components/matrix_box.rb
+++ b/app/components/matrix_box.rb
@@ -35,6 +35,10 @@ class Components::MatrixBox < Components::Base
   prop :identify, _Boolean, default: false
   prop :votes, _Boolean, default: true
   prop :footer, _Union(Array, _Boolean, nil), default: -> { [] }
+  # Project context — when an observation matrix box is rendered inside a
+  # project-filtered observations index, a project admin sees an Exclude
+  # button that moves the observation to the project's excluded list.
+  prop :project, _Nilable(Project), default: nil
 
   def view_template(&block)
     if @object
@@ -61,6 +65,7 @@ class Components::MatrixBox < Components::Base
         render_details_section(panel)
         render_log_footer(panel)
         render_identify_footer(panel)
+        render_project_admin_footer(panel)
         render_custom_footer(panel, &custom_footer) if custom_footer
       end
     end
@@ -275,5 +280,26 @@ class Components::MatrixBox < Components::Base
 
   def render_custom_footer(panel, &block)
     panel.with_footer(classes: "text-center", &block)
+  end
+
+  def render_project_admin_footer(panel)
+    return unless show_project_exclude_button?
+
+    panel.with_footer(classes: "text-center") do
+      button_to(
+        :EXCLUDE.t,
+        exclude_observation_project_update_path(
+          project_id: @project.id, id: @data[:what].id
+        ),
+        method: :post,
+        class: "btn btn-default btn-sm",
+        form: { data: { turbo: true } }
+      )
+    end
+  end
+
+  def show_project_exclude_button?
+    @project && @data && @data[:type] == :observation &&
+      @project.is_admin?(@user)
   end
 end

--- a/app/components/matrix_table.rb
+++ b/app/components/matrix_table.rb
@@ -62,9 +62,10 @@ class Components::MatrixTable < Components::Base
 
   def render_cached_boxes
     @objects.each do |object|
-      # Skip fragment cache when @project is present since the admin-only
-      # Exclude button is user-specific and would cache incorrectly.
-      if !@identify && !@project && should_cache_object?(object)
+      # Skip fragment cache only when the current user will see the
+      # admin-only Exclude button. Non-admins see the same output as the
+      # non-project case, so caching is still safe for them.
+      if !@identify && !project_admin_view? && should_cache_object?(object)
         cache([I18n.locale, object]) do
           MatrixBox(user: @user, object: object)
         end
@@ -73,6 +74,10 @@ class Components::MatrixTable < Components::Base
                   identify: @identify, project: @project)
       end
     end
+  end
+
+  def project_admin_view?
+    @project&.is_admin?(@user)
   end
 
   def should_cache_object?(object)

--- a/app/components/matrix_table.rb
+++ b/app/components/matrix_table.rb
@@ -34,6 +34,9 @@ class Components::MatrixTable < Components::Base
   prop :user, _Nilable(User), default: nil
   prop :cached, _Boolean, default: false
   prop :identify, _Boolean, default: false
+  # Project context — passed through to each MatrixBox so a project admin
+  # sees an Exclude button on the observations grid filtered by project.
+  prop :project, _Nilable(Project), default: nil
 
   def view_template(&block)
     ul(
@@ -59,12 +62,15 @@ class Components::MatrixTable < Components::Base
 
   def render_cached_boxes
     @objects.each do |object|
-      if !@identify && should_cache_object?(object)
+      # Skip fragment cache when @project is present since the admin-only
+      # Exclude button is user-specific and would cache incorrectly.
+      if !@identify && !@project && should_cache_object?(object)
         cache([I18n.locale, object]) do
           MatrixBox(user: @user, object: object)
         end
       else
-        MatrixBox(user: @user, object: object, identify: @identify)
+        MatrixBox(user: @user, object: object,
+                  identify: @identify, project: @project)
       end
     end
   end
@@ -78,7 +84,8 @@ class Components::MatrixTable < Components::Base
 
   def render_matrix_boxes
     @objects.each do |object|
-      MatrixBox(user: @user, object: object, identify: @identify)
+      MatrixBox(user: @user, object: object,
+                identify: @identify, project: @project)
     end
   end
 end

--- a/app/components/projects/obs_footer.rb
+++ b/app/components/projects/obs_footer.rb
@@ -2,48 +2,49 @@
 
 module Components
   module Projects
-    # Renders Add/Remove button for an observation on the Update tab.
+    # Renders action buttons on a project Updates tab matrix box.
+    # When showing excluded observations, only an Add button is shown
+    # (which also un-excludes). Otherwise, both Add and Exclude are shown.
     class ObsFooter < Components::Base
-      def initialize(project:, obs:, in_project:)
+      def initialize(project:, obs:, show_excluded:)
         super()
         @project = project
         @obs = obs
-        @in_project = in_project
+        @show_excluded = show_excluded
       end
 
       def view_template
-        div(id: "update_footer_#{@obs.id}") do
-          if @in_project
-            render_remove_button
-          else
-            render_add_button
-          end
+        div(id: "update_footer_#{@obs.id}", class: "text-center") do
+          render_add_button
+          render_exclude_button unless @show_excluded
         end
       end
 
       private
 
-      def render_remove_button
-        button_to(
-          :REMOVE.t,
-          remove_observation_project_update_path(
-            project_id: @project.id, id: @obs.id
-          ),
-          method: :delete,
-          class: "btn btn-default btn-sm",
-          data: { turbo: true }
-        )
-      end
-
       def render_add_button
         button_to(
           :ADD.t,
           add_observation_project_update_path(
-            project_id: @project.id, id: @obs.id
+            project_id: @project.id, id: @obs.id,
+            show_excluded: @show_excluded
           ),
           method: :post,
-          class: "btn btn-default btn-sm",
-          data: { turbo: true }
+          class: "btn btn-default btn-sm mx-1",
+          form: { data: { turbo: true } }
+        )
+      end
+
+      def render_exclude_button
+        button_to(
+          :EXCLUDE.t,
+          exclude_observation_project_update_path(
+            project_id: @project.id, id: @obs.id,
+            show_excluded: @show_excluded
+          ),
+          method: :post,
+          class: "btn btn-default btn-sm mx-1",
+          form: { data: { turbo: true } }
         )
       end
     end

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -115,8 +115,8 @@ module Projects
           )
         end
         format.html do
-          redirect_back(
-            fallback_location: project_updates_path(
+          redirect_back_or_to(
+            project_updates_path(
               project_id: @project.id, show_excluded: show_excluded?
             )
           )

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -9,11 +9,13 @@ module Projects
     def index
       results = build_index_results
       render(Views::Controllers::Projects::Updates::Index.new(
-               project: @project, user: @user, results: results
+               project: @project, user: @user, results: results,
+               show_excluded: show_excluded?
              ), layout: true)
     end
 
-    # Single observation add via Turbo
+    # Single observation add via Turbo. If excluded, un-excludes as a side
+    # effect inside Project#add_observation.
     def add_observation
       obs = Observation.safe_find(params[:id])
       if obs
@@ -24,29 +26,23 @@ module Projects
       end
     end
 
-    # Single observation remove via Turbo
-    def remove_observation
+    # Single observation exclude via Turbo.
+    def exclude_observation
       obs = Observation.safe_find(params[:id])
       if obs
-        @project.remove_observation(obs)
+        @project.exclude_observation(obs)
         render_footer_update(obs)
       else
         head(:not_found)
       end
     end
 
-    # Bulk add all candidates
+    # Bulk add all observations on the current filtered list.
     def add_all
-      count = bulk_add_candidates
+      count = bulk_add_candidates(current_scope)
       flash_notice(:project_updates_added_all.t(count: count))
-      redirect_to(project_updates_path(project_id: @project.id))
-    end
-
-    # Bulk remove all candidates from project
-    def clear
-      count = bulk_remove_candidates
-      flash_notice(:project_updates_cleared.t(count: count))
-      redirect_to(project_updates_path(project_id: @project.id))
+      redirect_to(project_updates_path(project_id: @project.id,
+                                       show_excluded: show_excluded?))
     end
 
     private
@@ -55,32 +51,43 @@ module Projects
       @project = find_or_goto_index(Project, params[:project_id])
     end
 
+    def show_excluded?
+      params[:show_excluded].present? &&
+        params[:show_excluded] != "false" &&
+        params[:show_excluded] != "0"
+    end
+
+    # The observation list the Updates tab is currently showing.
+    def current_scope
+      if show_excluded?
+        @project.excluded_observations.order(created_at: :desc)
+      else
+        @project.new_candidate_observations
+      end
+    end
+
     def build_index_results
-      candidates = @project.candidate_observations
-      pagination = build_pagination(candidates)
-      obs_page = paginated_observations(candidates, pagination)
-      page_ids = obs_page.map(&:id)
-      member_ids = @project.observations.where(id: page_ids).
-                   pluck(:id).to_set
+      scope = current_scope
+      pagination = build_pagination(scope)
+      obs_page = paginated_observations(scope, pagination)
       { observations: obs_page,
         pagination: pagination,
-        member_ids: member_ids,
-        new_count: @project.new_candidate_observations_count,
+        current_count: pagination.num_total,
         base_url: request.path }
     end
 
-    def build_pagination(candidates)
+    def build_pagination(scope)
       pagination = PaginationData.new(
         number_arg: :page,
         number: params[:page],
         num_per_page: calc_layout_params["count"]
       )
-      pagination.num_total = candidates.count
+      pagination.num_total = scope.count
       pagination
     end
 
-    def paginated_observations(candidates, pagination)
-      candidates.
+    def paginated_observations(scope, pagination)
+      scope.
         offset(pagination.from).
         limit(pagination.num_per_page).
         includes(
@@ -99,38 +106,40 @@ module Projects
     end
 
     def render_footer_update(obs)
-      in_project = @project.observations.exists?(obs.id)
       respond_to do |format|
         format.turbo_stream do
           render(
             partial: "projects/updates/footer_update",
             locals: { project: @project, obs: obs,
-                      in_project: in_project }
+                      count_label: count_label_for_current_scope }
           )
         end
         format.html do
-          redirect_to(project_updates_path(project_id: @project.id))
+          redirect_back(
+            fallback_location: project_updates_path(
+              project_id: @project.id, show_excluded: show_excluded?
+            )
+          )
         end
       end
     end
 
-    def bulk_add_candidates
-      candidates = @project.candidate_observations.
-                   where.not(id: @project.observations.select(:id))
-      count = 0
-      candidates.find_each do |obs|
-        @project.add_observation(obs)
-        count += 1
-      end
-      count
+    def count_label_for_current_scope
+      count = current_scope.count
+      key = count_label_key
+      key.t(count: count)
     end
 
-    def bulk_remove_candidates
-      in_project = @project.candidate_observations.
-                   where(id: @project.observations.select(:id))
+    def count_label_key
+      return :project_updates_excluded_count if show_excluded?
+
+      :project_updates_count
+    end
+
+    def bulk_add_candidates(scope)
       count = 0
-      in_project.find_each do |obs|
-        @project.remove_observation(obs)
+      scope.find_each do |obs|
+        @project.add_observation(obs)
         count += 1
       end
       count

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -73,7 +73,8 @@ module Projects
       { observations: obs_page,
         pagination: pagination,
         current_count: pagination.num_total,
-        base_url: request.path }
+        request_url: request.fullpath,
+        form_action_url: request.path }
     end
 
     def build_pagination(scope)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -78,6 +78,10 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   has_many :observations, through: :project_observations
   has_many :locations, through: :observations
 
+  has_many :project_excluded_observations, dependent: :destroy
+  has_many :excluded_observations, through: :project_excluded_observations,
+                                   source: :observation
+
   has_many :project_species_lists, dependent: :destroy
   has_many :species_lists, through: :project_species_lists
 
@@ -321,8 +325,10 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Add observation (and its images) to this project if not already done so.
+  # If the observation was excluded, remove it from the excluded list.
   # Saves it.
   def add_observation(obs)
+    unexclude_observation(obs)
     return if observations.include?(obs)
 
     imgs = obs.images.select { |img| img.user_id == obs.user_id }
@@ -338,6 +344,37 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     imgs_to_delete(obs).each { |img| images.delete(img) }
     observations.delete(obs)
     touch
+  end
+
+  # Exclude observation from this project's Updates tab candidate list.
+  # If currently in the project, remove it first.
+  def exclude_observation(obs)
+    remove_observation(obs)
+    return if excluded_observations.include?(obs)
+
+    excluded_observations.push(obs)
+    touch
+  end
+
+  # Un-exclude observation. Does not add it back to the project.
+  def unexclude_observation(obs)
+    return unless excluded_observations.include?(obs)
+
+    excluded_observations.delete(obs)
+    touch
+  end
+
+  # Remove all observations matching the given name (including synonyms)
+  # from both this project's observations and its excluded_observations.
+  def purge_observations_matching_name(name)
+    matching_ids = Observation.names(lookup: [name.id],
+                                     include_synonyms: true).pluck(:id)
+    return if matching_ids.empty?
+
+    observations.where(id: matching_ids).
+      find_each { |obs| remove_observation(obs) }
+    project_excluded_observations.
+      where(observation_id: matching_ids).destroy_all
   end
 
   def imgs_to_delete(obs)
@@ -391,12 +428,15 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     # Already exists, no-op
   end
 
-  # Remove target name from this project.
+  # Remove target name from this project. Also removes observations
+  # matching this name (including synonyms) from both the project's
+  # observations and its excluded_observations lists.
   def remove_target_name(name)
     record = project_target_names.find_by(name: name)
     return unless record
 
     record.destroy
+    purge_observations_matching_name(name)
     touch
   end
 
@@ -473,9 +513,16 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   delegate :count, to: :candidate_observations, prefix: true
 
-  def new_candidate_observations_count
-    candidate_observations.where.not(id: observations.select(:id)).count
+  # Candidate observations not already in the project and not excluded.
+  # Used for the default Updates tab list and its badge count.
+  def new_candidate_observations
+    candidate_observations.
+      where.not(id: observations.select(:id)).
+      where.not(id: excluded_observations.select(:id))
   end
+
+  delegate :count, to: :new_candidate_observations,
+                   prefix: true, allow_nil: false
 
   def self.find_by_title_with_wildcards(str)
     find_using_wildcards("title", str)

--- a/app/models/project_excluded_observation.rb
+++ b/app/models/project_excluded_observation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Join table between projects and observations the project admin has
+# excluded from the project's Updates tab candidate list.
+class ProjectExcludedObservation < ApplicationRecord
+  belongs_to :project
+  belongs_to :observation
+end

--- a/app/views/controllers/observations/index.html.erb
+++ b/app/views/controllers/observations/index.html.erb
@@ -19,6 +19,7 @@ flash_error(@error) if @error && @objects.empty?
   <%= render(Components::MatrixTable.new(
     objects: @objects,
     user: @user,
-    cached: true
+    cached: true,
+    project: @project
   )) %>
 <% end %>

--- a/app/views/controllers/projects/updates/_footer_update.erb
+++ b/app/views/controllers/projects/updates/_footer_update.erb
@@ -1,5 +1,2 @@
-<%= turbo_stream.replace("update_footer_#{obs.id}") do %>
-  <%= render(Components::Projects::ObsFooter.new(
-               project: project, obs: obs, in_project: in_project
-             )) %>
-<% end %>
+<%= turbo_stream.remove("box_#{obs.id}") %>
+<%= turbo_stream.update("project_updates_count", count_label) %>

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -15,7 +15,8 @@ module Views
             @user = user
             @observations = results[:observations]
             @pagination = results[:pagination]
-            @base_url = results[:base_url]
+            @request_url = results[:request_url]
+            @form_action_url = results[:form_action_url]
             @current_count = results[:current_count]
             @show_excluded = show_excluded
           end
@@ -97,8 +98,8 @@ module Views
 
             render(Components::IndexPaginationNav.new(
                      pagination_data: @pagination,
-                     request_url: @base_url,
-                     form_action_url: @base_url,
+                     request_url: @request_url,
+                     form_action_url: @form_action_url,
                      q_params: nil,
                      letter_param: nil
                    ))

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -9,15 +9,15 @@ module Views
           register_output_helper :add_page_title
           register_value_helper :container_class
 
-          def initialize(project:, user:, results:)
+          def initialize(project:, user:, results:, show_excluded:)
             super()
             @project = project
             @user = user
             @observations = results[:observations]
             @pagination = results[:pagination]
-            @member_ids = results[:member_ids]
             @base_url = results[:base_url]
-            @new_count = results[:new_count]
+            @current_count = results[:current_count]
+            @show_excluded = show_excluded
           end
 
           def view_template
@@ -35,35 +35,59 @@ module Views
 
           def render_toolbar
             div(class: "d-flex justify-content-between " \
-                       "align-items-center mb-3") do
-              span do
-                :project_updates_count.t(count: @new_count)
-              end
-              div { render_bulk_buttons }
+                       "align-items-center mb-3 flex-wrap") do
+              render_count_and_toggle
+              div { render_add_all_button }
             end
           end
 
-          def render_bulk_buttons
+          def render_count_and_toggle
+            div(class: "d-flex align-items-center") do
+              span(id: "project_updates_count", class: "mr-3") do
+                plain(count_label)
+              end
+              render_show_excluded_toggle
+            end
+          end
+
+          def count_label
+            count_label_key.t(count: @current_count)
+          end
+
+          def count_label_key
+            return :project_updates_excluded_count if @show_excluded
+
+            :project_updates_count
+          end
+
+          def render_show_excluded_toggle
+            form(
+              action: project_updates_path(project_id: @project.id),
+              method: "get",
+              class: "form-inline mb-0 show-excluded-form",
+              data: { controller: "autosubmit",
+                      autosubmit_delay_value: "0" }
+            ) do
+              label(class: "checkbox-inline") do
+                input(type: "checkbox", name: "show_excluded", value: "1",
+                      checked: @show_excluded,
+                      data: { action: "change->autosubmit#submit" })
+                plain(" #{:project_updates_show_excluded.t}")
+              end
+            end
+          end
+
+          def render_add_all_button
             button_to(
               :project_updates_add_all.t,
               add_all_project_updates_path(
-                project_id: @project.id
+                project_id: @project.id,
+                show_excluded: @show_excluded
               ),
               method: :post,
-              class: "btn btn-default mr-2",
-              form: { data: {
-                turbo_confirm: :project_updates_confirm_add_all.t
-              } }
-            )
-            button_to(
-              :project_updates_clear.t,
-              clear_project_updates_path(
-                project_id: @project.id
-              ),
-              method: :delete,
               class: "btn btn-default",
               form: { data: {
-                turbo_confirm: :project_updates_confirm_clear.t
+                turbo_confirm: :project_updates_confirm_add_all.t
               } }
             )
           end
@@ -88,7 +112,7 @@ module Views
                        )) do
                   render(Components::Projects::ObsFooter.new(
                            project: @project, obs: obs,
-                           in_project: @member_ids.include?(obs.id)
+                           show_excluded: @show_excluded
                          ))
                 end
               end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -763,6 +763,8 @@
   edit: edit
   ENABLE: Enable
   enable: enable
+  EXCLUDE: Exclude
+  exclude: exclude
   IMPORT: Import
   INDEX_OBJECT: "[TYPE] [:INDEX]"
   # merge one object into another
@@ -3021,12 +3023,11 @@
   # Project Updates Tab
   project_updates_title: Update
   project_updates_count: "[count] matching observations"
+  project_updates_excluded_count: "[count] excluded observations"
+  project_updates_show_excluded: Show Excluded
   project_updates_add_all: Add All
-  project_updates_clear: Clear
   project_updates_confirm_add_all: Add all matching observations to this project?
-  project_updates_confirm_clear: Remove all matching observations from this project?
   project_updates_added_all: "Added [count] observations to this project."
-  project_updates_cleared: "Removed [count] observations from this project."
 
   ##############################################################################
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -689,11 +689,10 @@ MushroomObserver::Application.routes.draw do
                         controller: "projects/updates" do
       member do
         post :add_observation
-        delete :remove_observation
+        post :exclude_observation
       end
       collection do
         post :add_all
-        delete :clear
       end
     end
     resources :violations, only: [:index], controller: "projects/violations"

--- a/db/migrate/20260416192916_create_project_excluded_observations.rb
+++ b/db/migrate/20260416192916_create_project_excluded_observations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateProjectExcludedObservations < ActiveRecord::Migration[7.2]
+  def change
+    create_table(:project_excluded_observations) do |t|
+      t.integer(:observation_id, null: false)
+      t.integer(:project_id, null: false)
+    end
+
+    add_index(:project_excluded_observations, :observation_id,
+              name: "index_project_excluded_observations_on_observation_id")
+    add_index(:project_excluded_observations, :project_id,
+              name: "index_project_excluded_observations_on_project_id")
+    add_index(:project_excluded_observations, [:project_id, :observation_id],
+              unique: true,
+              name: "index_project_excluded_observations_on_project_and_obs")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_07_193046) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_16_192916) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -592,6 +592,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_193046) do
     t.index ["name", "project_id"], name: "index_project_aliases_on_name_and_project_id", unique: true
     t.index ["project_id"], name: "index_project_aliases_on_project_id"
     t.index ["target_type", "target_id"], name: "index_project_aliases_on_target_type_and_target_id"
+  end
+
+  create_table "project_excluded_observations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "observation_id", null: false
+    t.integer "project_id", null: false
+    t.index ["observation_id"], name: "index_project_excluded_observations_on_observation_id"
+    t.index ["project_id", "observation_id"], name: "index_project_excluded_observations_on_project_and_obs", unique: true
+    t.index ["project_id"], name: "index_project_excluded_observations_on_project_id"
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|

--- a/test/components/projects/obs_footer_test.rb
+++ b/test/components/projects/obs_footer_test.rb
@@ -4,22 +4,23 @@ require("test_helper")
 
 module Projects
   class ObsFooterTest < ComponentTestCase
-    def test_renders_add_button_when_not_in_project
-      html = render_footer(in_project: false)
+    def test_renders_add_and_exclude_buttons_by_default
+      html = render_footer(show_excluded: false)
+
+      assert_html(html, "#update_footer_#{obs.id}")
+      assert_includes(html, :ADD.l)
+      assert_includes(html, :EXCLUDE.l)
+      assert_html(html, "form[action*='add_observation']")
+      assert_html(html, "form[action*='exclude_observation']")
+    end
+
+    def test_renders_only_add_button_when_showing_excluded
+      html = render_footer(show_excluded: true)
 
       assert_html(html, "#update_footer_#{obs.id}")
       assert_includes(html, :ADD.l)
       assert_html(html, "form[action*='add_observation']")
-      assert_no_html(html, "form[action*='remove_observation']")
-    end
-
-    def test_renders_remove_button_when_in_project
-      html = render_footer(in_project: true)
-
-      assert_html(html, "#update_footer_#{obs.id}")
-      assert_includes(html, :REMOVE.l)
-      assert_html(html, "form[action*='remove_observation']")
-      assert_no_html(html, "form[action*='add_observation']")
+      assert_no_html(html, "form[action*='exclude_observation']")
     end
 
     private
@@ -32,9 +33,9 @@ module Projects
       observations(:coprinus_comatus_obs)
     end
 
-    def render_footer(in_project:)
+    def render_footer(show_excluded:)
       render(Components::Projects::ObsFooter.new(
-               project: project, obs: obs, in_project: in_project
+               project: project, obs: obs, show_excluded: show_excluded
              ))
     end
   end

--- a/test/controllers/projects/updates_controller_test.rb
+++ b/test/controllers/projects/updates_controller_test.rb
@@ -98,14 +98,28 @@ module Projects
       assert_includes(@project.excluded_observations.reload, @matching_obs)
     end
 
+    def test_add_observation_turbo_stream
+      post(:add_observation,
+           params: { project_id: @project.id,
+                     id: @matching_obs.id },
+           as: :turbo_stream)
+
+      assert_response(:success)
+      assert_includes(@project.observations.reload, @matching_obs)
+      assert_includes(@response.body, %(<turbo-stream action="remove"))
+      assert_includes(@response.body, %(<turbo-stream action="update"))
+    end
+
     def test_exclude_observation_turbo_stream
       post(:exclude_observation,
            params: { project_id: @project.id,
-                     id: @matching_obs.id,
-                     format: :turbo_stream })
+                     id: @matching_obs.id },
+           as: :turbo_stream)
 
       assert_response(:success)
       assert_includes(@project.excluded_observations.reload, @matching_obs)
+      assert_includes(@response.body, %(<turbo-stream action="remove"))
+      assert_includes(@response.body, %(<turbo-stream action="update"))
     end
 
     def test_exclude_observation_not_found

--- a/test/controllers/projects/updates_controller_test.rb
+++ b/test/controllers/projects/updates_controller_test.rb
@@ -7,8 +7,8 @@ module Projects
     def setup
       super
       @project = projects(:rare_fungi_project)
-      # Add an observation matching a target name
-      @matching_obs = observations(:coprinus_comatus_obs)
+      # An observation matching a target name AND target location
+      @matching_obs = observations(:agaricus_campestris_obs)
       login("rolf")
     end
 
@@ -19,14 +19,12 @@ module Projects
     end
 
     def test_index_with_pagination
-      # Create extra candidates matching both target name and location
       burbank = locations(:burbank)
       name = names(:coprinus_comatus)
       2.times do
         Observation.create!(name: name, user: users(:rolf),
                             location: burbank, when: Time.zone.now)
       end
-      # Set layout_count to 1 so pagination triggers
       users(:rolf).update!(layout_count: 1)
 
       get(:index, params: { project_id: @project.id })
@@ -42,8 +40,19 @@ module Projects
       assert_redirected_to(project_path(@project))
     end
 
-    def test_index_shows_matching_observations
+    def test_index_default_hides_excluded
+      @project.exclude_observation(@matching_obs)
+
       get(:index, params: { project_id: @project.id })
+
+      assert_response(:success)
+      assert_not_includes(assigns_matrix_observations, @matching_obs)
+    end
+
+    def test_index_show_excluded
+      @project.exclude_observation(@matching_obs)
+
+      get(:index, params: { project_id: @project.id, show_excluded: "1" })
 
       assert_response(:success)
     end
@@ -58,60 +67,73 @@ module Projects
       assert_includes(@project.observations.reload, @matching_obs)
     end
 
-    def test_add_observation_turbo_stream
+    def test_add_observation_un_excludes
+      @project.exclude_observation(@matching_obs)
+      assert_includes(@project.excluded_observations, @matching_obs)
+
       post(:add_observation,
+           params: { project_id: @project.id,
+                     id: @matching_obs.id })
+
+      assert_not_includes(@project.excluded_observations.reload, @matching_obs)
+      assert_includes(@project.observations.reload, @matching_obs)
+    end
+
+    def test_exclude_observation
+      post(:exclude_observation,
+           params: { project_id: @project.id,
+                     id: @matching_obs.id })
+
+      assert_includes(@project.excluded_observations.reload, @matching_obs)
+    end
+
+    def test_exclude_observation_from_project
+      @project.add_observation(@matching_obs)
+
+      post(:exclude_observation,
+           params: { project_id: @project.id,
+                     id: @matching_obs.id })
+
+      assert_not_includes(@project.observations.reload, @matching_obs)
+      assert_includes(@project.excluded_observations.reload, @matching_obs)
+    end
+
+    def test_exclude_observation_turbo_stream
+      post(:exclude_observation,
            params: { project_id: @project.id,
                      id: @matching_obs.id,
                      format: :turbo_stream })
 
       assert_response(:success)
-      assert_includes(@project.observations.reload, @matching_obs)
+      assert_includes(@project.excluded_observations.reload, @matching_obs)
     end
 
-    def test_remove_observation
-      @project.add_observation(@matching_obs)
-      assert_includes(@project.observations, @matching_obs)
+    def test_exclude_observation_not_found
+      post(:exclude_observation,
+           params: { project_id: @project.id,
+                     id: 999_999 })
 
-      delete(:remove_observation,
-             params: { project_id: @project.id,
-                       id: @matching_obs.id })
-
-      assert_not_includes(@project.observations.reload, @matching_obs)
-    end
-
-    def test_remove_observation_turbo_stream
-      @project.add_observation(@matching_obs)
-
-      delete(:remove_observation,
-             params: { project_id: @project.id,
-                       id: @matching_obs.id,
-                       format: :turbo_stream })
-
-      assert_response(:success)
-      assert_not_includes(@project.observations.reload, @matching_obs)
+      assert_response(:not_found)
     end
 
     def test_add_all
       post(:add_all, params: { project_id: @project.id })
 
       assert_redirected_to(
-        project_updates_path(project_id: @project.id)
+        project_updates_path(project_id: @project.id,
+                             show_excluded: false)
       )
       assert_flash(/Added/)
     end
 
-    def test_clear
-      # Use an obs that matches both target name AND target location
-      candidate = observations(:agaricus_campestris_obs)
-      @project.add_observation(candidate)
+    def test_add_all_with_show_excluded
+      @project.exclude_observation(@matching_obs)
 
-      delete(:clear, params: { project_id: @project.id })
+      post(:add_all, params: { project_id: @project.id,
+                               show_excluded: "1" })
 
-      assert_redirected_to(
-        project_updates_path(project_id: @project.id)
-      )
-      assert_flash(/Removed/)
-      assert_not_includes(@project.observations.reload, candidate)
+      assert_includes(@project.observations.reload, @matching_obs)
+      assert_not_includes(@project.excluded_observations.reload, @matching_obs)
     end
 
     def test_add_observation_not_found
@@ -122,12 +144,14 @@ module Projects
       assert_response(:not_found)
     end
 
-    def test_remove_observation_not_found
-      delete(:remove_observation,
-             params: { project_id: @project.id,
-                       id: 999_999 })
+    private
 
-      assert_response(:not_found)
+    # Helper to pull observations from the rendered view for assertions.
+    def assigns_matrix_observations
+      # Parse matrix box ids from response body.
+      response.body.scan(/id="box_(\d+)"/).map do |match|
+        Observation.find(match.first.to_i)
+      end
     end
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -336,4 +336,73 @@ class ProjectTest < UnitTestCase
     assert(proj.errors[:field_slip_prefix].any?,
            "Should reject invalid field_slip_prefix")
   end
+
+  def test_exclude_and_unexclude_observation
+    proj = projects(:rare_fungi_project)
+    obs = observations(:agaricus_campestris_obs)
+
+    proj.exclude_observation(obs)
+    assert_includes(proj.excluded_observations.reload, obs)
+    assert_not_includes(proj.observations.reload, obs)
+
+    proj.unexclude_observation(obs)
+    assert_not_includes(proj.excluded_observations.reload, obs)
+  end
+
+  def test_exclude_observation_removes_from_project
+    proj = projects(:rare_fungi_project)
+    obs = observations(:agaricus_campestris_obs)
+    proj.add_observation(obs)
+    assert_includes(proj.observations.reload, obs)
+
+    proj.exclude_observation(obs)
+    assert_not_includes(proj.observations.reload, obs)
+    assert_includes(proj.excluded_observations.reload, obs)
+  end
+
+  def test_add_observation_removes_from_excluded
+    proj = projects(:rare_fungi_project)
+    obs = observations(:agaricus_campestris_obs)
+    proj.exclude_observation(obs)
+    assert_includes(proj.excluded_observations.reload, obs)
+
+    proj.add_observation(obs)
+    assert_includes(proj.observations.reload, obs)
+    assert_not_includes(proj.excluded_observations.reload, obs)
+  end
+
+  def test_new_candidate_observations_excludes_excluded
+    proj = projects(:rare_fungi_project)
+    obs = observations(:agaricus_campestris_obs)
+    assert_includes(proj.new_candidate_observations, obs)
+
+    proj.exclude_observation(obs)
+    assert_not_includes(proj.new_candidate_observations.reload, obs)
+  end
+
+  def test_new_candidate_observations_excludes_in_project
+    proj = projects(:rare_fungi_project)
+    obs = observations(:agaricus_campestris_obs)
+    proj.add_observation(obs)
+    assert_not_includes(proj.new_candidate_observations.reload, obs)
+  end
+
+  def test_remove_target_name_purges_matching_observations
+    proj = projects(:rare_fungi_project)
+    matching_name = names(:agaricus_campestris)
+    added_obs = observations(:agaricus_campestris_obs)
+    excluded_obs = Observation.create!(
+      name: matching_name, user: users(:rolf),
+      location: locations(:burbank), when: Time.zone.now
+    )
+    proj.add_observation(added_obs)
+    proj.exclude_observation(excluded_obs)
+    assert_includes(proj.observations.reload, added_obs)
+    assert_includes(proj.excluded_observations.reload, excluded_obs)
+
+    proj.remove_target_name(matching_name)
+
+    assert_not_includes(proj.observations.reload, added_obs)
+    assert_not_includes(proj.excluded_observations.reload, excluded_obs)
+  end
 end


### PR DESCRIPTION
Fixes #4134.

## Summary
- Updates tab now lists only candidate observations that are not already in the project and not in a new `excluded_observations` list, with a Show Excluded toggle to view (and re-add from) the excluded list.
- Project admins can Exclude an observation from the Updates tab and from the project-filtered Observations tab (`/observations?project=N`). Adding an excluded observation clears it from the excluded list.
- Removing a target name now purges matching observations (including synonyms) from both `observations` and `excluded_observations`.
- Clear button and Remove button on the Updates tab are gone; `project_observations` list is managed by Add / Exclude transitions instead.

## Changes
- New `project_excluded_observations` join table (mirrors `project_observations`) and `ProjectExcludedObservation` model.
- `Project#exclude_observation`, `#unexclude_observation`, `#purge_observations_matching_name`; `#add_observation` un-excludes on add; `#new_candidate_observations` scope subtracts both in-project and excluded.
- `UpdatesController`: new `exclude_observation` action, removed `clear` and `remove_observation`; `index` respects `show_excluded` param; HTML fallback uses `redirect_back` so Exclude on the Observations tab doesn't flip tabs.
- `MatrixBox` / `MatrixTable` accept an optional `project:` prop; admin-only Exclude button renders on project-filtered observation boxes, fragment caching is bypassed when a project context is present.
- Locale keys added (`EXCLUDE`, `project_updates_show_excluded`, `project_updates_excluded_count`) and obsolete clear-related keys removed.

## Test plan
- [x] Model tests: exclude/unexclude, add removes from excluded, new_candidate_observations subtracts both sets, remove_target_name purges both lists.
- [x] Controller tests: new `exclude_observation` action, `show_excluded` filter, add un-excludes, `add_all` with show_excluded.
- [x] Component tests: ObsFooter renders Add+Exclude by default, Add only when showing excluded.
- [ ] Manual: verify the Show Excluded checkbox auto-submits and the Exclude turbo_stream stays on each tab.
- [ ] Manual: verify removing a target name clears matching observations from both the project list and the excluded list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)