### PR TITLE
`Header::ContextNavHelper`: convert dropdown + sidebar builders to Phlex

### DIFF
--- a/.claude/rules/gh_pr_bodies.md
+++ b/.claude/rules/gh_pr_bodies.md
@@ -1,9 +1,28 @@
 # PR body formatting
 
-When using `gh pr create` or `gh pr edit`, **always** write the body to
-a file first and pass it via `--body-file`. Never use a HEREDOC
-(`$(cat <<'EOF' ... EOF)`) for a PR body that contains backticks for
-code formatting.
+When using `gh pr create` or `gh pr edit`, **always** write the body to a file first and pass it via `--body-file`. Never use a HEREDOC (`$(cat <<'EOF' ... EOF)`) for a PR body that contains backticks for code formatting.
+
+## No hard-wrapped paragraphs
+
+**Never hard-wrap a paragraph at ~70-72 columns.** Write each paragraph as a single logical line in the source. The only line breaks in a Markdown body should be: between paragraphs (one blank line), in code blocks, in lists, in tables. Inside a paragraph: no breaks.
+
+GitHub renders soft-wrapped paragraphs perfectly. Hard-wrapping does nothing for the reader and makes the body harder to edit, harder to diff, and harder to copy a sentence out of. The user has flagged this enough times that it's a hard rule.
+
+Wrong:
+
+```
+Adds `Location.dubious_reasons_for(user:, place_name:, approved:)` that
+encapsulates the `user_format` + `dubious_name?(…, true)` pattern that
+lived as 2-3 lines in 4 controllers across 6 call sites.
+```
+
+Right:
+
+```
+Adds `Location.dubious_reasons_for(user:, place_name:, approved:)` that encapsulates the `user_format` + `dubious_name?(…, true)` pattern that lived as 2-3 lines in 4 controllers across 6 call sites.
+```
+
+Lists and tables and code blocks still use their natural line structure — this rule is about prose paragraphs only.
 
 ## Why
 

--- a/app/components/context_nav.rb
+++ b/app/components/context_nav.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Top-bar dropdown + mobile sidebar rendering for a page's context-nav
+# (formerly `Header::ContextNavHelper#add_context_nav` + its rats' nest
+# of private builder methods). Two Phlex components share the
+# `[text, url, args]` tuple shape: `TopBar` builds the right-side
+# dropdown that appears next to the page title, `Sidebar` builds the
+# `xs`-only collapsible nav. The `add_context_nav(links)` helper is
+# the entry point views (ERB + Phlex) call to populate both
+# `content_for` blocks at once — see
+# `app/helpers/header/context_nav_helper.rb`.
+module Components::ContextNav
+  # Shared link-rendering logic. Included by both `TopBar` and
+  # `Sidebar`. Pulled out as a module so the two components don't
+  # have to inherit from a common base just to share a few methods,
+  # which would interfere with `Components::Base`'s Phlex wiring.
+  module LinkRendering
+    private
+
+    # Strips MO-specific keys from the args hash and blends in any
+    # extra_args' class. Returns a kwargs hash safe to splat into a
+    # `link_to` / `button_to` / `CrudButton::*` call.
+    def merge_context_nav_link_args(args, extra_args)
+      kwargs = args.except(:button, :target)
+      kwargs[:class] = class_names(kwargs[:class], extra_args[:class])
+      kwargs.merge(extra_args.except(:class))
+    end
+
+    # Dispatch one `[text, url, args]` link tuple to the right HTML
+    # element. Buttons go through the corresponding `CrudButton::*`
+    # subclass; plain `link_to` is the default.
+    def render_crud_button_or_link(str, url, args, kwargs)
+      case args[:button]
+      when :post
+        button_to(str, url, **kwargs)
+      when :destroy
+        # Context-nav destroy tabs render as plain `[ DESTROY ]`-style
+        # text links — opt out of `CrudButton::Delete`'s default icon
+        # AND button-frame via `icon: nil` + `btn: nil` (callers can
+        # override either by passing the kwarg).
+        render(Components::CrudButton::Delete.new(
+                 name: str, target: args[:target] || url,
+                 **kwargs.reverse_merge(icon: nil, btn: nil)
+               ))
+      when :put
+        render(Components::CrudButton::Put.new(
+                 name: str, target: url, **kwargs
+               ))
+      when :patch
+        render(Components::CrudButton::Patch.new(
+                 name: str, target: url, **kwargs
+               ))
+      else
+        link_to(str, url, kwargs)
+      end
+    end
+  end
+end

--- a/app/components/context_nav/sidebar.rb
+++ b/app/components/context_nav/sidebar.rb
@@ -3,10 +3,13 @@
 # Mobile (`xs`-only) sidebar version of the context-nav menu —
 # rendered into `content_for(:context_nav_mobile)` by
 # `add_context_nav(links)`. Renders the same `[text, url, args]`
-# tuples as `TopBar`, but flattened into indented `active_link_to`
-# rows under a heading (no dropdown, no per-link button dispatch —
-# the sidebar always uses `link_to` even when the tuple says
-# `button: :destroy`, matching pre-Phlex behavior).
+# tuples as `TopBar`, flattened into indented rows under a heading
+# (no dropdown). Dispatches each tuple through
+# `LinkRendering#render_crud_button_or_link` so `button: :destroy` /
+# `:post` / `:put` / `:patch` actually render as their respective
+# forms — pre-Phlex `sidebar_nav_link` collapsed every tuple to a
+# plain `active_link_to`, which meant mobile users couldn't trigger
+# destroy / post actions from the sidebar at all. Fixed here.
 class Components::ContextNav::Sidebar < Components::Base
   include Components::ContextNav::LinkRendering
 
@@ -46,25 +49,25 @@ class Components::ContextNav::Sidebar < Components::Base
     end
   end
 
-  # Pre-Phlex `sidebar_nav_link` always used `active_link_to` —
-  # ignoring `args[:button]` — so `[ DESTROY ]` / `[ POST ]` tabs
-  # collapse to plain text links in the mobile sidebar. Preserved
-  # for parity.
   def render_sidebar_link(link)
     str, url, args = link
-    kwargs = sidebar_link_kwargs(args || {})
-    link_to(str, url, kwargs)
+    args ||= {}
+    kwargs = sidebar_link_kwargs(args)
+    render_crud_button_or_link(str, url, args, kwargs)
   end
 
   # Builds the kwargs hash for one sidebar link: indent + mobile-only
-  # classes, the nav-active Stimulus data attrs (inlined from
-  # `LinkHelper#active_link_to`), and a button-specific d-block strip.
+  # classes, the nav-active Stimulus data attrs (only for plain anchor
+  # links — buttons / forms aren't tracked by `nav-active`), and a
+  # button-specific d-block strip.
   def sidebar_link_kwargs(args)
     kwargs = merge_context_nav_link_args(
       args,
       class: class_names(CSS_CLASSES[:indent], CSS_CLASSES[:mobile_only])
     )
     strip_d_block_for_button!(kwargs, args)
+    return kwargs if args[:button].present?
+
     kwargs[:data] = (kwargs[:data] || {}).merge(
       nav_active_target: "link",
       action: "nav-active#navigate"

--- a/app/components/context_nav/sidebar.rb
+++ b/app/components/context_nav/sidebar.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Mobile (`xs`-only) sidebar version of the context-nav menu —
+# rendered into `content_for(:context_nav_mobile)` by
+# `add_context_nav(links)`. Renders the same `[text, url, args]`
+# tuples as `TopBar`, but flattened into indented `active_link_to`
+# rows under a heading (no dropdown, no per-link button dispatch —
+# the sidebar always uses `link_to` even when the tuple says
+# `button: :destroy`, matching pre-Phlex behavior).
+class Components::ContextNav::Sidebar < Components::Base
+  include Components::ContextNav::LinkRendering
+
+  # Inlined from `SidebarHelper#sidebar_css_classes` (single relevant
+  # caller after the conversion). Bootstrap 3 / list-group classes
+  # the mobile sidebar shares with other `_sidebar.*` partials. Kept
+  # as a frozen literal so subclasses can `merge` for variants
+  # without mutating the canonical set.
+  CSS_CLASSES = {
+    wrapper: "navbar navbar-inverse sidebar-nav list-group",
+    heading: "list-group-item disabled font-weight-bold",
+    item: "list-group-item",
+    admin: "list-group-item list-group-item-danger indent",
+    indent: "list-group-item indent",
+    mobile_only: "visible-xs",
+    desktop_only: "hidden-xs"
+  }.freeze
+
+  def initialize(links:)
+    super()
+    @links = links.compact
+  end
+
+  def view_template
+    return if @links.empty?
+
+    render_heading
+    @links.each { |link| render_sidebar_link(link) }
+  end
+
+  private
+
+  def render_heading
+    div(class: class_names(CSS_CLASSES[:heading],
+                           CSS_CLASSES[:mobile_only])) do
+      plain("#{:app_context_actions.t}:")
+    end
+  end
+
+  # Pre-Phlex `sidebar_nav_link` always used `active_link_to` —
+  # ignoring `args[:button]` — so `[ DESTROY ]` / `[ POST ]` tabs
+  # collapse to plain text links in the mobile sidebar. Preserved
+  # for parity.
+  def render_sidebar_link(link)
+    str, url, args = link
+    kwargs = sidebar_link_kwargs(args || {})
+    link_to(str, url, kwargs)
+  end
+
+  # Builds the kwargs hash for one sidebar link: indent + mobile-only
+  # classes, the nav-active Stimulus data attrs (inlined from
+  # `LinkHelper#active_link_to`), and a button-specific d-block strip.
+  def sidebar_link_kwargs(args)
+    kwargs = merge_context_nav_link_args(
+      args,
+      class: class_names(CSS_CLASSES[:indent], CSS_CLASSES[:mobile_only])
+    )
+    strip_d_block_for_button!(kwargs, args)
+    kwargs[:data] = (kwargs[:data] || {}).merge(
+      nav_active_target: "link",
+      action: "nav-active#navigate"
+    )
+    kwargs
+  end
+
+  def strip_d_block_for_button!(kwargs, args)
+    return unless args[:button].present? && kwargs[:class].present?
+
+    kwargs[:class] = kwargs[:class].gsub("d-block", "").strip
+  end
+end

--- a/app/components/context_nav/top_bar.rb
+++ b/app/components/context_nav/top_bar.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Right-side dropdown that appears next to the page title (the
+# "Context Actions" menu). Rendered into `content_for(:context_nav)`
+# by `add_context_nav(links)`.
+#
+# Takes the same `[text, url, args]` tuple shape MO's tab builders
+# (`Tabs::*Helper`) already produce. The dispatch on `args[:button]`
+# (`:post` / `:destroy` / `:put` / `:patch` / nil) chooses between
+# `button_to`, the corresponding `CrudButton::*` subclass, or plain
+# `link_to`; see `LinkRendering#render_crud_button_or_link`.
+class Components::ContextNav::TopBar < Components::Base
+  include Components::ContextNav::LinkRendering
+
+  def initialize(links:)
+    super()
+    @links = links.compact
+  end
+
+  def view_template
+    return if @links.empty?
+
+    # Bootstrap 3: the dropdown wrapper has to be an `<li>` for
+    # alignment with the surrounding nav structure.
+    li(class: "dropdown d-inline-block") do
+      render_dropdown_toggle
+      render_dropdown_menu
+    end
+  end
+
+  private
+
+  def render_dropdown_toggle
+    a(class: "dropdown-toggle", id: "context_nav_toggle",
+      role: "button", data: { toggle: "dropdown" },
+      aria: { haspopup: "true", expanded: "false" }) do
+      span(data: { dropdown_current_target: "title" }) do
+        plain(:app_context_actions.l)
+      end
+      span(class: "caret ml-2")
+    end
+  end
+
+  def render_dropdown_menu
+    ul(id: "context_nav", class: "dropdown-menu",
+       aria: { labelledby: "context_nav_toggle" }) do
+      @links.each { |link| li { render_link_item(link) } }
+    end
+  end
+
+  # One link inside the dropdown menu. Mirrors the pre-Phlex
+  # `context_nav_link` helper: merges args, strips the
+  # `d-block` class on buttons (other links need it),
+  # dispatches via `render_crud_button_or_link`.
+  def render_link_item(link)
+    str, url, args = link
+    args ||= {}
+    kwargs = merge_context_nav_link_args(args, {})
+    if args[:button].present? && kwargs[:class].present?
+      kwargs[:class] = kwargs[:class].gsub("d-block", "").strip
+    end
+    render_crud_button_or_link(str, url, args, kwargs.compact_blank)
+  end
+end

--- a/app/helpers/header/context_nav_helper.rb
+++ b/app/helpers/header/context_nav_helper.rb
@@ -1,105 +1,71 @@
 # frozen_string_literal: true
 
-#  Helpers for the top nav bar's context menu, formerly "tabset links".
-#  Views should define the menu's content with an array of InternalLink.tabs
-
-#  add_context_nav(links)      # add content_for(:context_nav)
-#  context_nav_links(links)    # convert links -> link_to's / button_to's
-#  nav_link(link)              # convert one link into an HTML link or button
+# Helpers for a page's context-nav menu (formerly the "tabset links"
+# / "action menu" / "page's right-side dropdown").
 #
+# Two entry points:
+#
+#   - `add_context_nav(links)` (most callers) — populates both
+#     `content_for(:context_nav)` (top-bar dropdown) and
+#     `content_for(:context_nav_mobile)` (mobile sidebar). The actual
+#     markup lives in `Components::ContextNav::TopBar` and
+#     `Components::ContextNav::Sidebar`; this helper just sets the
+#     `content_for` blocks the layout reads.
+#   - `context_nav_links(links)` (a few ERB callers — see
+#     `users/show/_profile.erb`) — returns an array of pre-rendered
+#     HTML strings for each link tuple, useful when the caller wants
+#     to wrap them in their own (non-dropdown) layout.
+#
+# Both take an array of `InternalLink.tab` tuples:
+#   [text, url, args]
+# where `args[:button]` (`:post` / `:destroy` / `:put` / `:patch` / nil)
+# chooses the HTML element.
 module Header
   module ContextNavHelper
-    # Shorthand to render shared context_nav partial for a given set of links.
-    # Called in the view, defines `:context_nav` which is rendered in layout.
     def add_context_nav(links)
       return unless links.present? && links.compact.length.positive?
 
-      add_context_nav_to_top_bar(links)
-      add_context_nav_to_sidebar(links)
+      links = links.compact
+      top_bar_html = render(Components::ContextNav::TopBar.new(links: links))
+      sidebar_html = render(Components::ContextNav::Sidebar.new(links: links))
+      content_for(:context_nav) { top_bar_html }
+      content_for(:context_nav_mobile) { sidebar_html }
     end
 
-    def add_context_nav_to_top_bar(links)
-      nav_links = context_nav_links(links)
-      content_for(:context_nav) do
-        context_nav_dropdown(title: :app_context_actions.l,
-                             id: "context_nav", links: nav_links)
-      end
-    end
-
-    def add_context_nav_to_sidebar(links)
-      classes = sidebar_css_classes
-      content_for(:context_nav_mobile) do
-        concat(
-          tag.div(
-            "#{:app_context_actions.t}:",
-            class: class_names(classes[:heading], classes[:mobile_only])
-          )
-        )
-        context_nav_sidebar_links(links, classes)
-      end
-    end
-
-    def context_nav_sidebar_links(links, classes)
-      links.each do |link|
-        concat(
-          sidebar_nav_link(
-            link,
-            class: class_names(classes[:indent], classes[:mobile_only])
-          )
-        )
-      end
-    end
-
-    # Convert an array (of arrays) of link attributes into an array of HTML
-    # that may be either links or CRUD button_to's, for RHS context nav menu
-    # Example
-    # links = [
-    #   ["text", "url", { class: "edit_form_link" }],
-    #   [nil, article, { button: :destroy }]
-    # ]
-    # context_nav_links(links) will make an array of the following HTML
-    #   "<a href="url" class="edit_form_link">text</a>",
-    #   "<form action='destroy'>" etc via destroy_button
-    #   (The above array gives default button text and class)
-    #
-    # Allows passing an extra_args hash to be merged with each link's args
-    #
+    # Returns an array of pre-rendered HTML strings — one per link
+    # tuple. Used by ERB callers that need the link conversion
+    # without the dropdown / sidebar wrapper (e.g.
+    # `users/show/_profile.erb` wraps each link in its own `<li>`
+    # under a `list-unstyled` `<ul>`).
     def context_nav_links(links, extra_args = {})
       return [] unless links
 
-      links.compact.map do |link|
-        context_nav_link(link, extra_args)
-      end
+      links.compact.map { |link| context_nav_link(link, extra_args) }
     end
 
-    # Unpacks the [text, url, args] array for a single link and figures out
-    # which HTML to return for that type of link
-    # Pass extra_args hash to modify the link/button attributes
-    #
+    # Convert one `[text, url, args]` tuple into a Rails-helper HTML
+    # string. The Phlex equivalent that EMITS into a Phlex buffer
+    # lives in `Components::ContextNav::LinkRendering`.
     def context_nav_link(link, extra_args = {})
       str, url, args = link
       args ||= {}
       kwargs = merge_context_nav_link_args(args, extra_args)
-      # remove d-block from buttons, other links need it
       if args[:button].present? && kwargs[:class].present?
         kwargs[:class] = kwargs[:class].gsub("d-block", "").strip
       end
-
       crud_button_or_link(str, url, args, kwargs.compact_blank)
     end
 
-    def sidebar_nav_link(link, extra_args = {})
-      str, url, args = link
-      args ||= {}
-      kwargs = merge_context_nav_link_args(args, extra_args)
-      # remove d-block from buttons, other links need it
-      if args[:button].present? && kwargs[:class].present?
-        kwargs[:class] = kwargs[:class].gsub("d-block", "").strip
-      end
-
-      active_link_to(str, url, **kwargs)
+    def merge_context_nav_link_args(args, extra_args)
+      kwargs = args.except(:button, :target)
+      kwargs[:class] = class_names(kwargs[:class], extra_args[:class])
+      kwargs.merge(extra_args.except(:class))
     end
 
+    # Helper-context dispatch — produces an HTML string (`SafeBuffer`)
+    # for one link. Mirrors
+    # `Components::ContextNav::LinkRendering#render_crud_button_or_link`,
+    # which emits the same shape into a Phlex buffer.
     def crud_button_or_link(str, url, args, kwargs)
       case args[:button]
       when :post
@@ -117,54 +83,6 @@ module Header
         patch_button(name: str, path: url, **kwargs)
       else
         link_to(str, url, kwargs)
-      end
-    end
-
-    # Make a hash of the kwargs that will be passed to link helper for HTML.
-    # e.g. { data: { pileus: "awesome" }, id: "best_pileus", class: "hidden" }
-    # Removes non-HTML args used by link_to/button helpers and merges with
-    # passed-in extra_args.
-    #   e.g. removes { name: "Click here to post", target: obs }
-    # Note that class_names need to be concatenated or the merge will overwrite.
-    #
-    def merge_context_nav_link_args(args, extra_args)
-      kwargs = args&.except(:button, :target)
-      # blend in the class names that may come from the extra_args
-      kwargs[:class] = class_names(kwargs[:class], extra_args[:class])
-      # merge in other args from extra_args (will overwrite keys!)
-      kwargs&.merge(extra_args&.except(:class))
-    end
-
-    # For Bootstrap 3, this must be an <li> element for alignment
-    def context_nav_dropdown(title: "", id: "", links: [])
-      tag.li(class: "dropdown d-inline-block") do
-        [
-          context_nav_dropdown_toggle(title:),
-          context_nav_dropdown_menu(id:, links:)
-        ].safe_join
-      end
-    end
-
-    def context_nav_dropdown_toggle(title:)
-      tag.a(
-        class: class_names(%w[dropdown-toggle]),
-        id: "context_nav_toggle", role: "button",
-        data: { toggle: "dropdown" },
-        aria: { haspopup: "true", expanded: "false" }
-      ) do
-        concat(tag.span(title, data: { dropdown_current_target: "title" }))
-        concat(tag.span(class: "caret ml-2"))
-      end
-    end
-
-    def context_nav_dropdown_menu(id:, links:)
-      tag.ul(
-        id:, class: "dropdown-menu",
-        aria: { labelledby: "context_nav_toggle" }
-      ) do
-        links.compact.each do |link|
-          concat(tag.li(link))
-        end
       end
     end
   end

--- a/test/components/context_nav/sidebar_test.rb
+++ b/test/components/context_nav/sidebar_test.rb
@@ -4,9 +4,12 @@ require("test_helper")
 
 module Components::ContextNav
   # Tests for the mobile (`xs`-only) sidebar that renders into
-  # `content_for(:context_nav_mobile)`. Sidebar collapses every link
-  # tuple to an `active_link_to` — ignoring `args[:button]` — so the
-  # mobile menu stays a flat list, matching pre-Phlex behavior.
+  # `content_for(:context_nav_mobile)`. Sidebar dispatches each link
+  # tuple via `LinkRendering#render_crud_button_or_link` (same as
+  # `TopBar`) so destroy / post / put / patch tuples render as their
+  # actual forms — pre-Phlex `sidebar_nav_link` collapsed everything
+  # to plain links, which was a bug (mobile users couldn't trigger
+  # the action). Fixed in this PR.
   class SidebarTest < ComponentTestCase
     def setup
       super
@@ -19,46 +22,64 @@ module Components::ContextNav
       assert_equal("", html)
     end
 
-    def test_renders_heading_and_link_rows
+    def test_renders_heading_and_plain_link_rows
       html = render_sidebar(simple_links)
 
-      # Heading: "Context Actions:" inside a list-group-item / heading
-      # div, mobile-only.
-      assert_html(html, "div.list-group-item.disabled.font-weight-bold.visible-xs",
+      # Heading row.
+      heading_classes =
+        "div.list-group-item.disabled.font-weight-bold.visible-xs"
+      assert_html(html, heading_classes,
                   text: "#{:app_context_actions.t}:")
-      # Each link becomes its own indented + mobile-only row.
+      # Each plain link is its own indented + mobile-only row.
       assert_html(html, "a.list-group-item.indent.visible-xs",
                   count: simple_links.length)
     end
 
-    # Sidebar deliberately collapses `button: :destroy` to a plain
-    # link (no form, no destroy mechanics) — this matches the
-    # pre-Phlex `sidebar_nav_link` shape, and the mobile menu has
-    # no good place for confirm dialogs anyway.
-    def test_destroy_tuple_renders_as_plain_link_in_sidebar
+    # `button: :destroy` now dispatches through `CrudButton::Delete`
+    # (with the `icon: nil` + `btn: nil` context-nav opt-outs from
+    # `LinkRendering`) — sidebar users get a working REMOVE form.
+    def test_destroy_tuple_renders_as_form_in_sidebar
       links = [[nil, @article, { button: :destroy }]]
       html = render_sidebar(links)
 
-      assert_no_html(html, "form")
+      assert_html(html, "form[action='#{view_context.article_path(@article)}']")
+      assert_html(html, "input[name='_method'][value='delete']")
     end
 
-    # Every sidebar link gets the Stimulus `nav-active` data attrs
-    # so the controller can highlight the current-page link.
-    def test_links_have_nav_active_data_attributes
+    # `button: :post` dispatches through Rails' `button_to` → form.
+    def test_post_tuple_renders_as_form_in_sidebar
+      links = [["Submit", "/items", { button: :post }]]
+      html = render_sidebar(links)
+
+      assert_html(html, "form[action='/items']")
+      assert_html(html, "button", text: "Submit")
+    end
+
+    # Plain anchor links get the Stimulus `nav-active` data attrs so
+    # the current-page link is highlighted. Forms / buttons aren't
+    # navigated to in the same sense, so they don't get those attrs.
+    def test_plain_links_have_nav_active_data_attributes
       html = render_sidebar(simple_links)
 
       assert_html(html, "a[data-nav-active-target='link']")
       assert_html(html, "a[data-action='nav-active#navigate']")
     end
 
-    def test_strips_d_block_class_from_buttons
-      links = [["Click", "/items", { button: :post, class: "d-block other-class" }]]
+    def test_button_tuples_do_not_get_nav_active_data_attributes
+      links = [[nil, @article, { button: :destroy }]]
       html = render_sidebar(links)
 
-      # The link still renders (sidebar collapses buttons to links),
-      # but the d-block was stripped out per pre-Phlex parity.
-      assert_html(html, "a.other-class")
-      assert_no_html(html, "a.d-block")
+      assert_no_html(html, "form[data-nav-active-target]")
+      assert_no_html(html, "button[data-nav-active-target]")
+    end
+
+    def test_strips_d_block_class_from_buttons
+      links = [["Click", "/items",
+                { button: :post, class: "d-block other-class" }]]
+      html = render_sidebar(links)
+
+      assert_html(html, "button.other-class")
+      assert_no_html(html, "button.d-block")
     end
 
     private

--- a/test/components/context_nav/sidebar_test.rb
+++ b/test/components/context_nav/sidebar_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Components::ContextNav
+  # Tests for the mobile (`xs`-only) sidebar that renders into
+  # `content_for(:context_nav_mobile)`. Sidebar collapses every link
+  # tuple to an `active_link_to` — ignoring `args[:button]` — so the
+  # mobile menu stays a flat list, matching pre-Phlex behavior.
+  class SidebarTest < ComponentTestCase
+    def setup
+      super
+      @article = articles(:premier_article)
+    end
+
+    def test_renders_nothing_when_links_empty
+      html = render(Components::ContextNav::Sidebar.new(links: []))
+
+      assert_equal("", html)
+    end
+
+    def test_renders_heading_and_link_rows
+      html = render_sidebar(simple_links)
+
+      # Heading: "Context Actions:" inside a list-group-item / heading
+      # div, mobile-only.
+      assert_html(html, "div.list-group-item.disabled.font-weight-bold.visible-xs",
+                  text: "#{:app_context_actions.t}:")
+      # Each link becomes its own indented + mobile-only row.
+      assert_html(html, "a.list-group-item.indent.visible-xs",
+                  count: simple_links.length)
+    end
+
+    # Sidebar deliberately collapses `button: :destroy` to a plain
+    # link (no form, no destroy mechanics) — this matches the
+    # pre-Phlex `sidebar_nav_link` shape, and the mobile menu has
+    # no good place for confirm dialogs anyway.
+    def test_destroy_tuple_renders_as_plain_link_in_sidebar
+      links = [[nil, @article, { button: :destroy }]]
+      html = render_sidebar(links)
+
+      assert_no_html(html, "form")
+    end
+
+    # Every sidebar link gets the Stimulus `nav-active` data attrs
+    # so the controller can highlight the current-page link.
+    def test_links_have_nav_active_data_attributes
+      html = render_sidebar(simple_links)
+
+      assert_html(html, "a[data-nav-active-target='link']")
+      assert_html(html, "a[data-action='nav-active#navigate']")
+    end
+
+    def test_strips_d_block_class_from_buttons
+      links = [["Click", "/items", { button: :post, class: "d-block other-class" }]]
+      html = render_sidebar(links)
+
+      # The link still renders (sidebar collapses buttons to links),
+      # but the d-block was stripped out per pre-Phlex parity.
+      assert_html(html, "a.other-class")
+      assert_no_html(html, "a.d-block")
+    end
+
+    private
+
+    def render_sidebar(links)
+      render(Components::ContextNav::Sidebar.new(links: links))
+    end
+
+    def simple_links
+      [
+        ["Edit", "/items/1/edit", { class: "edit_link" }],
+        ["Show", "/items/1", { class: "show_link" }]
+      ]
+    end
+  end
+end

--- a/test/components/context_nav/top_bar_test.rb
+++ b/test/components/context_nav/top_bar_test.rb
@@ -46,8 +46,9 @@ module Components::ContextNav
     def test_dropdown_toggle_shows_context_actions_label
       html = render_top_bar(simple_links)
 
-      assert_html(html, "a.dropdown-toggle span[data-dropdown-current-target='title']",
-                  text: :app_context_actions.l)
+      title_sel =
+        "a.dropdown-toggle span[data-dropdown-current-target='title']"
+      assert_html(html, title_sel, text: :app_context_actions.l)
     end
 
     # `args[:button] => :destroy` routes through `CrudButton::Delete`

--- a/test/components/context_nav/top_bar_test.rb
+++ b/test/components/context_nav/top_bar_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Components::ContextNav
+  # Tests for the right-side dropdown that renders into
+  # `content_for(:context_nav)`. Covers the basic structure, the
+  # per-link dispatch via `args[:button]`, and the `d-block`-stripping
+  # quirk inherited from the pre-Phlex helper.
+  class TopBarTest < ComponentTestCase
+    def setup
+      super
+      @article = articles(:premier_article)
+    end
+
+    # No links → no markup at all (the entire dropdown is conditional
+    # on having something to put inside it).
+    def test_renders_nothing_when_links_empty
+      html = render(Components::ContextNav::TopBar.new(links: []))
+
+      assert_equal("", html)
+    end
+
+    # Compacts nil entries before the empty check — a tabs helper
+    # that returns `[edit_tab, destroy_tab_if_admin]` shouldn't
+    # collapse the dropdown when one entry is nil.
+    def test_renders_nothing_when_all_links_are_nil
+      html = render(Components::ContextNav::TopBar.new(links: [nil, nil]))
+
+      assert_equal("", html)
+    end
+
+    def test_renders_bootstrap_dropdown_structure
+      html = render_top_bar(simple_links)
+
+      assert_html(html, "li.dropdown.d-inline-block")
+      assert_html(html, "a.dropdown-toggle#context_nav_toggle")
+      assert_html(html, "ul.dropdown-menu#context_nav")
+      # Each link tuple becomes one <li> inside the dropdown menu
+      assert_html(html, "ul.dropdown-menu li", count: simple_links.length)
+    end
+
+    # The dropdown's toggle shows the localized "Context Actions"
+    # label inside a span with the `dropdown_current_target` hook
+    # so the Stimulus controller can rewrite it on submenu changes.
+    def test_dropdown_toggle_shows_context_actions_label
+      html = render_top_bar(simple_links)
+
+      assert_html(html, "a.dropdown-toggle span[data-dropdown-current-target='title']",
+                  text: :app_context_actions.l)
+    end
+
+    # `args[:button] => :destroy` routes through `CrudButton::Delete`
+    # with the context-nav opt-outs (`icon: nil`, `btn: nil`) so the
+    # destroy renders as plain `[ DESTROY ]`-style text.
+    def test_destroy_button_renders_as_plain_text_link
+      links = [[nil, @article, { button: :destroy }]]
+      html = render_top_bar(links)
+
+      assert_html(html, "form[action='#{view_context.article_path(@article)}']")
+      assert_html(html, "input[name='_method'][value='delete']")
+      assert_no_html(html, ".glyphicon-remove-circle")
+      assert_no_html(html, ".btn.btn-outline-default")
+    end
+
+    # `args[:button] => :post` uses Rails' `button_to`.
+    def test_post_button_renders_as_form
+      links = [["Click", "/items", { button: :post }]]
+      html = render_top_bar(links)
+
+      assert_html(html, "form[action='/items']")
+      assert_html(html, "button", text: "Click")
+    end
+
+    # Plain links (no `args[:button]`) render as `<a>`.
+    def test_plain_link_renders_as_anchor
+      links = [["Edit", "/items/1/edit", { class: "edit_item_link" }]]
+      html = render_top_bar(links)
+
+      assert_html(html, "a.edit_item_link[href='/items/1/edit']", text: "Edit")
+    end
+
+    # The dropdown menu strips `d-block` from button classes — the
+    # pre-Phlex helper did this so button-style links don't get
+    # forced to display: block inside the dropdown.
+    def test_strips_d_block_class_from_buttons
+      links = [["Submit", "/items", { button: :post, class: "d-block btn-lg" }]]
+      html = render_top_bar(links)
+
+      assert_html(html, "button.btn-lg")
+      assert_no_html(html, "button.d-block")
+    end
+
+    private
+
+    def render_top_bar(links)
+      render(Components::ContextNav::TopBar.new(links: links))
+    end
+
+    def simple_links
+      [
+        ["Edit", "/items/1/edit", { class: "edit_link" }],
+        ["Show", "/items/1", { class: "show_link" }]
+      ]
+    end
+  end
+end

--- a/test/controllers/licenses_controller_test.rb
+++ b/test/controllers/licenses_controller_test.rb
@@ -79,8 +79,12 @@ class LicensesControllerTest < FunctionalTestCase
       "a[href = '#{edit_license_path(license.id)}']", true,
       "License page missing link to edit License"
     )
+    # Two destroy buttons: one in the top-bar dropdown, one in the
+    # mobile-sidebar context-nav (the sidebar collapsed every tuple
+    # to a plain link before #4392; now it correctly emits the
+    # destroy form so mobile users can actually trigger the delete).
     assert_select(
-      "button", { text: "Destroy", count: 1 },
+      "button", { text: "Destroy", count: 2 },
       "Show page for unused License in use should have Destroy button"
     )
   end

--- a/test/integration/capybara/images_integration_test.rb
+++ b/test/integration/capybara/images_integration_test.rb
@@ -45,7 +45,13 @@ class ImagesIntegrationTest < CapybaraIntegrationTestCase
     visit(edit_image_path(img.id))
     assert_selector("body.images__edit")
     visit(image_path(img.id))
-    click_button(class: "destroy_image_link_#{img.id}")
+    # `#context_nav` is the top-bar dropdown menu's `<ul>`. The destroy
+    # button now also lives in the mobile sidebar (#4392 sidebar bug
+    # fix) so an unscoped `click_button` is ambiguous — scope to the
+    # top-bar to disambiguate.
+    within("#context_nav") do
+      click_button(class: "destroy_image_link_#{img.id}")
+    end
     assert_flash_success
   end
 end


### PR DESCRIPTION
## Summary

Converts the top-bar dropdown + mobile sidebar markup builders in `Header::ContextNavHelper` to two Phlex components — `Components::ContextNav::TopBar` (the right-side "Context Actions" dropdown) and `Components::ContextNav::Sidebar` (the `xs`-only collapsible nav). The helper's public API stays the same: views still call `add_context_nav(links)` to populate both `content_for` blocks, and a handful of ERB partials that consumed `context_nav_links(links)` directly (e.g. `users/show/_profile.erb` wraps each link in its own custom `<ul>`) keep that interface too.

## What moved to Phlex

- `add_context_nav_to_top_bar` / `context_nav_dropdown` / `context_nav_dropdown_toggle` / `context_nav_dropdown_menu` → `Components::ContextNav::TopBar`
- `add_context_nav_to_sidebar` / `context_nav_sidebar_links` / `sidebar_nav_link` → `Components::ContextNav::Sidebar`
- The `[text, url, args]`-tuple → HTML dispatch (`button_to` for `:post`, `CrudButton::*` for `:destroy` / `:put` / `:patch`, `link_to` otherwise) lives in `Components::ContextNav::LinkRendering`, a private mixin both components include
- `sidebar_css_classes` (a one-method module — `SidebarHelper` — whose only caller was the sidebar builder) inlines as a `CSS_CLASSES` constant on `Components::ContextNav::Sidebar`

## What stayed in the helper

- `add_context_nav(links)` — the entry-point. Now a 6-line shim that renders the two components into the `content_for` blocks
- `context_nav_links(links, extra_args = {})` — kept for ERB callers that build their own non-dropdown layout
- `context_nav_link(link, extra_args = {})` — the per-link converter
- `merge_context_nav_link_args` / `crud_button_or_link` — supporting methods

The helper module went from ~170 lines to ~85, half-size, but doesn't *just* delegate — it keeps the helper-context (string-returning) version of the link dispatch for ERB callers that need it. The Phlex components have their own emit-to-buffer parallel implementations, which is a small DRY hit but each lives in the right context.

## Behavior change — sidebar destroy / post / put / patch tuples now actually work

Pre-Phlex `sidebar_nav_link` collapsed *every* tuple to a plain `active_link_to(str, url, **kwargs)`, ignoring `args[:button]`. For a destroy tuple like `[nil, article, { button: :destroy }]`, that produced `<a href="/articles/123">…</a>` — a plain anchor to the article's show page, **not** the destroy action. Mobile users tapping "DESTROY" in the sidebar would navigate to the article instead of triggering the delete.

`Sidebar` now dispatches each tuple through `LinkRendering#render_crud_button_or_link` (same as `TopBar`), so destroy / post / put / patch tuples render as their actual forms with the correct `_method` field and Turbo confirm wiring. The `nav-active` Stimulus data attrs still apply to plain anchor links (those are what the nav-active controller tracks); buttons / forms skip them.

Parity confirms exactly this. On `species_lists#show`, the diff between main and this branch is one element: the pre-Phlex mobile "Clear This List" tab rendered as `<a data-confirm="Are you sure?" data-nav-active-target="link" …>` (an anchor — rails-ujs is gone, so the `data-confirm` was a no-op; mobile users couldn't actually clear the list). On the branch it's `<form data-turbo="true" action="…/clear"><input name="_method" value="put"><button>Clear This List</button></form>` — the actual working PUT. `articles#show` and `observations#show` were byte-identical (those tabs' context-nav happens not to include destroy/post tuples).

## Other behavior preserved

- The `d-block` class is stripped from button kwargs in both top-bar and sidebar (pre-Phlex quirk where buttons inside the dropdown shouldn't be forced to `display: block`).
- The destroy-tab `icon: nil, btn: nil` opt-out from #4387 is preserved.
- Top-bar dispatch + structure unchanged from main.

## Tests

15 new component tests across the two components:

- TopBar: renders nothing when empty / nil-only; Bootstrap dropdown structure (`li.dropdown` → `a.dropdown-toggle` → `ul.dropdown-menu` → `<li>` per link); `args[:button] => :destroy` routes through `CrudButton::Delete` with the context-nav opt-outs; `:post` → form; plain → `<a>`; `d-block` stripped from button classes
- Sidebar: renders nothing when empty; heading + indented mobile-only link rows for plain anchors; `:destroy` → form (the bug fix); `:post` → form; plain links get `nav-active` data attrs, forms don't; `d-block` stripped

## Hard-rule addendum to `.claude/rules/gh_pr_bodies.md`

Adds the user's "no hard-wrapped paragraphs in PR bodies" rule. Markdown source: one logical paragraph = one source line; breaks only between paragraphs / in lists / in tables / in code blocks. GitHub renders soft-wrapping perfectly; hard-wrapping makes the body harder to edit, diff, and copy a sentence out of.

## Test plan

- [x] `bin/rails test test/components/context_nav/` — 15 tests, 0 failures
- [x] `bin/rails test test/controllers/articles_controller_test.rb -n test_context_nav_dropdown_helper` — passes (was the regression-canary for the #4387 destroy-tab opt-out)
- [x] `bundle exec rubocop` on every touched file — 0 offenses
- [x] Full-page parity vs `main` for `articles#show`, `species_lists#show`, `observations#show` — `articles#show` and `observations#show` byte-identical; `species_list#show` shows exactly the legitimate sidebar-form fix described above and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
