### PR TITLE
RadioField: per-choice opts (disabled / append / label_block)

### DIFF
--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -23,6 +23,23 @@ class Components::ApplicationForm < Superform::Rails::Form
   # @example Standalone with FieldProxy
   #   proxy = FieldProxy.new("chosen_name", :name_id)
   #   RadioField.new(proxy, [1, "Opt 1"], [2, "Opt 2"])
+  #
+  # @example Per-choice options (third element of the tuple):
+  #   RadioField.new(field,
+  #     [1, "Existing"],
+  #     [2, "Placeholder", { disabled: true,
+  #                          append: -> { a(href: …) { "Create" } } }],
+  #     [3, nil, { label_block: -> {
+  #       strong { "Bold label" }
+  #       div(class: "ml-4 text-muted") { "Help text below" }
+  #     }}]
+  #   )
+  #   # → `disabled` adds the attr to the input; `append` runs as
+  #   #   `trusted_html` after the `<label>` (sibling — keeps links
+  #   #   out of the label so a stray click doesn't activate the radio);
+  #   #   `label_block` is invoked inside `<label>` via instance_exec in
+  #   #   RadioField's Phlex context, replacing the text label for that
+  #   #   one option (compound multi-element labels without string-building).
   class RadioField < Phlex::HTML
     include Phlex::Slotable
     include Components::TrustedHtml
@@ -37,7 +54,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     def initialize(field, *collection, wrapper_options: {}, **attributes)
       super()
       @field = field
-      @collection = collection
+      @collection, @per_choice_opts = split_per_choice_opts(collection)
       @attributes = attributes
       @wrapper_options = wrapper_options
     end
@@ -63,28 +80,67 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     def render_choice(choice)
       value_str = choice.value.to_s
+      opts = @per_choice_opts[value_str] || {}
       div(class: radio_class) do
         label(for: option_input_id(value_str)) do
-          # Stringify value so Phlex doesn't dasherize symbols
-          # (e.g. `:mycoportal_image_list` → `"mycoportal-image-list"`).
-          # Use a value-derived index so the rendered id is value-based
-          # (`field_id_<value>`), matching MO's pre-upstream convention
-          # used by JS/CSS, rather than upstream's default index-based id.
-          # `checked` is computed here because upstream Radio's
-          # `field.value == @value` doesn't coerce types — MO routinely
-          # pairs boolean/symbol field values with string option values.
-          render(Superform::Rails::Components::Radio.new(
-                   @field,
-                   value: value_str,
-                   index: index_for(value_str),
-                   checked: option_checked?(value_str),
-                   **@attributes
-                 ))
+          render_choice_radio(value_str, opts)
           whitespace
-          trusted_html(choice.text)
+          render_choice_label(choice, opts)
           render_between_slot
         end
+        # `append` is a sibling of `<label>` inside `.radio` — keeps
+        # links/buttons out of the label so a stray click doesn't
+        # activate the radio. HTML-safe content; callers typically
+        # build it with `capture { a(...) }` or a sub-component.
+        trusted_html(opts[:append]) if opts[:append]
       end
+    end
+
+    def render_choice_radio(value_str, opts)
+      # Stringify value so Phlex doesn't dasherize symbols
+      # (e.g. `:mycoportal_image_list` → `"mycoportal-image-list"`).
+      # Use a value-derived index so the rendered id is value-based
+      # (`field_id_<value>`), matching MO's pre-upstream convention
+      # used by JS/CSS, rather than upstream's default index-based id.
+      # `checked` is computed here because upstream Radio's
+      # `field.value == @value` doesn't coerce types — MO routinely
+      # pairs boolean/symbol field values with string option values.
+      render(Superform::Rails::Components::Radio.new(
+               @field,
+               value: value_str,
+               index: index_for(value_str),
+               checked: option_checked?(value_str),
+               disabled: opts[:disabled],
+               **@attributes
+             ))
+    end
+
+    # `label_block:` takes precedence over `choice.text` and runs in
+    # RadioField's Phlex render context — gives callers the full Phlex
+    # DSL for compound labels (e.g. `strong { ... } div { ... }`)
+    # without forcing them to pre-build an html_safe string.
+    def render_choice_label(choice, opts)
+      if opts[:label_block]
+        instance_exec(&opts[:label_block])
+      else
+        trusted_html(choice.text)
+      end
+    end
+
+    # Accept either `[value, label]` (the original two-tuple) or
+    # `[value, label, opts]` (extended) per choice. Strip the opts so
+    # Superform's `Radios` iteration sees the plain two-tuples it
+    # expects; remember opts indexed by stringified value for
+    # `render_choice` to look up.
+    def split_per_choice_opts(collection)
+      pairs = []
+      opts_by_value = {}
+      collection.each do |entry|
+        value, label, opts = entry
+        pairs << [value, label]
+        opts_by_value[value.to_s] = opts if opts
+      end
+      [pairs, opts_by_value]
     end
 
     # `between` content is rendered after the label text inside each

--- a/test/components/application_form/radio_field_test.rb
+++ b/test/components/application_form/radio_field_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for Components::ApplicationForm::RadioField — focused on the
+# per-choice opts extensions (disabled / append / label_block). Basic
+# rendering is covered indirectly by callers (form_carousel_item,
+# project_violations_form, etc.).
+class RadioFieldTest < ComponentTestCase
+  def test_renders_simple_two_tuple_choices
+    html = render_field([[1, "Option 1"], [2, "Option 2"]])
+
+    # Each option wrapped in .radio with a label-for matching the radio id.
+    assert_html(html, ".radio > label[for='target_1'] > input" \
+                      "[type='radio'][name='target'][value='1']")
+    assert_html(html, ".radio > label[for='target_2'] > input" \
+                      "[type='radio'][name='target'][value='2']")
+    assert_includes(html, "Option 1")
+    assert_includes(html, "Option 2")
+  end
+
+  def test_preselects_choice_matching_field_value
+    html = render_field([[1, "A"], [2, "B"]], field_value: 2)
+
+    assert_html(html, "input[value='1']:not([checked])")
+    assert_html(html, "input[value='2'][checked]")
+  end
+
+  def test_per_choice_disabled_adds_input_attr
+    html = render_field([
+                          [1, "Enabled"],
+                          [2, "Disabled", { disabled: true }]
+                        ])
+
+    assert_html(html, "input[value='1']:not([disabled])")
+    assert_html(html, "input[value='2'][disabled]")
+  end
+
+  def test_per_choice_append_emits_after_label_inside_radio_wrap
+    append_html = "<a href='/create'>Create</a>".html_safe
+    html = render_field([
+                          [1, "A"],
+                          [2, "B", { append: append_html }]
+                        ])
+
+    # Append rendered as a sibling of the label, inside the .radio wrap,
+    # so a click on the link doesn't activate the radio.
+    assert_html(html, ".radio > label[for='target_2']")
+    assert_html(html, ".radio > a[href='/create']")
+    # Sibling, not nested:
+    assert_no_html(html, "label[for='target_2'] a[href='/create']")
+  end
+
+  def test_per_choice_label_block_replaces_text_label
+    block = lambda do
+      strong { "Bold part" }
+      div(class: "ml-4 text-muted") { "Help text" }
+    end
+    html = render_field([
+                          [1, "Plain text label"],
+                          [2, nil, { label_block: block }]
+                        ])
+
+    # Option 1 keeps the plain text label.
+    assert_includes(html, "Plain text label")
+    # Option 2's label content is rendered by the block, inside <label>.
+    assert_html(html, "label[for='target_2'] > strong",
+                text: "Bold part")
+    assert_html(html, "label[for='target_2'] > div.ml-4.text-muted",
+                text: "Help text")
+  end
+
+  def test_per_choice_label_block_takes_precedence_over_text
+    block = -> { span { "From block" } }
+    html = render_field([
+                          [1, "From text", { label_block: block }]
+                        ])
+
+    assert_html(html, "label > span", text: "From block")
+    assert_not_includes(html, "From text")
+  end
+
+  private
+
+  def render_field(choices, field_value: nil)
+    proxy = Components::ApplicationForm::FieldProxy.new(
+      nil, "target", field_value
+    )
+    render(Components::ApplicationForm::RadioField.new(proxy, *choices))
+  end
+end


### PR DESCRIPTION
## Summary

Extends `Components::ApplicationForm::RadioField`'s choice format from two-tuples \`[value, label]\` to optional three-tuples \`[value, label, opts]\`, adding three per-choice options:

| Opt | Effect |
|---|---|
| \`disabled: true\` | adds the attr to that one radio input |
| \`append: SafeBuffer\` | emitted as a sibling of \`<label>\` inside \`.radio\` — keeps links/buttons out of the label so a stray click doesn't toggle the radio |
| \`label_block: Proc\` | invoked inside \`<label>\` via \`instance_exec\` in RadioField's Phlex render context, replacing the text label for that one option |

### Why

Three near-term PRs need these:
- **PR C (TrustSettingsForm)** — needs \`label_block:\` for compound \`<strong>label</strong><div class="ml-4 text-muted">help</div>\` per option, without forcing the caller to pre-build an html_safe string via \`helpers.tag.*\` (which throws a Phlex deprecation).
- **PR #4277 (project_violations target-location radio)** — currently includes these same extensions; will rebase to inherit them and shrink to just the caller-side usage.
- **PR D (target-location modal extraction)** — needs \`disabled:\` for placeholder rows + \`append:\` for the per-row "Create" link.

Pulled out as its own PR so all three downstream PRs share one source of truth and avoid duplicate diffs.

### Compatibility

The two-tuple form is unchanged and unaffected — \`split_per_choice_opts\` strips opts before handing pairs to Superform's \`Radios\` iteration. All existing callers (form_carousel_item, form_name_feedback, form_list_feedback, project_form) continue to pass plain two-tuples and still work.

## Test plan

- [x] New \`radio_field_test.rb\` — 6 tests, 32 assertions, covers both basic + per-choice-opts paths
- [x] All RadioField callers' existing tests — 120/120 pass (form_carousel, form_name_feedback, form_list_feedback, project_form, application_form, parity)
- [x] RuboCop clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)