### PR TITLE
Backfill name_versions.user_id from rss_log

### DIFF
--- a/db/migrate/20260522000000_backfill_name_version_user_ids.rb
+++ b/db/migrate/20260522000000_backfill_name_version_user_ids.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# All name_versions records created before the fix in PR #4257 have user_id
+# equal to the name creator's user_id (copied from the name record by
+# clone_versioned_model) because update_name_version never called ver.save.
+# This migration uses each name's rss_log -- which always recorded the correct
+# editor login -- to backfill the right user_id into each name_versions row.
+class BackfillNameVersionUserIds < ActiveRecord::Migration[7.2]
+  def up
+    user_cache = {}
+
+    Name.includes(:rss_log).find_each do |name|
+      next unless name.rss_log
+
+      # parse_log returns [tag, args, time] newest-first; reverse for
+      # chronological order so we can reason about ordering.
+      entries = name.rss_log.parse_log.reverse
+      next if entries.empty?
+
+      versions = Name::Version.where(name_id: name.id).order(:version).to_a
+      next if versions.empty?
+
+      versions.each do |version|
+        next unless version.updated_at
+
+        # Match to the log entry closest in time to the version's updated_at.
+        # Both timestamps are second-precision; they should differ by ≤ 1 s
+        # since save_version and user_log run in the same request.  We use a
+        # generous 120 s window to absorb slow servers or retries.
+        match = entries.min_by { |_, _, t| (t - version.updated_at).abs }
+        next unless match
+
+        _, args, time = match
+        next if (time - version.updated_at).abs > 120
+
+        login = args[:user].to_s
+        next if login.blank? || login == "."
+
+        user = user_cache[login] ||= User.find_by(login: login)
+        next unless user
+        next if version.user_id == user.id
+
+        version.update_columns(user_id: user.id)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260522000000_backfill_name_version_user_ids.rb
+++ b/db/migrate/20260522000000_backfill_name_version_user_ids.rb
@@ -9,15 +9,13 @@ class BackfillNameVersionUserIds < ActiveRecord::Migration[7.2]
   def up
     user_cache = {}
 
-    Name.includes(:rss_log).find_each do |name|
+    Name.includes(:rss_log, :versions).find_each do |name|
       next unless name.rss_log
 
-      # parse_log returns [tag, args, time] newest-first; reverse for
-      # chronological order so we can reason about ordering.
-      entries = name.rss_log.parse_log.reverse
+      entries = name.rss_log.parse_log
       next if entries.empty?
 
-      versions = Name::Version.where(name_id: name.id).order(:version).to_a
+      versions = name.versions.sort_by(&:version)
       next if versions.empty?
 
       versions.each do |version|
@@ -27,7 +25,14 @@ class BackfillNameVersionUserIds < ActiveRecord::Migration[7.2]
         # Both timestamps are second-precision; they should differ by ≤ 1 s
         # since save_version and user_log run in the same request.  We use a
         # generous 120 s window to absorb slow servers or retries.
-        match = entries.min_by { |_, _, t| (t - version.updated_at).abs }
+        #
+        # user_log runs after save_version, so the rss_log entry is always at
+        # or after version.updated_at. Ties are broken by preferring entries
+        # at/after the version time (diff >= 0 beats diff < 0).
+        match = entries.min_by do |_, _, t|
+          diff = t - version.updated_at
+          [diff.abs, diff.negative? ? 1 : 0]
+        end
         next unless match
 
         _, args, time = match
@@ -36,7 +41,7 @@ class BackfillNameVersionUserIds < ActiveRecord::Migration[7.2]
         login = args[:user].to_s
         next if login.blank? || login == "."
 
-        user = user_cache[login] ||= User.find_by(login: login)
+        user = user_cache.fetch(login) { user_cache[login] = User.find_by(login: login) }
         next unless user
         next if version.user_id == user.id
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_05_160002) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_22_000000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil


### PR DESCRIPTION
> [!WARNING]  
> Deploy at a low-traffic hour. The website will be down while the migration is running.
> CC estimated that would take 5 minutes  locally, longer on the server.


## Summary

Backfills NameVersions UserId's from RssLog

- All `name_versions` rows created before PR #4257 hold the name **creator's** `user_id` rather than the editor's, because `update_name_version` set `ver.user_id` in memory but never called `ver.save` (fixed in #4257)
- `clone_versioned_model` (acts_as_versioned) copies the name's `user_id` column — the creator's id — into every new version row, so without the save the DB was never corrected
- This migration uses each name's rss_log, which always recorded the correct editor login via `user_add_with_date`, to backfill the right `user_id` into each `name_versions` row
- Each version row is matched to the closest rss_log entry by timestamp (both are second-precision; created in the same request, so they differ by ≤ 1 s); a 120 s window absorbs any slow-server edge cases

## Test plan

- [x] Run `bin/rails db:migrate` locally and verify name 53423 (Puccinia circaeae) footer now shows Joe Cohen as last modifier
- [x] Check a few other recently-edited names to confirm footer user is correct
- [x] Verify the migration is idempotent (re-running skips rows where `user_id` is already correct)
> After running the migration once:
> 1. Note the current user_id on a known-fixed version in the Rails console:
> `v = Name::Version.where(name_id: 53423).last`
> v.user_id  # should now be Joe Cohen's id
> 2. Re-run the migration's up method directly (Rails won't re-run it via db:migrate because it's already in schema_migrations):
`BackfillNameVersionUserIds.new.up`
> 3. Confirm the value didn't change:
`Name::Version.where(name_id: 53423).last.user_id ` # same id as before
>
> If you want to be more thorough — confirm no rows were touched — wrap step 2 in a transaction and add a counter
```ruby
require Rails.root.join("db/migrate/20260522000000_backfill_name_version_user_ids") ; ActiveRecord::Base.transaction do
  BackfillNameVersionUserIds.new.up
  raise ActiveRecord::Rollback  # leave DB untouched
end
```
> That lets you run the second pass safely without risk of any side effects, and the fact that it completes without error confirms the guard logic works.

Fixes #4252

🤖 Generated with [Claude Code](https://claude.com/claude-code)