### PR TITLE
Form labels: emit matching for= attrs across Phlex + ERB

### DIFF
--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -82,24 +82,41 @@ class Components::ApplicationForm < Superform::Rails::Form
       )
     end
 
+    # Emit the array-mode input directly rather than delegating to
+    # upstream's `Superform::Rails::Components::Checkbox`. Upstream's
+    # `Checkbox` decides which of {boolean, collection, array} branch
+    # to render based on `field.parent.is_a?(Superform::Field)`; when
+    # called from this iteration the parent is the form root, so
+    # upstream picks the boolean branch — which renders all per-option
+    # inputs with the bare `dom.id` (duplicate ids) and a hidden 0/1
+    # pair per option (wrong for an array submission).
+    #
+    # The shape emitted here mirrors MO's existing block-mode
+    # `option(value)` helper above: one `<input type="checkbox"
+    # id="{field_id}_{index}" name="{field_name}[]" value="{value}">`
+    # per option, wrapped in a `<label for="{id}">` so click-focus and
+    # screen-reader association both work.
     def render_checkbox_option(choice)
       value_str = choice.value.to_s
+      input_id = option_input_id(value_str)
       div(class: option_wrap_class) do
-        label do
-          # Mirrors RadioField: stringify value, use value-derived index so
-          # the rendered id is value-based (matching MO's convention used
-          # for the block-mode `option(value)` path), not upstream's
-          # default array-position index.
-          render(Superform::Rails::Components::Checkbox.new(
-                   field,
-                   value: value_str,
-                   index: index_for(value_str),
-                   **@attributes
-                 ))
+        label(for: input_id) do
+          input(
+            type: :checkbox,
+            id: input_id,
+            name: "#{field.dom.name}[]",
+            value: value_str,
+            checked: checked_in_array?(choice.value),
+            **@attributes.except(:id, :name, :value, :type, :checked)
+          )
           whitespace
           trusted_html(choice.text)
         end
       end
+    end
+
+    def option_input_id(value_str)
+      "#{field.dom.id}_#{index_for(value_str)}"
     end
 
     def index_for(value_str)

--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -53,7 +53,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     def render_choice(choice)
       value_str = choice.value.to_s
       div(class: radio_class) do
-        label do
+        label(for: option_input_id(value_str)) do
           # Stringify value so Phlex doesn't dasherize symbols
           # (e.g. `:mycoportal_image_list` → `"mycoportal-image-list"`).
           # Use a value-derived index so the rendered id is value-based
@@ -77,6 +77,10 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     def index_for(value_str)
       value_str.parameterize(separator: "_")
+    end
+
+    def option_input_id(value_str)
+      "#{@field.dom.id}_#{index_for(value_str)}"
     end
 
     def option_checked?(value_str)

--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -24,7 +24,12 @@ class Components::ApplicationForm < Superform::Rails::Form
   #   proxy = FieldProxy.new("chosen_name", :name_id)
   #   RadioField.new(proxy, [1, "Opt 1"], [2, "Opt 2"])
   class RadioField < Phlex::HTML
+    include Phlex::Slotable
     include Components::TrustedHtml
+
+    slot :between
+
+    public :between_slot
 
     attr_reader :wrapper_options, :field, :attributes
 
@@ -71,8 +76,20 @@ class Components::ApplicationForm < Superform::Rails::Form
                  ))
           whitespace
           trusted_html(choice.text)
+          render_between_slot
         end
       end
+    end
+
+    # `between` content is rendered after the label text inside each
+    # option's `<label>`, wrapped in `<div class="d-inline-block ml-3">`
+    # — matching ERB `radio_with_label`'s `between:` shape. Applied
+    # uniformly to every option (one slot per RadioField call). For
+    # per-option metadata, supply different content per call site.
+    def render_between_slot
+      return unless between_slot
+
+      div(class: "d-inline-block ml-3") { render(between_slot) }
     end
 
     def index_for(value_str)

--- a/app/components/application_form/read_only_field.rb
+++ b/app/components/application_form/read_only_field.rb
@@ -52,7 +52,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def render_label(text, _inline)
-      label(class: "mr-3") { text } if text
+      label(for: field.dom.id, class: "mr-3") { text } if text
     end
 
     def field_attributes

--- a/app/components/application_form/static_text_field.rb
+++ b/app/components/application_form/static_text_field.rb
@@ -52,7 +52,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def render_label(text, _inline)
-      label(class: "mr-3") { text } if text
+      label(for: field.dom.id, class: "mr-3") { text } if text
     end
   end
 end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -117,15 +117,26 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # Bootstrap radio: form, field, value, label, class, checked
+  #
+  # The label's `for=` matches the id Rails' `radio_button` generates for
+  # the input — which sanitizes the value (lowercase, spaces → underscores,
+  # special chars stripped). Without sanitization here, a value like
+  # "Hello World" or a non-trivial symbol would yield a label
+  # `for="field_Hello World"` while the input id is `"field_hello_world"`,
+  # breaking label click-focus and screen-reader association.
+  # `parameterize(separator: "_")` is the public-API equivalent of Rails'
+  # internal `sanitized_value` and matches Phlex `RadioField`'s `index_for`.
   def radio_with_label(**args)
     args = auto_label_if_form_is_account_prefs(args)
     args = check_for_help_block(args)
     opts = separate_field_options_from_args(args, [:value])
 
     wrap_class = form_group_wrap_class(args, "radio")
+    value_id_suffix = args[:value].to_s.parameterize(separator: "_")
+    label_for = "#{args[:field]}_#{value_id_suffix}"
 
     tag.div(class: wrap_class) do
-      concat(args[:form].label("#{args[:field]}_#{args[:value]}") do
+      concat(args[:form].label(label_for) do
         concat(args[:form].radio_button(args[:field], args[:value], opts))
         concat(args[:label])
         if args[:between].present?

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -679,6 +679,27 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(form, "textarea")
   end
 
+  # Regression: ReadOnlyField label should carry `for=` pointing at the
+  # hidden input's id, matching the ERB `form.label(field, ...)` output.
+  def test_read_only_field_label_has_for_attribute
+    form = render_form do
+      read_only_field(:number, label: "Number:", value: "42")
+    end
+
+    assert_html(form, "label[for='collection_number_number']")
+    assert_html(form, "input[type='hidden'][id='collection_number_number']")
+  end
+
+  # Regression: StaticTextField label should carry `for=` pointing at the
+  # field's dom id (even though there's no input — matches ERB output).
+  def test_static_field_label_has_for_attribute
+    form = render_form do
+      static_field(:number, label: "Number:", value: "42")
+    end
+
+    assert_html(form, "label[for='collection_number_number']")
+  end
+
   private
 
   def render_form(local: true, &block)

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -611,6 +611,43 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(form, "div.radio.ml-4", count: 2)
   end
 
+  # Regression: each per-option label carries `for=` pointing at its
+  # input's id (matching ERB radio_with_label, which uses
+  # form.label("#{field}_#{value}")).
+  def test_radio_field_per_option_label_has_for_attribute
+    form = render_form do
+      radio_field(:number, [1, "A"], [2, "B"])
+    end
+
+    assert_html(form, "label[for='collection_number_number_1']")
+    assert_html(form, "label[for='collection_number_number_2']")
+    assert_html(form, "input[type='radio'][id='collection_number_number_1']")
+    assert_html(form, "input[type='radio'][id='collection_number_number_2']")
+  end
+
+  # Regression: array-mode checkbox per-option labels also carry `for=`,
+  # AND the inputs get value-suffixed ids (so multiple options don't
+  # collide). MO's CheckboxField bypasses upstream's Checkbox component
+  # for this case because upstream mis-detects array mode when the
+  # field's parent isn't another Superform::Field. Array mode is reached
+  # via `field(:foo).checkbox([v, label], …)` directly.
+  def test_checkbox_field_array_mode_per_option_label_has_for_attribute
+    form = render_form do
+      render(field(:number).checkbox([1, "A"], [2, "B"]))
+    end
+
+    assert_html(form, "label[for='collection_number_number_1']")
+    assert_html(form, "label[for='collection_number_number_2']")
+    assert_html(form, "input[type='checkbox'][id='collection_number_number_1']")
+    assert_html(form, "input[type='checkbox'][id='collection_number_number_2']")
+    # Each option submits its own value under `field[]`
+    array_name = "collection_number[number][]"
+    assert_html(form,
+                "input[type='checkbox'][name='#{array_name}'][value='1']")
+    assert_html(form,
+                "input[type='checkbox'][name='#{array_name}'][value='2']")
+  end
+
   # RadioField standalone tests (via FieldProxy)
   def test_radio_field_with_field_proxy
     proxy = Components::ApplicationForm::FieldProxy.new(

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -625,6 +625,26 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(form, "input[type='radio'][id='collection_number_number_2']")
   end
 
+  # Regression: RadioField `between` slot renders after each option's
+  # label text inside the `<label>`, wrapped in `<div class="d-inline-block
+  # ml-3">`. Matches ERB `radio_with_label`'s `between:` shape. Applied
+  # uniformly to every option (one slot per RadioField call).
+  def test_radio_field_with_between_slot
+    form = render_form do
+      component = Components::ApplicationForm::RadioField.new(
+        field(:number), [1, "A"], [2, "B"]
+      )
+      component.with_between do
+        span(class: "help-note") { "(see notes)" }
+      end
+      render(component)
+    end
+
+    assert_html(form, "div.radio div.d-inline-block.ml-3 span.help-note",
+                count: 2)
+    assert_includes(form, "(see notes)")
+  end
+
   # Regression: array-mode checkbox per-option labels also carry `for=`,
   # AND the inputs get value-suffixed ids (so multiple options don't
   # collide). MO's CheckboxField bypasses upstream's Checkbox component

--- a/test/helpers/forms_helper_test.rb
+++ b/test/helpers/forms_helper_test.rb
@@ -39,4 +39,42 @@ class FormsHelperTest < ActionView::TestCase
     assert_includes(html, "change-&gt;file-input#validate",
                     "Should trigger validation on change")
   end
+
+  # Regression: label `for=` must match the id Rails' `radio_button`
+  # generates. Rails' internal `sanitized_value` lowercases the value,
+  # replaces whitespace with underscores, and strips other non-word
+  # chars; values like "Hello World" or symbols with special chars
+  # would otherwise produce a `for=` that doesn't match the input id.
+  def test_radio_with_label_for_attr_matches_sanitized_radio_button_id
+    form = ActionView::Helpers::FormBuilder.new(
+      :widget, nil, self, {}
+    )
+
+    # Mixed-case value with whitespace — exercises the sanitization
+    html = radio_with_label(
+      form: form, field: :flavor, value: "Hello World", label: "Pick one"
+    )
+
+    # Rails sanitizes "Hello World" → "hello_world" for the input id;
+    # our label `for=` uses `parameterize(separator: "_")` to match.
+    assert_match(/type="radio"[^>]+id="widget_flavor_hello_world"/, html,
+                 "Radio input id should be Rails-sanitized form of value")
+    assert_match(/<label[^>]+for="widget_flavor_hello_world"/, html,
+                 "Label `for=` must match the radio input's sanitized id")
+  end
+
+  # Simpler symbol-value case — the common pattern in MO callers
+  # (e.g. :txt, :rtf, :csv from species_lists/downloads).
+  def test_radio_with_label_for_attr_with_symbol_value
+    form = ActionView::Helpers::FormBuilder.new(
+      :report, nil, self, {}
+    )
+
+    html = radio_with_label(
+      form: form, field: :type, value: :txt, label: "Plain Text"
+    )
+
+    assert_match(/type="radio"[^>]+id="report_type_txt"/, html)
+    assert_match(/<label[^>]+for="report_type_txt"/, html)
+  end
 end


### PR DESCRIPTION
## Summary

Closes the ERB ↔ Phlex divergence in form `<label>` emission, plus the `RadioField` `between` slot gap. Covers [issue #4258](https://github.com/MushroomObserver/mushroom-observer/issues/4258) items 2, 4, and 9.

Four commits, all in support of the same goal: every form helper that emits a `<label>` emits a `for=` matching the input's exact rendered id, and `RadioField` supports the same `between:` shape ERB does.

### Commit 1: Phlex `ReadOnlyField` + `StaticTextField` — add `for=`

Both emitted `<label class="mr-3">…</label>` with no `for=`, while the ERB analogues (`*_with_label`) go through Rails' `form.label(field, …)` which always emits `for=`. Match the ERB by setting `for: field.dom.id` on both.

### Commit 2: Phlex `RadioField` + `CheckboxField` array-mode — add `for=` + durable override for upstream array-id bug

Both per-option label wrappers (`RadioField#render_choice`, `CheckboxField#render_checkbox_option`) emitted `<label>` without `for=`. Added `for: option_input_id(value_str)` to both.

While adding the test, surfaced an upstream Superform issue: per-option inputs in checkbox array mode all shared the field's `dom.id` (no value suffix), because upstream `Checkbox#field_attributes` falls through to its `boolean?` branch when MO's array-mode call shape doesn't satisfy `collection?` (`field.parent.is_a?(Superform::Field)`). Fix locally by stopping the delegation for the array case — emit the input directly, mirroring MO's existing block-mode `option(value)` helper.

### Commit 3: ERB `radio_with_label` — parameterize value in `for=` (was #4264, item 9)

`radio_with_label` interpolated the value verbatim into the label's `for=`. Rails' `radio_button` sanitizes the value when generating the input id, so `value: "Hello World"` produced `for="…_Hello World"` paired with `id="…_hello_world"` — a mismatch. Apply `parameterize(separator: "_")` to match (public-API equivalent of Rails' internal `sanitized_value`, matches Phlex `RadioField#index_for`).

### Commit 4: Phlex `RadioField` — add `between` slot (item 2)

`RadioField` had no `between` slot, so the ERB `radio_with_label` `between:` shape was unrepresentable in Phlex. Add `slot :between`, render after each option's label text wrapped in `<div class="d-inline-block ml-3">` (matches ERB shape). Applied uniformly to every option — no current production caller passes per-option betweens, but the API is now parity-complete.

Bundled with the other commits because it touches the same `render_choice` method as the for-attr work, so landing separately would create avoidable merge conflicts.

## Test plan

- [x] `bundle exec rubocop` clean on all changed files
- [x] 58 tests / 311 assertions pass across `application_form_test.rb`, plus `forms_helper_test.rb` for the ERB side
- [x] Regression tests added:
  - Phlex side: `test_read_only_field_label_has_for_attribute`, `test_static_field_label_has_for_attribute`, `test_radio_field_per_option_label_has_for_attribute`, `test_checkbox_field_array_mode_per_option_label_has_for_attribute`, `test_radio_field_with_between_slot`
  - ERB side: `test_radio_with_label_for_attr_matches_sanitized_radio_button_id`, `test_radio_with_label_for_attr_with_symbol_value`
- [ ] Visual eyeball: `/names/:id/edit` (read-only rank + deprecated), name-change-request page, merge-request page, `/species_lists/download` (ERB radios)