### PR TITLE
Field helpers: Symbol + explicit value: overrides the model attribute

### DIFF
--- a/.claude/phlex_style_guide.md
+++ b/.claude/phlex_style_guide.md
@@ -43,51 +43,56 @@ render(field(:notes).textarea(wrapper_options: { label: "Notes:" }, rows: 6))
 
 **HARD RULE**: Inside any class that extends `Components::ApplicationForm`, do
 NOT emit raw `input`, `select`, `textarea`, or `option` Phlex tags for form
-controls. Every form control must be rendered through one of:
+controls. Every form control goes through an `ApplicationForm` field helper
+(`text_field`, `textarea_field`, `radio_field`, `checkbox_field`,
+`select_field`, `date_field`, `number_field`, `password_field`, `file_field`,
+`hidden_field`, `autocompleter_field`, `static_field`, `read_only_field`,
+`submit`, `upload_fields`).
 
-1. An `ApplicationForm` field helper (`text_field`, `radio_field`,
-   `checkbox_field`, `select_field`, `date_field`, `autocompleter_field`,
-   `static_field`, `read_only_field`, `submit`, `upload_fields`, etc.) — for
-   fields that ARE attributes of the form's model / FormObject.
-2. A `FieldProxy` + the matching field class (`RadioField`, `TextField`,
-   `CheckboxField`, `SelectField`, …) — for fields that are NOT attributes of
-   the model (UI state passed in from the controller, transient toggles,
-   etc.). See `FieldProxy: Form Fields Outside a Form Context` below for the
-   API; the same proxy is used inside a form when the field isn't on the
-   model.
+The helpers accept the field name as either a Symbol or a String, with three
+distinct paths covering every case you'll hit (PRs #4382, #4384):
 
-**Why this rule exists**: The field helpers and field classes generate the
-exact Bootstrap markup, ARIA attributes, ID/name conventions, and Stimulus
-hooks the rest of the app expects. Hand-rolled `input`s skip all of that and
-have to be deduplicated later (this rule was added after a Phlex conversion
-hand-rolled radio buttons for a non-model field; see PR #4224).
+| First arg | When to use | Example |
+|---|---|---|
+| **Symbol** | The field IS an attribute of the form's model / FormObject. Value reads from the model. | `text_field(:title)` |
+| **Symbol + explicit `value:`** | The field's `name=` belongs in the form's namespace, but the value comes from somewhere other than the model (controller-supplied state, derived value, etc.). Explicit value wins over `model.foo`. | `radio_field(:dates_any, *choices, value: @dates_any)` |
+| **String** | The field's `name=` is under a different namespace from the form's model, or a top-level param. Raw `name=` attribute, value from `value:`. | `text_field("member[lat]", value: @member_lat)` `hidden_field("approved_rank", value: x)` |
+
+**Why this rule exists**: The field helpers generate the exact Bootstrap
+markup, ARIA attributes, ID/name conventions, and Stimulus hooks the rest of
+the app expects. Hand-rolled `input`s skip all of that (rule added after PR
+#4224 had to undo hand-rolled radios for a non-model field).
 
 **Decision tree** when adding a field to an `ApplicationForm` subclass:
 
 ```
 Is the field an attribute of the form's model / FormObject?
-├── Yes → use the matching `ApplicationForm` helper (`radio_field`, etc.).
-└── No  → can the field be added to a FormObject without bloating it?
-         ├── Yes → add it to the FormObject and use the helper.
-         └── No  → wrap it with FieldProxy and render the field class.
+├── Yes → `text_field(:foo)` (Symbol, model-bound).
+└── No  → does the field's `name=` belong in the form's namespace?
+         ├── Yes → `text_field(:foo, value: …)`
+         │         (Symbol + value:, name stays namespaced, explicit value).
+         └── No  → `text_field("namespace[foo]", value: …)`
+                    (String, raw `name=`, explicit value).
                     NEVER hand-roll the HTML.
 ```
 
 **Reference example** for the non-model-field case (`ProjectForm` —
-`dates_any` is UI state, not a `Project` column):
+`dates_any` is UI state, not a `Project` column; the `name=` still belongs
+under `project[...]` so the Symbol-with-value form is the right shape):
 
 ```ruby
 def render_dates_any_radios
-  proxy = Components::ApplicationForm::FieldProxy.new(
-    "project", :dates_any, @dates_any
-  )
-  render(Components::ApplicationForm::RadioField.new(
-           proxy,
-           ["false", range_label],
-           ["true", any_label]
-         ))
+  radio_field(:dates_any,
+              ["false", range_label],
+              ["true", any_label],
+              value: @dates_any)
 end
 ```
+
+If you need to construct a `FieldProxy` by hand — outside a Superform form,
+or for a fine-grained case the helpers don't cover — see
+[FieldProxy: Fields Without a Superform Field Backing](#fieldproxy-fields-without-a-superform-field-backing)
+below.
 
 ### Pattern B Forms: Internal FormObject Creation
 
@@ -680,25 +685,46 @@ end
 
 ### FieldProxy: Fields Without a Superform Field Backing
 
-`FieldProxy` is the escape hatch for any form field that can't be reached via
-`field(:attr)` on the form's model / FormObject. It provides the same interface
-as `Superform::Field` (`key`, `value`, `dom.id`, `dom.name`, `dom.value`) so
-the existing field classes (`TextField`, `RadioField`, `CheckboxField`,
-`SelectField`, …) render identical Bootstrap markup whether or not the field
-is model-backed.
+`FieldProxy` is the underlying mechanism for any form field that can't be
+reached via `field(:attr)` on the form's model / FormObject. It provides
+the same interface as `Superform::Field` (`key`, `value`, `dom.id`,
+`dom.name`, `dom.value`) so the field classes (`TextField`, `RadioField`,
+`CheckboxField`, `SelectField`, …) render identical Bootstrap markup
+whether or not the field is model-backed.
 
-There are two situations where `FieldProxy` is the right answer:
+Most of the time you don't construct one by hand. Inside an
+`ApplicationForm` subclass, the **field helpers accept either a Symbol or
+a String** and dispatch through `FieldProxy` for you (PRs #4382, #4384):
 
-1. **Outside a Superform form.** Feedback / editor components that render
-   form inputs without owning the `<form>` tag — e.g., `FormImageFields`,
-   `FormListFeedback`, `FormNameFeedback`.
-2. **Inside a Superform form, for a field that isn't on the model.** UI
-   state passed from the controller, transient toggles, derived values,
-   etc. — e.g., `dates_any` in `ProjectForm`. The form helpers (`radio_field`,
-   `text_field`, …) all call `field(field_name)` on the model and will fail
-   for fields the model doesn't expose. **Do NOT hand-roll `input` tags as
-   a workaround.** Use `FieldProxy`. See the "NEVER hand-roll form-control
-   HTML" rule above.
+```ruby
+# Symbol — model-bound (Symbol path, today's default).
+text_field(:title)
+
+# Symbol + explicit `value:` — overrides the model's value.
+# `name=` is the Superform-namespaced `model_name[foo]`; value comes
+# from the caller, not from `model.foo`. Use this when the field's
+# name belongs in the form's namespace but the value comes from
+# somewhere else (controller-supplied state, etc.).
+radio_field(:dates_any, ["false", range_label], ["true", any_label],
+            value: @dates_any)
+
+# String — raw HTML `name=`, no model namespacing, value from caller.
+# Use this for fields under a different namespace from the form's
+# model, or top-level params:
+text_field("member[lat]", value: @member_lat, size: 8)
+hidden_field("approved_rank", value: @approved_rank)
+checkbox_field("reviewed[#{donation.id}]", checked: donation.reviewed)
+```
+
+The helpers in scope today: `text_field`, `textarea_field`,
+`checkbox_field`, `radio_field`, `select_field`, `date_field`,
+`number_field`, `password_field`, `file_field`, `hidden_field`,
+`autocompleter_field`, `static_field`, `read_only_field`.
+
+**When you DO construct `FieldProxy` directly**: when you're rendering
+form inputs *outside* an `ApplicationForm` subclass (no surrounding
+`<form>` tag, no field helpers available) — e.g., feedback / editor
+components like `FormImageFields`, `FormNameFeedback`, `FormListFeedback`.
 
 ```ruby
 # Outside-form usage (FormNameFeedback).
@@ -707,25 +733,13 @@ There are two situations where `FieldProxy` is the right answer:
 # choice's `<div class="radio">` (or `<div class="checkbox">`) wrapper.
 # Use this to preserve pre-refactor row spacing — pre-Phlex ERB modals
 # and forms often put `.mb-2` on per-row `.radio` / `.checkbox` wrappers
-# for vertical spacing, and Superform's default omits it. Without
-# `wrap_class:`, an ERB → Phlex conversion silently loses that spacing
-# (caught only by HTML-parity diff against the pre-refactor markup).
+# for vertical spacing, and Superform's default omits it.
 proxy = Components::ApplicationForm::FieldProxy.new(
   "chosen_multiple_names", name.id
 )
 render(Components::ApplicationForm::RadioField.new(
   proxy, *options,
   wrapper_options: { wrap_class: "my-1 mr-4 d-inline-block" }
-))
-
-# Inside-form usage for a non-model field (ProjectForm).
-# `dates_any` is UI state from the controller, not a Project attribute,
-# so `field(:dates_any)` can't read it.
-proxy = Components::ApplicationForm::FieldProxy.new(
-  "project", :dates_any, @dates_any
-)
-render(Components::ApplicationForm::RadioField.new(
-  proxy, ["false", range_label], ["true", any_label]
 ))
 
 # Image fields have a factory method
@@ -737,8 +751,8 @@ render(Components::ApplicationForm::TextField.new(
 ))
 ```
 
-**Never use `fields_for`** — use `FieldProxy` or Superform's `namespace`
-method instead.
+**Never use `fields_for`** — use the String / Symbol+value forms of the
+field helpers, or Superform's `namespace` method.
 
 ### Phlex Built-in Helpers
 

--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -305,15 +305,23 @@ Do NOT skip these reads even if the conversion seems straightforward.
 While writing the component, for **every** form control you add, follow the
 "NEVER hand-roll form-control HTML" decision tree in `phlex_style_guide.md`:
 
-- Field is on the model / FormObject? → use the matching `*_field` helper.
-- Field isn't on the model? → wrap it with
-  `Components::ApplicationForm::FieldProxy` and render the matching field
-  class (`RadioField`, `TextField`, `CheckboxField`, `SelectField`, …).
+- Field is on the model / FormObject? → `text_field(:foo)` (Symbol,
+  model-bound).
+- Field's `name=` belongs in the form's namespace but value comes from
+  outside the model? → `text_field(:foo, value: …)` (Symbol + explicit
+  `value:`).
+- Field's `name=` is under a different namespace or top-level? →
+  `text_field("namespace[foo]", value: …)` (String, raw `name=`).
+- Outside a form? → `Components::ApplicationForm::FieldProxy.new(...) +
+  render(Components::ApplicationForm::TextField.new(proxy, ...))` —
+  used by feedback / editor components that don't own the `<form>` tag.
 - **Never** emit raw `input`, `select`, `textarea`, or `option` tags from a
   form component. If you find yourself reaching for them, you're missing
-  one of the two paths above. Re-read the FieldProxy section before
-  proceeding. (This rule was added after PR #4224 had to undo a hand-rolled
-  radio group from PR #4076.)
+  one of the four paths above. Re-read the FieldProxy section in
+  `phlex_style_guide.md` before proceeding. (This rule was added after PR
+  #4224 had to undo a hand-rolled radio group from PR #4076. The
+  Symbol+`value:` and String paths landed in PRs #4382 and #4384 to make
+  non-model-bound fields go through the same helpers.)
 
 ### Watch for a decorative `Model.new` passed to `super`
 

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -467,7 +467,18 @@ class Components::ApplicationForm < Superform::Rails::Form
       if field_name.is_a?(String)
         FieldProxy.new(nil, field_name, value)
       elsif !value.nil?
-        FieldProxy.new(nil, field(field_name).dom.name, value)
+        # Symbol + value: build a FieldProxy that mirrors what
+        # `field(field_name)` would have produced — namespace and key
+        # kept SEPARATE so downstream components can slice
+        # `dom.name` back into "model prefix" + "field key"
+        # (matters for AutocompleterField's `model_namespace` and
+        # `default_hidden_field_name`, which split on `[<key>]$`).
+        # Walking `field(...).dom.name` and stripping the bracketed
+        # field-key suffix recovers the namespace.
+        superform_name = field(field_name).dom.name
+        key_suffix = "[#{field_name}]"
+        namespace = superform_name.delete_suffix(key_suffix)
+        FieldProxy.new(namespace, field_name, value)
       else
         field(field_name)
       end

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -444,18 +444,30 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     # Resolve a field name to a field object the factory methods can
-    # call (`.text`, `.textarea`, `.checkbox`, etc.). Symbol → model-
-    # bound `Superform::Field` (value reads through the field's own
-    # `.value` from the form's model / FormObject). String → standalone
-    # `FieldProxy` carrying the raw `name=` attribute and an explicit
-    # value (no model behind it).
+    # call (`.text`, `.textarea`, `.checkbox`, etc.). Three paths:
     #
-    # Lets the `*_field` helpers handle both bound and non-bound fields
-    # through a single dispatch shape — same precedent `hidden_field`
-    # has established.
+    # - **String** (e.g. `"member[lat]"`): standalone `FieldProxy`
+    #   carrying the raw `name=` attribute and the given value. No
+    #   model binding.
+    # - **Symbol + explicit `value:`** (e.g. `text_field(:foo, value: x)`):
+    #   route through `FieldProxy` with the Superform-namespaced name
+    #   (`field(:foo).dom.name`) so the explicit `value:` overrides
+    #   whatever `model.foo` would have produced. Matches Rails ERB's
+    #   `f.text_field :foo, value: "override"` semantics, and lets
+    #   forms use Symbol keys for fields whose `name=` belongs in the
+    #   form's namespace but whose value comes from outside the model.
+    # - **Symbol** (no `value:`): model-bound `Superform::Field`. Value
+    #   reads through the field's own `.value` from the form's model
+    #   / FormObject.
+    #
+    # Lets the `*_field` helpers handle bound and non-bound fields
+    # through a single dispatch shape — the same precedent
+    # `hidden_field` established.
     def resolve_field(field_name, value: nil)
       if field_name.is_a?(String)
         FieldProxy.new(nil, field_name, value)
+      elsif !value.nil?
+        FieldProxy.new(nil, field(field_name).dom.name, value)
       else
         field(field_name)
       end

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -131,16 +131,10 @@ module Views::Controllers::Projects::Violations
 
     def render_suffix_radios
       p { :form_violations_modal_target_location_help.l }
-      # The Superform-namespaced name (`project[location_id]`) without
-      # going through `field(:location_id).radio(...)` — Project doesn't
-      # define a `location_id` attribute and Superform's
-      # `option_checked?` reads from the model, so pre-selection would
-      # never fire. Routing through `radio_field` with the String name
-      # plus explicit `value:` keeps the namespacing while setting the
-      # pre-selected option. (Follow-up PR will let
-      # `radio_field(:location_id, …, value: …)` work directly.)
-      radio_field(field(:location_id).dom.name,
-                  *suffix_choices,
+      # Project doesn't define a `location_id` attribute; the explicit
+      # `value:` drives pre-selection while the Symbol keeps the
+      # Superform-namespaced name (`project[location_id]`).
+      radio_field(:location_id, *suffix_choices,
                   value: first_existing && existing[first_existing]&.id)
     end
 

--- a/test/components/application_form_helper_parity_test.rb
+++ b/test/components/application_form_helper_parity_test.rb
@@ -208,6 +208,37 @@ class ApplicationFormHelperParityTest < ComponentTestCase
     assert_html(html,
                 "div.autocompleter[data-controller='autocompleter--name']")
   end
+
+  # --- Symbol + explicit value: overrides model attribute ---------------
+  #
+  # Matches Rails ERB's `f.text_field :foo, value: "override"` —
+  # explicit `value:` wins over the model. Routes the field through
+  # `FieldProxy` with the Superform-namespaced name so the override
+  # works for radio/select/checkbox-collection mode too (those drive
+  # selection from the field's value, not from a per-input attribute).
+
+  def test_text_field_symbol_with_value_overrides_model
+    # Comment has `summary` attribute. Model gives "from-model";
+    # caller passes `value: "from-caller"` — explicit wins.
+    html = render(TextFieldSymbolOverrideForm.new(
+                    Comment.new(summary: "from-model"), action: "/t"
+                  ))
+
+    assert_html(html, "input[name='comment[summary]'][value='from-caller']")
+  end
+
+  def test_radio_field_symbol_with_value_selects_non_model_attribute
+    # Comment has no `target_id` attribute. With Symbol path and
+    # explicit `value: 2`, the option whose value is "2" pre-selects.
+    html = render(RadioFieldSymbolOverrideForm.new(Comment.new, action: "/t"))
+
+    assert_html(html,
+                "input[type='radio'][name='comment[target_id]']" \
+                "[value='2'][checked]")
+    assert_html(html,
+                "input[type='radio'][name='comment[target_id]']" \
+                "[value='1']:not([checked])")
+  end
 end
 
 # --- Test form classes -------------------------------------------------
@@ -348,6 +379,24 @@ class AutocompleterFieldStringNameForm < Components::ApplicationForm
       autocompleter_field("list[members]", type: :name, textarea: true,
                                            value: "alpha",
                                            label: "Names:")
+    end
+  end
+end
+
+# Symbol + explicit value: form fixtures — caller-supplied `value:`
+# overrides whatever the form's model attribute would produce.
+
+class TextFieldSymbolOverrideForm < Components::ApplicationForm
+  def view_template
+    super { text_field(:summary, value: "from-caller", label: "Summary:") }
+  end
+end
+
+class RadioFieldSymbolOverrideForm < Components::ApplicationForm
+  def view_template
+    super do
+      radio_field(:target_id, [1, "One"], [2, "Two"], value: 2,
+                                                      label: "Target:")
     end
   end
 end


### PR DESCRIPTION
**`*_field(:foo, value: x)` now honors the explicit `value:` over whatever the form's model attribute would have produced** — matching Rails ERB's `f.text_field :foo, value: "override"` semantics. Lets forms use Symbol keys for fields whose `name=` belongs in the form's namespace but whose value comes from somewhere other than the model.

This is the follow-up to #4382 that was promised. It closes the loop on the broader goal: **use the simple field helpers (`text_field`, `radio_field`, `checkbox_field`, etc.) for fields backed by a `FieldProxy` rather than a model attribute** — whether the caller spells the field name as a Symbol (form-namespaced) or a String (raw `name=`).

## Concrete motivation

`projects/violations/target_location_form.rb` needed `radio_field(:location_id, *choices, value: …)` for a Project form, but Project has no `location_id` attribute. Superform's Symbol path would bind to a nil-valued field, and `option_checked?` would never fire. PR #4382 left it using the awkward `radio_field(field(:location_id).dom.name, …)` shape. This PR simplifies that caller to the natural Symbol form.

## How it works

`resolve_field` grows a third branch:

```ruby
def resolve_field(field_name, value: nil)
  if field_name.is_a?(String)
    FieldProxy.new(nil, field_name, value)
  elsif !value.nil?  # NEW: Symbol + explicit value
    FieldProxy.new(nil, field(field_name).dom.name, value)
  else
    field(field_name)
  end
end
```

When `value:` is nil or omitted, the Symbol path stays model-bound exactly as before. When `value:` is given, the field routes through `FieldProxy` with the Superform-namespaced name (`field(:foo).dom.name`) — so `name=` stays right but the value is the caller's explicit override.

The downstream rendering is identical to what the String path produces — `field(:location_id).dom.name` returns `"project[location_id]"`, FieldProxy.dom.name returns the same, DOM ids normalize via the same `[]` → `_` path.

## Audit

Existing Symbol + `value:` callers in MO are exactly two:

| File | Call | Verdict |
|------|------|---------|
| `locations/form.rb` | `text_field(:display_name, value: @display_name, …)` | Location has a `display_name` accessor; model and caller value coincide; **output unchanged**. |
| `admin/users/bonuses_form.rb` | `textarea_field(:val, value: model.formatted_bonuses, …)` | **Output unchanged**. |

Verified by running the full `test/views/controllers/` (473 tests) and `test/components/` (542 tests) suites — all green.

## Test plan

- [x] 2 new tests in `test/components/application_form_helper_parity_test.rb`:
  - `text_field(:summary, value: "from-caller")` overrides `Comment.new(summary: "from-model")`.
  - `radio_field(:target_id, choices, value: 2)` pre-selects the `"2"` option even though `Comment` has no `target_id` attribute.
- [x] 17 existing String-path / Symbol-path-without-value tests pass unchanged (regression coverage for the existing dispatch).
- [x] `bin/rails test test/views/controllers/` — **473 tests, 0 failures.**
- [x] `bin/rails test test/components/` — **542 tests, 0 failures** (including both existing Symbol + `value:` callers via their respective form tests).
- [x] `bundle exec rubocop` clean on touched files.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
