### PR TITLE
Fix Digestor warnings at source: ERBTracker skip constant-style render args

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -118,22 +118,6 @@ MushroomObserver::Application.configure do
   # Set log level.
   config.log_level = :ERROR
 
-  # Suppress template digesting errors for Phlex components
-  # (Phlex components don't have ERB templates to digest)
-  config.action_view.logger = Logger.new($stdout).tap do |logger|
-    logger.level = Logger::ERROR
-
-    # Filter out the Phlex component template errors
-    original_formatter = Logger::Formatter.new
-    logger.formatter = proc do |severity, datetime, progname, msg|
-      if msg.to_s.include?("Couldn't find template for digesting: Components/")
-        next
-      end
-
-      original_formatter.call(severity, datetime, progname, msg)
-    end
-  end
-
   # Raise error when a before_action's only/except options reference missing
   # actions
   config.action_controller.raise_on_missing_callback_actions = true

--- a/config/initializers/erb_dependency_tracker.rb
+++ b/config/initializers/erb_dependency_tracker.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Teach ActionView's ERB dependency tracker to skip constant-style
+# render arguments — i.e. `render(Components::Foo.new(...))` or
+# `render(Views::Bar.new(...))`. Those are Phlex class references,
+# not Rails partial paths.
+#
+# Why this matters
+# ----------------
+# ERBTracker's `RENDER_ARGUMENTS` regex can't see `::` as a delimiter,
+# so for `render(Components::MatrixTable.new(...))` it captures only
+# the first segment `Components` as the "dependency name". That then
+# passes through `add_dynamic_dependency`, which appends
+# `"#{dep.pluralize}/#{dep.singularize}"` — producing the bogus
+# `"Components/Component"` partial path. The Digestor then tries to
+# find a template for that name, fails, and logs:
+#
+#     ERROR -- :   Couldn't find template for digesting: Components/Component
+#
+# Same story for `Views::...` → `"Views/View"`. Every ERB partial that
+# renders a Phlex class produces one of these benign-but-noisy log
+# lines per test run.
+#
+# By Rails convention, dynamic render dependencies are instance- or
+# local-variable names (lowercase), e.g. `render @post`, `render
+# product`. A capitalized leading character is always a constant
+# reference, which by definition isn't a partial path — so dropping
+# them costs nothing and silences the noise at its source.
+require "action_view/dependency_tracker"
+
+ActionView::DependencyTracker::ERBTracker.prepend(
+  Module.new do
+    private
+
+    def add_dynamic_dependency(dependencies, dependency)
+      return if dependency&.match?(/\A[[:upper:]]/)
+
+      super
+    end
+  end
+)


### PR DESCRIPTION
## Summary

Replaces #4372. Fixes #4371 at the source instead of filtering the symptom.

`ActionView::DependencyTracker::ERBTracker` scans ERB templates for `render` calls and extracts dependency names so the Digestor can compute fragment-cache keys. Its `RENDER_ARGUMENTS` regex recognizes `.` as a method-chain delimiter but not `::`, so when an ERB partial does

```erb
<%= render(Components::MatrixTable.new(...)) %>
```

the tracker captures only `Components` as the "dependency name". It then feeds that to `add_dynamic_dependency`, which appends `"#{dep.pluralize}/#{dep.singularize}"` — yielding the bogus `"Components/Component"` partial path. The Digestor then can't find a template for it and logs:

```
ERROR -- :  Couldn't find template for digesting: Components/Component
```

Same shape produces `"Views/View"` for `render(Views::Foo.new(...))`. The MO codebase has 233 ERB files that render Phlex classes this way, so the warning fires constantly in test output.

## The fix

A small `prepend` on `ERBTracker#add_dynamic_dependency` that drops any dependency name starting with an uppercase letter. By Rails convention, dynamic render dependencies are instance/local variable names (lowercase) — `render @post`, `render product`. Leading-uppercase always means a constant reference, which by definition isn't a partial path. Dropping them costs nothing and removes the noise at its source.

```ruby
require "action_view/dependency_tracker"

ActionView::DependencyTracker::ERBTracker.prepend(
  Module.new do
    private

    def add_dynamic_dependency(dependencies, dependency)
      return if dependency&.match?(/\A[[:upper:]]/)

      super
    end
  end
)
```

## Why not #4372's approach?

#4372 filters the log message after the fact (the existing filter in `config/environments/test.rb` already does this for `Components/`). The smell @andrnimm flagged is real: a log filter quietly throws away every log line whose text happens to match, including any genuine errors that share the substring. And the filter is test-environment-only — same bogus digesting still happens in dev / production, just unobserved.

The initializer here addresses the root cause and applies in every environment.

## Other changes

- `config/environments/test.rb`: deletes the post-hoc log filter (no longer needed; the warning isn't emitted in the first place).

## Test plan

- [x] `bin/rails test test/controllers/rss_logs_controller_test.rb` — 17 tests, 0 failures, **0 "Couldn't find template" warnings** (previously emitted one per test).
- [x] `bin/rails test test/controllers/observations_controller_index_test.rb test/controllers/observations_controller_show_test.rb` — 81 tests, 0 failures, 0 warnings.
- [x] `bundle exec rubocop` clean.
- [ ] CI green.

Fixes #4371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
