### PR TITLE
Phlex conversion rule: views/ vs components/

### DIFF
--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -1,8 +1,58 @@
 ---
-paths: app/components/**/*.rb, app/views/**/*.erb
+paths: app/components/**/*.rb, app/views/**/*.rb, app/views/**/*.erb
 ---
 
-# Phlex Form Conversions
+# Phlex Conversions
+
+## Decide first: reusable or single-use?
+
+The first decision when converting an ERB helper / partial / template to
+Phlex is **where the new Phlex class lives**. Make this decision before
+writing any code — it determines the namespace, the file path, the test
+location, and how reviewers reason about reuse.
+
+- **Reusable component** → `app/components/<name>.rb`, class
+  `Components::<Name>` (flat namespace), tests in `test/components/`.
+  Use this when the class is genuinely intended to be rendered from more
+  than one controller, or one obvious second caller already exists.
+
+- **Single-use view file** → `app/views/controllers/<controller>/<name>.rb`,
+  class `Views::Controllers::<Controller>::<Name>` (deep namespace
+  mirroring the controller tree), tests in `test/views/controllers/...`.
+  Use this when the class only renders for one controller's pages,
+  including the case where the only "second caller" is a turbo_stream
+  response in that same controller.
+
+Both inherit from `Phlex::HTML` via `Components::Base` (`Views::Base` is
+a thin subclass). The split is for organization and intent, not
+capability — they can do the same things.
+
+Why this matters:
+
+- **`app/views/` stays organized like the ERB tree it replaces.** A
+  Phlex single-use view sits next to the action templates it serves —
+  the same place a partial used to live. Reviewers find it where they
+  expect.
+- **`app/components/` stays small and meaningful.** It contains real
+  building blocks, not page-specific fragments. Putting a page-specific
+  fragment there implies "reuse me elsewhere" — an invitation that
+  rarely turns out well.
+- **Eventually action templates themselves migrate to Phlex.** When
+  `index.html.erb` becomes `index.rb`, it joins the same
+  `app/views/controllers/<controller>/` directory as the partial-
+  equivalents already there. The structure scales.
+
+If a single-use class becomes reusable later, move it: rename file,
+flatten namespace, update callers. Cheap refactor. Don't speculatively
+put a single-use class in `app/components/` "just in case."
+
+Example of the single-use pattern: see
+`app/views/controllers/account/api_keys/table.rb`
+(`Views::Controllers::Account::APIKeys::Table`) — the api_keys index
+table chunk, rendered by both the index page and the post-CUD
+turbo_stream response, both within the api_keys controller.
+
+## Phlex Form Conversions
 
 Before writing ANY Phlex form component, you MUST:
 

--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -52,6 +52,59 @@ Example of the single-use pattern: see
 table chunk, rendered by both the index page and the post-CUD
 turbo_stream response, both within the api_keys controller.
 
+## Collapse deep namespaces in `Views::Controllers::*`
+
+The `Views::Controllers::<Controller>::<Name>` namespace is four levels
+deep for most controllers (deeper for nested controllers like
+`Account::APIKeys`). **Do not** indent four times. Open the whole chain
+in a single declaration:
+
+```ruby
+# DO
+module Views::Controllers::Account::APIKeys
+  class Table < Views::Base
+    def view_template
+      # ...
+    end
+  end
+end
+
+# DON'T
+module Views
+  module Controllers
+    module Account
+      module APIKeys
+        class Table < Views::Base
+          def view_template
+            # ...                  # body buried at 10 spaces
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+This works because the parent namespaces (`Views`, `Views::Controllers`,
+etc.) are already autoloadable — Zeitwerk discovers them from the
+directory structure once `app/views/` is registered with
+`namespace: Views` in `config/initializers/phlex.rb`. Ruby will resolve
+the chain when it evaluates the `module` line.
+
+Apply the same shorthand in tests:
+
+```ruby
+module Views::Controllers::Account::APIKeys
+  class TableTest < ComponentTestCase
+    # ...
+  end
+end
+```
+
+Inside the namespace, sibling classes reference each other unqualified:
+`render(Form.new(...))` rather than the full
+`render(Views::Controllers::Account::APIKeys::Form.new(...))`.
+
 ## Phlex Form Conversions
 
 Before writing ANY Phlex form component, you MUST:

--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+# Views and Components namespaces bootstrapped together in this initializer.
+# Both extend Phlex::Kit so callers can render via `render Views::Foo` and
+# `render Components::Bar` shorthand (no `.new(...)`) inside a Phlex render
+# context.
 module Views
+  extend Phlex::Kit
 end
 
-# Views and Components namespaces bootstrapped together in this initializer
 module Components # rubocop:disable Style/OneClassPerFile
   extend Phlex::Kit
 end


### PR DESCRIPTION
## Summary

Two changes setting up the views/components split for the upcoming move PR:

1. **Decision rule** added at the top of `.claude/rules/phlex_conversions.md` covering where a Phlex conversion belongs:

   - **Reusable component** → `app/components/<name>.rb`, class `Components::<Name>` (flat namespace). Use when the class is genuinely intended to be rendered from more than one controller, or an obvious second caller already exists.
   - **Single-use view file** → `app/views/controllers/<controller>/<name>.rb`, class `Views::Controllers::<Controller>::<Name>` (deep namespace mirroring the controller tree). Use when the class only renders for one controller's pages, including the case where the only "second caller" is a turbo_stream response in that same controller.

   Both inherit from `Phlex::HTML` via `Components::Base`; `Views::Base` is a thin subclass. The split is for organization and intent, not capability.

2. **`Views` namespace extends `Phlex::Kit`** in `config/initializers/phlex.rb`, mirroring what we already do for `Components`. This is what the [Phlex Rails docs](https://www.phlex.fun/rails/views.html) recommend — it lets callers `render Views::Foo.new(...)` inside a Phlex render context (and `render Views::Foo` shorthand once we adopt that).

## Why the rule matters

- `app/views/` stays organized like the ERB tree it replaces — partial-equivalents sit next to the action templates they serve.
- `app/components/` stays small and meaningful — real building blocks, not page-specific fragments.
- When action templates themselves migrate to Phlex, they join the same `app/views/controllers/<controller>/` directory as the partial-equivalents — the structure scales.

The pattern was established by #4321 (`Views::Controllers::Account::APIKeys::Table`).

## Audit (preview of the move PR)

A follow-up PR will move existing single-use Phlex classes from `app/components/` to their controller's `app/views/` subtree. Preliminary audit:

- **152 components** in `app/components/` (excluding base/infrastructure).
- **~92 (60%) single-use** → would move. Mostly per-controller forms (e.g., `herbarium_form`, `name_form`, `observation_form`, `species_list_form`), per-controller modals/widgets, and admin pages.
- **~38 (25%) reusable** → stay. Generic building blocks like `Panel`, `Modal`, `MatrixTable`, `MatrixBox`, `Alert`, `ObjectFooter`, `BaseImage`, `CrudActionButton`, `InteractiveImage`, `SearchForm`, etc., each rendered from multiple controllers.
- **~22 (15%) appear unused** by grep → flagged for review/deletion separately.

The move is mechanical (rename, flatten/deepen namespace, update render call sites) but spans many files. The cleanup of unused components is a separate concern.

## Test plan

- [x] `Views.is_a?(Phlex::Kit) == true` and `Components.is_a?(Phlex::Kit) == true` verified.
- [x] Existing Phlex component tests still pass (sanity check that the Kit extension didn't break anything).
- [x] No code changes affecting existing render paths — the Kit extension is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
