### PR TITLE
ApplicationForm field helpers: accept String name for non-bound fields + sweep callers

### DIFF
--- a/app/components/application_form/field.rb
+++ b/app/components/application_form/field.rb
@@ -3,64 +3,11 @@
 class Components::ApplicationForm < Superform::Rails::Form
   # Override the Field class to use our custom field components.
   # Acts as a factory/dispatcher: each method builds the matching
-  # Bootstrap-styled field component for the form field.
+  # Bootstrap-styled field component for the form field. The
+  # factory methods themselves live in `FieldFactoryMethods` so
+  # the same surface is shared with `FieldProxy` (the non-bound
+  # equivalent).
   class Field < Superform::Rails::Form::Field
-    def text(wrapper_options: {}, **attributes)
-      TextField.new(self, wrapper_options: wrapper_options, **attributes)
-    end
-
-    def textarea(wrapper_options: {}, **attributes)
-      TextareaField.new(self, wrapper_options: wrapper_options, **attributes)
-    end
-
-    def file(wrapper_options: {}, **attributes)
-      FileField.new(self, wrapper_options: wrapper_options, **attributes)
-    end
-
-    def checkbox(*options, wrapper_options: {}, **attributes)
-      CheckboxField.new(self, *options,
-                        wrapper_options: wrapper_options, **attributes)
-    end
-
-    def radio(*options, wrapper_options: {}, **attributes)
-      RadioField.new(self, *options,
-                     wrapper_options: wrapper_options, **attributes)
-    end
-
-    def select(options, wrapper_options: {}, **attributes)
-      SelectField.new(self, collection: options,
-                            wrapper_options: wrapper_options, **attributes)
-    end
-
-    def read_only(wrapper_options: {}, **attributes)
-      ReadOnlyField.new(self, wrapper_options: wrapper_options, **attributes)
-    end
-
-    # Autocompleter-specific options that should NOT go in field attributes.
-    # Note: :value stays in attributes since it goes to the text/textarea field
-    AUTOCOMPLETER_OPTIONS = [:find_text, :keep_text, :edit_text, :create_text,
-                             :create, :create_path, :hidden_name, :hidden_value,
-                             :hidden_data, :controller_data, :controller_id,
-                             :map_outlet].freeze
-
-    def autocompleter(type:, textarea: false, wrapper_options: {},
-                      **attributes)
-      # Extract autocompleter-specific options from attributes
-      ac_options = attributes.slice(*AUTOCOMPLETER_OPTIONS)
-      field_attributes = attributes.except(*AUTOCOMPLETER_OPTIONS)
-
-      AutocompleterField.new(self, type: type, textarea: textarea,
-                                   attributes: field_attributes,
-                                   wrapper_options: wrapper_options,
-                                   **ac_options)
-    end
-
-    def static(wrapper_options: {}, **attributes)
-      StaticTextField.new(self, wrapper_options: wrapper_options, **attributes)
-    end
-
-    def date(wrapper_options: {}, **attributes)
-      DateField.new(self, wrapper_options: wrapper_options, **attributes)
-    end
+    include FieldFactoryMethods
   end
 end

--- a/app/components/application_form/field_factory_methods.rb
+++ b/app/components/application_form/field_factory_methods.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Shared factory-method surface for things that stand in as a
+  # form field: the model-bound `Field` (Superform::Field subclass)
+  # and the standalone `FieldProxy` (raw `name=`, no model). Each
+  # method returns the matching Bootstrap-styled MO field component
+  # with the includer (`self` — a Field or FieldProxy) as its
+  # backing field.
+  #
+  # The downstream components only depend on `.dom.{id,name}`,
+  # `.value`, `.key`, `.parent`, all of which both Field and
+  # FieldProxy provide.
+  #
+  module FieldFactoryMethods
+    # Autocompleter-specific options that should NOT go in field
+    # attributes. `:value` stays in attributes since it goes to
+    # the text/textarea field.
+    AUTOCOMPLETER_OPTIONS = [:find_text, :keep_text, :edit_text,
+                             :create_text, :create, :create_path,
+                             :hidden_name, :hidden_value, :hidden_data,
+                             :controller_data, :controller_id,
+                             :map_outlet].freeze
+
+    def text(wrapper_options: {}, **attributes)
+      TextField.new(self, wrapper_options: wrapper_options, **attributes)
+    end
+
+    def textarea(wrapper_options: {}, **attributes)
+      TextareaField.new(self, wrapper_options: wrapper_options, **attributes)
+    end
+
+    def file(wrapper_options: {}, **attributes)
+      FileField.new(self, wrapper_options: wrapper_options, **attributes)
+    end
+
+    def checkbox(*options, wrapper_options: {}, **attributes)
+      CheckboxField.new(self, *options,
+                        wrapper_options: wrapper_options, **attributes)
+    end
+
+    def radio(*options, wrapper_options: {}, **attributes)
+      RadioField.new(self, *options,
+                     wrapper_options: wrapper_options, **attributes)
+    end
+
+    def select(options, wrapper_options: {}, **attributes)
+      SelectField.new(self, collection: options,
+                            wrapper_options: wrapper_options, **attributes)
+    end
+
+    def read_only(wrapper_options: {}, **attributes)
+      ReadOnlyField.new(self, wrapper_options: wrapper_options, **attributes)
+    end
+
+    def autocompleter(type:, textarea: false, wrapper_options: {},
+                      **attributes)
+      ac_options = attributes.slice(*AUTOCOMPLETER_OPTIONS)
+      field_attributes = attributes.except(*AUTOCOMPLETER_OPTIONS)
+
+      AutocompleterField.new(self, type: type, textarea: textarea,
+                                   attributes: field_attributes,
+                                   wrapper_options: wrapper_options,
+                                   **ac_options)
+    end
+
+    def static(wrapper_options: {}, **attributes)
+      StaticTextField.new(self, wrapper_options: wrapper_options, **attributes)
+    end
+
+    def date(wrapper_options: {}, **attributes)
+      DateField.new(self, wrapper_options: wrapper_options, **attributes)
+    end
+  end
+end

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -36,7 +36,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).text(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.text(
         wrapper_options: wrapper_opts,
         **field_opts
       )
@@ -61,7 +62,8 @@ class Components::ApplicationForm < Superform::Rails::Form
 
       # `monospace:` is handled by TextareaField itself via wrapper_options.
 
-      field_component = field(field_name).textarea(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.textarea(
         wrapper_options: wrapper_opts,
         **field_opts
       )
@@ -97,7 +99,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).checkbox(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.checkbox(
         *choices,
         wrapper_options: wrapper_opts,
         **field_opts
@@ -119,7 +122,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).radio(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.radio(
         *choices,
         wrapper_options: wrapper_opts,
         **field_opts
@@ -142,7 +146,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).select(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.select(
         options_list,
         wrapper_options: wrapper_opts,
         **field_opts
@@ -164,7 +169,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).date(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.date(
         wrapper_options: wrapper_opts,
         **field_opts
       )
@@ -191,7 +197,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       # validation error).
       field_opts[:value] = "" unless field_opts.key?(:value)
 
-      field_component = field(field_name).text(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.text(
         wrapper_options: wrapper_opts,
         type: "password",
         **field_opts
@@ -232,18 +239,7 @@ class Components::ApplicationForm < Superform::Rails::Form
       # `hidden_field_tag` (browsers otherwise repopulate hidden fields
       # on back-button). Caller can override with `autocomplete:`.
       options = { autocomplete: "off" }.merge(options)
-      # Both paths render through `HiddenField` — the dedicated
-      # hidden-input component. `HiddenField` only needs `.dom.id`,
-      # `.dom.name`, `.value` on its `field` argument; Superform's
-      # `Field` and our `FieldProxy` both provide them. So the
-      # Symbol path can pass the Superform field directly — no
-      # FieldProxy rebuild, value auto-reads from model / FormObject
-      # via the field's own `.value`.
-      f = if field_name.is_a?(String)
-            FieldProxy.new(nil, field_name, options[:value])
-          else
-            field(field_name)
-          end
+      f = resolve_field(field_name, value: options[:value])
       render(HiddenField.new(f, **options))
     end
 
@@ -263,7 +259,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       # nil` opts out.
       field_opts[:min] = 1 unless field_opts.key?(:min)
 
-      field_component = field(field_name).text(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.text(
         wrapper_options: wrapper_opts,
         type: "number",
         **field_opts
@@ -286,7 +283,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*static_wrapper_opts)
       field_opts = options.except(*static_wrapper_opts)
 
-      field_component = field(field_name).static(
+      f = resolve_field(field_name, value: wrapper_opts[:value])
+      field_component = f.static(
         wrapper_options: wrapper_opts,
         **field_opts
       )
@@ -308,7 +306,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*read_only_wrapper_opts)
       field_opts = options.except(*read_only_wrapper_opts)
 
-      field_component = field(field_name).read_only(
+      f = resolve_field(field_name, value: wrapper_opts[:value])
+      field_component = f.read_only(
         wrapper_options: wrapper_opts,
         **field_opts
       )
@@ -333,7 +332,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).file(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.file(
         wrapper_options: wrapper_opts,
         **field_opts
       )
@@ -355,7 +355,8 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
-      field_component = field(field_name).autocompleter(
+      f = resolve_field(field_name, value: field_opts[:value])
+      field_component = f.autocompleter(
         type: type,
         textarea: textarea,
         wrapper_options: wrapper_opts,
@@ -428,6 +429,24 @@ class Components::ApplicationForm < Superform::Rails::Form
       return options if options[:prefs].blank?
 
       options.merge(label: :"prefs_#{field_name}".t).except(:prefs)
+    end
+
+    # Resolve a field name to a field object the factory methods can
+    # call (`.text`, `.textarea`, `.checkbox`, etc.). Symbol → model-
+    # bound `Superform::Field` (value reads through the field's own
+    # `.value` from the form's model / FormObject). String → standalone
+    # `FieldProxy` carrying the raw `name=` attribute and an explicit
+    # value (no model behind it).
+    #
+    # Lets the `*_field` helpers handle both bound and non-bound fields
+    # through a single dispatch shape — same precedent `hidden_field`
+    # has established.
+    def resolve_field(field_name, value: nil)
+      if field_name.is_a?(String)
+        FieldProxy.new(nil, field_name, value)
+      else
+        field(field_name)
+      end
     end
   end
 end

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -99,11 +99,16 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
+      # In collection/block mode (`*choices` or `&block`), `value:` is
+      # the array-of-checked-ids that drives `checked` state, NOT a
+      # value attribute on every input — strip it. In boolean mode it
+      # IS the checkbox's submitted value when checked, so leave it.
+      collection_mode = choices.any? || block
       f = resolve_field(field_name, value: field_opts[:value])
       field_component = f.checkbox(
         *choices,
         wrapper_options: wrapper_opts,
-        **field_opts
+        **(collection_mode ? field_opts.except(:value) : field_opts)
       )
 
       set_help_slot(field_component, wrapper_opts[:help])
@@ -122,11 +127,15 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
+      # `value:` (String-form path) only carries the selected option for
+      # `option_checked?`; strip it from the attributes the field
+      # forwards onto each `<input type="radio">` (where `value=` is
+      # the per-option value, not the field's currently-selected value).
       f = resolve_field(field_name, value: field_opts[:value])
       field_component = f.radio(
         *choices,
         wrapper_options: wrapper_opts,
-        **field_opts
+        **field_opts.except(:value)
       )
 
       yield(field_component) if block_given?
@@ -146,11 +155,14 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_opts = options.slice(*WRAPPER_OPTIONS)
       field_opts = options.except(*WRAPPER_OPTIONS)
 
+      # `value:` only carries the selected option in the String-form
+      # path; `<select>` itself takes no `value=` attribute, so drop
+      # it from the attributes forwarded to the element.
       f = resolve_field(field_name, value: field_opts[:value])
       field_component = f.select(
         options_list,
         wrapper_options: wrapper_opts,
-        **field_opts
+        **field_opts.except(:value)
       )
 
       yield(field_component) if block_given?

--- a/app/components/application_form/field_proxy.rb
+++ b/app/components/application_form/field_proxy.rb
@@ -60,9 +60,19 @@ class Components::ApplicationForm < Superform::Rails::Form
       end
 
       def id
-        return @field_key.to_s if @namespace.blank?
-
-        "#{@namespace}_#{@field_key}".tr("[]", "_").gsub(/__+/, "_")
+        # When `field_key` is a String containing the full raw `name=`
+        # attribute (with `[...]` segments), we still need to normalize
+        # it to a valid HTML id — otherwise a name like
+        # `"reviewed[385495444]"` would produce an `id` with literal
+        # brackets, and Capybara / `getElementById` lookups would fail.
+        # Applies the same `[]`→`_` normalization the namespaced case
+        # uses, then strips trailing `_` (from a trailing `]`).
+        raw = if @namespace.blank?
+                @field_key.to_s
+              else
+                "#{@namespace}_#{@field_key}"
+              end
+        raw.tr("[]", "_").gsub(/__+/, "_").chomp("_")
       end
 
       def name

--- a/app/components/application_form/field_proxy.rb
+++ b/app/components/application_form/field_proxy.rb
@@ -5,9 +5,20 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Provides the same interface as Superform::Field for field components.
   # Unlike Superform fields, these can be created and rendered many times.
   #
-  # @example
+  # @example Hand-built (still works; equivalent to the helper below)
   #   proxy = FieldProxy.new("observation[good_image][123]", :notes, "text")
   #   render(TextField.new(proxy, wrapper_options: {}))
+  #
+  # @example Via the form's field helpers with a String `field_name`
+  #   text_field("observation[good_image][123][notes]", value: "text")
+  #   # Internally: FieldProxy.new(nil, "observation[...]", "text").text(...)
+  #
+  # Mirrors `Field`'s factory-method surface (`text`, `textarea`,
+  # `checkbox`, `radio`, `select`, `autocompleter`, `date`, `file`,
+  # `read_only`, `static`) so the form's `*_field` helpers can dispatch
+  # Symbol → `field(name)` (model-bound) and String → `FieldProxy.new(...)`
+  # (raw `name=` attribute) through one code path. Same precedent
+  # `hidden_field` has established; this generalizes it.
   class FieldProxy
     attr_reader :key, :value, :dom
 
@@ -26,6 +37,8 @@ class Components::ApplicationForm < Superform::Rails::Form
     def parent
       nil
     end
+
+    include FieldFactoryMethods
 
     # Factory method to create a FieldProxy for image fields.
     # @param type [Symbol] :good_image or :image

--- a/app/views/controllers/admin/donations/review_form.rb
+++ b/app/views/controllers/admin/donations/review_form.rb
@@ -64,8 +64,11 @@ module Views::Controllers::Admin::Donations
     end
 
     def render_checkbox(donation)
+      # Field id is the donation id (an Integer) under the form's
+      # `reviewed[...]` namespace. Symbols can't start with a digit,
+      # so spell the full raw `name=` explicitly.
       checkbox_field(
-        donation.id.to_s,
+        "reviewed[#{donation.id}]",
         checked: donation.reviewed,
         label: false
       )

--- a/app/views/controllers/descriptions/form.rb
+++ b/app/views/controllers/descriptions/form.rb
@@ -143,13 +143,8 @@ module Views::Controllers::Descriptions
     # --- Merge fields ---
 
     def render_merge_fields
-      render_flat_hidden_field("old_desc_id", @old_desc_id)
-      render_flat_hidden_field("delete_after", @delete_after)
-    end
-
-    def render_flat_hidden_field(name, value)
-      proxy = Components::ApplicationForm::FieldProxy.new(nil, name, value)
-      render(Components::ApplicationForm::HiddenField.new(proxy))
+      hidden_field("old_desc_id", value: @old_desc_id)
+      hidden_field("delete_after", value: @delete_after)
     end
 
     # --- Helper methods ---

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -267,19 +267,15 @@ module Views::Controllers::FieldSlips
       # FieldSlip submits matrix params as flat `observation_ids[]`
       # and namespaced `field_slip[primary_observation_id]` — both
       # unchanged from the ERB version, so the controller doesn't
-      # need to move. Since FieldSlip doesn't have its own
-      # `observation_ids=` accessor (the join is via the occurrence),
-      # we use `FieldProxy` directly instead of `field(:foo).checkbox`.
-      obs_ids_proxy = Components::ApplicationForm::FieldProxy.new(
-        nil, "observation_ids", checked_ids
-      )
-      primary_proxy = Components::ApplicationForm::FieldProxy.new(
-        "field_slip", :primary_observation_id, primary_id
-      )
+      # need to move. FieldSlip doesn't have an `observation_ids=`
+      # accessor (the join is via the occurrence), so we drive both
+      # fields through the String form of `checkbox_field` /
+      # `radio_field` — raw `name=` attribute, value carried by the
+      # `value:` option, no Superform model binding.
+      @checked_ids = checked_ids
+      @primary_id = primary_id
       ul(class: "row list-unstyled mt-3", data: matrix_data) do
-        observations.each do |obs|
-          render_observation_row(obs, obs_ids_proxy, primary_proxy)
-        end
+        observations.each { |obs| render_observation_row(obs) }
       end
     end
 
@@ -290,37 +286,33 @@ module Views::Controllers::FieldSlips
       }
     end
 
-    def render_observation_row(obs, obs_ids_proxy, primary_proxy)
+    def render_observation_row(obs)
       MatrixBox(user: @user, object: obs, votes: false) do
-        render_include_checkbox(obs, obs_ids_proxy)
-        render_primary_radio(obs, primary_proxy)
+        render_include_checkbox(obs)
+        render_primary_radio(obs)
         render_field_slip_link(obs.field_slip) if obs.field_slip
       end
     end
 
     # `cb.option(obs.id)` renders one `<input type="checkbox"
     # name="observation_ids[]" value="…">`. CheckboxField looks up
-    # `checked` via membership of `obs.id` in `obs_ids_proxy.value`
-    # (the array of currently-checked ids).
-    def render_include_checkbox(obs, obs_ids_proxy)
-      data = { action: "field-slip-form#includeToggled" }
-      render(Components::ApplicationForm::CheckboxField.new(
-               obs_ids_proxy,
-               wrapper_options: { label: false, wrap_class: "my-0" },
-               data: data
-             )) do |cb|
+    # `checked` via membership of `obs.id` in the field's value (the
+    # array of currently-checked ids passed as `value:` here).
+    def render_include_checkbox(obs)
+      checkbox_field("observation_ids",
+                     value: @checked_ids,
+                     label: false, wrap_class: "my-0",
+                     data: { action: "field-slip-form#includeToggled" }) do |cb|
         cb.option(obs.id) { "Include" }
       end
     end
 
-    def render_primary_radio(obs, primary_proxy)
-      data = { action: "field-slip-form#primarySelected" }
-      render(Components::ApplicationForm::RadioField.new(
-               primary_proxy,
-               [obs.id, :create_occurrence_primary.t],
-               wrapper_options: { wrap_class: "my-0" },
-               data: data
-             ))
+    def render_primary_radio(obs)
+      radio_field("field_slip[primary_observation_id]",
+                  [obs.id, :create_occurrence_primary.t],
+                  value: @primary_id,
+                  wrap_class: "my-0",
+                  data: { action: "field-slip-form#primarySelected" })
     end
 
     def render_field_slip_link(field_slip)

--- a/app/views/controllers/glossary_terms/images/remove_form.rb
+++ b/app/views/controllers/glossary_terms/images/remove_form.rb
@@ -70,16 +70,11 @@ module Views::Controllers::GlossaryTerms::Images
     # `glossary_terms/images_controller.rb#detach`). Wraps each
     # checkbox in MO's standard `.checkbox` BS3 markup.
     def render_select_checkbox(image)
-      proxy = Components::ApplicationForm::FieldProxy.new(
-        "selected", image.id, nil
-      )
-      render(Components::ApplicationForm::CheckboxField.new(
-               proxy,
-               wrapper_options: { label: "#{:image.t} ##{image.id}",
-                                  wrap_class: "my-0" },
-               checked_value: "yes",
-               unchecked_value: "no"
-             ))
+      checkbox_field("selected[#{image.id}]",
+                     label: "#{:image.t} ##{image.id}",
+                     wrap_class: "my-0",
+                     checked_value: "yes",
+                     unchecked_value: "no")
     end
   end
 end

--- a/app/views/controllers/names/form.rb
+++ b/app/views/controllers/names/form.rb
@@ -39,10 +39,7 @@ module Views::Controllers::Names
     def render_approved_rank_field
       return unless @approved_rank
 
-      proxy = Components::ApplicationForm::FieldProxy.new(
-        nil, "approved_rank", @approved_rank
-      )
-      render(Components::ApplicationForm::HiddenField.new(proxy))
+      hidden_field("approved_rank", value: @approved_rank)
     end
 
     def button_text

--- a/app/views/controllers/projects/form.rb
+++ b/app/views/controllers/projects/form.rb
@@ -94,18 +94,14 @@ module Views::Controllers::Projects
     end
 
     # `dates_any` is UI state passed in from the controller, not a Project
-    # attribute, so we can't use `field(:dates_any)`. FieldProxy gives
-    # RadioField the field name, value, and namespace it needs without
-    # a model accessor.
+    # attribute, so we use the String form of `radio_field` to emit
+    # `name="project[dates_any]"` without trying to bind through
+    # Superform's `field(...)`.
     def render_dates_any_radios
-      proxy = Components::ApplicationForm::FieldProxy.new(
-        "project", :dates_any, @dates_any
-      )
-      render(Components::ApplicationForm::RadioField.new(
-               proxy,
-               ["false", range_label],
-               ["true", any_label]
-             ))
+      radio_field("project[dates_any]",
+                  ["false", range_label],
+                  ["true", any_label],
+                  value: @dates_any)
     end
 
     def range_label

--- a/app/views/controllers/projects/members/trust_settings.rb
+++ b/app/views/controllers/projects/members/trust_settings.rb
@@ -75,17 +75,9 @@ module Views::Controllers::Projects::Members
 
     def render_options
       p { plain(:trust_settings_help.l) }
-      field = commit_field
-      render(Components::ApplicationForm::RadioField.new(
-               field, *radio_choices,
-               wrapper_options: { wrap_class: "mb-2" }
-             ))
-    end
-
-    def commit_field
-      Components::ApplicationForm::FieldProxy.new(
-        nil, "commit", current_commit_value
-      )
+      radio_field("commit", *radio_choices,
+                  value: current_commit_value,
+                  wrap_class: "mb-2")
     end
 
     # Map current_trust_level back to the commit-label that would

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -131,13 +131,14 @@ module Views::Controllers::Projects::Violations
 
     def render_suffix_radios
       p { :form_violations_modal_target_location_help.l }
-      # `radio_field` with the String-form name produces the
-      # Superform-namespaced `project[location_id]` (cribbed from
-      # `field(:location_id).dom.name`) without going through
-      # Superform's `field(:x).radio(...)` — Project doesn't define
-      # a `location_id` attribute and Superform's `option_checked?`
-      # reads from the model, so pre-selection would never fire.
-      # The String form keeps explicit value control.
+      # The Superform-namespaced name (`project[location_id]`) without
+      # going through `field(:location_id).radio(...)` — Project doesn't
+      # define a `location_id` attribute and Superform's
+      # `option_checked?` reads from the model, so pre-selection would
+      # never fire. Routing through `radio_field` with the String name
+      # plus explicit `value:` keeps the namespacing while setting the
+      # pre-selected option. (Follow-up PR will let
+      # `radio_field(:location_id, …, value: …)` work directly.)
       radio_field(field(:location_id).dom.name,
                   *suffix_choices,
                   value: first_existing && existing[first_existing]&.id)

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -131,22 +131,16 @@ module Views::Controllers::Projects::Violations
 
     def render_suffix_radios
       p { :form_violations_modal_target_location_help.l }
-      # Use a FieldProxy with the Superform-namespaced name
-      # (`project[location_id]`, derived from
-      # `field(:location_id).dom.name`) so the radio's `name` attr
-      # matches the rest of the form's namespacing. We can't go
-      # through Superform's `field(:x).radio(...)` directly because
-      # Project doesn't define a `location_id` attribute and
-      # Superform's option_checked? reads from the model —
-      # pre-selection would never fire. The FieldProxy keeps
-      # explicit value control.
-      proxy = Components::ApplicationForm::FieldProxy.new(
-        nil, field(:location_id).dom.name,
-        first_existing && existing[first_existing]&.id
-      )
-      render(Components::ApplicationForm::RadioField.new(
-               proxy, *suffix_choices
-             ))
+      # `radio_field` with the String-form name produces the
+      # Superform-namespaced `project[location_id]` (cribbed from
+      # `field(:location_id).dom.name`) without going through
+      # Superform's `field(:x).radio(...)` — Project doesn't define
+      # a `location_id` attribute and Superform's `option_checked?`
+      # reads from the model, so pre-selection would never fire.
+      # The String form keeps explicit value control.
+      radio_field(field(:location_id).dom.name,
+                  *suffix_choices,
+                  value: first_existing && existing[first_existing]&.id)
     end
 
     # Each suffix becomes a `[value, label, opts]` choice for

--- a/test/components/application_form_helper_parity_test.rb
+++ b/test/components/application_form_helper_parity_test.rb
@@ -156,6 +156,58 @@ class ApplicationFormHelperParityTest < ComponentTestCase
     # wrap is justified: label area left, create button right.
     assert_html(html, "div.d-flex.justify-content-between")
   end
+
+  # --- String field_name: raw `name=` (no model binding) -----------------
+  #
+  # Each `*_field` helper accepts the same Symbol/String pair as
+  # `hidden_field`: Symbol → bound to the form's model; String → raw
+  # HTML `name` attribute, value carried via the `value:` option.
+  # Lets non-bound fields (operation state, nested namespaces) go
+  # through the same helpers as model attributes.
+
+  def test_text_field_accepts_string_name
+    html = render(TextFieldStringNameForm.new(Comment.new, action: "/t"))
+
+    assert_html(html, "input[type='text'][name='member[lat]'][value='39.2']")
+  end
+
+  def test_textarea_field_accepts_string_name
+    html = render(
+      TextareaFieldStringNameForm.new(Comment.new, action: "/t")
+    )
+
+    assert_html(html, "textarea[name='member[notes][Cap]']", text: "soft")
+  end
+
+  def test_checkbox_field_accepts_string_name
+    html = render(
+      CheckboxFieldStringNameForm.new(Comment.new, action: "/t")
+    )
+
+    assert_html(html,
+                "input[type='checkbox'][name='member[specimen]']" \
+                "[value='1'][checked]")
+  end
+
+  def test_select_field_accepts_string_name
+    html = render(
+      SelectFieldStringNameForm.new(Comment.new, action: "/t")
+    )
+
+    assert_html(html, "select[name='member[value]']")
+    assert_html(html, "select[name='member[value]'] option[value='2']",
+                text: "Two")
+  end
+
+  def test_autocompleter_field_accepts_string_name_textarea
+    html = render(
+      AutocompleterFieldStringNameForm.new(Comment.new, action: "/t")
+    )
+
+    assert_html(html, "textarea[name='list[members]']", text: "alpha")
+    assert_html(html,
+                "div.autocompleter[data-controller='autocompleter--name']")
+  end
 end
 
 # --- Test form classes -------------------------------------------------
@@ -251,6 +303,51 @@ class AutocompleterCreateForm < Components::ApplicationForm
                create_text: "Create new",
                wrapper_options: { label: "Name" }
              ))
+    end
+  end
+end
+
+# String-`field_name` form fixtures — each helper accepts a raw HTML
+# `name=` (e.g. nested non-model namespaces like `member[lat]`,
+# `list[members]`) just like `hidden_field` already does.
+
+class TextFieldStringNameForm < Components::ApplicationForm
+  def view_template
+    super { text_field("member[lat]", value: "39.2", label: "Lat:") }
+  end
+end
+
+class TextareaFieldStringNameForm < Components::ApplicationForm
+  def view_template
+    super { textarea_field("member[notes][Cap]", value: "soft", rows: 1) }
+  end
+end
+
+class CheckboxFieldStringNameForm < Components::ApplicationForm
+  def view_template
+    super do
+      checkbox_field("member[specimen]", value: "1", checked: true,
+                                         label: "Specimen?")
+    end
+  end
+end
+
+class SelectFieldStringNameForm < Components::ApplicationForm
+  def view_template
+    super do
+      select_field("member[value]",
+                   [["One", 1], ["Two", 2], ["Three", 3]],
+                   label: "Confidence:")
+    end
+  end
+end
+
+class AutocompleterFieldStringNameForm < Components::ApplicationForm
+  def view_template
+    super do
+      autocompleter_field("list[members]", type: :name, textarea: true,
+                                           value: "alpha",
+                                           label: "Names:")
     end
   end
 end


### PR DESCRIPTION
**This (and the follow-up below) lets us use the simple field helpers — `text_field`, `checkbox_field`, `radio_field`, `select_field`, `autocompleter_field`, etc. — for fields backed by a `FieldProxy` rather than a model attribute.** That's the whole point of the churn here, the next PR, and the cleanups along the way.

Today, those helpers all bind to the form's model: `text_field(:title)` reads `model.title` and renders `name="model_name[title]"`. Fields that aren't on a model — transient operation state, nested non-model namespaces like `member[lat]`, `list[members]`, top-level redirect ids — had no path through the helpers. Callers were forced into `Components::ApplicationForm::FieldProxy.new(...)` + `render(Components::ApplicationForm::TextField.new(proxy, ...))` boilerplate at every site.

This PR makes those helpers accept **either** a Symbol (model-bound, as today) **or** a String (raw HTML `name=`, value carried via the `value:` option) — the same shape `hidden_field` already had. The follow-up PR (tracked in memory) will align Symbol+`value:` semantics with Rails ERB so the last remaining workaround can go too.

## Before / after at a call site

```ruby
# Before — explicit FieldProxy + Phlex-class rendering at every site
proxy = Components::ApplicationForm::FieldProxy.new(
  "member", :specimen, "1"
)
render(Components::ApplicationForm::CheckboxField.new(
  proxy, checked: @member_specimen, label: "Specimen?"
))

# After — same shape as `hidden_field` already had
checkbox_field("member[specimen]", value: "1",
                                   checked: @member_specimen,
                                   label: "Specimen?")
```

## How the helper layer works

`FieldProxy` already mirrored most of `Superform::Rails::Field`'s shape (`.dom.{id,name}`, `.value`, `.key`, `.parent`). It was missing the factory methods (`.text`, `.textarea`, `.checkbox`, `.select`, `.radio`, `.autocompleter`, `.date`, `.file`, `.read_only`, `.static`) that MO's `Field` subclass overrides to build the Bootstrap-styled field components. The fix:

- **Extract the factory-method surface into `FieldFactoryMethods`** — one module, single source of truth. Both `Field` and `FieldProxy` include it. `AUTOCOMPLETER_OPTIONS` lives alongside the autocompleter method that uses it.
- **Each `*_field` helper grows one line**: `f = resolve_field(field_name, value: …)`. Symbol → `field(field_name)` (Superform). String → `FieldProxy.new(nil, field_name, value)`. Downstream `.text/.textarea/...` calls work identically on either — both quack the same.

`hidden_field` is harmonized to use the same `resolve_field` helper (it was carrying the pattern inline before).

While integrating: discovered three helpers were forwarding the field's `value:` onto each rendered input/option as an HTML `value=` attribute, clobbering per-choice values. Stripped `value:` from the attrs forwarded to the field in `radio_field`, `select_field`, and collection/block-mode `checkbox_field`. Boolean-mode `checkbox_field` still forwards `value:` (it IS the submitted value when checked).

Also fixed a DOM-id bug surfaced by CI: bracketed String field names (e.g. `"reviewed[385495444]"`, `"project[dates_any]"`) were producing invalid HTML ids with literal brackets, which `getElementById` / Capybara / CSS `#id` selectors all fail on. The id normalization now applies `[]` → `_` for the no-namespace case too, and strips the trailing `_` left by a closing `]`.

## Caller sweep (commit 2)

| File | Before | After |
|------|--------|-------|
| `names/form.rb` | `FieldProxy.new` + `HiddenField.new` | `hidden_field("approved_rank", value: …)` |
| `descriptions/form.rb` | `render_flat_hidden_field` wrapper | 2× `hidden_field("…", value: …)` (wrapper deleted) |
| `projects/form.rb` | `FieldProxy.new` + `RadioField.new` | `radio_field("project[dates_any]", choices, value: …)` |
| `projects/members/trust_settings.rb` | `commit_field` private + `RadioField.new` | `radio_field("commit", *choices, value: …)` (wrapper deleted) |
| `projects/violations/target_location_form.rb` | `FieldProxy.new` + `RadioField.new` | `radio_field(field(:location_id).dom.name, *choices, value: …)` — last awkward shape; follow-up PR cleans this up |
| `field_slips/form.rb` | 2× `FieldProxy.new` threaded through three private methods | `checkbox_field("observation_ids", value: @checked_ids, …) { \|cb\| cb.option(obs.id) … }` + `radio_field("field_slip[primary_observation_id]", …, value: @primary_id)`; instance ivars replace the threaded proxies |
| `glossary_terms/images/remove_form.rb` | `FieldProxy.new` + `CheckboxField.new` | `checkbox_field("selected[#{image.id}]", …)` |
| `admin/donations/review_form.rb` | `checkbox_field(donation.id.to_s, …)` relying on the prior Superform-`field()` dispatch to fold the form's model name | `checkbox_field("reviewed[#{donation.id}]", …)` — String semantics are now uniform across helpers (String = raw `name=`, Symbol = model-bound), so this caller spells out the namespace explicitly. Symbols can't start with a digit so Symbol-keying isn't available for numeric ids. |

## Why now

Found while converting `species_lists/write_in/_form.html.erb` to Phlex — that form has three nested non-model namespaces (`list[]`, `member[]`, top-level) and writing it against the old `FieldProxy.new + render(...Field.new(proxy, ...))` boilerplate at every site would have buried the form's intent in plumbing. With this change, the upcoming write-in conversion shortens substantially.

## Test plan

- [x] `test/components/application_form_helper_parity_test.rb`:
  - 5 new tests cover the String path for `text_field`, `textarea_field`, `checkbox_field`, `select_field`, `autocompleter_field` (textarea mode — the case that was previously blocked because `FieldProxy` lacked `.textarea`).
  - The 12 existing Symbol-path tests still pass unchanged.
- [x] `bin/rails test test/components/` — **517 tests, 0 failures, 0 errors.**
- [x] `bin/rails test test/views/controllers/` — **473 tests, 0 failures, 0 errors.**
- [x] `bin/rails test test/controllers/projects/ test/controllers/admin/donations_controller_test.rb test/controllers/field_slips_controller_test.rb test/controllers/glossary_terms/images_controller_test.rb` — **229 tests, 0 failures, 0 errors.**
- [x] `bin/rails test test/controllers/names/descriptions_controller_test.rb test/controllers/locations/descriptions_controller_test.rb test/controllers/descriptions/` — **75 tests, 0 failures, 0 errors.**
- [x] `bundle exec rubocop` clean on all touched files.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
