### PR TITLE
Map popups: thumbnail + taxon + date + confidence; colored markers

### DIFF
--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -59,3 +59,99 @@
   height:      15px;
   background-position: 0px 15px;
 }
+
+//
+// Google Maps InfoWindow popup content (issue #4131).
+// Tighten the default iw chrome and style the .media popup for
+// single-observation markers so the image and text sit snug together.
+//
+.gm-style-iw-c {
+  padding: 0 !important;
+}
+.gm-style-iw-d {
+  overflow: auto !important;
+  padding: 12px 12px 8px;
+}
+.gm-style-iw-chr {
+  // Pull the close-X to the top-right corner without reserving a full
+  // header row above the content.
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+}
+
+.map-popup {
+  font-size: 13px;
+  line-height: 1.35;
+  min-width: 200px;
+  max-width: 320px;
+
+  a { color: $link-color; }
+
+  // Thumbnail link + image — strip everything that could draw an edge
+  // (link underline, Bootstrap .thumbnail styling, focus outline, box
+  // shadow). Do NOT touch .media-left itself — its display:table-cell
+  // is what makes the Bootstrap .media layout keep text on the right.
+  .media-left a,
+  .media-object.map-popup-thumb {
+    display: block !important;
+    text-decoration: none !important;
+    border: 0 !important;
+    outline: 0 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    background: transparent !important;
+  }
+
+  .media-object.map-popup-thumb {
+    width: 72px;
+    height: 72px;
+    object-fit: cover;
+    border-radius: 4px !important;
+    margin: 0;
+    vertical-align: top;
+  }
+
+  .media-heading {
+    font-size: 14px;
+    margin: 0 0 2px;
+  }
+
+  .small {
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  // "N Observations [Show All] [Map All]" row sits on its own line
+  // with a little breathing room before the name links below it.
+  .map-popup-header {
+    margin-bottom: 8px;
+  }
+
+  // Show All / Map All buttons inside group popups. Native browser
+  // focus outline is distracting when it persists after clicking
+  // inside a small popup; suppress it and use a subtle box-shadow
+  // only on :focus-visible (keyboard-only) for accessibility.
+  .map-popup-btn {
+    margin-left: 6px;
+
+    &:focus { outline: 0; }
+    &:focus-visible {
+      outline: 0;
+      box-shadow: 0 0 0 2px rgba(59, 121, 204, 0.4);
+    }
+  }
+}
+
+.map-popup-single {
+  padding-right: 20px; // room for the close X
+}
+
+.map-popup-group {
+  padding-right: 20px; // room for the close X
+  > span + span::before,
+  > a + a::before {
+    content: none;
+  }
+}

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -152,10 +152,16 @@
     display: block !important;
     text-decoration: none !important;
     border: 0 !important;
-    outline: 0 !important;
     box-shadow: none !important;
     padding: 0 !important;
     background: transparent !important;
+  }
+
+  // Suppress only the persistent mouse-click outline; keep the
+  // browser's default keyboard-focus indicator on :focus-visible so
+  // keyboard users still see where focus lands.
+  .media-left a:focus:not(:focus-visible) {
+    outline: 0;
   }
 
   .media-object.map-popup-thumb {
@@ -183,17 +189,18 @@
     margin-bottom: 8px;
   }
 
-  // Show All / Map All buttons inside group popups. Native browser
-  // focus outline is distracting when it persists after clicking
-  // inside a small popup; suppress it and use a subtle box-shadow
-  // only on :focus-visible (keyboard-only) for accessibility.
+  // Show All / Map All buttons inside group popups. The native focus
+  // outline is distracting when it persists after a mouse click in a
+  // small popup; suppress it only for that case via
+  // :focus:not(:focus-visible). Keyboard users still get the browser's
+  // default focus indicator (via :focus-visible), and the rule also
+  // degrades gracefully in browsers without :focus-visible support
+  // (the whole rule is ignored, so outlines remain everywhere).
   .map-popup-btn {
     margin-left: 6px;
 
-    &:focus { outline: 0; }
-    &:focus-visible {
+    &:focus:not(:focus-visible) {
       outline: 0;
-      box-shadow: 0 0 0 2px rgba(59, 121, 204, 0.4);
     }
   }
 }

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -81,6 +81,60 @@
   z-index: 2;
 }
 
+// Map container sizing (#4131 follow-up).
+//
+// Keep the 3:2 aspect ratio for narrow viewports, but cap the height
+// relative to the browser window so the map + legend still fit on
+// screen when the window is wide (e.g. a typical laptop where 66% of
+// a wide content column would overflow the viewport).
+//
+// Using CSS aspect-ratio rather than the old padding-bottom trick —
+// padding isn't constrained by max-height, so the previous attempt
+// silently did nothing on wide windows.
+.map-container {
+  aspect-ratio: 3 / 2;
+  max-height: calc(100vh - 240px); // leaves room for nav + title + legend
+  min-height: 300px;
+}
+
+// Legend rendered under every map by MapHelper#map_legend (#4131).
+// Two rows: shape meanings (circle vs. box) then color meanings
+// (consensus bands + group).
+.map-legend {
+  .map-legend-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+    margin-top: 4px;
+  }
+
+  .map-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+  }
+
+  .map-legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 1px solid #888;
+    background: transparent;
+    flex-shrink: 0;
+  }
+
+  .map-legend-circle {
+    border-radius: 50%;
+  }
+  // .map-legend-box swatch is the default square .map-legend-swatch.
+
+  .map-legend-dot {
+    border: 0;
+    border-radius: 50%;
+  }
+}
+
 .map-popup {
   font-size: 13px;
   line-height: 1.35;

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -118,26 +118,30 @@ module Mappable
     # Objects may be observations, or Mappable::MinimalLocations/Observations,
     # whose properties are different. Names::MapsController#show sends obs.
     #
-    # For single observations, this always returns points if we have lat/lng...
-    # ignores "dubiousness" when the point disagrees with location.
-    #
-    # For maps of multiple observations, it returns only sets of location boxes.
-    # Even though points are noticeable at any zoom, they may get collapsed with
-    # other nearby points into tiny boxes, becoming undetectable on the map.
+    # Shape semantics:
+    # - Obs with unambiguous GPS → point (circle on the map).
+    # - Obs without GPS but with a known location → box at that
+    #   location's edges (represents the area the obs is known to be
+    #   within, not a pinpoint).
+    # - Bare Location → box at the location's edges.
+    # The old behavior demoted all obs to boxes once the collection
+    # exceeded max_objects; we removed that because the
+    # map_controller.js now falls back to a colored square marker when
+    # multiple points collapse into a sub-pixel box during grouping
+    # (#4131). Obs-with-GPS always stays a circle.
     def init_sets(objects)
       objects = [objects] unless objects.is_a?(Array)
       raise("Tried to create empty map!") if objects.empty?
 
       @sets = {}
       is_collection = objects.many?
-      will_be_grouped = objects.count > @max_objects
       objects.each do |obj|
         loc = obj.location? ? obj : obj.location
         mappable = mappable_location?(is_collection, loc)
         if obj.location? && mappable
           add_box_set(loc, [obj], MAX_PRECISION)
         elsif obj.observation?
-          if (!will_be_grouped || !loc) && obj.lat # && !obj.lat_lng_dubious?
+          if obj.lat && !obj.lat_lng_dubious?
             add_point_set(obj, [obj], MAX_PRECISION)
           elsif loc && mappable
             add_box_set(loc, [obj], MAX_PRECISION)

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -27,10 +27,19 @@
 #
 module Mappable
   class MapSet
+    # Marker colors used in the map popup enhancement (issue #4131).
+    # Groups / multi-observation / box markers get the neutral blue.
+    # Single-observation markers use a traffic-light palette based on the
+    # consensus vote percentage.
+    GROUP_COLOR = "#3B79CC" # bootstrap primary
+    CONFIRMED_COLOR = "#5CB85C" # >=80% — bootstrap success
+    TENTATIVE_COLOR = "#F0AD4E" # 0<x<80% — bootstrap warning
+    DISPUTED_COLOR  = "#D9534F" # <=0% — bootstrap danger
+
     attr_reader :north, :south, :east, :west, :is_point, :is_box,
                 :north_east, :south_east, :south_west, :north_west, :lat, :lng,
                 :north_south_distance, :east_west_distance, :center, :edges
-    attr_accessor :objects, :title, :caption
+    attr_accessor :objects, :title, :caption, :color
 
     def initialize(objects = [])
       @objects = objects.is_a?(Array) ? objects : [objects]
@@ -60,6 +69,28 @@ module Mappable
     # NOTE: does not update extents!
     def add_objects(objects)
       @objects += objects
+    end
+
+    # True iff the set represents exactly one observation. A set may
+    # also contain a Location object (the obs's location, bucketed
+    # into the same geographic cell), so count observations rather
+    # than all @objects — otherwise single-obs sets that were
+    # bucketed with their location get colored as groups.
+    def single_observation?
+      observations.length == 1
+    end
+
+    # Hex color chosen for the marker/box and the popup dot.
+    # - Blue for groups (>1 observation or location-only).
+    # - Single observations: traffic-light based on consensus %.
+    def compute_color
+      return GROUP_COLOR unless single_observation?
+
+      pct = ::Vote.percent(observations.first.vote_cache)
+      return DISPUTED_COLOR if pct <= 0
+      return CONFIRMED_COLOR if pct >= 80
+
+      TENTATIVE_COLOR
     end
 
     def observations

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -80,7 +80,7 @@ module Mappable
       observations.length == 1
     end
 
-    # Hex color chosen for the marker/box and the popup dot.
+    # Hex color for the marker or box stroke.
     # - Blue for groups (>1 observation or location-only).
     # - Single observations: traffic-light based on consensus %.
     def compute_color

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -223,7 +223,10 @@ class Components::Map < Components::Base
     text = obs.respond_to?(:text_name) ? obs.text_name : nil
     text = obs.name.text_name if text.blank? && obs.respond_to?(:name) &&
                                  obs.name.respond_to?(:text_name)
-    return ERB::Util.html_escape(text.to_s.t) if text.present?
+    # `.t` returns html_safe textile output; don't wrap in html_escape
+    # again (double-escape potential on any `&` the input contains, and
+    # redundant with Rails' safe-buffer handling).
+    return text.to_s.t if text.present?
 
     "#{:Observation.t} ##{obs.id}"
   end

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -178,13 +178,15 @@ class Components::Map < Components::Base
     obs.when.web_date.to_s
   end
 
-  # Plain-text confidence line. The marker color is the visual cue; the
-  # popup just names the percentage.
+  # Plain-text confidence line. The marker color is the visual cue;
+  # the popup just names the percentage. `.floor` keeps the text from
+  # crossing a traffic-light threshold ahead of the underlying value
+  # (e.g. 79.6% should read "79%", not "80%").
   def consensus_indicator(obs)
     return nil unless obs.respond_to?(:vote_cache)
 
     pct = ::Vote.percent(obs.vote_cache)
-    ERB::Util.html_escape("#{:Confidence.t}: #{pct.round}%")
+    ERB::Util.html_escape("#{:Confidence.t}: #{pct.floor}%")
   end
 
   def location_line(set)

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -21,6 +21,8 @@ class Components::Map < Components::Base
   include Phlex::Rails::Helpers::ContentTag
   include Phlex::Rails::Helpers::LinkTo
 
+  MAX_GROUP_NAMES = 3
+
   prop :objects, _Array(_Any), default: -> { [] }
   prop :user, _Nilable(User), default: nil
   prop :map_div, String, default: "map_div"
@@ -94,6 +96,7 @@ class Components::Map < Components::Base
   def mappable_collection
     collection = Mappable::CollapsibleCollectionOfObjects.new(mappable_objects)
     collection.sets.each_value do |mapset|
+      mapset.color = mapset.compute_color
       mapset.title = mapset_marker_title(mapset)
       mapset.caption = mapset_info_window(mapset)
       mapset.objects = nil
@@ -131,25 +134,57 @@ class Components::Map < Components::Base
     end.uniq
   end
 
-  # Info window content for map marker popup
+  # Info window content for map marker popup. Enhanced for issue #4131
+  # (see MapHelper#mapset_info_window for the parallel implementation
+  # used by non-Phlex callers).
   def mapset_info_window(set)
     lines = []
-    lines << observation_line(set)
+    lines.concat(observation_lines(set)).compact!
     lines << location_line(set)
     lines << mapset_coords(set)
     lines.compact.join("<br>")
   end
 
-  def observation_line(set)
+  def observation_lines(set)
     observations = set.observations
-    return mapset_observation_header(set) if observations.length > 1
-    return mapset_observation_link(observations.first) if single_obs?(set)
-
-    nil
+    if observations.length == 1 && observations.first&.id
+      single_observation_lines(observations.first, set)
+    elsif observations.length > 1
+      [mapset_observation_header(set), *group_name_links(observations)]
+    else
+      []
+    end
   end
 
-  def single_obs?(set)
-    set.observations.length == 1 && set.observations.first&.id
+  def single_observation_lines(obs, _set)
+    [
+      mapset_observation_link(obs),
+      obs_date(obs),
+      consensus_indicator(obs)
+    ].compact
+  end
+
+  def group_name_links(observations)
+    sorted = observations.sort_by { |o| [o.when || Date.new(0), o.id] }.reverse
+    top = sorted.first(MAX_GROUP_NAMES)
+    links = top.map { |o| mapset_observation_link(o) }
+    links << "<span>…</span>" if sorted.length > MAX_GROUP_NAMES
+    links
+  end
+
+  def obs_date(obs)
+    return nil unless obs.respond_to?(:when) && obs.when.present?
+
+    obs.when.web_date.to_s
+  end
+
+  # Plain-text confidence line. The marker color is the visual cue; the
+  # popup just names the percentage.
+  def consensus_indicator(obs)
+    return nil unless obs.respond_to?(:vote_cache)
+
+    pct = ::Vote.percent(obs.vote_cache)
+    ERB::Util.html_escape("#{:Confidence.t}: #{pct.round}%")
   end
 
   def location_line(set)
@@ -165,18 +200,30 @@ class Components::Map < Components::Base
   end
 
   def mapset_observation_header(set)
-    count = set.observations.length
-    "#{:Observations.t}: #{count}"
+    "#{:Observations.t}: #{set.observations.length}"
   end
 
   def mapset_location_header(set)
-    count = set.underlying_locations.length
-    "#{:Locations.t}: #{count}"
+    "#{:Locations.t}: #{set.underlying_locations.length}"
   end
 
+  # Observation link — opens in a new tab (issue #4131 request #2).
+  # Prefers the consensus text_name when available for clarity; falls
+  # back to "Observation #<id>" for callers that didn't load a name.
   def mapset_observation_link(obs)
     url = observation_path(id: obs.id)
-    "<a href=\"#{url}\">#{:Observation.t} ##{obs.id}</a>"
+    label = observation_label(obs)
+    "<a href=\"#{url}\" target=\"_blank\" rel=\"noopener noreferrer\">" \
+      "#{label}</a>"
+  end
+
+  def observation_label(obs)
+    text = obs.respond_to?(:text_name) ? obs.text_name : nil
+    text = obs.name.text_name if text.blank? && obs.respond_to?(:name) &&
+                                 obs.name.respond_to?(:text_name)
+    return ERB::Util.html_escape(text.to_s.t) if text.present?
+
+    "#{:Observation.t} ##{obs.id}"
   end
 
   def mapset_location_link(loc)

--- a/app/controllers/names/maps_controller.rb
+++ b/app/controllers/names/maps_controller.rb
@@ -16,8 +16,10 @@ module Names
 
       @query = find_or_create_query(:Observation, names: { lookup: @name.id })
       @any_content_filters_applied = check_if_preference_filters_applied
+      # Popups hit `obs.name.display_name` for the species label, so
+      # eager-load :name alongside :location to avoid N+1 (#4131).
       @observations = @query.scope.limit(MO.query_max_array).
-                      includes(:location).
+                      includes(:location, :name).
                       select { |o| o.lat || o.location }
     end
   end

--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -31,11 +31,18 @@ module Observations
       end
 
       @observations = [
-        Mappable::MinimalObservation.new(id: @observation.id,
-                                         lat: lat,
-                                         lng: lng,
-                                         location: @observation.location,
-                                         location_id: @observation.location_id)
+        Mappable::MinimalObservation.new(
+          id: @observation.id,
+          lat: lat, lng: lng,
+          location: @observation.location,
+          location_id: @observation.location_id,
+          name_id: @observation.name_id,
+          text_name: @observation.name&.text_name,
+          display_name: @observation.name&.display_name,
+          when: @observation.when,
+          vote_cache: @observation.vote_cache,
+          thumb_image_id: @observation.thumb_image_id
+        )
       ]
     end
 
@@ -43,24 +50,31 @@ module Observations
 
     def find_locations_matching_observations
       location_ids = Set[]
-      columns = [:id, :lat, :lng, :gps_hidden, :location_id].map do |col|
-        Observation[col]
-      end
+      name_ids = Set[]
       minimal_obs_query = @query.scope.
                           where(Observation[:lat].not_eq(nil).
                                 or(Observation[:location_id].not_eq(nil))).
-                          limit(MO.query_max_array).select(*columns)
+                          limit(MO.query_max_array).
+                          select(*minimal_obs_columns)
       @observations = minimal_obs_query.map do |obs|
         obs = obs.attributes.symbolize_keys!
-        # Adding this to the set is a flag to look up the location. Because we
-        # selected obs attributes not instances, we can't call `obs.location`
-        # and we shouldn't anyway. Getting the Locations in bulk is quicker.
         location_ids << obs[:location_id].to_i if obs[:location_id].present?
+        name_ids << obs[:name_id].to_i if obs[:name_id].present?
         obs[:lat] = obs[:lng] = nil if obs[:gps_hidden].to_s.to_boolean == true
         Mappable::MinimalObservation.new(obs.except(:gps_hidden))
       end
 
       eager_load_related_locations(location_ids) unless location_ids.empty?
+      eager_load_related_names(name_ids) unless name_ids.empty?
+    end
+
+    # Columns selected for minimal-observation map rendering. `name_id`,
+    # `when`, `vote_cache`, and `thumb_image_id` are used by popup
+    # content for #4131.
+    def minimal_obs_columns
+      [:id, :lat, :lng, :gps_hidden, :location_id,
+       :name_id, :when, :vote_cache, :thumb_image_id].
+        map { |c| Observation[c] }
     end
 
     def eager_load_related_locations(location_ids)
@@ -74,6 +88,18 @@ module Observations
 
       @observations.each do |obs|
         obs.location = locations[obs.location_id] if obs.location_id
+      end
+    end
+
+    def eager_load_related_names(name_ids)
+      rows = Name.where(id: name_ids).
+             pluck(:id, :text_name, :display_name).
+             to_h { |id, text, display| [id, [text, display]] }
+      @observations.each do |obs|
+        next unless (pair = rows[obs.name_id])
+
+        obs.text_name = pair[0]
+        obs.display_name = pair[1]
       end
     end
   end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -135,9 +135,13 @@ module MapHelper
     url = observation_path(id: obs.id, params: q)
     tag.div(class: "media-left pr-2") do
       link_to(url, target: "_blank", rel: "noopener noreferrer") do
+        # Empty alt: the adjacent taxon-name link inside the same
+        # .media already provides the accessible label, so the
+        # thumbnail is decorative in this context.
         image_tag(Image.url(:small, obs.thumb_image_id),
                   class: "media-object map-popup-thumb",
-                  loading: "lazy")
+                  loading: "lazy",
+                  alt: "")
       end
     end
   end
@@ -190,11 +194,16 @@ module MapHelper
 
   # Plain-text "Confidence: NN%" line. The marker color already conveys
   # the semantic bucket, so no dot/pill is needed inside the popup.
+  #
+  # Use `.floor` so the displayed percentage never crosses a
+  # traffic-light threshold the underlying value hasn't crossed yet
+  # — e.g. 79.6% should show "79%" with an orange marker, never
+  # "80%" (which would look like the green/confirmed bucket).
   def mapset_consensus_indicator(obs)
     return nil unless obs.respond_to?(:vote_cache)
 
     pct = ::Vote.percent(obs.vote_cache)
-    "#{:Confidence.t}: #{pct.round}%"
+    "#{:Confidence.t}: #{pct.floor}%"
   end
 
   def mapset_observation_header(set)

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module MapHelper
+  include MapLegendHelper
+
   # args could include query_param.
   # returns an array of mapsets, each suitable for a marker or box
   def make_map(objects: [], **args)
@@ -32,7 +34,7 @@ module MapHelper
       show_all: :show_all.t,
       map_all: :map_all.t
     }.to_json
-    map_html(map_args)
+    safe_join([map_html(map_args), map_legend])
   end
 
   # Returns a CollapsibleCollection of mapsets, containing all data necessary
@@ -59,8 +61,7 @@ module MapHelper
   end
 
   def map_html(map_args)
-    tag.div(class: "w-100 position-relative",
-            style: "padding-bottom: 66%;") do
+    tag.div(class: "w-100 position-relative map-container") do
       tag.div(
         "",
         id: map_args[:map_div],

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -134,7 +134,7 @@ module MapHelper
 
     q = args[:query_param] ? { q: args[:query_param] } : {}
     url = observation_path(id: obs.id, params: q)
-    tag.div(class: "media-left pr-2") do
+    tag.div(class: "media-left") do
       link_to(url, target: "_blank", rel: "noopener noreferrer") do
         # Empty alt: the adjacent taxon-name link inside the same
         # .media already provides the accessible label, so the

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -49,6 +49,7 @@ module MapHelper
   def mappable_collection(objects, args)
     collection = Mappable::CollapsibleCollectionOfObjects.new(objects)
     collection.sets.map do |_key, mapset|
+      mapset.color = mapset.compute_color
       mapset.title = mapset_marker_title(mapset)
       mapset.caption = mapset_info_window(mapset, args)
       mapset.objects = nil # can't delete, it's part of the MapSet object
@@ -104,34 +105,121 @@ module MapHelper
     end.compact_blank.uniq
   end
 
+  # Info window popup content. Enhanced for #4131 to match iNat's
+  # denser layout — Bootstrap .media object with a thumbnail on the
+  # left and details on the right for a single observation; a compact
+  # vertical list for groups.
+  MAX_GROUP_NAMES = 3
+
   def mapset_info_window(set, args)
-    lines = []
+    observations = set.observations
+    if observations.length == 1 && observations.first&.id
+      mapset_single_observation_popup(observations.first, set, args)
+    else
+      mapset_group_popup(set, args)
+    end
+  end
+
+  def mapset_single_observation_popup(obs, set, args)
+    tag.div(class: "media map-popup map-popup-single") do
+      concat(mapset_thumbnail_media_left(obs, args))
+      concat(mapset_single_observation_body(obs, set, args))
+    end
+  end
+
+  def mapset_thumbnail_media_left(obs, args)
+    return safe_join([]) unless obs.respond_to?(:thumb_image_id) &&
+                                obs.thumb_image_id
+
+    q = args[:query_param] ? { q: args[:query_param] } : {}
+    url = observation_path(id: obs.id, params: q)
+    tag.div(class: "media-left pr-2") do
+      link_to(url, target: "_blank", rel: "noopener noreferrer") do
+        image_tag(Image.url(:small, obs.thumb_image_id),
+                  class: "media-object map-popup-thumb",
+                  loading: "lazy")
+      end
+    end
+  end
+
+  def mapset_single_observation_body(obs, set, args)
+    tag.div(class: "media-body") do
+      concat(tag.div(mapset_observation_link(obs, args),
+                     class: "media-heading"))
+      date = mapset_observation_date(obs)
+      concat(tag.div(date, class: "small")) if date
+      conf = mapset_consensus_indicator(obs)
+      concat(tag.div(conf, class: "small")) if conf
+      locations = set.underlying_locations
+      if locations.length == 1 && locations.first&.id
+        concat(tag.div(mapset_location_link(locations.first, args),
+                       class: "small"))
+      end
+      concat(tag.div(mapset_coords(set), class: "small text-muted"))
+    end
+  end
+
+  def mapset_group_popup(set, args)
     observations = set.observations
     locations = set.underlying_locations
+    lines = []
     lines << mapset_observation_header(set) if observations.length > 1
+    lines.concat(mapset_group_name_links(observations, args))
     lines << mapset_location_header(set) if locations.length > 1
-    if observations.length == 1 && observations.first&.id
-      lines << mapset_observation_link(observations.first, args)
-    end
-    if locations.length == 1 && locations.first&.id # obj maybe not saved yet
+    if locations.length == 1 && locations.first&.id
       lines << mapset_location_link(locations.first, args)
     end
     lines << mapset_coords(set)
-    lines.safe_join(safe_br)
+    tag.div(lines.safe_join(safe_br), class: "map-popup map-popup-group")
+  end
+
+  def mapset_group_name_links(observations, args)
+    sorted = observations.sort_by { |o| [o.when || Date.new(0), o.id] }.reverse
+    top = sorted.first(MAX_GROUP_NAMES)
+    links = top.map { |o| mapset_observation_link(o, args) }
+    links << tag.span("…") if sorted.length > MAX_GROUP_NAMES
+    links
+  end
+
+  def mapset_observation_date(obs)
+    return nil if obs.respond_to?(:when) && obs.when.blank?
+    return nil unless obs.respond_to?(:when)
+
+    obs.when.web_date
+  end
+
+  # Plain-text "Confidence: NN%" line. The marker color already conveys
+  # the semantic bucket, so no dot/pill is needed inside the popup.
+  def mapset_consensus_indicator(obs)
+    return nil unless obs.respond_to?(:vote_cache)
+
+    pct = ::Vote.percent(obs.vote_cache)
+    "#{:Confidence.t}: #{pct.round}%"
   end
 
   def mapset_observation_header(set)
     show, map = mapset_associated_links(set, :observation)
-    map_point_text(:Observations.t, set.observations.length, show, map)
+    tag.div(
+      map_point_text(:Observations.t, set.observations.length, show, map),
+      class: "map-popup-header"
+    )
   end
 
   def mapset_location_header(set)
     show, map = mapset_associated_links(set, :location)
-    map_point_text(:Locations.t, set.underlying_locations.length, show, map)
+    tag.div(
+      map_point_text(:Locations.t, set.underlying_locations.length, show, map),
+      class: "map-popup-header"
+    )
   end
 
+  # Count-first phrasing: "2 Observations [Show All] [Map All]".
+  # Show/Map All are rendered as small buttons by
+  # mapset_associated_links_for_type so they have real padding and
+  # don't rely on a focus outline for visual separation.
   def map_point_text(label, count, show, map)
-    label.html_safe << ": " << count.to_s << " (" << show << " | " << map << ")"
+    parts = ["#{count} #{label}".html_safe, show, map]
+    safe_join(parts, " ")
   end
 
   # Links to obs, locs or names within the current mapset, or maps of these
@@ -141,7 +229,9 @@ module MapHelper
     mapset_associated_links_for_type(set, type)
   end
 
-  # Helper for the above
+  # Helper for the above. Renders the two links as small buttons
+  # (btn btn-default btn-xs) so the popup has real spacing without
+  # relying on the focus outline for visual weight (#4131).
   def mapset_associated_links_for_type(set, type)
     query_type = type.to_s.camelize.to_sym
     path_helper = :"#{type.to_s.pluralize}_path"
@@ -149,18 +239,42 @@ module MapHelper
     # This will correctly merge the in_box param into the query.
     query = controller.
             find_or_create_query(query_type, in_box: mapset_box_params(set))
+    btn = "btn btn-default btn-xs map-popup-btn"
     # Add the query params to the link data for debugging.
     # Can remove when we start splatting query params in the URL.
     [link_to(:show_all.t, add_q_param(send(path_helper), query),
-             data: query.params),
+             class: btn, data: query.params),
      link_to(:map_all.t, add_q_param(send(:"map_#{path_helper}"), query),
-             data: query.params)]
+             class: btn, data: query.params)]
   end
 
+  # Observation link in popups. Prefers the consensus text_name when
+  # available (new minimal_observation attr for #4131), falls back to
+  # "Observation #<id>" otherwise (e.g. pre-existing callers that use
+  # full Observation objects or didn't load the name). Always opens in
+  # a new tab — per Jaci's request, clicking should not navigate the
+  # map page away.
   def mapset_observation_link(obs, args)
     params = args[:query_param] ? { q: args[:query_param] } : {}
-    link_to("#{:Observation.t} ##{obs.id}",
-            observation_path(id: obs.id, params: params))
+    label = mapset_observation_label(obs)
+    link_to(label, observation_path(id: obs.id, params: params),
+            target: "_blank", rel: "noopener noreferrer")
+  end
+
+  # Preferred order: display_name (has MO textile markers — bold italic
+  # for non-deprecated names, italic-only for deprecated) → text_name
+  # (plain, wrap in <em>) → "Observation #<id>".
+  def mapset_observation_label(obs)
+    display = obs.respond_to?(:display_name) ? obs.display_name : nil
+    display ||= obs.name.display_name if display.blank? &&
+                                         obs.respond_to?(:name) &&
+                                         obs.name.respond_to?(:display_name)
+    return display.to_s.t if display.present?
+
+    text = obs.respond_to?(:text_name) ? obs.text_name : nil
+    return tag.em(text.to_s) if text.present?
+
+    "#{:Observation.t} ##{obs.id}"
   end
 
   def mapset_location_link(loc, args)

--- a/app/helpers/map_legend_helper.rb
+++ b/app/helpers/map_legend_helper.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Legend shown under every map rendered via MapHelper#make_map.
+# Two rows: shape meanings (circle vs. box) and color meanings
+# (consensus bands + group). See #4131.
+module MapLegendHelper
+  def map_legend
+    tag.div(class: "map-legend small text-muted mt-2") do
+      concat(map_legend_shape_row)
+      concat(map_legend_color_row)
+    end
+  end
+
+  private
+
+  def map_legend_shape_row
+    tag.div(class: "map-legend-row") do
+      concat(map_legend_shape_swatch(:circle, :map_legend_circle.t))
+      concat(map_legend_shape_swatch(:box, :map_legend_box.t))
+    end
+  end
+
+  def map_legend_color_row
+    tag.div(class: "map-legend-row") do
+      map_legend_color_entries.each do |color, label|
+        concat(map_legend_color_swatch(color, label))
+      end
+    end
+  end
+
+  def map_legend_color_entries
+    [
+      [Mappable::MapSet::CONFIRMED_COLOR, :map_legend_confirmed.t],
+      [Mappable::MapSet::TENTATIVE_COLOR, :map_legend_tentative.t],
+      [Mappable::MapSet::DISPUTED_COLOR, :map_legend_disputed.t],
+      [Mappable::MapSet::GROUP_COLOR, :map_legend_group.t]
+    ]
+  end
+
+  def map_legend_shape_swatch(shape, label)
+    tag.span(class: "map-legend-item") do
+      concat(tag.span("", class: "map-legend-swatch map-legend-#{shape}"))
+      concat(label)
+    end
+  end
+
+  def map_legend_color_swatch(color, label)
+    tag.span(class: "map-legend-item") do
+      concat(tag.span("", class: "map-legend-swatch map-legend-dot",
+                          style: "background:#{color};"))
+      concat(label)
+    end
+  end
+end

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -90,7 +90,13 @@ export default class extends GeocodeController {
         // Everything except the obs form map: draw the map.
         if (!(this.map_type === "observation" && this.editable)) {
           this.drawMap()
-          this.buildOverlays()
+          // Defer overlays until the map is idle — that's when
+          // map.getProjection() becomes available, which
+          // rectangleTooSmall() needs to decide whether to render
+          // a box vs. fall back to a square marker.
+          google.maps.event.addListenerOnce(this.map, "idle", () => {
+            this.buildOverlays()
+          })
         }
       })
       .catch((e) => {
@@ -180,11 +186,15 @@ export default class extends GeocodeController {
 
   drawMarker(set) {
     this.verbose("map:drawMarker")
+    // Per-marker color comes from the server (Mappable::MapSet#compute_color
+    // for issue #4131). Falls back to the controller default for editable
+    // markers / legacy callers that don't set a color.
+    const color = (set && set.color) || this.marker_color
     const markerOptions = {
       position: { lat: set.lat, lng: set.lng },
       map: this.map,
       draggable: this.editable,
-      background: this.marker_color,
+      icon: this.colored_circle_icon(color),
       zoomOnClick: false
     }
 
@@ -240,9 +250,13 @@ export default class extends GeocodeController {
   // For point markers: make a clickable InfoWindow
   giveMarkerInfoWindow(marker, set) {
     this.verbose("map:giveMarkerInfoWindow")
+    // maxWidth keeps the popup from stretching unnecessarily wide; without
+    // it Google fills the available map width, which leaves a lot of blank
+    // space on the right and pushes the close X far from the content.
     const info_window = new google.maps.InfoWindow({
       content: set.caption,
-      position: { lat: set.lat, lng: set.lng }
+      position: { lat: set.lat, lng: set.lng },
+      maxWidth: 280
     })
 
     google.maps.event.addListener(marker, "click", () => {
@@ -284,10 +298,24 @@ export default class extends GeocodeController {
     const bounds = this.boundsOf(set)
     if (!bounds) return false
 
+    // Per-box color from the server (#4131). Rectangles are group markers
+    // so this is usually GROUP_COLOR, but honor whatever the server set.
+    const color = (set && set.color) || this.marker_color
+
+    // If the rectangle would render sub-pixel at the current zoom, draw
+    // a standard-sized square marker at its center instead so it's still
+    // visible (#4131). Only applies to the info map; editable/location
+    // maps always get the real rectangle.
+    if (this.map_type === "info" && !this.editable &&
+        this.rectangleTooSmall(bounds)) {
+      this.drawBoxAsSquareMarker(set, color)
+      return
+    }
+
     const clickable = this.map_type === "info",
       editable = this.editable && this.map_type !== "observation",
       rectangleOptions = {
-        strokeColor: this.marker_color,
+        strokeColor: color,
         strokeOpacity: 1,
         strokeWeight: 3,
         map: this.map,
@@ -308,6 +336,58 @@ export default class extends GeocodeController {
       this.rectangle = rectangle
       // this.map.fitBounds(bounds) // Only fit bounds if it's a location map
       this.makeRectangleEditable()
+    }
+  }
+
+  // Pixel threshold below which a rectangle collapses into something
+  // indistinguishable from a marker. Swap it for a square marker only
+  // when BOTH dimensions fall below the threshold — otherwise a thin
+  // tall strip or wide flat strip is still a meaningful shape and should
+  // render as the real rectangle.
+  MIN_RECT_PIXELS = 15
+
+  // `bounds` here is the plain {north, south, east, west} object
+  // returned by this.boundsOf(set), NOT a google.maps.LatLngBounds.
+  rectangleTooSmall(bounds) {
+    if (!bounds) return false
+    const projection = this.map.getProjection()
+    if (!projection) return false
+    const zoom = this.map.getZoom()
+    if (zoom === undefined) return false
+    const scale = Math.pow(2, zoom)
+    const ne = projection.fromLatLngToPoint(
+      new google.maps.LatLng(bounds.north, bounds.east)
+    )
+    const sw = projection.fromLatLngToPoint(
+      new google.maps.LatLng(bounds.south, bounds.west)
+    )
+    const widthPx = Math.abs(ne.x - sw.x) * scale
+    const heightPx = Math.abs(sw.y - ne.y) * scale
+    return widthPx < this.MIN_RECT_PIXELS && heightPx < this.MIN_RECT_PIXELS
+  }
+
+  // Draws a square marker at the center of a box that's too small to
+  // render as a rectangle. Visually distinct from single-observation
+  // circle markers (square vs circle signals "group").
+  drawBoxAsSquareMarker(set, color) {
+    const marker = new google.maps.Marker({
+      position: { lat: set.lat, lng: set.lng },
+      map: this.map,
+      title: set.title,
+      icon: this.colored_square_icon(color),
+      zoomOnClick: false
+    })
+    this.giveMarkerInfoWindow(marker, set)
+  }
+
+  colored_square_icon(color) {
+    return {
+      path: "M -6 -6 L 6 -6 L 6 6 L -6 6 z",
+      fillColor: color,
+      fillOpacity: 1,
+      strokeColor: "#ffffff",
+      strokeWeight: 1.5,
+      scale: 1
     }
   }
 
@@ -693,5 +773,19 @@ export default class extends GeocodeController {
     // console.log(str);
     // document.getElementById("log").
     //   insertAdjacentText("beforeend", str + "<br/>");
+  }
+
+  // Colored circle icon for google.maps.Marker. Using SymbolPath.CIRCLE
+  // is the most compatible way to get per-marker fill colors on the
+  // classic Marker API without swapping to AdvancedMarkerElement.
+  colored_circle_icon(color) {
+    return {
+      path: google.maps.SymbolPath.CIRCLE,
+      fillColor: color,
+      fillOpacity: 1,
+      strokeColor: "#ffffff",
+      strokeWeight: 1.5,
+      scale: 8
+    }
   }
 }

--- a/app/models/mappable/minimal_observation.rb
+++ b/app/models/mappable/minimal_observation.rb
@@ -11,14 +11,21 @@ module Mappable
     attribute :lng, :float
     attribute :location_id, :integer
     attribute :location, Location
-    # Additional attributes used by map popups (issue #4131). They are
-    # optional — callers that don't set them leave the popup without the
-    # corresponding field. All map to columns on `observations`.
+    # Additional attributes used by map popups (issue #4131). All
+    # optional — callers that don't set them leave the popup without
+    # the corresponding field.
+    #
+    # `name_id`, `when`, `vote_cache`, and `thumb_image_id` come from
+    # the `observations` table.
+    # `text_name` and `display_name` come from the `names` table;
+    # callers that don't start from a full Observation bulk-load them
+    # by name_id alongside the obs rows (see
+    # Observations::MapsController#eager_load_related_names).
     attribute :name_id, :integer
     attribute :text_name, :string
-    # Textile-formatted display name from the Name model — bold italic
-    # for non-deprecated names, italic-only for deprecated. Safe to pass
-    # through `.t` to produce the popup-ready HTML.
+    # Textile-formatted display name — bold italic for non-deprecated
+    # names, italic-only for deprecated. Safe to pass through `.t` to
+    # produce the popup-ready HTML.
     attribute :display_name, :string
     attribute :when, :date
     attribute :vote_cache, :float

--- a/app/models/mappable/minimal_observation.rb
+++ b/app/models/mappable/minimal_observation.rb
@@ -11,6 +11,18 @@ module Mappable
     attribute :lng, :float
     attribute :location_id, :integer
     attribute :location, Location
+    # Additional attributes used by map popups (issue #4131). They are
+    # optional — callers that don't set them leave the popup without the
+    # corresponding field. All map to columns on `observations`.
+    attribute :name_id, :integer
+    attribute :text_name, :string
+    # Textile-formatted display name from the Name model — bold italic
+    # for non-deprecated names, italic-only for deprecated. Safe to pass
+    # through `.t` to produce the popup-ready HTML.
+    attribute :display_name, :string
+    attribute :when, :date
+    attribute :vote_cache, :float
+    attribute :thumb_image_id, :integer
 
     validates :lat, numericality: { in: -90..90 }
     validates :lng, numericality: { in: -180..180 }

--- a/app/views/controllers/observations/maps/index.html.erb
+++ b/app/views/controllers/observations/maps/index.html.erb
@@ -4,9 +4,12 @@ container_class(:full)
 add_index_title(@query, map: true)
 add_context_nav(observation_maps_tabs(query: @query))
 
-objects = @observations
-objects += @locations if @locations.any?
+# Pass only the observations. CollapsibleCollectionOfObjects#init_sets
+# turns obs-with-GPS into a point and obs-without-GPS into a box built
+# from the obs's .location, so the locations are already implicitly
+# represented. Unioning @locations in addition produced duplicate box
+# overlays on top of obs points (#4131 follow-up).
 %>
 
-<%= make_map(objects: objects, # CollapsibleCollection
+<%= make_map(objects: @observations, # CollapsibleCollection
              query_param: q_param(@query), zoom: 2, map_type: "info") %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -897,6 +897,12 @@
   update_object: Update [TYPE]
   show_all: Show All
   map_all: Map All
+  map_legend_circle: Observation with GPS
+  map_legend_box: Location area (no GPS) or group of observations
+  map_legend_confirmed: Confirmed (≥80%)
+  map_legend_tentative: Tentative
+  map_legend_disputed: Disputed (≤0%)
+  map_legend_group: Multiple observations
   show_location: Show [LOCATION]
   show_location_description: Show [DESCRIPTION]
   about_this_taxon: About this taxon

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -496,6 +496,7 @@
   citation: citation
   CITATIONS: Citations
   citations: citations
+  Confidence: Confidence
   CONFIDENCE_LEVEL: Confidence Level
   confidence_level: confidence level
   CONFIDENCE_LEVELS: Confidence Levels

--- a/test/classes/collapsible_map_test.rb
+++ b/test/classes/collapsible_map_test.rb
@@ -412,6 +412,25 @@ class CollapsibleMapTest < UnitTestCase
     assert_obj_arrays_equal([obs.location], mapset.underlying_locations)
   end
 
+  # Regression for the #4131 follow-up: observations with valid GPS
+  # should stay as point sets even when the collection is larger than
+  # max_map_objects. The pre-fix behavior demoted every obs to a
+  # location box once `objects.count > max_objects`, discarding the
+  # real GPS precision. The small-box → square-marker fallback in
+  # map_controller.js handles the "points collapse to invisible
+  # boxes" concern that motivated the old demotion.
+  def test_mapping_keeps_gps_points_even_in_large_collection
+    obs_with_gps = observations(:unknown_with_lat_lng)
+    assert(obs_with_gps.lat && obs_with_gps.location)
+    # Force the collection to be "large" with a tiny max_objects cap.
+    coll = Mappable::CollapsibleCollectionOfObjects.new([obs_with_gps], 0)
+    mapset = coll.mapsets.first
+    assert_mapset_is_point(mapset, obs_with_gps.lat, obs_with_gps.lng)
+    assert_obj_arrays_equal([obs_with_gps], mapset.observations,
+                            "Obs with GPS should stay a point even when " \
+                            "the collection exceeds max_objects")
+  end
+
   def test_mapping_one_location
     loc = locations(:albion)
     coll = Mappable::CollapsibleCollectionOfObjects.new(loc)

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -65,9 +65,14 @@ class MapSetTest < UnitTestCase
 
   private
 
+  # Deterministic id counter so tests don't depend on RNG state.
+  def next_obs_id
+    @next_obs_id = (@next_obs_id || 0) + 1
+  end
+
   def build_obs(lat:, lng:, vote_cache: 3.0)
     Mappable::MinimalObservation.new(
-      id: rand(1_000_000), lat: lat, lng: lng,
+      id: next_obs_id, lat: lat, lng: lng,
       name_id: 1, text_name: "Test name",
       when: Time.zone.today, vote_cache: vote_cache
     )

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class MapSetTest < UnitTestCase
+  # ------------------------------------------------------------------
+  # #compute_color — issue #4131
+  # ------------------------------------------------------------------
+
+  def test_color_blue_for_multi_observation_group
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 3.0))
+    assert_equal(Mappable::MapSet::GROUP_COLOR, set.compute_color)
+  end
+
+  def test_color_blue_for_location_only
+    set = set_of(locations(:burbank))
+    assert_equal(Mappable::MapSet::GROUP_COLOR, set.compute_color)
+  end
+
+  def test_color_green_for_single_obs_confirmed
+    # 2.4 / 3 * 100 = 80.0 — exactly the threshold.
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 2.4))
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color)
+  end
+
+  def test_color_orange_for_single_obs_tentative
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 1.5))
+    assert_equal(Mappable::MapSet::TENTATIVE_COLOR, set.compute_color)
+  end
+
+  def test_color_red_for_single_obs_disputed_at_zero
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 0.0))
+    assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  def test_color_red_for_single_obs_negative
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: -1.5))
+    assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  def test_color_red_for_single_obs_missing_vote_cache
+    # Vote.percent returns 0.0 when the value is blank -> disputed.
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: nil))
+    assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  # On the observations index map the controller passes obs AND their
+  # locations. CollapsibleCollectionOfObjects can put a single obs and
+  # its location in the same bucket, giving @objects.size == 2 even
+  # though there's just one observation. The set should still colour
+  # by that observation's consensus, not blue.
+  def test_color_for_single_obs_bucketed_with_its_location
+    obs = build_obs(lat: 34.1, lng: -118.3, vote_cache: 2.4)
+    set = set_of(obs, locations(:burbank))
+    assert_equal(1, set.observations.length)
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color,
+                 "Single obs bucketed with its location should still " \
+                 "use the consensus color, not GROUP_COLOR")
+  end
+
+  # ------------------------------------------------------------------
+  # Helpers
+  # ------------------------------------------------------------------
+
+  private
+
+  def build_obs(lat:, lng:, vote_cache: 3.0)
+    Mappable::MinimalObservation.new(
+      id: rand(1_000_000), lat: lat, lng: lng,
+      name_id: 1, text_name: "Test name",
+      when: Time.zone.today, vote_cache: vote_cache
+    )
+  end
+
+  def set_of(*objects)
+    Mappable::MapSet.new(objects)
+  end
+end

--- a/test/components/map_test.rb
+++ b/test/components/map_test.rb
@@ -94,4 +94,88 @@ class MapTest < ComponentTestCase
 
     assert_html(html, "#map_div")
   end
+
+  # ------------------------------------------------------------------
+  # #4131 popup content + marker color
+  # ------------------------------------------------------------------
+
+  def test_single_observation_popup_carries_color_name_date_consensus
+    # Confirmed consensus (>= 80%) → green color.
+    obs = build_min_obs(lat: 34.1, lng: -118.3, vote_cache: 2.4,
+                        text_name: "Agaricus campestris",
+                        when: Date.new(2024, 5, 1))
+    caption, color = parse_first_set(render_map_json([obs]))
+
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, color,
+                 "80% consensus should yield green")
+    assert_includes(caption, "Agaricus campestris")
+    assert_includes(caption, 'target="_blank"')
+    assert_includes(caption, 'rel="noopener noreferrer"')
+    assert_match(/May 1, 2024|2024-05-01/, caption)
+    # Plain "Confidence: NN%" text — no pill/dot markup inside the popup;
+    # the marker color on the map is the visual cue.
+    assert_match(/Confidence:\s*80%/, caption)
+    assert_not_includes(caption, "●")
+    assert_not_includes(caption, "nowrap")
+  end
+
+  def test_multi_observation_popup_lists_recent_names_and_no_date
+    obs_a = build_min_obs(lat: 10, lng: 10, vote_cache: 3.0,
+                          text_name: "Oldest sp.",
+                          when: Date.new(2020, 1, 1))
+    obs_b = build_min_obs(lat: 10, lng: 10, vote_cache: 3.0,
+                          text_name: "Middle sp.",
+                          when: Date.new(2023, 1, 1))
+    obs_c = build_min_obs(lat: 10, lng: 10, vote_cache: 3.0,
+                          text_name: "Newest sp.",
+                          when: Date.new(2025, 1, 1))
+    caption, color = parse_first_set(render_map_json([obs_a, obs_b, obs_c]))
+
+    assert_equal(Mappable::MapSet::GROUP_COLOR, color)
+    # Most recent first.
+    assert(caption.index("Newest sp.") < caption.index("Middle sp."),
+           "Group popup should list most recent name first")
+    assert(caption.index("Middle sp.") < caption.index("Oldest sp."))
+    # No consensus dot / percentage line for groups.
+    assert_no_match(/\d+%/, caption,
+                    "Group popup should omit consensus %")
+  end
+
+  def test_multi_observation_popup_ellipses_beyond_three
+    four_obs = Array.new(4) do |i|
+      build_min_obs(lat: 5, lng: 5, vote_cache: 3.0,
+                    text_name: "Species #{i}",
+                    when: Date.new(2020 + i, 1, 1))
+    end
+    caption, _color = parse_first_set(render_map_json(four_obs))
+
+    assert_includes(caption, "Species 3")
+    assert_includes(caption, "Species 2")
+    assert_includes(caption, "Species 1")
+    assert_not_includes(caption, "Species 0")
+    assert_includes(caption, "…")
+  end
+
+  private
+
+  def build_min_obs(lat:, lng:, vote_cache:, text_name: nil, when: nil)
+    Mappable::MinimalObservation.new(
+      id: rand(1_000_000),
+      lat: lat, lng: lng,
+      name_id: 1, text_name: text_name,
+      when: binding.local_variable_get(:when),
+      vote_cache: vote_cache
+    )
+  end
+
+  def render_map_json(objects)
+    html = render(Components::Map.new(objects: objects))
+    doc = Nokogiri::HTML(html)
+    JSON.parse(doc.at_css("#map_div")["data-collection"])
+  end
+
+  def parse_first_set(collection)
+    set = collection["sets"].values.first
+    [set["caption"], set["color"]]
+  end
 end

--- a/test/components/map_test.rb
+++ b/test/components/map_test.rb
@@ -103,7 +103,7 @@ class MapTest < ComponentTestCase
     # Confirmed consensus (>= 80%) → green color.
     obs = build_min_obs(lat: 34.1, lng: -118.3, vote_cache: 2.4,
                         text_name: "Agaricus campestris",
-                        when: Date.new(2024, 5, 1))
+                        observed_on: Date.new(2024, 5, 1))
     caption, color = parse_first_set(render_map_json([obs]))
 
     assert_equal(Mappable::MapSet::CONFIRMED_COLOR, color,
@@ -122,13 +122,13 @@ class MapTest < ComponentTestCase
   def test_multi_observation_popup_lists_recent_names_and_no_date
     obs_a = build_min_obs(lat: 10, lng: 10, vote_cache: 3.0,
                           text_name: "Oldest sp.",
-                          when: Date.new(2020, 1, 1))
+                          observed_on: Date.new(2020, 1, 1))
     obs_b = build_min_obs(lat: 10, lng: 10, vote_cache: 3.0,
                           text_name: "Middle sp.",
-                          when: Date.new(2023, 1, 1))
+                          observed_on: Date.new(2023, 1, 1))
     obs_c = build_min_obs(lat: 10, lng: 10, vote_cache: 3.0,
                           text_name: "Newest sp.",
-                          when: Date.new(2025, 1, 1))
+                          observed_on: Date.new(2025, 1, 1))
     caption, color = parse_first_set(render_map_json([obs_a, obs_b, obs_c]))
 
     assert_equal(Mappable::MapSet::GROUP_COLOR, color)
@@ -145,7 +145,7 @@ class MapTest < ComponentTestCase
     four_obs = Array.new(4) do |i|
       build_min_obs(lat: 5, lng: 5, vote_cache: 3.0,
                     text_name: "Species #{i}",
-                    when: Date.new(2020 + i, 1, 1))
+                    observed_on: Date.new(2020 + i, 1, 1))
     end
     caption, _color = parse_first_set(render_map_json(four_obs))
 
@@ -158,12 +158,14 @@ class MapTest < ComponentTestCase
 
   private
 
-  def build_min_obs(lat:, lng:, vote_cache:, text_name: nil, when: nil)
+  # `observed_on:` avoids `when` — a Ruby keyword that can't be used
+  # as a method argument name — and maps to the model's `when:` attr.
+  def build_min_obs(lat:, lng:, vote_cache:, text_name: nil, observed_on: nil)
     Mappable::MinimalObservation.new(
       id: rand(1_000_000),
       lat: lat, lng: lng,
       name_id: 1, text_name: text_name,
-      when: binding.local_variable_get(:when),
+      when: observed_on,
       vote_cache: vote_cache
     )
   end


### PR DESCRIPTION
Fixes #4131. Separate issue #4139 was filed for the pre-existing scoping bug on the Occurrence Map link — out of scope here.

## Summary
- Single-observation popup is now a Bootstrap `.media` layout: thumbnail on the left; species name (bold italic for non-deprecated, italic-only for deprecated), observed date, `Confidence: NN%`, location link, small muted coordinates on the right. The observation link opens in a new tab (`target="_blank" rel="noopener noreferrer"`).
- Multi-observation popup: `"N Observations [Show All] [Map All]"` — count first, two small buttons, extra breathing room before the first taxon link. Up to three most-recent taxon links, `…` if more, no date/confidence.
- Marker color now communicates consensus: blue for groups / location-only; green (≥ 80%), orange (0 < x < 80%), red (≤ 0%) for singles. Rectangles share the same palette.
- A bounding box that would render sub-pixel (< 15×15 px) at the current zoom is swapped for a same-color square marker — otherwise it disappeared entirely on world-zoom maps.
- Google Maps InfoWindow chrome tightened (`.gm-style-iw-c`, `-d`, `-chr`) so the close-X sits in the corner and the popup has no dead top space.

## Implementation
- **`Mappable::MapSet`**: `compute_color` picks blue vs traffic-light using `Vote.percent(vote_cache)`; `single_observation?` counts observations, not all objects (fixes the "blue markers everywhere" bug where a single obs bucketed with its own location passed `@objects.size == 2` and was mis-colored).
- **`Mappable::MinimalObservation`**: new optional attrs `name_id`, `text_name`, `display_name`, `when`, `vote_cache`, `thumb_image_id`.
- **`Observations::MapsController`**: selects the new columns; bulk-loads `text_name` + `display_name` from `Name` (alongside the existing bulk location load) — no N+1.
- **`map_controller.js`**: per-marker color via `colored_circle_icon`; rectangles via `strokeColor`; overlay construction deferred to the first map `idle` event so `map.getProjection()` is available for the pixel-size check; `rectangleTooSmall(bounds)` falls back to `colored_square_icon`.
- **`MapHelper`** and **`Components::Map`**: parallel popup rebuilds so every map surface (obs index, obs show, location show, name distribution, herbarium, project maps) gets the new layout.
- **`_maps.scss`**: InfoWindow chrome overrides, thumbnail edge-stripping (`text-decoration`, `border`, `outline`, `box-shadow` all zeroed with `!important` because the iw stylesheet loads after ours), button spacing + focus-visible handling.

## Tests
- 8 `MapSet#compute_color` cases covering each color band, 80% and 0% boundaries, group/location-only fallback, and the regression where a single obs bucketed with its location was mis-colored.
- Map component tests assert popup carries color + name + date + confidence (plain `Confidence: NN%`, no pill/dot), `target="_blank"` + `rel="noopener noreferrer"`, most-recent-first ordering in groups, `…` overflow beyond 3.
- Existing controller and class tests still pass.

## Test plan
- [x] Unit + component + controller tests (24 map tests, 8 MapSet tests).
- [x] Manual: visit Southeast Rare Challenge project map (`/observations/map?q[projects][]=331`) — expect traffic-light single-obs markers, blue group markers, square fallbacks on sub-pixel boxes.
- [x] Manual: visit a name's Occurrence Map (e.g. `/names/50933/map`) — all 12 observations show with correct colors; click a popup to verify layout, date, confidence, new-tab link.
- [x] Manual: observation index map and location index map also render the new popups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)