### PR TITLE
Update disconnecting db connection pool

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -42,6 +42,6 @@ if rails_env == "production"
     # expiry thread tries to use the inherited cache connection.
     # Surfaced by Trilogy 2.11.0 which now raises explicitly on
     # concurrent connection use (previously silent/undefined behavior).
-    ActiveRecord::Base.clear_all_connections!
+    ActiveRecord::Base.connection_handler.clear_all_connections!
   end
 end


### PR DESCRIPTION
Calls `clear_all_connections!` on `connection_handler` instead of directly on `ActiveRecord::Base`
The deprecated `ActiveRecord::Base` method was removed in Rails 7.2. https://guides.rubyonrails.org/7_2_release_notes.html#active-record-removals


