### PR TITLE
Remove user_stats.checklist cache

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -5,11 +5,6 @@
 #  This class calculates a checklist of species observed by users,
 #  projects, etc.
 #
-#  == Class Methods
-#
-#  all_site_taxa_by_user::  Calculate checklist taxon stats for all users
-#                           (only the stats, not the names)
-#
 #  == Methods
 #
 #  num_genera::      Number of genera seen.
@@ -277,62 +272,6 @@ class Checklist
   def counts
     calc_counts unless @counts
     @counts
-  end
-
-  # `+` here is Arel extensions shorthand for `CONCAT`
-  # The group statement is to be sure names without synonyms are sorted
-  # separately in the array by giving all of them negative values in the group.
-  # The idea is that we don't want those with synonyms and those without
-  # to overlap; putting them last is arbitrary.
-  # rubocop:disable Style/StringConcatenation
-  def self.all_site_taxa_by_user
-    synonym_map = {}
-
-    synonyms = Name.connection.select_rows(
-      Name.select(
-        Arel.sql("GROUP_CONCAT(names.id)"),
-        (Name[:deprecated].cast("char") + "," +
-         Name[:text_name].cast("char") + "," +
-         Name[:id].cast("char") + "," +
-         Name[:rank].cast("char")).minimum
-      ).group(
-        Name[:synonym_id].when(present?).then(Name[:synonym_id]).
-        else(Name[:id] * -1)
-      )
-    )
-    synonyms.each do |row|
-      ids, tuple = *row
-      ids.split(",").each { |id| synonym_map[id.to_i] = tuple }
-    end
-
-    calculate_taxa_by_user(synonym_map)
-  end
-  # rubocop:enable Style/StringConcatenation
-
-  private_class_method def self.calculate_taxa_by_user(synonym_map)
-    taxa = {}
-    genera = {}
-    species = {}
-    genus_ranks = Name.genus_display_ranks
-    Observation.select(:user_id, :name_id).each do |row|
-      user_id = row[:user_id]
-      name_id = row[:name_id]
-      _dep, text_name, _id, rank = *synonym_map[name_id].split(",")
-      g, s = *text_name.split
-      taxa[user_id] ||= {}
-      genera[user_id] ||= {}
-      species[user_id] ||= {}
-      taxa[user_id][text_name] = true
-      genera[user_id][g] = true if genus_ranks.include?(rank.to_i)
-      if rank.to_i <= Name.ranks[:Species]
-        species[user_id][[g, s].join(" ")] = true
-      end
-    end
-
-    { users: taxa.keys,
-      taxa: taxa.transform_values(&:size),
-      genera: genera.transform_values(&:size),
-      species: species.transform_values(&:size) }
   end
 
   private

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -65,7 +65,6 @@
 #
 #  languages::
 #  bonuses::
-#  checklists::
 #
 # rubocop:disable Metrics/ClassLength
 class UserStats < ApplicationRecord
@@ -75,7 +74,6 @@ class UserStats < ApplicationRecord
   # automatically with YAML and stored as plain old text strings.
   serialize :languages, type: Hash, coder: YAML
   serialize :bonuses, coder: YAML
-  serialize :checklist, type: Hash, coder: YAML
 
   ALL_FIELDS = {
     name_description_authors: { weight: 100 },
@@ -96,8 +94,7 @@ class UserStats < ApplicationRecord
     comments: { weight: 1 },
     votes: { weight: 1 },
     translation_strings: { weight: 1 },
-    languages: { weight: 0, default: {} },
-    checklist: { weight: 0, default: {} }
+    languages: { weight: 0, default: {} }
   }.freeze
 
   # Sum up all the bonuses the User has earned.
@@ -204,8 +201,6 @@ class UserStats < ApplicationRecord
                        refresh_translation_strings
                      when "languages"
                        refresh_languages
-                     when "checklist"
-                       refresh_checklist
                      when /^(\w+)_versions/
                        parent_type = $LAST_MATCH_INFO[1]
                        refresh_versions(parent_type, field)
@@ -346,18 +341,6 @@ class UserStats < ApplicationRecord
       end
     end
 
-    def refresh_checklist
-      checklist_data = Checklist.all_site_taxa_by_user
-      checklist_data[:users].to_h do |user_id|
-        checklist_hash = {
-          taxa: checklist_data[:taxa][user_id],
-          genera: checklist_data[:genera][user_id],
-          species: checklist_data[:species][user_id]
-        }
-        [user_id, { checklist: checklist_hash }]
-      end
-    end
-
     # For each record we're about to update, check for incomplete entries that
     # the counters may have added - having a `user_id` but lacking an `id`.
     # Check that is an existing user and fill out the rest of the attributes
@@ -481,8 +464,6 @@ class UserStats < ApplicationRecord
               count_translation_strings(user_id, by_lang: false)
             when "languages"
               count_translation_strings(user_id, by_lang: true)
-            when "checklist"
-              count_checklist(user_id)
             when /^(\w+)_versions/
               parent_type = $LAST_MATCH_INFO[1]
               count_versions(parent_type, user_id)
@@ -525,12 +506,6 @@ class UserStats < ApplicationRecord
     all.to_h do |lang|
       [locale_index[lang.language_id], lang.cnt]
     end
-  end
-
-  # Gets checklist counts to save as a serialized hash
-  def count_checklist(user_id)
-    cl = Checklist::ForUser.new(User.find(user_id))
-    { taxa: cl.num_taxa, genera: cl.num_genera, species: cl.num_species }
   end
 
   # This counts versions where the editor was not the original author

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -48,29 +48,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "840c66551f2dd1076c9e69bac37c8b464ed7b4887c6a3759c64b9bd8d2478080",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/classes/checklist.rb",
-      "line": 125,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Name.select(Arel.sql(\"GROUP_CONCAT(names.id)\"), ((((((Name[:deprecated].cast(\"char\") + \",\") + Name[:text_name].cast(\"char\")) + \",\") + Name[:id].cast(\"char\")) + \",\") + Name[:rank].cast(\"char\")).minimum)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Checklist",
-        "method": "s(:self).all_site_taxa_by_user"
-      },
-      "user_input": "Name[:deprecated].cast(\"char\")",
-      "confidence": "High",
-      "cwe_id": [
-        89
-      ],
-      "note": "Safe: hardcoded SQL with no user input"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "dd5044f522b1b5ab980da2941a14bcb54700f5ec4f307a699a6415e12b8a6f79",
       "check_name": "SQL",
       "message": "Possible SQL injection",

--- a/db/migrate/20260420173244_remove_checklist_from_user_stats.rb
+++ b/db/migrate/20260420173244_remove_checklist_from_user_stats.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveChecklistFromUserStats < ActiveRecord::Migration[7.2]
+  def change
+    remove_column(:user_stats, :checklist, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_07_193046) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_20_173244) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -906,7 +906,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_193046) do
     t.integer "votes", default: 0, null: false
     t.string "languages"
     t.string "bonuses"
-    t.string "checklist"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "user_index"

--- a/test/classes/localization_files_test.rb
+++ b/test/classes/localization_files_test.rb
@@ -229,7 +229,7 @@ class LocalizationFilesTest < UnitTestCase
   end
 
   def test_user_data_translations
-    non_integers = [:languages, :checklist]
+    non_integers = [:languages]
     user_tags = UserStats::ALL_FIELDS.except(*non_integers).keys.map do |field|
       :"user_stats_#{field}"
     end

--- a/test/models/checklist_test.rb
+++ b/test/models/checklist_test.rb
@@ -170,19 +170,6 @@ class ChecklistTest < UnitTestCase
     )
   end
 
-  def test_all_site_taxa_by_user
-    result = Checklist.all_site_taxa_by_user
-    assert_equal([:genera, :species, :taxa, :users], result.keys.sort,
-                 "all_site_taxa_by_user should return " \
-                 ":users, :taxa, :genera, :species keys")
-    assert_kind_of(Array, result[:users],
-                   "all_site_taxa_by_user :users should be an Array")
-    assert_kind_of(Hash, result[:genera],
-                   "all_site_taxa_by_user :genera should be a Hash")
-    assert_kind_of(Hash, result[:species],
-                   "all_site_taxa_by_user :species should be a Hash")
-  end
-
   def test_checklist_for_project_merges_target_names
     proj = projects(:rare_fungi_project)
     # Project has target names but no observations


### PR DESCRIPTION
## Summary
- Drops the serialized `user_stats.checklist` hash (column, maintenance, and class method) now that the user show page's Life List footer computes counts live via `Checklist::ForUser`.
- Shrinks `UserStats` by removing the `refresh_checklist` / `count_checklist` branches and the `checklist` entry in `ALL_FIELDS`.
- Removes `Checklist.all_site_taxa_by_user` + `calculate_taxa_by_user` (only caller was the deleted refresh path) and its brakeman ignore.

## Stacking
Based on `njw-4128-name-tab-cleanup` (PR #4138) because that branch is what removes the last reader of the cache. Will auto-retarget to `main` once #4138 merges.

## Test plan
- [x] `bin/rails test test/models/user_stats_test.rb test/models/checklist_test.rb test/controllers/checklists_controller_test.rb test/controllers/users_controller_test.rb test/classes/localization_files_test.rb`
- [x] `bin/rails test test/models/ test/classes/` — 1941 tests, 0 failures
- [x] `bin/rails db:migrate` applies cleanly
- [x] `bundle exec rubocop` clean on touched files
- [ ] Production deploy order: merge #4138 first so no running code reads `user_stats.checklist`, then merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)