### PR TITLE
Fix Phlex `SelectField` `option` with nil key

### DIFF
--- a/app/components/application_form/select_field.rb
+++ b/app/components/application_form/select_field.rb
@@ -38,7 +38,13 @@ class Components::ApplicationForm < Superform::Rails::Form
     # Compares as strings to handle boolean values (Phlex omits value="false")
     def options(*collection)
       map_options(collection).each do |key, value|
-        option(selected: option_selected?(key), value: key) { value }
+        # Coerce nil → "" so `<option value="">` renders (not `<option>`).
+        # Phlex's HTML DSL omits nil-valued attributes; the browser would
+        # then submit the option's text content. Matches Rails select-helper
+        # behavior so callers passing `[nil, "Label"]` get the expected
+        # empty-string submission.
+        option_value = key.nil? ? "" : key
+        option(selected: option_selected?(key), value: option_value) { value }
       end
     end
 

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -131,6 +131,26 @@ class ApplicationFormTest < ComponentTestCase
     assert_includes(form, "Option 3")
   end
 
+  # Regression: a [nil, "Label"] pair must render `<option value="">Label`,
+  # not `<option>Label` (which would submit "Label" as the value).
+  # Phlex's HTML DSL omits nil-valued attributes by default, so SelectField
+  # has to coerce nil keys to "" to match Rails' select-helper behavior.
+  def test_select_field_nil_key_renders_empty_value_attribute
+    options = [[nil, "(No Project)"], ["778455076", "EOL Project"]]
+    form = render_form do
+      select_field(:number, options, label: "Project")
+    end
+
+    assert_match(
+      %r{<option[^>]*value=""[^>]*>\(No Project\)</option>}, form,
+      "nil option key must render as value=\"\" so the browser submits " \
+      "an empty string instead of the option's text content"
+    )
+    assert_match(
+      %r{<option[^>]*value="778455076"[^>]*>EOL Project</option>}, form
+    )
+  end
+
   # Slot tests
   def test_text_field_with_between_slot
     form = render_form do


### PR DESCRIPTION
## Summary

`Components::ApplicationForm::SelectField#options` emitted `<option>(No Project)</option>` (no `value` attribute) for `[nil, "Label"]` option pairs, because Phlex's HTML DSL omits nil-valued attributes by default. The browser then submits the option's text content (`(No Project)`) on form selection instead of the empty string the controller expects — silently breaking the "no value selected" semantics on any Phlex select that uses a labeled-blank-option pair.

Coerce nil keys to `""` so the rendered HTML matches Rails' `select` helper output: `<option value="">(No Project)</option>`.

This pattern is used today in `sequence_form` (`[nil] + sequence_archive_options`), in the upcoming field-slip Phlex form (`[nil, "(No Project)"]` for the project select), and would have been a latent footgun for every future Phlex select with a labeled blank option.

Note: upstream Superform 0.7 has a `blank_option` helper that handles nil keys via a separate path, but it also omits `value=""` (so even routing through it doesn't fix this without a parallel override). Fixing in `options()` directly is the minimal change that preserves the existing call sites' contract.

## Test plan

- [x] New regression test `test_select_field_nil_key_renders_empty_value_attribute` in `application_form_test.rb` asserts `<option value="">(No Project)</option>` for nil-keyed pair and `<option value="778455076">EOL Project</option>` for non-nil pair.
- [x] All 110 tests pass across `application_form_test.rb`, `sequence_form_test.rb`, `name_form_test.rb`, `descriptions/*_test.rb`, `identify_filter_form_test.rb`, `search_form_test.rb` (every component test that exercises `SelectField`).
- [x] `bundle exec rubocop` clean on both changed files.
- [ ] Visual eyeball on a Phlex select with a blank option (e.g. `/sequences/new` archive selector, or any future caller) — confirm the "(blank)" option still appears and is selected by default when the field has no value.