### PR TITLE
species_lists_controller: trim under 250 lines; drop ClassLength disable

### DIFF
--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -7,27 +7,10 @@
 #  for the one exception).  In the end all these Name's cause rudimentary
 #  Observation's to spring into existence.
 #
-class SpeciesListsController < ApplicationController # rubocop:disable Metrics/ClassLength
-  # `Metrics/ClassLength` disabled — this controller serves the full
-  # SpeciesList CRUD surface (index, show, new, create, edit, update,
-  # destroy, clear) plus the Phlex view-render hooks (`render_index_view`,
-  # `render_phlex_new`, `render_phlex_edit`) the no-Phlex-resolver
-  # convention requires. Splitting into action-class modules is the
-  # other option and is uglier. Reconsider after #4386 / #4387 era
-  # if more action conversions push us further over.
+class SpeciesListsController < ApplicationController
   before_action :login_required
   before_action :require_successful_user, only: [:new, :create]
   before_action :store_location, only: [:show]
-  # Bullet wants us to eager load synonyms for @deprecated_names in
-  # edit_species_list, and I thought it would be possible, but I can't
-  # get it to work.  Seems toooo minor to waste any more time on.
-  # Also, as of 20231212, it wants a cached column for Observation.name,
-  # but this is not as simple as an AR default column_cache because count
-  # needs to be recalculated whenever an observation's consensus name
-  # changes, not just on create or destroy of the Observation.name.
-  around_action :skip_bullet, if: -> { defined?(Bullet) }, only: [
-    :create, :update
-  ]
 
   ##############################################################################
   # INDEX
@@ -111,11 +94,9 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
     return unless (@species_list = find_species_list!)
 
     set_project_ivar
-    case params[:flow]
-    when "next"
-      redirect_to_next_object(:next, SpeciesList, params[:id]) and return
-    when "prev"
-      redirect_to_next_object(:prev, SpeciesList, params[:id]) and return
+    if %w[next prev].include?(params[:flow])
+      return redirect_to_next_object(params[:flow].to_sym,
+                                     SpeciesList, params[:id])
     end
 
     init_ivars_for_show
@@ -288,19 +269,11 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
 
     @place_name = @species_list.place_name
     @dubious_where_reasons = []
-    # `approved_where` lives under the species_list namespace (post-Phlex)
-    # so the dubious-confirmation flag travels with the form's other
-    # fields as a regular form param. The pre-Phlex form passed this
-    # value as a top-level URL query param; the new SpeciesListForm
-    # posts it as a hidden field via `hidden_field(:approved_where, ...)`.
-    approved_where = params.dig(:species_list, :approved_where)
-    unless (@place_name != approved_where) &&
-           @species_list.location_id.nil?
-      return
-    end
+    return if @species_list.location_id
 
     @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @place_name
+      user: @user, place_name: @place_name,
+      approved: params.dig(:species_list, :approved_where)
     )
   end
 


### PR DESCRIPTION
## Summary

After #4390 (`SpeciesList#sync_projects`) and #4391 (`Location.dubious_reasons_for`) trimmed the controller, the `# rubocop:disable Metrics/ClassLength` directive at line 10 of `species_lists_controller.rb` needed only one small additional pass to come off cleanly. Three changes; net -27 lines.

## 1. Drop the `skip_bullet` around-action (and its 8-line stale comment)

```ruby
# Bullet wants us to eager load synonyms for @deprecated_names in
# edit_species_list, and I thought it would be possible, but I can't
# get it to work.  Seems toooo minor to waste any more time on.
# Also, as of 20231212, it wants a cached column for Observation.name,
# but this is not as simple as an AR default column_cache because count
# needs to be recalculated whenever an observation's consensus name
# changes, not just on create or destroy of the Observation.name.
around_action :skip_bullet, if: -> { defined?(Bullet) }, only: [
  :create, :update
]
```

The comment described a code path that doesn't exist in this controller anymore. `@deprecated_names` is set only by `SpeciesLists::WriteInController` (via `init_name_vars_from_sorter` in `SpeciesLists::SharedPrivateMethods`), not by the main controller's `:create` / `:update` flow. Conceptually a system test can't catch a Bullet error here that the integration test would miss — Bullet operates at the Rails query layer regardless of whether the request originated from Rack::Test or Cuprite, and the existing 3 integration tests cover the create/update path end-to-end.

All 37 controller tests + 3 Capybara integration tests pass without the skip. If Bullet ever surfaces a real warning in CI, we add a targeted skip back.

## 2. Collapse `case params[:flow]` in `#show`

Before:

```ruby
case params[:flow]
when "next"
  redirect_to_next_object(:next, SpeciesList, params[:id]) and return
when "prev"
  redirect_to_next_object(:prev, SpeciesList, params[:id]) and return
end
```

After:

```ruby
if %w[next prev].include?(params[:flow])
  return redirect_to_next_object(params[:flow].to_sym,
                                 SpeciesList, params[:id])
end
```

Both branches did the same thing with different symbols — pick the symbol off the param directly.

## 3. Simplify `#validate_place_name`

Before:

```ruby
@place_name = @species_list.place_name
@dubious_where_reasons = []
# `approved_where` lives under the species_list namespace (post-Phlex)
# so the dubious-confirmation flag travels with the form's other
# fields as a regular form param. The pre-Phlex form passed this
# value as a top-level URL query param; the new SpeciesListForm
# posts it as a hidden field via `hidden_field(:approved_where, ...)`.
approved_where = params.dig(:species_list, :approved_where)
unless (@place_name != approved_where) &&
       @species_list.location_id.nil?
  return
end

@dubious_where_reasons = Location.dubious_reasons_for(
  user: @user, place_name: @place_name
)
```

After:

```ruby
@place_name = @species_list.place_name
@dubious_where_reasons = []
return if @species_list.location_id

@dubious_where_reasons = Location.dubious_reasons_for(
  user: @user, place_name: @place_name,
  approved: params.dig(:species_list, :approved_where)
)
```

The "user already confirmed this name" gate now lives inside the helper (`Location.dubious_reasons_for`'s `approved:` arg), where it belongs. The remaining gate (`if location_id.nil?` → species-list-specific "no need to dubious-check if we already resolved the location") collapses to one line. The "unknown / blank place name → set Unknown location" mutation block stays — that's species_list-specific state mutation, not something the helper expresses.

## Behavior verification for `validate_place_name`

| Case | Original behavior | After |
|---|---|---|
| unknown/blank place_name | unknown-mutation sets `location_id`, gate returns | unknown-mutation sets `location_id`, `return if location_id` returns |
| `location_id` already set | gate returns | `return if location_id` returns |
| `place_name == approved` | gate returns | helper returns `[]` via its `approved == place_name` early return |
| `place_name != approved` + no location | runs `dubious_name?` check | runs `dubious_name?` check |

Two existing tests cover the corner cases:

- `test_create_with_dubious_place_name_renders_warning` — dubious place_name + no `approved_where` + `location_id` nil → check runs and populates `@dubious_where_reasons`.
- `test_create_with_unknown_place_redirects_to_new_location` — novel place_name + `approved_where` matches + `location_id` nil → dubious check skipped, save succeeds with nil `location_id`, redirects to `/locations/new`.

Both pass with the simplification.

## ClassLength

`Metrics/ClassLength` reads 247 lines (was 258 with the `# rubocop:disable` suppressing it). The disable directive deletes cleanly.

## Test plan

- [x] `bin/rails test test/controllers/species_lists_controller_test.rb` — 37 tests, 0 failures
- [x] `bin/rails test test/integration/capybara/species_lists_integration_test.rb` — 3 tests, 0 failures
- [x] `bin/rails test test/controllers/observations/species_lists_controller_test.rb test/controllers/species_lists/` — 50 tests, 0 failures
- [x] `bundle exec rubocop app/controllers/species_lists_controller.rb` — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
