### PR TITLE
project_violations: route radios through RadioField

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -13,6 +13,18 @@
       font-size: 90% !important
     }
   }
+
+  // When the row has a sibling button-link next to the label (e.g.
+  // a "Create" link on placeholder rows in the project-violations
+  // target-location modal), flex-layout the row so the label and
+  // the button stay on the same line regardless of label wrap.
+  // Default inline-block flow puts the button on a new line at
+  // x=0 when the label wraps — confusing visually.
+  &:has(> a.btn) {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
 }
 
 // Theme- AND variant-aware "pressed" styles for button-styled

--- a/app/components/project_violations_form.rb
+++ b/app/components/project_violations_form.rb
@@ -258,29 +258,42 @@ class Components::ProjectViolationsForm < Components::Base
 
   def render_suffix_radios(suffixes, existing, first_existing)
     p { :form_violations_modal_target_location_help.l }
-    suffixes.each do |suffix|
-      div(class: "radio") do
-        render_suffix_choice(suffix, existing[suffix], first_existing == suffix)
+    field = Components::ApplicationForm::FieldProxy.new(
+      nil, "location_id", first_existing && existing[first_existing]&.id
+    )
+    render(Components::ApplicationForm::RadioField.new(
+             field, *suffix_choices(suffixes, existing)
+           ))
+  end
+
+  # Each suffix becomes a `[value, label, opts]` choice for
+  # `RadioField`. Existing-location rows submit the location id;
+  # placeholder rows are disabled (so they're inert / not submitted)
+  # and `append:` a "Create" link as a sibling of the label inside
+  # the `.radio` wrap — kept outside `<label>` so clicking the link
+  # doesn't accidentally toggle the radio.
+  def suffix_choices(suffixes, existing)
+    suffixes.map do |suffix|
+      location = existing[suffix]
+      if location
+        [location.id, " #{suffix}"]
+      else
+        [suffix, " #{suffix}",
+         { disabled: true, append: suffix_create_link(suffix) }]
       end
     end
   end
 
-  def render_suffix_choice(suffix, location, checked)
-    label do
-      if location
-        input(type: "radio", name: "location_id",
-              value: location.id, checked: checked)
-        plain(" #{suffix}")
-      else
-        input(type: "radio", name: "location_id", disabled: true)
-        plain(" #{suffix} ")
-        a(
-          href: new_location_path(display_name: suffix),
-          target: "_blank", rel: "noopener",
-          class: "btn btn-default btn-xs"
-        ) { :form_violations_modal_target_location_create.l }
-      end
-    end
+  def suffix_create_link(suffix)
+    # HTML-safe string built via Rails `tag.a` (returns SafeBuffer)
+    # so `RadioField` can emit it via `trusted_html`. Leading space
+    # gives a small gap between the disabled label text and the link.
+    " ".html_safe + helpers.tag.a(
+      :form_violations_modal_target_location_create.l,
+      href: new_location_path(display_name: suffix),
+      target: "_blank", rel: "noopener",
+      class: "btn btn-default btn-xs"
+    )
   end
 
   def render_csrf_and_method


### PR DESCRIPTION
## Summary

Last item from `bootstrap_checkbox_radio_todo.md` — the bare `<input type="radio" name="location_id">` calls in the target-location modal of `ProjectViolationsForm`. Each row is one of two variants:
- Existing location → real radio
- No existing location → disabled radio + "Create" link

`RadioField` didn't fit out of the box (uniform `[value, label]` iteration, no per-row disabled state or trailing content). Two options were on the table: a separate per-item helper, or extend `RadioField`. Extended `RadioField` — the new capability is a general improvement, applicable to any future mixed-state radio group.

## Changes

- **`RadioField`** now accepts optional per-choice options as a third tuple element: `[value, label, opts]`. Supported keys:
  - `disabled:` — passed through to the `<input>`.
  - `append:` — HTML-safe content rendered as a *sibling* of `<label>` inside the `.radio` div (not inside `<label>`, since that's questionable HTML and a click could accidentally activate the radio).
- **`ProjectViolationsForm#suffix_choices`** builds the choices for the location-target modal; placeholder rows pass `{ disabled: true, append: suffix_create_link(suffix) }`.
- **`_form_elements.scss`** adds `.radio:has(> a.btn)` / `.checkbox:has(> a.btn)` → `display: flex; align-items: flex-start; gap: 0.5rem`. Without this, when a row's label wraps to two lines, the inline-block `<a class="btn">` ends up on a new line at `x=0` (the inline-block doesn't inherit the label's `padding-left: 20px`). Flex keeps label + button on the same row regardless of wrap.

## Test plan

- [x] `bin/rails test test/components` — 916/916 green
- [x] Browser verification of all-existing rows on `/projects/334/violations` (obs 573031)
- [x] Browser verification of mixed-state rows on `/projects/334/violations` (obs 573030, synthetic test data) — 3 enabled rows + 2 disabled rows with Create links, all label+Create pairs on same row regardless of label wrap
- [x] CI green

## Follow-up

This branch finishes the bootstrap-checkbox-radio centralization TODO. The TODO doc on the `nimmo-field-slip-forms-phlex` branch can be deleted once #4270 merges.

A separate annoyance surfaced while testing: 3 form components (`ProjectViolationsForm`, `OccurrenceResolveForm`, `TrustSettingsModal`) inherit from `Components::Base` and manually emit `<form>` + CSRF/method hidden fields, when CLAUDE.md says all forms should inherit from `Components::ApplicationForm` (Superform), which handles that automatically. Worth a follow-up PR to convert them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)