### PR TITLE
hidden_field: route both paths through HiddenField

### DIFF
--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -217,18 +217,19 @@ class Components::ApplicationForm < Superform::Rails::Form
       # `hidden_field_tag` (browsers otherwise repopulate hidden fields
       # on back-button). Caller can override with `autocomplete:`.
       options = { autocomplete: "off" }.merge(options)
-      if field_name.is_a?(String)
-        proxy = FieldProxy.new(nil, field_name, options[:value])
-        render(HiddenField.new(proxy, **options))
-      else
-        # Symbol path goes through Superform's field machinery so the
-        # value auto-reads from the model / FormObject when no explicit
-        # `value:` is passed (e.g. `hidden_field(:project_id)` reading
-        # `form.model.project_id`). `TextField`'s view_template
-        # special-cases `type: "hidden"` to skip the `form-control`
-        # class and the form-group wrapper.
-        render(field(field_name).text(**options, type: "hidden"))
-      end
+      # Both paths render through `HiddenField` — the dedicated
+      # hidden-input component. `HiddenField` only needs `.dom.id`,
+      # `.dom.name`, `.value` on its `field` argument; Superform's
+      # `Field` and our `FieldProxy` both provide them. So the
+      # Symbol path can pass the Superform field directly — no
+      # FieldProxy rebuild, value auto-reads from model / FormObject
+      # via the field's own `.value`.
+      f = if field_name.is_a?(String)
+            FieldProxy.new(nil, field_name, options[:value])
+          else
+            field(field_name)
+          end
+      render(HiddenField.new(f, **options))
     end
 
     # Number field with label and Bootstrap form-group wrapper

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -221,6 +221,12 @@ class Components::ApplicationForm < Superform::Rails::Form
         proxy = FieldProxy.new(nil, field_name, options[:value])
         render(HiddenField.new(proxy, **options))
       else
+        # Symbol path goes through Superform's field machinery so the
+        # value auto-reads from the model / FormObject when no explicit
+        # `value:` is passed (e.g. `hidden_field(:project_id)` reading
+        # `form.model.project_id`). `TextField`'s view_template
+        # special-cases `type: "hidden"` to skip the `form-control`
+        # class and the form-group wrapper.
         render(field(field_name).text(**options, type: "hidden"))
       end
     end

--- a/app/components/application_form/text_field.rb
+++ b/app/components/application_form/text_field.rb
@@ -23,29 +23,19 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def view_template
-      # Hidden inputs don't render visibly and don't get styled, so
-      # they skip the `form-control` class — emitting it produced
-      # weird markup (`<input type="hidden" class="form-control">`)
-      # and made symbol-keyed `hidden_field(:foo)` inconsistent with
-      # string-keyed `hidden_field("foo")` (which routes through
-      # `HiddenField`, no class).
-      if attributes[:type] == "hidden"
-        input(**attributes)
-      elsif wrapper_options[:label] == false
-        # `label: false` skips the form-group wrapper but the visible
-        # input still wants Bootstrap styling.
-        render_styled_input
+      # Hidden fields and label:false don't get wrappers
+      if attributes[:type] == "hidden" || wrapper_options[:label] == false
+        input(**attributes, class: class_names(attributes[:class],
+                                               "form-control"))
       else
-        render_with_wrapper { render_styled_input }
+        render_with_wrapper do
+          input(**attributes, class: class_names(attributes[:class],
+                                                 "form-control"))
+        end
       end
     end
 
     private
-
-    def render_styled_input
-      input(**attributes, class: class_names(attributes[:class],
-                                             "form-control"))
-    end
 
     def render_with_wrapper(&field_input)
       div(class: wrapper_class, data: wrapper_options[:wrap_data]) do

--- a/app/components/application_form/text_field.rb
+++ b/app/components/application_form/text_field.rb
@@ -23,19 +23,29 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def view_template
-      # Hidden fields and label:false don't get wrappers
-      if attributes[:type] == "hidden" || wrapper_options[:label] == false
-        input(**attributes, class: class_names(attributes[:class],
-                                               "form-control"))
+      # Hidden inputs don't render visibly and don't get styled, so
+      # they skip the `form-control` class — emitting it produced
+      # weird markup (`<input type="hidden" class="form-control">`)
+      # and made symbol-keyed `hidden_field(:foo)` inconsistent with
+      # string-keyed `hidden_field("foo")` (which routes through
+      # `HiddenField`, no class).
+      if attributes[:type] == "hidden"
+        input(**attributes)
+      elsif wrapper_options[:label] == false
+        # `label: false` skips the form-group wrapper but the visible
+        # input still wants Bootstrap styling.
+        render_styled_input
       else
-        render_with_wrapper do
-          input(**attributes, class: class_names(attributes[:class],
-                                                 "form-control"))
-        end
+        render_with_wrapper { render_styled_input }
       end
     end
 
     private
+
+    def render_styled_input
+      input(**attributes, class: class_names(attributes[:class],
+                                             "form-control"))
+    end
 
     def render_with_wrapper(&field_input)
       div(class: wrapper_class, data: wrapper_options[:wrap_data]) do

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -302,6 +302,82 @@ class ApplicationFormTest < ComponentTestCase
     assert_not_includes(form, "form-group")
   end
 
+  # Regression: hidden inputs used to emit `class="form-control"` —
+  # harmless visually (hidden inputs don't render) but wrong markup,
+  # and made the Symbol path (which routes through
+  # `field(:x).text(type: "hidden")` → TextField) inconsistent with
+  # the String path (which routes through HiddenField, no class).
+  # `TextField#view_template` now special-cases `type: "hidden"` to
+  # skip the class — fixes both the Symbol-keyed `hidden_field` call
+  # and any direct caller of `field(:x).text(type: "hidden")`.
+  def test_hidden_field_symbol_key_does_not_emit_form_control
+    form = render_form do
+      hidden_field(:secret, value: "x")
+    end
+    doc = Nokogiri::HTML(form)
+    input = doc.at_css("input[type='hidden'][name*='secret']")
+    assert(input, "Hidden input must render")
+    assert_not_includes(input["class"] || "", "form-control",
+                        "Symbol-keyed hidden_field must not emit form-control")
+  end
+
+  def test_hidden_field_string_key_does_not_emit_form_control
+    form = render_form do
+      hidden_field("approved_where", value: "x")
+    end
+    doc = Nokogiri::HTML(form)
+    input = doc.at_css("input[type='hidden'][name='approved_where']")
+    assert(input, "Hidden input must render")
+    assert_not_includes(input["class"] || "", "form-control",
+                        "String-keyed hidden_field must not emit form-control")
+  end
+
+  # Symbol-keyed `hidden_field` keeps Superform's namespaced name
+  # (e.g. `<model_name>[<field>]`) — the whole point of going through
+  # `field(...)` rather than the raw String path. Locks that in.
+  def test_hidden_field_symbol_key_uses_superform_namespace
+    form = render_form do
+      hidden_field(:secret, value: "x")
+    end
+    # The render_form helper builds an anonymous form whose model
+    # defaults to a Collection Number; the form's namespace is
+    # "collection_number". The hidden field should be namespaced
+    # under it.
+    assert_match(/name="collection_number\[secret\]"/, form,
+                 "Symbol-keyed hidden_field must namespace under the model")
+  end
+
+  # Most callers in the codebase rely on the Symbol path auto-reading
+  # the value from the form's model/FormObject (e.g.
+  # `description_form.rb hidden_field(:project_id)` reads
+  # `form.model.project_id`). Going through `field(:x).text(...)`
+  # preserves that.
+  def test_hidden_field_symbol_key_auto_reads_value_from_model
+    # `@collection_number.name` == "Rolf Singer" per the fixture.
+    form = render_form do
+      hidden_field(:name) # no explicit value:
+    end
+    doc = Nokogiri::HTML(form)
+    input = doc.at_css("input[type='hidden'][name='collection_number[name]']")
+    assert(input, "Hidden input must render")
+    assert_equal("Rolf Singer", input["value"],
+                 "Symbol-keyed hidden_field with no value: must auto-read " \
+                 "from the form's model/FormObject")
+  end
+
+  # Caller's explicit `value:` always wins, even when the model has
+  # a value for the attribute. (HiddenField's `@attributes.fetch(:value)`
+  # uses the override before falling back to `@field.value`.)
+  def test_hidden_field_symbol_key_explicit_value_overrides_model
+    form = render_form do
+      hidden_field(:name, value: "OVERRIDE")
+    end
+    doc = Nokogiri::HTML(form)
+    input = doc.at_css("input[type='hidden'][name='collection_number[name]']")
+    assert_equal("OVERRIDE", input["value"],
+                 "Explicit value: must override the model's value")
+  end
+
   # Number field tests
   def test_number_field_renders_with_basic_options
     form = render_form do

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -304,12 +304,11 @@ class ApplicationFormTest < ComponentTestCase
 
   # Regression: hidden inputs used to emit `class="form-control"` —
   # harmless visually (hidden inputs don't render) but wrong markup,
-  # and made the Symbol path (which routes through
-  # `field(:x).text(type: "hidden")` → TextField) inconsistent with
-  # the String path (which routes through HiddenField, no class).
-  # `TextField#view_template` now special-cases `type: "hidden"` to
-  # skip the class — fixes both the Symbol-keyed `hidden_field` call
-  # and any direct caller of `field(:x).text(type: "hidden")`.
+  # and inconsistent between Symbol and String paths (Symbol detoured
+  # through TextField; String through HiddenField). Both paths now
+  # route through `HiddenField`, the dedicated hidden-input component.
+  # The Symbol path passes Superform's `field(:x)` directly — same
+  # `.dom.id`/`.dom.name`/`.value` interface as `FieldProxy`.
   def test_hidden_field_symbol_key_does_not_emit_form_control
     form = render_form do
       hidden_field(:secret, value: "x")
@@ -350,8 +349,9 @@ class ApplicationFormTest < ComponentTestCase
   # Most callers in the codebase rely on the Symbol path auto-reading
   # the value from the form's model/FormObject (e.g.
   # `description_form.rb hidden_field(:project_id)` reads
-  # `form.model.project_id`). Going through `field(:x).text(...)`
-  # preserves that.
+  # `form.model.project_id`). Passing Superform's `field(:x)` directly
+  # to HiddenField preserves that — `HiddenField` reads `.value` off
+  # the field, and Superform's field knows the model's value.
   def test_hidden_field_symbol_key_auto_reads_value_from_model
     # `@collection_number.name` == "Rolf Singer" per the fixture.
     form = render_form do


### PR DESCRIPTION
## Summary

`hidden_field` had an architectural inconsistency: Symbol-keyed calls (`hidden_field(:foo)`) routed through `TextField` (via `field(:foo).text(type: "hidden")`), while String-keyed calls (`hidden_field("foo")`) routed through the dedicated `HiddenField` component. Same conceptual element, two different rendering paths — and the Symbol path emitted a stray `class="form-control"` on the hidden input as a side-effect of going through `TextField`.

## Fix

Route **both** paths through `HiddenField`. The Symbol path now passes Superform's `field(field_name)` directly to `HiddenField` — no FieldProxy rebuild, no detour through `TextField`.

```ruby
def hidden_field(field_name, **options)
  options = { autocomplete: "off" }.merge(options)
  f = if field_name.is_a?(String)
        FieldProxy.new(nil, field_name, options[:value])
      else
        field(field_name)
      end
  render(HiddenField.new(f, **options))
end
```

This works because `HiddenField` is duck-typed — it only needs `.dom.id`, `.dom.name`, and `.value` on its `field` argument. Superform's `Field` provides all three, same interface as our `FieldProxy`. Value still auto-reads from the form's model / FormObject because Superform's field knows the model's value (so `description_form.rb` `hidden_field(:project_id)` still reads `form.model.project_id`, etc.). Caller's explicit `value:` still wins via `HiddenField`'s `@attributes.fetch(:value) { @field.value }` fallback.

## Why now

Caught in HTML-parity diff of #4310 (SpeciesListForm Phlex conversion) — `hidden_field(:approved_where)` was emitting `class="form-control"` on the hidden input. Fixing the architecture (rather than just the output) means every Symbol-keyed caller in the codebase (`description_form`, `project_alias_form`, `inat_import_confirm_form`, `species_list_form`, …) now produces clean markup AND routes through the component that semantically owns hidden inputs.

## Tests

5 regression tests in `test/components/application_form_test.rb`:

- Symbol-keyed `hidden_field(:foo, value:)` doesn't emit form-control.
- String-keyed `hidden_field("foo", value:)` doesn't emit form-control (locks in existing behavior).
- Symbol-keyed `hidden_field(:foo, value:)` keeps Superform's `<model>[foo]` namespace.
- Symbol-keyed `hidden_field(:name)` (no `value:`) auto-reads from the model — covers the most-common usage in the codebase.
- Explicit `value:` overrides the model's value.

## Test plan

- [x] `bin/rails test test/components/` — 988 tests, 0 failures
- [x] `bundle exec rubocop` clean on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)