### PR TITLE
Keep synonym-only-observed targets in Unobserved (Fixes #4152)

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -72,18 +72,22 @@ class Checklist
       target_names.size
     end
 
-    # Target names with at least one observation — direct or via a synonym
-    # in this project's observations — counted by target name record.
+    # Number of target names with at least one observation whose
+    # consensus name is the target name itself. Observations using a
+    # synonym do not count — see issue #4152. The goal is to encourage
+    # admins and members to re-identify obs to match the project's
+    # target names rather than letting synonyms silently satisfy them.
     def num_targets_observed
-      observed_target_name_ids.size
+      directly_observed_target_name_ids.size
     end
 
     def num_targets_unobserved
       num_targets - num_targets_observed
     end
 
-    # Target name tuples for which no synonym has an observation in the
-    # project. Rendered in the "Unobserved targets" panel.
+    # Target name tuples without a direct observation in the project.
+    # Includes targets whose synonym was observed — those are surfaced
+    # with the `+` marker via duplicate_synonyms (see #4152).
     def unobserved_target_taxa
       calc_checklist unless defined?(@unobserved_target_taxa)
       @unobserved_target_taxa
@@ -93,13 +97,12 @@ class Checklist
 
     def calc_checklist
       super
-      merge_observed_targets_into_taxa
       compute_unobserved_target_taxa
       # @duplicate_synonyms and @any_deprecated are set by `super` from
       # the observation-query results only. Recompute them across the
       # full rendered set (observed + unobserved targets) so the `+`
-      # marker fires for synonym-pairs that appear only among unobserved
-      # targets, and the `*` footnote legend appears when the only
+      # marker fires for synonym-pairs that span observed and unobserved
+      # panels, and the `*` footnote legend appears when the only
       # deprecated name on the page is an unobserved target.
       recompute_rendered_taxa_flags
     end
@@ -123,60 +126,27 @@ class Checklist
       @target_names ||= @project.target_names.to_a
     end
 
-    # Target name ids whose synonym group intersects with the project's
-    # observed name ids. A name without a synonym_id forms a group of one.
-    def observed_target_name_ids
-      @observed_target_name_ids ||= compute_observed_target_name_ids
+    # Target name ids whose own name appears as the consensus name of
+    # at least one observation in the project. Synonym observations do
+    # not count — see issue #4152.
+    def directly_observed_target_name_ids
+      @directly_observed_target_name_ids ||=
+        compute_directly_observed_target_name_ids
     end
 
-    def compute_observed_target_name_ids
+    def compute_directly_observed_target_name_ids
       return Set.new if target_names.empty?
 
       obs_name_ids = @observations.distinct.pluck(:name_id).to_set
       return Set.new if obs_name_ids.empty?
 
-      syn_ids = target_names.filter_map(&:synonym_id).uniq
-      siblings_by_syn = syn_ids.any? ? sibling_ids_by_synonym(syn_ids) : {}
-
       target_names.filter_map do |name|
-        target_observed?(name, obs_name_ids, siblings_by_syn) ? name.id : nil
+        name.id if obs_name_ids.include?(name.id)
       end.to_set
     end
 
-    def sibling_ids_by_synonym(syn_ids)
-      Name.where(synonym_id: syn_ids).
-        group_by(&:synonym_id).
-        transform_values { |names| names.map(&:id) }
-    end
-
-    def target_observed?(name, obs_name_ids, siblings_by_syn)
-      if name.synonym_id
-        (siblings_by_syn[name.synonym_id] || []).
-          any? { |id| obs_name_ids.include?(id) }
-      else
-        obs_name_ids.include?(name.id)
-      end
-    end
-
-    # Add observed-via-synonym targets to @taxa so they appear in the
-    # appropriate panel alongside query-observed names. Targets whose own
-    # name_id is already in @taxa are left alone.
-    def merge_observed_targets_into_taxa
-      return if target_names.empty?
-
-      taxa_ids = @taxa.to_set { |entry| entry[1] }
-      observed = observed_target_name_ids
-      target_names.each do |name|
-        next if taxa_ids.include?(name.id)
-        next unless observed.include?(name.id)
-
-        @taxa << target_tuple(name)
-      end
-      @taxa.sort_by! { |entry| entry[0] }
-    end
-
     def compute_unobserved_target_taxa
-      observed = observed_target_name_ids
+      observed = directly_observed_target_name_ids
       @unobserved_target_taxa =
         target_names.
         reject { |name| observed.include?(name.id) }.

--- a/test/models/checklist_test.rb
+++ b/test/models/checklist_test.rb
@@ -304,8 +304,10 @@ class ChecklistTest < UnitTestCase
     assert_equal(1, data.num_targets_unobserved)
   end
 
-  # L1-2/L1-3: Observation of a synonym (not the target itself) counts
-  # the target as observed.
+  # L1-2/L1-3: Observation of a synonym (not the target itself) does
+  # not count the target as observed; the target stays in the
+  # Unobserved panel and gets the `+` marker via duplicate_synonyms.
+  # Issue #4152.
   def test_num_targets_observed_via_synonym
     proj = projects(:rare_fungi_project)
     # macrolepiota_rachodes and macrolepiota_rhacodes share a synonym group
@@ -313,14 +315,24 @@ class ChecklistTest < UnitTestCase
     proj.observations << obs_of(names(:macrolepiota_rhacodes))
 
     data = Checklist::ForProject.new(proj)
-    # 3 targets now (the 2 rare_fungi + macrolepiota_rachodes);
-    # macrolepiota_rachodes is observed via its synonym.
+    # 3 targets now (the 2 rare_fungi + macrolepiota_rachodes); none of
+    # them has a direct observation, so all three are unobserved.
     assert_equal(3, data.num_targets)
-    assert_equal(1, data.num_targets_observed)
+    assert_equal(0, data.num_targets_observed)
+    assert_equal(3, data.num_targets_unobserved)
     assert_includes(data.unobserved_target_taxa.pluck(0),
                     "Coprinus comatus")
-    assert_not_includes(data.unobserved_target_taxa.pluck(0),
-                        "Macrolepiota rachodes")
+    assert_includes(data.unobserved_target_taxa.pluck(0),
+                    "Macrolepiota rachodes",
+                    "Synonym-only-observed target stays in Unobserved")
+    # Target's synonym observation populates @taxa with the synonym's
+    # row, but the target itself does not appear in the observed taxa.
+    assert_not_includes(data.taxa.pluck(0), "Macrolepiota rachodes")
+    assert_includes(data.taxa.pluck(0), "Macrolepiota rhacodes")
+    # Both rows share the synonym_id so both rows show the `+` marker.
+    target_synonym_id = names(:macrolepiota_rachodes).synonym_id
+    assert_includes(data.duplicate_synonyms, target_synonym_id,
+                    "+ marker should fire for the shared synonym group")
   end
 
   # L1-4: Targets exist, zero observations → all unobserved.
@@ -344,6 +356,32 @@ class ChecklistTest < UnitTestCase
     assert_equal(0, data.num_targets_observed)
     assert_includes(data.unobserved_target_taxa.pluck(0),
                     "Macrolepiota rachodes")
+  end
+
+  # Issue #4152 edge case: both names of a synonym pair are targets,
+  # only one (A) is directly observed. A appears observed; B stays
+  # in Unobserved; both rows share the synonym group so both get `+`.
+  def test_target_pair_one_directly_observed
+    proj = projects(:rare_fungi_project)
+    proj.project_target_names.destroy_all
+
+    name_a = names(:macrolepiota_rhacodes) # the directly-observed one
+    name_b = names(:macrolepiota_rachodes) # synonym, also a target
+    add_target(proj, name_a)
+    add_target(proj, name_b)
+    proj.observations << obs_of(name_a)
+
+    data = Checklist::ForProject.new(proj)
+    assert_equal(2, data.num_targets)
+    assert_equal(1, data.num_targets_observed,
+                 "Only A is directly observed")
+    assert_includes(data.taxa.pluck(0), name_a.text_name)
+    assert_not_includes(data.taxa.pluck(0), name_b.text_name)
+    assert_includes(data.unobserved_target_taxa.pluck(0),
+                    name_b.text_name,
+                    "Synonym-only target B stays in Unobserved")
+    assert_includes(data.duplicate_synonyms, name_a.synonym_id,
+                    "+ marker should fire across both panels")
   end
 
   # ==========================================================================

--- a/test/models/checklist_test.rb
+++ b/test/models/checklist_test.rb
@@ -484,16 +484,6 @@ class ChecklistTest < UnitTestCase
     assert_equal(1, data.num_species_observed)
   end
 
-  private
-
-  def obs_of(name)
-    Observation.create!(name: name, user: users(:rolf), when: Time.zone.now)
-  end
-
-  def add_target(project, name)
-    ProjectTargetName.create!(project: project, name: name)
-  end
-
   def test_checklist_for_project_include_sub_locations
     proj = projects(:bolete_project)
     california = locations(:california)
@@ -573,5 +563,15 @@ class ChecklistTest < UnitTestCase
     assert_equal(1, data.num_species)
     assert_equal(["Coprinus"], data.genera)
     assert_equal([["Coprinus comatus", obs.name_id]], data.species)
+  end
+
+  private
+
+  def obs_of(name)
+    Observation.create!(name: name, user: users(:rolf), when: Time.zone.now)
+  end
+
+  def add_target(project, name)
+    ProjectTargetName.create!(project: project, name: name)
   end
 end


### PR DESCRIPTION
## Summary

When a project target name had no direct observation but a synonym did, the row was merged into the **Species and below** panel — with `(0)` and a link to an empty observation list (filtered on the target's name only). Confusing: the row claimed the target was observed but the link disagreed.

After this change:
- Targets appear in **Species and below** only when the project has at least one observation whose consensus name *is* the target name.
- A target whose only matches are synonym observations stays in **Unobserved targets** with a Name show-page link, matching every other unobserved target.
- The `+` marker still fires on both the unobserved target row and the observed synonym row (both share `synonym_id`; `recompute_rendered_taxa_flags` already merges across panels).
- `num_targets_observed` is now direct-only. The summary line `"X targets, Y observed, Z unobserved"` matches what's in the panels and encourages admins to re-identify observations to the project's target names rather than letting synonyms silently satisfy them.

Resolution comments on the issue: https://github.com/MushroomObserver/mushroom-observer/issues/4152#issuecomment-4374019461

## Test plan

- [x] `bin/rails test` — all 5,130 tests pass
- [x] `bundle exec rubocop` — clean
- [x] Updated `test_num_targets_observed_via_synonym` (was asserting the old synonym-aware count)
- [x] Added `test_target_pair_one_directly_observed` for the edge case where both names of a synonym pair are project targets
- [x] Manual: follow the repro in the issue (target with synonym, observation uses synonym) and confirm:
  - Target appears in Unobserved targets panel (not Species and below)
  - Target row shows `+`, synonym row also shows `+`
  - Target link goes to the Name show page
  - Summary counts target as unobserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)