### PR TITLE
Fix OccurrenceResolveForm Add All submission (#4284)

### DIFF
--- a/app/components/occurrence_resolve_form.rb
+++ b/app/components/occurrence_resolve_form.rb
@@ -101,7 +101,7 @@ class Components::OccurrenceResolveForm < Components::Base
 
   def selected_hidden_fields
     @selected.each do |obs|
-      input(type: "hidden", name: "observation_ids[]",
+      input(type: "hidden", name: "occurrence[observation_ids][]",
             value: obs.id)
     end
     input(type: "hidden",

--- a/test/components/occurrence_resolve_form_test.rb
+++ b/test/components/occurrence_resolve_form_test.rb
@@ -30,14 +30,18 @@ class OccurrenceResolveFormTest < ComponentTestCase
     # Form posts to occurrences_path
     assert_html(html, "form[action='/occurrences'][method='post']")
 
-    # Hidden fields for selected observations
+    # Hidden fields for selected observations — must use the namespaced
+    # `occurrence[observation_ids][]` shape because OccurrencesController#create
+    # reads `params.dig(:occurrence, :observation_ids)` (PR #4250).
+    # Flat `observation_ids[]` would be silently ignored and the controller
+    # would flash "must include at least one additional observation".
     assert_html(html,
                 "input[type='hidden']" \
-                "[name='observation_ids[]']" \
+                "[name='occurrence[observation_ids][]']" \
                 "[value='#{@obs1.id}']")
     assert_html(html,
                 "input[type='hidden']" \
-                "[name='observation_ids[]']" \
+                "[name='occurrence[observation_ids][]']" \
                 "[value='#{@obs2.id}']")
     assert_html(html,
                 "input[type='hidden']" \
@@ -163,7 +167,7 @@ class OccurrenceResolveFormTest < ComponentTestCase
     # No observation_ids hidden fields in edit flow
     obs_ids = doc.css(
       "input[type='hidden']" \
-      "[name='observation_ids[]']"
+      "[name='occurrence[observation_ids][]']"
     )
     assert_equal(0, obs_ids.size,
                  "Edit flow should not have obs hidden fields")

--- a/test/system/occurrence_form_system_test.rb
+++ b/test/system/occurrence_form_system_test.rb
@@ -19,8 +19,9 @@ class OccurrenceFormSystemTest < ApplicationSystemTestCase
 
     # Check Include for a recent observation. The Phlex create form
     # namespaces the field as `occurrence[observation_ids][]` (via
-    # `checkbox_field(:observation_ids)`), distinct from the flat
-    # `observation_ids[]` emitted by OccurrenceResolveForm.
+    # `checkbox_field(:observation_ids)`). OccurrenceResolveForm
+    # emits hidden fields with the same name so its Add All submission
+    # goes through the same controller param path (#4284).
     checkboxes = all(
       "input[name='occurrence[observation_ids][]'][type='checkbox']"
     )


### PR DESCRIPTION
## Summary

- Fixes #4284. The project-gap modal's "Add All" button posted hidden fields as flat `observation_ids[]`, but `OccurrencesController#create` reads `params.dig(:occurrence, :observation_ids)` after PR #4250. The controller saw zero extra observations and flashed "must include at least one additional observation" instead of creating the occurrence.
- Rename the hidden field to `occurrence[observation_ids][]` so the modal posts what the controller parses.
- Update `OccurrenceResolveFormTest#test_create_flow` (and the `test_edit_flow_authenticity_token` selector) to assert the namespaced name. The first assertion fails on `main` and passes after the fix.

## Out of scope

- The Include-checkbox label-click regression mentioned in the issue is a separate problem in `OccurrenceForm` (the create page), not in the resolve modal. Filing/handling that separately.

## Test plan

- [x] `bin/rails test test/components/occurrence_resolve_form_test.rb test/components/occurrence_form_test.rb test/controllers/occurrences_controller_test.rb` — 91 tests, 470 assertions, 0 failures
- [x] `bundle exec rubocop` clean on changed files
- [x] Browser smoke-test of the repro: view obs from two projects, "Add Matching Observation" → check the second obs → "Create Occurrence" → "Add All" in the modal. Confirm the new occurrence has both observations and both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)