### PR TITLE
checkbox_field: positional choices in Rails shape

### DIFF
--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -29,7 +29,16 @@ class Components::ApplicationForm < Superform::Rails::Form
     attr_reader :wrapper_options
 
     def initialize(field, *options, wrapper_options: {}, **attributes)
-      @options = options
+      # MO convention: array-mode options arrive as Rails-shape
+      # `[label, value]` pairs (matching `select_field` and
+      # `radio_field`'s positional-choices shape). Flip to
+      # Superform-shape `[value, label]` for the underlying
+      # `Choices::Mapper` to unpack correctly. Non-pair options
+      # (bare values, hashes) pass through unchanged — Mapper handles
+      # them itself.
+      @options = options.map do |opt|
+        opt.is_a?(Array) && opt.size == 2 ? [opt[1], opt[0]] : opt
+      end
       @wrapper_options = wrapper_options
       # Upstream 0.7 Checkbox#initialize is (field, index: nil, **attributes).
       super(field, **attributes)

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -72,18 +72,33 @@ class Components::ApplicationForm < Superform::Rails::Form
       render(field_component)
     end
 
-    # Checkbox field with label and Bootstrap checkbox wrapper
+    # Checkbox field with label and Bootstrap checkbox wrapper.
+    #
+    # Three call styles:
+    # - Boolean: `checkbox_field(:public, label: "Public")` — one
+    #   checkbox bound to a single field on the model.
+    # - Array (multi-value collection):
+    #   `checkbox_field(:tag_ids, ["Foo", 1], ["Bar", 2])` —
+    #   renders N checkboxes that post as `model[tag_ids][]=<value>`
+    #   for each checked option. Pairs are `[label, value]`,
+    #   matching `select_field` and `radio_field`.
+    # - Block (matrix layout):
+    #   `checkbox_field(:foo) { |cb| cb.option(value) }` — caller
+    #   drives per-cell rendering inside the standard wrapper.
+    #
     # @param field_name [Symbol] the field name
+    # @param choices [Array<Array>] optional `[label, value]` pairs
+    #   that switch the component into array (collection) mode.
     # @param options [Hash] all field and wrapper options
     # Wrapper options: :label, :prefs, :class_name
-    # @yield [field_component] Optional block to set slots:
-    #   `with_between`, `with_append`, `with_help`
-    def checkbox_field(field_name, **options, &block)
+    # @yield [field_component] Optional block — see `Field#checkbox`.
+    def checkbox_field(field_name, *choices, **options, &block)
       options = auto_label_for_prefs(field_name, options)
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
       field_component = field(field_name).checkbox(
+        *choices,
         wrapper_options: wrapper_opts,
         **field_opts
       )

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -177,6 +177,37 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(form, "div.checkbox.mt-3")
   end
 
+  # Collection mode: `checkbox_field(:field, [label, value], ...)`
+  # renders N checkboxes that post as `model[field][]=<value>` for
+  # each checked option. Pairs are `[label, value]` — matching
+  # `select_field` and `radio_field`. Previously this API path was
+  # unreachable: callers had to bypass `checkbox_field` and call
+  # `field(:foo).checkbox(...)` directly.
+  def test_checkbox_field_array_mode_renders_one_checkbox_per_choice
+    form = render_form do
+      checkbox_field(:placeholder,
+                     ["Foo", 1],
+                     ["Bar", 2],
+                     ["Baz", 3])
+    end
+
+    # Each option becomes a checkbox with the field name suffixed `[]`
+    # so the controller receives an array of selected values. Values
+    # are the SECOND element of each pair (Rails shape).
+    name_attr = "#{@collection_number.class.model_name.singular}" \
+                "[placeholder][]"
+    assert_html(form,
+                "input[type='checkbox'][name='#{name_attr}'][value='1']")
+    assert_html(form,
+                "input[type='checkbox'][name='#{name_attr}'][value='2']")
+    assert_html(form,
+                "input[type='checkbox'][name='#{name_attr}'][value='3']")
+    # Labels (first element of each pair) render alongside each input.
+    assert_includes(form, "Foo")
+    assert_includes(form, "Bar")
+    assert_includes(form, "Baz")
+  end
+
   # Select field tests
   def test_select_field_renders_with_basic_options
     options = [["Option 1", "1"], ["Option 2", "2"], ["Option 3", "3"]]
@@ -863,7 +894,8 @@ class ApplicationFormTest < ComponentTestCase
   # via `field(:foo).checkbox([v, label], …)` directly.
   def test_checkbox_field_array_mode_per_option_label_has_for_attribute
     form = render_form do
-      render(field(:number).checkbox([1, "A"], [2, "B"]))
+      # Rails-shape pairs: `[label, value]` (matches `select_field`).
+      render(field(:number).checkbox(["A", 1], ["B", 2]))
     end
 
     assert_html(form, "label[for='collection_number_number_1']")


### PR DESCRIPTION
## Summary

Two coupled changes that align `checkbox_field` with the other MO form helpers:

1. **`checkbox_field` accepts positional `*choices`** (parity with `radio_field`). The underlying `Field#checkbox(*options, **)` has always supported collection mode; the helper just didn't expose it, so collection-mode checkboxes had to bypass the helper:

   ```ruby
   # Before — awkward bypass
   render(field(:tag_ids).checkbox(*options))

   # After
   checkbox_field(:tag_ids, ["Foo", 1], ["Bar", 2])
   ```

2. **`CheckboxField#initialize` flips incoming `[label, value]` pairs to the Superform-internal `[value, label]` shape** that `Choices::Mapper` expects. This matches PR #4364's `SelectField` change — every MO field helper now reads its positional choices as `[label, value]`. `select_field`, `radio_field`, and `checkbox_field` array mode all use the same shape — no more per-helper footgun.

## Why both at once

Exposing collection mode through the helper (#1) without aligning the pair shape (#2) would lock in a long-term inconsistency: `select_field([label, value])` vs `checkbox_field([value, label])`. Doing both keeps the rule simple — *all* MO positional-choice helpers use `[label, value]`.

Rails itself splits the convention: `options_for_select` uses `[label, value]`, but `collection_check_boxes(:foo, items, :value_method, :text_method)` puts the value method first. We pick MO-internal consistency over per-helper Rails fidelity.

## How it surfaced

While building the species-lists projects/edit form's project-membership checkbox group — first new array-mode caller in the app — I noticed `checkbox_field(:foo, *options)` didn't work and had to bypass the helper. The fix is small enough to ship standalone.

## Compatibility

- No production view callers use array-mode today, so nothing in `app/views/**/*.rb` needs changes.
- One in-file test (the only positional-array caller in tests, `field(:number).checkbox([1, "A"], [2, "B"])`) updated to Rails-shape (`["A", 1], ["B", 2]`).
- All boolean-mode and block-mode callers unaffected.
- Doc comment expanded with all three call styles.

Added a new test (`test_checkbox_field_array_mode_renders_one_checkbox_per_choice`) exercising the helper path end-to-end with Rails-shape pairs, locking the convention in.

## Test plan

- [x] `bin/rails test test/components/` — 508 tests, 2547 assertions, 0 failures
- [x] `bundle exec rubocop --format simple` clean on all touched files
- [x] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
