### PR TITLE
Replace hand-rolled form inputs with helpers / FieldProxy (group A of #4225)

### DIFF
--- a/app/components/description_form.rb
+++ b/app/components/description_form.rb
@@ -139,8 +139,16 @@ class Components::DescriptionForm < Components::ApplicationForm
   # --- Merge fields ---
 
   def render_merge_fields
-    input(type: "hidden", name: "old_desc_id", value: @old_desc_id)
-    input(type: "hidden", name: "delete_after", value: @delete_after)
+    render_flat_hidden_field("old_desc_id", @old_desc_id)
+    render_flat_hidden_field("delete_after", @delete_after)
+  end
+
+  def render_flat_hidden_field(name, value)
+    proxy = Components::ApplicationForm::FieldProxy.new(nil, name, value)
+    render(Components::ApplicationForm::TextField.new(
+             proxy,
+             attributes: { type: "hidden" }
+           ))
   end
 
   # --- Helper methods ---

--- a/app/components/external_link_form.rb
+++ b/app/components/external_link_form.rb
@@ -34,12 +34,8 @@ class Components::ExternalLinkForm < Components::ApplicationForm
   end
 
   def render_hidden_fields
-    input(type: "hidden", name: "external_link[user_id]", value: @user&.id)
-    input(
-      type: "hidden",
-      name: "external_link[observation_id]",
-      value: @observation.id
-    )
+    hidden_field(:user_id, value: @user&.id)
+    hidden_field(:observation_id, value: @observation.id)
   end
 
   def render_site_select

--- a/app/components/name_form.rb
+++ b/app/components/name_form.rb
@@ -37,7 +37,13 @@ class Components::NameForm < Components::ApplicationForm
   def render_approved_rank_field
     return unless @approved_rank
 
-    input(type: "hidden", name: "approved_rank", value: @approved_rank)
+    proxy = Components::ApplicationForm::FieldProxy.new(
+      nil, "approved_rank", @approved_rank
+    )
+    render(Components::ApplicationForm::TextField.new(
+             proxy,
+             attributes: { type: "hidden" }
+           ))
   end
 
   def button_text

--- a/app/components/occurrence_edit_form.rb
+++ b/app/components/occurrence_edit_form.rb
@@ -64,8 +64,7 @@ class Components::OccurrenceEditForm < Components::ApplicationForm
   end
 
   def render_submit
-    input(type: "submit", value: :edit_occurrence_submit.l,
-          class: "btn btn-default center-block my-3")
+    submit(:edit_occurrence_submit.l, center: true)
   end
 
   def render_obs_box(obs)

--- a/app/components/occurrence_form.rb
+++ b/app/components/occurrence_form.rb
@@ -18,8 +18,7 @@ class Components::OccurrenceForm < Components::ApplicationForm
   def view_template
     hidden_field(:observation_id)
     render_observation_grid
-    input(type: "submit", value: :create_occurrence_submit.l,
-          class: "btn btn-default center-block my-3")
+    submit(:create_occurrence_submit.l, center: true)
   end
 
   def form_action

--- a/app/components/translation_form.rb
+++ b/app/components/translation_form.rb
@@ -26,7 +26,7 @@ class Components::TranslationForm < Components::ApplicationForm
 
   def view_template
     super do
-      input(type: "hidden", name: "tag", value: @tag)
+      render_hidden_tag_field
       render_language_header
       render_tag_textareas
       render_buttons
@@ -38,6 +38,14 @@ class Components::TranslationForm < Components::ApplicationForm
 
   def form_action
     translation_path(@tag, for_page: @for_page)
+  end
+
+  def render_hidden_tag_field
+    proxy = Components::ApplicationForm::FieldProxy.new(nil, "tag", @tag)
+    render(Components::ApplicationForm::TextField.new(
+             proxy,
+             attributes: { type: "hidden" }
+           ))
   end
 
   def form_dataset


### PR DESCRIPTION
## Summary
Addresses **Group A — quick wins** from #4225. Every form control inside an `ApplicationForm` subclass now goes through a field helper or `FieldProxy` + field class, not a raw `input` / `select` / `textarea` call.

- `external_link_form`: hidden `user_id` and `observation_id` → `hidden_field`
- `name_form`: `approved_rank` → `FieldProxy` + `TextField(type: "hidden")`
- `translation_form`: flat `tag` hidden input → `FieldProxy` + `TextField(type: "hidden")`
- `description_form`: `old_desc_id` and `delete_after` → `FieldProxy` + `TextField(type: "hidden")` (extracted shared `render_flat_hidden_field` helper)
- `occurrence_form`: submit `input` → `submit()` helper
- `occurrence_edit_form`: submit `input` → `submit()` helper

Group B (bare-select sites in `identify_filter_form` and `translation_form`) and Group C (`occurrence_form` / `occurrence_edit_form` array-param checkboxes/radios and the manual `_method=patch` form) remain open per the umbrella issue.

Refs #4225.

## Test plan
- [x] `bundle exec rubocop` clean on all six changed files
- [x] `bin/rails test test/components/external_link_form_test.rb test/components/name_form_test.rb test/components/translation_form_test.rb test/components/occurrence_form_test.rb test/components/occurrence_edit_form_test.rb` — 80 tests, 318 assertions, 0 failures
- [x] `bin/rails test test/controllers/names/descriptions_controller_test.rb -n /merge/` — 2 tests, 8 assertions, 0 failures (covers the `old_desc_id` / `delete_after` path)
- [x] Self-review grep `^\s*(input|select|textarea|option)\(` on all six files — only Group B / Group C call sites remain
- [ ] Smoke-test in browser: create/edit external link, create misspelled name with `approved_rank`, edit a translation, merge two name descriptions, create and edit an occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)