### PR TITLE
Bump erb gem to 6.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     docile (1.4.1)
     domain_name (0.6.20240107)
     drb (2.2.3)
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo


### PR DESCRIPTION
See https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316/