### PR TITLE
link_helper: extract icon_link_to + link_icon into Phlex components

### DIFF
--- a/app/components/icon_link.rb
+++ b/app/components/icon_link.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# Anchor / button styled as an icon-with-label link. The label is
+# visually hidden by default (sr-only) but available as both the
+# tooltip and an accessible name. Optionally renders with a swappable
+# "active" icon + label pair driven by JS state — used by
+# bookmark-style toggles where the same target switches appearance.
+#
+# Drop-in equivalent of the long-standing `icon_link_to(text, path,
+# **opts)` helper in `app/helpers/link_helper.rb`. The helper now
+# renders this component so existing ERB and Phlex callers keep
+# working unchanged.
+#
+# @example Plain icon link
+#   render(Components::IconLink.new("Edit", edit_path(@obj),
+#                                   icon: :edit))
+#
+# @example Show the text alongside the icon
+#   render(Components::IconLink.new("Delete", path,
+#                                   icon: :delete, show_text: true))
+#
+# @example State-swap (active icon + label)
+#   render(Components::IconLink.new("Subscribe", subscribe_path,
+#                                   icon: :bullhorn,
+#                                   active_icon: :check,
+#                                   active_content: "Subscribed"))
+#
+# @example Render as button_to (POSTs instead of GETs)
+#   render(Components::IconLink.new("Delete", path,
+#                                   icon: :delete, button_to: true,
+#                                   data: { method: :delete }))
+class Components::IconLink < Components::Base
+  LABEL_SHOW_CLASSES = "pl-2 d-none d-sm-inline font-weight-bold"
+
+  CONSUMED_OPTS = [:class, :icon, :icon_class, :show_text,
+                   :active_icon, :active_content, :button_to].freeze
+
+  attr_reader :content, :path, :opts
+
+  def initialize(content, path, **opts)
+    super()
+    @content = content
+    @path = path
+    @opts = opts
+  end
+
+  def view_template
+    return unless @content
+
+    if icon_type.blank?
+      render_link_or_button { trusted_or_plain(@content) }
+    else
+      render_link_or_button { render_inner }
+    end
+  end
+
+  private
+
+  def icon_type
+    @opts[:icon]
+  end
+
+  def stateful?
+    @opts[:active_icon] && @opts[:active_content]
+  end
+
+  # Output order matches the legacy `icon_link_to` helper:
+  # icon, active_icon (if stateful), label, active_label (if stateful).
+  def render_inner
+    render_icons
+    render_labels
+  end
+
+  def render_icons
+    render(Components::LinkIcon.new(type: icon_type, html_class: icon_class))
+    return unless stateful?
+
+    render(Components::LinkIcon.new(
+             type: @opts[:active_icon], html_class: icon_active_class
+           ))
+  end
+
+  def render_labels
+    span(class: label_class) { trusted_or_plain(@content) }
+    return unless stateful?
+
+    span(class: label_active_class) do
+      trusted_or_plain(@opts[:active_content])
+    end
+  end
+
+  # Content can be a textile-rendered html_safe string (e.g. a name's
+  # display_name). `plain` would re-escape; `trusted_html` emits it
+  # as-is. Plain Strings go through `plain` so user-typed text is
+  # escaped normally.
+  def trusted_or_plain(text)
+    if text.respond_to?(:html_safe?) && text.html_safe?
+      trusted_html(text)
+    else
+      plain(text)
+    end
+  end
+
+  def icon_class
+    class_names(@opts[:icon_class], "px-2")
+  end
+
+  def icon_active_class
+    class_names(icon_class, "active-icon")
+  end
+
+  def label_class
+    @opts[:show_text] ? LABEL_SHOW_CLASSES : "sr-only"
+  end
+
+  def label_active_class
+    class_names(label_class, "active-label")
+  end
+
+  def link_attrs
+    base = {
+      title: @content,
+      class: class_names("icon-link", @opts[:class]),
+      data: { toggle: "tooltip", title: @content,
+              active_title: @opts[:active_content] }
+    }
+    base[:role] = "button" if @opts[:button_to]
+    base.deep_merge(@opts.except(*CONSUMED_OPTS))
+  end
+
+  def render_link_or_button(&block)
+    if @opts[:button_to]
+      button_to(@path, **link_attrs, &block)
+    else
+      link_to(@path, **link_attrs, &block)
+    end
+  end
+end

--- a/app/components/link_icon.rb
+++ b/app/components/link_icon.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Renders a Bootstrap 3 Glyphicon `<span>` with the MO `link-icon`
+# class added. Optionally adds a tooltip + screen-reader title.
+#
+# Drop-in equivalent of the long-standing `link_icon(type, **args)`
+# helper in `app/helpers/link_helper.rb`; the helper now renders this
+# component so existing ERB and Phlex callers keep working unchanged.
+#
+# @example Just the glyph
+#   render(Components::LinkIcon.new(type: :globe))
+#   # => <span class="glyphicon glyphicon-globe link-icon"></span>
+#
+# @example With tooltip + screen-reader title + extra CSS
+#   render(Components::LinkIcon.new(
+#     type: :edit, title: :EDIT.l, html_class: "text-primary"
+#   ))
+#   # => <span class="glyphicon glyphicon-edit link-icon text-primary"
+#   #          title="Edit" data-toggle="tooltip">
+#   #      <span class="sr-only">Edit</span>
+#   #    </span>
+class Components::LinkIcon < Components::Base
+  prop :type, _Nilable(Symbol), default: nil
+  prop :title, _Nilable(String), default: nil
+  prop :html_class, _Nilable(String), default: nil
+  prop :data, Hash, default: -> { {} }
+  prop :attributes, Hash, default: -> { {} }
+
+  def view_template
+    glyph = LinkHelper::LINK_ICON_INDEX[@type]
+    return unless glyph
+
+    span(class: span_class(glyph),
+         title: @title.presence,
+         data: span_data,
+         **@attributes) do
+      span(class: "sr-only") { plain(@title) } if @title.present?
+    end
+  end
+
+  private
+
+  def span_class(glyph)
+    base = "glyphicon glyphicon-#{glyph} link-icon"
+    @html_class ? "#{base} #{@html_class}" : base
+  end
+
+  def span_data
+    @title.present? ? { toggle: "tooltip" }.merge(@data) : @data
+  end
+end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -68,48 +68,19 @@ module LinkHelper
     end
   end
 
-  # Icon link with optional active state. (Tooltip title must be swapped in JS.)
-  # Now also accepts active state options: active_icon, active_content
-  # NOTE: Takes same args as link_to, e.g.
-  # icon_link_to(text, path, **args). Can also print a button_to.
+  # Icon link with optional active state. (Tooltip title must be
+  # swapped in JS.) Takes same args as `link_to`, e.g.
+  # `icon_link_to(text, path, **args)`. Can also print a `button_to`
+  # via `button_to: true`. Delegates to `Components::IconLink` —
+  # render the component directly in Phlex views.
   def icon_link_to(text = nil, path = nil, options = {}, &block)
     return unless text
 
-    link_path = block ? text : path # because positional
+    link_path = block ? text : path # positional: block ⇒ first arg is path
     content = block ? capture(&block) : text
-    opts = block ? path : options # because positional
-    icon_type = opts[:icon]
-    return link_to(link, opts) { content } if icon_type.blank?
+    opts = block ? path : options
 
-    opts[:role] = "button" if opts[:button_to]
-    active_icon = opts[:active_icon]
-    active_content = opts[:active_content]
-    stateful = active_icon && active_content
-    icon_class = class_names(opts[:icon_class], "px-2")
-    icon_active_class = class_names(icon_class, "active-icon")
-    label_show_classes = "pl-2 d-none d-sm-inline font-weight-bold"
-    label_class = opts[:show_text] ? label_show_classes : "sr-only"
-    label_active_class = class_names(label_class, "active-label")
-
-    link_opts = {
-      title: content, # title is what shows up in tooltip
-      class: class_names("icon-link", opts[:class]),
-      data: { toggle: "tooltip", title: content, # needed for swapping only
-              active_title: opts[:active_content] }
-    }.deep_merge(opts.except(:class, :icon, :icon_class, :show_text,
-                             :active_icon, :active_content, :button_to))
-
-    inner_html = capture do
-      concat(link_icon(icon_type, class: icon_class))
-      concat(link_icon(active_icon, class: icon_active_class)) if stateful
-      concat(tag.span(content, class: label_class))
-      concat(tag.span(active_content, class: label_active_class)) if stateful
-    end
-    if opts[:button_to]
-      button_to(inner_html, link_path, **link_opts)
-    else
-      link_to(inner_html, link_path, **link_opts)
-    end
+    render(Components::IconLink.new(content, link_path, **opts))
   end
 
   # NOTE: above re: MO tabs
@@ -123,21 +94,20 @@ module LinkHelper
     icon_link_to(add_q_param(link), opts) { content }
   end
 
-  # pass title if it's a plain button (say for collapse) but you want a tooltip
+  # Glyphicon `<span>` with the MO `link-icon` class. Pass `title:`
+  # for a tooltip + screen-reader label. Delegates to
+  # `Components::LinkIcon` — render the component directly in Phlex
+  # views.
   def link_icon(type, **args)
-    return "" unless (glyph = LINK_ICON_INDEX[type])
+    return "" unless LINK_ICON_INDEX[type]
 
-    text = ""
-    args[:class] = class_names("glyphicon glyphicon-#{glyph} link-icon",
-                               args[:class])
-
-    if args[:title].present?
-      title = args[:title]
-      args[:data] = { toggle: "tooltip" }.merge(args[:data] || {})
-      text = tag.span(title, class: "sr-only")
-    end
-
-    tag.span(text, **args)
+    render(Components::LinkIcon.new(
+             type: type,
+             title: args[:title],
+             html_class: args[:class],
+             data: args[:data] || {},
+             attributes: args.except(:title, :class, :data)
+           ))
   end
 
   def external_link(link)

--- a/test/components/icon_link_test.rb
+++ b/test/components/icon_link_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class IconLinkTest < ComponentTestCase
+  def test_plain_icon_link
+    html = render(Components::IconLink.new(
+                    "Edit", "/foo", icon: :edit
+                  ))
+
+    # Outer anchor: href, tooltip title, icon-link class, and the
+    # data-toggle/data-title pair the bootstrap tooltip plugin reads.
+    assert_html(html, "a[href='/foo'][title='Edit'].icon-link" \
+                      "[data-toggle='tooltip'][data-title='Edit']")
+    # Icon glyph + screen-reader-only label inside the anchor.
+    assert_html(html, "a span.glyphicon-edit")
+    assert_html(html, "a span.sr-only", text: "Edit")
+  end
+
+  def test_blank_text_renders_nothing
+    # Matches legacy `icon_link_to` — silent no-op when text is nil.
+    html = render(Components::IconLink.new(nil, "/x", icon: :edit))
+
+    assert_equal("", html)
+  end
+
+  def test_no_icon_falls_back_to_plain_link
+    html = render(Components::IconLink.new("Label", "/x"))
+
+    # Without an `:icon`, render as a plain link with the text.
+    # (The legacy helper had a typo here referencing undefined `link`
+    # — fixed in the component to render correctly.)
+    assert_html(html, "a[href='/x']", text: "Label")
+    # No icon span when no icon was passed.
+    assert_no_html(html, "a span.glyphicon")
+  end
+
+  def test_show_text_replaces_sr_only_with_visible_label
+    html = render(Components::IconLink.new(
+                    "Delete", "/d", icon: :delete, show_text: true
+                  ))
+
+    assert_no_html(html, "a span.sr-only")
+    assert_html(html, "a span.font-weight-bold", text: "Delete")
+  end
+
+  def test_stateful_renders_active_icon_and_label
+    html = render(Components::IconLink.new(
+                    "Subscribe", "/s",
+                    icon: :tracking,
+                    active_icon: :check, active_content: "Subscribed"
+                  ))
+
+    # Both icons + both labels render; the active pair carries the
+    # `active-icon` / `active-label` modifier classes the JS toggles
+    # on/off via the bootstrap tooltip's data-active-title swap.
+    assert_html(html, "a span.glyphicon-bullhorn")
+    assert_html(html, "a span.glyphicon-ok-circle.active-icon")
+    assert_html(html, "a span.sr-only", text: "Subscribe")
+    assert_html(html, "a span.sr-only.active-label", text: "Subscribed")
+    # data-active-title flips to the active text on toggle.
+    assert_html(html, "a[data-active-title='Subscribed']")
+  end
+
+  def test_button_to_mode
+    html = render(Components::IconLink.new(
+                    "Delete", "/d", icon: :delete, button_to: true
+                  ))
+
+    # button_to wraps a button in a form; `role='button'` is added so
+    # the form-styled `<button>` is announced as a button by AT.
+    assert_html(html, "form[action='/d'] button[role='button']")
+    assert_html(html, "form button span.glyphicon-remove-circle")
+  end
+
+  def test_extra_class_appends_to_icon_link
+    html = render(Components::IconLink.new(
+                    "Edit", "/x", icon: :edit, class: "extra-thing"
+                  ))
+
+    # Caller's `:class` deep-merges with the default `icon-link` class.
+    assert_html(html, "a.icon-link.extra-thing")
+  end
+
+  def test_arbitrary_data_attrs_deep_merge_onto_link
+    html = render(Components::IconLink.new(
+                    "X", "/x",
+                    icon: :edit, data: { my_attr: "v" }
+                  ))
+
+    # `data: { ... }` from the caller deep_merges with the tooltip
+    # data attrs, so both the tooltip wiring AND the caller's custom
+    # attrs end up on the anchor.
+    assert_html(html, "a[data-my-attr='v'][data-toggle='tooltip']")
+  end
+end

--- a/test/components/link_icon_test.rb
+++ b/test/components/link_icon_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class LinkIconTest < ComponentTestCase
+  def test_glyph_only
+    html = render(Components::LinkIcon.new(type: :globe))
+
+    assert_html(html, "span.glyphicon.glyphicon-globe.link-icon")
+    # No sr-only inner span when title is absent — just the bare glyph.
+    assert_no_html(html, "span.sr-only")
+  end
+
+  def test_unknown_type_renders_nothing
+    html = render(Components::LinkIcon.new(type: :bogus_not_a_real_icon))
+
+    # Unknown icon type silently emits nothing — matches the legacy
+    # `link_icon` helper's `return "" unless LINK_ICON_INDEX[type]`.
+    assert_equal("", html)
+  end
+
+  def test_title_adds_tooltip_and_sr_only_label
+    html = render(Components::LinkIcon.new(
+                    type: :edit, title: :EDIT.l,
+                    html_class: "text-primary"
+                  ))
+
+    assert_html(html,
+                "span.glyphicon-edit.link-icon.text-primary" \
+                "[title='#{:EDIT.l}'][data-toggle='tooltip']")
+    # Screen-reader label so the icon-only link has an accessible name.
+    assert_html(html, "span.sr-only", text: :EDIT.l)
+  end
+
+  def test_caller_data_attrs_merge_with_tooltip_data
+    html = render(Components::LinkIcon.new(
+                    type: :globe, title: "Tooltip text",
+                    data: { other: "v" }
+                  ))
+
+    # Tooltip toggle still present alongside caller's custom data attr.
+    assert_html(html, "span[data-toggle='tooltip'][data-other='v']")
+  end
+
+  def test_attributes_passed_through
+    html = render(Components::LinkIcon.new(
+                    type: :globe, attributes: { id: "my_icon" }
+                  ))
+
+    assert_html(html, "span#my_icon.glyphicon-globe")
+  end
+end


### PR DESCRIPTION
## Summary

Componentizes the two largest helpers in `app/helpers/link_helper.rb` — same shape that the `*_button` family already follows (each helper renders a `Components::CrudButton::*` subclass under the hood).

- **`Components::LinkIcon`** — Bootstrap 3 Glyphicon `<span>` with the MO `link-icon` class added, plus an optional tooltip + screen-reader title.
- **`Components::IconLink`** — anchor / button-to with an icon + label inside; supports `button_to: true` mode, swappable `active_icon` / `active_content` pair (used by toggle-style links like the subscribe / interest indicators), and arbitrary deep-merged caller attrs. Uses `Components::LinkIcon` for the icon glyph itself.

The helpers stay in `link_helper.rb` for back-compat — both are now thin wrappers that `render(Components::LinkIcon.new(...))` / `render(Components::IconLink.new(...))`. Every existing ERB and Phlex caller keeps working unchanged (the helpers are already registered as Phlex output helpers via `Components::Base` and `Components::Input`).

## Side fix

The legacy `icon_link_to` had a latent bug in the no-icon branch — `return link_to(link, opts) { content }` references `link`, which was never defined. The branch only fires when an explicit `icon: nil` is passed, which no current caller does, so it never surfaced. The component fixes it correctly: when no icon is set, render a plain link / button_to with the content.

## Tests

- `test/components/link_icon_test.rb` (5 tests) — glyph rendering, unknown-type silent-empty, tooltip + sr-only label, caller data-attr merge, attribute passthrough.
- `test/components/icon_link_test.rb` (8 tests) — plain link, nil-text silent-empty, no-icon fallback (the fixed branch), `show_text: true` swap, stateful active-pair render, `button_to: true` mode, caller `:class` deep-merge, caller `:data` deep-merge.

Byte-equivalent output verified against the old helper across all four major call shapes (plain, show_text, stateful, button_to) before the rewrite.

## Test plan

- [x] `bin/rails test test/components/` — 579 tests, all green
- [x] `bin/rails test test/helpers/` — 86 tests, all green
- [x] `bin/rails test test/controllers/visual_groups_controller_test.rb test/controllers/account/preferences_controller_test.rb test/controllers/projects_controller_test.rb` — representative sweep of callers, green
- [x] `bundle exec rubocop` on 5 touched files — 0 offenses

Follow-up PR will tackle `modal_link_to`, `external_link`, and `active_link_to` (the next three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
