### PR TITLE
Add missing indexes for slow queries surfaced by 2026-04-27 outage

### DIFF
--- a/db/migrate/20260427180000_add_indexes_for_slow_queries.rb
+++ b/db/migrate/20260427180000_add_indexes_for_slow_queries.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Three indexes that close gaps surfaced by the slow query log during
+# the 2026-04-27 outage. All three drive frequently-hit queries that
+# were doing full table scans of tables with 1.8M+ rows.
+#
+# - `observation_images.image_id` (#4175): touch propagation from an
+#   Image to its associated Observations runs an UPDATE-with-JOIN
+#   keyed on `image_id`. Currently scans the full table per call;
+#   creating an observation with N images costs ~2.5N seconds of pure
+#   scan time. With the index each lookup is sub-millisecond.
+# - `rss_logs.updated_at` (#4176): the activity-feed sort key. With
+#   no index, every page load that hits the feed scans 1.98M rows to
+#   sort. With the index `ORDER BY updated_at DESC LIMIT N` walks the
+#   index backward.
+# - `rss_logs.observation_id` (#4176): the join key into observations
+#   used by the same activity-feed dedup logic. Without it the LEFT
+#   JOIN does a full row scan per matched rss_log.
+class AddIndexesForSlowQueries < ActiveRecord::Migration[7.2]
+  def change
+    add_index(:observation_images, :image_id,
+              name: "index_observation_images_on_image_id")
+    add_index(:rss_logs, :updated_at,
+              name: "index_rss_logs_on_updated_at")
+    add_index(:rss_logs, :observation_id,
+              name: "index_rss_logs_on_observation_id")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_24_170000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_27_180000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -515,6 +515,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_24_170000) do
     t.integer "image_id", default: 0, null: false
     t.integer "observation_id", default: 0, null: false
     t.integer "rank", default: 0, null: false
+    t.index ["image_id"], name: "index_observation_images_on_image_id"
     t.index ["observation_id"], name: "index_observation_images_on_observation_id"
   end
 
@@ -692,6 +693,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_24_170000) do
     t.integer "glossary_term_id"
     t.integer "article_id"
     t.datetime "created_at", precision: nil, null: false
+    t.index ["observation_id"], name: "index_rss_logs_on_observation_id"
+    t.index ["updated_at"], name: "index_rss_logs_on_updated_at"
   end
 
   create_table "sequences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
Fixes #4175 and #4176.

## Summary

Three missing indexes, found by digging into the MySQL slow query log during the 2026-04-27 outage analysis. Each closes a full-scan path on a 1.8M+ row table that was driving multi-second queries on the hot path.

## Why these matter

| Index | Used by | Slow log evidence |
|---|---|---|
| \`observation_images.image_id\` | UPDATE-with-JOIN for the touch propagation from an Image to its associated Observations | 9 captured UPDATEs, each examining 1,886,146 rows, ~2.5s each. With 9 images per observation create, ~22s pure scan time per request. |
| \`rss_logs.updated_at\` | The activity feed's \`ORDER BY rss_logs.updated_at DESC\` | 4.5s SELECT returning 700,354 rows scanning 1,978,507 |
| \`rss_logs.observation_id\` | The activity feed's LEFT JOIN to observations (used in the non-primary-occurrence dedup) | Same 4.5s query — JOIN was a row-by-row lookup |

The first one is the actual trigger of the 2026-04-27 cascade. A single observation create wedged a Puma worker for 2:40 because the touch propagation hit the unindexed JOIN nine times. The other two were contributing to general feed slowness and showed up in the same slow log window.

## EXPLAIN confirms the fix

Verified against a production-snapshot dev DB:

**Image-touch UPDATE:**
\`\`\`
| 1 | SIMPLE | observation_images | ref     | index_observation_images_on_image_id | image_id | 1 row |
| 1 | UPDATE | observations       | eq_ref  | PRIMARY                              | id       | 1 row |
\`\`\`
1 row instead of 1.88M.

**Activity-feed query (with LIMIT 50):**
\`\`\`
| 1 | SIMPLE | rss_logs     | index  | index_rss_logs_on_updated_at | Backward index scan | 50 rows |
| 1 | SIMPLE | observations | eq_ref | PRIMARY                      | id                  | 1 row   |
| 1 | SIMPLE | occurrences  | eq_ref | PRIMARY                      | id                  | 1 row   |
\`\`\`
50 rows examined instead of 1.98M.

## Migration timing

~1.5s total locally (~600K row \`observation_images\`, smaller \`rss_logs\`). Production index builds will take longer because the tables are bigger but should still finish in single-digit minutes. \`add_index\` in MySQL 8 doesn't lock the table for reads/writes (online DDL) so this is safe to run on a live database.

## Out of scope

The activity-feed query also has a complex \`NOT IN\` correlated subquery (the multi-occurrence dedup) that's structurally suspect. With these indexes the query should perform fine in practice; if it's still slow after deploy, we'll revisit. Tracked at the bottom of #4176.

The original 2026-04-27 outage analysis (#4175) also flagged four operational concerns that aren't fixed here — Puma worker count, async email fan-out from \`ObservationsController#create\`, slow-request alerting, and duplicate-resubmission protection. Those each warrant their own discussion; this PR is just the index fix that takes the immediate trigger off the table.

## Test plan

- [x] Rubocop clean
- [x] Migration runs cleanly locally on a production-snapshot dev DB (~1.5s total)
- [x] EXPLAIN confirms both queries now use the index path
- [ ] Production deploy: time the migration, confirm post-deploy that observation create with multiple images is fast and the activity feed page renders quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)