### PR TITLE
testing.md: no cosmetic Bootstrap classes in component tests (with exception) + sweep

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -244,6 +244,87 @@ or jq the JSON to find missed lines on any file.
 
 **IMPORTANT**: Follow this pattern for all Phlex component tests.
 
+### Don't pin cosmetic CSS classes
+
+Component test selectors should **not** include Bootstrap styling /
+spacing / typography classes — `.btn`, `.btn-default`,
+`.btn-outline-default`, `.btn-sm`, `.btn-lg`, `.mt-2`, `.ml-3`,
+`.px-4`, `.py-4`, `.help-note`, `.help-block`, `.font-weight-bold`,
+`.text-*`, etc. They're decoration; a Bootstrap-version upgrade or
+a designer's tweak will rename them, and every test that pinned the
+old name will fail.
+
+A component test asserts the *contract* of a component — what it
+does, what it submits, what it links to, what it triggers, what it
+makes visible. The visual styling is what designers and Bootstrap
+upgrades own.
+
+**Drop:**
+- All `.btn` family classes (`.btn`, `.btn-default`,
+  `.btn-outline-default`, `.btn-sm`, `.btn-lg`, `.btn-link`, etc.).
+- Spacing utilities (`.m{tbrlxy}-*`, `.p{tbrlxy}-*`, `.mt-3`,
+  `.py-4`, etc.).
+- Typography (`.help-note`, `.help-block`, `.font-weight-bold`,
+  `.text-muted`, `.lead`, etc.).
+- Bootstrap layout helpers that are pure styling (`.row`, `.col-*`).
+
+**Keep:**
+- HTML attributes that drive behavior — `href`, `data-*` (Stimulus
+  targets / actions, Turbo method / confirm, etc.), `name`, `type`,
+  `value`, `aria-*`, `target`, `rel`, `id`.
+- Visibility classes — `.d-none`, `.hidden`, `[hidden]` carry real
+  state.
+- Structural Bootstrap component slots that the Phlex wrapper depends
+  on — `.modal-body`, `.modal-footer`, `.panel-heading`, `.input-group`.
+  Use them when asserting placement (`.modal-body > p[data-*]`); drop
+  them when asserting existence (`p[data-*]` alone is just as good).
+
+Examples:
+
+```ruby
+# ❌ Pins styling — breaks on Bootstrap upgrade.
+assert_html(html, "a.btn.btn-sm.btn-outline-default[href='/foo']")
+assert_html(html, "p.help-note", text: :explanation.l)
+assert_html(html, "div.help-block.mt-4")
+
+# ✅ Pins behavior + structure — survives styling churn.
+assert_html(html, "a[href='/foo']")            # contract: where it goes
+assert_html(html, "a[href='/foo'][target='_blank']")  # contract: new tab
+assert_includes(html, :explanation.l)          # contract: text appears
+assert_html(html, "p[data-confirm-modal-target='message']")
+                                               # contract: Stimulus wiring
+```
+
+For visibility behavior, `.d-none` and friends are fair game because
+they describe a state, not paint:
+
+```ruby
+# ✅ Fine — `.d-none` is a behavior assertion, not a paint job.
+assert_html(html, ".create-button.d-none")    # button is initially hidden
+```
+
+When a component genuinely needs a class on its element to function
+(a Stimulus controller's CSS hook, an SVG transform target, etc.),
+test the `data-controller=` / `data-*-target=` attribute that actually
+drives it, not the class name on the same element.
+
+**Exception: styling-abstraction components.** Tests for components
+whose *job* is to produce specific Bootstrap classes — `CrudButton`
+(variant + size of the rendered button), `Panel` / `Modal` /
+`ModalConfirm` (Bootstrap slot structure), `Alert`, the
+`ApplicationForm` field helpers' wrapper options (`:monospace` →
+`text-monospace`, `:center` → `center-block`, `wrap_class: "x"` →
+`x`, `:button` → `input-group` / `input-group-btn`, etc.) — *should*
+assert on those classes. The class output IS the contract of the
+unit. When Bootstrap upgrades, both the helper and these tests
+update together.
+
+Heuristic: would dropping the class assertion gut the test? If yes,
+keep it. If the test was "verify a button styled this way exists",
+that IS the contract — the class assertion stays. If the test was
+"verify the page renders some content" and the class on the
+surrounding element is incidental, drop it.
+
 ### Consolidate Assertions Per Render
 
 Render once, assert many things. Don't create separate test methods that render

--- a/test/components/account_preferences_form_test.rb
+++ b/test/components/account_preferences_form_test.rb
@@ -50,7 +50,7 @@ class AccountPreferencesFormTest < ComponentTestCase
     # help-page anchor. Pre-conversion ERB used `tag.span(safe_join)`
     # to keep the `<a>` from being escaped; the Phlex view does the
     # same via `trusted_html`.
-    assert_html(html, ".help-note a[href*='how_to_use#license']")
+    assert_html(html, "a[href*='how_to_use#license']")
   end
 
   def test_privacy_grandfather_anonymous_option_for_pre_cutoff_users
@@ -123,9 +123,9 @@ class AccountPreferencesFormTest < ComponentTestCase
     html = render_form
 
     assert_html(html, "textarea[name='user[notes_template]'][rows='1']")
-    # Help paragraph sits inline between label and textarea via the
+    # Help text sits inline between label and textarea via the
     # `with_between` slot.
-    assert_html(html, "p.help-note", text: :prefs_notes_template_explanation.l)
+    assert_includes(html, :prefs_notes_template_explanation.l)
   end
 
   # ---- Section 6: Email ----
@@ -153,8 +153,10 @@ class AccountPreferencesFormTest < ComponentTestCase
      :email_general_question].each do |sym|
       assert_html(html, "input[type='checkbox'][name='user[#{sym}]']")
     end
-    # Closing textile note at the bottom of the section.
-    assert_html(html, "div.help-block.mt-4")
+    # Closing textile note at the bottom of the section. The text is
+    # textile-rendered, so the i18n string is a substring of the
+    # rendered output.
+    assert_includes(html, :prefs_email_note.l)
   end
 
   # ---- Multiple submits ----

--- a/test/components/form_location_feedback_test.rb
+++ b/test/components/form_location_feedback_test.rb
@@ -11,7 +11,9 @@ class FormLocationFeedbackTest < ComponentTestCase
   def test_renders_warning_alert_with_reasons
     html = render_feedback(["Location not found".html_safe])
 
-    assert_html(html, ".alert-warning#dubious_location_messages.my-3")
+    # `#dubious_location_messages` is the durable identifier; the
+    # `.alert-warning` / `.my-3` Bootstrap classes are pure paint.
+    assert_html(html, "#dubious_location_messages")
     assert_html(html, "body", text: "Location not found")
     assert_html(html, ".help-note")
     # Help note should include the button name

--- a/test/components/form_location_map_test.rb
+++ b/test/components/form_location_map_test.rb
@@ -14,8 +14,9 @@ class FormLocationMapTest < ComponentTestCase
                 attribute: { "data-map-type" => "location",
                              "data-location-format" => "postal" })
 
-    # Button group with toggle and clear buttons
-    assert_html(html, "div.btn-group[role='group']")
+    # Button group with toggle and clear buttons. `role='group'` is
+    # the ARIA contract; `.btn-group` is Bootstrap-styling decoration.
+    assert_html(html, "div[role='group']")
     assert_html(html, "span.map-show")
     assert_html(html, "span.map-hide")
     assert_html(html, "button.map-clear[type='button']",

--- a/test/components/form_notes_test.rb
+++ b/test/components/form_notes_test.rb
@@ -48,6 +48,10 @@ class FormNotesTest < ComponentTestCase
     assert_html(html, "#test_notes_fields div.help-block")
     # No `above_help` in multi-part mode even if the caller passes
     # one — multi-part users typically know what each field is for.
+    # `.help-block` here is used as the IDENTIFIER of the textile-
+    # help div (no other selector marks it). Per the cosmetic-
+    # classes rule, identifier classes that mark a specific
+    # element are fair game; pure decoration is not.
     assert_no_html(html,
                    "#test_notes_fields > div.help-block:first-child")
   end
@@ -73,12 +77,10 @@ class FormNotesTest < ComponentTestCase
                 "textarea[name='observation[notes][other]'][rows='10']")
     # Textarea label exists for screen readers but is visually hidden:
     # the panel heading already says "Notes", so the field's own
-    # visible label would be a duplicate.
-    assert_html(html,
-                "label.sr-only[for='observation_notes_other']")
-    assert_no_html(html,
-                   "label.mr-3[for='observation_notes_other']",
-                   "single-part textarea label must be sr-only, not mr-3")
+    # visible label would be a duplicate. `.sr-only` IS a visibility
+    # behavior class (per the cosmetic-classes rule, behavior classes
+    # are kept) — it's what makes the label invisible-to-sighted-users.
+    assert_html(html, "label.sr-only[for='observation_notes_other']")
   end
 
   def test_single_part_mode_renders_above_help_above_textarea


### PR DESCRIPTION
## Summary

Component tests routinely pin Bootstrap styling / spacing / typography classes — `.btn`, `.btn-sm`, `.btn-outline-default`, `.mt-3`, `.ml-4`, `.help-note`, `.help-block`, `.font-weight-bold`, etc. — in their selectors. With Bootstrap 4 / 5 on the upgrade path, every test that pinned the old name turns into churn the moment the upgrade lands.

This PR adds a section to `.claude/rules/testing.md` under **Component Test Structure** that:

- States the rule: assert on contract attrs (`href`, `data-*`, `name`, `type`, `aria-*`, `target`, `rel`, `id`), not Bootstrap styling.
- Carves out visibility classes (`.d-none`, `.hidden`, `[hidden]`) and structural Bootstrap component slots (`.modal-body`, `.modal-footer`, `.panel-heading`, `.input-group`) — those carry behavior / placement.
- Calls out the **styling-abstraction exception**: tests for components whose *job* is to produce specific Bootstrap classes (`CrudButton`, `Panel`, `Modal`, `Alert`, the `ApplicationForm` field-helper wrapper options — `:monospace` → `text-monospace`, `:center` → `center-block`, `wrap_class:` flow-through, `:button` → `input-group` / `input-group-btn`, etc.) *should* assert the classes — the class output IS the contract. When Bootstrap upgrades, helper + tests update together.
- Gives a "would dropping the class assertion gut the test?" heuristic for the gray zone.

## Sweep (intentionally conservative)

Four view-level test files where the cosmetic class was clearly incidental (the element had a stronger id / data-attr / structural anchor already):

| File | Change |
|---|---|
| `account_preferences_form_test.rb` | Drop `.help-note`, `p.help-note`, `div.help-block.mt-4` — switch to text-presence + `[href*=...]` assertions. |
| `form_location_feedback_test.rb` | Collapse `.alert-warning#dubious_location_messages.my-3` → `#dubious_location_messages`. |
| `form_location_map_test.rb` | Drop `.btn-group` from `div.btn-group[role='group']` — `role='group'` is the ARIA contract. |
| `form_notes_test.rb` | Drop the redundant `assert_no_html(label.mr-3, ...)` (already covered by the positive `label.sr-only` assertion). |

Everything else — `CrudButton`, `Panel`, `Modal`, `ModalConfirm`, `Alert`, `Carousel`, `ApplicationForm`, `CollapseHelpBlock`, `TableFormAccordion`, the `application_form/*` field-helper unit tests — falls under the styling-abstraction exception and is left alone. Existing tests outside that bucket will be cleaned opportunistically as people touch them; the rule's job is to prevent NEW tests from adding to the churn-on-Bootstrap-upgrade pile.

## Test plan

- [x] `bin/rails test test/components/` — 569 tests / 2845 assertions, all green
- [x] `bundle exec rubocop` on touched files — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
