### PR TITLE
TextareaField: honor monospace at component level

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -224,10 +224,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
-    # Handle monospace option
-    if wrapper_opts.delete(:monospace)
-      field_opts[:class] = class_names(field_opts[:class], "text-monospace")
-    end
+    # `monospace:` is handled by TextareaField itself via wrapper_options.
 
     field_component = field(field_name).textarea(
       wrapper_options: wrapper_opts,

--- a/app/components/application_form/textarea_field.rb
+++ b/app/components/application_form/textarea_field.rb
@@ -27,12 +27,20 @@ class Components::ApplicationForm < Superform::Rails::Form
         # Use value attribute, then field value, as default content
         default_value = attributes.delete(:value) || field.dom.value
         content ||= proc { default_value }
-        textarea(**attributes, class: class_names(attributes[:class],
-                                                  "form-control"), &content)
+        textarea(**attributes, class: textarea_class, &content)
       end
     end
 
     private
+
+    # `wrapper_options[:monospace] == true` appends `text-monospace` to
+    # the textarea's class chain. Matches the ERB `text_area_with_label`
+    # helper's `:monospace` option so callers (and direct component
+    # instantiators) get the same emission either way.
+    def textarea_class
+      mono = "text-monospace" if wrapper_options[:monospace]
+      class_names(attributes[:class], "form-control", mono)
+    end
 
     def render_with_wrapper
       div(class: wrapper_class, data: wrapper_options[:wrap_data]) do

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -72,6 +72,22 @@ class ApplicationFormTest < ComponentTestCase
     assert_includes(form, "text-monospace")
   end
 
+  # Regression: TextareaField applies `text-monospace` when instantiated
+  # directly with `wrapper_options[:monospace]` — not just via the helper.
+  # Matches ERB `text_area_with_label`'s `:monospace` semantics so direct
+  # component callers (e.g. FieldProxy-backed textareas) get parity.
+  def test_textarea_field_monospace_at_component_level
+    form = Components::ApplicationForm.new(@collection_number,
+                                           action: "/test_form_path")
+    field = form.field(:notes)
+    component = Components::ApplicationForm::TextareaField.new(
+      field, wrapper_options: { label: "Notes", monospace: true }
+    )
+
+    html = render(component)
+    assert_html(html, "textarea.form-control.text-monospace")
+  end
+
   def test_textarea_field_with_rows
     form = render_form do
       textarea_field(:notes, label: "Notes", rows: 10)


### PR DESCRIPTION
## Summary

[Issue #4258](https://github.com/MushroomObserver/mushroom-observer/issues/4258) item 1.

`monospace: true` was wired in the `ApplicationForm#textarea_field` helper (lines 227-230 of `application_form.rb`): the helper extracted `monospace` from `wrapper_opts`, deleted the key, and appended `text-monospace` to the field's class chain before passing to `field.textarea(**field_opts)`.

**Net effect**: callers using the helper got `text-monospace`; callers instantiating `Components::ApplicationForm::TextareaField` directly (e.g. `form_image_fields.rb`, `translation_form.rb` for FieldProxy-backed textareas) did **NOT** — the component class never read `wrapper_options[:monospace]`.

Move the handling into `TextareaField` itself so the option works at the component level too, matching ERB `text_area_with_label`'s `:monospace` semantics for all entry points. The helper still slices `monospace` into `wrapper_opts` via `WRAPPER_OPTIONS`; the component reads it from `wrapper_options` in a new `textarea_class` private method.

No production code currently relies on direct-instantiation monospace (both direct callers omit the option), so this is purely a forward-looking parity improvement.

## Test plan

- [x] Existing `test_textarea_field_with_monospace` (helper path) still passes.
- [x] New regression `test_textarea_field_monospace_at_component_level` locks down direct instantiation (`TextareaField.new(field, wrapper_options: { monospace: true })`).
- [x] 54 tests / 292 assertions pass across `application_form_test.rb`.
- [x] `bundle exec rubocop` clean on changed files.