### PR TITLE
Phlex form helpers honor `prefs: true`

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -77,6 +77,7 @@
 class Components::ApplicationForm < Superform::Rails::Form
   include Phlex::Slotable
   include Phlex::Rails::Helpers::TurboFrameTag
+  include UploadHelpers
 
   # Automatically set form ID based on class name unless explicitly provided
   # @param model [ActiveRecord::Base] the model object for the form
@@ -199,6 +200,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @yield [field_component] Optional block to set slots: `with_between`,
   #   `with_append` (after input, end of form-group), `with_help`
   def text_field(field_name, **options)
+    options = auto_label_for_prefs(field_name, options)
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
@@ -221,6 +223,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @yield [field_component] Optional block to set slots: `with_between`,
   #   `with_append`, `with_help`
   def textarea_field(field_name, **options)
+    options = auto_label_for_prefs(field_name, options)
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
@@ -247,6 +250,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @yield [field_component] Optional block to set slots: `with_between`,
   #   `with_append`, `with_help`
   def checkbox_field(field_name, **options, &block)
+    options = auto_label_for_prefs(field_name, options)
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
@@ -267,6 +271,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @example
   #   radio_field(:target, [1, "Option 1"], [2, "Option 2"])
   def radio_field(field_name, *options, **kwargs)
+    kwargs = auto_label_for_prefs(field_name, kwargs)
     wrapper_opts = kwargs.slice(*WRAPPER_OPTIONS)
     field_opts = kwargs.except(*WRAPPER_OPTIONS)
 
@@ -285,6 +290,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @yield [field_component] Optional block to set slots: `with_between`,
   #   `with_append`, `with_help`
   def select_field(field_name, options_list, **options)
+    options = auto_label_for_prefs(field_name, options)
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
@@ -356,6 +362,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @yield [field_component] Optional block to set slots: `with_between`,
   #   `with_append`, `with_help`
   def number_field(field_name, **options)
+    options = auto_label_for_prefs(field_name, options)
     wrapper_opts = options.slice(*WRAPPER_OPTIONS)
     field_opts = options.except(*WRAPPER_OPTIONS)
 
@@ -495,74 +502,13 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
   end
 
-  # Renders image upload fields in a :upload namespace
-  # Creates params[:model][:upload][image], etc. (nested under form model)
-  # Pass a block to render content in the file field's between slot.
-  def upload_fields(file_field_label: "#{:IMAGE.l}:", **args, &between_block)
-    args => {
-      copyright_holder:, copyright_year:, licenses:, upload_license_id:
-    }
+  # Image upload helpers (`upload_fields`, `image_namespace`, and their
+  # private renderers) live in `application_form/upload_helpers.rb` and
+  # are mixed in via `include UploadHelpers` at the top of this class.
 
-    namespace(:upload) do |upload|
-      render_upload_image_field(upload, file_field_label, &between_block)
-      render_upload_copyright_holder(upload, copyright_holder)
-      render_upload_year(upload, copyright_year)
-      render_upload_license(upload, licenses, upload_license_id)
-    end
-  end
-
-  # Creates a namespace for image fields indexed by image ID.
-  # Generates params like: observation[good_image][123][notes]
-  # @param type [Symbol] :good_image or :image (for existing vs new uploads)
-  # @param image_id [Integer, String] the image ID
-  # @yield [namespace] the nested namespace for field building
-  def image_namespace(type, image_id, &block)
-    namespace(type) do |type_ns|
-      type_ns.namespace(image_id.to_s, &block)
-    end
-  end
-
-  # Lightweight field proxy for use outside of form rendering context.
-  # Provides the same interface as Superform::Field for field components.
-  # Unlike Superform fields, these can be created and rendered many times.
-  #
-  # @example
-  #   proxy = FieldProxy.new("observation[good_image][123]", :notes, "text")
-  #   render(TextField.new(proxy, wrapper_options: {}))
-  class FieldProxy
-    attr_reader :key, :value, :dom
-
-    def initialize(namespace, field_key, field_value = nil)
-      @key = field_key
-      @value = field_value
-      @dom = DOMProxy.new(namespace, field_key, field_value)
-    end
-
-    # Minimal DOM proxy that provides id, name, value for field components
-    class DOMProxy
-      def initialize(namespace, field_key, field_value)
-        @namespace = namespace
-        @field_key = field_key
-        @field_value = field_value
-      end
-
-      def id
-        return @field_key.to_s if @namespace.blank?
-
-        "#{@namespace}_#{@field_key}".tr("[]", "_").gsub(/__+/, "_")
-      end
-
-      def name
-        return @field_key.to_s if @namespace.blank?
-
-        "#{@namespace}[#{@field_key}]"
-      end
-
-      def value
-        @field_value.to_s
-      end
-    end
-  end
+  # `FieldProxy` (and its inner `DOMProxy`) live in
+  # `application_form/field_proxy.rb` — Zeitwerk autoloads them. Use the
+  # `image_field_proxy` factory below for image-field convenience.
 
   # Factory method to create a FieldProxy for image fields
   # @param type [Symbol] :good_image or :image
@@ -584,59 +530,14 @@ class Components::ApplicationForm < Superform::Rails::Form
     field_component.with_help { help_content }
   end
 
-  def render_upload_image_field(upload, label, &between_block)
-    file_component = upload.field(:image).file(
-      wrapper_options: { label: label }
-    )
-    file_component.with_between(&between_block) if between_block
-    render(file_component)
-  end
+  # Mirrors ERB `auto_label_if_form_is_account_prefs`: when `prefs: true`
+  # is present, resolve the label from the `prefs_<field>` i18n key and
+  # drop the `:prefs` option so it doesn't flow downstream. Used by the
+  # same set of helpers the ERB applies it to: text, textarea, select,
+  # checkbox, radio, number.
+  def auto_label_for_prefs(field_name, options)
+    return options if options[:prefs].blank?
 
-  def render_upload_copyright_holder(upload, holder)
-    render(
-      upload.field(:copyright_holder).text(
-        wrapper_options: { label: "#{:image_copyright_holder.l}:",
-                           inline: true },
-        value: holder
-      )
-    )
-  end
-
-  def render_upload_year(upload, year)
-    render(
-      upload.field(:copyright_year).select(
-        upload_year_options,
-        wrapper_options: { label: "#{:WHEN.l}:", inline: true },
-        selected: year
-      )
-    )
-  end
-
-  def render_upload_license(upload, licenses, selected_id)
-    # Superform expects [value, display] but Rails returns [display, value]
-    # So we need to swap them
-    swapped_licenses = licenses.map { |display, value| [value, display] }
-
-    license_select = upload.field(:license_id).select(
-      swapped_licenses,
-      wrapper_options: { label: "#{:LICENSE.l}:", inline: true },
-      selected: selected_id
-    )
-
-    license_select.with_append { render_copyright_warning }
-
-    render(license_select)
-  end
-
-  def render_copyright_warning
-    div(class: "help-block") do
-      plain("(")
-      plain(:image_copyright_warning.t)
-      plain(")")
-    end
-  end
-
-  def upload_year_options
-    (1980..Time.zone.now.year).to_a.reverse.map { |y| [y.to_s, y] }
+    options.merge(label: :"prefs_#{field_name}".t).except(:prefs)
   end
 end

--- a/app/components/application_form/field_proxy.rb
+++ b/app/components/application_form/field_proxy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Lightweight field proxy for use outside of form rendering context.
+  # Provides the same interface as Superform::Field for field components.
+  # Unlike Superform fields, these can be created and rendered many times.
+  #
+  # @example
+  #   proxy = FieldProxy.new("observation[good_image][123]", :notes, "text")
+  #   render(TextField.new(proxy, wrapper_options: {}))
+  class FieldProxy
+    attr_reader :key, :value, :dom
+
+    def initialize(namespace, field_key, field_value = nil)
+      @key = field_key
+      @value = field_value
+      @dom = DOMProxy.new(namespace, field_key, field_value)
+    end
+
+    # Minimal DOM proxy that provides id, name, value for field components
+    class DOMProxy
+      def initialize(namespace, field_key, field_value)
+        @namespace = namespace
+        @field_key = field_key
+        @field_value = field_value
+      end
+
+      def id
+        return @field_key.to_s if @namespace.blank?
+
+        "#{@namespace}_#{@field_key}".tr("[]", "_").gsub(/__+/, "_")
+      end
+
+      def name
+        return @field_key.to_s if @namespace.blank?
+
+        "#{@namespace}[#{@field_key}]"
+      end
+
+      def value
+        @field_value.to_s
+      end
+    end
+  end
+end

--- a/app/components/application_form/upload_helpers.rb
+++ b/app/components/application_form/upload_helpers.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Image-upload-specific helpers extracted from ApplicationForm to keep
+  # the main class focused on field helpers. Only forms that handle image
+  # uploads need these. Included into ApplicationForm via
+  # `include UploadHelpers` in application_form.rb.
+  module UploadHelpers
+    # Renders image upload fields in a :upload namespace
+    # Creates params[:model][:upload][image], etc. (nested under form model)
+    # Pass a block to render content in the file field's between slot.
+    def upload_fields(file_field_label: "#{:IMAGE.l}:", **args, &between_block)
+      args => {
+        copyright_holder:, copyright_year:, licenses:, upload_license_id:
+      }
+
+      namespace(:upload) do |upload|
+        render_upload_image_field(upload, file_field_label, &between_block)
+        render_upload_copyright_holder(upload, copyright_holder)
+        render_upload_year(upload, copyright_year)
+        render_upload_license(upload, licenses, upload_license_id)
+      end
+    end
+
+    # Creates a namespace for image fields indexed by image ID.
+    # Generates params like: observation[good_image][123][notes]
+    # @param type [Symbol] :good_image or :image (for existing vs new uploads)
+    # @param image_id [Integer, String] the image ID
+    # @yield [namespace] the nested namespace for field building
+    def image_namespace(type, image_id, &block)
+      namespace(type) do |type_ns|
+        type_ns.namespace(image_id.to_s, &block)
+      end
+    end
+
+    private
+
+    def render_upload_image_field(upload, label, &between_block)
+      file_component = upload.field(:image).file(
+        wrapper_options: { label: label }
+      )
+      file_component.with_between(&between_block) if between_block
+      render(file_component)
+    end
+
+    def render_upload_copyright_holder(upload, holder)
+      render(
+        upload.field(:copyright_holder).text(
+          wrapper_options: { label: "#{:image_copyright_holder.l}:",
+                             inline: true },
+          value: holder
+        )
+      )
+    end
+
+    def render_upload_year(upload, year)
+      render(
+        upload.field(:copyright_year).select(
+          upload_year_options,
+          wrapper_options: { label: "#{:WHEN.l}:", inline: true },
+          selected: year
+        )
+      )
+    end
+
+    def render_upload_license(upload, licenses, selected_id)
+      # Superform expects [value, display] but Rails returns [display, value]
+      # So we need to swap them
+      swapped_licenses = licenses.map { |display, value| [value, display] }
+
+      license_select = upload.field(:license_id).select(
+        swapped_licenses,
+        wrapper_options: { label: "#{:LICENSE.l}:", inline: true },
+        selected: selected_id
+      )
+
+      license_select.with_append { render_copyright_warning }
+
+      render(license_select)
+    end
+
+    def render_copyright_warning
+      div(class: "help-block") do
+        plain("(")
+        plain(:image_copyright_warning.t)
+        plain(")")
+      end
+    end
+
+    def upload_year_options
+      (1980..Time.zone.now.year).to_a.reverse.map { |y| [y.to_s, y] }
+    end
+  end
+end

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -80,6 +80,52 @@ class ApplicationFormTest < ComponentTestCase
     assert_includes(form, 'rows="10"')
   end
 
+  # Regression: `prefs: true` auto-resolves the label from the
+  # `prefs_<field>` i18n key, matching ERB
+  # `auto_label_if_form_is_account_prefs`. Six helpers honor this:
+  # text_field, textarea_field, select_field, checkbox_field,
+  # radio_field, number_field — same set as ERB.
+  def test_text_field_prefs_auto_resolves_label_from_i18n
+    form = render_form do
+      text_field(:login, prefs: true)
+    end
+
+    # `:prefs_login.t` → "Login" (config/locales/en.txt)
+    assert_match(%r{<label[^>]*>\s*Login\s*</label>}, form)
+  end
+
+  def test_checkbox_field_prefs_auto_resolves_label_from_i18n
+    form = render_form do
+      checkbox_field(:no_emails, prefs: true)
+    end
+
+    # `:prefs_no_emails.t` → "Opt out of _all_ email from MO."
+    assert_includes(form, "Opt out of")
+  end
+
+  def test_auto_label_for_prefs_returns_options_unchanged_when_no_prefs
+    form = Components::ApplicationForm.new(@collection_number,
+                                           action: "/test_form_path")
+
+    result = form.send(:auto_label_for_prefs, :name, label: "Original")
+    assert_equal({ label: "Original" }, result,
+                 "Without :prefs, options should be untouched")
+  end
+
+  def test_auto_label_for_prefs_drops_prefs_key_when_resolving
+    form = Components::ApplicationForm.new(@collection_number,
+                                           action: "/test_form_path")
+
+    result = form.send(:auto_label_for_prefs, :login,
+                       prefs: true, class: "extra")
+    assert_equal("Login", result[:label])
+    assert_not(result.key?(:prefs),
+               ":prefs should be removed after resolution so it " \
+               "doesn't leak into wrapper_options downstream")
+    assert_equal("extra", result[:class],
+                 "Unrelated options should pass through")
+  end
+
   # Checkbox field tests - CollectionNumber doesn't have boolean fields,
   # so we'll just test the rendering with a placeholder field
   def test_checkbox_field_renders_with_basic_options


### PR DESCRIPTION
## Summary

[Issue #4258](https://github.com/MushroomObserver/mushroom-observer/issues/4258) item 8.

Adds the Phlex-side equivalent of ERB `auto_label_if_form_is_account_prefs`: when callers pass `prefs: true` to a form helper, auto-resolve the label from the `prefs_<field>` i18n key and strip the `:prefs` key so it doesn't flow into wrapper options. Applies to the same six helpers ERB does it for: `text_field`, `textarea_field`, `select_field`, `checkbox_field`, `radio_field`, `number_field`.

Implementation: small private helper `auto_label_for_prefs(field_name, options)` on `ApplicationForm`, called as the first line of each of the 6 public helpers. Direct mirror of the ERB shape, so the i18n keys MO already maintains (`config/locales/en.txt`: `prefs_login`, `prefs_no_emails`, …) work identically across both rendering paths.

## Two module extractions (`field_proxy.rb`, `upload_helpers.rb`)

Adding the prefs helper pushed the `application_form.rb` class over the rubocop `Metrics/ClassLength` limit (250 lines). Rather than disable the cop, extract the same chunks PR #4250 extracts:

- **`application_form/field_proxy.rb`**: hosts `FieldProxy` + inner `DOMProxy` (self-contained, used by FieldProxy-backed field rendering outside the form context).
- **`application_form/upload_helpers.rb`**: hosts `upload_fields`, `image_namespace`, and the private `render_upload_*` renderers (only relevant to forms that handle image uploads).

Both extracts match the file structure PR #4250 introduces, so when both eventually merge they'll align cleanly. Zeitwerk autoloads both.

## Test plan

- [x] 57 tests / 302 assertions pass in `application_form_test.rb`, including new regressions:
  - `test_text_field_prefs_auto_resolves_label_from_i18n` — `prefs_login` → "Login" appears in the rendered label.
  - `test_checkbox_field_prefs_auto_resolves_label_from_i18n` — `prefs_no_emails` → "Opt out of …" appears in the rendered label.
  - `test_auto_label_for_prefs_returns_options_unchanged_when_no_prefs` — passthrough when `:prefs` is absent.
  - `test_auto_label_for_prefs_drops_prefs_key_when_resolving` — confirms `:prefs` is removed after resolution.
- [x] Upload-helper-using form tests pass: `glossary_term_form`, `account_profile_form`, `project_form`, plus `observation_form`, `herbarium_form`, `name_form`, `sequence_form` — confirms the upload-helpers module extraction is behaviorally invisible.
- [x] `bundle exec rubocop` clean across all changed files.
- [ ] Visual eyeball on `/account/preferences/email` (existing prefs page) once a Phlex prefs form is wired in. For now the Phlex helpers are forward-looking — no existing Phlex form passes `prefs: true`, so this is API parity rather than a behavior change.