### PR TITLE
Fix Name footer showing creator instead of last editor

### DIFF
--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -413,16 +413,6 @@ class Name < AbstractModel
   # destruction as a merge and orphan the log.
   self.autolog_events = [:destroyed]
 
-  # Callbacks whenever new version is created.
-  versioned_class.before_save do |ver|
-    # ver.user_id = @current_user || 0
-    # if (ver.version != 1) &&
-    #    Name::Version.where(name_id: ver.name_id,
-    #                        user_id: ver.user_id).none?
-    #   UserStats.update_contribution(:add, :name_versions)
-    # end
-  end
-
   # This is called before a name is created to let us populate things like
   # classification and lifeform from the parent (if infrageneric only).
   def inherit_stuff

--- a/app/models/name/resolve.rb
+++ b/app/models/name/resolve.rb
@@ -27,6 +27,7 @@ module Name::Resolve
                            user_id: ver.user_id).none?
       UserStats.update_contribution(:add, :name_versions, user_id)
     end
+    ver.save
   end
 
   module ClassMethods

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -4293,6 +4293,7 @@ class NameTest < UnitTestCase
 
     last_version = name.versions.reload.last
     assert_equal(mary.id, last_version.user_id,
-                 "Last version user_id should be the editor (mary), not the creator (rolf)")
+                 "Last version user_id should be the editor (mary), " \
+                 "not the creator (rolf)")
   end
 end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -4280,4 +4280,19 @@ class NameTest < UnitTestCase
     name = names(:lactarius_subalpinus)
     assert_not(name.update(search_name: ""))
   end
+
+  # Regression test for https://github.com/MushroomObserver/mushroom-observer/issues/4252
+  # Versions must record who made each edit, not the name's original creator.
+  def test_version_records_editor_not_creator
+    name = names(:coprinus_comatus)
+    assert_equal(rolf.id, name.user_id,
+                 "Fixture name should be created by rolf")
+
+    name.notes = "Updated by a different user"
+    name.save_with_log(mary)
+
+    last_version = name.versions.reload.last
+    assert_equal(mary.id, last_version.user_id,
+                 "Last version user_id should be the editor (mary), not the creator (rolf)")
+  end
 end


### PR DESCRIPTION
## Summary

- `update_name_version` in `Name::Resolve` set `ver.user_id` in memory but never called `ver.save`, so `name_versions` always stored the original creator's `user_id` regardless of who made the edit
- Added `ver.save` after the contribution check so the editor's id is persisted; the check runs before the save so first-editor contribution points are still awarded correctly
- Added regression test via `save_with_log` (the real code path) confirming the last version's `user_id` matches the editor, not the creator

Fixes #4252

## Test plan

- [x] `bin/rails test test/models/name_test.rb -n test_version_records_editor_not_creator`
- [x] `bin/rails test test/controllers/names_controller_update_test.rb -n '/test_edit_name_add_author|test_edit_deprecated_name_remove_author/'`
- [x] `bin/rails test test/controllers/observations/namings_controller_test.rb -n test_propose_naming_with_author_when_name_without_author_already_exists`
- [x] Verify on staging: edit a name as a non-creator and confirm the footer shows the correct "Last modified by" user

🤖 Generated with [Claude Code](https://claude.com/claude-code)