### PR TITLE
Convert api-keys verified indicator to Phlex CheckboxField

### DIFF
--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -54,10 +54,20 @@ class Components::ApplicationForm < Superform::Rails::Form
     # (matching Rails' `form.check_box` output — browsers otherwise
     # repopulate the hidden's "0" on back-button and silently clobber a
     # checked box).
+    #
+    # When `disabled: true` is passed, the hidden sidecar is omitted —
+    # disabled inputs aren't submitted, so the sidecar would be dead
+    # markup (and the checkbox itself never toggles).
     def render_boolean_inputs
-      input(name: field.dom.name, type: :hidden, value: "0",
-            autocomplete: "off")
+      unless disabled?
+        input(name: field.dom.name, type: :hidden, value: "0",
+              autocomplete: "off")
+      end
       input(type: :checkbox, value: "1", **attributes)
+    end
+
+    def disabled?
+      @attributes[:disabled] == true
     end
 
     # Render a single array-mode checkbox (name="…[]"). Intended for use

--- a/app/components/application_form/field_proxy.rb
+++ b/app/components/application_form/field_proxy.rb
@@ -17,6 +17,16 @@ class Components::ApplicationForm < Superform::Rails::Form
       @dom = DOMProxy.new(namespace, field_key, field_value)
     end
 
+    # FieldProxy stands in for a Superform::Field outside a form
+    # context, where the field has no parent. Superform's
+    # `Checkbox#collection?` checks `field.parent.is_a?(Superform::Field)`
+    # to decide whether to render array-mode markup; returning nil here
+    # routes to the boolean branch, which is what FieldProxy-backed
+    # standalone checkboxes want.
+    def parent
+      nil
+    end
+
     # Factory method to create a FieldProxy for image fields.
     # @param type [Symbol] :good_image or :image
     # @param image_id [Integer, String] the image ID

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -61,13 +61,21 @@ module APIKeysHelper
     end
   end
 
+  # Read-only ✓ indicator shown for verified keys. Renders MO's
+  # canonical `<div class="checkbox"><label><input type="checkbox"
+  # checked disabled></label></div>` shape via the centralized
+  # `CheckboxField` so the markup stays in lockstep with form-mode
+  # checkboxes (BS3/4/5 migration changes one file, not many).
+  # The `disabled:` mode skips the hidden sidecar — the input is
+  # never submitted, so the sidecar would just be noise.
   def api_keys_dummy_verified_check_box(key)
-    tag.div(class: "checkbox my-0", id: "verified_key_#{key.id}") do
-      tag.label(:verified) do
-        check_box_tag(:verified, "verified", true, disabled: true)
-        # concat(:verified.l)
-      end
-    end
+    render(Components::ApplicationForm::CheckboxField.new(
+             Components::ApplicationForm::FieldProxy.new(
+               nil, "verified_key_#{key.id}", true
+             ),
+             wrapper_options: { label: false, wrap_class: "my-0" },
+             disabled: true
+           ))
   end
 
   # This table cell is operated by Bootstrap collapse.js.


### PR DESCRIPTION
## Summary

Step 4 from `bootstrap_checkbox_radio_todo.md`. The "active" column on `/account/api_keys` shows either an Activate button (unverified keys) or a read-only ✓ indicator (verified keys). The latter was rendering via a bare `check_box_tag(:verified, "verified", true, disabled: true)` — flagged in the audit. Routes through `Components::ApplicationForm::CheckboxField` instead.

Rendered shape unchanged visually; the unused outer-wrap `id="verified_key_<id>"` is dropped (grep confirms no callers).

## Supporting changes

- **`CheckboxField`** boolean mode now skips the hidden sidecar when `disabled: true` is passed. Disabled inputs aren't submitted, so the sidecar would just be dead markup. Default boolean mode still emits the sidecar for `autocomplete="off"` back-button safety.
- **`FieldProxy`** gains a `parent` method returning `nil`. Superform's `Checkbox#collection?` calls `field.parent` to decide array-vs-boolean rendering; without this, a FieldProxy-backed boolean checkbox crashes with `NoMethodError`.

> **Note**: The `FieldProxy#parent` fix is identical to the one in PR #4271. If both merge, the duplicate-line addition resolves cleanly.

## Test plan

- [x] `bin/rails test test/components test/helpers test/controllers/account` — 1017/1017 green
- [x] `bin/rails test test/system/account_api_keys_system_test.rb` — 1/1 green
- [ ] Spot-check `/account/api_keys` — verified row shows the ✓ checkbox; unverified row shows the Activate button
- [ ] CI green

## Out of scope

The disabled checkbox is doing UI work as a status indicator (a `<span class="glyphicon glyphicon-ok">` would be more honest). Keeping the current shape — the conversion is mechanical and the visual is identical to before.

## Follow-ups

Continuing the `bootstrap_checkbox_radio_todo.md` plan. Remaining call sites that still bypass the centralization:
- `namings_helper.rb:408` — proposed-naming reasons checkboxes
- `form_carousel_item.rb` — `thumb_image_id` radio
- `activity_log_type_filters.rb` — `q[type][]` filter checkboxes
- `project_violations_form.rb` — `location_id` radios

🤖 Generated with [Claude Code](https://claude.com/claude-code)