### PR TITLE
Speed up Project show: memoize visible obs + widen show_includes

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -78,7 +78,9 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   has_many :images, through: :project_images
 
   has_many :project_observations, dependent: :delete_all
-  has_many :observations, through: :project_observations
+  has_many :observations, through: :project_observations,
+                          after_add: :invalidate_visible_observations_cache!,
+                          after_remove: :invalidate_visible_observations_cache!
   has_many :locations, through: :observations
 
   has_many :project_excluded_observations, dependent: :delete_all
@@ -160,7 +162,13 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   scope :show_includes, lambda {
     strict_loading.includes(
       { comments: :user },
-      :location
+      :admin_group,
+      :location,
+      :species_lists,
+      :target_locations,
+      :target_names,
+      :user,
+      :user_group
     )
   }
   scope :violations_includes, lambda {
@@ -388,6 +396,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
     insert_project_observations(new_obs_ids)
     insert_project_images_for(new_obs_ids)
+    invalidate_visible_observations_cache!
     touch
     new_obs_ids.size
   end
@@ -857,8 +866,33 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   ##############################################################################
 
   # Observations excluding non-primary members of multi-obs occurrences.
+  #
+  # The underlying `exclude_non_primary` scope adds a LEFT OUTER JOIN on
+  # `occurrences` with an `(occurrence_id IS NULL OR primary = id)` OR
+  # predicate, which the planner can't serve from the
+  # `(project_id, observation_id)` index. On big projects the dedup
+  # scan runs to 0.3-1.7s and is invoked separately by every show-page
+  # widget (tab counts, checklist, location count, constraint
+  # violations). Pluck the visible IDs once per Project instance and
+  # have every downstream query use a flat PK lookup. Mutators that
+  # add/remove/exclude observations call
+  # `invalidate_visible_observations_cache!` so the memo stays
+  # consistent within a single Project instance.
   def visible_observations
-    observations.exclude_non_primary
+    Observation.where(id: visible_observation_ids)
+  end
+
+  def visible_observation_ids
+    @visible_observation_ids ||=
+      observations.exclude_non_primary.pluck(:id)
+  end
+
+  # Wired as `after_add` / `after_remove` on the `observations`
+  # association, so the splat absorbs the record-arg that AR passes.
+  # Also called directly from `bulk_add_observations`, which uses
+  # `ProjectObservation.insert_all` and so bypasses the callbacks.
+  def invalidate_visible_observations_cache!(*)
+    @visible_observation_ids = nil
   end
 
   def out_of_range_observations


### PR DESCRIPTION
## Summary

Cuts most of the DB cost on the Project show page (project-show.txt request was 6.5s, almost all DB).

- **Memoize `Project#visible_observation_ids`**: every project show-page widget — tab counts, checklist, location count, all four constraint-violation passes — calls `visible_observations`, which runs `exclude_non_primary`. That scope adds a `LEFT OUTER JOIN occurrences` plus `(occurrence_id IS NULL OR primary_observation_id = observations.id)`, an OR-on-null shape the planner can't serve from the `(project_id, observation_id)` index. On big projects the dedup scan ran 0.3-1.7s and was paid 8+ times in a single request. Pluck the visible IDs once per Project instance; every subsequent caller goes through a flat `id IN (...)` PK lookup.
- `after_add` / `after_remove` callbacks on `:observations` keep the memo consistent when the collection mutates. `bulk_add_observations` invalidates explicitly because `insert_all` bypasses AR callbacks.
- **Widen `Project.show_includes`** to eager-load `:user`, `:user_group`, `:admin_group`, `:species_lists`, `:target_names`, `:target_locations`. These triggered strict_loading violations on every show-page render (a few +30-50ms of round-trips on top of the dedup cost) and are needed by `member?`, `is_admin?`, the tabs component, the checklist, and the object footer.

No schema change here. Structurally materializing the dedup (e.g. boolean on `project_observations` updated by an Occurrence callback) is the follow-up — this PR is the easy-to-review first step.

## Test plan

- [x] `bin/rails test test/models/project_test.rb test/models/checklist_test.rb test/controllers/projects_controller_test.rb test/controllers/projects/...` plus integration + component tests — 191 tests, 1111 assertions, 0 failures
- [x] `bundle exec rubocop app/models/project.rb` clean
- [ ] **Local browser timing**: load `/projects/<big_project_id>` on this branch vs. main and compare the Rails log line `Completed 200 OK in Xms`. project-show.txt was 6552ms on main with ActiveRecord at 6169ms — expect a substantial drop and no strict_loading violations in the log.
- [ ] Smoke test mutations that invalidate the memo: add observation to project, remove observation, exclude observation, then re-render show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)