### PR TITLE
Skip ConfigTest#test_secrets when credentials cannot decrypt

### DIFF
--- a/test/classes/config_test.rb
+++ b/test/classes/config_test.rb
@@ -5,7 +5,19 @@ require("test_helper")
 # A place to put tests related to the overall RoR configuration
 
 class ConfigTest < UnitTestCase
+  # Sanity-checks that credentials.yml.enc decrypted and contains
+  # the expected marker value. Skipped on CI runs that have no
+  # RAILS_MASTER_KEY available — most commonly PRs from forked
+  # repos, since GitHub Actions does not pass repo secrets to
+  # workflows triggered by fork PRs. The credentials hash is
+  # entirely empty in that case (decryption silently no-ops);
+  # we use that as the unambiguous "no master key" signal so a
+  # genuine credentials regression (e.g. test_secret renamed)
+  # still fails the assertion when the key is present.
   def test_secrets
+    if Rails.application.credentials.config.empty?
+      skip("RAILS_MASTER_KEY missing; credentials cannot decrypt")
+    end
     assert_equal("magic", Rails.application.credentials.test_secret)
   end
 end


### PR DESCRIPTION
## Summary

`ConfigTest#test_secrets` asserts `Rails.application.credentials.test_secret == "magic"` to sanity-check that `credentials.yml.enc` decrypted at boot. On fork-PR CI runs `RAILS_MASTER_KEY` is unavailable (GitHub Actions doesn't pass repo secrets to fork-triggered workflows), so the credentials hash is silently empty, `test_secret` is nil, and the assertion fails. External-contributor PRs (e.g. #4239) can't pass CI.

This is the last credentials-related barrier still failing fork-PR CI after PR #4240 closed the iNat side.

## Fix

Skip the assertion when the credentials hash is *entirely* empty — the unambiguous "no master key" signal:

```ruby
def test_secrets
  if Rails.application.credentials.config.empty?
    skip("RAILS_MASTER_KEY missing; credentials cannot decrypt")
  end
  assert_equal("magic", Rails.application.credentials.test_secret)
end
```

A genuine credentials regression — `test_secret` renamed or removed while the key IS present — still fails the assertion as intended. The skip only fires when there's nothing for the assertion to check against.

## Test plan

- [x] With `config/master.key` present: 1 test, 2 assertions, 0 skips (normal).
- [x] With `config/master.key` moved aside and `RAILS_MASTER_KEY` unset (simulates fork-PR CI): 1 test, 1 skip, 0 failures, 0 errors.
- [x] `bundle exec rubocop test/classes/config_test.rb` — clean.

## Alternative considered

Migrating the test marker to a Rails 7+ environment-specific credentials file (`config/credentials/test.yml.enc` + a checked-in `test.key`) would eliminate the skip entirely. That's a larger change and currently buys nothing — `test_secrets` is the only test that asserts on credential values. Deferred until a second such test appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)