### PR TITLE
OccurrenceResolveForm: render via Modal :form_content slot (restore .modal-footer)

### DIFF
--- a/app/components/occurrence_resolve_form.rb
+++ b/app/components/occurrence_resolve_form.rb
@@ -30,10 +30,27 @@ class Components::OccurrenceResolveForm < Components::ApplicationForm
     super(@occurrence || Occurrence.new, **)
   end
 
+  # Declares to Modal that this form renders its own `.modal-body`
+  # and `.modal-footer` divs (via Modal's `:form_content` slot, added
+  # in #4293) so the form tag wraps both — submit in `.modal-footer`
+  # is naturally inside the form.
+  def self.owns_modal_sections?
+    true
+  end
+
+  # The form (Superform's default view_template) wraps both modal
+  # sections. Intro + project list live in `.modal-body`; Cancel /
+  # Add All live in `.modal-footer`. Hidden fields go at the top of
+  # the form (next to Superform's CSRF + `_method` inputs).
   def view_template
-    render_intro
-    render_project_list
-    super { render_form_body }
+    super do
+      selected_hidden_fields if @selected
+      div(class: "modal-body") do
+        render_intro
+        render_project_list
+      end
+      div(class: "modal-footer") { render_buttons }
+    end
   end
 
   # Superform calls this to compute the `<form action=…>` URL.
@@ -65,11 +82,6 @@ class Components::OccurrenceResolveForm < Components::ApplicationForm
     end
   end
 
-  def render_form_body
-    selected_hidden_fields if @selected
-    render_buttons(cancel_path)
-  end
-
   def cancel_path
     if @selected
       new_occurrence_path(observation_id: @selected.first.id)
@@ -92,17 +104,16 @@ class Components::OccurrenceResolveForm < Components::ApplicationForm
     hidden_field("occurrence[primary_observation_id]", value: @primary.id)
   end
 
-  def render_buttons(cancel_path)
-    div(class: "text-right mt-3") do
-      a(href: cancel_path, class: "btn btn-default mr-3",
-        data: { dismiss: "modal" }) do
-        :occurrence_resolve_projects_cancel.l
-      end
-      submit(
-        :occurrence_resolve_projects_add_all.l,
-        as: :button, btn_class: "btn-primary", value: "add_all",
-        name: @selected ? "project_resolution" : "resolution"
-      )
+  def render_buttons
+    a(href: cancel_path, class: "btn btn-default",
+      data: { dismiss: "modal" }) do
+      :occurrence_resolve_projects_cancel.l
     end
+    whitespace
+    submit(
+      :occurrence_resolve_projects_add_all.l,
+      as: :button, btn_class: "btn-primary", value: "add_all",
+      name: @selected ? "project_resolution" : "resolution"
+    )
   end
 end

--- a/app/components/occurrence_resolve_form.rb
+++ b/app/components/occurrence_resolve_form.rb
@@ -73,9 +73,13 @@ class Components::OccurrenceResolveForm < Components::ApplicationForm
     return unless projects&.any?
 
     strong { :occurrence_resolve_projects_projects.l }
-    ul do
+    # `list-unstyled` drops the bullet + left padding. Each row is a
+    # flex container so the id badge (button) sits inline with the
+    # project-title link.
+    ul(class: "list-unstyled mt-2") do
       projects.each do |project|
-        li do
+        li(class: "d-flex align-items-center mb-1") do
+          show_title_id_badge(project, "rss-id mr-3")
           a(href: project_path(project)) { plain(project.title) }
         end
       end

--- a/app/views/controllers/field_slips/edit.html.erb
+++ b/app/views/controllers/field_slips/edit.html.erb
@@ -17,7 +17,7 @@
                auto_open: true,
                user: @user
              )) do |m|
-        m.with_body do
+        m.with_form_content do
           render(Components::OccurrenceResolveForm.new(
                    gaps: @field_slip_project_gaps,
                    primary: @field_slip_occurrence.primary_observation,

--- a/app/views/controllers/field_slips/new.html.erb
+++ b/app/views/controllers/field_slips/new.html.erb
@@ -18,7 +18,7 @@
                auto_open: true,
                user: @user
              )) do |m|
-        m.with_body do
+        m.with_form_content do
           render(Components::OccurrenceResolveForm.new(
                    gaps: @field_slip_project_gaps,
                    primary: @field_slip_occurrence.primary_observation,

--- a/app/views/controllers/occurrences/edit.rb
+++ b/app/views/controllers/occurrences/edit.rb
@@ -42,7 +42,7 @@ module Views
                    auto_open: true,
                    user: @user
                  )) do |m|
-            m.with_body do
+            m.with_form_content do
               render(Components::OccurrenceResolveForm.new(
                        gaps: @project_gaps,
                        primary: @occurrence.primary_observation,

--- a/app/views/controllers/occurrences/new.rb
+++ b/app/views/controllers/occurrences/new.rb
@@ -40,7 +40,7 @@ module Views
                    auto_open: true,
                    user: @user
                  )) do |m|
-            m.with_body do
+            m.with_form_content do
               render(Components::OccurrenceResolveForm.new(**@project_confirm))
             end
           end

--- a/test/components/occurrence_resolve_form_test.rb
+++ b/test/components/occurrence_resolve_form_test.rb
@@ -185,7 +185,15 @@ class OccurrenceResolveFormTest < ComponentTestCase
 
     assert_html(html, "form > .modal-body > p",
                 text: :occurrence_resolve_projects_intro.l)
-    assert_html(html, "form > .modal-body > ul > li > a",
+    # Project list uses `ul.list-unstyled` (no bullets, no left
+    # padding). Each row is a flex container with a clickable id-badge
+    # button (Stimulus clipboard target) followed by the project link.
+    assert_html(html, "form > .modal-body > ul.list-unstyled > li.d-flex")
+    assert_html(html,
+                ".modal-body > ul > li > button.badge.badge-id" \
+                "[data-controller='clipboard']",
+                text: @project.id.to_s)
+    assert_html(html, ".modal-body > ul > li > a",
                 text: @project.title)
     assert_html(html, "form > .modal-footer > button[type='submit']",
                 text: :occurrence_resolve_projects_add_all.l)

--- a/test/components/occurrence_resolve_form_test.rb
+++ b/test/components/occurrence_resolve_form_test.rb
@@ -173,6 +173,32 @@ class OccurrenceResolveFormTest < ComponentTestCase
                  "Edit flow should not have obs hidden fields")
   end
 
+  def test_form_wraps_modal_body_and_modal_footer
+    # Per the Modal :form_content slot pattern (#4293), the form spans
+    # both `.modal-body` (intro + project list) and `.modal-footer`
+    # (cancel + submit) — submit lives in the footer but is naturally
+    # inside the form.
+    gaps = { projects: [@project] }
+    html = render_resolve_form(
+      gaps: gaps, primary: @obs1, selected: [@obs1, @obs2]
+    )
+
+    assert_html(html, "form > .modal-body > p",
+                text: :occurrence_resolve_projects_intro.l)
+    assert_html(html, "form > .modal-body > ul > li > a",
+                text: @project.title)
+    assert_html(html, "form > .modal-footer > button[type='submit']",
+                text: :occurrence_resolve_projects_add_all.l)
+    assert_html(html, "form > .modal-footer > a[data-dismiss='modal']",
+                text: :occurrence_resolve_projects_cancel.l)
+  end
+
+  def test_owns_modal_sections_class_method_returns_true
+    # ModalTurboForm and similar wrappers auto-detect this to choose
+    # Modal's :form_content slot. Locks the contract in.
+    assert(Components::OccurrenceResolveForm.owns_modal_sections?)
+  end
+
   def test_multiple_projects_listed
     proj2 = projects(:bolete_project)
     gaps = { projects: [@project, proj2] }


### PR DESCRIPTION
## Summary

Uses Modal's `:form_content` slot (added in #4293) so the form tag wraps both `.modal-body` (intro + project list + hidden fields) and `.modal-footer` (Cancel + Add All) — submit lives in the footer but is naturally inside the form.

## Before this change

Post-#4279 the form was rendered inside Modal's `.modal-body` slot and emitted its buttons in `.text-right.mt-3`, with **no `.modal-footer` at all**. That dropped BS3's footer chrome (top border, right alignment, button spacing) compared to the pre-Phlex `OccurrenceResolveModal` HTML.

## Changes

- `OccurrenceResolveForm.view_template` now renders its own `<div class="modal-body">` and `<div class="modal-footer">` inside Superform's form yield. Intro + project list move into `.modal-body`, Cancel + Add All move into `.modal-footer`. Hidden fields stay at the top of the form (next to Superform's CSRF + `_method` inputs).
- Declares `self.owns_modal_sections?` returning `true`. `ModalTurboForm` and other wrappers can auto-detect this to choose `:form_content`.
- All 4 callers updated from `m.with_body { render(form) }` to `m.with_form_content { render(form) }`:
  - `app/views/controllers/occurrences/new.rb`
  - `app/views/controllers/occurrences/edit.rb`
  - `app/views/controllers/field_slips/new.html.erb`
  - `app/views/controllers/field_slips/edit.html.erb`

## Tests

- New assertions on the `form > .modal-body` / `form > .modal-footer` structure
- Lock-in test for `owns_modal_sections?`
- Existing test assertions unchanged — the form's external surface (action, hidden fields, button names) is preserved exactly

## Test plan

- [x] `bin/rails test test/components/occurrence_resolve_form_test.rb` — 8/8 pass
- [x] `bin/rails test test/controllers/occurrences_controller_test.rb` — pass
- [x] `bin/rails test test/controllers/field_slips_controller_test.rb` — pass
- [x] `bundle exec rubocop` clean
- [x] CI green
- [x] Manual: create an occurrence that triggers project gaps, verify modal shows footer chrome with Cancel + Add All inside the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)