### PR TITLE
Activity-log filters: ButtonStyleCheckbox + caption fix + UX cleanup

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -49,7 +49,10 @@ $btn-active-variants: (
   success: ($btn-success-color, $btn-success-bg, $btn-success-border),
   info: ($btn-info-color, $btn-info-bg, $btn-info-border),
   warning: ($btn-warning-color, $btn-warning-bg, $btn-warning-border),
-  danger: ($btn-danger-color, $btn-danger-bg, $btn-danger-border)
+  danger: ($btn-danger-color, $btn-danger-bg, $btn-danger-border),
+  // MO's `.btn-outline-default` (see `_links_buttons_alerts.scss`)
+  // — uses input vars rather than the BS3 button vars.
+  outline-default: ($input-color, $input-bg, $input-border)
 );
 
 @each $variant, $colors in $btn-active-variants {
@@ -74,6 +77,14 @@ $btn-active-variants: (
   input[type=checkbox] {
     vertical-align: text-top;
   }
+}
+
+// Button-styled filter checkboxes (rss-log type filters etc.):
+// CSS-only "pressed" state via `:has()` matching the inner checked
+// input — no JS to toggle `.active`. Same pattern as
+// `.thumb_img_btn` in `_carousel.scss`.
+.filter-checkbox:has(input[type="checkbox"]:checked) {
+  @include button-active-state;
 }
 
 // Remove browser default gradients on select elements

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -17,13 +17,33 @@
   font-weight: normal !important;
 }
 
+// Custom variant (not in BS3) that mirrors form-input styling, so
+// it visually plays nicely with input groups. Defines the full set
+// of interactive states using BS3's `darken()` step pattern (same
+// math `button-variant` uses for `.btn-{variant}`), pulling from
+// the theme-mapped `$input-*` vars so dark themes get dark hover/
+// active visuals automatically.
 .btn-outline-default {
   color: $input-color;
   background-color: $input-bg;
   border-color: $input-border;
 
-  &:hover {
-    color: inherit;
+  &:hover,
+  &:focus,
+  &.focus {
+    color: $input-color;
+    background-color: darken($input-bg, 5%);
+    border-color: darken($input-border, 10%);
+    text-decoration: none;
+  }
+
+  &:active,
+  &.active {
+    color: $input-color;
+    background-color: darken($input-bg, 10%);
+    border-color: darken($input-border, 12%);
+    background-image: none;
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   }
 }
 

--- a/app/components/activity_log_type_filters.rb
+++ b/app/components/activity_log_type_filters.rb
@@ -31,16 +31,29 @@ class Components::ActivityLogTypeFilters < Components::Base
   end
 
   def render_filter_buttons
-    div(class: "btn-group pb-1 hidden-xs text-nowrap") do
+    # "Show:" label sits OUTSIDE the .btn-group: BS3 `.btn-group`
+    # floats and inline-blocks its children expecting `.btn`-shaped
+    # elements, and a non-`.btn` span inside breaks the layout (the
+    # span ends up after the group). Sibling-of-group keeps it
+    # inline-aligned without being subject to the group's layout
+    # rules.
+    div(class: "px-3 pb-1 hidden-xs text-nowrap") do
       render_show_label
-      render_everything_button
-      render_type_buttons
-      render_submit_button
+      div(class: "btn-group") do
+        render_everything_button
+        render_type_buttons
+        render_submit_button
+      end
     end
   end
 
+  # Inline label for the whole filter group. Was rendered as a
+  # disabled btn-default to share vertical rhythm with the other
+  # button-styled controls, but that's misleading (looks like a
+  # button you can't press). Plain text with `text-muted` and
+  # margin matches the BS3 caption-style without the affordance.
   def render_show_label
-    span(class: "btn btn-default btn-sm disabled") { :rss_show.t }
+    span(class: "text-muted mr-2") { :rss_show.t }
   end
 
   def render_everything_button
@@ -55,16 +68,29 @@ class Components::ActivityLogTypeFilters < Components::Base
     end
   end
 
+  # "Apply" reads more naturally than "Submit" for a filter-
+  # narrowing action where there's nothing being created. The
+  # filter buttons use `.btn-outline-default` (subtle, input-
+  # style); the Apply button uses the solid `.btn-default` so it
+  # stands out as the commit action.
   def render_submit_button
-    input(type: "submit", value: :SUBMIT.t, class: "btn btn-default btn-sm")
+    input(type: "submit", value: :APPLY.t,
+          class: "btn btn-default btn-sm")
   end
 
-  # Individual type checkbox styled as button
+  # Individual type checkbox styled as a Bootstrap button. Routes
+  # through `ButtonStyleCheckbox` so the markup stays in lockstep
+  # with the rest of MO's button-style radio/checkbox helpers
+  # (BS3/4/5 migration changes one file, not many). The "pressed"
+  # active state is CSS-only via `.filter-checkbox:has(input:checked)`
+  # in `_form_elements.scss`.
   def render_type_checkbox(type)
-    label(class: type_button_classes(type)) do
-      input(type: "checkbox", name: "q[type][]", value: type,
-            checked: type_checked?(type), id: "type_#{type}",
-            class: "mt-0 mr-2")
+    render(Components::ApplicationForm::ButtonStyleCheckbox.new(
+             name: "q[type][]", value: type,
+             id: "type_#{type}", checked: type_checked?(type),
+             label: { class: type_button_classes },
+             class: "mt-0 mr-2"
+           )) do
       filter_for_type(type)
     end
   end
@@ -92,14 +118,18 @@ class Components::ActivityLogTypeFilters < Components::Base
   # CSS class helpers
 
   def everything_button_classes
-    class_names("btn btn-default btn-sm", { active: @types == ["all"] })
+    class_names("btn btn-outline-default btn-sm",
+                { active: @types == ["all"] })
   end
 
-  def type_button_classes(type)
-    class_names(
-      "btn btn-default btn-sm filter-checkbox my-0",
-      { active: @types == [type] }
-    )
+  # No server-side `active:` class — the SCSS rule
+  # `.filter-checkbox:has(input:checked)` paints the pressed visual
+  # whenever the inner checkbox is checked. Side effect: multi-
+  # selected filters now ALL show as active (previously, only
+  # sole-selected types did because of the strict `@types == [type]`
+  # check). Honest UX — selected = visually active.
+  def type_button_classes
+    "btn btn-outline-default btn-sm filter-checkbox my-0"
   end
 
   # Query param helpers

--- a/app/components/application_form/button_style_checkbox.rb
+++ b/app/components/application_form/button_style_checkbox.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Bootstrap 3 button-styled checkbox: a `<label class="btn …">`
+  # wrapping an `<input type="checkbox">` plus arbitrary block content
+  # (the visible text/icons). NO `.checkbox` div wrap — that wrap is
+  # for vertical checkbox-list layout; this component is for
+  # checkboxes that look like buttons (BS3's
+  # `.btn-group[data-toggle="buttons"]` pattern, or standalone
+  # button-styled checkboxes scattered across a filter UI).
+  #
+  # Parallel of `ButtonStyleRadio`. Same constructor shape, same
+  # caller ergonomics — just emits `type="checkbox"` and supports
+  # name-array shapes like `q[type][]` for multi-select filters.
+  #
+  # Standalone (no Superform context) — takes raw HTML kwargs rather
+  # than a `Field` / `FieldProxy`, since the call sites (filter UIs,
+  # in-form toolbars) don't always have a form context available.
+  #
+  # @example
+  #   render(Components::ApplicationForm::ButtonStyleCheckbox.new(
+  #     name: "q[type][]", value: "observation",
+  #     id: "type_observation", checked: types.include?("observation"),
+  #     label: { class: "btn btn-default filter-checkbox" }
+  #   )) do
+  #     plain "Observations"
+  #   end
+  class ButtonStyleCheckbox < Phlex::HTML
+    include Components::TrustedHtml
+
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(name:, value:, id:, checked: false,
+                   label: {}, **input_attrs)
+      # rubocop:enable Metrics/ParameterLists
+      super()
+      @name = name
+      @value = value
+      @id = id
+      @checked = checked
+      @label_attrs = label
+      @input_attrs = input_attrs
+    end
+
+    def view_template(&block)
+      label(for: @id, **@label_attrs) do
+        input(**input_attributes)
+        yield if block
+      end
+    end
+
+    private
+
+    def input_attributes
+      { type: :checkbox, name: @name, id: @id, value: @value,
+        checked: @checked, **@input_attrs }
+    end
+  end
+end

--- a/app/helpers/header/filters_helper.rb
+++ b/app/helpers/header/filters_helper.rb
@@ -221,10 +221,26 @@ module Header
       end
     end
 
+    # Space-separated RssLog type tag list (e.g. "species_list project").
+    # Looks each tag up in the canonical all-caps plural translation
+    # (`SPECIES_LISTS`, `PROJECTS`, etc.) by pluralizing (lowercase)
+    # then upcasing — the reverse order leaves a trailing lowercase
+    # `s` (`SPECIES_LISTs`) since ActiveSupport's Inflector adds `s`
+    # in lowercase regardless of input case. `all` is the sentinel
+    # for "all types" — no plural; use `:ALL` directly.
+    #
+    # Was `val.titleize.split.join(", ")` which split "Species List
+    # Project" into four comma-separated tokens.
+    def type_tags_to_label(val)
+      val.split.map do |tag|
+        (tag == "all" ? :ALL : tag.pluralize.upcase.to_sym).t
+      end.join(", ")
+    end
+
     # For values that aren't ids, just join and maybe truncate
     def param_val_itself(key, val, truncate)
-      if key == :type # lowercase strings joined by spaces
-        string = val.titleize.split.join(", ")
+      if key == :type
+        string = type_tags_to_label(val)
       elsif val.is_a?(Array)
         string = truncate ? val.first(CAPTION_TRUNCATE) : val
         string = string.join(", ")

--- a/app/helpers/header/filters_helper.rb
+++ b/app/helpers/header/filters_helper.rb
@@ -226,14 +226,18 @@ module Header
     # (`SPECIES_LISTS`, `PROJECTS`, etc.) by pluralizing (lowercase)
     # then upcasing — the reverse order leaves a trailing lowercase
     # `s` (`SPECIES_LISTs`) since ActiveSupport's Inflector adds `s`
-    # in lowercase regardless of input case. `all` is the sentinel
-    # for "all types" — no plural; use `:ALL` directly.
+    # in lowercase regardless of input case. `all` and `none` are
+    # sentinels (no plural form) — use `:ALL` / `:NONE` directly.
+    # The `none` sentinel arises when the controller sanitizes
+    # invalid type tags down to `"none"` (see RssLogsController).
     #
     # Was `val.titleize.split.join(", ")` which split "Species List
     # Project" into four comma-separated tokens.
+    SENTINEL_TYPE_TAGS = { "all" => :ALL, "none" => :NONE }.freeze
+
     def type_tags_to_label(val)
       val.split.map do |tag|
-        (tag == "all" ? :ALL : tag.pluralize.upcase.to_sym).t
+        (SENTINEL_TYPE_TAGS[tag] || tag.pluralize.upcase.to_sym).t
       end.join(", ")
     end
 

--- a/test/components/activity_log_type_filters_test.rb
+++ b/test/components/activity_log_type_filters_test.rb
@@ -15,22 +15,24 @@ class ActivityLogTypeFiltersTest < ComponentTestCase
   def test_renders_show_label
     html = render_component(nil, ["all"])
 
-    assert_html(html, "span.btn.btn-default.btn-sm.disabled",
-                text: :rss_show.t)
+    # Was styled as a disabled btn-default — misleading affordance.
+    # Now a plain `text-muted` span: visibly a label, not a button.
+    assert_html(html, "span.text-muted", text: :rss_show.t)
   end
 
   def test_renders_everything_button_active_when_all_types
     html = render_component(nil, ["all"])
 
     # When all types, everything button should be active (no link)
-    assert_html(html, "span.btn.btn-default.btn-sm.active", text: :rss_all.t)
+    assert_html(html, "span.btn.btn-outline-default.btn-sm.active",
+                text: :rss_all.t)
   end
 
   def test_renders_everything_button_as_link_when_not_all
     html = render_component(nil, ["observation"])
 
     # When not all types, everything button should have a link
-    assert_html(html, "span.btn.btn-default.btn-sm a.filter-only",
+    assert_html(html, "span.btn.btn-outline-default.btn-sm a.filter-only",
                 text: :rss_all.t)
   end
 
@@ -43,7 +45,7 @@ class ActivityLogTypeFiltersTest < ComponentTestCase
       assert_html(html, "input[type='checkbox'][name='q[type][]']" \
                         "[value='#{type_str}'][id='type_#{type_str}']")
       # Check label exists
-      assert_html(html, "label.btn.btn-default.btn-sm.filter-checkbox")
+      assert_html(html, "label.btn.btn-outline-default.btn-sm.filter-checkbox")
     end
   end
 
@@ -66,14 +68,21 @@ class ActivityLogTypeFiltersTest < ComponentTestCase
     assert_no_html(html, "input[type='checkbox'][value='name'][checked]")
   end
 
-  def test_active_class_on_single_selected_type
+  def test_selected_type_checkbox_drives_active_state_via_css
     html = render_component(nil, ["observation"])
 
-    # The observation label should have active class
-    assert_html(html, "label.active:has(input[value='observation'])")
-
-    # The name label should NOT have active class
-    assert_html(html, "label:not(.active):has(input[value='name'])")
+    # No server-side `.active` class anymore — the CSS rule
+    # `.filter-checkbox:has(input[type="checkbox"]:checked)` paints
+    # the "pressed" visual using theme-aware custom properties.
+    # The structural check: selected type's checkbox is checked
+    # inside a `.filter-checkbox` label; unselected isn't. CSS
+    # handles the visual.
+    assert_html(html,
+                "label.filter-checkbox " \
+                "input[type='checkbox'][value='observation'][checked]")
+    assert_no_html(html,
+                   "label.filter-checkbox " \
+                   "input[type='checkbox'][value='name'][checked]")
   end
 
   def test_type_filter_link_present_when_not_selected
@@ -87,8 +96,13 @@ class ActivityLogTypeFiltersTest < ComponentTestCase
   def test_renders_submit_button
     html = render_component(nil, ["all"])
 
+    # "Apply" reads better than "Submit" for a filter-narrowing
+    # action. Filter buttons use `.btn-outline-default` (subtle);
+    # the Apply button uses solid `.btn-default` so it stands out
+    # as the commit action.
     assert_html(html,
-                "input[type='submit'][value='#{:SUBMIT.t}'].btn.btn-default")
+                "input[type='submit'][value='#{:APPLY.t}']" \
+                ".btn.btn-default")
   end
 
   # NOTE: Testing with a real query requires the controller to have q_param

--- a/test/components/application_form/button_style_checkbox_test.rb
+++ b/test/components/application_form/button_style_checkbox_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for Components::ApplicationForm::ButtonStyleCheckbox — the
+# button-styled checkbox parallel of ButtonStyleRadio. Used by the
+# activity-log filter UI and other multi-select filter contexts.
+# Unlike CheckboxField, this component is standalone (no
+# Field/FieldProxy) and has NO `.checkbox` div wrap.
+class ButtonStyleCheckboxTest < ComponentTestCase
+  def test_renders_label_wrapping_checkbox_input
+    html = render(klass.new(
+                    name: "q[type][]", value: "observation",
+                    id: "type_observation"
+                  )) { "Observations" }
+
+    # <label for="type_observation">
+    #   <input type="checkbox" ...>Observations
+    # </label>
+    assert_html(html, "label[for='type_observation'] > input[type='checkbox']" \
+                      "[name='q[type][]'][value='observation']" \
+                      "[id='type_observation']")
+    assert_includes(html, "Observations")
+    # No `.checkbox` div wrap — intentional (this is the filter-button
+    # variant, not the vertical-checkbox-list variant).
+    assert_no_html(html, ".checkbox")
+  end
+
+  def test_checked_true_sets_input_attr
+    html = render(klass.new(
+                    name: "n[]", value: "1", id: "x", checked: true
+                  ))
+
+    assert_html(html, "input[type='checkbox'][checked]")
+  end
+
+  def test_checked_default_false_omits_attr
+    html = render(klass.new(name: "n[]", value: "1", id: "x"))
+
+    assert_html(html, "input[type='checkbox']:not([checked])")
+  end
+
+  def test_label_attrs_passed_through
+    html = render(klass.new(
+                    name: "n[]", value: "1", id: "x",
+                    label: { class: "btn btn-default filter-checkbox",
+                             data: { action: "click->filter#toggle" } }
+                  ))
+
+    assert_html(html, "label.btn.btn-default.filter-checkbox[for='x']")
+    assert_html(html, "label[data-action='click->filter#toggle']")
+  end
+
+  def test_input_attrs_passed_through_via_splat
+    html = render(klass.new(
+                    name: "n[]", value: "1", id: "x",
+                    class: "form-control",
+                    data: { filter_id: "1" }
+                  ))
+
+    assert_html(html, "input[type='checkbox'].form-control" \
+                      "[data-filter-id='1']")
+  end
+
+  def test_renders_without_block_content
+    html = render(klass.new(name: "n[]", value: "1", id: "x"))
+
+    # Label exists, contains the input, no extra content.
+    assert_html(html, "label[for='x'] > input[type='checkbox']")
+  end
+
+  # Multiple instances with the same name[] form a multi-select group
+  # — that's the whole reason this component exists separately from
+  # ButtonStyleRadio. Verify the name-array shape is preserved.
+  def test_multiple_instances_share_name_array_shape
+    html_a = render(klass.new(name: "q[type][]", value: "a", id: "ta"))
+    html_b = render(klass.new(name: "q[type][]", value: "b", id: "tb"))
+
+    assert_html(html_a, "input[name='q[type][]'][value='a']")
+    assert_html(html_b, "input[name='q[type][]'][value='b']")
+  end
+
+  private
+
+  def klass
+    Components::ApplicationForm::ButtonStyleCheckbox
+  end
+end

--- a/test/helpers/header/filters_helper_test.rb
+++ b/test/helpers/header/filters_helper_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for Header::FiltersHelper#type_tags_to_label — the filter
+# caption type-tag formatter. Covers the SENTINEL_TYPE_TAGS branches
+# (`"all"` and `"none"`) and the normal pluralize-and-localize path.
+#
+# Originally surfaced via
+# `RssLogsControllerTest#test_type_filter_rejects_invalid_types`
+# (the `:NONES` bug), but that test only asserts the controller
+# behavior, not the caption output. This file covers the helper
+# directly so future refactors of `SENTINEL_TYPE_TAGS` or the
+# `pluralize.upcase.to_sym` path can't silently regress.
+module Header
+  class FiltersHelperTest < ActionView::TestCase
+    include FiltersHelper
+
+    def test_all_sentinel_maps_to_all_label
+      assert_equal(:ALL.l, type_tags_to_label("all"))
+    end
+
+    def test_none_sentinel_maps_to_none_label
+      # This is the regression case: the controller sanitizes invalid
+      # type tags down to `"none"`, then the caption gets rendered.
+      # Pre-SENTINEL_TYPE_TAGS this hit `:NONES.l` (no such translation)
+      # and triggered the missing-translations check in test teardown.
+      assert_equal(:NONE.l, type_tags_to_label("none"))
+    end
+
+    def test_normal_tag_pluralizes_and_localizes
+      # `"observation"` → `"observations".upcase.to_sym` → `:OBSERVATIONS`
+      assert_equal(:OBSERVATIONS.l, type_tags_to_label("observation"))
+    end
+
+    def test_pluralize_runs_before_upcase
+      # Order matters: `tag.pluralize.upcase` (correct) vs
+      # `tag.upcase.pluralize` (broken — Inflector adds lowercase 's',
+      # yielding `:SPECIES_LISTs`).
+      assert_equal(:SPECIES_LISTS.l, type_tags_to_label("species_list"))
+    end
+
+    def test_multiple_tags_joined_by_comma
+      result = type_tags_to_label("observation species_list")
+
+      assert_equal("#{:OBSERVATIONS.l}, #{:SPECIES_LISTS.l}", result)
+    end
+
+    def test_mix_of_sentinel_and_normal_tags
+      result = type_tags_to_label("all observation")
+
+      assert_equal("#{:ALL.l}, #{:OBSERVATIONS.l}", result)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Current:
<img width="1880" height="246" alt="Screenshot 2026-05-17 at 11 34 37 AM" src="https://github.com/user-attachments/assets/daa77114-b0c4-49f8-b20e-6acfb7b3a8f2" />

Proposed:
<img width="1864" height="262" alt="Screenshot 2026-05-17 at 11 37 23 AM" src="https://github.com/user-attachments/assets/cba48193-ac4c-4688-907f-9e3209e4f986" />

Routes the bare `<input type="checkbox" name="q[type][]">` calls in `Components::ActivityLogTypeFilters` through a new reusable `Components::ApplicationForm::ButtonStyleCheckbox` — the checkbox parallel of `ButtonStyleRadio` (merged in #4274). One of the last items from `bootstrap_checkbox_radio_todo.md`.

Bundled with a few related changes I noticed while visually testing the page:

- A funny pre-existing bug in the filter-caption strip ("Species, List, Project" instead of "Observation Lists, Projects")
- "Show:" label rendered as a disabled-button (harder to read, doesn't work as a button)
- "Submit" → "Apply" + color swap so the commit action stands out
- Proper hover/focus/active states on the MO-custom `.btn-outline-default` so you can tell what's currently selected easier

## Centralization

- **New** `Components::ApplicationForm::ButtonStyleCheckbox` — `<label class="btn …"><input type="checkbox">content</label>`, no `.checkbox` div wrap. Mirrors `ButtonStyleRadio`'s constructor/API shape.
- **`ActivityLogTypeFilters#render_type_checkbox`** routes through it.
- **`_form_elements.scss`** adds `.filter-checkbox:has(input[type="checkbox"]:checked)` as a consumer of the `button-active-state` mixin (introduced in #4275). Variant-aware "pressed" state via CSS — no JS to toggle `.active`. The server-side `active:` class on the label is dropped (it was a strict `@types == [type]` sole-selected check); CSS now marks every checked filter as active, which is the honest multi-select UX.

## Filter-caption fix (`header/filters_helper.rb`)

The filter caption in the page header was rendering an RSS-type filter as comma-separated words of the *titleized* tag — `species_list project` → "Species, List, Project" (split each word with a comma). 

Replaced with a translation lookup: pluralize each lowercase tag, upcase, resolve to the canonical `:SPECIES_LISTS`, `:PROJECTS`, etc. — matches the labels rendered on the filter buttons themselves. Order matters: `tag.upcase.pluralize` would leave a trailing lowercase `s` (`SPECIES_LISTs`) since ActiveSupport's Inflector adds the `s` in lowercase regardless of input case. `all` is special-cased to `:ALL` since there's no `:ALLS` translation.

Extracted to a private `type_tags_to_label` method to keep `param_val_itself` under the Cyclomatic/Perceived complexity caps.

## UX cleanup in the filter form

- **"Show:" label** — was `<span class="btn btn-default btn-sm disabled">`. Looked like a disabled button (misleading affordance). Now a plain `<span class="text-muted">` outside the `.btn-group` — BS3 `.btn-group` floats/inline-blocks its children expecting `.btn` shapes, so non-`.btn` children inside break the layout (the span ends up after the group).
- **"Submit" → "Apply"** — reads better for a filter-narrowing action where nothing is being created.
- **Button-variant swap** — filter buttons (Everything, type checkboxes) now use `.btn-outline-default` (subtle, input-styled); Apply uses solid `.btn-default` so it stands out as the commit action.
- **`.btn-outline-default` interactive states** (`_links_buttons_alerts.scss`) — was just base + minimal `:hover`. Adds `:hover`/`:focus`/`:active`/`.active` using BS3's `darken()` step pattern. The variant now has the full set of interactive feedback like any other `.btn-*` variant.
- **`outline-default` in `$btn-active-variants` map** — so the `:has(input:checked)` CSS custom-properties scoping works for the swapped filter buttons too.
- **`px-3`** added to the filter row's outer wrap div for horizontal padding consistency with the page header.

## Test plan

- [x] `bin/rails test test/components test/helpers` — 985/985 green
- [x] Browser spot-check: `/activity_logs` — filter buttons render as outline, Apply as solid, "Show:" as muted text, multi-selected filters all show as active, filter caption above the buttons reads "Observation Lists, Projects" etc.
- [x] CI green

## Follow-ups (from the BS3 checkbox/radio TODO)

Last remaining call site: `project_violations_form.rb` — `location_id` radios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)