### PR TITLE
Get all system tests green, fix "create herbarium on the fly" modal in create obs form

### DIFF
--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -385,6 +385,14 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   end
 
   def redirect_to_create_location_or_referrer_or_show_location
+    # Turbo-stream callers (the herbarium-create modal embedded in the
+    # obs form, project pages, etc.) should never get a redirect:
+    # we're in a modal that needs to close + update the parent page.
+    # `show_modal_flash_or_show_herbarium` dispatches on format and
+    # renders `_update_observation.erb` for turbo_stream, which closes
+    # the modal and populates the obs-form's herbarium fields.
+    return show_modal_flash_or_show_herbarium if request.format.turbo_stream?
+
     redirect_to_create_location || redirect_to_referrer ||
       show_modal_flash_or_show_herbarium
   end

--- a/app/views/controllers/herbaria/_update_observation.erb
+++ b/app/views/controllers/herbaria/_update_observation.erb
@@ -4,10 +4,12 @@
 
 <%= turbo_stream.update("page_flash") { flash_notices_html } %>
 
-<%= turbo_stream.update_input("herbarium_record_herbarium_name",
+<%# Obs form's herbarium-name field is namespaced under the
+    observation Superform: id is `observation_herbarium_record_*`. %>
+<%= turbo_stream.update_input("observation_herbarium_record_herbarium_name",
                               @herbarium.name) %>
 
-<%= turbo_stream.update_input("herbarium_record_herbarium_id",
+<%= turbo_stream.update_input("observation_herbarium_record_herbarium_id",
                               @herbarium.id) %>
 
 <%= turbo_stream.remove("create_herbarium_btn") %>

--- a/test/system/herbarium_form_system_test.rb
+++ b/test/system/herbarium_form_system_test.rb
@@ -27,16 +27,16 @@ class HerbariumFormSystemTest < ApplicationSystemTestCase
     assert_selector("#observation_naming_specimen")
     scroll_to(find("#observation_naming_specimen"), align: :top)
     check("observation_specimen")
-    assert_selector("#herbarium_record_herbarium_name")
+    assert_selector("#observation_herbarium_record_herbarium_name")
     assert_selector(".create-link", text: :create_herbarium.l)
     click_link(:create_herbarium.l)
 
     assert_selector("#modal_herbarium")
     create_herbarium_with_new_location
 
-    assert_no_selector("#modal_herbarium")
-    assert_field("herbarium_record_herbarium_name",
-                 with: "Herbarium des Cévennes")
+    assert_no_selector("#modal_herbarium", wait: 15)
+    assert_field("observation_herbarium_record_herbarium_name",
+                 with: "Herbarium des Cévennes", wait: 15)
   end
 
   # Verify validation errors appear inside the modal, not on the page
@@ -141,6 +141,13 @@ class HerbariumFormSystemTest < ApplicationSystemTestCase
 
       # Verify autocompleter switched to location_google mode
       assert_selector("[data-type='location_google']", wait: 5)
+
+      # In a real browser the user's focus/click sequence fires
+      # `ourClick` on the place-name input after the mode swap,
+      # which triggers `scheduleGoogleRefresh` → geocoding. The
+      # JS-driven `execute_script("...click()")` above bypasses
+      # those events, so we have to fire one manually here.
+      find_field("herbarium_place_name").click
 
       # Wait for hidden ID to be set (proves geocoding worked)
       assert_field("herbarium_location_id", with: "-1", type: :hidden, wait: 10)

--- a/test/system/image_upload_system_test.rb
+++ b/test/system/image_upload_system_test.rb
@@ -67,7 +67,8 @@ class ImageUploadSystemTest < ApplicationSystemTestCase
     begin
       # Attach the non-image file and expect an alert
       alert_text = accept_alert do
-        attach_file("upload_image", text_file.path, visible: false)
+        attach_file("project_upload_image", text_file.path,
+                    visible: false)
       end
 
       assert_equal("Please select an image file (JPG, PNG, GIF, etc.)",


### PR DESCRIPTION
## Gets all system tests green

### Summary

Fixes a real product UX bug surfaced by `HerbariumFormSystemTest#test_observation_form_create_fungarium_new_location`: creating a herbarium via the modal on \`/observations/new\` closed the modal but left the obs-form's herbarium-name field empty (reverting to the user's default herbarium), so the user had to manually re-pick the herbarium they just created.

### Root causes (two stacked bugs)

1. **`herbaria_controller#create` never reached its turbo-stream success branch.** The chain \`redirect_to_create_location || redirect_to_referrer || show_modal_flash_or_show_herbarium\` always short-circuited on \`redirect_to_referrer\` for turbo requests (referrer is always set). The \`show_modal_flash_or_show_herbarium\` partial — which closes the modal and updates obs-form fields — was dead code for turbo callers.
2. **`_update_observation.erb` targeted pre-namespace field ids.** The two \`turbo_stream.update_input\` calls used \`herbarium_record_*\` ids; the obs form's herbarium fields are now Superform-namespaced as \`observation_herbarium_record_*\`. The turbo-stream actions silently no-opped.

### Fixes

- **`herbaria_controller.rb`**: when \`request.format.turbo_stream?\`, dispatch directly to \`show_modal_flash_or_show_herbarium\`, bypassing the html-only redirect chain.
- **`_update_observation.erb`**: update the two field-target ids to \`observation_herbarium_record_herbarium_name\` and \`_id\`.
- **`herbarium_form_system_test.rb`**: fix the corresponding selector (same pre-namespace miss in the assertion), and add a manual input-click after the create-button click in `create_herbarium_with_new_location` — \`execute_script(\"...click()\")\` bypasses the focus/click event sequence that fires the autocompleter's geocoding refresh in a real browser.

## Test plan

- [x] `test/system/herbarium_form_system_test.rb` — 5/5 tests, 54 assertions pass
- [x] `test/system/observation_form_system_test.rb` — 9/9 tests, 356 assertions pass (resolves the pre-existing failures in memory: \`test_autofill_location_from_geotagged_image\`, \`test_post_edit_and_destroy_with_details_and_location\`, \`test_map_click_fills_lat_lng_fields\`)
- [x] `test/controllers/herbaria_controller_test.rb` — 71/71 tests, 486 assertions pass
- [x] RuboCop clean on touched files
- [ ] Browser smoke test: create herbarium via modal on /observations/new, verify obs-form herbarium-name field is populated with new herbarium name
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)