### PR TITLE
Coverage catch-up: ButtonStyleRadio + ImagesToRemoveForm + RadioField append-Proc

### DIFF
--- a/app/components/application_form/radio_field.rb
+++ b/app/components/application_form/radio_field.rb
@@ -88,11 +88,23 @@ class Components::ApplicationForm < Superform::Rails::Form
           render_choice_label(choice, opts)
           render_between_slot
         end
-        # `append` is a sibling of `<label>` inside `.radio` — keeps
-        # links/buttons out of the label so a stray click doesn't
-        # activate the radio. HTML-safe content; callers typically
-        # build it with `capture { a(...) }` or a sub-component.
-        trusted_html(opts[:append]) if opts[:append]
+        render_choice_append(opts)
+      end
+    end
+
+    # `append` is a sibling of `<label>` inside `.radio` — keeps
+    # links/buttons out of the label so a stray click doesn't
+    # activate the radio. Accepts either a `Proc`/lambda (invoked in
+    # RadioField's Phlex render context — full DSL) or an html_safe
+    # `SafeBuffer` (emitted via `trusted_html`).
+    def render_choice_append(opts)
+      append = opts[:append]
+      return unless append
+
+      if append.respond_to?(:call)
+        instance_exec(&append)
+      else
+        trusted_html(append)
       end
     end
 

--- a/test/components/application_form/button_style_radio_test.rb
+++ b/test/components/application_form/button_style_radio_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for Components::ApplicationForm::ButtonStyleRadio — the
+# button-styled radio component used by FormCarousel and elsewhere.
+# Unlike RadioField, this component is standalone (no Field/FieldProxy)
+# and has NO `.radio` div wrap.
+class ButtonStyleRadioTest < ComponentTestCase
+  def test_renders_label_wrapping_radio_input
+    html = render(klass.new(
+                    name: "obs[thumb]", value: "42",
+                    id: "thumb_42"
+                  )) { "Pick this" }
+
+    # <label for="thumb_42"><input type="radio" ...>Pick this</label>
+    assert_html(html, "label[for='thumb_42'] > input[type='radio']" \
+                      "[name='obs[thumb]'][value='42'][id='thumb_42']")
+    assert_includes(html, "Pick this")
+    # No `.radio` div wrap — that's intentional.
+    assert_no_html(html, ".radio")
+  end
+
+  def test_checked_true_sets_input_attr
+    html = render(klass.new(
+                    name: "n", value: "1", id: "x", checked: true
+                  ))
+
+    assert_html(html, "input[type='radio'][checked]")
+  end
+
+  def test_checked_default_false_omits_attr
+    html = render(klass.new(name: "n", value: "1", id: "x"))
+
+    assert_html(html, "input[type='radio']:not([checked])")
+  end
+
+  def test_label_attrs_passed_through
+    html = render(klass.new(
+                    name: "n", value: "1", id: "x",
+                    label: { class: "btn btn-default thumb_img_btn",
+                             data: { action: "click->form-images#set" } }
+                  ))
+
+    assert_html(html, "label.btn.btn-default.thumb_img_btn[for='x']")
+    assert_html(html, "label[data-action='click->form-images#set']")
+  end
+
+  def test_input_attrs_passed_through_via_splat
+    html = render(klass.new(
+                    name: "n", value: "1", id: "x",
+                    class: "form-control",
+                    data: { thumb_id: "1" }
+                  ))
+
+    assert_html(html, "input[type='radio'].form-control" \
+                      "[data-thumb-id='1']")
+  end
+
+  def test_renders_without_block_content
+    html = render(klass.new(name: "n", value: "1", id: "x"))
+
+    # Label exists, contains the input, no extra content.
+    assert_html(html, "label[for='x'] > input[type='radio']")
+  end
+
+  private
+
+  def klass
+    Components::ApplicationForm::ButtonStyleRadio
+  end
+end

--- a/test/components/application_form/radio_field_test.rb
+++ b/test/components/application_form/radio_field_test.rb
@@ -70,6 +70,30 @@ class RadioFieldTest < ComponentTestCase
                 text: "Help text")
   end
 
+  def test_per_choice_append_accepts_proc
+    append_block = -> { a(href: "/from_proc") { "Create" } }
+    html = render_field([
+                          [1, "A"],
+                          [2, "B", { append: append_block }]
+                        ])
+
+    # Proc invoked in RadioField's Phlex render context — sibling of
+    # the label, inside .radio, just like the SafeBuffer form.
+    assert_html(html, ".radio > a[href='/from_proc']", text: "Create")
+    assert_no_html(html, "label[for='target_2'] a[href='/from_proc']")
+  end
+
+  def test_per_choice_nil_opts_tolerated
+    # `[value, label, nil]` 3-tuple should be treated the same as
+    # `[value, label]` — split_per_choice_opts skips the assignment.
+    html = render_field([[1, "A"], [2, "B", nil]])
+
+    assert_html(html, "input[type='radio'][value='1']")
+    assert_html(html, "input[type='radio'][value='2']")
+    assert_includes(html, "A")
+    assert_includes(html, "B")
+  end
+
   def test_per_choice_label_block_takes_precedence_over_text
     block = -> { span { "From block" } }
     html = render_field([

--- a/test/components/images_to_remove_form_test.rb
+++ b/test/components/images_to_remove_form_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for Components::ImagesToRemoveForm — bulk-removal matrix used
+# by glossary term edit. Inherits Superform (PUT request, CSRF + _method
+# emitted automatically).
+class ImagesToRemoveFormTest < ComponentTestCase
+  def setup
+    super
+    @user = users(:rolf)
+    @model = glossary_terms(:plane_glossary_term)
+  end
+
+  def test_renders_form_with_put_method_and_action
+    html = render_form
+
+    assert_html(html, "form[action='/test_action']")
+    # Superform: explicit method: :put → POST + hidden _method=put.
+    assert_html(html, "form[method='post']")
+    assert_html(html, "input[type='hidden'][name='_method'][value='put']")
+    assert_html(html, "input[type='hidden'][name='authenticity_token']")
+  end
+
+  def test_renders_one_checkbox_per_image_with_yes_no_values
+    html = render_form
+
+    @model.images.each do |image|
+      # Visible checkbox: name="selected[<id>]", value="yes"
+      assert_html(html, "input[type='checkbox']" \
+                        "[name='selected[#{image.id}]'][value='yes']")
+      # Hidden sidecar carries the "no" default for unchecked state.
+      assert_html(html, "input[type='hidden']" \
+                        "[name='selected[#{image.id}]'][value='no']")
+    end
+  end
+
+  def test_each_checkbox_wrap_has_my_0_class
+    html = render_form
+
+    # Each per-image .checkbox wrapper gets `my-0` so BS3's default
+    # 10px vertical margin doesn't leave visible gaps inside the
+    # MatrixBox cell.
+    @model.images.each do |image|
+      assert_html(html, ".checkbox.my-0 input[name='selected[#{image.id}]']")
+    end
+  end
+
+  def test_renders_submit_buttons_above_and_below_matrix
+    html = render_form
+
+    # Two submit inputs (top + bottom), both centered.
+    submits = html.scan(/<input[^>]*type="submit"/).count
+    assert_equal(2, submits,
+                 "expected 2 submit buttons (top + bottom)")
+  end
+
+  def test_renders_matrix_with_one_box_per_image
+    html = render_form
+
+    # MatrixTable renders a `.row.list-unstyled` wrap; each MatrixBox
+    # contains the image preview + checkbox for one image.
+    assert_html(html, ".row.list-unstyled")
+    assert_equal(@model.images.count, html.scan("matrix-box").count,
+                 "expected one .matrix-box per image")
+  end
+
+  private
+
+  def render_form
+    render(Components::ImagesToRemoveForm.new(
+             @model, form_action: "/test_action", user: @user
+           ))
+  end
+end


### PR DESCRIPTION
## Summary

Three tightly-related coverage additions for recently-merged Tier 1 PRs:

- **\`Components::ApplicationForm::ButtonStyleRadio\`** (landed in #4274 without tests) — 6 tests covering label-wraps-radio structure (no \`.radio\` div), checked/unchecked input states, label/data attrs passthrough, \`**input_attrs\` splat, no-block render.
- **\`Components::ImagesToRemoveForm\`** (landed in #4271 without tests) — 5 tests covering PUT + CSRF wiring, per-image checkbox \`selected[<id>]=yes\` + hidden \`=no\` sidecar, \`.checkbox.my-0\` wrap class (regression target), top+bottom submit buttons, one matrix box per image.
- **\`RadioField\` follow-ups to #4281** — \`append:\` was documented as accepting a \`Proc\` but the implementation only handled \`SafeBuffer\`. Aligned the implementation with the docs (extracted \`render_choice_append\` that branches on \`respond_to?(:call)\`, matching \`label_block\`). Added 2 tests: Proc \`append\` rendering as label-sibling, and \`[value, label, nil]\` 3-tuple tolerance.

## Why

Per the coverage audit: these components have no line-coverage gap (existing controller tests transit the lines) but no assertion coverage. Coveralls passes today but regressions would slip through silently.

## Test plan

- [x] \`bin/rails test test/components/application_form/button_style_radio_test.rb\` — 6 tests, 16 assertions
- [x] \`bin/rails test test/components/images_to_remove_form_test.rb\` — 5 tests, 18 assertions
- [x] \`bin/rails test test/components/application_form/radio_field_test.rb\` — 8 tests, 44 assertions
- [x] RuboCop clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)