### PR TITLE
Lock in two .claude/rules: PR bodies via --body-file + Phlex-conversion placement

### DIFF
--- a/.claude/rules/gh_pr_bodies.md
+++ b/.claude/rules/gh_pr_bodies.md
@@ -1,0 +1,65 @@
+# PR body formatting
+
+When using `gh pr create` or `gh pr edit`, **always** write the body to
+a file first and pass it via `--body-file`. Never use a HEREDOC
+(`$(cat <<'EOF' ... EOF)`) for a PR body that contains backticks for
+code formatting.
+
+## Why
+
+Inside `$(...)`, backticks must be escaped as `` \` ``. The escape
+character passes through `gh` to the GitHub API and GitHub Markdown
+then renders the backslash as a literal character before the tick.
+A line that should display as `Foo::Bar` ships as `\Foo::Bar\` — the
+classes/methods/files in the PR description lose their monospace
+treatment, and the diff between intent and rendering goes unnoticed
+unless someone (the human author) catches it after the fact. This has
+been caught on multiple PRs.
+
+The user has flagged this enough times that it's now a permanent rule,
+not a "remember next time" thing.
+
+## Do
+
+```bash
+cat > /tmp/pr_body.md <<'EOF'
+## Summary
+- `Foo::Bar` renamed to `Baz::Qux`
+- `app/components/foo.rb` → `app/views/controllers/foo/form.rb`
+
+## Test plan
+- [x] `bin/rails test ...`
+EOF
+
+gh pr create --title "..." --body-file /tmp/pr_body.md
+# or, for edits:
+gh pr edit 1234 --body-file /tmp/pr_body.md
+```
+
+The Markdown body file is plain — no shell escaping. Backticks render
+correctly. Multi-line code blocks, links, lists, all work.
+
+## Don't
+
+```bash
+# ❌ HEREDOC mangles backticks via $(...) escaping:
+gh pr create --title "..." --body "$(cat <<'EOF'
+- \`Foo::Bar\` renamed   # ← backslashes render literally on GitHub
+EOF
+)"
+```
+
+If you absolutely cannot write to a file (extremely rare), use
+single-quoted string concatenation rather than `$(...)`. But the file
+path is always available and is always the right choice.
+
+## Verify
+
+After creating or editing, spot-check the rendered body:
+
+```bash
+gh pr view <num> --json body --jq .body | head -20
+```
+
+If you see `\\\`` anywhere, the body got mangled — re-edit with
+`--body-file`.

--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -11,17 +11,44 @@ Phlex is **where the new Phlex class lives**. Make this decision before
 writing any code — it determines the namespace, the file path, the test
 location, and how reviewers reason about reuse.
 
-- **Reusable component** → `app/components/<name>.rb`, class
-  `Components::<Name>` (flat namespace), tests in `test/components/`.
-  Use this when the class is genuinely intended to be rendered from more
-  than one controller, or one obvious second caller already exists.
+**Default placement when converting an ERB view to Phlex.** ERB files
+living under `app/views/` get converted to Phlex classes under
+`app/views/controllers/<controller>/<name>.rb`. This applies to
+*everything* in the views tree — forms, tables, panels, sidebars, navs,
+modals, headers, page wrappers, footers, list rows, partials of any
+kind. The default is the views tree, not `app/components/`.
 
-- **Single-use view file** → `app/views/controllers/<controller>/<name>.rb`,
-  class `Views::Controllers::<Controller>::<Name>` (deep namespace
-  mirroring the controller tree), tests in `test/views/controllers/...`.
-  Use this when the class only renders for one controller's pages,
-  including the case where the only "second caller" is a turbo_stream
-  response in that same controller.
+**Exception: true UI primitives.** If while converting you extract a
+chunk that's a genuine, reusable UI building block — a button group, a
+badge, an alert, a generic widget that you'd recognize as a
+"component" regardless of where it happens to be rendered today —
+that piece can live in `app/components/` even if only one caller
+currently exists. The "speculated future caller" carve-out applies
+*only* to recognizably-generic UI primitives. It does NOT apply to
+page-specific fragments wearing component clothing (e.g. a
+`Components::WhateverShowDetails` that only ever renders one
+controller's show page — that's a view, put it in
+`app/views/controllers/`).
+
+Heuristic: would a reader who doesn't know this codebase look at the
+class name and the file's contents and say "yes, that's a component"?
+If yes, `app/components/`. If they'd say "that's the
+`whatever_controller`'s `show` page", `app/views/controllers/`.
+
+- **Single-use view file (default for ERB conversions)** →
+  `app/views/controllers/<controller>/<name>.rb`, class
+  `Views::Controllers::<Controller>::<Name>` (deep namespace mirroring
+  the controller tree), tests in `test/views/controllers/...`. Use this
+  when the class only renders for one controller's pages, including
+  the case where the only "second caller" is a turbo_stream response
+  in that same controller.
+
+- **Reusable component (UI primitives or genuinely multi-caller)** →
+  `app/components/<name>.rb`, class `Components::<Name>` (flat
+  namespace), tests in `test/components/`. Use this for true UI
+  building blocks (button groups, badges, alerts, etc.) regardless of
+  current caller count, OR for non-primitive classes that already have
+  a concrete second caller.
 
 Both inherit from `Phlex::HTML` via `Components::Base` (`Views::Base` is
 a thin subclass). The split is for organization and intent, not


### PR DESCRIPTION
## Summary

Two small project-level rule changes that lock in conventions the user has had to flag repeatedly:

### 1. `.claude/rules/gh_pr_bodies.md` (new file)

PR bodies should always come from a file passed via `--body-file`, never from a HEREDOC. Inside `$(cat <<'EOF' ... EOF)`, backticks must be escaped (`` \` ``); `gh` passes that escape through to the GitHub API, and GitHub Markdown then renders the backslash as a literal character before the tick. A line that should read `Foo::Bar` ships as `\Foo::Bar\`. I've shipped a few PRs with that drift; this rule prevents the next one. `.claude/rules/*.md` files without a `paths:` frontmatter are auto-loaded into every session.

This PR's body is itself written to `/tmp/pr_rules_body.md` and submitted via `gh pr create --body-file` — verifying the rule by following it.

### 2. `.claude/rules/phlex_conversions.md` (clarification)

The "decide first: reusable or single-use?" section needed two precise points the previous wording elided:

- **ERB files under `app/views/` get converted to Phlex classes under `app/views/controllers/`, not `app/components/`.** The rule is about the source location — anything that lived as ERB under `views/` is by definition controller-specific content. Applies to tables, sidebars, panels, navs, modals, page wrappers, list rows — not just forms.
- **Carve-out for true UI primitives.** If during a conversion you extract a genuine reusable building block (button group, badge, alert, etc.), that piece can go to `app/components/` even with no concrete second caller, because it's recognizably-generic UI. The speculated-future-caller carve-out applies *only* to such primitives.

Adds the "would a stranger call this a component?" heuristic for deciding between the two homes when the case is fuzzy.

## Test plan

- [x] `gh pr view <num> --json body --jq .body` spot-check after publishing — no escaped backticks.
- [x] No code changes; rule-file-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
