### PR TITLE
Expand Project constraint violations to four kinds (Fixes #4136)

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -774,6 +774,21 @@
   background-color: orange;
 }
 
+// Project violations page (#4136) — `button_to` renders each per-row
+// action as its own inline form, and the modal trigger is a plain
+// <button>. Adjacent elements touch by default; add a small gap on
+// both axes so the action buttons don't visually merge, including
+// when they wrap to a second line.
+.project-violations td .button_to,
+.project-violations td > button {
+  display: inline-block;
+  margin: 0 4px 4px 0;
+}
+.project-violations td .button_to:last-child,
+.project-violations td > button:last-child {
+  margin-right: 0;
+}
+
 .opacity-0 {
   opacity: 0 !important;
 }

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -782,6 +782,11 @@
 .project-violations td .button_to,
 .project-violations td > button {
   display: inline-block;
+  // `button_to` wraps its <button> in a <form>, while the modal
+  // trigger is a bare <button>. Without an explicit vertical-align
+  // their baselines differ and the last button sits half a line
+  // higher than its siblings.
+  vertical-align: top;
   margin: 0 4px 4px 0;
 }
 .project-violations td .button_to:last-child,

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -142,8 +142,14 @@ module Report
 
     # coordinateUncertaintyInMeters
     def coordinate_uncertainty(row)
-      if row.loc_id.present? &&
-         (row.obs_lat.blank? || gps_hidden?(row))
+      return if row.loc_id.blank?
+
+      if gps_hidden?(row)
+        return unless public_lat(row)
+
+        box = loc_box(row)
+        distance_to_farthest_corner(public_lat(row), public_lng(row), box)
+      elsif row.obs_lat.blank?
         distance_from_center_to_farthest_corner(row)
       end
     end
@@ -262,9 +268,22 @@ module Report
     end
 
     def add_gps_hidden!(rows, col)
-      ids = plain_query.where(gps_hidden: true).pluck(:id).to_set
-      vals = rows.map { |r| [r.obs_id, ids.include?(r.obs_id) ? "1" : nil] }
-      add_column!(rows, vals, col)
+      latlng_by_id = gps_hidden_latlng
+      rows.each { |row| set_gps_hidden_vals(row, col, latlng_by_id) }
+    end
+
+    def gps_hidden_latlng
+      plain_query.where(gps_hidden: true).
+        pluck(:id, :lat, :lng).
+        to_h { |id, lat, lng| [id, [lat, lng]] }
+    end
+
+    def set_gps_hidden_vals(row, col, latlng_by_id)
+      return unless (latlng = latlng_by_id[row.obs_id])
+
+      row.add_val("1", col)
+      row.add_val(latlng[0]&.round, col + 1)
+      row.add_val(latlng[1]&.round, col + 2)
     end
 
     def information_withheld(row)
@@ -274,31 +293,11 @@ module Report
     end
 
     def public_lat(row)
-      return loc_center_lat(row) if gps_hidden?(row)
-
-      row.best_lat
+      gps_hidden?(row) ? row.val(5) : row.best_lat
     end
 
     def public_lng(row)
-      return loc_center_lng(row) if gps_hidden?(row)
-
-      row.best_lng
-    end
-
-    def loc_center_lat(row)
-      north = row.loc_north(14)
-      south = row.loc_south(14)
-      return nil unless north && south
-
-      ((north + south) / 2).round(4)
-    end
-
-    def loc_center_lng(row)
-      east = row.loc_east(14)
-      west = row.loc_west(14)
-      return nil unless east && west
-
-      ((east + west) / 2).round(4)
+      gps_hidden?(row) ? row.val(6) : row.best_lng
     end
 
     def explode_notes(row)

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -145,10 +145,10 @@ module Report
       return if row.loc_id.blank?
 
       if gps_hidden?(row)
-        return unless public_lat(row)
+        return unless public_lat(row) && public_lng(row)
 
         box = loc_box(row)
-        distance_to_farthest_corner(public_lat(row), public_lng(row), box)
+        max_distance_to_any_corner(public_lat(row), public_lng(row), box)
       elsif row.obs_lat.blank?
         distance_from_center_to_farthest_corner(row)
       end
@@ -265,6 +265,17 @@ module Report
 
     def distance_to_se_corner(lat, lng, box)
       Haversine.distance(lat, lng, box.south, box.east).to_meters.round
+    end
+
+    def max_distance_to_any_corner(lat, lng, box)
+      box_corners(box).map do |clat, clng|
+        Haversine.distance(lat, lng, clat, clng).to_meters
+      end.max.round
+    end
+
+    def box_corners(box)
+      [[box.north, box.east], [box.north, box.west],
+       [box.south, box.east], [box.south, box.west]]
     end
 
     def add_gps_hidden!(rows, col)

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -13,6 +13,7 @@ require "haversine"
 module Report
   class Mycoportal < CSV
     CODE_NAME_QUALIFIER = "code name aff. species"
+    GPS_HIDDEN_MESSAGE = "Coordinates obscured by observer"
 
     # MCP uses Symbiota, which is largely based on Darwin Core (DwC).
     # Label names for the columns in the report.
@@ -44,6 +45,7 @@ module Report
         "decimalLatitude",
         "decimalLongitude",
         "coordinateUncertaintyInMeters",
+        "informationWithheld",
         "minimumElevationInMeters",
         "maximumElevationInMeters",
         "disposition" # herbaria, "vouchered", or nil
@@ -69,9 +71,10 @@ module Report
         row.state, # stateProvince
         row.county, # county
         row.locality, # locality
-        row.best_lat, # decimalLatitude
-        row.best_lng, # decimalLongitude
+        public_lat(row), # decimalLatitude
+        public_lng(row), # decimalLongitude
         coordinate_uncertainty(row), # coordinateUncertaintyInMeters
+        information_withheld(row), # informationWithheld
         row.best_low, # minimumElevationInMeters
         row.best_high, # maximumElevationInMeters
         disposition(row) # disposition
@@ -140,7 +143,7 @@ module Report
     # coordinateUncertaintyInMeters
     def coordinate_uncertainty(row)
       if row.loc_id.present? &&
-         row.obs_lat.blank?
+         (row.obs_lat.blank? || gps_hidden?(row))
         distance_from_center_to_farthest_corner(row)
       end
     end
@@ -166,6 +169,7 @@ module Report
       add_collector_ids!(rows, 1)
       add_herbarium_accession_numbers!(rows, 2)
       add_sequence_ids!(rows, 3)
+      add_gps_hidden!(rows, 4)
     end
 
     def collector_ids(row)
@@ -178,6 +182,10 @@ module Report
 
     def sequence_ids(row)
       row.val(3)
+    end
+
+    def gps_hidden?(row)
+      row.val(4).present?
     end
 
     def sort_before(rows)
@@ -251,6 +259,46 @@ module Report
 
     def distance_to_se_corner(lat, lng, box)
       Haversine.distance(lat, lng, box.south, box.east).to_meters.round
+    end
+
+    def add_gps_hidden!(rows, col)
+      ids = plain_query.where(gps_hidden: true).pluck(:id).to_set
+      vals = rows.map { |r| [r.obs_id, ids.include?(r.obs_id) ? "1" : nil] }
+      add_column!(rows, vals, col)
+    end
+
+    def information_withheld(row)
+      return unless gps_hidden?(row)
+
+      GPS_HIDDEN_MESSAGE
+    end
+
+    def public_lat(row)
+      return loc_center_lat(row) if gps_hidden?(row)
+
+      row.best_lat
+    end
+
+    def public_lng(row)
+      return loc_center_lng(row) if gps_hidden?(row)
+
+      row.best_lng
+    end
+
+    def loc_center_lat(row)
+      north = row.loc_north(14)
+      south = row.loc_south(14)
+      return nil unless north && south
+
+      ((north + south) / 2).round(4)
+    end
+
+    def loc_center_lng(row)
+      east = row.loc_east(14)
+      west = row.loc_west(14)
+      return nil unless east && west
+
+      ((east + west) / 2).round(4)
     end
 
     def explode_notes(row)

--- a/app/components/observation_form_projects.rb
+++ b/app/components/observation_form_projects.rb
@@ -76,19 +76,25 @@ class Components::ObservationFormProjects < Components::Base
 
   def render_constraint_alert(level, projects, help_text)
     render(Components::Alert.new(level: level)) do
-      div do
-        plain("#{:form_observations_projects_out_of_range.t(
-          date: @observation.when,
-          place_name: @observation.place_name
-        )}:")
-      end
+      div { plain("#{:form_observations_projects_out_of_range.t}:") }
       ul do
         projects.each do |proj|
-          li { "#{proj.title} (#{proj.constraints})" }
+          li { "#{proj.title} (#{constraint_kind_labels(proj)})" }
         end
       end
       p { help_text }
     end
+  end
+
+  # Joined, localized kind labels for the violations this observation
+  # incurs against `proj` (Non-target name; Out-of-range date; etc.).
+  # Replaces the old `proj.constraints` rendering, which surfaced the
+  # project's date/location *settings* — useless when those are blank
+  # but the observation fails on target_name / target_location.
+  def constraint_kind_labels(proj)
+    proj.violation_kinds_for(@observation).map do |kind|
+      :"form_observations_projects_kind_#{kind}".l
+    end.join("; ")
   end
 
   def render_ignore_checkbox(project_ns)

--- a/app/components/project_violations_form.rb
+++ b/app/components/project_violations_form.rb
@@ -61,7 +61,6 @@ class Components::ProjectViolationsForm < Components::Base
       thead do
         tr do
           th { :form_violations_th_name.l }
-          th { :form_violations_th_kinds.l }
           th { :form_violations_th_details.l }
           th { :form_violations_th_actions.l }
         end
@@ -77,7 +76,6 @@ class Components::ProjectViolationsForm < Components::Base
     kinds = violation.kinds
     tr do
       td { render_obs_link(obs) }
-      td { render_kinds(kinds) }
       td { render_details(obs, kinds) }
       td { render_actions(obs, kinds) }
     end
@@ -86,13 +84,6 @@ class Components::ProjectViolationsForm < Components::Base
   def render_obs_link(obs)
     link_to_object(obs, obs.text_name)
     plain(" (#{obs.id})")
-  end
-
-  def render_kinds(kinds)
-    kinds.each do |kind|
-      span(class: "label label-warning") { kind_label(kind) }
-      plain(" ")
-    end
   end
 
   def kind_label(kind)

--- a/app/components/project_violations_form.rb
+++ b/app/components/project_violations_form.rb
@@ -303,10 +303,19 @@ class Components::ProjectViolationsForm < Components::Base
     suffixes.reject { |s| Location.understood_countries.include?(s) }
   end
 
+  # Returns progressively-shorter trailing slices of a comma-separated
+  # location name, including the full name itself. So
+  # "Berkeley, Alameda Co., California, USA" yields four candidates,
+  # and "California, USA" yields two ("California, USA" and "USA"); the
+  # bare-country entries are filtered out by the caller. JoeCohen review
+  # on PR #4182: the full obs location name itself is a valid target
+  # candidate (e.g. for state- or national-park-level locations like
+  # "California, USA" or "Great Smoky Mountain National Park, USA"), so
+  # the previous "(1..)" range that omitted the full name was wrong.
   def comma_suffixes(name)
     parts = name.split(",").map(&:strip).reject(&:empty?)
-    return [] if parts.length < 2
+    return [] if parts.empty?
 
-    (1..(parts.length - 1)).map { |i| parts[i..].join(", ") }
+    (0..(parts.length - 1)).map { |i| parts[i..].join(", ") }
   end
 end

--- a/app/components/project_violations_form.rb
+++ b/app/components/project_violations_form.rb
@@ -1,91 +1,86 @@
 # frozen_string_literal: true
 
-# Form for viewing and removing project constraint violations.
-# Renders a table of non-compliant observations with checkboxes
-# for removal by authorized users.
-class Components::ProjectViolationsForm < Components::ApplicationForm
-  def initialize(model, violations:, user:, **)
-    @violations = violations
-    @user = user
-    super(model, id: "project_violations_form", method: :put, **)
-  end
+# One row per violating observation (#4136). Each row shows the obs's
+# name, the kinds of violation that apply, the relevant detail
+# (date / lat,lng / location), and per-kind action buttons keyed
+# off `Project::VIOLATION_KINDS`:
+#
+#   :date              - obs.when outside project.start_date / end_date
+#                        Action: Exclude, Extend
+#   :bbox              - obs's GPS / location not contained in
+#                        project.location's bbox
+#                        Action: Exclude (no auto-widen of project bbox)
+#   :target_name       - project has target_names but obs.name is not in
+#                        the expansion (synonyms + sub-taxa)
+#                        Action: Exclude, Add Target Name
+#   :target_location   - project has target_locations but no comma-suffix
+#                        of obs.location.name (or obs.where) matches
+#                        Action: Exclude, Add Target Location (modal)
+#
+# Exclude is offered to admins and the obs's own user. The other
+# actions are admin-only because they mutate project-level config.
+class Components::ProjectViolationsForm < Components::Base
+  register_value_helper :form_authenticity_token
+
+  prop :project, Project
+  prop :violations, _Array(Project::Violation)
+  prop :user, User
 
   def view_template
     h4 do
       trusted_html("#{:PROJECT.l}: ")
-      link_to_object(model)
+      link_to_object(@project)
     end
-    super do
-      render_help_text
-      render_violations_table
-      submit(submit_text)
-    end
-  end
 
-  def form_action
-    project_violations_update_path(project_id: model.id)
+    if @violations.empty?
+      p { :form_violations_no_violations.l }
+      return
+    end
+
+    help_block(:div, :form_violations_help.l)
+    render_violations_table
+    render_location_modals
   end
 
   private
 
-  def violations_removable?
-    @violations_removable ||=
-      model.violations_removable_by_current_user?(@user)
+  def admin?
+    @admin ||= @project.is_admin?(@user)
   end
 
-  def render_help_text
-    return unless violations_removable?
-
-    help_block(:div, :form_violations_help.l)
+  def can_exclude?(obs)
+    admin? || obs.user_id == @user.id
   end
 
-  def submit_text
-    if violations_removable?
-      :form_violations_remove_selected.l
-    else
-      :form_violations_show_project.l
-    end
+  def violations_path
+    project_violations_update_path(project_id: @project.id)
   end
 
   def render_violations_table
-    Table(@violations) do |t|
-      define_columns(t)
+    table(class: "table table-striped project-violations") do
+      thead do
+        tr do
+          th { :form_violations_th_name.l }
+          th { :form_violations_th_kinds.l }
+          th { :form_violations_th_details.l }
+          th { :form_violations_th_actions.l }
+        end
+      end
+      tbody do
+        @violations.each { |v| render_row(v) }
+      end
     end
   end
 
-  def define_columns(tbl)
-    tbl.column(nil) { |obs| render_checkbox(obs) }
-    tbl.column("#{:CONSTRAINTS.l}:") do |obs|
-      render_obs_link(obs)
+  def render_row(violation)
+    obs = violation.obs
+    kinds = violation.kinds
+    tr do
+      td { render_obs_link(obs) }
+      td { render_kinds(kinds) }
+      td { render_details(obs, kinds) }
+      td { render_actions(obs, kinds) }
     end
-    tbl.column("#{:DATES.l}: #{model.date_range}") do |obs|
-      styled_obs_when(obs)
-    end
-    define_location_columns(tbl)
-    tbl.column(nil) { |obs| user_link(obs.user) }
-  end
-
-  def define_location_columns(tbl)
-    tbl.column(latitude_header) do |obs|
-      styled_obs_lat(obs)
-    end
-    tbl.column(longitude_header) do |obs|
-      styled_obs_lng(obs)
-    end
-    tbl.column(location_header) do |obs|
-      styled_obs_where(obs)
-    end
-  end
-
-  def render_checkbox(obs)
-    return unless can_remove?(obs)
-
-    checkbox_field("remove_#{obs.id}", label: false)
-  end
-
-  def can_remove?(obs)
-    (model.admin_group_user_ids + [obs.user_id]).
-      include?(@user.id)
   end
 
   def render_obs_link(obs)
@@ -93,93 +88,222 @@ class Components::ProjectViolationsForm < Components::ApplicationForm
     plain(" (#{obs.id})")
   end
 
-  # Column headers
-
-  def latitude_header
-    return :form_violations_latitude_none.l unless model.location
-
-    "Lat: #{model.location.north} to #{model.location.south}"
-  end
-
-  def longitude_header
-    return :form_violations_longitude_none.l unless model.location
-
-    "Lon: #{model.location.west} to #{model.location.east}"
-  end
-
-  def location_header
-    return :form_violations_location_none.t unless model.location
-
-    # Capture output helper result as string (location_link
-    # is an output helper that writes directly to buffer).
-    capture do
-      location_link(
-        model.location.display_name, model.location,
-        nil, false
-      )
+  def render_kinds(kinds)
+    kinds.each do |kind|
+      span(class: "label label-warning") { kind_label(kind) }
+      plain(" ")
     end
   end
 
-  # Styled cell methods
+  def kind_label(kind)
+    :"form_violations_kind_#{kind}".l
+  end
 
-  def styled_obs_when(obs)
-    if model.violates_date_range?(obs)
-      span(class: "violation-highlight") { obs.when.to_s }
-    else
-      plain(obs.when.to_s)
+  def render_details(obs, kinds)
+    parts = kinds.filter_map { |k| detail_for(obs, k) }
+    parts.each_with_index do |line, i|
+      br if i.positive?
+      plain(line)
     end
   end
 
-  def styled_obs_lat(obs)
-    return if obs.lat.blank?
+  def detail_for(obs, kind)
+    case kind
+    when :date
+      "#{kind_label(:date)}: #{obs.when} (#{@project.date_range})"
+    when :bbox
+      bbox_detail(obs)
+    when :target_name
+      "#{kind_label(:target_name)}: #{obs.text_name}"
+    when :target_location
+      "#{kind_label(:target_location)}: #{obs_where(obs)}"
+    end
+  end
 
-    displayed = coord_or_hidden(obs, obs.lat)
-    if model.location_id.nil? ||
-       model.location.contains_lat?(obs.lat)
-      trusted_html(displayed.to_s)
+  def bbox_detail(obs)
+    if obs.lat.present?
+      "#{kind_label(:bbox)}: #{obs.lat}, #{obs.lng}"
     else
-      span(class: "violation-highlight") do
-        trusted_html(displayed.to_s)
+      "#{kind_label(:bbox)}: #{obs_where(obs)}"
+    end
+  end
+
+  def obs_where(obs)
+    obs.location_id ? obs.location&.name : obs.where
+  end
+
+  def render_actions(obs, kinds)
+    render_exclude_button(obs) if can_exclude?(obs)
+    return unless admin?
+
+    render_extend_button(obs) if kinds.include?(:date)
+    render_add_target_name_button(obs) if kinds.include?(:target_name)
+    render_add_target_location_trigger(obs) if kinds.include?(:target_location)
+  end
+
+  def render_exclude_button(obs)
+    button_to(
+      :form_violations_action_exclude.l, violations_path,
+      method: :put, class: "btn btn-default btn-xs",
+      params: { do: "exclude", obs_id: obs.id }
+    )
+  end
+
+  def render_extend_button(obs)
+    button_to(
+      :form_violations_action_extend.l, violations_path,
+      method: :put, class: "btn btn-default btn-xs",
+      params: { do: "extend", obs_id: obs.id }
+    )
+  end
+
+  def render_add_target_name_button(obs)
+    button_to(
+      :form_violations_action_add_target_name.l, violations_path,
+      method: :put, class: "btn btn-default btn-xs",
+      params: { do: "add_target_name", obs_id: obs.id }
+    )
+  end
+
+  def render_add_target_location_trigger(obs)
+    button(
+      type: "button",
+      class: "btn btn-default btn-xs",
+      data: {
+        toggle: "modal",
+        target: "##{location_modal_id(obs)}"
+      }
+    ) { :form_violations_action_add_target_location.l }
+  end
+
+  def render_location_modals
+    @violations.each do |v|
+      next unless admin? && v.kinds.include?(:target_location)
+
+      render_location_modal(v.obs)
+    end
+  end
+
+  def render_location_modal(obs)
+    div(
+      class: "modal fade",
+      id: location_modal_id(obs),
+      tabindex: "-1",
+      role: "dialog",
+      aria: { labelledby: "#{location_modal_id(obs)}_label" }
+    ) do
+      div(class: "modal-dialog", role: "document") do
+        div(class: "modal-content") do
+          render_location_modal_header(obs)
+          render_location_modal_body(obs)
+        end
       end
     end
   end
 
-  def styled_obs_lng(obs)
-    return if obs.lng.blank?
-
-    displayed = coord_or_hidden(obs, obs.lng)
-    if model.location_id.nil? ||
-       model.location.contains_lng?(obs.lng)
-      trusted_html(displayed.to_s)
-    else
-      span(class: "violation-highlight") do
-        trusted_html(displayed.to_s)
+  def render_location_modal_header(obs)
+    div(class: "modal-header") do
+      button(
+        type: "button", class: "close",
+        data: { dismiss: "modal" }, aria: { label: :CLOSE.l }
+      ) do
+        span(aria: { hidden: "true" }) { "×" }
+      end
+      h4(class: "modal-title", id: "#{location_modal_id(obs)}_label") do
+        plain(:form_violations_modal_target_location_title.l)
       end
     end
   end
 
-  def coord_or_hidden(obs, coord)
-    if !obs.gps_hidden? ||
-       @user == obs.user ||
-       model.trusted_by?(@user) && model.admin?(@user)
-      coord
+  def render_location_modal_body(obs)
+    suffixes = location_suffixes_for(obs)
+    if suffixes.empty?
+      div(class: "modal-body") do
+        p { :form_violations_modal_target_location_no_suffixes.l }
+      end
+      div(class: "modal-footer") do
+        button(
+          type: "button", class: "btn btn-default",
+          data: { dismiss: "modal" }
+        ) { :CANCEL.l }
+      end
     else
-      :hidden.l
+      render_suffix_form(obs, suffixes)
     end
   end
 
-  def styled_obs_where(obs)
-    # Capture output helper result as string (location_link
-    # is an output helper that writes directly to buffer).
-    loc_html = capture do
-      location_link(obs.place_name, obs.location, nil, false)
+  def render_suffix_form(obs, suffixes)
+    form(method: "post", action: violations_path) do
+      render_csrf_and_method
+      input(type: "hidden", name: "do", value: "add_target_location")
+      input(type: "hidden", name: "obs_id", value: obs.id)
+      div(class: "modal-body") { render_suffix_radios(obs, suffixes) }
+      render_modal_footer
     end
-    if obs.lat.present? || model&.location&.found_here?(obs)
-      trusted_html(loc_html)
-    else
-      span(class: "violation-highlight") do
-        trusted_html(loc_html)
+  end
+
+  def render_modal_footer
+    div(class: "modal-footer") do
+      button(
+        type: "submit", class: "btn btn-primary"
+      ) { :form_violations_modal_target_location_submit.l }
+      button(
+        type: "button", class: "btn btn-default",
+        data: { dismiss: "modal" }
+      ) { :CANCEL.l }
+    end
+  end
+
+  def render_suffix_radios(obs, suffixes)
+    p { :form_violations_modal_target_location_help.l }
+    suffixes.each_with_index do |suffix, i|
+      div(class: "radio") { render_suffix_choice(obs, suffix, i) }
+    end
+  end
+
+  def render_suffix_choice(_obs, suffix, index)
+    existing = Location.find_by(name: suffix)
+    label do
+      if existing
+        input(type: "radio", name: "location_id",
+              value: existing.id, checked: index.zero?)
+        plain(" #{suffix}")
+      else
+        input(type: "radio", name: "location_id", disabled: true)
+        plain(" #{suffix} ")
+        a(
+          href: new_location_path(display_name: suffix),
+          target: "_blank", rel: "noopener",
+          class: "btn btn-default btn-xs"
+        ) { :form_violations_modal_target_location_create.l }
       end
     end
+  end
+
+  def render_csrf_and_method
+    input(type: "hidden", name: "_method", value: "put")
+    input(type: "hidden", name: "authenticity_token",
+          value: form_authenticity_token)
+  end
+
+  def location_modal_id(obs)
+    "location_target_modal_#{obs.id}"
+  end
+
+  # Return the comma-suffixes of the obs's location (or where), excluding
+  # any suffix that is a bare country name (Q3 of #4136 design).
+  def location_suffixes_for(obs)
+    name = obs.location_id ? obs.location&.name : obs.where
+    return [] if name.blank?
+
+    suffixes = comma_suffixes(name)
+    suffixes.reject { |s| Location.understood_countries.include?(s) }
+  end
+
+  def comma_suffixes(name)
+    parts = name.split(",").map(&:strip).reject(&:empty?)
+    return [] if parts.length < 2
+
+    (1..(parts.length - 1)).map { |i| parts[i..].join(", ") }
   end
 end

--- a/app/components/project_violations_form.rb
+++ b/app/components/project_violations_form.rb
@@ -224,11 +224,22 @@ class Components::ProjectViolationsForm < Components::Base
   end
 
   def render_suffix_form(obs, suffixes)
+    # Batch-load every Location whose name matches one of this modal's
+    # suffixes in a single query, instead of issuing one query per
+    # suffix inside `render_suffix_choice` (Copilot review on PR #4182).
+    existing = Location.where(name: suffixes).index_by(&:name)
+    # Pre-check the first suffix that has a Location, not the first
+    # suffix overall — otherwise a modal whose most-specific suffix is
+    # missing renders with no enabled radio selected by default and
+    # silent submit becomes a no-op (Copilot review on PR #4182).
+    first_existing = suffixes.find { |s| existing.key?(s) }
     form(method: "post", action: violations_path) do
       render_csrf_and_method
       input(type: "hidden", name: "do", value: "add_target_location")
       input(type: "hidden", name: "obs_id", value: obs.id)
-      div(class: "modal-body") { render_suffix_radios(obs, suffixes) }
+      div(class: "modal-body") do
+        render_suffix_radios(suffixes, existing, first_existing)
+      end
       render_modal_footer
     end
   end
@@ -245,19 +256,20 @@ class Components::ProjectViolationsForm < Components::Base
     end
   end
 
-  def render_suffix_radios(obs, suffixes)
+  def render_suffix_radios(suffixes, existing, first_existing)
     p { :form_violations_modal_target_location_help.l }
-    suffixes.each_with_index do |suffix, i|
-      div(class: "radio") { render_suffix_choice(obs, suffix, i) }
+    suffixes.each do |suffix|
+      div(class: "radio") do
+        render_suffix_choice(suffix, existing[suffix], first_existing == suffix)
+      end
     end
   end
 
-  def render_suffix_choice(_obs, suffix, index)
-    existing = Location.find_by(name: suffix)
+  def render_suffix_choice(suffix, location, checked)
     label do
-      if existing
+      if location
         input(type: "radio", name: "location_id",
-              value: existing.id, checked: index.zero?)
+              value: location.id, checked: checked)
         plain(" #{suffix}")
       else
         input(type: "radio", name: "location_id", disabled: true)

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -111,7 +111,7 @@ module Projects
         format.turbo_stream do
           render(
             partial: "projects/updates/footer_update",
-            locals: { project: @project, obs: obs,
+            locals: { project: @project, user: @user, obs: obs,
                       count_label: count_label_for_current_scope }
           )
         end

--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -25,9 +25,9 @@ module Projects
     end
 
     def update
-      return unless find_or_goto_index(Project, params[:project_id])
+      @project = find_or_goto_index(Project, params[:project_id])
+      return unless @project
 
-      @project = Project.find(params[:project_id])
       dispatch_action
 
       redirect_to(project_violations_path(project_id: @project.id))
@@ -35,8 +35,12 @@ module Projects
 
     private
 
+    # Eager-loaded variant of `find_or_goto_index` for the index
+    # action, which renders the full violations list. `find_by`
+    # returns nil rather than raising, so the `||` fallback fires
+    # cleanly on a missing id.
     def find_project!
-      @project = Project.violations_includes.find(params[:project_id]) ||
+      @project = Project.violations_includes.find_by(id: params[:project_id]) ||
                  flash_error_and_goto_index(Project, params[:project_id])
     end
 

--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-# Show and remove non-compliant Observations from a Project
+# Show and manage Project constraint violations.
+#
+# Per #4136, the violations page lists every observation that fails one
+# or more of the project's four constraints (date, bbox, target name,
+# target location) and offers per-row actions to bring it into
+# compliance: Exclude (always), Extend dates (date kind), Add Target
+# Name (target_name kind), Add Target Location (target_location kind).
 module Projects
-  # Actions
-  # -------
-  # index (get)
-  # edit (get)
-  # update (patch)
-  #
   class ViolationsController < ApplicationController
     before_action :login_required
     # Cannot figure out the eager loading here.
@@ -25,18 +25,12 @@ module Projects
     end
 
     def update
-      unless (@project = find_or_goto_index(Project, params[:project_id]))
-        return
-      end
+      return unless find_or_goto_index(Project, params[:project_id])
 
-      params[:project]&.each do |key, value|
-        next unless key =~ /|remove_\d+$/ && value == "1"
+      @project = Project.find(params[:project_id])
+      dispatch_action
 
-        obs_id = key.sub("remove_", "")
-        remove_observation_if_permitted(obs_id)
-      end
-
-      redirect_to(project_path(@project))
+      redirect_to(project_violations_path(project_id: @project.id))
     end
 
     private
@@ -44,6 +38,62 @@ module Projects
     def find_project!
       @project = Project.violations_includes.find(params[:project_id]) ||
                  flash_error_and_goto_index(Project, params[:project_id])
+    end
+
+    def dispatch_action
+      case params[:do]
+      when "exclude" then handle_exclude
+      when "extend" then handle_extend
+      when "add_target_name" then handle_add_target_name
+      when "add_target_location" then handle_add_target_location
+      else handle_legacy_remove_selected
+      end
+    end
+
+    def handle_exclude
+      obs = Observation.safe_find(params[:obs_id])
+      return unless obs && permitted_to_exclude?(obs)
+
+      @project.exclude_observation(obs)
+    end
+
+    def handle_extend
+      return unless admin?
+
+      obs = Observation.safe_find(params[:obs_id])
+      return unless obs&.when
+
+      extend_project_dates_to_include(obs.when)
+    end
+
+    def handle_add_target_name
+      return unless admin?
+
+      obs = Observation.safe_find(params[:obs_id])
+      name = obs&.name
+      return unless name
+
+      @project.add_target_name(name)
+    end
+
+    def handle_add_target_location
+      return unless admin?
+
+      location = Location.safe_find(params[:location_id])
+      return unless location
+
+      @project.add_target_location(location)
+    end
+
+    # Back-compat: the old "Remove Selected" form sent
+    # params[:project][:remove_<id>] = "1" with no `do` param.
+    def handle_legacy_remove_selected
+      params[:project]&.each do |key, value|
+        next unless key =~ /\Aremove_\d+\z/ && value == "1"
+
+        obs_id = key.sub("remove_", "")
+        remove_observation_if_permitted(obs_id)
+      end
     end
 
     def remove_observation_if_permitted(obs_id)
@@ -54,6 +104,25 @@ module Projects
       return unless permitted_removers.include?(@user.id)
 
       @project.remove_observations([obs])
+    end
+
+    def admin?
+      @project.is_admin?(@user)
+    end
+
+    def permitted_to_exclude?(obs)
+      admin? || obs.user_id == @user.id
+    end
+
+    def extend_project_dates_to_include(date)
+      changes = {}
+      if @project.start_date && date < @project.start_date
+        changes[:start_date] = date
+      end
+      changes[:end_date] = date if @project.end_date && date > @project.end_date
+      return if changes.empty?
+
+      @project.update!(changes)
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -165,7 +165,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   }
   scope :violations_includes, lambda {
     strict_loading.includes(
-      { observations: [:location, :user] }
+      { observations: [:location, :name, :user] },
+      :target_names, :target_locations
     )
   }
 
@@ -247,9 +248,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def count_violations
-    return out_of_range_observations.count unless location
-
-    out_of_range_observations.to_a.union(out_of_area_observations).size
+    violations.size
   end
 
   def constraints
@@ -257,7 +256,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def constraints?
-    start_date || end_date || location
+    start_date || end_date || location ||
+      target_names.any? || target_locations.any?
   end
 
   # Check if user has permission to edit a given object.
@@ -524,9 +524,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     project_target_names.any? || project_target_locations.any?
   end
 
-  # Observations matching target names (with synonyms) AND within
-  # target locations. When only one type of target is set, matches
-  # on that alone.
+  # Observations matching target names (with synonyms / sub-taxa)
+  # AND within target locations, then further constrained by the
+  # project's date range and (when set) bounding box. When only one
+  # kind of target is set, matches on that alone. The date and bbox
+  # filters mirror the violations-page rule so an obs is a candidate
+  # iff it would NOT be a violation if added.
   def candidate_observations
     name_ids = candidate_name_ids
     loc_ids = candidate_location_ids
@@ -540,7 +543,34 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
             else
               Observation.where(id: loc_ids)
             end
+    scope = constrain_to_project_date_range(scope)
+    scope = constrain_to_project_bbox(scope)
     scope.order(created_at: :desc)
+  end
+
+  # GPS-inside-bbox OR (no GPS AND obs.location bbox is fully
+  # contained in project bbox). Mirrors out_of_area_observations'
+  # inverse so candidate_observations and the bbox violation kind
+  # agree on what "in" means.
+  def constrain_to_project_bbox(scope)
+    return scope if location.nil?
+
+    box_kwargs = location.bounding_box
+    m_box = Mappable::Box.new(**box_kwargs)
+    return scope unless m_box.valid?
+
+    gps_in_ids = Observation.gps_in_box(m_box).select(:id)
+    no_gps_in_ids = Observation.where(lat: nil).joins(:location).
+                    merge(Location.in_box(**box_kwargs)).select(:id)
+    scope.where(id: gps_in_ids).or(scope.where(id: no_gps_in_ids))
+  end
+
+  def constrain_to_project_date_range(scope)
+    return scope if start_date.nil? && end_date.nil?
+    return scope.where(Observation[:when].lteq(end_date)) if start_date.nil?
+    return scope.where(Observation[:when].gteq(start_date)) if end_date.nil?
+
+    scope.where(Observation[:when].between(start_date..end_date))
   end
 
   private
@@ -705,13 +735,42 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     observations.where(name:).count
   end
 
+  VIOLATION_KINDS = [:date, :bbox, :target_name, :target_location].freeze
+
+  # One entry per offending observation, with the set of violation
+  # kinds that apply. Sorted alphabetically by obs.name.sort_name so
+  # repeated runs render in a stable order. (Each violation Struct is
+  # `[obs, kinds]`, where `kinds` is a subset of VIOLATION_KINDS.)
+  Violation = Struct.new(:obs, :kinds)
+
   def violations
-    out_of_range_observations.to_a.union(out_of_area_observations)
+    return [] unless constraints?
+
+    rows = visible_observations.includes(:name, :location).
+           filter_map do |obs|
+      kinds = violation_kinds_for(obs)
+      next if kinds.empty?
+
+      Violation.new(obs, kinds)
+    end
+    rows.sort_by { |v| v.obs.name&.sort_name.to_s.downcase }
+  end
+
+  # Returns the kinds of violation that apply to the given observation
+  # (subset of VIOLATION_KINDS). Empty if the observation passes all
+  # configured constraints.
+  def violation_kinds_for(observation)
+    kinds = []
+    kinds << :date if violates_date_range?(observation)
+    kinds << :bbox if violates_location?(observation)
+    kinds << :target_name if violates_target_name?(observation)
+    kinds << :target_location if violates_target_location?(observation)
+    kinds
   end
 
   # Is at least one violation removable by the given user?
   def violations_removable_by_current_user?(user)
-    user_ids = violations.map(&:user_id)
+    user_ids = violations.map { |v| v.obs.user_id }
     return false unless user_ids.any?
 
     admin_group_user_ids.union(user_ids).include?(user.id)
@@ -766,8 +825,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def violates_constraints?(observation)
-    violates_location?(observation) ||
-      violates_date_range?(observation)
+    violation_kinds_for(observation).any?
   end
 
   def violates_location?(observation)
@@ -777,7 +835,49 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def violates_date_range?(observation)
+    return false if start_date.nil? && end_date.nil?
+
     !(start_date..end_date).cover?(observation.when)
+  end
+
+  # Target-name violation: project has a non-empty target_names list
+  # AND the observation's name (with synonyms and sub-taxa expansion,
+  # matching candidate_observations) is not in it.
+  def violates_target_name?(observation)
+    return false unless target_names.any?
+
+    expanded_target_name_id_set.exclude?(observation.name_id)
+  end
+
+  # Target-location violation: project has a non-empty target_locations
+  # list AND no target's name is a comma-suffix (or exact) match of
+  # the obs's location name (or `where`, when there's no location).
+  # GPS overlap with a target_location does NOT satisfy the rule.
+  def violates_target_location?(observation)
+    return false unless target_locations.any?
+
+    !target_location_suffix_match?(observation)
+  end
+
+  def target_location_suffix_match?(observation)
+    name = if observation.location_id
+             observation.location&.name
+           else
+             observation.where
+           end
+    return false if name.blank?
+
+    target_locations.any? do |tl|
+      name == tl.name || name.end_with?(", #{tl.name}")
+    end
+  end
+
+  # Memoized: project's target_names with synonyms + sub-taxa expanded
+  # into a Set of name_ids, matching the candidate_observations rule.
+  # Used by violates_target_name? as a per-obs membership test.
+  def expanded_target_name_id_set
+    @expanded_target_name_id_set ||=
+      expanded_target_name_ids(target_name_ids).to_set
   end
 
   def trackers

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -247,8 +247,22 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     obs.user == user || member?(user)
   end
 
+  # SQL-based count over the four violation kinds (#4136). Each branch
+  # plucks ids of OFFENDING observations and merges them into a Set
+  # for dedup; total cost is O(violations) rather than the
+  # O(visible_observations) cost of the full Ruby iteration in
+  # `#violations`. Called from the projects index
+  # (Tabs::ProjectsHelper#violations_button), so any per-project
+  # work multiplies by the number of projects rendered.
   def count_violations
-    violations.size
+    return 0 unless constraints?
+
+    ids = Set.new
+    collect_date_violation_ids(ids)
+    collect_bbox_violation_ids(ids)
+    collect_target_name_violation_ids(ids)
+    collect_target_location_violation_ids(ids)
+    ids.size
   end
 
   def constraints
@@ -612,6 +626,57 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     end.reduce(:or)
   end
 
+  # Same shape as `location_suffix_conditions` but against
+  # `observations.where` (used when an obs has no location_id).
+  def where_suffix_conditions
+    tbl = Observation.arel_table
+    target_locations.map do |tl|
+      escaped = self.class.sanitize_sql_like(tl.name)
+      tbl[:where].matches("%, #{escaped}").
+        or(tbl[:where].eq(tl.name))
+    end.reduce(:or)
+  end
+
+  # ----- helpers for SQL-based count_violations (#4136) -----
+
+  def collect_date_violation_ids(ids)
+    return unless start_date || end_date
+
+    ids.merge(out_of_range_observations.ids)
+  end
+
+  def collect_bbox_violation_ids(ids)
+    return unless location
+
+    ids.merge(obs_geoloc_outside_project_location.ids)
+    ids.merge(obs_without_geoloc_location_not_contained_in_location.ids)
+  end
+
+  def collect_target_name_violation_ids(ids)
+    return unless target_names.any?
+
+    ids.merge(
+      visible_observations.
+        where.not(name_id: expanded_target_name_id_set.to_a).ids
+    )
+  end
+
+  def collect_target_location_violation_ids(ids)
+    return unless target_locations.any?
+
+    passing = passing_target_location_ids
+    ids.merge(visible_observations.where.not(id: passing).ids)
+  end
+
+  def passing_target_location_ids
+    with_loc = visible_observations.joins(:location).
+               where(location_suffix_conditions).
+               pluck("observations.id")
+    without_loc = visible_observations.where(location_id: nil).
+                  where(where_suffix_conditions).pluck(:id)
+    (with_loc + without_loc).uniq
+  end
+
   public
 
   delegate :count, to: :candidate_observations, prefix: true
@@ -834,6 +899,11 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     !location.found_here?(observation)
   end
 
+  # Ruby 3.4 (and 3.0+) handles beginless/endless ranges in
+  # `Range#cover?` correctly — `(start..nil).cover?(date)`,
+  # `(nil..end).cover?(date)`, and `(...).cover?(nil)` all return
+  # the right boolean without raising. Verified locally; see Copilot
+  # review on PR #4182.
   def violates_date_range?(observation)
     return false if start_date.nil? && end_date.nil?
 

--- a/app/views/controllers/projects/_tab_counts_update.erb
+++ b/app/views/controllers/projects/_tab_counts_update.erb
@@ -1,0 +1,10 @@
+<%# Shared partial: re-render the project_tabs nav so the
+    Observations / Names / Locations / Update tab counts refresh
+    after any add / remove / exclude / target-list mutation
+    (#4136 Q6). Callers pass `project`, `user`, and `current_tab`. %>
+<%= turbo_stream.replace("project_tabs") do %>
+  <%= render(Components::Projects::Tabs.new(
+               project: project, user: user,
+               current_tab: current_tab
+             )) %>
+<% end %>

--- a/app/views/controllers/projects/target_locations/_locations_update.erb
+++ b/app/views/controllers/projects/target_locations/_locations_update.erb
@@ -11,10 +11,7 @@
                user: user
              )) %>
 <% end %>
-<%= turbo_stream.replace("project_tabs") do %>
-  <%= render(Components::Projects::Tabs.new(
-               project: project, user: user,
-               current_tab: "locations"
-             )) %>
-<% end %>
+<%= render(partial: "projects/tab_counts_update",
+           locals: { project: project, user: user,
+                     current_tab: "locations" }) %>
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/controllers/projects/target_names/_checklist_update.erb
+++ b/app/views/controllers/projects/target_names/_checklist_update.erb
@@ -18,10 +18,7 @@ end
                context: Components::Checklist::Context.new(**context_args)
              )) %>
 <% end %>
-<%= turbo_stream.replace("project_tabs") do %>
-  <%= render(Components::Projects::Tabs.new(
-               project: project, user: user,
-               current_tab: "checklists"
-             )) %>
-<% end %>
+<%= render(partial: "projects/tab_counts_update",
+           locals: { project: project, user: user,
+                     current_tab: "checklists" }) %>
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/controllers/projects/updates/_footer_update.erb
+++ b/app/views/controllers/projects/updates/_footer_update.erb
@@ -1,2 +1,5 @@
 <%= turbo_stream.remove("box_#{obs.id}") %>
 <%= turbo_stream.update("project_updates_count", count_label) %>
+<%= render(partial: "projects/tab_counts_update",
+           locals: { project: project, user: user,
+                     current_tab: "updates" }) %>

--- a/app/views/controllers/projects/violations/index.html.erb
+++ b/app/views/controllers/projects/violations/index.html.erb
@@ -4,5 +4,5 @@
 %>
 
 <%= render(Components::ProjectViolationsForm.new(
-      @project, violations: @violations, user: @user
+      project: @project, violations: @violations, user: @user
     )) %>

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1848,10 +1848,14 @@
   form_observations_original_name: Original Name
 
   form_observations_there_is_a_problem_with_projects: This observation violates the constraints of one or more selected projects. "+[:SEE_MESSAGE_BELOW]+":#project_messages
-  form_observations_projects_out_of_range: The observation date ([date]) or location ([place_name]) is outside the range of these checked project(s)
-  form_observations_projects_out_of_range_help: "Either:\n- Uncheck out-of-range projects; or\n- Change the observation date or location if it is incorrect"
+  form_observations_projects_out_of_range: This observation violates one or more constraints of these checked project(s)
+  form_observations_projects_out_of_range_help: "Either:\n- Uncheck the project(s); or\n- Change the observation to align with project requirements"
   form_observations_projects_out_of_range_admin_help: "; or\n- (undesirably) Check [:form_observations_projects_ignore_project_constraints] to ignore the project constraints.\nThen click [button_name]."
   form_observations_projects_ignore_project_constraints: Ignore Project Constraints
+  form_observations_projects_kind_date: Out-of-range date
+  form_observations_projects_kind_bbox: Out-of-bbox location
+  form_observations_projects_kind_target_name: Non-target name
+  form_observations_projects_kind_target_location: Non-target location
 
   form_observations_there_is_a_problem_with_location: There is a problem with the location. "+[:SEE_MESSAGE_BELOW]+":#location_messages
   form_observations_there_is_a_problem_with_name: There is a problem with the name. "+[:SEE_MESSAGE_BELOW]+":#name_messages

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3655,13 +3655,31 @@
   show_project_violation_count: Project has [count] constraint violation(s)
 
   # project/violations/index
-  form_violations_help: Check the Observations to be removed, then Submit
+  form_violations_help: Each row shows an Observation that fails one or more of this Project's constraints. Use the per-row actions to bring it into compliance.
   violations_index_title: "[:CONSTRAINT_VIOLATIONS]"
   form_violations_latitude_none: "Lat: Any"
   form_violations_location_none: "[:LOCATION]: Any"
   form_violations_longitude_none: "Lon: Any"
   form_violations_remove_selected: Remove Selected
   form_violations_show_project: Show Project
+  form_violations_no_violations: No constraint violations.
+  form_violations_th_name: Name
+  form_violations_th_kinds: Violations
+  form_violations_th_details: Details
+  form_violations_th_actions: Actions
+  form_violations_kind_date: Date
+  form_violations_kind_bbox: Location (bbox)
+  form_violations_kind_target_name: Target name
+  form_violations_kind_target_location: Target location
+  form_violations_action_exclude: Exclude
+  form_violations_action_extend: Extend dates
+  form_violations_action_add_target_name: Add Target Name
+  form_violations_action_add_target_location: Add Target Location
+  form_violations_modal_target_location_title: Add Target Location
+  form_violations_modal_target_location_help: Choose a comma-suffix of this Observation's location to add as a Target Location. Suffixes whose Location does not yet exist can be created in a new tab.
+  form_violations_modal_target_location_no_suffixes: This Observation's location has no usable suffixes. Use Exclude instead.
+  form_violations_modal_target_location_create: Create
+  form_violations_modal_target_location_submit: Add Target
 
   # users/by_name
   users_by_name_title: Users by Name

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3668,13 +3668,12 @@
   form_violations_show_project: Show Project
   form_violations_no_violations: No constraint violations.
   form_violations_th_name: Name
-  form_violations_th_kinds: Violations
-  form_violations_th_details: Details
+  form_violations_th_details: Violation Details
   form_violations_th_actions: Actions
   form_violations_kind_date: Date
   form_violations_kind_bbox: Location (bbox)
-  form_violations_kind_target_name: Target name
-  form_violations_kind_target_location: Target location
+  form_violations_kind_target_name: Non-target name
+  form_violations_kind_target_location: Non-target location
   form_violations_action_exclude: Exclude
   form_violations_action_extend: Extend dates
   form_violations_action_add_target_name: Add Target Name

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3671,7 +3671,7 @@
   form_violations_th_details: Violation Details
   form_violations_th_actions: Actions
   form_violations_kind_date: Date
-  form_violations_kind_bbox: Location (bbox)
+  form_violations_kind_bbox: Outside project location
   form_violations_kind_target_name: Non-target name
   form_violations_kind_target_location: Non-target location
   form_violations_action_exclude: Exclude
@@ -3679,8 +3679,8 @@
   form_violations_action_add_target_name: Add Target Name
   form_violations_action_add_target_location: Add Target Location
   form_violations_modal_target_location_title: Add Target Location
-  form_violations_modal_target_location_help: Choose a comma-suffix of this Observation's location to add as a Target Location. Suffixes whose Location does not yet exist can be created in a new tab.
-  form_violations_modal_target_location_no_suffixes: This Observation's location has no usable suffixes. Use Exclude instead.
+  form_violations_modal_target_location_help: Choose a region of this Observation's location to add as a Target Location. The full location name and any trailing comma-separated regions are offered. Choices whose Location does not yet exist can be created in a new tab.
+  form_violations_modal_target_location_no_suffixes: This Observation's location is not specific enough to add as a Target Location. Either Exclude this Observation, or add a more specific location via the Project Locations page.
   form_violations_modal_target_location_create: Create
   form_violations_modal_target_location_submit: Add Target
 

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -777,9 +777,13 @@ class ReportTest < UnitTestCase
     pub_lng = obs.lng.round
 
     # public lat/lng is the real GPS rounded to 0 decimal places.
-    # pub_lat is positive, so SE corner (south, east) is farthest.
-    uncertainty = Haversine.distance(pub_lat, pub_lng, loc.south, loc.east).
-                  to_meters.round.to_s
+    # uncertainty is the max distance to any of the four location corners.
+    uncertainty = [
+      [loc.north, loc.east], [loc.north, loc.west],
+      [loc.south, loc.east], [loc.south, loc.west]
+    ].map do |clat, clng|
+      Haversine.distance(pub_lat, pub_lng, clat, clng).to_meters
+    end.max.round.to_s
 
     expect = hashed_expect(obs).merge(
       decimalLatitude: pub_lat.to_s,

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -785,7 +785,8 @@ class ReportTest < UnitTestCase
       decimalLongitude: loc.center_lng.round(4).to_s,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
-      coordinateUncertaintyInMeters: uncertainty
+      coordinateUncertaintyInMeters: uncertainty,
+      informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     ).values
 
     do_csv_test(Report::Mycoportal, obs, expect, &:id)
@@ -811,7 +812,8 @@ class ReportTest < UnitTestCase
       decimalLongitude: loc.center_lng.round(4).to_s,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
-      coordinateUncertaintyInMeters: uncertainty
+      coordinateUncertaintyInMeters: uncertainty,
+      informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     ).values
 
     do_csv_test(Report::Mycoportal, obs, expect, &:id)
@@ -831,7 +833,8 @@ class ReportTest < UnitTestCase
     )
     expect = hashed_expect(obs).merge(
       stateProvince: "Puerto Rico",
-      locality: "Humacao18.094914, -65.801449"
+      locality: "Humacao18.094914, -65.801449",
+      informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     )
     [:decimalLatitude,
      :decimalLongitude,
@@ -938,6 +941,7 @@ class ReportTest < UnitTestCase
       decimalLatitude: obs_location&.center_lat&.to_s,
       decimalLongitude: obs_location&.center_lng&.to_s,
       coordinateUncertaintyInMeters: default_uncertainty || nil,
+      informationWithheld: nil,
       # if low/high are nil, value must be empty string, not zero
       minimumElevationInMeters: minimum_elevation,
       maximumElevationInMeters: maximum_elevation,

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -773,16 +773,17 @@ class ReportTest < UnitTestCase
   def test_mycoportal_coordinate_uncertainty_lat_lng_hidden
     obs = observations(:trusted_hidden)
     loc = obs.location
+    pub_lat = obs.lat.round
+    pub_lng = obs.lng.round
 
-    # obs lat/lng is in the NE quadrant of loc; so SE corner is the furthest
-    uncertainty = Haversine.distance(loc.center_lat, loc.center_lng,
-                                     loc.south, loc.west).
+    # public lat/lng is the real GPS rounded to 0 decimal places.
+    # pub_lat is positive, so SE corner (south, east) is farthest.
+    uncertainty = Haversine.distance(pub_lat, pub_lng, loc.south, loc.east).
                   to_meters.round.to_s
 
-    # public lat/lng is the loc center because obs coordinates are hidden.
     expect = hashed_expect(obs).merge(
-      decimalLatitude: loc.center_lat.round(4).to_s,
-      decimalLongitude: loc.center_lng.round(4).to_s,
+      decimalLatitude: pub_lat.to_s,
+      decimalLongitude: pub_lng.to_s,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
       coordinateUncertaintyInMeters: uncertainty,
@@ -798,21 +799,18 @@ class ReportTest < UnitTestCase
     # There are many (5,285) Obss with gps hidden, but no lat/lng
     obs.update!(location_id: loc.id, where: loc.name,
                 lat: nil, lng: nil)
-    loc = obs.location
-    uncertainty = Haversine.distance(
-      loc.center_lat, loc.center_lng, loc.north, loc.east
-    ).to_meters.round.to_s
 
+    # No GPS → public lat/lng and uncertainty are all nil.
     expect = hashed_expect(obs).merge(
       country: "South Africa",
       stateProvince: "Gauteng",
       county: nil,
       locality: "City of Tshwane Metropolitan Municipality, Pretoria",
-      decimalLatitude: loc.center_lat.round(4).to_s,
-      decimalLongitude: loc.center_lng.round(4).to_s,
+      decimalLatitude: nil,
+      decimalLongitude: nil,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
-      coordinateUncertaintyInMeters: uncertainty,
+      coordinateUncertaintyInMeters: nil,
       informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     ).values
 
@@ -831,15 +829,16 @@ class ReportTest < UnitTestCase
       location_lat: nil,
       location_lng: nil
     )
+    # Has GPS but no location: public lat/lng are rounded GPS; no uncertainty.
     expect = hashed_expect(obs).merge(
       stateProvince: "Puerto Rico",
       locality: "Humacao18.094914, -65.801449",
+      decimalLatitude: obs.lat.round.to_s,
+      decimalLongitude: obs.lng.round.to_s,
+      coordinateUncertaintyInMeters: nil,
       informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     )
-    [:decimalLatitude,
-     :decimalLongitude,
-     :coordinateUncertaintyInMeters,
-     :minimumElevationInMeters,
+    [:minimumElevationInMeters,
      :maximumElevationInMeters].each { |key| expect[key] = nil }
     expect = expect.values
 

--- a/test/components/observation_form_test.rb
+++ b/test/components/observation_form_test.rb
@@ -121,6 +121,40 @@ class ObservationFormTest < ComponentTestCase
     assert_html(html, "input[name='field_code'][type='text']")
   end
 
+  # #4136: per-project warning annotation lists the violation kinds
+  # that apply to this obs against this project, not the project's
+  # date/location *settings* (which are uninformative when the project
+  # only has target_names / target_locations).
+  def test_constraint_warning_lists_violation_kinds_per_project
+    user = users(:rolf)
+    proj = projects(:rare_fungi_project)
+    proj.project_target_names.destroy_all
+    proj.project_target_locations.destroy_all
+    proj.update!(start_date: nil, end_date: nil, location: nil)
+    proj.add_target_name(names(:agaricus))
+    proj.add_target_location(locations(:burbank))
+    obs = observations(:falmouth_2023_09_obs) # Boletus, Falmouth — neither
+    User.current = user
+
+    html = render_form(
+      observation: obs, user: user, mode: :update,
+      projects: [proj], project_checks: { proj.id => true },
+      suspect_checked_projects: [proj]
+    )
+
+    assert_includes(html, :form_observations_projects_out_of_range.l)
+    assert_includes(html, proj.title)
+    assert_includes(html, :form_observations_projects_kind_target_name.l)
+    assert_includes(html, :form_observations_projects_kind_target_location.l)
+    # Old-style "(Dates: Any; Location: )" annotation should be gone.
+    assert_no_match(/Dates: Any/, html)
+    # Help text reflects the new wording.
+    assert_includes(
+      html,
+      "Change the observation to align with project requirements"
+    )
+  end
+
   private
 
   def render_form(observation:, user:, mode: :create, **extras)

--- a/test/components/project_violations_form_test.rb
+++ b/test/components/project_violations_form_test.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProjectViolationsFormTest < ComponentTestCase
+  def setup
+    super
+    @project = projects(:falmouth_2023_09_project)
+    @admin = @project.user
+  end
+
+  def test_renders_one_row_per_violation
+    violations = @project.violations
+    html = render_form(violations: violations)
+
+    violations.each do |v|
+      assert_html(html, "a[href*='#{v.obs.id}']")
+    end
+    assert_html(html, "table.project-violations")
+    # tbody has one row per violation (header tr lives in thead)
+    body = html.scan(%r{<tbody>(.*?)</tbody>}m).first.first
+    assert_equal(violations.size, body.scan("<tr").size)
+  end
+
+  def test_renders_kind_labels_per_row
+    violations = @project.violations
+    html = render_form(violations: violations)
+
+    violations.each do |v|
+      v.kinds.each do |kind|
+        assert_includes(html, :"form_violations_kind_#{kind}".l)
+      end
+    end
+  end
+
+  def test_violations_sorted_by_sort_name_in_render
+    violations = @project.violations
+    html = render_form(violations: violations)
+
+    rendered_ids = html.scan(/observation_link_(\d+)/).flatten.map(&:to_i).uniq
+    expected_ids = violations.map { |v| v.obs.id }
+    assert_equal(expected_ids, rendered_ids,
+                 "Rows should render in violations order (sort_name asc)")
+  end
+
+  def test_no_violations_message
+    proj = projects(:eol_project)
+    html = render_form(project: proj, violations: [], user: proj.user)
+
+    assert_includes(html, :form_violations_no_violations.l)
+    assert_no_match(/<table/, html)
+  end
+
+  def test_admin_sees_exclude_buttons
+    violations = @project.violations
+    html = render_form(violations: violations)
+
+    # button_to renders a <form method=post> with a hidden _method=put
+    # and a <button type=submit>Label</button>.
+    assert_includes(html, :form_violations_action_exclude.l)
+    assert_html(html, "form.button_to[action$='/violations']")
+    assert_html(html, "input[type='hidden'][name='do'][value='exclude']")
+    assert_html(html, "input[type='hidden'][name='_method'][value='put']")
+  end
+
+  def test_admin_sees_extend_button_on_date_violation
+    proj = setup_date_violation_project
+    date_v = proj.violations.find { |v| v.kinds.include?(:date) }
+    assert(date_v, "Setup must produce a date violation")
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: proj.user)
+
+    assert_includes(html, :form_violations_action_extend.l)
+    assert_html(html, "input[type='hidden'][name='do'][value='extend']")
+  end
+
+  def test_admin_sees_add_target_name_button_on_target_name_violation
+    proj = setup_target_name_violation_project
+    name_v = proj.violations.find { |v| v.kinds.include?(:target_name) }
+    assert(name_v, "Setup must produce a target_name violation")
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: proj.user)
+
+    assert_includes(html, :form_violations_action_add_target_name.l)
+    assert_html(html,
+                "input[type='hidden'][name='do'][value='add_target_name']")
+  end
+
+  def test_target_location_modal_renders_for_admin
+    proj = setup_target_location_violation_project
+    target_loc_v =
+      proj.violations.find { |v| v.kinds.include?(:target_location) }
+    assert(target_loc_v,
+           "Setup must produce a target_location violation; check Burbank " \
+           "vs Falmouth fixture pairing")
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: proj.user)
+    obs_id = target_loc_v.obs.id
+
+    assert_html(html, "#location_target_modal_#{obs_id}.modal")
+    assert_html(
+      html,
+      "#location_target_modal_#{obs_id} " \
+      "input[type='hidden'][name='do'][value='add_target_location']"
+    )
+    assert_html(
+      html,
+      "#location_target_modal_#{obs_id} " \
+      "input[type='hidden'][name='obs_id'][value='#{obs_id}']"
+    )
+    # Modal trigger button is rendered too.
+    assert_includes(html, :form_violations_action_add_target_location.l)
+  end
+
+  def test_target_location_modal_excludes_country_suffix
+    proj = setup_target_location_violation_project
+    target_loc_v =
+      proj.violations.find { |v| v.kinds.include?(:target_location) }
+    assert(target_loc_v, "Setup must produce a target_location violation")
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: proj.user)
+    obs = target_loc_v.obs
+    place = obs.location_id ? obs.location.name : obs.where
+    bare_country = place.split(",").last&.strip
+
+    skip_if_no_country = bare_country.blank? ||
+                         Location.understood_countries.exclude?(bare_country)
+    assert_not(skip_if_no_country,
+               "Test setup expects fixture with a country tail (got: #{place})")
+
+    assert_no_match(
+      /<input[^>]*type="radio"[^>]*value="#{Regexp.escape(bare_country)}"/,
+      html,
+      "Bare-country suffix should not appear as a selectable radio"
+    )
+  end
+
+  def test_non_admin_only_sees_exclude_for_own_obs
+    proj = setup_date_violation_project
+    own_violation = proj.violations.find { |v| v.obs.user_id == users(:roy).id }
+    others_violation =
+      proj.violations.find { |v| v.obs.user_id != users(:roy).id }
+    assert(own_violation && others_violation,
+           "Setup must yield violations from the test user and someone else")
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: users(:roy))
+
+    # Exclude button is keyed by obs_id; the form contains an
+    # `input[name='obs_id'][value='<id>']`.
+    assert_match(
+      /name="obs_id"[^>]*value="#{own_violation.obs.id}"/, html,
+      "Own obs should have an Exclude form"
+    )
+    assert_no_match(
+      /name="obs_id"[^>]*value="#{others_violation.obs.id}"/, html,
+      "Other user's obs should not have an Exclude form for non-admin"
+    )
+    # Admin-only actions are not rendered for non-admin.
+    assert_no_match(/value="extend"/, html)
+    assert_no_match(/value="add_target_name"/, html)
+    assert_no_match(/value="add_target_location"/, html)
+  end
+
+  def test_target_location_modal_offers_create_for_missing_location
+    proj = setup_target_location_violation_project
+    target_loc_v =
+      proj.violations.find { |v| v.kinds.include?(:target_location) }
+    assert(target_loc_v, "Setup must produce a target_location violation")
+
+    obs = target_loc_v.obs
+    place = obs.location_id ? obs.location.name : obs.where
+    place_parts = place.split(",").map(&:strip)
+    # Pick the most-specific suffix that has multiple comma segments
+    # and isn't a bare country.
+    candidate_suffix = place_parts[1..].join(", ")
+    return if candidate_suffix.blank? ||
+              Location.understood_countries.include?(candidate_suffix)
+    return if Location.find_by(name: candidate_suffix)
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: proj.user)
+
+    # Disabled radio plus a Create link to /locations/new with the suffix.
+    assert_html(html, "input[type='radio'][disabled]")
+    assert_match(
+      %r{<a [^>]*href="/locations/new\?display_name=[^"]*"[^>]*target="_blank"},
+      html, "Create link to /locations/new should appear for missing suffix"
+    )
+  end
+
+  private
+
+  def render_form(violations:, project: @project, user: @admin)
+    render(Components::ProjectViolationsForm.new(
+             project: project, violations: violations, user: user
+           ))
+  end
+
+  # Project keyed only on date constraints, with a roy-owned obs out of
+  # range so test_non_admin_only_sees_exclude_for_own_obs has a target.
+  def setup_date_violation_project
+    proj = projects(:falmouth_2023_09_project)
+    # Falmouth project already has multi-user violations; make sure
+    # there's at least one obs owned by `roy`.
+    roy_obs = observations(:nybg_2023_09_obs)
+    roy_obs.update!(user: users(:roy)) unless roy_obs.user == users(:roy)
+    proj
+  end
+
+  def setup_target_name_violation_project
+    proj = projects(:rare_fungi_project)
+    proj.project_target_locations.destroy_all
+    proj.project_target_names.destroy_all
+    proj.update!(start_date: nil, end_date: nil, location: nil)
+    proj.add_target_name(names(:agaricus))
+    off_target = observations(:peltigera_obs)
+    proj.add_observation(off_target)
+    proj
+  end
+
+  def setup_target_location_violation_project
+    proj = projects(:rare_fungi_project)
+    # rare_fungi_project already has burbank as a target_location via
+    # rare_fungi_target_burbank fixture; clear and re-add to be explicit.
+    proj.project_target_locations.destroy_all
+    proj.add_target_location(locations(:burbank))
+    proj.update!(start_date: nil, end_date: nil, location: nil)
+    proj.project_target_names.destroy_all
+    elsewhere = observations(:falmouth_2023_09_obs)
+    proj.add_observation(elsewhere)
+    proj
+  end
+end

--- a/test/components/project_violations_form_test.rb
+++ b/test/components/project_violations_form_test.rb
@@ -166,6 +166,30 @@ class ProjectViolationsFormTest < ComponentTestCase
     assert_no_match(/value="add_target_location"/, html)
   end
 
+  # Regression for J1 of PR #4182 review: a 2-part location like
+  # "California, USA" should yield the full name as a candidate. The
+  # earlier (1..) range produced an empty list after the bare-country
+  # filter and the modal showed "Use Exclude instead", which made no
+  # sense for a state-level target.
+  def test_comma_suffixes_includes_full_name
+    component = Components::ProjectViolationsForm.new(
+      project: projects(:rare_fungi_project),
+      violations: [],
+      user: rolf
+    )
+
+    assert_equal(["California, USA", "USA"],
+                 component.send(:comma_suffixes, "California, USA"))
+    assert_equal(
+      ["Berkeley, Alameda Co., California, USA",
+       "Alameda Co., California, USA", "California, USA", "USA"],
+      component.send(:comma_suffixes,
+                     "Berkeley, Alameda Co., California, USA")
+    )
+    assert_equal([], component.send(:comma_suffixes, ""))
+    assert_equal(["USA"], component.send(:comma_suffixes, "USA"))
+  end
+
   def test_target_location_modal_offers_create_for_missing_location
     proj = setup_target_location_violation_project
     target_loc_v =

--- a/test/controllers/projects/violations_controller_test.rb
+++ b/test/controllers/projects/violations_controller_test.rb
@@ -2,216 +2,175 @@
 
 require("test_helper")
 
-# test functions and view contents of ProjectsViolationsController
+# Functional tests for Projects::ViolationsController. The page is keyed
+# off Project::VIOLATION_KINDS (#4136); this exercises rendering and
+# the four PUT actions (exclude, extend, add_target_name,
+# add_target_location) plus back-compat for the legacy
+# "Remove Selected" form.
 module Projects
   class ViolationsControllerTest < FunctionalTestCase
-    def test_index_by_owner
+    def test_index_renders_for_owner
       project = projects(:falmouth_2023_09_project)
       violations = project.violations
-      violations_count = violations.size
-      assert(violations_count.positive?,
-             "Test needs Project fixture with constraint violations")
-      assert(project.observations.count > violations_count,
-             "Test need Project fixture with compliant Observation(s)")
-      compliant_observation = observations(:falmouth_2023_09_obs)
-      hidden_obs = observations(:brett_woods_2023_09_obs)
-      assert(hidden_obs.gps_hidden &&
-             violations.include?(hidden_obs) &&
-             !project.location.found_here?(hidden_obs),
-             "Test needs obs with hidden gps, outside project location")
+      assert(violations.any?,
+             "Test needs Project fixture with violations")
 
       user = project.user
       login(user.login)
       get(:index, params: { project_id: project.id })
 
       assert_response(:success)
-      assert_form_action(action: :update)
-
-      assert_select("#content", { text: /#{project.title}/ },
-                    "Page missing project name")
-      assert_select("#content a[href = '#{project_path(project)}']", true,
-                    "Page missing a link to project show page")
-
-      assert_select("#project_violations_form", { text: /#{:CONSTRAINTS.l}/ })
-      assert_select("#project_violations_form",
-                    { text: /#{project.date_range}/ },
-                    "Missing Project date range")
-      assert_select(
-        "#project_violations_form",
-        { text: /#{project.location.north} \S+ #{project.location.south}/ },
-        "Missing Project latitude range"
-      )
-      assert_select(
-        "#project_violations_form",
-        { text: /#{project.location.west} \S+ #{project.location.east}/ },
-        "Missing Project longitude range"
-      )
-      project.violations.each do |violation|
-        assert_select(
-          "#project_violations_form a[href *= '#{violation.id}']", { count: 1 },
-          "Non-compliant list should have a link to Observation #{violation.id}"
-        )
-        assert_select(
-          "input[type=checkbox][id *= '#{violation.id}']",
-          { count: 1 },
-          "Non-compliant list should have a checkbox for Obs #{violation.id}"
-        )
+      assert_select("#content", { text: /#{project.title}/ })
+      assert_select("a[href = '#{project_path(project)}']", true,
+                    "Missing project link")
+      violations.each do |v|
+        assert_select("a[href*='#{v.obs.id}']", { count: 1 },
+                      "Missing obs link for #{v.obs.id}")
       end
-
-      assert_select(
-        "#project_violations_form a[href *= '#{compliant_observation.id}']",
-        { count: 0 },
-        "Non-compliant list should not link to compliant Observation"
-      )
-      assert_select(
-        "#project_violations_form", { text: /#{hidden_obs.lat}/, count: 1 },
-        "Violation list should display hidden geoloc to trusted user"
-      )
-
-      # Obs outside project location with no lat/lng should have
-      # location wrapped in violation-highlight
-      loc_violator = observations(:nybg_2023_09_obs)
-      assert(loc_violator.lat.blank? &&
-             !project.location.found_here?(loc_violator),
-             "Test needs obs without lat/lng, outside project location")
-      assert_select(
-        "#project_violations_form td span.violation-highlight",
-        { text: /#{Regexp.escape(loc_violator.place_name)}/ },
-        "Location should be highlighted for obs outside project location"
-      )
     end
 
-    def test_index_by_member
-      project = projects(:falmouth_2023_09_project)
-      violations = project.violations
-      violations_count = violations.size
-      assert(violations_count.positive?,
-             "Test needs Project fixture with constraint violations")
-      user = users(:roy)
-      assert(project.member?(user) && !project.is_admin?(user) &&
-             violations.map(&:user).include?(user) &&
-             violations.map(&:user).uniq.size > 1,
-             "Test needs non-admin project member user with violation(s) " \
-             "who isn't the only person with violation")
+    def test_index_no_violations
+      project = projects(:eol_project)
+      assert_empty(project.violations,
+                   "Test needs project with no violations")
 
-      login(user.login)
+      login(project.user.login)
       get(:index, params: { project_id: project.id })
 
       assert_response(:success)
-
-      project.violations.each do |violation|
-        assert_select(
-          "#project_violations_form a[href *= '#{violation.id}']", { count: 1 },
-          "Non-compliant list should have a link to Observation #{violation.id}"
-        )
-        if violation.user == user
-          assert_select(
-            "input[type=checkbox][id *= '#{violation.id}']",
-            { count: 1 },
-            "Non-compliant list should have a checkbox for Obs #{violation.id}"
-          )
-        else
-          assert_select(
-            "input[type=checkbox][id *= '#{violation.id}']",
-            { count: 0 },
-            "Non-compliant list should omit a checkbox for Obs #{violation.id}"
-          )
-        end
-      end
+      assert_select("p", { text: /#{:form_violations_no_violations.l}/ })
     end
 
-    def test_index_by_non_member
+    def test_update_legacy_remove_selected
       project = projects(:falmouth_2023_09_project)
-      violations = project.violations
-      hidden_obs = observations(:brett_woods_2023_09_obs)
-      assert(hidden_obs.gps_hidden &&
-             violations.include?(hidden_obs) &&
-             !project.location.found_here?(hidden_obs),
-             "Test needs obs with hidden gps, outside project location")
-      user = users(:zero_user)
-
-      login(user.login)
-      get(:index, params: { project_id: project.id })
-
-      violations.each do |violation|
-        assert_select(
-          "#project_violations_form a[href *= '#{violation.id}']", { count: 1 },
-          "Non-compliant list should have a link to Observation #{violation.id}"
-        )
-      end
-
-      assert_select(
-        "#project_violations_form", { text: /#{hidden_obs.lat}/, count: 0 },
-        "Violation list should hide hidden geoloc from untrusted user"
-      )
-    end
-
-    def test_index_project_without_location
-      project = projects(:nowhere_2023_09_project)
-      violation = observations(:falmouth_2022_obs)
-      assert(project.location_id.nil? &&
-             project.violations.include?(violation) &&
-              violation.lat.present?,
-             "Test needs Project lacking a Location, " \
-             "with (date) violation which has a geolocation")
-
-      login(project.user.login)
-      get(:index, params: { project_id: project.id })
-
-      assert_select(
-        "#project_violations_form th",
-        { text: /#{:form_violations_latitude_none.l}/ }
-      )
-      assert_select(
-        "#project_violations_form th",
-        { text: /#{:form_violations_longitude_none.l}/ }
-      )
-      assert_select(
-        "#project_violations_form th",
-        { text: /#{:form_violations_location_none.l}/ }
-      )
-
-      highlighted_violations =
-        "#project_violations_form tr td span.violation-highlight"
-      coordinate = /\d+\.\d+/
-      assert_select(
-        highlighted_violations, { text: coordinate, count: 0 },
-        "Observation lat/lon should not be highlighted as a violation " \
-        "for a Project which lacks a Location"
-      )
-    end
-
-    def test_update
-      project = projects(:falmouth_2023_09_project)
-      violations = project.violations
-      assert(violations.size > 1,
-             "Test needs Project fixture with multiple violations")
-      nybg_2023_09_obs = observations(:nybg_2023_09_obs)
-      assert(violations.include?(nybg_2023_09_obs))
-
+      victim = project.violations.first.obs
       params = { project_id: project.id,
-                 project: { "remove_#{nybg_2023_09_obs.id}" => "1" } }
+                 project: { "remove_#{victim.id}" => "1" } }
 
       login(project.user.login)
-      assert_difference(
-        "project.violations.count", -1,
-        "Failed to remove exactly one Obs from Project"
-      ) do
-        post(:update, params: params)
+      assert_difference("project.observations.count", -1) do
+        put(:update, params: params)
       end
+      assert_not_includes(project.observations, victim)
+    end
 
-      assert_not_includes(project.observations, nybg_2023_09_obs,
-                          "Failed to remove checked violation from Project")
+    def test_update_exclude
+      project = projects(:falmouth_2023_09_project)
+      victim = project.violations.first.obs
+      params = { project_id: project.id, do: "exclude", obs_id: victim.id }
+
+      login(project.user.login)
+      put(:update, params: params)
+
+      assert_redirected_to(project_violations_path(project_id: project.id))
+      assert_includes(project.excluded_observations, victim)
+      assert_not_includes(project.observations, victim)
+    end
+
+    def test_update_extend_widens_dates
+      project = projects(:falmouth_2023_09_project)
+      future_violation =
+        project.violations.find { |v| v.kinds.include?(:date) }
+      assert(future_violation, "Test needs a date violation in fixtures")
+      victim = future_violation.obs
+      params = { project_id: project.id, do: "extend", obs_id: victim.id }
+
+      login(project.user.login)
+      put(:update, params: params)
+
+      project.reload
+      assert(project.start_date.nil? || project.start_date <= victim.when)
+      assert(project.end_date.nil? || project.end_date >= victim.when)
+    end
+
+    def test_update_add_target_name
+      proj = projects(:rare_fungi_project)
+      proj.project_target_names.destroy_all
+      proj.add_target_name(names(:agaricus))
+      proj.update!(start_date: nil, end_date: nil, location: nil)
+      proj.project_target_locations.destroy_all
+      off_target = observations(:peltigera_obs)
+      proj.add_observation(off_target)
+
+      params = { project_id: proj.id, do: "add_target_name",
+                 obs_id: off_target.id }
+      login(proj.user.login)
+      put(:update, params: params)
+
+      assert_redirected_to(project_violations_path(project_id: proj.id))
+      assert_includes(proj.target_names.reload, off_target.name)
+    end
+
+    def test_update_add_target_location
+      proj = projects(:rare_fungi_project)
+      proj.project_target_locations.destroy_all
+      proj.add_target_location(locations(:burbank))
+      proj.update!(start_date: nil, end_date: nil, location: nil)
+      proj.project_target_names.destroy_all
+      elsewhere = observations(:falmouth_2023_09_obs)
+      proj.add_observation(elsewhere)
+      new_target = locations(:falmouth)
+
+      params = { project_id: proj.id, do: "add_target_location",
+                 obs_id: elsewhere.id, location_id: new_target.id }
+      login(proj.user.login)
+      put(:update, params: params)
+
+      assert_redirected_to(project_violations_path(project_id: proj.id))
+      assert_includes(proj.target_locations.reload, new_target)
+    end
+
+    def test_update_admin_only_actions_no_op_for_non_admin
+      proj = projects(:falmouth_2023_09_project)
+      stranger = users(:zero_user)
+      assert_not(proj.is_admin?(stranger))
+      original_start = proj.start_date
+      original_end = proj.end_date
+      victim = proj.violations.first.obs
+
+      login(stranger.login)
+      put(:update, params: { project_id: proj.id, do: "extend",
+                             obs_id: victim.id })
+
+      proj.reload
+      assert_equal(original_start, proj.start_date,
+                   "Non-admin should not be able to extend project dates")
+      assert_equal(original_end, proj.end_date)
+    end
+
+    def test_update_exclude_by_obs_owner
+      proj = projects(:falmouth_2023_09_project)
+      victim = proj.violations.first.obs
+
+      login(victim.user.login)
+      put(:update, params: { project_id: proj.id, do: "exclude",
+                             obs_id: victim.id })
+
+      assert_redirected_to(project_violations_path(project_id: proj.id))
+      assert_includes(proj.excluded_observations, victim,
+                      "Obs owner can self-exclude their own violation")
+    end
+
+    def test_update_exclude_by_stranger_is_forbidden
+      proj = projects(:falmouth_2023_09_project)
+      victim = proj.violations.first.obs
+      stranger = users(:zero_user)
+      assert_not_equal(stranger, victim.user)
+      assert_not(proj.is_admin?(stranger))
+
+      login(stranger.login)
+      put(:update, params: { project_id: proj.id, do: "exclude",
+                             obs_id: victim.id })
+
+      assert_not_includes(proj.excluded_observations, victim,
+                          "Stranger cannot exclude someone else's obs")
     end
 
     def test_update_nonexistent_project
-      id = observations(:minimal_unknown_obs).id
-      nybg_2023_09_obs = observations(:nybg_2023_09_obs)
-      params = { project_id: id,
-                 project: { "remove_#{nybg_2023_09_obs.id}" => "1" } }
+      id = -1
+      params = { project_id: id, do: "exclude", obs_id: 0 }
       login
-      post(:update, params: params)
-
+      put(:update, params: params)
       assert_redirected_to(projects_path)
     end
   end

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -280,13 +280,19 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
     )
 
     within("#project_messages") do # out-of-range warning message
-      assert(has_text?(:form_observations_projects_out_of_range.l(
-                         date: Time.zone.today.web_date,
-                         place_name: last_location.display_name
-                       )),
-             "Missing out-of-range warning with observation date")
-      assert(has_text?(proj.title) && has_text?(proj.constraints),
-             "Warning is missing out-of-range project's title or constraints")
+      assert(has_text?(:form_observations_projects_out_of_range.l),
+             "Missing constraint-violation warning headline")
+      assert(has_text?(proj.title),
+             "Warning is missing out-of-range project's title")
+      # Per-project annotation now lists the violation kinds that
+      # apply to this obs (#4136) instead of the project's
+      # date/location *settings*. past_project has both a date range
+      # and a location, so this obs hits both :date and :bbox.
+      assert(
+        has_text?(:form_observations_projects_kind_date.l) &&
+        has_text?(:form_observations_projects_kind_bbox.l),
+        "Warning should list the kinds of violation per project"
+      )
     end
     # assert_selector("#ignore_project_dates", visible: :hidden)
     assert_selector("##{proj_checkbox}[checked='checked']")

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -557,4 +557,181 @@ class ProjectTest < UnitTestCase
                     "Species obs should stay because it's still covered " \
                     "by the remaining species target")
   end
+
+  # ------------------------------------------------------------------
+  #  #4136 expanded violation concept
+  # ------------------------------------------------------------------
+
+  def test_violation_kinds_for_target_name_mismatch
+    proj = projects(:rare_fungi_project)
+    proj.project_target_names.destroy_all
+    proj.project_target_locations.destroy_all
+    proj.update!(start_date: nil, end_date: nil, location: nil)
+    proj.add_target_name(names(:agaricus))
+    off_target = observations(:peltigera_obs)
+    proj.add_observation(off_target)
+
+    kinds = proj.violation_kinds_for(off_target)
+
+    assert_includes(kinds, :target_name)
+    assert_not_includes(kinds, :date)
+    assert_not_includes(kinds, :bbox)
+    assert(proj.violates_constraints?(off_target))
+  end
+
+  def test_violation_kinds_for_target_name_passes_subtaxa
+    proj = projects(:rare_fungi_project)
+    proj.project_target_names.destroy_all
+    proj.project_target_locations.destroy_all
+    proj.update!(start_date: nil, end_date: nil, location: nil)
+    proj.add_target_name(names(:agaricus))
+    species_obs = observations(:agaricus_campestris_obs)
+    proj.add_observation(species_obs)
+
+    kinds = proj.violation_kinds_for(species_obs)
+
+    assert_not_includes(
+      kinds, :target_name,
+      "Sub-taxa of target genus should not be a target_name " \
+      "violation (#4130 + #4136 combined)"
+    )
+  end
+
+  def test_violation_kinds_for_target_location_mismatch
+    proj = build_target_location_project
+    california_loc = locations(:california)
+    obs_in_ca = observations(:california_obs)
+    proj.add_target_location(california_loc)
+    obs_outside = observations(:falmouth_2023_09_obs)
+    proj.add_observation(obs_in_ca)
+    proj.add_observation(obs_outside)
+
+    assert_not_includes(proj.violation_kinds_for(obs_in_ca), :target_location)
+    assert_includes(proj.violation_kinds_for(obs_outside), :target_location)
+  end
+
+  def test_violations_sorted_by_sort_name
+    proj = projects(:falmouth_2023_09_project)
+    sort_names = proj.violations.map { |v| v.obs.name&.sort_name.to_s.downcase }
+
+    assert_equal(sort_names, sort_names.sort,
+                 "Violations should be sorted by obs.name.sort_name")
+  end
+
+  def test_count_violations_matches_violations_size
+    proj = projects(:falmouth_2023_09_project)
+
+    assert_equal(proj.violations.size, proj.count_violations)
+  end
+
+  def test_candidate_observations_respects_date_range
+    proj = build_target_name_project_with_dates
+    in_range = observations(:agaricus_campestris_obs)
+    in_range.update!(when: proj.start_date + 1.day)
+    out_of_range = observations(:agaricus_campestrus_obs)
+    out_of_range.update!(when: proj.end_date + 10.days)
+
+    candidate_ids = proj.candidate_observations.pluck(:id)
+
+    assert_includes(candidate_ids, in_range.id)
+    assert_not_includes(
+      candidate_ids, out_of_range.id,
+      "Out-of-date-range obs should be filtered from candidates"
+    )
+  end
+
+  def test_candidate_observations_respects_bbox_with_gps
+    proj = build_target_name_project_with_location
+    inside = observations(:agaricus_campestris_obs)
+    inside.update!(lat: proj.location.center_lat,
+                   lng: proj.location.center_lng,
+                   gps_hidden: false, gps_dubious: false)
+    outside = observations(:agaricus_campestrus_obs)
+    outside.update!(lat: 0.0, lng: 0.0,
+                    gps_hidden: false, gps_dubious: false)
+
+    candidate_ids = proj.candidate_observations.pluck(:id)
+
+    assert_includes(candidate_ids, inside.id)
+    assert_not_includes(candidate_ids, outside.id,
+                        "GPS outside project bbox should be filtered out")
+  end
+
+  # Q9: an obs with no GPS but whose Location is fully contained in the
+  # project's bbox should pass the candidate filter, mirroring the
+  # violations-side rule.
+  def test_candidate_observations_includes_no_gps_with_location_in_bbox
+    proj = build_target_name_project_with_location
+    inside = observations(:agaricus_campestris_obs)
+    burbank_sub = locations(:burbank) # by definition contained in itself
+    inside.update!(lat: nil, lng: nil, location: burbank_sub)
+
+    candidate_ids = proj.candidate_observations.pluck(:id)
+
+    assert_includes(
+      candidate_ids, inside.id,
+      "Obs without GPS but with location contained in project bbox " \
+      "should remain a candidate"
+    )
+  end
+
+  def test_violation_kinds_combine_date_and_target_name
+    proj = projects(:rare_fungi_project)
+    proj.project_target_locations.destroy_all
+    proj.project_target_names.destroy_all
+    proj.update!(location: nil,
+                 start_date: Date.parse("2030-01-01"),
+                 end_date: Date.parse("2030-12-31"))
+    proj.add_target_name(names(:agaricus))
+    off_target = observations(:peltigera_obs) # not Agaricus, not in 2030
+    proj.add_observation(off_target)
+
+    kinds = proj.violation_kinds_for(off_target)
+
+    assert_includes(kinds, :date)
+    assert_includes(kinds, :target_name)
+    assert_not_includes(kinds, :bbox)
+    assert_not_includes(kinds, :target_location)
+  end
+
+  def test_violations_excludes_excluded_observations
+    proj = projects(:falmouth_2023_09_project)
+    violation_obs = proj.violations.first.obs
+
+    proj.exclude_observation(violation_obs)
+
+    assert_not_includes(proj.violations.map(&:obs), violation_obs,
+                        "Excluded obs should not surface as a violation")
+  end
+
+  private
+
+  def build_target_location_project
+    Project.create!(
+      title: "Target Loc #{SecureRandom.hex(4)}",
+      open_membership: true,
+      user: users(:rolf)
+    )
+  end
+
+  def build_target_name_project_with_dates
+    proj = projects(:rare_fungi_project)
+    proj.project_target_names.destroy_all
+    proj.project_target_locations.destroy_all
+    proj.update!(location: nil,
+                 start_date: Date.parse("2010-01-01"),
+                 end_date: Date.parse("2010-12-31"))
+    proj.add_target_name(names(:agaricus))
+    proj
+  end
+
+  def build_target_name_project_with_location
+    proj = projects(:rare_fungi_project)
+    proj.project_target_names.destroy_all
+    proj.project_target_locations.destroy_all
+    proj.update!(location: locations(:burbank),
+                 start_date: nil, end_date: nil)
+    proj.add_target_name(names(:agaricus))
+    proj
+  end
 end


### PR DESCRIPTION
Fixes #4136. Built on top of #4153 (`njw-4130-subtaxa-in-project-names`); should land after #4153.

## Summary
- Expand the Project constraint-violation concept from two kinds (date, bbox) to four (date, bbox, target_name, target_location), per the locked design in #4136.
- Rebuild the violations page around per-row actions (Exclude / Extend / Add Target Name / Add Target Location-with-modal) instead of the bulk-remove checkbox form.
- `Project#violates_constraints?` now covers all four kinds, so the API v2 add path, obs create form's project warning, and field slip flow all gate on the same rule the page surfaces (Q1).
- `Project#candidate_observations` (Update tab + new-candidates count) gains the same date and bbox filters mirroring the violations rule, so an obs is a candidate iff it would not be a violation if added (Q9).
- Refresh the four project-page tab counts (Observations / Names / Locations / Update) via a shared turbo-stream partial after every Add / Exclude — the Update-tab footer-update path didn't broadcast tab counts before (Q6).

## Scope decisions resolved up-front
| # | Decision |
|---|---|
| Q1 | Write paths (API v2, obs create, field slip) gate on all four kinds via `violates_constraints?` |
| Q2 | Sort by `obs.name.sort_name`; one row per obs with multiple action buttons |
| Q3 | Modal drops only suffixes that *exactly equal* a country name (so `California, USA` stays) |
| Q4 | No-comma `obs.where` ⇒ Exclude only, no Add Target Location |
| Q5 | No special-casing for "consensus is already a synonym/sub-taxon" — admin trims if it ever happens |
| Q6 | Shared `_tab_counts_update.erb` partial; existing turbo paths now reuse it |
| Q7 | Recompute `count_violations` on Summary render; revisit if slow |
| Q8 | #4134 already merged 2026-04-20 — `excluded_observations` plumbing in place |
| Q9 | Update-tab candidate filter mirrors violations bbox rule (GPS-inside OR location-fully-contained) |

## Changes

**Model**
- `Project::VIOLATION_KINDS = %i[date bbox target_name target_location]` and a `Violation` Struct (obs, kinds).
- `#violation_kinds_for(obs)` returns the subset that applies. Drives both `#violations` (one entry per offending obs, eager-loaded, sorted by `sort_name`) and `#violates_constraints?`.
- New predicates `#violates_target_name?`, `#violates_target_location?`, `#target_location_suffix_match?`. Memoized `#expanded_target_name_id_set` caches the synonyms+sub-taxa expansion.
- `#candidate_observations` runs through `constrain_to_project_date_range` + `constrain_to_project_bbox` (uses `Observation.gps_in_box` plus `Location.in_box` for the no-GPS branch).
- `Project.violations_includes` scope now eager-loads names + targets too.

**Violations page**
- `Components::ProjectViolationsForm` rebuilt: one row per `Violation`, kind labels, detail per kind, action buttons keyed off the kinds. `button_to` PUT for each.
- Inline Bootstrap-3 modal per target_location-violating obs with comma-suffix radios. Each suffix is selectable iff a `Location` with that exact name exists; otherwise the radio is disabled and a Create link opens `/locations/new?display_name=<suffix>` in a new tab.

**Controller**
- `Projects::ViolationsController#update` is now a dispatcher on `params[:do]` for `exclude` / `extend` / `add_target_name` / `add_target_location`, with a back-compat path for the legacy "Remove Selected" form.

**Tab-count broadcasts**
- New shared partial `app/views/controllers/projects/_tab_counts_update.erb` factors out the existing `turbo_stream.replace("project_tabs")` block. Now reused by `_footer_update.erb` (Updates tab Add / Exclude — previously did not broadcast), `_checklist_update.erb` (target_names), and `_locations_update.erb` (target_locations).

**Locale**
- New `form_violations_kind_*`, `form_violations_action_*`, and modal-copy strings under `config/locales/en.txt`.

## Tests
- **Model** (10 new): kinds-for in isolation and combined (date + target_name); kinds excludes excluded obs; sort-by-sort_name; count_violations matches violations.size; sub-taxa pass target_name; candidate_observations respects date / GPS-bbox / no-GPS-location-bbox.
- **Component** (11 new): one row per obs with link, kind labels, sort order, empty-state, admin sees Exclude / Extend / Add Target Name / Add Target Location buttons, modal markup with `do` and `obs_id` hidden inputs, country-suffix exclusion, Create link for missing Location, non-admin permission gating (only Exclude on own obs, no admin-only buttons).
- **Controller** (10, mostly rewritten): index renders, no-violations message, legacy `remove_selected` back-compat, exclude / extend / add_target_name / add_target_location actions, exclude permission paths (admin / owner / stranger), admin-only actions are no-ops for non-admin, nonexistent project.

Full model suite (741 tests) and projects controller suite green; RuboCop clean on all touched files.

## Out of scope (deliberate)
- Auto-refresh of the violations page after a "Create new location" round-trip — same caveat called out in the locked design.
- Promoting bulk add to a background job for very large targets (deferred).
- Adding unique indexes on `project_observations` / `project_images` (#4181, separate).

## Test plan
- [x] `bin/rails test test/models/project_test.rb`
- [x] `bin/rails test test/controllers/projects/`
- [x] `bin/rails test test/components/project_violations_form_test.rb`
- [x] `bundle exec rubocop` clean on all touched files
- [ ] Manual smoke in dev: violations page renders all four kinds, each action button works, location modal radios + Create link behave, tab counts refresh after Add / Exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
