### PR TITLE
Cleanup project locations tab (Fixes #4147)

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -204,8 +204,13 @@ form {
 // The containing form uses `form-inline`, which turns .form-group into
 // inline-block/width:auto. Override so the autocompleter wrap and textarea
 // stretch to fill the form width (up to 40em), instead of collapsing to the
-// browser's default textarea size.
-#target_names_widget {
+// browser's default textarea size. We use ID selectors here (not the
+// shared `.project-target-widget` class) because Bootstrap's
+// `.form-inline .form-group` has class-class specificity (20) — a class
+// rule alone would tie and lose on source order, while id-class
+// specificity (110) reliably wins.
+#target_names_widget,
+#target_locations_widget {
   .form-group {
     display: block;
     width: 100%;

--- a/app/components/project_target_locations_widget.rb
+++ b/app/components/project_target_locations_widget.rb
@@ -6,35 +6,20 @@
 # locations table re-renders without a full page reload.
 #
 # Pattern B: creates its own FormObject internally so the view
-# only needs to pass the `project:` kwarg.
-class Components::ProjectTargetLocationsWidget < Components::ApplicationForm
-  # Optional positional model arg is accepted for ModalForm
-  # compatibility (ignored) — see Pattern B in
-  # .claude/phlex_style_guide.md.
-  def initialize(_model = nil, project:, **)
-    @project = project
-    super(FormObject::ProjectTargetLocationsAdd.new,
-          id: "target_locations_widget", local: false, **)
-  end
-
-  def around_template
-    @attributes[:class] = "form-inline mb-3"
-    super
-  end
-
-  def view_template
-    super do
-      autocompleter_field(
-        :locations,
-        type: :location,
-        textarea: true,
-        label: "#{:LOCATIONS.t}:"
-      )
-      submit(:project_target_location_add.t, class: "ml-2 mt-2")
-    end
-  end
-
+# only needs to pass the `project:` kwarg. Shared shape lives in
+# `Components::ProjectTargetWidgetBase`.
+class Components::ProjectTargetLocationsWidget <
+      Components::ProjectTargetWidgetBase
   def form_action
     project_target_locations_path(project_id: @project.id)
   end
+
+  private
+
+  def dom_id = "target_locations_widget"
+  def form_object = FormObject::ProjectTargetLocationsAdd.new
+  def field_name = :locations
+  def autocompleter_type = :location
+  def label_key = :project_target_locations_to_add_label
+  def submit_key = :project_target_location_add
 end

--- a/app/components/project_target_names_widget.rb
+++ b/app/components/project_target_names_widget.rb
@@ -6,35 +6,20 @@
 # checklist re-renders without a full page reload.
 #
 # Pattern B: creates its own FormObject internally so the view
-# only needs to pass the `project:` kwarg.
-class Components::ProjectTargetNamesWidget < Components::ApplicationForm
-  # Optional positional model arg is accepted for ModalForm
-  # compatibility (ignored) — see Pattern B in
-  # .claude/phlex_style_guide.md.
-  def initialize(_model = nil, project:, **)
-    @project = project
-    super(FormObject::ProjectTargetNamesAdd.new,
-          id: "target_names_widget", local: false, **)
-  end
-
-  def around_template
-    @attributes[:class] = "form-inline mb-3"
-    super
-  end
-
-  def view_template
-    super do
-      autocompleter_field(
-        :names,
-        type: :name,
-        textarea: true,
-        label: :project_target_names_to_add_label.t
-      )
-      submit(:project_target_name_add.t, class: "ml-2 mt-2")
-    end
-  end
-
+# only needs to pass the `project:` kwarg. Shared shape lives in
+# `Components::ProjectTargetWidgetBase`.
+class Components::ProjectTargetNamesWidget <
+      Components::ProjectTargetWidgetBase
   def form_action
     project_target_names_path(project_id: @project.id)
   end
+
+  private
+
+  def dom_id = "target_names_widget"
+  def form_object = FormObject::ProjectTargetNamesAdd.new
+  def field_name = :names
+  def autocompleter_type = :name
+  def label_key = :project_target_names_to_add_label
+  def submit_key = :project_target_name_add
 end

--- a/app/components/project_target_widget_base.rb
+++ b/app/components/project_target_widget_base.rb
@@ -6,9 +6,9 @@
 # below; the rendering shape is otherwise identical.
 #
 # The DOM id stays distinct per subclass (turbo-stream wrappers
-# replace by id), but both subclasses share the
-# `project-target-widget` class so the textarea-width CSS rule in
-# `_form_elements.scss` applies to both.
+# replace by id), and `_form_elements.scss` targets those ids for the
+# textarea-width override. Both subclasses also share the
+# `project-target-widget` class.
 class Components::ProjectTargetWidgetBase < Components::ApplicationForm
   # Optional positional model arg is accepted for ModalForm
   # compatibility (ignored) — see Pattern B in

--- a/app/components/project_target_widget_base.rb
+++ b/app/components/project_target_widget_base.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Shared base for the two inline forms that add target names or target
+# locations to a Project (Pattern B / Superform). Subclasses fill in
+# the few pieces that vary per type via the abstract methods listed
+# below; the rendering shape is otherwise identical.
+#
+# The DOM id stays distinct per subclass (turbo-stream wrappers
+# replace by id), but both subclasses share the
+# `project-target-widget` class so the textarea-width CSS rule in
+# `_form_elements.scss` applies to both.
+class Components::ProjectTargetWidgetBase < Components::ApplicationForm
+  # Optional positional model arg is accepted for ModalForm
+  # compatibility (ignored) — see Pattern B in
+  # .claude/phlex_style_guide.md.
+  def initialize(_model = nil, project:, **)
+    @project = project
+    super(form_object, id: dom_id, local: false, **)
+  end
+
+  def around_template
+    @attributes[:class] = "form-inline mb-3 project-target-widget"
+    super
+  end
+
+  def view_template
+    super do
+      autocompleter_field(
+        field_name,
+        type: autocompleter_type,
+        textarea: true,
+        label: label_key.l
+      )
+      submit(submit_key.l, class: "ml-2 mt-2")
+    end
+  end
+
+  # Subclasses must implement: dom_id, form_object, field_name,
+  # autocompleter_type, label_key, submit_key, form_action.
+end

--- a/app/components/projects/locations_table.rb
+++ b/app/components/projects/locations_table.rb
@@ -18,8 +18,10 @@ module Components
 
       def view_template
         div(id: "locations_table") do
+          render_target_summary if @grouped_data.any?
           render_target_groups if @grouped_data.any?
           render_ungrouped if @ungrouped_locations.any?
+          render_target_remove_footnote if show_target_remove_footnote?
         end
       end
 
@@ -29,6 +31,37 @@ module Components
         return @admin if defined?(@admin)
 
         @admin = @project.is_admin?(@user)
+      end
+
+      # --- Summary line above the table ---
+
+      def render_target_summary
+        total = @grouped_data.size
+        with_obs = @grouped_data.count do |group|
+          target_obs_count(group[:target], group[:sub_locations]).positive?
+        end
+        without_obs = total - with_obs
+
+        div(class: "my-3") do
+          plain(
+            :project_target_locations_summary.l(
+              total: total, with_obs: with_obs, without_obs: without_obs
+            )
+          )
+        end
+      end
+
+      # --- Footnote explaining the red X (admin-only) ---
+
+      def show_target_remove_footnote?
+        @grouped_data.any? && admin?
+      end
+
+      def render_target_remove_footnote
+        p(class: "mt-3") do
+          span(class: "glyphicon glyphicon-remove text-danger")
+          plain(" #{:project_target_locations_remove_footnote.l}")
+        end
       end
 
       # --- Target location groups (collapsible) ---

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3061,10 +3061,13 @@
   # Project Target Locations
   project_target_locations_title: Target Locations
   project_target_location_add: Add
+  project_target_locations_to_add_label: "Target Locations to Add:"
   project_target_locations_added: "Added target locations: [names]."
   project_target_location_removed: Removed target location "[name]".
   project_target_location_not_found: No matching locations found.
   project_target_location_confirm_remove: Remove "[name]" from target locations?
+  project_target_locations_summary: "Target locations: [total] total, [with_obs] with observations, [without_obs] with no observations."
+  project_target_locations_remove_footnote: Remove this target location from the project
 
   # Project Updates Tab
   project_updates_title: Update
@@ -3155,7 +3158,7 @@
   checklist_for_project_location_title: Checklist for [project] at [location]
   checklist_for_project_title: Checklist for [project]
   checklist_for_species_list_title: Checklist for [list]
-  checklist_target_summary: "Targets: [total] total, [observed] observed, [unobserved] not yet observed."
+  checklist_target_summary: "Target names: [total] total, [observed] observed, [unobserved] not yet observed."
   checklist_observed_summary: "[species] species and [higher] higher-level [taxa_word] observed (synonyms counted once)."
   checklist_observed_species_only: "[species] species observed (synonyms counted once)."
   checklist_observed_higher_only: "[higher] higher-level [taxa_word] observed (synonyms counted once)."

--- a/test/components/project_target_locations_widget_test.rb
+++ b/test/components/project_target_locations_widget_test.rb
@@ -31,7 +31,7 @@ class ProjectTargetLocationsWidgetTest < ComponentTestCase
       html,
       ".autocompleter[data-controller~='autocompleter--location']"
     )
-    assert_includes(html, :LOCATIONS.l)
+    assert_includes(html, :project_target_locations_to_add_label.l)
   end
 
   def test_renders_submit_button
@@ -43,6 +43,19 @@ class ProjectTargetLocationsWidgetTest < ComponentTestCase
       html,
       "input[type='submit']" \
       "[value='#{:project_target_location_add.l}']"
+    )
+  end
+
+  # Same shared class as the names widget — see the names-widget
+  # test for context. Issue #4147.
+  def test_form_carries_shared_widget_class
+    project = projects(:rare_fungi_project)
+
+    html = render_widget(project: project)
+
+    assert_html(
+      html,
+      "form#target_locations_widget.form-inline.project-target-widget"
     )
   end
 

--- a/test/components/project_target_names_widget_test.rb
+++ b/test/components/project_target_names_widget_test.rb
@@ -48,6 +48,20 @@ class ProjectTargetNamesWidgetTest < ComponentTestCase
     )
   end
 
+  # The `project-target-widget` class is shared with the locations
+  # widget and is the hook for `_form_elements.scss` to widen the
+  # textarea inside the surrounding form-inline form (#4147).
+  def test_form_carries_shared_widget_class
+    project = projects(:rare_fungi_project)
+
+    html = render_widget(project: project)
+
+    assert_html(
+      html,
+      "form#target_names_widget.form-inline.project-target-widget"
+    )
+  end
+
   private
 
   def render_widget(project:)

--- a/test/components/projects/locations_table_test.rb
+++ b/test/components/projects/locations_table_test.rb
@@ -76,6 +76,57 @@ module Projects
       assert_no_html(html, ".panel-collapse-trigger")
     end
 
+    # Summary line counts targets whose aggregate (target + sub-locations)
+    # obs count is positive. One target with sub-obs, one target with no
+    # obs anywhere → 2 total, 1 with observations, 1 without.
+    def test_summary_counts_targets_by_aggregate_obs
+      burbank = locations(:burbank)
+      california = locations(:california)
+      albion = locations(:albion)
+      grouped = [
+        { target: burbank, sub_locations: [albion] },
+        { target: california, sub_locations: [] }
+      ]
+      # burbank has no direct obs, but albion (its sub) does → with_obs;
+      # california has no obs anywhere → without_obs.
+      obs_counts = { albion.id => 4 }
+      html = render_table(
+        user: users(:rolf), grouped: grouped, obs_counts: obs_counts
+      )
+
+      assert_includes(
+        html,
+        :project_target_locations_summary.l(
+          total: 2, with_obs: 1, without_obs: 1
+        )
+      )
+    end
+
+    def test_summary_hidden_when_no_target_locations
+      html = render_table(
+        user: users(:rolf), grouped: [],
+        ungrouped: [locations(:albion)]
+      )
+
+      assert_not_includes(
+        html, :project_target_locations_summary.l(
+                total: 0, with_obs: 0, without_obs: 0
+              )
+      )
+    end
+
+    def test_admin_sees_remove_footnote
+      html = render_table(user: users(:rolf))
+
+      assert_includes(html, :project_target_locations_remove_footnote.l)
+    end
+
+    def test_non_admin_does_not_see_remove_footnote
+      html = render_table(user: users(:mary))
+
+      assert_not_includes(html, :project_target_locations_remove_footnote.l)
+    end
+
     private
 
     def project

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -93,7 +93,7 @@ class ChecklistsControllerTest < FunctionalTestCase
 
     assert_response(:success)
     # Line 1 — target-name summary.
-    assert_match(/Targets: 2 total.*1 observed.*1 not yet observed/,
+    assert_match(/Target names: 2 total.*1 observed.*1 not yet observed/,
                  @response.body)
     # Line 2 — observed summary with synonyms-counted-once note.
     assert_match(/1 species observed \(synonyms counted once\)/,


### PR DESCRIPTION
Fixes #4147. Inspired by the names-tab cleanup from PR #4138.

## Summary
- New summary line above the locations table: `"Target locations: N total, X with observations, Y with no observations."` — rendered only when the project has target locations. "With observations" counts a target whenever the aggregate (target + its sub-locations) obs count is positive.
- New admin-only footnote at the bottom of the table: `"Remove this target location from the project"`. Mirrors the names-tab footnote pattern from `Components::Checklist::Contents`.
- The textarea on the locations tab now matches the wider rendering on the names tab. The width override in `_form_elements.scss` previously keyed on `#target_names_widget` only; the SCSS rule now lists both widget DOM ids.
- DRY refactor: both target widgets shared near-identical Pattern B templates differing only in seven small pieces. Extracted into `Components::ProjectTargetWidgetBase` with thin subclasses overriding `dom_id`, `form_object`, `field_name`, `autocompleter_type`, `label_key`, `submit_key`, `form_action`. DOM ids stay distinct so existing turbo-stream replaces still work. New shared `project-target-widget` class on the form as a marker.
- Locations widget label changed from generic `LOCATIONS:` to `Target Locations to Add:`, matching the names widget pattern (new locale key `project_target_locations_to_add_label`).
- Names tab summary leading word changed from `"Targets:"` to `"Target names:"` so the two tabs read consistently.

## Specificity note (SCSS)

The width fix lives in `app/assets/stylesheets/mo/_form_elements.scss` and uses ID selectors rather than the new shared class. Bootstrap's `.form-inline .form-group` is class-class specificity (20); a class-only selector on our side would tie and lose on source order. ID-class (110) reliably wins. The comment in the SCSS captures the reason.

## Tests
- 4 new `Components::Projects::LocationsTable` tests covering summary aggregation, summary hidden state, admin-sees-footnote, non-admin-does-not.
- 1 new test on each target widget asserting the shared `project-target-widget` class on the form.
- 1 controller-test update for the new `"Target names:"` leading word.

## Test plan
- [x] `bin/rails test test/components/projects/locations_table_test.rb test/components/project_target_*_widget_test.rb test/controllers/projects/ test/controllers/checklists_controller_test.rb` — green
- [x] `bin/rails test test/controllers/projects/ test/components/ test/models/project_test.rb` (1033 tests) — green
- [x] `bundle exec rubocop` clean on all changed files
- [x] Manual: visit a project's Locations tab as admin → verify summary line above table, wider textbox, footnote at bottom; visit as non-admin → no footnote, no remove X. Hard-reload required (or `assets:clobber`) to pick up the SCSS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)