### PR TITLE
Align ERB and Phlex autocompleter HTML emission

### DIFF
--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -159,7 +159,13 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def input_data_attributes
-      { target_attr_key => "input", autocompleter: true }.merge(extra_data)
+      # Use string "true" (not boolean true) so Phlex emits
+      # `data-autocompleter="true"` instead of the boolean shorthand
+      # `data-autocompleter`. Matches ERB `autocompleter_field` helper output.
+      # Functionally equivalent — autocompleter base_controller overwrites this
+      # to `"connected"` on connect — but normalizes the rendered HTML between
+      # the two emission paths.
+      { target_attr_key => "input", autocompleter: "true" }.merge(extra_data)
     end
 
     def autocompleter_wrapper_options

--- a/app/helpers/autocompleter_helper.rb
+++ b/app/helpers/autocompleter_helper.rb
@@ -117,7 +117,7 @@ module AutocompleterHelper
 
   def autocompleter_has_id_indicator(target_key)
     link_icon(:check, title: :autocompleter_has_id.l,
-                      class: "ml-3 px-2 text-success has-id-indicator",
+                      class: "px-2 text-success has-id-indicator",
                       data: { target_key => "hasIdIndicator" })
   end
 


### PR DESCRIPTION
## Summary

Two tiny parity nits surfaced while building the field-slip form Phlex parity test (a follow-up PR):

- **ERB `autocompleter_has_id_indicator` had `ml-3`** on the indicator span; the Phlex `AutocompleterField` did not. Drop `ml-3` from the ERB helper — Phlex's tighter spacing is the better looking version.
- **Phlex `AutocompleterField` was passing `autocompleter: true`** (boolean), which Phlex DSL renders as the shorthand `data-autocompleter`; ERB emits `data-autocompleter="true"`. Switch Phlex to the string `"true"` so the rendered HTML matches the ERB.

No behavior change — `autocompleter/base_controller.js` overwrites `data-autocompleter` to `"connected"` on Stimulus connect, so the initial value of the attribute is functionally irrelevant. The change normalizes only the pre-connect HTML emission.

This unblocks parity-testing future ERB→Phlex form conversions (e.g. field slips, eventually the 8 remaining ERB autocompleter views) without bespoke per-form normalization.

## Test plan

- [x] `bundle exec rubocop` clean on both changed files
- [x] `test/components/autocompleter_field_test.rb` (12 tests)
- [x] `test/components/herbarium_form_test.rb`, `herbarium_record_form_test.rb`, `naming_form_test.rb`, `naming_fields_test.rb`, `identify_filter_form_test.rb`, `search_form_test.rb` (59 tests)
- [x] No test in the repo pins `ml-3` on the indicator span or asserts a literal `data-autocompleter` value (only namespaced `data-autocompleter--TYPE-target` and post-connect `[data-autocompleter='connected']`)
- [ ] Visual eyeball on the 8 ERB views that still use `autocompleter_field`: `/herbaria/show`, `/field_slips/index`, `/search/advanced`, `/species_lists/new` (and write_in/observations variants), shared search-status partial — confirm the indicator spacing after `ml-3` removal looks acceptable next to the label's `mr-3` margin.