### PR TITLE
Make test setup resets unbypassable (#4238)

### DIFF
--- a/test/controllers/admin/blocked_ips_controller_test.rb
+++ b/test/controllers/admin/blocked_ips_controller_test.rb
@@ -6,9 +6,12 @@ module Admin
   class BlockedIpsControllerTest < FunctionalTestCase
     def setup
       super
-      # Ensure blocked_ips.txt exists (may not exist on CI)
+      # Ensure these files exist (may not on CI; ip_stats_file may
+      # also have been deleted by IpStatsTest's teardown earlier in
+      # the same parallel worker — see #4238).
       FileUtils.touch(MO.blocked_ips_file)
       FileUtils.touch(MO.okay_ips_file)
+      FileUtils.touch(MO.ip_stats_file)
       # Reset IpStats to ensure clean state, especially when running
       # in parallel with other tests that modify blocked_ips.txt
       IpStats.reset!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -182,13 +182,24 @@ module ActiveSupport
 
     # Add more helper methods to be used by all tests here...
 
-    # Standard setup to run before every test.  Sets the locale, timezone,
-    # and makes sure User doesn't think a user is logged in.
-    def setup
-      # Disable cop; there's no block in which to limit the time zone change
-      I18n.locale = :en if I18n.locale != :en # rubocop:disable Rails/I18nLocaleAssignment
-      # Disable cop; there's no block in which to limit the time zone change
-      Time.zone = "America/New_York" # rubocop:disable Rails/TimeZoneAssignment
+    # Standard setup to run before every test. Sets the locale,
+    # timezone, makes sure User doesn't think a user is logged in,
+    # and clears Symbol.missing_tags so the teardown assertion only
+    # sees tags raised by the test that just ran.
+    #
+    # Registered as a `setup do` callback rather than `def setup`
+    # so it runs unconditionally — many test classes override
+    # `def setup` without calling `super`, which previously
+    # bypassed these resets and let global state (most notably
+    # I18n.locale and Symbol.missing_tags) leak between tests
+    # within a parallel worker. See #4238.
+    setup do
+      # rubocop:disable Rails/I18nLocaleAssignment
+      I18n.locale = :en if I18n.locale != :en
+      # rubocop:enable Rails/I18nLocaleAssignment
+      # rubocop:disable Rails/TimeZoneAssignment
+      Time.zone = "America/New_York"
+      # rubocop:enable Rails/TimeZoneAssignment
       User.current = nil
       clear_logs unless defined?(@@cleared_logs)
       Symbol.missing_tags = []


### PR DESCRIPTION
## Summary

Closes #4238 — intermittent test failures with reproducible seeds where global state (Symbol.missing_tags, I18n.locale) leaks between tests within a parallel worker. The "downstream" test that fails has nothing wrong with it; an earlier test in the worker left global state in a wrong shape, and a later test's teardown assertion notices.

## Root cause

The state-reset code already lived in `test_helper.rb`'s `def setup` — it resets `I18n.locale`, `Time.zone`, `User.current`, `Symbol.missing_tags`, and runs `clear_logs` once. The expectation was that every test runs through this. But **21 test classes** override `def setup` without calling `super`, silently bypassing the resets. The 21 offenders include four of the five test classes that surface the reproducible failures (the fifth is the file-deletion case, addressed separately).

```
$ grep -rln "def setup" test | xargs grep -L "super" | wc -l
21
```

## Fix

Move the body of `def setup` into a `setup do` callback. Callbacks run unconditionally for every test regardless of whether the test class overrides `def setup` (or whether it calls `super`).

The pattern is already used in `test_helper.rb` for the thread-locals reset (`Thread.current[:mushroom_observer_user] = nil`); now applied to the rest of the per-test resets.

Also closes the file-deletion gap surfaced by seed 8848: `Admin::BlockedIpsControllerTest#setup` now also `FileUtils.touch(MO.ip_stats_file)`. The setup already touches `blocked_ips_file` and `okay_ips_file` for the same reason; `ip_stats_file` was the gap (deleted unconditionally by `IpStatsTest#teardown`).

## Verification

All four reproducible seeds from the issue thread now pass cleanly:

| Seed  | Family                              | Before  | After  |
|-------|-------------------------------------|---------|--------|
| 9700  | `Symbol.missing_tags` leak          | 1+ fail | 0 fail |
| 51587 | `I18n.locale = :fr` leak            | 1 fail  | 0 fail |
| 31777 | `I18n.locale = :fr` leak            | 1 fail  | 0 fail |
| 8848  | `MO.ip_stats_file` deleted          | 1 err   | 0 err  |

Each seed: 5156 tests, 37571 assertions, 0 failures, 0 errors after this change. (Plus an unrelated Sprockets cache corruption surfaced during testing — clearing `tmp/cache/assets` resolved it. Cause was multiple parallel `rails test` invocations on the same machine; doesn't affect CI or single-shell use.)

## Out of scope

Identifying the actual tests that leak `:runtime_updated` (probably calling `:"runtime_updated_#{x}".l` with `x = ""` somewhere) or that set `I18n.locale = :fr` without resetting. Those leaks no longer cause visible failures; the seeds make the offenders bisect-findable if a future contributor wants to clean up at the source.

## Test plan

- [x] All four reproducible seeds pass.
- [x] `bundle exec rubocop test/test_helper.rb test/controllers/admin/blocked_ips_controller_test.rb` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)