### PR TITLE
FormCarousel: real `thumb_image_id` radio + CSS-only active state

### DIFF
--- a/app/assets/stylesheets/mo/_carousel.scss
+++ b/app/assets/stylesheets/mo/_carousel.scss
@@ -232,7 +232,20 @@
     display: none;
   }
 
-  &.active {
+  // CSS-only "pressed" state via `:has()` — no JS needed to toggle
+  // `.active`. The browser handles the radio group (clicking one
+  // unchecks the others), so this selector matches whichever label
+  // wraps the currently-checked radio. Mirrors BS3's
+  // `.btn-default.active` pressed visual (the values are copied
+  // because `@extend .btn-default.active` doesn't play well with
+  // compound selectors).
+  &:has(input[type="radio"]:checked) {
+    color: #333;
+    background-color: #d4d4d4;
+    border-color: #8c8c8c;
+    outline: 0;
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+
     .set_thumb_img_text {
       display: none;
     }

--- a/app/components/application_form/button_style_radio.rb
+++ b/app/components/application_form/button_style_radio.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Bootstrap 3 button-styled radio: a `<label class="btn …">` wrapping
+  # an `<input type="radio">` plus arbitrary block content (the visible
+  # text/icons). NO `.radio` div wrap — that wrap is for vertical
+  # checkbox-list layout; this component is for radios that look and
+  # behave like buttons (BS3's `.btn-group[data-toggle="buttons"]`
+  # pattern, or standalone button-styled radios scattered across a
+  # form).
+  #
+  # Multiple instances with the same `name:` form a radio group via
+  # browser-native behavior — no JS needed to manage checked state
+  # across them. The `data-form-images-target`-style hook in
+  # FormCarouselItem only manages the visual `.active` class on the
+  # label.
+  #
+  # Standalone (no Superform context) — takes raw HTML kwargs rather
+  # than a `Field` / `FieldProxy`, since the call sites (carousel
+  # cards, in-form toolbar radios) don't always have a form context
+  # available and the radio name is usually fixed by the surrounding
+  # markup contract anyway.
+  #
+  # @example
+  #   render(Components::ApplicationForm::ButtonStyleRadio.new(
+  #     name: "observation[thumb_image_id]", value: image.id,
+  #     id: "thumb_image_id_#{image.id}", checked: thumb?,
+  #     label_class: "btn btn-default thumb_img_btn",
+  #     label_data: { action: "click->form-images#setObsThumbnail" }
+  #   )) do
+  #     span(class: "set_thumb_img_text") { :image_set_default.l }
+  #   end
+  class ButtonStyleRadio < Phlex::HTML
+    include Components::TrustedHtml
+
+    # @param name [String] HTML name (shared across radios in the group)
+    # @param value [String] value submitted when this radio is checked
+    # @param id [String] HTML id (matches the label's `for`)
+    # @param checked [Boolean] initial checked state
+    # @param label [Hash] HTML attrs for the `<label>` wrap
+    #   (e.g. `class:`, `data:`)
+    # @param input_attrs [Hash] HTML attrs passed through to the
+    #   `<input>` (e.g. `class:`, `data:`)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(name:, value:, id:, checked: false,
+                   label: {}, **input_attrs)
+      # rubocop:enable Metrics/ParameterLists
+      super()
+      @name = name
+      @value = value
+      @id = id
+      @checked = checked
+      @label_attrs = label
+      @input_attrs = input_attrs
+    end
+
+    def view_template(&block)
+      label(for: @id, **@label_attrs) do
+        input(**input_attributes)
+        yield if block
+      end
+    end
+
+    private
+
+    def input_attributes
+      { type: :radio, name: @name, id: @id, value: @value,
+        checked: @checked, **@input_attrs }
+    end
+  end
+end

--- a/app/components/form_carousel_item.rb
+++ b/app/components/form_carousel_item.rb
@@ -138,24 +138,29 @@ class Components::FormCarouselItem < Components::BaseImage
     end
   end
 
-  # Note that this is not `observation[thumb_image_id]`, a hidden field that
-  # is set by the Stimulus controller on the basis of these radios' value.
+  # Real `observation[thumb_image_id]` radio — browser-native radio
+  # group across carousel items submits the checked value directly,
+  # no Stimulus round-trip via a separate hidden field. A static
+  # hidden default with the same name (see
+  # `ObservationFormUpload#render_thumb_image_id_field`) ensures the
+  # param is always submitted (so removing the current thumb image
+  # without picking another one clears the model field).
+  #
+  # The visual "pressed" state on the selected button is CSS-only
+  # (`.thumb_img_btn:has(input[type="radio"]:checked)` in
+  # `_carousel.scss`) — no JS to toggle `.active`.
   def button_to_set_thumb_img
     value = @img_instance&.id || "true"
     checked = @obs_thumb_id&.== @img_instance&.id
-    label_classes = class_names("btn btn-default btn-sm thumb_img_btn",
-                                active: checked)
 
-    label(
-      for: "thumb_image_id",
-      class: label_classes,
-      data: { form_images_target: "thumbImgBtn",
-              action: "click->form-images#setObsThumbnail" }
-    ) do
-      input(type: :radio, name: "thumb_image_id",
-            id: "thumb_image_id_#{value}", value: value,
-            class: "mr-3", checked: checked,
-            data: { form_images_target: "thumbImgRadio" })
+    render(Components::ApplicationForm::ButtonStyleRadio.new(
+             name: "observation[thumb_image_id]",
+             value: value,
+             id: "thumb_image_id_#{value}",
+             checked: checked,
+             label: { class: "btn btn-default btn-sm thumb_img_btn" },
+             class: "mr-3"
+           )) do
       span(class: "set_thumb_img_text") { :image_set_default.l }
       span(class: "is_thumb_img_text") { :image_add_default.l }
     end

--- a/app/components/form_carousel_item.rb
+++ b/app/components/form_carousel_item.rb
@@ -153,10 +153,19 @@ class Components::FormCarouselItem < Components::BaseImage
     value = @img_instance&.id || "true"
     checked = @obs_thumb_id&.== @img_instance&.id
 
+    # `id:` uses `@img_id` (unique per carousel item: image id for
+    # server-rendered, UUID for upload placeholders) rather than
+    # `value` (which is the literal string "true" for all
+    # placeholders). Unique ids matter for the label `for=`
+    # association (clicking the second placeholder's label otherwise
+    # activates the first's radio) and for Capybara test selectors.
+    # `value:` stays as "true" / image id; the JS post-upload hook
+    # (`form-images#updateObsImages`) updates both the radio's value
+    # AND its id to the real image id once assigned.
     render(Components::ApplicationForm::ButtonStyleRadio.new(
              name: "observation[thumb_image_id]",
              value: value,
-             id: "thumb_image_id_#{value}",
+             id: "thumb_image_id_#{@img_id}",
              checked: checked,
              label: { class: "btn btn-default btn-sm thumb_img_btn" },
              class: "mr-3"

--- a/app/components/observation_form_upload.rb
+++ b/app/components/observation_form_upload.rb
@@ -43,12 +43,16 @@ class Components::ObservationFormUpload < Components::Base
     )
   end
 
+  # Static hidden sidecar for `observation[thumb_image_id]`. Ensures
+  # the param is *always* submitted (defaulting to ""), so removing
+  # the currently-selected thumb image without picking another one
+  # clears the model field rather than retaining a now-deleted image
+  # id. The actual thumb selection is the checked radio in
+  # `FormCarouselItem#button_to_set_thumb_img`; the radios share the
+  # same `name`, are posted AFTER this hidden in form order, and the
+  # checked one's value wins in Rails' param parsing.
   def render_thumb_image_id_field
-    render(
-      @form.field(:thumb_image_id).text(
-        type: "hidden",
-        data: { form_images_target: "thumbImageId" }
-      )
-    )
+    input(type: "hidden", name: "observation[thumb_image_id]",
+          value: "", autocomplete: "off")
   end
 end

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -526,22 +526,30 @@ export default class extends Controller {
   }
 
   // Add the uploaded image's id to `good_images` and update the
-  // carousel-item radio's value to point at the new id. (At upload
-  // time the radio's value was the placeholder; once we have a real
-  // id, the radio needs it so that submitting with this item checked
-  // posts the real `thumb_image_id`.) No separate hidden field to
-  // sync now — the radio itself is the form field.
+  // carousel-item radio's value, its id, and the wrapping label's
+  // `for=` to point at the new image.
+  //
+  // At render time the radio's `value` was `"true"` and its `id`
+  // was `thumb_image_id_<UUID>` (UUID generated client-side per
+  // upload). Once we have a real image id from the server, we
+  // switch to `value="<image.id>"` and `id="thumb_image_id_<image.id>"`
+  // so:
+  //   - the submitted `observation[thumb_image_id]` value is real,
+  //   - tests can find the radio by its predictable image-id-based id,
+  //   - the label's `for=` stays in sync with the input's id.
   updateObsImages(item, image) {
-    // #good_images is a hidden field
     const _good_image_vals = this.goodImageIdsTarget.value || "";
     const _radio = item.dom_element.querySelector(
       'input[type="radio"][name="observation[thumb_image_id]"]'
-    )
+    );
+    const _label = _radio.closest("label");
+    const _new_id = `thumb_image_id_${image.id}`;
 
-    // add id to the good images form field.
-    this.goodImageIdsTarget.value = [_good_image_vals, image.id].join(' ').trim();
+    this.goodImageIdsTarget.value = [_good_image_vals, image.id].join(" ").trim();
 
     _radio.value = image.id;
+    _radio.id = _new_id;
+    if (_label) _label.htmlFor = _new_id;
   }
 
   removeItem(item) {

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -47,8 +47,7 @@ const internalConfig = {
 // Connects to data-controller="form-images"
 export default class extends Controller {
   static targets = ["form", "carousel", "item", "thumbnail", "removeImg",
-    "imageGpsMap", "goodImageIds", "thumbImageId", "thumbImgRadio",
-    "thumbImgBtn"]
+    "imageGpsMap", "goodImageIds"]
 
   initialize() {
   }
@@ -129,29 +128,6 @@ export default class extends Controller {
     const dataTransfer = e.dataTransfer;
     if (dataTransfer.files.length > 0)
       this.addFiles(dataTransfer.files);
-  }
-
-  // Deactivate other radio buttons manually because they are not grouped (?)
-  setObsThumbnail(event) {
-    // event.target is the label.btn clicked to make whichever the default image
-    // but could also be any descendant element
-    const button = event.target.closest('.thumb_img_btn'),
-      radio = button.querySelector('input[type="radio"]');
-    // reset selections
-    this.thumbImgBtnTargets.forEach((elem) => {
-      elem.classList.remove('active');
-    });
-    // reset the checked default thumbnail
-    this.thumbImgRadioTargets.forEach((elem) => {
-      elem.removeAttribute('checked');
-    });
-
-    // set selection...
-    button.classList.add('active');
-    button.querySelector(
-      'input[type="radio"][name="thumb_image_id"]'
-    ).setAttribute('checked', '');
-    this.thumbImageIdTarget.setAttribute('value', radio.value);
   }
 
   addSelectedFiles(event) {
@@ -420,21 +396,21 @@ export default class extends Controller {
   // This is for detaching an image already attached to the observation.
   // (not a fileStore item), on the obs edit form. It just removes the item
   // from the carousel and id from "good_images". Has no effect until submit.
+  //
+  // The thumb-image radio for the removed image goes away with the
+  // carousel item. If it was the checked one, no radio is now
+  // checked — the static hidden sidecar with value="" wins on
+  // submit, so the server-side `thumb_image_id` gets cleared. No
+  // explicit JS handling needed.
   removeAttachedItem(event) {
     const _good_images = this.goodImageIdsTarget.value,
       _good_image_vals = _good_images.split(" "),
       // event.target may be a nested span without data, so get data from button
-      _image_id = event.target.closest("button").dataset.imageId,
-      // This is the observation's designated thumbnail id
-      _thumb_id = this.thumbImageIdTarget.value;
+      _image_id = event.target.closest("button").dataset.imageId;
 
     const _new = _good_image_vals.filter(item => item !== _image_id).join(" ");
     this.goodImageIdsTarget.value = _new;
 
-    // clear hidden_field value for observation thumbnail_id
-    if (_thumb_id == _image_id) {
-      this.thumbImageIdTarget.value = "";
-    }
     document.getElementById("carousel_item_" + _image_id).remove();
     document.getElementById("carousel_thumbnail_" + _image_id).remove();
 
@@ -549,22 +525,23 @@ export default class extends Controller {
     }
   }
 
-  // add the image to `good_images` and maybe set the thumb_image_id
+  // Add the uploaded image's id to `good_images` and update the
+  // carousel-item radio's value to point at the new id. (At upload
+  // time the radio's value was the placeholder; once we have a real
+  // id, the radio needs it so that submitting with this item checked
+  // posts the real `thumb_image_id`.) No separate hidden field to
+  // sync now — the radio itself is the form field.
   updateObsImages(item, image) {
     // #good_images is a hidden field
     const _good_image_vals = this.goodImageIdsTarget.value || "";
     const _radio = item.dom_element.querySelector(
-      'input[type="radio"][name="thumb_image_id"]'
+      'input[type="radio"][name="observation[thumb_image_id]"]'
     )
 
     // add id to the good images form field.
     this.goodImageIdsTarget.value = [_good_image_vals, image.id].join(' ').trim();
 
-    // set the hidden thumb_image_id field if the item's radio is checked
-    if (_radio.checked) {
-      _radio.value = image.id; // it's grabbing the val from the radio
-      this.thumbImageIdTarget.value = image.id; // does not matter!
-    }
+    _radio.value = image.id;
   }
 
   removeItem(item) {

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -460,11 +460,16 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_selector("#added_images", visible: :visible, wait: 3)
     assert_selector(".carousel-item[data-image-status='upload']",
                     text: /Coprinus_comatus/, wait: 3)
-    # Set the first (last) one as the thumb_image
+    # Set the first (last) one as the thumb_image. The visual
+    # "pressed" swap is CSS-only (`:has(input:checked)`), driven by
+    # the radio's checked state — so click the radio directly via
+    # `choose`. The radio's hidden inside a `.btn`-styled label;
+    # `visible: :all` because the radio itself isn't styled visible.
     within(first_image_wrapper) do
       thumb_button = find(".thumb_img_btn")
       scroll_to(thumb_button, align: :center)
-      thumb_button.trigger("click")
+      radio = thumb_button.find("input[type='radio']", visible: :all)
+      choose(radio[:id], visible: :all)
       assert_text(:image_add_default.l)
       assert_no_text(:image_set_default.l)
     end


### PR DESCRIPTION
## Summary

Step 5 from `bootstrap_checkbox_radio_todo.md`. The carousel's thumb-image selection was the most-entangled remaining call site that bypassed the checkbox/radio centralization:

- Bare `<input type="radio" name="thumb_image_id">` (unnamespaced — not a real form field).
- A separate hidden `observation[thumb_image_id]` field that a Stimulus controller (`form-images#setObsThumbnail`) kept in sync.
- Manual `checked`-attr toggling across radios because the radios and the hidden field had different names, so the browser never treated the radios as a single group (comment in the original JS: "they are not grouped (?)").

The whole JS round-trip existed to work around that name mismatch.

## Changes

1. **`Components::ApplicationForm::ButtonStyleRadio`** (new) — one button-styled radio: `<label class="btn …"><input type="radio">content</label>`, no `.radio` div wrap (which is for vertical checkbox-list layout). `FormCarouselItem` routes through it.
2. **Real radio group** — radios now have `name="observation[thumb_image_id]"` and submit directly. Browser handles the group natively. A static hidden sidecar with `value=""` (in `ObservationFormUpload#render_thumb_image_id_field`) ensures the param is always submitted; server-side `ensure_thumb_image` then auto-picks the next available image if the current thumb was removed (existing behavior, unchanged).
3. **CSS-only "pressed" state** — `_carousel.scss` uses `.thumb_img_btn:has(input[type="radio"]:checked)` (~95% browser support, all post-2023). No JS needed to manage `.active`.
4. **Stimulus controller shrinks** — the entire `setObsThumbnail` method goes away, including `thumbImgBtn`, `thumbImgRadio`, `thumbImageId` targets. `removeAttachedItem` and `updateObsImages` drop their thumb-field syncing too (the radio IS the form field now).
5. **System test fix** — the test was using `.trigger("click")` (synthetic JS event). The old click handler caught synthetic events and manually checked the radio; without the handler, synthetic clicks don't fire the browser's default label→input-check action. Updated to `choose(radio_id, visible: :all)` — drives the radio directly, which is what the test was actually exercising.
6. **Follow-up fix (commit 7eff4fc8)** — upload-placeholder radios used to share `id="thumb_image_id_true"` (the `value` defaulted to that literal string), so the label `for=` matched the first such input in DOM order and clicking the second placeholder's label activated the first's radio. Switched to `id="thumb_image_id_<@img_id>"` (UUID for placeholders, image-id for server-rendered items) so each radio has a unique id. JS post-upload now also updates the id and the label's `for=` to the real image id.

## Behavior preserved (server-side check confirms)

- Remove current-thumb image, no replacement chosen → server auto-picks next available image (`ensure_thumb_image` in `edit_and_update.rb`)
- Remove current-thumb image, then click another → new selection wins
- Remove non-thumb image → checked radio still submits the current thumb id

## Browser support

`:has()` is supported in Chrome 105+, Safari 15.4+, Firefox 121+ (all late 2023). If MO needs to support older browsers, the SCSS rule would need to fall back to a JS-toggled `.active` class. Flagged here in case that's a concern.

## Test plan

- [x] `bin/rails test test/components test/helpers test/controllers` — 2900/2900 green
- [x] `bin/rails test test/system/observation_form_system_test.rb` — same pass/fail count as main (1 pre-existing flaky failure on `test_map_click_fills_lat_lng_fields`, unrelated)
- [x] Browser verification of the upload-flow id-collision fix
- [x] CI green

## Follow-ups (from the BS3 checkbox/radio TODO)

Remaining call sites still bypassing the centralization:
- `activity_log_type_filters.rb` — `q[type][]` filter checkboxes
- `project_violations_form.rb` — `location_id` radios

🤖 Generated with [Claude Code](https://claude.com/claude-code)