### PR TITLE
Map clustering + GPS trust fixes (#4159)

### DIFF
--- a/app/assets/stylesheets/mo/_left_nav.scss
+++ b/app/assets/stylesheets/mo/_left_nav.scss
@@ -25,6 +25,12 @@
     text-overflow: ellipsis;
     padding: 4px;
 
+    // overflow: hidden above clips the keyboard focus ring at the
+    // item's edges. Pull the outline inside so it renders fully.
+    &:focus-visible {
+      outline-offset: -2px;
+    }
+
     &.active,
     &:hover,
     &:focus,

--- a/app/assets/stylesheets/mo/_logo.scss
+++ b/app/assets/stylesheets/mo/_logo.scss
@@ -5,3 +5,11 @@
 #logo_link:hover {
   background-color: transparent;
 }
+
+// The link sits at the top of the sidebar and its parent column has
+// horizontal overflow constraints; the keyboard focus ring renders
+// outside the link's box and gets clipped at the bottom. Pull the
+// outline inside so the full ring is visible.
+#logo_link:focus-visible {
+  outline-offset: -2px;
+}

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -134,17 +134,22 @@
     border-radius: 50%;
   }
 
-  // Border-style swatches: show the stroke style without implying
-  // a shape.
+  // Border-style swatches. Fill is a neutral gray; the ring color
+  // encodes precision so the legend mirrors the marker rendering:
+  //   crisp  — dark ring  (precise GPS)
+  //   dashed — gray ring  (mixed precision)
+  //   none   — white ring (fuzzy / location-only)
   .map-legend-border-crisp {
-    border: 2px solid #555;
+    border: 2px solid #333;
+    background: #aaa;
   }
   .map-legend-border-dashed {
-    border: 2px dashed #555;
+    border: 2px solid #888;
+    background: #aaa;
   }
   .map-legend-border-none {
-    border: 0;
-    background: #C69B71;
+    border: 2px solid #fff;
+    background: #aaa;
   }
 }
 

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -234,3 +234,64 @@
     content: none;
   }
 }
+
+// Cluster popup (#4159). Members grouped by species, listed with
+// counts on the right and a "Click to zoom in" link underneath.
+.map-popup-cluster {
+  padding-right: 20px; // room for the close X
+  min-width: 260px;
+
+  .map-popup-cluster-header {
+    margin-bottom: 6px;
+  }
+  .map-popup-cluster-title {
+    font-size: 15px;
+    line-height: 1.2;
+  }
+  .map-popup-cluster-subtitle {
+    color: #666;
+    font-size: 12px;
+  }
+  .map-popup-cluster-actions {
+    margin-top: 6px;
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .map-popup-cluster-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 240px;
+    overflow-y: auto;
+
+    li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      padding: 3px 0;
+      border-bottom: 1px solid #eee;
+
+      &:last-child { border-bottom: 0; }
+    }
+  }
+
+  .map-popup-cluster-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .map-popup-cluster-count {
+    flex: 0 0 auto;
+    color: #2a6f2a;
+    font-size: 13px;
+  }
+  .map-popup-cluster-zoom-row {
+    text-align: center;
+    margin-top: 10px;
+  }
+}

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -97,9 +97,9 @@
   min-height: 300px;
 }
 
-// Legend rendered under every map by MapHelper#map_legend (#4131).
-// Two rows: shape meanings (circle vs. box) then color meanings
-// (consensus bands + group).
+// Legend rendered under maps with at least one observation by
+// MapHelper#map_legend (#4159). Three rows: shape (single vs
+// multiple observation), border (precision), and color (consensus).
 .map-legend {
   .map-legend-row {
     display: flex;
@@ -132,6 +132,19 @@
   .map-legend-dot {
     border: 0;
     border-radius: 50%;
+  }
+
+  // Border-style swatches: show the stroke style without implying
+  // a shape.
+  .map-legend-border-crisp {
+    border: 2px solid #555;
+  }
+  .map-legend-border-dashed {
+    border: 2px dashed #555;
+  }
+  .map-legend-border-none {
+    border: 0;
+    background: #C69B71;
   }
 }
 

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -98,8 +98,8 @@
 }
 
 // Legend rendered under maps with at least one observation by
-// MapHelper#map_legend (#4159). Three rows: shape (single vs
-// multiple observation), border (precision), and color (consensus).
+// MapHelper#map_legend (#4159). Two rows: border (precision) and
+// color (consensus).
 .map-legend {
   .map-legend-row {
     display: flex;
@@ -124,32 +124,30 @@
     flex-shrink: 0;
   }
 
-  .map-legend-circle {
-    border-radius: 50%;
-  }
-  // .map-legend-box swatch is the default square .map-legend-swatch.
-
   .map-legend-dot {
     border: 0;
     border-radius: 50%;
   }
 
-  // Border-style swatches. Fill is a neutral gray; the ring color
-  // encodes precision so the legend mirrors the marker rendering:
+  // Border-style swatches mirror the circular markers on the map:
+  // fill is a neutral gray; the ring color encodes precision.
   //   crisp  — dark ring  (precise GPS)
   //   dashed — gray ring  (mixed precision)
   //   none   — white ring (fuzzy / location-only)
+  .map-legend-border-crisp,
+  .map-legend-border-dashed,
+  .map-legend-border-none {
+    border-radius: 50%;
+    background: #aaa;
+  }
   .map-legend-border-crisp {
     border: 2px solid #333;
-    background: #aaa;
   }
   .map-legend-border-dashed {
     border: 2px solid #888;
-    background: #aaa;
   }
   .map-legend-border-none {
     border: 2px solid #fff;
-    background: #aaa;
   }
 }
 

--- a/app/assets/stylesheets/mo/_maps.scss
+++ b/app/assets/stylesheets/mo/_maps.scss
@@ -72,6 +72,14 @@
   overflow: auto !important;
   padding: 12px 12px 8px;
 }
+// The InfoWindow content has `overflow: auto`, which clips browser
+// focus rings on links/buttons that sit at the edge of the content
+// box. Pull the outline inside the element so it renders fully
+// without changing its visual weight.
+.gm-style-iw-d a:focus-visible,
+.gm-style-iw-d button:focus-visible {
+  outline-offset: -2px;
+}
 .gm-style-iw-chr {
   // Pull the close-X to the top-right corner without reserving a full
   // header row above the content.
@@ -277,11 +285,12 @@
   }
 
   .map-popup-cluster-name {
+    // Allow long species names to wrap rather than truncating with
+    // ellipsis; the previous `overflow: hidden` was clipping the
+    // focus outline on the link inside.
     flex: 1 1 auto;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow-wrap: break-word;
   }
   .map-popup-cluster-count {
     flex: 0 0 auto;

--- a/app/classes/mappable/box_methods.rb
+++ b/app/classes/mappable/box_methods.rb
@@ -155,6 +155,40 @@ module Mappable
       expanded.contains?(pt_lat, pt_lng)
     end
 
+    # Great-circle-ish distance in km from the nearest edge of this
+    # bbox to the given point. Returns 0 when the point is inside.
+    # Handles east<west (antimeridian-wrapping) bboxes. Used by
+    # Observation#set_gps_dubious for #4159.
+    KM_PER_DEGREE = 111.0
+
+    def km_from_point(pt_lat, pt_lng)
+      km_lat = lat_degrees_from_point(pt_lat) * KM_PER_DEGREE
+      km_lng = lng_degrees_from_point(pt_lng) * KM_PER_DEGREE *
+               Math.cos(pt_lat * Math::PI / 180.0)
+      Math.sqrt((km_lat * km_lat) + (km_lng * km_lng))
+    end
+
+    def lat_degrees_from_point(pt_lat)
+      return south - pt_lat if pt_lat < south
+      return pt_lat - north if pt_lat > north
+
+      0.0
+    end
+
+    def lng_degrees_from_point(pt_lng)
+      return 0.0 if lng_inside?(pt_lng)
+
+      d_east = (pt_lng - east).abs % 360
+      d_west = (pt_lng - west).abs % 360
+      [d_east, 360 - d_east, d_west, 360 - d_west].min
+    end
+
+    def lng_inside?(pt_lng)
+      return pt_lng.between?(west, east) if east >= west
+
+      pt_lng >= west || pt_lng <= east
+    end
+
     # These (or Arel equivalents) are necessary for update_all to be efficient.
     # Used in update_box_area_and_center_columns to populate or restore columns.
     module ClassMethods

--- a/app/classes/mappable/clustered_collection.rb
+++ b/app/classes/mappable/clustered_collection.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#
+#  = Clustered Map Collection Class
+#
+#  Parallel to CollapsibleCollectionOfObjects but WITHOUT geographic
+#  bucketing — one MapSet per source object. Used when the caller
+#  wants the client to cluster dynamically via
+#  @googlemaps/markerclusterer (issue #4159).
+#
+#  Exposes the same `sets` / `extents` / `representative_points`
+#  attributes so the existing JS collection consumer doesn't have to
+#  branch on payload shape.
+#
+
+module Mappable
+  class ClusteredCollection
+    attr_accessor :sets, :extents, :representative_points
+
+    def initialize(sets)
+      @sets = sets
+      @extents = calc_extents
+      @representative_points =
+        [@extents.north_west, @extents.center, @extents.south_east]
+    end
+
+    def mapsets
+      @sets.values
+    end
+
+    private
+
+    def calc_extents
+      result = Mappable::MapSet.new
+      mapsets.each { |mapset| result.update_extents_with_box(mapset) }
+      result
+    end
+  end
+end

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -42,7 +42,8 @@ module Mappable
     attr_reader :north, :south, :east, :west, :is_point, :is_box,
                 :north_east, :south_east, :south_west, :north_west, :lat, :lng,
                 :north_south_distance, :east_west_distance, :center, :edges
-    attr_accessor :objects, :title, :caption, :color, :glyph, :border_style
+    attr_accessor :objects, :title, :caption, :color, :glyph, :border_style,
+                  :cluster_name, :cluster_url
 
     def initialize(objects = [])
       @objects = objects.is_a?(Array) ? objects : [objects]

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -42,7 +42,7 @@ module Mappable
     attr_reader :north, :south, :east, :west, :is_point, :is_box,
                 :north_east, :south_east, :south_west, :north_west, :lat, :lng,
                 :north_south_distance, :east_west_distance, :center, :edges
-    attr_accessor :objects, :title, :caption, :color
+    attr_accessor :objects, :title, :caption, :color, :glyph, :border_style
 
     def initialize(objects = [])
       @objects = objects.is_a?(Array) ? objects : [objects]
@@ -106,6 +106,33 @@ module Mappable
       return :confirmed if pct >= 80
 
       :tentative
+    end
+
+    # Glyph: :dot for a single observation, :square for multiple or
+    # for location-only sets. Part of the issue #4159 "dot = single,
+    # square = multiple" rule.
+    def compute_glyph
+      single_observation? ? :dot : :square
+    end
+
+    # Border style:
+    # :crisp  — every observation has precise GPS (or the set is
+    #           location-only, whose boundary is precise by definition).
+    # :none   — no observation in the set has usable GPS.
+    # :dashed — a mix of precise and location-only observations.
+    def compute_border_style
+      obs = observations
+      return :crisp if obs.empty? # location-only
+
+      with_gps = obs.count { |o| observation_has_gps?(o) }
+      return :crisp if with_gps == obs.length
+      return :none if with_gps.zero?
+
+      :dashed
+    end
+
+    def observation_has_gps?(obs)
+      obs.lat.present? && !obs.lat_lng_dubious?
     end
 
     def observations

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -108,11 +108,17 @@ module Mappable
       :tentative
     end
 
-    # Glyph: :dot for a single observation, :square for multiple or
-    # for location-only sets. Part of the issue #4159 "dot = single,
-    # square = multiple" rule.
+    # Glyph:
+    #   :dot       — a single observation (rendered as a circle marker)
+    #   :square    — multiple observations (rendered as a square marker
+    #                at the box center on info maps)
+    #   :rectangle — no observations; a location-only set whose box
+    #                should render as the bare outline (#4159).
     def compute_glyph
-      single_observation? ? :dot : :square
+      return :rectangle if observations.empty?
+      return :dot if single_observation?
+
+      :square
     end
 
     # Border style:

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -139,7 +139,7 @@ module Mappable
     end
 
     def observation_has_gps?(obs)
-      obs.lat.present? && !obs.lat_lng_dubious?
+      obs.lat.present? && obs.lng.present? && !obs.lat_lng_dubious?
     end
 
     def observations

--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -27,14 +27,17 @@
 #
 module Mappable
   class MapSet
-    # Marker colors used in the map popup enhancement (issue #4131).
-    # Groups / multi-observation / box markers get the neutral blue.
-    # Single-observation markers use a traffic-light palette based on the
-    # consensus vote percentage.
-    GROUP_COLOR = "#3B79CC" # bootstrap primary
+    # Marker colors. Color is driven purely by observation consensus:
+    # a set whose members all fall in the same consensus band gets that
+    # band's traffic-light color; a mix of bands gets MIXED_COLOR. Sets
+    # containing only locations (no observations) fall back to
+    # LOCATION_ONLY_COLOR — there's no vote information to classify.
+    # See issue #4159.
     CONFIRMED_COLOR = "#5CB85C" # >=80% — bootstrap success
     TENTATIVE_COLOR = "#F0AD4E" # 0<x<80% — bootstrap warning
     DISPUTED_COLOR  = "#D9534F" # <=0% — bootstrap danger
+    MIXED_COLOR     = "#C69B71" # observations in different consensus bands
+    LOCATION_ONLY_COLOR = "#3B79CC" # bootstrap primary; no obs to classify
 
     attr_reader :north, :south, :east, :west, :is_point, :is_box,
                 :north_east, :south_east, :south_west, :north_west, :lat, :lng,
@@ -81,16 +84,28 @@ module Mappable
     end
 
     # Hex color for the marker or box stroke.
-    # - Blue for groups (>1 observation or location-only).
-    # - Single observations: traffic-light based on consensus %.
+    # Aggregates the consensus bands of the set's observations:
+    # - All observations in the same band → that band's color.
+    # - Observations spanning multiple bands → MIXED_COLOR.
+    # - No observations (location-only set) → LOCATION_ONLY_COLOR.
     def compute_color
-      return GROUP_COLOR unless single_observation?
+      bands = observations.map { |o| consensus_band(o) }.uniq
+      return LOCATION_ONLY_COLOR if bands.empty?
+      return MIXED_COLOR if bands.length > 1
 
-      pct = ::Vote.percent(observations.first.vote_cache)
-      return DISPUTED_COLOR if pct <= 0
-      return CONFIRMED_COLOR if pct >= 80
+      case bands.first
+      when :confirmed then CONFIRMED_COLOR
+      when :tentative then TENTATIVE_COLOR
+      when :disputed then DISPUTED_COLOR
+      end
+    end
 
-      TENTATIVE_COLOR
+    def consensus_band(obs)
+      pct = ::Vote.percent(obs.vote_cache)
+      return :disputed if pct <= 0
+      return :confirmed if pct >= 80
+
+      :tentative
     end
 
     def observations

--- a/app/controllers/concerns/clustered_observation_map.rb
+++ b/app/controllers/concerns/clustered_observation_map.rb
@@ -25,6 +25,7 @@ module ClusteredObservationMap
     rows = capped_observation_rows
     record_observation_count_ivars(rows)
     build_minimal_observations_from_rows(rows)
+    @cluster_query_string = cluster_query_string
   end
 
   def capped_observation_rows
@@ -69,6 +70,24 @@ module ClusteredObservationMap
       total: @observations_total_count,
       cap: @observations_cap
     }
+  end
+
+  # URL-encoded base for the cluster popup's Show All / Map All
+  # links. The client uses this instead of `window.location.search`
+  # so the destination URL works no matter how the source page got
+  # to its filters — explicit `q[...]` params, a saved `q=ABC`
+  # identifier, or no URL params at all (e.g. a Names map page that
+  # built its query from `params[:id]`).
+  #
+  # Returns "q[key]=value&…" with `in_box` stripped (the client adds
+  # the cluster's bbox), suitable for handing straight to
+  # URLSearchParams.
+  def cluster_query_string
+    return "" unless @query
+
+    filters = q_param(@query) || {}
+    filters = filters.deep_stringify_keys.except("in_box")
+    { q: filters }.to_query
   end
 
   # The base scope that the cap fetch and the total-count query both

--- a/app/controllers/concerns/clustered_observation_map.rb
+++ b/app/controllers/concerns/clustered_observation_map.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Shared loader + JSON refetch payload for controllers that map a
+# query of observations with the dynamic-clustering pipeline (#4159).
+# Caller sets `@query` (an `::Query::Observations`-shaped query) before
+# invoking `find_locations_matching_observations`. The concern then
+# populates `@observations`, `@observations_capped`,
+# `@observations_loaded_count`, `@observations_total_count`, and
+# `@observations_cap` for the view + JSON paths to read.
+#
+# Used by `Observations::MapsController#index` and
+# `Names::MapsController#show`.
+module ClusteredObservationMap
+  extend ActiveSupport::Concern
+
+  private
+
+  # Capped at MapHelper::CLUSTER_MAX_OBJECTS so the client never has
+  # to cluster more points than it can handle. Fetches `cap + 1` rows
+  # so we can detect overflow cheaply (no separate COUNT query); the
+  # extra row is trimmed before building the minimal observations. A
+  # client-side viewport refetch (also keyed off this cap) pulls the
+  # in-viewport subset back under the cap when the user zooms or pans.
+  def find_locations_matching_observations
+    rows = capped_observation_rows
+    record_observation_count_ivars(rows)
+    build_minimal_observations_from_rows(rows)
+  end
+
+  def capped_observation_rows
+    cap = MapHelper::CLUSTER_MAX_OBJECTS
+    rows = mapped_observations_scope.limit(cap + 1).
+           select(*minimal_obs_columns).to_a
+    @observations_capped = rows.size > cap
+    @observations_cap = cap
+    @observations_capped ? rows.first(cap) : rows
+  end
+
+  # Total is only surfaced in the cap banner, so skip the extra
+  # COUNT(*) when the initial fetch already has everything.
+  def record_observation_count_ivars(rows)
+    @observations_loaded_count = rows.size
+    @observations_total_count = if @observations_capped
+                                  count_observations_matching_query
+                                else
+                                  @observations_loaded_count
+                                end
+  end
+
+  def build_minimal_observations_from_rows(rows)
+    location_ids = Set[]
+    name_ids = Set[]
+    @observations = rows.map do |row|
+      build_minimal_observation(row, location_ids, name_ids)
+    end
+    eager_load_related_locations(location_ids) unless location_ids.empty?
+    eager_load_related_names(name_ids) unless name_ids.empty?
+  end
+
+  # Payload for the JSON refetch on map zoom/pan. The client rebuilds
+  # all overlays from the returned collection and updates the cap
+  # banner visibility based on `capped`.
+  def map_refetch_payload
+    args = { query_param: q_param(@query), map_type: "info" }
+    {
+      collection: view_context.clustered_collection(@observations, args),
+      capped: @observations_capped,
+      loaded: @observations_loaded_count,
+      total: @observations_total_count,
+      cap: @observations_cap
+    }
+  end
+
+  # The base scope that the cap fetch and the total-count query both
+  # run against. Pulled out so callers that need a different filter
+  # (e.g. only obs with thumbnails) can override.
+  def mapped_observations_scope
+    @query.scope.
+      where(Observation[:lat].not_eq(nil).
+            or(Observation[:location_id].not_eq(nil)))
+  end
+
+  # COUNT(*) of the same WHERE used for the banner's "of <total>".
+  # Separate query — the cap fetch already ran under LIMIT, so its
+  # row count can't double as a total.
+  def count_observations_matching_query
+    mapped_observations_scope.count
+  end
+
+  def build_minimal_observation(row, location_ids, name_ids)
+    obs = row.attributes.symbolize_keys!
+    track_related_ids(obs, location_ids, name_ids)
+    obs[:lat] = obs[:lng] = nil if obs[:gps_hidden].to_s.to_boolean == true
+    Mappable::MinimalObservation.new(obs.except(:gps_hidden))
+  end
+
+  def track_related_ids(obs, location_ids, name_ids)
+    location_ids << obs[:location_id].to_i if obs[:location_id].present?
+    name_ids << obs[:name_id].to_i if obs[:name_id].present?
+  end
+
+  # Columns selected for minimal-observation map rendering. `name_id`,
+  # `when`, `vote_cache`, `thumb_image_id` are used by popup content
+  # (#4131). `gps_dubious` lets the map layer skip recomputing the
+  # per-obs predicate used for point-vs-box positioning (#4159).
+  def minimal_obs_columns
+    [:id, :lat, :lng, :gps_hidden, :gps_dubious, :location_id,
+     :name_id, :when, :vote_cache, :thumb_image_id].
+      map { |c| Observation[c] }
+  end
+
+  def eager_load_related_locations(location_ids)
+    locations = {}
+    @locations = Location.where(id: location_ids).
+                 select(:id, :name, :north, :south, :east, :west).map do |loc|
+      locations[loc.id] = Mappable::MinimalLocation.new(
+        loc.attributes.symbolize_keys
+      )
+    end
+
+    @observations.each do |obs|
+      obs.location = locations[obs.location_id] if obs.location_id
+    end
+  end
+
+  def eager_load_related_names(name_ids)
+    rows = Name.where(id: name_ids).
+           pluck(:id, :text_name, :display_name).
+           to_h { |id, text, display| [id, [text, display]] }
+    @observations.each do |obs|
+      next unless (pair = rows[obs.name_id])
+
+      obs.text_name = pair[0]
+      obs.display_name = pair[1]
+    end
+  end
+end

--- a/app/controllers/names/maps_controller.rb
+++ b/app/controllers/names/maps_controller.rb
@@ -3,6 +3,8 @@
 #  map::                         Show distribution map.
 module Names
   class MapsController < ApplicationController
+    include(ClusteredObservationMap)
+
     before_action :login_required
 
     def controller_model_name
@@ -10,17 +12,20 @@ module Names
     end
 
     # Draw a map of all the locations where this name has been observed.
+    # Uses the dynamic-clustering pipeline shared with
+    # `Observations::MapsController#index` (#4159).
     def show
       @name = find_or_goto_index(Name, params[:id].to_s)
       return unless @name
 
       @query = find_or_create_query(:Observation, names: { lookup: @name.id })
       @any_content_filters_applied = check_if_preference_filters_applied
-      # Popups hit `obs.name.display_name` for the species label, so
-      # eager-load :name alongside :location to avoid N+1 (#4131).
-      @observations = @query.scope.limit(MO.query_max_array).
-                      includes(:location, :name).
-                      select { |o| o.lat || o.location }
+      find_locations_matching_observations
+
+      respond_to do |format|
+        format.html
+        format.json { render(json: map_refetch_payload) }
+      end
     end
   end
 end

--- a/app/controllers/names/maps_controller.rb
+++ b/app/controllers/names/maps_controller.rb
@@ -18,7 +18,8 @@ module Names
       @name = find_or_goto_index(Name, params[:id].to_s)
       return unless @name
 
-      @query = find_or_create_query(:Observation, names: { lookup: @name.id })
+      @query = build_name_distribution_query
+      update_stored_query(@query)
       @any_content_filters_applied = check_if_preference_filters_applied
       find_locations_matching_observations
 
@@ -26,6 +27,35 @@ module Names
         format.html
         format.json { render(json: map_refetch_payload) }
       end
+    end
+
+    private
+
+    # Build a fresh query for this name's distribution. Bypasses the
+    # session-stored query that `find_or_create_query` would otherwise
+    # merge in — that merge silently inherited an `in_box` (or other
+    # filter) from a previous map navigation, restricting the
+    # Occurrence Map to a stale bbox (#4139).
+    #
+    # If the URL itself carries an `in_box` (e.g. the JS viewport
+    # refetch sending the current map bounds), honor that — but
+    # nothing else from `params[:q]` or the session.
+    def build_name_distribution_query
+      args = { names: { lookup: @name.id } }
+      box = in_box_param_hash
+      args[:in_box] = box if box.present?
+      create_query(:Observation, args)
+    end
+
+    def in_box_param_hash
+      raw = params[:q]
+      return nil unless raw
+
+      hash = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw
+      if hash.respond_to?(:with_indifferent_access)
+        hash = hash.with_indifferent_access
+      end
+      hash[:in_box]
     end
   end
 end

--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -2,6 +2,8 @@
 
 module Observations
   class MapsController < ApplicationController
+    include(ClusteredObservationMap)
+
     before_action :login_required
 
     def controller_model_name
@@ -80,113 +82,6 @@ module Observations
           thumb_image_id: @observation.thumb_image_id
         )
       ]
-    end
-
-    private
-
-    # Payload for the JSON refetch on map zoom/pan. The client rebuilds
-    # all overlays from the returned collection and updates the cap
-    # banner visibility based on `capped`.
-    def map_refetch_payload
-      args = { query_param: q_param(@query), map_type: "info" }
-      {
-        collection: view_context.clustered_collection(@observations, args),
-        capped: @observations_capped,
-        loaded: @observations_loaded_count,
-        total: @observations_total_count,
-        cap: @observations_cap
-      }
-    end
-
-    # Capped at MapHelper::CLUSTER_MAX_OBJECTS so the client never has
-    # to cluster more points than it can handle. Fetches `cap + 1`
-    # rows so we can detect overflow cheaply (no separate COUNT
-    # query); the extra row is trimmed before building the minimal
-    # observations. A running refetch on viewport change (handled
-    # client-side) pulls the in-viewport subset back under the cap
-    # when the user zooms or pans.
-    def find_locations_matching_observations
-      cap = MapHelper::CLUSTER_MAX_OBJECTS
-      rows = @query.scope.
-             where(Observation[:lat].not_eq(nil).
-                   or(Observation[:location_id].not_eq(nil))).
-             limit(cap + 1).
-             select(*minimal_obs_columns).to_a
-
-      @observations_capped = rows.size > cap
-      rows = rows.first(cap) if @observations_capped
-      @observations_loaded_count = rows.size
-      @observations_cap = cap
-      # Total is only surfaced in the cap banner, so skip the extra
-      # COUNT(*) when the initial fetch already has everything.
-      @observations_total_count = if @observations_capped
-                                    count_observations_matching_query
-                                  else
-                                    @observations_loaded_count
-                                  end
-
-      location_ids = Set[]
-      name_ids = Set[]
-      @observations = rows.map do |row|
-        build_minimal_observation(row, location_ids, name_ids)
-      end
-
-      eager_load_related_locations(location_ids) unless location_ids.empty?
-      eager_load_related_names(name_ids) unless name_ids.empty?
-    end
-
-    # COUNT(*) of the same WHERE used for the banner's "of <total>".
-    # Separate query — the fetch above already ran under LIMIT, so its
-    # row count can't double as a total.
-    def count_observations_matching_query
-      @query.scope.
-        where(Observation[:lat].not_eq(nil).
-              or(Observation[:location_id].not_eq(nil))).
-        count
-    end
-
-    def build_minimal_observation(row, location_ids, name_ids)
-      obs = row.attributes.symbolize_keys!
-      location_ids << obs[:location_id].to_i if obs[:location_id].present?
-      name_ids << obs[:name_id].to_i if obs[:name_id].present?
-      obs[:lat] = obs[:lng] = nil if obs[:gps_hidden].to_s.to_boolean == true
-      Mappable::MinimalObservation.new(obs.except(:gps_hidden))
-    end
-
-    # Columns selected for minimal-observation map rendering. `name_id`,
-    # `when`, `vote_cache`, `thumb_image_id` are used by popup content
-    # (#4131). `gps_dubious` lets the map layer skip recomputing the
-    # per-obs predicate used for point-vs-box positioning (#4159).
-    def minimal_obs_columns
-      [:id, :lat, :lng, :gps_hidden, :gps_dubious, :location_id,
-       :name_id, :when, :vote_cache, :thumb_image_id].
-        map { |c| Observation[c] }
-    end
-
-    def eager_load_related_locations(location_ids)
-      locations = {}
-      @locations = Location.where(id: location_ids).
-                   select(:id, :name, :north, :south, :east, :west).map do |loc|
-        locations[loc.id] = Mappable::MinimalLocation.new(
-          loc.attributes.symbolize_keys
-        )
-      end
-
-      @observations.each do |obs|
-        obs.location = locations[obs.location_id] if obs.location_id
-      end
-    end
-
-    def eager_load_related_names(name_ids)
-      rows = Name.where(id: name_ids).
-             pluck(:id, :text_name, :display_name).
-             to_h { |id, text, display| [id, [text, display]] }
-      @observations.each do |obs|
-        next unless (pair = rows[obs.name_id])
-
-        obs.text_name = pair[0]
-        obs.display_name = pair[1]
-      end
     end
   end
 end

--- a/app/controllers/observations/maps_controller.rb
+++ b/app/controllers/observations/maps_controller.rb
@@ -15,6 +15,42 @@ module Observations
       @query = find_or_create_query(:Observation)
       @any_content_filters_applied = check_if_preference_filters_applied
       find_locations_matching_observations
+
+      respond_to do |format|
+        format.html
+        format.json { render(json: map_refetch_payload) }
+      end
+    end
+
+    # Rendered caption HTML for a single observation — used by the
+    # client to lazy-load popup content when the user clicks a marker
+    # on a clustered map (#4159). Sending pre-rendered captions for
+    # every obs in the bulk payload was the dominant refetch cost; on
+    # click we only need one.
+    def popup
+      observation = find_or_goto_index(Observation, params[:id].to_s)
+      return unless observation
+
+      lat = permission?(observation) ? observation.lat : observation.public_lat
+      lng = permission?(observation) ? observation.lng : observation.public_lng
+      minimal = Mappable::MinimalObservation.new(
+        id: observation.id,
+        lat: lat, lng: lng,
+        location: observation.location,
+        location_id: observation.location_id,
+        name_id: observation.name_id,
+        text_name: observation.name&.text_name,
+        display_name: observation.name&.display_name,
+        when: observation.when,
+        vote_cache: observation.vote_cache,
+        thumb_image_id: observation.thumb_image_id
+      )
+      set = Mappable::MapSet.new([minimal])
+      # params[:q] arrives as ActionController::Parameters; URL helpers
+      # inside mapset_info_window reject unpermitted parameters, so
+      # convert to a plain Hash before passing through.
+      args = { query_param: params[:q].presence&.to_unsafe_h }
+      render(json: { html: view_context.mapset_info_window(set, args) })
     end
 
     # Show map of one observation by id.
@@ -48,31 +84,81 @@ module Observations
 
     private
 
+    # Payload for the JSON refetch on map zoom/pan. The client rebuilds
+    # all overlays from the returned collection and updates the cap
+    # banner visibility based on `capped`.
+    def map_refetch_payload
+      args = { query_param: q_param(@query), map_type: "info" }
+      {
+        collection: view_context.clustered_collection(@observations, args),
+        capped: @observations_capped,
+        loaded: @observations_loaded_count,
+        total: @observations_total_count,
+        cap: @observations_cap
+      }
+    end
+
+    # Capped at MapHelper::CLUSTER_MAX_OBJECTS so the client never has
+    # to cluster more points than it can handle. Fetches `cap + 1`
+    # rows so we can detect overflow cheaply (no separate COUNT
+    # query); the extra row is trimmed before building the minimal
+    # observations. A running refetch on viewport change (handled
+    # client-side) pulls the in-viewport subset back under the cap
+    # when the user zooms or pans.
     def find_locations_matching_observations
+      cap = MapHelper::CLUSTER_MAX_OBJECTS
+      rows = @query.scope.
+             where(Observation[:lat].not_eq(nil).
+                   or(Observation[:location_id].not_eq(nil))).
+             limit(cap + 1).
+             select(*minimal_obs_columns).to_a
+
+      @observations_capped = rows.size > cap
+      rows = rows.first(cap) if @observations_capped
+      @observations_loaded_count = rows.size
+      @observations_cap = cap
+      # Total is only surfaced in the cap banner, so skip the extra
+      # COUNT(*) when the initial fetch already has everything.
+      @observations_total_count = if @observations_capped
+                                    count_observations_matching_query
+                                  else
+                                    @observations_loaded_count
+                                  end
+
       location_ids = Set[]
       name_ids = Set[]
-      minimal_obs_query = @query.scope.
-                          where(Observation[:lat].not_eq(nil).
-                                or(Observation[:location_id].not_eq(nil))).
-                          limit(MO.query_max_array).
-                          select(*minimal_obs_columns)
-      @observations = minimal_obs_query.map do |obs|
-        obs = obs.attributes.symbolize_keys!
-        location_ids << obs[:location_id].to_i if obs[:location_id].present?
-        name_ids << obs[:name_id].to_i if obs[:name_id].present?
-        obs[:lat] = obs[:lng] = nil if obs[:gps_hidden].to_s.to_boolean == true
-        Mappable::MinimalObservation.new(obs.except(:gps_hidden))
+      @observations = rows.map do |row|
+        build_minimal_observation(row, location_ids, name_ids)
       end
 
       eager_load_related_locations(location_ids) unless location_ids.empty?
       eager_load_related_names(name_ids) unless name_ids.empty?
     end
 
+    # COUNT(*) of the same WHERE used for the banner's "of <total>".
+    # Separate query — the fetch above already ran under LIMIT, so its
+    # row count can't double as a total.
+    def count_observations_matching_query
+      @query.scope.
+        where(Observation[:lat].not_eq(nil).
+              or(Observation[:location_id].not_eq(nil))).
+        count
+    end
+
+    def build_minimal_observation(row, location_ids, name_ids)
+      obs = row.attributes.symbolize_keys!
+      location_ids << obs[:location_id].to_i if obs[:location_id].present?
+      name_ids << obs[:name_id].to_i if obs[:name_id].present?
+      obs[:lat] = obs[:lng] = nil if obs[:gps_hidden].to_s.to_boolean == true
+      Mappable::MinimalObservation.new(obs.except(:gps_hidden))
+    end
+
     # Columns selected for minimal-observation map rendering. `name_id`,
-    # `when`, `vote_cache`, and `thumb_image_id` are used by popup
-    # content for #4131.
+    # `when`, `vote_cache`, `thumb_image_id` are used by popup content
+    # (#4131). `gps_dubious` lets the map layer skip recomputing the
+    # per-obs predicate used for point-vs-box positioning (#4159).
     def minimal_obs_columns
-      [:id, :lat, :lng, :gps_hidden, :location_id,
+      [:id, :lat, :lng, :gps_hidden, :gps_dubious, :location_id,
        :name_id, :when, :vote_cache, :thumb_image_id].
         map { |c| Observation[c] }
     end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -67,10 +67,13 @@ module MapHelper
       locations: :Locations.t,
       show_all: :show_all.t,
       map_all: :map_all.t,
-      # Banner template for viewport-refetch updates (#4159). Client
-      # replaces __LOADED__ / __TOTAL__ with the formatted counts.
-      map_cap_banner: :map_cap_banner.t(loaded: "__LOADED__",
-                                        total: "__TOTAL__")
+      # Raw template — the client substitutes `[loaded]` / `[total]`
+      # with the formatted counts on each refetch. We bypass `.t` to
+      # skip textile processing (double-underscore placeholders would
+      # be italicized, etc.). Banner text has no textile markup, so
+      # sending the raw string preserves what the ERB-rendered
+      # version produces (#4159).
+      map_cap_banner: I18n.t(:map_cap_banner)
     }
   end
 

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -34,7 +34,7 @@ module MapHelper
       show_all: :show_all.t,
       map_all: :map_all.t
     }.to_json
-    safe_join([map_html(map_args), map_legend])
+    safe_join([map_html(map_args), map_legend(objects: objects)])
   end
 
   # Returns a CollapsibleCollection of mapsets, containing all data necessary

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -2,19 +2,40 @@
 
 module MapHelper
   include MapLegendHelper
+  include MapPopupHelper
+
+  # Upper bound on points for client-side dynamic clustering
+  # (issue #4159). Above this, fall back to server-side bucketing.
+  CLUSTER_MAX_OBJECTS = 20_000
 
   # args could include query_param.
   # returns an array of mapsets, each suitable for a marker or box
   def make_map(objects: [], **args)
     nothing_to_map = args[:nothing_to_map] || :runtime_map_nothing_to_map.t
-    # There's nothing to map if the location is unknown.
-    objects = objects.reject do |obj|
+    objects = reject_unknown_locations(objects)
+    return tag.div(nothing_to_map, class: "w-100") unless objects.any?
+
+    map_args = build_map_args(objects, args, nothing_to_map)
+    safe_join([map_html(map_args), map_legend(objects: objects)])
+  end
+
+  def reject_unknown_locations(objects)
+    objects.reject do |obj|
       name = obj.respond_to?(:location) ? obj.location&.name : obj.name
       Location.is_unknown?(name)
     end
-    return tag.div(nothing_to_map, class: "w-100") unless objects.any?
+  end
 
-    default_args = {
+  def build_map_args(objects, args, nothing_to_map)
+    map_args = default_map_args.
+               merge(args.except(:nothing_to_map, :clustering))
+    add_collection_to_args(map_args, objects, args)
+    map_args[:localization] = build_localization(nothing_to_map).to_json
+    map_args
+  end
+
+  def default_map_args
+    {
       map_div: "map_div",
       controller: "map",
       map_target: "mapDiv",
@@ -23,18 +44,59 @@ module MapHelper
       map_open: true,
       editable: false,
       controls: [:large_map, :map_type].to_json,
-      location_format: User.current_location_format # method has a default
+      location_format: User.current_location_format
     }
-    map_args = default_args.merge(args.except(:nothing_to_map))
-    map_args[:collection] = mappable_collection(objects, map_args).to_json
-    map_args[:localization] = {
+  end
+
+  def add_collection_to_args(map_args, objects, args)
+    if args[:clustering] && objects.size <= CLUSTER_MAX_OBJECTS
+      map_args[:collection] = clustered_collection(objects, map_args).to_json
+      map_args[:clustering] = true
+    else
+      map_args[:collection] = mappable_collection(objects, map_args).to_json
+    end
+  end
+
+  def build_localization(nothing_to_map)
+    {
       nothing_to_map: nothing_to_map,
       observations: :Observations.t,
       locations: :Locations.t,
       show_all: :show_all.t,
       map_all: :map_all.t
-    }.to_json
-    safe_join([map_html(map_args), map_legend(objects: objects)])
+    }
+  end
+
+  # Clustering mode (issue #4159): skip server-side geographic
+  # bucketing. Each mappable object becomes a singleton MapSet so the
+  # client can feed every observation marker through
+  # @googlemaps/markerclusterer and group them dynamically at zoom.
+  #
+  # Returns a shape compatible with CollapsibleCollectionOfObjects —
+  # a `sets` hash plus the `extents` / `representative_points`
+  # derived attributes — so the existing JS collection consumer
+  # doesn't have to branch on payload shape.
+  def clustered_collection(objects, args)
+    sets = {}
+    objects.each do |obj|
+      set = Mappable::MapSet.new([obj])
+      set.color = set.compute_color
+      set.glyph = set.compute_glyph
+      set.border_style = set.compute_border_style
+      set.title = mapset_marker_title(set)
+      set.caption = mapset_info_window(set, args)
+      set.objects = nil
+      sets[singleton_key(obj)] = set
+    end
+    Mappable::ClusteredCollection.new(sets)
+  end
+
+  # Unique key per mappable object for the sets hash. MinimalObservation
+  # IDs start at 1; Location objects share the integer space but
+  # carry their own ids.
+  def singleton_key(obj)
+    prefix = obj.respond_to?(:observation?) && obj.observation? ? "o" : "l"
+    "#{prefix}#{obj.id}"
   end
 
   # Returns a CollapsibleCollection of mapsets, containing all data necessary
@@ -106,233 +168,5 @@ module MapHelper
         end
       end
     end.compact_blank.uniq
-  end
-
-  # Info window popup content. Enhanced for #4131 to match iNat's
-  # denser layout — Bootstrap .media object with a thumbnail on the
-  # left and details on the right for a single observation; a compact
-  # vertical list for groups.
-  MAX_GROUP_NAMES = 3
-
-  def mapset_info_window(set, args)
-    observations = set.observations
-    if observations.length == 1 && observations.first&.id
-      mapset_single_observation_popup(observations.first, set, args)
-    else
-      mapset_group_popup(set, args)
-    end
-  end
-
-  def mapset_single_observation_popup(obs, set, args)
-    tag.div(class: "media map-popup map-popup-single") do
-      concat(mapset_thumbnail_media_left(obs, args))
-      concat(mapset_single_observation_body(obs, set, args))
-    end
-  end
-
-  def mapset_thumbnail_media_left(obs, args)
-    return safe_join([]) unless obs.respond_to?(:thumb_image_id) &&
-                                obs.thumb_image_id
-
-    q = args[:query_param] ? { q: args[:query_param] } : {}
-    url = observation_path(id: obs.id, params: q)
-    tag.div(class: "media-left") do
-      link_to(url, target: "_blank", rel: "noopener noreferrer") do
-        # Empty alt: the adjacent taxon-name link inside the same
-        # .media already provides the accessible label, so the
-        # thumbnail is decorative in this context.
-        image_tag(Image.url(:small, obs.thumb_image_id),
-                  class: "media-object map-popup-thumb",
-                  loading: "lazy",
-                  alt: "")
-      end
-    end
-  end
-
-  def mapset_single_observation_body(obs, set, args)
-    tag.div(class: "media-body") do
-      concat(tag.div(mapset_observation_link(obs, args),
-                     class: "media-heading"))
-      date = mapset_observation_date(obs)
-      concat(tag.div(date, class: "small")) if date
-      conf = mapset_consensus_indicator(obs)
-      concat(tag.div(conf, class: "small")) if conf
-      locations = set.underlying_locations
-      if locations.length == 1 && locations.first&.id
-        concat(tag.div(mapset_location_link(locations.first, args),
-                       class: "small"))
-      end
-      concat(tag.div(mapset_coords(set), class: "small text-muted"))
-    end
-  end
-
-  def mapset_group_popup(set, args)
-    observations = set.observations
-    locations = set.underlying_locations
-    lines = []
-    lines << mapset_observation_header(set) if observations.length > 1
-    lines.concat(mapset_group_name_links(observations, args))
-    lines << mapset_location_header(set) if locations.length > 1
-    if locations.length == 1 && locations.first&.id
-      lines << mapset_location_link(locations.first, args)
-    end
-    lines << mapset_coords(set)
-    tag.div(lines.safe_join(safe_br), class: "map-popup map-popup-group")
-  end
-
-  def mapset_group_name_links(observations, args)
-    sorted = observations.sort_by { |o| [o.when || Date.new(0), o.id] }.reverse
-    top = sorted.first(MAX_GROUP_NAMES)
-    links = top.map { |o| mapset_observation_link(o, args) }
-    links << tag.span("…") if sorted.length > MAX_GROUP_NAMES
-    links
-  end
-
-  def mapset_observation_date(obs)
-    return nil if obs.respond_to?(:when) && obs.when.blank?
-    return nil unless obs.respond_to?(:when)
-
-    obs.when.web_date
-  end
-
-  # Plain-text "Confidence: NN%" line. The marker color already conveys
-  # the semantic bucket, so no dot/pill is needed inside the popup.
-  #
-  # Use `.floor` so the displayed percentage never crosses a
-  # traffic-light threshold the underlying value hasn't crossed yet
-  # — e.g. 79.6% should show "79%" with an orange marker, never
-  # "80%" (which would look like the green/confirmed bucket).
-  def mapset_consensus_indicator(obs)
-    return nil unless obs.respond_to?(:vote_cache)
-
-    pct = ::Vote.percent(obs.vote_cache)
-    "#{:Confidence.t}: #{pct.floor}%"
-  end
-
-  def mapset_observation_header(set)
-    show, map = mapset_associated_links(set, :observation)
-    tag.div(
-      map_point_text(:Observations.t, set.observations.length, show, map),
-      class: "map-popup-header"
-    )
-  end
-
-  def mapset_location_header(set)
-    show, map = mapset_associated_links(set, :location)
-    tag.div(
-      map_point_text(:Locations.t, set.underlying_locations.length, show, map),
-      class: "map-popup-header"
-    )
-  end
-
-  # Count-first phrasing: "2 Observations [Show All] [Map All]".
-  # Show/Map All are rendered as small buttons by
-  # mapset_associated_links_for_type so they have real padding and
-  # don't rely on a focus outline for visual separation.
-  def map_point_text(label, count, show, map)
-    parts = ["#{count} #{label}".html_safe, show, map]
-    safe_join(parts, " ")
-  end
-
-  # Links to obs, locs or names within the current mapset, or maps of these
-  def mapset_associated_links(set, type)
-    return unless [:observation, :location, :name].include?(type)
-
-    mapset_associated_links_for_type(set, type)
-  end
-
-  # Helper for the above. Renders the two links as small buttons
-  # (btn btn-default btn-xs) so the popup has real spacing without
-  # relying on the focus outline for visual weight (#4131).
-  def mapset_associated_links_for_type(set, type)
-    query_type = type.to_s.camelize.to_sym
-    path_helper = :"#{type.to_s.pluralize}_path"
-    # We probably already have a query, from the index that got us here.
-    # This will correctly merge the in_box param into the query.
-    query = controller.
-            find_or_create_query(query_type, in_box: mapset_box_params(set))
-    btn = "btn btn-default btn-xs map-popup-btn"
-    # Add the query params to the link data for debugging.
-    # Can remove when we start splatting query params in the URL.
-    [link_to(:show_all.t, add_q_param(send(path_helper), query),
-             class: btn, data: query.params),
-     link_to(:map_all.t, add_q_param(send(:"map_#{path_helper}"), query),
-             class: btn, data: query.params)]
-  end
-
-  # Observation link in popups. Prefers the consensus text_name when
-  # available (new minimal_observation attr for #4131), falls back to
-  # "Observation #<id>" otherwise (e.g. pre-existing callers that use
-  # full Observation objects or didn't load the name). Always opens in
-  # a new tab — per Jaci's request, clicking should not navigate the
-  # map page away.
-  def mapset_observation_link(obs, args)
-    params = args[:query_param] ? { q: args[:query_param] } : {}
-    label = mapset_observation_label(obs)
-    link_to(label, observation_path(id: obs.id, params: params),
-            target: "_blank", rel: "noopener noreferrer")
-  end
-
-  # Preferred order: display_name (has MO textile markers — bold italic
-  # for non-deprecated names, italic-only for deprecated) → text_name
-  # (plain, wrap in <em>) → "Observation #<id>".
-  def mapset_observation_label(obs)
-    display = obs.respond_to?(:display_name) ? obs.display_name : nil
-    display ||= obs.name.display_name if display.blank? &&
-                                         obs.respond_to?(:name) &&
-                                         obs.name.respond_to?(:display_name)
-    return display.to_s.t if display.present?
-
-    text = obs.respond_to?(:text_name) ? obs.text_name : nil
-    return tag.em(text.to_s) if text.present?
-
-    "#{:Observation.t} ##{obs.id}"
-  end
-
-  def mapset_location_link(loc, args)
-    params = args[:query_param] ? { q: args[:query_param] } : {}
-    link_to(loc.display_name.t, location_path(id: loc.id, params: params))
-  end
-
-  # These are query params for the links back to MO indexes, slightly enlarged
-  def mapset_box_params(set)
-    { north: tweak_up(set.north, 0.001, 90),
-      south: tweak_down(set.south, 0.001, -90),
-      east: tweak_up(set.east, 0.001, 180),
-      west: tweak_down(set.west, 0.001, -180) }
-  end
-
-  def tweak_up(value, amount, max)
-    [max, value.to_f + amount].min
-  end
-
-  def tweak_down(value, amount, min)
-    [min, value.to_f - amount].max
-  end
-
-  # These are coords printed in text
-  def mapset_coords(set)
-    if set.is_point
-      format_latitude(set.lat) + safe_nbsp + format_longitude(set.lng)
-    else
-      content_tag(:center,
-                  format_latitude(set.north) + safe_br +
-                  format_longitude(set.west) + safe_nbsp +
-                  format_longitude(set.east) + safe_br +
-                  format_latitude(set.south))
-    end
-  end
-
-  def format_latitude(val)
-    format_lxxxitude(val, "N", "S")
-  end
-
-  def format_longitude(val)
-    format_lxxxitude(val, "E", "W")
-  end
-
-  def format_lxxxitude(val, dir1, dir2)
-    deg = val.abs.round(4)
-    "#{deg}°#{val.negative? ? dir2 : dir1}".html_safe
   end
 end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -5,8 +5,11 @@ module MapHelper
   include MapPopupHelper
 
   # Upper bound on points for client-side dynamic clustering
-  # (issue #4159). Above this, fall back to server-side bucketing.
-  CLUSTER_MAX_OBJECTS = 20_000
+  # (issue #4159). The controller truncates at this cap and surfaces
+  # a banner so the user knows to narrow by filter or by zooming in.
+  # The client-side viewport refetch (also keyed off this cap) will
+  # pull in the in-viewport subset when the user zooms/pans.
+  CLUSTER_MAX_OBJECTS = 10_000
 
   # args could include query_param.
   # returns an array of mapsets, each suitable for a marker or box
@@ -84,11 +87,38 @@ module MapHelper
       set.glyph = set.compute_glyph
       set.border_style = set.compute_border_style
       set.title = mapset_marker_title(set)
-      set.caption = mapset_info_window(set, args)
+      # caption is intentionally omitted — the client lazy-loads it
+      # from observations/maps#popup on marker click. Rendering N
+      # thumbnail-bearing popups at bulk-fetch time dominated refetch
+      # cost (#4159).
+      set.cluster_name = cluster_object_label(obj)
+      set.cluster_url = cluster_object_url(obj, args)
       set.objects = nil
       sets[singleton_key(obj)] = set
     end
     Mappable::ClusteredCollection.new(sets)
+  end
+
+  # Plain text name grouping-key used by cluster popups — authors are
+  # stripped by using the obs's `text_name` (fall back to the stringified
+  # display_name for locations / unexpected shapes).
+  def cluster_object_label(obj)
+    return obj.text_name if obj.respond_to?(:text_name) &&
+                            obj.text_name.present?
+    return obj.display_name.to_s if obj.respond_to?(:display_name)
+
+    ""
+  end
+
+  def cluster_object_url(obj, args)
+    params = args[:query_param] ? { q: args[:query_param] } : {}
+    if obj.respond_to?(:observation?) && obj.observation?
+      observation_path(id: obj.id, params: params)
+    elsif obj.respond_to?(:location?) && obj.location?
+      location_path(id: obj.id, params: params)
+    else
+      ""
+    end
   end
 
   # Unique key per mappable object for the sets hash. MinimalObservation

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -68,12 +68,13 @@ module MapHelper
       show_all: :show_all.t,
       map_all: :map_all.t,
       # Raw template — the client substitutes `[loaded]` / `[total]`
-      # with the formatted counts on each refetch. We bypass `.t` to
-      # skip textile processing (double-underscore placeholders would
-      # be italicized, etc.). Banner text has no textile markup, so
-      # sending the raw string preserves what the ERB-rendered
-      # version produces (#4159).
-      map_cap_banner: I18n.t(:map_cap_banner)
+      # with the formatted counts on each refetch. We bypass MO's
+      # `:sym.t` extension to skip textile processing (double-
+      # underscore placeholders would be italicized, etc.) and look
+      # up the key directly under MO's locale namespace. Banner text
+      # has no textile markup, so the raw string matches what the
+      # ERB-rendered version produces (#4159).
+      map_cap_banner: I18n.t("#{MO.locale_namespace}.map_cap_banner")
     }
   end
 

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -66,7 +66,11 @@ module MapHelper
       observations: :Observations.t,
       locations: :Locations.t,
       show_all: :show_all.t,
-      map_all: :map_all.t
+      map_all: :map_all.t,
+      # Banner template for viewport-refetch updates (#4159). Client
+      # replaces __LOADED__ / __TOTAL__ with the formatted counts.
+      map_cap_banner: :map_cap_banner.t(loaded: "__LOADED__",
+                                        total: "__TOTAL__")
     }
   end
 

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -52,6 +52,8 @@ module MapHelper
     collection = Mappable::CollapsibleCollectionOfObjects.new(objects)
     collection.sets.map do |_key, mapset|
       mapset.color = mapset.compute_color
+      mapset.glyph = mapset.compute_glyph
+      mapset.border_style = mapset.compute_border_style
       mapset.title = mapset_marker_title(mapset)
       mapset.caption = mapset_info_window(mapset, args)
       mapset.objects = nil # can't delete, it's part of the MapSet object

--- a/app/helpers/map_legend_helper.rb
+++ b/app/helpers/map_legend_helper.rb
@@ -2,16 +2,14 @@
 
 # Legend shown under maps that include at least one observation.
 # Suppressed on location-only maps, where consensus bands are
-# meaningless. Three rows: shape (single vs multiple observation),
-# border (precision of the members), and color (consensus band).
-# See #4159.
+# meaningless. Two rows: border (precision of the members) and
+# color (consensus band). See #4159.
 module MapLegendHelper
   # Pass objects so we can suppress the legend on location-only maps.
   def map_legend(objects: nil)
     return "".html_safe unless legend_applies?(objects)
 
     tag.div(class: "map-legend small text-muted mt-2") do
-      concat(map_legend_shape_row)
       concat(map_legend_border_row)
       concat(map_legend_color_row)
     end
@@ -26,13 +24,6 @@ module MapLegendHelper
     return true if objects.nil?
 
     objects.any? { |o| o.respond_to?(:observation?) && o.observation? }
-  end
-
-  def map_legend_shape_row
-    tag.div(class: "map-legend-row") do
-      concat(map_legend_shape_swatch(:circle, :map_legend_circle.t))
-      concat(map_legend_shape_swatch(:box, :map_legend_box.t))
-    end
   end
 
   def map_legend_border_row
@@ -71,13 +62,6 @@ module MapLegendHelper
       [Mappable::MapSet::DISPUTED_COLOR, :map_legend_disputed.t],
       [Mappable::MapSet::MIXED_COLOR, :map_legend_mixed.t]
     ]
-  end
-
-  def map_legend_shape_swatch(shape, label)
-    tag.span(class: "map-legend-item") do
-      concat(tag.span("", class: "map-legend-swatch map-legend-#{shape}"))
-      concat(label)
-    end
   end
 
   def map_legend_color_swatch(color, label)

--- a/app/helpers/map_legend_helper.rb
+++ b/app/helpers/map_legend_helper.rb
@@ -2,8 +2,9 @@
 
 # Legend shown under maps that include at least one observation.
 # Suppressed on location-only maps, where consensus bands are
-# meaningless. Two rows: shape meanings (circle vs. box) and color
-# meanings (consensus bands + mixed + location-only). See #4159.
+# meaningless. Three rows: shape (single vs multiple observation),
+# border (precision of the members), and color (consensus band).
+# See #4159.
 module MapLegendHelper
   # Pass objects so we can suppress the legend on location-only maps.
   def map_legend(objects: nil)
@@ -11,6 +12,7 @@ module MapLegendHelper
 
     tag.div(class: "map-legend small text-muted mt-2") do
       concat(map_legend_shape_row)
+      concat(map_legend_border_row)
       concat(map_legend_color_row)
     end
   end
@@ -30,6 +32,22 @@ module MapLegendHelper
     tag.div(class: "map-legend-row") do
       concat(map_legend_shape_swatch(:circle, :map_legend_circle.t))
       concat(map_legend_shape_swatch(:box, :map_legend_box.t))
+    end
+  end
+
+  def map_legend_border_row
+    tag.div(class: "map-legend-row") do
+      concat(map_legend_border_swatch(:crisp, :map_legend_border_crisp.t))
+      concat(map_legend_border_swatch(:dashed, :map_legend_border_dashed.t))
+      concat(map_legend_border_swatch(:none, :map_legend_border_none.t))
+    end
+  end
+
+  def map_legend_border_swatch(style, label)
+    tag.span(class: "map-legend-item") do
+      concat(tag.span("", class: "map-legend-swatch " \
+                                 "map-legend-border-#{style}"))
+      concat(label)
     end
   end
 

--- a/app/helpers/map_legend_helper.rb
+++ b/app/helpers/map_legend_helper.rb
@@ -59,13 +59,17 @@ module MapLegendHelper
     end
   end
 
+  # The location-only color row is intentionally omitted: the legend
+  # only renders on maps that include at least one observation, and
+  # obs-bearing MapSets always have a consensus band — so the blue
+  # "location-only" color would never appear on a map whose legend is
+  # visible.
   def map_legend_color_entries
     [
       [Mappable::MapSet::CONFIRMED_COLOR, :map_legend_confirmed.t],
       [Mappable::MapSet::TENTATIVE_COLOR, :map_legend_tentative.t],
       [Mappable::MapSet::DISPUTED_COLOR, :map_legend_disputed.t],
-      [Mappable::MapSet::MIXED_COLOR, :map_legend_mixed.t],
-      [Mappable::MapSet::LOCATION_ONLY_COLOR, :map_legend_location_only.t]
+      [Mappable::MapSet::MIXED_COLOR, :map_legend_mixed.t]
     ]
   end
 

--- a/app/helpers/map_legend_helper.rb
+++ b/app/helpers/map_legend_helper.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
-# Legend shown under every map rendered via MapHelper#make_map.
-# Two rows: shape meanings (circle vs. box) and color meanings
-# (consensus bands + group). See #4131.
+# Legend shown under maps that include at least one observation.
+# Suppressed on location-only maps, where consensus bands are
+# meaningless. Two rows: shape meanings (circle vs. box) and color
+# meanings (consensus bands + mixed + location-only). See #4159.
 module MapLegendHelper
-  def map_legend
+  # Pass objects so we can suppress the legend on location-only maps.
+  def map_legend(objects: nil)
+    return "".html_safe unless legend_applies?(objects)
+
     tag.div(class: "map-legend small text-muted mt-2") do
       concat(map_legend_shape_row)
       concat(map_legend_color_row)
@@ -12,6 +16,15 @@ module MapLegendHelper
   end
 
   private
+
+  # Legend is meaningful only when the map shows at least one
+  # observation. When `objects` is nil (callers that predate this
+  # argument), fall back to the old unconditional behavior.
+  def legend_applies?(objects)
+    return true if objects.nil?
+
+    objects.any? { |o| o.respond_to?(:observation?) && o.observation? }
+  end
 
   def map_legend_shape_row
     tag.div(class: "map-legend-row") do
@@ -33,7 +46,8 @@ module MapLegendHelper
       [Mappable::MapSet::CONFIRMED_COLOR, :map_legend_confirmed.t],
       [Mappable::MapSet::TENTATIVE_COLOR, :map_legend_tentative.t],
       [Mappable::MapSet::DISPUTED_COLOR, :map_legend_disputed.t],
-      [Mappable::MapSet::GROUP_COLOR, :map_legend_group.t]
+      [Mappable::MapSet::MIXED_COLOR, :map_legend_mixed.t],
+      [Mappable::MapSet::LOCATION_ONLY_COLOR, :map_legend_location_only.t]
     ]
   end
 

--- a/app/helpers/map_popup_helper.rb
+++ b/app/helpers/map_popup_helper.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+# Info-window popup markup for map markers. Extracted from MapHelper
+# to keep that module under Metrics/ModuleLength. Included back into
+# MapHelper so every method stays available to map partials/components
+# as before.
+module MapPopupHelper
+  MAX_GROUP_NAMES = 3
+
+  def mapset_info_window(set, args)
+    observations = set.observations
+    if observations.length == 1 && observations.first&.id
+      mapset_single_observation_popup(observations.first, set, args)
+    else
+      mapset_group_popup(set, args)
+    end
+  end
+
+  def mapset_single_observation_popup(obs, set, args)
+    tag.div(class: "media map-popup map-popup-single") do
+      concat(mapset_thumbnail_media_left(obs, args))
+      concat(mapset_single_observation_body(obs, set, args))
+    end
+  end
+
+  def mapset_thumbnail_media_left(obs, args)
+    return safe_join([]) unless obs.respond_to?(:thumb_image_id) &&
+                                obs.thumb_image_id
+
+    q = args[:query_param] ? { q: args[:query_param] } : {}
+    url = observation_path(id: obs.id, params: q)
+    tag.div(class: "media-left") do
+      link_to(url, target: "_blank", rel: "noopener noreferrer") do
+        # Empty alt: the adjacent taxon-name link inside the same
+        # .media already provides the accessible label, so the
+        # thumbnail is decorative in this context.
+        image_tag(Image.url(:small, obs.thumb_image_id),
+                  class: "media-object map-popup-thumb",
+                  loading: "lazy",
+                  alt: "")
+      end
+    end
+  end
+
+  def mapset_single_observation_body(obs, set, args)
+    tag.div(class: "media-body") do
+      concat(tag.div(mapset_observation_link(obs, args),
+                     class: "media-heading"))
+      concat(mapset_single_observation_meta(obs))
+      concat(mapset_single_observation_location(set, args))
+      concat(tag.div(mapset_coords(set), class: "small text-muted"))
+    end
+  end
+
+  def mapset_single_observation_meta(obs)
+    result = safe_join([])
+    date = mapset_observation_date(obs)
+    result += tag.div(date, class: "small") if date
+    conf = mapset_consensus_indicator(obs)
+    result += tag.div(conf, class: "small") if conf
+    result
+  end
+
+  def mapset_single_observation_location(set, args)
+    locations = set.underlying_locations
+    return safe_join([]) unless locations.length == 1 && locations.first&.id
+
+    tag.div(mapset_location_link(locations.first, args), class: "small")
+  end
+
+  def mapset_group_popup(set, args)
+    lines = mapset_group_popup_lines(set, args)
+    tag.div(lines.safe_join(safe_br), class: "map-popup map-popup-group")
+  end
+
+  def mapset_group_popup_lines(set, args)
+    observations = set.observations
+    lines = []
+    lines << mapset_observation_header(set) if observations.length > 1
+    lines.concat(mapset_group_name_links(observations, args))
+    lines.concat(mapset_group_location_lines(set, args))
+    lines << mapset_coords(set)
+    lines
+  end
+
+  def mapset_group_location_lines(set, args)
+    locations = set.underlying_locations
+    return [mapset_location_header(set)] if locations.length > 1
+    if locations.length == 1 && locations.first&.id
+      return [mapset_location_link(locations.first, args)]
+    end
+
+    []
+  end
+
+  def mapset_group_name_links(observations, args)
+    sorted = observations.sort_by { |o| [o.when || Date.new(0), o.id] }.reverse
+    top = sorted.first(MAX_GROUP_NAMES)
+    links = top.map { |o| mapset_observation_link(o, args) }
+    links << tag.span("…") if sorted.length > MAX_GROUP_NAMES
+    links
+  end
+
+  def mapset_observation_date(obs)
+    return nil if obs.respond_to?(:when) && obs.when.blank?
+    return nil unless obs.respond_to?(:when)
+
+    obs.when.web_date
+  end
+
+  # Plain-text "Confidence: NN%" line. The marker color already conveys
+  # the semantic bucket, so no dot/pill is needed inside the popup.
+  #
+  # Use `.floor` so the displayed percentage never crosses a
+  # traffic-light threshold the underlying value hasn't crossed yet
+  # — e.g. 79.6% should show "79%" with an orange marker, never
+  # "80%" (which would look like the green/confirmed bucket).
+  def mapset_consensus_indicator(obs)
+    return nil unless obs.respond_to?(:vote_cache)
+
+    pct = ::Vote.percent(obs.vote_cache)
+    "#{:Confidence.t}: #{pct.floor}%"
+  end
+
+  def mapset_observation_header(set)
+    show, map = mapset_associated_links(set, :observation)
+    tag.div(
+      map_point_text(:Observations.t, set.observations.length, show, map),
+      class: "map-popup-header"
+    )
+  end
+
+  def mapset_location_header(set)
+    show, map = mapset_associated_links(set, :location)
+    tag.div(
+      map_point_text(:Locations.t, set.underlying_locations.length, show, map),
+      class: "map-popup-header"
+    )
+  end
+
+  # Count-first phrasing: "2 Observations [Show All] [Map All]".
+  def map_point_text(label, count, show, map)
+    count_label = safe_join([count.to_s, label], " ")
+    safe_join([count_label, show, map], " ")
+  end
+
+  # Links to obs, locs or names within the current mapset, or maps of these
+  def mapset_associated_links(set, type)
+    return unless [:observation, :location, :name].include?(type)
+
+    mapset_associated_links_for_type(set, type)
+  end
+
+  def mapset_associated_links_for_type(set, type)
+    path_helper = :"#{type.to_s.pluralize}_path"
+    query = mapset_links_query(set, type)
+    [mapset_link(:show_all, send(path_helper), query),
+     mapset_link(:map_all, send(:"map_#{path_helper}"), query)]
+  end
+
+  def mapset_links_query(set, type)
+    query_type = type.to_s.camelize.to_sym
+    controller.find_or_create_query(query_type,
+                                    in_box: mapset_box_params(set))
+  end
+
+  def mapset_link(label_sym, path, query)
+    link_to(label_sym.t, add_q_param(path, query),
+            class: "btn btn-default btn-xs map-popup-btn",
+            data: query.params)
+  end
+
+  def mapset_observation_link(obs, args)
+    params = args[:query_param] ? { q: args[:query_param] } : {}
+    label = mapset_observation_label(obs)
+    link_to(label, observation_path(id: obs.id, params: params),
+            target: "_blank", rel: "noopener noreferrer")
+  end
+
+  # Preferred order: display_name (has MO textile markers) → text_name
+  # (wrap in <em>) → "Observation #<id>".
+  def mapset_observation_label(obs)
+    display = mapset_display_name(obs)
+    return display.to_s.t if display.present?
+
+    text = obs.respond_to?(:text_name) ? obs.text_name : nil
+    return tag.em(text.to_s) if text.present?
+
+    "#{:Observation.t} ##{obs.id}"
+  end
+
+  def mapset_display_name(obs)
+    if obs.respond_to?(:display_name) && obs.display_name.present?
+      return obs.display_name
+    end
+    return unless obs.respond_to?(:name) &&
+                  obs.name.respond_to?(:display_name)
+
+    obs.name.display_name
+  end
+
+  def mapset_location_link(loc, args)
+    params = args[:query_param] ? { q: args[:query_param] } : {}
+    link_to(loc.display_name.t, location_path(id: loc.id, params: params))
+  end
+
+  # These are query params for the links back to MO indexes, slightly enlarged
+  def mapset_box_params(set)
+    { north: tweak_up(set.north, 0.001, 90),
+      south: tweak_down(set.south, 0.001, -90),
+      east: tweak_up(set.east, 0.001, 180),
+      west: tweak_down(set.west, 0.001, -180) }
+  end
+
+  def tweak_up(value, amount, max)
+    [max, value.to_f + amount].min
+  end
+
+  def tweak_down(value, amount, min)
+    [min, value.to_f - amount].max
+  end
+
+  # These are coords printed in text
+  def mapset_coords(set)
+    return mapset_point_coords(set) if set.is_point
+
+    mapset_box_coords(set)
+  end
+
+  def mapset_point_coords(set)
+    format_latitude(set.lat) + safe_nbsp + format_longitude(set.lng)
+  end
+
+  def mapset_box_coords(set)
+    content_tag(:center, mapset_box_coords_inner(set))
+  end
+
+  def mapset_box_coords_inner(set)
+    format_latitude(set.north) + safe_br +
+      format_longitude(set.west) + safe_nbsp +
+      format_longitude(set.east) + safe_br +
+      format_latitude(set.south)
+  end
+
+  def format_latitude(val)
+    format_lxxxitude(val, "N", "S")
+  end
+
+  def format_longitude(val)
+    format_lxxxitude(val, "E", "W")
+  end
+
+  def format_lxxxitude(val, dir1, dir2)
+    deg = val.abs.round(4)
+    dir = val.negative? ? dir2 : dir1
+    safe_join(["#{deg}°#{dir}"])
+  end
+end

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -225,10 +225,16 @@ module Tabs
       external_name_tab("Wikipedia", name, wikipedia_term_search_url(name))
     end
 
+    # Drop `add_q_param` here so the link always lands on the full
+    # distribution map for the name. Carrying the current query
+    # context inherits whatever filters happen to be in scope —
+    # notably an `in_box` filter from a prior map popup's
+    # Show All / Map All click — which silently restricts the map
+    # to that bbox (issue #4139).
     def occurrence_map_for_name_tab(name)
       InternalLink::Model.new(
         :show_name_distribution_map.t, name,
-        add_q_param(map_name_path(id: name.id)),
+        map_name_path(id: name.id),
         html_options: { data: { action: "links#disable" } }
       ).tab
     end

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -312,7 +312,15 @@ export default class extends GeocodeController {
       if (e === null || b.e > e) e = b.e
       if (w === null || b.w < w) w = b.w
     }
-    return (n !== null) ? { n, s, e, w } : null
+    if (n === null) return null
+    // Naive min/max longitude is wrong for clusters that span the
+    // antimeridian (e.g., a marker near +179° and one near -179°
+    // would compute an outline covering most of the globe). Bail
+    // on the outline in that case rather than drawing a misleading
+    // overlay; doing wrap-aware longitude unioning correctly is a
+    // bigger change for an edge case MO data rarely produces.
+    if ((e - w) > 180) return null
+    return { n, s, e, w }
   }
 
   // Skip drawing the overlay when the outline is the same size as the
@@ -458,12 +466,18 @@ export default class extends GeocodeController {
   // Whether fitBounds on this cluster would actually reveal its members.
   // When every member shares a GPS point, bounds collapse to zero
   // extent and fitBounds pushes to max zoom with a single visible pin.
+  // Wrap-aware longitude span so antimeridian-crossing clusters
+  // (rare in MO data, but possible) aren't classified as "can't
+  // zoom" because of a negative naïve delta.
   clusterCanZoomFurther(bounds) {
     if (!bounds) return false
     const ne = bounds.getNorthEast()
     const sw = bounds.getSouthWest()
     const EPS = 1e-5
-    return (ne.lat() - sw.lat()) > EPS || (ne.lng() - sw.lng()) > EPS
+    const latSpan = ne.lat() - sw.lat()
+    const directLngSpan = Math.abs(ne.lng() - sw.lng())
+    const lngSpan = Math.min(directLngSpan, 360 - directLngSpan)
+    return latSpan > EPS || lngSpan > EPS
   }
 
   clusterRenderer() {
@@ -562,17 +576,22 @@ export default class extends GeocodeController {
            !last.contains(currentBounds.getSouthWest())
   }
 
+  // Build the JSON refetch URL from the server-emitted
+  // `cluster_query_string` (the page's filter set with `in_box`
+  // already stripped) plus the current viewport. Same reasoning as
+  // `clusterQueryUrl`: source URLs that use a saved-query id
+  // (`?q=ABC`) or have no q params (`/names/:id/map`) won't
+  // round-trip through `window.location.search` cleanly — mixing a
+  // scalar `q` with a hash `q[in_box]` produces a URL the server
+  // can't parse as a single query.
   buildRefetchUrl(bounds) {
     const ne = bounds.getNorthEast()
     const sw = bounds.getSouthWest()
-    const params = new URLSearchParams(window.location.search)
-    for (const key of Array.from(params.keys())) {
-      if (key.startsWith("q[in_box]")) params.delete(key)
-    }
-    params.set("q[in_box][north]", String(ne.lat()))
-    params.set("q[in_box][south]", String(sw.lat()))
-    params.set("q[in_box][east]", String(ne.lng()))
-    params.set("q[in_box][west]", String(sw.lng()))
+    const params = new URLSearchParams(this.cluster_query_string)
+    params.append("q[in_box][north]", String(ne.lat()))
+    params.append("q[in_box][south]", String(sw.lat()))
+    params.append("q[in_box][east]", String(ne.lng()))
+    params.append("q[in_box][west]", String(sw.lng()))
     const path = window.location.pathname.replace(/\.json$/, "")
     return `${path}.json?${params.toString()}`
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -153,11 +153,11 @@ export default class extends GeocodeController {
     this.verbose("map:buildOverlays")
     for (const [_xywh, set] of Object.entries(this.collection.sets)) {
       // Server-computed shape (#4159):
-      //   "dot"    → single observation; render as a circle marker
-      //              (at the obs's GPS point, or the location's
-      //              centroid when the obs has no GPS).
-      //   "square" → multi-observation or location-only; render as
-      //              a rectangle covering the bucket's extents.
+      //   "dot"       → single observation; circle marker.
+      //   "square"    → multi-observation; fixed-size square marker
+      //                 at the box center on info maps.
+      //   "rectangle" → location-only set; bare outline rectangle at
+      //                 the box extents (no center marker).
       // Fall back to the pre-#4159 extents-based decision when the
       // server didn't provide a glyph (e.g., legacy callers, editable
       // location maps).
@@ -165,6 +165,8 @@ export default class extends GeocodeController {
                     (this.isPoint(set) ? "dot" : "square")
       if (glyph === "dot") {
         this.drawMarker(set)
+      } else if (glyph === "rectangle" && !this.editable) {
+        this.drawLocationOutline(set)
       } else {
         this.drawRectangle(set)
       }
@@ -324,51 +326,74 @@ export default class extends GeocodeController {
     // (#4159), or the location-only blue if no observations were in
     // the set. Always honor whatever the server computed.
     const color = (set && set.color) || this.marker_color
+    const border = (set && set.border_style) || "crisp"
 
-    // If the rectangle would render sub-pixel at the current zoom, draw
-    // a standard-sized square marker at its center instead so it's still
-    // visible (#4131). Only applies to the info map; editable/location
-    // maps always get the real rectangle.
-    if (this.map_type === "info" && !this.editable &&
-        this.rectangleTooSmall(bounds)) {
-      this.drawBoxAsSquareMarker(set, color)
+    // Info maps: every multi-obs set renders as a fixed-size square
+    // marker at the box's center (#4159). The underlying extents
+    // surface as an outline overlay when the user clicks a
+    // location-only marker and the box is visibly larger than the
+    // marker footprint.
+    if (this.map_type === "info" && !this.editable) {
+      this.drawBoxAsSquareMarker(set, color, border)
       return
     }
 
-    const clickable = this.map_type === "info",
-      editable = this.editable && this.map_type !== "observation",
-      border = (set && set.border_style) || "crisp",
+    const editable = this.editable && this.map_type !== "observation",
       rectangleOptions = {
         strokeColor: color,
-        strokeOpacity: this.rectangleStrokeOpacity(border),
+        strokeOpacity: 1,
         strokeWeight: 3,
         fillColor: color,
-        fillOpacity: border === "none" ? 0.12 : 0,
+        fillOpacity: 0,
         map: this.map,
         bounds: bounds,
-        clickable: clickable,
+        clickable: false,
         draggable: false,
         editable: editable
       },
       rectangle = new google.maps.Rectangle(rectangleOptions)
 
-    // Dashed rectangles: Google Maps Rectangle has no dashed option,
-    // so overlay a dashed polyline around the edges when the server
-    // marks the set as having mixed precision (#4159).
-    if (border === "dashed") {
-      this.overlayDashedRectangle(bounds, color)
-    }
-
     if (this.map_type === "observation") {
       // that's it. obs rectangles for MO locations are not clickable
       this.rectangle = rectangle
-    } else if (!this.editable) {
-      // there could be many, does not set this.rectangle
-      this.giveRectangleInfoWindow(rectangle, set)
     } else {
       this.rectangle = rectangle
-      // this.map.fitBounds(bounds) // Only fit bounds if it's a location map
       this.makeRectangleEditable()
+    }
+  }
+
+  // Location-only sets on info maps: draw the box outline at its true
+  // extents with no center marker. Opens the caption in an info window
+  // on click so clustered location maps keep their per-box popup.
+  drawLocationOutline(set) {
+    this.verbose("map:drawLocationOutline")
+    const bounds = this.boundsOf(set)
+    if (!bounds) return false
+
+    const color = (set && set.color) || this.marker_color
+    const rectangle = new google.maps.Rectangle({
+      strokeColor: color,
+      strokeOpacity: 1,
+      strokeWeight: 2,
+      fillColor: color,
+      fillOpacity: 0.25,
+      map: this.map,
+      bounds: bounds,
+      clickable: true,
+      draggable: false,
+      editable: false
+    })
+    if (set && set.caption) {
+      const info_window = new google.maps.InfoWindow({
+        content: set.caption,
+        position: bounds
+          ? { lat: (bounds.north + bounds.south) / 2,
+              lng: (bounds.east + bounds.west) / 2 }
+          : rectangle.getBounds().getCenter()
+      })
+      google.maps.event.addListener(rectangle, "click", () => {
+        info_window.open(this.map, rectangle)
+      })
     }
   }
 
@@ -402,26 +427,40 @@ export default class extends GeocodeController {
   // Draws a square marker at the center of a box that's too small to
   // render as a rectangle. Visually distinct from single-observation
   // circle markers (square vs circle signals "group").
-  drawBoxAsSquareMarker(set, color) {
+  drawBoxAsSquareMarker(set, color, border = "crisp") {
     const marker = new google.maps.Marker({
       position: { lat: set.lat, lng: set.lng },
       map: this.map,
       title: set.title,
-      icon: this.colored_square_icon(color),
+      icon: this.colored_square_icon(color, border),
       zoomOnClick: false
     })
     this.giveMarkerInfoWindow(marker, set)
+    if (border === "none" && this.hasBoxExtents(set)) {
+      this.attachFuzzyBoxOverlay(marker, set)
+    }
   }
 
-  colored_square_icon(color) {
+  // Square marker used for every multi-obs set on info maps (#4159).
+  // Same fill/ring scheme as the single-obs dot — see
+  // colored_circle_icon.
+  colored_square_icon(color, border = "crisp") {
     return {
       path: "M -6 -6 L 6 -6 L 6 6 L -6 6 z",
       fillColor: color,
       fillOpacity: 1,
-      strokeColor: "#ffffff",
+      strokeColor: this.borderStrokeColor(border),
+      strokeOpacity: 1,
       strokeWeight: 1.5,
       scale: 1
     }
+  }
+
+  // Ring color by precision band (#4159).
+  borderStrokeColor(border) {
+    if (border === "none") return "#ffffff"
+    if (border === "dashed") return "#888888"
+    return "#333333"
   }
 
   // Add listeners to the rectangle for dragging and resizing (possibly also
@@ -442,22 +481,6 @@ export default class extends GeocodeController {
       })
     })
     // }, 1000)
-  }
-
-  // For rectangles (there could be many on page): make a clickable info window
-  // https://stackoverflow.com/questions/26171285/googlemaps-api-rectangle-and-infowindow-coupling-issue
-  giveRectangleInfoWindow(rectangle, set) {
-    this.verbose("map:giveRectangleInfoWindow")
-    this.verbose(rectangle)
-
-    const center = rectangle.getBounds().getCenter()
-    const info_window = new google.maps.InfoWindow({
-      content: set.caption,
-      position: center
-    })
-    google.maps.event.addListener(rectangle, "click", () => {
-      info_window.open(this.map, rectangle)
-    })
   }
 
   //
@@ -808,43 +831,44 @@ export default class extends GeocodeController {
     //   insertAdjacentText("beforeend", str + "<br/>");
   }
 
-  // Colored circle icon for google.maps.Marker. Using SymbolPath.CIRCLE
-  // is the most compatible way to get per-marker fill colors on the
-  // classic Marker API without swapping to AdvancedMarkerElement.
-  //
-  // border: "crisp" → solid white ring around the dot (precise GPS).
-  //         "none"  → no ring (fuzzy / location-only position).
-  // "dashed" doesn't apply to dots (that's reserved for multi-obs
-  // squares); treat as "crisp" if it ever arrives.
+  // Colored circle icon for google.maps.Marker. Fill is always the
+  // consensus color; the ring color encodes precision (#4159):
+  //   crisp  → dark ring   (precise GPS)
+  //   none   → white ring  (fuzzy / location-only)
+  //   dashed → gray ring   (mixed; only applies to multi-obs squares
+  //                         in practice, but harmless on dots too)
   colored_circle_icon(color, border = "crisp") {
-    const noBorder = border === "none"
     return {
       path: google.maps.SymbolPath.CIRCLE,
       fillColor: color,
       fillOpacity: 1,
-      strokeColor: noBorder ? color : "#ffffff",
-      strokeOpacity: noBorder ? 0 : 1,
-      strokeWeight: noBorder ? 0 : 1.5,
+      strokeColor: this.borderStrokeColor(border),
+      strokeOpacity: 1,
+      strokeWeight: 1.5,
       scale: 8
     }
   }
 
-  // When a fuzzy single-obs dot's popup is opened, overlay the
-  // location's bounding box as a faint rectangle so the uncertainty
-  // is still visible. Google auto-closes the previously open
-  // InfoWindow when another opens, but doesn't emit an event on the
+  // When a location-only marker's popup is opened, overlay the
+  // region's bounding box as an outline so the uncertainty area is
+  // visible. Skipped when the extents don't render visibly larger
+  // than the marker itself (would just be a same-sized square on top
+  // of the marker). Google auto-closes the previously open
+  // InfoWindow when another opens but doesn't emit an event on the
   // old one — so track a single controller-level overlay and clear
   // it before adding a new one.
   attachFuzzyBoxOverlay(marker, set) {
     marker.addListener("click", () => {
       this.clearFuzzyBoxOverlay()
+      const bounds = this.boundsOf(set)
+      if (!bounds || this.rectangleTooSmall(bounds)) return
       this.fuzzyBoxOverlay = new google.maps.Rectangle({
         strokeColor: set.color,
-        strokeOpacity: 0.7,
-        strokeWeight: 1.5,
+        strokeOpacity: 1,
+        strokeWeight: 2,
         fillColor: set.color,
-        fillOpacity: 0.08,
-        bounds: this.boundsOf(set),
+        fillOpacity: 0.25,
+        bounds: bounds,
         clickable: false,
         map: this.map
       })
@@ -859,46 +883,5 @@ export default class extends GeocodeController {
     if (!this.fuzzyBoxOverlay) return
     this.fuzzyBoxOverlay.setMap(null)
     this.fuzzyBoxOverlay = null
-  }
-
-  // Rectangle stroke opacity by server-computed border style.
-  // "crisp"  → solid border.
-  // "none"   → suppress the stroke (rectangle survives via a
-  //            semi-transparent fill; see drawRectangle).
-  // "dashed" → base stroke is suppressed; a dashed polyline overlay
-  //            draws the apparent border.
-  rectangleStrokeOpacity(border) {
-    if (border === "none" || border === "dashed") return 0
-    return 1
-  }
-
-  // Draw a dashed polyline around the four edges of a bounding box.
-  // Google Maps Polyline supports dashed strokes via icon repeats
-  // (the solid stroke is hidden with strokeOpacity: 0). Used by
-  // drawRectangle for multi-obs sets with mixed precision.
-  overlayDashedRectangle(bounds, color) {
-    const path = [
-      { lat: bounds.north, lng: bounds.west },
-      { lat: bounds.north, lng: bounds.east },
-      { lat: bounds.south, lng: bounds.east },
-      { lat: bounds.south, lng: bounds.west },
-      { lat: bounds.north, lng: bounds.west }
-    ]
-    return new google.maps.Polyline({
-      path: path,
-      strokeOpacity: 0,
-      icons: [{
-        icon: {
-          path: "M 0,-1 0,1",
-          strokeColor: color,
-          strokeOpacity: 1,
-          scale: 3
-        },
-        offset: "0",
-        repeat: "14px"
-      }],
-      clickable: false,
-      map: this.map
-    })
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -45,6 +45,12 @@ export default class extends GeocodeController {
     this.lastFetchedBounds = null
     this.refetchTimer = 0
     this.refetchInFlight = null
+    // Server-emitted "q[...]=…" base for cluster popup Show All /
+    // Map All links. We can't rebuild this from window.location
+    // alone — the source URL might be a saved-query id (`?q=ABC`)
+    // or, on /names/:id/map, have no q params at all (#4159).
+    this.cluster_query_string =
+      this.mapDivTarget.dataset.clusterQueryString || ""
     // Refetch deferral (#4159): clearing overlays in the middle of
     // reading a popup is jarring, so we park the refetch while an
     // InfoWindow is open and flush it on close.
@@ -374,23 +380,23 @@ export default class extends GeocodeController {
     )
   }
 
-  // Build a Show-All / Map-All URL by preserving the current page's
-  // `q[...]` params (so user/etc. filters carry over) and overriding
-  // `q[in_box][n/s/e/w]` with the cluster outline box. An optional
-  // `name` scopes the result further via `q[names][lookup][]=<name>`
-  // (used by per-species links in the cluster popup); when present,
-  // any existing `q[names]` params are dropped so the species filter
-  // wins.
+  // Build a Show-All / Map-All URL from the server-emitted
+  // `cluster_query_string` (the page's underlying `q[...]` filter
+  // params, with `in_box` already stripped). The bbox of the
+  // clicked cluster is appended as `q[in_box][n/s/e/w]`. An
+  // optional `name` scopes further via `q[names][lookup][]=<name>`,
+  // dropping any existing `q[names]` so the species filter wins.
+  //
+  // Using the server's base instead of `window.location.search`
+  // makes this work for source URLs that don't expose the filters
+  // directly — e.g. `/names/2792/map` (no q params at all) or
+  // `?q=ABC` (a saved-query id) (#4159).
   clusterQueryUrl(path, box, opts = {}) {
-    const params = new URLSearchParams()
-    const current = new URLSearchParams(window.location.search)
-    const IN_BOX_PREFIX = "q[in_box]"
-    const NAMES_PREFIX = "q[names]"
-    for (const [key, value] of current.entries()) {
-      if (!key.startsWith("q[")) continue
-      if (key.startsWith(IN_BOX_PREFIX)) continue
-      if (opts.name && key.startsWith(NAMES_PREFIX)) continue
-      params.append(key, value)
+    const params = new URLSearchParams(this.cluster_query_string)
+    if (opts.name) {
+      for (const key of Array.from(params.keys())) {
+        if (key.startsWith("q[names]")) params.delete(key)
+      }
     }
     params.append("q[in_box][north]", String(box.n))
     params.append("q[in_box][south]", String(box.s))

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -601,9 +601,11 @@ export default class extends GeocodeController {
       banner.style.display = ""
       const loaded = Number(data.loaded).toLocaleString()
       const total = Number(data.total).toLocaleString()
-      banner.textContent =
-        `Showing the first ${loaded} of ${total} observations. ` +
-        "Zoom in or narrow your filter to see the rest."
+      const template = (this.localized_text &&
+                        this.localized_text.map_cap_banner) || ""
+      banner.textContent = template.
+        replace("__LOADED__", loaded).
+        replace("__TOTAL__", total)
     } else {
       banner.style.display = "none"
     }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,5 +1,6 @@
 import GeocodeController from "controllers/geocode_controller"
 import { Loader } from "@googlemaps/js-api-loader"
+import { MarkerClusterer } from "@googlemaps/markerclusterer"
 
 // Connects to data-controller="map"
 // The connected element can be a map, or in the case of a form with a map UI,
@@ -29,6 +30,12 @@ export default class extends GeocodeController {
     this.collection = this.mapDivTarget.dataset.collection
     if (this.collection)
       this.collection = JSON.parse(this.collection)
+    // Dynamic-clustering mode (#4159). When true, each collection set
+    // is a singleton and the client wraps them in a MarkerClusterer
+    // that regroups them at each zoom level.
+    this.clustering = this.mapDivTarget.dataset.clustering === "true"
+    this.cluster_markers = []
+    this.markerClusterer = null
     this.localized_text = this.mapDivTarget.dataset.localization
     if (this.localized_text)
       this.localized_text = JSON.parse(this.localized_text)
@@ -169,6 +176,75 @@ export default class extends GeocodeController {
         this.drawRectangle(set)
       }
     }
+    if (this.clustering) this.initMarkerClusterer()
+  }
+
+  // Wrap every marker collected during buildOverlays in a
+  // MarkerClusterer. The clusterer handles visibility, so markers
+  // are attached to the map only at zoom levels where they aren't
+  // part of a larger cluster. See #4159.
+  initMarkerClusterer() {
+    if (this.cluster_markers.length === 0) return
+
+    this.markerClusterer = new MarkerClusterer({
+      map: this.map,
+      markers: this.cluster_markers.map((m) => m.marker),
+      renderer: this.clusterRenderer()
+    })
+  }
+
+  clusterRenderer() {
+    return {
+      render: ({ count, position, markers }) => {
+        const color = this.aggregateClusterColor(markers)
+        const label = count > 99 ? "99+" : String(count)
+        const scale = count < 10 ? 14 : count < 100 ? 18 : 22
+        return new google.maps.Marker({
+          position,
+          label: {
+            text: label,
+            color: "#fff",
+            fontSize: "12px",
+            fontWeight: "700"
+          },
+          icon: {
+            path: google.maps.SymbolPath.CIRCLE,
+            fillColor: color,
+            fillOpacity: 0.9,
+            strokeColor: "#fff",
+            strokeWeight: 1.5,
+            scale: scale
+          },
+          title: `${count} observations`,
+          zIndex: 1000 + markers.length
+        })
+      }
+    }
+  }
+
+  // Aggregate consensus-band color across every member of a cluster.
+  // Mirrors Mappable::MapSet#compute_color on the Ruby side — we need
+  // it in JS because cluster membership changes dynamically with
+  // zoom and can't be baked in server-side (#4159).
+  aggregateClusterColor(markers) {
+    const bands = new Set()
+    for (const marker of markers) {
+      const data = marker.moData
+      if (!data) continue
+      const pct = data.vote_pct
+      if (pct == null) continue
+      if (pct <= 0) bands.add("disputed")
+      else if (pct >= 80) bands.add("confirmed")
+      else bands.add("tentative")
+    }
+    if (bands.size === 0) return "#3B79CC"  // location-only fallback
+    if (bands.size > 1) return "#C69B71"    // mixed
+    const band = bands.values().next().value
+    return {
+      confirmed: "#5CB85C",
+      tentative: "#F0AD4E",
+      disputed: "#D9534F"
+    }[band]
   }
 
   isPoint(set) {
@@ -206,7 +282,10 @@ export default class extends GeocodeController {
     const border = (set && set.border_style) || "crisp"
     const markerOptions = {
       position: { lat: set.lat, lng: set.lng },
-      map: this.map,
+      // In clustering mode, don't attach to the map — the
+      // MarkerClusterer decides visibility based on current zoom
+      // (#4159).
+      map: this.clustering ? null : this.map,
       draggable: this.editable,
       icon: this.colored_circle_icon(color, border),
       zoomOnClick: false
@@ -217,6 +296,11 @@ export default class extends GeocodeController {
     }
     const marker = new google.maps.Marker(markerOptions)
     this.marker = marker
+    // Metadata the cluster renderer uses to compute cluster color.
+    marker.moData = {
+      vote_pct: this.votePctFromSet(set),
+      has_gps: border !== "none"
+    }
 
     if (!this.editable && set != null) {
       this.giveMarkerInfoWindow(marker, set)
@@ -225,10 +309,25 @@ export default class extends GeocodeController {
       if (border === "none" && this.hasBoxExtents(set)) {
         this.attachFuzzyBoxOverlay(marker, set)
       }
+      if (this.clustering) {
+        this.cluster_markers.push({ marker, set })
+      }
     } else {
       this.getElevations([set], "point")
       this.makeMarkerEditable(marker)
     }
+  }
+
+  // Reverse-engineer the consensus band color shipped by
+  // MapSet#compute_color. Singleton MapSets (clustering mode) carry
+  // just the color hex; the band is enough for cluster-color math.
+  votePctFromSet(set) {
+    if (!set || !set.color) return null
+    const color = set.color
+    if (color === "#5CB85C") return 90  // confirmed
+    if (color === "#F0AD4E") return 40  // tentative
+    if (color === "#D9534F") return -1  // disputed
+    return null // mixed / location-only
   }
 
   // Only for single markers: listeners for dragging the marker

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -152,9 +152,18 @@ export default class extends GeocodeController {
 
     this.verbose("map:buildOverlays")
     for (const [_xywh, set] of Object.entries(this.collection.sets)) {
-      // this.verbose({ set })
-      // NOTE: according to the MapSet class, location sets are always is_box.
-      if (this.isPoint(set)) {
+      // Server-computed shape (#4159):
+      //   "dot"    → single observation; render as a circle marker
+      //              (at the obs's GPS point, or the location's
+      //              centroid when the obs has no GPS).
+      //   "square" → multi-observation or location-only; render as
+      //              a rectangle covering the bucket's extents.
+      // Fall back to the pre-#4159 extents-based decision when the
+      // server didn't provide a glyph (e.g., legacy callers, editable
+      // location maps).
+      const glyph = set.glyph ||
+                    (this.isPoint(set) ? "dot" : "square")
+      if (glyph === "dot") {
         this.drawMarker(set)
       } else {
         this.drawRectangle(set)
@@ -164,6 +173,10 @@ export default class extends GeocodeController {
 
   isPoint(set) {
     return (set.north === set.south) && (set.east === set.west)
+  }
+
+  hasBoxExtents(set) {
+    return set && set.north !== set.south && set.east !== set.west
   }
 
   //
@@ -186,15 +199,16 @@ export default class extends GeocodeController {
 
   drawMarker(set) {
     this.verbose("map:drawMarker")
-    // Per-marker color comes from the server (Mappable::MapSet#compute_color
-    // for issue #4131). Falls back to the controller default for editable
-    // markers / legacy callers that don't set a color.
+    // Per-marker color and border style come from the server
+    // (Mappable::MapSet — issues #4131, #4159). Falls back to the
+    // controller default for editable markers / legacy callers.
     const color = (set && set.color) || this.marker_color
+    const border = (set && set.border_style) || "crisp"
     const markerOptions = {
       position: { lat: set.lat, lng: set.lng },
       map: this.map,
       draggable: this.editable,
-      icon: this.colored_circle_icon(color),
+      icon: this.colored_circle_icon(color, border),
       zoomOnClick: false
     }
 
@@ -206,6 +220,11 @@ export default class extends GeocodeController {
 
     if (!this.editable && set != null) {
       this.giveMarkerInfoWindow(marker, set)
+      // Fuzzy single-obs dots (no GPS) show the location's bounding
+      // box as an overlay while their popup is open (#4159).
+      if (border === "none" && this.hasBoxExtents(set)) {
+        this.attachFuzzyBoxOverlay(marker, set)
+      }
     } else {
       this.getElevations([set], "point")
       this.makeMarkerEditable(marker)
@@ -258,6 +277,9 @@ export default class extends GeocodeController {
       position: { lat: set.lat, lng: set.lng },
       maxWidth: 280
     })
+    // Expose on the marker so other code (e.g. fuzzy-box overlays
+    // for #4159) can listen for close events.
+    marker.infoWindow = info_window
 
     google.maps.event.addListener(marker, "click", () => {
       info_window.open({ anchor: marker, map: this.map })
@@ -315,10 +337,13 @@ export default class extends GeocodeController {
 
     const clickable = this.map_type === "info",
       editable = this.editable && this.map_type !== "observation",
+      border = (set && set.border_style) || "crisp",
       rectangleOptions = {
         strokeColor: color,
-        strokeOpacity: 1,
+        strokeOpacity: this.rectangleStrokeOpacity(border),
         strokeWeight: 3,
+        fillColor: color,
+        fillOpacity: border === "none" ? 0.12 : 0,
         map: this.map,
         bounds: bounds,
         clickable: clickable,
@@ -326,6 +351,13 @@ export default class extends GeocodeController {
         editable: editable
       },
       rectangle = new google.maps.Rectangle(rectangleOptions)
+
+    // Dashed rectangles: Google Maps Rectangle has no dashed option,
+    // so overlay a dashed polyline around the edges when the server
+    // marks the set as having mixed precision (#4159).
+    if (border === "dashed") {
+      this.overlayDashedRectangle(bounds, color)
+    }
 
     if (this.map_type === "observation") {
       // that's it. obs rectangles for MO locations are not clickable
@@ -779,14 +811,94 @@ export default class extends GeocodeController {
   // Colored circle icon for google.maps.Marker. Using SymbolPath.CIRCLE
   // is the most compatible way to get per-marker fill colors on the
   // classic Marker API without swapping to AdvancedMarkerElement.
-  colored_circle_icon(color) {
+  //
+  // border: "crisp" → solid white ring around the dot (precise GPS).
+  //         "none"  → no ring (fuzzy / location-only position).
+  // "dashed" doesn't apply to dots (that's reserved for multi-obs
+  // squares); treat as "crisp" if it ever arrives.
+  colored_circle_icon(color, border = "crisp") {
+    const noBorder = border === "none"
     return {
       path: google.maps.SymbolPath.CIRCLE,
       fillColor: color,
       fillOpacity: 1,
-      strokeColor: "#ffffff",
-      strokeWeight: 1.5,
+      strokeColor: noBorder ? color : "#ffffff",
+      strokeOpacity: noBorder ? 0 : 1,
+      strokeWeight: noBorder ? 0 : 1.5,
       scale: 8
     }
+  }
+
+  // When a fuzzy single-obs dot's popup is opened, overlay the
+  // location's bounding box as a faint rectangle so the uncertainty
+  // is still visible. Google auto-closes the previously open
+  // InfoWindow when another opens, but doesn't emit an event on the
+  // old one — so track a single controller-level overlay and clear
+  // it before adding a new one.
+  attachFuzzyBoxOverlay(marker, set) {
+    marker.addListener("click", () => {
+      this.clearFuzzyBoxOverlay()
+      this.fuzzyBoxOverlay = new google.maps.Rectangle({
+        strokeColor: set.color,
+        strokeOpacity: 0.7,
+        strokeWeight: 1.5,
+        fillColor: set.color,
+        fillOpacity: 0.08,
+        bounds: this.boundsOf(set),
+        clickable: false,
+        map: this.map
+      })
+    })
+    if (marker.infoWindow) {
+      marker.infoWindow.addListener("closeclick",
+                                    () => this.clearFuzzyBoxOverlay())
+    }
+  }
+
+  clearFuzzyBoxOverlay() {
+    if (!this.fuzzyBoxOverlay) return
+    this.fuzzyBoxOverlay.setMap(null)
+    this.fuzzyBoxOverlay = null
+  }
+
+  // Rectangle stroke opacity by server-computed border style.
+  // "crisp"  → solid border.
+  // "none"   → suppress the stroke (rectangle survives via a
+  //            semi-transparent fill; see drawRectangle).
+  // "dashed" → base stroke is suppressed; a dashed polyline overlay
+  //            draws the apparent border.
+  rectangleStrokeOpacity(border) {
+    if (border === "none" || border === "dashed") return 0
+    return 1
+  }
+
+  // Draw a dashed polyline around the four edges of a bounding box.
+  // Google Maps Polyline supports dashed strokes via icon repeats
+  // (the solid stroke is hidden with strokeOpacity: 0). Used by
+  // drawRectangle for multi-obs sets with mixed precision.
+  overlayDashedRectangle(bounds, color) {
+    const path = [
+      { lat: bounds.north, lng: bounds.west },
+      { lat: bounds.north, lng: bounds.east },
+      { lat: bounds.south, lng: bounds.east },
+      { lat: bounds.south, lng: bounds.west },
+      { lat: bounds.north, lng: bounds.west }
+    ]
+    return new google.maps.Polyline({
+      path: path,
+      strokeOpacity: 0,
+      icons: [{
+        icon: {
+          path: "M 0,-1 0,1",
+          strokeColor: color,
+          strokeOpacity: 1,
+          scale: 3
+        },
+        offset: "0",
+        repeat: "14px"
+      }],
+      clickable: false,
+      map: this.map
+    })
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -298,8 +298,9 @@ export default class extends GeocodeController {
     const bounds = this.boundsOf(set)
     if (!bounds) return false
 
-    // Per-box color from the server (#4131). Rectangles are group markers
-    // so this is usually GROUP_COLOR, but honor whatever the server set.
+    // Per-box color from the server: the aggregated consensus color
+    // (#4159), or the location-only blue if no observations were in
+    // the set. Always honor whatever the server computed.
     const color = (set && set.color) || this.marker_color
 
     // If the rectangle would render sub-pixel at the current zoom, draw

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,6 +1,6 @@
 import GeocodeController from "controllers/geocode_controller"
 import { Loader } from "@googlemaps/js-api-loader"
-import { MarkerClusterer } from "@googlemaps/markerclusterer"
+import { MarkerClusterer, SuperClusterAlgorithm } from "@googlemaps/markerclusterer"
 
 // Connects to data-controller="map"
 // The connected element can be a map, or in the case of a form with a map UI,
@@ -36,6 +36,20 @@ export default class extends GeocodeController {
     this.clustering = this.mapDivTarget.dataset.clustering === "true"
     this.cluster_markers = []
     this.markerClusterer = null
+    // Initial fetch was capped — if so, refetching for smaller
+    // viewports exposes obs that were truncated. Tracked as the
+    // "last fetch" state so pans/zooms that expand or narrow the
+    // viewport know whether to re-request from the server (#4159).
+    this.lastFetchedCapped =
+      this.mapDivTarget.dataset.capped === "true"
+    this.lastFetchedBounds = null
+    this.refetchTimer = 0
+    this.refetchInFlight = null
+    // Refetch deferral (#4159): clearing overlays in the middle of
+    // reading a popup is jarring, so we park the refetch while an
+    // InfoWindow is open and flush it on close.
+    this.activeInfoWindow = null
+    this.refetchPending = false
     this.localized_text = this.mapDivTarget.dataset.localization
     if (this.localized_text)
       this.localized_text = JSON.parse(this.localized_text)
@@ -103,6 +117,11 @@ export default class extends GeocodeController {
           // a box vs. fall back to a square marker.
           google.maps.event.addListenerOnce(this.map, "idle", () => {
             this.buildOverlays()
+            if (this.clustering) {
+              google.maps.event.addListener(this.map, "idle", () => {
+                this.scheduleViewportRefetch()
+              })
+            }
           })
         }
       })
@@ -191,20 +210,248 @@ export default class extends GeocodeController {
     this.markerClusterer = new MarkerClusterer({
       map: this.map,
       markers: this.cluster_markers.map((m) => m.marker),
-      renderer: this.clusterRenderer()
+      renderer: this.clusterRenderer(),
+      // Supercluster's default maxZoom (16) breaks clusters apart
+      // fully zoomed-in, which hides the count badge on stacks of
+      // observations that share a single geographic point (e.g. many
+      // obs at one location centroid, with no GPS or dubious GPS).
+      // Google Maps' max zoom is 22; matching it keeps the "N" badge
+      // visible even when the underlying data can't be separated
+      // spatially (#4159).
+      algorithm: new SuperClusterAlgorithm({ maxZoom: 22 }),
+      // Default behavior zooms in on single click; override with a
+      // popup listing the cluster's members. Zoom is exposed as a link
+      // inside the popup when further zoom would actually separate
+      // them (#4159).
+      onClusterClick: (_event, cluster, _map) => {
+        this.showClusterPopup(cluster)
+      }
     })
+  }
+
+  showClusterPopup(cluster) {
+    const bounds = cluster.bounds
+    const markers = cluster.markers || []
+    const canZoom = this.clusterCanZoomFurther(bounds)
+    const color = this.aggregateClusterColor(markers)
+    const outlineBox = this.computeClusterOutlineBox(markers)
+    const content = this.buildClusterPopupHtml(markers, canZoom, outlineBox)
+
+    if (this.clusterInfoWindow) this.clusterInfoWindow.close()
+    this.clearFuzzyBoxOverlay()
+
+    this.clusterInfoWindow = new google.maps.InfoWindow({
+      content,
+      position: cluster.position,
+      maxWidth: 320
+    })
+    this.clusterInfoWindow.open({ map: this.map })
+    this.noteInfoWindowOpened(this.clusterInfoWindow)
+
+    if (outlineBox && this.outlineLargerThanClusterBadge(outlineBox, bounds)) {
+      this.fuzzyBoxOverlay = new google.maps.Rectangle({
+        strokeColor: color,
+        strokeOpacity: 1,
+        strokeWeight: 2,
+        fillColor: color,
+        fillOpacity: 0.25,
+        bounds: {
+          north: outlineBox.n, south: outlineBox.s,
+          east: outlineBox.e, west: outlineBox.w
+        },
+        clickable: false,
+        map: this.map
+      })
+    }
+
+    google.maps.event.addListenerOnce(
+      this.clusterInfoWindow, "closeclick", () => {
+        this.clearFuzzyBoxOverlay()
+        this.noteInfoWindowClosed(this.clusterInfoWindow)
+      }
+    )
+    google.maps.event.addListenerOnce(
+      this.clusterInfoWindow, "domready", () => {
+        this.wireClusterZoomLink(bounds)
+      }
+    )
+  }
+
+  wireClusterZoomLink(bounds) {
+    const els = document.getElementsByClassName("map-popup-cluster-zoom")
+    for (const el of els) {
+      el.addEventListener("click", (event) => {
+        event.preventDefault()
+        this.map.fitBounds(bounds)
+        if (this.clusterInfoWindow) this.clusterInfoWindow.close()
+        this.clearFuzzyBoxOverlay()
+      })
+    }
+  }
+
+  // Union of all member boxes. For GPS obs the "box" collapses to a
+  // point (set.north === set.south, etc.), so this degrades gracefully
+  // to the GPS extent. For a Wilder-Ridge-style cluster where every
+  // member uses its location bbox, the union equals that bbox.
+  computeClusterOutlineBox(markers) {
+    let n = null
+    let s = null
+    let e = null
+    let w = null
+    for (const marker of markers) {
+      const b = marker.moData && marker.moData.box
+      if (!b || b.n == null) continue
+      if (n === null || b.n > n) n = b.n
+      if (s === null || b.s < s) s = b.s
+      if (e === null || b.e > e) e = b.e
+      if (w === null || b.w < w) w = b.w
+    }
+    return (n !== null) ? { n, s, e, w } : null
+  }
+
+  // Skip drawing the overlay when the outline is the same size as the
+  // cluster badge itself — an outline that's identical in area to the
+  // marker is visual noise. Compares the outline's extents to the
+  // MarkerClusterer-computed member bounds; if they match within a
+  // small epsilon the outline adds no information.
+  outlineLargerThanClusterBadge(outline, bounds) {
+    if (!bounds) return true
+    const ne = bounds.getNorthEast()
+    const sw = bounds.getSouthWest()
+    const EPS = 1e-4
+    return Math.abs(outline.n - ne.lat()) > EPS ||
+           Math.abs(outline.s - sw.lat()) > EPS ||
+           Math.abs(outline.e - ne.lng()) > EPS ||
+           Math.abs(outline.w - sw.lng()) > EPS
+  }
+
+  // Group cluster markers by species (text_name); sort by obs count
+  // desc, then species name asc. Each list row links to the first
+  // observation of that species.
+  buildClusterPopupHtml(markers, canZoom, outlineBox) {
+    const groups = this.groupClusterMarkersBySpecies(markers)
+    const totalObs = markers.length
+    const speciesCount = groups.length
+
+    const parts = ['<div class="map-popup map-popup-cluster">']
+    parts.push(
+      '<div class="map-popup-cluster-header">' +
+      '<div class="map-popup-cluster-title">' +
+      `<strong>${totalObs} ${totalObs === 1 ? "observation" : "observations"}` +
+      "</strong></div>" +
+      '<div class="map-popup-cluster-subtitle">' +
+      `${speciesCount} ${speciesCount === 1 ? "species" : "species"}` +
+      "</div>" +
+      this.buildClusterActionButtons(outlineBox) +
+      "</div>"
+    )
+    parts.push('<ul class="map-popup-cluster-list">')
+    for (const group of groups) {
+      parts.push(this.renderClusterListItem(group))
+    }
+    parts.push("</ul>")
+    if (canZoom) {
+      parts.push(
+        '<div class="map-popup-cluster-zoom-row">' +
+        '<a href="#" class="map-popup-cluster-zoom">Click to zoom in</a>' +
+        "</div>"
+      )
+    }
+    parts.push("</div>")
+    return parts.join("")
+  }
+
+  buildClusterActionButtons(outlineBox) {
+    if (!outlineBox) return ""
+    const showAll = this.clusterQueryUrl("/observations", outlineBox)
+    const mapAll = this.clusterQueryUrl("/observations/map", outlineBox)
+    const btn = "btn btn-default btn-xs map-popup-btn"
+    return (
+      '<div class="map-popup-cluster-actions">' +
+      `<a href="${showAll}" class="${btn}">Show All</a>` +
+      `<a href="${mapAll}" class="${btn}">Map All</a>` +
+      "</div>"
+    )
+  }
+
+  // Build a Show-All / Map-All URL by preserving the current page's
+  // `q[...]` params (so user/name/etc. filters carry over) and
+  // overriding `q[in_box][n/s/e/w]` with the cluster outline box.
+  clusterQueryUrl(path, box) {
+    const params = new URLSearchParams()
+    const current = new URLSearchParams(window.location.search)
+    const IN_BOX_PREFIX = "q[in_box]"
+    for (const [key, value] of current.entries()) {
+      if (key.startsWith("q[") && !key.startsWith(IN_BOX_PREFIX)) {
+        params.append(key, value)
+      }
+    }
+    params.append("q[in_box][north]", String(box.n))
+    params.append("q[in_box][south]", String(box.s))
+    params.append("q[in_box][east]", String(box.e))
+    params.append("q[in_box][west]", String(box.w))
+    return `${path}?${params.toString()}`
+  }
+
+  groupClusterMarkersBySpecies(markers) {
+    const groups = new Map()
+    for (const marker of markers) {
+      const data = marker.moData || {}
+      const name = data.cluster_name || "Unknown"
+      let group = groups.get(name)
+      if (!group) {
+        group = { name, count: 0, url: null }
+        groups.set(name, group)
+      }
+      group.count += 1
+      if (!group.url && data.cluster_url) group.url = data.cluster_url
+    }
+    return Array.from(groups.values()).sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count
+      return a.name.localeCompare(b.name)
+    })
+  }
+
+  renderClusterListItem(group) {
+    const name = this.escapeHtml(group.name)
+    const nameHtml = group.url
+      ? `<a href="${group.url}" target="_blank" rel="noopener noreferrer">` +
+        `<i>${name}</i></a>`
+      : `<i>${name}</i>`
+    return (
+      "<li>" +
+      `<span class="map-popup-cluster-name">${nameHtml}</span>` +
+      `<strong class="map-popup-cluster-count">${group.count}</strong>` +
+      "</li>"
+    )
+  }
+
+  escapeHtml(text) {
+    const tmp = document.createElement("div")
+    tmp.textContent = text == null ? "" : String(text)
+    return tmp.innerHTML
+  }
+
+  // Whether fitBounds on this cluster would actually reveal its members.
+  // When every member shares a GPS point, bounds collapse to zero
+  // extent and fitBounds pushes to max zoom with a single visible pin.
+  clusterCanZoomFurther(bounds) {
+    if (!bounds) return false
+    const ne = bounds.getNorthEast()
+    const sw = bounds.getSouthWest()
+    const EPS = 1e-5
+    return (ne.lat() - sw.lat()) > EPS || (ne.lng() - sw.lng()) > EPS
   }
 
   clusterRenderer() {
     return {
       render: ({ count, position, markers }) => {
         const color = this.aggregateClusterColor(markers)
-        const label = count > 99 ? "99+" : String(count)
-        const scale = count < 10 ? 14 : count < 100 ? 18 : 22
+        const border = this.aggregateClusterBorder(markers)
         return new google.maps.Marker({
           position,
           label: {
-            text: label,
+            text: String(count),
             color: "#fff",
             fontSize: "12px",
             fontWeight: "700"
@@ -213,15 +460,171 @@ export default class extends GeocodeController {
             path: google.maps.SymbolPath.CIRCLE,
             fillColor: color,
             fillOpacity: 0.9,
-            strokeColor: "#fff",
+            strokeColor: this.borderStrokeColor(border),
+            strokeOpacity: 1,
             strokeWeight: 1.5,
-            scale: scale
+            // Scale up with digit count so the label always fits.
+            scale: this.clusterMarkerScale(count)
           },
           title: `${count} observations`,
           zIndex: 1000 + markers.length
         })
       }
     }
+  }
+
+  clusterMarkerScale(count) {
+    if (count < 10) return 14
+    if (count < 100) return 18
+    if (count < 1000) return 22
+    return 26
+  }
+
+  //
+  //  VIEWPORT REFETCH (#4159) — large obs sets are capped server-side;
+  //  when the user pans/zooms into a smaller viewport we re-query with
+  //  q[in_box] so the truncated obs become visible at the new scale.
+  //
+
+  scheduleViewportRefetch() {
+    if (!this.clustering) return
+    // An open popup (obs detail or cluster summary) means the user is
+    // reading something — tearing markers out from under them is
+    // jarring. Park the refetch until they dismiss the popup.
+    if (this.activeInfoWindow) {
+      this.refetchPending = true
+      return
+    }
+    if (this.refetchTimer) clearTimeout(this.refetchTimer)
+    this.refetchTimer = setTimeout(() => this.refetchForViewport(), 500)
+  }
+
+  refetchForViewport() {
+    const bounds = this.map.getBounds()
+    if (!bounds) return
+    if (!this.viewportRefetchNeeded(bounds)) return
+    if (this.refetchInFlight) this.refetchInFlight.abort()
+
+    const controller = new AbortController()
+    this.refetchInFlight = controller
+    const url = this.buildRefetchUrl(bounds)
+
+    fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal
+    }).
+      then((response) => response.json()).
+      then((data) => this.applyRefetch(data, bounds)).
+      catch((error) => {
+        if (error.name !== "AbortError") {
+          console.error("map refetch failed", error)
+        }
+      }).
+      finally(() => {
+        if (this.refetchInFlight === controller) this.refetchInFlight = null
+      })
+  }
+
+  // Only re-hit the server when it can change the picture:
+  // - last fetch was capped (smaller viewport might expose hidden obs
+  //   or, on zoom-out, pull in obs from newly-visible area), or
+  // - last fetch was bounded and the current viewport extends outside
+  //   that box (we don't have data for the new area).
+  viewportRefetchNeeded(currentBounds) {
+    if (this.lastFetchedCapped) return true
+    const last = this.lastFetchedBounds
+    if (!last) return false // initial fetch was global and not capped
+
+    return !last.contains(currentBounds.getNorthEast()) ||
+           !last.contains(currentBounds.getSouthWest())
+  }
+
+  buildRefetchUrl(bounds) {
+    const ne = bounds.getNorthEast()
+    const sw = bounds.getSouthWest()
+    const params = new URLSearchParams(window.location.search)
+    for (const key of Array.from(params.keys())) {
+      if (key.startsWith("q[in_box]")) params.delete(key)
+    }
+    params.set("q[in_box][north]", String(ne.lat()))
+    params.set("q[in_box][south]", String(sw.lat()))
+    params.set("q[in_box][east]", String(ne.lng()))
+    params.set("q[in_box][west]", String(sw.lng()))
+    const path = window.location.pathname.replace(/\.json$/, "")
+    return `${path}.json?${params.toString()}`
+  }
+
+  applyRefetch(data, bounds) {
+    if (!data || !data.collection) return
+    // A popup opened mid-fetch. Drop this payload and mark the
+    // refetch as pending; when the popup closes we'll pull fresh
+    // data for the current viewport (which may have moved further
+    // while the popup was open).
+    if (this.activeInfoWindow) {
+      this.refetchPending = true
+      return
+    }
+
+    this.clearOverlays()
+    this.collection = data.collection
+    this.buildOverlays()
+    this.updateCapBanner(data)
+
+    this.lastFetchedBounds = bounds
+    this.lastFetchedCapped = Boolean(data.capped)
+  }
+
+  clearOverlays() {
+    if (this.markerClusterer) {
+      this.markerClusterer.clearMarkers()
+      this.markerClusterer = null
+    }
+    this.cluster_markers = []
+    this.clearFuzzyBoxOverlay()
+    if (this.clusterInfoWindow) {
+      this.clusterInfoWindow.close()
+      this.clusterInfoWindow = null
+    }
+    this.activeInfoWindow = null
+    // The non-cluster markers/rectangles created by buildOverlays
+    // attach directly to this.map; tracking them individually would
+    // add a lot of bookkeeping, so we clear by iterating the overlay
+    // records we do keep (clusterMarkers, fuzzy box). Anything else
+    // will be GC'd when the new buildOverlays pass replaces the
+    // dataset-driven references.
+  }
+
+  updateCapBanner(data) {
+    const banner = document.getElementById("map_cap_banner")
+    if (!banner) return
+    if (data.capped) {
+      banner.style.display = ""
+      const loaded = Number(data.loaded).toLocaleString()
+      const total = Number(data.total).toLocaleString()
+      banner.textContent =
+        `Showing the first ${loaded} of ${total} observations. ` +
+        "Zoom in or narrow your filter to see the rest."
+    } else {
+      banner.style.display = "none"
+    }
+  }
+
+  // Aggregate precision state across cluster members. Returns the same
+  // values as MapSet#compute_border_style so the ring colors on the
+  // cluster badge match the per-set markers.
+  aggregateClusterBorder(markers) {
+    let anyGps = false
+    let anyNone = false
+    for (const marker of markers) {
+      const data = marker.moData
+      if (!data) continue
+      if (data.has_gps) anyGps = true
+      else anyNone = true
+      if (anyGps && anyNone) return "dashed"
+    }
+    if (anyGps && !anyNone) return "crisp"
+    if (anyNone && !anyGps) return "none"
+    return "crisp"
   }
 
   // Aggregate consensus-band color across every member of a cluster.
@@ -298,10 +701,20 @@ export default class extends GeocodeController {
     }
     const marker = new google.maps.Marker(markerOptions)
     this.marker = marker
-    // Metadata the cluster renderer uses to compute cluster color.
+    // Metadata the cluster renderer / popup uses. `vote_pct` and
+    // `has_gps` drive cluster color / border aggregation.
+    // `cluster_name` + `cluster_url` let the popup group by species.
+    // `box` is the set's geographic footprint (a point for GPS obs,
+    // the location bbox for fuzzy obs) so the popup can draw an
+    // outline overlay covering all members (#4159).
     marker.moData = {
       vote_pct: this.votePctFromSet(set),
-      has_gps: border !== "none"
+      has_gps: border !== "none",
+      cluster_name: set ? set.cluster_name : null,
+      cluster_url: set ? set.cluster_url : null,
+      box: set
+        ? { n: set.north, s: set.south, e: set.east, w: set.west }
+        : null
     }
 
     if (!this.editable && set != null) {
@@ -367,24 +780,94 @@ export default class extends GeocodeController {
     // }, 1000)
   }
 
-  // For point markers: make a clickable InfoWindow
+  // For point markers: make a clickable InfoWindow. In clustering
+  // mode the caption HTML is not shipped in the bulk payload (too
+  // expensive at 10K obs) — we lazy-fetch it from the server on
+  // click and cache on the set so subsequent clicks are instant
+  // (#4159).
   giveMarkerInfoWindow(marker, set) {
     this.verbose("map:giveMarkerInfoWindow")
-    // maxWidth keeps the popup from stretching unnecessarily wide; without
-    // it Google fills the available map width, which leaves a lot of blank
-    // space on the right and pushes the close X far from the content.
     const info_window = new google.maps.InfoWindow({
-      content: set.caption,
+      content: set.caption ||
+               '<div class="map-popup map-popup-loading">Loading…</div>',
       position: { lat: set.lat, lng: set.lng },
       maxWidth: 280
     })
-    // Expose on the marker so other code (e.g. fuzzy-box overlays
-    // for #4159) can listen for close events.
     marker.infoWindow = info_window
 
     google.maps.event.addListener(marker, "click", () => {
       info_window.open({ anchor: marker, map: this.map })
+      this.noteInfoWindowOpened(info_window)
+      if (!set.caption && this.clustering) {
+        this.loadMarkerPopup(info_window, set)
+      }
     })
+    google.maps.event.addListener(info_window, "closeclick", () => {
+      this.noteInfoWindowClosed(info_window)
+    })
+  }
+
+  noteInfoWindowOpened(info_window) {
+    this.activeInfoWindow = info_window
+  }
+
+  noteInfoWindowClosed(info_window) {
+    if (this.activeInfoWindow === info_window) {
+      this.activeInfoWindow = null
+      this.flushPendingRefetch()
+    }
+  }
+
+  flushPendingRefetch() {
+    if (!this.refetchPending) return
+    this.refetchPending = false
+    this.scheduleViewportRefetch()
+  }
+
+  loadMarkerPopup(info_window, set) {
+    const url = this.markerPopupUrl(set)
+    if (!url) {
+      console.warn("map popup: no URL derived from set", set)
+      info_window.setContent('<div class="map-popup">No details</div>')
+      return
+    }
+    fetch(url, {
+      headers: { Accept: "application/json" },
+      credentials: "same-origin"
+    }).
+      then(async (response) => {
+        if (!response.ok) {
+          const body = await response.text()
+          throw new Error(
+            `map popup HTTP ${response.status} ${url}\n${body.slice(0, 200)}`
+          )
+        }
+        return response.json()
+      }).
+      then((data) => {
+        if (!data || data.html == null) {
+          throw new Error(`map popup: malformed response ${JSON.stringify(data)}`)
+        }
+        set.caption = data.html
+        info_window.setContent(data.html)
+      }).
+      catch((error) => {
+        console.error(error)
+        info_window.setContent(
+          '<div class="map-popup">Error loading details</div>'
+        )
+      })
+  }
+
+  // Clustered singleton sets carry `cluster_url` = /observations/:id.
+  // The popup lives at /observations/:id/map_popup.
+  markerPopupUrl(set) {
+    if (!set || !set.cluster_url) return null
+    const match = set.cluster_url.match(/^(\/observations\/\d+)(\?|$)/)
+    if (!match) return null
+    const base = match[1]
+    const query = set.cluster_url.slice(match[1].length) // preserves ?q=...
+    return `${base}/map_popup${query}`
   }
 
   //

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -347,7 +347,7 @@ export default class extends GeocodeController {
     )
     parts.push('<ul class="map-popup-cluster-list">')
     for (const group of groups) {
-      parts.push(this.renderClusterListItem(group))
+      parts.push(this.renderClusterListItem(group, outlineBox))
     }
     parts.push("</ul>")
     if (canZoom) {
@@ -375,21 +375,30 @@ export default class extends GeocodeController {
   }
 
   // Build a Show-All / Map-All URL by preserving the current page's
-  // `q[...]` params (so user/name/etc. filters carry over) and
-  // overriding `q[in_box][n/s/e/w]` with the cluster outline box.
-  clusterQueryUrl(path, box) {
+  // `q[...]` params (so user/etc. filters carry over) and overriding
+  // `q[in_box][n/s/e/w]` with the cluster outline box. An optional
+  // `name` scopes the result further via `q[names][lookup][]=<name>`
+  // (used by per-species links in the cluster popup); when present,
+  // any existing `q[names]` params are dropped so the species filter
+  // wins.
+  clusterQueryUrl(path, box, opts = {}) {
     const params = new URLSearchParams()
     const current = new URLSearchParams(window.location.search)
     const IN_BOX_PREFIX = "q[in_box]"
+    const NAMES_PREFIX = "q[names]"
     for (const [key, value] of current.entries()) {
-      if (key.startsWith("q[") && !key.startsWith(IN_BOX_PREFIX)) {
-        params.append(key, value)
-      }
+      if (!key.startsWith("q[")) continue
+      if (key.startsWith(IN_BOX_PREFIX)) continue
+      if (opts.name && key.startsWith(NAMES_PREFIX)) continue
+      params.append(key, value)
     }
     params.append("q[in_box][north]", String(box.n))
     params.append("q[in_box][south]", String(box.s))
     params.append("q[in_box][east]", String(box.e))
     params.append("q[in_box][west]", String(box.w))
+    if (opts.name) {
+      params.append("q[names][lookup][]", opts.name)
+    }
     return `${path}?${params.toString()}`
   }
 
@@ -400,11 +409,10 @@ export default class extends GeocodeController {
       const name = data.cluster_name || "Unknown"
       let group = groups.get(name)
       if (!group) {
-        group = { name, count: 0, url: null }
+        group = { name, count: 0 }
         groups.set(name, group)
       }
       group.count += 1
-      if (!group.url && data.cluster_url) group.url = data.cluster_url
     }
     return Array.from(groups.values()).sort((a, b) => {
       if (b.count !== a.count) return b.count - a.count
@@ -412,10 +420,19 @@ export default class extends GeocodeController {
     })
   }
 
-  renderClusterListItem(group) {
+  // Species row links land on the observations index filtered by
+  // this species + the cluster's bounding box — the user's stated
+  // preference over landing on a single arbitrary obs. Preserves the
+  // current page's other q[...] filters via clusterQueryUrl. Falls
+  // back to plain italic text when no outline box is available
+  // (shouldn't happen in practice — cluster popups always have one).
+  renderClusterListItem(group, outlineBox) {
     const name = this.escapeHtml(group.name)
-    const nameHtml = group.url
-      ? `<a href="${group.url}" target="_blank" rel="noopener noreferrer">` +
+    const url = outlineBox &&
+      this.clusterQueryUrl("/observations", outlineBox,
+                           { name: group.name })
+    const nameHtml = url
+      ? `<a href="${url}" target="_blank" rel="noopener noreferrer">` +
         `<i>${name}</i></a>`
       : `<i>${name}</i>`
     return (
@@ -604,8 +621,8 @@ export default class extends GeocodeController {
       const template = (this.localized_text &&
                         this.localized_text.map_cap_banner) || ""
       banner.textContent = template.
-        replace("__LOADED__", loaded).
-        replace("__TOTAL__", total)
+        replace("[loaded]", loaded).
+        replace("[total]", total)
     } else {
       banner.style.display = "none"
     }
@@ -705,10 +722,12 @@ export default class extends GeocodeController {
     this.marker = marker
     // Metadata the cluster renderer / popup uses. `vote_pct` and
     // `has_gps` drive cluster color / border aggregation.
-    // `cluster_name` + `cluster_url` let the popup group by species.
-    // `box` is the set's geographic footprint (a point for GPS obs,
-    // the location bbox for fuzzy obs) so the popup can draw an
-    // outline overlay covering all members (#4159).
+    // `cluster_name` is the species label used for grouping in the
+    // cluster popup. `cluster_url` is `/observations/:id` for the
+    // single-marker lazy popup fetch (markerPopupUrl). `box` is the
+    // set's geographic footprint (a point for GPS obs, the location
+    // bbox for fuzzy obs) so the cluster popup can draw an outline
+    // overlay covering all members (#4159).
     marker.moData = {
       vote_pct: this.votePctFromSet(set),
       has_gps: border !== "none",

--- a/app/models/mappable/minimal_observation.rb
+++ b/app/models/mappable/minimal_observation.rb
@@ -32,8 +32,10 @@ module Mappable
     attribute :thumb_image_id, :integer
     # Cached `gps_dubious` flag from the `observations` table (#4159).
     # Set by the controller when minimal obs are loaded; the mapping
-    # layer reads it instead of recomputing.
-    attribute :gps_dubious, :boolean, default: false
+    # layer reads it instead of recomputing. No default — if the
+    # column wasn't provided (e.g. legacy callers, specs), stay nil
+    # so `lat_lng_dubious?` falls back to an on-the-fly computation.
+    attribute :gps_dubious, :boolean
 
     validates :lat, numericality: { in: -90..90 }
     validates :lng, numericality: { in: -180..180 }

--- a/app/models/mappable/minimal_observation.rb
+++ b/app/models/mappable/minimal_observation.rb
@@ -30,6 +30,10 @@ module Mappable
     attribute :when, :date
     attribute :vote_cache, :float
     attribute :thumb_image_id, :integer
+    # Cached `gps_dubious` flag from the `observations` table (#4159).
+    # Set by the controller when minimal obs are loaded; the mapping
+    # layer reads it instead of recomputing.
+    attribute :gps_dubious, :boolean, default: false
 
     validates :lat, numericality: { in: -90..90 }
     validates :lng, numericality: { in: -180..180 }
@@ -57,8 +61,14 @@ module Mappable
       true
     end
 
+    # Mirrors Observation#lat_lng_dubious? — reads the cached column
+    # populated by the controller. Falls back to an on-the-fly check
+    # when the attribute wasn't provided (pre-backfill data, specs).
     def lat_lng_dubious?
-      lat && location && !location.lat_lng_close?(lat, lng)
+      return gps_dubious unless gps_dubious.nil?
+      return false unless lat && location
+
+      location.km_from_point(lat, lng) > ::Observation::DUBIOUS_GPS_KM
     end
 
     private

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -234,6 +234,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # because a before_destroy must precede the has_many's
   before_save :cache_content_filter_data
   before_save :prefer_minimum_bounding_box_to_earth
+  before_save :set_gps_dubious
 
   # rubocop:enable Rails/ActiveRecordCallbacksOrder
   after_update :notify_users_after_change
@@ -493,9 +494,34 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     self[:alt] = alt
   end
 
-  # Is lat/lng more than 10% outside of location extents?
+  # Kilometers of slack between an observation's GPS and its
+  # location's bounding box before we consider the GPS "dubious" and
+  # stop matching it in GPS-based searches (issue #4159). At 50 km
+  # the false-positive rate from narrow location bboxes (tight trail
+  # or park polygons with GPS from nearby photos) is low while clear
+  # data errors (hemisphere flips, wrong country, lab-photo GPS) are
+  # still caught.
+  DUBIOUS_GPS_KM = 50
+
+  # Is lat/lng more than DUBIOUS_GPS_KM from the location's bbox?
+  # Reads the cached `gps_dubious` column when populated; falls back
+  # to recomputing for unsaved/just-built records.
   def lat_lng_dubious?
-    lat && location && !location.lat_lng_close?(lat, lng)
+    return compute_gps_dubious? if new_record? || gps_inputs_changed?
+
+    gps_dubious
+  end
+
+  def compute_gps_dubious?
+    return false unless lat && location
+
+    location.km_from_point(lat, lng) > DUBIOUS_GPS_KM
+  end
+
+  def gps_inputs_changed?
+    will_save_change_to_attribute?(:lat) ||
+      will_save_change_to_attribute?(:lng) ||
+      will_save_change_to_attribute?(:location_id)
   end
 
   def place_name_and_coordinates
@@ -1349,5 +1375,14 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       #            south: -89,
       # Also see ObservationAPI#prefer_minimum_bounding_box_to_earth!
       presence || Location.unknown
+  end
+
+  # Keeps the cached `gps_dubious` column in sync on save. Gates the
+  # re-computation on attribute changes so untouched obs don't pay the
+  # recompute cost on every save.
+  def set_gps_dubious
+    return unless new_record? || gps_inputs_changed?
+
+    self.gps_dubious = compute_gps_dubious?
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -513,7 +513,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def compute_gps_dubious?
-    return false unless lat && location
+    return false unless lat && lng && location
 
     location.km_from_point(lat, lng) > DUBIOUS_GPS_KM
   end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -347,6 +347,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # they stay reachable via in_box (#4159).
     def self.gps_untrusted_for_search
       Observation[:lat].eq(nil).
+        or(Observation[:lng].eq(nil)).
         or(Observation[:gps_hidden].eq(true)).
         or(Observation[:gps_dubious].eq(true))
     end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -324,12 +324,21 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # In these the box.east edge is in the w hemisphere, -180..
     #      and the box.west edge is in the e hemisphere, ..180
     scope :gps_in_box_over_dateline, lambda { |box|
-      where(
-        (Observation[:lat] >= box.south).
-        and(Observation[:lat] <= box.north).
-        and(Observation[:lng] >= box.west).
-        or(Observation[:lng] <= box.east)
-      ).distinct
+      # Exclude obs from the GPS-match path when their GPS shouldn't
+      # be trusted for search: gps_hidden leaks private coords, and
+      # gps_dubious (>50 km from the obs's own location bbox) lets
+      # mislabeled or lab-photo GPS leak into location searches
+      # (#4159). These obs can still match via the location-center
+      # path.
+      where(Observation[:gps_hidden].eq(false).
+            or(Observation[:gps_hidden].eq(nil))).
+        where(Observation[:gps_dubious].eq(false)).
+        where(
+          (Observation[:lat] >= box.south).
+          and(Observation[:lat] <= box.north).
+          and(Observation[:lng] >= box.west).
+          or(Observation[:lng] <= box.east)
+        ).distinct
     }
     scope :cached_location_center_in_box_over_dateline, lambda { |box|
       where(
@@ -368,12 +377,18 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       end
     }
     scope :gps_in_box, lambda { |box|
-      where(
-        (Observation[:lat] >= box.south).
-        and(Observation[:lat] <= box.north).
-        and(Observation[:lng] <= box.east).
-        and(Observation[:lng] >= box.west)
-      ).distinct
+      # Exclude obs from the GPS-match path when their GPS shouldn't
+      # be trusted for search — see gps_in_box_over_dateline above
+      # for the full reasoning (#4159).
+      where(Observation[:gps_hidden].eq(false).
+            or(Observation[:gps_hidden].eq(nil))).
+        where(Observation[:gps_dubious].eq(false)).
+        where(
+          (Observation[:lat] >= box.south).
+          and(Observation[:lat] <= box.north).
+          and(Observation[:lng] <= box.east).
+          and(Observation[:lng] >= box.west)
+        ).distinct
     }
     scope :cached_location_center_in_box, lambda { |box|
       # odd! AR will toss entire condition if below order is west, east

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -340,9 +340,20 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
           or(Observation[:lng] <= box.east)
         ).distinct
     }
+    # The "lat IS NULL OR gps_hidden OR gps_dubious" predicate is
+    # Arel-ugly inline, so pull it out. Obs whose GPS isn't
+    # search-trusted — no lat, private, or contradicting the
+    # labeled location — fall back to the location center path so
+    # they stay reachable via in_box (#4159).
+    def self.gps_untrusted_for_search
+      Observation[:lat].eq(nil).
+        or(Observation[:gps_hidden].eq(true)).
+        or(Observation[:gps_dubious].eq(true))
+    end
+
     scope :cached_location_center_in_box_over_dateline, lambda { |box|
       where(
-        Observation[:lat].eq(nil).
+        gps_untrusted_for_search.
         and(Observation[:location_lat] >= box.south).
         and(Observation[:location_lat] <= box.north).
         and(Observation[:location_lng] >= box.west).
@@ -352,7 +363,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :associated_location_center_in_box_over_dateline, lambda { |box|
       left_outer_joins(:location).
         where(
-          Observation[:lat].eq(nil).
+          gps_untrusted_for_search.
           and(Location[:center_lat] >= box.south).
           and(Location[:center_lat] <= box.north).
           and(Location[:center_lng] >= box.west).
@@ -393,7 +404,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :cached_location_center_in_box, lambda { |box|
       # odd! AR will toss entire condition if below order is west, east
       where(
-        Observation[:lat].eq(nil).
+        gps_untrusted_for_search.
         and(Observation[:location_lat] >= box.south).
         and(Observation[:location_lat] <= box.north).
         and(Observation[:location_lng] <= box.east).
@@ -403,7 +414,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :associated_location_center_in_box, lambda { |box|
       left_outer_joins(:location).
         where(
-          Observation[:lat].eq(nil).
+          gps_untrusted_for_search.
           and(Location[:center_lat] >= box.south).
           and(Location[:center_lat] <= box.north).
           and(Location[:center_lng] <= box.east).

--- a/app/views/controllers/names/maps/show.html.erb
+++ b/app/views/controllers/names/maps/show.html.erb
@@ -4,8 +4,16 @@ add_page_title(:name_map_title.t(name: @name.display_name))
 add_context_nav(name_map_tabs(name: @name, query: @query))
 %>
 
-<%= make_map(
-  objects: @observations, # CollapsibleCollection
-  query_param: q_param(@query), zoom: 2, map_type: "info",
-  nothing_to_map: :name_map_no_maps.tp(name: @name.display_name)
-) %>
+<div id="map_cap_banner" class="alert alert-warning mt-2"
+     <%= raw('style="display:none"') unless @observations_capped %>>
+  <%= :map_cap_banner.t(
+        loaded: number_with_delimiter(@observations_loaded_count),
+        total: number_with_delimiter(@observations_total_count)
+      ) %>
+</div>
+
+<%= make_map(objects: @observations,
+             clustering: true,
+             capped: @observations_capped,
+             query_param: q_param(@query), zoom: 2, map_type: "info",
+             nothing_to_map: :name_map_no_maps.tp(name: @name.display_name)) %>

--- a/app/views/controllers/names/maps/show.html.erb
+++ b/app/views/controllers/names/maps/show.html.erb
@@ -15,5 +15,6 @@ add_context_nav(name_map_tabs(name: @name, query: @query))
 <%= make_map(objects: @observations,
              clustering: true,
              capped: @observations_capped,
+             cluster_query_string: @cluster_query_string,
              query_param: q_param(@query), zoom: 2, map_type: "info",
              nothing_to_map: :name_map_no_maps.tp(name: @name.display_name)) %>

--- a/app/views/controllers/observations/maps/index.html.erb
+++ b/app/views/controllers/observations/maps/index.html.erb
@@ -22,4 +22,5 @@ add_context_nav(observation_maps_tabs(query: @query))
 <%= make_map(objects: @observations,
              clustering: true,
              capped: @observations_capped,
+             cluster_query_string: @cluster_query_string,
              query_param: q_param(@query), zoom: 2, map_type: "info") %>

--- a/app/views/controllers/observations/maps/index.html.erb
+++ b/app/views/controllers/observations/maps/index.html.erb
@@ -11,6 +11,15 @@ add_context_nav(observation_maps_tabs(query: @query))
 # overlays on top of obs points (#4131 follow-up).
 %>
 
+<div id="map_cap_banner" class="alert alert-warning mt-2"
+     <%= raw('style="display:none"') unless @observations_capped %>>
+  <%= :map_cap_banner.t(
+        loaded: number_with_delimiter(@observations_loaded_count),
+        total: number_with_delimiter(@observations_total_count)
+      ) %>
+</div>
+
 <%= make_map(objects: @observations,
              clustering: true,
+             capped: @observations_capped,
              query_param: q_param(@query), zoom: 2, map_type: "info") %>

--- a/app/views/controllers/observations/maps/index.html.erb
+++ b/app/views/controllers/observations/maps/index.html.erb
@@ -11,5 +11,6 @@ add_context_nav(observation_maps_tabs(query: @query))
 # overlays on top of obs points (#4131 follow-up).
 %>
 
-<%= make_map(objects: @observations, # CollapsibleCollection
+<%= make_map(objects: @observations,
+             clustering: true,
              query_param: q_param(@query), zoom: 2, map_type: "info") %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -25,7 +25,7 @@ pin "vanilla-lazyload" # @17.8.5
 pin "lightgallery" # @2.7.2
 pin "lightgallery/plugins/zoom", to: "lightgallery--plugins--zoom.js" # @2.7.2
 pin "@googlemaps/js-api-loader", to: "https://ga.jspm.io/npm:@googlemaps/js-api-loader@1.16.2/dist/index.esm.js"
-pin "@googlemaps/markerclusterer", to: "https://ga.jspm.io/npm:@googlemaps/markerclusterer@2.5.3/dist/index.esm.js"
+pin "@googlemaps/markerclusterer", to: "https://esm.sh/@googlemaps/markerclusterer@2.5.3"
 pin "jstz" # @2.1.1
 
 pin_all_from "app/javascript/src", under: "src", to: "src"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -25,6 +25,7 @@ pin "vanilla-lazyload" # @17.8.5
 pin "lightgallery" # @2.7.2
 pin "lightgallery/plugins/zoom", to: "lightgallery--plugins--zoom.js" # @2.7.2
 pin "@googlemaps/js-api-loader", to: "https://ga.jspm.io/npm:@googlemaps/js-api-loader@1.16.2/dist/index.esm.js"
+pin "@googlemaps/markerclusterer", to: "https://ga.jspm.io/npm:@googlemaps/markerclusterer@2.5.3/dist/index.esm.js"
 pin "jstz" # @2.1.1
 
 pin_all_from "app/javascript/src", under: "src", to: "src"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -899,8 +899,11 @@
   update_object: Update [TYPE]
   show_all: Show All
   map_all: Map All
-  map_legend_circle: Observation with GPS
-  map_legend_box: Location area (no GPS) or group of observations
+  map_legend_circle: Single observation
+  map_legend_box: Multiple observations
+  map_legend_border_crisp: All with GPS
+  map_legend_border_dashed: Mix of GPS and location-only
+  map_legend_border_none: All location-only (no GPS)
   map_legend_confirmed: Confirmed (≥80%)
   map_legend_tentative: Tentative
   map_legend_disputed: Disputed (≤0%)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -899,8 +899,6 @@
   update_object: Update [TYPE]
   show_all: Show All
   map_all: Map All
-  map_legend_circle: Single observation
-  map_legend_box: Multiple observations
   map_legend_border_crisp: All with GPS
   map_legend_border_dashed: Mix of GPS and location-only
   map_legend_border_none: All location-only (no GPS)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -909,6 +909,7 @@
   map_legend_disputed: Disputed (≤0%)
   map_legend_mixed: Mixed consensus
   map_legend_location_only: Location only (no observations)
+  map_cap_banner: Showing the first [loaded] of [total] observations. Zoom in or narrow your filter to see the rest.
   show_location: Show [LOCATION]
   show_location_description: Show [DESCRIPTION]
   about_this_taxon: About this taxon

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -904,7 +904,8 @@
   map_legend_confirmed: Confirmed (≥80%)
   map_legend_tentative: Tentative
   map_legend_disputed: Disputed (≤0%)
-  map_legend_group: Multiple observations
+  map_legend_mixed: Mixed consensus
+  map_legend_location_only: Location only (no observations)
   show_location: Show [LOCATION]
   show_location_description: Show [DESCRIPTION]
   about_this_taxon: About this taxon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -623,6 +623,7 @@ MushroomObserver::Application.routes.draw do
                 shallow: true, controller: "observations/external_links"
 
       get("map", to: "observations/maps#show")
+      get("map_popup", to: "observations/maps#popup")
       get("suggestions", to: "observations/namings/suggestions#show",
                          as: "naming_suggestions_for")
       get("emails/new", to: "observations/emails#new",

--- a/db/migrate/20260424170000_add_gps_dubious_to_observations.rb
+++ b/db/migrate/20260424170000_add_gps_dubious_to_observations.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Cached flag: true when `Observation#lat` / `lng` is geographically
+# far (>50 km) from its `location`'s bounding box. GPS-based search
+# scopes (`gps_in_box`, `gps_in_box_over_dateline`) exclude dubious
+# rows so obs whose GPS contradicts an explicit label don't leak into
+# location-filtered results (issue #4159).
+#
+# The column is populated by `Observation#set_gps_dubious` on save and
+# backfilled once by `script/backfill_gps_dubious.rb`.
+class AddGpsDubiousToObservations < ActiveRecord::Migration[7.2]
+  def change
+    add_column(:observations, :gps_dubious,
+               :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_16_192916) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_24_170000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -557,6 +557,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_16_192916) do
     t.decimal "location_lat", precision: 15, scale: 10
     t.decimal "location_lng", precision: 15, scale: 10
     t.integer "occurrence_id"
+    t.boolean "gps_dubious", default: false, null: false
     t.index ["location_id"], name: "index_observations_on_location_id"
     t.index ["name_id"], name: "index_observations_on_name_id"
     t.index ["needs_naming"], name: "needs_naming_index"

--- a/script/backfill_gps_dubious.rb
+++ b/script/backfill_gps_dubious.rb
@@ -38,7 +38,8 @@ class GpsDubiousBackfill
   private
 
   def scope
-    Observation.where.not(lat: nil).where.not(location_id: nil)
+    Observation.where.not(lat: nil).where.not(lng: nil).
+      where.not(location_id: nil)
   end
 
   def process(obs)

--- a/script/backfill_gps_dubious.rb
+++ b/script/backfill_gps_dubious.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Backfill Observation#gps_dubious for every obs with a recorded GPS
+# and a location. Run once after the add_gps_dubious_to_observations
+# migration ships. Idempotent — safe to re-run (only writes rows
+# whose computed value differs from the stored one).
+#
+#   bin/rails runner script/backfill_gps_dubious.rb
+#
+# Issue #4159 — see app/models/observation.rb#set_gps_dubious and
+# Mappable::BoxMethods#km_from_point for the underlying predicate.
+
+require "English"
+
+class GpsDubiousBackfill
+  BATCH_SIZE = 1_000
+
+  def initialize
+    @processed = 0
+    @flagged = 0
+    @started_at = Time.current
+  end
+
+  def run
+    total = scope.count
+    puts("Backfilling gps_dubious across #{total} obs...")
+
+    scope.includes(:location).in_batches(of: BATCH_SIZE) do |batch|
+      batch.each { |obs| process(obs) }
+      print_progress(total)
+    end
+
+    elapsed = (Time.current - @started_at).round
+    puts("\nDone. Changed #{@flagged} rows (net flagged) in #{elapsed}s.")
+  end
+
+  private
+
+  def scope
+    Observation.where.not(lat: nil).where.not(location_id: nil)
+  end
+
+  def process(obs)
+    @processed += 1
+    computed = obs.compute_gps_dubious?
+    return if computed == obs.gps_dubious
+
+    obs.update_column(:gps_dubious, computed)
+    @flagged += 1 if computed
+  end
+
+  def print_progress(total)
+    pct = (@processed.to_f / total * 100).round(1)
+    elapsed = (Time.current - @started_at).round
+    print("\r  #{@processed}/#{total} (#{pct}%) in #{elapsed}s")
+    $stdout.flush
+  end
+end
+
+GpsDubiousBackfill.new.run

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -82,6 +82,89 @@ class MapSetTest < UnitTestCase
   end
 
   # ------------------------------------------------------------------
+  # #compute_glyph — issue #4159 ("dot = single, square = multiple")
+  # ------------------------------------------------------------------
+
+  def test_glyph_dot_for_single_observation
+    set = set_of(build_obs(lat: 10, lng: 10))
+    assert_equal(:dot, set.compute_glyph)
+  end
+
+  def test_glyph_square_for_multiple_observations
+    set = set_of(build_obs(lat: 10, lng: 10),
+                 build_obs(lat: 10, lng: 10))
+    assert_equal(:square, set.compute_glyph)
+  end
+
+  def test_glyph_square_for_location_only
+    set = set_of(locations(:burbank))
+    assert_equal(:square, set.compute_glyph)
+  end
+
+  def test_glyph_dot_for_single_obs_bucketed_with_its_location
+    set = set_of(build_obs(lat: 34.1, lng: -118.3),
+                 locations(:burbank))
+    assert_equal(:dot, set.compute_glyph,
+                 "One obs bucketed with its location is still a single obs")
+  end
+
+  # ------------------------------------------------------------------
+  # #compute_border_style — issue #4159
+  # ------------------------------------------------------------------
+
+  def test_border_crisp_when_single_obs_has_gps
+    set = set_of(build_obs(lat: 10, lng: 10))
+    assert_equal(:crisp, set.compute_border_style)
+  end
+
+  def test_border_none_when_single_obs_has_no_gps
+    # Location-only positioning — no lat/lng on the obs.
+    obs = Mappable::MinimalObservation.new(
+      id: 999, lat: nil, lng: nil,
+      location: locations(:burbank),
+      name_id: 1, text_name: "Test", when: Time.zone.today,
+      vote_cache: 3.0
+    )
+    set = set_of(obs)
+    assert_equal(:none, set.compute_border_style)
+  end
+
+  def test_border_crisp_when_all_members_have_gps
+    set = set_of(build_obs(lat: 10, lng: 10),
+                 build_obs(lat: 10.01, lng: 10.01))
+    assert_equal(:crisp, set.compute_border_style)
+  end
+
+  def test_border_none_when_no_member_has_gps
+    a = Mappable::MinimalObservation.new(
+      id: 1, lat: nil, lng: nil, location: locations(:burbank),
+      name_id: 1, text_name: "A", when: Time.zone.today, vote_cache: 3.0
+    )
+    b = Mappable::MinimalObservation.new(
+      id: 2, lat: nil, lng: nil, location: locations(:burbank),
+      name_id: 1, text_name: "B", when: Time.zone.today, vote_cache: 3.0
+    )
+    set = set_of(a, b)
+    assert_equal(:none, set.compute_border_style)
+  end
+
+  def test_border_dashed_when_members_are_mixed_precision
+    precise = build_obs(lat: 34.1, lng: -118.3)
+    fuzzy = Mappable::MinimalObservation.new(
+      id: 999, lat: nil, lng: nil, location: locations(:burbank),
+      name_id: 1, text_name: "Fuzzy", when: Time.zone.today,
+      vote_cache: 3.0
+    )
+    set = set_of(precise, fuzzy)
+    assert_equal(:dashed, set.compute_border_style)
+  end
+
+  def test_border_crisp_for_location_only_set
+    set = set_of(locations(:burbank))
+    assert_equal(:crisp, set.compute_border_style)
+  end
+
+  # ------------------------------------------------------------------
   # Helpers
   # ------------------------------------------------------------------
 

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -4,59 +4,81 @@ require("test_helper")
 
 class MapSetTest < UnitTestCase
   # ------------------------------------------------------------------
-  # #compute_color — issue #4131
+  # #compute_color — issue #4159 (was #4131)
   # ------------------------------------------------------------------
 
-  def test_color_blue_for_multi_observation_group
-    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
-                 build_obs(lat: 10, lng: 10, vote_cache: 3.0))
-    assert_equal(Mappable::MapSet::GROUP_COLOR, set.compute_color)
-  end
-
-  def test_color_blue_for_location_only
+  # Location-only sets have no observations to classify; they keep the
+  # neutral blue and the legend is suppressed on maps with no obs.
+  def test_color_location_only_for_no_observations
     set = set_of(locations(:burbank))
-    assert_equal(Mappable::MapSet::GROUP_COLOR, set.compute_color)
+    assert_equal(Mappable::MapSet::LOCATION_ONLY_COLOR, set.compute_color)
   end
 
-  def test_color_green_for_single_obs_confirmed
+  def test_color_confirmed_for_single_obs_confirmed
     # 2.4 / 3 * 100 = 80.0 — exactly the threshold.
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 2.4))
     assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color)
   end
 
-  def test_color_orange_for_single_obs_tentative
+  def test_color_tentative_for_single_obs_tentative
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 1.5))
     assert_equal(Mappable::MapSet::TENTATIVE_COLOR, set.compute_color)
   end
 
-  def test_color_red_for_single_obs_disputed_at_zero
+  def test_color_disputed_for_single_obs_at_zero
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 0.0))
     assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
   end
 
-  def test_color_red_for_single_obs_negative
+  def test_color_disputed_for_single_obs_negative
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: -1.5))
     assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
   end
 
-  def test_color_red_for_single_obs_missing_vote_cache
-    # Vote.percent returns 0.0 when the value is blank -> disputed.
+  def test_color_disputed_for_single_obs_missing_vote_cache
+    # Vote.percent returns 0.0 when vote_cache is blank -> disputed.
     set = set_of(build_obs(lat: 10, lng: 10, vote_cache: nil))
     assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  # Multi-obs sets: same-band members take that band's color.
+  def test_color_confirmed_when_all_members_confirmed
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 2.4))
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color)
+  end
+
+  def test_color_disputed_when_all_members_disputed
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: -1.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 0.0))
+    assert_equal(Mappable::MapSet::DISPUTED_COLOR, set.compute_color)
+  end
+
+  # Mixed-band members use MIXED_COLOR.
+  def test_color_mixed_when_members_in_different_bands
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: 1.5))
+    assert_equal(Mappable::MapSet::MIXED_COLOR, set.compute_color)
+  end
+
+  def test_color_mixed_with_confirmed_plus_disputed
+    set = set_of(build_obs(lat: 10, lng: 10, vote_cache: 3.0),
+                 build_obs(lat: 10, lng: 10, vote_cache: -1.0))
+    assert_equal(Mappable::MapSet::MIXED_COLOR, set.compute_color)
   end
 
   # On the observations index map the controller passes obs AND their
   # locations. CollapsibleCollectionOfObjects can put a single obs and
   # its location in the same bucket, giving @objects.size == 2 even
-  # though there's just one observation. The set should still colour
-  # by that observation's consensus, not blue.
+  # though there's just one observation. The set should still color
+  # by that observation's consensus.
   def test_color_for_single_obs_bucketed_with_its_location
     obs = build_obs(lat: 34.1, lng: -118.3, vote_cache: 2.4)
     set = set_of(obs, locations(:burbank))
     assert_equal(1, set.observations.length)
     assert_equal(Mappable::MapSet::CONFIRMED_COLOR, set.compute_color,
                  "Single obs bucketed with its location should still " \
-                 "use the consensus color, not GROUP_COLOR")
+                 "use the consensus color, not LOCATION_ONLY_COLOR")
   end
 
   # ------------------------------------------------------------------

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -96,9 +96,11 @@ class MapSetTest < UnitTestCase
     assert_equal(:square, set.compute_glyph)
   end
 
-  def test_glyph_square_for_location_only
+  def test_glyph_rectangle_for_location_only
     set = set_of(locations(:burbank))
-    assert_equal(:square, set.compute_glyph)
+    assert_equal(:rectangle, set.compute_glyph,
+                 "Location-only sets render as bare outline rectangles " \
+                 "(#4159) — no center marker.")
   end
 
   def test_glyph_dot_for_single_obs_bucketed_with_its_location

--- a/test/components/map_test.rb
+++ b/test/components/map_test.rb
@@ -131,7 +131,9 @@ class MapTest < ComponentTestCase
                           observed_on: Date.new(2025, 1, 1))
     caption, color = parse_first_set(render_map_json([obs_a, obs_b, obs_c]))
 
-    assert_equal(Mappable::MapSet::GROUP_COLOR, color)
+    # All three members are confirmed (vote_cache 3.0), so the group
+    # inherits the confirmed band's color (#4159).
+    assert_equal(Mappable::MapSet::CONFIRMED_COLOR, color)
     # Most recent first.
     assert(caption.index("Newest sp.") < caption.index("Middle sp."),
            "Group popup should list most recent name first")

--- a/test/controllers/names/maps_controller_test.rb
+++ b/test/controllers/names/maps_controller_test.rb
@@ -31,5 +31,50 @@ module Names
       get(:show, params: { id: names(:conocybe_filaris).id })
       assert_template("names/maps/show")
     end
+
+    # Regression: the Occurrence Map for a name must not inherit a
+    # spatial filter (`in_box`) from the session's stored query —
+    # that's what made #4139 sticky even after the URL stopped
+    # carrying `q=…`. Session-stored prior query had `in_box`; the
+    # Occurrence Map for a name should still render the full
+    # distribution.
+    def test_show_ignores_in_box_from_session_query
+      login
+      stale_query = Query.lookup_and_save(
+        :Observation,
+        in_box: { north: 40, south: 30, east: -70, west: -80 }
+      )
+      @request.session[:query_record] = stale_query.id
+
+      get(:show, params: { id: names(:agaricus_campestris).id })
+
+      assert_template("names/maps/show")
+      assert_not(assigns(:query).params.key?(:in_box),
+                 "Names map query must not inherit in_box from the " \
+                 "session — should be a fresh name-only query (#4139)")
+      assert_equal(
+        { lookup: [names(:agaricus_campestris).id] },
+        assigns(:query).params[:names],
+        "Names map query should be scoped to just the requested name"
+      )
+    end
+
+    # When the URL itself carries an in_box (e.g. the JS viewport
+    # refetch), the controller honors it. This is the only path that
+    # should put in_box on the query.
+    def test_show_honors_in_box_from_url
+      login
+      get(:show, params: {
+            id: names(:agaricus_campestris).id,
+            q: { in_box: { north: 40, south: 30, east: -70, west: -80 } }
+          })
+
+      assert_template("names/maps/show")
+      assert_equal(
+        { north: 40.0, south: 30.0, east: -70.0, west: -80.0 },
+        assigns(:query).params[:in_box].transform_values(&:to_f).symbolize_keys,
+        "URL-supplied in_box should pass through to the query"
+      )
+    end
   end
 end

--- a/test/controllers/names_controller_show_test.rb
+++ b/test/controllers/names_controller_show_test.rb
@@ -199,6 +199,33 @@ class NamesControllerShowTest < FunctionalTestCase
     assert_select("a[href *= 'mycoportal.org']")
   end
 
+  # Regression: the Occurrence Map link in the show page's tabs
+  # should never inherit `q[in_box]` (or any other query context)
+  # from the URL the user arrived on. Otherwise navigating
+  # "name → name → occurrence map" silently restricts the map to
+  # whatever spatial filter happened to be in scope (#4139).
+  def test_occurrence_map_tab_strips_in_box_query_context
+    login
+    name = names(:coprinus_comatus)
+    get(:show, params: {
+          id: name.id,
+          q: { in_box: { north: 40, south: 30, east: -70, west: -80 },
+               model: "Observation" }
+        })
+
+    assert_select(
+      "a[href*='/names/#{name.id}/map']", { minimum: 1 }
+    ) do |links|
+      links.each do |link|
+        href = link["href"]
+        assert_no_match(/in_box/, href,
+                        "Occurrence Map tab link must not inherit " \
+                        "in_box from the URL's query context " \
+                        "(href=#{href.inspect})")
+      end
+    end
+  end
+
   def test_show_name_locked
     name = Name.where(locked: true).first
     # login

--- a/test/controllers/observations/maps_controller_test.rb
+++ b/test/controllers/observations/maps_controller_test.rb
@@ -68,5 +68,99 @@ module Observations
         "Non-owner map of hidden observation should not include geoloc with lng"
       )
     end
+
+    # Lazy-loaded single-observation popup used by the cluster map (#4159).
+    # Exercises the `popup` action end-to-end: builds a MinimalObservation
+    # + MapSet and renders `mapset_info_window` as a JSON `html` payload.
+    def test_map_observation_popup
+      obs = observations(:unknown_with_lat_lng)
+      login
+      get(:popup, params: { id: obs.id })
+
+      assert_response(:success)
+      json = JSON.parse(@response.body)
+      assert_kind_of(String, json["html"],
+                     "popup JSON should carry a rendered html string")
+      assert_includes(json["html"], obs.name.text_name,
+                      "popup html should render the observation's name")
+      assert_includes(
+        json["html"], "/observations/#{obs.id}",
+        "popup html should link back to the observation show page"
+      )
+    end
+
+    # With a `q[...]` param present, the action must convert
+    # ActionController::Parameters to a plain Hash before handing it
+    # to URL helpers inside `mapset_info_window`. Regression guard
+    # against "unable to convert unpermitted parameters to hash".
+    def test_map_observation_popup_with_query_param
+      obs = observations(:unknown_with_lat_lng)
+      login
+      get(:popup,
+          params: { id: obs.id, q: { model: "Observation" } })
+
+      assert_response(:success)
+      json = JSON.parse(@response.body)
+      assert_match(
+        /q(%5B|\[)model(%5D|\])/, json["html"],
+        "popup links should carry the q[model] query param through"
+      )
+    end
+
+    # JSON format on the index action is the refetch path used by the
+    # client-side viewport listener (#4159). Covers
+    # map_refetch_payload end-to-end.
+    def test_map_observations_json_refetch_payload
+      login
+      get(:index, format: :json)
+
+      assert_response(:success)
+      json = JSON.parse(@response.body)
+      %w[collection capped loaded total cap].each do |key|
+        assert(json.key?(key),
+               "JSON refetch payload should include #{key}")
+      end
+      assert_kind_of(Hash, json["collection"])
+      assert_equal(MapHelper::CLUSTER_MAX_OBJECTS, json["cap"])
+    end
+
+    # When the result set exceeds the cap, the controller runs the
+    # extra COUNT(*) query to populate `total` for the banner. We
+    # exercise that branch by temporarily shrinking the cap so any
+    # multi-obs fixture set overflows.
+    def test_map_observations_json_capped_runs_total_count
+      login
+      with_cluster_max_objects(1) do
+        get(:index, format: :json)
+      end
+
+      assert_response(:success)
+      json = JSON.parse(@response.body)
+      assert(json["capped"],
+             "cap of 1 should produce a capped response")
+      assert_equal(1, json["loaded"],
+                   "loaded count should be clamped to the cap")
+      assert_equal(1, json["cap"])
+      assert_operator(
+        json["total"], :>, json["loaded"],
+        "capped payload should surface the true total from " \
+        "count_observations_matching_query"
+      )
+    end
+
+    private
+
+    # Swap `MapHelper::CLUSTER_MAX_OBJECTS` for the duration of a
+    # block. `remove_const` before `const_set` avoids the
+    # "already-initialized constant" warning.
+    def with_cluster_max_objects(value)
+      original = MapHelper::CLUSTER_MAX_OBJECTS
+      MapHelper.send(:remove_const, :CLUSTER_MAX_OBJECTS)
+      MapHelper.const_set(:CLUSTER_MAX_OBJECTS, value)
+      yield
+    ensure
+      MapHelper.send(:remove_const, :CLUSTER_MAX_OBJECTS)
+      MapHelper.const_set(:CLUSTER_MAX_OBJECTS, original)
+    end
   end
 end

--- a/test/helpers/map_helper_test.rb
+++ b/test/helpers/map_helper_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Covers the small, branch-heavy helpers `MapHelper` exposes to
+# the clustered-collection code path (issue #4159). Fuller coverage
+# of `make_map` and its ERB consumers lives in the map_controller
+# and view-level tests.
+class MapHelperTest < ActionView::TestCase
+  # ------------------------------------------------------------------
+  # cluster_object_label
+  # ------------------------------------------------------------------
+
+  def test_cluster_object_label_prefers_text_name
+    obj = Struct.new(:text_name, :display_name).new("Hypholoma", "ignored")
+    assert_equal("Hypholoma", cluster_object_label(obj))
+  end
+
+  # Hits the `return obj.display_name.to_s if obj.respond_to?(:display_name)`
+  # branch — objects that expose `display_name` but no `text_name`.
+  def test_cluster_object_label_falls_back_to_display_name
+    obj = Struct.new(:display_name).new("Amanita muscaria var. formosa")
+    assert_equal("Amanita muscaria var. formosa",
+                 cluster_object_label(obj))
+  end
+
+  # Hits the final `""` return — object exposes neither `text_name`
+  # nor `display_name`.
+  def test_cluster_object_label_empty_when_no_name_fields
+    assert_equal("", cluster_object_label(Object.new))
+  end
+
+  def test_cluster_object_label_empty_when_text_name_is_blank
+    obj = Struct.new(:text_name, :display_name).new("", "Display Name")
+    assert_equal("Display Name", cluster_object_label(obj),
+                 "blank text_name should fall through to display_name")
+  end
+
+  # ------------------------------------------------------------------
+  # cluster_object_url
+  # ------------------------------------------------------------------
+
+  def test_cluster_object_url_for_observation
+    obs = observations(:minimal_unknown_obs)
+    url = cluster_object_url(obs, {})
+    assert_match(%r{\A/observations/#{obs.id}(\?|\z)}, url,
+                 "observation? objects should resolve to /observations/:id")
+  end
+
+  # Hits the `location_path(id: obj.id, params: params)` branch.
+  # `Location` includes `Mappable::BoxMethods`, which defines
+  # `observation? => false` and `location? => true`.
+  def test_cluster_object_url_for_location
+    loc = locations(:burbank)
+    url = cluster_object_url(loc, {})
+    assert_match(%r{\A/locations/#{loc.id}(\?|\z)}, url,
+                 "location? objects should resolve to /locations/:id")
+  end
+
+  # Hits the final `""` branch — the object is neither an observation
+  # nor a location (e.g., an unexpected shape that slipped through).
+  def test_cluster_object_url_empty_for_unknown_shape
+    assert_equal("", cluster_object_url(Object.new, {}))
+  end
+
+  def test_cluster_object_url_preserves_query_param
+    obs = observations(:minimal_unknown_obs)
+    url = cluster_object_url(obs, { query_param: { model: "Observation" } })
+    assert_match(/q(%5B|\[)model(%5D|\])=Observation/, url,
+                 "query_param arg should thread into the URL's q[model]")
+  end
+end

--- a/test/helpers/map_popup_helper_test.rb
+++ b/test/helpers/map_popup_helper_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Coverage for `MapPopupHelper#mapset_observation_label` fallbacks
+# (#4159). `display_name` is the preferred label; these tests exercise
+# the `text_name` wrap branch and the final "Observation #<id>"
+# fallback when neither is available.
+class MapPopupHelperTest < ActionView::TestCase
+  # mapset_display_name returns nil for obs without a display_name,
+  # so the method falls through to the text_name branch and wraps
+  # it in <em>.
+  def test_mapset_observation_label_wraps_text_name_in_em
+    obs = Struct.new(:id, :text_name).new(42, "Amanita muscaria")
+    result = mapset_observation_label(obs)
+    assert_includes(result, "<em>Amanita muscaria</em>",
+                    "text_name-only obs should render as italic plain text")
+  end
+
+  # text_name is present but blank — still falls through to the
+  # final "Observation #<id>" return.
+  def test_mapset_observation_label_falls_back_when_text_name_blank
+    obs = Struct.new(:id, :text_name).new(7, "")
+    result = mapset_observation_label(obs)
+    assert_match(/#7\z/, result,
+                 "blank text_name should fall through to id fallback")
+  end
+
+  # Neither display_name nor text_name available — returns the
+  # "Observation #<id>" string.
+  def test_mapset_observation_label_final_fallback_to_id
+    obs = Struct.new(:id).new(99)
+    result = mapset_observation_label(obs)
+    assert_match(/#99\z/, result,
+                 "obs with no name fields should render as 'Observation #id'")
+    assert_includes(result, :Observation.t,
+                    "id-fallback label should use the :Observation locale key")
+  end
+end

--- a/test/models/checklist_test.rb
+++ b/test/models/checklist_test.rb
@@ -134,39 +134,60 @@ class ChecklistTest < UnitTestCase
     assert_equal(1, data.num_taxa)
   end
 
-  # Test that checklist uses bounding box matching, not exact location match
+  # Checklist#ForProject filters obs via `within_locations`, which
+  # runs `in_box` under the hood — so obs match not only via exact
+  # `location_id` equality but also via their cached location center
+  # (or their own GPS when the label agrees). Obs whose GPS falls in
+  # the target's bbox but whose label points somewhere else are
+  # `gps_dubious` and deliberately excluded (#4159: label wins).
   def test_checklist_for_project_uses_bounding_box_matching
     proj = projects(:bolete_project)
     target_location = locations(:albion)
 
-    # Create observation with exact location match
+    # Obs with exact location match — counts via cached location center.
     obs_exact = Observation.create!(
       name: names(:coprinus_comatus),
       user: mary,
       location: target_location,
       when: Time.zone.now
     )
+    obs_exact.update_columns(
+      location_lat: target_location.center_lat,
+      location_lng: target_location.center_lng
+    )
     proj.observations << obs_exact
 
-    # Create observation with GPS coords inside bounding box but different
-    # location_id
-    obs_gps_inside = Observation.create!(
+    # Obs at the target with GPS inside the target — GPS and label
+    # agree, so it matches via the GPS path.
+    obs_gps_agreeing = Observation.create!(
       name: names(:coprinus_comatus),
       user: mary,
-      location: locations(:burbank), # Different location
-      lat: target_location.center_lat, # But GPS inside albion's box
+      location: target_location,
+      lat: target_location.center_lat,
       lng: target_location.center_lng,
       when: Time.zone.now
     )
-    proj.observations << obs_gps_inside
+    proj.observations << obs_gps_agreeing
+
+    # Obs at a DIFFERENT location with GPS inside the target's bbox.
+    # GPS disagrees with the label, so it's gps_dubious (#4159) and
+    # excluded from GPS searches. Should NOT be counted here.
+    obs_with_dubious_gps = Observation.create!(
+      name: names(:coprinus_comatus),
+      user: mary,
+      location: locations(:burbank),
+      lat: target_location.center_lat,
+      lng: target_location.center_lng,
+      when: Time.zone.now
+    )
+    proj.observations << obs_with_dubious_gps
 
     data = Checklist::ForProject.new(proj, target_location)
-
-    # Both observations should be counted (bounding box matching)
     assert_equal(
       2, data.counts["Coprinus comatus"],
-      "Checklist should count observations with GPS coords inside bounding " \
-      "box, not just exact location matches"
+      "Checklist should count obs whose label or GPS-agreeing-with-label " \
+      "position falls inside the target, and exclude obs whose GPS " \
+      "contradicts their stated location."
     )
   end
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -555,6 +555,31 @@ class LocationTest < UnitTestCase
                  "Opposite side of globe should not be 'close' to Location.")
   end
 
+  # BoxMethods#km_from_point on a box that straddles the antimeridian
+  # exercises the dateline branch of `lng_inside?`: a point is inside
+  # when it's either >= west (east hemisphere side of the wrap) or
+  # <= east (west hemisphere side). Both "inside" cases must return
+  # zero distance; points outside the wrap must return positive km.
+  def test_km_from_point_on_dateline_wrapping_box
+    loc = locations(:east_lt_west_location)
+    lat = (loc.north + loc.south) / 2.0
+
+    assert_in_delta(
+      0, loc.km_from_point(lat, loc.west + 0.1), 1e-6,
+      "A point east of `west` on a wrapping box is inside the box."
+    )
+    assert_in_delta(
+      0, loc.km_from_point(lat, loc.east - 0.1), 1e-6,
+      "A point west of `east` on a wrapping box is inside the box."
+    )
+
+    # Antipodal longitude (roughly 0° here) is in the non-wrapped gap
+    # between east and west, so it should be clearly outside.
+    assert_operator(loc.km_from_point(lat, 0.0), :>, 0,
+                    "A point in the non-wrapped longitude gap is " \
+                    "outside the box.")
+  end
+
   # ----------------------------------------------------
   #  Scopes
   #    Explicit tests of some scopes to improve coverage

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1650,6 +1650,74 @@ class ObservationTest < UnitTestCase
     )
   end
 
+  # `gps_hidden` obs keep their private GPS out of the GPS-match path
+  # but remain reachable via their labeled location center. See
+  # Observation::Scopes#gps_in_box / #cached_location_center_in_box
+  # (#4159).
+  def test_scope_in_box_excludes_gps_hidden_from_gps_path
+    burbank = locations(:burbank)
+    lat = burbank.center_lat
+    lng = burbank.center_lng
+    obs_hidden = Observation.create!(
+      user: rolf, when: Time.zone.now,
+      location: burbank, lat: lat, lng: lng, gps_hidden: true
+    )
+    obs_hidden.update_columns(
+      location_lat: burbank.center_lat,
+      location_lng: burbank.center_lng
+    )
+    assert_not(obs_hidden.gps_dubious,
+               "Burbank GPS inside Burbank bbox shouldn't be dubious")
+
+    # gps_in_box directly: hidden obs must be excluded despite having
+    # lat/lng inside the search box (leak prevention).
+    assert_not_includes(
+      Observation.gps_in_box(Mappable::Box.new(**cal_box)).map(&:id),
+      obs_hidden.id,
+      "gps_hidden obs must not match gps_in_box via its private GPS"
+    )
+
+    # End-to-end in_box still finds it — the location center falls in
+    # the cal bbox, so the location-center fallback catches it.
+    assert_includes(
+      Observation.in_box(**cal_box).map(&:id), obs_hidden.id,
+      "gps_hidden obs whose location center is in the box should " \
+      "still be returned by in_box via the location-center path"
+    )
+  end
+
+  # `gps_dubious` obs (GPS >50 km from label bbox) don't match the
+  # GPS path but do match via their labeled location center (#4159).
+  def test_scope_in_box_excludes_gps_dubious_from_gps_path
+    nybg = locations(:nybg_location)
+    burbank = locations(:burbank)
+    # Label = NYBG, GPS = Burbank — they're ~4000 km apart, so
+    # before_save sets gps_dubious = true.
+    obs_dubious = Observation.create!(
+      user: rolf, when: Time.zone.now,
+      location: nybg, lat: burbank.center_lat, lng: burbank.center_lng
+    )
+    obs_dubious.update_columns(
+      location_lat: nybg.center_lat, location_lng: nybg.center_lng
+    )
+    assert(obs_dubious.gps_dubious,
+           "Burbank GPS on an NYBG-labeled obs should be dubious")
+
+    # Must not leak into a California search via the (wrong) GPS.
+    assert_not_includes(
+      Observation.in_box(**cal_box).map(&:id), obs_dubious.id,
+      "gps_dubious obs must not match a California in_box search " \
+      "via its out-of-box GPS"
+    )
+
+    # Still reachable via an NYBG-box search — the label is trusted.
+    assert_includes(
+      Observation.in_box(**nybg_box).map(&:id), obs_dubious.id,
+      "gps_dubious obs should still match in_box when the labeled " \
+      "location center falls in the search box"
+    )
+  end
+
   def test_scope_in_box_with_taxon
     args = { north: "36.2718",
              south: "29.852",


### PR DESCRIPTION
## Summary

Adds client-side dynamic clustering on observation maps, a visual
redesign of map markers, and a bundle of downstream fixes that
surfaced during manual testing on real data.

- **Dynamic clustering** via `@googlemaps/markerclusterer` — each
  observation becomes a singleton MapSet on the server; the client
  groups them at zoom with a custom renderer that aggregates
  consensus color and precision state.
- **Viewport-driven refetch** — controller caps results at 10K, shows
  a banner with total count ("Showing the first 10,000 of 75,674
  observations. Zoom in or narrow your filter to see the rest."), and
  the client re-requests on pan/zoom when the last fetch was capped
  or the viewport moves outside the loaded box.
- **Cluster popups** group members by species with counts, show the
  location outline overlay, and surface Show All / Map All links
  built from the current `q[...]` params + the cluster box. Popups
  stay put while the map reloads under them.
- **Location outlines** — `MapSet#compute_glyph` returns `:rectangle`
  for location-only sets, which render as a filled outline at the
  true extents (no more center square marker on location show pages
  or pure-location maps).
- **Marker design** — filled circles/squares with a precision-based
  ring (dark = crisp GPS, gray = mixed, white = fuzzy / location-
  only). Cluster badges use the same scheme. Legend mirrors it.
- **Lazy popup fetch** on marker click — drops the ~10K pre-rendered
  captions from the bulk payload (dominant refetch cost pre-change),
  replaced by `GET /observations/:id/map_popup`.

## GPS correctness

Two query-layer fixes ride along because the clustering work made
them unavoidably visible:

- `Observation.gps_in_box` now excludes `gps_hidden` obs from the
  GPS-match path — they were previously leaking private coordinates
  into any `in_box`-based query (e.g., a Massachusetts `within_locations`
  search pulling in a USA-labeled gps_hidden obs and parking a pin
  in the Pacific).
- New `gps_dubious` cached boolean on observations, set by a
  `before_save` when GPS is >50 km from the location's bbox edge
  (dateline-aware via `Mappable::BoxMethods#km_from_point`).
  `gps_in_box` also excludes dubious rows — so a Nashville-labeled
  obs with California GPS no longer matches a California search.
  Backfill script (`script/backfill_gps_dubious.rb`) is idempotent
  and flags ~6,100 of ~180,000 GPS-bearing obs.

## Test plan

- [x] Load `/observations/map` for a large user (75K+ obs). Banner
      shows "first 10,000 of <total>"; zooming into a sub-10K area
      refetches and hides the banner.
- [x] Zoom back out — refetch pulls the wider set back in.
- [x] Open a marker popup, then pan. Popup stays; when closed,
      refetch fires for the current viewport.
- [x] Click a cluster badge — popup lists member species grouped
      with counts, "Click to zoom in" hidden when all members share
      a point, Show All / Map All go to the expected in_box URLs.
- [x] `/observations/map?q[within_locations][]=<California>` — no
      stray pins in Nashville / elsewhere; mislabeled obs with GPS
      outside California now hidden (they'll still show on their
      stated-location maps).
- [x] Location show page (`/locations/:id`) — single outline, no
      center marker.
- [x] Hard-refresh cycles through the deferred `in_box` scenarios
      captured in memory; no regression on single-obs / editable
      location form maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)