### PR TITLE
Suppress expected logger noise in safe_done test

### DIFF
--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1177,7 +1177,7 @@ class InatImportJobTest < ActiveJob::TestCase
     end
 
     swallowed = true
-    begin
+    Rails.logger.stub(:error, nil) do
       raise(StandardError.new("original error"))
     rescue StandardError
       begin


### PR DESCRIPTION
## Summary

- `test_safe_done_swallows_done_failure_when_handling_error` intentionally triggers the `safe_done` error path, which logs an ERROR via `Rails.logger`. This produced a confusing log line in test output even though all tests passed.
- Wraps the relevant block in `Rails.logger.stub(:error, nil)` to silence the expected log call without changing what the test verifies.

## Test plan

- [x] `bin/rails test test/jobs/inat_import_job_test.rb -n test_safe_done_swallows_done_failure_when_handling_error` passes with no logger output
- [x] `bin/rails test test/jobs/inat_import_job_test.rb` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)