### PR TITLE
Fix BS3 modal unclickable at narrow viewports (drop translate3d hack)

### DIFF
--- a/app/assets/stylesheets/mo/_layout.scss
+++ b/app/assets/stylesheets/mo/_layout.scss
@@ -43,7 +43,18 @@ $sidebar-max-width: 18rem;
     -webkit-transition: all .25s ease-out;
     -o-transition: all .25s ease-out;
     transition: all .25s ease-out;
-    -webkit-transform: translate3d(0,0,0);
+    // NOTE: Do not add `transform:` (or `filter:` / `perspective:`)
+    // to .row-offcanvas. Any of those creates a CSS containing block
+    // for descendants, which breaks `position: fixed` on BS3 modals
+    // — the modal becomes positioned relative to .row-offcanvas
+    // instead of the viewport, ending up inline in document flow
+    // while the backdrop (which is appended to <body>, outside
+    // .row-offcanvas) still fills the viewport on top. Result: modal
+    // is visible but unclickable at narrow widths. Previously we had
+    // `-webkit-transform: translate3d(0,0,0)` here as a hardware-
+    // acceleration hack for the offcanvas slide; modern browsers
+    // composite without that, and the side-effect was breaking the
+    // project-violations target-location modal on mobile.
   }
 
   .row-offcanvas-right {


### PR DESCRIPTION
## Summary

Drops `-webkit-transform: translate3d(0,0,0)` from `.row-offcanvas` inside the narrow-viewport media query. That transform was a 2012-era hardware-acceleration hack that's obsolete in modern browsers, and it had an active negative side effect: it created a CSS containing block for descendants, which broke `position: fixed` on BS3 modals.

### Effect at narrow viewport (before fix)

- Modal element lives inside \`.row-offcanvas\` → its `position: fixed` becomes positioned relative to `.row-offcanvas` (which is in document flow), so the modal appears INLINE in the page rather than as a floating overlay.
- Modal backdrop is appended to \`<body>\` by BS3 JS → outside \`.row-offcanvas\` → still fills the viewport.
- Result: modal is visible (you can see it inline somewhere on the page) but unclickable, because the full-viewport backdrop sits on top of the inline modal content.

### How surfaced

Hit while testing the target-location modal on `/projects/<id>/violations` on a narrow browser window. Confirmed via browser dev tools that the bug also exists on \`main\` (predates the modal-related PR work in flight).

### Test plan

- [x] Manual: open `/projects/<id>/violations` (e.g. `/projects/334/violations`) at narrow viewport, click "Add Target Location" → modal opens as proper centered overlay, radios + buttons clickable. Verified.
- [x] Manual: same page at desktop width → modal opens correctly as before (no regression).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)