### PR TITLE
Tab POROs leaves: convert general_helper + related_objects_helper

### DIFF
--- a/app/classes/tab/external_search.rb
+++ b/app/classes/tab/external_search.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# External search link — Google Maps / Google Search / Wikipedia
+# lookups for a given query string. Replaces
+# `Tabs::GeneralHelper#search_tab_for` and `#external_search_urls`.
+class Tab::ExternalSearch < Tab::Base
+  URLS = {
+    Google_Maps: "https://maps.google.com/maps?q=",
+    Google_Search: "https://www.google.com/search?q=",
+    Wikipedia: "https://en.wikipedia.org/w/index.php?search="
+  }.freeze
+
+  def self.sites
+    URLS.keys
+  end
+
+  def initialize(site:, query:)
+    super()
+    @site = site
+    @query = query
+  end
+
+  def title
+    @site.to_s.titlecase
+  end
+
+  def path
+    "#{URLS.fetch(@site)}#{@query}"
+  end
+
+  def html_options
+    { id: "search_link_to_#{@site}_#{@query}" }
+  end
+end

--- a/app/classes/tab/object/index.rb
+++ b/app/classes/tab/object/index.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Polymorphic "List Xs" index link. Replaces
+# `Tabs::GeneralHelper#object_index_tab`. Carries the current Query
+# through via `q_param`.
+class Tab::Object::Index < Tab::Base
+  def initialize(object:, q_param: nil, title: nil)
+    super()
+    @object = object
+    @q_param = q_param
+    @title_override = title
+  end
+
+  def title
+    @title_override || :list_objects.t(type: @object.type_tag)
+  end
+
+  def path
+    args = @object.index_link_args
+    return args unless @q_param && args.is_a?(Hash)
+
+    args.merge(q: @q_param)
+  end
+
+  def html_options
+    { class: "#{@object.type_tag.to_s.pluralize}_index_link" }
+  end
+
+  def model
+    @object
+  end
+end

--- a/app/classes/tab/object/return.rb
+++ b/app/classes/tab/object/return.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Polymorphic "Cancel and show this object" link — works with any
+# object that responds to `#type_tag` (i18n key) and `#show_link_args`
+# (the route helper args). Replaces `Tabs::GeneralHelper#object_return_tab`.
+class Tab::Object::Return < Tab::Base
+  def initialize(object:, title: nil)
+    super()
+    @object = object
+    @title_override = title
+  end
+
+  def title
+    @title_override || :cancel_and_show.t(type: @object.type_tag)
+  end
+
+  def path
+    @object.show_link_args
+  end
+
+  def html_options
+    { class: "#{@object.type_tag}_return_link" }
+  end
+
+  def model
+    @object
+  end
+end

--- a/app/classes/tab/object/show.rb
+++ b/app/classes/tab/object/show.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Polymorphic "Show this object" link. Replaces
+# `Tabs::GeneralHelper#show_object_tab`.
+class Tab::Object::Show < Tab::Base
+  def initialize(object:, title: nil)
+    super()
+    @object = object
+    @title_override = title
+  end
+
+  def title
+    @title_override || :show_object.t(type: @object.type_tag)
+  end
+
+  def path
+    @object.show_link_args
+  end
+
+  def html_options
+    { class: "#{@object.type_tag}_link" }
+  end
+
+  def model
+    @object
+  end
+end

--- a/app/classes/tab/object/show_parent.rb
+++ b/app/classes/tab/object/show_parent.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Polymorphic "Show this object's parent" link. Replaces
+# `Tabs::GeneralHelper#show_parent_tab`. The object must respond to
+# `#parent`, and the parent must respond to `#type_tag` and
+# `#show_link_args`.
+class Tab::Object::ShowParent < Tab::Base
+  def initialize(object:, title: nil)
+    super()
+    @object = object
+    @title_override = title
+  end
+
+  def title
+    @title_override || :show_object.t(type: @object.parent.type_tag)
+  end
+
+  def path
+    @object.parent.show_link_args
+  end
+
+  def html_options
+    { class: "parent_#{@object.parent.type_tag}_link" }
+  end
+
+  def model
+    @object
+  end
+end

--- a/app/classes/tab/related/query.rb
+++ b/app/classes/tab/related/query.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Generic "related index" link — appears on a filtered index of one
+# model and points at the equivalent filtered index of a related
+# model (e.g. "Images at these Locations" on a Locations index that
+# was itself filtered from an Observation query). Wraps
+# `InternalLink::RelatedQuery`. Replaces
+# `Tabs::RelatedObjectsHelper#related_objects_tab` and the per-model
+# variants (`related_images_tab`, `related_locations_tab` etc.).
+#
+# Use `.for(...)` to apply the `Query.related?(target, filter)`
+# guard — returns nil when no bridge exists between filter and
+# target, matching the original helpers' `return unless ...` shape.
+# Call `.new(...)` directly only when the caller has already
+# checked the bridge applies.
+class Tab::Related::Query < Tab::Base
+  def self.for(model:, filter:, current_query:, controller:)
+    return nil unless current_query &&
+                      ::Query.related?(model.name.to_sym, filter)
+
+    new(model: model, filter: filter,
+        current_query: current_query, controller: controller)
+  end
+
+  def initialize(model:, filter:, current_query:, controller:)
+    super()
+    @model = model
+    @filter = filter
+    @current_query = current_query
+    @controller = controller
+  end
+
+  def title
+    internal_link.tab[0]
+  end
+
+  def path
+    internal_link.tab[1]
+  end
+
+  def html_options
+    internal_link.tab[2] || {}
+  end
+
+  def to_internal_link
+    internal_link
+  end
+
+  private
+
+  def internal_link
+    @internal_link ||= ::InternalLink::RelatedQuery.new(
+      @model, @filter, @current_query, @controller
+    )
+  end
+end

--- a/app/helpers/tabs/general_helper.rb
+++ b/app/helpers/tabs/general_helper.rb
@@ -2,58 +2,47 @@
 
 module Tabs
   module GeneralHelper
-    def search_tab_for(site_symbol, search_string)
-      return unless (url = external_search_urls[site_symbol])
+    # The tab definitions migrated to PORO classes:
+    # - `Tab::Object::Return`, `Tab::Object::Show`,
+    #   `Tab::Object::ShowParent`, `Tab::Object::Index` for the four
+    #   polymorphic "act on any object" tabs
+    # - `Tab::ExternalSearch` for the parameterized external search
+    #   link (Google_Maps / Google_Search / Wikipedia)
+    #
+    # The methods below remain as thin legacy-shape adapters so
+    # existing helper-chain callers (Phlex views, ERB templates,
+    # and other `Tabs::*Helper` methods that compose this one)
+    # keep working unchanged. Each PR that migrates a downstream
+    # domain (observations, names, locations) replaces these calls
+    # with direct PORO instantiation; once all downstream callers
+    # migrate, this file can be deleted.
 
-      InternalLink.new(
-        site_symbol.to_s.titlecase, "#{url}#{search_string}",
-        html_options: { id: "search_link_to_#{site_symbol}_#{search_string}" }
-      ).tab
+    def search_tab_for(site_symbol, search_string)
+      return unless ::Tab::ExternalSearch::URLS.key?(site_symbol)
+
+      ::Tab::ExternalSearch.new(site: site_symbol,
+                                query: search_string).to_a
     end
 
-    # Dictionary of urls for searches on external sites
     def external_search_urls
-      {
-        Google_Maps: "https://maps.google.com/maps?q=",
-        Google_Search: "https://www.google.com/search?q=",
-        Wikipedia: "https://en.wikipedia.org/w/index.php?search="
-      }.freeze
+      ::Tab::ExternalSearch::URLS
     end
 
     def object_return_tab(obj, text = nil)
-      text ||= :cancel_and_show.t(type: obj.type_tag)
-
-      InternalLink::Model.new(
-        text, obj, obj.show_link_args,
-        html_options: { class: "#{obj.type_tag}_return_link" }
-      ).tab
+      ::Tab::Object::Return.new(object: obj, title: text).to_a
     end
 
     def show_object_tab(obj, text = nil)
-      text ||= :show_object.t(type: obj.type_tag)
-
-      InternalLink::Model.new(
-        text, obj, obj.show_link_args,
-        html_options: { class: "#{obj.type_tag}_link" }
-      ).tab
+      ::Tab::Object::Show.new(object: obj, title: text).to_a
     end
 
     def show_parent_tab(obj, text = nil)
-      text ||= :show_object.t(type: obj.parent.type_tag)
-
-      InternalLink::Model.new(
-        text, obj, obj.parent.show_link_args,
-        html_options: { class: "parent_#{obj.parent.type_tag}_link" }
-      ).tab
+      ::Tab::Object::ShowParent.new(object: obj, title: text).to_a
     end
 
     def object_index_tab(obj, text = nil)
-      text ||= :list_objects.t(type: obj.type_tag)
-
-      InternalLink::Model.new(
-        text, obj, add_q_param(obj.index_link_args),
-        html_options: { class: "#{obj.type_tag.to_s.pluralize}_index_link" }
-      ).tab
+      ::Tab::Object::Index.new(object: obj, q_param: q_param,
+                               title: text).to_a
     end
   end
 end

--- a/app/helpers/tabs/related_objects_helper.rb
+++ b/app/helpers/tabs/related_objects_helper.rb
@@ -2,38 +2,51 @@
 
 module Tabs
   module RelatedObjectsHelper
-    # These build links for indexes of a related object, filtered by the
-    # current query (or indexes of the same object, from a map). This new
-    # joined filtered query is passed as a new, provisional `q` - it is not
-    # saved as a QueryRecord because it's derived from that original query.
+    # The related-query tab definitions migrated to
+    # `Tab::Related::Query` (under `app/classes/tab/related/query.rb`).
+    # Use `Tab::Related::Query.for(model:, filter:, current_query:,
+    # controller:)` from new code — the factory returns nil when no
+    # bridge exists between `filter` and `model.name.to_sym`
+    # (matching the original `return unless ...` guard).
     #
-    # The `model` is the index you want, the `type` is the filtering subquery.
+    # The methods below remain as thin legacy-shape adapters during
+    # the migration. Each downstream helper / view that consumed
+    # them migrates to the PORO directly; once all callers have
+    # migrated, this file can be deleted.
+
     def related_objects_tab(model, type, current_query)
-      InternalLink::RelatedQuery.new(model, type, current_query, controller).tab
+      ::Tab::Related::Query.new(
+        model: model, filter: type,
+        current_query: current_query, controller: controller
+      ).to_a
     end
 
     def related_images_tab(type, current_query)
-      return unless current_query && Query.related?(:Image, type)
-
-      related_objects_tab(Image, type, current_query)
+      ::Tab::Related::Query.for(
+        model: Image, filter: type,
+        current_query: current_query, controller: controller
+      )&.to_a
     end
 
     def related_locations_tab(type, current_query)
-      return unless current_query && Query.related?(:Location, type)
-
-      related_objects_tab(Location, type, current_query)
+      ::Tab::Related::Query.for(
+        model: Location, filter: type,
+        current_query: current_query, controller: controller
+      )&.to_a
     end
 
     def related_names_tab(type, current_query)
-      return unless current_query && Query.related?(:Name, type)
-
-      related_objects_tab(Name, type, current_query)
+      ::Tab::Related::Query.for(
+        model: Name, filter: type,
+        current_query: current_query, controller: controller
+      )&.to_a
     end
 
     def related_observations_tab(type, current_query)
-      return unless current_query && Query.related?(:Observation, type)
-
-      related_objects_tab(Observation, type, current_query)
+      ::Tab::Related::Query.for(
+        model: Observation, filter: type,
+        current_query: current_query, controller: controller
+      )&.to_a
     end
   end
 end

--- a/test/classes/tab/external_search_test.rb
+++ b/test/classes/tab/external_search_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class TabExternalSearchTest < UnitTestCase
+  def test_google_maps
+    tab = Tab::ExternalSearch.new(site: :Google_Maps, query: "Burbank")
+
+    assert_equal("Google Maps", tab.title)
+    assert_equal("https://maps.google.com/maps?q=Burbank", tab.path)
+    assert_equal("search_link_to_Google_Maps_Burbank",
+                 tab.html_options[:id])
+  end
+
+  def test_google_search
+    tab = Tab::ExternalSearch.new(site: :Google_Search, query: "Foo")
+
+    assert_equal("Google Search", tab.title)
+    assert_equal("https://www.google.com/search?q=Foo", tab.path)
+  end
+
+  def test_wikipedia
+    tab = Tab::ExternalSearch.new(site: :Wikipedia, query: "Bar")
+
+    assert_equal("Wikipedia", tab.title)
+    assert_equal("https://en.wikipedia.org/w/index.php?search=Bar",
+                 tab.path)
+  end
+
+  def test_sites_class_method
+    assert_equal([:Google_Maps, :Google_Search, :Wikipedia],
+                 Tab::ExternalSearch.sites)
+  end
+
+  def test_unknown_site_raises
+    assert_raises(KeyError) do
+      Tab::ExternalSearch.new(site: :Unknown, query: "X").path
+    end
+  end
+end

--- a/test/classes/tab/object/parity_test.rb
+++ b/test/classes/tab/object/parity_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Output-parity test for `Tabs::GeneralHelper` → `Tab::Object::*` +
+# `Tab::ExternalSearch` migration. RHS InternalLink constructions
+# below are byte-for-byte copies of the pre-conversion helper-method
+# bodies.
+module Tab::Object
+  class ParityTest < UnitTestCase
+    def setup
+      @project = projects(:bolete_project)
+    end
+
+    def test_return_default_title
+      text = :cancel_and_show.t(type: @project.type_tag)
+      expected = ::InternalLink::Model.new(
+        text, @project, @project.show_link_args,
+        html_options: { class: "#{@project.type_tag}_return_link" }
+      ).tab
+
+      assert_equal(expected,
+                   Tab::Object::Return.new(object: @project).to_a)
+    end
+
+    def test_return_title_override
+      expected = ::InternalLink::Model.new(
+        "Custom", @project, @project.show_link_args,
+        html_options: { class: "#{@project.type_tag}_return_link" }
+      ).tab
+
+      assert_equal(
+        expected,
+        Tab::Object::Return.new(object: @project, title: "Custom").to_a
+      )
+    end
+
+    def test_show
+      text = :show_object.t(type: @project.type_tag)
+      expected = ::InternalLink::Model.new(
+        text, @project, @project.show_link_args,
+        html_options: { class: "#{@project.type_tag}_link" }
+      ).tab
+
+      assert_equal(expected,
+                   Tab::Object::Show.new(object: @project).to_a)
+    end
+
+    def test_show_parent
+      desc = name_descriptions(:agaricus_campestras_desc)
+      text = :show_object.t(type: desc.parent.type_tag)
+      expected = ::InternalLink::Model.new(
+        text, desc, desc.parent.show_link_args,
+        html_options: { class: "parent_#{desc.parent.type_tag}_link" }
+      ).tab
+
+      assert_equal(expected,
+                   Tab::Object::ShowParent.new(object: desc).to_a)
+    end
+
+    def test_index_no_q_param
+      text = :list_objects.t(type: @project.type_tag)
+      expected = ::InternalLink::Model.new(
+        text, @project, @project.index_link_args,
+        html_options: {
+          class: "#{@project.type_tag.to_s.pluralize}_index_link"
+        }
+      ).tab
+
+      assert_equal(expected,
+                   Tab::Object::Index.new(object: @project).to_a)
+    end
+
+    def test_external_search_google_maps
+      expected = ::InternalLink.new(
+        "Google Maps", "https://maps.google.com/maps?q=Burbank",
+        html_options: { id: "search_link_to_Google_Maps_Burbank" }
+      ).tab
+
+      assert_equal(
+        expected,
+        Tab::ExternalSearch.new(site: :Google_Maps,
+                                query: "Burbank").to_a
+      )
+    end
+  end
+end

--- a/test/classes/tab/object/tabs_test.rb
+++ b/test/classes/tab/object/tabs_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Polymorphic Tab POROs that work with any object responding to
+# `#type_tag`, `#show_link_args`, `#index_link_args`, and `#parent`.
+module Tab::Object
+  class TabsTest < UnitTestCase
+    def setup
+      @project = projects(:bolete_project)
+      @herbarium = herbaria(:nybg_herbarium)
+    end
+
+    def test_return_default_title
+      tab = Tab::Object::Return.new(object: @project)
+
+      assert_equal(:cancel_and_show.t(type: :project), tab.title)
+      assert_equal(@project.show_link_args, tab.path)
+      assert_equal(@project, tab.model)
+      assert_equal("project_return_link", tab.html_options[:class])
+    end
+
+    def test_return_title_override
+      tab = Tab::Object::Return.new(object: @project, title: "Custom")
+
+      assert_equal("Custom", tab.title)
+    end
+
+    def test_show_default_title
+      tab = Tab::Object::Show.new(object: @herbarium)
+
+      assert_equal(:show_object.t(type: :herbarium), tab.title)
+      assert_equal(@herbarium.show_link_args, tab.path)
+      assert_equal(@herbarium, tab.model)
+      assert_equal("herbarium_link", tab.html_options[:class])
+    end
+
+    def test_show_title_override
+      tab = Tab::Object::Show.new(object: @herbarium, title: "Other")
+
+      assert_equal("Other", tab.title)
+    end
+
+    def test_show_parent
+      desc = name_descriptions(:agaricus_campestras_desc)
+      tab = Tab::Object::ShowParent.new(object: desc)
+
+      assert_equal(:show_object.t(type: desc.parent.type_tag),
+                   tab.title)
+      assert_equal(desc.parent.show_link_args, tab.path)
+      assert_equal("parent_#{desc.parent.type_tag}_link",
+                   tab.html_options[:class])
+    end
+
+    def test_index_default_title
+      tab = Tab::Object::Index.new(object: @project)
+
+      assert_equal(:list_objects.t(type: :project), tab.title)
+      assert_equal(@project.index_link_args, tab.path)
+      assert_equal("projects_index_link", tab.html_options[:class])
+    end
+
+    def test_index_with_q_param
+      tab = Tab::Object::Index.new(object: @project, q_param: "ABC")
+      path = tab.path
+
+      assert_equal("ABC", path[:q])
+      # Original hash entries are preserved.
+      @project.index_link_args.each do |k, v|
+        assert_equal(v, path[k])
+      end
+    end
+  end
+end

--- a/test/classes/tab/related/query_test.rb
+++ b/test/classes/tab/related/query_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# `.for(...)` returns nil when the inputs make a related-query
+# impossible — those branches don't reach into the controller for
+# URL building, so they can be tested without a real request
+# context. The success branches (Tab::Base behavior + URL
+# construction) go through `InternalLink::RelatedQuery` which
+# needs `controller.add_q_param`, which in turn needs a live
+# request — those are exercised via downstream caller tests that
+# already have a controller context, not here.
+module Tab::Related
+  class QueryTest < UnitTestCase
+    def test_for_returns_nil_when_no_current_query
+      assert_nil(Tab::Related::Query.for(
+                   model: Image, filter: :Observation,
+                   current_query: nil, controller: nil
+                 ))
+    end
+
+    def test_for_returns_nil_when_no_bridge
+      query = ::Query.lookup(:Observation)
+      stub_no_bridge = ->(*) { false }
+
+      ::Query.stub(:related?, stub_no_bridge) do
+        assert_nil(Tab::Related::Query.for(
+                     model: Image, filter: :Observation,
+                     current_query: query, controller: nil
+                   ))
+      end
+    end
+
+    def test_for_returns_tab_when_bridge_exists
+      query = ::Query.lookup(:Observation)
+      stub_bridge_ok = ->(*) { true }
+
+      ::Query.stub(:related?, stub_bridge_ok) do
+        tab = Tab::Related::Query.for(
+          model: Image, filter: :Observation,
+          current_query: query, controller: nil
+        )
+
+        assert_not_nil(tab)
+        assert_kind_of(Tab::Related::Query, tab)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Scaffolding PR for the upcoming `locations` / `names` / `observations` Tab POROs work. Converts the 2 leaf helpers in observations' dependency web so the downstream domains can compose `Tab::Object::Return` / `Tab::Related::Query` etc. directly in their Collections instead of threading helper-chain calls.

## What's a "leaf" here?

I mapped observations' transitive dependency closure across `tabs/*_helper.rb`:

```
observations_helper
├─ general_helper           ← LEAF (no outbound tabs/* deps)
├─ related_objects_helper   ← LEAF
├─ locations_helper         → general, related_objects
└─ names_helper             → general, related_objects
```

Doing the leaves first means subsequent PRs (locations, names, observations) get straight-line PORO composition with no transitional `helpers:` proxy / `Tab.from_legacy` adapter needed.

## 4 polymorphic Tab POROs under `Tab::Object::*`

Each works with any object that responds to `#type_tag` (i18n key), `#show_link_args` (routing hash), `#index_link_args`, and (for `ShowParent`) `#parent`:

- **`Tab::Object::Return`** — `:cancel_and_show.t(type:)` with class `"<type>_return_link"`. Replaces `object_return_tab(obj, text)`.
- **`Tab::Object::Show`** — `:show_object.t(type:)` with class `"<type>_link"`. Replaces `show_object_tab(obj, text)`.
- **`Tab::Object::ShowParent`** — `:show_object.t(type: obj.parent.type_tag)` with class `"parent_<parent_type>_link"`. Replaces `show_parent_tab(obj, text)`.
- **`Tab::Object::Index`** — `:list_objects.t(type:)` with class `"<types>_index_link"`, threading the current `q_param`. Replaces `object_index_tab(obj, text)`.

All accept an optional `title:` override for callers that want non-default wording.

## `Tab::ExternalSearch` (parameterized over site enum)

`Google_Maps` / `Google_Search` / `Wikipedia` lookups, one class parameterized over the site. URLs are now `Tab::ExternalSearch::URLS` (was an `external_search_urls` method). Replaces `search_tab_for(site_symbol, search_string)`.

## `Tab::Related::Query` (with `.for(...)` factory)

Wraps `InternalLink::RelatedQuery` (which the original `related_objects_tab(model, type, query, controller)` built directly). The `.for(model:, filter:, current_query:, controller:)` factory applies the `Query.related?(target, filter)` guard and returns nil when no bridge exists — matching the original 4 `related_*_tab` methods' `return unless ...` shape. Replaces `related_objects_tab`, `related_images_tab`, `related_locations_tab`, `related_names_tab`, `related_observations_tab`.

The PORO accepts `controller:` because `InternalLink::RelatedQuery` itself calls `controller.add_q_param(...)` for URL construction — refactoring InternalLink::RelatedQuery to take a resolved `q_param` instead is a separate effort.

## Helpers slimmed to thin delegators (no caller updates in this PR)

Both `tabs/general_helper.rb` and `tabs/related_objects_helper.rb` keep their public method signatures, with each method body collapsed to a 1-line `::Tab::SomeClass.new(...).to_a` (or `.for(...).to_a`) call. The downstream caller migration (~25 files across `app/helpers/`, `app/views/`, and `app/components/`) happens in the next PR(s) when locations/names/observations get converted and their views/composers update to use POROs directly.

This shape is intentional — small PR, no caller surface, easy to revert, parity-guaranteed by the delegator pattern. Once all downstream callers migrate, both helper files can be deleted.

## Honest cost/benefit (asked + answered mid-review)

- **`Tab::Object::*` polymorphic utility tabs**: roughly neutral on standalone value vs the helper methods. The win is enabling downstream Collections to compose these directly.
- **`Tab::ExternalSearch`**: clear win — small fixed enum becomes class-level data.
- **`Tab::Related::Query`**: thin wrapper around `InternalLink::RelatedQuery`; only earns its keep through composability downstream.

I accepted the scaffolding cost knowing the value is enabling the high-value downstream domain conversions (Project / SpeciesList / Herbarium style) rather than the leaves themselves.

## Tests

- 7 single-Tab tests (`Tab::Object::Return` / `Show` / `ShowParent` / `Index` + override branches)
- 5 `Tab::ExternalSearch` tests (per-site URL construction, sites class method, KeyError on unknown site)
- 3 `Tab::Related::Query.for` tests (nil branches via stub — the success branches hit `controller.add_q_param` which needs a real request context, exercised downstream in caller tests)
- 5 output-parity tests (PORO `.to_a` == legacy `InternalLink.new(...).tab`)

## Test plan

- [x] `bin/rails test test/classes/tab/object/ test/classes/tab/external_search_test.rb test/classes/tab/related/` — 21 tests, 60 assertions, all green
- [x] `bin/rails test test/classes/tab/ test/components/nav_tabs_test.rb test/helpers/header/context_nav_helper_test.rb` — 127 tests, 416 assertions, all green
- [x] `bundle exec rubocop` on every touched file — 0 offenses
- [x] CI green
- [ ] Spot-check downstream callers: helper method signatures preserved, so `object_return_tab(@project)` calls inside ERB / Phlex still produce the same `[title, url, opts]` tuple.
