### PR TITLE
Aggregate map marker color by consensus band (#4159)

### DIFF
--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -27,14 +27,17 @@
 #
 module Mappable
   class MapSet
-    # Marker colors used in the map popup enhancement (issue #4131).
-    # Groups / multi-observation / box markers get the neutral blue.
-    # Single-observation markers use a traffic-light palette based on the
-    # consensus vote percentage.
-    GROUP_COLOR = "#3B79CC" # bootstrap primary
+    # Marker colors. Color is driven purely by observation consensus:
+    # a set whose members all fall in the same consensus band gets that
+    # band's traffic-light color; a mix of bands gets MIXED_COLOR. Sets
+    # containing only locations (no observations) fall back to
+    # LOCATION_ONLY_COLOR — there's no vote information to classify.
+    # See issue #4159.
     CONFIRMED_COLOR = "#5CB85C" # >=80% — bootstrap success
     TENTATIVE_COLOR = "#F0AD4E" # 0<x<80% — bootstrap warning
     DISPUTED_COLOR  = "#D9534F" # <=0% — bootstrap danger
+    MIXED_COLOR     = "#C69B71" # observations in different consensus bands
+    LOCATION_ONLY_COLOR = "#3B79CC" # bootstrap primary; no obs to classify
 
     attr_reader :north, :south, :east, :west, :is_point, :is_box,
                 :north_east, :south_east, :south_west, :north_west, :lat, :lng,
@@ -81,16 +84,28 @@ module Mappable
     end
 
     # Hex color for the marker or box stroke.
-    # - Blue for groups (>1 observation or location-only).
-    # - Single observations: traffic-light based on consensus %.
+    # Aggregates the consensus bands of the set's observations:
+    # - All observations in the same band → that band's color.
+    # - Observations spanning multiple bands → MIXED_COLOR.
+    # - No observations (location-only set) → LOCATION_ONLY_COLOR.
     def compute_color
-      return GROUP_COLOR unless single_observation?
+      bands = observations.map { |o| consensus_band(o) }.uniq
+      return LOCATION_ONLY_COLOR if bands.empty?
+      return MIXED_COLOR if bands.length > 1
 
-      pct = ::Vote.percent(observations.first.vote_cache)
-      return DISPUTED_COLOR if pct <= 0
-      return CONFIRMED_COLOR if pct >= 80
+      case bands.first
+      when :confirmed then CONFIRMED_COLOR
+      when :tentative then TENTATIVE_COLOR
+      when :disputed then DISPUTED_COLOR
+      end
+    end
 
-      TENTATIVE_COLOR
+    def consensus_band(obs)
+      pct = ::Vote.percent(obs.vote_cache)
+      return :disputed if pct <= 0
+      return :confirmed if pct >= 80
+
+      :tentative
     end
 
     def observations

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -34,7 +34,7 @@ module MapHelper
       show_all: :show_all.t,
       map_all: :map_all.t
     }.to_json
-    safe_join([map_html(map_args), map_legend])
+    safe_join([map_html(map_args), map_legend(objects: objects)])
   end
 
   # Returns a CollapsibleCollection of mapsets, containing all data necessary

--- a/app/helpers/map_legend_helper.rb
+++ b/app/helpers/map_legend_helper.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
-# Legend shown under every map rendered via MapHelper#make_map.
-# Two rows: shape meanings (circle vs. box) and color meanings
-# (consensus bands + group). See #4131.
+# Legend shown under maps that include at least one observation.
+# Suppressed on location-only maps, where consensus bands are
+# meaningless. Two rows: shape meanings (circle vs. box) and color
+# meanings (consensus bands + mixed + location-only). See #4159.
 module MapLegendHelper
-  def map_legend
+  # Pass objects so we can suppress the legend on location-only maps.
+  def map_legend(objects: nil)
+    return "".html_safe unless legend_applies?(objects)
+
     tag.div(class: "map-legend small text-muted mt-2") do
       concat(map_legend_shape_row)
       concat(map_legend_color_row)
@@ -12,6 +16,15 @@ module MapLegendHelper
   end
 
   private
+
+  # Legend is meaningful only when the map shows at least one
+  # observation. When `objects` is nil (callers that predate this
+  # argument), fall back to the old unconditional behavior.
+  def legend_applies?(objects)
+    return true if objects.nil?
+
+    objects.any? { |o| o.respond_to?(:observation?) && o.observation? }
+  end
 
   def map_legend_shape_row
     tag.div(class: "map-legend-row") do
@@ -33,7 +46,8 @@ module MapLegendHelper
       [Mappable::MapSet::CONFIRMED_COLOR, :map_legend_confirmed.t],
       [Mappable::MapSet::TENTATIVE_COLOR, :map_legend_tentative.t],
       [Mappable::MapSet::DISPUTED_COLOR, :map_legend_disputed.t],
-      [Mappable::MapSet::GROUP_COLOR, :map_legend_group.t]
+      [Mappable::MapSet::MIXED_COLOR, :map_legend_mixed.t],
+      [Mappable::MapSet::LOCATION_ONLY_COLOR, :map_legend_location_only.t]
     ]
   end
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -298,8 +298,9 @@ export default class extends GeocodeController {
     const bounds = this.boundsOf(set)
     if (!bounds) return false
 
-    // Per-box color from the server (#4131). Rectangles are group markers
-    // so this is usually GROUP_COLOR, but honor whatever the server set.
+    // Per-box color from the server: the aggregated consensus color
+    // (#4159), or the location-only blue if no observations were in
+    // the set. Always honor whatever the server computed.
     const color = (set && set.color) || this.marker_color
 
     // If the rectangle would render sub-pixel at the current zoom, draw

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -904,7 +904,8 @@
   map_legend_confirmed: Confirmed (≥80%)
   map_legend_tentative: Tentative
   map_legend_disputed: Disputed (≤0%)
-  map_legend_group: Multiple observations
+  map_legend_mixed: Mixed consensus
+  map_legend_location_only: Location only (no observations)
   show_location: Show [LOCATION]
   show_location_description: Show [DESCRIPTION]
   about_this_taxon: About this taxon

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -4,59 +4,81 @@ require("test_helper")
 
 class MapSetTest < UnitTestCase
   # ------------------------------------------------------------------
-  # #compute_color — issue #4131
+  # #compute_color — issue #4159 (was #4131)
   # ------------------------------------------------------------------
 
-  def test_color_blue_for_multi_observation_group
-    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
-                 build_obs(lat: 10, lng: 10, vote_cache: 3.0))
-    assert_equal(Mappable::MapSet::GROUP_COLOR, set.compute_color)
-  end
-
-  def test_color_blue_for_location_only
+  # Location-only sets have no observations to classify; they keep the
+  # neutral blue and the legend is suppressed on maps with no obs.
+  def test_color_location_only_for_no_observations
     set = set_of(locations(:burbank))
-    assert_equal(Mappable::MapSet::GROUP_COLOR, set.compute_color)
+    assert_equal(Mappable::MapSet::LOCATION_ONLY_COLOR, set.compute_color)
   end
 
-  def test_color_green_for_single_obs_confirmed
+  def test_color_confirmed_for_single_obs_confirmed
     # 2.4 / 3 * 100 = 80.0 — exactly the threshold.
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 2.4))
     assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color)
   end
 
-  def test_color_orange_for_single_obs_tentative
+  def test_color_tentative_for_single_obs_tentative
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 1.5))
     assert_equal(Mappable::MapSet::TENTATIVE_COLOR, set.compute_color)
   end
 
-  def test_color_red_for_single_obs_disputed_at_zero
+  def test_color_disputed_for_single_obs_at_zero
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 0.0))
     assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
   end
 
-  def test_color_red_for_single_obs_negative
+  def test_color_disputed_for_single_obs_negative
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: -1.5))
     assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
   end
 
-  def test_color_red_for_single_obs_missing_vote_cache
-    # Vote.percent returns 0.0 when the value is blank -> disputed.
+  def test_color_disputed_for_single_obs_missing_vote_cache
+    # Vote.percent returns 0.0 when vote_cache is blank -> disputed.
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: nil))
     assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  # Multi-obs sets: same-band members take that band's color.
+  def test_color_confirmed_when_all_members_confirmed
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 2.4))
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color)
+  end
+
+  def test_color_disputed_when_all_members_disputed
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: -1.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 0.0))
+    assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  # Mixed-band members use MIXED_COLOR.
+  def test_color_mixed_when_members_in_different_bands
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 1.5))
+    assert_equal(Mappable::MapSet::MIXED_COLOR, set.compute_color)
+  end
+
+  def test_color_mixed_with_confirmed_plus_disputed
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: -1.0))
+    assert_equal(Mappable::MapSet::MIXED_COLOR, set.compute_color)
   end
 
   # On the observations index map the controller passes obs AND their
   # locations. CollapsibleCollectionOfObjects can put a single obs and
   # its location in the same bucket, giving @objects.size == 2 even
-  # though there's just one observation. The set should still colour
-  # by that observation's consensus, not blue.
+  # though there's just one observation. The set should still color
+  # by that observation's consensus.
   def test_color_for_single_obs_bucketed_with_its_location
     obs = build_obs(lat: 34.1, lng: -118.3, vote_cache: 2.4)
     set = set_of(obs, locations(:burbank))
     assert_equal(1, set.observations.length)
     assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color,
                  "Single obs bucketed with its location should still " \
-                 "use the consensus color, not GROUP_COLOR")
+                 "use the consensus color, not LOCATION_ONLY_COLOR")
   end
 
   # ------------------------------------------------------------------

--- a/test/components/map_test.rb
+++ b/test/components/map_test.rb
@@ -131,7 +131,9 @@ class MapTest < ComponentTestCase
                           observed_on: Date.new(2025, 1, 1))
     caption, color = parse_first_set(render_map_json([obs_a, obs_b, obs_c]))
 
-    assert_equal(Mappable::MapSet::GROUP_COLOR, color)
+    # All three members are confirmed (vote_cache 3.0), so the group
+    # inherits the confirmed band's color (#4159).
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, color)
     # Most recent first.
     assert(caption.index("Newest sp.") < caption.index("Middle sp."),
            "Group popup should list most recent name first")


### PR DESCRIPTION
First PR against #4159 (see https://github.com/MushroomObserver/mushroom-observer/issues/4159#issuecomment-4304786829 for the full design).

## Summary
- Replace the "any group is blue" rule in `Mappable::MapSet#compute_color` with a consensus-band aggregation: all-confirmed → green, all-tentative → yellow, all-disputed → red, spanning bands → new `MIXED_COLOR` (`#C69B71`). Sets with zero observations keep the neutral blue as `LOCATION_ONLY_COLOR`.
- Suppress the map legend on maps that contain only locations (no observations to classify). Previously the legend appeared under location-only maps like `/locations/30625` where confirmed/tentative/disputed are meaningless.
- Legend refreshed: drops `map_legend_group`, adds `map_legend_mixed` and `map_legend_location_only`.

Scope deliberately narrow. Shape rules (dot = single, square = multiple), border styles (crisp / dashed / none), and dynamic clustering via `@googlemaps/markerclusterer` all come in later PRs.

## Changes
- `app/classes/mappable/map_set.rb` — new constants, new `compute_color`, helper `consensus_band`.
- `app/helpers/map_legend_helper.rb` — legend accepts `objects:` and suppresses when none are observations; new color entries.
- `app/helpers/map_helper.rb` — passes `objects` through to the legend.
- `app/javascript/controllers/map_controller.js` — code comment update (no behavior change).
- `config/locales/en.txt` — new keys, dropped old one.
- Tests rewritten to reflect the new aggregation rule.

## Test plan
- [x] `bin/rails test` — 4967 tests, 0 failures.
- [x] `bundle exec rubocop` clean on touched files.
- [ ] Manual check: a location-only map (e.g. `/locations/:id`) no longer shows the legend.
- [ ] Manual check: a multi-obs group that's all-confirmed renders green, mixed renders brown, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)