### PR TITLE
Fix map_controller race: openMap can fire before google.maps loads

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -108,7 +108,12 @@ export default class extends GeocodeController {
       this.mapBounds = this.boundsOf(this.collection.extents)
     }
 
-    loader
+    // Store the loader promise so `openMap()` can await it before
+    // calling `drawMap()`. Without this gate, clicking the "Open Map"
+    // button before the Google Maps API finishes loading throws an
+    // uncaught `google is not defined` from `new google.maps.Map(...)`
+    // and leaves the controller permanently broken (no retry).
+    this.googleMapsReady = loader
       .load()
       .then((google) => {
         if (this.needElevationsValue == true)
@@ -130,6 +135,7 @@ export default class extends GeocodeController {
             }
           })
         }
+        return google
       })
       .catch((e) => {
         console.error("error loading gmaps: " + e)
@@ -1309,17 +1315,29 @@ export default class extends GeocodeController {
     this.opened = true
     this.controlWrapTarget.classList.add("map-open")
 
+    // Defer `drawMap()` until the google.maps API is loaded. The
+    // button can be clicked the instant the controller connects,
+    // which is well before the Google Maps loader resolves; calling
+    // `new google.maps.Map(...)` before the API loads threw a silent
+    // `google is not defined` and left `this.map` permanently
+    // undefined. Awaiting the stored loader promise makes the open
+    // robust regardless of the page-load / click timing.
     if (this.map == undefined) {
-      this.drawMap()
-      this.makeMapClickable()
-    } else if (this.mapBounds) {
-      this.map.fitBounds(this.mapBounds)
+      this.googleMapsReady.then(() => {
+        this.drawMap()
+        this.makeMapClickable()
+        setTimeout(() => {
+          this.checkForMarker()
+          this.checkForBox() // regardless if point
+        }, 500) // wait for map to open
+      })
+    } else {
+      if (this.mapBounds) this.map.fitBounds(this.mapBounds)
+      setTimeout(() => {
+        this.checkForMarker()
+        this.checkForBox()
+      }, 500)
     }
-
-    setTimeout(() => {
-      this.checkForMarker()
-      this.checkForBox() // regardless if point
-    }, 500) // wait for map to open
   }
 
   makeMapClickable() {

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -757,7 +757,8 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
           })()
         JS
         break if ready
-        sleep 0.1
+
+        sleep(0.1)
       end
     end
 

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -740,16 +740,35 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # This attribute controls whether makeMapClickable() is called
     assert_selector("#observation_form_map[data-editable='true']")
 
+    # Wait for the map controller to actually finish drawing. The
+    # `data-map='connected'` attribute is set in `connect()` BEFORE
+    # the google.maps loader resolves, so it doesn't gate `this.map`.
+    # Wait for `controller.map` to be defined (drawMap to have run)
+    # so the click trigger has a real map to fire on.
+    Timeout.timeout(10) do
+      loop do
+        ready = evaluate_script(<<~JS)
+          (() => {
+            const f = document.getElementById('observation_form');
+            const c = window.Stimulus.getControllerForElementAndIdentifier(
+              f, 'map'
+            );
+            return !!(c && c.map);
+          })()
+        JS
+        break if ready
+        sleep 0.1
+      end
+    end
+
     # Trigger a Google Maps click event
     execute_script(<<~JS)
       const form = document.getElementById('observation_form');
       const controller = window.Stimulus.getControllerForElementAndIdentifier(
         form, 'map'
       );
-      if (controller && controller.map) {
-        const location = new google.maps.LatLng(45.5231, -122.6765);
-        google.maps.event.trigger(controller.map, 'click', { latLng: location });
-      }
+      const location = new google.maps.LatLng(45.5231, -122.6765);
+      google.maps.event.trigger(controller.map, 'click', { latLng: location });
     JS
 
     # Verify lat/lng fields are now populated


### PR DESCRIPTION
## Summary

`ObservationFormSystemTest#test_map_click_fills_lat_lng_fields` was failing on main. Root cause: a race between the "Open Map" button click and the `@googlemaps/js-api-loader` promise.

## What was happening

`map_controller#openMap` calls `drawMap()`, which does:

```js
this.map = new google.maps.Map(this.mapDivTarget, this.mapOptions)
```

The `google.maps` API is loaded asynchronously by the loader in `connect()` (`loader.load().then(...)`). Until that promise resolves, `google.maps` is undefined.

The "Open Map" button is enabled the moment the controller connects — there's no gating. If the user (or the test) clicks before the loader resolves, `drawMap()` throws `google is not defined` inside the Stimulus action handler, the error is swallowed by the event loop, and the controller is left permanently broken: `this.map` stays `undefined` and no retry happens when the loader eventually resolves.

The failing test reproduces this reliably because it clicks the button immediately after the page loads. Real users would hit the same bug if they click fast on a slow connection.

## Fix

- Store the loader's promise as `this.googleMapsReady` in `connect()` so callers can await it.
- In `openMap()`, gate `drawMap()` + `makeMapClickable()` on `this.googleMapsReady.then(...)`. The map is now drawn only after the API has loaded, regardless of how fast the button is clicked.

## Test side

The failing test was waiting on `[data-map='connected']` before triggering the synthetic map-click. That attribute is set in `connect()` BEFORE the loader resolves, so it doesn't gate `this.map`. Replaced with a polling wait on `controller.map` being defined — the actual "map has finished drawing" signal.

## Test plan

- [x] `bin/rails test test/system/observation_form_system_test.rb` — 9/9 pass (was 8/9 on main: this test was the failing one)
- [ ] CI green
- [ ] Manual: open a new observation page, immediately click "Open Map" — map should render every time, no broken state

🤖 Generated with [Claude Code](https://claude.com/claude-code)