### PR TITLE
ImageEditForm: fix license select showing ID instead of name

### DIFF
--- a/app/components/image_edit_form.rb
+++ b/app/components/image_edit_form.rb
@@ -49,7 +49,7 @@ class Components::ImageEditForm < Components::ApplicationForm
     date_field(:when, inline: true,
                       label: "#{:form_images_when_taken.l}:",
                       help: :form_images_when_help.t)
-    select_field(:license_id, @licenses,
+    select_field(:license_id, superform_license_options,
                  label: "#{:LICENSE.t}:",
                  help: :form_images_license_help.t)
     # Two-paragraph help: notes-specific + textile-syntax help.
@@ -107,6 +107,10 @@ class Components::ImageEditForm < Components::ApplicationForm
   # only the image owner OR a member of the project can toggle.
   def cannot_modify_project?(project)
     model.user_id != @user.id && !project.member?(@user)
+  end
+
+  def superform_license_options
+    @licenses.map { |display, id| [id, display] }
   end
 
   def project_checked?(project_id)

--- a/test/components/image_edit_form_test.rb
+++ b/test/components/image_edit_form_test.rb
@@ -34,6 +34,18 @@ class ImageEditFormTest < ComponentTestCase
     assert_html(html, "select[name='image[when(2i)]']")
   end
 
+  def test_license_select_shows_name_not_id
+    img = images(:agaricus_campestris_image)
+    html = render_form(image: img)
+
+    # Each option's value attribute must be the numeric ID and
+    # its visible text must be the license name — not the reverse.
+    @licenses.each do |name, id|
+      selector = "select[name='image[license_id]'] option[value='#{id}']"
+      assert_html(html, selector, text: name)
+    end
+  end
+
   def test_no_project_section_when_no_projects
     img = images(:agaricus_campestris_image)
     html = render_form(image: img, projects: [])


### PR DESCRIPTION
Fixes #4358 