### PR TITLE
Fix prod 500: SearchController#pattern fallthrough when session return-to set

### DIFF
--- a/app/classes/login_system.rb
+++ b/app/classes/login_system.rb
@@ -86,12 +86,22 @@ module LoginSystem
   end
 
   # move to the last store_location call or to the passed default one
+  #
+  # Always returns truthy so callers can chain `... and return` safely
+  # — otherwise the assignment-to-nil in the `else` branch leaks out
+  # as a falsy return value, the `and return` short-circuits, and the
+  # caller silently keeps executing past the redirect. (See the
+  # SearchController#pattern 500 incident on 2026-05-31 — production
+  # log showed a successful `Redirected to ...observations?...`
+  # followed milliseconds later by `Completed 500 Internal Server
+  # Error` because control fell through to a `send(:"_path")` call.)
   def redirect_back_or_default(default)
     if session["return-to"].nil?
       redirect_to(default)
     else
-      redirect_to(session["return-to"])
+      url = session["return-to"]
       session["return-to"] = nil
+      redirect_to(url)
     end
   end
 end

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -375,8 +375,15 @@ module ApplicationController::Queries
   #     redirect_to_next_object(:next, Image, params[:id].to_s)
   #   end
   #
+  # Returns truthy on both branches so callers chaining `... and return`
+  # don't silently fall through when the object isn't found (the
+  # not-found path internally redirects to the index via
+  # `find_or_goto_index`; before this change it then returned nil
+  # because of the implicit-return guard, which combined with the
+  # caller's `and return` walked control into `show`'s body without
+  # `@object` set).
   def redirect_to_next_object(method, model, id)
-    return unless (object = find_or_goto_index(model, id))
+    return true unless (object = find_or_goto_index(model, id))
 
     next_params = find_query_and_next_object(object, method, id)
     object = next_params[:object]

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -20,7 +20,8 @@ class SearchController < ApplicationController
     type = type.to_s.pluralize.to_sym unless type == :google
 
     unless (PATTERN_SEARCHABLE_MODELS + [:google]).include?(type)
-      flash_and_redirect_invalid_search(type) and return
+      flash_and_redirect_invalid_search(type)
+      return
     end
 
     return if pattern_too_long?(pattern)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -146,6 +146,28 @@ class SearchControllerTest < FunctionalTestCase
     assert_redirected_to(herbaria_path)
   end
 
+  # Regression for the production 500 incident on 2026-05-31. A bot
+  # GET'd `/search/pattern` with no `pattern_search` params while
+  # `session["return-to"]` was set to a previous `/observations?q=...`
+  # URL. The invalid-type guard called
+  # `flash_and_redirect_invalid_search(:"") and return` — but
+  # `redirect_back_or_default` returned nil in the "return-to was
+  # set" branch (its last statement was `session["return-to"] =
+  # nil`), so `and return` short-circuited and control fell through
+  # to `forward_pattern_search(:"", "")`, which crashed inside
+  # `send(:"#{type}_path")` with `NoMethodError: undefined method
+  # '_path' for an instance of SearchController`.
+  def test_pattern_search_no_params_with_return_to_in_session
+    @request.session["return-to"] = observations_path(q: "abc")
+
+    assert_nothing_raised do
+      get(:pattern)
+    end
+    # Honors the return-to (the production behavior); doesn't 500
+    # by falling through to a `send(:"_path")` call.
+    assert_redirected_to(observations_path(q: "abc"))
+  end
+
   def test_pattern_search_matching_an_id_redirects_to_show
     login
 


### PR DESCRIPTION
## Summary

Fixes a production 500 in `SearchController#pattern` reported in `production.log` on 2026-05-31 at 21:05:21 UTC. A bot GET'd `/search/pattern` with no `pattern_search` params and got a `NoMethodError: undefined method '_path' for an instance of SearchController` from `app/controllers/search_controller.rb:85`.

## The bug — a 2-bug chain

**Bug 1: `redirect_back_or_default` returns nil in the `session["return-to"]` branch.**

```ruby
# app/classes/login_system.rb
def redirect_back_or_default(default)
  if session["return-to"].nil?
    redirect_to(default)
  else
    redirect_to(session["return-to"])
    session["return-to"] = nil           # ← last statement; method returns nil
  end
end
```

The final assignment IS the method's return value, so callers that chain `... and return` silently fall through.

**Bug 2: `SearchController#pattern` relied on the broken idiom.**

```ruby
unless (PATTERN_SEARCHABLE_MODELS + [:google]).include?(type)
  flash_and_redirect_invalid_search(type) and return    # nil and return → no return
end
```

`flash_and_redirect_invalid_search` calls `redirect_back_or_default("/")`. With the request's `session["return-to"]` set (it was — pointed at a previous `/observations?q=...`), the helper returned nil, the `and return` short-circuited, control fell through to `save_pattern_and_proceed(:"", "")` → `forward_pattern_search(:"", "")` → `redirect_to(send(:"#{type}_path"))` → `send(:"_path")` → `NoMethodError`.

(Rails would normally raise `DoubleRender` since `redirect_back_or_default` already issued a redirect, but the route-helper resolution crashed first.)

## Why the existing test missed it

`test_pattern_search_invalid_redirects_to_indexes` already exercises `get(:pattern, params: { pattern_search: { pattern: "x", type: nil } })` and asserts `assert_redirected_to("/")`. That passes because the test session has no `return-to` set — so `redirect_back_or_default` takes the FIRST branch (`redirect_to(default)`), which returns a truthy URL string, the `and return` works, and the action returns cleanly. The bug only fires when `session["return-to"]` IS set.

## Fix — three layers, defense in depth

**1. Make `redirect_back_or_default` reliably truthy** (`app/classes/login_system.rb`). Move the `session["return-to"] = nil` assignment ABOVE the `redirect_to` so the redirect's return value is the method's return value. Every caller of this helper that chains `... and return` becomes safe.

**2. Same fix on `redirect_to_next_object`** (`app/controllers/application_controller/queries.rb`). That helper has the same pattern:

```ruby
def redirect_to_next_object(method, model, id)
  return unless (object = find_or_goto_index(model, id))   # nil return on not-found
  # ... eventually a redirect_to(...)
end
```

When the object isn't found, `find_or_goto_index` already redirected to the index AND returned nil. The outer `return unless` propagates nil. At least 8 controllers chain `redirect_to_next_object(...) and return` in their `show` actions (`images_controller.rb`, `comments_controller.rb`, `collection_numbers_controller.rb`, `users_controller.rb`, `herbarium_records_controller.rb`, `sequences_controller.rb`, plus a couple more) — same fall-through-on-not-found risk. Changed the early-return to `return true`.

**3. Stop relying on the idiom at the SearchController call site** (`app/controllers/search_controller.rb`). Replaced `flash_and_redirect_invalid_search(type) and return` with the explicit two-statement form. Same behavior, no idiom fragility:

```ruby
unless (PATTERN_SEARCHABLE_MODELS + [:google]).include?(type)
  flash_and_redirect_invalid_search(type)
  return
end
```

## Regression test

`test_pattern_search_no_params_with_return_to_in_session` — sets `@request.session["return-to"]` to an observations URL, then GETs `:pattern` with no params. Asserts no exception is raised AND that the redirect honors the return-to (the production behavior — no 500, no fallthrough to `_path` crash). Without any of the three fix layers, this test raises `NoMethodError`.

## Did this 500 cause the 7-minute outage?

**Very unlikely.** Evidence from production.log:

- The 500 was a one-shot `NoMethodError`. Rails caught it, rendered the 500 page, released the Puma worker. The worker (PID 424140) processed the next request 1 second later (`Started GET "/names/21086" at 21:05:22`).
- Total errors 21:00-21:09 = 4. Two are bot routing errors, one is our 500, one is another routing error. No error storm.
- Request volume was normal at the moment of the 500 (131/min, in line with surrounding minutes).
- Slow-request investigation: the slowest requests at 21:05-21:15 were 5.2s (POST `/observations`) and 3.4s (`glossary_terms#show`). Nothing > 6s.

The slow-request clusters that ARE consistent with worker saturation are at different times:
- **05:06 UTC** — 3 concurrent `observations/maps#index` each 36-38s.
- **05:44 UTC** — 3 concurrent requests within 100ms taking 57-72s (`account/login`, `observations/search#show`, `observations/search#new`).
- **17:57 UTC** — 2 concurrent `observations/maps#index` 35-40s.

If the uptime monitor's outage was around one of those, it's a different bug class than this fix. Worth investigating `observations/maps#index` and `observations/search#new` as separate issues.

## Test plan

- [x] `bin/rails test test/controllers/search_controller_test.rb` — 19 tests, 184 assertions, 0 failures (regression test included)
- [x] `bundle exec rubocop` on 4 touched files — 0 offenses
- [ ] CI green
- [ ] Spot-check the controllers that chain `redirect_to_next_object ... and return` (`images#show`, `comments#show`, etc.) — their fall-through paths now correctly return on object-not-found
