### PR TITLE
Repair + alert for stale observation vote_cache (#4171)

### DIFF
--- a/script/repair_observation_vote_cache.rb
+++ b/script/repair_observation_vote_cache.rb
@@ -66,52 +66,68 @@ def affected_observation_ids
     WHERE ABS(IFNULL(obs.vote_cache, 0)) < 0.01
       AND IFNULL(n.vote_cache, 0) > 0.01
   SQL
-  ActiveRecord::Base.connection.execute(sql).pluck(0)
+  ActiveRecord::Base.connection.select_values(sql)
 end
 
 def recompute_consensus_for(obs)
   Observation::NamingConsensus.new(obs).calc_consensus
 end
 
-# Returns [:repaired, :unchanged] for tally bookkeeping.
-def process_obs(obs, obs_id)
-  if DRY_RUN
-    consensus = Observation::NamingConsensus.new(obs)
-    calc = Observation::ConsensusCalculator.new(consensus.namings)
-    _best, val = calc.calc(User.current)
-    return :unchanged unless val.to_f.abs > 0.01
+EPSILON = 1e-4
 
-    log("  obs #{obs_id}: 0.0 → #{val.round(3)}") if VERBOSE
-  else
-    before = obs.vote_cache
-    recompute_consensus_for(obs)
-    obs.reload
-    return :unchanged if obs.vote_cache == before
+# nil and 0.0 are equivalent for our purposes (both mean "no useful
+# vote_cache recorded"); coerce to compare cleanly.
+def vote_cache_changed?(before, after)
+  (before.to_f - after.to_f).abs > EPSILON
+end
 
-    log("  obs #{obs_id} repaired") if VERBOSE
-  end
+def dry_run_process(obs, obs_id)
+  consensus = Observation::NamingConsensus.new(obs)
+  calc = Observation::ConsensusCalculator.new(consensus.namings)
+  _best, val = calc.calc(User.current)
+  return :unchanged unless val.to_f.abs > EPSILON
+
+  log("  obs #{obs_id}: 0.0 → #{val.round(3)}") if VERBOSE
   :repaired
+end
+
+def live_process(obs, obs_id)
+  before = obs.vote_cache
+  recompute_consensus_for(obs)
+  obs.reload
+  return :unchanged unless vote_cache_changed?(before, obs.vote_cache)
+
+  log("  obs #{obs_id} repaired") if VERBOSE
+  :repaired
+end
+
+# Returns :repaired or :unchanged for tally bookkeeping.
+def process_obs(obs, obs_id)
+  DRY_RUN ? dry_run_process(obs, obs_id) : live_process(obs, obs_id)
 end
 
 ids = affected_observation_ids
 log("Found #{ids.size} observations with stale vote_cache")
 
-tally = { repaired: 0, unchanged: 0, errors: 0 }
+tally = { repaired: 0, unchanged: 0, missing: 0, errors: 0 }
 ids.each_with_index do |obs_id, i|
   log("  #{i}/#{ids.size} processed") if (i % 200).zero? && i.positive?
 
   obs = Observation.find_by(id: obs_id)
-  next unless obs
+  if obs.nil?
+    tally[:missing] += 1
+    log("  ? obs #{obs_id} disappeared between query and load")
+    next
+  end
 
   tally[process_obs(obs, obs_id)] += 1
 rescue StandardError => e
   tally[:errors] += 1
   log("  ! obs #{obs_id}: #{e.class}: #{e.message}")
 end
-repaired = tally[:repaired]
-unchanged = tally[:unchanged]
-errors = tally[:errors]
 
 log("=" * 60)
-log("Done: #{repaired} #{DRY_RUN ? "would be repaired" : "repaired"}, " \
-    "#{unchanged} unchanged, #{errors} errors in #{elapsed}s")
+verb = DRY_RUN ? "would be repaired" : "repaired"
+log("Done: #{tally[:repaired]} #{verb}, " \
+    "#{tally[:unchanged]} unchanged, #{tally[:missing]} missing, " \
+    "#{tally[:errors]} errors in #{elapsed}s")

--- a/script/repair_observation_vote_cache.rb
+++ b/script/repair_observation_vote_cache.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#  USAGE::
+#
+#    bin/rails runner script/repair_observation_vote_cache.rb \
+#      [-n|--dry-run] [-v|--verbose]
+#
+#  DESCRIPTION::
+#
+#    One-shot repair for #4171: ~1,951 historical observations have a
+#    stale `vote_cache` that says 0% even though their consensus name's
+#    Naming has a real positive `vote_cache`. The data is fine; only
+#    the obs cache wasn't refreshed at the time of an old edit (mostly
+#    2011-2012, on a handful of users). The map popup uses
+#    `obs.vote_cache` directly, so the stale value shows up there as
+#    "0% confidence" even though the obs show page reads correctly.
+#
+#    Strategy: walk the affected obs and call
+#    `Observation::NamingConsensus#calc_consensus` on each.
+#    `calc_consensus` recomputes from the live Naming/Vote rows and
+#    saves via `update_single_obs_consensus`, with an idempotent early
+#    return when nothing actually changed. Safe to re-run.
+#
+#    Use --dry-run to count without saving (still constructs the
+#    consensus calculator per obs so you can see runtime). Use
+#    --verbose to list each affected obs id.
+#
+################################################################################
+
+require_relative("../config/boot")
+require_relative("../config/environment")
+
+dry_run = false
+verbose = false
+ARGV.each do |flag|
+  case flag
+  when "-n", "--dry-run" then dry_run = true
+  when "-v", "--verbose" then verbose = true
+  else
+    puts("USAGE: bin/rails runner script/repair_observation_vote_cache.rb " \
+         "[-n|--dry-run] [-v|--verbose]")
+    exit(1)
+  end
+end
+DRY_RUN = dry_run
+VERBOSE = verbose
+
+START = Time.zone.now
+
+def elapsed
+  (Time.zone.now - START).round(1)
+end
+
+def log(msg)
+  puts("[#{elapsed}s] #{msg}")
+end
+
+# Affected: obs whose own vote_cache is ~0/nil but which has a Naming
+# at the same name with a real positive vote_cache.
+def affected_observation_ids
+  sql = <<~SQL.squish
+    SELECT obs.id
+    FROM observations obs
+    JOIN namings n ON n.observation_id = obs.id AND n.name_id = obs.name_id
+    WHERE ABS(IFNULL(obs.vote_cache, 0)) < 0.01
+      AND IFNULL(n.vote_cache, 0) > 0.01
+  SQL
+  ActiveRecord::Base.connection.execute(sql).pluck(0)
+end
+
+def recompute_consensus_for(obs)
+  Observation::NamingConsensus.new(obs).calc_consensus
+end
+
+# Returns [:repaired, :unchanged] for tally bookkeeping.
+def process_obs(obs, obs_id)
+  if DRY_RUN
+    consensus = Observation::NamingConsensus.new(obs)
+    calc = Observation::ConsensusCalculator.new(consensus.namings)
+    _best, val = calc.calc(User.current)
+    return :unchanged unless val.to_f.abs > 0.01
+
+    log("  obs #{obs_id}: 0.0 → #{val.round(3)}") if VERBOSE
+  else
+    before = obs.vote_cache
+    recompute_consensus_for(obs)
+    obs.reload
+    return :unchanged if obs.vote_cache == before
+
+    log("  obs #{obs_id} repaired") if VERBOSE
+  end
+  :repaired
+end
+
+ids = affected_observation_ids
+log("Found #{ids.size} observations with stale vote_cache")
+
+tally = { repaired: 0, unchanged: 0, errors: 0 }
+ids.each_with_index do |obs_id, i|
+  log("  #{i}/#{ids.size} processed") if (i % 200).zero? && i.positive?
+
+  obs = Observation.find_by(id: obs_id)
+  next unless obs
+
+  tally[process_obs(obs, obs_id)] += 1
+rescue StandardError => e
+  tally[:errors] += 1
+  log("  ! obs #{obs_id}: #{e.class}: #{e.message}")
+end
+repaired = tally[:repaired]
+unchanged = tally[:unchanged]
+errors = tally[:errors]
+
+log("=" * 60)
+log("Done: #{repaired} #{DRY_RUN ? "would be repaired" : "repaired"}, " \
+    "#{unchanged} unchanged, #{errors} errors in #{elapsed}s")

--- a/script/repair_observation_vote_cache.rb
+++ b/script/repair_observation_vote_cache.rb
@@ -4,27 +4,47 @@
 #  USAGE::
 #
 #    bin/rails runner script/repair_observation_vote_cache.rb \
-#      [-n|--dry-run] [-v|--verbose]
+#      [-n|--dry-run] [--no-email] [-v|--verbose]
 #
 #  DESCRIPTION::
 #
-#    One-shot repair for #4171: ~1,951 historical observations have a
-#    stale `vote_cache` that says 0% even though their consensus name's
-#    Naming has a real positive `vote_cache`. The data is fine; only
-#    the obs cache wasn't refreshed at the time of an old edit (mostly
-#    2011-2012, on a handful of users). The map popup uses
-#    `obs.vote_cache` directly, so the stale value shows up there as
-#    "0% confidence" even though the obs show page reads correctly.
+#    Find + fix + alert for #4171: observations whose `vote_cache`
+#    is stuck near 0 even though their consensus-name Naming has a
+#    real positive `vote_cache`. The map popup reads `obs.vote_cache`
+#    directly, so the stale value shows up there as "0% confidence"
+#    even though the obs show page reads correctly.
 #
-#    Strategy: walk the affected obs and call
-#    `Observation::NamingConsensus#calc_consensus` on each.
-#    `calc_consensus` recomputes from the live Naming/Vote rows and
-#    saves via `update_single_obs_consensus`, with an idempotent early
-#    return when nothing actually changed. Safe to re-run.
+#    Default behavior: find affected obs, repair them by calling
+#    `Observation::NamingConsensus#calc_consensus` (which recomputes
+#    from the live Naming/Vote rows and saves), and email
+#    `MO.webmaster_email_address` with a per-obs detail block of
+#    what was just fixed. Safe to re-run; `calc_consensus`'s
+#    `update_single_obs_consensus` has an idempotent early-return
+#    when nothing actually changed.
 #
-#    Use --dry-run to count without saving (still constructs the
-#    consensus calculator per obs so you can see runtime). Use
-#    --verbose to list each affected obs id.
+#    Designed to run in two modes:
+#
+#    1. **Once on deploy**, with `--no-email`, to clear the
+#       historical backlog (1,951 obs on dev DB, mostly 2011-2012).
+#       Suppresses the email so we don't ship a giant alert about
+#       known historical data.
+#    2. **As a daily cronjob**, default flags. Once the backlog is
+#       cleared, each run finds 0 or near-0 affected obs and stays
+#       silent. When a new occurrence trips it, the obs is auto-fixed
+#       *and* an email goes to webmaster with enough detail
+#       (timestamps, source, inat_id, user) to investigate the
+#       trigger while the trail is fresh (rss_log entries, recent
+#       web request logs).
+#
+#    Exit code: 0 if no affected obs found, 1 if any were repaired
+#    (regardless of whether email was sent), 2 on bad usage.
+#
+#  FLAGS::
+#
+#    -n / --dry-run  — find only; don't repair, don't email
+#    --no-email      — repair, but don't send an email
+#                      (use for the deploy-time backlog clear)
+#    -v / --verbose  — log each affected obs id with before/after
 #
 ################################################################################
 
@@ -32,21 +52,25 @@ require_relative("../config/boot")
 require_relative("../config/environment")
 
 dry_run = false
+no_email = false
 verbose = false
 ARGV.each do |flag|
   case flag
   when "-n", "--dry-run" then dry_run = true
+  when "--no-email"      then no_email = true
   when "-v", "--verbose" then verbose = true
   else
-    puts("USAGE: bin/rails runner script/repair_observation_vote_cache.rb " \
-         "[-n|--dry-run] [-v|--verbose]")
-    exit(1)
+    warn("USAGE: bin/rails runner script/repair_observation_vote_cache.rb " \
+         "[-n|--dry-run] [--no-email] [-v|--verbose]")
+    exit(2)
   end
 end
 DRY_RUN = dry_run
+NO_EMAIL = no_email
 VERBOSE = verbose
 
 START = Time.zone.now
+EPSILON = 1e-4
 
 def elapsed
   (Time.zone.now - START).round(1)
@@ -56,24 +80,27 @@ def log(msg)
   puts("[#{elapsed}s] #{msg}")
 end
 
-# Affected: obs whose own vote_cache is ~0/nil but which has a Naming
-# at the same name with a real positive vote_cache.
-def affected_observation_ids
+# Find affected obs with everything the email needs in one query.
+# Pick a single representative Naming per obs (lowest matching id) so
+# duplicates from `(observation_id, name_id)` having no uniqueness
+# constraint don't show up multiple times. LEFT JOIN users so we
+# don't hit `User.find_by` per row when formatting the alert.
+def stale_observations
   sql = <<~SQL.squish
-    SELECT obs.id
+    SELECT obs.id, obs.created_at, obs.updated_at, obs.user_id,
+           obs.source, obs.inat_id, n.id, n.vote_cache, u.login
     FROM observations obs
-    JOIN namings n ON n.observation_id = obs.id AND n.name_id = obs.name_id
+    JOIN namings n ON n.id = (
+      SELECT MIN(n2.id) FROM namings n2
+      WHERE n2.observation_id = obs.id AND n2.name_id = obs.name_id
+    )
+    LEFT JOIN users u ON u.id = obs.user_id
     WHERE ABS(IFNULL(obs.vote_cache, 0)) < 0.01
       AND IFNULL(n.vote_cache, 0) > 0.01
+    ORDER BY obs.created_at DESC
   SQL
-  ActiveRecord::Base.connection.select_values(sql)
+  ActiveRecord::Base.connection.execute(sql).to_a
 end
-
-def recompute_consensus_for(obs)
-  Observation::NamingConsensus.new(obs).calc_consensus
-end
-
-EPSILON = 1e-4
 
 # nil and 0.0 are equivalent for our purposes (both mean "no useful
 # vote_cache recorded"); coerce to compare cleanly.
@@ -81,53 +108,103 @@ def vote_cache_changed?(before, after)
   (before.to_f - after.to_f).abs > EPSILON
 end
 
-def dry_run_process(obs, obs_id)
-  consensus = Observation::NamingConsensus.new(obs)
-  calc = Observation::ConsensusCalculator.new(consensus.namings)
-  _best, val = calc.calc(User.current)
-  return :unchanged unless val.to_f.abs > EPSILON
+# `obs.source` is a Rails enum stored as integer (e.g. 5 →
+# `mo_inat_import`). Map back to the symbolic key for human-readable
+# diagnostics.
+def source_label(source_value)
+  return nil if source_value.nil?
 
-  log("  obs #{obs_id}: 0.0 → #{val.round(3)}") if VERBOSE
-  :repaired
+  Observation.sources.key(source_value) ||
+    Observation.sources.key(source_value.to_i)
 end
 
-def live_process(obs, obs_id)
+def format_obs_line(row)
+  obs_id, created_at, updated_at, user_id, source, inat_id,
+    naming_id, naming_vc, user_login = row
+  format("- obs %d: %s\n    " \
+         "user %d (%s), created %s, updated %s\n    " \
+         "source=%s, inat_id=%s, naming %d vc=%.3f",
+         obs_id, Observation.show_url(obs_id),
+         user_id, user_login || "?",
+         created_at, updated_at,
+         source_label(source).inspect, inat_id.inspect,
+         naming_id, naming_vc.to_f)
+end
+
+def alert_header(count)
+  verb = DRY_RUN ? "would be repaired" : "were repaired"
+  [
+    "vote_cache integrity check found #{count} observation(s) " \
+    "whose obs.vote_cache was stale (≈ 0) despite the matching-name " \
+    "Naming having a real positive vote_cache. They #{verb}.",
+    "",
+    "Tracking and root-cause hunt: " \
+    "https://github.com/MushroomObserver/mushroom-observer/issues/4171",
+    "",
+    "Per-obs detail (most recent first, up to 50):",
+    ""
+  ]
+end
+
+def format_alert(rows)
+  lines = alert_header(rows.size)
+  lines.concat(rows.first(50).map { |r| format_obs_line(r) })
+  lines << "" << "(#{rows.size - 50} more not listed)" if rows.size > 50
+  lines.join("\n")
+end
+
+def recompute_and_classify(obs)
   before = obs.vote_cache
-  recompute_consensus_for(obs)
+  Observation::NamingConsensus.new(obs).calc_consensus
   obs.reload
-  return :unchanged unless vote_cache_changed?(before, obs.vote_cache)
-
-  log("  obs #{obs_id} repaired") if VERBOSE
-  :repaired
+  if vote_cache_changed?(before, obs.vote_cache)
+    log("  obs #{obs.id} repaired") if VERBOSE
+    :repaired
+  else
+    :unchanged
+  end
 end
 
-# Returns :repaired or :unchanged for tally bookkeeping.
-def process_obs(obs, obs_id)
-  DRY_RUN ? dry_run_process(obs, obs_id) : live_process(obs, obs_id)
+# Returns :repaired / :unchanged / :missing for tally bookkeeping.
+def process_obs(obs_id)
+  obs = Observation.find_by(id: obs_id)
+  return :missing if obs.nil?
+  return :repaired if DRY_RUN
+
+  recompute_and_classify(obs)
 end
 
-ids = affected_observation_ids
-log("Found #{ids.size} observations with stale vote_cache")
+def send_alert(rows)
+  WebmasterMailer.build(
+    sender_email: MO.webmaster_email_address,
+    subject: "[MO] vote_cache integrity check: " \
+             "#{rows.size} observation(s) repaired",
+    message: format_alert(rows)
+  ).deliver_now
+end
+
+rows = stale_observations
+log("Found #{rows.size} observation(s) with stale vote_cache")
+exit(0) if rows.empty?
 
 tally = { repaired: 0, unchanged: 0, missing: 0, errors: 0 }
-ids.each_with_index do |obs_id, i|
-  log("  #{i}/#{ids.size} processed") if (i % 200).zero? && i.positive?
-
-  obs = Observation.find_by(id: obs_id)
-  if obs.nil?
-    tally[:missing] += 1
-    log("  ? obs #{obs_id} disappeared between query and load")
-    next
-  end
-
-  tally[process_obs(obs, obs_id)] += 1
+rows.each_with_index do |row, i|
+  log("  #{i}/#{rows.size} processed") if (i % 200).zero? && i.positive?
+  tally[process_obs(row[0])] += 1
 rescue StandardError => e
   tally[:errors] += 1
-  log("  ! obs #{obs_id}: #{e.class}: #{e.message}")
+  log("  ! obs #{row[0]}: #{e.class}: #{e.message}")
 end
 
-log("=" * 60)
 verb = DRY_RUN ? "would be repaired" : "repaired"
+log("=" * 60)
 log("Done: #{tally[:repaired]} #{verb}, " \
     "#{tally[:unchanged]} unchanged, #{tally[:missing]} missing, " \
     "#{tally[:errors]} errors in #{elapsed}s")
+
+if tally[:repaired].positive? && !DRY_RUN && !NO_EMAIL
+  send_alert(rows.first(tally[:repaired]))
+  log("Sent alert email to #{MO.webmaster_email_address}")
+end
+
+exit(1)


### PR DESCRIPTION
Fixes #4171. Folds in the alert/cron concern that was originally split into #4173 — one script does both jobs.

## Summary

`script/repair_observation_vote_cache.rb` is a unified find + fix + alert script for the ~1,951 observations whose `vote_cache` is stuck at 0 even though their consensus name's Naming has a real positive value. The map popup reads `obs.vote_cache` directly, so the stale value shows up there as "0% confidence" even though the obs show page reads correctly.

Default behavior: find affected obs, repair them via `Observation::NamingConsensus#calc_consensus`, and email `MO.webmaster_email_address` with a per-obs detail block of what was just fixed. Safe to re-run; `calc_consensus`'s `update_single_obs_consensus` has an idempotent early-return.

## Two-mode operation

1. **Once on deploy**, with `--no-email`, to clear the historical backlog (1,951 obs on dev DB, mostly 2011-2012). Suppresses the email so the deploy doesn't ship a giant alert about known historical data.

2. **As a daily cronjob**, default flags. After the backlog is cleared, each run finds 0 or near-0 affected obs and stays silent. When a new occurrence trips it, the obs is auto-fixed *and* an email goes to webmaster with enough detail (timestamps, source, inat_id, user) to investigate the trigger while the trail is still fresh.

## Flags

- `--dry-run` / `-n` — find only; don't repair, don't email
- `--no-email` — repair, but don't send an email (for the deploy-time clear)
- `--verbose` / `-v` — log each affected obs id with before/after

Exit: 0 if nothing affected, 1 if any rows repaired (whether email was sent or not), 2 on bad usage.

## Email body shape

```
vote_cache integrity check found N observation(s) whose obs.vote_cache
was stale (≈ 0) despite the matching-name Naming having a real positive
vote_cache. They were repaired.

Tracking and root-cause hunt:
https://github.com/MushroomObserver/mushroom-observer/issues/4171

Per-obs detail (most recent first, up to 50):

- obs 608373: https://mushroomobserver.org/observations/608373
    user 53484 (Pipsissewa), created 2025-11-06 19:00:05 UTC, updated 2025-11-06 19:00:06 UTC
    source=:mo_inat_import, inat_id=179746626, naming 828612 vc=2.607
```

Routed via `WebmasterMailer.build`. Recipient is `MO.webmaster_email_address`, which resolves to webmaster@mushroomobserver.org in production.

## Why combined and not two scripts

Originally the repair (this PR) and the integrity check (#4173) were separate. The find/format/SQL logic was shared between them, and the natural cron deployment is "run the unified script daily — it self-heals and emails when it does anything." Splitting was scope creep; combining is simpler and the cron is the only way the email path runs anyway. #4173 closed in favor of this PR.

## Deploy plan

After merge:
1. `bin/rails runner script/repair_observation_vote_cache.rb --no-email` — clears the ~1,951 historical backlog silently.
2. Add a daily cron entry: `bin/rails runner script/repair_observation_vote_cache.rb` (no flags).
3. Wait. Next time the residual trigger fires, the alert email will land in webmaster's inbox with fresh-enough data to trace it.

## Test plan

- [x] Rubocop clean
- [x] Dry-run on production-snapshot dev DB (post-historical-repair): finds 0, exits 0, no email
- [x] Manufactured stale obs locally: script repairs it, follow-up dry-run finds 0
- [x] Email body format verified locally (canonical `/observations/:id` URL, `:mo_inat_import` enum label, no `User.find_by` per row, no duplicate rows from JOIN)
- [ ] Verify on real deployment that the email actually delivers to the webmaster account

## Out of scope

- Investigating obs 608373's specific trigger — pre-repair data no longer available, deferred to whenever the cron next catches a live occurrence
- Cron schedule registration — depends on deploy infrastructure

## Addressed in review

Copilot's review on the original separate PRs ([#4172](https://github.com/MushroomObserver/mushroom-observer/pull/4172), [#4173](https://github.com/MushroomObserver/mushroom-observer/pull/4173)) flagged: silent missing-obs (added `:missing` tally), `pluck(0)` adapter portability (switched to `select_values`/`execute`), float-equality fragility (epsilon comparison, nil/0.0 normalization), N+1 with `User.find_by` per row (LEFT JOIN users), broken `/names/observations/:id` URL (use `Observation.show_url`), enum integer vs symbol (`Observation.sources.key`), JOIN duplicates from non-unique (observation_id, name_id) (subquery picks one Naming per obs). All fixed in this combined version. The N+1 with `find_by` per id is acknowledged but accepted for a one-shot/cron job that runs in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)