### PR TITLE
Fix Superform 0.7.0 attributes: keyword deprecation

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -528,7 +528,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   #
   # @example
   #   proxy = FieldProxy.new("observation[good_image][123]", :notes, "text")
-  #   render(TextField.new(proxy, attributes: {}, wrapper_options: {}))
+  #   render(TextField.new(proxy, wrapper_options: {}))
   class FieldProxy
     attr_reader :key, :value, :dom
 

--- a/app/components/translation_form.rb
+++ b/app/components/translation_form.rb
@@ -254,7 +254,8 @@ class Components::TranslationForm < Components::ApplicationForm
              collection: locale_options,
              # id: nil drops the FieldProxy-supplied id so the rendered
              # <select> matches the original markup (no id attribute).
-             attributes: { id: nil, data: locale_select_data },
+             id: nil,
+             data: locale_select_data,
              wrapper_options: { label: false }
            ))
   end


### PR DESCRIPTION
## Summary

- Superform 0.7.0 deprecated passing HTML attributes as an `attributes:` keyword to component initializers; they should now be spread as direct keyword arguments
- `TranslationForm#render_locale_select` was the only caller still using the old API, causing repeated `[DEPRECATION]` warnings in the test suite
- Also updated a stale `FieldProxy` example comment that showed the old `attributes: {}` form

## Test plan

- [x] Run `bin/rails test` and confirm no `[DEPRECATION] Passing \`attributes:\` keyword to Components::ApplicationForm::SelectField` warnings appear
- [x] Verify translation form locale select still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)