### PR TITLE
Components::Modal: add :form_content slot for form-wrapped body+footer

### DIFF
--- a/app/components/modal.rb
+++ b/app/components/modal.rb
@@ -33,6 +33,29 @@
 #   )) do |m|
 #     m.with_body { render(...) }
 #   end
+#
+# @example form-wrapped body + footer (form spans both — submit button
+#   in `.modal-footer` is naturally inside the form)
+#
+#   When set, `with_form_content` REPLACES `with_body` and `with_footer`.
+#   The caller renders a single component (typically an ApplicationForm
+#   subclass) that emits its own `<div class="modal-body">` and
+#   `<div class="modal-footer">` inside the form's yield, so the form
+#   tag wraps both:
+#
+#       <div class="modal-content">
+#         <div class="modal-header">...</div>
+#         <form ...>
+#           <div class="modal-body">...fields...</div>
+#           <div class="modal-footer">...buttons...</div>
+#         </form>
+#       </div>
+#
+#   render(Components::Modal.new(
+#     id: "modal_x", title: "Edit thing", user: @user
+#   )) do |m|
+#     m.with_form_content { render(Components::ThingForm.new(@thing)) }
+#   end
 class Components::Modal < Components::Base
   include Phlex::Slotable
 
@@ -62,8 +85,14 @@ class Components::Modal < Components::Base
   slot :title_content
   slot :body
   slot :footer
+  # When set, REPLACES body+footer slots. Caller renders a single
+  # component (typically a form) that emits its own `.modal-body` and
+  # `.modal-footer` divs, so a single `<form>` tag can wrap both —
+  # keeps the submit button (in `.modal-footer`) naturally inside the
+  # form. See the form-wrapped example in the class docstring.
+  slot :form_content
 
-  public :title_content_slot, :body_slot, :footer_slot
+  public :title_content_slot, :body_slot, :footer_slot, :form_content_slot
 
   def view_template(&block)
     yield(self) if block
@@ -75,8 +104,7 @@ class Components::Modal < Components::Base
       div(class: @dialog_class, role: "document") do
         div(class: "modal-content") do
           render_header
-          render_body
-          render_footer
+          render_content
         end
       end
     end
@@ -132,6 +160,15 @@ class Components::Modal < Components::Base
            data: { dismiss: "modal" },
            aria: { label: :CLOSE.l }) do
       span(aria: { hidden: "true" }) { "×" }
+    end
+  end
+
+  def render_content
+    if form_content_slot
+      render(form_content_slot)
+    else
+      render_body
+      render_footer
     end
   end
 

--- a/test/components/modal_test.rb
+++ b/test/components/modal_test.rb
@@ -85,4 +85,55 @@ class ModalTest < ComponentTestCase
     assert_html(html, ".modal-title > strong", text: "custom")
     assert_not_includes(html, "ignored")
   end
+
+  def test_form_content_slot_replaces_body_and_footer
+    # `with_form_content` lets the caller render a single component
+    # (typically a form) that emits its own `.modal-body` and
+    # `.modal-footer`, so a single `<form>` tag wraps both — keeping
+    # the submit button (in `.modal-footer`) naturally inside the form.
+    html = render(Components::Modal.new(
+                    id: "modal_form", title: "Edit"
+                  )) do |m|
+      m.with_form_content do
+        '<form action="/x" method="post">' \
+          '<div class="modal-body"><input name="foo"></div>' \
+          '<div class="modal-footer">' \
+          '<button type="submit">Save</button>' \
+          "</div>" \
+          "</form>".html_safe
+      end
+    end
+
+    # Modal chrome is still rendered (header + close button).
+    assert_html(html, ".modal#modal_form .modal-content > .modal-header")
+    # The form_content output replaces the default body+footer slot
+    # rendering — there is exactly one `.modal-body` and one
+    # `.modal-footer`, and both live inside the same `<form>`.
+    assert_html(html, ".modal-content > form[action='/x']", count: 1)
+    assert_html(html, ".modal-content > form > .modal-body > input[name='foo']")
+    assert_html(html,
+                ".modal-content > form > .modal-footer > button[type='submit']",
+                text: "Save")
+    # The submit button is inside the form (HTML5 form submission works
+    # without needing `form='id'` attribute association on the button).
+    assert_html(html, "form > .modal-footer button[type='submit']")
+  end
+
+  def test_form_content_slot_supersedes_body_and_footer_slots
+    # When both `with_form_content` and the body/footer slots are set,
+    # `with_form_content` wins. (Callers shouldn't mix them; this just
+    # documents the precedence so a stray `with_body` call doesn't
+    # silently double-render.)
+    html = render(Components::Modal.new(
+                    id: "modal_either", title: "T"
+                  )) do |m|
+      m.with_body { "<p>should-not-appear</p>".html_safe }
+      m.with_footer { "<button>also-not</button>".html_safe }
+      m.with_form_content { "<form><p>wins</p></form>".html_safe }
+    end
+
+    assert_html(html, ".modal-content > form > p", text: "wins")
+    assert_no_html(html, ".modal-body")
+    assert_no_html(html, ".modal-footer")
+  end
 end


### PR DESCRIPTION
## Summary

Some MO forms had the submit buttons in the .modal-footer, prior to refactoring.
 
The existing `:body` and `:footer` slots render as separate sibling `<div>`s inside `.modal-content`, which forces any form rendered inside a modal to live entirely in `.modal-body`. That leaves no clean way to put a submit button in `.modal-footer` while keeping it inside the form.

The new `:form_content` slot **replaces** `:body` and `:footer` when set, and lets the caller render a single component (typically an `ApplicationForm` subclass) that emits its own `.modal-body` and `.modal-footer` divs inside its form yield:

```html
<div class="modal-content">
  <div class="modal-header">...</div>
  <form ...>
    <div class="modal-body">...fields...</div>
    <div class="modal-footer">...buttons including submit...</div>
  </form>
</div>
```

This matches the pre-Phlex modal HTML structure and works the same across BS3/4/5 (Bootstrap inspects the `.modal-*` divs, not form ancestry).

## Why

Two refactors that need this:

- **#4292** (TrustSettingsForm) — HTML parity diff showed the refactor moved Cancel/Save into `.text-right.mt-3` inside `.modal-body`, losing the `.modal-footer` chrome. Will switch to the new slot.
- **OccurrenceResolveForm** (already merged in #4279) — same pattern; intro + project list + buttons all crammed into `.modal-body`. Will be migrated separately to use the new slot.

## Test plan

- [x] Two new tests in `test/components/modal_test.rb`:
  - `:form_content` renders form-wrapped body and footer correctly
  - `:form_content` takes precedence over `:body` / `:footer` if both are set on the same modal (so a stray `with_body` call doesn't silently double-render)
- [x] All existing Modal / ModalTurboForm / ModalConfirm / ModalProgressSpinner / OccurrenceResolveForm / TrustSettingsModal tests still pass (19 tests, 123 assertions)
- [x] `bundle exec rubocop` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)