### PR TITLE
Collapse the four classification columns to one (#4163)

### DIFF
--- a/app/controllers/concerns/descriptions/moves.rb
+++ b/app/controllers/concerns/descriptions/moves.rb
@@ -123,17 +123,10 @@ module Descriptions::Moves
       #   desc.ok_for_export = src.ok_for_export
       # end
 
-      # This can really gum up the works and it's really hard to figure out
-      # what the problem is when it occurs, since error message is cryptic.
-      if @dest.is_a?(Name) && desc.classification.present?
-        begin
-          Name.validate_classification(@dest.rank, desc.classification)
-        rescue StandardError => e
-          flash_error(:runtime_description_move_invalid_classification.t)
-          flash_error(e.to_s)
-          desc.classification = ""
-        end
-      end
+      # The classification-validation block that lived here is gone
+      # along with the description column itself (discussion #4163).
+      # Classification belongs to Name now, so moving a description
+      # between Names doesn't carry classification with it.
 
       # Okay, *now* we can try to save the new description...
       if desc.save

--- a/app/controllers/names/classification/refresh_controller.rb
+++ b/app/controllers/names/classification/refresh_controller.rb
@@ -5,15 +5,14 @@ module Names::Classification
   class RefreshController < ApplicationController
     before_action :login_required
 
-    # PUT callback
+    # PUT callback. Description-mirror write went away with the column
+    # itself (discussion #4163) — only the Name needs updating now.
     def update
       return unless find_name!
       return unless make_sure_name_below_genus!(@name)
       return unless make_sure_genus_has_classification!(@name)
 
       @name.update(classification: @name.accepted_genus.classification)
-      desc = @name.description
-      desc&.update(classification: @name.accepted_genus.classification)
       redirect_to(@name.show_link_args)
     end
 

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -161,7 +161,6 @@ module Names
       @description.save
 
       set_default_description_if_public
-      update_parent_classification_cache
       @name.save if @name.changed?
       log_description_created
       flash_notice(:runtime_name_description_success.t(id: @description.id))
@@ -175,15 +174,6 @@ module Names
       return unless !@name.description && @description.fully_public?
 
       @name.description = @description
-    end
-
-    # called by :create
-    # Keep the parent's classification cache up to date.
-    def update_parent_classification_cache
-      return unless (@name.description == @description) &&
-                    (@name.classification != @description.classification)
-
-      @name.classification = @description.classification
     end
 
     public
@@ -241,29 +231,21 @@ module Names
         flash_notice(
           :runtime_edit_name_description_success.t(id: @description.id)
         )
-        update_classification_cache_and_save_name
         log_description_updated
         resolve_merge_conflicts_and_delete_old_description # does not redirect
         redirect_to(@description.show_link_args)
       end
     end
 
-    # Update name's classification cache.
-    def update_classification_cache_and_save_name
-      name = @description.name
-      if (name.description == @description) &&
-         (name.classification != @description.classification)
-        name.classification = @description.classification
-        name.save if name.changed?
-      end
-    end
-
     # TODO: should public, public_write and source_type be removed from list?
     # They should be individually checked and set, since we
     # don't want them to have arbitrary values
+    #
+    # `:classification` was removed in discussion #4163 — classification
+    # is edited via `Names::ClassificationController` and lives on Name.
     def permitted_name_description_params
       params.required(:description).
-        permit(:classification, :gen_desc, :diag_desc, :distribution, :habitat,
+        permit(:gen_desc, :diag_desc, :distribution, :habitat,
                :look_alikes, :uses, :refs, :notes, :source_name, :project_id,
                :source_type, :public, :public_write)
     end

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -126,15 +126,12 @@ module Names
       @description = NameDescription.new
       @description.name = @name
 
-      # Create new description.
+      # Create new description. NameDescription has no validations
+      # (the only one was the classification syntax check, removed
+      # along with the column in #4163), so save always succeeds.
       @description.attributes = permitted_name_description_params
       @description.source_type = @description.source_type.to_sym
-      if @description.valid?
-        save_new_description_flash_and_redirect
-      else
-        flash_object_errors(@description)
-        render_new
-      end
+      save_new_description_flash_and_redirect
     end
 
     private
@@ -145,10 +142,6 @@ module Names
 
     def find_description_parent
       @name = Name.find(@description.parent_id.to_s)
-    end
-
-    def render_new
-      render("new", location: new_name_description_path(@name.id))
     end
 
     def render_edit
@@ -215,26 +208,22 @@ module Names
     end
 
     # called by :update
+    # NameDescription has no validations after #4163 — save can't
+    # return false, only raise — so the only branch is "no changes
+    # made" vs. "saved successfully".
     def save_updated_description_if_changed_or_flash
-      # No changes made.
-      if !@description.changed?
+      unless @description.changed?
         flash_warning(:runtime_edit_name_description_no_change.t)
-        render_edit
-
-      # Try to save and flash if there were error(s).
-      elsif !@description.save
-        flash_object_errors(@description)
-        render_edit
-
-      # Updated successfully.
-      else
-        flash_notice(
-          :runtime_edit_name_description_success.t(id: @description.id)
-        )
-        log_description_updated
-        resolve_merge_conflicts_and_delete_old_description # does not redirect
-        redirect_to(@description.show_link_args)
+        return render_edit
       end
+
+      @description.save
+      flash_notice(
+        :runtime_edit_name_description_success.t(id: @description.id)
+      )
+      log_description_updated
+      resolve_merge_conflicts_and_delete_old_description # does not redirect
+      redirect_to(@description.show_link_args)
     end
 
     # TODO: should public, public_write and source_type be removed from list?

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -435,16 +435,20 @@ class Name < AbstractModel
   # Let attached observations update their cache if these fields changed.
   # Also, `touch` if it changes the obs name and should invalidate HTML
   # caches of the observation.
+  #
+  # `classification` is no longer cached on Observation (discussion
+  # #4163) — clade lookups route through `names.classification`
+  # directly via `Observation#one_clade`, so changes here don't need
+  # to fan out to obs rows.
   def update_observation_cache
     touch_cases = text_name_changed? || author_changed? || deprecated_changed?
-    no_touch_cases = lifeform_changed? || classification_changed?
+    no_touch_cases = lifeform_changed?
     return unless touch_cases || no_touch_cases
 
     updates = {}
     updates[:updated_at] = Time.zone.now if touch_cases && !no_touch_cases
     updates[:lifeform] = lifeform if lifeform_changed?
     updates[:text_name] = text_name if text_name_changed?
-    updates[:classification] = classification if classification_changed?
     Observation.where(name_id: id).update_all(updates) if updates.present?
   end
 

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -347,6 +347,7 @@ class Name < AbstractModel
       display_name
       author
       citation
+      classification
       deprecated
       correct_spelling
       notes
@@ -364,7 +365,6 @@ class Name < AbstractModel
     # "accepted_name_id",
     "synonym_id",
     "description_id",
-    "classification", # (versioned in the default desc)
     "locked"
   )
 

--- a/app/models/name/merge.rb
+++ b/app/models/name/merge.rb
@@ -93,13 +93,12 @@ class Name
     def move_primary_description(old_name)
       return unless !description && old_name.description
 
-      # Move old_name's description to self if self lacks one
+      # Move old_name's description to self if self lacks one.
+      # The classification reconciliation that used to live here was
+      # tied to `name_descriptions.classification` — which is gone
+      # along with the column (discussion #4163). Classification stays
+      # whatever `self.classification` already says.
       self.description = old_name.description
-      # Update the classification cache if that changed in the process.
-      if description &&
-         (classification != description.classification)
-        self.classification = description.classification
-      end
     end
 
     def move_versions(old_name)

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -253,14 +253,6 @@ module Name::Scopes
       has_default_description(false).joins(:observations).distinct.
         group(:name_id).order(Observation[:name_id].count.desc, Name[:id].desc)
     }
-    # used by Name::Taxonomy
-    scope :has_description_classification_differing, lambda {
-      joins(:description).
-        where(rank: 0..Name.ranks[:Genus]).
-        where(NameDescription[:classification].not_eq(Name[:classification])).
-        where(NameDescription[:classification].not_blank).distinct
-    }
-
     # Query just ignores `has_observations(false)`, so for now we will here too.
     scope :has_observations, lambda { |bool = true|
       return all unless bool

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -325,6 +325,14 @@ module Name::Taxonomy
   # updated_at or rss_log or anything.  Just changes the classification field
   # in the name records (discussion #4163 — was also fanning out to
   # name_descriptions and observations, both since dropped).
+  #
+  # `update_all` bypasses `acts_as_versioned`, so propagated subtaxa
+  # do *not* get a `name_versions` row for the change. This is
+  # intentional: a genus edit can touch tens of thousands of subtaxa
+  # and creating one version row per subtaxon would dominate the
+  # transaction. Direct edits via `Name#change_classification` (or
+  # the audit's per-Name path) still get versioned. See discussion
+  # #4163's "bulk-update paths" caveat.
   def propagate_classification
     raise("Name#propagate_classification only works on genera for now.") \
       if rank != "Genus"

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -617,13 +617,5 @@ module Name::Taxonomy
       end
       results
     end
-
-    # Was a nightly job that copied `name_descriptions.classification`
-    # back to `names.classification` when they diverged. The
-    # description column is gone (discussion #4163) so there's nothing
-    # to reconcile — `names.classification` is the only home now.
-    def refresh_classification_caches(_dry_run: false)
-      []
-    end
   end
 end

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -309,31 +309,28 @@ module Name::Taxonomy
 
   # Change this name's classification.  Change its synonyms and its parent
   # genus, too, if below genus.  Propagate to subtaxa if at or below genus.
+  # Description-mirror writes were dropped along with the column itself
+  # (discussion #4163).
   def change_classification(new_str)
     # Eager load synonym association to avoid N+1 query in synonyms method
     root = Name.includes(synonym: :names).
            find((below_genus? && accepted_genus || self).id)
     root.synonyms.each do |name|
       name.update(classification: new_str)
-      name.description.update(classification: new_str) if name.description_id
     end
     root.propagate_classification if root.rank == "Genus"
   end
 
   # Copy the classification of a genus to all of its children.  Does not change
   # updated_at or rss_log or anything.  Just changes the classification field
-  # in the name and default description records.
-  #
-  # The Observation cache write was dropped along with
-  # `observations.classification` itself (discussion #4163).
+  # in the name records (discussion #4163 — was also fanning out to
+  # name_descriptions and observations, both since dropped).
   def propagate_classification
     raise("Name#propagate_classification only works on genera for now.") \
       if rank != "Genus"
 
     subtaxa = subtaxa_whose_classification_needs_to_be_changed
     Name.where(id: subtaxa).
-      update_all(classification: classification)
-    NameDescription.where(name_id: subtaxa).
       update_all(classification: classification)
   end
 
@@ -613,19 +610,12 @@ module Name::Taxonomy
       results
     end
 
-    # This is meant to be run nightly to ensure that all the classification
-    # caches are up to date.  It only pays attention to genera or higher.
-    def refresh_classification_caches(dry_run: false)
-      query = Name.has_description_classification_differing
-      msgs = query.map do |name|
-        "Classification for #{name.search_name} didn't match description."
-      end
-      unless dry_run || msgs.none?
-        query.update_all(
-          Name[:classification].eq(NameDescription[:classification]).to_sql
-        )
-      end
-      msgs
+    # Was a nightly job that copied `name_descriptions.classification`
+    # back to `names.classification` when they diverged. The
+    # description column is gone (discussion #4163) so there's nothing
+    # to reconcile — `names.classification` is the only home now.
+    def refresh_classification_caches(_dry_run: false)
+      []
     end
   end
 end

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -323,6 +323,9 @@ module Name::Taxonomy
   # Copy the classification of a genus to all of its children.  Does not change
   # updated_at or rss_log or anything.  Just changes the classification field
   # in the name and default description records.
+  #
+  # The Observation cache write was dropped along with
+  # `observations.classification` itself (discussion #4163).
   def propagate_classification
     raise("Name#propagate_classification only works on genera for now.") \
       if rank != "Genus"
@@ -331,8 +334,6 @@ module Name::Taxonomy
     Name.where(id: subtaxa).
       update_all(classification: classification)
     NameDescription.where(name_id: subtaxa).
-      update_all(classification: classification)
-    Observation.where(name_id: subtaxa).
       update_all(classification: classification)
   end
 

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -26,7 +26,6 @@
 #
 #  ==== Description Fields
 #  license::          (V) License description info is kept under.
-#  classification::   (V) Taxonomic classification.
 #  gen_desc::         (V) General description.
 #  diag_desc::        (V) Diagnostic description.
 #  distribution::     (V) Distribution.
@@ -155,9 +154,10 @@ class NameDescription < Description
   EOL_NOTE_FIELDS = [
     :gen_desc, :diag_desc, :distribution, :habitat, :look_alikes, :uses
   ].freeze
-  ALL_NOTE_FIELDS = (
-    [:classification] + EOL_NOTE_FIELDS + [:refs, :notes]
-  ).freeze
+  # `classification` was removed from description content in
+  # discussion #4163 — it lives on Name now and is versioned via
+  # `name_versions` instead of `name_description_versions`.
+  ALL_NOTE_FIELDS = (EOL_NOTE_FIELDS + [:refs, :notes]).freeze
   SEARCHABLE_FIELDS = ALL_NOTE_FIELDS
 
   acts_as_versioned(
@@ -183,7 +183,6 @@ class NameDescription < Description
 
   versioned_class.before_save { |x| x.user_id = User.current_id }
   after_update :notify_users
-  after_save :update_classification_cache
 
   # Don't add any authors until someone has written something "useful".
   def author_worthy?
@@ -267,21 +266,6 @@ class NameDescription < Description
   #
   ##############################################################################
 
-  # Make sure the classification cached in Name is kept up to date.
-  # `name.skip_notify` keeps the Name's after_update from firing a
-  # second notification — the description's own `notify_users` already
-  # tells description authors/reviewers/etc. about this edit. The Name
-  # version is still created. (Goes away with the description column —
-  # discussion #4163.)
-  def update_classification_cache
-    if (name.description_id == id) &&
-       (name.classification != classification)
-      name.skip_notify = true
-      name.update(classification: classification)
-      name.propagate_classification if name.rank == "Genus"
-    end
-  end
-
   # This is called after saving potential changes to a Name.  It will determine
   # if the changes are important enough to notify the authors, and do so.
   def notify_users
@@ -350,15 +334,7 @@ class NameDescription < Description
     end
   end
 
-  ##############################################################################
-
-  protected
-
-  validate :check_requirements
-  def check_requirements # :nodoc:
-    self.classification = Name.validate_classification(parent.rank,
-                                                       classification)
-  rescue StandardError => e
-    errors.add(:classification, e.to_s)
-  end
+  # `check_requirements` validated the classification syntax on
+  # description save. Both the field and validation moved to Name
+  # (discussion #4163).
 end

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -268,9 +268,15 @@ class NameDescription < Description
   ##############################################################################
 
   # Make sure the classification cached in Name is kept up to date.
+  # `name.skip_notify` keeps the Name's after_update from firing a
+  # second notification — the description's own `notify_users` already
+  # tells description authors/reviewers/etc. about this edit. The Name
+  # version is still created. (Goes away with the description column —
+  # discussion #4163.)
   def update_classification_cache
     if (name.description_id == id) &&
        (name.classification != classification)
+      name.skip_notify = true
       name.update(classification: classification)
       name.propagate_classification if name.rank == "Genus"
     end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -305,11 +305,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Cache location and name data used by content filters.
+  # `classification` cache was dropped in discussion #4163 — clade
+  # filtering now reads it from `names.classification` directly.
   def cache_content_filter_data
     if name && name_id_changed?
       self.lifeform = name.lifeform
       self.text_name = name.text_name
-      self.classification = name.classification
     end
     return unless location_id_changed?
 
@@ -334,12 +335,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # This is meant to be run nightly to ensure that the cached name
   # and location data used by content filters is kept in sync.
+  # `classification` is no longer cached on observations (discussion
+  # #4163) — content filters read it from `names.classification`.
   def self.refresh_content_filter_caches(dry_run: false)
     refresh_cached_column(type: "name", foreign: "lifeform",
                           dry_run: dry_run) +
       refresh_cached_column(type: "name", foreign: "text_name",
-                            dry_run: dry_run) +
-      refresh_cached_column(type: "name", foreign: "classification",
                             dry_run: dry_run) +
       refresh_cached_column(type: "location", foreign: "name", local: "where",
                             dry_run: dry_run)

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -213,15 +213,24 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       clades.map! { |val| one_clade(val) }
       or_clause(*clades).distinct
     }
+    # For above-genus clades the membership predicate runs against
+    # `names.classification` (8 MB scan) rather than the now-removed
+    # `observations.classification` cache (was 73 MB). The matching
+    # `name_ids` are then joined back to observations through the
+    # existing `name_id` index. Discussion #4163 — measured 5-9× faster
+    # than the old in-place LIKE on observations even before dropping
+    # the cache.
     scope :one_clade, lambda { |val|
       # parse_name_and_rank defined below
       text_name, rank = parse_name_and_rank(val)
 
       if Name.ranks_above_genus.include?(rank)
-        where(text_name: text_name).or(
-          where(Observation[:classification].
-          matches("%#{rank}: _#{text_name}_%"))
-        )
+        name_ids = Name.where(text_name: text_name).
+                   or(Name.where(
+                        Name[:classification].
+                          matches("%#{rank}: _#{text_name}_%")
+                      )).select(:id)
+        where(name_id: name_ids)
       else
         where(text_name: text_name).or(
           where(Observation[:text_name].matches("#{text_name} %"))

--- a/app/views/controllers/api2/_name_description.json.jbuilder
+++ b/app/views/controllers/api2/_name_description.json.jbuilder
@@ -23,5 +23,8 @@ json.look_alikes(object.look_alikes.to_s.tl_for_api) \
 json.uses(object.uses.to_s.tl_for_api) if object.uses.present?
 json.notes(object.notes.to_s.tl_for_api) if object.notes.present?
 json.refs(object.refs.to_s.tl_for_api) if object.refs.present?
-json.classification(object.classification.to_s.tl_for_api) \
-  if object.classification.present?
+# Classification moved off the description in discussion #4163;
+# serve `name.classification` so API consumers keep getting the field
+# they expect.
+json.classification(object.name.classification.to_s.tl_for_api) \
+  if object.name&.classification.present?

--- a/app/views/controllers/api2/_name_description.xml.builder
+++ b/app/views/controllers/api2/_name_description.xml.builder
@@ -25,5 +25,8 @@ xml.tag!(
   xml_string(xml, :uses, object.uses)
   xml_string(xml, :notes, object.notes)
   xml_string(xml, :refs, object.refs)
-  xml_string(xml, :classification, object.classification)
+  # Classification moved off the description in discussion #4163;
+  # serve `name.classification` so API consumers keep getting the
+  # field they expect.
+  xml_string(xml, :classification, object.name&.classification)
 end

--- a/app/views/controllers/names/versions/show.html.erb
+++ b/app/views/controllers/names/versions/show.html.erb
@@ -12,6 +12,15 @@ column_classes(:six)
     <%= render(partial: "names/show/nomenclature",
                locals: { name: @name, synonyms: false }) %>
     <%= render(partial: "names/show/lifeform_panel") %>
+    <% if @name.classification.present? %>
+      <%= render(Components::Panel.new(
+            panel_class: "name-section",
+            panel_id: "name_classification"
+          )) do |panel| %>
+        <%= panel.with_heading { :show_name_classification.l } %>
+        <%= panel.with_body { @name.classification.tpl } %>
+      <% end %>
+    <% end %>
     <% if @name.has_notes? %>
       <%= render(partial: "names/show/notes_panel") %>
     <% end %>

--- a/app/views/mailers/name_change_mailer/build.html.erb
+++ b/app/views/mailers/name_change_mailer/build.html.erb
@@ -62,6 +62,11 @@
         many_liners.push([("form_names_" + field.to_s).to_sym.t, new_val]) if new_val != old_val
       end
     end
+    # Classification lives on Name now (discussion #4163) — surface
+    # diffs at the Name level instead of via NameDescription's note fields.
+    if new_name.classification != old_name.classification
+      many_liners.push([:form_names_classification.t, new_name.classification])
+    end
   else
     intro = :email_object_new_intro.l(
       type: :name,

--- a/db/migrate/20260426000001_add_classification_to_name_versions.rb
+++ b/db/migrate/20260426000001_add_classification_to_name_versions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Move classification versioning from name_descriptions onto Name itself.
+# `acts_as_versioned` snapshots versioned columns into `name_versions`,
+# so the column has to exist on both tables. The corresponding
+# `non_versioned_columns` exclusion + `if_changed:` add land in the same
+# commit. Discussion #4163.
+class AddClassificationToNameVersions < ActiveRecord::Migration[7.2]
+  def change
+    add_column(:name_versions, :classification, :text)
+  end
+end

--- a/db/migrate/20260426000002_remove_classification_from_observations.rb
+++ b/db/migrate/20260426000002_remove_classification_from_observations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Drop the `observations.classification` denormalized cache. Clade
+# membership now reads from `names.classification` (a smaller column,
+# scanned ~5-9× faster — see discussion #4163). The column had one
+# reader (`Observation#one_clade`) and a fan-out cache callback
+# (`Name#update_observation_cache`), both removed in the prior commit.
+class RemoveClassificationFromObservations < ActiveRecord::Migration[7.2]
+  def change
+    remove_column(:observations, :classification, :text)
+  end
+end

--- a/db/migrate/20260426000003_remove_classification_from_name_descriptions.rb
+++ b/db/migrate/20260426000003_remove_classification_from_name_descriptions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Drop the `name_descriptions.classification` column and its
+# corresponding column on the version history table. Classification
+# now lives only on Name and is versioned via `name_versions`
+# (discussion #4163). All read paths and the `update_classification_cache`
+# callback were removed in the prior commit.
+class RemoveClassificationFromNameDescriptions < ActiveRecord::Migration[7.2]
+  def change
+    remove_column(:name_descriptions, :classification, :text)
+    remove_column(:name_description_versions, :classification, :text)
+  end
+end

--- a/db/migrate/20260426000004_backfill_latest_name_version_classification.rb
+++ b/db/migrate/20260426000004_backfill_latest_name_version_classification.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# One-shot backfill: copy `names.classification` into the latest
+# version row of each Name. Older versions keep their NULL classification
+# — they pre-date `acts_as_versioned` capturing the column (#4163) and
+# the smart version browser (Phase 3 of the classification roadmap)
+# will infer their values by walking up the genus chain.
+#
+# The latest row is special: it's the version that was current at the
+# moment of this deploy, so its classification is exactly
+# `names.classification` right now. That's a real fact worth keeping
+# rather than losing to NULL.
+class BackfillLatestNameVersionClassification < ActiveRecord::Migration[7.2]
+  def up
+    execute(<<~SQL.squish)
+      UPDATE name_versions nv
+      JOIN (SELECT name_id, MAX(version) AS max_version
+            FROM name_versions
+            GROUP BY name_id) latest
+        ON nv.name_id = latest.name_id
+       AND nv.version = latest.max_version
+      JOIN names ON names.id = nv.name_id
+       SET nv.classification = names.classification
+      WHERE nv.classification IS NULL
+        AND names.classification IS NOT NULL
+    SQL
+  end
+
+  def down
+    raise(ActiveRecord::IrreversibleMigration.new(
+            "Backfilled rows can't be distinguished from regular " \
+            "versioned writes after the fact."
+          ))
+  end
+end

--- a/db/migrate/20260426000004_backfill_latest_name_version_classification.rb
+++ b/db/migrate/20260426000004_backfill_latest_name_version_classification.rb
@@ -10,8 +10,18 @@
 # moment of this deploy, so its classification is exactly
 # `names.classification` right now. That's a real fact worth keeping
 # rather than losing to NULL.
+#
+# Adds an index on `name_versions(name_id, version)` first. Without
+# it the GROUP BY in the backfill UPDATE has to full-sort the table
+# and the per-row JOIN-back has nothing to look up by — pathologically
+# slow on production-scale data. The index sticks around to speed up
+# `name.versions` queries in production going forward (every Name show
+# page hits this) — none of the version tables had any index until
+# now.
 class BackfillLatestNameVersionClassification < ActiveRecord::Migration[7.2]
   def up
+    add_index(:name_versions, [:name_id, :version],
+              name: "index_name_versions_on_name_id_and_version")
     execute(<<~SQL.squish)
       UPDATE name_versions nv
       JOIN (SELECT name_id, MAX(version) AS max_version
@@ -27,6 +37,8 @@ class BackfillLatestNameVersionClassification < ActiveRecord::Migration[7.2]
   end
 
   def down
+    remove_index(:name_versions,
+                 name: "index_name_versions_on_name_id_and_version")
     raise(ActiveRecord::IrreversibleMigration.new(
             "Backfilled rows can't be distinguished from regular " \
             "versioned writes after the fact."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_24_170000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_26_000001) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -454,6 +454,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_24_170000) do
     t.integer "rank"
     t.string "lifeform", limit: 1024, default: " ", null: false
     t.integer "icn_id"
+    t.text "classification"
   end
 
   create_table "names", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_26_000002) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_26_000003) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -391,7 +391,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_26_000002) do
     t.text "uses"
     t.text "notes"
     t.text "refs"
-    t.text "classification"
   end
 
   create_table "name_description_writers", charset: "utf8mb3", force: :cascade do |t|
@@ -424,7 +423,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_26_000002) do
     t.text "uses"
     t.text "notes"
     t.text "refs"
-    t.text "classification"
     t.integer "project_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_26_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_26_000002) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -549,7 +549,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_26_000001) do
     t.integer "alt"
     t.string "lifeform", limit: 1024
     t.string "text_name", limit: 100
-    t.text "classification"
     t.boolean "gps_hidden", default: false, null: false
     t.integer "source"
     t.datetime "log_updated_at", precision: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_26_000003) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_26_000004) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -453,6 +453,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_26_000004) do
     t.string "lifeform", limit: 1024, default: " ", null: false
     t.integer "icn_id"
     t.text "classification"
+    t.index ["name_id", "version"], name: "index_name_versions_on_name_id_and_version"
   end
 
   create_table "names", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/script/refresh_caches
+++ b/script/refresh_caches
@@ -13,7 +13,6 @@
 #    Synonym.make_sure_all_referenced_synonyms_exist
 #    Name.fix_self_referential_misspellings
 #    Name.make_sure_names_are_bolded_correctly
-#    Name.refresh_classification_caches
 #    Name.propagate_generic_classifications (currently disabled)
 #    Observation.make_sure_no_observations_are_misspelled
 #    Observation.refresh_content_filter_caches
@@ -62,8 +61,6 @@ msgs = progress("unused or missing synonyms...",
                 Name, :fix_self_referential_misspellings) +
        progress("misformatted names...",
                 Name, :make_sure_names_are_bolded_correctly) +
-       progress("classification caches...",
-                Name, :refresh_classification_caches) +
        # progress("generic classifications...",
        #          Name, :propagate_generic_classifications) +
        progress("misspelled observations...",

--- a/test/application_mailer/name_change.html
+++ b/test/application_mailer/name_change.html
@@ -18,14 +18,6 @@ Subject: [MO] Petigera Has Been Changed
 <strong>License changed to:</strong> Creative Commons Non-commercial v3.0<br />
 <strong>Reviewed changed to:</strong> Approved<br />
 <strong>Status changed to:</strong> Accepted</p></div>
-<div class="textile"><p><strong>Taxonomic Classification changed to:</strong></p></div>
-<div style='margin-left:20px; margin-right:20px; padding-left:20px; padding-right:20px; padding-top:10px; padding-bottom:10px; border:1px dotted; background:#E0E0E0; color:#000000;'>
-<div class="textile"><p>Kingdom: <em>Fungi</em><br />
-Phylum: <em>Ascomycota</em><br />
-Class: <em>Ascomycetes</em><br />
-Order: <em>Lecanorales</em><br />
-Family: <em>Peltigeraceae</em></p></div>
-</div>
 <div class="textile"><p><strong>General Description changed to:</strong></p></div>
 <div style='margin-left:20px; margin-right:20px; padding-left:20px; padding-right:20px; padding-top:10px; padding-bottom:10px; border:1px dotted; background:#E0E0E0; color:#000000;'>
 <div class="textile"><p>Broad leafy lichens with soft, felty undersurface, generally with conspicuous veins and rhizines.</p></div>
@@ -49,6 +41,14 @@ Family: <em>Peltigeraceae</em></p></div>
 <div class="textile"><p><strong>Uses changed to:</strong></p></div>
 <div style='margin-left:20px; margin-right:20px; padding-left:20px; padding-right:20px; padding-top:10px; padding-bottom:10px; border:1px dotted; background:#E0E0E0; color:#000000;'>
 <div class="textile"><p>Good for making birds nests&#8230; if you&#8217;re a bird.</p></div>
+</div>
+<div class="textile"><p><strong>Taxonomic Classification changed to:</strong></p></div>
+<div style='margin-left:20px; margin-right:20px; padding-left:20px; padding-right:20px; padding-top:10px; padding-bottom:10px; border:1px dotted; background:#E0E0E0; color:#000000;'>
+<div class="textile"><p>Kingdom: <em>Fungi</em><br />
+Phylum: <em>Ascomycota</em><br />
+Class: <em>Ascomycetes</em><br />
+Order: <em>Lecanorales</em><br />
+Family: <em>Peltigeraceae</em></p></div>
 </div>
 <div class="textile"><p>You received this email because you are an author of a description of the changed name.<br />
 Here are some handy links:</p></div>

--- a/test/application_mailer/name_change.text
+++ b/test/application_mailer/name_change.text
@@ -18,15 +18,6 @@ License changed to: Creative Commons Non-commercial v3.0
 Reviewed changed to: Approved
 Status changed to: Accepted
 
-Taxonomic Classification changed to:
---------------------------------------------------
-Kingdom: Fungi
-Phylum: Ascomycota
-Class: Ascomycetes
-Order: Lecanorales
-Family: Peltigeraceae
---------------------------------------------------
-
 General Description changed to:
 --------------------------------------------------
 Broad leafy lichens with soft, felty undersurface, generally with conspicuous veins and rhizines.
@@ -55,6 +46,15 @@ Other felt lichens such as Lobaria, Pseudocyphellaria, Sticta and Nephroma look 
 Uses changed to:
 --------------------------------------------------
 Good for making birds nests... if you're a bird.
+--------------------------------------------------
+
+Taxonomic Classification changed to:
+--------------------------------------------------
+Kingdom: Fungi
+Phylum: Ascomycota
+Class: Ascomycetes
+Order: Lecanorales
+Family: Peltigeraceae
 --------------------------------------------------
 
 You received this email because you are an author of a description of the changed name.

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -36,7 +36,6 @@ class InatObsTest < UnitTestCase
       needs_naming: false,
       # name_id needs work
       name_id: names(:somion_unicolor).id,
-      classification: "Domain: _Eukarya_\r\nKingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Agaricomycetes_\r\nOrder: _Polyporales_\r\nFamily: _Cerrenaceae_\r\n", # rubocop:disable Layout/LineLength
       lifeform: " ",
 
       # miscellaneous

--- a/test/controllers/names/classification/inherit_controller_test.rb
+++ b/test/controllers/names/classification/inherit_controller_test.rb
@@ -114,7 +114,7 @@ module Names::Classification
       new_str = "#{parent1.classification}\r\nFamily: _Agaricaceae_\r\n"
       assert_equal(new_str, name.reload.classification)
       assert_equal(new_str, names(:boletus_edulis).classification)
-      assert_equal(new_str, observations(:boletus_edulis_obs).classification)
+      # Classification is no longer cached on Observation (#4163).
     end
   end
 end

--- a/test/controllers/names/classification/propagate_controller_test.rb
+++ b/test/controllers/names/classification/propagate_controller_test.rb
@@ -6,24 +6,21 @@ module Names::Classification
   class PropagateControllerTest < FunctionalTestCase
     include ObjectLinkHelper
 
+    # Description-mirror assertions removed — classification only
+    # lives on Name now (discussion #4163).
     def test_propagate_classification
       genus = names(:coprinus)
       child = names(:coprinus_comatus)
       val   = genus.classification
       assert_equal(val, child.classification)
-      assert_equal(val, child.description.classification)
 
       # Make sure bogus requests don't crash.
       login("rolf")
-      # put(:update)
       put(:update, params: { id: 666 })
-      # put(:update, params: { id: "bogus" }) # Does not work, Rails enforces id
       put(:update, params: { id: child.id })
       put(:update, params: { id: names(:ascomycota).id })
       assert_equal(val, genus.reload.classification)
-      assert_equal(val, genus.description.reload.classification)
       assert_equal(val, child.reload.classification)
-      assert_equal(val, child.description.reload.classification)
 
       # Make sure have to be logged in. (update_column should avoid callbacks)
       new_val = names(:peltigera).classification
@@ -36,7 +33,6 @@ module Names::Classification
       login("rolf")
       put(:update, params: { id: genus.id })
       assert_equal(new_val, child.reload.classification)
-      assert_equal(new_val, child.description.reload.classification)
     end
   end
 end

--- a/test/controllers/names/classification/refresh_controller_test.rb
+++ b/test/controllers/names/classification/refresh_controller_test.rb
@@ -6,37 +6,29 @@ module Names::Classification
   class RefreshControllerTest < FunctionalTestCase
     include ObjectLinkHelper
 
+    # Description-mirror assertions removed — classification only
+    # lives on Name now (discussion #4163).
     def test_refresh_classification
       genus = names(:coprinus)
       child = names(:coprinus_comatus)
       val   = genus.classification
       time  = genus.updated_at
       assert_equal(val, child.classification)
-      assert_equal(val, child.description.classification)
       assert_equal(time, child.updated_at)
-      assert_equal(time, child.description.updated_at)
 
       # Make sure bogus requests don't crash.
       login("rolf")
-      # put(:update)
       put(:update, params: { id: 666 })
-      # put(:update, params: { id: "bogus" }) # Does not work, Rails enforces id
       put(:update, params: { id: genus.id })
       put(:update, params: { id: child.id }) # no change!
       assert_equal(val, genus.reload.classification)
-      assert_equal(val, genus.description.reload.classification)
       assert_equal(val, child.reload.classification)
-      assert_equal(val, child.description.reload.classification)
       assert_equal(time, genus.updated_at)
-      assert_equal(time, genus.description.updated_at)
       assert_equal(time, child.updated_at)
-      assert_equal(time, child.description.updated_at)
 
       # Make sure have to be logged in. (update_column should avoid callbacks)
       new_val = names(:peltigera).classification
-      # disable cop because we're trying to avoid callbacks
       child.update_columns(classification: new_val)
-      child.description.update_columns(classification: new_val)
       logout
       put(:update, params: { id: child.id })
       assert_equal(new_val, child.reload.classification)

--- a/test/controllers/names/classification_controller_test.rb
+++ b/test/controllers/names/classification_controller_test.rb
@@ -80,8 +80,8 @@ module Names
       assert_equal(new_str, names(:agaricus).classification)
       assert_equal(new_str,
                    names(:agaricus_campestras).description.classification)
-      assert_equal(new_str,
-                   observations(:agaricus_campestras_obs).classification)
+      # Classification is no longer cached on Observation — clade
+      # filtering reads it from `names.classification` now (#4163).
     end
   end
 end

--- a/test/controllers/names/classification_controller_test.rb
+++ b/test/controllers/names/classification_controller_test.rb
@@ -78,10 +78,8 @@ module Names
       assert_redirected_to(name.show_link_args)
       assert_equal(new_str, name.reload.classification)
       assert_equal(new_str, names(:agaricus).classification)
-      assert_equal(new_str,
-                   names(:agaricus_campestras).description.classification)
-      # Classification is no longer cached on Observation — clade
-      # filtering reads it from `names.classification` now (#4163).
+      # Description and Observation no longer carry classification
+      # caches — both columns dropped in discussion #4163.
     end
   end
 end

--- a/test/controllers/names/descriptions/moves_controller_test.rb
+++ b/test/controllers/names/descriptions/moves_controller_test.rb
@@ -97,17 +97,11 @@ module Names::Descriptions
       assert_flash_success
     end
 
-    def test_move_description_clashing_classifications
+    # Classification-clash check on move went away with the column
+    # itself (discussion #4163). A description move no longer carries
+    # classification with it, so there's nothing to clash with.
+    def test_move_description_to_compatible_target
       login("dick")
-      params = {
-        id: peltigera_desc.id,
-        description_move_or_merge: { target: names(:basidiomycota).id,
-                                     delete: 0 }
-      }
-      post(:create, params: params)
-      assert_flash_text(/The classification has incorrect syntax/)
-
-      # Now try compatible classification
       params = {
         id: peltigera_desc.id,
         description_move_or_merge: { target: coprinus_name.id, delete: 0 }

--- a/test/controllers/names/descriptions_controller_test.rb
+++ b/test/controllers/names/descriptions_controller_test.rb
@@ -238,20 +238,20 @@ module Names
     end
 
     # Edit a draft for a project (POST).
+    # Classification edits no longer go through the description form
+    # (discussion #4163) — the helper now exercises gen_desc and
+    # diag_desc only.
     def edit_draft_post_helper(draft, user, params: {}, permission: true,
                                success: true)
       gen_desc = "This is a very general description."
       assert_not_equal(gen_desc, draft.gen_desc)
       diag_desc = "This is a diagnostic description"
       assert_not_equal(diag_desc, draft.diag_desc)
-      classification = "Family: _Agaricaceae_"
-      assert_not_equal(classification, draft.classification)
       params = {
         id: draft.id,
         description: {
           gen_desc: gen_desc,
-          diag_desc: diag_desc,
-          classification: classification
+          diag_desc: diag_desc
         }.merge(params)
       }
       put_requires_login(:update, params, user.login)
@@ -268,11 +268,9 @@ module Names
       if permission && success
         assert_equal(gen_desc, draft.gen_desc)
         assert_equal(diag_desc, draft.diag_desc)
-        assert_equal(classification, draft.classification)
       else
         assert_not_equal(gen_desc, draft.gen_desc)
         assert_not_equal(diag_desc, draft.diag_desc)
-        assert_not_equal(classification, draft.classification)
       end
     end
 
@@ -409,15 +407,9 @@ module Names
                              dick, permission: false)
     end
 
-    def test_edit_draft_post_bad_classification
-      edit_draft_post_helper(
-        name_descriptions(:draft_coprinus_comatus),
-        rolf,
-        params: { classification: "**Domain**: Eukarya" },
-        permission: true,
-        success: false
-      )
-    end
+    # bad-classification test removed — descriptions no longer carry
+    # classification (discussion #4163). See
+    # Names::ClassificationControllerTest for the validation path.
 
     # ------------------------------
     #  Test creating descriptions.
@@ -567,40 +559,8 @@ module Names
       assert_equal(true, desc.public_write)
     end
 
-    def test_create_name_description_bogus_classification
-      name = names(:agaricus_campestris)
-      login("dick")
-
-      bad_class = "*Order*: Agaricales\r\nFamily: Agaricaceae"
-      good_class = "Family: Agaricaceae\r\nOrder: Agaricales"
-      final_class = "Order: _Agaricales_\r\nFamily: _Agaricaceae_"
-
-      params = {
-        name_id: name.id,
-        description: empty_notes.merge(
-          source_type: "public",
-          source_name: "",
-          public: "1",
-          public_write: "1"
-        )
-      }
-
-      params[:description][:classification] = bad_class
-      post(:create, params: params)
-      assert_flash_error
-      assert_template("names/descriptions/new")
-      assert_select("#name_description_form")
-
-      params[:description][:classification] = good_class
-      post(:create, params: params)
-      assert_flash_success
-      desc = NameDescription.last
-      assert_redirected_to(name_description_path(desc.id))
-
-      name.reload
-      assert_equal(final_class, name.classification)
-      assert_equal(final_class, desc.classification)
-    end
+    # Classification validation moved with the column to Name itself
+    # (discussion #4163) — see Names::ClassificationControllerTest.
 
     def test_create_name_description_source
       login("dick")
@@ -681,33 +641,9 @@ module Names
       )
     end
 
-    # Cover update_classification_cache_and_save_name
-    def test_update_description_changes_classification_cache
-      desc = name_descriptions(:peltigera_desc)
-      name = desc.name
-      name.update(description: desc) # ensure it's the default
-      old_class = name.classification
-
-      # Use the correct format - Rails will reorder as Order before Family
-      new_class = "Order: _Peltigerales_\r\nFamily: _Peltigeraceae_"
-      assert_not_equal(new_class, old_class)
-
-      login("rolf")
-      params = {
-        id: desc.id,
-        description: {
-          classification: new_class,
-          gen_desc: desc.gen_desc,
-          diag_desc: desc.diag_desc
-        }
-      }
-      put(:update, params: params)
-
-      name.reload
-      desc.reload
-      assert_equal(new_class, desc.classification)
-      assert_equal(new_class, name.classification)
-    end
+    # The classification cache write went away with the column itself
+    # (discussion #4163). Classification edits go through
+    # Names::ClassificationController.
 
     # Cover save_updated_description_if_changed_or_flash no changes
     def test_update_description_no_changes
@@ -717,8 +653,7 @@ module Names
         id: desc.id,
         description: {
           gen_desc: desc.gen_desc,
-          diag_desc: desc.diag_desc,
-          classification: desc.classification
+          diag_desc: desc.diag_desc
         }
       }
       put(:update, params: params)

--- a/test/fixtures/name_description_versions.yml
+++ b/test/fixtures/name_description_versions.yml
@@ -9,7 +9,6 @@ agaricus_campestras_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
   version: 1
   notes: This should prevent me from merging, too... with some “special” chars
-  classification: ''
 
 # Another name with notes (not mergeable)
 agaricus_campestros_desc_version_1:
@@ -19,7 +18,6 @@ agaricus_campestros_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
   version: 1
   notes: Need two to get an error
-  classification: ''
 
 russula_brevipes_author_notes_desc_version_1:
   name_description_id: <%= ActiveRecord::FixtureSet.
@@ -28,7 +26,6 @@ russula_brevipes_author_notes_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
   version: 1
   notes: Here are some notes
-  classification: ''
 
 russula_cremoricolor_no_author_notes_desc_version_1:
   name_description_id: <%= ActiveRecord::FixtureSet.
@@ -37,7 +34,6 @@ russula_cremoricolor_no_author_notes_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
   version: 1
   notes: Here are some notes
-  classification: ''
 
 russula_cremoricolor_author_notes_desc_version_1:
   name_description_id: <%= ActiveRecord::FixtureSet.
@@ -46,7 +42,6 @@ russula_cremoricolor_author_notes_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
   version: 1
   notes: Some different notes
-  classification: ''
 
 peltigera_desc_version_1:
   name_description_id: <%= ActiveRecord::FixtureSet.
@@ -55,7 +50,6 @@ peltigera_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:rolf) %>
   version: 1
   license_id: <%= ActiveRecord::FixtureSet.identify(:ccnc25) %>
-  classification: ''
 
 peltigera_desc_version_2:
   name_description_id: <%= ActiveRecord::FixtureSet.
@@ -64,7 +58,6 @@ peltigera_desc_version_2:
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
   version: 2
   license_id: <%= ActiveRecord::FixtureSet.identify(:ccnc30) %>
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   gen_desc: "Broad leafy lichens with soft, felty undersurface, generally with conspicuous veins and rhizines."
   diag_desc: "Large foliose lichens with either green algae or cyanobacterial photopartners; apothecia on the upper surface of the lobes; soredia, isidia, and/or lobules often present; undersurface ecorticate, often with raised veins and rhizines; upper surface smooth to often tomentose."
   distribution: Cosmopolitan.
@@ -79,7 +72,6 @@ suillus_desc_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:dick) %>
   version: 1
   gen_desc: A __Suillus__ by any other name would smell as sweet...
-  classification: ''
 
 # A draft of Coprinus comatus owned by a member (katrina) of the EOL Project
 draft_coprinus_comatus_version_1:
@@ -113,7 +105,6 @@ draft_lactarius_alpinus_version_1:
   user_id: <%= ActiveRecord::FixtureSet.identify(:katrina) %>
   version: 1
   updated_at: 2009-05-04 19:56:25
-  classification: "**Domain**: Eukarya"
 
 peltigera_alt_desc_version_1:
   name_description_id: <%= ActiveRecord::FixtureSet.
@@ -142,7 +133,6 @@ peltigera_source_desc_version_1:
 boletus_edulis_desc_version_1:
   name_description_id: <%= ActiveRecord::FixtureSet.
    identify(:boletus_edulis_desc) %>
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_"
   license_id: <%= ActiveRecord::FixtureSet.identify(:ccnc30) %>
   updated_at: 2012-07-12 06:32:18
   user_id: <%= ActiveRecord::FixtureSet.identify(:roy) %>

--- a/test/fixtures/name_descriptions.yml
+++ b/test/fixtures/name_descriptions.yml
@@ -18,14 +18,12 @@ agaricus_campestras_desc:
   <<: *DEFAULTS
   name: agaricus_campestras
   notes: This should... ¡prevent me from merging!
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
 # Another name with notes (not mergeable)
 agaricus_campestros_desc:
   <<: *DEFAULTS
   name: agaricus_campestros
   notes: Need two to get an error
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
 russula_brevipes_author_notes_desc:
   <<: *DEFAULTS
@@ -53,7 +51,6 @@ peltigera_desc:
   ok_for_export: 1
   last_review: 2009-01-02 02:01:01
   license: ccnc30
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   gen_desc: "Broad leafy lichens with soft, felty undersurface, generally with conspicuous veins and rhizines."
   diag_desc: "Large foliose lichens with either green algae or cyanobacterial photopartners; apothecia on the upper surface of the lobes; soredia, isidia, and/or lobules often present; undersurface ecorticate, often with raised veins and rhizines; upper surface smooth to often tomentose."
   distribution: Cosmopolitan.
@@ -117,7 +114,6 @@ draft_lactarius_alpinus:
   <<: *DEFAULTS
   name: lactarius_alpinus
   user: katrina
-  classification: "**Domain**: Eukarya"
   source_type: <%= NameDescription.source_types[:project] %>
   source_name: EOL Project
   project: eol_project
@@ -166,7 +162,6 @@ coprinus_desc:
   name: coprinus
   authors: katrina
   editors: katrina
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   created_at: 2007-02-26 20:48:00
   updated_at: 2007-02-27 20:48:00
 
@@ -178,7 +173,6 @@ coprinus_comatus_desc:
   admin_groups:  reviewers
   reader_groups: all_users
   writer_groups: all_users
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   created_at: 2007-02-26 20:48:00
   updated_at: 2007-02-27 20:48:00
 
@@ -200,7 +194,6 @@ agaricus_desc:
 
 # There was an identical case in the wild which Danny could not edit.
 boletus_edulis_desc:
-  classification:   "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_"
   created_at:       2012-07-12 06:32:18
   last_view:        2017-12-09 03:38:34
   license:          ccnc30

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -32,7 +32,6 @@ DEFAULTS: &DEFAULTS
   is_collection_location: 1
   lifeform: " "
   text_name: Boletus edulis
-  classification: ""
   rss_log: $LABEL_rss_log
   needs_naming: 1
   source: nil
@@ -85,7 +84,6 @@ coprinus_comatus_obs:
   user: rolf
   name: coprinus_comatus
   text_name: Coprinus comatus
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   location:
   where: Glendale, California
   specimen: 1
@@ -112,7 +110,6 @@ agaricus_campestris_obs:
   user: rolf
   name: agaricus_campestris
   text_name: Agaricus campestris
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   notes:
     :Other: From the lawn next door
   thumb_image: agaricus_campestris_image
@@ -132,7 +129,6 @@ agaricus_campestrus_obs:
   user: rolf
   name: agaricus_campestrus
   text_name: Agaricus campestrus
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   notes:
     :Other: From somewhere else
 
@@ -147,7 +143,6 @@ agaricus_campestras_obs:
   user: rolf
   name: agaricus_campestras
   text_name: Agaricus campestras
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   notes:
     :Other: From somewhere else
 
@@ -162,7 +157,6 @@ agaricus_campestros_obs:
   user: rolf
   name: agaricus_campestros
   text_name: Agaricus campestros
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
   notes:
     :Other: From somewhere else
 
@@ -333,7 +327,6 @@ peltigera_obs:
   where: "Briceland, California, USA"
   name: peltigera
   text_name: Peltigera
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   specimen: 1
   notes:
     :Other: "Growing on a hardwood"
@@ -356,7 +349,6 @@ peltigera_mary_obs:
   where: "Briceland, California, USA"
   name: peltigera
   text_name: Peltigera
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Ascomycota_\r\nClass: _Ascomycetes_\r\nOrder: _Lecanorales_\r\nFamily: _Peltigeraceae_"
   specimen: 1
   notes:
     :Other: "Growing on a hardwood"
@@ -734,7 +726,6 @@ chlorophyllum_rachodes_obs:
   log_updated_at: 2023-02-04 04:06:04
   when: 2023-02-04
   name: chlorophyllum_rachodes
-  classification: "Kingdom: _Fungi_\r\nPhylum: _Basidiomycota_\r\nClass: _Basidiomycetes_\r\nOrder: _Agaricales_\r\nFamily: _Agaricaceae_"
 
 wolf_fart:
   <<: *DEFAULTS

--- a/test/models/cache_test.rb
+++ b/test/models/cache_test.rb
@@ -37,9 +37,9 @@ class CacheTest < UnitTestCase
     assert_not_equal(first_updated_at, name.observations.first.updated_at)
   end
 
-  # Prove that changing a name's classification will update
-  # observations.classification for all the attached observations without
-  # changing the updated_at field.
+  # Prove that changing a name's classification via its description
+  # propagates forward to names.classification (which is now the sole
+  # cache — discussion #4163). Observations are no longer cached.
   def test_changing_classification
     name = names(:peltigera)
     desc = name.description
@@ -50,8 +50,8 @@ class CacheTest < UnitTestCase
     new_str = desc.classification.sub("Ascomycota", "Basidiomycota")
     desc.update(classification: new_str)
     assert_equal(new_str, name.reload.classification)
-    assert(name.observations.all? { |o| o.classification == new_str })
-    # Name modification date is updated, but not observations.
+    # Observations don't cache classification anymore — the data lives
+    # on the name and is read from there at query time.
     assert_not_equal(name_updated_at, name.updated_at)
     assert_equal(first_updated_at, name.observations.first.updated_at)
   end
@@ -72,11 +72,13 @@ class CacheTest < UnitTestCase
     assert_names_equal(new_name, obs.reload.name)
     assert_equal(new_name.lifeform, obs.lifeform)
     assert_equal(new_name.text_name, obs.text_name)
-    assert_equal(new_name.classification, obs.classification)
+    # Classification is no longer cached on Observation — discussion #4163.
   end
 
-  # Prove that observation caches are updated when a classification is bulk-
-  # changed in all of a genus's subtaxa (and that updated_at not changed).
+  # Prove that propagating a classification to a genus's subtaxa
+  # updates names.classification on each subtaxon and does not touch
+  # observations.updated_at. Observations no longer cache classification
+  # (discussion #4163), so the assertion is on the names instead.
   def test_propagate_classification
     name = names(:agaricus)
     saved_obs_updated_ats =
@@ -87,8 +89,8 @@ class CacheTest < UnitTestCase
     name.update(classification: new_classification)
     name.propagate_classification
 
-    Observation.names(lookup: "Agaricus", include_subtaxa: 1).each do |obs|
-      assert_equal(new_classification, obs.classification)
+    Name.subtaxa_of_genus_or_below("Agaricus").each do |subtaxon|
+      assert_equal(new_classification, subtaxon.classification)
     end
     assert_equal(
       saved_obs_updated_ats,

--- a/test/models/cache_test.rb
+++ b/test/models/cache_test.rb
@@ -37,22 +37,16 @@ class CacheTest < UnitTestCase
     assert_not_equal(first_updated_at, name.observations.first.updated_at)
   end
 
-  # Prove that changing a name's classification via its description
-  # propagates forward to names.classification (which is now the sole
-  # cache — discussion #4163). Observations are no longer cached.
+  # Prove that changing a name's classification doesn't ripple out to
+  # cached columns on observations (discussion #4163 — they no longer
+  # exist) or touch obs updated_at.
   def test_changing_classification
     name = names(:peltigera)
-    desc = name.description
-    assert_not_nil(desc)
     assert_not_empty(name.observations)
-    name_updated_at = name.updated_at
     first_updated_at = name.observations.first.updated_at
-    new_str = desc.classification.sub("Ascomycota", "Basidiomycota")
-    desc.update(classification: new_str)
+    new_str = name.classification.sub("Ascomycota", "Basidiomycota")
+    name.update(classification: new_str)
     assert_equal(new_str, name.reload.classification)
-    # Observations don't cache classification anymore — the data lives
-    # on the name and is read from there at query time.
-    assert_not_equal(name_updated_at, name.updated_at)
     assert_equal(first_updated_at, name.observations.first.updated_at)
   end
 

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2124,6 +2124,11 @@ class NameTest < UnitTestCase
     assert_no_enqueued_jobs do
       desc.save
     end
+    # The classification mirror to Name now creates a Name version
+    # (discussion #4163), bumping the in-memory value on desc.name.
+    # Reload the test's separate `name` reference so its version stays
+    # in sync with what subsequent NameChangeMailer args report.
+    name.reload
     assert_equal(description_version + 1, desc.version)
     assert_equal(0, desc.authors.length)
     assert_equal(1, desc.editors.length)
@@ -2309,8 +2314,11 @@ class NameTest < UnitTestCase
           mailer_args[:receiver] == mary &&
           mailer_args[:name] == name &&
           mailer_args[:description].nil? &&
-          mailer_args[:old_name_ver] == name_version &&
-          mailer_args[:new_name_ver] == name_version + 1 &&
+          # The earlier classification reset bumped Name to
+          # name_version + 1 (discussion #4163); this citation save
+          # bumps to + 2.
+          mailer_args[:old_name_ver] == name_version + 1 &&
+          mailer_args[:new_name_ver] == name_version + 2 &&
           mailer_args[:old_desc_ver].zero? &&
           mailer_args[:new_desc_ver].zero? &&
           mailer_args[:review_status] == "no_change"
@@ -2319,7 +2327,7 @@ class NameTest < UnitTestCase
       name.citation = "Rolf added this."
       name.save
     end
-    assert_equal(name_version + 1, name.version)
+    assert_equal(name_version + 2, name.version)
     assert_equal(description_version + 4, desc.version)
     assert_equal(2, desc.authors.length)
     assert_equal(2, desc.editors.length)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2114,7 +2114,6 @@ class NameTest < UnitTestCase
     # Rolf erases notes: no emails (no authors yet), Rolf becomes editor.
     User.current = rolf
     desc.reload
-    desc.classification = ""
     desc.gen_desc = ""
     desc.diag_desc = ""
     desc.distribution = ""
@@ -2124,11 +2123,6 @@ class NameTest < UnitTestCase
     assert_no_enqueued_jobs do
       desc.save
     end
-    # The classification mirror to Name now creates a Name version
-    # (discussion #4163), bumping the in-memory value on desc.name.
-    # Reload the test's separate `name` reference so its version stays
-    # in sync with what subsequent NameChangeMailer args report.
-    name.reload
     assert_equal(description_version + 1, desc.version)
     assert_equal(0, desc.authors.length)
     assert_equal(1, desc.editors.length)
@@ -2314,11 +2308,8 @@ class NameTest < UnitTestCase
           mailer_args[:receiver] == mary &&
           mailer_args[:name] == name &&
           mailer_args[:description].nil? &&
-          # The earlier classification reset bumped Name to
-          # name_version + 1 (discussion #4163); this citation save
-          # bumps to + 2.
-          mailer_args[:old_name_ver] == name_version + 1 &&
-          mailer_args[:new_name_ver] == name_version + 2 &&
+          mailer_args[:old_name_ver] == name_version &&
+          mailer_args[:new_name_ver] == name_version + 1 &&
           mailer_args[:old_desc_ver].zero? &&
           mailer_args[:new_desc_ver].zero? &&
           mailer_args[:review_status] == "no_change"
@@ -2327,7 +2318,7 @@ class NameTest < UnitTestCase
       name.citation = "Rolf added this."
       name.save
     end
-    assert_equal(name_version + 2, name.version)
+    assert_equal(name_version + 1, name.version)
     assert_equal(description_version + 4, desc.version)
     assert_equal(2, desc.authors.length)
     assert_equal(2, desc.editors.length)
@@ -3420,16 +3411,16 @@ class NameTest < UnitTestCase
                  Name.matching_desired_new_parsed_name(parsed).order(:author))
   end
 
+  # Refresh used to copy `name_descriptions.classification` back to
+  # `names.classification` when they diverged. The description column
+  # is gone (#4163) so the method is now a no-op shim — assert it
+  # returns no messages and leaves names unchanged.
   def test_refresh_classification_caches
     name = names(:coprinus_comatus)
-    bad  = name.classification = "Phylum: _Ascomycota_"
-    good = name.description.classification
-    name.save
-    assert_not_equal(good, bad)
-
-    Name.refresh_classification_caches
-    assert_equal(good, name.reload.classification)
-    assert_equal(good, name.description.reload.classification)
+    bad  = "Phylum: _Ascomycota_"
+    name.update_column(:classification, bad)
+    assert_empty(Name.refresh_classification_caches)
+    assert_equal(bad, name.reload.classification)
   end
 
   def test_changing_classification_propagates_to_subtaxa
@@ -3438,8 +3429,7 @@ class NameTest < UnitTestCase
     new_classification = names(:peltigera).classification
     assert_not_equal(new_classification, name.classification)
     assert_not_equal(new_classification, child.classification)
-    name.description.classification = new_classification
-    name.description.save
+    name.change_classification(new_classification)
     assert_equal(new_classification, name.reload.classification)
     assert_equal(new_classification, child.reload.classification)
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -3411,18 +3411,6 @@ class NameTest < UnitTestCase
                  Name.matching_desired_new_parsed_name(parsed).order(:author))
   end
 
-  # Refresh used to copy `name_descriptions.classification` back to
-  # `names.classification` when they diverged. The description column
-  # is gone (#4163) so the method is now a no-op shim — assert it
-  # returns no messages and leaves names unchanged.
-  def test_refresh_classification_caches
-    name = names(:coprinus_comatus)
-    bad  = "Phylum: _Ascomycota_"
-    name.update_column(:classification, bad)
-    assert_empty(Name.refresh_classification_caches)
-    assert_equal(bad, name.reload.classification)
-  end
-
   def test_changing_classification_propagates_to_subtaxa
     name  = names(:coprinus)
     child = names(:coprinus_comatus)


### PR DESCRIPTION
## Summary

Implements the proposal from discussion #4163. Three findings made the four-column classification storage hard to defend:

1. The `observations.classification` cache made queries **slower**, not faster — measured 5-9× slowdown on `Observation#one_clade` because a leading-wildcard `LIKE` can't use an index, so a 73 MB sequential scan beat the smaller scan on `names.classification` plus an indexed `name_id IN (...)` join.
2. The per-description classification feature was used by 0.05% of names; of the 38 divergent cases, 46 of 54 looked like snapshot drift rather than intentional alternate-taxonomy choices.
3. The version history was fictional — ~85% of names have no description, so most classification edits had no audit trail anywhere.

This PR collapses to a single source of truth: **`names.classification`**, versioned via `name_versions`.

## What changed

- **Version `Name#classification` on `name_versions`** — adds the column to the version table, moves it out of `non_versioned_columns`, adds it to `acts_as_versioned if_changed:`. Edits now produce a versioned audit trail for every Name (vs. ~15% before).
- **Rewrite `Observation#one_clade`** to route through `names.classification` instead of the obs cache — single-statement subquery, uses the existing `name_id` index. **Measured 5-9× faster** across realistic clades (Agaricales, Russulaceae, Tremellales, Lecanorales, Hymenochaetaceae). Removes the highest-fanout cache-invalidation callback (`Name#update_observation_cache` previously fanned out to every obs of a name).
- **Drop `observations.classification`** — column removed, fixture references stripped, `Observation#cache_content_filter_data` and `refresh_content_filter_caches` no longer touch it.
- **Drop `name_descriptions.classification` and `name_description_versions.classification`** — removed from `NameDescription::ALL_NOTE_FIELDS`, `update_classification_cache` callback and `check_requirements` validation gone, descriptions form/controller stops accepting the param, `Name#change_classification` / `propagate_classification` / `move_primary_description` and `Names::Classification::RefreshController` no longer mirror to descriptions, `Descriptions::Moves` concern no longer validates classification on move. API consumers still see a `classification` field on `_name_description.json` / `_name_description.xml` — sourced from `name.classification` so external callers don't need to change endpoints. `NameChangeMailer` now diffs `name.classification` directly instead of pulling from description note fields, so classification edits still appear in change-notification emails.
- **Backfill the latest version row of each Name** with current `names.classification` so the post-deploy version-show page has accurate data for the most recent version. Older version rows stay NULL — see "Version history caveat" below. Migration also adds an index on `name_versions(name_id, version)` (none of the version tables had any index before — useful for the backfill UPDATE and for ongoing `name.versions` queries).
- **Show classification on the Name version page** when the row's classification is non-NULL (matches the existing notes-panel "show when set" pattern).
- **Remove dead code** that the schema collapse made unreachable: the `else` branch of `if @description.valid?` in `create`, the `render_new` helper, the `elsif !@description.save` branch of `save_updated_description_if_changed_or_flash`, and the now-empty `Name.refresh_classification_caches` shim.

## Storage / perf at production scale

| | Before | After |
|---|---:|---:|
| `names.classification` | 8.4 MB | 8.4 MB |
| `name_descriptions.classification` | 1.3 MB | — |
| `name_description_versions.classification` | 1.3 MB | — |
| `observations.classification` | 72.8 MB | — |
| `name_versions.classification` (new, gated by `if_changed`) | — | small |
| **Total** | **83.8 MB** | **~8.4 MB** |

Plus: `Observation#one_clade` 5-9× faster (340 ms → 40-70 ms on local production-copy data, measured as `count` of typical above-genus clades, query cache disabled, mean of 5 reps after warmup).

## Version history caveat (read this if you're reviewing)

`acts_as_versioned` snapshots forward — each version row records the post-save state. So when classification was added to `if_changed:` in this PR, version rows that already existed got nothing retroactive. The included backfill migration handles the **latest** row of each Name (the one that was current at deploy time) by copying `names.classification` into it. Older rows stay NULL deliberately — any value we backfilled into them would be a guess (the genuine pre-edit values were already overwritten in `names.classification`), and putting guesses there would prevent the smart version browser (#4166, follow-up) from being able to infer values from the genus chain.

So:
- **Newest version row of each Name**: accurate (deploy-time value, equals the live `names.classification` right after the migration runs).
- **Older version rows**: NULL. The version show page hides the classification panel when NULL. Once #4166 lands, those NULLs get filled by walking up the genus chain.
- **Future edits**: snapshot correctly via `acts_as_versioned`.

There's one path that still bypasses versioning: `Name#propagate_classification` uses `update_all` (genus → tens of thousands of subtaxa would otherwise mean tens of thousands of version-row inserts per genus edit). The genus's own version row captures the change; subtaxa pick it up via inheritance in the smart browser. Documented inline in the method.

## Migration notes

- Four migrations: `20260426000001_add_classification_to_name_versions`, `20260426000002_remove_classification_from_observations`, `20260426000003_remove_classification_from_name_descriptions`, `20260426000004_backfill_latest_name_version_classification`.
- The audit script on `njw-4155-classification-audit` still has the obs/description `update_all` writes in `sync_synonym_classification`. When that branch rebases onto main after this lands, those writes need to be removed AND `sync_synonym_classification` needs to be updated to create per-row version trails — both tracked in #4166.
- **Do not re-run the audit script in production until #4166 ships.** Audit Phase 2 changes would otherwise have no audit trail (no Name version row, no description-version fallback since that column is gone too).

## Test plan

- [x] Full test suite green (5020 tests, 36269 assertions, 0 failures)
- [x] Rubocop clean on all changed Ruby files
- [x] Smoke-test that `Name.update(classification: …)` creates a `name_versions` row
- [x] Smoke-test the backfill migration: latest version row matches live `names.classification` after running
- [x] Mailer fixtures updated for the new ordering of the classification diff section
- [x] Browser smoke-test of the rewritten `Observation#one_clade`: set the **Clade** content filter via `/account/preferences/edit` to an above-genus value (e.g. "Agaricales"), save, then visit `/observations` and confirm it returns only obs in that clade.
- [x] Browser smoke-test the description form: confirm the classification field is gone and gen_desc/etc. still save.
- [x] Browser smoke-test `/names/:id/classification/edit`: confirm classification edits still flow through `Names::ClassificationController`.

## Follow-up

- #4166 (Phase 3 of the classification roadmap): smart version browser + audit script Phase 2 versioning. Must ship before audit runs in production again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)