### PR TITLE
Add assert_html_element_equivalent helper to ComponentTestCase

### DIFF
--- a/test/component_test_case.rb
+++ b/test/component_test_case.rb
@@ -336,6 +336,63 @@ class ComponentTestCase < UnitTestCase
     puts("=" * 60)
   end
 
+  # Assert that the subtree rooted at +selector+ is structurally
+  # equivalent between two HTML strings.
+  #
+  # Compares element name, attribute set (order-agnostic), attribute
+  # values, text content, and child structure recursively. Attribute
+  # order does NOT affect equivalence — only attribute presence and
+  # values do. This is the right helper when verifying that a Phlex
+  # refactor preserves the markup contract a JS/CSS layer depends on:
+  # missing classes, missing attributes, and nesting changes will all
+  # fail the assertion; cosmetic attribute reordering won't.
+  #
+  # Pair with `compare_html_elements` (also in this file) — that helper
+  # prints a side-by-side diff for interactive debugging but doesn't
+  # assert and IS attribute-order sensitive (compares via `to_html`).
+  # Use `compare_html_elements` when investigating; use this one in a
+  # checked-in test.
+  #
+  # @param expected_html [String] HTML rendered by the pre-change code.
+  # @param actual_html [String] HTML rendered by the post-change code.
+  # @param selector [String] CSS selector identifying the element whose
+  #   subtree should be compared. Only the first match in each HTML
+  #   string is examined.
+  # @param label [String, nil] Human-readable identifier used in the
+  #   failure message and the names of the dumped HTML files.
+  # @param strip_csrf [Boolean] When true (default), the value of any
+  #   `<input name="authenticity_token">` is replaced with a constant
+  #   before comparison so per-render CSRF rotation doesn't cause
+  #   spurious failures. Set false to compare tokens verbatim.
+  #
+  # On failure, both subtrees are written to /tmp/html_parity_*.html
+  # for inspection and the assertion message names the first mismatch
+  # (element name, attribute set, attribute value, text, child count)
+  # along with the path from the selector root to the differing node.
+  CSRF_INPUT_RE =
+    /(<input[^>]*?name="authenticity_token"[^>]*?value=")[^"]+(")/
+
+  def assert_html_element_equivalent(expected_html, actual_html,
+                                     selector:, label: nil,
+                                     strip_csrf: true)
+    expected_subtree = extract_subtree(expected_html, selector, strip_csrf)
+    actual_subtree = extract_subtree(actual_html, selector, strip_csrf)
+    assert(expected_subtree,
+           "Expected HTML had no element matching #{selector.inspect}")
+    assert(actual_subtree,
+           "Actual HTML had no element matching #{selector.inspect}")
+
+    diff = html_node_diff(expected_subtree, actual_subtree, "")
+    return if diff.nil?
+
+    dump_label = sanitize_filename(label || selector)
+    File.write("/tmp/html_parity_expected_#{dump_label}.html",
+               expected_subtree.to_html)
+    File.write("/tmp/html_parity_actual_#{dump_label}.html",
+               actual_subtree.to_html)
+    flunk("HTML subtree mismatch (#{label || selector}): #{diff}")
+  end
+
   private
 
   # Helper to compare attributes between two Nokogiri elements
@@ -360,5 +417,79 @@ class ComponentTestCase < UnitTestCase
         puts("  #{key}: ✗ ERB=#{erb_val.inspect} vs Phlex=#{phlex_val.inspect}")
       end
     end
+  end
+
+  # --- assert_html_element_equivalent support ---
+
+  def extract_subtree(html, selector, strip_csrf)
+    src = strip_csrf ? html.gsub(CSRF_INPUT_RE, '\1CSRF\2') : html
+    Nokogiri::HTML5.fragment(src).at_css(selector)
+  end
+
+  # Returns a path-prefixed diff string on the first mismatch found
+  # walking +expected+ and +actual+ in lockstep, or nil if equivalent.
+  def html_node_diff(expected, actual, path)
+    return name_mismatch(expected, actual, path) \
+      if expected.name != actual.name
+
+    here = "#{path}<#{expected.name}>"
+    attr_diff = html_attribute_diff(expected, actual, here)
+    return attr_diff if attr_diff
+
+    expected_leaf = expected.element_children.empty?
+    actual_leaf = actual.element_children.empty?
+    if expected_leaf != actual_leaf
+      return "#{here}: structure differs (one has element children, " \
+             "the other doesn't)"
+    end
+    return html_text_diff(expected, actual, here) if expected_leaf
+
+    html_children_diff(expected, actual, here)
+  end
+
+  def name_mismatch(expected, actual, path)
+    "#{path}: element name #{expected.name.inspect} != #{actual.name.inspect}"
+  end
+
+  def html_attribute_diff(expected, actual, here)
+    expected_attrs = expected.attributes.transform_values(&:value)
+    actual_attrs = actual.attributes.transform_values(&:value)
+    missing = expected_attrs.keys - actual_attrs.keys
+    return "#{here}: missing attributes #{missing.inspect}" if missing.any?
+
+    extra = actual_attrs.keys - expected_attrs.keys
+    return "#{here}: unexpected attributes #{extra.inspect}" if extra.any?
+
+    expected_attrs.each do |k, v|
+      next if v == actual_attrs[k]
+
+      return "#{here}: attribute #{k}=#{v.inspect} != " \
+             "#{actual_attrs[k].inspect}"
+    end
+    nil
+  end
+
+  def html_text_diff(expected, actual, here)
+    return nil if expected.content == actual.content
+
+    "#{here}: text #{expected.content.inspect} != #{actual.content.inspect}"
+  end
+
+  def html_children_diff(expected, actual, here)
+    e_kids = expected.element_children
+    a_kids = actual.element_children
+    if e_kids.size != a_kids.size
+      return "#{here}: child element count #{e_kids.size} != #{a_kids.size}"
+    end
+
+    e_kids.each_with_index do |child, i|
+      sub = html_node_diff(child, a_kids[i], "#{here}[#{i}]")
+      return sub if sub
+    end
+    nil
+  end
+
+  def sanitize_filename(str)
+    str.to_s.gsub(/[^A-Za-z0-9._-]/, "_")
   end
 end

--- a/test/component_test_case_test.rb
+++ b/test/component_test_case_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for the helpers defined on ComponentTestCase itself.
+class ComponentTestCaseTest < ComponentTestCase
+  # --- assert_html_element_equivalent ---
+
+  def test_passes_for_identical_subtree
+    html = '<form><input name="x" value="1"></form>'
+    assert_html_element_equivalent(html, html, selector: "form")
+  end
+
+  def test_passes_when_attribute_order_differs
+    expected = '<input name="x" value="1" class="y">'
+    actual = '<input class="y" value="1" name="x">'
+    assert_html_element_equivalent(expected, actual, selector: "input")
+  end
+
+  def test_passes_for_nested_equivalent_structure
+    expected = '<div class="wrap"><span data-target="t">hi</span></div>'
+    actual = '<div class="wrap"><span data-target="t">hi</span></div>'
+    assert_html_element_equivalent(expected, actual, selector: "div")
+  end
+
+  def test_fails_for_missing_attribute
+    expected = '<input name="x" class="y">'
+    actual = '<input name="x">'
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "input")
+    end
+    assert_match(/missing attributes.*class/, error.message)
+  end
+
+  def test_fails_for_unexpected_attribute
+    expected = '<input name="x">'
+    actual = '<input name="x" id="extra">'
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "input")
+    end
+    assert_match(/unexpected attributes.*id/, error.message)
+  end
+
+  def test_fails_for_different_attribute_value
+    expected = '<a href="/old">x</a>'
+    actual = '<a href="/new">x</a>'
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "a")
+    end
+    assert_match(%r{attribute href.*"/old".*"/new"}, error.message)
+  end
+
+  def test_fails_for_different_text_content
+    expected = "<span>hello</span>"
+    actual = "<span>goodbye</span>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "span")
+    end
+    assert_match(/text.*hello.*goodbye/, error.message)
+  end
+
+  def test_fails_for_different_child_count
+    expected = "<ul><li>a</li><li>b</li></ul>"
+    actual = "<ul><li>a</li></ul>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "ul")
+    end
+    assert_match(/child element count 2 != 1/, error.message)
+  end
+
+  def test_fails_for_different_element_name
+    expected = "<div><span>x</span></div>"
+    actual = "<div><p>x</p></div>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "div")
+    end
+    assert_match(/element name.*span.*p/, error.message)
+  end
+
+  def test_path_in_error_message_locates_nested_mismatch
+    expected = "<form><div><input name=\"a\"></div></form>"
+    actual = "<form><div><input name=\"b\"></div></form>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "form")
+    end
+    # Path should include the form > div > input chain
+    assert_match(/<form>.*<div>.*<input>/, error.message)
+  end
+
+  def test_fails_when_selector_not_found_in_expected
+    expected = "<div></div>"
+    actual = "<span></span>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "span")
+    end
+    assert_match(/Expected HTML had no element matching/, error.message)
+  end
+
+  def test_fails_when_selector_not_found_in_actual
+    expected = "<span></span>"
+    actual = "<div></div>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(expected, actual, selector: "span")
+    end
+    assert_match(/Actual HTML had no element matching/, error.message)
+  end
+
+  def test_strips_csrf_token_by_default
+    expected = '<form><input name="authenticity_token" type="hidden" ' \
+               'value="abc123"></form>'
+    actual = '<form><input name="authenticity_token" type="hidden" ' \
+             'value="xyz789"></form>'
+    assert_html_element_equivalent(expected, actual, selector: "form")
+  end
+
+  def test_does_not_strip_csrf_when_disabled
+    expected = '<form><input name="authenticity_token" type="hidden" ' \
+               'value="abc"></form>'
+    actual = '<form><input name="authenticity_token" type="hidden" ' \
+             'value="xyz"></form>'
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(
+        expected, actual, selector: "form", strip_csrf: false
+      )
+    end
+    assert_match(/attribute value.*abc.*xyz/, error.message)
+  end
+
+  def test_label_appears_in_failure_message
+    expected = "<span>a</span>"
+    actual = "<span>b</span>"
+    error = assert_raises(Minitest::Assertion) do
+      assert_html_element_equivalent(
+        expected, actual, selector: "span", label: "demo-label"
+      )
+    end
+    assert_match(/demo-label/, error.message)
+  end
+
+  def test_selector_scopes_comparison_so_surrounding_html_ignored
+    # Anything outside the selected element should not affect parity.
+    expected = "<header>OLD</header><main><p>same</p></main>"
+    actual = "<header>NEW</header><main><p>same</p></main>"
+    assert_html_element_equivalent(expected, actual, selector: "main")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `assert_html_element_equivalent(expected_html, actual_html, selector:, label: nil, strip_csrf: true)` to `ComponentTestCase` for before/after parity checks during Phlex refactors. Walks the subtree at `selector` recursively and asserts element name, attribute set (order-agnostic), attribute values, text content, and child count all match.
- Sits alongside the existing `compare_html_elements` (which prints a diagnostic and is attribute-order-sensitive). New cross-referencing docstrings explain when to reach for which.
- Strips `<input name="authenticity_token">` values before comparison by default (toggleable via `strip_csrf:`) so rotating CSRF tokens don't cause spurious failures. Path-prefixed failure messages locate the first mismatch; both subtrees are dumped to `/tmp/html_parity_*.html` for inspection.

Motivation: during #4225 Group B I built throwaway scaffolding that did this whole-tree (and was deleted before merge). The selector-scoped, assertion-based, attribute-order-agnostic shape is the version worth keeping around — it complements the existing diagnostic helper without overlapping.

## Test plan
- [x] `bin/rails test test/component_test_case_test.rb` — 16 tests, 89 assertions, 0 failures (covers happy path, every mismatch kind, selector-not-found in either side, CSRF strip default vs. disabled, label propagation, nested-path reporting)
- [x] `bundle exec rubocop test/component_test_case.rb test/component_test_case_test.rb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)