### PR TITLE
Fix 2 system test failures (external_link helper + autocompleter wait)

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -105,8 +105,16 @@ module LinkHelper
   # `Components::ExternalSiteLink` — render the component directly
   # in Phlex views. (Component is named for the destination — an
   # external site — to avoid collision with the AR model.)
+  #
+  # `concat` preserves the long-standing side-effect emission
+  # contract of this helper, so ERB callers can write a bare
+  # `external_link(link)` line inside a `tag.li(...) do ... end`
+  # block (no `<%= %>` / `concat` wrapping needed at the call
+  # site). The previous ERB-only helper used `concat` for this
+  # reason; the Phlex-component refactor (PR #4401) accidentally
+  # dropped the `concat` and the lone caller fell silent.
   def external_link(link)
-    render(Components::ExternalSiteLink.new(link: link))
+    concat(render(Components::ExternalSiteLink.new(link: link)))
   end
 
   # NOTE: Specific to glyphicons

--- a/test/system/herbarium_form_system_test.rb
+++ b/test/system/herbarium_form_system_test.rb
@@ -92,9 +92,13 @@ class HerbariumFormSystemTest < ApplicationSystemTestCase
       # vs our database which has "Burbank, California, USA" (without county)
       fill_in("herbarium_place_name", with: "burbank")
 
-      # Wait for geocoding to complete - verify Google's format appears
+      # Wait for geocoding to complete - verify Google's format appears.
+      # Wait is 20s (not the test default ~2s, not even 10s) because the
+      # roundtrip is a live Google Geocoding API call — in full-suite runs
+      # with browser under load (and Google occasionally rate-limiting), 10s
+      # was flaky enough to bite the species_lists PR (#4405) CI run.
       assert_field("herbarium_place_name",
-                   with: "Burbank, Los Angeles Co., California, USA", wait: 10)
+                   with: "Burbank, Los Angeles Co., California, USA", wait: 20)
 
       # Hidden ID should be -1 (new location marker) since this is geocoded
       assert_field("herbarium_location_id", with: "-1", type: :hidden)


### PR DESCRIPTION
## Summary

Two unrelated system test failures surfaced during the species_lists Tab POROs PR (#4405) sweep. Both pre-existed on `main`; fixing them in a dedicated PR per project convention.

## Fix 1: `external_link` helper dropped `concat`

PR #4401 converted `Components::ExternalLink` → `Components::ExternalSiteLink` and rewrote `LinkHelper#external_link` to:

```ruby
def external_link(link)
  render(Components::ExternalSiteLink.new(link: link))
end
```

The previous (ERB-only) version of this helper used `concat(link_to(...))` to emit into the output_buffer as a side effect; the rewrite returned the rendered string instead. The sole caller, `app/views/controllers/observations/show/_external_links.erb:24`, was written for the side-effect contract — `(external_link(link))` as a bare statement inside a `tag.li do ... end` block:

```erb
tag.li(id: "external_link_#{link.id}") do
  (external_link(link))                              # <-- bare; was concat before
  concat([...].safe_join(" ")) if link.can_edit?(user) || in_admin_mode?
end
```

After the rewrite the bare call computed-then-discarded the rendered HTML, so the external-link `<a>` (with the "On MycoPortal" / "iNat 12345" text) silently disappeared from observation show pages — though the edit/destroy buttons next to it kept rendering because they used `concat` directly.

**Fix**: wrap the `render(...)` in `concat(...)` to preserve the original helper's side-effect emission contract. One-liner; ERB caller stays unchanged.

Caught by `ObservationShowSystemTest#test_add_and_edit_external_links`, which has been red on `main` since the original conversion landed.

## Fix 2: Herbarium autocompleter test wait bump

`HerbariumFormSystemTest#test_location_autocompleter_mode_switching` was using `assert_field(..., wait: 10)` to await a live Google Geocoding API roundtrip (`"burbank"` → `"Burbank, Los Angeles Co., California, USA"`). Passes in isolation but flaked under the full-suite run on PR #4405's CI — the browser is under more load and Google occasionally rate-limits.

**Fix**: bumped to `wait: 20` with a comment explaining the live-API dependency. A larger fix (mocking the Geocoder; or switching to a deterministic database location) is out of scope for this PR.

## Test plan

- [x] `PARALLEL_WORKERS=1 bin/rails test test/system/observation_show_system_test.rb -n test_add_and_edit_external_links` — passes
- [x] `PARALLEL_WORKERS=1 bin/rails test test/system/herbarium_form_system_test.rb test/system/observation_show_system_test.rb` — 10 tests, 0 failures
- [x] `PARALLEL_WORKERS=1 bin/rails test:system` (full suite) — 60 tests, 1020 assertions, **0 failures, 0 errors**
- [x] `bundle exec rubocop` on touched files — 0 offenses
- [ ] CI green
