### PR TITLE
Parameterize value in ERB radio_with_label for= attribute

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -117,15 +117,26 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # Bootstrap radio: form, field, value, label, class, checked
+  #
+  # The label's `for=` matches the id Rails' `radio_button` generates for
+  # the input — which sanitizes the value (lowercase, spaces → underscores,
+  # special chars stripped). Without sanitization here, a value like
+  # "Hello World" or a non-trivial symbol would yield a label
+  # `for="field_Hello World"` while the input id is `"field_hello_world"`,
+  # breaking label click-focus and screen-reader association.
+  # `parameterize(separator: "_")` is the public-API equivalent of Rails'
+  # internal `sanitized_value` and matches Phlex `RadioField`'s `index_for`.
   def radio_with_label(**args)
     args = auto_label_if_form_is_account_prefs(args)
     args = check_for_help_block(args)
     opts = separate_field_options_from_args(args, [:value])
 
     wrap_class = form_group_wrap_class(args, "radio")
+    value_id_suffix = args[:value].to_s.parameterize(separator: "_")
+    label_for = "#{args[:field]}_#{value_id_suffix}"
 
     tag.div(class: wrap_class) do
-      concat(args[:form].label("#{args[:field]}_#{args[:value]}") do
+      concat(args[:form].label(label_for) do
         concat(args[:form].radio_button(args[:field], args[:value], opts))
         concat(args[:label])
         if args[:between].present?

--- a/test/helpers/forms_helper_test.rb
+++ b/test/helpers/forms_helper_test.rb
@@ -39,4 +39,42 @@ class FormsHelperTest < ActionView::TestCase
     assert_includes(html, "change-&gt;file-input#validate",
                     "Should trigger validation on change")
   end
+
+  # Regression: label `for=` must match the id Rails' `radio_button`
+  # generates. Rails' internal `sanitized_value` lowercases the value,
+  # replaces whitespace with underscores, and strips other non-word
+  # chars; values like "Hello World" or symbols with special chars
+  # would otherwise produce a `for=` that doesn't match the input id.
+  def test_radio_with_label_for_attr_matches_sanitized_radio_button_id
+    form = ActionView::Helpers::FormBuilder.new(
+      :widget, nil, self, {}
+    )
+
+    # Mixed-case value with whitespace — exercises the sanitization
+    html = radio_with_label(
+      form: form, field: :flavor, value: "Hello World", label: "Pick one"
+    )
+
+    # Rails sanitizes "Hello World" → "hello_world" for the input id;
+    # our label `for=` uses `parameterize(separator: "_")` to match.
+    assert_match(/type="radio"[^>]+id="widget_flavor_hello_world"/, html,
+                 "Radio input id should be Rails-sanitized form of value")
+    assert_match(/<label[^>]+for="widget_flavor_hello_world"/, html,
+                 "Label `for=` must match the radio input's sanitized id")
+  end
+
+  # Simpler symbol-value case — the common pattern in MO callers
+  # (e.g. :txt, :rtf, :csv from species_lists/downloads).
+  def test_radio_with_label_for_attr_with_symbol_value
+    form = ActionView::Helpers::FormBuilder.new(
+      :report, nil, self, {}
+    )
+
+    html = radio_with_label(
+      form: form, field: :type, value: :txt, label: "Plain Text"
+    )
+
+    assert_match(/type="radio"[^>]+id="report_type_txt"/, html)
+    assert_match(/<label[^>]+for="report_type_txt"/, html)
+  end
 end


### PR DESCRIPTION
## Summary

[Issue #4258](https://github.com/MushroomObserver/mushroom-observer/issues/4258) item 9 — recommended fix.

`radio_with_label` interpolated the value verbatim into the label's `for=`:

```ruby
args[:form].label("#{args[:field]}_#{args[:value]}") …
```

But Rails' `radio_button` internally sanitizes the value when generating the input's id (lowercase, whitespace → underscore, other non-word chars stripped). So for a value like `"Hello World"`:

```html
<label for="widget_flavor_Hello World">
  <input type="radio" id="widget_flavor_hello_world" …>
</label>
```

The for-attr never matched the input id, breaking label click-focus and screen-reader association.

Apply `parameterize(separator: "_")` to the value before interpolation. It's the public-API equivalent of Rails' internal `sanitized_value` and matches Phlex `RadioField#index_for`, so ERB and Phlex emit identical for-attrs.

## Test plan

- [x] New regression tests in `forms_helper_test.rb`:
  - `test_radio_with_label_for_attr_matches_sanitized_radio_button_id` — exercises the original bug case (`"Hello World"`); asserts both the radio input `id=` and the label `for=` end up `widget_flavor_hello_world`.
  - `test_radio_with_label_for_attr_with_symbol_value` — common MO caller pattern (`:txt`, `:rtf`, `:csv` from `species_lists/downloads`); asserts the for/id pair for symbols.
- [x] 4 tests / 18 assertions pass
- [x] `bundle exec rubocop` clean on both changed files
- [ ] Visual eyeball on a page with radio buttons that uses non-trivial values (e.g. `species_lists/download` with `:txt`/`:rtf`/`:csv`, `support/donate` with `:amount` integers + "other"). Behavior change is invisible for typical values; only visible when a value would have failed sanitization before.