### PR TITLE
SpeciesList#sync_projects: move project-sync logic to the model

### DIFF
--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -353,28 +353,20 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
   end
 
   # `submitted_ids` is the `species_list[project_ids][]` array from
-  # the form: the projects the user wants the SL attached to. Only
-  # projects in `@user.projects_member` are toggled — non-member
-  # projects the SL belongs to are preserved by omission (disabled
-  # checkboxes don't submit, and the iteration excludes them anyway).
+  # the form. Delegate the actual sync to `SpeciesList#sync_projects`
+  # and flash the per-change notification + the trailing "and the
+  # observations too" hint.
   def update_projects(spl, submitted_ids)
-    return unless submitted_ids
+    changes = spl.sync_projects(submitted_ids, user: @user)
+    changes.each { |project, change| flash_project_change(project, change) }
+    return if changes.empty?
 
-    desired = submitted_ids.compact_blank.map(&:to_i)
-    any_changes = false
-    Project.where(id: @user.projects_member.map(&:id)).
-      includes(:species_lists).find_each do |project|
-      before = spl.projects.include?(project)
-      after = desired.include?(project.id)
-      next if before == after
+    flash_notice(:species_list_show_manage_observations_too.t)
+  end
 
-      change_project_species_lists(
-        project: project, spl: spl, change: (after ? :add : :remove)
-      )
-      any_changes = true
-    end
-
-    flash_notice(:species_list_show_manage_observations_too.t) if any_changes
+  def flash_project_change(project, change)
+    key = change == :added ? :attached_to_project : :removed_from_project
+    flash_notice(key.t(object: :species_list, project: project.title))
   end
 
   def init_list_for_clone(clone_id)
@@ -385,18 +377,6 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
     @species_list.place_name = clone.place_name
     @species_list.location = clone.location
     @species_list.title = clone.title
-  end
-
-  def change_project_species_lists(project:, spl:, change: :add)
-    if change == :add
-      project.add_species_list(spl)
-      flash_notice(:attached_to_project.t(object: :species_list,
-                                          project: project.title))
-    else
-      project.remove_species_list(spl)
-      flash_notice(:removed_from_project.t(object: :species_list,
-                                           project: project.title))
-    end
   end
 
   def permitted_species_list_args

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -184,6 +184,40 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
     show_link_args.tap { |result| result[:project] = project.id if project }
   end
 
+  # Sync this species_list's project membership against
+  # `submitted_project_ids` (typically the `project_ids[]` array a
+  # form posted). Only toggles among projects the given `user` is a
+  # member of — non-member projects already attached to the list are
+  # preserved (the form disables those checkboxes; the iteration
+  # excludes them too).
+  #
+  # Returns an array of `[project, :added | :removed]` pairs so the
+  # caller can emit per-change notifications. Returns `[]` when
+  # `submitted_project_ids` is nil (no `project_ids[]` field on the
+  # submission), or when nothing actually changed.
+  def sync_projects(submitted_project_ids, user:)
+    return [] if submitted_project_ids.nil?
+
+    desired_ids = submitted_project_ids.compact_blank.map(&:to_i)
+    member_project_ids = user.projects_member.map(&:id)
+    changes = []
+    Project.where(id: member_project_ids).
+      includes(:species_lists).find_each do |project|
+      before = projects.include?(project)
+      after = desired_ids.include?(project.id)
+      next if before == after
+
+      if after
+        project.add_species_list(self)
+        changes << [project, :added]
+      else
+        project.remove_species_list(self)
+        changes << [project, :removed]
+      end
+    end
+    changes
+  end
+
   def self.find_by_title_with_wildcards(str)
     find_using_wildcards("title", str)
   end

--- a/test/models/species_list_test.rb
+++ b/test/models/species_list_test.rb
@@ -158,4 +158,74 @@ class SpeciesListTest < UnitTestCase
       "SpeciesList#location_id should change upon defining that Location"
     )
   end
+
+  # Sync semantics: nil submission means "form had no project_ids field" —
+  # treat as no-op, don't tear down existing memberships.
+  def test_sync_projects_with_nil_submission_returns_no_changes
+    list = species_lists(:unknown_species_list)
+    user = users(:rolf)
+
+    assert_empty(list.sync_projects(nil, user: user))
+  end
+
+  # Empty array means the form posted `project_ids[]` but nothing was
+  # checked. Existing memberships in member projects should be removed.
+  def test_sync_projects_empty_submission_removes_member_project_memberships
+    project = projects(:eol_project)
+    user = project.user_group.users.first
+    list = species_lists(:unknown_species_list)
+    project.add_species_list(list)
+    list.reload
+
+    changes = list.sync_projects([], user: user)
+
+    assert_equal(1, changes.length)
+    assert_equal([project, :removed], changes.first)
+    assert_not_includes(list.reload.projects, project)
+  end
+
+  # Newly-checked project shows up in the submitted ids — model
+  # mutates the join and returns `[project, :added]`.
+  def test_sync_projects_adds_newly_submitted_member_project
+    project = projects(:eol_project)
+    user = project.user_group.users.first
+    list = species_lists(:query_first_list)
+    assert_not_includes(list.projects, project)
+
+    changes = list.sync_projects([project.id.to_s], user: user)
+
+    assert_equal([[project, :added]], changes)
+    assert_includes(list.reload.projects, project)
+  end
+
+  # Non-member projects already attached to the list are NOT touched
+  # (the form disables those checkboxes; even an empty submission
+  # shouldn't strip them).
+  def test_sync_projects_leaves_non_member_projects_alone
+    project = projects(:eol_project)
+    # `zero_user` is intentionally a member of zero projects.
+    user = users(:zero_user)
+    assert_empty(user.projects_member,
+                 "Test setup: zero_user must be in no projects")
+    list = species_lists(:unknown_species_list)
+    project.add_species_list(list)
+
+    changes = list.sync_projects([], user: user)
+
+    assert_empty(changes)
+    assert_includes(list.reload.projects, project)
+  end
+
+  # Membership unchanged → no change reported.
+  def test_sync_projects_is_idempotent_when_submission_matches
+    project = projects(:eol_project)
+    user = project.user_group.users.first
+    list = species_lists(:unknown_species_list)
+    project.add_species_list(list)
+    list.reload
+
+    changes = list.sync_projects([project.id.to_s], user: user)
+
+    assert_empty(changes)
+  end
 end


### PR DESCRIPTION
## Summary

Moves the per-project add / remove logic from
`SpeciesListsController#update_projects` (+ its
`change_project_species_lists` helper) onto the model as
`SpeciesList#sync_projects(submitted_project_ids, user:)`. The
controller stays in charge of `flash_notice` (which the model has no
business doing), but the relationship logic — what's "desired" vs.
"current," which projects are even toggleable for the given user,
mutating the join through `Project#add_species_list` /
`#remove_species_list` — now lives on the model where it can be
unit-tested directly.

```ruby
# In SpeciesList:
def sync_projects(submitted_project_ids, user:)
  # Returns [[project, :added | :removed], …] for the caller to flash.
end

# In SpeciesListsController:
def update_projects(spl, submitted_ids)
  changes = spl.sync_projects(submitted_ids, user: @user)
  changes.each { |project, change| flash_project_change(project, change) }
  return if changes.empty?

  flash_notice(:species_list_show_manage_observations_too.t)
end
```

`change_project_species_lists` (the per-change flash + mutation helper)
deletes; the per-change flash collapses into a tiny
`flash_project_change(project, change)`.

## Why

1. **Controller stays smaller.** It was already at `# rubocop:disable
   Metrics/ClassLength` after #4389; this trims a bit and pushes
   future relationship-logic changes to the right place.
2. **Testability.** Hitting the sync semantics from the controller
   needed the full HTTP round-trip (login, params, flash assertions).
   On the model it's straight-up
   `list.sync_projects([id.to_s], user: user)` followed by
   `assert_includes(list.reload.projects, project)`.

## Behavior preserved

- `flash_notice` semantics: one per change ("Attached to X" /
  "Removed from X") plus the trailing "manage the observations too"
  hint when anything actually changed.
- The "non-member projects are preserved" guarantee: the model's
  iteration is scoped to
  `Project.where(id: user.projects_member.map(&:id))`, exactly the
  same scope the old controller code used.
- The empty-array path (form posted `project_ids[]` but nothing
  checked) still strips member-project memberships; the `nil` path
  (no `project_ids[]` field at all) is the no-op.

## Tests

5 new model tests on `SpeciesList#sync_projects`:

- `nil` submission → no-op (no `project_ids[]` field on the form)
- empty submission → removes existing memberships in member projects
- newly-checked project → added
- non-member projects already attached → left alone (uses
  `zero_user`, who is intentionally a member of no projects)
- idempotent when submission matches current state

## Test plan

- [x] `bin/rails test test/models/species_list_test.rb` — 10 tests, 0 failures
- [x] `bin/rails test test/controllers/species_lists_controller_test.rb` — 37 tests, 0 failures
- [x] `bundle exec rubocop` on every touched file — 0 offenses

## Net delta

```
app/controllers/species_lists_controller.rb | 44 +++++-------------
app/models/species_list.rb                  | 34 ++++++++++++++
test/models/species_list_test.rb            | 70 +++++++++++++++++++++++++++++
3 files changed, 116 insertions(+), 32 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
