### PR TITLE
Fix undefined method error in sibling_sequences archive link

### DIFF
--- a/app/helpers/observations/sibling_records_helper.rb
+++ b/app/helpers/observations/sibling_records_helper.rb
@@ -19,10 +19,7 @@ module Observations::SiblingRecordsHelper
   def sibling_sequences(siblings)
     sibling_record_list(siblings, :sequences) do |seq, sib|
       parts = [link_to(seq.format_name, sequence_path(seq.id))]
-      if seq.deposit?
-        parts << link_to(seq.bases_trimmed, seq.deposit_url,
-                         target: "_blank", rel: "noopener")
-      end
+      parts << sibling_sequence_archive_link(seq) if seq.deposit?
       parts << sibling_attribution(sib)
       parts.safe_join(" ")
     end
@@ -53,6 +50,12 @@ module Observations::SiblingRecordsHelper
       items.map { |rec, sib| tag.li { yield(rec, sib) } }.
         safe_join
     end
+  end
+
+  def sibling_sequence_archive_link(seq)
+    link = link_to(:show_observation_archive_link.t, seq.accession_url,
+                   target: "_blank", rel: "noopener")
+    "[".html_safe + link + "]".html_safe
   end
 
   def sibling_herbarium_record_content(record, sibling)

--- a/test/helpers/observations/sibling_records_helper_test.rb
+++ b/test/helpers/observations/sibling_records_helper_test.rb
@@ -53,6 +53,19 @@ class SiblingRecordsHelperTest < ActionView::TestCase
     assert_nil(result)
   end
 
+  def test_sibling_sequences_with_deposit_links_to_archive
+    seq = sequences(:deposited_sequence)
+    sibling = seq.observation
+    html = sibling_sequences([sibling])
+
+    assert_match(:show_observation_archive_link.t, html)
+    assert_match(CGI.escapeHTML(seq.accession_url), html)
+    assert_match('target="_blank"', html)
+    assert_match('rel="noopener"', html)
+    assert_match(%r{\[<a [^>]*>#{:show_observation_archive_link.t}</a>\]},
+                 html)
+  end
+
   def test_sibling_external_link_items_with_links
     el = external_links(:coprinus_comatus_obs_mycoportal_link)
     sibling = el.observation


### PR DESCRIPTION
## Summary
- The deposit branch of `Observations::SiblingRecordsHelper#sibling_sequences` called `seq.bases_trimmed` and `seq.deposit_url` — neither method exists on `Sequence`. Any observation show page whose sibling list included a sequence with archive+accession set crashed in production with `undefined method 'bases_trimmed' for an instance of Sequence` (e.g. obs/558830).
- Replaced with the same label and URL the regular show page uses (`:show_observation_archive_link.t` + `seq.accession_url`, see `Tabs::SequencesHelper#sequence_archive_tab`), wrapped in `[...]` to match the visual separation used on obs/570075.
- Added a helper test using the `:deposited_sequence` fixture — the gap that let the original bug ship — and verified it fails on the pre-fix code.

## Test plan
- [x] `bin/rails test test/helpers/observations/sibling_records_helper_test.rb` — 13 tests, 69 assertions, all pass
- [x] `bundle exec rubocop app/helpers/observations/sibling_records_helper.rb test/helpers/observations/sibling_records_helper_test.rb` — no offenses
- [x] New test errors on the pre-fix code (verified via `git stash`)
- [x] Manual: visit obs/558830 and confirm the page renders with `[Show Archive Record]` next to the sibling sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)