### PR TITLE
Rename ERB `hidden_field_with_label` → `read_only_field_with_label`

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -399,9 +399,17 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   #   end
   # end
 
-  # We have fields like this. Prints a static value for submitted field,
-  # from either a "text" option (first choice) or a "value" option
-  def hidden_field_with_label(**args)
+  # Renders a labeled, non-editable display of a value plus a real
+  # `<input type="hidden">` carrying the same value, so the user can
+  # see what's being submitted but can't change it. The Phlex analogue
+  # is `Components::ApplicationForm::ReadOnlyField`; this is the ERB
+  # equivalent (NOT to be confused with a bare hidden input, which is
+  # `f.hidden_field` / Phlex's `HiddenField`).
+  #
+  # Renamed from `hidden_field_with_label` (which mis-described the
+  # output — it emits a visible static-text display in addition to the
+  # hidden input).
+  def read_only_field_with_label(**args)
     opts = separate_field_options_from_args(args)
     text = opts[:text] || opts[:value] || ""
 


### PR DESCRIPTION
## Summary

[Issue #4258](https://github.com/MushroomObserver/mushroom-observer/issues/4258) item 3.

> This concerns a soon-to-be-retired ERB helper that is named misleadingly. It may misdirect Claude about what the equivalent Phlex method is, on the remaining conversions. Seems wise to fix, even if temporary. 


The old ERB helper name mis-described the output. `hidden_field_with_label` sounds like "a hidden input plus a label", but the helper actually emits a label, a **visible** `<p class="form-control-static">{value}</p>` static-text display, AND a real `<input type="hidden">`. It's the ERB equivalent of `Components::ApplicationForm::ReadOnlyField`, not of `HiddenField`.

The old name was a documented footgun: a caller mapping `hidden_field_with_label` → Phlex `HiddenField` during an ERB→Phlex conversion would silently lose the visible static-text display.

Rename to `read_only_field_with_label` so the Phlex/ERB pair shares the "read-only" naming. **Zero callers in the codebase**, so this is a pure definition rename — no caller updates needed. Bare hidden inputs continue to use `f.hidden_field` (ERB) / `Components::ApplicationForm::HiddenField` (Phlex).

## Test plan

- [x] `bundle exec rubocop` clean
- [x] `test/helpers/forms_helper_test.rb` (2 tests, 8 assertions) passes
- [x] `grep -rn hidden_field_with_label` across `app/` `test/` `config/` returns no remaining references in production code (only the comment in the renamed helper itself, which explains the rename)