### PR TITLE
Drop step 4 of name lookup; rely on classification data (#4154)

### DIFF
--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -15,7 +15,7 @@ class Lookup::Names < Lookup
 
     names = add_synonyms_if_necessary(original_names)
     names_plus_subtaxa = add_subtaxa_if_necessary(names)
-    names = add_synonyms_again(names, names_plus_subtaxa)
+    names = add_deprecated_synonyms_of_subtaxa(names, names_plus_subtaxa)
     names -= original_names if @params[:exclude_original_names]
     names.map(&:id)
   end
@@ -130,15 +130,29 @@ class Lookup::Names < Lookup
     end
   end
 
-  def add_synonyms_again(names, names_plus_subtaxa)
-    if names.length >= names_plus_subtaxa.length
-      names
-    elsif @params[:include_synonyms] &&
-          @params[:include_subtaxa_synonyms] != false
-      add_synonyms(names_plus_subtaxa)
-    else
-      names_plus_subtaxa
-    end
+  # After sub-taxa expansion, also include any DEPRECATED synonyms of
+  # the expanded set — these are misspellings and historical name
+  # variants of things that *are* in the target's clade. We do not
+  # re-add non-deprecated synonyms here: doing so would match
+  # current-name species whose deprecated synonym happened to fall
+  # under one of our targets (e.g., an `Agaricus` search would match
+  # Protostropharia semiglobata via the deprecated
+  # `Agaricus semiglobatus`). See discussion #4154.
+  def add_deprecated_synonyms_of_subtaxa(names, names_plus_subtaxa)
+    return names if names.length >= names_plus_subtaxa.length
+    return names_plus_subtaxa unless @params[:include_synonyms]
+
+    names_plus_subtaxa + new_deprecated_synonyms(names_plus_subtaxa)
+  end
+
+  def new_deprecated_synonyms(names_plus_subtaxa)
+    syn_ids = names_plus_subtaxa.pluck(:synonym_id).compact
+    return [] if syn_ids.empty?
+
+    existing_ids = names_plus_subtaxa.to_set(&:id)
+    Name.where(synonym_id: limited_id_set(syn_ids), deprecated: true).
+      distinct.select(*minimal_name_columns).
+      reject { |n| existing_ids.include?(n.id) }
   end
 
   def add_other_spellings(names)

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -13,9 +13,17 @@ class Lookup::Names < Lookup
   def lookup_ids
     return [] if @vals.blank?
 
+    # No final pass to re-synonymize the sub-taxa expansion. A
+    # deprecated subtaxon that shares a synonym group with a
+    # current-name species in a different clade would otherwise drag
+    # that unrelated species in (e.g., an `Agaricus` search would
+    # match Protostropharia semiglobata via `Agaricus semiglobatus`).
+    # Deprecated variants that really are in the target clade are
+    # expected to surface through the sub-taxa expansion on their own
+    # classification (see Name#propagate_classification). See
+    # discussion #4154.
     names = add_synonyms_if_necessary(original_names)
-    names_plus_subtaxa = add_subtaxa_if_necessary(names)
-    names = add_deprecated_synonyms_of_subtaxa(names, names_plus_subtaxa)
+    names = add_subtaxa_if_necessary(names)
     names -= original_names if @params[:exclude_original_names]
     names.map(&:id)
   end
@@ -128,31 +136,6 @@ class Lookup::Names < Lookup
     else
       names
     end
-  end
-
-  # After sub-taxa expansion, also include any DEPRECATED synonyms of
-  # the expanded set — these are misspellings and historical name
-  # variants of things that *are* in the target's clade. We do not
-  # re-add non-deprecated synonyms here: doing so would match
-  # current-name species whose deprecated synonym happened to fall
-  # under one of our targets (e.g., an `Agaricus` search would match
-  # Protostropharia semiglobata via the deprecated
-  # `Agaricus semiglobatus`). See discussion #4154.
-  def add_deprecated_synonyms_of_subtaxa(names, names_plus_subtaxa)
-    return names if names.length >= names_plus_subtaxa.length
-    return names_plus_subtaxa unless @params[:include_synonyms]
-
-    names_plus_subtaxa + new_deprecated_synonyms(names_plus_subtaxa)
-  end
-
-  def new_deprecated_synonyms(names_plus_subtaxa)
-    syn_ids = names_plus_subtaxa.pluck(:synonym_id).compact
-    return [] if syn_ids.empty?
-
-    existing_ids = names_plus_subtaxa.to_set(&:id)
-    Name.where(synonym_id: limited_id_set(syn_ids), deprecated: true).
-      distinct.select(*minimal_name_columns).
-      reject { |n| existing_ids.include?(n.id) }
   end
 
   def add_other_spellings(names)

--- a/app/classes/pattern_search/name.rb
+++ b/app/classes/pattern_search/name.rb
@@ -12,7 +12,6 @@ module PatternSearch
       lichen: [:lichen, :parse_boolean],
       include_misspellings: [:misspellings, :parse_no_include_only],
       include_subtaxa: [:include_subtaxa, :parse_boolean],
-      include_subtaxa_synonyms: [:include_subtaxa_synonyms, :parse_boolean],
       include_synonyms: [:include_synonyms, :parse_boolean],
       rank: [:rank, :parse_rank_range],
 

--- a/app/classes/pattern_search/observation.rb
+++ b/app/classes/pattern_search/observation.rb
@@ -13,7 +13,6 @@ module PatternSearch
       name: [:names, :parse_list_of_names],
       exclude_consensus: [:exclude_consensus, :parse_boolean], # of_look_alikes
       include_subtaxa: [:include_subtaxa, :parse_boolean],
-      include_subtaxa_synonyms: [:include_subtaxa_synonyms, :parse_boolean],
       include_synonyms: [:include_synonyms, :parse_boolean],
       include_all_name_proposals: [:include_all_name_proposals, :parse_boolean],
 

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -15,7 +15,6 @@ class Query::NameDescriptions < Query
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,
-                       include_subtaxa_synonyms: :boolean,
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean })
   query_attr(:name_query, { subquery: :Name })

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -15,7 +15,6 @@ class Query::Names < Query
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,
-                       include_subtaxa_synonyms: :boolean,
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean })
   query_attr(:text_name_has, :string)

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -15,7 +15,6 @@ class Query::Observations < Query
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,
-                       include_subtaxa_synonyms: :boolean,
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean,
                        include_all_name_proposals: :boolean,

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -9,7 +9,6 @@ class Query::Projects < Query
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,
-                       include_subtaxa_synonyms: :boolean,
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean,
                        include_all_name_proposals: :boolean,

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -19,7 +19,6 @@ class Query::SpeciesLists < Query
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,
-                       include_subtaxa_synonyms: :boolean,
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean,
                        include_all_name_proposals: :boolean,

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -188,7 +188,6 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       lookup_args = args.slice(:include_synonyms,
                                :include_misspellings,
                                :include_subtaxa,
-                               :include_subtaxa_synonyms,
                                :include_immediate_subtaxa,
                                :exclude_original_names)
       name_ids = Lookup::Names.new(lookup, **lookup_args).ids

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -493,30 +493,21 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   private
 
   # Same expansion rule as candidate_name_ids: each given name plus
-  # its synonyms plus sub-taxa of both, without expanding synonyms of
-  # sub-taxa. See candidate_name_ids for the rationale on
-  # include_subtaxa_synonyms: false.
+  # its synonyms plus sub-taxa of both.
   def expanded_target_name_ids(name_ids)
     return [] if name_ids.empty?
 
     Lookup::Names.new(name_ids,
                       include_synonyms: true,
-                      include_subtaxa: true,
-                      include_subtaxa_synonyms: false).ids
+                      include_subtaxa: true).ids
   end
 
   def candidate_name_ids
     return unless target_names.any?
 
-    # include_subtaxa_synonyms: false skips the final round of synonym
-    # expansion that would otherwise match current-name species whose
-    # deprecated synonym happens to fall under one of our targets
-    # (e.g., an Agaricus target would otherwise pull in Protostropharia
-    # semiglobata via the deprecated "Agaricus semiglobatus").
     Observation.names(lookup: target_name_ids,
                       include_synonyms: true,
-                      include_subtaxa: true,
-                      include_subtaxa_synonyms: false).select(:id)
+                      include_subtaxa: true).select(:id)
   end
 
   def candidate_location_ids

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1253,7 +1253,6 @@
   search_term_include_all_name_proposals: include_all_name_proposals
   search_term_include_misspellings: include_misspellings
   search_term_include_subtaxa: include_subtaxa
-  search_term_include_subtaxa_synonyms: include_subtaxa_synonyms
   search_term_include_synonyms: include_synonyms
   search_term_is_collection_location: is_collection_location
   search_term_lichen: lichen
@@ -3946,7 +3945,6 @@
   observation_term_exclude_consensus: Exclude Observations whose consensus name is one of these names. (When using exclude_consensus you must also use "include_all_name_proposals:yes".)
   observation_term_include_all_name_proposals: Include all name proposals, not just the consensus.
   observation_term_include_subtaxa: Include observations of subtaxa of the given names.
-  observation_term_include_subtaxa_synonyms: Also include observations of synonyms of those subtaxa. Defaults to true when include_synonyms is true and subtaxa expansion is enabled (include_subtaxa or include_immediate_subtaxa); set to false to keep subtaxa confined to the original name's taxonomy.
   observation_term_include_synonyms: Include observations of synonyms of the given names.
   observation_term_herbarium: Specimen at a fungarium.
   observation_term_herbaria: "[:observation_term_herbarium]"
@@ -4001,7 +3999,6 @@
   name_term_rank: Rank or range of ranks, e.g., "genus" or "species-form".
   name_term_include_synonyms: Include synonyms of the given names.
   name_term_include_subtaxa: Include subtaxa of the given names.
-  name_term_include_subtaxa_synonyms: "[:observation_term_include_subtaxa_synonyms]"
   name_term_include_immediate_subtaxa: Include immediate subtaxa of the given names.
   name_term_exclude_original_names: Exclude the names entered above.
   name_term_has_observations: Only names for which we have observations?

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -145,17 +145,17 @@ class LookupTest < UnitTestCase
 
     assert_lookup_names([name2], ["Peltigera"])
     assert_lookup_names([name3], ["Petigera"])
-    assert_lookup_names([name1, name2, name4, name5, name6, name7],
+    assert_lookup_names([name1, name2, name3, name4, name5, name6, name7],
                         ["Peltigeraceae"],
                         include_subtaxa: true)
     assert_lookup_names([name1, name2, name3, name4, name5, name6, name7],
                         ["Peltigeraceae"],
                         include_subtaxa: true,
                         include_synonyms: true)
-    assert_lookup_names([name1, name2],
+    assert_lookup_names([name1, name2, name3],
                         ["Peltigeraceae"],
                         include_immediate_subtaxa: true)
-    assert_lookup_names([name1, name2, name4, name5, name6, name7],
+    assert_lookup_names([name1, name2, name3, name4, name5, name6, name7],
                         ["Peltigera"],
                         include_subtaxa: true)
     assert_lookup_names([name2, name4, name6],

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -685,6 +685,7 @@ petigera:
   correct_spelling: peltigera
   deprecated: true
   synonym: peltigera_synonym
+  classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   created_at: 2009-01-02 01:01:01
   updated_at: 2009-01-02 01:01:01
   lifeform: " lichen "

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -1884,8 +1884,14 @@ class NameTest < UnitTestCase
   end
 
   def test_ancestors_2
-    # use Petigera instead of Peltigera because it has no classification string
-    pet = names(:petigera)
+    # Need a deprecated genus with NO classification string to exercise
+    # the fallback path in all_parents / children. Petigera used to
+    # serve this purpose, but it now carries a classification (see
+    # #4154), so we synthesize an equivalent fixture here.
+    pet = create_test_name("Petigera")
+    pet.update!(deprecated: true, classification: nil,
+                correct_spelling: names(:peltigera),
+                synonym_id: names(:peltigera).synonym_id)
     assert_name_arrays_equal([], pet.all_parents)
     assert_name_arrays_equal([], pet.children)
 
@@ -1984,8 +1990,10 @@ class NameTest < UnitTestCase
 
   def test_ancestors_3
     # Names with Ascomycota in classification OR search_name starting with it.
-    # Includes: Ascomycota itself + Ascomycetes through Peltigera.
-    assert_equal(5, Name.classification_has("Ascomycota").count)
+    # Includes: Ascomycota itself + Ascomycetes through Peltigera, plus
+    # Petigera (deprecated misspelling of Peltigera, whose fixture now
+    # also carries the classification — see #4154).
+    assert_equal(6, Name.classification_has("Ascomycota").count)
 
     kng = names(:fungi)
     phy = names(:ascomycota)


### PR DESCRIPTION
Follow-up to #4153 / discussion #4154.

## Summary
- Removes the fourth pass in `Lookup::Names#lookup_ids` that re-synonymized the sub-taxa expansion. That pass was the mechanism behind the Agaricus → Protostropharia 21K-obs drag, and the only legitimate cases it was serving were deprecated synonyms whose `classification` column happened to be empty.
- Classification data is now the sole source of truth for "what's in this clade." The existing `Name#propagate_classification` keeps genus classifications synced to subtaxa and deprecated synonyms; a separate effort will close the ~42% of production names that currently lack classification strings.
- Removes the `include_subtaxa_synonyms` flag and all its plumbing added in #4153 (`Lookup::Names`, `Observation.names`, `PatternSearch::Observation` / `::Name`, `Query::Observations` / `::Names` / `::Projects` / `::NameDescriptions` / `::SpeciesLists`, locale keys). Project's `candidate_name_ids` and `expanded_target_name_ids` simplify to plain `include_synonyms: true, include_subtaxa: true`.

## Stacking
Based on `njw-4130-subtaxa-in-project-names` (PR #4153) since that branch introduces the flag this one deletes. Will retarget to `main` once #4153 merges.

## Test changes
- Petigera fixture gains Peltigera's classification string, so it surfaces through the regular `add_higher_names` path in sub-taxon searches of Peltigeraceae / Peltigera.
- `NameTest#test_ancestors_2` synthesizes an inline "Petigera"-shaped deprecated name with null classification to preserve its no-classification fallback coverage.
- `NameTest#test_ancestors_3` bumps the expected Ascomycota count from 5 to 6.
- `LookupTest#test_lookup_names_by_name_classifications` asserts Petigera shows up via classification rather than via the removed step 4.

## Test plan
- [x] `bin/rails test` — 4942 tests, 0 failures
- [x] `bundle exec rubocop` clean
- [ ] Release note: `/observations?pattern=<genus>+include_synonyms:true+include_subtaxa:true` URLs may return fewer results where the old step-4 expansion was dragging in unrelated current-name species. Project candidate queries benefit from the same narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)