### PR TITLE
Fix flaky herbarium-record create test

### DIFF
--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -308,7 +308,13 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     post(:create, params:)
     mary = User.find(mary.id) # Reload user
     assert_equal(herbarium_count + 1, mary.curated_herbaria.count)
-    herbarium = Herbarium.reorder(created_at: :desc)[0]
+    # Look up by the attribute the test controls, not by
+    # `reorder(created_at: :desc)`: MySQL DATETIME is second-precision, so
+    # the new herbarium ties with fixture-loaded herbaria and the
+    # tiebreaker is implementation-defined (flaky).
+    herbarium = Herbarium.find_by(name: mary.personal_herbarium_name)
+    assert_not_nil(herbarium,
+                   "Mary's personal herbarium should have been created")
     assert(herbarium.curators.member?(mary))
   end
 


### PR DESCRIPTION
## Summary
`test_create_herbarium_record_new_herbarium` used `Herbarium.reorder(created_at: :desc)[0]` to find the just-created herbarium. That flakes ~50% of the time locally.

**Root cause:** MySQL `DATETIME` is second-precision by default. Only one herbarium fixture (`nybg_herbarium`) pins `created_at` — the rest get `Time.now` at fixture load. Within the same second, Mary's newly-created herbarium ties with all those fixture herbaria, and MySQL's tiebreaker for the `ORDER BY created_at DESC` is implementation-defined.

**Fix:** Look up by the attribute the test controls — the personal-herbarium name Mary just used — per the guidance in `.claude/rules/testing.md` ("Never use `Model.last` / `Model.order(...).last` to find a record just created by a test").

## Test plan
- [x] Ran the test 8 times in isolation — all pass (previously ~50% flake).
- [x] `bundle exec rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)