### PR TITLE
Obscure GPS in MyCoPortal export for gps_hidden observations

### DIFF
--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -142,8 +142,14 @@ module Report
 
     # coordinateUncertaintyInMeters
     def coordinate_uncertainty(row)
-      if row.loc_id.present? &&
-         (row.obs_lat.blank? || gps_hidden?(row))
+      return if row.loc_id.blank?
+
+      if gps_hidden?(row)
+        return unless public_lat(row)
+
+        box = loc_box(row)
+        distance_to_farthest_corner(public_lat(row), public_lng(row), box)
+      elsif row.obs_lat.blank?
         distance_from_center_to_farthest_corner(row)
       end
     end
@@ -262,9 +268,22 @@ module Report
     end
 
     def add_gps_hidden!(rows, col)
-      ids = plain_query.where(gps_hidden: true).pluck(:id).to_set
-      vals = rows.map { |r| [r.obs_id, ids.include?(r.obs_id) ? "1" : nil] }
-      add_column!(rows, vals, col)
+      latlng_by_id = gps_hidden_latlng
+      rows.each { |row| set_gps_hidden_vals(row, col, latlng_by_id) }
+    end
+
+    def gps_hidden_latlng
+      plain_query.where(gps_hidden: true).
+        pluck(:id, :lat, :lng).
+        to_h { |id, lat, lng| [id, [lat, lng]] }
+    end
+
+    def set_gps_hidden_vals(row, col, latlng_by_id)
+      return unless (latlng = latlng_by_id[row.obs_id])
+
+      row.add_val("1", col)
+      row.add_val(latlng[0]&.round, col + 1)
+      row.add_val(latlng[1]&.round, col + 2)
     end
 
     def information_withheld(row)
@@ -274,31 +293,11 @@ module Report
     end
 
     def public_lat(row)
-      return loc_center_lat(row) if gps_hidden?(row)
-
-      row.best_lat
+      gps_hidden?(row) ? row.val(5) : row.best_lat
     end
 
     def public_lng(row)
-      return loc_center_lng(row) if gps_hidden?(row)
-
-      row.best_lng
-    end
-
-    def loc_center_lat(row)
-      north = row.loc_north(14)
-      south = row.loc_south(14)
-      return nil unless north && south
-
-      ((north + south) / 2).round(4)
-    end
-
-    def loc_center_lng(row)
-      east = row.loc_east(14)
-      west = row.loc_west(14)
-      return nil unless east && west
-
-      ((east + west) / 2).round(4)
+      gps_hidden?(row) ? row.val(6) : row.best_lng
     end
 
     def explode_notes(row)

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -145,10 +145,10 @@ module Report
       return if row.loc_id.blank?
 
       if gps_hidden?(row)
-        return unless public_lat(row)
+        return unless public_lat(row) && public_lng(row)
 
         box = loc_box(row)
-        distance_to_farthest_corner(public_lat(row), public_lng(row), box)
+        max_distance_to_any_corner(public_lat(row), public_lng(row), box)
       elsif row.obs_lat.blank?
         distance_from_center_to_farthest_corner(row)
       end
@@ -265,6 +265,17 @@ module Report
 
     def distance_to_se_corner(lat, lng, box)
       Haversine.distance(lat, lng, box.south, box.east).to_meters.round
+    end
+
+    def max_distance_to_any_corner(lat, lng, box)
+      box_corners(box).map do |clat, clng|
+        Haversine.distance(lat, lng, clat, clng).to_meters
+      end.max.round
+    end
+
+    def box_corners(box)
+      [[box.north, box.east], [box.north, box.west],
+       [box.south, box.east], [box.south, box.west]]
     end
 
     def add_gps_hidden!(rows, col)

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -13,6 +13,7 @@ require "haversine"
 module Report
   class Mycoportal < CSV
     CODE_NAME_QUALIFIER = "code name aff. species"
+    GPS_HIDDEN_MESSAGE = "Coordinates obscured by observer"
 
     # MCP uses Symbiota, which is largely based on Darwin Core (DwC).
     # Label names for the columns in the report.
@@ -44,6 +45,7 @@ module Report
         "decimalLatitude",
         "decimalLongitude",
         "coordinateUncertaintyInMeters",
+        "informationWithheld",
         "minimumElevationInMeters",
         "maximumElevationInMeters",
         "disposition" # herbaria, "vouchered", or nil
@@ -69,9 +71,10 @@ module Report
         row.state, # stateProvince
         row.county, # county
         row.locality, # locality
-        row.best_lat, # decimalLatitude
-        row.best_lng, # decimalLongitude
+        public_lat(row), # decimalLatitude
+        public_lng(row), # decimalLongitude
         coordinate_uncertainty(row), # coordinateUncertaintyInMeters
+        information_withheld(row), # informationWithheld
         row.best_low, # minimumElevationInMeters
         row.best_high, # maximumElevationInMeters
         disposition(row) # disposition
@@ -140,7 +143,7 @@ module Report
     # coordinateUncertaintyInMeters
     def coordinate_uncertainty(row)
       if row.loc_id.present? &&
-         row.obs_lat.blank?
+         (row.obs_lat.blank? || gps_hidden?(row))
         distance_from_center_to_farthest_corner(row)
       end
     end
@@ -166,6 +169,7 @@ module Report
       add_collector_ids!(rows, 1)
       add_herbarium_accession_numbers!(rows, 2)
       add_sequence_ids!(rows, 3)
+      add_gps_hidden!(rows, 4)
     end
 
     def collector_ids(row)
@@ -178,6 +182,10 @@ module Report
 
     def sequence_ids(row)
       row.val(3)
+    end
+
+    def gps_hidden?(row)
+      row.val(4).present?
     end
 
     def sort_before(rows)
@@ -251,6 +259,46 @@ module Report
 
     def distance_to_se_corner(lat, lng, box)
       Haversine.distance(lat, lng, box.south, box.east).to_meters.round
+    end
+
+    def add_gps_hidden!(rows, col)
+      ids = plain_query.where(gps_hidden: true).pluck(:id).to_set
+      vals = rows.map { |r| [r.obs_id, ids.include?(r.obs_id) ? "1" : nil] }
+      add_column!(rows, vals, col)
+    end
+
+    def information_withheld(row)
+      return unless gps_hidden?(row)
+
+      GPS_HIDDEN_MESSAGE
+    end
+
+    def public_lat(row)
+      return loc_center_lat(row) if gps_hidden?(row)
+
+      row.best_lat
+    end
+
+    def public_lng(row)
+      return loc_center_lng(row) if gps_hidden?(row)
+
+      row.best_lng
+    end
+
+    def loc_center_lat(row)
+      north = row.loc_north(14)
+      south = row.loc_south(14)
+      return nil unless north && south
+
+      ((north + south) / 2).round(4)
+    end
+
+    def loc_center_lng(row)
+      east = row.loc_east(14)
+      west = row.loc_west(14)
+      return nil unless east && west
+
+      ((east + west) / 2).round(4)
     end
 
     def explode_notes(row)

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -777,9 +777,13 @@ class ReportTest < UnitTestCase
     pub_lng = obs.lng.round
 
     # public lat/lng is the real GPS rounded to 0 decimal places.
-    # pub_lat is positive, so SE corner (south, east) is farthest.
-    uncertainty = Haversine.distance(pub_lat, pub_lng, loc.south, loc.east).
-                  to_meters.round.to_s
+    # uncertainty is the max distance to any of the four location corners.
+    uncertainty = [
+      [loc.north, loc.east], [loc.north, loc.west],
+      [loc.south, loc.east], [loc.south, loc.west]
+    ].map do |clat, clng|
+      Haversine.distance(pub_lat, pub_lng, clat, clng).to_meters
+    end.max.round.to_s
 
     expect = hashed_expect(obs).merge(
       decimalLatitude: pub_lat.to_s,

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -785,7 +785,8 @@ class ReportTest < UnitTestCase
       decimalLongitude: loc.center_lng.round(4).to_s,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
-      coordinateUncertaintyInMeters: uncertainty
+      coordinateUncertaintyInMeters: uncertainty,
+      informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     ).values
 
     do_csv_test(Report::Mycoportal, obs, expect, &:id)
@@ -811,7 +812,8 @@ class ReportTest < UnitTestCase
       decimalLongitude: loc.center_lng.round(4).to_s,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
-      coordinateUncertaintyInMeters: uncertainty
+      coordinateUncertaintyInMeters: uncertainty,
+      informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     ).values
 
     do_csv_test(Report::Mycoportal, obs, expect, &:id)
@@ -831,7 +833,8 @@ class ReportTest < UnitTestCase
     )
     expect = hashed_expect(obs).merge(
       stateProvince: "Puerto Rico",
-      locality: "Humacao18.094914, -65.801449"
+      locality: "Humacao18.094914, -65.801449",
+      informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     )
     [:decimalLatitude,
      :decimalLongitude,
@@ -938,6 +941,7 @@ class ReportTest < UnitTestCase
       decimalLatitude: obs_location&.center_lat&.to_s,
       decimalLongitude: obs_location&.center_lng&.to_s,
       coordinateUncertaintyInMeters: default_uncertainty || nil,
+      informationWithheld: nil,
       # if low/high are nil, value must be empty string, not zero
       minimumElevationInMeters: minimum_elevation,
       maximumElevationInMeters: maximum_elevation,

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -773,16 +773,17 @@ class ReportTest < UnitTestCase
   def test_mycoportal_coordinate_uncertainty_lat_lng_hidden
     obs = observations(:trusted_hidden)
     loc = obs.location
+    pub_lat = obs.lat.round
+    pub_lng = obs.lng.round
 
-    # obs lat/lng is in the NE quadrant of loc; so SE corner is the furthest
-    uncertainty = Haversine.distance(loc.center_lat, loc.center_lng,
-                                     loc.south, loc.west).
+    # public lat/lng is the real GPS rounded to 0 decimal places.
+    # pub_lat is positive, so SE corner (south, east) is farthest.
+    uncertainty = Haversine.distance(pub_lat, pub_lng, loc.south, loc.east).
                   to_meters.round.to_s
 
-    # public lat/lng is the loc center because obs coordinates are hidden.
     expect = hashed_expect(obs).merge(
-      decimalLatitude: loc.center_lat.round(4).to_s,
-      decimalLongitude: loc.center_lng.round(4).to_s,
+      decimalLatitude: pub_lat.to_s,
+      decimalLongitude: pub_lng.to_s,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
       coordinateUncertaintyInMeters: uncertainty,
@@ -798,21 +799,18 @@ class ReportTest < UnitTestCase
     # There are many (5,285) Obss with gps hidden, but no lat/lng
     obs.update!(location_id: loc.id, where: loc.name,
                 lat: nil, lng: nil)
-    loc = obs.location
-    uncertainty = Haversine.distance(
-      loc.center_lat, loc.center_lng, loc.north, loc.east
-    ).to_meters.round.to_s
 
+    # No GPS → public lat/lng and uncertainty are all nil.
     expect = hashed_expect(obs).merge(
       country: "South Africa",
       stateProvince: "Gauteng",
       county: nil,
       locality: "City of Tshwane Metropolitan Municipality, Pretoria",
-      decimalLatitude: loc.center_lat.round(4).to_s,
-      decimalLongitude: loc.center_lng.round(4).to_s,
+      decimalLatitude: nil,
+      decimalLongitude: nil,
       minimumElevationInMeters: obs.alt.to_s,
       maximumElevationInMeters: obs.alt.to_s,
-      coordinateUncertaintyInMeters: uncertainty,
+      coordinateUncertaintyInMeters: nil,
       informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     ).values
 
@@ -831,15 +829,16 @@ class ReportTest < UnitTestCase
       location_lat: nil,
       location_lng: nil
     )
+    # Has GPS but no location: public lat/lng are rounded GPS; no uncertainty.
     expect = hashed_expect(obs).merge(
       stateProvince: "Puerto Rico",
       locality: "Humacao18.094914, -65.801449",
+      decimalLatitude: obs.lat.round.to_s,
+      decimalLongitude: obs.lng.round.to_s,
+      coordinateUncertaintyInMeters: nil,
       informationWithheld: Report::Mycoportal::GPS_HIDDEN_MESSAGE
     )
-    [:decimalLatitude,
-     :decimalLongitude,
-     :coordinateUncertaintyInMeters,
-     :minimumElevationInMeters,
+    [:minimumElevationInMeters,
      :maximumElevationInMeters].each { |key| expect[key] = nil }
     expect = expect.values
 


### PR DESCRIPTION
## Summary

- Fixes #4178
- For `gps_hidden` observations, sets `decimalLatitude` and `decimalLongitude` to match the nightly published `observations.csv` dump (`round(lat, 0)` / `round(lng, 0)`).
- Adds `informationWithheld` field to the MyCoPortal TSV export, set to `"Coordinates obscured by observer"` (constant `GPS_HIDDEN_MESSAGE`) when `gps_hidden: true`
- `coordinateUncertaintyInMeters` for `gps_hidden` observations is the Haversine distance from those rounded coordinates to the farthest corner of the observation's location. If there is no GPS (lat/lng null), all three coordinate fields are nil.
 
## Test plan

- [x] All 54 report tests pass
- [x] `test_mycoportal_coordinate_uncertainty_lat_lng_hidden` — rounded GPS as public lat/lng; uncertainty from rounded point to SE corner of location
- [x] `test_mycoportal_coordinate_uncertainty_nil_lat_lng_hidden` — no GPS → nil lat, lng, and uncertainty
- [x] `test_mycoportal_coordinate_uncertainty_lat_lng_hidden_nil_location` — rounded GPS with no location → nil uncertainty
- [x] `hashed_expect` default includes `informationWithheld: nil` so all non-hidden tests cover the field

## Manual test
 - Run a report
 - [x] Report entries corresponding to your observations with hidden GPS should obscure the hidden lat/lng

🤖 Generated with [Claude Code](https://claude.com/claude-code)