### PR TITLE
Carousel thumb button: theme-aware active state

### DIFF
--- a/app/assets/stylesheets/mo/_carousel.scss
+++ b/app/assets/stylesheets/mo/_carousel.scss
@@ -235,16 +235,13 @@
   // CSS-only "pressed" state via `:has()` — no JS needed to toggle
   // `.active`. The browser handles the radio group (clicking one
   // unchecks the others), so this selector matches whichever label
-  // wraps the currently-checked radio. Mirrors BS3's
-  // `.btn-default.active` pressed visual (the values are copied
-  // because `@extend .btn-default.active` doesn't play well with
-  // compound selectors).
+  // wraps the currently-checked radio. The `button-active-state`
+  // mixin (in `_form_elements.scss`) pulls active-state colors
+  // from theme-aware custom properties scoped to whichever
+  // `.btn-{variant}` class the element has — no more hardcoded
+  // default-theme grays leaking through in dark themes.
   &:has(input[type="radio"]:checked) {
-    color: #333;
-    background-color: #d4d4d4;
-    border-color: #8c8c8c;
-    outline: 0;
-    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    @include button-active-state;
 
     .set_thumb_img_text {
       display: none;

--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -15,6 +15,48 @@
   }
 }
 
+// Theme- AND variant-aware "pressed" styles for button-styled
+// radios/checkboxes that drive their active state via
+// `:has(input:checked)` rather than the BS3 `.active` class.
+//
+// Each `.btn-{variant}` exposes its active-state colors as CSS
+// custom properties (computed via BS3's `darken()` logic, matching
+// what `button-variant` generates internally for `.active`). The
+// `button-active-state` mixin then references those custom
+// properties — variant-agnostic. Whichever `.btn-{variant}` class
+// the element has, the right colors apply automatically. Dark
+// themes get dark pressed colors for free, since the source vars
+// are theme-mapped (`$BUTTON_*` → `$btn-default-*` etc. in
+// `_map_theme_vars_to_bootstrap_vars.scss`).
+//
+// Sass `@extend .btn-default.active` won't work — compound
+// selectors are no longer extendable.
+$btn-active-variants: (
+  default: ($btn-default-color, $btn-default-bg, $btn-default-border),
+  primary: ($btn-primary-color, $btn-primary-bg, $btn-primary-border),
+  success: ($btn-success-color, $btn-success-bg, $btn-success-border),
+  info: ($btn-info-color, $btn-info-bg, $btn-info-border),
+  warning: ($btn-warning-color, $btn-warning-bg, $btn-warning-border),
+  danger: ($btn-danger-color, $btn-danger-bg, $btn-danger-border)
+);
+
+@each $variant, $colors in $btn-active-variants {
+  .btn-#{$variant} {
+    --btn-active-color: #{nth($colors, 1)};
+    --btn-active-bg: #{darken(nth($colors, 2), 10%)};
+    --btn-active-border: #{darken(nth($colors, 3), 12%)};
+  }
+}
+
+@mixin button-active-state {
+  color: var(--btn-active-color);
+  background-color: var(--btn-active-bg);
+  border-color: var(--btn-active-border);
+  background-image: none;
+  outline: 0;
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+
 // rss-log filter buttons with checkboxes
 .filter-form {
   input[type=checkbox] {


### PR DESCRIPTION
## Summary

Tiny follow-up to #4274. That PR introduced the CSS-only "pressed" state on `.thumb_img_btn` via `:has(input[type="radio"]:checked)` — but hardcoded BS3's default gray colors directly in the rule. Those values would render wrong in any dark theme.

## Fix

Replace the hardcoded values with a new `button-active-state` Sass mixin in `_form_elements.scss`:

- Each `.btn-{variant}` gets CSS custom properties (`--btn-active-color`, `--btn-active-bg`, `--btn-active-border`) computed via BS3's own `darken()` logic — same math `button-variant` uses internally for `.btn-{variant}.active`.
- The `button-active-state` mixin references those custom properties — variant-agnostic. Whichever `.btn-{variant}` class the element has, the right colors apply automatically.
- Source values come from MO's theme-mapped Bootstrap vars (`$btn-default-bg` etc.), set per-theme in `_map_theme_vars_to_bootstrap_vars.scss`. Dark themes get dark pressed colors for free.

The thumb button rule in `_carousel.scss` becomes:

```scss
&:has(input[type="radio"]:checked) {
  @include button-active-state;
  // ... text-swap as before
}
```

## Why not `@extend .btn-default.active`?

Sass disallows extending compound selectors. The custom-properties + mixin pattern is the cleanest workaround that stays theme- and variant-aware.

## Test plan

- [x] `bin/rails assets:precompile` succeeds
- [x] `bin/rails test test/components/form_carousel_item_test.rb` — 5/5 green
- [ ] Spot-check `/observations/new` and `/obs/{id}/edit` with the default theme — pressed thumb button looks identical to before
- [ ] Spot-check in a dark theme (e.g. Amanita) — pressed thumb button now matches the theme rather than showing the BS3 gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)