### PR TITLE
Restore link_icon / modal_link_to to AutocompleterField (Components::Input)

### DIFF
--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -4,10 +4,13 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Bootstrap autocompleter input field component with dropdown suggestions
   # Wraps a text input with Stimulus autocompleter controller
   # rubocop:disable Metrics/ClassLength
-  class AutocompleterField < Superform::Rails::Components::Input
+  # Inherits from `Components::Input` (MO's thin subclass of
+  # Superform's `Components::Input`) to pick up the shared MO
+  # output-helper registrations — `link_icon` (used by
+  # `render_has_id_indicator`), `icon_link_to`, and `modal_link_to`
+  # (used by the create-link block).
+  class AutocompleterField < ::Components::Input
     include Phlex::Slotable
-
-    register_output_helper :icon_link_to
 
     # Types with dedicated Stimulus controllers
     SUPPORTED_TYPE_CONTROLLERS = [

--- a/app/components/input.rb
+++ b/app/components/input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# MO base class for components that inherit from `Superform::Rails::
+# Components::Input` (Phlex components for `<input>`-derived form
+# controls). The Superform class doesn't share an inheritance line
+# with `Components::Base`, so MO output-helper registrations on
+# `Components::Base` aren't inherited — every MO-side Input
+# subclass that needs them has to either register them itself or
+# inherit from a base class that does. This is that base class.
+#
+# Registers the MO output helpers Input-derived field components
+# typically need (`link_icon`, `icon_link_to`, `modal_link_to`) so
+# subclasses can call them without per-class duplication.
+class Components::Input < Superform::Rails::Components::Input
+  register_output_helper :link_icon
+  register_output_helper :icon_link_to
+  register_output_helper :modal_link_to
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -28,6 +28,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Capybara.server = :puma
     # Capybara.current_driver = :mo_cuprite
     Capybara.server_host = "localhost"
+    # Bind to 3000 (not the OS-assigned ephemeral port that would
+    # otherwise be Capybara's default) because the Google Maps API
+    # key the front-end uses is HTTP-Referer-restricted in Google
+    # Cloud Console to `http://localhost:3000/*`. Tests that
+    # exercise the Maps geocoder / autocompleter would otherwise
+    # be rejected by Google's API. **Stop your `bin/rails server`
+    # before running system tests** to avoid `Errno::EADDRINUSE`.
+    # If the Maps key's referer restriction is ever broadened to
+    # `http://localhost:*/*`, this can become `nil` (ephemeral) and
+    # tests will run alongside a running dev server.
     Capybara.server_port = 3000
     # Normalize whitespaces when using `has_text?` and similar matchers,
     # i.e., ignore newlines, trailing spaces, etc.


### PR DESCRIPTION
## Summary

PR #4376 ("Centralize helper registrations") removed `register_output_helper :link_icon` and `register_output_helper :modal_link_to` from `AutocompleterField`, on the (incorrect) assumption that the same registrations on `Components::Base` would cover it via inheritance.

They don't. `AutocompleterField` inherits from `Superform::Rails::Components::Input` — a Superform gem class — **not** from `Components::Base`. With the registrations gone, every autocompleter call to `link_icon` (in `render_has_id_indicator`, which produces the green check next to autocompleted entries) and `modal_link_to` (in the create-link block) raised `NoMethodError` at render time. That broke the autocompleter dropdown rendering, which then cascaded through every form/modal that included an autocompleter.

Restore the registrations, but at one level up: new `Components::Input < Superform::Rails::Components::Input` carries the shared MO output helpers, and `AutocompleterField` (and any future Input-derived MO component that needs the same helpers) inherits from `Components::Input` rather than registering each helper itself.

## System test impact

Before this PR:

```
14 failures, 2 errors  # in the 7 originally-affected system test files
```

After this PR:

```
0 failures, 0 errors  # autocompleter and modal tests all pass
```

(7 tests still depend on Google Maps API key being available; those are unrelated to this PR.)

## Drive-by: document the port-3000 requirement

Add a comment to `test/application_system_test_case.rb` explaining why `Capybara.server_port = 3000` (rather than the OS-assigned ephemeral port that would otherwise be Capybara's default): the Google Maps API key in MO's JS controllers is HTTP-Referer-restricted in Google Cloud Console to `http://localhost:3000/*`. Tests running on any other port get Maps-API-rejected. Documents the consequence that devs need to stop `bin/rails server` before running system tests locally.

## Test plan

- [x] `bin/rails test test/system/autocompleter_system_test.rb -n test_autocompleter_in_naming_modal` — now passes (was failing).
- [x] `bin/rails test test/components/` — 517 tests, 0 failures (no regression in unit-level form rendering).
- [x] `bundle exec rubocop` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
