### PR TITLE
Prevent creation of non-fungi/slime-mold MO Names from iNat identification taxa

### DIFF
--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -35,8 +35,8 @@ class Inat
     # disable cop to facilitate comparing numbers to iNat url's & documentation
     FUNGI_TAXON_ID = 47170 # rubocop:disable Style/NumericLiterals
     MYCETOZOA_TAXON_ID = 47685 # rubocop:disable Style/NumericLiterals
-    IMPORTABLE_TAXON_IDS_ARG = [FUNGI_TAXON_ID, MYCETOZOA_TAXON_ID].join(",").
-                               freeze
+    IMPORTABLE_TAXON_IDS = [FUNGI_TAXON_ID, MYCETOZOA_TAXON_ID].freeze
+    IMPORTABLE_TAXON_IDS_ARG = IMPORTABLE_TAXON_IDS.join(",").freeze
 
     # base url for iNat CC-licensed and public domain photos
     LICENSED_PHOTO_BASE =

--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -108,6 +108,7 @@ class Inat
     def create_missing_identification_names
       inat_obs[:identifications].each do |ident|
         taxon = Inat::Taxon.new(ident[:taxon])
+        next unless taxon.importable?
         next if taxon.name.present?
 
         create_mo_name(taxon)

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -304,13 +304,22 @@ class Inat
       "\n#{
         self[:identifications].each_with_object([]) do |ident, ary|
           ident_taxon = Inat::Taxon.new(ident[:taxon])
-          display_name = ident_taxon.name&.text_name || ident[:taxon][:name]
-          ary << "&nbsp;&nbsp;_#{display_name}_ " \
+          display = ident_display(ident_taxon, ident[:taxon])
+          ary << "&nbsp;&nbsp;#{display} " \
                  "by #{ident[:user][:login]} " \
                  "#{ident[:created_at_details][:date]}"
         end.join("\n")
       }"
     end
+
+    def ident_display(taxon, taxon_hash)
+      if taxon.importable?
+        "_#{taxon.name&.text_name || taxon_hash[:name]}_"
+      else
+        "\"_#{taxon_hash[:name]}_\":#{SITE}/taxa/#{taxon_hash[:id]}"
+      end
+    end
+    private :ident_display
 
     def lat_lon_accuracy
       "#{self[:location]} +/-#{self[:public_positional_accuracy]} m"

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -341,27 +341,8 @@ class Inat
 
     def importable? = taxon_importable? && observed_on_present?
 
-    def taxon_importable? = fungi? || slime_mold?
+    def taxon_importable? = @obs_taxon.importable?
     def observed_on_present? = !observed_on_missing?
     def observed_on_missing? = self.when.nil?
-
-    ##########
-
-    private
-
-    # ----- Other
-
-    def fungi?
-      # !! makes it return a boolean
-      !!@obs.dig(:taxon, :ancestor_ids)&.include?(
-        Inat::Constants::FUNGI_TAXON_ID
-      )
-    end
-
-    def slime_mold?
-      !!@obs.dig(:taxon, :ancestor_ids)&.include?(
-        Inat::Constants::MYCETOZOA_TAXON_ID
-      )
-    end
   end
 end

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -299,8 +299,6 @@ class Inat
     private :copyright
 
     def suggested_id_names
-      # Get unique suggested taxon ids
-      # (iNat allows multiple suggestions for a single observation)
       "\n#{
         self[:identifications].each_with_object([]) do |ident, ary|
           ident_taxon = Inat::Taxon.new(ident[:taxon])

--- a/app/classes/inat/taxon.rb
+++ b/app/classes/inat/taxon.rb
@@ -68,6 +68,13 @@ class Inat
       @taxon[:name]
     end
 
+    def importable?
+      ancestor_ids = @taxon[:ancestor_ids]
+      return false if ancestor_ids.blank?
+
+      ancestor_ids.intersect?(IMPORTABLE_TAXON_IDS)
+    end
+
     #########
 
     private

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -405,6 +405,16 @@ class InatObsTest < UnitTestCase
     )
   end
 
+  def test_suggested_id_names_links_unimportable_taxon_to_inat
+    obs = mock_observation("ceanothus_cordulatus")
+    ident_taxon = obs[:identifications].first[:taxon]
+    expected_link =
+      "\"_#{ident_taxon[:name]}_\":#{SITE}/taxa/#{ident_taxon[:id]}"
+
+    assert_includes(obs.suggested_id_names, expected_link,
+                    "Non-importable ident taxon should link to iNat taxa page")
+  end
+
   def mock_observation(filename)
     mock_search = File.read("test/inat/#{filename}.txt")
     Inat::Obs.new(

--- a/test/classes/inat_taxon_test.rb
+++ b/test/classes/inat_taxon_test.rb
@@ -180,6 +180,18 @@ class InatTaxonTest < UnitTestCase
     assert_equal("Xeromphalina campanella", inat_taxon.full_name_string)
   end
 
+  def test_importable
+    fungi_obs = mock_observation("somion_unicolor")
+    fungi_ident_taxon = Inat::Taxon.new(fungi_obs[:identifications].last[:taxon])
+    assert(fungi_ident_taxon.importable?,
+           "Fungi identification taxon should be importable")
+
+    plant_obs = mock_observation("ceanothus_cordulatus")
+    plant_ident_taxon = Inat::Taxon.new(plant_obs[:identifications].last[:taxon])
+    assert_not(plant_ident_taxon.importable?,
+               "Plant identification taxon should not be importable")
+  end
+
   def test_returns_nil_when_no_mo_match
     assert_not(Name.exists?(text_name: "Calostoma lutescens"),
                "Test needs iNat taxon without an MO matching Name")

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -523,6 +523,29 @@ class InatImportJobTest < ActiveJob::TestCase
     end
   end
 
+  def test_unimportable_identification_taxon_not_created
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+
+    # Replace the fungi identification taxon with a plant one
+    parsed_response = JSON.parse(@mock_inat_response, symbolize_names: true)
+    ident_taxon =
+      parsed_response[:results].first[:identifications].first[:taxon]
+    ident_taxon[:name] = "Quercus alba"
+    # disable cop to facilitate comparing numbers to iNat ids
+    ident_taxon[:ancestor_ids] = [48460, 47126, 211194, 47125, 47124, 47132] # rubocop:disable Style/NumericLiterals
+    @mock_inat_response = JSON.generate(parsed_response)
+
+    stub_inat_interactions
+
+    assert_no_difference(
+      "Name.where(text_name: \"Quercus alba\").count",
+      "Should not create MO Name for non-fungi identification taxon"
+    ) do
+      InatImportJob.perform_now(@inat_import)
+    end
+  end
+
   def test_import_zero_results
     create_ivars_from_filename("zero_results")
     @inat_import.update(inat_ids: "123", token: "MockCode")

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -536,6 +536,8 @@ class InatImportJobTest < ActiveJob::TestCase
     ident_taxon[:ancestor_ids] = [48460, 47126, 211194, 47125, 47124, 47132] # rubocop:disable Style/NumericLiterals
     @mock_inat_response = JSON.generate(parsed_response)
 
+    assert_not(Name.exists?(text_name: "Quercus alba"),
+               "Test requires 'Quercus alba' to not exist in MO before import")
     stub_inat_interactions
 
     assert_no_difference(


### PR DESCRIPTION
Fixes #4058

## Manual Tests

### Prerequisites

Create a test iNat observation initially ID'd as a plant;
add a new suggested ID as a fungus, 
use that observation for the tests below.

---

- [x] ### 1. Non-importable identification appears as a link in the snapshot

**Steps**:
1. Note the non-fungi taxon name (e.g., "Quercus alba").
1. Run the iNat import for the observation.
2. Open the resulting MO observation.
3. Read the "iNat Snapshot" section of the Notes.
4. Find the "Suggested IDs" line.

**Expected**: the non-fungi identification appears as a clickable link
of the form `https://www.inaturalist.org/taxa/{id}` with the iNat
taxon name as the link text, formatted in italics.

**Not expected**: plain italic text with no link (the pre-fix behavior).

1. Search MO for the non-fungi taxon name.

**Expected**: no MO Name exists for the non-fungi taxon after import.

**Not expected**: a newly created MO Name for the non-fungi taxon.

---

- [x] ### 2. Importable identifications are unaffected (regression)

**Setup**: 
- Cleanup
  - Delete the MO_Observation_URL from the test iNat obs
  - Delete the just imported MO Observation
- Modify the test iNat observation so that all identifications are
fungi or slime molds, with at least one identification that has
no existing MO Name. (Ex: Chlorociboria clavula)

**Steps**:
1. Confirm the fungi ident taxon does not already exist in MO.
2. Run the iNat import.
3. Open the resulting MO observation.
4. Check the Suggested IDs in the Notes snapshot.
5. Search MO for the newly imported fungi taxon name.

**Expected**:
- The fungi identification appears as plain italic text in the snapshot
  (no iNat link).
- An MO Name was created for the previously missing fungi taxon.

- Cleanup
  - Delete the MO_Observation_URL from the test iNat obs (or delete the iNat obs)
  - Delete the just imported MO Observation
