### PR TITLE
Fix #4360: cross-model q param renders unfiltered Image index

### DIFF
--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -111,11 +111,28 @@ module ApplicationController::Queries
       query.params.any? { |arg, val| new_args[arg] != val }
   end
 
-  # Turn old query into a new query for given model,
-  # (re-using the old query if it's still correct),
-  # and returning nil if no new query can be found.
+  # Turn old query into a new query for given model — re-use the
+  # old query as-is when its model matches; otherwise try to bridge
+  # via a subquery (e.g. an Observation query landing on the Images
+  # index becomes an Image query with `observation_query: {...}`).
+  # Returns nil only when no bridge is defined for the
+  # filter→target pair (see `RELATED_QUERIES` in
+  # `Query::Modules::Subqueries`).
+  #
+  # Bug fix for #4360: previously this method returned nil for any
+  # model mismatch, causing the caller to fall back to the
+  # unfiltered index. So a URL like
+  # `/images?q[model]=Observation&q[pattern]=Foo` (which is a
+  # legitimate cross-model search produced by MO's search links)
+  # silently rendered the full Image index — a >60s response that
+  # could trigger downtime alerts. The bridge below resolves to a
+  # proper Image query that returns 0 hits when no Observations
+  # match.
   def find_new_query_for_model(model, old_query)
-    old_query_correct_for_model(model, old_query) || nil
+    return nil unless old_query
+    return old_query if old_query_correct_for_model(model, old_query)
+
+    old_query.subquery_of(model.to_sym)
   end
 
   def old_query_correct_for_model(model, old_query)

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -111,6 +111,37 @@ class ImagesControllerTest < FunctionalTestCase
     assert_template("index")
   end
 
+  # Regression for #4360: a cross-model q param (Observation query
+  # landing on the Images index) used to silently fall back to the
+  # full unfiltered Image index — a >60s response that could trigger
+  # downtime alerts. The query-coercion bridge in
+  # `find_new_query_for_model` should map the Observation query to an
+  # Image query via the `observation_query` subquery instead.
+  def test_index_cross_model_q_param_with_hits
+    pattern = "USA"
+    params = { q: { model: :Observation, pattern: } }
+
+    login
+    get(:index, params:)
+
+    assert_template("index", partial: "_image")
+    # Should NOT have flashed "no matches" — the bridge produces hits.
+    assert_no_flash
+  end
+
+  def test_index_cross_model_q_param_no_hits_flashes_error
+    pattern = "nothingMatchesAxotl"
+    params = { q: { model: :Observation, pattern: } }
+
+    login
+    get(:index, params:)
+
+    # Zero matching Observations → zero matching Images → "no matches"
+    # flash, not a silent fall-back to the unfiltered Image index.
+    assert_flash_text(:runtime_no_matches.l(type: :images.l))
+    assert_template("index")
+  end
+
   def test_show_image
     image = images(:peltigera_image)
     assert(ImageVote.where(image: image).many?,


### PR DESCRIPTION
Fixes #4360.

## What was broken

URLs like `/images?q[model]=Observation&q[pattern]=Foo` (cross-model search — produced by MO's own search links) **silently rendered the full unfiltered Image index** when the inner model query couldn't be re-used as-is. On prod that's a >60-second response that triggers downtime alerts when the Image table is hot.

Root cause: `ApplicationController::Queries#find_new_query_for_model` only returned the old query when its model exactly matched the target controller's model — otherwise nil. The caller then fell back to creating a default query, which is the full Image index.

## What's the fix

The model-bridging infrastructure already existed but wasn't wired into the dispatch path. `Query::Modules::Subqueries#current_or_related_query` (and the `subquery_of` instance method) maps a query from one model to another via the `RELATED_QUERIES` table. An Observation query becomes:

```ruby
Query.lookup(:Observation, pattern: "Foo").subquery_of(:Image)
# => #<Query::Images params: {observation_query: {pattern: "Foo"}}>
```

The image query joins to observations and naturally returns 0 rows when no observations match — no special-case "0 hits" code needed.

Three-line change in `find_new_query_for_model`: try `old_query.subquery_of(model.to_sym)` after the same-model check.

## Tests

Two regression tests in `images_controller_test.rb`:

- `test_index_cross_model_q_param_with_hits` — pattern that matches → image hits, no flash.
- `test_index_cross_model_q_param_no_hits_flashes_error` — pattern that matches nothing → 0 images → "no matches" flash. **No silent fall-back to unfiltered.**

219 tests in the broader image/observation/name controllers pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)