### PR TITLE
Tolerate nil iNat credentials at module load

### DIFF
--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -17,11 +17,12 @@ class Inat
     # iNat's id for the MO application
     # Differs in production vs. test & development.
     # Safe-navigated so module load doesn't crash when credentials
-    # can't be decrypted (e.g. CI runs for PRs from forked repos,
-    # which GitHub Actions doesn't pass repo secrets to). Tests
-    # that actually exercise iNat OAuth still need real credentials
-    # or stubs; those that don't (the vast majority) don't care
-    # about the value here.
+    # can't be decrypted — e.g. CI runs for PRs from forked repos,
+    # because GitHub Actions does not pass repo secrets to
+    # workflows triggered by fork PRs. Tests that actually
+    # exercise iNat OAuth still need real credentials or stubs;
+    # those that don't (the vast majority) don't care about the
+    # value here.
     APP_ID = Rails.application.credentials.inat&.id
 
     # URL to obtain authorization (an "Authorization Code")

--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -14,16 +14,18 @@ class Inat
     # test & development redirect to the local server.
     REDIRECT_URI = Rails.configuration.redirect_uri
 
-    # iNat's id for the MO application
-    # Differs in production vs. test & development.
-    # Safe-navigated so module load doesn't crash when credentials
-    # can't be decrypted — e.g. CI runs for PRs from forked repos,
-    # because GitHub Actions does not pass repo secrets to
-    # workflows triggered by fork PRs. Tests that actually
-    # exercise iNat OAuth still need real credentials or stubs;
-    # those that don't (the vast majority) don't care about the
-    # value here.
+    # iNat's id and secret for the MO application.
+    # Differ in production vs. test & development.
+    # Safe-navigated so module load and stubs/jobs don't crash
+    # when credentials can't be decrypted — e.g. CI runs for PRs
+    # from forked repos, because GitHub Actions does not pass
+    # repo secrets to workflows triggered by fork PRs. When
+    # credentials are missing both end up nil; the OAuth stub
+    # helper and InatImportJob#authenticate both pass them
+    # through, so the WebMock body comparison still matches and
+    # tests run end-to-end.
     APP_ID = Rails.application.credentials.inat&.id
+    APP_SECRET = Rails.application.credentials.inat&.secret
 
     # URL to obtain authorization (an "Authorization Code")
     # to allow MO to access an iNat user's private data

--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -15,8 +15,14 @@ class Inat
     REDIRECT_URI = Rails.configuration.redirect_uri
 
     # iNat's id for the MO application
-    # Differs in production vs. test & development
-    APP_ID = Rails.application.credentials.inat.id
+    # Differs in production vs. test & development.
+    # Safe-navigated so module load doesn't crash when credentials
+    # can't be decrypted (e.g. CI runs for PRs from forked repos,
+    # which GitHub Actions doesn't pass repo secrets to). Tests
+    # that actually exercise iNat OAuth still need real credentials
+    # or stubs; those that don't (the vast majority) don't care
+    # about the value here.
+    APP_ID = Rails.application.credentials.inat&.id
 
     # URL to obtain authorization (an "Authorization Code")
     # to allow MO to access an iNat user's private data

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -54,7 +54,7 @@ class InatImportJob < ApplicationJob
     token_service = Inat::APIToken.new(
       app_id: APP_ID, site: SITE,
       redirect_uri: REDIRECT_URI,
-      secret: Rails.application.credentials.inat.secret
+      secret: APP_SECRET
     )
     token = token_service.obtain_api_token(inat_import.token)
     inat_import.update(token: token)

--- a/test/jobs/inat_import_job_test_doubles.rb
+++ b/test/jobs/inat_import_job_test_doubles.rb
@@ -29,8 +29,8 @@ module InatImportJobTestDoubles
   })
     stub_request(:post, "#{SITE}/oauth/token").
       with(
-        body: { "client_id" => Rails.application.credentials.inat.id,
-                "client_secret" => Rails.application.credentials.inat.secret,
+        body: { "client_id" => APP_ID,
+                "client_secret" => APP_SECRET,
                 "code" => "MockCode",
                 "grant_type" => "authorization_code",
                 "redirect_uri" => REDIRECT_URI }


### PR DESCRIPTION
## Summary

Makes the test suite both **load** and **run to completion** on CI runs from forked repos, where GitHub Actions doesn't pass repo secrets — so `RAILS_MASTER_KEY` is empty, `credentials.yml.enc` can't be decrypted, and every `Rails.application.credentials.inat.*` lookup returns `nil`.

Symptom on PR #4239 (a typo fix from a fork):

```
app/classes/inat/constants.rb:19: undefined method 'id' for nil (NoMethodError)
    APP_ID = Rails.application.credentials.inat.id
```

## Fix

Three places were reading `Rails.application.credentials.inat.<x>` directly. Route them all through safe-navigated constants:

- `Inat::Constants::APP_ID = Rails.application.credentials.inat&.id` (was eager `.id`).
- New `Inat::Constants::APP_SECRET = Rails.application.credentials.inat&.secret`.
- `InatImportJob#authenticate` uses `APP_SECRET` instead of an inline lookup.
- `test/jobs/inat_import_job_test_doubles.rb`'s OAuth WebMock stub uses `APP_ID` / `APP_SECRET` instead of inline lookups.

When credentials are missing, both sides of the WebMock body comparison see `nil` for `client_id` and `client_secret`, the URL-encoded form is identical (`client_id=&client_secret=…`), and the stub matches normally — tests run end-to-end.

## Why not simpler — just add `&.` to the constant?

I tried that first (commit `6eaf3cf`). It fixes the load crash but the test suite still fails at runtime: `InatImportJob#authenticate` and the OAuth stub both crash on the `.id` / `.secret` part of `credentials.inat.id`. So the original PR didn't actually unblock #4239 — only the load phase. Routing all three call sites through the constants is the minimal change that does.

## Test plan

- [x] `bin/rails test test/jobs/inat_import_job_test.rb test/classes/inat_obs_test.rb test/controllers/inat_imports_controller_test.rb` with credentials present — 101 tests, 885 assertions, 0 failures.
- [x] Same tests with `config/master.key` moved aside and `RAILS_MASTER_KEY` unset (simulates fork-PR CI) — 42 inat job tests, 566 assertions, 0 failures.
- [x] `bundle exec rubocop` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)