### PR TITLE
Add Components::NavTabs; convert project tab bars to use it

### DIFF
--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -74,6 +74,28 @@ page-specific fragments wearing component clothing (e.g. a
 controller's show page — that's a view, put it in
 `app/views/controllers/`).
 
+**Reusable Bootstrap components are a Phlex goal in this codebase.**
+One of the reasons we moved to Phlex is to grow a library of
+reusable Bootstrap building blocks — `Components::Table`,
+`Components::Panel`, `Components::CrudButton::*`, `Components::Modal`,
+`Components::NavTabs`, etc. — so that the next view doesn't reach
+for raw `<ul class="nav nav-tabs">` / `<table>` / `<div class="panel">`
+markup. If a view uses a recognizable Bootstrap pattern (nav-tabs,
+panel, button group, modal, table, alert, breadcrumb, badge,
+progress bar, pagination strip — basically anything from
+[the Bootstrap component docs](https://getbootstrap.com/docs/3.4/components/))
+and there's no component for it yet, **extract one** as part of the
+conversion, even if there's only one caller right now. The next
+view that needs the same pattern shouldn't have to copy markup; it
+should reach for `render(Components::TheThing.new(...))` and have
+the Bootstrap classes / structure already baked in.
+
+Conversely, if a component already exists for the Bootstrap
+pattern you're rendering (`Components::Table`, `Components::Panel`,
+`Components::CrudButton::*`, etc.), use it rather than hand-rolling
+the markup — see the Tables / Tabs / etc. sections below for the
+specific guidance and component APIs.
+
 Heuristic: would a reader who doesn't know this codebase look at the
 class name and the file's contents and say "yes, that's a component"?
 If yes, `app/components/`. If they'd say "that's the

--- a/app/components/nav_tabs.rb
+++ b/app/components/nav_tabs.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+# Bootstrap `nav-tabs` strip — `<ul class="nav nav-tabs">` of
+# `<li class="nav-item"><a class="nav-link [active]">` links. Each
+# tab is a navigation link to a different page (NOT an in-page panel
+# trigger — this is NOT Bootstrap's tabs-with-panels component, just
+# the navigation-strip pattern using the same tab styling). If MO
+# ever needs in-page panel switching, a separate `Components::TabPanels`
+# would use `NavTabs` for the strip + add the `.tab-content > .tab-pane`
+# block.
+#
+# Caller wraps the strip with their own outer chrome (the existing
+# project_tabs and project_admin_subtabs callers use slightly
+# different wrapper divs / ids — keeping wrapping out of this
+# component avoids parameterizing it for a pattern that varies more
+# than the component itself).
+#
+# @example Plain
+#   render(Components::NavTabs.new(current: "members")) do |tabs|
+#     tabs.tab("Details",        details_path,        key: "details")
+#     tabs.tab("#{n} Members",   members_path,        key: "members")
+#     tabs.tab("#{n} Aliases",   aliases_path,        key: "aliases")
+#   end
+#
+# @example With per-link extra class (matches `project_tabs` markup)
+#   render(Components::NavTabs.new(current: @current_tab,
+#                                  link_class: "mt-3")) do |tabs|
+#     tabs.tab(:SUMMARY.t, project_path(@project), key: "projects")
+#     tabs.tab("#{n} #{:OBS.l}", observations_path(...), key: "obs")
+#   end
+#
+# @example With wrapper chrome at the call site
+#   div(class: "col-xs-12", id: "project_tabs") do
+#     render(Components::NavTabs.new(current: @current_tab,
+#                                    link_class: "mt-3")) do |tabs|
+#       # ...
+#     end
+#   end
+class Components::NavTabs < Components::Base
+  # @param current [String, Symbol, nil] tab key marked `.active`
+  # @param link_class [String, nil] extra CSS classes appended to
+  #   every tab's `<a class="nav-link …">` (e.g. `"mt-3"`)
+  # @param attributes [Hash] arbitrary HTML attrs forwarded to the
+  #   `<ul>` element (`data:`, ARIA, etc.). The `class:` is always
+  #   `"nav nav-tabs"` and is not overridable from here.
+  def initialize(current: nil, link_class: nil, attributes: {})
+    super()
+    @current = current
+    @link_class = link_class
+    @attributes = attributes
+    @tabs = []
+  end
+
+  def view_template(&block)
+    # `vanish` evaluates the block for its side effects (each
+    # `tabs.tab(...)` push into `@tabs`) and discards any output —
+    # the block configures, the `<ul>` below renders.
+    vanish(&block)
+    ul(class: "nav nav-tabs", **@attributes) do
+      @tabs.each { |tab| render_tab(tab) }
+    end
+  end
+
+  # Register a tab. Three call shapes:
+  #
+  # **Bare text + path:**
+  #
+  #     tabs.tab("Details", details_path, key: "details")
+  #
+  # **InternalLink object** (MO's tab-builder convention — carries the
+  # auto-generated `<thing>_link` test-selector class and any
+  # other html_options the link declared):
+  #
+  #     tabs.tab(InternalLink.new("Details", details_path), key: "details")
+  #
+  # **Array splat from an MO tab helper** — the existing
+  # `app/helpers/tabs/<thing>_helper.rb` methods return
+  # `[title, url, html_options]` (the `InternalLink#tab` shape):
+  #
+  #     tabs.tab(*projects_index_tab, key: "index")
+  #
+  # In all three shapes, `current:` (ctor) is matched against `key:`
+  # to decide which tab gets `.active`. With an InternalLink object
+  # or a 3-element splat, the carried `html_options` merge onto the
+  # rendered `<a>` — its `:class` appends to the `nav-link`
+  # (+ optional `link_class:`) base; other attrs pass through.
+  #
+  # **`html_options[:class]` from InternalLink must NOT carry
+  # Bootstrap nav-tab classes** (`nav-link`, `active`, `mt-3`, etc.)
+  # — those are NavTabs' responsibility. The class slot in
+  # html_options is for identifier / behavior classes only (e.g.
+  # `InternalLink`'s auto-generated `<title>_link` for test
+  # selectors, or a Stimulus hook class). Tab styling is owned by
+  # the component so the same InternalLink object can render
+  # correctly in any tab context (top-level tabs, sub-tabs,
+  # future panel-tab triggers).
+  #
+  # @return [nil] to prevent ERB output
+  def tab(text_or_link, path = nil, html_options = {}, key: nil)
+    @tabs << build_tab(text_or_link, path, html_options, key)
+    nil
+  end
+
+  private
+
+  def build_tab(text_or_link, path, html_options, key)
+    if text_or_link.is_a?(::InternalLink)
+      title, url, opts = text_or_link.tab
+      { text: title, path: url, key: key, link_attrs: opts }
+    else
+      { text: text_or_link, path: path, key: key,
+        link_attrs: html_options || {} }
+    end
+  end
+
+  def render_tab(tab)
+    li(class: "nav-item") do
+      a(href: tab[:path], **anchor_attrs(tab)) do
+        trusted_or_plain(tab[:text])
+      end
+    end
+  end
+
+  def anchor_attrs(tab)
+    extra = tab[:link_attrs].dup
+    extra_class = extra.delete(:class)
+    extra.merge(class: link_classes_for(tab, extra_class))
+  end
+
+  def link_classes_for(tab, extra_class = nil)
+    parts = []
+    parts << @link_class if @link_class
+    parts << "nav-link"
+    parts << "active" if @current && tab[:key] == @current
+    parts << extra_class if extra_class
+    parts.join(" ")
+  end
+
+  # Tab text may be a textile-rendered html_safe string (e.g. a
+  # name's display_name); `plain` would re-escape, `trusted_html`
+  # emits as-is.
+  def trusted_or_plain(text)
+    if text.respond_to?(:html_safe?) && text.html_safe?
+      trusted_html(text)
+    else
+      plain(text)
+    end
+  end
+end

--- a/app/helpers/tabs/projects_helper.rb
+++ b/app/helpers/tabs/projects_helper.rb
@@ -60,6 +60,100 @@ module Tabs
       ).tab
     end
 
+    # --- Project banner top-level tabs (rendered by
+    # `Views::Controllers::Projects::Tabs` via Components::NavTabs).
+    # Each method returns an `InternalLink#tab` array; the view picks
+    # which to render based on project state. `alt_title:` keeps the
+    # auto-generated `<thing>_link` test-selector class stable across
+    # count changes ("3 Observations" → still `observations_link`,
+    # not `3_observations_link`).
+
+    def project_summary_tab(project)
+      InternalLink.new(
+        :SUMMARY.t, project_path(id: project.id), alt_title: "summary"
+      ).tab
+    end
+
+    def project_observations_tab(project)
+      count = project.visible_observations.count
+      InternalLink.new(
+        "#{count} #{:OBSERVATIONS.l}",
+        observations_path(project: project),
+        alt_title: "observations"
+      ).tab
+    end
+
+    def project_species_lists_tab(project)
+      count = project.species_lists.length
+      InternalLink.new(
+        "#{count} #{:SPECIES_LISTS.l}",
+        species_lists_path(project: project),
+        alt_title: "species_lists"
+      ).tab
+    end
+
+    def project_names_tab(project)
+      InternalLink.new(
+        "#{project.name_count} #{:NAMES.l}",
+        checklist_path(project_id: project.id),
+        alt_title: "checklists"
+      ).tab
+    end
+
+    def project_locations_tab(project)
+      InternalLink.new(
+        "#{project.location_count} #{:LOCATIONS.l}",
+        project_locations_path(project_id: project.id),
+        alt_title: "locations"
+      ).tab
+    end
+
+    def project_updates_tab(project)
+      count = project.new_candidate_observations_count
+      InternalLink.new(
+        "#{count} #{:project_updates_title.l}",
+        project_updates_path(project_id: project.id),
+        alt_title: "updates"
+      ).tab
+    end
+
+    def project_admin_tab(project)
+      InternalLink.new(
+        :show_project_admin_tab.l,
+        project_admin_path(project_id: project.id),
+        alt_title: "admin"
+      ).tab
+    end
+
+    # --- Project Admin sub-tabs (rendered by
+    # `Views::Controllers::Projects::AdminSubtabs` via NavTabs).
+
+    def project_admin_details_tab(project)
+      InternalLink.new(
+        :show_project_admin_details_tab.l,
+        project_admin_path(project_id: project.id),
+        alt_title: "details"
+      ).tab
+    end
+
+    def project_admin_members_tab(project)
+      count = project.user_group.users.count
+      InternalLink.new(
+        "#{count} #{:MEMBERS.l}",
+        project_members_path(project.id),
+        alt_title: "members"
+      ).tab
+    end
+
+    def project_admin_aliases_tab(project)
+      count = project.aliases.count
+      InternalLink.new(
+        "#{count} #{:PROJECT_ALIASES.l}",
+        project_aliases_path(project_id: project.id),
+        alt_title: "aliases"
+      ).tab
+    end
+
     # Add some alternate sorting criteria.
     def projects_index_sorts
       [

--- a/app/views/controllers/projects/admin_subtabs.rb
+++ b/app/views/controllers/projects/admin_subtabs.rb
@@ -20,46 +20,13 @@ module Views::Controllers::Projects
       div(class: "row") do
         div(class: "col-xs-12 pl-4 mt-2 mb-3",
             id: "project_admin_subtabs") do
-          ul(class: "nav nav-tabs") do
-            details_subtab
-            members_subtab
-            aliases_subtab
+          render(Components::NavTabs.new(current: @current_subtab)) do |tabs|
+            tabs.tab(*project_admin_details_tab(@project), key: "details")
+            tabs.tab(*project_admin_members_tab(@project), key: "members")
+            tabs.tab(*project_admin_aliases_tab(@project), key: "aliases")
           end
         end
       end
-    end
-
-    private
-
-    def details_subtab
-      subtab_item(:show_project_admin_details_tab.l,
-                  project_admin_path(project_id: @project.id),
-                  "details")
-    end
-
-    def members_subtab
-      count = @project.user_group.users.count
-      subtab_item("#{count} #{:MEMBERS.l}",
-                  project_members_path(@project.id),
-                  "members")
-    end
-
-    def aliases_subtab
-      count = @project.aliases.count
-      subtab_item("#{count} #{:PROJECT_ALIASES.l}",
-                  project_aliases_path(project_id: @project.id),
-                  "aliases")
-    end
-
-    def subtab_item(text, path, key)
-      li(class: "nav-item") do
-        a(href: path, class: subtab_classes(key)) { plain(text) }
-      end
-    end
-
-    def subtab_classes(key)
-      base = "nav-link"
-      "#{base} #{"active" if @current_subtab == key}"
     end
   end
 end

--- a/app/views/controllers/projects/tabs.rb
+++ b/app/views/controllers/projects/tabs.rb
@@ -15,97 +15,66 @@ module Views::Controllers::Projects
 
     def view_template
       div(class: "col-xs-12", id: "project_tabs") do
-        ul(class: "nav nav-tabs") do
-          summary_tab
+        render(Components::NavTabs.new(current: @current_tab,
+                                       link_class: "mt-3")) do |tabs|
+          summary_tab(tabs)
           if @project.observations.any?
-            observation_tabs
+            observation_tabs(tabs)
           else
-            non_observation_tabs
+            non_observation_tabs(tabs)
           end
-          admin_tab
+          admin_tab(tabs)
         end
       end
     end
 
     private
 
-    def non_observation_tabs
-      species_list_tabs if @project.species_lists.any?
-      names_tab
-      locations_tab
-      update_tab
+    def non_observation_tabs(tabs)
+      species_lists_tab(tabs) if @project.species_lists.any?
+      names_tab(tabs)
+      locations_tab(tabs)
+      update_tab(tabs)
     end
 
-    def observation_tabs
-      observations_tab
-      species_lists_tab
-      names_tab
-      locations_tab
-      update_tab
+    def observation_tabs(tabs)
+      observations_tab(tabs)
+      species_lists_tab(tabs)
+      names_tab(tabs)
+      locations_tab(tabs)
+      update_tab(tabs)
     end
 
-    def admin_tab
+    def admin_tab(tabs)
       return unless @project.is_admin?(@user)
 
-      tab_item(:show_project_admin_tab.l,
-               project_admin_path(project_id: @project.id),
-               "admin")
+      tabs.tab(*project_admin_tab(@project), key: "admin")
     end
 
-    def summary_tab
-      tab_item(:SUMMARY.t, project_path(id: @project.id),
-               "projects")
+    def summary_tab(tabs)
+      tabs.tab(*project_summary_tab(@project), key: "projects")
     end
 
-    def observations_tab
-      count = @project.visible_observations.count
-      tab_item("#{count} #{:OBSERVATIONS.l}",
-               observations_path(project: @project),
-               "observations")
+    def observations_tab(tabs)
+      tabs.tab(*project_observations_tab(@project), key: "observations")
     end
 
-    def species_lists_tab
-      count = @project.species_lists.length
-      tab_item("#{count} #{:SPECIES_LISTS.l}",
-               species_lists_path(project: @project),
-               "species_lists")
+    def species_lists_tab(tabs)
+      tabs.tab(*project_species_lists_tab(@project), key: "species_lists")
     end
 
-    def names_tab
-      tab_item("#{@project.name_count} #{:NAMES.l}",
-               checklist_path(project_id: @project.id),
-               "checklists")
+    def names_tab(tabs)
+      tabs.tab(*project_names_tab(@project), key: "checklists")
     end
 
-    def locations_tab
-      tab_item("#{@project.location_count} #{:LOCATIONS.l}",
-               project_locations_path(project_id: @project.id),
-               "locations")
+    def locations_tab(tabs)
+      tabs.tab(*project_locations_tab(@project), key: "locations")
     end
 
-    def update_tab
-      return unless @project.has_targets? &&
-                    @project.is_admin?(@user)
+    def update_tab(tabs)
+      return unless @project.has_targets? && @project.is_admin?(@user)
 
-      count = @project.new_candidate_observations_count
-      tab_item("#{count} #{:project_updates_title.l}",
-               project_updates_path(project_id: @project.id),
-               "updates")
-    end
-
-    def species_list_tabs
-      species_lists_tab
-    end
-
-    def tab_item(text, path, tab_name)
-      li(class: "nav-item") do
-        a(href: path, class: tab_classes(tab_name)) { text }
-      end
-    end
-
-    def tab_classes(tab_name)
-      base = "mt-3 nav-link"
-      "#{base} #{"active" if @current_tab == tab_name}"
+      tabs.tab(*project_updates_tab(@project), key: "updates")
     end
   end
 end

--- a/test/components/nav_tabs_test.rb
+++ b/test/components/nav_tabs_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class NavTabsTest < ComponentTestCase
+  def test_renders_nav_tabs_ul_with_one_li_per_tab
+    html = render_with do |tabs|
+      tabs.tab("Summary", "/summary", key: "summary")
+      tabs.tab("Details", "/details", key: "details")
+    end
+
+    # Outer structure: <ul class="nav nav-tabs"> with one <li class="nav-item">
+    # per tab, each containing an <a class="nav-link">.
+    assert_html(html, "ul.nav.nav-tabs")
+    assert_html(html, "ul.nav-tabs > li.nav-item", count: 2)
+    assert_html(html, "a.nav-link[href='/summary']", text: "Summary")
+    assert_html(html, "a.nav-link[href='/details']", text: "Details")
+  end
+
+  def test_current_key_marks_matching_tab_active
+    html = render_with(current: "details") do |tabs|
+      tabs.tab("Summary", "/summary", key: "summary")
+      tabs.tab("Details", "/details", key: "details")
+    end
+
+    # Only the matching tab gets `.active`.
+    assert_html(html, "a.nav-link.active[href='/details']")
+    assert_no_html(html, "a.nav-link.active[href='/summary']")
+  end
+
+  def test_no_current_means_no_active_tab
+    html = render_with do |tabs|
+      tabs.tab("Summary", "/summary", key: "summary")
+    end
+
+    assert_no_html(html, "a.nav-link.active")
+  end
+
+  def test_tab_without_key_never_marked_active
+    html = render_with(current: "anything") do |tabs|
+      tabs.tab("Static", "/x") # no key:
+    end
+
+    assert_no_html(html, "a.nav-link.active")
+  end
+
+  def test_link_class_appended_to_every_tab_link
+    html = render_with(link_class: "mt-3") do |tabs|
+      tabs.tab("One", "/one", key: "one")
+      tabs.tab("Two", "/two", key: "two")
+    end
+
+    # Per-link extra class lands on every <a>; `nav-link` and (when
+    # current) `active` come after.
+    assert_html(html, "a.mt-3.nav-link[href='/one']")
+    assert_html(html, "a.mt-3.nav-link[href='/two']")
+  end
+
+  def test_attributes_forwarded_to_ul
+    html = render_with(attributes: { id: "my_tabs",
+                                     data: { x: "v" } }) do |tabs|
+      tabs.tab("One", "/one")
+    end
+
+    assert_html(html, "ul#my_tabs[data-x='v'].nav.nav-tabs")
+  end
+
+  def test_html_safe_tab_text_not_escaped
+    html = render_with do |tabs|
+      tabs.tab("<b>bold</b>".html_safe, "/x", key: "x")
+    end
+
+    # Textile-rendered html_safe text passes through, not re-escaped.
+    assert_html(html, "a.nav-link b", text: "bold")
+  end
+
+  private
+
+  def render_with(**ctor_args, &block)
+    render(Components::NavTabs.new(**ctor_args), &block)
+  end
+end


### PR DESCRIPTION
## Summary

Extracts the Bootstrap `nav-tabs` strip (`<ul class="nav nav-tabs"><li class="nav-item"><a class="nav-link [active]">…`) into `Components::NavTabs` so the project_tabs + project_admin_subtabs callers — and any future MO view that wants nav-tabs styling — share one source of markup. Also extracts the project tab definitions to `app/helpers/tabs/projects_helper.rb` so the per-tab labels/urls/selectors live alongside the rest of the tab-builder library.

## What changed

**`Components::NavTabs`** (`app/components/nav_tabs.rb`) — caller wraps the strip with their own outer chrome (existing `project_tabs` / `project_admin_subtabs` use slightly different wrappers, so keeping wrapping out of the component avoids parameterizing for a pattern that varies more than the component itself).

`tab(...)` accepts three input shapes:

- bare `tab(text, path, key: …)` — quick one-offs;
- an `InternalLink` object directly — `tab(InternalLink.new(...), key: …)`;
- a 3-element splat from MO's existing `app/helpers/tabs/*_helper.rb` methods — `tab(*projects_index_tab, key: "index")` — the `InternalLink#tab` `[title, url, html_options]` shape.

`current:` (ctor) is matched against `key:` (per-tab) to decide `.active`. `link_class:` (ctor) is a single extra class appended to every `<a class="nav-link">` (e.g. `"mt-3"` for the project banner). `attributes:` forwards arbitrary HTML attrs to the `<ul>`. With an InternalLink or 3-arg splat, the carried `html_options` merge onto the rendered `<a>` — its `:class` appends to the `nav-link` base; other attrs pass through.

The component docstring calls out that **`html_options[:class]` from InternalLink must NOT carry Bootstrap nav-tab classes** (`nav-link`, `active`, `mt-3`, etc.) — those are NavTabs' responsibility. The class slot in html_options is for identifier / behavior classes only (auto-generated `<thing>_link` for test selectors, Stimulus hooks). Tab styling is owned by the component so the same `InternalLink` object can render correctly in any tab context (top-level tabs, sub-tabs, future panel-tab triggers).

It is NOT Bootstrap's tabs-with-panels component — just the navigation-strip pattern using the same tab styling. If MO ever needs in-page panel switching, a separate `Components::TabPanels` would use `NavTabs` for the strip + add the `.tab-content > .tab-pane` block.

**Project tab definitions extracted to `app/helpers/tabs/projects_helper.rb`** — ten new methods, each returning an `InternalLink#tab` array:

- `project_summary_tab(project)`
- `project_observations_tab(project)`
- `project_species_lists_tab(project)`
- `project_names_tab(project)`
- `project_locations_tab(project)`
- `project_updates_tab(project)`
- `project_admin_tab(project)`
- `project_admin_details_tab(project)`
- `project_admin_members_tab(project)`
- `project_admin_aliases_tab(project)`

`alt_title:` keeps the auto-generated `<thing>_link` test-selector class stable across count changes — `"3 Observations"` still renders `observations_link`, not `3_observations_link`.

**Callers refactored:**

- `Views::Controllers::Projects::Tabs` — `tabs.tab(*project_summary_tab(@project), key: "projects")` etc. The conditional dispatch (`has_targets?`, `is_admin?`, `observations.any?`, `species_lists.any?`) stays in the view; the tab definitions live in the helper.
- `Views::Controllers::Projects::AdminSubtabs` — same splat pattern for the three admin sub-tabs; the private `define_tabs` / `member_count` / `alias_count` methods are gone (counts now live in the helper).

**Phlex docs** (`.claude/rules/phlex_conversions.md`) — new "Reusable Bootstrap components are a Phlex goal in this codebase" subsection inside "Decide first." Calls out the existing library (`Components::Table`, `Components::Panel`, `Components::CrudButton::*`, `Components::Modal`, `Components::NavTabs`) and links to the Bootstrap component docs. The rule: if a view uses a recognizable Bootstrap pattern and no component exists for it yet, extract one as part of the conversion, even if there's only one caller today.

## Test plan

- [x] `bin/rails test test/components/nav_tabs_test.rb test/views/controllers/projects/` — 113 tests, 490 assertions, all green
- [x] `bin/rails test test/controllers/projects/ test/helpers/tabs/` — 150 tests, 879 assertions, all green
- [x] `bundle exec rubocop` on all 5 touched files — 0 offenses
- [ ] CI green
- [ ] Browser-verify: project show page tab bar (Summary / Observations / Species Lists / Names / Locations / Admin) renders + highlights the active tab; project admin page sub-tab bar (Details / Members / Aliases) renders + highlights the active tab; click each tab and confirm correct navigation.
