### PR TITLE
SelectField: accept Rails-shape [label, value] pairs

### DIFF
--- a/app/components/application_form/select_field.rb
+++ b/app/components/application_form/select_field.rb
@@ -32,25 +32,40 @@ class Components::ApplicationForm < Superform::Rails::Form
       end
     end
 
-    # Override to use `selected` attribute if field.value is nil or an array.
-    # Arrays occur with range fields (e.g., confidence: [-3.0, -1.0]) where we
-    # pass individual `selected` values for each select in the range pair.
-    # Compares as strings to handle boolean values (Phlex omits value="false")
+    # Renders the options.
+    #
+    # IMPORTANT: This wrapper accepts Rails-helper-shape `[label, value]`
+    # pairs (e.g. `[["Member", "member"], ["Admin", "admin"]]`), NOT
+    # Superform's native `[value, label]` shape. Callers can hand
+    # this method the same arrays they'd pass to Rails'
+    # `select_tag` / `options_for_select` — no swap needed.
+    #
+    # The pair is flipped internally so we still produce
+    # `<option value="value">label</option>` markup. (Superform
+    # 0.7's `Choices::Mapper` yields generic `[a, b]` pairs; we
+    # interpret those as `[label, value]` here.)
+    #
+    # Also overrides Superform's `options(*collection)` to use the
+    # wrapper's `selected:` attribute when `field.value` is nil or an
+    # array (arrays occur with range fields, e.g.
+    # `confidence: [-3.0, -1.0]`). Compares as strings to handle
+    # boolean values (Phlex omits `value="false"`).
     def options(*collection)
-      map_options(collection).each do |key, value|
-        # Coerce nil → "" so `<option value="">` renders (not `<option>`).
-        # Phlex's HTML DSL omits nil-valued attributes; the browser would
-        # then submit the option's text content. Matches Rails select-helper
-        # behavior so callers passing `[nil, "Label"]` get the expected
-        # empty-string submission.
-        option_value = key.nil? ? "" : key
-        option(selected: option_selected?(key), value: option_value) { value }
+      map_options(collection).each do |label, value|
+        # Coerce nil → "" so `<option value="">` renders (not
+        # `<option>`). Phlex's HTML DSL omits nil-valued attributes;
+        # the browser would then submit the option's text content.
+        # Matches Rails select-helper behavior so callers passing
+        # `["Label", nil]` get the expected empty-string submission.
+        option_value = value.nil? ? "" : value
+        option(selected: option_selected?(value),
+               value: option_value) { label }
       end
     end
 
-    def option_selected?(key)
+    def option_selected?(value)
       val = use_selected_attribute? ? attributes[:selected] : field.value
-      val.to_s == key.to_s
+      val.to_s == value.to_s
     end
 
     def use_selected_attribute?

--- a/app/components/application_form/upload_helpers.rb
+++ b/app/components/application_form/upload_helpers.rb
@@ -63,12 +63,10 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def render_upload_license(upload, licenses, selected_id)
-      # Superform expects [value, display] but Rails returns [display, value]
-      # So we need to swap them
-      swapped_licenses = licenses.map { |display, value| [value, display] }
-
+      # `licenses` is Rails-shape `[[label, value], ...]` (from
+      # `License.available_names_and_ids`); pass through.
       license_select = upload.field(:license_id).select(
-        swapped_licenses,
+        licenses,
         wrapper_options: { label: "#{:LICENSE.l}:", inline: true },
         selected: selected_id
       )

--- a/app/components/description_form.rb
+++ b/app/components/description_form.rb
@@ -91,15 +91,11 @@ class Components::DescriptionForm < Components::ApplicationForm
   # --- License field ---
 
   def render_license_field
-    select_field(:license_id, license_options, label: "#{:License.l}:") do
+    # `@licenses` is Rails-shape `[[label, id], ...]` from
+    # `License.available_names_and_ids`; pass through.
+    select_field(:license_id, @licenses, label: "#{:License.l}:") do
       help_block(:p, :form_description_license_help.t)
     end
-  end
-
-  def license_options
-    # @licenses comes as [[label, id], ...] from License.available_names_and_ids
-    # Superform expects [[value, label], ...]
-    @licenses.map { |label, id| [id, label] }
   end
 
   # --- Note fields ---

--- a/app/components/description_form.rb
+++ b/app/components/description_form.rb
@@ -218,13 +218,13 @@ class Components::DescriptionForm < Components::ApplicationForm
 
   def source_type_options_all
     Description::ALL_SOURCE_TYPES.map do |type|
-      [type, :"form_description_source_#{type}".l]
+      [:"form_description_source_#{type}".l, type]
     end
   end
 
   def source_type_options_basic
     Description::BASIC_SOURCE_TYPES.map do |type|
-      [type, :"form_description_source_#{type}".l]
+      [:"form_description_source_#{type}".l, type]
     end
   end
 

--- a/app/components/external_link_form.rb
+++ b/app/components/external_link_form.rb
@@ -43,7 +43,7 @@ class Components::ExternalLinkForm < Components::ApplicationForm
     options = if model.persisted?
                 [@site.name]
               else
-                @sites.sort_by(&:name).map { |site| [site.id, site.name] }
+                @sites.sort_by(&:name).map { |site| [site.name, site.id] }
               end
 
     select_field(:external_site_id, options,

--- a/app/components/form_image_fields.rb
+++ b/app/components/form_image_fields.rb
@@ -79,7 +79,7 @@ class Components::FormImageFields < Components::Base
     field = image_field_proxy(:license_id, selected_license)
     render(Components::ApplicationForm::SelectField.new(
              field,
-             collection: superform_license_options,
+             collection: license_options,
              wrapper_options: { label: :form_images_select_license.t.html_safe } # rubocop:disable Rails/OutputSafety
            ))
   end
@@ -96,11 +96,6 @@ class Components::FormImageFields < Components::Base
   def image_field_proxy(field_key, value)
     type = @upload ? :image : :good_image
     ApplicationForm.image_field_proxy(type, @img_id, field_key, value)
-  end
-
-  # Superform expects [value, display] but Rails returns [display, value]
-  def superform_license_options
-    license_options.map { |display, value| [value, display] }
   end
 
   def license_options

--- a/app/components/names_lookup_field_group.rb
+++ b/app/components/names_lookup_field_group.rb
@@ -124,9 +124,9 @@ class Components::NamesLookupFieldGroup < Components::Base
   end
 
   def render_select_field(field_name)
-    # Superform uses [value, label] order (opposite of Rails)
-    # Use string "false"/"true" instead of booleans for HTML rendering
-    options = [%w[false no], %w[true yes]]
+    # Rails-shape `[label, value]`. Use string "false"/"true" instead
+    # of booleans for HTML rendering (Phlex omits `value="false"`).
+    options = [%w[no false], %w[yes true]]
     field_component = @names_namespace.field(field_name).select(
       options,
       wrapper_options: {

--- a/app/components/search_form.rb
+++ b/app/components/search_form.rb
@@ -20,10 +20,10 @@ class Components::SearchForm < Components::ApplicationForm
 
   register_output_helper :search_bar_toggle
 
-  # Boolean select option styles
+  # Boolean select option styles. Rails-shape `[label, value]` pairs.
   BOOL_OPTIONS = {
-    nil_yes: [["", ""], ["true", "yes"]],
-    nil_boolean: [["", ""], ["true", "yes"], ["false", "no"]]
+    nil_yes: [["", ""], ["yes", "true"]],
+    nil_boolean: [["", ""], ["yes", "true"], ["no", "false"]]
   }.freeze
 
   # Additional wrapper options for search-specific fields
@@ -252,7 +252,9 @@ class Components::SearchForm < Components::ApplicationForm
   end
 
   def render_select_misspellings(field_name:)
-    # Superform uses [value, label] order (opposite of Rails)
+    # Rails-shape `[label, value]`. Label == value here, so the
+    # ordering doesn't matter visually — listed as
+    # `[label, value]` for consistency with everything else.
     # Valid values from query_attr: [:no, :include, :only]
     options = [%w[no no], %w[include include], %w[only only]]
     select_field(field_name, options,
@@ -302,9 +304,9 @@ class Components::SearchForm < Components::ApplicationForm
   end
 
   def render_select_confidence_range(field_name:)
-    # Superform uses [value, label] - Vote.opinion_menu returns [label, value]
-    options = [[nil, ""]] +
-              Vote.opinion_menu.map { |label, value| [value, label] }
+    # `Vote.opinion_menu` already returns Rails-shape `[[label, value], ...]`
+    # — pass through to our SelectField wrapper as-is.
+    options = [["", nil]] + Vote.opinion_menu
     value, range_value = sorted_confidence_range(field_value(field_name))
 
     render(ApplicationForm::SelectRangeField.new(

--- a/app/views/controllers/account/form.rb
+++ b/app/views/controllers/account/form.rb
@@ -82,11 +82,10 @@ module Views::Controllers::Account
     end
 
     def theme_options
-      # Superform expects [value, display] format (opposite of Rails).
       # "RANDOM" is a sentinel value that triggers random theme
       # selection.
-      [["RANDOM", :theme_random.l]] +
-        MO.themes.map { |t| [t, t.to_sym.l] }
+      [[:theme_random.l, "RANDOM"]] +
+        MO.themes.map { |t| [t.to_sym.l, t] }
     end
   end
 end

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -122,16 +122,12 @@ module Views::Controllers::FieldSlips
     end
 
     def render_project_select
-      select_field(:project_id, project_options,
+      # `FieldSlip#projects` returns Rails-shape `[[title, id], ...]`
+      # — pass through to SelectField.
+      select_field(:project_id, model.projects,
                    inline: true,
                    label: "#{:Project.t}:",
                    selected: model.project&.id)
-    end
-
-    def project_options
-      # FieldSlip#projects returns `[title, id]` pairs from `pluck`;
-      # Superform expects `[value, label]`, so swap.
-      model.projects.map { |title, id| [id, title] }
     end
 
     def render_date_field

--- a/app/views/controllers/names/form.rb
+++ b/app/views/controllers/names/form.rb
@@ -198,14 +198,12 @@ module Views::Controllers::Names
     end
 
     def rank_options
-      # Superform expects [value, label]
-      Name.all_ranks.map { |r| [r, rank_as_string(r)] }
+      Name.all_ranks.map { |r| [rank_as_string(r), r] }
     end
 
     def status_options
-      # Superform expects [value, label]
       # Use strings because Phlex omits value attribute for boolean false
-      [["false", :ACCEPTED.l], ["true", :DEPRECATED.l]]
+      [[:ACCEPTED.l, "false"], [:DEPRECATED.l, "true"]]
     end
 
     def show_misspelling_fields?

--- a/app/views/controllers/observations/identify/form.rb
+++ b/app/views/controllers/observations/identify/form.rb
@@ -129,9 +129,8 @@ module Views::Controllers::Observations::Identify
                                         ))
     end
 
-    # Superform expects [value, label].
     def type_options
-      [[:clade, :CLADE.l], [:region, :REGION.l]]
+      [[:CLADE.l, :clade], [:REGION.l, :region]]
     end
 
     # --- Dual-target helpers ---

--- a/app/views/controllers/observations/namings/fields.rb
+++ b/app/views/controllers/observations/namings/fields.rb
@@ -94,12 +94,9 @@ class Views::Controllers::Observations::Namings::Fields < Views::Base
     @context == "blank" ? "collapse" : nil
   end
 
+  # `Vote.{confidence,opinion}_menu` are already Rails-shape
+  # `[[label, value], ...]` pairs — pass through to SelectField.
   def confidence_menu
-    # Superform expects [value, label] but Rails returns [label, value]
-    raw_menu.map { |label, value| [value, label] }
-  end
-
-  def raw_menu
     if @vote&.value&.nonzero?
       Vote.confidence_menu
     else

--- a/app/views/controllers/occurrences/form.rb
+++ b/app/views/controllers/occurrences/form.rb
@@ -162,8 +162,10 @@ module Views::Controllers::Occurrences
     end
 
     def render_location_select(attrs_ns, locations)
+      # `locations` is already Rails-shape `[[name, id], ...]` from
+      # `distinct_locations` — pass straight through to SelectField.
       render(attrs_ns.field(:location_id).select(
-               location_options(locations),
+               locations,
                wrapper_options: { label: :edit_occurrence_location.l }
              ))
     end
@@ -172,12 +174,6 @@ module Views::Controllers::Occurrences
       render(attrs_ns.field(:when).date(
                wrapper_options: { label: :WHEN.l, inline: true }
              ))
-    end
-
-    # Superform expects `[value, label]`; Rails' select helper
-    # returns `[label, value]`, so swap.
-    def location_options(locations)
-      locations.map { |name, id| [id, name] }
     end
 
     def distinct_locations

--- a/app/views/controllers/projects/aliases/form.rb
+++ b/app/views/controllers/projects/aliases/form.rb
@@ -75,8 +75,8 @@ module Views::Controllers::Projects::Aliases
 
     def target_type_options
       [
-        ["location", :LOCATION.l],
-        ["user", :USER.l]
+        [:LOCATION.l, "location"],
+        [:USER.l, "user"]
       ]
     end
 

--- a/app/views/controllers/translations/form.rb
+++ b/app/views/controllers/translations/form.rb
@@ -251,9 +251,11 @@ module Views::Controllers::Translations
       proxy = Components::ApplicationForm::FieldProxy.new(
         nil, "locale", @lang.locale
       )
+      # `Language.menu_options` returns Rails-shape `[[name, locale], ...]`
+      # — pass through to SelectField.
       render(Components::ApplicationForm::SelectField.new(
                proxy,
-               collection: locale_options,
+               collection: Language.menu_options,
                # id: nil drops the FieldProxy-supplied id so the
                # rendered <select> matches the original markup (no id
                # attribute).
@@ -261,12 +263,6 @@ module Views::Controllers::Translations
                data: locale_select_data,
                wrapper_options: { label: false }
              ))
-    end
-
-    def locale_options
-      # Language.menu_options returns [name, locale]; Superform
-      # expects [value, label], so swap to [locale, name].
-      Language.menu_options.map { |name, locale| [locale, name] }
     end
 
     def locale_select_data

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -193,22 +193,19 @@ class ApplicationFormTest < ComponentTestCase
     assert_includes(form, "Option 3")
   end
 
-  # Regression: a [nil, "Label"] pair must render `<option value="">Label`,
-  # not `<option>Label` (which would submit "Label" as the value).
-  # Phlex's HTML DSL omits nil-valued attributes by default, so SelectField
-  # has to coerce nil keys to "" to match Rails' select-helper behavior.
-  def test_select_field_nil_key_renders_empty_value_attribute
-    options = [[nil, "(No Project)"], ["778455076", "EOL Project"]]
+  # Regression: a `[Label, nil]` pair (Rails-shape, value is nil) must
+  # render `<option value="">Label`, not `<option>Label` (which would
+  # submit "Label" as the value). Phlex's HTML DSL omits nil-valued
+  # attributes by default, so SelectField coerces nil values to "" to
+  # match Rails' select-helper behavior.
+  def test_select_field_nil_value_renders_empty_value_attribute
+    options = [["(No Project)", nil], ["EOL Project", "778455076"]]
     form = render_form do
       select_field(:number, options, label: "Project")
     end
 
-    assert_html(
-      form, "option[value='']", text: "(No Project)"
-    )
-    assert_html(
-      form, "option[value='778455076']", text: "EOL Project"
-    )
+    assert_html(form, "option[value='']", text: "(No Project)")
+    assert_html(form, "option[value='778455076']", text: "EOL Project")
   end
 
   # Slot tests

--- a/test/components/description_form_test.rb
+++ b/test/components/description_form_test.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for the polymorphic NameDescription / LocationDescription form.
+# The form has three different source-type rendering paths (admin all-types
+# select, new-record basic-types select, locked existing-record hidden field)
+# and a license select whose option values must be License ids, not labels —
+# this is the path that regressed in PR #4364 when SelectField switched to
+# Rails-shape pairs. Coverage targets every branch and locks in the
+# label/value shape of every <option> so callers can't drift again.
+class DescriptionFormTest < ComponentTestCase
+  def setup
+    super
+    @user = users(:rolf)
+    # `source_type = "public"` mirrors `initialize_description_source` —
+    # the controller seeds new descriptions before rendering so the form
+    # has a basic source type to display.
+    @new_name_desc = NameDescription.new(name: names(:peltigera),
+                                         source_type: "public")
+    @existing_name_desc = name_descriptions(:peltigera_desc)
+    @new_loc_desc = LocationDescription.new(location: locations(:albion),
+                                            source_type: "public")
+    @existing_loc_desc = location_descriptions(:albion_desc)
+    @licenses = License.available_names_and_ids
+    @license = License.first
+  end
+
+  def test_new_name_description_form_renders_basic_source_type_select
+    html = render_form(description: @new_name_desc)
+
+    # Form structure — id derived from model type
+    assert_html(html, "form#name_description_form")
+    assert_html(html, "form[action*='/names/']")
+    assert_html(html, "form[action*='/descriptions']")
+
+    # Source-type select for new, non-admin user gets the basic 3 types
+    # (public, source, user) — not the full all-types list.
+    assert_html(html,
+                "select[name='description[source_type]']")
+    assert_basic_source_type_options(html)
+
+    # The submission-value of every option must be the symbolic type,
+    # NOT the localized label. Regression guard for #4364: SelectField
+    # now reads `[label, value]` pairs; if a caller passes the flipped
+    # `[value, label]` shape by mistake, this assertion fails.
+    Description::BASIC_SOURCE_TYPES.each do |type|
+      assert_html(html,
+                  "select[name='description[source_type]'] " \
+                  "option[value='#{type}']",
+                  text: :"form_description_source_#{type}".l)
+    end
+
+    # source_name (text field) and project_id (hidden)
+    assert_html(html, "input[name='description[source_name]']")
+    assert_html(html, "input[type='hidden'][name='description[project_id]']")
+
+    # License select: option values are License ids, option text is the
+    # display name. The shape contract that broke #4358 lives here.
+    assert_license_select_shape(html)
+
+    # Permissions section — new descriptions: author and admin (creator),
+    # so the checkboxes render.
+    assert_html(html,
+                "input[type='checkbox'][name='description[public_write]']")
+    assert_html(html, "input[type='checkbox'][name='description[public]']")
+
+    # Note fields — every NameDescription note field gets a textarea.
+    NameDescription.all_note_fields.each do |field|
+      assert_html(html, "textarea[name='description[#{field}]']")
+    end
+
+    # Two submit buttons (top + bottom), value = CREATE for a new record.
+    assert_html(html,
+                "input[type='submit'][value='#{:CREATE.l}']",
+                count: 2)
+  end
+
+  def test_admin_mode_renders_all_source_types
+    stub_admin_mode!
+    html = render_form(description: @new_name_desc)
+
+    assert_all_source_type_options(html)
+
+    # Spot-check that one of the non-basic types is present with the
+    # correct value. `project` is in ALL but not BASIC.
+    assert_html(html,
+                "select[name='description[source_type]'] " \
+                "option[value='project']",
+                text: :form_description_source_project.l)
+  end
+
+  def test_existing_description_locks_source_type_to_hidden_field
+    # An existing description not in admin mode falls through to the
+    # hidden-field branch: source_type can't be changed once set.
+    html = render_form(description: @existing_name_desc)
+
+    assert_no_html(html, "select[name='description[source_type]']")
+    assert_html(html,
+                "input[type='hidden'][name='description[source_type]']")
+
+    # Submit buttons read SAVE_EDITS, not CREATE, for an existing record.
+    assert_html(html,
+                "input[type='submit'][value='#{:SAVE_EDITS.l}']",
+                count: 2)
+  end
+
+  def test_location_description_form
+    html = render_form(description: @new_loc_desc)
+
+    # id and action route through the locations controller.
+    assert_html(html, "form#location_description_form")
+    assert_html(html, "form[action*='/locations/']")
+    assert_html(html, "form[action*='/descriptions']")
+
+    # LocationDescription gets its own note-field set — different from
+    # NameDescription's. No `<hr>` separator omission either; the
+    # textile-help header block is name-only.
+    LocationDescription.all_note_fields.each do |field|
+      assert_html(html, "textarea[name='description[#{field}]']")
+    end
+  end
+
+  def test_merge_opts_renders_merge_hidden_fields
+    html = render_form(
+      description: @existing_name_desc,
+      merge_opts: { merge: true, old_desc_id: 42, delete_after: "1" }
+    )
+
+    # `render_flat_hidden_field` uses the raw name (no `description[...]`
+    # wrapper) so the merge controller can read flat params.
+    assert_html(html,
+                "input[type='hidden'][name='old_desc_id'][value='42']")
+    assert_html(html,
+                "input[type='hidden'][name='delete_after'][value='1']")
+  end
+
+  def test_merge_opts_omitted_when_not_merging
+    html = render_form(description: @existing_name_desc)
+
+    assert_no_html(html, "input[name='old_desc_id']")
+    assert_no_html(html, "input[name='delete_after']")
+  end
+
+  private
+
+  def render_form(description:, merge_opts: {})
+    render(Components::DescriptionForm.new(
+             description,
+             licenses: @licenses,
+             user: @user,
+             merge_opts: merge_opts
+           ))
+  end
+
+  def assert_basic_source_type_options(html)
+    Description::BASIC_SOURCE_TYPES.each do |type|
+      assert_html(html,
+                  "select[name='description[source_type]'] " \
+                  "option[value='#{type}']")
+    end
+    # `project` and `foreign` are in ALL but not BASIC.
+    extras = Description::ALL_SOURCE_TYPES - Description::BASIC_SOURCE_TYPES
+    extras.each do |t|
+      assert_no_html(html,
+                     "select[name='description[source_type]'] " \
+                     "option[value='#{t}']")
+    end
+  end
+
+  def assert_all_source_type_options(html)
+    Description::ALL_SOURCE_TYPES.each do |type|
+      assert_html(html,
+                  "select[name='description[source_type]'] " \
+                  "option[value='#{type}']",
+                  text: :"form_description_source_#{type}".l)
+    end
+  end
+
+  def assert_license_select_shape(html)
+    # Every option's value must be the License id; its text must be the
+    # License display name. This is the contract #4358 broke.
+    assert_html(html, "select[name='description[license_id]']")
+    assert_html(html,
+                "select[name='description[license_id]'] " \
+                "option[value='#{@license.id}']",
+                text: @license.display_name)
+    # Confirm the inverse doesn't happen — there should be NO option whose
+    # `value=` is the human label.
+    assert_no_html(html,
+                   "select[name='description[license_id]'] " \
+                   "option[value='#{@license.display_name}']")
+  end
+end


### PR DESCRIPTION
Fixes #4358.

## Summary

Our `Components::ApplicationForm::SelectField` was inheriting
Superform's `[value, label]` argument shape — the reverse of every
other helper in the Rails ecosystem (`options_for_select`, the
`collection_*` helpers, `Vote.confidence_menu`,
`License.available_names_and_ids`, …). That mismatch was a recurring
footgun: every caller had to either hand-flip the array
(`.map { |l, v| [v, l] }`) or wrap it in a pass-through
\"_options\" helper to remind the next reader which shape the next
SelectField wanted.

This PR fixes the asymmetry at the source. `SelectField#options`
now reads pairs as `|label, value|`, matching Rails. Every caller in
the app and tests has been updated to pass option arrays in Rails
order. The pass-through \"_options\" helpers I'd introduced (or
inherited) — `license_options`, `location_options`, `project_options`,
`locale_options`, and the `confidence_menu` / `raw_menu` pair — are
deleted. The values are now inlined at the call site (or the upstream
variable was renamed where that improved clarity, e.g.
`raw_menu` → `confidence_menu`).

Net effect: callers can pass option arrays exactly as Rails' own
`select` helpers expect — no shape gymnastics, no helper indirection.

### Files touched

**Core:**
- `app/components/application_form/select_field.rb` — unpack pairs as `|label, value|`
- `test/components/application_form_test.rb` — invert test inputs to Rails shape

**Callers (un-flips + pass-through removals):**
- `app/components/application_form/upload_helpers.rb`
- `app/components/description_form.rb` *(removed `license_options`)*
- `app/components/external_link_form.rb`
- `app/components/form_image_fields.rb`
- `app/components/names_lookup_field_group.rb`
- `app/components/search_form.rb`
- `app/views/controllers/account/form.rb`
- `app/views/controllers/field_slips/form.rb` *(removed `project_options`)*
- `app/views/controllers/names/form.rb`
- `app/views/controllers/observations/identify/form.rb`
- `app/views/controllers/observations/namings/fields.rb` *(removed `confidence_menu` pass-through; renamed `raw_menu` → `confidence_menu`)*
- `app/views/controllers/occurrences/form.rb` *(removed `location_options`)*
- `app/views/controllers/projects/aliases/form.rb`
- `app/views/controllers/translations/form.rb` *(removed `locale_options`)*

## Test plan

- [x] `bin/rails test test/components/ test/views/` — 1044 tests, 0 failures
- [x] `bin/rails test test/controllers/` — 1942 tests, 0 failures
- [x] `bundle exec rubocop` clean on all touched files
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
