### PR TITLE
Switch `superform` from @nimmolo's fork to upstream ~> 0.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem("literal")
 # Enable Slot API for Phlex
 gem("phlex-slotable")
 # Superform for type-safe forms with Phlex
-gem("superform", github: "nimmolo/superform", branch: "nimmo-add-radio-fields")
+gem("superform", "~> 0.7.0")
 # Strict ivars: raises a NameError if an ivar is nil (undefined). Must be
 # required in config/boot.rb to work: https://github.com/yippee-fun/strict_ivars
 # gem("strict_ivars", require: false)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,15 +5,6 @@ GIT
     mo_acts_as_versioned (0.6.6)
       activerecord (>= 3.0.9)
 
-GIT
-  remote: https://github.com/nimmolo/superform.git
-  revision: 25449f8adf9febad3531ba3e3e3038629c031fbb
-  branch: nimmo-add-radio-fields
-  specs:
-    superform (0.6.1)
-      phlex-rails (~> 2.0)
-      zeitwerk (~> 2.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -245,7 +236,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -410,7 +401,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rbtree (0.4.6)
     rdoc (7.2.0)
       erb
@@ -535,6 +526,9 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
+    superform (0.7.0)
+      phlex-rails (~> 2.0)
+      zeitwerk (~> 2.6)
     terser (1.2.7)
       execjs (>= 0.3.0, < 3)
     thor (1.5.0)
@@ -659,7 +653,7 @@ DEPENDENCIES
   sprockets (~> 4.2.1)
   sprockets-rails
   stimulus-rails
-  superform!
+  superform (~> 0.7.0)
   terser
   trilogy
   turbo-rails

--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -123,38 +123,34 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Override the Field class to use our custom components
   class Field < Superform::Rails::Form::Field
     def text(wrapper_options: {}, **attributes)
-      TextField.new(self, attributes: attributes,
-                          wrapper_options: wrapper_options)
+      TextField.new(self, wrapper_options: wrapper_options, **attributes)
     end
 
     def textarea(wrapper_options: {}, **attributes)
-      TextareaField.new(self, attributes: attributes,
-                              wrapper_options: wrapper_options)
+      TextareaField.new(self, wrapper_options: wrapper_options, **attributes)
     end
 
     def file(wrapper_options: {}, **attributes)
-      FileField.new(self, attributes: attributes,
-                          wrapper_options: wrapper_options)
+      FileField.new(self, wrapper_options: wrapper_options, **attributes)
     end
 
     def checkbox(*options, wrapper_options: {}, **attributes)
-      CheckboxField.new(self, *options, attributes: attributes,
-                                        wrapper_options: wrapper_options)
+      CheckboxField.new(self, *options,
+                        wrapper_options: wrapper_options, **attributes)
     end
 
     def radio(*options, wrapper_options: {}, **attributes)
-      RadioField.new(self, *options, attributes: attributes,
-                                     wrapper_options: wrapper_options)
+      RadioField.new(self, *options,
+                     wrapper_options: wrapper_options, **attributes)
     end
 
     def select(options, wrapper_options: {}, **attributes)
-      SelectField.new(self, collection: options, attributes: attributes,
-                            wrapper_options: wrapper_options)
+      SelectField.new(self, collection: options,
+                            wrapper_options: wrapper_options, **attributes)
     end
 
     def read_only(wrapper_options: {}, **attributes)
-      ReadOnlyField.new(self, attributes: attributes,
-                              wrapper_options: wrapper_options)
+      ReadOnlyField.new(self, wrapper_options: wrapper_options, **attributes)
     end
 
     # Autocompleter-specific options that should NOT go in field attributes
@@ -177,13 +173,11 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def static(wrapper_options: {}, **attributes)
-      StaticTextField.new(self, attributes: attributes,
-                                wrapper_options: wrapper_options)
+      StaticTextField.new(self, wrapper_options: wrapper_options, **attributes)
     end
 
     def date(wrapper_options: {}, **attributes)
-      DateField.new(self, attributes: attributes,
-                          wrapper_options: wrapper_options)
+      DateField.new(self, wrapper_options: wrapper_options, **attributes)
     end
   end
 

--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -31,7 +31,7 @@ class Components::ApplicationForm < Superform::Rails::Form
                 :custom_controller_id, :map_outlet
 
     def initialize(field, type:, textarea: false, **options)
-      super(field, attributes: {})
+      super(field)
       @autocompleter_type = type
       @textarea = textarea
       extract_options(options)

--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: true
 
 class Components::ApplicationForm < Superform::Rails::Form
-  # Bootstrap checkbox field component with checkbox wrapper and slots
+  # Bootstrap checkbox field component.
+  #
+  # **Boolean mode** (no positional options): renders the canonical Rails
+  # hidden+checkbox pair wrapped in a single `<div class="checkbox"><label>`.
+  # Delegates the input rendering to `Superform::Rails::Components::Checkbox`
+  # (boolean branch), so we inherit the hidden-field convention and
+  # checked-state computation.
+  #
+  # **Array mode** (options passed): renders a group of checkboxes for a
+  # single multi-valued field via `Superform::Rails::Components::Checkboxes`,
+  # wrapping each option in its own `<div class="checkbox"><label>`.
+  # The caller must back this with a FormObject attribute that's array-typed
+  # (returns `[]` not `nil` when empty) so upstream `Checkbox` picks the
+  # array branch — otherwise it'll fall back to boolean rendering per option.
   class CheckboxField < Superform::Rails::Components::Checkbox
     include Phlex::Slotable
     include FieldWithHelp
+    include Components::TrustedHtml
 
     slot :between
     slot :append
@@ -14,29 +28,38 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options
 
-    def initialize(field, *options, attributes: {}, wrapper_options: {})
-      super(field, *options, attributes: attributes)
+    def initialize(field, *options, wrapper_options: {}, **attributes)
+      @options = options
       @wrapper_options = wrapper_options
+      # Upstream 0.7 Checkbox#initialize is (field, index: nil, **attributes).
+      super(field, **attributes)
     end
 
-    def view_template
-      render_with_wrapper do
-        # Inherits proper checkbox behavior from Superform
-        # (hidden input + checked)
-        super
+    def view_template(&block)
+      if @options.any?
+        render_array_mode
+      elsif block
+        # Block mode: caller drives rendering via `cb.option(value)` for
+        # one or more checkboxes inside MO's standard wrapper. Used for
+        # matrix-style layouts where one checkbox_field call produces
+        # exactly one cell of a larger group.
+        render_boolean_with_wrapper { yield(self) }
+      else
+        render_boolean_with_wrapper { super }
       end
     end
 
-    # Override Superform's option to skip its label wrapper, since
-    # render_with_wrapper already provides one. Avoids invalid nested labels.
+    # Render a single array-mode checkbox (name="…[]"). Intended for use
+    # inside a block passed to `checkbox_field`, when the caller wants
+    # one cell of a larger checkbox matrix.
     def option(value)
       input(
-        **attributes,
         type: :checkbox,
-        id: "#{dom.id}_#{value}",
-        name: "#{dom.name}[]",
+        id: "#{field.dom.id}_#{value}",
+        name: "#{field.dom.name}[]",
         value: value.to_s,
-        checked: checked_in_array?(value)
+        checked: checked_in_array?(value),
+        **@attributes.except(:id, :name, :value, :type, :checked)
       )
       return unless block_given?
 
@@ -45,10 +68,44 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     private
 
-    def render_with_wrapper(&checkbox_block)
-      div(class: checkbox_class) do
+    # --- Array mode ---
+
+    def render_array_mode
+      render(checkboxes_component) do |choice|
+        render_checkbox_option(choice)
+      end
+    end
+
+    def checkboxes_component
+      Superform::Rails::Components::Checkboxes.new(
+        field, options: @options, **@attributes
+      )
+    end
+
+    def render_checkbox_option(choice)
+      div(class: option_wrap_class) do
+        label do
+          render(choice.build_input(**@attributes))
+          whitespace
+          trusted_html(choice.text)
+        end
+      end
+    end
+
+    def checked_in_array?(value)
+      field_value = field.value
+      return false if field_value.nil?
+
+      field_value = [field_value] unless field_value.is_a?(Array)
+      field_value.map(&:to_s).include?(value.to_s)
+    end
+
+    # --- Boolean mode wrapper ---
+
+    def render_boolean_with_wrapper(&checkbox_block)
+      div(class: boolean_wrap_class) do
         label(for: checkbox_id, **label_attributes) do
-          render_content(&checkbox_block)
+          render_boolean_content(&checkbox_block)
           render_help_in_label_row
         end
         render_help_after_field
@@ -56,13 +113,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       end
     end
 
-    # Use custom ID if provided, otherwise use Superform's generated ID
-    def checkbox_id
-      attributes[:id] || field.dom.id
-    end
-
     # MO's default render order is checkbox-then-label
-    def render_content
+    def render_boolean_content
       text = label_text
       if label_position_before?
         if text
@@ -81,7 +133,11 @@ class Components::ApplicationForm < Superform::Rails::Form
       end
     end
 
-    # Pass `label_position: :before` to render label-then-checkbox
+    # Use custom ID if provided, otherwise use Superform's generated ID
+    def checkbox_id
+      @attributes[:id] || field.dom.id
+    end
+
     def label_position_before?
       wrapper_options[:label_position] == :before
     end
@@ -93,34 +149,27 @@ class Components::ApplicationForm < Superform::Rails::Form
       label_option.is_a?(String) ? label_option : field.key.to_s.humanize
     end
 
-    def checkbox_class
+    def boolean_wrap_class
       classes = "checkbox"
       classes += " #{wrapper_options[:wrap_class]}" if wrap_class?
       classes
     end
+
+    # Each per-option label gets its own .checkbox wrapper too
+    alias option_wrap_class boolean_wrap_class
 
     def wrap_class?
       wrapper_options[:wrap_class].present?
     end
 
     def label_attributes
-      {}.tap do |attrs|
-        attrs[:class] = wrapper_options[:label_class] if label_class?
-        attrs[:data] = wrapper_options[:label_data] if label_data?
-        attrs[:aria] = wrapper_options[:label_aria] if label_aria?
+      attrs = {}
+      [:label_class, :label_data, :label_aria].each do |opt|
+        next unless wrapper_options[opt]
+
+        attrs[opt.to_s.sub("label_", "").to_sym] = wrapper_options[opt]
       end
-    end
-
-    def label_class?
-      wrapper_options[:label_class]
-    end
-
-    def label_data?
-      wrapper_options[:label_data]
-    end
-
-    def label_aria?
-      wrapper_options[:label_aria]
+      attrs
     end
   end
 end

--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -83,13 +83,27 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def render_checkbox_option(choice)
+      value_str = choice.value.to_s
       div(class: option_wrap_class) do
         label do
-          render(choice.build_input(**@attributes))
+          # Mirrors RadioField: stringify value, use value-derived index so
+          # the rendered id is value-based (matching MO's convention used
+          # for the block-mode `option(value)` path), not upstream's
+          # default array-position index.
+          render(Superform::Rails::Components::Checkbox.new(
+                   field,
+                   value: value_str,
+                   index: index_for(value_str),
+                   **@attributes
+                 ))
           whitespace
           trusted_html(choice.text)
         end
       end
+    end
+
+    def index_for(value_str)
+      value_str.parameterize(separator: "_")
     end
 
     def checked_in_array?(value)

--- a/app/components/application_form/date_field.rb
+++ b/app/components/application_form/date_field.rb
@@ -21,7 +21,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :field, :attributes, :wrapper_options
 
-    def initialize(field, attributes:, wrapper_options: {})
+    def initialize(field, wrapper_options: {}, **attributes)
       super()
       @field = field
       @attributes = attributes

--- a/app/components/application_form/file_field.rb
+++ b/app/components/application_form/file_field.rb
@@ -25,8 +25,8 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options
 
-    def initialize(field, attributes:, wrapper_options: {})
-      super(field, attributes: attributes)
+    def initialize(field, wrapper_options: {}, **attributes)
+      super(field, **attributes)
       @wrapper_options = wrapper_options
     end
 

--- a/app/components/application_form/hidden_field.rb
+++ b/app/components/application_form/hidden_field.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Renders a bare `<input type="hidden">` for a Superform field or
+  # `FieldProxy`. Use this when you need a hidden input but can't reach
+  # the `hidden_field` form helper — typically for `FieldProxy`-backed
+  # non-model fields rendered inside an `ApplicationForm` subclass.
+  #
+  # The form-attached helper `ApplicationForm#hidden_field` is preferred
+  # for model fields; reach for this class only when the helper doesn't
+  # apply.
+  #
+  # @example FieldProxy-backed hidden input
+  #   proxy = ApplicationForm::FieldProxy.new(nil, "old_desc_id", id)
+  #   render(ApplicationForm::HiddenField.new(proxy))
+  #
+  # @example Explicit value override
+  #   render(ApplicationForm::HiddenField.new(field, value: "x"))
+  class HiddenField < Phlex::HTML
+    def initialize(field, **attributes)
+      super()
+      @field = field
+      @attributes = attributes
+    end
+
+    def view_template
+      input(
+        type: "hidden",
+        id: @field.dom.id,
+        name: @field.dom.name,
+        value: @attributes.fetch(:value) { @field.value },
+        **@attributes.except(:value)
+      )
+    end
+  end
+end

--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 class Components::ApplicationForm < Superform::Rails::Form
-  # Bootstrap radio button group component with radio wrapper per option
+  # Bootstrap radio button group component.
   #
-  # Renders each option as:
+  # Each option renders as:
   #   <div class="radio">
   #     <label><input type="radio" ...> label text</label>
   #   </div>
   #
-  # Accepts a Superform field or a FieldProxy for standalone use.
+  # Delegates per-option markup generation to
+  # `Superform::Rails::Components::Radios`, using its block form so we can
+  # wrap each option in the Bootstrap `.radio` div and emit HTML-safe label
+  # text via `trusted_html`. The component works equally with a Superform
+  # field or a `FieldProxy` (standalone use outside a form).
   #
   # @example Superform field
   #   field(:target).radio(
@@ -24,8 +28,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options, :field, :attributes
 
-    def initialize(field, *collection, attributes: {},
-                   wrapper_options: {})
+    def initialize(field, *collection, wrapper_options: {}, **attributes)
       super()
       @field = field
       @collection = collection
@@ -34,39 +37,50 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def view_template
-      map_options(@collection).each do |value, label_text|
-        render_radio_option(value, label_text)
+      render(radios_component) do |choice|
+        render_choice(choice)
       end
     end
 
     private
 
-    def render_radio_option(value, label_text)
+    def radios_component
+      Superform::Rails::Components::Radios.new(
+        @field, options: @collection, **@attributes
+      )
+    end
+
+    def render_choice(choice)
+      value_str = choice.value.to_s
       div(class: radio_class) do
         label do
-          input(**radio_attributes(value))
+          # Stringify value so Phlex doesn't dasherize symbols
+          # (e.g. `:mycoportal_image_list` → `"mycoportal-image-list"`).
+          # Use a value-derived index so the rendered id is value-based
+          # (`field_id_<value>`), matching MO's pre-upstream convention
+          # used by JS/CSS, rather than upstream's default index-based id.
+          # `checked` is computed here because upstream Radio's
+          # `field.value == @value` doesn't coerce types — MO routinely
+          # pairs boolean/symbol field values with string option values.
+          render(Superform::Rails::Components::Radio.new(
+                   @field,
+                   value: value_str,
+                   index: index_for(value_str),
+                   checked: option_checked?(value_str),
+                   **@attributes
+                 ))
           whitespace
-          trusted_html(label_text)
+          trusted_html(choice.text)
         end
       end
     end
 
-    def radio_attributes(value)
-      @attributes.merge(
-        type: :radio,
-        name: field.dom.name,
-        id: radio_id(value),
-        value: value.to_s,
-        checked: option_checked?(value)
-      )
+    def index_for(value_str)
+      value_str.parameterize(separator: "_")
     end
 
-    def radio_id(value)
-      "#{field.dom.id}_#{value.to_s.parameterize(separator: "_")}"
-    end
-
-    def option_checked?(value)
-      field.value.to_s == value.to_s
+    def option_checked?(value_str)
+      @field.value.to_s == value_str
     end
 
     def radio_class
@@ -75,10 +89,6 @@ class Components::ApplicationForm < Superform::Rails::Form
         classes += " #{wrapper_options[:wrap_class]}"
       end
       classes
-    end
-
-    def map_options(collection)
-      Superform::Rails::OptionMapper.new(collection)
     end
   end
 end

--- a/app/components/application_form/read_only_field.rb
+++ b/app/components/application_form/read_only_field.rb
@@ -21,7 +21,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options, :field, :attributes
 
-    def initialize(field, attributes:, wrapper_options: {})
+    def initialize(field, wrapper_options: {}, **attributes)
       super()
       @field = field
       @attributes = attributes

--- a/app/components/application_form/select_field.rb
+++ b/app/components/application_form/select_field.rb
@@ -15,8 +15,10 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options
 
-    def initialize(field, collection:, attributes:, wrapper_options: {})
-      super(field, collection: collection, attributes: attributes)
+    def initialize(field, collection:, wrapper_options: {}, **attributes)
+      # Upstream Superform 0.7 renamed `collection:` to `options:` and
+      # deprecated passing `attributes:` as a keyword. Spread instead.
+      super(field, options: collection, **attributes)
       @wrapper_options = wrapper_options
     end
 
@@ -28,7 +30,7 @@ class Components::ApplicationForm < Superform::Rails::Form
           select(**select_attrs, class: select_classes, &options_block)
         else
           select(**select_attrs, class: select_classes) do
-            options(*@collection)
+            options(*@options)
           end
         end
       end

--- a/app/components/application_form/static_text_field.rb
+++ b/app/components/application_form/static_text_field.rb
@@ -20,7 +20,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options, :field, :attributes
 
-    def initialize(field, attributes:, wrapper_options: {})
+    def initialize(field, wrapper_options: {}, **attributes)
       super()
       @field = field
       @attributes = attributes

--- a/app/components/application_form/text_field.rb
+++ b/app/components/application_form/text_field.rb
@@ -17,8 +17,8 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options
 
-    def initialize(field, attributes:, wrapper_options: {})
-      super(field, attributes: attributes)
+    def initialize(field, wrapper_options: {}, **attributes)
+      super(field, **attributes)
       @wrapper_options = wrapper_options
     end
 

--- a/app/components/application_form/textarea_field.rb
+++ b/app/components/application_form/textarea_field.rb
@@ -17,8 +17,8 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     attr_reader :wrapper_options
 
-    def initialize(field, attributes:, wrapper_options: {})
-      super(field, attributes: attributes)
+    def initialize(field, wrapper_options: {}, **attributes)
+      super(field, **attributes)
       @wrapper_options = wrapper_options
     end
 

--- a/app/components/description_form.rb
+++ b/app/components/description_form.rb
@@ -145,10 +145,7 @@ class Components::DescriptionForm < Components::ApplicationForm
 
   def render_flat_hidden_field(name, value)
     proxy = Components::ApplicationForm::FieldProxy.new(nil, name, value)
-    render(Components::ApplicationForm::TextField.new(
-             proxy,
-             attributes: { type: "hidden" }
-           ))
+    render(Components::ApplicationForm::HiddenField.new(proxy))
   end
 
   # --- Helper methods ---

--- a/app/components/form_image_fields.rb
+++ b/app/components/form_image_fields.rb
@@ -53,7 +53,7 @@ class Components::FormImageFields < Components::Base
     field = image_field_proxy(:notes, @image&.notes)
     render(Components::ApplicationForm::TextareaField.new(
              field,
-             attributes: { rows: 2 },
+             rows: 2,
              wrapper_options: { label: :form_images_notes.l }
            ))
   end
@@ -62,7 +62,7 @@ class Components::FormImageFields < Components::Base
     field = image_field_proxy(:when, @image&.when)
     render(Components::ApplicationForm::DateField.new(
              field,
-             attributes: { value: @image&.when },
+             value: @image&.when,
              wrapper_options: { label: :form_images_when_taken.l }
            ))
   end
@@ -71,7 +71,6 @@ class Components::FormImageFields < Components::Base
     field = image_field_proxy(:copyright_holder, @image&.copyright_holder)
     render(Components::ApplicationForm::TextField.new(
              field,
-             attributes: {},
              wrapper_options: { label: :form_images_copyright_holder.l }
            ))
   end
@@ -81,7 +80,6 @@ class Components::FormImageFields < Components::Base
     render(Components::ApplicationForm::SelectField.new(
              field,
              collection: superform_license_options,
-             attributes: {},
              wrapper_options: { label: :form_images_select_license.t.html_safe } # rubocop:disable Rails/OutputSafety
            ))
   end
@@ -90,7 +88,7 @@ class Components::FormImageFields < Components::Base
     field = image_field_proxy(:original_name, @image&.original_name)
     render(Components::ApplicationForm::TextField.new(
              field,
-             attributes: { size: 40 },
+             size: 40,
              wrapper_options: { label: :form_images_original_name.l }
            ))
   end

--- a/app/components/name_form.rb
+++ b/app/components/name_form.rb
@@ -40,10 +40,7 @@ class Components::NameForm < Components::ApplicationForm
     proxy = Components::ApplicationForm::FieldProxy.new(
       nil, "approved_rank", @approved_rank
     )
-    render(Components::ApplicationForm::TextField.new(
-             proxy,
-             attributes: { type: "hidden" }
-           ))
+    render(Components::ApplicationForm::HiddenField.new(proxy))
   end
 
   def button_text

--- a/app/components/observation_form_upload.rb
+++ b/app/components/observation_form_upload.rb
@@ -25,11 +25,9 @@ class Components::ObservationFormUpload < Components::Base
     render(
       Components::ApplicationForm::FileField.new(
         field_proxy,
-        attributes: {
-          multiple: true,
-          controller: "form-images",
-          action: "change->form-images#addSelectedFiles"
-        },
+        multiple: true,
+        controller: "form-images",
+        action: "change->form-images#addSelectedFiles",
         wrapper_options: { label: false }
       )
     )

--- a/app/components/translation_form.rb
+++ b/app/components/translation_form.rb
@@ -42,10 +42,7 @@ class Components::TranslationForm < Components::ApplicationForm
 
   def render_hidden_tag_field
     proxy = Components::ApplicationForm::FieldProxy.new(nil, "tag", @tag)
-    render(Components::ApplicationForm::TextField.new(
-             proxy,
-             attributes: { type: "hidden" }
-           ))
+    render(Components::ApplicationForm::HiddenField.new(proxy))
   end
 
   def form_dataset
@@ -132,12 +129,10 @@ class Components::TranslationForm < Components::ApplicationForm
   def build_textarea_component(proxy, rows, ttag)
     Components::ApplicationForm::TextareaField.new(
       proxy,
-      attributes: {
-        rows: rows,
-        data: {
-          translation_target: "textarea",
-          action: "translation#formChanged"
-        }
+      rows: rows,
+      data: {
+        translation_target: "textarea",
+        action: "translation#formChanged"
       },
       wrapper_options: { label: ttag }
     )


### PR DESCRIPTION
## Summary

Drops the `nimmolo/superform` fork pin in favor of the released `~> 0.7.0` gem. Upstream now has @nimmolo's multiple-select work (rubymonolith/superform#64), but the maintainer redesigned Checkbox/Radio along different lines than @nimmolo's collection branch (rubymonolith/superform#65 declined) — so MO's custom field components are here adapted to delegate to upstream's plural `Checkboxes` / `Radios` components via their block syntax.

### Deprecation refactor

Version 0.7 deprecates the `attributes:` keyword on `Components::Base#initialize`, so every `*Field` constructor and every `Field` override + direct call site now spreads `**attributes` instead of passing `attributes:` as a keyword. Eliminates the `[DEPRECATION] Passing 'attributes:' keyword to ...` warning that fired on every render.

### Component changes

- **`SelectField`** — passes `options:` instead of deprecated `collection:` to upstream; reads `@options` from the parent ivar.
- **`RadioField`** — delegates to `Components::Radios` via block form. Stringifies the value so Phlex doesn't dasherize symbol attrs (e.g. `:mycoportal_image_list`). Uses a value-derived `index` so the rendered id is value-based (matching MO's pre-upstream convention). Computes `checked` ourselves with stringified comparison — upstream `Radio`'s `field.value == @value` doesn't coerce types, and MO routinely pairs boolean/symbol field values with string option values.
- **`CheckboxField`** — keeps inheritance from upstream `Checkbox`; branches on (a) boolean mode → `super`, (b) block-given → existing `cb.option(value)` matrix pattern used by `PermissionsForm`, (c) positional options → delegate to `Components::Checkboxes` via block, wrapping each option in MO's `.checkbox` div.
- **`HiddenField`** (new) — replaces the three `TextField.new(proxy, type: "hidden")` call sites in `description_form`, `name_form`, `translation_form`. Purely for brevity and consistency.

## Test plan

- [x] `bundle exec rubocop app/components/` clean (164 files)
- [x] `bin/rails test test/components/` — 875 tests, 4536 assertions, 0 failures
- [x] `bin/rails db:test:prepare && bin/rails test` (full suite) — 5160 tests, 36915 assertions, 0 failures
- [x] Smoke test in browser: any form that uses radio buttons (e.g. project create with `dates_any`, observations download format select), any matrix-checkbox form (description permissions), any plain checkbox form (login `remember_me`, name edit `locked`), translation modal (locale dropdown), identify navbar filter (clade/region toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)