### PR TITLE
Fix CheckboxField block-mode label association (#4286)

### DIFF
--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -42,8 +42,12 @@ class Components::ApplicationForm < Superform::Rails::Form
         # Block mode: caller drives rendering via `cb.option(value)` for
         # one or more checkboxes inside MO's standard wrapper. Used for
         # matrix-style layouts where one checkbox_field call produces
-        # exactly one cell of a larger group.
-        render_boolean_with_wrapper { yield(self) }
+        # exactly one cell of a larger group. `label_for: nil` because the
+        # caller's input id (`field.dom.id + "_" + value`) isn't knowable
+        # here — falling through to DOM nesting keeps label clicks working
+        # (HTML spec: a <label> with no `for=` toggles its first nested
+        # form control).
+        render_boolean_with_wrapper(label_for: nil) { yield(self) }
       else
         render_boolean_with_wrapper { render_boolean_inputs }
       end
@@ -181,9 +185,11 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     # --- Boolean mode wrapper ---
 
-    def render_boolean_with_wrapper(&checkbox_block)
+    def render_boolean_with_wrapper(label_for: checkbox_id, &checkbox_block)
       div(class: boolean_wrap_class) do
-        label(for: checkbox_id, **label_attributes) do
+        label_attrs = label_attributes
+        label_attrs = label_attrs.merge(for: label_for) if label_for
+        label(**label_attrs) do
           render_boolean_content(&checkbox_block)
           render_help_in_label_row
         end

--- a/test/components/occurrence_form_test.rb
+++ b/test/components/occurrence_form_test.rb
@@ -135,6 +135,17 @@ class OccurrenceFormTest < ComponentTestCase
     label = cb.parent
     assert_equal("label", label.name)
     assert_includes(label.text, "Include")
+
+    # Regression: #4286 — clicking the "Include" text must toggle the
+    # nested checkbox. Per HTML spec, a <label> with `for=` pointing at
+    # a non-existent id does NOT fall back to its nested input, so the
+    # wrapper must either omit `for=` (and rely on DOM nesting) or
+    # match the actual input's id.
+    return unless label["for"]
+
+    assert_equal(cb["id"], label["for"],
+                 "Label `for` must match the nested checkbox id, " \
+                 "otherwise label clicks don't toggle the checkbox")
   end
 
   def test_matrix_ul_stimulus_wiring


### PR DESCRIPTION
## Summary

- Fixes #4286. On the Occurrence Create page, clicking the "Include" text next to a recent observation's checkbox did nothing — only direct clicks on the checkbox toggled it.
- `Components::ApplicationForm::CheckboxField` block mode emitted `<label for="<field.dom.id>">` while `cb.option(value)` rendered the actual input with `id="<field.dom.id>_<value>"`. Per HTML spec, a `<label>` whose `for=` points at no element does NOT fall back to its nested input, so the click landed on dead air.
- Fix: in block mode, omit `for=` on the wrapper label. DOM nesting (the input rendered inside the label by the caller's block) becomes the label's labeled control. Boolean mode keeps `for=` because there the input id matches `field.dom.id`.

## Test plan

- [x] `bin/rails test test/components/occurrence_form_test.rb test/components/application_form_test.rb test/components/application_form_helper_parity_test.rb test/components/occurrence_edit_form_test.rb test/components/occurrence_resolve_form_test.rb` — 109 tests, 526 assertions, 0 failures
- [x] `bundle exec rubocop` clean on changed files
- [x] Failing-first regression test in `OccurrenceFormTest#test_recent_controls_include_checkbox_label` asserts that the wrapper label either omits `for=` or matches the nested input's id.
- [ ] Browser smoke-test: visit `/occurrences/new?observation_id=<id>`, click the "Include" text (not the checkbox itself) for a recent observation, confirm the checkbox toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)