### PR TITLE
Close coverage gaps from PRs #4191 and #4153

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -265,10 +265,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     ids.size
   end
 
-  def constraints
-    "#{:DATES.t}: #{date_range}; #{:LOCATION.t}: #{place_name}"
-  end
-
   def constraints?
     start_date || end_date || location ||
       target_names.any? || target_locations.any?
@@ -831,14 +827,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     kinds << :target_name if violates_target_name?(observation)
     kinds << :target_location if violates_target_location?(observation)
     kinds
-  end
-
-  # Is at least one violation removable by the given user?
-  def violations_removable_by_current_user?(user)
-    user_ids = violations.map { |v| v.obs.user_id }
-    return false unless user_ids.any?
-
-    admin_group_user_ids.union(user_ids).include?(user.id)
   end
 
   ##############################################################################

--- a/test/components/project_violations_form_test.rb
+++ b/test/components/project_violations_form_test.rb
@@ -115,6 +115,44 @@ class ProjectViolationsFormTest < ComponentTestCase
     assert_includes(html, :form_violations_action_add_target_location.l)
   end
 
+  # Covers the `suffixes.empty?` branch of render_location_modal_body —
+  # when the obs's location yields no usable suffixes (the only practical
+  # case after the J1 fix is a country-only string like "USA"), the modal
+  # body shows the "no usable suffixes" message and a Cancel button
+  # without rendering a submit form.
+  def test_target_location_modal_no_suffixes_message_for_country_only_where
+    proj = setup_target_location_violation_project
+    target_loc_v =
+      proj.violations.find { |v| v.kinds.include?(:target_location) }
+    assert(target_loc_v, "Setup must produce a target_location violation")
+
+    obs = target_loc_v.obs
+    obs.update!(location_id: nil, where: "USA")
+
+    proj.reload
+    refreshed = proj.violations.find { |v| v.obs.id == obs.id }
+    assert(refreshed,
+           "Obs should still violate target_location after where=USA")
+
+    html = render_form(project: proj, violations: proj.violations,
+                       user: proj.user)
+    modal_id = "location_target_modal_#{obs.id}"
+
+    assert_html(html, "##{modal_id}.modal")
+    assert_includes(
+      html, :form_violations_modal_target_location_no_suffixes.l,
+      "Modal body should show the no-usable-suffixes message"
+    )
+    assert_html(html, "##{modal_id} .modal-footer button[data-dismiss='modal']")
+    modal_pattern = %r{<div[^>]+id="#{modal_id}".*?</div>\s*</div>\s*</div>}m
+    modal_html = html.scan(modal_pattern).first.to_s
+    assert_no_match(
+      /<form[^>]+>[^<]*<input[^>]+name="do"[^>]+value="add_target_location"/m,
+      modal_html,
+      "Empty-suffixes branch must not render an add_target_location form"
+    )
+  end
+
   def test_target_location_modal_excludes_country_suffix
     proj = setup_target_location_violation_project
     target_loc_v =

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -694,6 +694,88 @@ class ProjectTest < UnitTestCase
     assert_not_includes(kinds, :target_location)
   end
 
+  # Covers Project#count_violations target_name path
+  # (collect_target_name_violation_ids id-merge against visible obs whose
+  # name_id is outside expanded_target_name_id_set). Project has only
+  # target_names, no other constraints, so that id-merge is the only path
+  # that can fire.
+  def test_count_violations_includes_target_name_violations
+    proj = Project.create!(
+      title: "Target Name Only #{SecureRandom.hex(4)}",
+      user: users(:rolf)
+    )
+    proj.add_target_name(names(:agaricus))
+    off_target = observations(:peltigera_obs)
+    proj.add_observation(off_target)
+
+    assert_equal(1, proj.count_violations,
+                 "Obs with non-target name should count as a violation")
+    assert_equal(proj.violations.size, proj.count_violations)
+    kinds = proj.violation_kinds_for(off_target)
+    assert_includes(kinds, :target_name)
+  end
+
+  # Covers Project#passing_target_location_ids with-loc branch
+  # (joins :location, applies location_suffix_conditions) and
+  # collect_target_location_violation_ids id-merge.
+  def test_count_violations_includes_target_location_violations_with_location
+    proj = Project.create!(
+      title: "Target Loc Only #{SecureRandom.hex(4)}",
+      user: users(:rolf)
+    )
+    proj.add_target_location(locations(:burbank))
+
+    in_burbank = observations(:agaricus_campestris_obs)
+    proj.add_observation(in_burbank)
+    in_falmouth = observations(:falmouth_2023_09_obs)
+    proj.add_observation(in_falmouth)
+
+    violation_obs_ids = proj.violations.map { |v| v.obs.id }
+    assert_includes(violation_obs_ids, in_falmouth.id,
+                    "Obs in Falmouth should violate Burbank target_location")
+    assert_not_includes(violation_obs_ids, in_burbank.id,
+                        "Obs in Burbank should pass via location_id branch")
+    assert_equal(proj.violations.size, proj.count_violations)
+  end
+
+  # Covers Project#passing_target_location_ids without-loc branch
+  # (visible_observations.where(location_id: nil) joined with
+  # where_suffix_conditions) and the observation.where leg of
+  # #target_location_suffix_match?.
+  # Both an obs whose `where` matches and one whose `where` doesn't are
+  # exercised so the boundary of the suffix match is locked down.
+  def test_count_violations_target_location_uses_obs_where_when_no_location
+    proj = Project.create!(
+      title: "Target Loc Where #{SecureRandom.hex(4)}",
+      user: users(:rolf)
+    )
+    proj.add_target_location(locations(:burbank))
+
+    # peltigera_obs: location_id is nil, where = "Briceland, California, USA"
+    # — should NOT match Burbank's suffix and so should violate.
+    off_target = observations(:peltigera_obs)
+    proj.add_observation(off_target)
+
+    on_target = Observation.create!(
+      user: users(:rolf), when: Date.parse("2024-06-01"),
+      name: names(:agaricus), location_id: nil,
+      where: "Burbank, California, USA"
+    )
+    proj.add_observation(on_target)
+
+    violation_obs_ids = proj.violations.map { |v| v.obs.id }
+    assert_includes(
+      violation_obs_ids, off_target.id,
+      "Obs.where=Briceland... should fail target_location suffix match"
+    )
+    assert_not_includes(
+      violation_obs_ids, on_target.id,
+      "Obs.where=Burbank... should pass target_location suffix match"
+    )
+    assert_equal(proj.violations.size, proj.count_violations)
+    assert_includes(proj.violation_kinds_for(off_target), :target_location)
+  end
+
   def test_violations_excludes_excluded_observations
     proj = projects(:falmouth_2023_09_project)
     violation_obs = proj.violations.first.obs


### PR DESCRIPTION
Off main. Follow-up to PR #4191 (njw-4136-expand-violations) and PR #4153 (njw-4130-subtaxa-in-project-names) — closes the line-coverage gaps that Coveralls and the SimpleCov before/after diff flagged after both merged.

## Summary
- **Two dead-code removals** in `app/models/project.rb`: `Project#constraints` (no callers since the obs-form replaced it) and `Project#violations_removable_by_current_user?` (added in #4191 but the violations form rebuild dropped the bulk-remove pattern that used it).
- **Three new model tests** covering `collect_target_name_violation_ids`, `collect_target_location_violation_ids`, and the with-loc / without-loc branches of `passing_target_location_ids` (which exercises `location_suffix_conditions`, `where_suffix_conditions`, and the `observation.where` leg of `target_location_suffix_match?`).
- **One new component test** covering the `suffixes.empty?` branch of `render_location_modal_body` — the only practical trigger after the J1 fix on PR #4182 is a country-only `where` string like `"USA"`. The test asserts the modal renders the no-usable-suffixes message and a Cancel button without an add_target_location form.

## Coverage gaps closed

| File | Lines | Resolution |
|---|---|---|
| `app/models/project.rb` | 269 | Dead code (`#constraints`) — removed |
| `app/models/project.rb` | 632-637 | `where_suffix_conditions` — covered by `test_count_violations_target_location_uses_obs_where_when_no_location` |
| `app/models/project.rb` | 658 | `collect_target_name_violation_ids` id-merge — covered by `test_count_violations_includes_target_name_violations` |
| `app/models/project.rb` | 667-668 | `collect_target_location_violation_ids` id-merge — covered by `test_count_violations_includes_target_location_violations_with_location` |
| `app/models/project.rb` | 672-677 | `passing_target_location_ids` both branches — covered by both new target_location tests |
| `app/models/project.rb` | 838-841 | Dead code (`#violations_removable_by_current_user?`) — removed |
| `app/models/project.rb` | 936 | `target_location_suffix_match?` `obs.where` leg — covered by `test_count_violations_target_location_uses_obs_where_when_no_location` |
| `app/components/project_violations_form.rb` | 212-220 | Empty-suffixes modal branch — covered by `test_target_location_modal_no_suffixes_message_for_country_only_where` |

## Test plan
- [x] `bin/rails test test/models/project_test.rb test/components/project_violations_form_test.rb` — 60 tests, 351 assertions, 0 failures
- [x] `bin/rails test test/controllers/ test/models/ test/components/` — 3498 tests, 0 failures
- [x] `bundle exec rubocop` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)