### PR TITLE
Location.dubious_reasons_for: collapse 6-site duplicate pattern

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -209,9 +209,10 @@ class LocationsController < ApplicationController
     init_caller_ivars_for_new
 
     # Render a blank form.
-    user_format = Location.user_format(@user, @display_name)
     if @display_name
-      @dubious_where_reasons = Location.dubious_name?(user_format, true)
+      @dubious_where_reasons = Location.dubious_reasons_for(
+        user: @user, place_name: @display_name
+      )
     end
     @location = Location.new
 
@@ -240,7 +241,7 @@ class LocationsController < ApplicationController
 
     # Need to create location.
     else
-      done = create_location_ivar_and_save(done, db_name)
+      done = create_location_ivar_and_save(done)
     end
 
     # If done, update any observations at @display_name,
@@ -278,7 +279,7 @@ class LocationsController < ApplicationController
       update_location_merge(merge)
     else
       email_admin_location_change if nontrivial_location_change?
-      update_location_change(db_name)
+      update_location_change
     end
   end
 
@@ -366,15 +367,14 @@ class LocationsController < ApplicationController
     @set_herbarium    = params[:set_herbarium]
   end
 
-  def create_location_ivar_and_save(done, db_name)
+  def create_location_ivar_and_save(done)
     @location = Location.new(permitted_location_params)
     @location.display_name = @display_name # (strip_squozen)
 
     # Validate name.
-    @dubious_where_reasons = []
-    if @display_name != @approved_name
-      @dubious_where_reasons = Location.dubious_name?(db_name, true)
-    end
+    @dubious_where_reasons = Location.dubious_reasons_for(
+      user: @user, place_name: @display_name, approved: @approved_name
+    )
 
     if @dubious_where_reasons.empty?
       if @location.save
@@ -434,17 +434,17 @@ class LocationsController < ApplicationController
   end
 
   # Just change this location in place.
-  def update_location_change(db_name)
+  def update_location_change
     @dubious_where_reasons = []
     @location.notes = params[:location][:notes].to_s.strip
     @location.locked = params[:location][:locked] == "1" if in_admin_mode?
-    determine_and_check_location(db_name) if !@location.locked || in_admin_mode?
+    determine_and_check_location if !@location.locked || in_admin_mode?
     return render_edit unless @dubious_where_reasons.empty?
 
     save_flash_and_redirect_or_render!
   end
 
-  def determine_and_check_location(db_name)
+  def determine_and_check_location
     @location.north = params[:location][:north] if params[:location][:north]
     @location.south = params[:location][:south] if params[:location][:south]
     @location.east  = params[:location][:east]  if params[:location][:east]
@@ -452,9 +452,10 @@ class LocationsController < ApplicationController
     @location.high  = params[:location][:high]  if params[:location][:high]
     @location.low   = params[:location][:low]   if params[:location][:low]
     @location.display_name = @display_name
-    return unless @display_name != params[:approved_where]
-
-    @dubious_where_reasons = Location.dubious_name?(db_name, true)
+    @dubious_where_reasons = Location.dubious_reasons_for(
+      user: @user, place_name: @display_name,
+      approved: params[:approved_where]
+    )
   end
 
   def save_flash_and_redirect_or_render!

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -107,8 +107,9 @@ module ObservationsController::Validators
       return true
     end
 
-    name = Location.user_format(@user, @observation.place_name)
-    @dubious_where_reasons = Location.dubious_name?(name, true)
+    @dubious_where_reasons = Location.dubious_reasons_for(
+      user: @user, place_name: @observation.place_name
+    )
     return true if @dubious_where_reasons.empty?
 
     @any_errors = true

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -205,11 +205,10 @@ module SpeciesLists
 
     def validate_place_name
       @place_name = params[:place_name] || @species_list.place_name
-      @dubious_where_reasons = []
-      return if @place_name == params[:approved_where]
-
-      db_name = Location.user_format(@user, @place_name)
-      @dubious_where_reasons = Location.dubious_name?(db_name, true)
+      @dubious_where_reasons = Location.dubious_reasons_for(
+        user: @user, place_name: @place_name,
+        approved: params[:approved_where]
+      )
     end
 
     def init_member_vars_for_reload

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -299,8 +299,9 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
       return
     end
 
-    db_name = Location.user_format(@user, @place_name)
-    @dubious_where_reasons = Location.dubious_name?(db_name, true)
+    @dubious_where_reasons = Location.dubious_reasons_for(
+      user: @user, place_name: @place_name
+    )
   end
 
   def check_for_clone

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -573,6 +573,26 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     provide_reasons ? reasons : reasons.any?
   end
 
+  # Reasons the given `place_name` looks "dubious" for the given user
+  # (typos, mismatched country, etc.) -- returns an array of reasons.
+  # Empty array means the name is clean; non-empty means the form
+  # should re-render and ask the user to confirm.
+  #
+  # `approved:` is the value of the `approved_where` form field the
+  # user submitted to skip this check after confirming. When non-nil
+  # and equal to `place_name`, returns `[]` immediately.
+  #
+  # Centralizes a pattern that lived as 2-3 lines in 4 controllers:
+  #   db_name = Location.user_format(user, place_name)
+  #   Location.dubious_name?(db_name, true)
+  # with an optional "skip if approved" gate around it.
+  def self.dubious_reasons_for(user:, place_name:, approved: nil)
+    return [] if !approved.nil? && place_name == approved
+
+    db_name = user_format(user, place_name)
+    dubious_name?(db_name, true) || []
+  end
+
   def self.check_for_empty_name(name)
     return [] if name.present?
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -69,6 +69,45 @@ class LocationTest < UnitTestCase
     good_location("Guanajuato, Mexico")
   end
 
+  def test_dubious_reasons_for_returns_empty_when_approved_matches
+    # When `approved:` equals `place_name`, the dubious check is short-
+    # circuited even for an obviously bad name.
+    bad_name = "Albion, California" # missing country -- normally dubious
+    reasons = Location.dubious_reasons_for(
+      user: rolf, place_name: bad_name, approved: bad_name
+    )
+    assert_equal([], reasons)
+  end
+
+  def test_dubious_reasons_for_runs_check_when_approved_differs
+    # When `approved:` does not match `place_name`, the dubious check
+    # runs and returns the reasons.
+    bad_name = "Albion, California"
+    reasons = Location.dubious_reasons_for(
+      user: rolf, place_name: bad_name, approved: "Something Else"
+    )
+    assert_not_empty(reasons)
+  end
+
+  def test_dubious_reasons_for_returns_empty_for_clean_name
+    reasons = Location.dubious_reasons_for(
+      user: rolf, place_name: "Albion, California, USA"
+    )
+    assert_equal([], reasons)
+  end
+
+  def test_dubious_reasons_for_normalizes_falsy_to_empty_array
+    # Defensive: if `dubious_name?` ever returns a falsy value, the
+    # helper still returns an array so callers can use `.empty?`
+    # without nil-checks.
+    Location.stub(:dubious_name?, nil) do
+      reasons = Location.dubious_reasons_for(
+        user: rolf, place_name: "Anywhere"
+      )
+      assert_equal([], reasons)
+    end
+  end
+
   def test_understood_country
     assert(Location.understood_country?("USA"))
     assert(Location.understood_country?("Afghanistan"))


### PR DESCRIPTION
## Summary

Adds `Location.dubious_reasons_for(user:, place_name:, approved:)` that
encapsulates the `user_format` + `dubious_name?(…, true)` pattern that
lived as 2-3 lines in 4 controllers across 6 call sites. The helper
always returns an `Array`, normalizing any defensive falsy result from
`dubious_name?` to `[]` so callers can use `.empty?` without nil-checks.

```ruby
# In Location:
def self.dubious_reasons_for(user:, place_name:, approved: nil)
  return [] if !approved.nil? && place_name == approved

  db_name = user_format(user, place_name)
  dubious_name?(db_name, true) || []
end
```

## 6 call sites collapsed onto the helper

- `app/controllers/locations_controller.rb#new` — no approved gate
  (`approved:` omitted).
- `app/controllers/locations_controller.rb#create_location_ivar_and_save`
  — `approved: @approved_name`. Drops the now-unused `db_name`
  parameter (the `#create` call site is updated to match).
- `app/controllers/locations_controller.rb#determine_and_check_location`
  — `approved: params[:approved_where]`. Drops the `db_name` param
  (also dropped from `update_location_change` and the `#update` call
  site).
- `app/controllers/species_lists_controller.rb#validate_place_name` —
  `approved: nil`. The surrounding pre-check already gates on
  `@place_name != approved_where && location_id.nil?`, which is
  strictly stronger than the helper's `approved:` gate, so it stays
  external.
- `app/controllers/species_lists/write_in_controller.rb#validate_place_name`
  — `approved: params[:approved_where]`.
- `app/controllers/observations_controller/validators.rb#validate_place_name`
  — no approved gate. The surrounding
  `@any_errors = true; return false` flow is preserved.

`db_name` is still computed at the top of `LocationsController#create`
and `#update` for the `find_by_name_or_reverse_name` lookup — just no
longer plumbed into the dubious-name path.

## Out of scope

- The surrounding `validate_place_name` shape (early returns, ivar
  setting, flash messages) was preserved beyond the dubious-name
  lookup collapse itself — this is targeted, not a method rewrite.
- `dubious_name?` and `user_format` are unchanged.
- The instance method shape was rejected — callers have a
  `place_name` string and a `user`, not a `Location` instance yet.

## Tests

4 new model tests on `Location.dubious_reasons_for`:

- returns `[]` when `approved == place_name`
- returns the dubious reasons when `approved != place_name`
- returns `[]` when the name is clean
- returns `[]` (not `nil`) when `dubious_name?` returns falsy

## Test plan

- [x] `bin/rails test test/models/location_test.rb -n /dubious_reasons_for/` — 4 tests, 0 failures
- [x] `bin/rails test test/models/location_test.rb -n test_dubious_name` — 1 test, 0 failures (existing behavior intact)
- [x] `bin/rails test test/controllers/species_lists_controller_test.rb` — 37 tests, 0 failures
- [x] `bin/rails test test/controllers/species_lists/write_in_controller_test.rb` — 22 tests, 0 failures
- [x] `bin/rails test test/controllers/locations_controller_test.rb` — 66 tests, 0 failures
- [x] `bin/rails test test/controllers/observations_controller_create_test.rb test/controllers/observations_controller_update_test.rb` — 79 tests, 0 failures
- [x] `bundle exec rubocop` on every touched file — 0 offenses

## Net delta

```
6 files changed, 85 insertions(+), 24 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
