### PR TITLE
Phlex `ProjectForm` - use `radio_field` helper for `dates_any` toggle

### DIFF
--- a/.claude/phlex_style_guide.md
+++ b/.claude/phlex_style_guide.md
@@ -29,6 +29,7 @@ fields. **Always use these helpers** instead of the verbose
 text_field(:name, label: "Name:", size: 40)
 textarea_field(:notes, label: "Notes:", rows: 6)
 checkbox_field(:approved, label: "Approved")
+radio_field(:status, ["active", "Active"], ["inactive", "Inactive"])
 select_field(:rank, rank_options, label: "Rank:")
 static_field(:display_name, label: "Name:", value: @model.name, inline: true)
 read_only_field(:locked_field, label: "Value:", value: @value)
@@ -36,6 +37,56 @@ read_only_field(:locked_field, label: "Value:", value: @value)
 # Bad - Verbose render(field(...)) pattern
 render(field(:name).text(wrapper_options: { label: "Name:" }, size: 40))
 render(field(:notes).textarea(wrapper_options: { label: "Notes:" }, rows: 6))
+```
+
+### NEVER hand-roll form-control HTML inside a form component
+
+**HARD RULE**: Inside any class that extends `Components::ApplicationForm`, do
+NOT emit raw `input`, `select`, `textarea`, or `option` Phlex tags for form
+controls. Every form control must be rendered through one of:
+
+1. An `ApplicationForm` field helper (`text_field`, `radio_field`,
+   `checkbox_field`, `select_field`, `date_field`, `autocompleter_field`,
+   `static_field`, `read_only_field`, `submit`, `upload_fields`, etc.) — for
+   fields that ARE attributes of the form's model / FormObject.
+2. A `FieldProxy` + the matching field class (`RadioField`, `TextField`,
+   `CheckboxField`, `SelectField`, …) — for fields that are NOT attributes of
+   the model (UI state passed in from the controller, transient toggles,
+   etc.). See `FieldProxy: Form Fields Outside a Form Context` below for the
+   API; the same proxy is used inside a form when the field isn't on the
+   model.
+
+**Why this rule exists**: The field helpers and field classes generate the
+exact Bootstrap markup, ARIA attributes, ID/name conventions, and Stimulus
+hooks the rest of the app expects. Hand-rolled `input`s skip all of that and
+have to be deduplicated later (this rule was added after a Phlex conversion
+hand-rolled radio buttons for a non-model field; see PR #4224).
+
+**Decision tree** when adding a field to an `ApplicationForm` subclass:
+
+```
+Is the field an attribute of the form's model / FormObject?
+├── Yes → use the matching `ApplicationForm` helper (`radio_field`, etc.).
+└── No  → can the field be added to a FormObject without bloating it?
+         ├── Yes → add it to the FormObject and use the helper.
+         └── No  → wrap it with FieldProxy and render the field class.
+                    NEVER hand-roll the HTML.
+```
+
+**Reference example** for the non-model-field case (`ProjectForm` —
+`dates_any` is UI state, not a `Project` column):
+
+```ruby
+def render_dates_any_radios
+  proxy = Components::ApplicationForm::FieldProxy.new(
+    "project", :dates_any, @dates_any
+  )
+  render(Components::ApplicationForm::RadioField.new(
+           proxy,
+           ["false", range_label],
+           ["true", any_label]
+         ))
+end
 ```
 
 ### Pattern B Forms: Internal FormObject Creation
@@ -521,18 +572,30 @@ def normalize_link(link)
 end
 ```
 
-### FieldProxy: Form Fields Outside a Form Context
+### FieldProxy: Fields Without a Superform Field Backing
 
-When you need to render Superform field components (e.g., `TextField`,
-`RadioField`) **outside** of a `Superform::Rails::Form`, use `FieldProxy`.
-This is common in feedback components and image field editors that render
-form inputs without owning the `<form>` tag.
+`FieldProxy` is the escape hatch for any form field that can't be reached via
+`field(:attr)` on the form's model / FormObject. It provides the same interface
+as `Superform::Field` (`key`, `value`, `dom.id`, `dom.name`, `dom.value`) so
+the existing field classes (`TextField`, `RadioField`, `CheckboxField`,
+`SelectField`, …) render identical Bootstrap markup whether or not the field
+is model-backed.
 
-`FieldProxy` provides the same interface as `Superform::Field` (`key`, `value`,
-`dom.id`, `dom.name`, `dom.value`) so field components work identically.
+There are two situations where `FieldProxy` is the right answer:
+
+1. **Outside a Superform form.** Feedback / editor components that render
+   form inputs without owning the `<form>` tag — e.g., `FormImageFields`,
+   `FormListFeedback`, `FormNameFeedback`.
+2. **Inside a Superform form, for a field that isn't on the model.** UI
+   state passed from the controller, transient toggles, derived values,
+   etc. — e.g., `dates_any` in `ProjectForm`. The form helpers (`radio_field`,
+   `text_field`, …) all call `field(field_name)` on the model and will fail
+   for fields the model doesn't expose. **Do NOT hand-roll `input` tags as
+   a workaround.** Use `FieldProxy`. See the "NEVER hand-roll form-control
+   HTML" rule above.
 
 ```ruby
-# Create a proxy for a namespaced field
+# Outside-form usage (FormNameFeedback)
 proxy = Components::ApplicationForm::FieldProxy.new(
   "chosen_multiple_names", name.id
 )
@@ -541,7 +604,17 @@ render(Components::ApplicationForm::RadioField.new(
   wrapper_options: { wrap_class: "my-1 mr-4 d-inline-block" }
 ))
 
-# For image fields, use the factory method
+# Inside-form usage for a non-model field (ProjectForm).
+# `dates_any` is UI state from the controller, not a Project attribute,
+# so `field(:dates_any)` can't read it.
+proxy = Components::ApplicationForm::FieldProxy.new(
+  "project", :dates_any, @dates_any
+)
+render(Components::ApplicationForm::RadioField.new(
+  proxy, ["false", range_label], ["true", any_label]
+))
+
+# Image fields have a factory method
 proxy = ApplicationForm.image_field_proxy(:good_image, 123, :notes, "text")
 render(Components::ApplicationForm::TextField.new(
   proxy,
@@ -549,11 +622,6 @@ render(Components::ApplicationForm::TextField.new(
   wrapper_options: { label: "Notes:" }
 ))
 ```
-
-**When to use FieldProxy:**
-- Components that render form inputs but don't own the `<form>` tag
-  (e.g., `FormImageFields`, `FormListFeedback`, `FormNameFeedback`)
-- Standalone radio groups or other inputs outside a Superform form
 
 **Never use `fields_for`** — use `FieldProxy` or Superform's `namespace`
 method instead.

--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -14,9 +14,25 @@ Before writing ANY Phlex form component, you MUST:
 
 Do NOT skip these reads even if the conversion seems straightforward.
 
+While writing the component, for **every** form control you add, follow the
+"NEVER hand-roll form-control HTML" decision tree in `phlex_style_guide.md`:
+
+- Field is on the model / FormObject? → use the matching `*_field` helper.
+- Field isn't on the model? → wrap it with
+  `Components::ApplicationForm::FieldProxy` and render the matching field
+  class (`RadioField`, `TextField`, `CheckboxField`, `SelectField`, …).
+- **Never** emit raw `input`, `select`, `textarea`, or `option` tags from a
+  form component. If you find yourself reaching for them, you're missing
+  one of the two paths above. Re-read the FieldProxy section before
+  proceeding. (This rule was added after PR #4224 had to undo a hand-rolled
+  radio group from PR #4076.)
+
 After writing the component:
 
 4. Write a component test in `test/components/` following the patterns in
    `.claude/rules/testing.md` (consolidate assertions per render, extract
    a DRY render helper, etc.). See `test/components/herbarium_form_test.rb`
    or `test/components/sequence_form_test.rb` for reference.
+5. Self-review the component diff for any literal `input(`, `select(`,
+   `textarea(`, or `option(` calls. If present, replace each with the
+   helper or FieldProxy pattern before opening the PR.

--- a/app/components/project_form.rb
+++ b/app/components/project_form.rb
@@ -91,23 +91,18 @@ class Components::ProjectForm < Components::ApplicationForm
     end
   end
 
+  # `dates_any` is UI state passed in from the controller, not a Project
+  # attribute, so we can't use `field(:dates_any)`. FieldProxy gives RadioField
+  # the field name, value, and namespace it needs without a model accessor.
   def render_dates_any_radios
-    render_radio("false", !@dates_any, range_label)
-    render_radio("true", @dates_any, any_label)
-  end
-
-  def render_radio(value, checked, label_text)
-    div(class: "radio") do
-      label do
-        input(type: :radio,
-              name: "project[dates_any]",
-              id: "project_dates_any_#{value}",
-              value: value,
-              checked: checked)
-        whitespace
-        plain(label_text)
-      end
-    end
+    proxy = Components::ApplicationForm::FieldProxy.new(
+      "project", :dates_any, @dates_any
+    )
+    render(Components::ApplicationForm::RadioField.new(
+             proxy,
+             ["false", range_label],
+             ["true", any_label]
+           ))
   end
 
   def range_label


### PR DESCRIPTION
## Background
Phlex superforms generally need all form fields to either be attributes of one of our db backed models, like `Project` or `Name` — or, if the form is not a CRUD form, the fields need to be attributes of a custom `FormObject` created for the form, as in the case of admin requests, etc. 

With either type of FormObject, Superform can work its validation magic and generally economize on form generation code by passing the fields to the form field helpers defined in `ApplicationForm`. These helpers are what keep our forms rendering consistent Bootstrap HTML.

### The plot twist
However, some CRUD forms in MO need an extra field or two that is not part of the db-backed model, but it also may not be worth creating a new `FormObject` separate from the db model. In these cases, Claude came up with a solution called `FormProxy` - it allows for a custom field to be added to the form and passed to the field helper, without junking up the model with an attribute that won't get saved, it's only passed to the helper for the form UI.

This works fine, if you know about it. However, Claude's right hand knoweth not what its left hand doeth, and so in @mo-nathan's PR, it found another way to render this field, creating its own render method that duplicates the code in `ApplicationForm#radio_field`. This PR is to remove that duplication.

## Summary
- Addresses @nimmolo's [review feedback](https://github.com/MushroomObserver/mushroom-observer/pull/4076/changes/BASE..842ba12dce1dcf0f1dfe09ac9be0566229e598b4#r3036907380) on #4076: The new Phlex `ProjectForm` was using its own inline radio button render method (`render_radio`) instead of using the shared `radio_field` / `ApplicationForm::RadioField` helper.
- Replaces the inline implementation with the existing `FieldProxy` + `RadioField` pattern (same approach `form_name_feedback.rb` uses for non-model-backed radio groups).
- What is `FieldProxy`? It's a Claude invention for Phlex forms, in cases like this where there's a field that is not an attribute of the form object.  In this case`dates_any` is UI state passed in from the controller, not a `Project` attribute, so `field(:dates_any)` can't read it from the model. A code comment explains this.

The rendered HTML from `radio_field` is identical (same name, value, id, checked attributes); only the rendering path changes.

## Test plan
- [x] `bin/rails test test/components/project_form_test.rb` — 4 tests, 26 assertions pass
- [x] `bin/rails test test/controllers/projects_controller_test.rb` — 44 tests, 323 assertions pass
- [x] `bundle exec rubocop app/components/project_form.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)