### PR TITLE
Remove misleading field.hidden alias on ApplicationForm::Field

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -176,9 +176,6 @@ class Components::ApplicationForm < Superform::Rails::Form
                                    **ac_options)
     end
 
-    # Alias for backwards compatibility
-    alias hidden read_only
-
     def static(wrapper_options: {}, **attributes)
       StaticTextField.new(self, attributes: attributes,
                                 wrapper_options: wrapper_options)


### PR DESCRIPTION
## Summary
- Removes `alias hidden read_only` (and its accompanying comment) on `Components::ApplicationForm::Field`.
- Added in d7dcfbb19 ("hidden_field -> read_only_field") for backwards compatibility during the rename.
- No callers in `app/` or `test/` (`grep -rEn "field\\([^)]*\\)\\.hidden\\b"` and `\\.hidden\\(` are both empty), and the alias is actively misleading:
  - `hidden_field` (form helper) → bare `<input type="hidden">`.
  - `field(:foo).hidden` (the alias) → resolves to `read_only`, which renders a visible `<div class="form-group">` with a static-text `<p class="form-control-static">` plus a hidden input.
- Same word, two very different UIs. The naming gap was raised while reviewing #4225 — easier to remove the dead alias than to keep explaining it.

## Test plan
- [x] `bin/rails test test/components/` — 875 tests, 4536 assertions, all pass
- [x] `bundle exec rubocop app/components/application_form.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)