### PR TITLE
Show Location edit icon to any logged-in user

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -708,6 +708,13 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
       descriptions.empty?
   end
 
+  # Locations are a shared resource: any logged-in user can edit one.
+  # (LocationsController#edit/#update only requires login. Destroy is
+  # still owner/admin-only — see can_destroy_location?.)
+  def can_edit?(user)
+    user.present?
+  end
+
   # Merge all the stuff that refers to +old_loc+ into +self+.  No changes are
   # made to +self+; +old_loc+ is destroyed; all the things that referred to
   # +old_loc+ are updated and saved.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -712,7 +712,9 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   # (LocationsController#edit/#update only requires login. Destroy is
   # still owner/admin-only — see can_destroy_location?.)
   def can_edit?(user)
-    user.present?
+    return false unless user
+
+    true
   end
 
   # Merge all the stuff that refers to +old_loc+ into +self+.  No changes are

--- a/app/views/controllers/locations/show/_coordinates.erb
+++ b/app/views/controllers/locations/show/_coordinates.erb
@@ -1,6 +1,4 @@
-<% heading_links = [
-  icon_link_to(*edit_location_tab(@location))
-]
+<% heading_links = []
 if @location.destroyable? && (in_admin_mode? || @location.user == @user)
   heading_links << destroy_button(target: @location, icon: :delete)
 end

--- a/app/views/controllers/locations/show/_coordinates.erb
+++ b/app/views/controllers/locations/show/_coordinates.erb
@@ -11,7 +11,9 @@ footer = icon_link_to(*observations_at_location_tab(@location))
       panel_id: "location_coordinates"
     )) do |panel| %>
   <%= panel.with_heading { :COORDINATES.l } %>
-  <%= panel.with_heading_links { heading_links.safe_join(" | ") } %>
+  <% if heading_links.any? %>
+    <%= panel.with_heading_links { heading_links.safe_join(" | ") } %>
+  <% end %>
   <%= panel.with_body do %>
     <div class="text-center mx-auto" style="max-width:30em">
       <div class="text-center my-4">

--- a/app/views/controllers/locations/show/_notes.html.erb
+++ b/app/views/controllers/locations/show/_notes.html.erb
@@ -1,9 +1,4 @@
 <%= render(Components::Panel.new(panel_id: "location_notes")) do |panel|
-      panel.with_heading do
-        concat(:NOTES.l)
-        concat(tag.span(class: "float-right") do
-          icon_link_to(*edit_location_tab(@location))
-        end)
-      end
+      panel.with_heading { :NOTES.l }
       panel.with_body { @location.notes.to_s.html_safe.tpl }
     end unless @location.notes.blank? %>

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -13,6 +13,16 @@ class LocationTest < UnitTestCase
     assert_not(Location.dubious_name?(str))
   end
 
+  # Locations are a shared resource; any logged-in user can edit.
+  # (Only nil user is rejected.)
+  def test_can_edit_allows_any_logged_in_user
+    loc = locations(:burbank)
+    assert(loc.can_edit?(rolf), "Creator should be able to edit")
+    assert(loc.can_edit?(mary),
+           "Non-creator logged-in user should be able to edit")
+    assert_not(loc.can_edit?(nil), "Nil user should not be able to edit")
+  end
+
   def test_dubious_name
     bad_location("Albion,California,  USA")
     bad_location("Albion, California")


### PR DESCRIPTION
## Summary
- The name-adjacent edit icon on the Location show page was gated on `AbstractModel#can_edit?`, which for Location reduces to "creator or admin only". That didn't match `LocationsController` — edit/update only require login, so any logged-in user can actually edit a location.
- The Coordinates and Notes subpanels each rendered their own unconditional edit icon to work around the over-strict header gate, leaving the creator with three edit icons (header + two panels) and non-creators with two (panels only).
- Fix at the model layer: `Location#can_edit?` returns true for any logged-in user. Drop the workaround icons.

## Changes
- `app/models/location.rb` — override `can_edit?` to allow any logged-in user (matches controller policy). Destroy is still creator/admin-only via `can_destroy_location?`, unchanged.
- `app/views/controllers/locations/show/_coordinates.erb` — drop redundant edit icon.
- `app/views/controllers/locations/show/_notes.html.erb` — drop redundant edit icon; collapse heading back to a plain `:NOTES.l`.
- `test/models/location_test.rb` — add unit test covering creator / non-creator / nil-user cases for `can_edit?`.

## Test plan
- [x] `bin/rails test test/models/location_test.rb test/controllers/locations_controller_test.rb` — 97 tests, 904 assertions, 0 failures
- [x] `bundle exec rubocop` clean on touched Ruby files
- [x] Manual: visit `/locations/:id` as a non-creator logged-in user; confirm a single edit icon appears next to the location name and none in Coordinates/Notes panels. Click it; confirm the edit form loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)