### PR TITLE
Per-worker email-debug.log to fix parallel test pollution

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -64,7 +64,7 @@ class ApplicationMailer < ActionMailer::Base
       value = v.nil? || v.instance_of?(String) ? v : v.id
       msg << " #{k}=#{value}"
     end
-    Rails.root.join("log/email-debug.log").open("a:utf-8") do |fh|
+    MO.email_debug_log_path.open("a:utf-8") do |fh|
       fh.puts("#{Time.zone.now} #{msg}")
     end
   end

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -212,6 +212,16 @@ MushroomObserver::Application.configure do
     format(IMAGE_CONFIG_DATA.config["local_image_files"], root: MO.root)
   end
 
+  # Path to the mail-delivery debug log. Per-worker in test mode so
+  # parallel workers don't write to a shared file (the
+  # MailDeliveryErrorLoggingTest reads this file by offset and would
+  # see other workers' lines if they shared it).
+  def config.email_debug_log_path
+    suffix = IMAGE_CONFIG_DATA.database_worker_number
+    name = suffix ? "email-debug-#{suffix}.log" : "email-debug.log"
+    MO.root.join("log", name)
+  end
+
   # Definition of image sources.  Keys are :test, :read and :write.  Values are
   # URLs.  Leave :write blank for read-only sources.  :transferred_flag tells MO
   # to test for existence of file by using image#transferred flag.

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require("pathname")
 require("yaml")
 
 class ImageConfigData
@@ -215,11 +216,16 @@ MushroomObserver::Application.configure do
   # Path to the mail-delivery debug log. Per-worker in test mode so
   # parallel workers don't write to a shared file (the
   # MailDeliveryErrorLoggingTest reads this file by offset and would
-  # see other workers' lines if they shared it).
+  # see other workers' lines if they shared it). Returned as a
+  # Pathname for callers that want to call open/exist?/etc. on it.
   def config.email_debug_log_path
-    suffix = IMAGE_CONFIG_DATA.database_worker_number
-    name = suffix ? "email-debug-#{suffix}.log" : "email-debug.log"
-    MO.root.join("log", name)
+    name = if env == "test" &&
+              (worker_num = IMAGE_CONFIG_DATA.database_worker_number)
+             "email-debug-#{worker_num}.log"
+           else
+             "email-debug.log"
+           end
+    Pathname.new("#{root}/log/#{name}")
   end
 
   # Definition of image sources.  Keys are :test, :read and :write.  Values are

--- a/config/initializers/mail_delivery_error_logging.rb
+++ b/config/initializers/mail_delivery_error_logging.rb
@@ -13,10 +13,9 @@ Rails.application.config.after_initialize do
     msg << " params=#{params.inspect}" if params.present?
     msg << " error=#{exception.class}: " \
            "#{exception.message}"
-    Rails.root.join("log/email-debug.log").
-      open("a:utf-8") do |fh|
-        fh.puts("#{Time.zone.now} #{msg}")
-      end
+    MO.email_debug_log_path.open("a:utf-8") do |fh|
+      fh.puts("#{Time.zone.now} #{msg}")
+    end
     raise(exception)
   end
 end

--- a/test/jobs/mail_delivery_error_logging_test.rb
+++ b/test/jobs/mail_delivery_error_logging_test.rb
@@ -6,7 +6,9 @@ require("net/smtp")
 class MailDeliveryErrorLoggingTest < ActiveJob::TestCase
   def setup
     super
-    @log_path = Rails.root.join("log/email-debug.log")
+    # Per-worker path so parallel workers don't pollute each other's
+    # offset-based log delta. See MO.email_debug_log_path.
+    @log_path = MO.email_debug_log_path
     @log_offset = File.exist?(@log_path) ? File.size(@log_path) : 0
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -218,11 +218,14 @@ module ActiveSupport
     # clear these logs periodically, they can get freaking huge, and that
     # causes this test to take up to several minutes to complete.
     def clear_logs
-      %w[development test email-debug process_image].each do |file|
-        file = Rails.root.join("log", "#{file}.log")
-        next unless File.exist?(file)
+      paths = %w[development test process_image].map do |name|
+        Rails.root.join("log", "#{name}.log")
+      end
+      paths << MO.email_debug_log_path
+      paths.each do |path|
+        next unless File.exist?(path)
 
-        File.truncate(file, 0)
+        File.truncate(path, 0)
       end
       @@cleared_logs = true
     end


### PR DESCRIPTION
## Summary

Fixes a flaky `MailDeliveryErrorLoggingTest#test_non_mail_job_failure_not_logged` failure under parallel testing.

## Symptom

Under `bin/rails test` (14 parallel workers), this test fails intermittently with output like:

```
FAIL MailDeliveryErrorLoggingTest#test_non_mail_job_failure_not_logged
  Non-mail job errors should not be logged to email-debug.log.
  Expected /DELIVERY FAILED/ to not match
    "... DELIVERY FAILED UserQuestionMailer#build params={...}
       error=Net::SMTPServerBusy: 450 Too many connections\n"
```

That `Net::SMTPServerBusy: 450 Too many connections` line is exactly what the sibling `test_mail_delivery_failure_re_raises_exception` writes — never something this test should produce.

## Root cause

`log/email-debug.log` is shared across all 14 workers. The test's design is "snapshot file size in `setup`, read everything appended since" — which is fine in single-process but breaks under parallel because **another worker can append between the offset capture and the delta read**. The polluting line above is from another worker running the sibling test concurrently.

## Fix

Route the path through new `MO.email_debug_log_path`, which appends the worker number in test mode and is unchanged in development/production — exactly the pattern already used by `MO.local_image_files`, `MO.blocked_ips_file`, etc.

Touch points:
- `config/consts.rb` — new helper.
- `config/initializers/mail_delivery_error_logging.rb` and `app/mailers/application_mailer.rb` — both writers go through the helper.
- `test/jobs/mail_delivery_error_logging_test.rb` — `@log_path` derived from the helper.
- `test/test_helper.rb` `clear_logs` — truncates through the helper too.

## Test plan

- [x] `bin/rails test` — 5137 tests, 36818 assertions, 0 failures, 0 errors
- [x] `bundle exec rubocop` clean on changed files
- [x] Manual repro: the previously-failing test now consistently passes when the suite is rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)