### PR TITLE
Centralize helper registrations + flatten Phlex view namespaces

### DIFF
--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -132,7 +132,42 @@ Inside the namespace, sibling classes reference each other unqualified:
 `render(Form.new(...))` rather than the full
 `render(Views::Controllers::Account::APIKeys::Form.new(...))`.
 
-## Helpers in Phlex views: when to move vs. register
+## Helpers available everywhere — no per-class registration
+
+A handful of helper sources are wired into the Phlex base classes:
+
+- **`Components::Base`** registers app-wide helpers: `q_param`,
+  `add_q_param`, `url_for`, `permission?`, `link_to_object`,
+  `user_link`, `location_link`, `link_icon`, `help_block`,
+  `make_table`, etc. — see the registration block at the top of
+  `app/components/base.rb` for the full list.
+- **`Components::Base`** also includes `Phlex::Rails::Helpers::Routes`
+  (every named route helper — `foo_path`, `bar_url`),
+  `Phlex::Rails::Helpers::AssetPath` (`asset_path`),
+  `Phlex::Rails::Helpers::LinkTo` (`link_to`),
+  `Phlex::Rails::Helpers::ButtonTo` (`button_to`),
+  `Phlex::Rails::Helpers::ClassNames` (`class_names`), and
+  `Phlex::Rails::Helpers::TurboFrameTag` (`turbo_frame_tag`).
+- **`Views::Base`** layers on the page-chrome helpers:
+  `add_page_title`, `add_new_title`, `add_edit_title`,
+  `add_context_nav`, `add_project_banner`, `container_class`,
+  `content_for`.
+- **`Views::Base`** also includes every top-level `Tabs::*Helper`
+  module via a `to_prepare` hook in `config/initializers/phlex.rb`.
+  Any tab builder (`object_return_tab(...)`,
+  `species_lists_index_tabs(...)`, `inat_import_form_new_tabs(...)`,
+  etc.) is callable from any view as if it were a class method.
+  Nested modules under `Tabs::Sidebar::*`, `Tabs::Locations::*`,
+  `Tabs::Names::*` are NOT auto-included — they stay scoped to
+  their specific callers.
+
+**Don't `register_value_helper`** for anything in those buckets.
+The registration is a no-op duplicate.
+
+If your view needs a helper that isn't in any of those buckets, it
+falls into the move-vs-register decision below.
+
+## Moving a helper into a Phlex view
 
 When converting an action template to Phlex, you'll often find page
 logic spread between the ERB and `app/helpers/...` modules. The

--- a/app/components/activity_log_type_filters.rb
+++ b/app/components/activity_log_type_filters.rb
@@ -7,8 +7,6 @@
 #   render(Components::ActivityLogTypeFilters.new(query:, types:))
 #
 class Components::ActivityLogTypeFilters < Components::Base
-  register_value_helper :q_param
-
   prop :query, _Nilable(Query)
   prop :types, _Array(String)
 

--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -176,7 +176,6 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Use register_value_helper for helpers that return values (not HTML)
   register_value_helper :in_admin_mode?
   register_value_helper :pluralize
-  register_value_helper :url_for
   register_value_helper :rank_as_string
   register_output_helper :help_note, mark_safe: true
 

--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -7,9 +7,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   class AutocompleterField < Superform::Rails::Components::Input
     include Phlex::Slotable
 
-    register_output_helper :link_icon
     register_output_helper :icon_link_to
-    register_output_helper :modal_link_to
 
     # Types with dedicated Stimulus controllers
     SUPPORTED_TYPE_CONTROLLERS = [

--- a/app/views/controllers/checklists/contents.rb
+++ b/app/views/controllers/checklists/contents.rb
@@ -5,8 +5,6 @@ module Views::Controllers::Checklists
   # #checklist_contents so the target-names turbo-stream can replace
   # the whole block when a target is added or removed.
   class Contents < ::Components::Base
-    register_output_helper :location_link, mark_safe: true
-
     def initialize(data:, context:)
       super()
       @data = data

--- a/app/views/controllers/checklists/show.rb
+++ b/app/views/controllers/checklists/show.rb
@@ -3,8 +3,6 @@
 # Phlex view for the checklist page. Replaces show.html.erb.
 module Views::Controllers::Checklists
   class Show < Views::Base
-    register_value_helper :checklist_show_tabs
-
     def initialize(data:, context:)
       super()
       @data = data

--- a/app/views/controllers/descriptions/permissions/form.rb
+++ b/app/views/controllers/descriptions/permissions/form.rb
@@ -12,7 +12,6 @@ module Views::Controllers::Descriptions::Permissions
   # writeins.
   class Form < ::Components::ApplicationForm
     register_value_helper :in_admin_mode?
-    register_output_helper :user_link, mark_safe: true
 
     WRITEIN_ROWS = 6
 
@@ -75,32 +74,6 @@ module Views::Controllers::Descriptions::Permissions
                      label_class: "p-0") do |cb|
         cb.option(group.id)
       end
-    end
-
-    def group_checked?(group, type)
-      if locked_all_users_group?(group)
-        type != :admin
-      elsif locked_reviewers_group?(group)
-        type == :admin
-      else
-        @description.send(:"#{type}_groups").include?(group)
-      end
-    end
-
-    def group_locked?(group)
-      locked_all_users_group?(group) || locked_reviewers_group?(group)
-    end
-
-    def locked_all_users_group?(group)
-      group.name == "all users" &&
-        @description.source_type.to_s == "public" &&
-        !in_admin_mode?
-    end
-
-    def locked_reviewers_group?(group)
-      group.name == "reviewers" &&
-        @description.source_type.to_s == "public" &&
-        !in_admin_mode?
     end
 
     def render_group_name(group)
@@ -186,16 +159,13 @@ module Views::Controllers::Descriptions::Permissions
                      label_class: "p-0")
     end
 
-    def name_description?
-      @description.is_a?(NameDescription)
-    end
-
+    # Only a NameDescription path exists — there is no
+    # `Locations::Descriptions::PermissionsController` (no route, no
+    # controller, no callers). The `else` branch this method used to
+    # carry referenced a `permissions_location_description_path` that
+    # would have raised NoMethodError if ever rendered.
     def form_action
-      if name_description?
-        permissions_name_description_path(@description.id)
-      else
-        permissions_location_description_path(@description.id)
-      end
+      permissions_name_description_path(@description.id)
     end
   end
 end

--- a/app/views/controllers/herbaria/curator_requests/form.rb
+++ b/app/views/controllers/herbaria/curator_requests/form.rb
@@ -4,8 +4,6 @@ module Views::Controllers::Herbaria::CuratorRequests
   # Form for requesting to be a herbarium curator. Rendered by the
   # herbaria/curator_requests controller's `new.html.erb`.
   class Form < ::Components::ApplicationForm
-    register_value_helper :herbaria_curator_requests_path
-
     def initialize(model, herbarium:, back: nil, q_param: nil, **options)
       @herbarium = herbarium
       @back = back

--- a/app/views/controllers/inat_imports.rb
+++ b/app/views/controllers/inat_imports.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Views
-  module Controllers
-    # Namespace for iNat import view components.
-    module InatImports
-    end
-  end
-end

--- a/app/views/controllers/inat_imports/new.rb
+++ b/app/views/controllers/inat_imports/new.rb
@@ -1,30 +1,22 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module InatImports
-      # Phlex view for the iNat import new/create page.
-      # Sets page title and context nav, then renders the
-      # form component.
-      class New < Views::Base
-        register_output_helper :add_page_title
-        register_output_helper :add_context_nav
-        register_value_helper :inat_import_form_new_tabs
+module Views::Controllers::InatImports
+  # Phlex view for the iNat import new/create page.
+  # Sets page title and context nav, then renders the
+  # form component.
+  class New < Views::Base
+    def initialize(form:, super_importer: false)
+      super()
+      @form = form
+      @super_importer = super_importer
+    end
 
-        def initialize(form:, super_importer: false)
-          super()
-          @form = form
-          @super_importer = super_importer
-        end
-
-        def view_template
-          add_page_title(:inat_import_create_title.l)
-          add_context_nav(inat_import_form_new_tabs)
-          render(Views::Controllers::InatImports::Form.new(
-                   @form, super_importer: @super_importer
-                 ))
-        end
-      end
+    def view_template
+      add_page_title(:inat_import_create_title.l)
+      add_context_nav(inat_import_form_new_tabs)
+      render(Views::Controllers::InatImports::Form.new(
+               @form, super_importer: @super_importer
+             ))
     end
   end
 end

--- a/app/views/controllers/info.rb
+++ b/app/views/controllers/info.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Namespace module for Info controller view templates
-module Views::Controllers::Info
-end

--- a/app/views/controllers/info/textile_sandbox.rb
+++ b/app/views/controllers/info/textile_sandbox.rb
@@ -1,43 +1,37 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Info
-      # Phlex view template for the textile sandbox page.
-      # Sets the page title and renders the form component.
-      #
-      # @example Usage in controller
-      #   render(Views::Controllers::Info::TextileSandbox.new(
-      #     textile_sandbox: textile_sandbox,
-      #     show_result: !code.nil?,
-      #     submit_type: submit
-      #   ))
-      class TextileSandbox < Views::Base
-        # Register Rails helpers
-        register_output_helper :help_block
-        register_output_helper :add_page_title
+module Views::Controllers::Info
+  # Phlex view template for the textile sandbox page.
+  # Sets the page title and renders the form component.
+  #
+  # @example Usage in controller
+  #   render(Views::Controllers::Info::TextileSandbox.new(
+  #     textile_sandbox: textile_sandbox,
+  #     show_result: !code.nil?,
+  #     submit_type: submit
+  #   ))
+  class TextileSandbox < Views::Base
+    # Register Rails helpers
 
-        # @param textile_sandbox [FormObject::TextileSandbox] the model
-        # @param show_result [Boolean] whether to show rendered result
-        # @param submit_type [String] the submit button clicked
-        def initialize(textile_sandbox:, show_result:, submit_type:)
-          super()
-          @textile_sandbox = textile_sandbox
-          @show_result = show_result
-          @submit_type = submit_type
-        end
+    # @param textile_sandbox [FormObject::TextileSandbox] the model
+    # @param show_result [Boolean] whether to show rendered result
+    # @param submit_type [String] the submit button clicked
+    def initialize(textile_sandbox:, show_result:, submit_type:)
+      super()
+      @textile_sandbox = textile_sandbox
+      @show_result = show_result
+      @submit_type = submit_type
+    end
 
-        def view_template
-          add_page_title(:sandbox_title.t)
-          help_block(:div, :sandbox_header.tp)
+    def view_template
+      add_page_title(:sandbox_title.t)
+      help_block(:div, :sandbox_header.tp)
 
-          render(Views::Controllers::Info::TextileSandboxForm.new(
-                   @textile_sandbox,
-                   show_result: @show_result,
-                   submit_type: @submit_type
-                 ))
-        end
-      end
+      render(Views::Controllers::Info::TextileSandboxForm.new(
+               @textile_sandbox,
+               show_result: @show_result,
+               submit_type: @submit_type
+             ))
     end
   end
 end

--- a/app/views/controllers/info/textile_sandbox_form.rb
+++ b/app/views/controllers/info/textile_sandbox_form.rb
@@ -6,8 +6,6 @@ module Views::Controllers::Info
   # codes. Rendered by `Views::Controllers::Info::TextileSandbox`
   # (the textile_sandbox page view).
   class TextileSandboxForm < ::Components::ApplicationForm
-    register_value_helper :asset_path
-
     # @param model [FormObject::TextileSandbox] struct with code attribute
     # @param show_result [Boolean] whether to show the rendered result
     #   above form

--- a/app/views/controllers/occurrences.rb
+++ b/app/views/controllers/occurrences.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Namespace module for Occurrences controller view templates
-module Views::Controllers::Occurrences
-end

--- a/app/views/controllers/projects.rb
+++ b/app/views/controllers/projects.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Namespace module for Projects controller view templates
-module Views::Controllers::Projects
-end

--- a/app/views/controllers/projects/admin/show.rb
+++ b/app/views/controllers/projects/admin/show.rb
@@ -1,76 +1,66 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Admin
-        # Admin tab default landing (Details sub-tab). Renders the
-        # project edit form for in-place edits, plus a Danger Zone
-        # section with the Delete Project action. Sub-tabs sit above
-        # the form so the user can swap to Members or Aliases without
-        # leaving the Admin context.
-        class Show < Views::Base
-          register_output_helper :add_project_banner
-          register_output_helper :add_page_title
-          register_output_helper :destroy_button, mark_safe: true
-          register_value_helper :container_class
+module Views::Controllers::Projects::Admin
+  # Admin tab default landing (Details sub-tab). Renders the
+  # project edit form for in-place edits, plus a Danger Zone
+  # section with the Delete Project action. Sub-tabs sit above
+  # the form so the user can swap to Members or Aliases without
+  # leaving the Admin context.
+  class Show < Views::Base
+    register_output_helper :destroy_button, mark_safe: true
+    def initialize(project:, user:, dates_any:, upload_params:)
+      super()
+      @project = project
+      @user = user
+      @dates_any = dates_any
+      @upload_params = upload_params
+    end
 
-          def initialize(project:, user:, dates_any:, upload_params:)
-            super()
-            @project = project
-            @user = user
-            @dates_any = dates_any
-            @upload_params = upload_params
-          end
+    def view_template
+      add_project_banner(@project)
+      add_page_title(:show_project_admin_title.l)
+      container_class(:wide)
 
-          def view_template
-            add_project_banner(@project)
-            add_page_title(:show_project_admin_title.l)
-            container_class(:wide)
+      render(Views::Controllers::Projects::AdminSubtabs.new(
+               project: @project, current_subtab: "details"
+             ))
+      render_form
+      render_danger_zone
+    end
 
-            render(Views::Controllers::Projects::AdminSubtabs.new(
-                     project: @project, current_subtab: "details"
-                   ))
-            render_form
-            render_danger_zone
-          end
+    private
 
-          private
+    def render_form
+      render(Views::Controllers::Projects::Form.new(
+               @project,
+               enctype: "multipart/form-data",
+               dates_any: @dates_any,
+               upload_params: @upload_params,
+               dirty_form: true
+             ))
+    end
 
-          def render_form
-            render(Views::Controllers::Projects::Form.new(
-                     @project,
-                     enctype: "multipart/form-data",
-                     dates_any: @dates_any,
-                     upload_params: @upload_params,
-                     dirty_form: true
-                   ))
-          end
-
-          def render_danger_zone
-            render(Components::Panel.new(
-                     panel_class: "panel-danger mt-4",
-                     panel_id: "project_danger_zone"
-                   )) do |panel|
-              panel.with_heading do
-                strong { plain(:show_project_admin_danger_zone.l) }
-              end
-              panel.with_body { render_destroy }
-            end
-          end
-
-          def render_destroy
-            p { plain(:show_project_admin_destroy_help.l) }
-            # The destroy_button helper auto-applies text-danger, which
-            # provides the red color cue against a default button bg.
-            destroy_button(
-              target: @project,
-              name: :destroy_object.t(type: :project),
-              class: "btn btn-default btn-lg"
-            )
-          end
+    def render_danger_zone
+      render(Components::Panel.new(
+               panel_class: "panel-danger mt-4",
+               panel_id: "project_danger_zone"
+             )) do |panel|
+        panel.with_heading do
+          strong { plain(:show_project_admin_danger_zone.l) }
         end
+        panel.with_body { render_destroy }
       end
+    end
+
+    def render_destroy
+      p { plain(:show_project_admin_destroy_help.l) }
+      # The destroy_button helper auto-applies text-danger, which
+      # provides the red color cue against a default button bg.
+      destroy_button(
+        target: @project,
+        name: :destroy_object.t(type: :project),
+        class: "btn btn-default btn-lg"
+      )
     end
   end
 end

--- a/app/views/controllers/projects/admin_requests/new.rb
+++ b/app/views/controllers/projects/admin_requests/new.rb
@@ -1,31 +1,23 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module AdminRequests
-        # Phlex view for the admin request form page.
-        # Replaces admin_requests/new.html.erb.
-        class New < Views::Base
-          register_output_helper :add_page_title
+module Views::Controllers::Projects::AdminRequests
+  # Phlex view for the admin request form page.
+  # Replaces admin_requests/new.html.erb.
+  class New < Views::Base
+    def initialize(project:)
+      super()
+      @project = project
+    end
 
-          def initialize(project:)
-            super()
-            @project = project
-          end
+    def view_template
+      add_page_title(
+        :admin_request_title.t(title: @project.title)
+      )
 
-          def view_template
-            add_page_title(
-              :admin_request_title.t(title: @project.title)
-            )
-
-            render(Views::Controllers::Projects::AdminRequests::Form.new(
-                     FormObject::EmailRequest.new,
-                     project: @project
-                   ))
-          end
-        end
-      end
+      render(Views::Controllers::Projects::AdminRequests::Form.new(
+               FormObject::EmailRequest.new,
+               project: @project
+             ))
     end
   end
 end

--- a/app/views/controllers/projects/aliases/edit.rb
+++ b/app/views/controllers/projects/aliases/edit.rb
@@ -1,51 +1,41 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Aliases
-        # Phlex view for the edit project alias form page.
-        # Replaces aliases/edit.html.erb.
-        class Edit < Views::Base
-          register_output_helper :add_project_banner
-          register_output_helper :add_page_title
-          register_value_helper :container_class
+module Views::Controllers::Projects::Aliases
+  # Phlex view for the edit project alias form page.
+  # Replaces aliases/edit.html.erb.
+  class Edit < Views::Base
+    def initialize(project_alias:, project:, user:)
+      super()
+      @project_alias = project_alias
+      @project = project
+      @user = user
+    end
 
-          def initialize(project_alias:, project:, user:)
-            super()
-            @project_alias = project_alias
-            @project = project
-            @user = user
-          end
+    def view_template
+      add_project_banner(@project)
+      add_page_title(
+        :project_alias_edit.l(name: @project_alias.name)
+      )
+      container_class(:text)
 
-          def view_template
-            add_project_banner(@project)
-            add_page_title(
-              :project_alias_edit.l(name: @project_alias.name)
-            )
-            container_class(:text)
+      render(Views::Controllers::Projects::Aliases::Form.new(
+               @project_alias, user: @user,
+                               local: true
+             ))
+      render_links
+    end
 
-            render(Views::Controllers::Projects::Aliases::Form.new(
-                     @project_alias, user: @user,
-                                     local: true
-                   ))
-            render_links
-          end
+    private
 
-          private
-
-          def render_links
-            pid = @project_alias.project_id
-            a(href: project_alias_path(
-              project_id: pid, id: @project_alias.id
-            )) { plain("Show") }
-            plain(" | ")
-            a(href: project_aliases_path(
-              project_id: pid
-            )) { plain("Back") }
-          end
-        end
-      end
+    def render_links
+      pid = @project_alias.project_id
+      a(href: project_alias_path(
+        project_id: pid, id: @project_alias.id
+      )) { plain("Show") }
+      plain(" | ")
+      a(href: project_aliases_path(
+        project_id: pid
+      )) { plain("Back") }
     end
   end
 end

--- a/app/views/controllers/projects/aliases/index.rb
+++ b/app/views/controllers/projects/aliases/index.rb
@@ -1,49 +1,47 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Aliases
-        # Phlex view for the project aliases index page.
-        # Replaces aliases/index.html.erb.
-        class Index < Views::Base
-          register_output_helper :add_project_banner
-          register_output_helper :add_page_title
-          register_value_helper :container_class
-          register_value_helper :project_alias_headers
-          register_value_helper :project_alias_rows
+# Phlex view for the project aliases index page.
+# Replaces aliases/index.html.erb.
+module Views::Controllers::Projects::Aliases
+  class Index < Views::Base
+    register_value_helper :project_alias_rows
 
-          def initialize(project:, project_aliases:)
-            super()
-            @project = project
-            @project_aliases = project_aliases
-          end
+    def initialize(project:, project_aliases:)
+      super()
+      @project = project
+      @project_aliases = project_aliases
+    end
 
-          def view_template
-            add_project_banner(@project)
-            add_page_title(:PROJECT_ALIASES.l)
-            container_class(:wide)
+    def view_template
+      add_project_banner(@project)
+      add_page_title(:PROJECT_ALIASES.l)
+      container_class(:wide)
 
-            render(Views::Controllers::Projects::AdminSubtabs.new(
-                     project: @project, current_subtab: "aliases"
-                   ))
+      render(Views::Controllers::Projects::AdminSubtabs.new(
+               project: @project, current_subtab: "aliases"
+             ))
 
-            make_table(
-              headers: project_alias_headers,
-              rows: project_alias_rows(@project_aliases),
-              table_opts: {
-                class: "table table-striped " \
-                       "table-project-members mt-3",
-                id: "index_project_alias_table"
-              }
-            )
+      make_table(
+        headers: alias_headers,
+        rows: project_alias_rows(@project_aliases),
+        table_opts: {
+          class: "table table-striped " \
+                 "table-project-members mt-3",
+          id: "index_project_alias_table"
+        }
+      )
 
-            a(href: new_project_alias_path(
-              project_id: @project.id
-            )) { plain(:project_alias_new.t) }
-          end
-        end
-      end
+      a(href: new_project_alias_path(
+        project_id: @project.id
+      )) { plain(:project_alias_new.t) }
+    end
+
+    private
+
+    # `project_alias_headers` was a one-line constant array of
+    # localized strings; inlined here since this is the only caller.
+    def alias_headers
+      [:NAME.t, :TARGET_TYPE.t, :TARGET.t, :ACTIONS.t]
     end
   end
 end

--- a/app/views/controllers/projects/aliases/new.rb
+++ b/app/views/controllers/projects/aliases/new.rb
@@ -1,38 +1,28 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Aliases
-        # Phlex view for the new project alias form page.
-        # Replaces aliases/new.html.erb.
-        class New < Views::Base
-          register_output_helper :add_project_banner
-          register_output_helper :add_page_title
-          register_value_helper :container_class
+module Views::Controllers::Projects::Aliases
+  # Phlex view for the new project alias form page.
+  # Replaces aliases/new.html.erb.
+  class New < Views::Base
+    def initialize(project_alias:, project:, user:)
+      super()
+      @project_alias = project_alias
+      @project = project
+      @user = user
+    end
 
-          def initialize(project_alias:, project:, user:)
-            super()
-            @project_alias = project_alias
-            @project = project
-            @user = user
-          end
+    def view_template
+      add_project_banner(@project)
+      add_page_title(:project_alias_new.l)
+      container_class(:text)
 
-          def view_template
-            add_project_banner(@project)
-            add_page_title(:project_alias_new.l)
-            container_class(:text)
-
-            render(Views::Controllers::Projects::Aliases::Form.new(
-                     @project_alias, user: @user,
-                                     local: true
-                   ))
-            a(href: project_aliases_path(
-              project_id: @project_alias.project_id
-            )) { plain("Back") }
-          end
-        end
-      end
+      render(Views::Controllers::Projects::Aliases::Form.new(
+               @project_alias, user: @user,
+                               local: true
+             ))
+      a(href: project_aliases_path(
+        project_id: @project_alias.project_id
+      )) { plain("Back") }
     end
   end
 end

--- a/app/views/controllers/projects/aliases/show.rb
+++ b/app/views/controllers/projects/aliases/show.rb
@@ -1,60 +1,51 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Aliases
-        # Phlex view for the project alias show page.
-        # Replaces aliases/show.html.erb.
-        class Show < Views::Base
-          register_output_helper :add_project_banner
-          register_value_helper :container_class
+module Views::Controllers::Projects::Aliases
+  # Phlex view for the project alias show page.
+  # Replaces aliases/show.html.erb.
+  class Show < Views::Base
+    def initialize(project:, project_alias:)
+      super()
+      @project = project
+      @project_alias = project_alias
+    end
 
-          def initialize(project:, project_alias:)
-            super()
-            @project = project
-            @project_alias = project_alias
-          end
+    def view_template
+      add_project_banner(@project)
+      container_class(:text)
 
-          def view_template
-            add_project_banner(@project)
-            container_class(:text)
+      render_fields
+      render_links
+    end
 
-            render_fields
-            render_links
-          end
+    private
 
-          private
+    def render_fields
+      render_field("Name:", @project_alias.name)
+      render_field("Target Type:",
+                   @project_alias.target_type)
+      render_field("Target:",
+                   @project_alias.target.try(
+                     :format_name
+                   ))
+    end
 
-          def render_fields
-            render_field("Name:", @project_alias.name)
-            render_field("Target Type:",
-                         @project_alias.target_type)
-            render_field("Target:",
-                         @project_alias.target.try(
-                           :format_name
-                         ))
-          end
+    def render_field(label, value)
+      p do
+        span(class: "font-weight-bold") { plain(label) }
+        whitespace
+        plain(value.to_s)
+      end
+    end
 
-          def render_field(label, value)
-            p do
-              span(class: "font-weight-bold") { plain(label) }
-              whitespace
-              plain(value.to_s)
-            end
-          end
-
-          def render_links
-            pid = @project_alias.project_id
-            a(href: edit_project_alias_path(
-              project_id: pid, id: @project_alias.id
-            )) { plain(:EDIT.t) }
-            plain(" | ")
-            a(href: project_aliases_path) do
-              plain(:BACK.t)
-            end
-          end
-        end
+    def render_links
+      pid = @project_alias.project_id
+      a(href: edit_project_alias_path(
+        project_id: pid, id: @project_alias.id
+      )) { plain(:EDIT.t) }
+      plain(" | ")
+      a(href: project_aliases_path) do
+        plain(:BACK.t)
       end
     end
   end

--- a/app/views/controllers/projects/field_slips/form.rb
+++ b/app/views/controllers/projects/field_slips/form.rb
@@ -4,8 +4,6 @@
 # `Projects::FieldSlipsController#new`.
 module Views::Controllers::Projects::FieldSlips
   class Form < ::Components::ApplicationForm
-    register_value_helper :project_field_slips_path
-
     def initialize(model, project:, **)
       @project = project
       super(model, local: false, **)

--- a/app/views/controllers/projects/field_slips/new.rb
+++ b/app/views/controllers/projects/field_slips/new.rb
@@ -1,110 +1,100 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module FieldSlips
-        # Phlex view for the field slips form page.
-        # Replaces field_slips/new.html.erb.
-        class New < Views::Base
-          register_output_helper :add_page_title
-          register_output_helper :link_to_object, mark_safe: true
-          register_value_helper :container_class
+module Views::Controllers::Projects::FieldSlips
+  # Phlex view for the field slips form page.
+  # Replaces field_slips/new.html.erb.
+  class New < Views::Base
+    def initialize(project:, user:, field_slip_max:)
+      super()
+      @project = project
+      @user = user
+      @field_slip_max = field_slip_max
+    end
 
-          def initialize(project:, user:, field_slip_max:)
-            super()
-            @project = project
-            @user = user
-            @field_slip_max = field_slip_max
+    def view_template
+      add_page_title(page_title)
+      container_class(:text_image)
+
+      div(class: "mt-3 pb-2") do
+        render_max_info
+        render_form
+        render_tracker_table if member?
+      end
+    end
+
+    private
+
+    def page_title
+      [
+        :field_slips_for_project_title.t,
+        link_to_object(@project),
+        :PROJECT.t
+      ].join(" ")
+    end
+
+    def default_count
+      @field_slip_max.zero? ? 0 : 6
+    end
+
+    def member?
+      @project.member?(User.current)
+    end
+
+    def render_max_info
+      div do
+        plain(
+          :field_slips_max_for_project.t(
+            max: @field_slip_max
+          )
+        )
+      end
+    end
+
+    def render_form
+      render(Views::Controllers::Projects::FieldSlips::Form.new(
+               FormObject::ProjectFieldSlip.new(
+                 field_slips: default_count
+               ),
+               project: @project
+             ))
+    end
+
+    def render_tracker_table
+      table(class: "table mt-3") do
+        render_tracker_header
+        tbody(id: "field_slip_job_trackers") do
+          render_tracker_rows
+        end
+      end
+    end
+
+    def render_tracker_header
+      thead do
+        tr do
+          th(scope: "col") { plain(:FILENAME.t) }
+          th(scope: "col", class: "text-center") do
+            plain(:USER.t)
           end
-
-          def view_template
-            add_page_title(page_title)
-            container_class(:text_image)
-
-            div(class: "mt-3 pb-2") do
-              render_max_info
-              render_form
-              render_tracker_table if member?
-            end
+          th(scope: "col", class: "text-center") do
+            plain(:SECONDS.t)
           end
-
-          private
-
-          def page_title
-            [
-              :field_slips_for_project_title.t,
-              link_to_object(@project),
-              :PROJECT.t
-            ].join(" ")
+          th(scope: "col", class: "text-center") do
+            plain(:PAGES.t)
           end
-
-          def default_count
-            @field_slip_max.zero? ? 0 : 6
-          end
-
-          def member?
-            @project.member?(User.current)
-          end
-
-          def render_max_info
-            div do
-              plain(
-                :field_slips_max_for_project.t(
-                  max: @field_slip_max
-                )
-              )
-            end
-          end
-
-          def render_form
-            render(Views::Controllers::Projects::FieldSlips::Form.new(
-                     FormObject::ProjectFieldSlip.new(
-                       field_slips: default_count
-                     ),
-                     project: @project
-                   ))
-          end
-
-          def render_tracker_table
-            table(class: "table mt-3") do
-              render_tracker_header
-              tbody(id: "field_slip_job_trackers") do
-                render_tracker_rows
-              end
-            end
-          end
-
-          def render_tracker_header
-            thead do
-              tr do
-                th(scope: "col") { plain(:FILENAME.t) }
-                th(scope: "col", class: "text-center") do
-                  plain(:USER.t)
-                end
-                th(scope: "col", class: "text-center") do
-                  plain(:SECONDS.t)
-                end
-                th(scope: "col", class: "text-center") do
-                  plain(:PAGES.t)
-                end
-                th(scope: "col", class: "text-right") do
-                  plain(:STATUS.t)
-                end
-              end
-            end
-          end
-
-          def render_tracker_rows
-            @project.trackers.order(id: :desc).each do |t|
-              render(
-                Views::Controllers::Projects::FieldSlips::TrackerRow.new(
-                  tracker: t, user: @user
-                )
-              )
-            end
+          th(scope: "col", class: "text-right") do
+            plain(:STATUS.t)
           end
         end
+      end
+    end
+
+    def render_tracker_rows
+      @project.trackers.order(id: :desc).each do |t|
+        render(
+          Views::Controllers::Projects::FieldSlips::TrackerRow.new(
+            tracker: t, user: @user
+          )
+        )
       end
     end
   end

--- a/app/views/controllers/projects/field_slips/tracker_row.rb
+++ b/app/views/controllers/projects/field_slips/tracker_row.rb
@@ -8,7 +8,6 @@
 module Views::Controllers::Projects::FieldSlips
   class TrackerRow < Views::Base
     register_value_helper :field_slip_link
-    register_value_helper :field_slip_job_tracker_path
     include Phlex::Rails::Helpers::NumberWithPrecision
 
     def initialize(tracker:, user:)

--- a/app/views/controllers/projects/members/add_obs_modal.rb
+++ b/app/views/controllers/projects/members/add_obs_modal.rb
@@ -1,76 +1,70 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Members
-        # Turbo-stream modal shown when a project member clicks
-        # "Add My Observations" (#4129). Composes Components::Modal
-        # directly — the submit is a put_button (button_to mini-form),
-        # so there's no wrapping form to coordinate, just a Cancel +
-        # Submit button row in `.modal-footer`. Renders nothing in the
-        # body when count is zero except the "none match" message.
-        class AddObsModal < Views::Base
-          def initialize(project:, candidate:, count:, batch_limit:)
-            super()
-            @project = project
-            @candidate = candidate
-            @count = count
-            @batch_limit = batch_limit
-          end
+module Views::Controllers::Projects::Members
+  # Turbo-stream modal shown when a project member clicks
+  # "Add My Observations" (#4129). Composes Components::Modal
+  # directly — the submit is a put_button (button_to mini-form),
+  # so there's no wrapping form to coordinate, just a Cancel +
+  # Submit button row in `.modal-footer`. Renders nothing in the
+  # body when count is zero except the "none match" message.
+  class AddObsModal < Views::Base
+    def initialize(project:, candidate:, count:, batch_limit:)
+      super()
+      @project = project
+      @candidate = candidate
+      @count = count
+      @batch_limit = batch_limit
+    end
 
-          def view_template
-            render(Components::Modal.new(
-                     id: "modal_add_obs",
-                     title: :change_member_add_obs.l
-                   )) do |m|
-              m.with_body { p { plain(body_text) } }
-              m.with_footer { render_footer_buttons }
-            end
-          end
+    def view_template
+      render(Components::Modal.new(
+               id: "modal_add_obs",
+               title: :change_member_add_obs.l
+             )) do |m|
+        m.with_body { p { plain(body_text) } }
+        m.with_footer { render_footer_buttons }
+      end
+    end
 
-          private
+    private
 
-          def body_text
-            if @count.zero?
-              :add_obs_modal_none.l
-            elsif @count <= @batch_limit
-              :add_obs_modal_all.l(count: @count)
-            else
-              :add_obs_modal_partial.l(count: @count, limit: @batch_limit)
-            end
-          end
+    def body_text
+      if @count.zero?
+        :add_obs_modal_none.l
+      elsif @count <= @batch_limit
+        :add_obs_modal_all.l(count: @count)
+      else
+        :add_obs_modal_partial.l(count: @count, limit: @batch_limit)
+      end
+    end
 
-          def render_footer_buttons
-            button(type: :button, class: "btn btn-default",
-                   data: { dismiss: "modal" }) do
-              plain(:CANCEL.l)
-            end
-            whitespace
-            render_submit_button if @count.positive?
-          end
+    def render_footer_buttons
+      button(type: :button, class: "btn btn-default",
+             data: { dismiss: "modal" }) do
+        plain(:CANCEL.l)
+      end
+      whitespace
+      render_submit_button if @count.positive?
+    end
 
-          def render_submit_button
-            put_button(
-              name: submit_label,
-              class: "btn btn-primary",
-              path: project_member_path(
-                project_id: @project.id,
-                candidate: @candidate.id,
-                commit: :change_member_add_obs.l,
-                target: :project_index
-              )
-            )
-          end
+    def render_submit_button
+      put_button(
+        name: submit_label,
+        class: "btn btn-primary",
+        path: project_member_path(
+          project_id: @project.id,
+          candidate: @candidate.id,
+          commit: :change_member_add_obs.l,
+          target: :project_index
+        )
+      )
+    end
 
-          def submit_label
-            if @count <= @batch_limit
-              :add_obs_modal_add_all.l
-            else
-              :add_obs_modal_add_next.l(limit: @batch_limit)
-            end
-          end
-        end
+    def submit_label
+      if @count <= @batch_limit
+        :add_obs_modal_add_all.l
+      else
+        :add_obs_modal_add_next.l(limit: @batch_limit)
       end
     end
   end

--- a/app/views/controllers/projects/members/edit.rb
+++ b/app/views/controllers/projects/members/edit.rb
@@ -1,45 +1,35 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Members
-        # Phlex view for the change member status page.
-        # Replaces members/edit.html.erb.
-        class Edit < Views::Base
-          register_output_helper :add_page_title
-          register_output_helper :add_context_nav
-          register_value_helper :project_member_form_edit_tabs
+module Views::Controllers::Projects::Members
+  # Phlex view for the change member status page.
+  # Replaces members/edit.html.erb.
+  class Edit < Views::Base
+    def initialize(project:, project_member:, user:)
+      super()
+      @project = project
+      @project_member = project_member
+      @user = user
+    end
 
-          def initialize(project:, project_member:, user:)
-            super()
-            @project = project
-            @project_member = project_member
-            @user = user
-          end
+    def view_template
+      add_page_title(
+        :change_member_status_title.t(
+          name: @project_member.user.legal_name,
+          title: @project.title
+        )
+      )
+      add_context_nav(
+        project_member_form_edit_tabs(
+          project: @project
+        )
+      )
 
-          def view_template
-            add_page_title(
-              :change_member_status_title.t(
-                name: @project_member.user.legal_name,
-                title: @project.title
-              )
-            )
-            add_context_nav(
-              project_member_form_edit_tabs(
-                project: @project
-              )
-            )
-
-            render(Views::Controllers::Projects::Members::Form.new(
-                     @project_member, project: @project
-                   ))
-            render(Views::Controllers::Projects::Members::Groups.new(
-                     project: @project, user: @user
-                   ))
-          end
-        end
-      end
+      render(Views::Controllers::Projects::Members::Form.new(
+               @project_member, project: @project
+             ))
+      render(Views::Controllers::Projects::Members::Groups.new(
+               project: @project, user: @user
+             ))
     end
   end
 end

--- a/app/views/controllers/projects/members/index.rb
+++ b/app/views/controllers/projects/members/index.rb
@@ -1,117 +1,108 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Members
-        # Phlex view for the project members index page.
-        # Replaces members/index.html.erb.
-        class Index < Views::Base
-          register_output_helper :add_project_banner
-          register_value_helper :container_class
+module Views::Controllers::Projects::Members
+  # Phlex view for the project members index page.
+  # Replaces members/index.html.erb.
+  class Index < Views::Base
+    def initialize(project:, users:, project_member:,
+                   user:)
+      super()
+      @project = project
+      @users = users
+      @project_member = project_member
+      @user = user
+    end
 
-          def initialize(project:, users:, project_member:,
-                         user:)
-            super()
-            @project = project
-            @users = users
-            @project_member = project_member
-            @user = user
+    def view_template
+      add_project_banner(@project)
+      container_class(:wide)
+
+      render(Views::Controllers::Projects::AdminSubtabs.new(
+               project: @project, current_subtab: "members"
+             ))
+      render(Views::Controllers::Projects::Members::Form.new(
+               @project_member, project: @project
+             ))
+      render_table
+    end
+
+    private
+
+    def render_table
+      table(class: "table table-striped " \
+                   "table-project-members mt-3") do
+        render_header
+        tbody do
+          @users.sort_by(&:login).each do |u|
+            render_row(u)
           end
+        end
+      end
+    end
 
-          def view_template
-            add_project_banner(@project)
-            container_class(:wide)
-
-            render(Views::Controllers::Projects::AdminSubtabs.new(
-                     project: @project, current_subtab: "members"
-                   ))
-            render(Views::Controllers::Projects::Members::Form.new(
-                     @project_member, project: @project
-                   ))
-            render_table
+    def render_header
+      thead do
+        tr do
+          th(class: "text-center") do
+            plain(:Login_name.t)
           end
+          th { plain(:Full_name.t) }
+          th { plain(:PROJECT_ALIASES.t) }
+          th { plain(:Status.t) }
+          th
+        end
+      end
+    end
 
-          private
+    def render_row(user)
+      tr do
+        render_avatar_cell(user)
+        td(class: "align-middle") { plain(user.name) }
+        render_aliases_cell(user)
+        render_status_cell(user)
+        render_edit_cell(user)
+      end
+    end
 
-          def render_table
-            table(class: "table table-striped " \
-                         "table-project-members mt-3") do
-              render_header
-              tbody do
-                @users.sort_by(&:login).each do |u|
-                  render_row(u)
-                end
-              end
-            end
-          end
+    def render_avatar_cell(user)
+      td(class: "text-center") do
+        render_user_image(user) if user.image
+        user_link(user, user.login)
+      end
+    end
 
-          def render_header
-            thead do
-              tr do
-                th(class: "text-center") do
-                  plain(:Login_name.t)
-                end
-                th { plain(:Full_name.t) }
-                th { plain(:PROJECT_ALIASES.t) }
-                th { plain(:Status.t) }
-                th
-              end
-            end
-          end
+    def render_user_image(user)
+      render(Components::InteractiveImage.new(
+               user: user,
+               image: user.image,
+               votes: false,
+               size: :thumbnail
+             ))
+    end
 
-          def render_row(user)
-            tr do
-              render_avatar_cell(user)
-              td(class: "align-middle") { plain(user.name) }
-              render_aliases_cell(user)
-              render_status_cell(user)
-              render_edit_cell(user)
-            end
-          end
+    def render_aliases_cell(user)
+      td(class: "align-middle") do
+        render(Views::Controllers::Projects::Aliases::Widget.new(
+                 project: @project, target: user
+               ))
+      end
+    end
 
-          def render_avatar_cell(user)
-            td(class: "text-center") do
-              render_user_image(user) if user.image
-              user_link(user, user.login)
-            end
-          end
+    def render_status_cell(user)
+      td(class: "align-middle") do
+        plain(@project.member_status(user))
+      end
+    end
 
-          def render_user_image(user)
-            render(Components::InteractiveImage.new(
-                     user: user,
-                     image: user.image,
-                     votes: false,
-                     size: :thumbnail
-                   ))
-          end
+    def render_edit_cell(user)
+      td(class: "align-middle") do
+        next unless @project.is_admin?(@user)
 
-          def render_aliases_cell(user)
-            td(class: "align-middle") do
-              render(Views::Controllers::Projects::Aliases::Widget.new(
-                       project: @project, target: user
-                     ))
-            end
-          end
-
-          def render_status_cell(user)
-            td(class: "align-middle") do
-              plain(@project.member_status(user))
-            end
-          end
-
-          def render_edit_cell(user)
-            td(class: "align-middle") do
-              next unless @project.is_admin?(@user)
-
-              a(href: edit_project_member_path(
-                project_id: @project.id,
-                candidate: user.id
-              )) do
-                plain(:change_member_status_change_status.t)
-              end
-            end
-          end
+        a(href: edit_project_member_path(
+          project_id: @project.id,
+          candidate: user.id
+        )) do
+          plain(:change_member_status_change_status.t)
         end
       end
     end

--- a/app/views/controllers/projects/members/new.rb
+++ b/app/views/controllers/projects/members/new.rb
@@ -1,81 +1,71 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Members
-        # Phlex view for the add members page.
-        # Replaces members/new.html.erb.
-        class New < Views::Base
-          register_output_helper :add_page_title
-          register_output_helper :add_context_nav
-          register_output_helper :post_button, mark_safe: true
-          register_value_helper :container_class
-          register_value_helper :project_members_form_new_tabs
+module Views::Controllers::Projects::Members
+  # Phlex view for the add members page.
+  # Replaces members/new.html.erb.
+  class New < Views::Base
+    register_output_helper :post_button, mark_safe: true
 
-          def initialize(project:, users:, project_member:,
-                         user:)
-            super()
-            @project = project
-            @users = users
-            @project_member = project_member
-            @user = user
+    def initialize(project:, users:, project_member:,
+                   user:)
+      super()
+      @project = project
+      @users = users
+      @project_member = project_member
+      @user = user
+    end
+
+    def view_template
+      add_page_title(
+        :add_members_title.t(title: @project.title)
+      )
+      add_context_nav(
+        project_members_form_new_tabs(project: @project)
+      )
+      container_class(:wide)
+
+      render(Views::Controllers::Projects::Members::Form.new(
+               @project_member, project: @project
+             ))
+      render_users_table
+    end
+
+    private
+
+    def render_users_table
+      table(class: "table table-striped " \
+                   "table-project-members mt-3") do
+        render_table_header
+        tbody do
+          @users.sort_by(&:login).each do |u|
+            render_user_row(u)
           end
+        end
+      end
+    end
 
-          def view_template
-            add_page_title(
-              :add_members_title.t(title: @project.title)
+    def render_table_header
+      thead do
+        tr do
+          th { plain(:Login_name.t) }
+          th { plain(:Full_name.t) }
+          th
+        end
+      end
+    end
+
+    def render_user_row(user)
+      tr do
+        td { user_link(user, user.login) }
+        td { plain(user.name) }
+        td do
+          post_button(
+            name: :ADD.t,
+            path: project_members_path(
+              project_id: @project.id,
+              candidate: user.id
             )
-            add_context_nav(
-              project_members_form_new_tabs(project: @project)
-            )
-            container_class(:wide)
-
-            render(Views::Controllers::Projects::Members::Form.new(
-                     @project_member, project: @project
-                   ))
-            render_users_table
-          end
-
-          private
-
-          def render_users_table
-            table(class: "table table-striped " \
-                         "table-project-members mt-3") do
-              render_table_header
-              tbody do
-                @users.sort_by(&:login).each do |u|
-                  render_user_row(u)
-                end
-              end
-            end
-          end
-
-          def render_table_header
-            thead do
-              tr do
-                th { plain(:Login_name.t) }
-                th { plain(:Full_name.t) }
-                th
-              end
-            end
-          end
-
-          def render_user_row(user)
-            tr do
-              td { user_link(user, user.login) }
-              td { plain(user.name) }
-              td do
-                post_button(
-                  name: :ADD.t,
-                  path: project_members_path(
-                    project_id: @project.id,
-                    candidate: user.id
-                  )
-                )
-              end
-            end
-          end
+          )
         end
       end
     end

--- a/app/views/controllers/projects/new.rb
+++ b/app/views/controllers/projects/new.rb
@@ -1,34 +1,26 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      # Phlex view for the new project form page.
-      # Replaces new.html.erb.
-      class New < Views::Base
-        register_output_helper :add_new_title
-        register_output_helper :add_context_nav
-        register_value_helper :project_form_new_tabs
+module Views::Controllers::Projects
+  # Phlex view for the new project form page.
+  # Replaces new.html.erb.
+  class New < Views::Base
+    def initialize(project:, dates_any:, upload_params:)
+      super()
+      @project = project
+      @dates_any = dates_any
+      @upload_params = upload_params
+    end
 
-        def initialize(project:, dates_any:, upload_params:)
-          super()
-          @project = project
-          @dates_any = dates_any
-          @upload_params = upload_params
-        end
+    def view_template
+      add_new_title(:create_object, :PROJECT)
+      add_context_nav(project_form_new_tabs)
 
-        def view_template
-          add_new_title(:create_object, :PROJECT)
-          add_context_nav(project_form_new_tabs)
-
-          render(Views::Controllers::Projects::Form.new(
-                   @project,
-                   enctype: "multipart/form-data",
-                   dates_any: @dates_any,
-                   upload_params: @upload_params
-                 ))
-        end
-      end
+      render(Views::Controllers::Projects::Form.new(
+               @project,
+               enctype: "multipart/form-data",
+               dates_any: @dates_any,
+               upload_params: @upload_params
+             ))
     end
   end
 end

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -1,217 +1,210 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      # Phlex view for the project show page.
-      # Replaces show.html.erb.
-      class Show < Views::Base
-        register_output_helper :add_show_title
-        register_output_helper :add_project_banner
-        register_output_helper :post_button, mark_safe: true
-        register_output_helper :violations_button, mark_safe: true
-        register_value_helper :permission!
-        register_value_helper :container_class
+module Views::Controllers::Projects
+  # Phlex view for the project show page.
+  # Replaces show.html.erb.
+  class Show < Views::Base
+    register_output_helper :add_show_title
+    register_output_helper :post_button, mark_safe: true
+    register_output_helper :violations_button, mark_safe: true
+    register_value_helper :permission!
+    def initialize(project:, user:, drafts:, comments:)
+      super()
+      @project = project
+      @user = user
+      @drafts = drafts
+      @comments = comments
+    end
 
-        def initialize(project:, user:, drafts:, comments:)
-          super()
-          @project = project
-          @user = user
-          @drafts = drafts
-          @comments = comments
-        end
+    def view_template
+      add_show_title(@project)
+      add_project_banner(@project)
+      container_class(:wide)
 
-        def view_template
-          add_show_title(@project)
-          add_project_banner(@project)
-          container_class(:wide)
+      render_list_search
+      render_summary_panel
+      render_actions
+      render_comments
+      render(Components::ObjectFooter.new(
+               user: @user, obj: @project
+             ))
+    end
 
-          render_list_search
-          render_summary_panel
-          render_actions
-          render_comments
-          render(Components::ObjectFooter.new(
-                   user: @user, obj: @project
-                 ))
-        end
+    private
 
-        private
+    def render_list_search
+      trusted_html(
+        view_context.render(
+          partial: "shared/list_search",
+          locals: { object: @project }
+        )
+      )
+    end
 
-        def render_list_search
-          trusted_html(
-            view_context.render(
-              partial: "shared/list_search",
-              locals: { object: @project }
-            )
-          )
-        end
-
-        def render_summary_panel
-          render(Components::Panel.new(
-                   panel_id: "project_summary"
-                 )) do |panel|
-            panel.with_body do
-              render_summary_body
-            end
-          end
-        end
-
-        def render_summary_body
-          p { trusted_html(@project.summary.to_s.tpl) }
-          render_drafts if @drafts.any?
-          render_created_at
-        end
-
-        def render_drafts
-          p do
-            b { plain("#{:show_project_drafts.t}:") }
-            whitespace
-            plain(@drafts.length.to_s)
-            br
-            render_draft_list
-          end
-        end
-
-        def render_draft_list
-          div(class: "ml-3") do
-            @drafts.each do |draft|
-              a(href: name_description_path(draft.id)) do
-                trusted_html(draft.name&.display_name&.t)
-              end
-              plain(" (")
-              user_link(draft.user)
-              plain(")")
-              br
-            end
-          end
-        end
-
-        def render_created_at
-          p do
-            strong { plain("#{:show_project_created_at.l}:") }
-            whitespace
-            plain(@project.created_at.web_date)
-          end
-        end
-
-        def render_actions
-          div(id: "project_join_trust_edit", class: "mb-4") do
-            render_membership_buttons
-            render_administer_button
-            render_admin_links
-            render_violations_button
-          end
-        end
-
-        # Shared classes for every button in render_actions so the row reads
-        # consistently at narrow and wide viewports. Issue #4145.
-        def action_button_class
-          "btn btn-default btn-lg my-2 mr-2"
-        end
-
-        def render_administer_button
-          return unless @user&.admin && !@project.is_admin?(@user)
-
-          post_button(
-            name: :show_project_administer.l,
-            class: action_button_class,
-            path: project_administration_path(project_id: @project.id)
-          )
-        end
-
-        def render_membership_buttons
-          if @project.can_join?(@user)
-            render_join_button
-          elsif @project.member?(@user)
-            render_member_buttons
-          end
-        end
-
-        def render_join_button
-          post_button(
-            name: :show_project_join.l,
-            class: action_button_class,
-            path: project_members_path(
-              project_id: @project.id,
-              candidate: @user.id,
-              target: :project_index
-            )
-          )
-        end
-
-        def render_member_buttons
-          render_trust_settings_button
-          render_leave_button if @project.can_leave?(@user)
-          render_add_obs_button
-        end
-
-        def render_trust_settings_button
-          modal_link_to(
-            "trust_settings",
-            :show_project_trust_settings.l,
-            trust_modal_project_member_path(
-              project_id: @project.id,
-              candidate: @user.id
-            ),
-            { class: action_button_class }
-          )
-        end
-
-        def render_leave_button
-          put_button(
-            name: :show_project_leave.t,
-            class: action_button_class,
-            path: project_member_path(
-              project_id: @project.id,
-              candidate: @user.id,
-              target: :project_index
-            )
-          )
-        end
-
-        def render_add_obs_button
-          modal_link_to(
-            "add_obs",
-            :change_member_add_obs.t,
-            add_obs_modal_project_member_path(
-              project_id: @project.id,
-              candidate: @user.id
-            ),
-            { class: action_button_class }
-          )
-        end
-
-        def render_admin_links
-          return if permission?(@project)
-
-          a(
-            href: new_project_admin_request_path(
-              project_id: @project.id
-            ),
-            class: action_button_class
-          ) { plain(:show_project_admin_request.l) }
-        end
-
-        def render_violations_button
-          return unless @project.constraints?
-
-          violations_button(@project)
-        end
-
-        def render_comments
-          trusted_html(
-            view_context.render(
-              partial: "comments/comments_for_object",
-              locals: {
-                object: @project,
-                comments: @comments,
-                controls: @user,
-                limit: nil
-              }
-            )
-          )
+    def render_summary_panel
+      render(Components::Panel.new(
+               panel_id: "project_summary"
+             )) do |panel|
+        panel.with_body do
+          render_summary_body
         end
       end
+    end
+
+    def render_summary_body
+      p { trusted_html(@project.summary.to_s.tpl) }
+      render_drafts if @drafts.any?
+      render_created_at
+    end
+
+    def render_drafts
+      p do
+        b { plain("#{:show_project_drafts.t}:") }
+        whitespace
+        plain(@drafts.length.to_s)
+        br
+        render_draft_list
+      end
+    end
+
+    def render_draft_list
+      div(class: "ml-3") do
+        @drafts.each do |draft|
+          a(href: name_description_path(draft.id)) do
+            trusted_html(draft.name&.display_name&.t)
+          end
+          plain(" (")
+          user_link(draft.user)
+          plain(")")
+          br
+        end
+      end
+    end
+
+    def render_created_at
+      p do
+        strong { plain("#{:show_project_created_at.l}:") }
+        whitespace
+        plain(@project.created_at.web_date)
+      end
+    end
+
+    def render_actions
+      div(id: "project_join_trust_edit", class: "mb-4") do
+        render_membership_buttons
+        render_administer_button
+        render_admin_links
+        render_violations_button
+      end
+    end
+
+    # Shared classes for every button in render_actions so the row reads
+    # consistently at narrow and wide viewports. Issue #4145.
+    def action_button_class
+      "btn btn-default btn-lg my-2 mr-2"
+    end
+
+    def render_administer_button
+      return unless @user&.admin && !@project.is_admin?(@user)
+
+      post_button(
+        name: :show_project_administer.l,
+        class: action_button_class,
+        path: project_administration_path(project_id: @project.id)
+      )
+    end
+
+    def render_membership_buttons
+      if @project.can_join?(@user)
+        render_join_button
+      elsif @project.member?(@user)
+        render_member_buttons
+      end
+    end
+
+    def render_join_button
+      post_button(
+        name: :show_project_join.l,
+        class: action_button_class,
+        path: project_members_path(
+          project_id: @project.id,
+          candidate: @user.id,
+          target: :project_index
+        )
+      )
+    end
+
+    def render_member_buttons
+      render_trust_settings_button
+      render_leave_button if @project.can_leave?(@user)
+      render_add_obs_button
+    end
+
+    def render_trust_settings_button
+      modal_link_to(
+        "trust_settings",
+        :show_project_trust_settings.l,
+        trust_modal_project_member_path(
+          project_id: @project.id,
+          candidate: @user.id
+        ),
+        { class: action_button_class }
+      )
+    end
+
+    def render_leave_button
+      put_button(
+        name: :show_project_leave.t,
+        class: action_button_class,
+        path: project_member_path(
+          project_id: @project.id,
+          candidate: @user.id,
+          target: :project_index
+        )
+      )
+    end
+
+    def render_add_obs_button
+      modal_link_to(
+        "add_obs",
+        :change_member_add_obs.t,
+        add_obs_modal_project_member_path(
+          project_id: @project.id,
+          candidate: @user.id
+        ),
+        { class: action_button_class }
+      )
+    end
+
+    def render_admin_links
+      return if permission?(@project)
+
+      a(
+        href: new_project_admin_request_path(
+          project_id: @project.id
+        ),
+        class: action_button_class
+      ) { plain(:show_project_admin_request.l) }
+    end
+
+    def render_violations_button
+      return unless @project.constraints?
+
+      violations_button(@project)
+    end
+
+    def render_comments
+      trusted_html(
+        view_context.render(
+          partial: "comments/comments_for_object",
+          locals: {
+            object: @project,
+            comments: @comments,
+            controls: @user,
+            limit: nil
+          }
+        )
+      )
     end
   end
 end

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -1,123 +1,113 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Updates
-        class Index < Views::Base
-          register_output_helper :add_project_banner
-          register_output_helper :add_page_title
-          register_value_helper :container_class
+module Views::Controllers::Projects::Updates
+  class Index < Views::Base
+    def initialize(project:, user:, results:, show_excluded:)
+      super()
+      @project = project
+      @user = user
+      @observations = results[:observations]
+      @pagination = results[:pagination]
+      @request_url = results[:request_url]
+      @form_action_url = results[:form_action_url]
+      @current_count = results[:current_count]
+      @show_excluded = show_excluded
+    end
 
-          def initialize(project:, user:, results:, show_excluded:)
-            super()
-            @project = project
-            @user = user
-            @observations = results[:observations]
-            @pagination = results[:pagination]
-            @request_url = results[:request_url]
-            @form_action_url = results[:form_action_url]
-            @current_count = results[:current_count]
-            @show_excluded = show_excluded
-          end
+    def view_template
+      add_project_banner(@project)
+      container_class(:full)
+      add_page_title(:project_updates_title.t)
 
-          def view_template
-            add_project_banner(@project)
-            container_class(:full)
-            add_page_title(:project_updates_title.t)
+      render_toolbar
+      render_pagination
+      render_matrix
+      render_pagination
+    end
 
-            render_toolbar
-            render_pagination
-            render_matrix
-            render_pagination
-          end
+    private
 
-          private
+    def render_toolbar
+      div(class: "d-flex justify-content-between " \
+                 "align-items-center mb-3 flex-wrap") do
+        render_count_and_toggle
+        div { render_add_all_button }
+      end
+    end
 
-          def render_toolbar
-            div(class: "d-flex justify-content-between " \
-                       "align-items-center mb-3 flex-wrap") do
-              render_count_and_toggle
-              div { render_add_all_button }
-            end
-          end
+    def render_count_and_toggle
+      div(class: "d-flex align-items-center") do
+        span(id: "project_updates_count", class: "mr-3") do
+          plain(count_label)
+        end
+        render_show_excluded_toggle
+      end
+    end
 
-          def render_count_and_toggle
-            div(class: "d-flex align-items-center") do
-              span(id: "project_updates_count", class: "mr-3") do
-                plain(count_label)
-              end
-              render_show_excluded_toggle
-            end
-          end
+    def count_label
+      count_label_key.t(count: @current_count)
+    end
 
-          def count_label
-            count_label_key.t(count: @current_count)
-          end
+    def count_label_key
+      return :project_updates_excluded_count if @show_excluded
 
-          def count_label_key
-            return :project_updates_excluded_count if @show_excluded
+      :project_updates_count
+    end
 
-            :project_updates_count
-          end
+    def render_show_excluded_toggle
+      form(
+        action: project_updates_path(project_id: @project.id),
+        method: "get",
+        class: "form-inline mb-0 show-excluded-form",
+        data: { controller: "autosubmit",
+                autosubmit_delay_value: "0" }
+      ) do
+        label(class: "checkbox-inline") do
+          input(type: "checkbox", name: "show_excluded", value: "1",
+                checked: @show_excluded,
+                data: { action: "change->autosubmit#submit" })
+          plain(" #{:project_updates_show_excluded.t}")
+        end
+      end
+    end
 
-          def render_show_excluded_toggle
-            form(
-              action: project_updates_path(project_id: @project.id),
-              method: "get",
-              class: "form-inline mb-0 show-excluded-form",
-              data: { controller: "autosubmit",
-                      autosubmit_delay_value: "0" }
-            ) do
-              label(class: "checkbox-inline") do
-                input(type: "checkbox", name: "show_excluded", value: "1",
-                      checked: @show_excluded,
-                      data: { action: "change->autosubmit#submit" })
-                plain(" #{:project_updates_show_excluded.t}")
-              end
-            end
-          end
+    def render_add_all_button
+      button_to(
+        :project_updates_add_all.t,
+        add_all_project_updates_path(
+          project_id: @project.id,
+          show_excluded: @show_excluded
+        ),
+        method: :post,
+        class: "btn btn-default",
+        form: { data: {
+          turbo_confirm: :project_updates_confirm_add_all.t
+        } }
+      )
+    end
 
-          def render_add_all_button
-            button_to(
-              :project_updates_add_all.t,
-              add_all_project_updates_path(
-                project_id: @project.id,
-                show_excluded: @show_excluded
-              ),
-              method: :post,
-              class: "btn btn-default",
-              form: { data: {
-                turbo_confirm: :project_updates_confirm_add_all.t
-              } }
-            )
-          end
+    def render_pagination
+      return unless @pagination.num_pages > 1
 
-          def render_pagination
-            return unless @pagination.num_pages > 1
+      render(Components::IndexPaginationNav.new(
+               pagination_data: @pagination,
+               request_url: @request_url,
+               form_action_url: @form_action_url,
+               q_params: nil,
+               letter_param: nil
+             ))
+    end
 
-            render(Components::IndexPaginationNav.new(
-                     pagination_data: @pagination,
-                     request_url: @request_url,
-                     form_action_url: @form_action_url,
-                     q_params: nil,
-                     letter_param: nil
+    def render_matrix
+      render(Components::MatrixTable.new) do
+        @observations.each do |obs|
+          render(Components::MatrixBox.new(
+                   user: @user, object: obs
+                 )) do
+            render(Views::Controllers::Projects::Updates::ObsFooter.new(
+                     project: @project, obs: obs,
+                     show_excluded: @show_excluded
                    ))
-          end
-
-          def render_matrix
-            render(Components::MatrixTable.new) do
-              @observations.each do |obs|
-                render(Components::MatrixBox.new(
-                         user: @user, object: obs
-                       )) do
-                  render(Views::Controllers::Projects::Updates::ObsFooter.new(
-                           project: @project, obs: obs,
-                           show_excluded: @show_excluded
-                         ))
-                end
-              end
-            end
           end
         end
       end

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -1,63 +1,57 @@
 # frozen_string_literal: true
 
-module Views
-  module Controllers
-    module Projects
-      module Violations
-        # Turbo-stream modal shown when a project admin clicks
-        # "Add Target Location" on a violating observation row (#4304).
-        # Composes Components::Modal directly with either:
-        #
-        #   - `:form_content` slot owned by TargetLocationForm when the
-        #     obs has usable comma-suffixes — the form spans both
-        #     `.modal-body` and `.modal-footer` so submit sits inside
-        #     the form naturally.
-        #   - A static "no usable suffixes" body + Cancel-only footer
-        #     when the obs's `where` is just a country and there's
-        #     nothing to pick.
-        #
-        # Lives under `Views::Controllers::Projects::Violations` (not
-        # `Components::`) per the convention #4300 set for
-        # one-controller-action modal wrappers — it isn't reusable, it's
-        # the rendering of one specific controller action.
-        class TargetLocationModal < Views::Base
-          def initialize(project:, obs:, user:)
-            super()
-            @project = project
-            @obs = obs
-            @user = user
-          end
+module Views::Controllers::Projects::Violations
+  # Turbo-stream modal shown when a project admin clicks
+  # "Add Target Location" on a violating observation row (#4304).
+  # Composes Components::Modal directly with either:
+  #
+  #   - `:form_content` slot owned by TargetLocationForm when the
+  #     obs has usable comma-suffixes — the form spans both
+  #     `.modal-body` and `.modal-footer` so submit sits inside
+  #     the form naturally.
+  #   - A static "no usable suffixes" body + Cancel-only footer
+  #     when the obs's `where` is just a country and there's
+  #     nothing to pick.
+  #
+  # Lives under `Views::Controllers::Projects::Violations` (not
+  # `Components::`) per the convention #4300 set for
+  # one-controller-action modal wrappers — it isn't reusable, it's
+  # the rendering of one specific controller action.
+  class TargetLocationModal < Views::Base
+    def initialize(project:, obs:, user:)
+      super()
+      @project = project
+      @obs = obs
+      @user = user
+    end
 
-          def view_template
-            render(Components::Modal.new(
-                     id: Views::Controllers::Projects::Violations::TargetLocationForm.modal_id_for(@obs),
-                     title: :form_violations_modal_target_location_title.l,
-                     user: @user
-                   )) do |m|
-              if Views::Controllers::Projects::Violations::TargetLocationForm.applicable?(@obs)
-                m.with_form_content do
-                  render(Views::Controllers::Projects::Violations::TargetLocationForm.new(
-                           obs: @obs, project: @project
-                         ))
-                end
-              else
-                render_no_suffixes_slots(m)
-              end
-            end
+    def view_template
+      render(Components::Modal.new(
+               id: Views::Controllers::Projects::Violations::TargetLocationForm.modal_id_for(@obs),
+               title: :form_violations_modal_target_location_title.l,
+               user: @user
+             )) do |m|
+        if Views::Controllers::Projects::Violations::TargetLocationForm.applicable?(@obs)
+          m.with_form_content do
+            render(Views::Controllers::Projects::Violations::TargetLocationForm.new(
+                     obs: @obs, project: @project
+                   ))
           end
-
-          private
-
-          def render_no_suffixes_slots(modal)
-            modal.with_body do
-              p { :form_violations_modal_target_location_no_suffixes.l }
-            end
-            modal.with_footer do
-              button(type: "button", class: "btn btn-default",
-                     data: { dismiss: "modal" }) { :CANCEL.l }
-            end
-          end
+        else
+          render_no_suffixes_slots(m)
         end
+      end
+    end
+
+    private
+
+    def render_no_suffixes_slots(modal)
+      modal.with_body do
+        p { :form_violations_modal_target_location_no_suffixes.l }
+      end
+      modal.with_footer do
+        button(type: "button", class: "btn btn-default",
+               data: { dismiss: "modal" }) { :CANCEL.l }
       end
     end
   end

--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -24,3 +24,21 @@ Rails.autoloaders.main.push_dir(
 Rails.autoloaders.main.push_dir(
   Rails.root.join("app/components"), namespace: Components
 )
+
+# Make every top-level `Tabs::*Helper` module callable from any Phlex
+# view (no `helpers.*` proxy, no per-class `register_value_helper`).
+# This runs inside `to_prepare` so it works both at boot (after
+# eager-load in production) and on every code reload (development).
+#
+# Nested helpers under `Tabs::Sidebar::*`, `Tabs::Locations::*`,
+# `Tabs::Names::*` are NOT included here — they stay scoped to their
+# specific callers (e.g. `Views::Layouts::ApplicationSidebar` includes
+# `Tabs::Sidebar::AdminHelper` etc. explicitly).
+Rails.application.config.to_prepare do
+  Tabs.constants.each do |name|
+    next unless name.to_s.end_with?("Helper")
+
+    mod = Tabs.const_get(name)
+    Views::Base.include(mod) if mod.is_a?(Module)
+  end
+end


### PR DESCRIPTION
## Summary

Five coupled cleanups that together collapse a lot of accumulated boilerplate across Phlex views:

1. **Tabs auto-include in `Views::Base`.** A `to_prepare` hook in `config/initializers/phlex.rb` includes every top-level `Tabs::*Helper` module into `Views::Base` after eager-load (production) or on every reload (development). View classes can now call any tab builder (`object_return_tab`, `species_lists_index_tabs`, etc.) directly — no `helpers.*` proxy, no per-class `register_value_helper`. Nested modules under `Tabs::Sidebar::*`, `Tabs::Locations::*`, etc. stay scoped to their existing callers.

2. **Drop redundant helper registrations** across 21 view + 3 component files. The registrations were all already inherited:
   - `q_param`, `add_q_param`, `url_for`, `permission?`, `link_to_object`, `user_link`, `location_link`, `help_block`, `link_icon`, and 17 others — already on `Components::Base`.
   - `add_page_title`, `add_new_title`, `add_edit_title`, `add_context_nav`, `add_project_banner`, `container_class`, `content_for` — already on `Views::Base`.
   - All `*_path` and `*_url` named-route helpers — provided by `Phlex::Rails::Helpers::Routes` (already in `Components::Base`).
   - `asset_path` — provided by `Phlex::Rails::Helpers::AssetPath`.
   - `*_tabs` and `object_return_tab` — auto-included via the new Tabs hook above.

3. **Flatten deep-nested namespaces** in 17 Phlex view files. Per the "Collapse deep namespaces" rule in `.claude/rules/phlex_conversions.md`, the four-level `module Views / module Controllers / module X / module Y / class Z` form gets rewritten as `module Views::Controllers::X::Y / class Z`. Body indentation shifts left by the appropriate amount; trailing `end`s drop to match.

4. **Delete 4 vestigial empty namespace files**: `occurrences.rb`, `projects.rb`, `info.rb`, `inat_imports.rb`. These each declared an empty `module Views::Controllers::Foo / end` — Zeitwerk auto-creates the namespace from the directory name.

5. **Dead-code cleanup in `Views::Controllers::Descriptions::Permissions::Form`.** Found while bringing this file to 100% per-file coverage:
   - Deleted 4 dead methods (`group_checked?`, `group_locked?`, `locked_all_users_group?`, `locked_reviewers_group?`). All defined but never called anywhere — leftover from the pre-Phlex ERB version's manual checked-state logic, made unnecessary when `checkbox_field` started inferring checked state from the model.
   - Simplified `form_action` from `if name_description? then permissions_name_description_path else permissions_location_description_path` to just the name-description path. The else branch called `permissions_location_description_path`, which doesn't exist — there is no `Locations::Descriptions::PermissionsController`, no route, no caller. The branch would have raised `NoMethodError` if ever rendered; deleting it removes a latent bug.

## Doc updates

`.claude/rules/phlex_conversions.md` gets a new "Helpers available everywhere — no per-class registration" section listing every helper that's already in scope on `Views::Base` (Components::Base registrations + `Phlex::Rails::Helpers::*` + Views::Base page-chrome + the new Tabs auto-include), so future contributors don't need to re-discover the inheritance chain.

## Inlines

`project_alias_headers` (a one-line constant array of localized strings) was registered on `Views::Controllers::Projects::Aliases::Index`. Moved into the view as a private `alias_headers` method, registration dropped.

## Stats

- 35 files changed (30 modified + 5 deleted)
- Net deletion of ~180 LOC of boilerplate
- All 1051 component + view tests pass
- All 28 touched Ruby files at 100% per-file coverage

## Test plan

- [x] `bin/rails test test/components/ test/views/` — 1051 tests, 5217 assertions, 0 failures
- [x] `bundle exec rubocop` clean across the diff
- [x] Per-file coverage at 100% for all touched files (`Descriptions::Permissions::Form` went from 91.4% to 100% after the dead-code delete + latent-bug fix)
- [x] CI green on this branch

## Follow-up queued

- Inline `field_slip_link` into `Views::Controllers::Projects::FieldSlips::TrackerRow` (PR #4377, already stacked on this branch)
- Inline / pass-through-the-controller `project_alias_rows` + `project_alias_row` + `project_alias_actions`
- Move misplaced tab helpers from `ProjectsHelper` → `Tabs::ProjectsHelper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
