### PR TITLE
ERB/Phlex form-helper parity nits (issue #4258 items 0 + 5)

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -477,15 +477,20 @@ class Components::ApplicationForm < Superform::Rails::Form
   #   `input[type='submit']` selectors.
   # @option options [String] :class additional CSS classes
   # @option options [Hash] :data additional data attributes
+  # `disable_with:` overrides the `data-disable-with` text (rails-ujs's
+  # disabled-state label for non-Turbo submits). Defaults to the button
+  # label (just disable, no text swap).
   def submit(value = submit_value, center: false, submits_with: nil, # rubocop:disable Metrics/ParameterLists
-             btn_class: "btn-default", as: :input, **options)
+             disable_with: nil, btn_class: "btn-default", as: :input,
+             **options)
     submits_with ||= :SUBMITTING.l
+    disable_with ||= value
     classes = ["btn", btn_class]
     classes << "center-block my-3" if center
     classes << options[:class] if options[:class].present?
 
     data = { turbo_submits_with: submits_with,
-             disable_with: value }.merge(options[:data] || {})
+             disable_with: disable_with }.merge(options[:data] || {})
     merged = options.merge(class: classes.join(" "), data: data)
 
     if as == :button

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -8,20 +8,29 @@
 module FormsHelper # rubocop:disable Metrics/ModuleLength
   # Bootstrap submit button
   # <%= submit_button(form: f, button: button.t, center: true) %>
+  #
+  # Emits both `data-turbo-submits-with` (Turbo's in-flight label) and
+  # `data-disable-with` (rails-ujs's in-flight label). MO uses
+  # `Turbo.config.forms.mode = "optin"`, so non-Turbo forms rely on the
+  # rails-ujs path. Pass `disable_with:` to override the disabled-state
+  # text; defaults to the button label (just disable, no text change).
+  # Matches the Phlex `Components::ApplicationForm#submit` data emission.
   def submit_button(**args)
     unless args[:form].is_a?(ActionView::Helpers::FormBuilder)
       return args[:button]
     end
 
-    # custom text for the button while submitting
     submits_with = args[:submits_with] || submits_default_text(args[:button])
+    disable_with = args[:disable_with] || args[:button]
     data = args[:data] || {}
 
-    opts = args.except(:form, :button, :class, :center, :data, :submits_with)
+    opts = args.except(:form, :button, :class, :center, :data,
+                       :submits_with, :disable_with)
     opts[:class] = "btn btn-default"
     opts[:class] += " center-block my-3" if args[:center] == true
     opts[:class] += " #{args[:class]}" if args[:class].present?
-    opts[:data] = { turbo_submits_with: submits_with }.deep_merge(data)
+    opts[:data] = { turbo_submits_with: submits_with,
+                    disable_with: disable_with }.deep_merge(data)
 
     args[:form].submit(args[:button], opts)
   end
@@ -208,7 +217,22 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   # The label row for autocompleters is potentially complicated, many buttons.
   # Content for `between` and `label_after` come right after the label on left,
   # content for `label_end` is at the end of the same line, right justified.
+  #
+  # Short-circuits to a bare `<label>` when no between/label_after/label_end
+  # content is supplied. The flex wrapper has nothing to space in that case
+  # and adds no visible layout, so emitting the wrapper just produces a
+  # `<div class="d-flex"><div><label/></div><div></div></div>` shape that
+  # has to be normalized away in ERB↔Phlex parity tests. Matches Phlex's
+  # `FieldLabelRow#simple_label?` short-circuit. The `help:` case is
+  # already routed through `args[:between]` by `check_for_help_block`, so
+  # the `between.blank?` check naturally retains the wrapper when help is
+  # present.
   def text_label_row(args, label_opts)
+    if args[:between].blank? && args[:label_after].blank? &&
+       args[:label_end].blank?
+      return args[:form].label(args[:field], args[:label], label_opts)
+    end
+
     display = args[:inline] == true ? "d-inline-flex" : "d-flex"
     tag.div(class: "#{display} justify-content-between") do
       concat(tag.div do


### PR DESCRIPTION
## Summary

Two small ERB ↔ Phlex emission divergences that block the upcoming field-slip Phlex conversion's parity test ([#4258 audit](https://github.com/MushroomObserver/mushroom-observer/issues/4258)). Done together because each is a few lines and they touch the same two files.

### Item 0 — `text_label_row` short-circuit

ERB `text_label_row` (used by every `*_with_label` helper that emits a label row) unconditionally emitted a flex wrapper around the label, even with no help/between/label_after/label_end content:

```html
<div class="d-flex justify-content-between">
  <div><label class="mr-3" for="…">…</label></div>
  <div></div>           <!-- empty when no help/between/label_end -->
</div>
```

Phlex's `FieldLabelRow#simple_label?` short-circuits to a bare `<label class="mr-3">…</label>` in that case. Match Phlex: emit the bare label when between/label_after/label_end are all blank. The flex container does nothing useful when only one of its two children is non-empty — the label sits at the left edge of its parent either way.

**Verified safe**: no JS or CSS targets the wrapper (grep across `app/javascript/` and `app/assets/stylesheets/` returns only unrelated `@extend` rules in `_top_nav.scss` and `_matrix_box.scss`).

The `help:` case is already routed through `args[:between]` by `check_for_help_block`, so the `between.blank?` check naturally keeps the wrapper when help is present.

### Item 5 — Submit button `data-disable-with` symmetry

Phlex `Components::ApplicationForm#submit` emitted both `data-turbo-submits-with` and `data-disable-with`; ERB `submit_button` emitted only `data-turbo-submits-with`. MO uses `Turbo.config.forms.mode = "optin"`, so non-Turbo forms rely on the rails-ujs `data-disable-with` path — keeping it in Phlex and adding it to ERB matches both halves.

Both helpers now accept a `disable_with:` kwarg that overrides the disabled-state text (defaults to the button label = just disable, no text swap).

## Test plan

- [x] `bundle exec rubocop` clean on both changed files
- [x] 55 tests pass: `application_form_test.rb`, `forms_helper_test.rb`
- [x] 225 tests / 2342 assertions pass: `field_slips_controller_test.rb`, `species_lists_controller_test.rb`, `observations_controller_{create,show,update}_test.rb`, `observations_integration_test.rb` (capybara, exercises ERB form rendering)
- [x] `observation_form_system_test.rb#test_create_minimal_observation` — end-to-end render with the new label-row short-circuit
- [ ] **Visual eyeball** on a few ERB forms to confirm the bare-label case (no help/between/label_end) still looks right — most MO forms hit this case so blast radius is wide. Try `/observations/new`, `/field_slips/new`, `/species_lists/new`.