### PR TITLE
Fix map cluster Show All returning nothing for shared-location observations

### DIFF
--- a/app/classes/mappable/map_set.rb
+++ b/app/classes/mappable/map_set.rb
@@ -39,6 +39,12 @@ module Mappable
     MIXED_COLOR     = "#C69B71" # observations in different consensus bands
     LOCATION_ONLY_COLOR = "#3B79CC" # bootstrap primary; no obs to classify
 
+    # Decimal places kept when emitting marker coordinates to the JS map.
+    # At 6 places the worst-case rounding error is ~5.5 cm, well below GPS
+    # accuracy, so the cluster popup's Show All / Map All box no longer
+    # rounds an obs's own coordinate outside the box it builds (#4318).
+    COORD_PRECISION = 6
+
     attr_reader :north, :south, :east, :west, :is_point, :is_box,
                 :north_east, :south_east, :south_west, :north_west, :lat, :lng,
                 :north_south_distance, :east_west_distance, :center, :edges
@@ -161,8 +167,8 @@ module Mappable
     end
 
     def update_extents_with_point(loc)
-      lat = loc.lat.to_f.round(4)
-      lng = loc.lng.to_f.round(4)
+      lat = loc.lat.to_f.round(COORD_PRECISION)
+      lng = loc.lng.to_f.round(COORD_PRECISION)
       if @north
         @north = lat if lat > @north
         @south = lat if lat < @south
@@ -191,10 +197,10 @@ module Mappable
     end
 
     def update_extents_with_box(loc)
-      n = loc.north.to_f.round(4)
-      s = loc.south.to_f.round(4)
-      e = loc.east.to_f.round(4)
-      w = loc.west.to_f.round(4)
+      n = loc.north.to_f.round(COORD_PRECISION)
+      s = loc.south.to_f.round(COORD_PRECISION)
+      e = loc.east.to_f.round(COORD_PRECISION)
+      w = loc.west.to_f.round(COORD_PRECISION)
       if @north
         @north = n if n > @north
         @south = s if s < @south
@@ -250,11 +256,11 @@ module Mappable
       if @north && @south
         @is_point = @north ? (@north - @south) < MO.box_epsilon : false
         @is_box = @north ? (@north - @south) >= MO.box_epsilon : false
-        @lat = ((@north + @south) / 2.0).round(4)
+        @lat = ((@north + @south) / 2.0).round(COORD_PRECISION)
         @north_south_distance = @north ? @north - @south : nil
       end
       if @east && @west
-        @lng = ((@east + @west) / 2.0).round(4)
+        @lng = ((@east + @west) / 2.0).round(COORD_PRECISION)
         @lng += 180 if @west > @east
         @east_west_distance = if @west > @east
                                 @east - @west + 360

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -412,14 +412,31 @@ export default class extends GeocodeController {
         if (key.startsWith("q[names]")) params.delete(key)
       }
     }
-    params.append("q[in_box][north]", String(box.n))
-    params.append("q[in_box][south]", String(box.s))
-    params.append("q[in_box][east]", String(box.e))
-    params.append("q[in_box][west]", String(box.w))
+    // Buffer the box edges before building the in_box query. A cluster
+    // whose members share one point (a point-geometry location, or GPS
+    // obs at a single spot) yields a zero-area box; without a buffer the
+    // server's in_box compares an obs's full-precision coordinate against
+    // a box edge sitting exactly on its emitted (rounded) value and can
+    // exclude it, so Show All / Map All return nothing (#4318).
+    //
+    // PAD expands a point cluster's query box to roughly an 8 ft square
+    // (~53 sq ft) — about as tight as GPS data supports, and a 20x margin
+    // over the 6-decimal emission rounding error — instead of the
+    // ~12 acres a 0.001 deg buffer would cover. Keeping it small limits
+    // Show All to the obs that actually shared the spot.
+    const PAD = 0.00001
+    params.append("q[in_box][north]", String(this.clamp(box.n + PAD, -90, 90)))
+    params.append("q[in_box][south]", String(this.clamp(box.s - PAD, -90, 90)))
+    params.append("q[in_box][east]", String(this.clamp(box.e + PAD, -180, 180)))
+    params.append("q[in_box][west]", String(this.clamp(box.w - PAD, -180, 180)))
     if (opts.name) {
       params.append("q[names][lookup][]", opts.name)
     }
     return `${path}?${params.toString()}`
+  }
+
+  clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value))
   }
 
   groupClusterMarkersBySpecies(markers) {

--- a/test/classes/map_set_test.rb
+++ b/test/classes/map_set_test.rb
@@ -167,6 +167,38 @@ class MapSetTest < UnitTestCase
   end
 
   # ------------------------------------------------------------------
+  # Coordinate precision emitted to the JS map — issue #4318
+  #
+  # Marker coordinates feed the cluster popup's Show All / Map All
+  # in_box query. Rounding them to only 4 places (~5.5 m) forced a
+  # large query buffer; 6 places (~5.5 cm) lets the buffer shrink
+  # while still re-including each obs's own coordinate.
+  # ------------------------------------------------------------------
+
+  def test_point_coordinates_keep_six_decimal_places
+    set = set_of(build_obs(lat: 12.3456789, lng: -45.9876543))
+
+    assert_equal(12.345679, set.lat)
+    assert_equal(-45.987654, set.lng)
+    assert_equal(12.345679, set.north)
+    assert_equal(-45.987654, set.east)
+  end
+
+  def test_box_coordinates_keep_six_decimal_places
+    loc = Mappable::MinimalLocation.new(
+      id: 1, name: "Somewhere, Test",
+      north: 12.3456789, south: 12.3454321,
+      east: -45.9876543, west: -45.9879876
+    )
+    set = set_of(loc)
+
+    assert_equal(12.345679, set.north)
+    assert_equal(12.345432, set.south)
+    assert_equal(-45.987654, set.east)
+    assert_equal(-45.987988, set.west)
+  end
+
+  # ------------------------------------------------------------------
   # Helpers
   # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

On the new JS map UI, clicking a cluster of observations that share one location and then clicking **Show All** (or **Map All**) lands on an empty page (#4318). Two *Pseudofistulina radicata* observations at "Parker Dam State Park, PA" produce a "2" badge, but Show All returns nothing. The generated URL has `north == south` and `east == west` — a zero-area box.

## Root cause

The cluster popup builds its Show All / Map All links from the union of the member marker boxes (`computeClusterOutlineBox`). When every member sits at one point — here because location 22185 is itself a point-geometry location (its bounding box equals its center) — that union collapses to a zero-area box, which `clusterQueryUrl` passed into `q[in_box]` with no buffer. Two issues compounded:

1. `Mappable::MapSet` rounded emitted coordinates to **4 decimals**, so the stored `location_lat` `41.1972999573` became `41.1973` — nudging the box edge *past* the observation's own coordinate.
2. With a zero-area box, the server's `in_box` then required the full-precision coordinate to fall exactly on that rounded edge (`location_lat >= south` with `south == 41.1973 > 41.1972999573` → false), so it matched nothing.

The server-side popup helper (`map_popup_helper.rb`'s `mapset_box_params`) already buffers its query box to avoid exactly this; the new JS path never ported that.

## Fix

- **Emit 6-decimal coordinates** (`COORD_PRECISION`) from `Mappable::MapSet`. This is headroom, not a precision claim — it shrinks the worst-case emission rounding error so a small buffer reliably clears it.
- **Buffer the `in_box` edges by ±0.00001°** in `clusterQueryUrl`, clamped to valid lat/lng ranges. For a point cluster this expands the query box to roughly an **8 ft square (~53 ft²)** — about as tight as GPS data supports — instead of the **~12 acres** a ±0.001° buffer would cover. Covers Show All, Map All, and the per-species row links (all route through `clusterQueryUrl`).

## Verification

- `map_set` + `collapsible_map` + `map` component + `maps_controller` suites pass; added two `MapSetTest` cases asserting 6-decimal emission on the point and box paths.
- RuboCop clean on both Ruby files.
- Against the real data (project 327 / location 22185): the new buffered box returns both observations (`[402121, 402125]`); the old zero-area box returned `[]`.

## Testing note

There is no JS unit-test runner in the repo, and the only map system test stubs around Google Maps, so the JS buffering math is not covered by an automated test. The server-side behavior it relies on is verified above. Recommend a manual browser check against the issue's URL before merge.

Fixes #4318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
