### PR TITLE
Stabilize Checklist::Contents coverage (seed-dependent line 72)

### DIFF
--- a/test/components/checklist/contents_test.rb
+++ b/test/components/checklist/contents_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Component tests for Components::Checklist::Contents.
+#
+# Exercises the three branches of `observed_summary_text` directly so
+# coverage is independent of whatever data the controller tests happen
+# to render. Before this file existed, coverage of the higher-only
+# branch (`elsif higher.positive?`) depended on whichever observation
+# `Observation.joins(:name).find_by(name: { deprecated: true })` in
+# `test_checklist_marks_deprecated` happened to return — an unordered
+# `find_by` whose result varied with test seed / parallel-worker
+# state. See #4XXX for the diagnosis.
+class Components::Checklist::ContentsTest < ComponentTestCase
+  # Both species and higher-level observed → :checklist_observed_summary
+  # branch (lines 67-68 in contents.rb).
+  def test_summary_both_species_and_higher_observed
+    html = render_contents(num_species: 2, num_higher: 3)
+
+    assert_html(html, "#checklist_contents")
+    # The combined-summary string interpolates "[species] species and
+    # [higher] higher-level [taxa_word] observed". Match the shape
+    # without coupling to exact wording or punctuation.
+    assert_match(/2 species and 3 higher-level taxa observed/, html)
+  end
+
+  # higher == 1 → :checklist_taxon (singular). Locks in the
+  # singular/plural switch on line 65 of contents.rb.
+  def test_summary_uses_singular_taxon_when_higher_is_one
+    html = render_contents(num_species: 1, num_higher: 1)
+
+    assert_match(/1 species and 1 higher-level taxon observed/, html)
+  end
+
+  # species > 0, higher == 0 → :checklist_observed_species_only branch
+  # (line 70 in contents.rb).
+  def test_summary_species_only
+    html = render_contents(num_species: 3, num_higher: 0)
+
+    assert_match(/3 species observed/, html)
+    assert_no_match(/higher-level/, html)
+  end
+
+  # species == 0, higher > 0 → :checklist_observed_higher_only branch
+  # (line 72 in contents.rb). The whole reason this file exists.
+  def test_summary_higher_only
+    html = render_contents(num_species: 0, num_higher: 2)
+
+    assert_match(/2 higher-level taxa observed/, html)
+    # No "N species observed" copy — the species-only branch must not
+    # fire when num_species is zero.
+    assert_no_match(/\d+ species observed/, html)
+  end
+
+  # Both counts zero → observed_summary_text returns nil and the
+  # inner summary div is suppressed.
+  def test_summary_omitted_when_no_observations
+    html = render_contents(num_species: 0, num_higher: 0)
+
+    assert_html(html, "#checklist_contents")
+    assert_no_match(/observed \(synonyms counted once\)/, html)
+  end
+
+  # Stub responding to every method `Components::Checklist::Contents`
+  # touches when rendering the summary + footnotes. `for_project?` in
+  # the component does `@data.is_a?(::Checklist::ForProject)`, so this
+  # stub (which isn't a ForProject) skips the target-summary and
+  # unobserved-targets panel. We deliberately leave taxa arrays empty
+  # so `render_panel_section` skips both observed panels — this test
+  # is about the summary line, not panel rendering.
+  ChecklistDataStub = Struct.new(
+    :num_species_observed, :num_higher_level_observed,
+    :species_level_observed_taxa, :higher_level_observed_taxa,
+    :unobserved_target_taxa, :duplicate_synonyms,
+    :any_deprecated_flag,
+    keyword_init: true
+  ) do
+    def any_deprecated?
+      any_deprecated_flag
+    end
+  end
+  private_constant :ChecklistDataStub
+
+  private
+
+  def stub_data(num_species:, num_higher:)
+    ChecklistDataStub.new(
+      num_species_observed: num_species,
+      num_higher_level_observed: num_higher,
+      species_level_observed_taxa: [],
+      higher_level_observed_taxa: [],
+      unobserved_target_taxa: [],
+      duplicate_synonyms: [],
+      any_deprecated_flag: false
+    )
+  end
+
+  def stub_context
+    Components::Checklist::Context.new(
+      user: users(:rolf), project: nil, show_user: nil,
+      location: nil, species_list: nil
+    )
+  end
+
+  def render_contents(num_species:, num_higher:)
+    render(Components::Checklist::Contents.new(
+             data: stub_data(num_species: num_species,
+                             num_higher: num_higher),
+             context: stub_context
+           ))
+  end
+end

--- a/test/components/checklist/contents_test.rb
+++ b/test/components/checklist/contents_test.rb
@@ -11,46 +11,51 @@ require("test_helper")
 # `Observation.joins(:name).find_by(name: { deprecated: true })` in
 # `test_checklist_marks_deprecated` happened to return — an unordered
 # `find_by` whose result varied with test seed / parallel-worker
-# state. See #4XXX for the diagnosis.
+# state. See PR #4301 for the diagnosis.
 class Components::Checklist::ContentsTest < ComponentTestCase
+  SUMMARY_SELECTOR = "#checklist_contents .my-4 > div"
+
   # Both species and higher-level observed → :checklist_observed_summary
   # branch (lines 67-68 in contents.rb).
   def test_summary_both_species_and_higher_observed
     html = render_contents(num_species: 2, num_higher: 3)
+    expected = :checklist_observed_summary.l(
+      species: 2, higher: 3, taxa_word: :checklist_taxa.l
+    )
 
     assert_html(html, "#checklist_contents")
-    # The combined-summary string interpolates "[species] species and
-    # [higher] higher-level [taxa_word] observed". Match the shape
-    # without coupling to exact wording or punctuation.
-    assert_match(/2 species and 3 higher-level taxa observed/, html)
+    assert_html(html, SUMMARY_SELECTOR, text: expected)
   end
 
   # higher == 1 → :checklist_taxon (singular). Locks in the
   # singular/plural switch on line 65 of contents.rb.
   def test_summary_uses_singular_taxon_when_higher_is_one
     html = render_contents(num_species: 1, num_higher: 1)
+    expected = :checklist_observed_summary.l(
+      species: 1, higher: 1, taxa_word: :checklist_taxon.l
+    )
 
-    assert_match(/1 species and 1 higher-level taxon observed/, html)
+    assert_html(html, SUMMARY_SELECTOR, text: expected)
   end
 
   # species > 0, higher == 0 → :checklist_observed_species_only branch
   # (line 70 in contents.rb).
   def test_summary_species_only
     html = render_contents(num_species: 3, num_higher: 0)
+    expected = :checklist_observed_species_only.l(species: 3)
 
-    assert_match(/3 species observed/, html)
-    assert_no_match(/higher-level/, html)
+    assert_html(html, SUMMARY_SELECTOR, text: expected)
   end
 
   # species == 0, higher > 0 → :checklist_observed_higher_only branch
   # (line 72 in contents.rb). The whole reason this file exists.
   def test_summary_higher_only
     html = render_contents(num_species: 0, num_higher: 2)
+    expected = :checklist_observed_higher_only.l(
+      higher: 2, taxa_word: :checklist_taxa.l
+    )
 
-    assert_match(/2 higher-level taxa observed/, html)
-    # No "N species observed" copy — the species-only branch must not
-    # fire when num_species is zero.
-    assert_no_match(/\d+ species observed/, html)
+    assert_html(html, SUMMARY_SELECTOR, text: expected)
   end
 
   # Both counts zero → observed_summary_text returns nil and the
@@ -59,7 +64,9 @@ class Components::Checklist::ContentsTest < ComponentTestCase
     html = render_contents(num_species: 0, num_higher: 0)
 
     assert_html(html, "#checklist_contents")
-    assert_no_match(/observed \(synonyms counted once\)/, html)
+    # `for_project?` is false for our stub, so render_target_summary is
+    # also skipped — `.my-4` has no inner divs at all.
+    assert_html(html, SUMMARY_SELECTOR, count: 0)
   end
 
   # Stub responding to every method `Components::Checklist::Contents`

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -19,7 +19,14 @@ class ChecklistsControllerTest < FunctionalTestCase
 
   def test_checklist_marks_deprecated
     login
-    observation = Observation.joins(:name).find_by(name: { deprecated: true })
+    # Order by id so the picked observation is the same under every test
+    # seed / parallel-worker assignment. Previously an unordered `find_by`
+    # returned different rows depending on MySQL's implementation-defined
+    # ordering, which silently varied which user's checklist was
+    # rendered and which branches of Components::Checklist::Contents got
+    # covered.
+    observation = Observation.joins(:name).where(name: { deprecated: true }).
+                  order(:id).first
     user = observation.user
     get(:show, params: { user_id: user.id })
     assert_select(".checklist a", text: /\) \*\z/)


### PR DESCRIPTION
## Summary

Coverage of `app/components/checklist/contents.rb:72` — the `elsif higher.positive?` branch of `observed_summary_text` — was seed-dependent: missed under `--seed 61015`, hit under `--seed 1580`. Diagnosis confirmed with stderr instrumentation across both seeds.

## Root cause

`test_checklist_marks_deprecated` in `test/controllers/checklists_controller_test.rb` did:

```ruby
observation = Observation.joins(:name).find_by(name: { deprecated: true })
user = observation.user
get(:show, params: { user_id: user.id })
```

With no `ORDER BY`, MySQL returns rows in implementation-defined order. Under different seeds / parallel-worker assignments, `find_by` returned different deprecated observations:

| Seed | obs returned | user | branch hit | line 72? |
|---|---|---|---|---|
| 61015 | 457573027 (`Baaaa...`) | dick | species + higher (L67-68) | no |
| 1580 | 98434105 (Petigera) | vouchered_only_user | higher only (L72) | yes |

The test's only assertion (`.checklist a` text matches `) *\z`) passed either way, so the variance was silent — it only showed up in coverage reports. No dedicated component test existed for `Components::Checklist::Contents`, so all coverage of its branches came through this single render.

## Fix

Two small changes:

- **New** `test/components/checklist/contents_test.rb` — five tests exercising every branch of `observed_summary_text` with a stub data object (both-positive, species-only, higher-only, singular-`taxon`, and both-zero). Coverage of lines 67-68, 70, and 72 is now seed-independent.
- `test_checklist_marks_deprecated` orders the `find_by` by id so it deterministically returns the same row across seeds and workers. Ends the silent variance.

## Test plan

- [x] `bin/rails test test/components/checklist/contents_test.rb` — 5 tests, 21 assertions, 0 failures.
- [x] `bin/rails test test/controllers/checklists_controller_test.rb test/models/checklist_test.rb test/components/checklist/` — 37 tests, 222 assertions, 0 failures.
- [x] `bundle exec rubocop` clean on both changed files.
- [x] Full-suite runs under both `--seed 61015` and `--seed 1580` (verified by user) now consistently cover line 72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)